### PR TITLE
[UX] Move delay message into spinner

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2930,10 +2930,12 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                                               skip_unnecessary_provisioning)
             except locks.LockTimeout:
                 if not communicated_with_user:
-                    logger.info(f'{colorama.Fore.YELLOW}'
-                                f'Launching delayed, check concurrent tasks: '
-                                f'sky api status')
-                    communicated_with_user = True
+                    rich_utils.force_update_status(
+                        ux_utils.spinner_message('Launching delayed  ' +
+                                                 colorama.Style.RESET_ALL +
+                                                 colorama.Style.DIM +
+                                                 'Check concurrent requests: ' +
+                                                 'sky api status '))
 
     def _locked_provision(
         self,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2931,7 +2931,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             except locks.LockTimeout:
                 if not communicated_with_user:
                     rich_utils.force_update_status(
-                        ux_utils.spinner_message('Launching delayed  ' +
+                        ux_utils.spinner_message('Launching - blocked by ' +
+                                                 'other requests ' +
                                                  colorama.Style.RESET_ALL +
                                                  colorama.Style.DIM +
                                                  'Check concurrent requests: ' +


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Addresses following comments https://github.com/skypilot-org/skypilot/pull/6530#discussion_r2261296452.

Tweaked the delay message when waiting to grab the cluster lock to happen in the spinner message instead of a standalone message. Also changed "tasks" in message to "requests".

This PR was tested by launching two sky launch requests simultaneously to the same cluster and verifying that the later request displays the desired "Launching delayed" message in the spinner.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
