### PR TITLE
[Tests] Fix endpoint comparison in unittests

### DIFF
--- a/tests/test_api_compatibility.py
+++ b/tests/test_api_compatibility.py
@@ -112,10 +112,12 @@ def get_field_info(model_class: Type) -> Dict[str, Dict[str, Any]]:
 def compare_field_types(type1: Any, type2: Any) -> bool:
     """Compare two type annotations for compatibility."""
     # Handle Optional types
+    # For Optional[Union[typea, typeb]], we need to compare the union types
+    # in set to avoid order dependency.
     if get_origin(type1) is Union and type(None) in get_args(type1):
-        type1 = next(arg for arg in get_args(type1) if arg is not type(None))
+        type1 = set(arg for arg in get_args(type1) if arg is not type(None))
     if get_origin(type2) is Union and type(None) in get_args(type2):
-        type2 = next(arg for arg in get_args(type2) if arg is not type(None))
+        type2 = set(arg for arg in get_args(type2) if arg is not type(None))
 
     # Handle List types
     if get_origin(type1) is list:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixing https://github.com/skypilot-org/skypilot/actions/runs/16816637819/job/47634899714?pr=6571

Previously the order of Union type will break the test. This pr fixes it.

```bash
master=typing.Union[int, str, NoneType] != current=typing.Union[str, int, NoneType]
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
