### PR TITLE
[Dashboard] Cluster & managed jobs log tailing

### DIFF
--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -150,7 +150,6 @@ export async function getClusterHistory() {
         workspace: cluster.workspace || 'default',
         autostop: -1,
         to_down: false,
-        cluster_hash: cluster.cluster_hash,
         usage_intervals: cluster.usage_intervals,
         command: cluster.last_creation_command || '',
         task_yaml: cluster.last_creation_yaml || '{}',
@@ -186,6 +185,7 @@ export async function streamClusterJobLogs({
         follow: false,
         cluster_name: clusterName,
         job_id: jobId,
+        tail: 1000,
         override_skypilot_config: {
           active_workspace: workspace || 'default',
         },

--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -5,6 +5,8 @@ import { showToast } from '@/data/connectors/toast';
 import { apiClient } from '@/data/connectors/client';
 import dashboardCache from '@/lib/cache';
 
+const DEFAULT_TAIL_LINES = 10000;
+
 /**
  * Truncates a string in the middle, preserving parts from beginning and end.
  * @param {string} str - The string to truncate
@@ -185,7 +187,7 @@ export async function streamClusterJobLogs({
         follow: false,
         cluster_name: clusterName,
         job_id: jobId,
-        tail: 1000,
+        tail: DEFAULT_TAIL_LINES,
         override_skypilot_config: {
           active_workspace: workspace || 'default',
         },

--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -10,7 +10,7 @@ import dashboardCache from '@/lib/cache';
 import { apiClient } from './client';
 
 // Configuration
-const DEFAULT_TAIL_LINES = 1000;
+const DEFAULT_TAIL_LINES = 10000;
 
 export async function getManagedJobs({ allUsers = true } = {}) {
   try {


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR adds log tailing for cluster jobs (managed jobs already had log tailling) and bumps up the tail limit to 10,000 instead of 1000. 

Tailing is necessary because if we stream the entire logs, the dashboard can crash (this can be reproduced by generating a log file of 100,000 lines).

Note:
This PR will be followed by further improvements to the log rendering in the dashboard. The first improvement will be a download button which allows users to download the full log file if they so choose.

<!-- Describe the tests ran -->
Ran a bash script to print 100,000 lines and verified that only the last 10,000 lines showed up in the dashboard.

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
