### PR TITLE
[Docs] Fix outdated --cookies flag reference in auth documentation

### DIFF
--- a/docs/source/reference/auth.rst
+++ b/docs/source/reference/auth.rst
@@ -404,7 +404,7 @@ During the login flow, the token provided by the web login will encode the cooki
 
 .. note::
 
-    If your auth proxy is not automatically detected, try using ``sky api login --relogin`` to force auth proxy mode.
+    If your auth proxy is not automatically detected, try using ``sky api login --relogin`` to force relogin.
 
 If the ``X-Auth-Request-Email`` header is set by your auth proxy, SkyPilot will use it as the username in all requests. You can customize the authentication header name if your auth proxy uses a different header than the default ``X-Auth-Request-Email``.
 

--- a/docs/source/reference/auth.rst
+++ b/docs/source/reference/auth.rst
@@ -404,7 +404,7 @@ During the login flow, the token provided by the web login will encode the cooki
 
 .. note::
 
-    If your auth proxy is not automatically detected, try using ``sky api login --relogin`` to force relogin.
+    If your auth proxy is not automatically detected or you would like to login with a different identity, try using ``sky api login --relogin`` to force relogin.
 
 If the ``X-Auth-Request-Email`` header is set by your auth proxy, SkyPilot will use it as the username in all requests. You can customize the authentication header name if your auth proxy uses a different header than the default ``X-Auth-Request-Email``.
 

--- a/docs/source/reference/auth.rst
+++ b/docs/source/reference/auth.rst
@@ -404,7 +404,7 @@ During the login flow, the token provided by the web login will encode the cooki
 
 .. note::
 
-    If your auth proxy is not automatically detected, try using ``sky api login --cookies`` to force auth proxy mode.
+    If your auth proxy is not automatically detected, try using ``sky api login --relogin`` to force auth proxy mode.
 
 If the ``X-Auth-Request-Email`` header is set by your auth proxy, SkyPilot will use it as the username in all requests. You can customize the authentication header name if your auth proxy uses a different header than the default ``X-Auth-Request-Email``.
 


### PR DESCRIPTION
## Summary
- Updates the authentication documentation to replace the outdated `--cookies` flag with `--relogin`
- The `sky api login` command was updated to use `--relogin` instead of `--cookies`, but the documentation wasn't updated

## Test plan
Documentation only change - no functional changes to test.

Fixes #6585

🤖 Generated with [Claude Code](https://claude.ai/code)