### PR TITLE
[UX] Add cli command for provision logs

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1682,7 +1682,9 @@ class RetryingVmProvisioner(object):
                 config_dict['handle'] = handle
                 logger.info(
                     ux_utils.finishing_message(
-                        f'Cluster launched: {cluster_name!r}.', log_path, cluster_name=cluster_name))
+                        f'Cluster launched: {cluster_name!r}.',
+                        log_path,
+                        cluster_name=cluster_name))
                 return config_dict
 
             # The cluster is not ready. We must perform error recording and/or

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1356,7 +1356,6 @@ class RetryingVmProvisioner(object):
             os.system(f'touch {log_path}')
         # Record provision log path on the current API request (server-side)
         try:
-            # Import lazily to avoid client-side import issues
             if annotations.is_on_api_server:
                 req_id = common_utils.get_current_request_id()
                 with requests_lib.update_request(req_id) as req:
@@ -1683,7 +1682,7 @@ class RetryingVmProvisioner(object):
                 config_dict['handle'] = handle
                 logger.info(
                     ux_utils.finishing_message(
-                        f'Cluster launched: {cluster_name!r}.', log_path))
+                        f'Cluster launched: {cluster_name!r}.', log_path, cluster_name=cluster_name))
                 return config_dict
 
             # The cluster is not ready. We must perform error recording and/or
@@ -1817,7 +1816,8 @@ class RetryingVmProvisioner(object):
                 log_abs_path,
                 stream_logs=False,
                 start_streaming_at='Shared connection to',
-                line_processor=log_utils.RayUpLineProcessor(log_abs_path),
+                line_processor=log_utils.RayUpLineProcessor(
+                    log_abs_path, cluster_name=cluster_handle.cluster_name),
                 # Reduce BOTO_MAX_RETRIES from 12 to 5 to avoid long hanging
                 # time during 'ray up' if insufficient capacity occurs.
                 env=dict(

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -857,6 +857,47 @@ def tail_logs(cluster_name: str,
 @usage_lib.entrypoint
 @server_common.check_server_healthy_or_start
 @annotations.client_api
+@rest.retry_transient_errors()
+def tail_provision_logs(cluster_name: str,
+                        follow: bool = True,
+                        tail: int = 0,
+                        output_stream: Optional['io.TextIOBase'] = None) -> int:
+    """Tails the provisioning logs (provision.log) for a cluster.
+
+    Args:
+        cluster_name: name of the cluster.
+        follow: follow the logs.
+        tail: lines from end to tail.
+        output_stream: optional stream to write logs.
+    Returns:
+        Exit code 0 on streaming success; raises on HTTP error.
+    """
+    body = payloads.ClusterNameBody(cluster_name=cluster_name)
+    params = {
+        'follow': str(follow).lower(),
+        'tail': tail,
+    }
+    response = server_common.make_authenticated_request(
+        'POST',
+        '/provision_logs',
+        json=json.loads(body.model_dump_json()),
+        params=params,
+        stream=True,
+        timeout=(client_common.API_SERVER_REQUEST_CONNECTION_TIMEOUT_SECONDS,
+                 None))
+    # Provision logs are not tied to an API request id for tailing
+    # Do not use resumable mode since this stream has no request_id context.
+    # Stream and then return 0 to indicate success.
+    stream_response(request_id=None,
+                    response=response,
+                    output_stream=output_stream,
+                    resumable=False)
+    return 0
+
+
+@usage_lib.entrypoint
+@server_common.check_server_healthy_or_start
+@annotations.client_api
 def download_logs(cluster_name: str,
                   job_ids: Optional[List[str]]) -> Dict[str, str]:
     """Downloads the logs of jobs.

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -885,14 +885,14 @@ def tail_provision_logs(cluster_name: str,
         stream=True,
         timeout=(client_common.API_SERVER_REQUEST_CONNECTION_TIMEOUT_SECONDS,
                  None))
-    # Provision logs are not tied to an API request id for tailing
-    # Do not use resumable mode since this stream has no request_id context.
-    # Stream and then return 0 to indicate success.
-    stream_response(request_id=None,
-                    response=response,
-                    output_stream=output_stream,
-                    resumable=False)
-    return 0
+    request_id: server_common.RequestId[int] = server_common.get_request_id(
+        response)
+    # Log request is idempotent when tail is 0, thus can resume previous
+    # streaming point on retry.
+    return stream_response(request_id=request_id,
+                           response=response,
+                           output_stream=output_stream,
+                           resumable=(tail == 0))
 
 
 @usage_lib.entrypoint

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -689,7 +689,8 @@ def _post_provision_setup(
 
     logger.info(
         ux_utils.finishing_message(f'Cluster launched: {cluster_name}.',
-                                   provision_logging.config.log_path))
+                                   provision_logging.config.log_path,
+                                   cluster_name=cluster_name))
     return cluster_info
 
 

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -690,7 +690,7 @@ def _post_provision_setup(
     logger.info(
         ux_utils.finishing_message(f'Cluster launched: {cluster_name}.',
                                    provision_logging.config.log_path,
-                                   cluster_name=cluster_name))
+                                   cluster_name=str(cluster_name)))
     return cluster_info
 
 

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -76,7 +76,8 @@ def _bulk_provision(
     logger.debug(f'\nWaiting for instances of {cluster_name!r} to be ready...')
     rich_utils.force_update_status(
         ux_utils.spinner_message('Launching - Checking instance status',
-                                 str(provision_logging.config.log_path)))
+                                 str(provision_logging.config.log_path),
+                                 cluster_name=str(cluster_name)))
     # AWS would take a very short time (<<1s) updating the state of the
     # instance.
     time.sleep(1)
@@ -462,9 +463,9 @@ def _post_provision_setup(
     docker_config = config_from_yaml.get('docker', {})
 
     with rich_utils.safe_status(
-            ux_utils.spinner_message(
-                'Launching - Waiting for SSH access',
-                provision_logging.config.log_path)) as status:
+            ux_utils.spinner_message('Launching - Waiting for SSH access',
+                                     provision_logging.config.log_path,
+                                     cluster_name=str(cluster_name))) as status:
         # If on Kubernetes, skip SSH check since the pods are guaranteed to be
         # ready by the provisioner, and we use kubectl instead of SSH to run the
         # commands and rsync on the pods. SSH will still be ready after a while
@@ -493,7 +494,8 @@ def _post_provision_setup(
             status.update(
                 ux_utils.spinner_message(
                     'Launching - Initializing docker container',
-                    provision_logging.config.log_path))
+                    provision_logging.config.log_path,
+                    cluster_name=str(cluster_name)))
             docker_user = instance_setup.initialize_docker(
                 cluster_name.name_on_cloud,
                 docker_config=docker_config,
@@ -541,7 +543,8 @@ def _post_provision_setup(
 
         runtime_preparation_str = (ux_utils.spinner_message(
             'Preparing SkyPilot runtime ({step}/3 - {step_name})',
-            provision_logging.config.log_path))
+            provision_logging.config.log_path,
+            cluster_name=str(cluster_name)))
         status.update(
             runtime_preparation_str.format(step=1, step_name='initializing'))
         instance_setup.internal_file_mounts(cluster_name.name_on_cloud,
@@ -679,7 +682,8 @@ def _post_provision_setup(
         if logging_agent:
             status.update(
                 ux_utils.spinner_message('Setting up logging agent',
-                                         provision_logging.config.log_path))
+                                         provision_logging.config.log_path,
+                                         cluster_name=str(cluster_name)))
             instance_setup.setup_logging_on_cluster(logging_agent, cluster_name,
                                                     cluster_info,
                                                     ssh_credentials)

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -784,3 +784,5 @@ class RequestPayload(BasePayload):
     status_msg: Optional[str] = None
     should_retry: bool = False
     finished_at: Optional[float] = None
+    # Optional path to provision.log for this request, if applicable
+    provision_log_path: Optional[str] = None

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -42,7 +42,8 @@ COL_USER_ID = 'user_id'
 COL_STATUS_MSG = 'status_msg'
 COL_SHOULD_RETRY = 'should_retry'
 COL_FINISHED_AT = 'finished_at'
-# Path to the cluster provision log (e.g., ~/sky_logs/<run_timestamp>/provision.log)
+# Path to the cluster provision log
+# (e.g., ~/sky_logs/<run_timestamp>/provision.log)
 COL_PROVISION_LOG_PATH = 'provision_log_path'
 REQUEST_LOG_PATH_PREFIX = '~/sky_logs/api_server/requests'
 

--- a/sky/utils/log_utils.py
+++ b/sky/utils/log_utils.py
@@ -54,7 +54,8 @@ class RayUpLineProcessor(LineProcessor):
     def __enter__(self) -> None:
         self.state = self.ProvisionStatus.LAUNCH
         self.status_display = rich_utils.safe_status(
-            ux_utils.spinner_message('Launching', self.log_path,
+            ux_utils.spinner_message('Launching',
+                                     self.log_path,
                                      cluster_name=self.cluster_name))
         self.status_display.start()
 
@@ -64,7 +65,8 @@ class RayUpLineProcessor(LineProcessor):
             logger.info('  Head VM is up.')
             self.status_display.update(
                 ux_utils.spinner_message(
-                    'Launching - Preparing SkyPilot runtime', self.log_path,
+                    'Launching - Preparing SkyPilot runtime',
+                    self.log_path,
                     cluster_name=self.cluster_name))
             self.state = self.ProvisionStatus.RUNTIME_SETUP
         if ('Pulling from' in log_line and
@@ -79,7 +81,8 @@ class RayUpLineProcessor(LineProcessor):
                 self.state == self.ProvisionStatus.PULLING_DOCKER_IMAGES):
             self.status_display.update(
                 ux_utils.spinner_message(
-                    'Launching - Preparing SkyPilot runtime', self.log_path,
+                    'Launching - Preparing SkyPilot runtime',
+                    self.log_path,
                     cluster_name=self.cluster_name))
             self.state = self.ProvisionStatus.RUNTIME_SETUP
 

--- a/sky/utils/log_utils.py
+++ b/sky/utils/log_utils.py
@@ -47,13 +47,15 @@ class RayUpLineProcessor(LineProcessor):
         RUNTIME_SETUP = 1
         PULLING_DOCKER_IMAGES = 2
 
-    def __init__(self, log_path: str):
+    def __init__(self, log_path: str, cluster_name: Optional[str] = None):
         self.log_path = log_path
+        self.cluster_name = cluster_name
 
     def __enter__(self) -> None:
         self.state = self.ProvisionStatus.LAUNCH
         self.status_display = rich_utils.safe_status(
-            ux_utils.spinner_message('Launching', self.log_path))
+            ux_utils.spinner_message('Launching', self.log_path,
+                                     cluster_name=self.cluster_name))
         self.status_display.start()
 
     def process_line(self, log_line: str) -> None:
@@ -62,19 +64,23 @@ class RayUpLineProcessor(LineProcessor):
             logger.info('  Head VM is up.')
             self.status_display.update(
                 ux_utils.spinner_message(
-                    'Launching - Preparing SkyPilot runtime', self.log_path))
+                    'Launching - Preparing SkyPilot runtime', self.log_path,
+                    cluster_name=self.cluster_name))
             self.state = self.ProvisionStatus.RUNTIME_SETUP
         if ('Pulling from' in log_line and
                 self.state == self.ProvisionStatus.RUNTIME_SETUP):
             self.status_display.update(
                 ux_utils.spinner_message(
-                    'Launching - Initializing docker container', self.log_path))
+                    'Launching - Initializing docker container',
+                    self.log_path,
+                    cluster_name=self.cluster_name))
             self.state = self.ProvisionStatus.PULLING_DOCKER_IMAGES
         if ('Status: Downloaded newer image' in log_line and
                 self.state == self.ProvisionStatus.PULLING_DOCKER_IMAGES):
             self.status_display.update(
                 ux_utils.spinner_message(
-                    'Launching - Preparing SkyPilot runtime', self.log_path))
+                    'Launching - Preparing SkyPilot runtime', self.log_path,
+                    cluster_name=self.cluster_name))
             self.state = self.ProvisionStatus.RUNTIME_SETUP
 
     def __exit__(self, except_type: Optional[Type[BaseException]],

--- a/sky/utils/ux_utils.py
+++ b/sky/utils/ux_utils.py
@@ -25,7 +25,12 @@ INDENT_LAST_SYMBOL = f'{colorama.Style.DIM}└── {colorama.Style.RESET_ALL}'
 BOLD = '\033[1m'
 RESET_BOLD = '\033[0m'
 
-# Log hint: recommend sky logs --provision <cluster>
+# Log path hint in the spinner during launching
+# (old, kept for backward compatibility)
+_LOG_PATH_HINT = (f'{colorama.Style.DIM}View logs: sky api logs -l '
+                  '{log_path}'
+                  f'{colorama.Style.RESET_ALL}')
+# Log hint: recommend sky logs --provision <cluster_name>
 _PROVISION_LOG_HINT = (
     f'{colorama.Style.DIM}View logs: '
     f'{BOLD}sky logs --provision {{cluster_name}}{RESET_BOLD}'
@@ -141,7 +146,7 @@ def log_path_hint(log_path: Union[str, 'pathlib.Path'],
     if log_path.startswith(constants.SKY_LOGS_DIRECTORY):
         log_path = log_path[len(constants.SKY_LOGS_DIRECTORY):]
     log_path = log_path.lstrip(os.path.sep)
-    return _LOG_PATH_HINT_LOCAL.format(log_path=log_path)
+    return _LOG_PATH_HINT.format(log_path=log_path)
 
 
 def provision_hint(cluster_name: Optional[str]) -> Optional[str]:

--- a/sky/utils/ux_utils.py
+++ b/sky/utils/ux_utils.py
@@ -25,10 +25,12 @@ INDENT_LAST_SYMBOL = f'{colorama.Style.DIM}└── {colorama.Style.RESET_ALL}'
 BOLD = '\033[1m'
 RESET_BOLD = '\033[0m'
 
-# Log path hint in the spinner during launching
-_LOG_PATH_HINT = (f'{colorama.Style.DIM}View logs: sky api logs -l '
-                  '{log_path}'
-                  f'{colorama.Style.RESET_ALL}')
+# Log hint: recommend sky logs --provision <cluster>
+_PROVISION_LOG_HINT = (
+    f'{colorama.Style.DIM}View logs: '
+    f'{BOLD}sky logs --provision {{cluster_name}}{RESET_BOLD}'
+    f'{colorama.Style.RESET_ALL}')
+# Legacy path hint retained for local-only cases where we don't have cluster
 _LOG_PATH_HINT_LOCAL = (f'{colorama.Style.DIM}View logs: '
                         '{log_path}'
                         f'{colorama.Style.RESET_ALL}')
@@ -126,7 +128,10 @@ class RedirectOutputForProcess:
 
 def log_path_hint(log_path: Union[str, 'pathlib.Path'],
                   is_local: bool = False) -> str:
-    """Gets the log path hint for the given log path."""
+    """Gets the log path hint for the given log path.
+
+    Kept for backward compatibility when only paths are available.
+    """
     log_path = str(log_path)
     expanded_home = os.path.expanduser('~')
     if log_path.startswith(expanded_home):
@@ -136,7 +141,13 @@ def log_path_hint(log_path: Union[str, 'pathlib.Path'],
     if log_path.startswith(constants.SKY_LOGS_DIRECTORY):
         log_path = log_path[len(constants.SKY_LOGS_DIRECTORY):]
     log_path = log_path.lstrip(os.path.sep)
-    return _LOG_PATH_HINT.format(log_path=log_path)
+    return _LOG_PATH_HINT_LOCAL.format(log_path=log_path)
+
+
+def provision_hint(cluster_name: Optional[str]) -> Optional[str]:
+    if not cluster_name:
+        return None
+    return _PROVISION_LOG_HINT.format(cluster_name=cluster_name)
 
 
 def starting_message(message: str) -> str:
@@ -150,7 +161,8 @@ def starting_message(message: str) -> str:
 def finishing_message(message: str,
                       log_path: Optional[Union[str, 'pathlib.Path']] = None,
                       is_local: bool = False,
-                      follow_up_message: Optional[str] = None) -> str:
+                      follow_up_message: Optional[str] = None,
+                      cluster_name: Optional[str] = None) -> str:
     """Gets the finishing message for the given message.
 
     Args:
@@ -168,6 +180,9 @@ def finishing_message(message: str,
     success_prefix = (f'{colorama.Style.RESET_ALL}{colorama.Fore.GREEN}✓ '
                       f'{message}{colorama.Style.RESET_ALL}{follow_up_message}'
                       f'{colorama.Style.RESET_ALL}')
+    hint = provision_hint(cluster_name)
+    if hint:
+        return f'{success_prefix}  {hint}'
     if log_path is None:
         return success_prefix
     path_hint = log_path_hint(log_path, is_local)
@@ -176,13 +191,17 @@ def finishing_message(message: str,
 
 def error_message(message: str,
                   log_path: Optional[Union[str, 'pathlib.Path']] = None,
-                  is_local: bool = False) -> str:
+                  is_local: bool = False,
+                  cluster_name: Optional[str] = None) -> str:
     """Gets the error message for the given message."""
     # We have to reset the color before the message, because sometimes if a
     # previous spinner with dimmed color overflows in a narrow terminal, the
     # color might be messed up.
     error_prefix = (f'{colorama.Style.RESET_ALL}{colorama.Fore.RED}⨯'
                     f'{colorama.Style.RESET_ALL} {message}')
+    hint = provision_hint(cluster_name)
+    if hint:
+        return f'{error_prefix}  {hint}'
     if log_path is None:
         return error_prefix
     path_hint = log_path_hint(log_path, is_local)
@@ -200,9 +219,16 @@ def retry_message(message: str) -> str:
 
 def spinner_message(message: str,
                     log_path: Optional[Union[str, 'pathlib.Path']] = None,
-                    is_local: bool = False) -> str:
-    """Gets the spinner message for the given message and log path."""
+                    is_local: bool = False,
+                    cluster_name: Optional[str] = None) -> str:
+    """Gets the spinner message for the given message and log path.
+
+    If cluster_name is provided, recommend `sky logs --provision <cluster>`.
+    """
     colored_spinner = f'[bold cyan]{message}[/]'
+    hint = provision_hint(cluster_name)
+    if hint:
+        return f'{colored_spinner}  {hint}'
     if log_path is None:
         return colored_spinner
     path_hint = log_path_hint(log_path, is_local)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR addresses a lack of observability into the provision logs when a cluster fails to be provisioned. Currently, users have to scroll through the terminal output of `sky launch` to find the command to run to stream the provision logs. This PR adds a new cli command that allows users to tail provision logs just by specifying a cluster name:

`sky logs --provision $CLUSTER_NAME`

Current status:
- [x] Adds a new field to store the path on the api server to the provision log within the request struct (modifies the request payload as well as the db schema)
- [x] add a new api server endpoint to stream the provision log
- [x] modify the client-side to be able to hit the api server endpoint


<!-- Describe the tests ran -->
Testing Plan
- [x] verified that the db schema has the new column
- [x] verified that when launching a new cluster, the db schema contains the path on the api server to the provision logs
- [x] verified that the path to the provision logs is indeed correct
- [x] verify the server and cli changes work properly

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
