### PR TITLE
[UX] Add cluster event table to explain state changes to user

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2121,6 +2121,10 @@ def _update_cluster_status(cluster_name: str) -> Optional[Dict[str, Any]]:
         # run_ray_status_to_check_all_nodes_up() is slow due to calling `ray get
         # head-ip/worker-ips`.
         record['status'] = status_lib.ClusterStatus.UP
+        # Add cluster event for instance status check.
+        global_user_state.add_cluster_event(
+            cluster_name, status_lib.ClusterStatus.UP,
+            'All nodes up + ray cluster healthy.')
         global_user_state.add_or_update_cluster(cluster_name,
                                                 handle,
                                                 requested_resources=None,
@@ -2205,9 +2209,16 @@ def _update_cluster_status(cluster_name: str) -> Optional[Dict[str, Any]]:
     #      regardless of the ray cluster's health.
     #  (2) Otherwise, we will reset the autostop setting, unless the cluster is
     #      autostopping/autodowning.
-    is_abnormal = ((0 < len(node_statuses) < handle.launched_nodes) or any(
-        status != status_lib.ClusterStatus.STOPPED for status in node_statuses))
+    some_nodes_terminated = 0 < len(node_statuses) < handle.launched_nodes
+    some_nodes_not_stopped = any(
+        status != status_lib.ClusterStatus.STOPPED for status in node_statuses)
+    is_abnormal = (some_nodes_terminated or some_nodes_not_stopped)
+
     if is_abnormal:
+        if some_nodes_terminated:
+            init_reason = 'one or more nodes terminated'
+        elif some_nodes_not_stopped:
+            init_reason = 'some nodes not stopped'
         logger.debug('The cluster is abnormal. Setting to INIT status. '
                      f'node_statuses: {node_statuses}')
         if record['autostop'] >= 0:
@@ -2291,6 +2302,9 @@ def _update_cluster_status(cluster_name: str) -> Optional[Dict[str, Any]]:
         # represent that the cluster is partially preempted.
         # TODO(zhwu): the definition of INIT should be audited/changed.
         # Adding a new status UNHEALTHY for abnormal status can be a choice.
+        global_user_state.add_cluster_event(
+            cluster_name, status_lib.ClusterStatus.INIT,
+            f'Cluster is abnormal because {init_reason} transitioning to INIT.')
         global_user_state.add_or_update_cluster(cluster_name,
                                                 handle,
                                                 requested_resources=None,
@@ -2301,6 +2315,8 @@ def _update_cluster_status(cluster_name: str) -> Optional[Dict[str, Any]]:
     # STOPPED.
     backend = backends.CloudVmRayBackend()
     backend.post_teardown_cleanup(handle, terminate=to_terminate, purge=False)
+    global_user_state.add_cluster_event(
+        cluster_name, None, 'All nodes stopped, terminating cluster.')
     return global_user_state.get_cluster_from_name(cluster_name)
 
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2124,7 +2124,8 @@ def _update_cluster_status(cluster_name: str) -> Optional[Dict[str, Any]]:
         # Add cluster event for instance status check.
         global_user_state.add_cluster_event(
             cluster_name, status_lib.ClusterStatus.UP,
-            'All nodes up + ray cluster healthy.')
+            'All nodes up + ray cluster healthy.',
+            global_user_state.ClusterEventType.STATUS_CHANGE)
         global_user_state.add_or_update_cluster(cluster_name,
                                                 handle,
                                                 requested_resources=None,
@@ -2304,7 +2305,8 @@ def _update_cluster_status(cluster_name: str) -> Optional[Dict[str, Any]]:
         # Adding a new status UNHEALTHY for abnormal status can be a choice.
         global_user_state.add_cluster_event(
             cluster_name, status_lib.ClusterStatus.INIT,
-            f'Cluster is abnormal because {init_reason} transitioning to INIT.')
+            f'Cluster is abnormal because {init_reason} transitioning to INIT.',
+            global_user_state.ClusterEventType.STATUS_CHANGE)
         global_user_state.add_or_update_cluster(cluster_name,
                                                 handle,
                                                 requested_resources=None,
@@ -2316,7 +2318,8 @@ def _update_cluster_status(cluster_name: str) -> Optional[Dict[str, Any]]:
     backend = backends.CloudVmRayBackend()
     backend.post_teardown_cleanup(handle, terminate=to_terminate, purge=False)
     global_user_state.add_cluster_event(
-        cluster_name, None, 'All nodes stopped, terminating cluster.')
+        cluster_name, None, 'All nodes stopped, terminating cluster.',
+        global_user_state.ClusterEventType.STATUS_CHANGE)
     return global_user_state.get_cluster_from_name(cluster_name)
 
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3017,11 +3017,6 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 except exceptions.ResourcesUnavailableError as e:
                     log_path = retry_provisioner.log_dir + '/provision.log'
 
-                    # Add cluster event for provisioning failure.
-                    global_user_state.add_cluster_event(
-                        cluster_name, status_lib.ClusterStatus.INIT,
-                        f'Provisioning failed: {str(e)[:100]}...')
-
                     error_message = (
                         f'{colorama.Fore.RED}Failed to provision all '
                         f'possible launchable resources.'

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1531,7 +1531,8 @@ class RetryingVmProvisioner(object):
             global_user_state.add_cluster_event(
                 cluster_name, status_lib.ClusterStatus.INIT,
                 f'Provisioning on {to_provision.cloud.display_name()} ' +
-                f'in {to_provision.region}')
+                f'in {to_provision.region}',
+                global_user_state.ClusterEventType.STATUS_CHANGE)
 
             global_user_state.set_owner_identity_for_cluster(
                 cluster_name, cloud_user_identity)
@@ -3037,7 +3038,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                         # Add cluster event for retry.
                         global_user_state.add_cluster_event(
                             cluster_name, status_lib.ClusterStatus.INIT,
-                            f'Retrying provisioning after {gap_seconds:.0f}s')
+                            f'Retrying provisioning after {gap_seconds:.0f}s',
+                            global_user_state.ClusterEventType.STATUS_CHANGE)
 
                         raise exceptions.ExecutionRetryableError(
                             error_message,
@@ -3094,7 +3096,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 # Add cluster event for runtime setup start
                 global_user_state.add_cluster_event(
                     handle.cluster_name, status_lib.ClusterStatus.INIT,
-                    'Setting up SkyPilot runtime on cluster')
+                    'Setting up SkyPilot runtime on cluster',
+                    global_user_state.ClusterEventType.STATUS_CHANGE)
 
                 cluster_info = provisioner.post_provision_runtime_setup(
                     repr(handle.launched_resources.cloud),
@@ -3286,7 +3289,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             global_user_state.add_cluster_event(
                 handle.cluster_name, status_lib.ClusterStatus.UP,
                 'Cluster successfully provisioned with ' +
-                f'{handle.launched_nodes} nodes')
+                f'{handle.launched_nodes} nodes',
+                global_user_state.ClusterEventType.STATUS_CHANGE)
 
             usage_lib.messages.usage.update_final_cluster_status(
                 status_lib.ClusterStatus.UP)

--- a/sky/core.py
+++ b/sky/core.py
@@ -633,10 +633,10 @@ def stop(cluster_name: str, purge: bool = False) -> None:
         raise exceptions.ClusterDoesNotExist(
             f'Cluster {cluster_name!r} does not exist.')
 
-    global_user_state.add_cluster_event(cluster_name,
-                            status_lib.ClusterStatus.STOPPED,
-                            'Cluster was stopped by user.',
-                            global_user_state.ClusterEventType.STATUS_CHANGE)
+    global_user_state.add_cluster_event(
+        cluster_name, status_lib.ClusterStatus.STOPPED,
+        'Cluster was stopped by user.',
+        global_user_state.ClusterEventType.STATUS_CHANGE)
 
     backend = backend_utils.get_backend_from_handle(handle)
 

--- a/sky/core.py
+++ b/sky/core.py
@@ -633,6 +633,10 @@ def stop(cluster_name: str, purge: bool = False) -> None:
         raise exceptions.ClusterDoesNotExist(
             f'Cluster {cluster_name!r} does not exist.')
 
+    global_user_state.add_cluster_event(cluster_name,
+                                        status_lib.ClusterStatus.STOPPED,
+                                        'Cluster was stopped by user.')
+
     backend = backend_utils.get_backend_from_handle(handle)
 
     if isinstance(backend, backends.CloudVmRayBackend):

--- a/sky/core.py
+++ b/sky/core.py
@@ -634,8 +634,9 @@ def stop(cluster_name: str, purge: bool = False) -> None:
             f'Cluster {cluster_name!r} does not exist.')
 
     global_user_state.add_cluster_event(cluster_name,
-                                        status_lib.ClusterStatus.STOPPED,
-                                        'Cluster was stopped by user.')
+                            status_lib.ClusterStatus.STOPPED,
+                            'Cluster was stopped by user.',
+                            global_user_state.ClusterEventType.STATUS_CHANGE)
 
     backend = backend_utils.get_backend_from_handle(handle)
 

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -445,10 +445,10 @@ def _execute_dag(
 
         if do_file_mounts:
             if cluster_name is not None:
-                global_user_state.add_cluster_event(cluster_name,
-                            status_lib.ClusterStatus.UP,
-                            'Syncing file mounts',
-                            global_user_state.ClusterEventType.STATUS_CHANGE)
+                global_user_state.add_cluster_event(
+                    cluster_name, status_lib.ClusterStatus.UP,
+                    'Syncing file mounts',
+                    global_user_state.ClusterEventType.STATUS_CHANGE)
             backend.sync_file_mounts(handle, task.file_mounts,
                                      task.storage_mounts)
 

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -439,14 +439,16 @@ def _execute_dag(
             if cluster_name is not None:
                 global_user_state.add_cluster_event(
                     cluster_name, status_lib.ClusterStatus.INIT,
-                    'Syncing files to cluster')
+                    'Syncing files to cluster',
+                    global_user_state.ClusterEventType.STATUS_CHANGE)
             backend.sync_workdir(handle, task.workdir, task.envs_and_secrets)
 
         if do_file_mounts:
             if cluster_name is not None:
                 global_user_state.add_cluster_event(cluster_name,
-                                                    status_lib.ClusterStatus.UP,
-                                                    'Syncing file mounts')
+                            status_lib.ClusterStatus.UP,
+                            'Syncing file mounts',
+                            global_user_state.ClusterEventType.STATUS_CHANGE)
             backend.sync_file_mounts(handle, task.file_mounts,
                                      task.storage_mounts)
 
@@ -460,7 +462,8 @@ def _execute_dag(
                 if cluster_name is not None:
                     global_user_state.add_cluster_event(
                         cluster_name, status_lib.ClusterStatus.UP,
-                        'Running setup commands to install dependencies')
+                        'Running setup commands to install dependencies',
+                        global_user_state.ClusterEventType.STATUS_CHANGE)
                 backend.setup(handle, task, detach_setup=detach_setup)
 
         if Stage.PRE_EXEC in stages and not dryrun:
@@ -476,7 +479,8 @@ def _execute_dag(
                 if cluster_name is not None:
                     global_user_state.add_cluster_event(
                         cluster_name, status_lib.ClusterStatus.UP,
-                        'Starting job execution')
+                        'Starting job execution',
+                        global_user_state.ClusterEventType.STATUS_CHANGE)
                 job_id = backend.execute(handle,
                                          task,
                                          detach_run,

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -646,6 +646,10 @@ def add_cluster_event(cluster_name: str,
                       reason: str, event_type: ClusterEventType) -> None:
     assert _SQLALCHEMY_ENGINE is not None
     cluster_hash = _get_hash_for_existing_cluster(cluster_name)
+    if cluster_hash is None:
+        logger.debug(f'Hash for cluster {cluster_name} not found. '
+                     'Skipping event.')
+        return
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         if (_SQLALCHEMY_ENGINE.dialect.name ==
                 db_utils.SQLAlchemyDialect.SQLITE.value):

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -641,7 +641,8 @@ def add_or_update_cluster(cluster_name: str,
 
 
 @_init_db
-def add_cluster_event(cluster_name: str, new_status: status_lib.ClusterStatus,
+def add_cluster_event(cluster_name: str,
+                      new_status: Optional[status_lib.ClusterStatus],
                       reason: str, event_type: ClusterEventType) -> None:
     assert _SQLALCHEMY_ENGINE is not None
     cluster_hash = _get_hash_for_existing_cluster(cluster_name)
@@ -666,7 +667,7 @@ def add_cluster_event(cluster_name: str, new_status: status_lib.ClusterStatus,
                     cluster_hash=cluster_hash,
                     name=cluster_name,
                     starting_status=last_status,
-                    ending_status=new_status.value,
+                    ending_status=new_status.value if new_status else None,
                     reason=reason,
                     transitioned_at=int(time.time()),
                     type=event_type.value,

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -162,6 +162,22 @@ cluster_history_table = sqlalchemy.Table(
     sqlalchemy.Column('workspace', sqlalchemy.Text, server_default=None),
 )
 
+# Table for cluster status change events.
+# starting_status: Status of the cluster at the start of the event.
+# ending_status: Status of the cluster at the end of the event.
+# reason: Reason for the transition.
+# transitioned_at: Timestamp of the transition.
+cluster_event_table = sqlalchemy.Table(
+    'cluster_events',
+    Base.metadata,
+    sqlalchemy.Column('cluster_hash', sqlalchemy.Text, primary_key=True),
+    sqlalchemy.Column('name', sqlalchemy.Text),
+    sqlalchemy.Column('starting_status', sqlalchemy.Text),
+    sqlalchemy.Column('ending_status', sqlalchemy.Text),
+    sqlalchemy.Column('reason', sqlalchemy.Text, primary_key=True),
+    sqlalchemy.Column('transitioned_at', sqlalchemy.Integer, primary_key=True),
+)
+
 ssh_key_table = sqlalchemy.Table(
     'ssh_key',
     Base.metadata,
@@ -612,6 +628,49 @@ def add_or_update_cluster(cluster_name: str,
         session.commit()
 
 
+@_init_db
+def add_cluster_event(cluster_name: str, new_status: status_lib.ClusterStatus,
+                      reason: str) -> None:
+    assert _SQLALCHEMY_ENGINE is not None
+    cluster_hash = _get_hash_for_existing_cluster(cluster_name)
+    with orm.Session(_SQLALCHEMY_ENGINE) as session:
+        if (_SQLALCHEMY_ENGINE.dialect.name ==
+                db_utils.SQLAlchemyDialect.SQLITE.value):
+            insert_func = sqlite.insert
+        elif (_SQLALCHEMY_ENGINE.dialect.name ==
+              db_utils.SQLAlchemyDialect.POSTGRESQL.value):
+            insert_func = postgresql.insert
+        else:
+            session.rollback()
+            raise ValueError('Unsupported database dialect')
+
+        cluster_row = session.query(cluster_table).filter_by(name=cluster_name)
+        last_status = cluster_row.first(
+        ).status if cluster_row and cluster_row.first() is not None else None
+
+        session.execute(
+            insert_func(cluster_event_table).values(
+                cluster_hash=cluster_hash,
+                name=cluster_name,
+                starting_status=last_status,
+                ending_status=new_status.value,
+                reason=reason,
+                transitioned_at=int(time.time()),
+            ))
+        session.commit()
+
+
+def get_last_cluster_event(cluster_name: str) -> Optional[str]:
+    assert _SQLALCHEMY_ENGINE is not None
+    with orm.Session(_SQLALCHEMY_ENGINE) as session:
+        row = session.query(cluster_event_table).filter_by(
+            name=cluster_name).order_by(
+                cluster_event_table.c.transitioned_at.desc()).first()
+    if row is None:
+        return None
+    return row.reason
+
+
 def _get_user_hash_or_current_user(user_hash: Optional[str]) -> str:
     """Returns the user hash or the current user hash, if user_hash is None.
 
@@ -987,6 +1046,7 @@ def get_clusters() -> List[Dict[str, Any]]:
         user_hash = _get_user_hash_or_current_user(row.user_hash)
         user = get_user(user_hash)
         user_name = user.name if user is not None else None
+        last_event = get_last_cluster_event(row.name)
         # TODO: use namedtuple instead of dict
         record = {
             'name': row.name,
@@ -1010,6 +1070,7 @@ def get_clusters() -> List[Dict[str, Any]]:
             'last_creation_yaml': row.last_creation_yaml,
             'last_creation_command': row.last_creation_command,
             'is_managed': bool(row.is_managed),
+            'last_event': last_event,
         }
 
         records.append(record)

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -6,6 +6,7 @@ Concepts:
 - Cluster handle: (non-user facing) an opaque backend handle for us to
   interact with a cluster.
 """
+import enum
 import functools
 import json
 import os
@@ -16,7 +17,6 @@ import time
 import typing
 from typing import Any, Dict, List, Optional, Set, Tuple
 import uuid
-import enum
 
 import sqlalchemy
 from sqlalchemy import exc as sqlalchemy_exc
@@ -163,6 +163,7 @@ cluster_history_table = sqlalchemy.Table(
     sqlalchemy.Column('workspace', sqlalchemy.Text, server_default=None),
 )
 
+
 class ClusterEventType(enum.Enum):
     """Type of cluster event."""
     DEBUG = 'DEBUG'
@@ -170,6 +171,7 @@ class ClusterEventType(enum.Enum):
 
     STATUS_CHANGE = 'STATUS_CHANGE'
     """Used to denote events that modify cluster status."""
+
 
 # Table for cluster status change events.
 # starting_status: Status of the cluster at the start of the event.

--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -262,7 +262,8 @@ class StrategyExecutor:
             return
         if self.pool is None:
             global_user_state.add_cluster_event(self.cluster_name, None,
-                                                'Cluster was cleaned up.')
+                            'Cluster was cleaned up.',
+                            global_user_state.ClusterEventType.STATUS_CHANGE)
             managed_job_utils.terminate_cluster(self.cluster_name)
 
     def _launch(self,

--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -261,6 +261,8 @@ class StrategyExecutor:
         if self.cluster_name is None:
             return
         if self.pool is None:
+            global_user_state.add_cluster_event(self.cluster_name, None,
+                                                'Cluster was cleaned up.')
             managed_job_utils.terminate_cluster(self.cluster_name)
 
     def _launch(self,

--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -261,9 +261,9 @@ class StrategyExecutor:
         if self.cluster_name is None:
             return
         if self.pool is None:
-            global_user_state.add_cluster_event(self.cluster_name, None,
-                            'Cluster was cleaned up.',
-                            global_user_state.ClusterEventType.STATUS_CHANGE)
+            global_user_state.add_cluster_event(
+                self.cluster_name, None, 'Cluster was cleaned up.',
+                global_user_state.ClusterEventType.STATUS_CHANGE)
             managed_job_utils.terminate_cluster(self.cluster_name)
 
     def _launch(self,

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -549,7 +549,8 @@ def _maybe_restart_controller(
             skylet_constants.SKYPILOT_DEFAULT_WORKSPACE):
         global_user_state.add_cluster_event(
             jobs_controller_type.value.cluster_name,
-            status_lib.ClusterStatus.INIT, 'Jobs controller restarted.')
+            status_lib.ClusterStatus.INIT, 'Jobs controller restarted.',
+            global_user_state.ClusterEventType.STATUS_CHANGE)
         handle = core.start(
             cluster_name=jobs_controller_type.value.cluster_name)
 

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -547,6 +547,9 @@ def _maybe_restart_controller(
                                  'controller'))
     with skypilot_config.local_active_workspace_ctx(
             skylet_constants.SKYPILOT_DEFAULT_WORKSPACE):
+        global_user_state.add_cluster_event(
+            jobs_controller_type.value.cluster_name,
+            status_lib.ClusterStatus.INIT, 'Jobs controller restarted.')
         handle = core.start(
             cluster_name=jobs_controller_type.value.cluster_name)
 

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -333,6 +333,8 @@ def update_managed_jobs_statuses(job_id: Optional[int] = None):
             if handle is not None:
                 try:
                     if pool is None:
+                        global_user_state.add_cluster_event(
+                            cluster_name, None, 'Cluster was cleaned up.')
                         terminate_cluster(cluster_name)
                 except Exception as e:  # pylint: disable=broad-except
                     error_msg = (

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -334,7 +334,8 @@ def update_managed_jobs_statuses(job_id: Optional[int] = None):
                 try:
                     if pool is None:
                         global_user_state.add_cluster_event(
-                            cluster_name, None, 'Cluster was cleaned up.')
+                            cluster_name, None, 'Cluster was cleaned up.',
+                            global_user_state.ClusterEventType.STATUS_CHANGE)
                         terminate_cluster(cluster_name)
                 except Exception as e:  # pylint: disable=broad-except
                     error_msg = (

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -100,6 +100,11 @@ def _bulk_provision(
         f'\nProvisioning {cluster_name!r} took {time.time() - start:.2f} '
         f'seconds.')
 
+    # Add cluster event for provisioning completion.
+    global_user_state.add_cluster_event(
+        str(cluster_name), status_lib.ClusterStatus.INIT,
+        f'Instances launched on {cloud.display_name()} in {region}')
+
     return provision_record
 
 

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -103,7 +103,8 @@ def _bulk_provision(
     # Add cluster event for provisioning completion.
     global_user_state.add_cluster_event(
         str(cluster_name), status_lib.ClusterStatus.INIT,
-        f'Instances launched on {cloud.display_name()} in {region}')
+        f'Instances launched on {cloud.display_name()} in {region}',
+        global_user_state.ClusterEventType.STATUS_CHANGE)
 
     return provision_record
 

--- a/sky/schemas/db/global_user_state/005_cluster_event.py
+++ b/sky/schemas/db/global_user_state/005_cluster_event.py
@@ -9,7 +9,6 @@ Create Date: 2025-08-08
 from typing import Sequence, Union
 
 from alembic import op
-import sqlalchemy as sa
 
 from sky.global_user_state import Base
 from sky.utils.db import db_utils
@@ -26,35 +25,6 @@ def upgrade():
     with op.get_context().autocommit_block():
         # Add new table for cluster events.
         db_utils.add_tables_to_db_sqlalchemy(Base.metadata, op.get_bind())
-
-        db_utils.add_column_to_table_alembic('cluster_events',
-                                             'cluster_hash',
-                                             sa.Text(),
-                                             server_default=None)
-        db_utils.add_column_to_table_alembic('cluster_events',
-                                             'name',
-                                             sa.Text(),
-                                             server_default=None)
-        db_utils.add_column_to_table_alembic('cluster_events',
-                                             'starting_status',
-                                             sa.Text(),
-                                             server_default=None)
-        db_utils.add_column_to_table_alembic('cluster_events',
-                                             'ending_status',
-                                             sa.Text(),
-                                             server_default=None)
-        db_utils.add_column_to_table_alembic('cluster_events',
-                                             'reason',
-                                             sa.Text(),
-                                             server_default=None)
-        db_utils.add_column_to_table_alembic('cluster_events',
-                                             'transitioned_at',
-                                             sa.Integer(),
-                                             server_default=None)
-        db_utils.add_column_to_table_alembic('cluster_events',
-                                             'type',
-                                             sa.Text(),
-                                             server_default=None)
 
 
 def downgrade():

--- a/sky/schemas/db/global_user_state/005_cluster_event.py
+++ b/sky/schemas/db/global_user_state/005_cluster_event.py
@@ -26,7 +26,7 @@ def upgrade():
     with op.get_context().autocommit_block():
         # Add new table for cluster events.
         db_utils.add_tables_to_db_sqlalchemy(Base.metadata, op.get_bind())
-        
+
         db_utils.add_column_to_table_alembic('cluster_events',
                                              'cluster_hash',
                                              sa.Text(),

--- a/sky/schemas/db/global_user_state/005_cluster_event.py
+++ b/sky/schemas/db/global_user_state/005_cluster_event.py
@@ -24,7 +24,8 @@ def upgrade():
     """Add new table for cluster events."""
     with op.get_context().autocommit_block():
         # Add new table for cluster events.
-        db_utils.add_tables_to_db_sqlalchemy(Base.metadata, op.get_bind())
+        db_utils.add_table_to_db_sqlalchemy(
+            Base.metadata, op.get_bind(), 'cluster_events')
 
 
 def downgrade():

--- a/sky/schemas/db/global_user_state/005_cluster_event.py
+++ b/sky/schemas/db/global_user_state/005_cluster_event.py
@@ -24,8 +24,8 @@ def upgrade():
     """Add new table for cluster events."""
     with op.get_context().autocommit_block():
         # Add new table for cluster events.
-        db_utils.add_table_to_db_sqlalchemy(
-            Base.metadata, op.get_bind(), 'cluster_events')
+        db_utils.add_table_to_db_sqlalchemy(Base.metadata, op.get_bind(),
+                                            'cluster_events')
 
 
 def downgrade():

--- a/sky/schemas/db/global_user_state/005_cluster_event.py
+++ b/sky/schemas/db/global_user_state/005_cluster_event.py
@@ -1,0 +1,61 @@
+"""Columns for whether the cluster is managed.
+
+Revision ID: 005
+Revises: 004
+Create Date: 2025-08-08
+
+"""
+# pylint: disable=invalid-name
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from sky.global_user_state import Base
+from sky.utils.db import db_utils
+
+# revision identifiers, used by Alembic.π
+revision: str = '005'
+down_revision: Union[str, Sequence[str], None] = '004'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    """Add new table for cluster events."""
+    with op.get_context().autocommit_block():
+        # Add new table for cluster events.
+        db_utils.add_tables_to_db_sqlalchemy(Base.metadata, op.get_bind())
+        
+        db_utils.add_column_to_table_alembic('cluster_events',
+                                             'cluster_hash',
+                                             sa.Text(),
+                                             server_default=None)
+        db_utils.add_column_to_table_alembic('cluster_events',
+                                             'name',
+                                             sa.Text(),
+                                             server_default=None)
+        db_utils.add_column_to_table_alembic('cluster_events',
+                                             'starting_status',
+                                             sa.Text(),
+                                             server_default=None)
+        db_utils.add_column_to_table_alembic('cluster_events',
+                                             'ending_status',
+                                             sa.Text(),
+                                             server_default=None)
+        db_utils.add_column_to_table_alembic('cluster_events',
+                                             'reason',
+                                             sa.Text(),
+                                             server_default=None)
+        db_utils.add_column_to_table_alembic('cluster_events',
+                                             'transitioned_at',
+                                             sa.Integer(),
+                                             server_default=None)
+        db_utils.add_column_to_table_alembic('cluster_events',
+                                             'type',
+                                             sa.Text(),
+                                             server_default=None)
+
+
+def downgrade():
+    pass

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -81,6 +81,7 @@ def show_status_table(cluster_records: List[_ClusterRecord],
                          _get_command,
                          truncate=not show_all,
                          show_by_default=False),
+            StatusColumn('LAST_EVENT', _get_last_event, show_by_default=False),
         ]
 
     columns = []
@@ -312,6 +313,14 @@ def _get_head_ip(cluster_record: _ClusterRecord, truncate: bool = True) -> str:
     if handle.head_ip is None:
         return '-'
     return handle.head_ip
+
+
+def _get_last_event(cluster_record: _ClusterRecord,
+                    truncate: bool = True) -> str:
+    del truncate
+    if cluster_record['last_event'] is None:
+        return 'No recorded events.'
+    return cluster_record['last_event']
 
 
 def _is_pending_autostop(cluster_record: _ClusterRecord) -> bool:

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -19,7 +19,7 @@ logger = sky_logging.init_logger(__name__)
 DB_INIT_LOCK_TIMEOUT_SECONDS = 10
 
 GLOBAL_USER_STATE_DB_NAME = 'state_db'
-GLOBAL_USER_STATE_VERSION = '004'
+GLOBAL_USER_STATE_VERSION = '005'
 GLOBAL_USER_STATE_LOCK_PATH = '~/.sky/locks/.state_db.lock'
 
 SPOT_JOBS_DB_NAME = 'spot_jobs_db'

--- a/tests/unit_tests/test_sky/utils/test_cli_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_cli_utils.py
@@ -141,6 +141,7 @@ def test_show_status_table():
             'resources_str_full': ('1x(cpus=8, mem=32, m6i.2xlarge, '
                                    'disk=50)'),
             'workspace': 'test-workspace',
+            'last_event': 'Test event.',
         }
 
         # Test basic table


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Added a cluster event table which keeps track of state transitions and events that happen. The goal of this is to provide more description to the user about why the cluster reaches certain states. This PR adds a column in sky status -v detailing the latest event that happened to a cluster to aid in debugging.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

This PR was tested by starting an AWS cluster and then terminating one of the worker nodes, verifying that the "LAST_EVENT" column in sky status -v showed the various stages of the cluster (provisioning, launching instances, successfully reaching UP, returning to INIT due to worker termination). The attached image shows the output at the end of this process where the cluster returned to INIT.

<img width="1720" height="88" alt="Screenshot 2025-08-08 at 11 26 00 AM" src="https://github.com/user-attachments/assets/57c18c20-674e-42a1-ae1c-d589eb31520d" />

The new column does cause line wrap in sky status -v which may not be ideal.

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
