### PR TITLE
[k8s] infer reason behind disappeared nodes from k8s events

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2315,9 +2315,12 @@ def _update_cluster_status(cluster_name: str) -> Optional[Dict[str, Any]]:
         # Adding a new status UNHEALTHY for abnormal status can be a choice.
         init_reason_regex = None
         if not status_reason:
-            # If there is not a status reason, don't re-add the event if there
-            # is already an event with the same reason which may have a
-            # status reason.
+            # If there is not a status reason, don't re-add (and overwrite) the
+            # event if there is already an event with the same reason which may
+            # have a status reason.
+            # Some status reason clears after a certain time (e.g. k8s events
+            # are only stored for an hour by default), so it is possible that
+            # the previous event has a status reason, but now it does not.
             init_reason_regex = f'^Cluster is abnormal because {init_reason} .*'
         global_user_state.add_cluster_event(
             cluster_name,

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2227,9 +2227,9 @@ def _update_cluster_status(cluster_name: str) -> Optional[Dict[str, Any]]:
             [status[1] for status in node_statuses if status[1] is not None])
 
         if some_nodes_terminated:
-            init_reason = f'one or more nodes terminated'
+            init_reason = 'one or more nodes terminated'
         elif some_nodes_not_stopped:
-            init_reason = f'some nodes are up and some nodes are stopped'
+            init_reason = 'some nodes are up and some nodes are stopped'
         logger.debug('The cluster is abnormal. Setting to INIT status. '
                      f'node_statuses: {node_statuses}')
         if record['autostop'] >= 0:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1781,6 +1781,7 @@ def _query_cluster_status_via_cloud_api(
         exceptions.ClusterStatusFetchingError: the cluster status cannot be
           fetched from the cloud provider.
     """
+    cluster_name = handle.cluster_name
     cluster_name_on_cloud = handle.cluster_name_on_cloud
     cluster_name_in_hint = common_utils.cluster_name_in_hint(
         handle.cluster_name, cluster_name_on_cloud)
@@ -1798,7 +1799,8 @@ def _query_cluster_status_via_cloud_api(
         cloud_name = repr(handle.launched_resources.cloud)
         try:
             node_status_dict = provision_lib.query_instances(
-                cloud_name, cluster_name_on_cloud, provider_config)
+                cloud_name, cluster_name, cluster_name_on_cloud,
+                provider_config)
             logger.debug(f'Querying {cloud_name} cluster '
                          f'{cluster_name_in_hint} '
                          f'status:\n{pprint.pformat(node_status_dict)}')

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2227,9 +2227,9 @@ def _update_cluster_status(cluster_name: str) -> Optional[Dict[str, Any]]:
             [status[1] for status in node_statuses if status[1] is not None])
 
         if some_nodes_terminated:
-            init_reason = f'one or more nodes terminated ({status_reason})'
+            init_reason = f'one or more nodes terminated'
         elif some_nodes_not_stopped:
-            init_reason = f'some nodes are up and some nodes are stopped ({status_reason})'
+            init_reason = f'some nodes are up and some nodes are stopped'
         logger.debug('The cluster is abnormal. Setting to INIT status. '
                      f'node_statuses: {node_statuses}')
         if record['autostop'] >= 0:
@@ -2313,12 +2313,19 @@ def _update_cluster_status(cluster_name: str) -> Optional[Dict[str, Any]]:
         # represent that the cluster is partially preempted.
         # TODO(zhwu): the definition of INIT should be audited/changed.
         # Adding a new status UNHEALTHY for abnormal status can be a choice.
+        init_reason_regex = None
+        if not status_reason:
+            # If there is not a status reason, don't re-add the event if there
+            # is already an event with the same reason which may have a
+            # status reason.
+            init_reason_regex = f'^Cluster is abnormal because {init_reason} .*'
         global_user_state.add_cluster_event(
             cluster_name,
             status_lib.ClusterStatus.INIT,
-            f'Cluster is abnormal because {init_reason}. Transitioned to INIT.',
+            f'Cluster is abnormal because {init_reason} ({status_reason}). Transitioned to INIT.',
             global_user_state.ClusterEventType.STATUS_CHANGE,
-            nop_if_duplicate=True)
+            nop_if_duplicate=True,
+            duplicate_regex=init_reason_regex)
         global_user_state.add_or_update_cluster(cluster_name,
                                                 handle,
                                                 requested_resources=None,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4659,6 +4659,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 logger.debug(f'instance statuses attempt {attempts + 1}')
                 node_status_dict = provision_lib.query_instances(
                     repr(cloud),
+                    handle.cluster_name,
                     cluster_name_on_cloud,
                     config['provider'],
                     non_terminated_only=False)

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -1088,7 +1088,7 @@ class AWS(clouds.Cloud):
 
         image_name = f'skypilot-{cluster_name.display_name}-{int(time.time())}'
 
-        status = provision_lib.query_instances('AWS',
+        status = provision_lib.query_instances('AWS', cluster_name.display_name,
                                                cluster_name.name_on_cloud,
                                                {'region': region})
         instance_ids = list(status.keys())

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -675,8 +675,6 @@ def add_cluster_event(cluster_name: str,
             if last_event == reason:
                 return
         try:
-            print(cluster_hash, cluster_name, last_status, new_status, reason,
-                  transitioned_at, event_type)
             session.execute(
                 insert_func(cluster_event_table).values(
                     cluster_hash=cluster_hash,

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -646,6 +646,7 @@ def add_cluster_event(cluster_name: str,
                       reason: str,
                       event_type: ClusterEventType,
                       nop_if_duplicate: bool = False,
+                      expose_duplicate_error: bool = False,
                       transitioned_at: Optional[int] = None) -> None:
     assert _SQLALCHEMY_ENGINE is not None
     cluster_hash = _get_hash_for_existing_cluster(cluster_name)
@@ -689,8 +690,13 @@ def add_cluster_event(cluster_name: str,
         except sqlalchemy.exc.IntegrityError as e:
             if 'UNIQUE constraint failed' in str(e):
                 # This can happen if the cluster event is added twice.
-                # We can ignore this error.
-                pass
+                # We can ignore this error unless the caller requests
+                # to expose the error.
+                if expose_duplicate_error:
+                    raise db_utils.UniqueConstraintViolationError(
+                        value=reason, message=str(e))
+                else:
+                    pass
             else:
                 raise e
 

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -646,7 +646,6 @@ def add_cluster_event(cluster_name: str,
                       reason: str,
                       event_type: ClusterEventType,
                       nop_if_duplicate: bool = False,
-                      expose_duplicate_error: bool = False,
                       transitioned_at: Optional[int] = None) -> None:
     assert _SQLALCHEMY_ENGINE is not None
     cluster_hash = _get_hash_for_existing_cluster(cluster_name)
@@ -690,13 +689,8 @@ def add_cluster_event(cluster_name: str,
         except sqlalchemy.exc.IntegrityError as e:
             if 'UNIQUE constraint failed' in str(e):
                 # This can happen if the cluster event is added twice.
-                # We can ignore this error unless the caller requests
-                # to expose the error.
-                if expose_duplicate_error:
-                    raise db_utils.UniqueConstraintViolationError(
-                        value=reason, message=str(e))
-                else:
-                    pass
+                # We can ignore this error.
+                pass
             else:
                 raise e
 

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -645,16 +645,13 @@ def add_cluster_event(cluster_name: str,
                       new_status: Optional[status_lib.ClusterStatus],
                       reason: str,
                       event_type: ClusterEventType,
-                      nop_if_duplicate: bool = False,
-                      transitioned_at: Optional[int] = None) -> None:
+                      nop_if_duplicate: bool = False) -> None:
     assert _SQLALCHEMY_ENGINE is not None
     cluster_hash = _get_hash_for_existing_cluster(cluster_name)
     if cluster_hash is None:
         logger.debug(f'Hash for cluster {cluster_name} not found. '
                      'Skipping event.')
         return
-    if transitioned_at is None:
-        transitioned_at = int(time.time())
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         if (_SQLALCHEMY_ENGINE.dialect.name ==
                 db_utils.SQLAlchemyDialect.SQLITE.value):
@@ -682,7 +679,7 @@ def add_cluster_event(cluster_name: str,
                     starting_status=last_status,
                     ending_status=new_status.value if new_status else None,
                     reason=reason,
-                    transitioned_at=transitioned_at,
+                    transitioned_at=int(time.time()),
                     type=event_type.value,
                 ))
             session.commit()

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -731,8 +731,7 @@ def get_last_cluster_event(cluster_hash: str,
     return row.reason
 
 
-def get_cluster_events(cluster_name: Optional[str],
-                       cluster_hash: Optional[str],
+def get_cluster_events(cluster_name: Optional[str], cluster_hash: Optional[str],
                        event_type: ClusterEventType) -> List[str]:
     """Returns the cluster events for the cluster.
 
@@ -759,6 +758,7 @@ def get_cluster_events(cluster_name: Optional[str],
             cluster_hash=cluster_hash, type=event_type.value).order_by(
                 cluster_event_table.c.transitioned_at.asc()).all()
     return [row.reason for row in rows]
+
 
 def _get_user_hash_or_current_user(user_hash: Optional[str]) -> str:
     """Returns the user hash or the current user hash, if user_hash is None.

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -172,9 +172,6 @@ class ClusterEventType(enum.Enum):
     STATUS_CHANGE = 'STATUS_CHANGE'
     """Used to denote events that modify cluster status."""
 
-    CLOUD_BACKEND_CHANGE = 'CLOUD_BACKEND_CHANGE'
-    """Used to denote events that are emitted from the cloud backend."""
-
 
 # Table for cluster status change events.
 # starting_status: Status of the cluster at the start of the event.

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -681,7 +681,7 @@ def add_cluster_event(cluster_name: str,
         if nop_if_duplicate:
             last_event = get_last_cluster_event(cluster_hash,
                                                 event_type=event_type)
-            if duplicate_regex is not None:
+            if duplicate_regex is not None and last_event is not None:
                 if re.search(duplicate_regex, last_event):
                     return
             elif last_event == reason:

--- a/sky/provision/__init__.py
+++ b/sky/provision/__init__.py
@@ -73,6 +73,7 @@ def _route_to_cloud_impl(func):
 @_route_to_cloud_impl
 def query_instances(
     provider_name: str,
+    cluster_name: str,
     cluster_name_on_cloud: str,
     provider_config: Optional[Dict[str, Any]] = None,
     non_terminated_only: bool = True,

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -585,11 +585,13 @@ def _filter_instances(ec2: 'mypy_boto3_ec2.ServiceResource',
 # stop() and terminate() for example already implicitly assume non-terminated.
 @common_utils.retry
 def query_instances(
+    cluster_name: str,
     cluster_name_on_cloud: str,
     provider_config: Optional[Dict[str, Any]] = None,
     non_terminated_only: bool = True,
 ) -> Dict[str, Tuple[Optional['status_lib.ClusterStatus'], Optional[str]]]:
     """See sky/provision/__init__.py"""
+    del cluster_name  # unused
     assert provider_config is not None, (cluster_name_on_cloud, provider_config)
     region = provider_config['region']
     ec2 = _default_ec2_resource(region)

--- a/sky/provision/azure/instance.py
+++ b/sky/provision/azure/instance.py
@@ -952,11 +952,13 @@ def delete_vm_and_attached_resources(subscription_id: str, resource_group: str,
 
 @common_utils.retry
 def query_instances(
+    cluster_name: str,
     cluster_name_on_cloud: str,
     provider_config: Optional[Dict[str, Any]] = None,
     non_terminated_only: bool = True,
 ) -> Dict[str, Tuple[Optional['status_lib.ClusterStatus'], Optional[str]]]:
     """See sky/provision/__init__.py"""
+    del cluster_name  # unused
     assert provider_config is not None, cluster_name_on_cloud
 
     subscription_id = provider_config['subscription_id']

--- a/sky/provision/cudo/instance.py
+++ b/sky/provision/cudo/instance.py
@@ -191,11 +191,13 @@ def get_cluster_info(
 
 
 def query_instances(
+    cluster_name: str,
     cluster_name_on_cloud: str,
     provider_config: Optional[Dict[str, Any]] = None,
     non_terminated_only: bool = True,
 ) -> Dict[str, Tuple[Optional['status_lib.ClusterStatus'], Optional[str]]]:
     """See sky/provision/__init__.py"""
+    del cluster_name  # unused
     assert provider_config is not None, (cluster_name_on_cloud, provider_config)
     instances = _filter_instances(cluster_name_on_cloud, None)
 

--- a/sky/provision/do/instance.py
+++ b/sky/provision/do/instance.py
@@ -242,11 +242,13 @@ def get_cluster_info(
 
 
 def query_instances(
+    cluster_name: str,
     cluster_name_on_cloud: str,
     provider_config: Optional[Dict[str, Any]] = None,
     non_terminated_only: bool = True,
 ) -> Dict[str, Tuple[Optional['status_lib.ClusterStatus'], Optional[str]]]:
     """See sky/provision/__init__.py"""
+    del cluster_name  # unused
     # terminated instances are not retrieved by the
     # API making `non_terminated_only` argument moot.
     del non_terminated_only

--- a/sky/provision/fluidstack/instance.py
+++ b/sky/provision/fluidstack/instance.py
@@ -287,11 +287,13 @@ def get_cluster_info(
 
 
 def query_instances(
+    cluster_name: str,
     cluster_name_on_cloud: str,
     provider_config: Optional[Dict[str, Any]] = None,
     non_terminated_only: bool = True,
 ) -> Dict[str, Tuple[Optional['status_lib.ClusterStatus'], Optional[str]]]:
     """See sky/provision/__init__.py"""
+    del cluster_name  # unused
     assert provider_config is not None, (cluster_name_on_cloud, provider_config)
     instances = _filter_instances(cluster_name_on_cloud, None)
     instances = _filter_instances(cluster_name_on_cloud, None)

--- a/sky/provision/gcp/instance.py
+++ b/sky/provision/gcp/instance.py
@@ -58,11 +58,13 @@ def _filter_instances(
 # for terminated instances, if they have already been fully deleted.
 @common_utils.retry
 def query_instances(
+    cluster_name: str,
     cluster_name_on_cloud: str,
     provider_config: Optional[Dict[str, Any]] = None,
     non_terminated_only: bool = True,
 ) -> Dict[str, Tuple[Optional['status_lib.ClusterStatus'], Optional[str]]]:
     """See sky/provision/__init__.py"""
+    del cluster_name  # unused
     assert provider_config is not None, (cluster_name_on_cloud, provider_config)
     zone = provider_config['availability_zone']
     project_id = provider_config['project_id']

--- a/sky/provision/hyperbolic/instance.py
+++ b/sky/provision/hyperbolic/instance.py
@@ -304,12 +304,13 @@ def get_cluster_info(
 
 
 def query_instances(
+    cluster_name: str,
     cluster_name_on_cloud: str,
     provider_config: Optional[dict] = None,
     non_terminated_only: bool = True,
 ) -> Dict[str, Tuple[Optional['status_lib.ClusterStatus'], Optional[str]]]:
     """Returns the status of the specified instances for Hyperbolic."""
-    del provider_config  # unused
+    del cluster_name, provider_config  # unused
     # Fetch all instances for this cluster
     instances = utils.list_instances(
         metadata={'skypilot': {

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1352,7 +1352,6 @@ def _get_pod_missing_reason(context: Optional[str], namespace: str,
         # return. Return None.
         return None
 
-
     # Analyze the events for failure
     failure_reason = None
     failure_decisiveness = 0
@@ -1376,7 +1375,7 @@ def _get_pod_missing_reason(context: Optional[str], namespace: str,
         elif event.startswith('TaintManagerEviction '):
             # usually the event message for TaintManagerEviction is not useful
             # so we record a more generic message.
-            _record_failure_reason(f'pod was evicted by taint manager', 2)
+            _record_failure_reason('pod was evicted by taint manager', 2)
         elif event.startswith('DeletingNode '):
             _record_failure_reason(event[len('DeletingNode '):], 3)
     return failure_reason

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1366,22 +1366,20 @@ def _get_pod_missing_reason(context: Optional[str], namespace: str,
     cluster_events = global_user_state.get_cluster_events(
         cluster_name, None, global_user_state.ClusterEventType.DEBUG)
     for event in cluster_events:
-        if event.startswith(f'[kubernetes pod {pod_name}] '):
-            event = event[len(f'[kubernetes pod {pod_name}] '):]
-        elif event.startswith(f'[kubernetes node {last_scheduled_node}] '):
-            event = event[len(f'[kubernetes node {last_scheduled_node}] '):]
-
+        if event.startswith('[kubernetes pod'):
+            event = event.split(']')[1].strip()
+        elif event.startswith('[kubernetes node'):
+            event = event.split(']')[1].strip()
         # Order these by "decisiveness" of the message -
         # the last one that matches is the most important.
         if event.startswith('NodeNotReady '):
             _record_failure_reason(event[len('NodeNotReady '):], 1)
-        if event.startswith('TaintManagerEviction '):
+        elif event.startswith('TaintManagerEviction '):
             # usually the event message for TaintManagerEviction is not useful
             # so we record a more generic message.
             _record_failure_reason(f'pod was evicted by taint manager', 2)
-        if event.startswith('DeletingNode '):
+        elif event.startswith('DeletingNode '):
             _record_failure_reason(event[len('DeletingNode '):], 3)
-
     return failure_reason
 
 

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1370,8 +1370,7 @@ def _get_pod_missing_reason(context: Optional[str], namespace: str,
             event = event.split(']')[1].strip()
         elif event.startswith('[kubernetes node'):
             event = event.split(']')[1].strip()
-        # Order these by "decisiveness" of the message -
-        # the last one that matches is the most important.
+
         if event.startswith('NodeNotReady '):
             _record_failure_reason(event[len('NodeNotReady '):], 1)
         elif event.startswith('TaintManagerEviction '):

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1304,19 +1304,16 @@ def _analyze_pod_events(context: Optional[str], namespace: str,
         node_events = sorted(
             node_events, key=lambda event: event.metadata.creation_timestamp)
 
-    print(len(pod_events), len(node_events))
     for event in pod_events:
-        print(event.reason, event.message)
         global_user_state.add_cluster_event(
-            cluster_name[:-9],
+            cluster_name,
             None,
             f'[kubernetes pod {pod_name}] {event.reason} {event.message}',
             global_user_state.ClusterEventType.DEBUG,
             transitioned_at=int(event.metadata.creation_timestamp.timestamp()))
     for event in node_events:
-        print(event.reason, event.message)
         global_user_state.add_cluster_event(
-            cluster_name[:-9],
+            cluster_name,
             None, f'[kubernetes node {last_scheduled_node}] '
             f'{event.reason} {event.message}',
             global_user_state.ClusterEventType.DEBUG,

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1328,6 +1328,7 @@ def _get_pod_missing_reason(context: Optional[str], namespace: str,
 
 
 def query_instances(
+    cluster_name: str,
     cluster_name_on_cloud: str,
     provider_config: Optional[Dict[str, Any]] = None,
     non_terminated_only: bool = True

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1308,18 +1308,18 @@ def _analyze_pod_events(context: Optional[str], namespace: str,
     for event in pod_events:
         print(event.reason, event.message)
         global_user_state.add_cluster_event(
-            cluster_name,
+            cluster_name[:-9],
             None,
             f'[kubernetes pod {pod_name}] {event.reason} {event.message}',
-            global_user_state.ClusterEventType.CLOUD_BACKEND_CHANGE,
+            global_user_state.ClusterEventType.DEBUG,
             transitioned_at=int(event.metadata.creation_timestamp.timestamp()))
     for event in node_events:
         print(event.reason, event.message)
         global_user_state.add_cluster_event(
-            cluster_name,
+            cluster_name[:-9],
             None, f'[kubernetes node {last_scheduled_node}] '
             f'{event.reason} {event.message}',
-            global_user_state.ClusterEventType.CLOUD_BACKEND_CHANGE,
+            global_user_state.ClusterEventType.DEBUG,
             transitioned_at=int(event.metadata.creation_timestamp.timestamp()))
 
 
@@ -1402,7 +1402,7 @@ def query_instances(
             # If the pod is not in the cluster_status, it means it's not
             # running.
             # Analyze what happened to the pod based on events.
-            _analyze_pod_events(context, namespace, cluster_name_on_cloud,
+            _analyze_pod_events(context, namespace, cluster_name,
                                 target_pod_name)
 
     return cluster_status

--- a/sky/provision/lambda_cloud/instance.py
+++ b/sky/provision/lambda_cloud/instance.py
@@ -226,11 +226,13 @@ def get_cluster_info(
 
 
 def query_instances(
+    cluster_name: str,
     cluster_name_on_cloud: str,
     provider_config: Optional[Dict[str, Any]] = None,
     non_terminated_only: bool = True,
 ) -> Dict[str, Tuple[Optional['status_lib.ClusterStatus'], Optional[str]]]:
     """See sky/provision/__init__.py"""
+    del cluster_name  # unused
     assert provider_config is not None, (cluster_name_on_cloud, provider_config)
     instances = _filter_instances(cluster_name_on_cloud, None)
 

--- a/sky/provision/nebius/instance.py
+++ b/sky/provision/nebius/instance.py
@@ -247,11 +247,13 @@ def get_cluster_info(
 
 
 def query_instances(
+    cluster_name: str,
     cluster_name_on_cloud: str,
     provider_config: Optional[Dict[str, Any]] = None,
     non_terminated_only: bool = True,
 ) -> Dict[str, Tuple[Optional['status_lib.ClusterStatus'], Optional[str]]]:
     """See sky/provision/__init__.py"""
+    del cluster_name  # unused
     assert provider_config is not None, (cluster_name_on_cloud, provider_config)
     instances = _filter_instances(provider_config['region'],
                                   cluster_name_on_cloud, None)

--- a/sky/provision/oci/instance.py
+++ b/sky/provision/oci/instance.py
@@ -32,6 +32,7 @@ logger = sky_logging.init_logger(__name__)
 @query_utils.debug_enabled(logger)
 @common_utils.retry
 def query_instances(
+    cluster_name: str,
     cluster_name_on_cloud: str,
     provider_config: Optional[Dict[str, Any]] = None,
     non_terminated_only: bool = True,
@@ -43,6 +44,7 @@ def query_instances(
     A None status means the instance is marked as "terminated"
     or "terminating".
     """
+    del cluster_name  # unusedå
     assert provider_config is not None, cluster_name_on_cloud
     region = provider_config['region']
 

--- a/sky/provision/paperspace/instance.py
+++ b/sky/provision/paperspace/instance.py
@@ -277,12 +277,13 @@ def get_cluster_info(
 
 
 def query_instances(
+    cluster_name: str,
     cluster_name_on_cloud: str,
     provider_config: Optional[Dict[str, Any]] = None,
     non_terminated_only: bool = True,
 ) -> Dict[str, Tuple[Optional['status_lib.ClusterStatus'], Optional[str]]]:
     """See sky/provision/__init__.py"""
-    del non_terminated_only
+    del cluster_name, non_terminated_only  #unused
     assert provider_config is not None, (cluster_name_on_cloud, provider_config)
     instances = _filter_instances(cluster_name_on_cloud, None)
 

--- a/sky/provision/runpod/instance.py
+++ b/sky/provision/runpod/instance.py
@@ -201,11 +201,13 @@ def get_cluster_info(
 
 
 def query_instances(
+    cluster_name: str,
     cluster_name_on_cloud: str,
     provider_config: Optional[Dict[str, Any]] = None,
     non_terminated_only: bool = True,
 ) -> Dict[str, Tuple[Optional['status_lib.ClusterStatus'], Optional[str]]]:
     """See sky/provision/__init__.py"""
+    del cluster_name  # unused
     assert provider_config is not None, (cluster_name_on_cloud, provider_config)
     instances = _filter_instances(cluster_name_on_cloud, None)
 

--- a/sky/provision/scp/instance.py
+++ b/sky/provision/scp/instance.py
@@ -427,10 +427,12 @@ def terminate_instances(
 
 
 def query_instances(
+    cluster_name: str,
     cluster_name_on_cloud: str,
     provider_config: Optional[Dict[str, Any]] = None,
     non_terminated_only: bool = True,
 ) -> Dict[str, Tuple[Optional['status_lib.ClusterStatus'], Optional[str]]]:
+    del cluster_name  # unused
     assert provider_config is not None, (cluster_name_on_cloud, provider_config)
     instances = _filter_instances(cluster_name_on_cloud, None)
 

--- a/sky/provision/vast/instance.py
+++ b/sky/provision/vast/instance.py
@@ -216,11 +216,13 @@ def open_ports(
 
 
 def query_instances(
+    cluster_name: str,
     cluster_name_on_cloud: str,
     provider_config: Optional[Dict[str, Any]] = None,
     non_terminated_only: bool = True,
 ) -> Dict[str, Tuple[Optional['status_lib.ClusterStatus'], Optional[str]]]:
     """See sky/provision/__init__.py"""
+    del cluster_name  # unused
     assert provider_config is not None, (cluster_name_on_cloud, provider_config)
     instances = _filter_instances(cluster_name_on_cloud, None)
     # "running", "frozen", "stopped", "unknown", "loading"

--- a/sky/provision/vsphere/instance.py
+++ b/sky/provision/vsphere/instance.py
@@ -393,11 +393,13 @@ def _get_cluster_name_filter(cluster_name_on_cloud):
 
 
 def query_instances(
+    cluster_name: str,
     cluster_name_on_cloud: str,
     provider_config: Optional[Dict[str, Any]] = None,
     non_terminated_only: bool = True,
 ) -> Dict[str, Tuple[Optional['status_lib.ClusterStatus'], Optional[str]]]:
     """See sky/provision/__init__.py"""
+    del cluster_name  # unused
     logger.info('New provision of Vsphere: query_instances().')
     assert provider_config is not None, cluster_name_on_cloud
     region = provider_config['region']

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -32,6 +32,23 @@ if typing.TYPE_CHECKING:
 _DB_TIMEOUT_S = 60
 
 
+class UniqueConstraintViolationError(Exception):
+    """Exception raised for unique constraint violation.
+    Attributes:
+        value -- the input value that caused the error
+        message -- explanation of the error
+    """
+
+    def __init__(self, value, message='Unique constraint violation'):
+        self.value = value
+        self.message = message
+        super().__init__(self.message)
+
+    def __str__(self):
+        return (f'UniqueConstraintViolationError: {self.message} '
+                f'(Value: {self.value})')
+
+
 class SQLAlchemyDialect(enum.Enum):
     SQLITE = 'sqlite'
     POSTGRESQL = 'postgresql'

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -31,21 +31,6 @@ if typing.TYPE_CHECKING:
 # For more info, see the PR description for #4552.
 _DB_TIMEOUT_S = 60
 
-class UniqueConstraintViolationError(Exception):
-    """
-    Exception raised for invalid input values.
-
-    Attributes:
-        value -- the input value that caused the error
-        message -- explanation of the error
-    """
-    def __init__(self, value, message="Unique constraint violation"):
-        self.value = value
-        self.message = message
-        super().__init__(self.message)
-
-    def __str__(self):
-        return f"UniqueConstraintViolationError: {self.message} (Value: {self.value})"
 
 class SQLAlchemyDialect(enum.Enum):
     SQLITE = 'sqlite'

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -31,6 +31,21 @@ if typing.TYPE_CHECKING:
 # For more info, see the PR description for #4552.
 _DB_TIMEOUT_S = 60
 
+class UniqueConstraintViolationError(Exception):
+    """
+    Exception raised for invalid input values.
+
+    Attributes:
+        value -- the input value that caused the error
+        message -- explanation of the error
+    """
+    def __init__(self, value, message="Unique constraint violation"):
+        self.value = value
+        self.message = message
+        super().__init__(self.message)
+
+    def __str__(self):
+        return f"UniqueConstraintViolationError: {self.message} (Value: {self.value})"
 
 class SQLAlchemyDialect(enum.Enum):
     SQLITE = 'sqlite'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
If a k8s pod disappears, try to investigate the reason behind pod deletion by inspecting k8s events.

<img width="1224" height="295" alt="Screenshot 2025-08-11 at 11 48 13 PM" src="https://github.com/user-attachments/assets/3812c161-f716-45de-bbf0-e6acdaf57b10" />

The hard part about the PR was that k8s events are only stored for an hour. Therefore, I add a mechanism to not clear the event out if the new event doesn't contain a meaningful status message (and previous event may have).

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
