### PR TITLE
[Docs] Add SDK Examples to QuickStart (2)

### DIFF
--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -112,6 +112,7 @@ from sky.client.sdk import storage_delete
 from sky.client.sdk import storage_ls
 from sky.client.sdk import stream_and_get
 from sky.client.sdk import tail_logs
+from sky import jobs as managed_jobs
 from sky.dag import Dag
 from sky.data import Storage
 from sky.data import StorageMode

--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -82,6 +82,7 @@ _set_http_proxy_env_vars()
 # pylint: disable=wrong-import-position
 from sky import backends
 from sky import clouds
+from sky import jobs as managed_jobs
 from sky.admin_policy import AdminPolicy
 from sky.admin_policy import MutatedUserRequest
 from sky.admin_policy import UserRequest
@@ -112,7 +113,6 @@ from sky.client.sdk import storage_delete
 from sky.client.sdk import storage_ls
 from sky.client.sdk import stream_and_get
 from sky.client.sdk import tail_logs
-from sky import jobs as managed_jobs
 from sky.dag import Dag
 from sky.data import Storage
 from sky.data import StorageMode


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Extending #6561 to:
- sky exec
- sky stop/down
- sky jobs launch

**NOTE**: Because we don't actually expose the managed jobs sdk, I added it to sky `__init__.py`. Please review if my placement is appropriate, or lmk if there is another official way we import the sdk.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
