### PR TITLE
Expose endpoints function through sky.endpoints

### DIFF
--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -98,6 +98,7 @@ from sky.client.sdk import cancel
 from sky.client.sdk import cost_report
 from sky.client.sdk import down
 from sky.client.sdk import download_logs
+from sky.client.sdk import endpoints
 from sky.client.sdk import exec  # pylint: disable=redefined-builtin
 from sky.client.sdk import get
 from sky.client.sdk import job_status
@@ -194,6 +195,7 @@ __all__ = [
     'down',
     'autostop',
     'cost_report',
+    'endpoints',
     # core APIs Job Management
     'queue',
     'cancel',


### PR DESCRIPTION
## Summary
This PR exposes the `endpoints` function from `sky/client/sdk.py` through the public API as `sky.endpoints`.

## Changes
- Added import of `endpoints` from `sky.client.sdk` in `sky/__init__.py`
- Added `'endpoints'` to the `__all__` list to make it part of the public API

## Usage
Users can now directly use:
```python
import sky
endpoints = sky.endpoints(cluster='my-cluster', port=8080)
```

This provides a convenient way to retrieve cluster endpoints for specified ports.