### PR TITLE
Nightly build trigger no tests if no change happened

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -19,16 +19,59 @@ jobs:
   check-date:
     runs-on: ubuntu-latest
     outputs:
-      should_run: ${{ steps.should_run.outputs.should_run }}
+      should_run: ${{ steps.compute_should_run.outputs.should_run }}
     steps:
       - uses: actions/checkout@v3
       - name: print latest_commit
         run: echo ${{ github.sha }}
-      - id: should_run
-        continue-on-error: true
-        name: check latest commit is less than a day
-        if: ${{ github.event_name == 'schedule' }}
-        run: test -z $(git rev-list  --after="24 hours"  ${{ github.sha }}) && echo "::set-output name=should_run::false"
+      - id: compute_should_run
+        name: determine whether nightly should run
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            if git rev-list --after="24 hours" ${{ github.sha }} | grep -q .; then
+              echo "should_run=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            # For manual dispatches, always run
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  gate-tests:
+    runs-on: ubuntu-latest
+    needs: [check-date]
+    outputs:
+      run_tests: ${{ steps.compute_gate.outputs.run_tests }}
+      publish_without_tests: ${{ steps.compute_gate.outputs.publish_without_tests }}
+    steps:
+      - id: compute_gate
+        name: compute run_tests gate for smoke tests
+        shell: bash
+        env:
+          EVENT: ${{ github.event_name }}
+          SKIP_BUILDKITE: ${{ inputs.skip_buildkite }}
+          SHOULD_RUN: ${{ needs.check-date.outputs.should_run }}
+        run: |
+          if [[ "$EVENT" == "workflow_dispatch" ]]; then
+            if [[ "$SKIP_BUILDKITE" == "true" ]]; then
+              echo "run_tests=false" >> "$GITHUB_OUTPUT"
+              echo "publish_without_tests=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "run_tests=true" >> "$GITHUB_OUTPUT"
+              echo "publish_without_tests=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            # For scheduled runs, rely on check-date
+            if [[ "$SHOULD_RUN" == "true" ]]; then
+              echo "run_tests=true" >> "$GITHUB_OUTPUT"
+              echo "publish_without_tests=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "run_tests=false" >> "$GITHUB_OUTPUT"
+              echo "publish_without_tests=false" >> "$GITHUB_OUTPUT"
+            fi
+          fi
 
   nightly-build-pypi:
     runs-on: ubuntu-latest
@@ -88,8 +131,8 @@ jobs:
           path: dist/
 
   smoke-tests-aws:
-    needs: nightly-build-pypi
-    if: ${{ github.event_name == 'workflow_dispatch' && !inputs.skip_buildkite || github.event_name == 'schedule' }}
+    needs: [gate-tests, nightly-build-pypi]
+    if: ${{ needs.gate-tests.outputs.run_tests == 'true' }}
     uses: ./.github/workflows/buildkite-trigger-wait.yml
     with:
       commit: ${{ github.sha }}
@@ -102,8 +145,8 @@ jobs:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
   backward-compat-test:
-    needs: nightly-build-pypi
-    if: ${{ github.event_name == 'workflow_dispatch' && !inputs.skip_buildkite || github.event_name == 'schedule' }}
+    needs: [gate-tests, nightly-build-pypi]
+    if: ${{ needs.gate-tests.outputs.run_tests == 'true' }}
     uses: ./.github/workflows/buildkite-trigger-wait.yml
     with:
       commit: ${{ github.sha }}
@@ -116,8 +159,8 @@ jobs:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
   smoke-tests-kubernetes:
-    needs: [smoke-tests-aws, backward-compat-test]
-    if: ${{ always() && (github.event_name == 'workflow_dispatch' && !inputs.skip_buildkite || github.event_name == 'schedule') }}
+    needs: [gate-tests, smoke-tests-aws, backward-compat-test]
+    if: ${{ needs.gate-tests.outputs.run_tests == 'true' && always() }}
     uses: ./.github/workflows/buildkite-trigger-wait.yml
     with:
       commit: ${{ github.sha }}
@@ -130,8 +173,8 @@ jobs:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
   smoke-tests-remote-server:
-    needs: smoke-tests-kubernetes
-    if: ${{ always() && (github.event_name == 'workflow_dispatch' && !inputs.skip_buildkite || github.event_name == 'schedule') }}
+    needs: [gate-tests, smoke-tests-kubernetes]
+    if: ${{ needs.gate-tests.outputs.run_tests == 'true' && always() }}
     uses: ./.github/workflows/buildkite-trigger-wait.yml
     with:
       commit: ${{ github.sha }}
@@ -144,8 +187,8 @@ jobs:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
   publish-and-validate-both:
-    needs: [nightly-build-pypi, smoke-tests-aws, smoke-tests-kubernetes, smoke-tests-remote-server, backward-compat-test]
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.skip_buildkite) || (always() && needs.smoke-tests-aws.result == 'success' && needs.smoke-tests-kubernetes.result == 'success' && needs.smoke-tests-remote-server.result == 'success' && needs.backward-compat-test.result == 'success') }}
+    needs: [gate-tests, nightly-build-pypi, smoke-tests-aws, smoke-tests-kubernetes, smoke-tests-remote-server, backward-compat-test]
+    if: ${{ needs.gate-tests.outputs.publish_without_tests == 'true' || (needs.gate-tests.outputs.run_tests == 'true' && needs.smoke-tests-aws.result == 'success' && needs.smoke-tests-kubernetes.result == 'success' && needs.smoke-tests-remote-server.result == 'success' && needs.backward-compat-test.result == 'success') }}
     uses: ./.github/workflows/publish-and-validate-both.yml
     with:
       package_name: skypilot-nightly


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolve #6607
                
Refactor to make logic more clear

`smoke-tests-kubernetes`  `smoke-tests-remote-server ` should not be triggerd if `check-date` determine that no test should be run

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
