### PR TITLE
[Core] last_event not populated in cluster records

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1111,8 +1111,6 @@ def get_clusters_from_history(
         days: Optional[int] = None) -> List[Dict[str, Any]]:
     """Get cluster reports from history.
 
-    Note that this method does not return `last_event`.
-
     Args:
         days: If specified, only include historical clusters (those not
               currently active) that were last used within the past 'days'
@@ -1208,7 +1206,6 @@ def get_clusters_from_history(
         workspace = (row.history_workspace
                      if row.history_workspace else row.workspace)
 
-        # TODO (kyuds): return last_event?
         record = {
             'name': row.name,
             'launched_at': launched_at,
@@ -1223,6 +1220,7 @@ def get_clusters_from_history(
             'workspace': workspace,
             'last_creation_yaml': row.last_creation_yaml,
             'last_creation_command': row.last_creation_command,
+            'last_event': get_last_cluster_event(row.name),
         }
 
         records.append(record)

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -686,11 +686,11 @@ def add_cluster_event(cluster_name: str,
                 raise e
 
 
-def get_last_cluster_event(cluster_name: str) -> Optional[str]:
+def get_last_cluster_event(cluster_hash: str) -> Optional[str]:
     assert _SQLALCHEMY_ENGINE is not None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         row = session.query(cluster_event_table).filter_by(
-            name=cluster_name,
+            cluster_hash=cluster_hash,
             type=ClusterEventType.STATUS_CHANGE.value).order_by(
                 cluster_event_table.c.transitioned_at.desc()).first()
     if row is None:
@@ -1075,7 +1075,7 @@ def get_clusters() -> List[Dict[str, Any]]:
         user_hash = _get_user_hash_or_current_user(row.user_hash)
         user = get_user(user_hash)
         user_name = user.name if user is not None else None
-        last_event = get_last_cluster_event(row.name)
+        last_event = get_last_cluster_event(row.cluster_hash)
         # TODO: use namedtuple instead of dict
         record = {
             'name': row.name,

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1034,6 +1034,7 @@ def get_cluster_from_name(
     user_hash = _get_user_hash_or_current_user(row.user_hash)
     user = get_user(user_hash)
     user_name = user.name if user is not None else None
+    last_event = get_last_cluster_event(row.name)
     # TODO: use namedtuple instead of dict
     record = {
         'name': row.name,
@@ -1057,6 +1058,7 @@ def get_cluster_from_name(
         'last_creation_yaml': row.last_creation_yaml,
         'last_creation_command': row.last_creation_command,
         'is_managed': bool(row.is_managed),
+        'last_event': last_event,
     }
 
     return record
@@ -1108,6 +1110,8 @@ def get_clusters() -> List[Dict[str, Any]]:
 def get_clusters_from_history(
         days: Optional[int] = None) -> List[Dict[str, Any]]:
     """Get cluster reports from history.
+
+    Note that this method does not return `last_event`.
 
     Args:
         days: If specified, only include historical clusters (those not
@@ -1204,6 +1208,7 @@ def get_clusters_from_history(
         workspace = (row.history_workspace
                      if row.history_workspace else row.workspace)
 
+        # TODO (kyuds): return last_event?
         record = {
             'name': row.name,
             'launched_at': launched_at,

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1034,7 +1034,7 @@ def get_cluster_from_name(
     user_hash = _get_user_hash_or_current_user(row.user_hash)
     user = get_user(user_hash)
     user_name = user.name if user is not None else None
-    last_event = get_last_cluster_event(row.name)
+    last_event = get_last_cluster_event(row.cluster_hash)
     # TODO: use namedtuple instead of dict
     record = {
         'name': row.name,
@@ -1220,7 +1220,7 @@ def get_clusters_from_history(
             'workspace': workspace,
             'last_creation_yaml': row.last_creation_yaml,
             'last_creation_command': row.last_creation_command,
-            'last_event': get_last_cluster_event(row.name),
+            'last_event': get_last_cluster_event(row.cluster_hash),
         }
 
         records.append(record)

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -318,7 +318,7 @@ def _get_head_ip(cluster_record: _ClusterRecord, truncate: bool = True) -> str:
 def _get_last_event(cluster_record: _ClusterRecord,
                     truncate: bool = True) -> str:
     del truncate
-    if cluster_record['last_event'] is None:
+    if cluster_record.get('last_event', None) is None:
         return 'No recorded events.'
     return cluster_record['last_event']
 


### PR DESCRIPTION
Co-authored-by: kyuds
References: PR #6609 and issue #6606.

<!-- Describe the changes in this PR -->

This PR addresses the cluster record not being populated in functions that return these records. It also handles situations where the cluster event table might not exist for backwards compatibility.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
