### PR TITLE
Query last event by cluster hash

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -686,11 +686,11 @@ def add_cluster_event(cluster_name: str,
                 raise e
 
 
-def get_last_cluster_event(cluster_name: str) -> Optional[str]:
+def get_last_cluster_event(cluster_hash: str) -> Optional[str]:
     assert _SQLALCHEMY_ENGINE is not None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         row = session.query(cluster_event_table).filter_by(
-            name=cluster_name,
+            cluster_hash=cluster_hash,
             type=ClusterEventType.STATUS_CHANGE.value).order_by(
                 cluster_event_table.c.transitioned_at.desc()).first()
     if row is None:
@@ -1073,7 +1073,7 @@ def get_clusters() -> List[Dict[str, Any]]:
         user_hash = _get_user_hash_or_current_user(row.user_hash)
         user = get_user(user_hash)
         user_name = user.name if user is not None else None
-        last_event = get_last_cluster_event(row.name)
+        last_event = get_last_cluster_event(row.cluster_hash)
         # TODO: use namedtuple instead of dict
         record = {
             'name': row.name,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The idea is that when a cluster is downed and a new cluster is launched with the same name, querying by cluster name cannot discern the difference between the two cluster whereas the cluster hash can. Prior to the PR, querying for the last event of a cluster has _a chance_ that the last event returned is from a previous cluster with the same name - this PR removes such possibility.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
