### PR TITLE
[UX] fix api logs

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -6069,8 +6069,11 @@ def api_logs(request_id: Optional[str], server_logs: bool,
     if request_id is not None and log_path is not None:
         raise click.BadParameter(
             'Only one of request ID and log path can be provided.')
-    sdk.stream_and_get(server_common.RequestId[None](request_id), log_path,
-                       tail)
+    # Only wrap request_id when it is provided; otherwise pass None so the
+    # server accepts log_path-only streaming.
+    req_id = (server_common.RequestId[None](request_id)
+              if request_id is not None else None)
+    sdk.stream_and_get(req_id, log_path, tail, follow=follow)
 
 
 @api.command('cancel', cls=_DocumentedCodeCommand)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR addresses an issue where running the command suggested by the hint during `sky launch` results in the following error:
```
❯ sky api logs -l sky-2025-08-11-13-29-04-142869/provision.log
RuntimeError: Failed to stream logs: Only one of request_id and log_path can be provided
```


<!-- Describe the tests ran -->
Manually verified that with this PR the `sky api logs -l` command works out of the box during `sky launch`.

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
