### PR TITLE
undo import jobs in sky init

### DIFF
--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -420,11 +420,12 @@ When you are ready to scale out (e.g., run 10s, 100s, or 1000s of jobs), **use**
     .. code-block:: python
 
       import sky
+      from sky import jobs as managed_jobs
 
       for i in range(100):
           resource = sky.Resources(use_spot=True)
           task = sky.Task(resources=resource, run='echo "Hello, SkyPilot!"')
-          sky.managed_jobs.launch(task, name=f'hello-{i}')
+          managed_jobs.launch(task, name=f'hello-{i}')
 
 After you launch the jobs, open the SkyPilot dashboard and check job status(es) in the Jobs tab.
 

--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -82,7 +82,6 @@ _set_http_proxy_env_vars()
 # pylint: disable=wrong-import-position
 from sky import backends
 from sky import clouds
-from sky import jobs as managed_jobs
 from sky.admin_policy import AdminPolicy
 from sky.admin_policy import MutatedUserRequest
 from sky.admin_policy import UserRequest


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Followup to https://github.com/skypilot-org/skypilot/pull/6597. Come to think of it, we should not just import big packages like this in sky willy nilly. Modify the quickstart to work with the change.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
