### PR TITLE
[Core] Support customizing ssh user for aws

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -106,6 +106,7 @@ Below is the configuration syntax and some example values. See detailed explanat
     :ref:`ssh_proxy_command <config-yaml-aws-ssh-proxy-command>`: ssh -W %h:%p user@host
     :ref:`security_group_name <config-yaml-aws-security-group-name>`: my-security-group
     :ref:`disk_encrypted <config-yaml-aws-disk-encrypted>`: false
+    :ref:`ssh_user <config-yaml-aws-ssh-user>`: ubuntu
     :ref:`prioritize_reservations <config-yaml-aws-prioritize-reservations>`: false
     :ref:`specific_reservations <config-yaml-aws-specific-reservations>`:
       - cr-a1234567
@@ -609,6 +610,15 @@ Set to ``true`` to encrypt the boot disk of all AWS instances launched by
 SkyPilot. This is useful for compliance with data protection regulations.
 
 Default: ``false``.
+
+.. _config-yaml-aws-ssh-user:
+
+``aws.ssh_user``
+~~~~~~~~~~~~~~~~
+
+SSH user (optional) for the SkyPilot nodes.
+
+Default: ``ubuntu``.
 
 .. _config-yaml-aws-prioritize-reservations:
 

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -471,9 +471,7 @@ class AWS(clouds.Cloud):
             cloud='aws',
             region=region_name,
             keys=('ssh_user',),
-            default_value=None)
-        if not ssh_user:
-            ssh_user = DEFAULT_SSH_USER
+            default_value=DEFAULT_SSH_USER)
 
         disk_encrypted = skypilot_config.get_effective_region_config(
             cloud='aws',

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -65,6 +65,7 @@ _CREDENTIAL_FILES = [
 ]
 
 DEFAULT_AMI_GB = 45
+DEFAULT_SSH_USER = 'ubuntu'
 
 # Temporary measure, as deleting per-cluster SGs is too slow.
 # See https://github.com/skypilot-org/skypilot/pull/742.
@@ -466,6 +467,14 @@ class AWS(clouds.Cloud):
         image_id = self._get_image_id(image_id_to_use, region_name,
                                       resources.instance_type)
 
+        ssh_user = skypilot_config.get_effective_region_config(
+            cloud='aws',
+            region=region_name,
+            keys=('ssh_user',),
+            default_value=None)
+        if not ssh_user:
+            ssh_user = DEFAULT_SSH_USER
+
         disk_encrypted = skypilot_config.get_effective_region_config(
             cloud='aws',
             region=region_name,
@@ -509,6 +518,7 @@ class AWS(clouds.Cloud):
             'region': region_name,
             'zones': ','.join(zone_names),
             'image_id': image_id,
+            'ssh_user': ssh_user,
             'security_group': security_group,
             'security_group_managed_by_skypilot':
                 str(security_group != user_security_group).lower(),

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -50,7 +50,7 @@ provider:
   disable_launch_config_check: true
 
 auth:
-  ssh_user: ubuntu
+  ssh_user: {{ssh_user}}
   ssh_private_key: {{ssh_private_key}}
 {% if ssh_proxy_command is not none %}
   ssh_proxy_command: {{ssh_proxy_command}}

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1205,6 +1205,9 @@ def get_config_schema():
                 'disk_encrypted': {
                     'type': 'boolean',
                 },
+                'ssh_user': {
+                    'type': 'string',
+                },
                 'security_group_name':
                     (_PROPERTY_NAME_OR_CLUSTER_NAME_TO_PROPERTY),
                 'vpc_name': {

--- a/tests/test_yamls/test_aws_config_ssh_user.yaml
+++ b/tests/test_yamls/test_aws_config_ssh_user.yaml
@@ -1,0 +1,10 @@
+aws:
+  vpc_name: fake-vpc
+  ssh_user: test-user
+  remote_identity:
+    - sky-serve-fake1-*: fake1-skypilot-role
+    - sky-serve-fake2-*: fake2-skypilot-role
+
+  security_group_name:
+    - sky-serve-fake1-*: fake-1-sg
+    - sky-serve-fake2-*: fake-2-sg


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Support customizing ssh user for aws

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Launch a cluster with `aws.ssh_user: test-user` in `config.yaml` 
  - Launch a managed job with `aws.ssh_user: test-user` in `config.yaml` 
  - Launch a cluster without setting `aws.ssh_user` in `config.yaml` 
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
