### PR TITLE
RAG example: use chunk_text as prompt for embeddings

### DIFF
--- a/llm/rag/scripts/compute_embeddings.py
+++ b/llm/rag/scripts/compute_embeddings.py
@@ -169,7 +169,7 @@ def compute_embeddings_batch(chunks: List[Dict],
         batch = chunks[i:i + batch_size]
 
         # Create prompt for each chunk - simplified prompt
-        prompts = [chunk['content'] for chunk in batch]
+        prompts = [chunk['chunk_text'] for chunk in batch]
 
         try:
             # Print request payload for debugging


### PR DESCRIPTION
In the rag example, the full document content was being used for the embeddings while we should use only the chunk text. This PR changes it.

https://github.com/skypilot-org/skypilot/issues/6630


