### PR TITLE
[Core] Lazy import grpc

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -18,7 +18,6 @@ from typing import (Any, Callable, Dict, List, Optional, Sequence, Set, Tuple,
 import uuid
 
 import colorama
-import grpc
 from packaging import version
 import psutil
 from typing_extensions import Literal
@@ -64,6 +63,7 @@ from sky.utils import ux_utils
 from sky.workspaces import core as workspaces_core
 
 if typing.TYPE_CHECKING:
+    import grpc
     import requests
     from requests import adapters
     from requests.packages.urllib3.util import retry as retry_lib
@@ -82,6 +82,7 @@ else:
     adapters = adaptors_common.LazyImport('requests.adapters')
     retry_lib = adaptors_common.LazyImport(
         'requests.packages.urllib3.util.retry')
+    grpc = adaptors_common.LazyImport('grpc')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -21,7 +21,6 @@ from typing import (Any, Callable, Dict, Iterable, List, Optional, Set, Tuple,
                     Union)
 
 import colorama
-import grpc
 import psutil
 import yaml
 
@@ -40,6 +39,7 @@ from sky import resources as resources_lib
 from sky import sky_logging
 from sky import skypilot_config
 from sky import task as task_lib
+from sky.adaptors import common as adaptors_common
 from sky.backends import backend_utils
 from sky.backends import wheel_utils
 from sky.clouds import cloud as sky_cloud
@@ -51,8 +51,6 @@ from sky.provision import instance_setup
 from sky.provision import metadata_utils
 from sky.provision import provisioner
 from sky.provision.kubernetes import utils as kubernetes_utils
-from sky.schemas.generated import autostopv1_pb2
-from sky.schemas.generated import autostopv1_pb2_grpc
 from sky.server.requests import requests as requests_lib
 from sky.skylet import autostop_lib
 from sky.skylet import constants
@@ -81,7 +79,17 @@ from sky.utils import ux_utils
 from sky.utils import volume as volume_lib
 
 if typing.TYPE_CHECKING:
+    import grpc
+
     from sky import dag
+    from sky.schemas.generated import autostopv1_pb2
+    from sky.schemas.generated import autostopv1_pb2_grpc
+else:
+    grpc = adaptors_common.LazyImport('grpc')
+    autostopv1_pb2 = adaptors_common.LazyImport(
+        'sky.schemas.generated.autostopv1_pb2')
+    autostopv1_pb2_grpc = adaptors_common.LazyImport(
+        'sky.schemas.generated.autostopv1_pb2_grpc')
 
 Path = str
 
@@ -2616,7 +2624,7 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
                                                     cluster_config_file)
         self.docker_user = docker_user
 
-    def get_grpc_channel(self) -> grpc.Channel:
+    def get_grpc_channel(self) -> 'grpc.Channel':
         if self.skylet_ssh_tunnel is None:
             self.open_and_update_skylet_tunnel()
         assert self.skylet_ssh_tunnel is not None
@@ -2819,7 +2827,7 @@ class LocalResourcesHandle(CloudVmRayResourceHandle):
 class SkyletClient:
     """The client to interact with a remote cluster through Skylet."""
 
-    def __init__(self, channel: grpc.Channel):
+    def __init__(self, channel: 'grpc.Channel'):
         self._autostop_stub = autostopv1_pb2_grpc.AutostopServiceStub(channel)
 
     def set_autostop(


### PR DESCRIPTION
After #6574, which introduced `grpc` as a dependency, our GCP catalog fetcher started failing: https://github.com/skypilot-org/skypilot-catalog/actions/runs/16925022238 as `grpc` is not part of the dependency of our GCP extras.

```bash
Traceback (most recent call last):
  File "/home/runner/.local/share/uv/python/cpython-3.10.18-linux-x86_64-gnu/lib/python3.10/runpy.py", line 187, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/home/runner/.local/share/uv/python/cpython-3.10.18-linux-x86_64-gnu/lib/python3.10/runpy.py", line 110, in _get_module_details
    __import__(pkg_name)
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/sky/__init__.py", line 83, in <module>
    from sky import backends
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/sky/backends/__init__.py", line 4, in <module>
    from sky.backends.cloud_vm_ray_backend import CloudVmRayBackend
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/sky/backends/cloud_vm_ray_backend.py", line 24, in <module>
    import grpc
ModuleNotFoundError: No module named 'grpc'
```

This PR fixes this by lazily importing `grpc` (and the generated files from protobuf).

Reference: #6302 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
