### PR TITLE
Reduce occurance of import sky

### DIFF
--- a/sky/admin_policy.py
+++ b/sky/admin_policy.py
@@ -8,7 +8,7 @@ import colorama
 import pydantic
 
 from sky import exceptions
-from sky import task as sky_task
+from sky import task as task_lib
 from sky.adaptors import common as adaptors_common
 from sky.utils import common_utils
 from sky.utils import config_utils
@@ -93,7 +93,7 @@ class UserRequest:
     def decode(cls, body: str) -> 'UserRequest':
         user_request_body = _UserRequestBody.model_validate_json(body)
         return cls(
-            task=sky_task.Task.from_yaml_config(
+            task=task_lib.Task.from_yaml_config(
                 common_utils.read_yaml_all_str(user_request_body.task)[0]),
             skypilot_config=config_utils.Config.from_dict(
                 common_utils.read_yaml_all_str(
@@ -127,7 +127,7 @@ class MutatedUserRequest:
                original_request: UserRequest) -> 'MutatedUserRequest':
         mutated_user_request_body = _MutatedUserRequestBody.model_validate_json(
             mutated_user_request_body)
-        task = sky_task.Task.from_yaml_config(
+        task = task_lib.Task.from_yaml_config(
             common_utils.read_yaml_all_str(mutated_user_request_body.task)[0])
         # Some internal Task fields are not serialized. We need to manually
         # restore them from the original request.

--- a/sky/admin_policy.py
+++ b/sky/admin_policy.py
@@ -7,8 +7,8 @@ from typing import Optional
 import colorama
 import pydantic
 
+import sky
 from sky import exceptions
-from sky import task as task_lib
 from sky.adaptors import common as adaptors_common
 from sky.utils import common_utils
 from sky.utils import config_utils
@@ -16,8 +16,6 @@ from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
     import requests
-
-    import sky
 else:
     requests = adaptors_common.LazyImport('requests')
 
@@ -93,7 +91,7 @@ class UserRequest:
     def decode(cls, body: str) -> 'UserRequest':
         user_request_body = _UserRequestBody.model_validate_json(body)
         return cls(
-            task=task_lib.Task.from_yaml_config(
+            task=sky.Task.from_yaml_config(
                 common_utils.read_yaml_all_str(user_request_body.task)[0]),
             skypilot_config=config_utils.Config.from_dict(
                 common_utils.read_yaml_all_str(
@@ -127,7 +125,7 @@ class MutatedUserRequest:
                original_request: UserRequest) -> 'MutatedUserRequest':
         mutated_user_request_body = _MutatedUserRequestBody.model_validate_json(
             mutated_user_request_body)
-        task = task_lib.Task.from_yaml_config(
+        task = sky.Task.from_yaml_config(
             common_utils.read_yaml_all_str(mutated_user_request_body.task)[0])
         # Some internal Task fields are not serialized. We need to manually
         # restore them from the original request.

--- a/sky/admin_policy.py
+++ b/sky/admin_policy.py
@@ -7,8 +7,8 @@ from typing import Optional
 import colorama
 import pydantic
 
-import sky
 from sky import exceptions
+from sky import task as sky_task
 from sky.adaptors import common as adaptors_common
 from sky.utils import common_utils
 from sky.utils import config_utils
@@ -16,6 +16,8 @@ from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
     import requests
+
+    import sky
 else:
     requests = adaptors_common.LazyImport('requests')
 
@@ -91,7 +93,7 @@ class UserRequest:
     def decode(cls, body: str) -> 'UserRequest':
         user_request_body = _UserRequestBody.model_validate_json(body)
         return cls(
-            task=sky.Task.from_yaml_config(
+            task=sky_task.Task.from_yaml_config(
                 common_utils.read_yaml_all_str(user_request_body.task)[0]),
             skypilot_config=config_utils.Config.from_dict(
                 common_utils.read_yaml_all_str(
@@ -125,7 +127,7 @@ class MutatedUserRequest:
                original_request: UserRequest) -> 'MutatedUserRequest':
         mutated_user_request_body = _MutatedUserRequestBody.model_validate_json(
             mutated_user_request_body)
-        task = sky.Task.from_yaml_config(
+        task = sky_task.Task.from_yaml_config(
             common_utils.read_yaml_all_str(mutated_user_request_body.task)[0])
         # Some internal Task fields are not serialized. We need to manually
         # restore them from the original request.

--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -11,12 +11,12 @@ import typing
 from typing import Optional
 
 from sky import backends
+from sky import dag as dag_lib
 from sky import exceptions
 from sky import execution
 from sky import global_user_state
 from sky import sky_logging
 from sky.backends import backend_utils
-from sky import dag as dag_lib
 from sky.jobs import scheduler
 from sky.jobs import state
 from sky.jobs import utils as managed_job_utils

--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -10,13 +10,13 @@ import traceback
 import typing
 from typing import Optional
 
-import sky
 from sky import backends
 from sky import exceptions
 from sky import execution
 from sky import global_user_state
 from sky import sky_logging
 from sky.backends import backend_utils
+from sky import dag as dag_lib
 from sky.jobs import scheduler
 from sky.jobs import state
 from sky.jobs import utils as managed_job_utils
@@ -61,7 +61,7 @@ class StrategyExecutor:
         """
         assert isinstance(backend, backends.CloudVmRayBackend), (
             'Only CloudVMRayBackend is supported.')
-        self.dag = sky.Dag()
+        self.dag = dag_lib.Dag()
         self.dag.add(task)
         # For jobs submitted to a pool, the cluster name might change after each
         # recovery. Initially this is set to an empty string to indicate that no

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Literal, Optional, Set, Tuple, Union
 
 import colorama
 
-import sky
 from sky import catalog
 from sky import check as sky_check
 from sky import clouds
@@ -288,7 +287,7 @@ class Resources:
         if infra is not None:
             infra_info = infra_utils.InfraInfo.from_str(infra)
             # Infra takes precedence over individually specified parameters
-            cloud = sky.CLOUD_REGISTRY.from_str(infra_info.cloud)
+            cloud = registry.CLOUD_REGISTRY.from_str(infra_info.cloud)
             region = infra_info.region
             zone = infra_info.zone
 

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -16,13 +16,13 @@ import colorama
 import psutil
 import requests
 
-import sky
 from sky import backends
 from sky import core
 from sky import exceptions
 from sky import execution
 from sky import global_user_state
 from sky import sky_logging
+from sky import task as task_lib
 from sky.backends import backend_utils
 from sky.jobs import scheduler as jobs_scheduler
 from sky.serve import constants as serve_constants
@@ -81,7 +81,7 @@ def launch_cluster(replica_id: int,
     try:
         config = common_utils.read_yaml(
             os.path.expanduser(service_task_yaml_path))
-        task = sky.Task.from_yaml_config(config)
+        task = task_lib.Task.from_yaml_config(config)
         if resources_override is not None:
             resources = task.resources
             overrided_resources = [
@@ -177,7 +177,7 @@ def terminate_cluster(cluster_name: str,
 
 def _get_resources_ports(service_task_yaml_path: str) -> str:
     """Get the resources ports used by the task."""
-    task = sky.Task.from_yaml(service_task_yaml_path)
+    task = task_lib.Task.from_yaml(service_task_yaml_path)
     # Already checked all ports are valid in sky.serve.core.up
     assert task.resources, task
     assert task.service is not None, task
@@ -195,7 +195,7 @@ def _should_use_spot(service_task_yaml_path: str,
         if use_spot_override is not None:
             assert isinstance(use_spot_override, bool)
             return use_spot_override
-    task = sky.Task.from_yaml(service_task_yaml_path)
+    task = task_lib.Task.from_yaml(service_task_yaml_path)
     spot_use_resources = [
         resources for resources in task.resources if resources.use_spot
     ]
@@ -688,7 +688,7 @@ class SkyPilotReplicaManager(ReplicaManager):
                  service_task_yaml_path: str) -> None:
         super().__init__(service_name, spec)
         self.service_task_yaml_path = service_task_yaml_path
-        task = sky.Task.from_yaml(service_task_yaml_path)
+        task = task_lib.Task.from_yaml(service_task_yaml_path)
         self._spot_placer: Optional[spot_placer.SpotPlacer] = (
             spot_placer.SpotPlacer.from_task(spec, task))
         # TODO(tian): Store launch/down pid in the replica table, to make the

--- a/sky/serve/server/impl.py
+++ b/sky/serve/server/impl.py
@@ -5,13 +5,13 @@ import shlex
 import signal
 import tempfile
 import threading
+import typing
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 import uuid
 
 import colorama
 import filelock
 
-import sky
 from sky import backends
 from sky import exceptions
 from sky import execution
@@ -25,6 +25,7 @@ from sky.serve import constants as serve_constants
 from sky.serve import serve_state
 from sky.serve import serve_utils
 from sky.skylet import constants
+from sky.skylet import job_lib
 from sky.utils import admin_policy_utils
 from sky.utils import command_runner
 from sky.utils import common
@@ -34,6 +35,9 @@ from sky.utils import dag_utils
 from sky.utils import rich_utils
 from sky.utils import subprocess_utils
 from sky.utils import ux_utils
+
+if typing.TYPE_CHECKING:
+    import sky
 
 logger = sky_logging.init_logger(__name__)
 
@@ -325,7 +329,7 @@ def up(
                                               [controller_job_id],
                                               stream_logs=False)
             controller_job_status = list(statuses.values())[0]
-            if controller_job_status == sky.JobStatus.PENDING:
+            if controller_job_status == job_lib.JobStatus.PENDING:
                 # Max number of services reached due to vCPU constraint.
                 # The controller job is pending due to ray job scheduling.
                 # We manually cancel the job here.

--- a/sky/serve/server/impl.py
+++ b/sky/serve/server/impl.py
@@ -5,7 +5,6 @@ import shlex
 import signal
 import tempfile
 import threading
-import typing
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 import uuid
 
@@ -36,14 +35,11 @@ from sky.utils import rich_utils
 from sky.utils import subprocess_utils
 from sky.utils import ux_utils
 
-if typing.TYPE_CHECKING:
-    import sky
-
 logger = sky_logging.init_logger(__name__)
 
 
 def _rewrite_tls_credential_paths_and_get_tls_env_vars(
-        service_name: str, task: 'sky.Task') -> Dict[str, Any]:
+        service_name: str, task: 'task_lib.Task') -> Dict[str, Any]:
     """Rewrite the paths of TLS credentials in the task.
 
     Args:
@@ -107,7 +103,7 @@ def _get_service_record(
 
 
 def up(
-    task: 'sky.Task',
+    task: 'task_lib.Task',
     service_name: Optional[str] = None,
     pool: bool = False,
 ) -> Tuple[str, str]:
@@ -425,7 +421,7 @@ def up(
 
 
 def update(
-    task: 'sky.Task',
+    task: 'task_lib.Task',
     service_name: str,
     mode: serve_utils.UpdateMode = serve_utils.DEFAULT_UPDATE_MODE,
     pool: bool = False,
@@ -580,7 +576,7 @@ def update(
 
 
 def apply(
-    task: 'sky.Task',
+    task: 'task_lib.Task',
     service_name: str,
     mode: serve_utils.UpdateMode = serve_utils.DEFAULT_UPDATE_MODE,
     pool: bool = False,

--- a/sky/volumes/server/core.py
+++ b/sky/volumes/server/core.py
@@ -7,12 +7,12 @@ import uuid
 
 import filelock
 
-import sky
 from sky import global_user_state
 from sky import models
 from sky import provision
 from sky import sky_logging
 from sky.utils import common_utils
+from sky.utils import registry
 from sky.utils import rich_utils
 from sky.utils import status_lib
 from sky.utils import ux_utils
@@ -180,7 +180,7 @@ def volume_apply(name: str, volume_type: str, cloud: str, region: Optional[str],
     with rich_utils.safe_status(ux_utils.spinner_message('Creating volume')):
         # Reuse the method for cluster name on cloud to
         # generate the storage name on cloud.
-        cloud_obj = sky.CLOUD_REGISTRY.from_str(cloud)
+        cloud_obj = registry.CLOUD_REGISTRY.from_str(cloud)
         assert cloud_obj is not None
         name_uuid = str(uuid.uuid4())[:6]
         name_on_cloud = common_utils.make_cluster_name_on_cloud(

--- a/sky/volumes/server/server.py
+++ b/sky/volumes/server/server.py
@@ -2,12 +2,12 @@
 
 import fastapi
 
-import sky
 from sky import clouds
 from sky import sky_logging
 from sky.server.requests import executor
 from sky.server.requests import payloads
 from sky.server.requests import requests as requests_lib
+from sky.utils import registry
 from sky.utils import volume
 from sky.volumes.server import core
 
@@ -55,7 +55,7 @@ async def volume_apply(request: fastapi.Request,
     if volume_type not in supported_volume_types:
         raise fastapi.HTTPException(
             status_code=400, detail=f'Invalid volume type: {volume_type}')
-    cloud = sky.CLOUD_REGISTRY.from_str(volume_cloud)
+    cloud = registry.CLOUD_REGISTRY.from_str(volume_cloud)
     if cloud is None:
         raise fastapi.HTTPException(status_code=400,
                                     detail=f'Invalid cloud: {volume_cloud}')

--- a/tests/unit_tests/test_sky/volumes/test_core.py
+++ b/tests/unit_tests/test_sky/volumes/test_core.py
@@ -443,7 +443,7 @@ class TestVolumeCore:
         mock_cloud.max_cluster_name_length.return_value = 63
         mock_cloud_registry = mock.MagicMock()
         mock_cloud_registry.from_str.return_value = mock_cloud
-        monkeypatch.setattr('sky.volumes.server.core.sky.CLOUD_REGISTRY',
+        monkeypatch.setattr('sky.utils.registry.CLOUD_REGISTRY',
                             mock_cloud_registry)
 
         # Mock common_utils.make_cluster_name_on_cloud
@@ -498,7 +498,7 @@ class TestVolumeCore:
         mock_cloud.max_cluster_name_length.return_value = 63
         mock_cloud_registry = mock.MagicMock()
         mock_cloud_registry.from_str.return_value = mock_cloud
-        monkeypatch.setattr('sky.volumes.server.core.sky.CLOUD_REGISTRY',
+        monkeypatch.setattr('sky.utils.registry.CLOUD_REGISTRY',
                             mock_cloud_registry)
 
         # Mock global_user_state to return existing volume
@@ -537,7 +537,7 @@ class TestVolumeCore:
         mock_cloud.max_cluster_name_length.return_value = 63
         mock_cloud_registry = mock.MagicMock()
         mock_cloud_registry.from_str.return_value = mock_cloud
-        monkeypatch.setattr('sky.volumes.server.core.sky.CLOUD_REGISTRY',
+        monkeypatch.setattr('sky.utils.registry.CLOUD_REGISTRY',
                             mock_cloud_registry)
 
         # Mock common_utils.make_cluster_name_on_cloud

--- a/tests/unit_tests/test_sky/volumes/test_server.py
+++ b/tests/unit_tests/test_sky/volumes/test_server.py
@@ -93,7 +93,7 @@ class TestVolumeServer:
         mock_cloud.is_same_cloud.return_value = True
         mock_cloud_registry = mock.MagicMock()
         mock_cloud_registry.from_str.return_value = mock_cloud
-        monkeypatch.setattr('sky.volumes.server.server.sky.CLOUD_REGISTRY',
+        monkeypatch.setattr('sky.utils.registry.CLOUD_REGISTRY',
                             mock_cloud_registry)
 
         # Create test client
@@ -147,7 +147,7 @@ class TestVolumeServer:
         mock_cloud.is_same_cloud.return_value = True
         mock_cloud_registry = mock.MagicMock()
         mock_cloud_registry.from_str.return_value = mock_cloud
-        monkeypatch.setattr('sky.volumes.server.server.sky.CLOUD_REGISTRY',
+        monkeypatch.setattr('sky.utils.registry.CLOUD_REGISTRY',
                             mock_cloud_registry)
 
         # Create test client
@@ -197,7 +197,7 @@ class TestVolumeServer:
         mock_cloud.is_same_cloud.return_value = True
         mock_cloud_registry = mock.MagicMock()
         mock_cloud_registry.from_str.return_value = mock_cloud
-        monkeypatch.setattr('sky.volumes.server.server.sky.CLOUD_REGISTRY',
+        monkeypatch.setattr('sky.utils.registry.CLOUD_REGISTRY',
                             mock_cloud_registry)
 
         # Create test client
@@ -262,7 +262,7 @@ class TestVolumeServer:
         # Mock cloud registry to return None
         mock_cloud_registry = mock.MagicMock()
         mock_cloud_registry.from_str.return_value = None
-        monkeypatch.setattr('sky.volumes.server.server.sky.CLOUD_REGISTRY',
+        monkeypatch.setattr('sky.utils.registry.CLOUD_REGISTRY',
                             mock_cloud_registry)
 
         # Create test client
@@ -298,7 +298,7 @@ class TestVolumeServer:
         mock_cloud.is_same_cloud.return_value = False  # Not Kubernetes
         mock_cloud_registry = mock.MagicMock()
         mock_cloud_registry.from_str.return_value = mock_cloud
-        monkeypatch.setattr('sky.volumes.server.server.sky.CLOUD_REGISTRY',
+        monkeypatch.setattr('sky.utils.registry.CLOUD_REGISTRY',
                             mock_cloud_registry)
 
         # Create test client
@@ -335,7 +335,7 @@ class TestVolumeServer:
         mock_cloud.is_same_cloud.return_value = True  # Is Kubernetes
         mock_cloud_registry = mock.MagicMock()
         mock_cloud_registry.from_str.return_value = mock_cloud
-        monkeypatch.setattr('sky.volumes.server.server.sky.CLOUD_REGISTRY',
+        monkeypatch.setattr('sky.utils.registry.CLOUD_REGISTRY',
                             mock_cloud_registry)
 
         # Create test client
@@ -377,7 +377,7 @@ class TestVolumeServer:
         mock_cloud = mock.MagicMock()
         mock_cloud_registry = mock.MagicMock()
         mock_cloud_registry.from_str.return_value = mock_cloud
-        monkeypatch.setattr('sky.volumes.server.server.sky.CLOUD_REGISTRY',
+        monkeypatch.setattr('sky.utils.registry.CLOUD_REGISTRY',
                             mock_cloud_registry)
 
         # Create test client


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
`import sky` statement in internal code imports a lot of (unnecessary) things at once, causing unnecessary circular import issues and overall making the codepath slower. Reduce the occurrence of `import sky` statements by importing more targeted modules whenever possible.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
