### PR TITLE
reduce use of import sky in test files (1)

### DIFF
--- a/tests/unit_tests/test_controller_utils.py
+++ b/tests/unit_tests/test_controller_utils.py
@@ -4,8 +4,9 @@ from unittest import mock
 
 import pytest
 
-import sky
 from sky import clouds
+from sky import exceptions
+from sky import resources as resources_lib
 from sky.jobs import constants as managed_job_constants
 from sky.serve import constants as serve_constants
 from sky.skylet import autostop_lib
@@ -78,7 +79,8 @@ def test_get_controller_resources(controller_type: str,
 
 
 def _check_controller_resources(
-        controller_resources: Set[sky.Resources], expected_infra_list: Set[str],
+        controller_resources: Set[resources_lib.Resources],
+        expected_infra_list: Set[str],
         default_controller_resources: Dict[str, Any]) -> None:
     """Helper function to check that the controller resources match the
     expected combinations."""
@@ -112,7 +114,7 @@ def test_get_controller_resources_with_task_resources(
     expected_infra_set = all_clouds
     controller_resources = controller_utils.get_controller_resources(
         controller=controller_utils.Controllers.from_type(controller_type),
-        task_resources=[sky.Resources(infra=c) for c in all_clouds])
+        task_resources=[resources_lib.Resources(infra=c) for c in all_clouds])
     _check_controller_resources(controller_resources, expected_infra_set,
                                 default_controller_resources)
 
@@ -127,16 +129,16 @@ def test_get_controller_resources_with_task_resources(
         cloud = registry.CLOUD_REGISTRY.from_str(cloud_str)
         try:
             cloud.check_features_are_supported(
-                sky.Resources(),
-                {sky.clouds.CloudImplementationFeatures.HOST_CONTROLLERS})
-        except sky.exceptions.NotSupportedError:
+                resources_lib.Resources(),
+                {clouds.CloudImplementationFeatures.HOST_CONTROLLERS})
+        except exceptions.NotSupportedError:
             return False
         return True
 
     expected_infra_set = {c for c in all_clouds if _could_host_controllers(c)}
     controller_resources = controller_utils.get_controller_resources(
         controller=controller_utils.Controllers.from_type(controller_type),
-        task_resources=[sky.Resources(infra=c) for c in all_clouds])
+        task_resources=[resources_lib.Resources(infra=c) for c in all_clouds])
     _check_controller_resources(controller_resources, expected_infra_set,
                                 default_controller_resources)
 
@@ -145,8 +147,8 @@ def test_get_controller_resources_with_task_resources(
     controller_resources = controller_utils.get_controller_resources(
         controller=controller_utils.Controllers.from_type(controller_type),
         task_resources=[
-            sky.Resources(accelerators='L4'),
-            sky.Resources(infra='runpod', accelerators='A40'),
+            resources_lib.Resources(accelerators='L4'),
+            resources_lib.Resources(infra='runpod', accelerators='A40'),
         ])
     assert len(controller_resources) == 1
     config = list(controller_resources)[0].to_yaml_config()
@@ -157,14 +159,18 @@ def test_get_controller_resources_with_task_resources(
     # regions, and zones. Each combination should contain the default resources
     # along with the cloud, region, and zone.
     all_cloud_regions_zones = [
-        sky.Resources(cloud=sky.AWS(), region='us-east-1', zone='us-east-1a'),
-        sky.Resources(cloud=sky.AWS(), region='ap-south-1', zone='ap-south-1b'),
-        sky.Resources(cloud=sky.GCP(),
-                      region='us-central1',
-                      zone='us-central1-a'),
-        sky.Resources(cloud=sky.GCP(),
-                      region='europe-west1',
-                      zone='europe-west1-b'),
+        resources_lib.Resources(cloud=clouds.AWS(),
+                                region='us-east-1',
+                                zone='us-east-1a'),
+        resources_lib.Resources(cloud=clouds.AWS(),
+                                region='ap-south-1',
+                                zone='ap-south-1b'),
+        resources_lib.Resources(cloud=clouds.GCP(),
+                                region='us-central1',
+                                zone='us-central1-a'),
+        resources_lib.Resources(cloud=clouds.GCP(),
+                                region='europe-west1',
+                                zone='europe-west1-b'),
     ]
     expected_infra_set = {
         'aws/us-east-1/us-east-1a',
@@ -186,9 +192,9 @@ def test_get_controller_resources_with_task_resources(
     controller_resources = controller_utils.get_controller_resources(
         controller=controller_utils.Controllers.from_type(controller_type),
         task_resources=[
-            sky.Resources(infra='aws/us-west-2'),
-            sky.Resources(infra='aws/us-west-2/us-west-2b'),
-            sky.Resources(infra='gcp/us-central1/us-central1-a')
+            resources_lib.Resources(infra='aws/us-west-2'),
+            resources_lib.Resources(infra='aws/us-west-2/us-west-2b'),
+            resources_lib.Resources(infra='gcp/us-central1/us-central1-a')
         ])
     expected_infra_set = {
         'aws/us-west-2',
@@ -204,14 +210,14 @@ def test_get_controller_resources_with_task_resources(
     controller_resources = controller_utils.get_controller_resources(
         controller=controller_utils.Controllers.from_type(controller_type),
         task_resources=[
-            sky.Resources(cloud=sky.GCP(), region='europe-west1'),
-            sky.Resources(cloud=sky.GCP()),
-            sky.Resources(cloud=sky.AWS(),
-                          region='eu-north-1',
-                          zone='eu-north-1a'),
-            sky.Resources(cloud=sky.AWS(), region='eu-north-1'),
-            sky.Resources(cloud=sky.AWS(), region='ap-south-1'),
-            sky.Resources(cloud=sky.Azure()),
+            resources_lib.Resources(cloud=clouds.GCP(), region='europe-west1'),
+            resources_lib.Resources(cloud=clouds.GCP()),
+            resources_lib.Resources(cloud=clouds.AWS(),
+                                    region='eu-north-1',
+                                    zone='eu-north-1a'),
+            resources_lib.Resources(cloud=clouds.AWS(), region='eu-north-1'),
+            resources_lib.Resources(cloud=clouds.AWS(), region='ap-south-1'),
+            resources_lib.Resources(cloud=clouds.Azure()),
         ])
     expected_infra_set = {
         'aws/eu-north-1',

--- a/tests/unit_tests/test_dag.py
+++ b/tests/unit_tests/test_dag.py
@@ -1,31 +1,32 @@
 """Unit tests for sky.dag."""
 import pytest
 
-import sky
+from sky import dag as dag_lib
+from sky import task as task_lib
 
 
 @pytest.fixture
 def empty_dag():
     """Fixture for an empty DAG."""
-    with sky.Dag() as dag:
+    with dag_lib.Dag() as dag:
         yield dag
 
 
 @pytest.fixture
 def single_task_dag():
     """Fixture for a DAG with single task."""
-    with sky.Dag() as dag:
-        sky.Task()
+    with dag_lib.Dag() as dag:
+        task_lib.Task()
         yield dag
 
 
 @pytest.fixture
 def linear_three_task_dag():
     """Fixture for a DAG with three tasks in a linear chain."""
-    with sky.Dag() as dag:
-        task1 = sky.Task()
-        task2 = sky.Task()
-        task3 = sky.Task()
+    with dag_lib.Dag() as dag:
+        task1 = task_lib.Task()
+        task2 = task_lib.Task()
+        task3 = task_lib.Task()
         dag.add_edge(task1, task2)
         dag.add_edge(task2, task3)
         yield dag
@@ -34,8 +35,8 @@ def linear_three_task_dag():
 @pytest.fixture
 def branching_dag():
     """Fixture for a DAG with one task branching into two tasks."""
-    with sky.Dag() as dag:
-        dag._tasks = [sky.Task() for _ in range(3)]
+    with dag_lib.Dag() as dag:
+        dag._tasks = [task_lib.Task() for _ in range(3)]
         dag.add_edge(dag.tasks[0], dag.tasks[1])
         dag.add_edge(dag.tasks[0], dag.tasks[2])
         yield dag
@@ -44,8 +45,8 @@ def branching_dag():
 @pytest.fixture
 def merging_dag():
     """Fixture for a DAG with two tasks merging into one task."""
-    with sky.Dag() as dag:
-        dag._tasks = [sky.Task() for _ in range(3)]
+    with dag_lib.Dag() as dag:
+        dag._tasks = [task_lib.Task() for _ in range(3)]
         dag.add_edge(dag.tasks[0], dag.tasks[2])
         dag.add_edge(dag.tasks[1], dag.tasks[2])
         yield dag
@@ -54,8 +55,8 @@ def merging_dag():
 @pytest.fixture
 def multi_parent_dag():
     """Fixture for a DAG with two tasks merging into one task."""
-    with sky.Dag() as dag:
-        dag._tasks = [sky.Task() for _ in range(3)]
+    with dag_lib.Dag() as dag:
+        dag._tasks = [task_lib.Task() for _ in range(3)]
         dag.add_edge(dag.tasks[0], dag.tasks[2])
         dag.add_edge(dag.tasks[1], dag.tasks[2])
         yield dag
@@ -64,8 +65,8 @@ def multi_parent_dag():
 @pytest.fixture
 def diamond_dag():
     """Fixture for a diamond-shaped DAG: A -> (B,C) -> D."""
-    with sky.Dag() as dag:
-        dag._tasks = [sky.Task() for _ in range(4)]
+    with dag_lib.Dag() as dag:
+        dag._tasks = [task_lib.Task() for _ in range(4)]
         dag.add_edge(dag.tasks[0], dag.tasks[1])
         dag.add_edge(dag.tasks[0], dag.tasks[2])
         dag.add_edge(dag.tasks[1], dag.tasks[3])
@@ -76,9 +77,9 @@ def diamond_dag():
 @pytest.fixture
 def cyclic_dag():
     """Fixture for a DAG with a cycle (invalid DAG)."""
-    with sky.Dag() as dag:
-        task1 = sky.Task()
-        task2 = sky.Task()
+    with dag_lib.Dag() as dag:
+        task1 = task_lib.Task()
+        task2 = task_lib.Task()
         dag.add_edge(task1, task2)
         dag.add_edge(task2, task1)  # Create cycle
         yield dag

--- a/tests/unit_tests/test_dag_utils.py
+++ b/tests/unit_tests/test_dag_utils.py
@@ -4,8 +4,7 @@ import textwrap
 import pytest
 import yaml
 
-import sky
-from sky import jobs
+from sky import task as task_lib
 from sky.utils import dag_utils
 from sky.utils import registry
 
@@ -17,7 +16,7 @@ def test_jobs_recovery_fill_default_values():
             cpus: 2+
         """)
     task_config = yaml.safe_load(task_str)
-    task = sky.Task.from_yaml_config(task_config)
+    task = task_lib.Task.from_yaml_config(task_config)
     dag = dag_utils.convert_entrypoint_to_dag(task)
     dag_utils.fill_default_config_in_dag_for_job_launch(dag)
 
@@ -34,7 +33,7 @@ def test_jobs_recovery_fill_default_values():
         """)
 
     task_config = yaml.safe_load(task_str)
-    task = sky.Task.from_yaml_config(task_config)
+    task = task_lib.Task.from_yaml_config(task_config)
     dag = dag_utils.convert_entrypoint_to_dag(task)
     dag_utils.fill_default_config_in_dag_for_job_launch(dag)
 
@@ -53,7 +52,7 @@ def test_jobs_recovery_fill_default_values():
         """)
 
     task_config = yaml.safe_load(task_str)
-    task = sky.Task.from_yaml_config(task_config)
+    task = task_lib.Task.from_yaml_config(task_config)
     dag = dag_utils.convert_entrypoint_to_dag(task)
     dag_utils.fill_default_config_in_dag_for_job_launch(dag)
 
@@ -69,7 +68,7 @@ def test_jobs_recovery_fill_default_values():
         """)
 
     task_config = yaml.safe_load(task_str)
-    task = sky.Task.from_yaml_config(task_config)
+    task = task_lib.Task.from_yaml_config(task_config)
     dag = dag_utils.convert_entrypoint_to_dag(task)
     dag_utils.fill_default_config_in_dag_for_job_launch(dag)
 
@@ -89,7 +88,7 @@ def test_jobs_recovery_fill_default_values():
         """)
 
     task_config = yaml.safe_load(task_str)
-    task = sky.Task.from_yaml_config(task_config)
+    task = task_lib.Task.from_yaml_config(task_config)
     dag = dag_utils.convert_entrypoint_to_dag(task)
     with pytest.raises(ValueError):
         dag_utils.fill_default_config_in_dag_for_job_launch(dag)

--- a/tests/unit_tests/test_sky/server/test_sdk_types.py
+++ b/tests/unit_tests/test_sky/server/test_sdk_types.py
@@ -2,7 +2,6 @@
 
 from typing import Callable, ForwardRef
 
-import sky
 from sky import catalog
 from sky import check
 from sky import core

--- a/tests/unit_tests/test_sky/test_cli_git_repo.py
+++ b/tests/unit_tests/test_sky/test_cli_git_repo.py
@@ -7,12 +7,11 @@ import unittest.mock as mock
 
 import pytest
 
-import sky
 from sky import exceptions
+from sky import task as task_lib
 from sky.client.cli import command
 from sky.client.cli import git
 from sky.utils import git as git_utils
-from sky.utils import ux_utils
 
 
 class TestUpdateTaskWorkdir:
@@ -20,7 +19,7 @@ class TestUpdateTaskWorkdir:
 
     def test_update_task_workdir_none_workdir_with_git_url(self):
         """Test updating task workdir when workdir is None and git_url is provided."""
-        task = sky.Task(name='test', run='echo hello')
+        task = task_lib.Task(name='test', run='echo hello')
         task.workdir = None
 
         command._update_task_workdir(task, None,
@@ -33,7 +32,7 @@ class TestUpdateTaskWorkdir:
 
     def test_update_task_workdir_none_workdir_no_git_url(self):
         """Test updating task workdir when workdir is None and no git_url is provided."""
-        task = sky.Task(name='test', run='echo hello')
+        task = task_lib.Task(name='test', run='echo hello')
         task.workdir = None
 
         command._update_task_workdir(task, None, None, 'main')
@@ -42,7 +41,7 @@ class TestUpdateTaskWorkdir:
 
     def test_update_task_workdir_none_workdir_with_git_url_none_ref(self):
         """Test updating task workdir when workdir is None, git_url is provided, and ref is None."""
-        task = sky.Task(name='test', run='echo hello')
+        task = task_lib.Task(name='test', run='echo hello')
         task.workdir = None
 
         command._update_task_workdir(task, None,
@@ -54,7 +53,7 @@ class TestUpdateTaskWorkdir:
 
     def test_update_task_workdir_dict_workdir_update_url(self):
         """Test updating task workdir when workdir is a dict and git_url is provided."""
-        task = sky.Task(name='test', run='echo hello')
+        task = task_lib.Task(name='test', run='echo hello')
         task.workdir = {
             'url': 'https://github.com/old/repo.git',
             'ref': 'old_ref'
@@ -70,7 +69,7 @@ class TestUpdateTaskWorkdir:
 
     def test_update_task_workdir_dict_workdir_update_ref(self):
         """Test updating task workdir when workdir is a dict and git_ref is provided."""
-        task = sky.Task(name='test', run='echo hello')
+        task = task_lib.Task(name='test', run='echo hello')
         task.workdir = {
             'url': 'https://github.com/test/repo.git',
             'ref': 'old_ref'
@@ -85,7 +84,7 @@ class TestUpdateTaskWorkdir:
 
     def test_update_task_workdir_dict_workdir_update_both(self):
         """Test updating task workdir when workdir is a dict and both git_url and git_ref are provided."""
-        task = sky.Task(name='test', run='echo hello')
+        task = task_lib.Task(name='test', run='echo hello')
         task.workdir = {
             'url': 'https://github.com/old/repo.git',
             'ref': 'old_ref'
@@ -102,7 +101,7 @@ class TestUpdateTaskWorkdir:
 
     def test_update_task_workdir_string_workdir(self):
         """Test updating task workdir when workdir is a string."""
-        task = sky.Task(name='test', run='echo hello')
+        task = task_lib.Task(name='test', run='echo hello')
         task.workdir = '/some/local/path'
 
         command._update_task_workdir(task, None,
@@ -115,7 +114,7 @@ class TestUpdateTaskWorkdir:
 
     def test_update_task_workdir_string_workdir_update(self):
         """Test updating task workdir when workdir is a string and override workdir is provided."""
-        task = sky.Task(name='test', run='echo hello')
+        task = task_lib.Task(name='test', run='echo hello')
         task.workdir = '/some/local/path'
 
         command._update_task_workdir(task, "abcd",
@@ -125,7 +124,7 @@ class TestUpdateTaskWorkdir:
 
     def test_update_task_workdir_no_changes(self):
         """Test updating task workdir when no git_url or git_ref is provided."""
-        task = sky.Task(name='test', run='echo hello')
+        task = task_lib.Task(name='test', run='echo hello')
         task.workdir = {
             'url': 'https://github.com/test/repo.git',
             'ref': 'main'
@@ -144,7 +143,7 @@ class TestUpdateTaskWorkdirAndSecretsFromWorkdir:
 
     def test_update_task_workdir_and_secrets_none_workdir(self):
         """Test updating task secrets when workdir is None."""
-        task = sky.Task(name='test', run='echo hello')
+        task = task_lib.Task(name='test', run='echo hello')
         task.workdir = None
 
         command._update_task_workdir_and_secrets_from_workdir(task)
@@ -154,7 +153,7 @@ class TestUpdateTaskWorkdirAndSecretsFromWorkdir:
 
     def test_update_task_workdir_and_secrets_string_workdir(self):
         """Test updating task secrets when workdir is a string."""
-        task = sky.Task(name='test', run='echo hello')
+        task = task_lib.Task(name='test', run='echo hello')
         task.workdir = '/some/local/path'
 
         command._update_task_workdir_and_secrets_from_workdir(task)
@@ -170,7 +169,7 @@ class TestUpdateTaskWorkdirAndSecretsFromWorkdir:
         os.environ[git_utils.GIT_TOKEN_ENV_VAR] = 'test_token'
 
         # Set up task
-        task = sky.Task(name='test', run='echo hello')
+        task = task_lib.Task(name='test', run='echo hello')
         task.workdir = {
             'url': 'https://github.com/test/repo.git',
             'ref': 'main'
@@ -208,7 +207,7 @@ class TestUpdateTaskWorkdirAndSecretsFromWorkdir:
         os.environ[git_utils.GIT_SSH_KEY_PATH_ENV_VAR] = '/path/to/ssh/key'
 
         # Set up task
-        task = sky.Task(name='test', run='echo hello')
+        task = task_lib.Task(name='test', run='echo hello')
         task.workdir = {
             'url': 'ssh://git@github.com/test/repo.git',
             'ref': 'main'
@@ -248,7 +247,7 @@ class TestUpdateTaskWorkdirAndSecretsFromWorkdir:
         os.environ[git_utils.GIT_TOKEN_ENV_VAR] = 'test_token'
 
         # Set up task
-        task = sky.Task(name='test', run='echo hello')
+        task = task_lib.Task(name='test', run='echo hello')
         task.workdir = {
             'url': 'https://github.com/test/repo.git',
             'ref': 'a1b2c3d4e5f6'
@@ -281,7 +280,7 @@ class TestUpdateTaskWorkdirAndSecretsFromWorkdir:
         os.environ[git_utils.GIT_TOKEN_ENV_VAR] = 'test_token'
 
         # Set up task
-        task = sky.Task(name='test', run='echo hello')
+        task = task_lib.Task(name='test', run='echo hello')
         task.workdir = {
             'url': 'https://github.com/test/repo.git',
             'ref': 'v1.0.0'
@@ -314,7 +313,7 @@ class TestUpdateTaskWorkdirAndSecretsFromWorkdir:
         os.environ[git_utils.GIT_TOKEN_ENV_VAR] = 'test_token'
 
         # Set up task
-        task = sky.Task(name='test', run='echo hello')
+        task = task_lib.Task(name='test', run='echo hello')
         task.workdir = {'url': 'https://github.com/test/repo.git'}
 
         # Mock GitRepo and clone info
@@ -345,7 +344,7 @@ class TestUpdateTaskWorkdirAndSecretsFromWorkdir:
         os.environ[git_utils.GIT_TOKEN_ENV_VAR] = 'test_token'
 
         # Set up task
-        task = sky.Task(name='test', run='echo hello')
+        task = task_lib.Task(name='test', run='echo hello')
         task.workdir = {
             'url': 'https://github.com/test/repo.git',
             'ref': 'main'
@@ -368,7 +367,7 @@ class TestUpdateTaskWorkdirAndSecretsFromWorkdir:
     def test_update_task_workdir_and_secrets_no_auth(self, mock_git_repo):
         """Test updating task secrets when no authentication is available."""
         # Set up task
-        task = sky.Task(name='test', run='echo hello')
+        task = task_lib.Task(name='test', run='echo hello')
         task.workdir = {
             'url': 'https://github.com/test/repo.git',
             'ref': 'main'
@@ -406,7 +405,7 @@ class TestUpdateTaskWorkdirAndSecretsFromWorkdir:
         os.environ[git_utils.GIT_TOKEN_ENV_VAR] = 'test_token'
 
         # Set up task
-        task = sky.Task(name='test', run='echo hello')
+        task = task_lib.Task(name='test', run='echo hello')
         task.workdir = {
             'url': 'https://github.com/test/repo.git',
             'ref': 'main'
@@ -431,7 +430,7 @@ class TestUpdateTaskWorkdirAndSecretsFromWorkdir:
         os.environ[git_utils.GIT_SSH_KEY_PATH_ENV_VAR] = '/path/to/ssh/key'
 
         # Set up task
-        task = sky.Task(name='test', run='echo hello')
+        task = task_lib.Task(name='test', run='echo hello')
         task.workdir = {
             'url': 'https://github.com/test/repo.git',
             'ref': 'main'

--- a/tests/unit_tests/test_sky/test_task.py
+++ b/tests/unit_tests/test_sky/test_task.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-import sky
+from sky import resources as resources_lib
 from sky import exceptions
 from sky import task
 
@@ -537,8 +537,6 @@ def test_from_yaml_config_env_and_secrets_overrides_independent():
 
 def test_docker_login_config_all_in_envs_or_secrets():
     """Test Docker login config when all variables are in envs OR all in secrets."""
-    import sky
-    from sky.skylet import constants
 
     # Test 1: All in envs (should work)
     task_obj1 = task.Task(name='test-docker-all-envs',
@@ -550,7 +548,7 @@ def test_docker_login_config_all_in_envs_or_secrets():
                           })
 
     # Verify Docker config validation passes
-    resources = sky.Resources(image_id='docker:nginx:latest')
+    resources = resources_lib.Resources(image_id='docker:nginx:latest')
     task_obj1.set_resources(resources)  # Should not raise an error
 
     # Test 2: All in secrets (should work)
@@ -562,7 +560,7 @@ def test_docker_login_config_all_in_envs_or_secrets():
                               'SKYPILOT_DOCKER_PASSWORD': 'secret-password'
                           })
 
-    task_obj2.set_resources(sky.Resources(image_id='docker:ubuntu:latest'))
+    task_obj2.set_resources(resources_lib.Resources(image_id='docker:ubuntu:latest'))
 
     # Test 3: Split across envs and secrets should fail
     with pytest.raises(
@@ -576,7 +574,7 @@ def test_docker_login_config_all_in_envs_or_secrets():
                 'SKYPILOT_DOCKER_SERVER': 'registry.com'
             },
             secrets={'SKYPILOT_DOCKER_PASSWORD': 'secret-password'})
-        task_obj3.set_resources(sky.Resources())
+        task_obj3.set_resources(resources_lib.Resources())
 
     # Test 4: Missing variables in envs should fail
     with pytest.raises(
@@ -590,7 +588,7 @@ def test_docker_login_config_all_in_envs_or_secrets():
                 'SKYPILOT_DOCKER_SERVER': 'registry.com'
                 # Missing SKYPILOT_DOCKER_PASSWORD
             })
-        task_obj4.set_resources(sky.Resources())
+        task_obj4.set_resources(resources_lib.Resources())
 
     # Test 5: Missing variables in secrets should fail
     with pytest.raises(
@@ -603,18 +601,16 @@ def test_docker_login_config_all_in_envs_or_secrets():
                 'SKYPILOT_DOCKER_USERNAME': 'user',
                 # Missing SKYPILOT_DOCKER_PASSWORD and SKYPILOT_DOCKER_SERVER
             })
-        task_obj5.set_resources(sky.Resources())
+        task_obj5.set_resources(resources_lib.Resources())
 
 
 def test_docker_login_config_update_methods():
     """Test Docker login config validation when using update_envs and update_secrets."""
-    import sky
-
     # Test 1: Add complete Docker config to envs all at once - should work
     task_obj = task.Task(name='test-docker-update-envs', run='echo hello')
 
     # Set resources first (no Docker config yet)
-    task_obj.set_resources(sky.Resources())
+    task_obj.set_resources(resources_lib.Resources())
 
     # Add all Docker vars to envs at once - should work
     task_obj.update_envs({
@@ -631,7 +627,7 @@ def test_docker_login_config_update_methods():
 
     # Test 2: Add complete Docker config to secrets all at once - should work
     task_obj2 = task.Task(name='test-docker-update-secrets', run='echo hello')
-    task_obj2.set_resources(sky.Resources())
+    task_obj2.set_resources(resources_lib.Resources())
 
     # Add all Docker vars to secrets at once - should work
     task_obj2.update_secrets({
@@ -642,7 +638,7 @@ def test_docker_login_config_update_methods():
 
     # Test 3: Updating incomplete Docker config should fail
     task_obj3 = task.Task(name='test-incomplete', run='echo hello')
-    task_obj3.set_resources(sky.Resources())
+    task_obj3.set_resources(resources_lib.Resources())
 
     # Add only some Docker vars - this should fail
     with pytest.raises(
@@ -657,8 +653,6 @@ def test_docker_login_config_update_methods():
 
 def test_docker_login_config_no_mixed_envs_secrets():
     """Test that Docker variables cannot be mixed between envs and secrets."""
-    import sky
-
     # This should fail because Docker variables are split between envs and secrets
     with pytest.raises(
             ValueError,
@@ -671,7 +665,7 @@ def test_docker_login_config_no_mixed_envs_secrets():
                 'SKYPILOT_DOCKER_SERVER': 'env-registry.com'
             },
             secrets={'SKYPILOT_DOCKER_PASSWORD': 'secret-password'})
-        task_obj.set_resources(sky.Resources(image_id='docker:ubuntu:latest'))
+        task_obj.set_resources(resources_lib.Resources(image_id='docker:ubuntu:latest'))
 
 
 def make_mock_volume_config(name='vol1',

--- a/tests/unit_tests/test_sky/test_task.py
+++ b/tests/unit_tests/test_sky/test_task.py
@@ -4,9 +4,10 @@ from unittest import mock
 
 import pytest
 
-from sky import resources as resources_lib
 from sky import exceptions
+from sky import resources as resources_lib
 from sky import task
+from sky.utils import registry
 
 
 def test_validate_workdir():
@@ -560,7 +561,8 @@ def test_docker_login_config_all_in_envs_or_secrets():
                               'SKYPILOT_DOCKER_PASSWORD': 'secret-password'
                           })
 
-    task_obj2.set_resources(resources_lib.Resources(image_id='docker:ubuntu:latest'))
+    task_obj2.set_resources(
+        resources_lib.Resources(image_id='docker:ubuntu:latest'))
 
     # Test 3: Split across envs and secrets should fail
     with pytest.raises(
@@ -665,7 +667,8 @@ def test_docker_login_config_no_mixed_envs_secrets():
                 'SKYPILOT_DOCKER_SERVER': 'env-registry.com'
             },
             secrets={'SKYPILOT_DOCKER_PASSWORD': 'secret-password'})
-        task_obj.set_resources(resources_lib.Resources(image_id='docker:ubuntu:latest'))
+        task_obj.set_resources(
+            resources_lib.Resources(image_id='docker:ubuntu:latest'))
 
 
 def make_mock_volume_config(name='vol1',
@@ -739,7 +742,7 @@ def test_resolve_volumes_single_success():
         t.resolve_and_validate_volumes()
         # Should override resource topology
         for r in t.resources:
-            assert r.cloud == sky.CLOUD_REGISTRY.from_str('aws')
+            assert r.cloud == registry.CLOUD_REGISTRY.from_str('aws')
             assert r.region == 'us-west1'
             assert r.zone == 'a'
 
@@ -766,7 +769,7 @@ def test_resolve_volumes_dict_volume_success():
         }
         t.resolve_and_validate_volumes()
         for r in t.resources:
-            assert r.cloud == sky.CLOUD_REGISTRY.from_str('aws')
+            assert r.cloud == registry.CLOUD_REGISTRY.from_str('aws')
 
 
 def test_resolve_volumes_topology_conflict_between_volumes():
@@ -811,6 +814,6 @@ def test_resolve_volumes_override_topology():
         }
         t.resolve_and_validate_volumes()
         for r in t.resources:
-            assert r.cloud == sky.CLOUD_REGISTRY.from_str('aws')
+            assert r.cloud == registry.CLOUD_REGISTRY.from_str('aws')
             assert r.region == 'us-west1'
             assert r.zone == 'a'

--- a/tests/unit_tests/test_sky/utils/test_cli_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_cli_utils.py
@@ -6,7 +6,6 @@ import time
 
 import pytest
 
-import sky
 from sky import backends
 from sky.resources import Resources
 from sky.utils import status_lib


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
We want to reduce the use of `import sky` unless necessary. This PR removes `import sky` from 7 test files. Further work will continue to reduce the use of `import sky` in the future.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
