### PR TITLE
standardize import statement format

### DIFF
--- a/sky/catalog/cudo_catalog.py
+++ b/sky/catalog/cudo_catalog.py
@@ -4,7 +4,7 @@ import typing
 from typing import Dict, List, Optional, Tuple, Union
 
 from sky.catalog import common
-import sky.provision.cudo.cudo_machine_type as cudo_mt
+from sky.provision.cudo import cudo_machine_type as cudo_mt
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:

--- a/sky/catalog/data_fetchers/fetch_cudo.py
+++ b/sky/catalog/data_fetchers/fetch_cudo.py
@@ -9,7 +9,7 @@ import os
 
 import cudo_compute
 
-import sky.provision.cudo.cudo_utils as utils
+from sky.provision.cudo import cudo_utils as utils
 
 VMS_CSV = 'cudo/vms.csv'
 

--- a/sky/client/common.py
+++ b/sky/client/common.py
@@ -32,7 +32,7 @@ if typing.TYPE_CHECKING:
     import requests
 
     import sky
-    import sky.dag as dag_lib
+    from sky import dag as dag_lib
 else:
     httpx = adaptors_common.LazyImport('httpx')
     requests = adaptors_common.LazyImport('requests')

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -67,8 +67,8 @@ if typing.TYPE_CHECKING:
 
     import sky
     from sky import backends
+    from sky import catalog
     from sky import models
-    import sky.catalog
     from sky.provision.kubernetes import utils as kubernetes_utils
     from sky.skylet import job_lib
 else:
@@ -235,7 +235,7 @@ def list_accelerators(
     require_price: bool = True,
     case_sensitive: bool = True
 ) -> server_common.RequestId[Dict[str,
-                                  List['sky.catalog.common.InstanceTypeInfo']]]:
+                                  List['catalog.common.InstanceTypeInfo']]]:
     """Lists the names of all accelerators offered by Sky.
 
     This will include all accelerators offered by Sky, including those

--- a/sky/client/sdk_async.py
+++ b/sky/client/sdk_async.py
@@ -20,10 +20,10 @@ import colorama
 
 from sky import admin_policy
 from sky import backends
+from sky import catalog
 from sky import exceptions
 from sky import models
 from sky import sky_logging
-import sky.catalog
 from sky.client import common as client_common
 from sky.client import sdk
 from sky.provision.kubernetes import utils as kubernetes_utils
@@ -302,7 +302,7 @@ async def list_accelerators(
     require_price: bool = True,
     case_sensitive: bool = True,
     stream_logs: Optional[StreamConfig] = DEFAULT_STREAM_CONFIG
-) -> Dict[str, List[sky.catalog.common.InstanceTypeInfo]]:
+) -> Dict[str, List[catalog.common.InstanceTypeInfo]]:
     """Async version of list_accelerators() that lists the names of all
     accelerators offered by Sky."""
     request_id = await context_utils.to_thread(sdk.list_accelerators, gpus_only,
@@ -346,7 +346,7 @@ async def optimize(
         admin_policy_request_options: Optional[
             admin_policy.RequestOptions] = None,
         stream_logs: Optional[StreamConfig] = DEFAULT_STREAM_CONFIG
-) -> sky.dag.Dag:
+) -> 'sky.Dag':
     """Async version of optimize() that finds the best execution plan for the
       given DAG."""
     request_id = await context_utils.to_thread(sdk.optimize, dag, minimize,

--- a/sky/provision/cudo/cudo_wrapper.py
+++ b/sky/provision/cudo/cudo_wrapper.py
@@ -4,7 +4,7 @@ from typing import Dict
 
 from sky import sky_logging
 from sky.adaptors import cudo
-import sky.provision.cudo.cudo_utils as utils
+from sky.provision.cudo import cudo_utils as utils
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/provision/paperspace/utils.py
+++ b/sky/provision/paperspace/utils.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from sky import sky_logging
 from sky.adaptors import common as adaptors_common
-import sky.provision.paperspace.constants as constants
+from sky.provision.paperspace import constants
 from sky.utils import common_utils
 
 if typing.TYPE_CHECKING:

--- a/sky/provision/runpod/utils.py
+++ b/sky/provision/runpod/utils.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from sky import sky_logging
 from sky.adaptors import runpod
 from sky.provision import docker_utils
-import sky.provision.runpod.api.commands as runpod_commands
+from sky.provision.runpod.api import commands as runpod_commands
 from sky.skylet import constants
 from sky.utils import common_utils
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Avoid using `import sky.x.y.z`, instead use `from sky.x.y import z`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
