### PR TITLE
[Core] Lazy import autostopv1_pb2

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2833,16 +2833,16 @@ class SkyletClient:
 
     def set_autostop(
         self,
-        request: autostopv1_pb2.SetAutostopRequest,
+        request: 'autostopv1_pb2.SetAutostopRequest',
         timeout: float = constants.SKYLET_GRPC_TIMEOUT_SECONDS
-    ) -> autostopv1_pb2.SetAutostopResponse:
+    ) -> 'autostopv1_pb2.SetAutostopResponse':
         return self._autostop_stub.SetAutostop(request, timeout=timeout)
 
     def is_autostopping(
         self,
-        request: autostopv1_pb2.IsAutostoppingRequest,
+        request: 'autostopv1_pb2.IsAutostoppingRequest',
         timeout: float = constants.SKYLET_GRPC_TIMEOUT_SECONDS
-    ) -> autostopv1_pb2.IsAutostoppingResponse:
+    ) -> 'autostopv1_pb2.IsAutostoppingResponse':
         return self._autostop_stub.IsAutostopping(request, timeout=timeout)
 
 

--- a/sky/skylet/autostop_lib.py
+++ b/sky/skylet/autostop_lib.py
@@ -9,7 +9,6 @@ from typing import List, Optional
 
 from sky import sky_logging
 from sky.adaptors import common as adaptors_common
-from sky.schemas.generated import autostopv1_pb2
 from sky.skylet import configs
 from sky.skylet import constants
 from sky.utils import message_utils
@@ -17,8 +16,13 @@ from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
     import psutil
+
+    from sky.schemas.generated import autostopv1_pb2
 else:
     psutil = adaptors_common.LazyImport('psutil')
+    # To avoid requiring protobuf to be installed on the client side.
+    autostopv1_pb2 = adaptors_common.LazyImport(
+        'sky.schemas.generated.autostopv1_pb2')
 
 logger = sky_logging.init_logger(__name__)
 
@@ -81,7 +85,7 @@ jobs or SSH connections."""
 
     @classmethod
     def from_protobuf(
-        cls, protobuf_value: autostopv1_pb2.AutostopWaitFor
+        cls, protobuf_value: 'autostopv1_pb2.AutostopWaitFor'
     ) -> Optional['AutostopWaitFor']:
         """Convert protobuf AutostopWaitFor enum to Python enum value."""
         protobuf_to_enum = {
@@ -96,7 +100,7 @@ jobs or SSH connections."""
                     f'Unknown protobuf AutostopWaitFor value: {protobuf_value}')
         return protobuf_to_enum[protobuf_value]
 
-    def to_protobuf(self) -> autostopv1_pb2.AutostopWaitFor:
+    def to_protobuf(self) -> 'autostopv1_pb2.AutostopWaitFor':
         """Convert this Python enum value to protobuf enum value."""
         enum_to_protobuf = {
             AutostopWaitFor.JOBS_AND_SSH:


### PR DESCRIPTION
PR #6640 only fixes it for GCP and Nebius, because they have `protobuf` as a dependency by default. [AWS](https://github.com/skypilot-org/skypilot-catalog/actions/runs/16930479294/job/47974652935), [Hyperbolic](https://github.com/skypilot-org/skypilot-catalog/actions/runs/16930282272), [Lambda](https://github.com/skypilot-org/skypilot-catalog/actions/runs/16930317068), and a few others are still failing because they don't have protobuf installed.

This PR fixes this by lazy importing `autostopv1_pb2` in `autostop_lib`.

The import stack:
```
Traceback (most recent call last):
  File "/home/runner/.local/share/uv/python/cpython-3.10.18-linux-x86_64-gnu/lib/python3.10/runpy.py", line 187, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/home/runner/.local/share/uv/python/cpython-3.10.18-linux-x86_64-gnu/lib/python3.10/runpy.py", line 110, in _get_module_details
    __import__(pkg_name)
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/sky/__init__.py", line 83, in <module>
    from sky import backends
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/sky/backends/__init__.py", line 2, in <module>
    from sky.backends.backend import Backend
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/sky/backends/backend.py", line 5, in <module>
    from sky.usage import usage_lib
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/sky/usage/usage_lib.py", line 341, in <module>
    messages = MessageCollection()
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/sky/usage/usage_lib.py", line 316, in __init__
    MessageType.USAGE: UsageMessageToReport(),
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/sky/usage/usage_lib.py", line 172, in __init__
    common_utils.get_using_remote_api_server())
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/sky/utils/common_utils.py", line 358, in get_using_remote_api_server
    from sky.server import common as server_common
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/sky/server/common.py", line 31, in <module>
    from sky import skypilot_config
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/sky/skypilot_config.py", line 76, in <module>
    from sky.utils import schemas
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/sky/utils/schemas.py", line 9, in <module>
    from sky.skylet import autostop_lib
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/sky/skylet/autostop_lib.py", line 12, in <module>
    from sky.schemas.generated import autostopv1_pb2
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/sky/schemas/generated/autostopv1_pb2.py", line 6, in <module>
    from google.protobuf import descriptor as _descriptor
ModuleNotFoundError: No module named 'google'
```

Tested locally that the AWS fetcher is working again, withhout `protobuf` installed:
```bash
% pip show protobuf
WARNING: Package(s) not found: protobuf
% python -m sky.catalog.data_fetchers.fetch_aws
us-east-2 downloading pricing table
us-east-2 downloading spot pricing table
us-east-1 downloading pricing table
```

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
