### PR TITLE
do not import sky in admin policy

### DIFF
--- a/sky/admin_policy.py
+++ b/sky/admin_policy.py
@@ -14,7 +14,6 @@ from sky.utils import common_utils
 from sky.utils import config_utils
 from sky.utils import ux_utils
 from sky.utils import yaml_utils
-from sky import task as task_lib
 
 if typing.TYPE_CHECKING:
     import requests

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -27,7 +27,6 @@ import os
 import typing
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from sky import admin_policy
 from sky import serve
 from sky import sky_logging
 from sky import skypilot_config
@@ -44,8 +43,11 @@ from sky.utils import registry
 
 if typing.TYPE_CHECKING:
     import pydantic
+
+    from sky import admin_policy
 else:
     pydantic = adaptors_common.LazyImport('pydantic')
+    admin_policy = adaptors_common.LazyImport('sky.admin_policy')
 
 logger = sky_logging.init_logger(__name__)
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Importing `sky` module is heavy because `sky` module's `__init__.py` imports a lot of usually unnecessary modules. By only importing what is actually needed, we can simplify the dependency graph.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
