### PR TITLE
[Dashboard] Prevent tour auto-start in new tabs by using localStorage for first-visit flag

### DIFF
--- a/sky/dashboard/src/hooks/useFirstVisit.js
+++ b/sky/dashboard/src/hooks/useFirstVisit.js
@@ -11,13 +11,13 @@ export function useFirstVisit() {
   useEffect(() => {
     setIsClient(true);
 
-    // Check if this is the first visit using sessionStorage for incognito compatibility
-    const hasVisited = sessionStorage.getItem(FIRST_VISIT_KEY);
+    // Check if this is the first visit using localStorage to share across tabs
+    const hasVisited = localStorage.getItem(FIRST_VISIT_KEY);
     const hasTourCompleted = localStorage.getItem(TOUR_COMPLETED_KEY);
 
     if (!hasVisited) {
       setIsFirstVisit(true);
-      sessionStorage.setItem(FIRST_VISIT_KEY, 'true');
+      localStorage.setItem(FIRST_VISIT_KEY, 'true');
     }
 
     if (hasTourCompleted) {
@@ -31,7 +31,7 @@ export function useFirstVisit() {
   };
 
   const resetFirstVisit = () => {
-    sessionStorage.removeItem(FIRST_VISIT_KEY);
+    localStorage.removeItem(FIRST_VISIT_KEY);
     localStorage.removeItem(TOUR_COMPLETED_KEY);
     setIsFirstVisit(true);
     setTourCompleted(false);


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

### Description

Resolve #6542

**Problem:**  
After restoring tour auto-start in #6565, opening a new browser tab triggers the tour again. It should only auto-start once per browser profile/session.

**Root cause:**  
`FIRST_VISIT_KEY` was stored in `sessionStorage`, which is scoped per tab. Each new tab appeared as a "first visit."

**Change:**  
Switch `FIRST_VISIT_KEY` from `sessionStorage` to `localStorage` to share state across tabs.

**Behavior:**
- Tour auto-starts only once across all tabs for the same browser profile.
- Manual start via the help button still works.
- Completion is still tracked via `TOUR_COMPLETED_KEY` in `localStorage`.

### Files Changed
`sky/dashboard/src/hooks/useFirstVisit.js`
- Read/write/remove `FIRST_VISIT_KEY` from `localStorage` instead of `sessionStorage`.
- Updated inline comment to reflect cross-tab behavior.

### Testing
1. Open the dashboard in one tab: tour auto-starts once.
2. Open a second tab (same profile): tour does not auto-start.
3. Click "Dismiss" on the prompt: no further prompts.
4. Manually start tour via help button: works.
5. After completion, refresh and open new tabs: tour does not reappear.

<img width="2984" height="1110" alt="image" src="https://github.com/user-attachments/assets/5866a97e-9aa5-45d4-a119-f2c7970ae1cf" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
