### PR TITLE
[UX] Provide last event info for clusters stored in cluster_history

### DIFF
--- a/sky/backends/backend.py
+++ b/sky/backends/backend.py
@@ -147,8 +147,9 @@ class Backend(Generic[_ResourceHandleType]):
     def teardown(self,
                  handle: _ResourceHandleType,
                  terminate: bool,
-                 purge: bool = False) -> None:
-        self._teardown(handle, terminate, purge)
+                 purge: bool = False,
+                 explicitly_requested: bool = False) -> None:
+        self._teardown(handle, terminate, purge, explicitly_requested)
 
     def register_info(self, **kwargs) -> None:
         """Register backend-specific information."""
@@ -200,5 +201,6 @@ class Backend(Generic[_ResourceHandleType]):
     def _teardown(self,
                   handle: _ResourceHandleType,
                   terminate: bool,
-                  purge: bool = False):
+                  purge: bool = False,
+                  explicitly_requested: bool = False):
         raise NotImplementedError

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2017,7 +2017,15 @@ def _update_cluster_status(cluster_name: str) -> Optional[Dict[str, Any]]:
     if handle.cluster_yaml is None:
         # Remove cluster from db since this cluster does not have a config file
         # or any other ongoing requests
-        global_user_state.remove_cluster(cluster_name, terminate=True)
+        global_user_state.add_cluster_event(
+            cluster_name,
+            None,
+            'Cluster has no YAML file. Removing the cluster from cache.',
+            global_user_state.ClusterEventType.STATUS_CHANGE,
+            nop_if_duplicate=True)
+        global_user_state.remove_cluster(cluster_name,
+                                         terminate=True,
+                                         remove_events=True)
         logger.debug(f'Cluster {cluster_name!r} has no YAML file. '
                      'Removing the cluster from cache.')
         return None
@@ -2352,10 +2360,10 @@ def _update_cluster_status(cluster_name: str) -> Optional[Dict[str, Any]]:
     # Now is_abnormal is False: either node_statuses is empty or all nodes are
     # STOPPED.
     backend = backends.CloudVmRayBackend()
-    backend.post_teardown_cleanup(handle, terminate=to_terminate, purge=False)
     global_user_state.add_cluster_event(
         cluster_name, None, 'All nodes stopped, terminating cluster.',
         global_user_state.ClusterEventType.STATUS_CHANGE)
+    backend.post_teardown_cleanup(handle, terminate=to_terminate, purge=False)
     return global_user_state.get_cluster_from_name(cluster_name)
 
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3168,8 +3168,15 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     # Do not remove the stopped cluster from the global state
                     # if failed to start.
                     if not e.no_failover:
+                        global_user_state.add_cluster_event(
+                            cluster_name,
+                            None,
+                            'Provision failed: ' + str(e),
+                            global_user_state.ClusterEventType.STATUS_CHANGE,
+                            nop_if_duplicate=True)
                         global_user_state.remove_cluster(cluster_name,
-                                                         terminate=True)
+                                                         terminate=True,
+                                                         remove_events=False)
                         usage_lib.messages.usage.update_final_cluster_status(
                             None)
                     logger.error(
@@ -4491,7 +4498,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                            f'provision yaml so it '
                            'has not been provisioned. Skipped.')
             global_user_state.remove_cluster(handle.cluster_name,
-                                             terminate=terminate)
+                                             terminate=terminate,
+                                             remove_events=terminate)
             return
         log_path = os.path.join(os.path.expanduser(self.log_dir),
                                 'teardown.log')
@@ -4828,7 +4836,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
         if not terminate or remove_from_db:
             global_user_state.remove_cluster(handle.cluster_name,
-                                             terminate=terminate)
+                                             terminate=terminate,
+                                             remove_events=False)
 
     def remove_cluster_config(self, handle: CloudVmRayResourceHandle) -> None:
         """Remove the YAML config of a cluster."""

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3978,7 +3978,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
     def _teardown(self,
                   handle: CloudVmRayResourceHandle,
                   terminate: bool,
-                  purge: bool = False):
+                  purge: bool = False,
+                  explicitly_requested: bool = False):
         """Tear down or stop the cluster.
 
         Args:
@@ -4053,7 +4054,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                         # ClusterOwnerIdentityMismatchError. The argument/flag
                         # `purge` should bypass such ID mismatch errors.
                         refresh_cluster_status=(
-                            not is_identity_mismatch_and_purge))
+                            not is_identity_mismatch_and_purge),
+                        explicitly_requested=explicitly_requested)
                 if terminate:
                     lock.force_unlock()
                 break
@@ -4434,7 +4436,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                          purge: bool = False,
                          post_teardown_cleanup: bool = True,
                          refresh_cluster_status: bool = True,
-                         remove_from_db: bool = True) -> None:
+                         remove_from_db: bool = True,
+                         explicitly_requested: bool = False) -> None:
         """Teardown the cluster without acquiring the cluster status lock.
 
         NOTE: This method should not be called without holding the cluster
@@ -4499,7 +4502,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                            'has not been provisioned. Skipped.')
             global_user_state.remove_cluster(handle.cluster_name,
                                              terminate=terminate,
-                                             remove_events=terminate)
+                                             remove_events=False)
             return
         log_path = os.path.join(os.path.expanduser(self.log_dir),
                                 'teardown.log')
@@ -4556,8 +4559,12 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     raise
 
             if post_teardown_cleanup:
-                self.post_teardown_cleanup(handle, terminate, purge,
-                                           remove_from_db)
+                self.post_teardown_cleanup(
+                    handle,
+                    terminate,
+                    purge,
+                    remove_from_db,
+                    explicitly_requested=explicitly_requested)
             return
 
         if (isinstance(cloud, clouds.IBM) and terminate and
@@ -4657,7 +4664,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                               terminate: bool,
                               purge: bool = False,
                               remove_from_db: bool = True,
-                              failover: bool = False) -> None:
+                              failover: bool = False,
+                              explicitly_requested: bool = False) -> None:
         """Cleanup local configs/caches and delete TPUs after teardown.
 
         This method will handle the following cleanup steps:
@@ -4837,7 +4845,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         if not terminate or remove_from_db:
             global_user_state.remove_cluster(handle.cluster_name,
                                              terminate=terminate,
-                                             remove_events=False)
+                                             remove_events=explicitly_requested)
 
     def remove_cluster_config(self, handle: CloudVmRayResourceHandle) -> None:
         """Remove the YAML config of a cluster."""

--- a/sky/backends/local_docker_backend.py
+++ b/sky/backends/local_docker_backend.py
@@ -325,7 +325,8 @@ class LocalDockerBackend(backends.Backend['LocalDockerResourceHandle']):
     def _teardown(self,
                   handle: LocalDockerResourceHandle,
                   terminate: bool,
-                  purge: bool = False):
+                  purge: bool = False,
+                  explicitly_requested: bool = False):
         """Teardown kills the container."""
         del purge  # Unused.
         if not terminate:
@@ -343,7 +344,7 @@ class LocalDockerBackend(backends.Backend['LocalDockerResourceHandle']):
 
         global_user_state.remove_cluster(cluster_name,
                                          terminate=True,
-                                         remove_events=False)
+                                         remove_events=explicitly_requested)
 
     # --- Utilities ---
 

--- a/sky/backends/local_docker_backend.py
+++ b/sky/backends/local_docker_backend.py
@@ -256,7 +256,9 @@ class LocalDockerBackend(backends.Backend['LocalDockerResourceHandle']):
                 logger.error(
                     'Unable to run container - nvidia runtime for docker not '
                     'found. Have you installed nvidia-docker on your machine?')
-            global_user_state.remove_cluster(cluster_name, terminate=True)
+            global_user_state.remove_cluster(cluster_name,
+                                             terminate=True,
+                                             remove_events=False)
             raise e
         self.containers[handle] = container
         logger.info(
@@ -339,7 +341,9 @@ class LocalDockerBackend(backends.Backend['LocalDockerResourceHandle']):
             container.remove(force=True)
         cluster_name = handle.get_cluster_name()
 
-        global_user_state.remove_cluster(cluster_name, terminate=True)
+        global_user_state.remove_cluster(cluster_name,
+                                         terminate=True,
+                                         remove_events=False)
 
     # --- Utilities ---
 

--- a/sky/core.py
+++ b/sky/core.py
@@ -596,7 +596,10 @@ def down(cluster_name: str, purge: bool = False) -> None:
 
     usage_lib.record_cluster_name_for_current_operation(cluster_name)
     backend = backend_utils.get_backend_from_handle(handle)
-    backend.teardown(handle, terminate=True, purge=purge)
+    backend.teardown(handle,
+                     terminate=True,
+                     purge=purge,
+                     explicitly_requested=True)
 
 
 @usage_lib.entrypoint

--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -153,6 +153,7 @@ export async function getClusterHistory() {
         total_cost: cluster.total_cost,
         workspace: cluster.workspace || 'default',
         autostop: -1,
+        last_event: cluster.last_event,
         to_down: false,
         usage_intervals: cluster.usage_intervals,
         command: cluster.last_creation_command || '',

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -857,7 +857,8 @@ def update_last_use(cluster_name: str):
 
 
 @_init_db
-def remove_cluster(cluster_name: str, terminate: bool) -> None:
+def remove_cluster(cluster_name: str, terminate: bool,
+                   remove_events: bool) -> None:
     """Removes cluster_name mapping."""
     assert _SQLALCHEMY_ENGINE is not None
     cluster_hash = _get_hash_for_existing_cluster(cluster_name)
@@ -885,6 +886,7 @@ def remove_cluster(cluster_name: str, terminate: bool) -> None:
 
         if terminate:
             session.query(cluster_table).filter_by(name=cluster_name).delete()
+        if remove_events:
             session.query(cluster_event_table).filter_by(
                 cluster_hash=cluster_hash).delete()
         else:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The goal of this PR is to enable users to inspect the reason why clusters terminated. It changes when we delete the cluster event table's records to ensure that if the user did not intend to delete the cluster the logs will remain and can be inspected via the dashboard.

<!-- Describe the tests ran -->

This code was tested by checking three conditions. 
1. If the user explicitly runs sky down the cluster event entries are wiped
2. If the user runs sky stop the entries remain in the table.
3. If we kill all of the nodes in the cluster the dashboard will show the last event despite the cluster being 'history' as shown by the below screenshot.

<img width="2162" height="844" alt="image" src="https://github.com/user-attachments/assets/17046248-c449-4963-94ae-243fce283177" />

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
