### PR TITLE
[Storage] Fix r2 mount issue

### DIFF
--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -4510,8 +4510,18 @@ class R2Store(S3CompatibleStore):
             extra_cli_args=['--checksum-algorithm', 'CRC32'],  # R2 specific
             cloud_name=cloudflare.NAME,
             default_region='auto',
-            mount_cmd_factory=mounting_utils.get_r2_mount_cmd,
+            mount_cmd_factory=cls._get_r2_mount_cmd,
         )
+
+    @classmethod
+    def _get_r2_mount_cmd(cls, bucket_name: str, mount_path: str,
+                          bucket_sub_path: Optional[str]) -> str:
+        """Factory method for R2 mount command."""
+        endpoint_url = cloudflare.create_endpoint()
+        return mounting_utils.get_r2_mount_cmd(cloudflare.R2_CREDENTIALS_PATH,
+                                               cloudflare.R2_PROFILE_NAME,
+                                               endpoint_url, bucket_name,
+                                               mount_path, bucket_sub_path)
 
     def mount_cached_command(self, mount_path: str) -> str:
         """R2-specific cached mount implementation using rclone."""


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously did not pass args correctly to mount for r2. This passes the correct credientals.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
