### PR TITLE
[Core] Prevent errors when user can't create security group

### DIFF
--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -713,7 +713,8 @@ def terminate_instances(
         instances.terminate()
     else:
         # Case 4: We are managing the non-default sg. The default SG does not
-        # exist. We must block on instance termination.
+        # exist. We must block on instance termination so that we can
+        # delete the security group.
         instances.terminate()
         for instance in instances:
             instance.wait_until_terminated()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR catches errors when we attempt to create a default security group for quick AWS deletion if the user does not have the permission.

<!-- Describe the tests ran -->

This PR was tested by creating an IAM user that has all EC2 permissions except for security group creation and then ensuring the user is still able to launch a cluster by supplying a pre-created security group in `.sky/config/yaml`. 

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
