### PR TITLE
[Core] Enable retention for cluster event table

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -235,7 +235,7 @@ Example:
   api_server:
     requests_retention_hours: -1 # Disable requests GC
 
-.. _config-yaml-jobs:
+.. _config-yaml-api-server-cluster-event-retention-hours:
 
 ``api_server.cluster_event_retention_hours``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -244,7 +244,7 @@ Retention period for cluster events in hours (optional). Set to a negative value
 
 Cluster event GC will remove cluster event entries in `sky status -v`, i.e., the logs and status of the cluster events.
 
-Default: ``24`` (1 day).
+Default: ``24.0`` (1 day).
 
 Example:
 

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -226,7 +226,7 @@ Retention period for finished requests in hours (optional). Set to a negative va
 
 Requests GC will remove request entries in `sky api status`, i.e., the logs and status of the requests. All the launched resources (clusters/jobs) will still be correctly running.
 
-Default: ``24`` (1 day).
+Default: ``24.0`` (1 day).
 
 Example:
 

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -29,6 +29,7 @@ Below is the configuration syntax and some example values. See detailed explanat
     :ref:`endpoint <config-yaml-api-server-endpoint>`: \http://xx.xx.xx.xx:8000
     :ref:`service_account_token <config-yaml-api-server-service-account-token>`: sky_xxx
     :ref:`requests_retention_hours <config-yaml-api-server-requests-gc-retention-hours>`: 24
+    :ref:`cluster_event_retention_hours <config-yaml-api-server-cluster-event-retention-hours>`: 24
 
   :ref:`allowed_clouds <config-yaml-allowed-clouds>`:
     - aws
@@ -233,6 +234,24 @@ Example:
 
   api_server:
     requests_retention_hours: -1 # Disable requests GC
+
+.. _config-yaml-jobs:
+
+``api_server.cluster_event_retention_hours``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Retention period for cluster events in hours (optional). Set to a negative value to disable cluster event GC.
+
+Cluster event GC will remove cluster event entries in `sky status -v`, i.e., the logs and status of the cluster events.
+
+Default: ``24`` (1 day).
+
+Example:
+
+.. code-block:: yaml
+
+  api_server:
+    cluster_event_retention_hours: -1 # Disable cluster event GC
 
 .. _config-yaml-jobs:
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1816,7 +1816,8 @@ if __name__ == '__main__':
         global_tasks.append(
             background.create_task(requests_lib.requests_gc_daemon()))
         global_tasks.append(
-            background.create_task(global_user_state.cluster_event_retention_daemon()))
+            background.create_task(
+                global_user_state.cluster_event_retention_daemon()))
         threading.Thread(target=background.run_forever, daemon=True).start()
 
         queue_server, workers = executor.start(config)

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1815,6 +1815,8 @@ if __name__ == '__main__':
             global_tasks.append(background.create_task(metrics_server.serve()))
         global_tasks.append(
             background.create_task(requests_lib.requests_gc_daemon()))
+        global_tasks.append(
+            background.create_task(global_user_state.cluster_event_retention_daemon()))
         threading.Thread(target=background.run_forever, daemon=True).start()
 
         queue_server, workers = executor.start(config)

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1535,6 +1535,9 @@ def get_config_schema():
             'requests_retention_hours': {
                 'type': 'integer',
             },
+            'cluster_event_retention_hours': {
+                'type': 'integer',
+            },
         }
     }
 

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1536,7 +1536,7 @@ def get_config_schema():
                 'type': 'integer',
             },
             'cluster_event_retention_hours': {
-                'type': 'integer',
+                'type': 'number',
             },
         }
     }

--- a/tests/test_global_user_state.py
+++ b/tests/test_global_user_state.py
@@ -13,8 +13,6 @@ def test_enabled_clouds_empty():
     assert sky.global_user_state.get_cached_enabled_clouds(
         sky.clouds.cloud.CloudCapability.COMPUTE, workspace='default') == []
 
-
-# TODO (lloyd-brown): Add test for cluster event retention daemon.
 @pytest.mark.asyncio
 async def test_cluster_event_retention_daemon():
     """Test the cluster event retention daemon runs correctly."""

--- a/tests/test_global_user_state.py
+++ b/tests/test_global_user_state.py
@@ -3,6 +3,8 @@ import sys
 import pytest
 
 import sky
+import unittest.mock as mock
+import asyncio
 
 
 @pytest.mark.skipif(sys.platform != 'linux', reason='Only test in CI.')
@@ -10,3 +12,31 @@ def test_enabled_clouds_empty():
     # In test environment, no cloud should be enabled.
     assert sky.global_user_state.get_cached_enabled_clouds(
         sky.clouds.cloud.CloudCapability.COMPUTE, workspace='default') == []
+
+# TODO (lloyd-brown): Add test for cluster event retention daemon.
+@pytest.mark.asyncio
+async def test_cluster_event_retention_daemon():
+    """Test the cluster event retention daemon runs correctly."""
+    with mock.patch(
+            'sky.global_user_state.skypilot_config') as mock_config:
+        with mock.patch(
+                'sky.global_user_state.cleanup_cluster_events_with_retention'
+        ) as mock_clean:
+            with mock.patch('asyncio.sleep') as mock_sleep:
+                # Configure negative retention (disabled)
+                mock_config.get_nested.return_value = -1
+
+                mock_sleep.side_effect = [None, asyncio.CancelledError()]
+
+                # Run the daemon
+                with pytest.raises(asyncio.CancelledError):
+                    await sky.global_user_state.cluster_event_retention_daemon()
+
+                # Verify cleanup was NOT called due to negative retention
+                mock_clean.assert_not_called()
+
+                # Verify sleep was called with max(-1, 3600) = 3600
+                assert mock_sleep.call_count == 2
+                mock_sleep.assert_any_call(3600)
+                
+

--- a/tests/test_global_user_state.py
+++ b/tests/test_global_user_state.py
@@ -13,6 +13,7 @@ def test_enabled_clouds_empty():
     assert sky.global_user_state.get_cached_enabled_clouds(
         sky.clouds.cloud.CloudCapability.COMPUTE, workspace='default') == []
 
+
 @pytest.mark.asyncio
 async def test_cluster_event_retention_daemon():
     """Test the cluster event retention daemon runs correctly."""

--- a/tests/test_global_user_state.py
+++ b/tests/test_global_user_state.py
@@ -1,10 +1,10 @@
+import asyncio
 import sys
+import unittest.mock as mock
 
 import pytest
 
 import sky
-import unittest.mock as mock
-import asyncio
 
 
 @pytest.mark.skipif(sys.platform != 'linux', reason='Only test in CI.')
@@ -13,12 +13,12 @@ def test_enabled_clouds_empty():
     assert sky.global_user_state.get_cached_enabled_clouds(
         sky.clouds.cloud.CloudCapability.COMPUTE, workspace='default') == []
 
+
 # TODO (lloyd-brown): Add test for cluster event retention daemon.
 @pytest.mark.asyncio
 async def test_cluster_event_retention_daemon():
     """Test the cluster event retention daemon runs correctly."""
-    with mock.patch(
-            'sky.global_user_state.skypilot_config') as mock_config:
+    with mock.patch('sky.global_user_state.skypilot_config') as mock_config:
         with mock.patch(
                 'sky.global_user_state.cleanup_cluster_events_with_retention'
         ) as mock_clean:
@@ -38,5 +38,17 @@ async def test_cluster_event_retention_daemon():
                 # Verify sleep was called with max(-1, 3600) = 3600
                 assert mock_sleep.call_count == 2
                 mock_sleep.assert_any_call(3600)
-                
 
+                # Now test when we run retention with a positive value.
+                mock_config.get_nested.return_value = 2  # every 2 hours.
+                mock_sleep.side_effect = [None, None, asyncio.CancelledError()]
+
+                with pytest.raises(asyncio.CancelledError):
+                    await sky.global_user_state.cluster_event_retention_daemon()
+
+                # Verify cleanup was called with the correct retention.
+                mock_clean.assert_called_with(2)
+
+                # Verify sleep was called with max(2 * 3600, 3600) = 7200
+                assert mock_sleep.call_count == 5
+                mock_sleep.assert_any_call(7200)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR introduces retention for the cluster event table. It adds a new entry to `sky/config.yaml` to change the rate of retention.

<!-- Describe the tests ran -->

This was tested with a new unit test that ensures that the retention daemon waits for enough time and calls the new clean up function to remove entries from the cluster event table. I also tested it manually by starting a cluster, confirming that corresponding entries existed in the cluster event table and then watching the retention daemon kick in and remove those entries.

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
