### PR TITLE
Fix tpu test example failure

### DIFF
--- a/examples/tpu/tpuvm_mnist.yaml
+++ b/examples/tpu/tpuvm_mnist.yaml
@@ -14,18 +14,20 @@ setup: |
     conda create -n flax python=3.10 -y
     conda activate flax
     # Make sure to install TPU related packages in a conda env to avoid package conflicts.
-    pip install \
-      -f https://storage.googleapis.com/jax-releases/libtpu_releases.html "jax[tpu]==0.4.35" \
+    pip install uv
+    uv pip install --prerelease=allow \
+      -f https://storage.googleapis.com/jax-releases/libtpu_releases.html -f https://storage.googleapis.com/jax-releases/jax_releases.html "jax[tpu]==0.4.35" \
       clu \
       tensorflow tensorflow-datasets
-    pip install -e flax
+    uv pip install -e flax
+    uv pip install --upgrade tensorflow-datasets
+    uv pip install --upgrade protobuf
   fi
 
 
 # The command to run.  Will be run under the working directory.
 run: |
   conda activate flax
-  pip install clu
   cd flax/examples/mnist
   python3 main.py --workdir=/tmp/mnist \
     --config=configs/default.py \


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolve #6669

Actually its older version of jaxlib get deprecated in pypi.
We need to specific the source link of older version of jaxlib.

And also some dependency need to be updated.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test --gcp -k test_tpu_vm` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
