### PR TITLE
Fixed nebius infinite waiting

### DIFF
--- a/sky/adaptors/nebius.py
+++ b/sky/adaptors/nebius.py
@@ -1,7 +1,8 @@
 """Nebius cloud adaptor."""
+import asyncio
 import os
 import threading
-from typing import List, Optional
+from typing import Any, Awaitable, Coroutine, List, Optional
 
 from sky import sky_logging
 from sky import skypilot_config
@@ -9,7 +10,44 @@ from sky.adaptors import common
 from sky.utils import annotations
 from sky.utils import ux_utils
 
+# Deafult read timeout for nebius SDK
+READ_TIMEOUT = 10
+
 logger = sky_logging.init_logger(__name__)
+
+_loop_lock = threading.Lock()
+
+
+def _get_event_loop() -> asyncio.AbstractEventLoop:
+    """Get event loop for nebius sdk."""
+    try:
+        # Reuse the event loop if it exists.
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop, create a new one.
+        with _loop_lock:
+            # Double-check in case another thread created a loop
+            try:
+                return asyncio.get_running_loop()
+            except RuntimeError:
+                loop = asyncio.new_event_loop()
+                threading.Thread(target=loop.run_forever, daemon=True).start()
+                asyncio.set_event_loop(loop)
+                return loop
+
+
+def sync_call(awaitable: Awaitable[Any]) -> Any:
+    """Synchronously run an awaitable in coroutine.
+    
+    This wrapper is used to workaround:
+    https://github.com/nebius/pysdk/issues/76
+    """
+    return asyncio.run_coroutine_threadsafe(_coro(awaitable),
+                                            _get_event_loop()).result()
+
+
+async def _coro(awaitable: Awaitable[Any]) -> Coroutine:
+    return await awaitable
 
 
 def tenant_id_path() -> str:

--- a/sky/adaptors/nebius.py
+++ b/sky/adaptors/nebius.py
@@ -38,7 +38,7 @@ def _get_event_loop() -> asyncio.AbstractEventLoop:
 
 def sync_call(awaitable: Awaitable[Any]) -> Any:
     """Synchronously run an awaitable in coroutine.
-    
+
     This wrapper is used to workaround:
     https://github.com/nebius/pysdk/issues/76
     """

--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -442,7 +442,9 @@ class Nebius(clouds.Cloud):
         del workspace_config  # Unused
         sdk = nebius.sdk()
         profile_client = nebius.iam().ProfileServiceClient(sdk)
-        profile = profile_client.get(nebius.iam().GetProfileRequest()).wait()
+        profile = nebius.sync_call(
+            profile_client.get(nebius.iam().GetProfileRequest(),
+                               timeout=nebius.READ_TIMEOUT))
         if profile.user_profile is not None:
             if profile.user_profile.attributes is None:
                 raise exceptions.CloudUserIdentityError(

--- a/sky/provision/nebius/utils.py
+++ b/sky/provision/nebius/utils.py
@@ -285,8 +285,8 @@ async def _launch_async(
                     id=fs['filesystem_id'])))
 
     service = nebius.vpc().SubnetServiceClient(nebius.sdk())
-    sub_net = service.list(nebius.vpc().ListSubnetsRequest(
-        parent_id=project_id,)).wait()
+    sub_net = await service.list(nebius.vpc().ListSubnetsRequest(
+        parent_id=project_id,))
 
     service = nebius.compute().InstanceServiceClient(nebius.sdk())
     await service.create(nebius.compute().CreateInstanceRequest(
@@ -363,8 +363,7 @@ async def _remove_async(instance_id: str) -> None:
     while retry_count < nebius.MAX_RETRIES_TO_DISK_DELETE:
         try:
             service = nebius.compute().DiskServiceClient(nebius.sdk())
-            service.delete(
-                nebius.compute().DeleteDiskRequest(id=disk_id)).wait()
+            await service.delete(nebius.compute().DeleteDiskRequest(id=disk_id))
             break
         except nebius.request_error():
             logger.debug('Waiting for disk deletion.')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Nebius has an issue that may cause the request blocks infinitely when called in sync code even if there is a timeout https://github.com/nebius/pysdk/issues/76, this PR workaround this issue by calling nebius sdk in coroutines with a read timeout for readonly requests.

close https://github.com/skypilot-org/skypilot/issues/6657

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Tested manually, scripts:

```bash
# Launch 2 nebius cluster
$ sky launch --infra nebius --cpus 2+ -y
$ sky launch --infra nebius --cpus 2+ -y
# In another terminal, start a refresh loop
$ while true; do SKYPILOT_DEBUG=1 sky status -r; done

# Try stop/start nebius cluster several times to repro 6657
$ SKYPILOT_DEBUG=1 sky stop -a -y
$ SKYPILOT_DEBUG=1 sky start -a -y

# No longer repros after this fix
```

- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
