### PR TITLE
Add fsGroupChangePolicy: OnRootMismatch on volume mount

### DIFF
--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -378,6 +378,7 @@ available_node_types:
         {% if volume_mounts %}
         securityContext:
           fsGroup: 1000
+          fsGroupChangePolicy: OnRootMismatch
         {% endif %}
 
         # Add node selector if GPU/TPUs are requested:


### PR DESCRIPTION
Add fsGroupChangePolicy: OnRootMismatch on volume mount.

The default policy is `fsGroupChangePolicy: Always`, which can be very slow for large PVCs.

Note that this may be undesirable if the root has the expected group but the subdirectories do not as it will not apply the `fsGroup` to them.

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

Tested by manually starting a job with this change applied to the skypilot API used to execute the job.
