### PR TITLE
[Serve] Fix version bump

### DIFF
--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -1,5 +1,4 @@
 """ReplicaManager: handles the creation and deletion of endpoint replicas."""
-import collections
 import dataclasses
 import functools
 import multiprocessing

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -1420,12 +1420,9 @@ class SkyPilotReplicaManager(ReplicaManager):
                 old_config_any_of = old_config.get('resources',
                                                    {}).pop('any_of', [])
 
-                def normalize_dict_list(lst):
-                    return collections.Counter(
-                        frozenset(d.items()) for d in lst)
-
-                if (normalize_dict_list(old_config_any_of) !=
-                        normalize_dict_list(new_config_any_of)):
+                if (resources_utils.normalize_any_of_resources_config(
+                        old_config_any_of) != resources_utils.
+                        normalize_any_of_resources_config(new_config_any_of)):
                     logger.info('Replica config changed (any_of), skipping. '
                                 f'old: {old_config_any_of}, '
                                 f'new: {new_config_any_of}')

--- a/sky/utils/resources_utils.py
+++ b/sky/utils/resources_utils.py
@@ -5,7 +5,7 @@ import itertools
 import json
 import math
 import typing
-from typing import Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 from sky import skypilot_config
 from sky.skylet import constants
@@ -435,3 +435,27 @@ def parse_time_minutes(time: str) -> int:
                 continue
 
     raise ValueError(f'Invalid time format: {time}')
+
+
+def normalize_any_of_resources_config(
+        any_of: List[Dict[str, Any]]) -> Tuple[str, ...]:
+    """Normalize a list of any_of resources config to a canonical form.
+
+    Args:
+        any_of: A list of any_of resources config.
+
+    Returns:
+        A normalized tuple representation that can be compared for equality.
+        Two lists with the same resource configurations in different orders
+        will produce the same normalized result.
+    """
+    if not any_of:
+        return tuple()
+
+    # Convert each config to JSON string with sorted keys, then sort the list
+    normalized_configs = [
+        json.dumps(config, sort_keys=True, separators=(',', ':'))
+        for config in any_of
+    ]
+
+    return tuple(sorted(normalized_configs))

--- a/tests/unit_tests/test_resources.py
+++ b/tests/unit_tests/test_resources.py
@@ -462,6 +462,51 @@ def test_resources_ordered_preference():
     assert resources_list[2].infra.region == 'eastus'
 
 
+def test_resources_any_of_dump_in_serve_version_bump():
+    any_of_1 = [
+        {
+            'accelerators': {
+                'H200': 1
+            },
+            'disk_size': 256,
+        },
+        {
+            'disk_size': 256,
+            'accelerators': {
+                'H100': 1
+            },
+        },
+        {
+            'disk_size': 256,
+            'accelerators': {
+                'L4': 4
+            },
+        },
+    ]
+    any_of_2 = [
+        {
+            'accelerators': {
+                'H100': 1
+            },
+            'disk_size': 256,
+        },
+        {
+            'accelerators': {
+                'L4': 4
+            },
+            'disk_size': 256,
+        },
+        {
+            'disk_size': 256,
+            'accelerators': {
+                'H200': 1
+            },
+        },
+    ]
+    assert (resources_utils.normalize_any_of_resources_config(any_of_1) ==
+            resources_utils.normalize_any_of_resources_config(any_of_2))
+
+
 def test_resources_any_of_ordered_exclusive():
     """Test that Resources raises ValueError if both any_of and ordered are specified."""
     config = {'any_of': [{'cpus': 8}], 'ordered': [{'cpus': 4}]}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously, update this yaml on the same svc/pool will fail due to dict is an unhashable type. This pr fixes this.

```yaml
# new-pool.yaml
pool:
  workers: 10

resources:
  accelerators: {H100:1, H200:1}

setup: |
  # Setup commands for all workers
  echo "Setup complete!"

```

```bash
sky jobs pool apply --pool gpu-pool new-pool.yaml                
YAML to run: new-pool.yaml
Pool spec:
Worker policy:  Fixed-size (10 workers)

Each pool worker will use the following resources (estimated):
Disk size 256 is not supported by Kubernetes. To add additional disk, use volumes.
Disk size 256 is not supported by Kubernetes. To add additional disk, use volumes.
Considered resources (1 node):
-------------------------------------------------------------------------------------------------------
 INFRA                 INSTANCE                         vCPUs   Mem(GB)   GPUS     COST ($)   CHOSEN   
-------------------------------------------------------------------------------------------------------
 Nebius (eu-north1)    gpu-h100-sxm_1gpu-16vcpu-200gb   16      200       H100:1   2.95          ✔     
 Nebius (eu-north1)    gpu-h200-sxm_1gpu-16vcpu-200gb   16      200       H200:1   3.50                
 GCP (us-central1-a)   a3-highgpu-1g                    26      234       H100:1   5.38                
-------------------------------------------------------------------------------------------------------
Applying config to pool 'gpu-pool'. Proceed? [Y/n]: 
RuntimeError: Server error during pool update: {"message":"Error","exception":"TypeError: unhashable type: 'dict'","traceback":"Traceback (most recent call last):\n  File \"/home/gcpuser/skypilot-runtime/lib/python3.10/site-packages/sky/serve/controller.py\", line 149, in update_service\n    self._replica_manager.update_version(version,\n  File \"/home/gcpuser/skypilot-runtime/lib/python3.10/site-packages/sky/serve/replica_managers.py\", line 1400, in update_version\n    if (normalize_dict_list(old_config_any_of) !=\n  File \"/home/gcpuser/skypilot-runtime/lib/python3.10/site-packages/sky/serve/replica_managers.py\", line 1397, in normalize_dict_list\n    return collections.Counter(\n  File \"/home/gcpuser/miniconda3/envs/skypilot-runtime/lib/python3.10/collections/__init__.py\", line 577, in __init__\n    self.update(iterable, **kwds)\n  File \"/home/gcpuser/miniconda3/envs/skypilot-runtime/lib/python3.10/collections/__init__.py\", line 670, in update\n    _count_elements(self, iterable)\n  File \"/home/gcpuser/skypilot-runtime/lib/python3.10/site-packages/sky/serve/replica_managers.py\", line 1398, in <genexpr>\n    frozenset(d.items()) for d in lst)\nTypeError: unhashable type: 'dict'\n"}

RuntimeError: Failed to update pools
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
