### PR TITLE
[resources] add info on whether disk size was explicitly specified by user

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -773,7 +773,7 @@ class Kubernetes(clouds.Cloud):
 
     @staticmethod
     def _warn_on_disk_size(resources: 'resources_lib.Resources'):
-        if resources.disk_size is not None:
+        if resources.disk_size_specified:
             logger.info(f'{colorama.Style.DIM}Disk size {resources.disk_size} '
                         'is not supported by Kubernetes. '
                         'To add additional disk, use volumes.'

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -2,7 +2,6 @@
 import collections
 import dataclasses
 import re
-import traceback
 import textwrap
 import typing
 from typing import Any, Dict, List, Literal, Optional, Set, Tuple, Union
@@ -1842,7 +1841,10 @@ class Resources:
                 'no_missing_accel_warnings', self._no_missing_accel_warnings),
         )
         assert not override
-        resources._disk_size_specified = override_disk_size_specified or self._disk_size_specified
+        resources.__dict__.update({
+            '_disk_size_specified': (override_disk_size_specified or
+                                     self._disk_size_specified)
+        })
         return resources
 
     def valid_on_region_zones(self, region: str, zones: List[str]) -> bool:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -363,6 +363,9 @@ def _get_single_resources_schema():
             '_cluster_config_overrides': {
                 'type': 'object',
             },
+            '_disk_size_specified': {
+                'type': 'boolean',
+            },
         }
     }
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
We want to determine if the disk size was set by the user or not. Simply relying on if disk size is 256 (the default) isn't the best at this because the user may have explicitly specified 256.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
