### PR TITLE
[UX] change cluster event wording pt2

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2351,7 +2351,7 @@ def _update_cluster_status(cluster_name: str) -> Optional[Dict[str, Any]]:
     backend = backends.CloudVmRayBackend()
     backend.post_teardown_cleanup(handle, terminate=to_terminate, purge=False)
     global_user_state.add_cluster_event(
-        cluster_name, None, 'All nodes stopped, terminating cluster.',
+        cluster_name, None, 'All nodes terminated, cleaning up the cluster.',
         global_user_state.ClusterEventType.STATUS_CHANGE)
     return global_user_state.get_cluster_from_name(cluster_name)
 

--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -261,9 +261,6 @@ class StrategyExecutor:
         if self.cluster_name is None:
             return
         if self.pool is None:
-            global_user_state.add_cluster_event(
-                self.cluster_name, None, 'Cluster was cleaned up.',
-                global_user_state.ClusterEventType.STATUS_CHANGE)
             managed_job_utils.terminate_cluster(self.cluster_name)
 
     def _launch(self,

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -337,9 +337,6 @@ def update_managed_jobs_statuses(job_id: Optional[int] = None):
             if handle is not None:
                 try:
                     if pool is None:
-                        global_user_state.add_cluster_event(
-                            cluster_name, None, 'Cluster was cleaned up.',
-                            global_user_state.ClusterEventType.STATUS_CHANGE)
                         terminate_cluster(cluster_name)
                 except Exception as e:  # pylint: disable=broad-except
                     error_msg = (


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Changes the wording of cluster events.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
