### PR TITLE
[UX] add download button for cluster job logs

### DIFF
--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { showToast } from '@/data/connectors/toast';
 import { apiClient } from '@/data/connectors/client';
+import { ENDPOINT } from '@/data/connectors/constants';
 import dashboardCache from '@/lib/cache';
 
 const DEFAULT_TAIL_LINES = 10000;
@@ -198,6 +199,58 @@ export async function streamClusterJobLogs({
   } catch (error) {
     console.error('Error in streamClusterJobLogs:', error);
     showToast(`Error in streamClusterJobLogs: ${error.message}`, 'error');
+  }
+}
+
+/**
+ * Downloads job logs as a zip via the API server.
+ * Flow:
+ * 1) POST /download_logs to fetch logs from the remote cluster to API server
+ * 2) POST /download to stream a zip back to the browser and trigger download
+ */
+export async function downloadJobLogs({ clusterName, jobIds = null, workspace }) {
+  try {
+    // Step 1: schedule server-side download; result is a mapping job_id -> folder path on API server
+    const mapping = await apiClient.fetch('/download_logs', {
+      cluster_name: clusterName,
+      job_ids: jobIds,
+      override_skypilot_config: {
+        active_workspace: workspace || 'default',
+      },
+    });
+
+    const folderPaths = Object.values(mapping || {});
+    if (!folderPaths.length) {
+      showToast('No logs found to download.', 'warning');
+      return;
+    }
+
+    // Step 2: request the zip and trigger browser download
+    const baseUrl = window.location.origin;
+    const fullUrl = `${baseUrl}${ENDPOINT}/download`;
+    const resp = await fetch(`${fullUrl}?relative=items`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ folder_paths: folderPaths }),
+    });
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(`Download failed: ${resp.status} ${text}`);
+    }
+    const blob = await resp.blob();
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const namePart = jobIds && jobIds.length === 1 ? `job-${jobIds[0]}` : 'jobs';
+    a.href = url;
+    a.download = `${clusterName}-${namePart}-logs-${ts}.zip`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    window.URL.revokeObjectURL(url);
+  } catch (error) {
+    console.error('Error downloading logs:', error);
+    showToast(`Error downloading logs: ${error.message}`, 'error');
   }
 }
 

--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -208,7 +208,11 @@ export async function streamClusterJobLogs({
  * 1) POST /download_logs to fetch logs from the remote cluster to API server
  * 2) POST /download to stream a zip back to the browser and trigger download
  */
-export async function downloadJobLogs({ clusterName, jobIds = null, workspace }) {
+export async function downloadJobLogs({
+  clusterName,
+  jobIds = null,
+  workspace,
+}) {
   try {
     // Step 1: schedule server-side download; result is a mapping job_id -> folder path on API server
     const mapping = await apiClient.fetch('/download_logs', {
@@ -241,7 +245,8 @@ export async function downloadJobLogs({ clusterName, jobIds = null, workspace })
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement('a');
     const ts = new Date().toISOString().replace(/[:.]/g, '-');
-    const namePart = jobIds && jobIds.length === 1 ? `job-${jobIds[0]}` : 'jobs';
+    const namePart =
+      jobIds && jobIds.length === 1 ? `job-${jobIds[0]}` : 'jobs';
     a.href = url;
     a.download = `${clusterName}-${namePart}-logs-${ts}.zip`;
     document.body.appendChild(a);

--- a/sky/dashboard/src/pages/clusters/[cluster]/[job].js
+++ b/sky/dashboard/src/pages/clusters/[cluster]/[job].js
@@ -10,7 +10,10 @@ import {
 } from '@/components/utils';
 import { RotateCwIcon, Download } from 'lucide-react';
 import { CircularProgress } from '@mui/material';
-import { streamClusterJobLogs, downloadJobLogs } from '@/data/connectors/clusters';
+import {
+  streamClusterJobLogs,
+  downloadJobLogs,
+} from '@/data/connectors/clusters';
 import { StatusBadge } from '@/components/elements/StatusBadge';
 import { LogFilter, formatLogs, stripAnsiCodes } from '@/components/utils';
 import { useMobile } from '@/hooks/useMobile';
@@ -390,19 +393,27 @@ export function JobDetailPage() {
                     </span>
                   </div>
                   <div className="flex items-center space-x-3">
-                    <Tooltip content="Download full logs" className="text-muted-foreground">
+                    <Tooltip
+                      content="Download full logs"
+                      className="text-muted-foreground"
+                    >
                       <button
-                        onClick={() => downloadJobLogs({
-                          clusterName: cluster,
-                          jobIds: job ? [job] : null,
-                          workspace: clusterData?.workspace,
-                        })}
+                        onClick={() =>
+                          downloadJobLogs({
+                            clusterName: cluster,
+                            jobIds: job ? [job] : null,
+                            workspace: clusterData?.workspace,
+                          })
+                        }
                         className="text-sky-blue hover:text-sky-blue-bright flex items-center"
                       >
                         <Download className="w-4 h-4" />
                       </button>
                     </Tooltip>
-                    <Tooltip content="Refresh logs" className="text-muted-foreground">
+                    <Tooltip
+                      content="Refresh logs"
+                      className="text-muted-foreground"
+                    >
                       <button
                         onClick={handleRefreshLogs}
                         disabled={isLoadingLogs}

--- a/sky/dashboard/src/pages/clusters/[cluster]/[job].js
+++ b/sky/dashboard/src/pages/clusters/[cluster]/[job].js
@@ -8,9 +8,9 @@ import {
   CustomTooltip as Tooltip,
   formatFullTimestamp,
 } from '@/components/utils';
-import { RotateCwIcon } from 'lucide-react';
+import { RotateCwIcon, Download } from 'lucide-react';
 import { CircularProgress } from '@mui/material';
-import { streamClusterJobLogs } from '@/data/connectors/clusters';
+import { streamClusterJobLogs, downloadJobLogs } from '@/data/connectors/clusters';
 import { StatusBadge } from '@/components/elements/StatusBadge';
 import { LogFilter, formatLogs, stripAnsiCodes } from '@/components/utils';
 import { useMobile } from '@/hooks/useMobile';
@@ -389,20 +389,31 @@ export function JobDetailPage() {
                       logs.)
                     </span>
                   </div>
-                  <Tooltip
-                    content="Refresh logs"
-                    className="text-muted-foreground"
-                  >
-                    <button
-                      onClick={handleRefreshLogs}
-                      disabled={isLoadingLogs}
-                      className="text-sky-blue hover:text-sky-blue-bright flex items-center"
-                    >
-                      <RotateCwIcon
-                        className={`w-4 h-4 ${isLoadingLogs ? 'animate-spin' : ''}`}
-                      />
-                    </button>
-                  </Tooltip>
+                  <div className="flex items-center space-x-3">
+                    <Tooltip content="Download full logs" className="text-muted-foreground">
+                      <button
+                        onClick={() => downloadJobLogs({
+                          clusterName: cluster,
+                          jobIds: job ? [job] : null,
+                          workspace: clusterData?.workspace,
+                        })}
+                        className="text-sky-blue hover:text-sky-blue-bright flex items-center"
+                      >
+                        <Download className="w-4 h-4" />
+                      </button>
+                    </Tooltip>
+                    <Tooltip content="Refresh logs" className="text-muted-foreground">
+                      <button
+                        onClick={handleRefreshLogs}
+                        disabled={isLoadingLogs}
+                        className="text-sky-blue hover:text-sky-blue-bright flex items-center"
+                      >
+                        <RotateCwIcon
+                          className={`w-4 h-4 ${isLoadingLogs ? 'animate-spin' : ''}`}
+                        />
+                      </button>
+                    </Tooltip>
+                  </div>
                 </div>
                 <div className="p-4">
                   {isPending ? (

--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -272,7 +272,8 @@ def zip_files_and_folders(items: List[str],
         if os.path.isabs(target):
             target = os.path.relpath(target, os.path.dirname(path))
         # Create a ZipInfo instance using the archive name
-        zi = zipfile.ZipInfo(archive_name + '/') if is_dir else zipfile.ZipInfo(archive_name)
+        zi = zipfile.ZipInfo(archive_name +
+                             '/') if is_dir else zipfile.ZipInfo(archive_name)
         # Set external attributes to mark as symlink
         zi.external_attr = 0xA1ED0000
         # Write symlink target as content
@@ -318,7 +319,10 @@ def zip_files_and_folders(items: List[str],
                             archive_name = _get_archive_name(dir_path, item)
                             # If it's a symlink, store it as a symlink
                             if os.path.islink(dir_path):
-                                _store_symlink(zipf, dir_path, archive_name, is_dir=True)
+                                _store_symlink(zipf,
+                                               dir_path,
+                                               archive_name,
+                                               is_dir=True)
                             else:
                                 zipf.write(dir_path, archive_name)
 
@@ -328,7 +332,10 @@ def zip_files_and_folders(items: List[str],
                                 continue
                             archive_name = _get_archive_name(file_path, item)
                             if os.path.islink(file_path):
-                                _store_symlink(zipf, file_path, archive_name, is_dir=False)
+                                _store_symlink(zipf,
+                                               file_path,
+                                               archive_name,
+                                               is_dir=False)
                                 continue
                             if stat.S_ISSOCK(os.stat(file_path).st_mode):
                                 continue

--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -252,17 +252,27 @@ def get_excluded_files(src_dir_path: str) -> List[str]:
 
 def zip_files_and_folders(items: List[str],
                           output_file: Union[str, pathlib.Path],
-                          log_file: Optional[TextIO] = None):
+                          log_file: Optional[TextIO] = None,
+                          relative_to_items: bool = False):
 
-    def _store_symlink(zipf, path: str, is_dir: bool):
+    def _get_archive_name(file_path: str, item_path: str) -> str:
+        """Get the archive name for a file based on the relative parameters."""
+        if relative_to_items:
+            # Make paths relative to the item itself
+            return os.path.relpath(file_path, os.path.dirname(item_path))
+        else:
+            # Default: use full path (existing behavior)
+            return file_path
+
+    def _store_symlink(zipf, path: str, archive_name: str, is_dir: bool):
         # Get the target of the symlink
         target = os.readlink(path)
         # Use relative path as absolute path will not be able to resolve on
         # remote API server.
         if os.path.isabs(target):
             target = os.path.relpath(target, os.path.dirname(path))
-        # Create a ZipInfo instance
-        zi = zipfile.ZipInfo(path + '/') if is_dir else zipfile.ZipInfo(path)
+        # Create a ZipInfo instance using the archive name
+        zi = zipfile.ZipInfo(archive_name + '/') if is_dir else zipfile.ZipInfo(archive_name)
         # Set external attributes to mark as symlink
         zi.external_attr = 0xA1ED0000
         # Write symlink target as content
@@ -281,7 +291,8 @@ def zip_files_and_folders(items: List[str],
                     # Add the file to the zip archive even if it matches
                     # patterns in dot ignore files, as it was explicitly
                     # specified by user.
-                    zipf.write(item)
+                    archive_name = _get_archive_name(item, item)
+                    zipf.write(item, archive_name)
                 elif os.path.isdir(item):
                     excluded_files = set([
                         os.path.join(item, f.rstrip('/'))
@@ -304,21 +315,23 @@ def zip_files_and_folders(items: List[str],
                         # directories)
                         for dir_name in dirs:
                             dir_path = os.path.join(root, dir_name)
+                            archive_name = _get_archive_name(dir_path, item)
                             # If it's a symlink, store it as a symlink
                             if os.path.islink(dir_path):
-                                _store_symlink(zipf, dir_path, is_dir=True)
+                                _store_symlink(zipf, dir_path, archive_name, is_dir=True)
                             else:
-                                zipf.write(dir_path)
+                                zipf.write(dir_path, archive_name)
 
                         for file in files:
                             file_path = os.path.join(root, file)
                             if file_path in excluded_files:
                                 continue
+                            archive_name = _get_archive_name(file_path, item)
                             if os.path.islink(file_path):
-                                _store_symlink(zipf, file_path, is_dir=False)
+                                _store_symlink(zipf, file_path, archive_name, is_dir=False)
                                 continue
                             if stat.S_ISSOCK(os.stat(file_path).st_mode):
                                 continue
-                            zipf.write(file_path)
+                            zipf.write(file_path, archive_name)
                 if log_file is not None:
                     log_file.write(f'Zipped {item}\n')

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1266,7 +1266,9 @@ async def download(download_body: payloads.DownloadBody,
         relative = request.query_params.get('relative', 'home')
         if relative == 'items':
             # Dashboard-friendly: entries relative to selected folders
-            storage_utils.zip_files_and_folders(folders, zip_path, relative_to_items=True)
+            storage_utils.zip_files_and_folders(folders,
+                                                zip_path,
+                                                relative_to_items=True)
         else:
             # CLI-friendly (default): entries with full paths for mapping
             storage_utils.zip_files_and_folders(folders, zip_path)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR adds a download button to the sky dashboard to allow users to download the full log files for their cluster jobs. 

Note: This PR only adds support for downloading cluster job logs.

TODO (in a followup PR):
- [ ] add support for downloading managed job logs

<!-- Describe the tests ran -->
This PR was tested manually by launching a cluster with a task yaml that prints 15,000 lines (the current log tail limit in the dashboard is 10,000 lines). I verified that the logs in the dashboard were truncated, but that the download functionality worked in both the cli and the dashboard. 

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
