### PR TITLE
Skip admin policy for backward compat test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -366,8 +366,8 @@ def setup_policy_server(request, tmp_path_factory):
     if hasattr(request.session, 'items'):
         has_smoke_tests = any(
             'smoke_tests' in item.location[0] for item in request.session.items)
-        has_backward_compat_test = any(
-            'backward_compat' in item.location[0] for item in request.session.items)
+        has_backward_compat_test = any('backward_compat' in item.location[0]
+                                       for item in request.session.items)
 
     # Only run the policy server for smoke tests and skip backward compatibility tests.
     if not has_smoke_tests or has_backward_compat_test:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

fix https://buildkite.com/skypilot-1/quicktest-core/builds/912#_

Old versions of skypilot does not support restful policy, thus we skip restful policy setup in backward compat test.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
