### PR TITLE
handle case where the cluster is already terminated during is_definitely_autostopping()

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4928,11 +4928,17 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             # We cannot check if the cluster is autostopping.
             return False
         if handle.is_grpc_enabled:
-            request = autostopv1_pb2.IsAutostoppingRequest()
-            response = backend_utils.invoke_skylet_with_retries(
-                handle, lambda: SkyletClient(handle.get_grpc_channel()).
-                is_autostopping(request))
-            return response.is_autostopping
+            try:
+                request = autostopv1_pb2.IsAutostoppingRequest()
+                response = backend_utils.invoke_skylet_with_retries(
+                    handle, lambda: SkyletClient(handle.get_grpc_channel()).
+                    is_autostopping(request))
+                return response.is_autostopping
+            except Exception as e:  # pylint: disable=broad-except
+                # The cluster may have been terminated, causing the gRPC call
+                # to timeout and fail.
+                logger.debug(f'Failed to check if cluster is autostopping: {e}')
+                return False
         else:
             logger.info(
                 'Using legacy remote execution for is_autostopping on '


### PR DESCRIPTION
Fixes https://buildkite.com/skypilot-1/smoke-tests/builds/2430/steps/canvas?jid=0198a7f9-1fbf-49c2-874f-6614e854648d

During status refresh (which also gets called during `sky down`), we call `backend.is_definitely_autostopping()`. At this point, the cluster might already be terminating/terminated, which will cause this call to fail. After moving the autostop to gRPC in #6574, we missed adding a try catch block to the gRPC call, so instead of returning False, we bubble up the gRPC timeout exception.

This PR fixes it by returning False from this function when encountering an exception.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
