### PR TITLE
Do not include missing pods if `non_terminated_only` is set to true

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1456,16 +1456,17 @@ def query_instances(
             for service in provider_config.get('services', [])
         ]))
 
-    for target_pod_name in target_pod_names:
-        if target_pod_name not in cluster_status:
-            # If the pod is not in the cluster_status, it means it's not
-            # running.
-            # Analyze what happened to the pod based on events.
-            reason = _get_pod_missing_reason(context, namespace, cluster_name,
-                                             target_pod_name)
-            reason = (f'{target_pod_name}: {reason}'
-                      if reason is not None else None)
-            cluster_status[target_pod_name] = (None, reason)
+    if not non_terminated_only:
+        for target_pod_name in target_pod_names:
+            if target_pod_name not in cluster_status:
+                # If the pod is not in the cluster_status, it means it's not
+                # running.
+                # Analyze what happened to the pod based on events.
+                reason = _get_pod_missing_reason(context, namespace, cluster_name,
+                                                target_pod_name)
+                reason = (f'{target_pod_name}: {reason}'
+                        if reason is not None else None)
+                cluster_status[target_pod_name] = (None, reason)
 
     return cluster_status
 

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1456,16 +1456,16 @@ def query_instances(
             for service in provider_config.get('services', [])
         ]))
 
-    if not non_terminated_only:
-        for target_pod_name in target_pod_names:
-            if target_pod_name not in cluster_status:
-                # If the pod is not in the cluster_status, it means it's not
-                # running.
-                # Analyze what happened to the pod based on events.
-                reason = _get_pod_missing_reason(context, namespace, cluster_name,
-                                                target_pod_name)
-                reason = (f'{target_pod_name}: {reason}'
-                        if reason is not None else None)
+    for target_pod_name in target_pod_names:
+        if target_pod_name not in cluster_status:
+            # If the pod is not in the cluster_status, it means it's not
+            # running.
+            # Analyze what happened to the pod based on events.
+            reason = _get_pod_missing_reason(context, namespace, cluster_name,
+                                             target_pod_name)
+            reason = (f'{target_pod_name}: {reason}'
+                      if reason is not None else None)
+            if not non_terminated_only:
                 cluster_status[target_pod_name] = (None, reason)
 
     return cluster_status


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
https://github.com/skypilot-org/skypilot/pull/6593 added a bug where status for pods that no longer exist are being returned even when `non_terminated_only` is specified. This PR fixes the issue.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
