### PR TITLE
[Test] Check serve status after termination

### DIFF
--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -92,6 +92,23 @@ _TEARDOWN_SERVICE = _SHOW_SERVE_STATUS + (
     r'     echo "$s" | grep -q "scheduled to be terminated\|No service to terminate" && break;'
     '     sleep 10;'
     '     [ $i -eq 20 ] && echo "Failed to terminate service {name}";'
+    'done; '
+    # Wait for service to be fully terminated
+    'start_time=$(date +%s); '
+    'timeout=360; '
+    'while true; do '
+    '    status_output=$(sky serve status {name} 2>&1); '
+    '    echo "Checking service termination status..."; '
+    '    echo "$status_output"; '
+    '    echo "$status_output" | grep -q "Service \'{name}\' not found" && echo "Service terminated successfully" && exit 0; '
+    '    current_time=$(date +%s); '
+    '    elapsed=$((current_time - start_time)); '
+    '    if [ "$elapsed" -ge "$timeout" ]; then '
+    '        echo "Timeout: Service {name} not terminated within 5 minutes"; '
+    '        exit 1; '
+    '    fi; '
+    '    echo "Service still terminating, waiting 10 seconds..."; '
+    '    sleep 10; '
     'done)')
 
 _SERVE_ENDPOINT_WAIT = (

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -95,7 +95,7 @@ _TEARDOWN_SERVICE = _SHOW_SERVE_STATUS + (
     'done; '
     # Wait for service to be fully terminated
     'start_time=$(date +%s); '
-    'timeout=360; '
+    'timeout=600; '
     'while true; do '
     '    status_output=$(sky serve status {name} 2>&1); '
     '    echo "Checking service termination status..."; '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolve #6694 

Check the service status after termination is submitted, and ensure all services are terminated.

<!-- Describe the tests ran -->

## Test

### Failure test

```bash
(sky) zpoint:~/codes/skypilot (master)$ pytest tests/smoke_tests/test_sky_serve.py::test_skyserve_aws_http --aws
D 08-18 17:22:34 skypilot_config.py:245] using default user config file: ~/.sky/config.yaml
D 08-18 17:22:34 skypilot_config.py:505] Config loaded from /home/zpoint/.sky/config.yaml:
D 08-18 17:22:34 skypilot_config.py:505] {}
D 08-18 17:22:34 skypilot_config.py:505] 
D 08-18 17:22:34 skypilot_config.py:512] Config syntax check passed for path: /home/zpoint/.sky/config.yaml
D 08-18 17:22:34 skypilot_config.py:272] using default project config file: .sky.yaml
D 08-18 17:22:34 skypilot_config.py:627] client config (before task and CLI overrides): 
D 08-18 17:22:34 skypilot_config.py:627] {}
D 08-18 17:22:34 skypilot_config.py:627] 
bringing up nodes...
INFO:     Started server process [43538]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:10000 (Press CTRL+C to quit)
[test-skyserve-aws] Test started. Log: less -r /tmp/test-skyserve-aws-fq64ubv1.log
[test-skyserve-aws] Passed.
[test-skyserve-aws] Log: less -r /tmp/test-skyserve-aws-fq64ubv1.log
[test-skyserve-aws] 
F
=================================================================================== FAILURES ====================================================================================
____________________________________________________________________________ test_skyserve_aws_http _____________________________________________________________________________
[gw0] linux -- Python 3.10.18 /home/zpoint/miniconda3/envs/sky/bin/python3
tests/smoke_tests/test_sky_serve.py:307: in test_skyserve_aws_http
    smoke_tests_utils.run_one_test(test)
tests/smoke_tests/smoke_tests_utils.py:525: in run_one_test
    subprocess_utils.run(
sky/utils/common_utils.py:683: in _record
    return f(*args, **kwargs)
sky/utils/subprocess_utils.py:45: in run
    return subprocess.run(cmd,
../../miniconda3/envs/sky/lib/python3.10/subprocess.py:526: in run
    raise CalledProcessError(retcode, process.args,
E   subprocess.CalledProcessError: Command 'echo "+ sky serve status t-ss-aws-http-838c6a5f-6c"; sky serve status t-ss-aws-http-838c6a5f-6c; echo "+ sky serve logs --controller t-ss-aws-http-838c6a5f-6c --no-follow"; sky serve logs --controller t-ss-aws-http-838c6a5f-6c --no-follow; echo "+ sky serve logs --load-balancer t-ss-aws-http-838c6a5f-6c --no-follow"; sky serve logs --load-balancer t-ss-aws-http-838c6a5f-6c --no-follow; (for i in `seq 1 20`; do     s=$(sky serve down -y t-ss-aws-http-838c6a5f-6c);     echo "Trying to terminate t-ss-aws-http-838c6a5f-6c";     echo "$s";     echo "$s" | grep -q "scheduled to be terminated\|No service to terminate" && break;     sleep 10;     [ $i -eq 20 ] && echo "Failed to terminate service t-ss-aws-http-838c6a5f-6c";done; start_time=$(date +%s); timeout=360; while true; do     status_output=$(sky serve status t-ss-aws-http-838c6a5f-6c 2>&1);     echo "Checking service termination status...";     echo "$status_output";     echo "$status_output" | grep -q "Service t-ss-aws-http-838c6a5f-6c not found" && echo "Service terminated successfully" && exit 0;     current_time=$(date +%s);     elapsed=$((current_time - start_time));     if [ "$elapsed" -ge "$timeout" ]; then         echo "Timeout: Service t-ss-aws-http-838c6a5f-6c not terminated within 5 minutes";         exit 1;     fi;     echo "Service still terminating, waiting 10 seconds...";     sleep 10; done)' returned non-zero exit status 1.
```

### Success test

```bash
(sky) zpoint:~/codes/skypilot (master)$ pytest tests/smoke_tests/test_sky_serve.py::test_skyserve_aws_http --aws
D 08-18 17:47:09 skypilot_config.py:245] using default user config file: ~/.sky/config.yaml
D 08-18 17:47:09 skypilot_config.py:505] Config loaded from /home/zpoint/.sky/config.yaml:
D 08-18 17:47:09 skypilot_config.py:505] {}
D 08-18 17:47:09 skypilot_config.py:505] 
D 08-18 17:47:09 skypilot_config.py:512] Config syntax check passed for path: /home/zpoint/.sky/config.yaml
D 08-18 17:47:09 skypilot_config.py:272] using default project config file: .sky.yaml
D 08-18 17:47:09 skypilot_config.py:627] client config (before task and CLI overrides): 
D 08-18 17:47:09 skypilot_config.py:627] {}
D 08-18 17:47:09 skypilot_config.py:627] 
bringing up nodes...
INFO:     Started server process [49966]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:10000 (Press CTRL+C to quit)
[test-skyserve-aws] Test started. Log: less -r /tmp/test-skyserve-aws-5rdzdovr.log
[test-skyserve-aws] Passed.
[test-skyserve-aws] Log: less -r /tmp/test-skyserve-aws-5rdzdovr.log
[test-skyserve-aws] 
.
1 passed, 1371 warnings in 303.92s (0:05:03)
(sky) zpoint:~/codes/skypilot (dev/zeping/srve_termination)$ 
```

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Relevant individual tests: `/smoke-test --serve` (CI) or `pytest tests/test_smoke.py::test_name` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
