### PR TITLE
[Dashboard] Support filtering with status and returning status counts in API server

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -311,6 +311,7 @@ export function ManagedJobsTable({
 }) {
   const [data, setData] = useState([]);
   const [totalCount, setTotalCount] = useState(0);
+  const [totalNoFilter, setTotalNoFilter] = useState(0);
   const [sortConfig, setSortConfig] = useState({
     key: null,
     direction: 'ascending',
@@ -323,6 +324,7 @@ export function ManagedJobsTable({
   const expandedRowRef = useRef(null);
   const [selectedStatuses, setSelectedStatuses] = useState([]);
   const [statusCounts, setStatusCounts] = useState({});
+  const [apiStatusCounts, setApiStatusCounts] = useState({});
   const [controllerStopped, setControllerStopped] = useState(false);
   const [controllerLaunching, setControllerLaunching] = useState(false);
   const [isRestarting, setIsRestarting] = useState(false);
@@ -371,12 +373,31 @@ export function ManagedJobsTable({
           );
           return f && f.value ? String(f.value) : undefined;
         };
+        // Determine statuses parameter based on current state
+        let statusesParam = undefined;
+
+        // If specific statuses are selected, use those
+        if (selectedStatuses.length > 0) {
+          statusesParam = selectedStatuses;
+        } else if (!showAllMode) {
+          // If not in "show all" mode but no specific statuses selected, show no jobs
+          statusesParam = [];
+        } else if (activeTab === 'active') {
+          // Show all active jobs
+          statusesParam = statusGroups.active;
+        } else if (activeTab === 'finished') {
+          // Show all finished jobs
+          statusesParam = statusGroups.finished;
+        }
+        // For activeTab === 'all' and showAllMode === true, don't set statuses (show all jobs)
+
         const params = {
           allUsers: true,
           nameMatch: getFilterValue('name'),
           userMatch: getFilterValue('user'),
           workspaceMatch: getFilterValue('workspace'),
           poolMatch: getFilterValue('pool'),
+          statuses: statusesParam,
           page: currentPage, // page index starting from 1
           limit: pageSize,
         };
@@ -403,8 +424,10 @@ export function ManagedJobsTable({
         const {
           jobs = [],
           total = 0,
+          totalNoFilter = 0,
           controllerStopped = false,
           cacheStatus = 'unknown',
+          statusCounts = {},
         } = jobsResponse || {};
 
         let isControllerStopped = !!controllerStopped;
@@ -426,8 +449,10 @@ export function ManagedJobsTable({
 
         setData(jobs);
         setTotalCount(total || 0);
+        setTotalNoFilter(totalNoFilter || 0);
         setControllerStopped(!!isControllerStopped);
         setControllerLaunching(!!isLaunching);
+        setApiStatusCounts(statusCounts);
         setIsInitialLoad(false);
 
         // Log cache status for debugging
@@ -438,6 +463,7 @@ export function ManagedJobsTable({
             isDataLoading,
             jobCount: jobs.length,
             totalCount: total,
+            totalNoFilter: totalNoFilter,
           });
         }
       } catch (err) {
@@ -451,7 +477,15 @@ export function ManagedJobsTable({
         setLoading(false); // Clear parent loading state
       }
     },
-    [setLoading, filters, currentPage, pageSize]
+    [
+      setLoading,
+      filters,
+      currentPage,
+      pageSize,
+      selectedStatuses,
+      showAllMode,
+      activeTab,
+    ]
   );
 
   // Expose fetchData to parent component
@@ -481,6 +515,11 @@ export function ManagedJobsTable({
   React.useEffect(() => {
     fetchData({ includeStatus: true });
   }, [filters, pageSize]);
+
+  // Fetch on status filter changes (activeTab, selectedStatuses, showAllMode)
+  React.useEffect(() => {
+    fetchData({ includeStatus: true });
+  }, [activeTab, selectedStatuses, showAllMode]);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -555,30 +594,10 @@ export function ManagedJobsTable({
     return statusGroups[activeTab].includes(status);
   };
 
-  // Filter data based on filters and selected statuses
+  // Server already applied all filters including status filtering
   const filteredData = React.useMemo(() => {
-    // Server already applied name/user/workspace/pool filters.
-    let filtered = data;
-
-    // If specific statuses are selected, show jobs with any of those statuses
-    if (selectedStatuses.length > 0) {
-      return filtered.filter((item) => selectedStatuses.includes(item.status));
-    }
-
-    // If no statuses are selected but we're in "show all" mode
-    if (showAllMode) {
-      // Show all jobs if activeTab is 'all', otherwise filter by active/finished
-      if (activeTab === 'all') {
-        return filtered; // Show all jobs regardless of status
-      }
-      return filtered.filter((item) =>
-        statusGroups[activeTab].includes(item.status)
-      );
-    }
-
-    // If no statuses are selected and we're not in "show all" mode, show no jobs
-    return [];
-  }, [data, activeTab, selectedStatuses, showAllMode]);
+    return data;
+  }, [data]);
 
   // Sort the filtered data
   const sortedData = React.useMemo(() => {
@@ -625,17 +644,15 @@ export function ManagedJobsTable({
       // We're not in "show all" mode if there are specific statuses selected
       setShowAllMode(false);
     }
+
+    // Reset to first page when changing status filters
+    setCurrentPage(1);
   };
 
-  // Update status counts when data changes
+  // Update status counts from API data
   useEffect(() => {
-    const safeData = data || [];
-    const counts = safeData.reduce((acc, job) => {
-      acc[job.status] = (acc[job.status] || 0) + 1;
-      return acc;
-    }, {});
-    setStatusCounts(counts);
-  }, [data]);
+    setStatusCounts(apiStatusCounts);
+  }, [apiStatusCounts]);
 
   // Page navigation handlers
   const goToPreviousPage = () => {
@@ -662,7 +679,7 @@ export function ManagedJobsTable({
           <div className="flex flex-wrap items-center">
             <span className="mr-2 text-sm font-medium">Statuses:</span>
             <div className="flex flex-wrap gap-2 items-center">
-              {!loading && (!data || data.length === 0) && !isInitialLoad && (
+              {!loading && totalNoFilter === 0 && !isInitialLoad && (
                 <span className="text-gray-500 mr-2">No jobs found</span>
               )}
               {Object.entries(statusCounts).map(([status, count]) => (
@@ -684,15 +701,19 @@ export function ManagedJobsTable({
                   </span>
                 </button>
               ))}
-              {data && data.length > 0 && (
+              {totalNoFilter > 0 && (
                 <div className="flex items-center ml-2 gap-2">
                   <span className="text-gray-500">(</span>
                   <button
                     onClick={() => {
                       // When showing all jobs, clear all selected statuses
-                      setActiveTab('all');
-                      setSelectedStatuses([]);
-                      setShowAllMode(true);
+                      // Use React.startTransition to batch state updates
+                      React.startTransition(() => {
+                        setActiveTab('all');
+                        setSelectedStatuses([]);
+                        setShowAllMode(true);
+                        setCurrentPage(1);
+                      });
                     }}
                     className={`text-sm font-medium ${
                       activeTab === 'all' && showAllMode
@@ -706,9 +727,13 @@ export function ManagedJobsTable({
                   <button
                     onClick={() => {
                       // When showing all active jobs, clear all selected statuses
-                      setActiveTab('active');
-                      setSelectedStatuses([]);
-                      setShowAllMode(true);
+                      // Use React.startTransition to batch state updates
+                      React.startTransition(() => {
+                        setActiveTab('active');
+                        setSelectedStatuses([]);
+                        setShowAllMode(true);
+                        setCurrentPage(1);
+                      });
                     }}
                     className={`text-sm font-medium ${
                       activeTab === 'active' && showAllMode
@@ -722,9 +747,13 @@ export function ManagedJobsTable({
                   <button
                     onClick={() => {
                       // When showing all finished jobs, clear all selected statuses
-                      setActiveTab('finished');
-                      setSelectedStatuses([]);
-                      setShowAllMode(true);
+                      // Use React.startTransition to batch state updates
+                      React.startTransition(() => {
+                        setActiveTab('finished');
+                        setSelectedStatuses([]);
+                        setShowAllMode(true);
+                        setCurrentPage(1);
+                      });
                     }}
                     className={`text-sm font-medium ${
                       activeTab === 'finished' && showAllMode

--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -22,6 +22,7 @@ export async function getManagedJobs(options = {}) {
       poolMatch,
       page,
       limit,
+      statuses,
     } = options;
 
     const body = {
@@ -34,6 +35,7 @@ export async function getManagedJobs(options = {}) {
     if (poolMatch !== undefined) body.pool_match = poolMatch;
     if (page !== undefined) body.page = page;
     if (limit !== undefined) body.limit = limit;
+    if (statuses !== undefined && statuses.length > 0) body.statuses = statuses;
 
     const response = await apiClient.post(`/jobs/queue`, body);
     const id = response.headers.get('X-Skypilot-Request-ID');
@@ -64,6 +66,8 @@ export async function getManagedJobs(options = {}) {
     const total = Array.isArray(parsed)
       ? managedJobs.length
       : (parsed?.total ?? managedJobs.length);
+    const totalNoFilter = parsed?.total_no_filter || total;
+    const statusCounts = parsed?.status_counts || {};
 
     // Process jobs data
     const jobData = managedJobs.map((job) => {
@@ -159,10 +163,22 @@ export async function getManagedJobs(options = {}) {
       };
     });
 
-    return { jobs: jobData, total, controllerStopped: false };
+    return {
+      jobs: jobData,
+      total,
+      totalNoFilter,
+      controllerStopped: false,
+      statusCounts,
+    };
   } catch (error) {
     console.error('Error fetching managed job data:', error);
-    return { jobs: [], total: 0, controllerStopped: false };
+    return {
+      jobs: [],
+      total: 0,
+      totalNoFilter: 0,
+      controllerStopped: false,
+      statusCounts: {},
+    };
   }
 }
 

--- a/sky/jobs/constants.py
+++ b/sky/jobs/constants.py
@@ -47,7 +47,7 @@ JOBS_CLUSTER_NAME_PREFIX_LENGTH = 25
 # The version of the lib files that jobs/utils use. Whenever there is an API
 # change for the jobs/utils, we need to bump this version and update
 # job.utils.ManagedJobCodeGen to handle the version update.
-MANAGED_JOBS_VERSION = 9
+MANAGED_JOBS_VERSION = 10
 
 # The command for setting up the jobs dashboard on the controller. It firstly
 # checks if the systemd services are available, and if not (e.g., Kubernetes

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -514,7 +514,7 @@ def queue_from_kubernetes_pod(
     except exceptions.CommandError as e:
         raise RuntimeError(str(e)) from e
 
-    jobs, _, result_type = managed_job_utils.load_managed_job_queue(
+    jobs, _, result_type, _, _ = managed_job_utils.load_managed_job_queue(
         job_table_payload)
 
     if result_type == managed_job_utils.ManagedJobQueueResultType.DICT:
@@ -587,31 +587,36 @@ def queue(
     pool_match: Optional[str] = None,
     page: Optional[int] = None,
     limit: Optional[int] = None,
-) -> Tuple[List[Dict[str, Any]], int]:
+    statuses: Optional[List[str]] = None,
+) -> Tuple[List[Dict[str, Any]], int, Dict[str, int], int]:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Gets statuses of managed jobs.
 
     Please refer to sky.cli.job_queue for documentation.
 
     Returns:
-        [
-            {
-                'job_id': int,
-                'job_name': str,
-                'resources': str,
-                'submitted_at': (float) timestamp of submission,
-                'end_at': (float) timestamp of end,
-                'job_duration': (float) duration in seconds,
-                'recovery_count': (int) Number of retries,
-                'status': (sky.jobs.ManagedJobStatus) of the job,
-                'cluster_resources': (str) resources of the cluster,
-                'region': (str) region of the cluster,
-                'user_name': (Optional[str]) job creator's user name,
-                'user_hash': (str) job creator's user hash,
-                'task_id': (int), set to 0 (except in pipelines, which may have multiple tasks), # pylint: disable=line-too-long
-                'task_name': (str), same as job_name (except in pipelines, which may have multiple tasks), # pylint: disable=line-too-long
-            }
-        ]
+        jobs: List[Dict[str, Any]]
+            [
+                {
+                    'job_id': int,
+                    'job_name': str,
+                    'resources': str,
+                    'submitted_at': (float) timestamp of submission,
+                    'end_at': (float) timestamp of end,
+                    'job_duration': (float) duration in seconds,
+                    'recovery_count': (int) Number of retries,
+                    'status': (sky.jobs.ManagedJobStatus) of the job,
+                    'cluster_resources': (str) resources of the cluster,
+                    'region': (str) region of the cluster,
+                    'user_name': (Optional[str]) job creator's user name,
+                    'user_hash': (str) job creator's user hash,
+                    'task_id': (int), set to 0 (except in pipelines, which may have multiple tasks), # pylint: disable=line-too-long
+                    'task_name': (str), same as job_name (except in pipelines, which may have multiple tasks), # pylint: disable=line-too-long
+                }
+            ]
+        total: int, total number of jobs after filter
+        status_counts: Dict[str, int], status counts after filter
+        total_no_filter: int, total number of jobs before filter
     Raises:
         sky.exceptions.ClusterNotUpError: the jobs controller is not up or
             does not exist.
@@ -645,13 +650,13 @@ def queue(
     elif user_match is not None:
         users = global_user_state.get_user_by_name_match(user_match)
         if not users:
-            return [], 0
+            return [], 0, {}, 0
         user_hashes = [user.id for user in users]
 
     accessible_workspaces = list(workspaces_core.get_workspaces().keys())
     code = managed_job_utils.ManagedJobCodeGen.get_job_table(
         skip_finished, accessible_workspaces, job_ids, workspace_match,
-        name_match, pool_match, page, limit, user_hashes)
+        name_match, pool_match, page, limit, user_hashes, statuses)
     returncode, job_table_payload, stderr = backend.run_on_head(
         handle,
         code,
@@ -664,11 +669,11 @@ def queue(
         raise RuntimeError('Failed to fetch managed jobs with returncode: '
                            f'{returncode}.\n{job_table_payload + stderr}')
 
-    jobs, total, result_type = managed_job_utils.load_managed_job_queue(
+    jobs, total, result_type, total_no_filter, status_counts = managed_job_utils.load_managed_job_queue(
         job_table_payload)
 
     if result_type == managed_job_utils.ManagedJobQueueResultType.DICT:
-        return jobs, total
+        return jobs, total, status_counts, total_no_filter
 
     # Backward compatibility for old jobs controller without filtering
     # TODO(hailong): remove this after 0.12.0
@@ -702,14 +707,18 @@ def queue(
     if job_ids:
         jobs = [job for job in jobs if job['job_id'] in job_ids]
 
-    return managed_job_utils.filter_jobs(jobs,
-                                         workspace_match,
-                                         name_match,
-                                         pool_match,
-                                         page=page,
-                                         limit=limit,
-                                         user_match=user_match,
-                                         enable_user_match=True)
+    filtered_jobs, total, status_counts = managed_job_utils.filter_jobs(
+        jobs,
+        workspace_match,
+        name_match,
+        pool_match,
+        page=page,
+        limit=limit,
+        user_match=user_match,
+        enable_user_match=True,
+        statuses=statuses,
+    )
+    return filtered_jobs, total, status_counts, total_no_filter
 
 
 @usage_lib.entrypoint

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -669,8 +669,8 @@ def queue(
         raise RuntimeError('Failed to fetch managed jobs with returncode: '
                            f'{returncode}.\n{job_table_payload + stderr}')
 
-    jobs, total, result_type, total_no_filter, status_counts = managed_job_utils.load_managed_job_queue(
-        job_table_payload)
+    (jobs, total, result_type, total_no_filter, status_counts
+    ) = managed_job_utils.load_managed_job_queue(job_table_payload)
 
     if result_type == managed_job_utils.ManagedJobQueueResultType.DICT:
         return jobs, total, status_counts, total_no_filter

--- a/sky/jobs/server/utils.py
+++ b/sky/jobs/server/utils.py
@@ -62,7 +62,8 @@ def check_version_mismatch_and_non_terminal_jobs() -> None:
     version_matches = controller_version == local_version
 
     # Load and filter jobs locally using existing method
-    jobs, _, _ = managed_job_utils.load_managed_job_queue(job_table_payload)
+    jobs, _, _, _, _ = managed_job_utils.load_managed_job_queue(
+        job_table_payload)
     non_terminal_jobs = [job for job in jobs if not job['status'].is_terminal()]
     has_non_terminal_jobs = len(non_terminal_jobs) > 0
 

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1133,6 +1133,7 @@ def dump_managed_job_queue(
     page: Optional[int] = None,
     limit: Optional[int] = None,
     user_hashes: Optional[List[Optional[str]]] = None,
+    statuses: Optional[List[str]] = None,
 ) -> str:
     # Make sure to get all jobs - some logic below (e.g. high priority job
     # detection) requires a full view of the jobs table.
@@ -1160,6 +1161,8 @@ def dump_managed_job_queue(
         if priority is not None and priority > highest_blocking_priority:
             highest_blocking_priority = priority
 
+    total_no_filter = len(jobs)
+
     if user_hashes:
         jobs = [
             job for job in jobs if job.get('user_hash', None) in user_hashes
@@ -1183,8 +1186,13 @@ def dump_managed_job_queue(
     if job_ids:
         jobs = [job for job in jobs if job['job_id'] in job_ids]
 
-    jobs, total = filter_jobs(jobs, workspace_match, name_match, pool_match,
-                              page, limit)
+    jobs, total, status_counts = filter_jobs(jobs,
+                                             workspace_match,
+                                             name_match,
+                                             pool_match,
+                                             page,
+                                             limit,
+                                             statuses=statuses)
     for job in jobs:
         end_at = job['end_at']
         if end_at is None:
@@ -1258,7 +1266,12 @@ def dump_managed_job_queue(
         else:
             job['details'] = None
 
-    return message_utils.encode_payload({'jobs': jobs, 'total': total})
+    return message_utils.encode_payload({
+        'jobs': jobs,
+        'total': total,
+        'total_no_filter': total_no_filter,
+        'status_counts': status_counts
+    })
 
 
 def filter_jobs(
@@ -1270,7 +1283,8 @@ def filter_jobs(
     limit: Optional[int],
     user_match: Optional[str] = None,
     enable_user_match: bool = False,
-) -> Tuple[List[Dict[str, Any]], int]:
+    statuses: Optional[List[str]] = None,
+) -> Tuple[List[Dict[str, Any]], int, Dict[str, int]]:
     """Filter jobs based on the given criteria.
 
     Args:
@@ -1282,9 +1296,12 @@ def filter_jobs(
         limit: Limit to filter.
         user_match: User name to filter.
         enable_user_match: Whether to enable user match.
+        statuses: Statuses to filter.
 
     Returns:
-        List of filtered jobs and total number of jobs.
+        List of filtered jobs
+        Total number of jobs
+        Dictionary of status counts
     """
 
     # TODO(hailong): refactor the whole function including the
@@ -1314,6 +1331,7 @@ def filter_jobs(
         end = min(start + limit, len(result))
         return result[start:end]
 
+    status_counts: Dict[str, int] = collections.defaultdict(int)
     result = []
     checks = [
         ('workspace', workspace_match),
@@ -1327,25 +1345,34 @@ def filter_jobs(
         if not all(
                 _pattern_matches(job, key, pattern) for key, pattern in checks):
             continue
+        status_counts[job['status'].value] += 1
+        if statuses:
+            if job['status'].value not in statuses:
+                continue
         result.append(job)
 
     total = len(result)
 
-    return _handle_page_and_limit(result, page, limit), total
+    return _handle_page_and_limit(result, page, limit), total, status_counts
 
 
 def load_managed_job_queue(
     payload: str
-) -> Tuple[List[Dict[str, Any]], int, ManagedJobQueueResultType]:
+) -> Tuple[List[Dict[str, Any]], int, ManagedJobQueueResultType, int, Dict[
+        str, int]]:
     """Load job queue from json string."""
     result = message_utils.decode_payload(payload)
     result_type = ManagedJobQueueResultType.DICT
+    status_counts = {}
     if isinstance(result, dict):
         jobs = result['jobs']
         total = result['total']
+        status_counts = result.get('status_counts', {})
+        total_no_filter = result.get('total_no_filter', total)
     else:
         jobs = result
         total = len(jobs)
+        total_no_filter = total
         result_type = ManagedJobQueueResultType.LIST
 
     for job in jobs:
@@ -1355,7 +1382,7 @@ def load_managed_job_queue(
             # TODO(cooperc): Remove check before 0.12.0.
             user = global_user_state.get_user(job['user_hash'])
             job['user_name'] = user.name if user is not None else None
-    return jobs, total, result_type
+    return jobs, total, result_type, total_no_filter, status_counts
 
 
 def _get_job_status_from_tasks(
@@ -1713,6 +1740,7 @@ class ManagedJobCodeGen:
         page: Optional[int] = None,
         limit: Optional[int] = None,
         user_hashes: Optional[List[Optional[str]]] = None,
+        statuses: Optional[List[str]] = None,
     ) -> str:
         code = textwrap.dedent(f"""\
         if managed_job_version < 9:
@@ -1720,7 +1748,7 @@ class ManagedJobCodeGen:
             # before #6652.
             # TODO(hailong): Remove compatibility before 0.12.0
             job_table = utils.dump_managed_job_queue()
-        else:
+        elif managed_job_version < 10:
             job_table = utils.dump_managed_job_queue(
                                 skip_finished={skip_finished},
                                 accessible_workspaces={accessible_workspaces!r},
@@ -1731,6 +1759,18 @@ class ManagedJobCodeGen:
                                 page={page!r},
                                 limit={limit!r},
                                 user_hashes={user_hashes!r})
+        else:
+            job_table = utils.dump_managed_job_queue(
+                                skip_finished={skip_finished},
+                                accessible_workspaces={accessible_workspaces!r},
+                                job_ids={job_ids!r},
+                                workspace_match={workspace_match!r},
+                                name_match={name_match!r},
+                                pool_match={pool_match!r},
+                                page={page!r},
+                                limit={limit!r},
+                                user_hashes={user_hashes!r},
+                                statuses={statuses!r})
         print(job_table, flush=True)
         """)
         return cls._build(code)

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -503,6 +503,7 @@ class JobsQueueBody(RequestBody):
     pool_match: Optional[str] = None
     page: Optional[int] = None
     limit: Optional[int] = None
+    statuses: Optional[List[str]] = None
 
 
 class JobsCancelBody(RequestBody):

--- a/sky/server/requests/serializers/encoders.py
+++ b/sky/server/requests/serializers/encoders.py
@@ -113,8 +113,15 @@ def encode_status_kubernetes(
 @register_encoder('jobs.queue')
 def encode_jobs_queue(jobs_or_tuple):
     # Support returning either a plain jobs list or a (jobs, total) tuple
-    if isinstance(jobs_or_tuple, tuple) and len(jobs_or_tuple) == 2:
-        jobs, total = jobs_or_tuple
+    status_counts = {}
+    if isinstance(jobs_or_tuple, tuple):
+        if len(jobs_or_tuple) == 2:
+            jobs, total = jobs_or_tuple
+            total_no_filter = total
+        elif len(jobs_or_tuple) == 4:
+            jobs, total, status_counts, total_no_filter = jobs_or_tuple
+        else:
+            raise ValueError(f'Invalid jobs tuple: {jobs_or_tuple}')
     else:
         jobs = jobs_or_tuple
         total = None
@@ -122,7 +129,12 @@ def encode_jobs_queue(jobs_or_tuple):
         job['status'] = job['status'].value
     if total is None:
         return jobs
-    return {'jobs': jobs, 'total': total}
+    return {
+        'jobs': jobs,
+        'total': total,
+        'total_no_filter': total_no_filter,
+        'status_counts': status_counts
+    }
 
 
 def _encode_serve_status(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Support filtering with status and returning status counts in API server

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
