### PR TITLE
[UX] fix managed job log tailing behavior

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -768,6 +768,12 @@ def stream_logs_by_id(job_id: int,
                             assert tail > 0
                             # Read only the last 'tail' lines using deque
                             read_from = collections.deque(f, maxlen=tail)
+                            # We set start_streaming to True here in case
+                            # truncating the log file removes the line that
+                            # contains LOG_FILE_START_STREAMING_AT. This does
+                            # not cause issues for log files shorter than tail
+                            # because tail_logs in sky/skylet/log_lib.py also
+                            # handles LOG_FILE_START_STREAMING_AT.
                             start_streaming = True
                         for line in read_from:
                             if log_lib.LOG_FILE_START_STREAMING_AT in line:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR addresses an issue with how managed jobs log tailing works for jobs in terminal states with long log files. If a user requests logs for a job that is in a terminal state or in the process of being cancelled, we previously executed the following code path (pseudo code):

```
LOG_FILE_START_STREAMING_AT = 'Waiting for task resources on '
with open(log_file) as f:
   start_streaming = False
   read_from = f
   if tail is not None:
      read_from = f[:-tail]
   for line in read_from:
      if LOG_FILE_START_STREAMING_AT in line:
         start_streaming = True
      if start_streaming:
         print(line)
```

To illustrate the bug, let the log file be 15,000 lines and the tail parameter be 10,000 lines. When we grab the last 10,000 lines of the log file with `read_from = f[:-tail]`, we may be removing the `LOG_FILE_START_STREAMING_AT` line. Thus, no log lines get printed. 

In this PR we add a line right after truncating `read_from` to set `start_streaming = True`. 

<!-- Describe the tests ran -->
I tested this PR by running a job that prints out 15,000 log lines and verified that the dashboard now properly displays the last 10,000 lines. 

I also verified that this change does not break existing functionality for jobs with shorter logs (ie less than 10,000 lines) by running a job that prints out 5 log lines and verified that no extra lines are printed than before.

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
