### PR TITLE
[Catalog] fix aws p5.4xlarge instance type gpu qty

### DIFF
--- a/sky/catalog/data_fetchers/fetch_aws.py
+++ b/sky/catalog/data_fetchers/fetch_aws.py
@@ -325,6 +325,8 @@ def _get_instance_types_df(region: str) -> Union[str, 'pd.DataFrame']:
                 # See also Standard_NV{vcpu}ads_A10_v5 support on Azure.
                 fraction = row['GpuInfo']['TotalGpuMemoryInMiB'] / L4_GPU_MEMORY
                 acc_count = round(fraction, 3)
+            if row['InstanceType'] == 'p5.4xlarge':
+                acc_count = 1
             return pd.Series({
                 'AcceleratorName': acc_name,
                 'AcceleratorCount': acc_count,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR addresses an issue where the following command:
```
❯ sky show-gpus H100 --infra aws            
GPU   QTY  CLOUD  INSTANCE_TYPE  DEVICE_MEM  vCPUs  HOST_MEM  HOURLY_PRICE  HOURLY_SPOT_PRICE  REGION     
H100  0.0  AWS    p5.4xlarge     80GB        16     256GB     $ 6.880       -                  us-east-1  
H100  8.0  AWS    p5.48xlarge    80GB        192    2048GB    $ 55.040      $ 9.667            us-east-2
```

incorrectly indicates that the p5.4xlarge instance type has 0.0 GPUs. We manually correct the catalog to set the QTY for this instance type to 1.0 to match [this](https://aws.amazon.com/ec2/instance-types/p5/) doc.

AWS API response for reference:
```
DEBUG: p5.4xlarge raw AWS GpuInfo: {'Gpus': [{'Name': 'H100', 'Manufacturer': 'NVIDIA', 'Count': 0, 'MemoryInfo': {'SizeInMiB': 81920}}], 'TotalGpuMemoryInMiB': 81920}
```

TODO:
- [ ] manually run the github action in `skypilot-catalog` repo to update the aws catalog
- [ ] within 7 hours, users catalogs will get updated (if someone mentions this issue prior to that, we can recommend them to delete their local catalog


<!-- Describe the tests ran -->
I manually ran `fetch_aws.py` and verified that the generated catalog indeed updates the QTY from 0.0 --> 1.0.

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
