### PR TITLE
Fix RunPod Docker image handling with any_of config

### DIFF
--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -673,7 +673,7 @@ If not specified, SkyPilot will use the default debian-based image suitable for 
 
 **Docker support**
 
-You can specify docker image to use by setting the image_id to ``docker:<image name>`` for Azure, AWS and GCP. For example,
+You can specify docker image to use by setting the image_id to ``docker:<image name>`` for Azure, AWS, GCP, and RunPod. For example,
 
 .. code-block:: yaml
 
@@ -779,7 +779,7 @@ https://github.com/IBM/vpc-img-inst
 .. code-block:: yaml
 
   resources:
-    image_id: ami-0868a20f5a3bf9702  # AWS example
+    image_id: ami-0868a20f5a3bf9702  # IBM example
     # image_id: projects/deeplearning-platform-release/global/images/common-cpu-v20230615-debian-11-py310  # GCP example
     # image_id: docker:pytorch/pytorch:1.13.1-cuda11.6-cudnn8-runtime # Docker example
 
@@ -791,6 +791,29 @@ OR
     image_id:
       us-east-1: ami-123
       us-west-2: ami-456
+
+
+**RunPod**
+
+RunPod natively supports Docker images. You can specify any Docker image:
+
+.. code-block:: yaml
+
+  resources:
+    image_id: docker:ubuntu:22.04
+    # Or use a specific registry
+    image_id: docker:nvcr.io/nvidia/pytorch:24.10-py3
+
+For multi-region deployments, you can specify different images per region:
+
+.. code-block:: yaml
+
+  resources:
+    image_id:
+      US: docker:us-registry.io/myapp:latest
+      CA: docker:ca-registry.io/myapp:latest
+      CZ: docker:eu-registry.io/myapp:latest
+
 
 .. _yaml-spec-resources-labels:
 

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1337,7 +1337,8 @@ class Resources:
                     'Kubernetes, please explicitly specify the cloud.') from e
 
         if self._region is not None:
-            # If the image_id has None as key (region-agnostic), use it for any region
+            # If the image_id has None as key (region-agnostic),
+            # use it for any region
             if None in self._image_id:
                 # Replace None key with the actual region
                 self._image_id = {self._region: self._image_id[None]}

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1260,10 +1260,14 @@ class Resources:
     def extract_docker_image(self) -> Optional[str]:
         if self.image_id is None:
             return None
-        if len(self.image_id) == 1 and self.region in self.image_id:
-            image_id = self.image_id[self.region]
-            if image_id.startswith('docker:'):
-                return image_id[len('docker:'):]
+        # Handle dict image_id
+        if len(self.image_id) == 1:
+            # Check if the single key matches the region or is None (any region)
+            image_key = list(self.image_id.keys())[0]
+            if image_key == self.region or image_key is None:
+                image_id = self.image_id[image_key]
+                if image_id.startswith('docker:'):
+                    return image_id[len('docker:'):]
         return None
 
     def _try_validate_image_id(self) -> None:
@@ -1333,13 +1337,18 @@ class Resources:
                     'Kubernetes, please explicitly specify the cloud.') from e
 
         if self._region is not None:
-            if self._region not in self._image_id:
+            # If the image_id has None as key (region-agnostic), use it for any region
+            if None in self._image_id:
+                # Replace None key with the actual region
+                self._image_id = {self._region: self._image_id[None]}
+            elif self._region not in self._image_id:
                 with ux_utils.print_exception_no_traceback():
                     raise ValueError(
                         f'image_id {self._image_id} should contain the image '
                         f'for the specified region {self._region}.')
-            # Narrow down the image_id to the specified region.
-            self._image_id = {self._region: self._image_id[self._region]}
+            else:
+                # Narrow down the image_id to the specified region.
+                self._image_id = {self._region: self._image_id[self._region]}
 
         # Check the image_id's are valid.
         for region, image_id in self._image_id.items():


### PR DESCRIPTION
## Summary
Fixes #6721 - RunPod fails to identify Docker images when using `any_of` with a simple string format.

## Root Cause
When using RunPod with `any_of` configuration:
```yaml
resources:
  image_id: docker:myimage:latest  # Simple string format
  any_of:
    - infra: runpod/*/US-CA-1
```

The issue occurs because:
1. **Initial parsing**: `image_id` string is stored as `{None: 'docker:myimage:latest'}` (None key means region-agnostic)
2. **Region determination**: During provisioning, RunPod determines the region is "US" based on the zone
3. **Validation failure**: `_try_validate_image_id()` expects the image_id dict to have key="US", but it has key=None
4. **Error**: `ValueError: image_id {None: 'docker:xxx'} should contain the image for the specified region US`

## Solution
Two key changes in `sky/resources.py`:

1. **`extract_docker_image()` method**: Now accepts both `None` key (region-agnostic) and matching region key
2. **`_try_validate_image_id()` method**: Automatically adapts `None`-keyed images to the actual region when determined

This allows the simpler syntax to work while maintaining backward compatibility with explicit region specification.

## Code References

### Existing narrowing behavior in `_try_validate_image_id()`
The original code already modifies `self._image_id` to narrow it down to the specified region:
https://github.com/skypilot-org/skypilot/blob/b06b3dc294f1f8d8494709d18238efdc6dd378db/sky/resources.py#L1336-L1342

### Docker image extraction logic
The `extract_docker_image()` method distinguishes between uniform and region-specific images:
https://github.com/skypilot-org/skypilot/blob/b06b3dc294f1f8d8494709d18238efdc6dd378db/sky/resources.py#L1260-L1267

### RunPod's handling of Docker images
When `extract_docker_image()` returns `None`, RunPod falls back to region-specific lookup:
https://github.com/skypilot-org/skypilot/blob/b06b3dc294f1f8d8494709d18238efdc6dd378db/sky/clouds/runpod.py#L190-L195

## Test plan
- [x] Tested with simple string format: `image_id: docker:myimage:latest`
- [x] Tested with region-specific format: `image_id: {US: docker:myimage:latest}`
- [x] Tested with multi-region format (different images per region)
- [x] Verified dryrun succeeds with all formats
- [x] Updated documentation to clarify RunPod Docker support

🤖 Generated with [Claude Code](https://claude.ai/code)