### PR TITLE
[Serve] Fix unpickle issue on class location change

### DIFF
--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -48,10 +48,11 @@ _PROCESS_POOL_REFRESH_INTERVAL = 20
 _RETRY_INIT_GAP_SECONDS = 60
 _DEFAULT_DRAIN_SECONDS = 120
 
-# TODO(tian): Backward compatibility. We move the ProcessStatus to
-# common_utils.ProcessStatus in #6666, but old ReplicaInfo in database will
-# still tries to unpickle using ProcessStatus in replica_managers. We set this
-# alias to avoid breaking changes. See #6729 for more details.
+# TODO(tian): Backward compatibility. Remove this after 3 minor release, i.e.
+# 0.13.0. We move the ProcessStatus to common_utils.ProcessStatus in #6666, but
+# old ReplicaInfo in database will still tries to unpickle using ProcessStatus
+# in replica_managers. We set this alias to avoid breaking changes. See #6729
+# for more details.
 ProcessStatus = common_utils.ProcessStatus
 
 

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -48,6 +48,12 @@ _PROCESS_POOL_REFRESH_INTERVAL = 20
 _RETRY_INIT_GAP_SECONDS = 60
 _DEFAULT_DRAIN_SECONDS = 120
 
+# TODO(tian): Backward compatibility. We move the ProcessStatus to
+# common_utils.ProcessStatus in #6666, but old ReplicaInfo in database will
+# still tries to unpickle using ProcessStatus in replica_managers. We set this
+# alias to avoid breaking changes. See #6729 for more details.
+ProcessStatus = common_utils.ProcessStatus
+
 
 # TODO(tian): Combine this with
 # sky/spot/recovery_strategy.py::StrategyExecutor::launch


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #6729. We change the location of `ProcessStatus` to `common_utils` in #6666. Previously created replica info object will still try to import the related module from replica managers which causes this bug. This PR fixes it.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
