### PR TITLE
[Test]Stagger test execution to reduce resource contention and total runtime

### DIFF
--- a/.github/workflows/buildkite-trigger-wait.yml
+++ b/.github/workflows/buildkite-trigger-wait.yml
@@ -40,6 +40,11 @@ on:
         type: boolean
         default: true
         description: "Whether to fail the job if the Buildkite build fails"
+      sleep_seconds:
+        required: false
+        type: number
+        default: 0
+        description: "Number of seconds to sleep before triggering the build"
     secrets:
       BUILDKITE_TOKEN:
         required: true
@@ -58,6 +63,14 @@ jobs:
     outputs:
       json: ${{ steps.trigger_buildkite.outputs.json }}
     steps:
+      # Sleep before triggering if specified
+      - name: Sleep before trigger
+        if: ${{ inputs.sleep_seconds > 0 }}
+        run: |
+          echo "Sleeping for ${{ inputs.sleep_seconds }} seconds before triggering Buildkite build..."
+          sleep ${{ inputs.sleep_seconds }}
+          echo "Sleep completed, proceeding with trigger..."
+
       # Trigger Buildkite smoke tests
       - name: Trigger Buildkite Smoke Tests
         id: trigger_buildkite

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -169,12 +169,12 @@ jobs:
       pipeline: "smoke-tests"
       build_env_vars: '{"ARGS": "--kubernetes --no-resource-heavy", "FILE_PATTERN": "test_cluster_job.py,test_region_and_zone.py,test_basic.py"}'
       timeout_minutes: 40
-      sleep_seconds: 1500  # 25-minute delay to reduce buildkite resource usage
+      sleep_seconds: 1200  # 20-minute delay to reduce buildkite resource usage
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
   smoke-tests-remote-server:
-    needs: [gate-tests, nightly-build-pypi]
+    needs: [gate-tests, smoke-tests-kubernetes]
     if: ${{ needs.gate-tests.outputs.run_tests == 'true' }}
     uses: ./.github/workflows/buildkite-trigger-wait.yml
     with:
@@ -184,7 +184,7 @@ jobs:
       pipeline: "smoke-tests"
       build_env_vars: '{"ARGS": "--remote-server", "FILE_PATTERN": "test_cluster_job.py"}'
       timeout_minutes: 40
-      sleep_seconds: 2100  # 35-minute delay to reduce buildkite resource usage
+      sleep_seconds: 1800  # 30-minute delay to reduce buildkite resource usage
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -184,7 +184,7 @@ jobs:
       pipeline: "smoke-tests"
       build_env_vars: '{"ARGS": "--remote-server", "FILE_PATTERN": "test_cluster_job.py"}'
       timeout_minutes: 40
-      sleep_seconds: 1800  # 30-minute delay to reduce buildkite resource usage
+      sleep_seconds: 1500  # 25-minute delay to reduce buildkite resource usage
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -159,8 +159,8 @@ jobs:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
   smoke-tests-kubernetes:
-    needs: [gate-tests, smoke-tests-aws, backward-compat-test]
-    if: ${{ needs.gate-tests.outputs.run_tests == 'true' && always() }}
+    needs: [gate-tests, nightly-build-pypi]
+    if: ${{ needs.gate-tests.outputs.run_tests == 'true' }}
     uses: ./.github/workflows/buildkite-trigger-wait.yml
     with:
       commit: ${{ github.sha }}
@@ -169,13 +169,13 @@ jobs:
       pipeline: "smoke-tests"
       build_env_vars: '{"ARGS": "--kubernetes --no-resource-heavy", "FILE_PATTERN": "test_cluster_job.py,test_region_and_zone.py,test_basic.py"}'
       timeout_minutes: 40
-      sleep_seconds: 1200  # 20-minute delay to reduce buildkite resource usage
+      sleep_seconds: 1500  # 25-minute delay to reduce buildkite resource usage
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
   smoke-tests-remote-server:
-    needs: [gate-tests, smoke-tests-kubernetes]
-    if: ${{ needs.gate-tests.outputs.run_tests == 'true' && always() }}
+    needs: [gate-tests, nightly-build-pypi]
+    if: ${{ needs.gate-tests.outputs.run_tests == 'true' }}
     uses: ./.github/workflows/buildkite-trigger-wait.yml
     with:
       commit: ${{ github.sha }}
@@ -184,7 +184,7 @@ jobs:
       pipeline: "smoke-tests"
       build_env_vars: '{"ARGS": "--remote-server", "FILE_PATTERN": "test_cluster_job.py"}'
       timeout_minutes: 40
-      sleep_seconds: 1800  # 30-minute delay to reduce buildkite resource usage
+      sleep_seconds: 2100  # 35-minute delay to reduce buildkite resource usage
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -169,6 +169,7 @@ jobs:
       pipeline: "smoke-tests"
       build_env_vars: '{"ARGS": "--kubernetes --no-resource-heavy", "FILE_PATTERN": "test_cluster_job.py,test_region_and_zone.py,test_basic.py"}'
       timeout_minutes: 40
+      sleep_seconds: 1200  # 20-minute delay to reduce buildkite resource usage
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
@@ -183,6 +184,7 @@ jobs:
       pipeline: "smoke-tests"
       build_env_vars: '{"ARGS": "--remote-server", "FILE_PATTERN": "test_cluster_job.py"}'
       timeout_minutes: 40
+      sleep_seconds: 1800  # 30-minute delay to reduce buildkite resource usage
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2084,9 +2084,15 @@ def test_autodown(generic_cloud: str):
     name = smoke_tests_utils.get_cluster_name()
     # Azure takes ~ 13m30s (810s) to autodown a VM, so here we use 900 to ensure
     # the VM is terminated.
-    autodown_timeout = 900 if generic_cloud in ('azure', 'kubernetes') else 240
-    total_timeout_minutes = 90 if generic_cloud in ('azure',
-                                                    'kubernetes') else 20
+    if generic_cloud == 'azure':
+        autodown_timeout = 900
+        total_timeout_minutes = 90
+    elif generic_cloud == 'kubernetes':
+        autodown_timeout = 300
+        total_timeout_minutes = 30
+    else:
+        autodown_timeout = 240
+        total_timeout_minutes = 20
     check_autostop_set = f's=$(sky status) && echo "$s" && echo "==check autostop set==" && echo "$s" | grep {name} | grep "1m (down)"'
     test = smoke_tests_utils.Test(
         'autodown',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->


Resolve #6730

Add staggered timing between AWS tests, Kubernetes tests, and remote server tests.  

- **Kubernetes tests** run on a local Kind cluster.  
- **Remote server tests** require launching a local Docker image and connecting to it.  

Both are resource-heavy on the Buildkite agent VM, increasing failure risk if run alongside other tests.  

**Before this PR**

**Fully sequential tests** (e.g., waiting for AWS → Kubernetes → remote, totaling **2.5 hours**):  

```bash
|-----aws tests-----|(1 hour)  
                        |-----kubernetes tests-----|(2 hours total, 1 hour runtime)  
                                                                  |-----remote server tests-----|(2.5 hours total, 0.5 hour runtime)  
```

**After this PR:** 

**Tests overlap** intelligently to reduce total time and resource contention:  

```bash
|-------------aws tests-------------|(1 hour)  
    (25m delay)|--------kubernetes tests--------|(1.4 hours total, 1 hour runtime)  
          (35m delay)|--remote server tests----|(1.1 hour total, 0.5 hour runtime)  
```  

**Key changes:**  
1. **Kubernetes tests start after 25m** (0.4-hour delay), when most AWS tests finish.  
2. **Remote tests start after 35m**, further reducing VM load.  
3. **Total runtime drops to ~1.4 hours** (vs. 2.5 hours sequential) with lower failure rates.  


[Tested on my personal repo](https://github.com/zpoint/skypilot/actions/runs/17065048316/job/48380304805)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
