### PR TITLE
Make API server metrics histogram buckets configurable

### DIFF
--- a/docs/source/reference/api-server/examples/api-server-metrics-setup.rst
+++ b/docs/source/reference/api-server/examples/api-server-metrics-setup.rst
@@ -55,6 +55,19 @@ The endpoint ``/grafana`` on the SkyPilot API server exposes the following metri
 
 You can also :ref:`setup GPU metric collection <api-server-gpu-metrics-setup>` to directly export GPU memory, utilization and power consumption.
 
+.. note::
+
+   You can override the request duration histogram buckets by setting the
+   ``SKY_APISERVER_HISTOGRAM_BUCKETS`` environment variable, e.g.:
+
+   .. code-block:: bash
+
+      helm upgrade skypilot skypilot/skypilot-nightly --devel \
+        --namespace skypilot \
+        --reuse-values \
+        --set extraEnvs[0].name=SKY_APISERVER_HISTOGRAM_BUCKETS \
+        --set extraEnvs[0].value='0.1,1.0,2.5,5.0,10.0,15.0,30.0,60.0,120.0,inf'
+
 Using existing Prometheus / Grafana
 -----------------------------------
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

One of our users reported that the P95/P99 only shows 10 seconds, this PR modify the default buckets of the request duration metrics to capture more detailed metrics and also allow users to override the default buckets via env var.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
