### PR TITLE
charts: fix rbac template rendering for default values after #6737

### DIFF
--- a/charts/skypilot/templates/rbac.yaml
+++ b/charts/skypilot/templates/rbac.yaml
@@ -45,7 +45,7 @@ roleRef:
 {{- if ne $namespace .Release.Namespace }}
 ---
 {{- include "skypilot.ensureNamespace" $namespace }}
-{{- end -}}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/skypilot/templates/rbac.yaml
+++ b/charts/skypilot/templates/rbac.yaml
@@ -42,7 +42,7 @@ roleRef:
   name: {{ .Release.Name }}-api-role
   apiGroup: rbac.authorization.k8s.io
 {{- $namespace := .Values.kubernetesCredentials.inclusterNamespace | default .Release.Namespace }}
-{{- if ne $namespace .Release.Namespace -}}
+{{- if ne $namespace .Release.Namespace }}
 ---
 {{- include "skypilot.ensureNamespace" $namespace }}
 {{- end -}}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

I've accidentally broken chart in #6737 (forgot to remove unnecessary whitespace trim). Now it should work as intended.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
