### PR TITLE
Add grpcio and protobuf to [server] extra depedencies

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -72,12 +72,17 @@ install_requires = [
     'aiohttp',
 ]
 
+# The grpc version at runtime has to be newer than the version
+# used to generate the code.
+GRPC = 'grpcio>=1.63.0'
+
 server_dependencies = [
     'casbin',
     'sqlalchemy_adapter',
     'passlib',
     'pyjwt',
     'aiohttp',
+    GRPC,
 ]
 
 local_ray = [
@@ -91,9 +96,7 @@ local_ray = [
 # See requirements-dev.txt for the version of grpc and protobuf
 # used to generate the code during development.
 remote = [
-    # The grpc version at runtime has to be newer than the version
-    # used to generate the code.
-    'grpcio>=1.63.0',
+    GRPC,
     # >= 5.26.1 because the runtime version can't be older than the version
     # used to generate the code.
     # < 7.0.0 because code generated for a major version V will be supported by

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -72,9 +72,18 @@ install_requires = [
     'aiohttp',
 ]
 
+# See requirements-dev.txt for the version of grpc and protobuf
+# used to generate the code during development.
+
 # The grpc version at runtime has to be newer than the version
 # used to generate the code.
 GRPC = 'grpcio>=1.63.0'
+# >= 5.26.1 because the runtime version can't be older than the version
+# used to generate the code.
+# < 7.0.0 because code generated for a major version V will be supported by
+# protobuf runtimes of version V and V+1.
+# https://protobuf.dev/support/cross-version-runtime-guarantee
+PROTOBUF = 'protobuf>=5.26.1, < 7.0.0'
 
 server_dependencies = [
     'casbin',
@@ -93,16 +102,9 @@ local_ray = [
     'ray[default] >= 2.2.0, != 2.6.0',
 ]
 
-# See requirements-dev.txt for the version of grpc and protobuf
-# used to generate the code during development.
 remote = [
     GRPC,
-    # >= 5.26.1 because the runtime version can't be older than the version
-    # used to generate the code.
-    # < 7.0.0 because code generated for a major version V will be supported by
-    # protobuf runtimes of version V and V+1.
-    # https://protobuf.dev/support/cross-version-runtime-guarantee
-    'protobuf >= 5.26.1, < 7.0.0',
+    PROTOBUF,
 ]
 
 # NOTE: Change the templates/jobs-controller.yaml.j2 file if any of the

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -92,6 +92,7 @@ server_dependencies = [
     'pyjwt',
     'aiohttp',
     GRPC,
+    PROTOBUF,
 ]
 
 local_ray = [


### PR DESCRIPTION
Previously, `grpcio` is not included as a server dependency:
```
% pip install 'skypilot-nightly[aws,gcp,server]==1.0.0.dev20250818'
% pip show grpcio
WARNING: Package(s) not found: grpcio
```

This PR now includes it.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
