### PR TITLE
[UX] Improve messages for VPC errors.

### DIFF
--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -690,4 +690,3 @@ def get_security_group_from_vpc_id(ec2: 'mypy_boto3_ec2.ServiceResource',
             return sg
 
     return None
-

--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -437,8 +437,6 @@ def _usable_subnets(
         utils.handle_boto_error(exc,
                                 'Failed to fetch available subnets from AWS.')
         raise exc
-    except Exception as e:
-        raise e
 
     if _are_user_subnets_pruned(subnets):
         _skypilot_log_error_and_exit_for_failover(

--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -371,9 +371,25 @@ def _usable_subnets(
                 s for s in candidate_subnets if s.vpc_id == vpc_id_of_sg
             ]
 
+            if not candidate_subnets:
+                _skypilot_log_error_and_exit_for_failover(
+                    'No candidate subnets found in specified VPC '
+                    f'{vpc_id_of_sg}.')
+
         available_subnets = [
             s for s in candidate_subnets if s.state == 'available'
         ]
+
+        if not available_subnets:
+            _skypilot_log_error_and_exit_for_failover(
+                'All candidate subnets are pending in specified VPC '
+                f'{vpc_id_of_sg}.')
+
+        if len(candidate_subnets) > len(available_subnets):
+            num_pruned = len(candidate_subnets) - len(available_subnets)
+            logger.debug(
+                f'{num_pruned} candidate subnets pruned since they are not '
+                'available.')
 
         if use_internal_ips:
             # Get private subnets.
@@ -386,6 +402,10 @@ def _usable_subnets(
                 if not _is_subnet_public(ec2, s.subnet_id, vpc_id_of_sg) and
                 not s.map_public_ip_on_launch
             ]
+            if not subnets:
+                _skypilot_log_error_and_exit_for_failover(
+                    'The use_internal_ips option is set to True, but all '
+                    'candidate subnets are public.')
         else:
             # Get public subnets.
             #
@@ -401,6 +421,10 @@ def _usable_subnets(
                 s for s in available_subnets
                 if _is_subnet_public(ec2, s.subnet_id, vpc_id_of_sg)
             ]
+            if not subnets:
+                _skypilot_log_error_and_exit_for_failover(
+                    'All candidate subnets are private, did you mean to '
+                    'set use_internal_ips to True?')
 
         subnets = sorted(
             subnets,
@@ -413,19 +437,10 @@ def _usable_subnets(
         utils.handle_boto_error(exc,
                                 'Failed to fetch available subnets from AWS.')
         raise exc
+    except Exception as e:
+        raise e
 
-    if not subnets:
-        vpc_msg = (f'Does a default VPC exist in region '
-                   f'{ec2.meta.client.meta.region_name}? ') if (
-                       vpc_id_of_sg is None) else ''
-        _skypilot_log_error_and_exit_for_failover(
-            f'No usable subnets found. {vpc_msg}'
-            'Try manually creating an instance in your specified region to '
-            'populate the list of subnets and try again. '
-            'Note that the subnet must map public IPs '
-            'on instance launch unless you set `use_internal_ips: true` in '
-            'the `provider` config.')
-    elif _are_user_subnets_pruned(subnets):
+    if _are_user_subnets_pruned(subnets):
         _skypilot_log_error_and_exit_for_failover(
             f'The specified subnets are not '
             f'usable: {_get_pruned_subnets(subnets)}')
@@ -544,6 +559,11 @@ def _get_subnet_and_vpc_id(ec2: 'mypy_boto3_ec2.ServiceResource',
     # not want SkyPilot to use.
     if vpc_id_of_sg is None:
         all_subnets = [s for s in all_subnets if s.vpc.is_default]
+        if not all_subnets:
+            _skypilot_log_error_and_exit_for_failover(
+                f'The default VPC in {region} either does not exist or '
+                'has no subnets.')
+
     subnets, vpc_id = _usable_subnets(
         ec2,
         user_specified_subnets=None,
@@ -670,3 +690,4 @@ def get_security_group_from_vpc_id(ec2: 'mypy_boto3_ec2.ServiceResource',
             return sg
 
     return None
+

--- a/tests/unit_tests/test_aws.py
+++ b/tests/unit_tests/test_aws.py
@@ -1,8 +1,13 @@
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import pytest
+import typing
 
 from sky.clouds.aws import AWS
+from sky.provision.aws import config
+
+import mypy_boto3_ec2
+# from mypy_boto3_ec2 import type_defs as ec2_type_defs
 
 
 def test_aws_label():
@@ -23,3 +28,60 @@ def test_aws_label():
         'sprinto:short',
         'thisiexample_string_with_123_characters_length_thing_thing_thing_thing_thing_thing_thing_thin_thing_thing_thing_thing_thing_thingthisiexample_string_with_123_characters_length_thing_thing_thing_thing_thing_thing_thing_thin_thing_thing_thing_thing_thing_thing',
     )[0])
+
+def test_usable_subnets(monkeypatch):
+    """Test the output of the usable_subnets function."""
+
+    vpc_name = "test_vpc"
+    vpc_id = "test-vpc-id"
+    region = "test-region"
+
+    subnets = MagicMock()
+    monkeypatch.setattr(subnets, 'all', lambda: [])
+
+    mock_ec2 = MagicMock(spec=mypy_boto3_ec2.ServiceResource)
+    mock_ec2.subnets = subnets
+    # monkeypatch.setattr(mock_ec2, 'subnets', subnets
+    # Case 1: default VPC has no subnets.
+    monkeypatch.setattr(config, '_get_vpc_id_by_name', lambda *args, **kwargs: vpc_id)
+    with pytest.raises(RuntimeError) as e:
+        config._get_subnet_and_vpc_id(ec2=mock_ec2, security_group_ids=None, region=region, availability_zone=None, use_internal_ips=False, vpc_name=None)
+    
+    error_message = str(e.value)
+    assert f"SKYPILOT_ERROR_NO_NODES_LAUNCHED: The default VPC in {region} either does not exist or has no subnets." == error_message
+
+    # Case 2: Specified VPC has no subnets.
+    with pytest.raises(RuntimeError) as e:
+        config._get_subnet_and_vpc_id(ec2=mock_ec2, security_group_ids=None, region=region, availability_zone=None, use_internal_ips=False, vpc_name=vpc_name)
+
+    error_message = str(e.value)
+    assert f"SKYPILOT_ERROR_NO_NODES_LAUNCHED: No candidate subnets found in specified VPC {vpc_id}." == error_message
+
+    # Case 3: All the subnets are public and use_internal_ips is True.
+    monkeypatch.setattr('sky.provision.aws.config._is_subnet_public', lambda *args, **kwargs: True)
+    subnet = MagicMock()
+    subnet.vpc = MagicMock()
+    subnet.vpc.is_default = True
+    subnet.vpc_id = vpc_id
+    subnet.state = 'available'
+    monkeypatch.setattr(subnets, 'all', lambda: [subnet])
+    with pytest.raises(RuntimeError) as e:
+        config._get_subnet_and_vpc_id(ec2=mock_ec2, security_group_ids=None, region=region, availability_zone=None, use_internal_ips=True, vpc_name=vpc_name)
+    
+    error_message = str(e.value)
+    assert f"SKYPILOT_ERROR_NO_NODES_LAUNCHED: The use_internal_ips option is set to True, but all candidate subnets are public." == error_message
+
+
+    # Case 4: All the subnets are private and use_internal_ips is False
+    monkeypatch.setattr('sky.provision.aws.config._is_subnet_public', lambda *args, **kwargs: False)
+    subnet = MagicMock()
+    subnet.vpc = MagicMock()
+    subnet.vpc.is_default = True
+    subnet.vpc_id = vpc_id
+    subnet.state = 'available'
+    monkeypatch.setattr(subnets, 'all', lambda: [subnet])
+    with pytest.raises(RuntimeError) as e:
+        config._get_subnet_and_vpc_id(ec2=mock_ec2, security_group_ids=None, region=region, availability_zone=None, use_internal_ips=False, vpc_name=vpc_name)
+    
+    error_message = str(e.value)
+    assert f"SKYPILOT_ERROR_NO_NODES_LAUNCHED: All candidate subnets are private, did you mean to set use_internal_ips to True?" == error_message

--- a/tests/unit_tests/test_aws.py
+++ b/tests/unit_tests/test_aws.py
@@ -1,13 +1,11 @@
-from unittest.mock import patch, MagicMock
+import typing
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
-import typing
 
 from sky.clouds.aws import AWS
 from sky.provision.aws import config
-
-import mypy_boto3_ec2
-# from mypy_boto3_ec2 import type_defs as ec2_type_defs
 
 
 def test_aws_label():
@@ -29,6 +27,7 @@ def test_aws_label():
         'thisiexample_string_with_123_characters_length_thing_thing_thing_thing_thing_thing_thing_thin_thing_thing_thing_thing_thing_thingthisiexample_string_with_123_characters_length_thing_thing_thing_thing_thing_thing_thing_thin_thing_thing_thing_thing_thing_thing',
     )[0])
 
+
 def test_usable_subnets(monkeypatch):
     """Test the output of the usable_subnets function."""
 
@@ -39,26 +38,38 @@ def test_usable_subnets(monkeypatch):
     subnets = MagicMock()
     monkeypatch.setattr(subnets, 'all', lambda: [])
 
-    mock_ec2 = MagicMock(spec=mypy_boto3_ec2.ServiceResource)
+    mock_ec2 = MagicMock()
     mock_ec2.subnets = subnets
     # monkeypatch.setattr(mock_ec2, 'subnets', subnets
     # Case 1: default VPC has no subnets.
-    monkeypatch.setattr(config, '_get_vpc_id_by_name', lambda *args, **kwargs: vpc_id)
+    monkeypatch.setattr(config, '_get_vpc_id_by_name',
+                        lambda *args, **kwargs: vpc_id)
     with pytest.raises(RuntimeError) as e:
-        config._get_subnet_and_vpc_id(ec2=mock_ec2, security_group_ids=None, region=region, availability_zone=None, use_internal_ips=False, vpc_name=None)
-    
+        config._get_subnet_and_vpc_id(ec2=mock_ec2,
+                                      security_group_ids=None,
+                                      region=region,
+                                      availability_zone=None,
+                                      use_internal_ips=False,
+                                      vpc_name=None)
+
     error_message = str(e.value)
     assert f"SKYPILOT_ERROR_NO_NODES_LAUNCHED: The default VPC in {region} either does not exist or has no subnets." == error_message
 
     # Case 2: Specified VPC has no subnets.
     with pytest.raises(RuntimeError) as e:
-        config._get_subnet_and_vpc_id(ec2=mock_ec2, security_group_ids=None, region=region, availability_zone=None, use_internal_ips=False, vpc_name=vpc_name)
+        config._get_subnet_and_vpc_id(ec2=mock_ec2,
+                                      security_group_ids=None,
+                                      region=region,
+                                      availability_zone=None,
+                                      use_internal_ips=False,
+                                      vpc_name=vpc_name)
 
     error_message = str(e.value)
     assert f"SKYPILOT_ERROR_NO_NODES_LAUNCHED: No candidate subnets found in specified VPC {vpc_id}." == error_message
 
     # Case 3: All the subnets are public and use_internal_ips is True.
-    monkeypatch.setattr('sky.provision.aws.config._is_subnet_public', lambda *args, **kwargs: True)
+    monkeypatch.setattr('sky.provision.aws.config._is_subnet_public',
+                        lambda *args, **kwargs: True)
     subnet = MagicMock()
     subnet.vpc = MagicMock()
     subnet.vpc.is_default = True
@@ -66,14 +77,19 @@ def test_usable_subnets(monkeypatch):
     subnet.state = 'available'
     monkeypatch.setattr(subnets, 'all', lambda: [subnet])
     with pytest.raises(RuntimeError) as e:
-        config._get_subnet_and_vpc_id(ec2=mock_ec2, security_group_ids=None, region=region, availability_zone=None, use_internal_ips=True, vpc_name=vpc_name)
-    
+        config._get_subnet_and_vpc_id(ec2=mock_ec2,
+                                      security_group_ids=None,
+                                      region=region,
+                                      availability_zone=None,
+                                      use_internal_ips=True,
+                                      vpc_name=vpc_name)
+
     error_message = str(e.value)
     assert f"SKYPILOT_ERROR_NO_NODES_LAUNCHED: The use_internal_ips option is set to True, but all candidate subnets are public." == error_message
 
-
     # Case 4: All the subnets are private and use_internal_ips is False
-    monkeypatch.setattr('sky.provision.aws.config._is_subnet_public', lambda *args, **kwargs: False)
+    monkeypatch.setattr('sky.provision.aws.config._is_subnet_public',
+                        lambda *args, **kwargs: False)
     subnet = MagicMock()
     subnet.vpc = MagicMock()
     subnet.vpc.is_default = True
@@ -81,7 +97,12 @@ def test_usable_subnets(monkeypatch):
     subnet.state = 'available'
     monkeypatch.setattr(subnets, 'all', lambda: [subnet])
     with pytest.raises(RuntimeError) as e:
-        config._get_subnet_and_vpc_id(ec2=mock_ec2, security_group_ids=None, region=region, availability_zone=None, use_internal_ips=False, vpc_name=vpc_name)
-    
+        config._get_subnet_and_vpc_id(ec2=mock_ec2,
+                                      security_group_ids=None,
+                                      region=region,
+                                      availability_zone=None,
+                                      use_internal_ips=False,
+                                      vpc_name=vpc_name)
+
     error_message = str(e.value)
     assert f"SKYPILOT_ERROR_NO_NODES_LAUNCHED: All candidate subnets are private, did you mean to set use_internal_ips to True?" == error_message

--- a/tests/unit_tests/test_aws.py
+++ b/tests/unit_tests/test_aws.py
@@ -42,7 +42,7 @@ def test_usable_subnets(monkeypatch):
     mock_ec2.subnets = subnets
     # monkeypatch.setattr(mock_ec2, 'subnets', subnets
     # Case 1: default VPC has no subnets.
-    monkeypatch.setattr(config, '_get_vpc_id_by_name',
+    monkeypatch.setattr(config, 'get_vpc_id_by_name',
                         lambda *args, **kwargs: vpc_id)
     with pytest.raises(RuntimeError) as e:
         config._get_subnet_and_vpc_id(ec2=mock_ec2,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This pull request aims to give more information to the user when they are unable to launch a cluster on AWS due to a VPC error.

<!-- Describe the tests ran -->
This was tested by verifying the output messages provided more clarity in each case and ensuring the normal code path functions as expected.

Case 1: The default VPC has no subnets or does not exist
Output is now:
```bash
E 08-19 11:07:15 config.py:52] SKYPILOT_ERROR_NO_NODES_LAUNCHED: The default VPC in ap-south-2 either does not exist or has no subnets.
```

Case 2: You specified a VPC with no subnets.
Output is now:
```bash
E 08-19 11:22:15 config.py:52] SKYPILOT_ERROR_NO_NODES_LAUNCHED: No candidate subnets found in specified VPC vpc-05c3bc628da4d4f1c.
```

Case 3: All the subnets are public and use_internal_ips is True
Output is now:
```bash
E 08-19 11:38:40 config.py:52] SKYPILOT_ERROR_NO_NODES_LAUNCHED: The use_internal_ips option is set to True, but all candidate subnets are public.
```

Case 4: All the subnets are private and use_internal_ips is false
Output is now:
```bash
E 08-19 11:27:13 config.py:52] SKYPILOT_ERROR_NO_NODES_LAUNCHED: All candidate subnets are private, did you mean to set use_internal_ips to True?
```

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
