### PR TITLE
Setting region more explicitly in aws logs

### DIFF
--- a/sky/logs/aws.py
+++ b/sky/logs/aws.py
@@ -130,7 +130,10 @@ class CloudwatchLoggingAgent(FluentbitAgent):
 
         # If region is specified, set it in the environment
         if self.config.region:
-            pre_cmd += f' export AWS_REGION={self.config.region};'
+            pre_cmd += (f' export AWS_REGION={self.config.region}'
+                        f' AWS_DEFAULT_REGION={self.config.region};'
+                        ' command -v aws &>/dev/null && '
+                        f'aws configure set region {self.config.region};')
         else:
             # If region is not specified, check if it's available in
             # the environment or credentials file


### PR DESCRIPTION
Setting `AWS_DEFAULT_REGION` and region via `aws configure set`, because it seems like the cloudwatch command later in this string doesn't respect `AWS_REGION`


Tested manually on our clusters

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
