### PR TITLE
[UX] Add client version and commit to sky api info

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -6200,6 +6200,9 @@ def api_info():
         user = api_server_user
     else:
         user = models.User.get_current_user()
+    # Print client version and commit.
+    click.echo(f'SkyPilot client version: {sky.__version__} '
+               f'commit: {sky.__commit__}')
     click.echo(f'Using SkyPilot API server and dashboard: {url}\n'
                f'{ux_utils.INDENT_SYMBOL}Status: {api_server_info.status}, '
                f'commit: {api_server_info.commit}, '

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -6201,7 +6201,7 @@ def api_info():
     else:
         user = models.User.get_current_user()
     # Print client version and commit.
-    click.echo(f'SkyPilot client version: {sky.__version__} '
+    click.echo(f'SkyPilot client version: {sky.__version__}, '
                f'commit: {sky.__commit__}')
     click.echo(f'Using SkyPilot API server and dashboard: {url}\n'
                f'{ux_utils.INDENT_SYMBOL}Status: {api_server_info.status}, '

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -351,7 +351,7 @@ class TestWithNoCloudEnabled:
         assert not result.exit_code
         output = result.stdout.split('\n')
         assert output[
-            0] == f'SkyPilot client version: {client_version} commit: {client_commit}'
+            0] == f'SkyPilot client version: {client_version}, commit: {client_commit}'
         assert output[
             1] == f'Using SkyPilot API server and dashboard: {server_url}'
         assert output[

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,9 +4,12 @@ from click import testing as cli_testing
 import requests
 
 from sky import clouds
+from sky import models
 from sky import server
 from sky.client.cli import command
+from sky.schemas.api import responses
 from sky.utils import status_lib
+from sky.utils import ux_utils
 
 CLOUDS_TO_TEST = [
     'aws', 'gcp', 'ibm', 'azure', 'lambda', 'scp', 'oci', 'vsphere', 'nebius'
@@ -35,8 +38,8 @@ def mock_server_api_version(monkeypatch, version):
 def mock_api_server_calls(monkeypatch):
     """Mock all API server related calls to prevent real network requests."""
     # Mock API server status checks
-    mock_api_info = mock.MagicMock()
-    mock_api_info.status = 'healthy'
+    mock_api_info = mock.MagicMock(spec=responses.APIHealthResponse)
+    mock_api_info.status = server.common.ApiServerStatus.HEALTHY
     mock_api_info.api_version = 1
     mock_api_info.version = '1.0.0'
     mock_api_info.commit = 'test_commit'
@@ -66,7 +69,7 @@ def mock_api_server_calls(monkeypatch):
         if '/api/health' in path:
             mock_response.json.return_value = {
                 'status': 'healthy',
-                'api_version': 1,
+                'api_version': "1",
                 'version': '1.0.0',
                 'version_on_disk': '1.0.0',
                 'commit': 'test_commit',
@@ -233,6 +236,8 @@ def mock_api_server_calls(monkeypatch):
     monkeypatch.setattr('sky.server.rest.request_without_retry',
                         mock_rest_request)
 
+    return mock_api_info
+
 
 class TestWithNoCloudEnabled:
 
@@ -318,6 +323,41 @@ class TestWithNoCloudEnabled:
         result = cli_runner.invoke(command.check, ['notarealcloud'])
         # In mocked environment, this should succeed rather than raise ValueError
         assert not result.exit_code
+
+    def test_cli_api_info(self, monkeypatch):
+        """Test that `sky api info` returns the expected output."""
+        mock_api_info = mock_api_server_calls(monkeypatch)
+
+        client_version = '1.0.0'
+        client_commit = '1234567890'
+
+        monkeypatch.setattr('sky.__version__', client_version)
+        monkeypatch.setattr('sky.__commit__', client_commit)
+
+        current_user = models.User(id='test_user_id', name='test_user')
+
+        mock_get_current_user = mock.MagicMock()
+        mock_get_current_user.return_value = current_user
+        monkeypatch.setattr(models.User, 'get_current_user',
+                            mock_get_current_user)
+
+        user = models.User.get_current_user()
+        server_url = 'http://localhost:8000'
+        monkeypatch.setattr('sky.server.common.get_server_url',
+                            lambda: server_url)
+
+        cli_runner = cli_testing.CliRunner()
+        result = cli_runner.invoke(command.api_info)
+        assert not result.exit_code
+        output = result.stdout.split('\n')
+        assert output[
+            0] == f'SkyPilot client version: {client_version} commit: {client_commit}'
+        assert output[
+            1] == f'Using SkyPilot API server and dashboard: {server_url}'
+        assert output[
+            2] == f'├── Status: {mock_api_info.status}, commit: {mock_api_info.commit}, version: {mock_api_info.version}'
+        assert output[3] == f'└── User: {current_user.name} ({current_user.id})'
+        assert len(output) == 5
 
 
 class TestHelperFunctions:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR adds client version and commit to sky api info.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

This PR was tested by running sky api info and verifying the client and server version.

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
