### PR TITLE
[UX] fix managed jobs log download paths

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4358,7 +4358,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         # strip the prefix to get just the relative part to avoid duplication
         # when constructing local paths.
         if run_timestamp.startswith(constants.SKY_LOGS_DIRECTORY):
-            run_timestamp = run_timestamp[len(constants.SKY_LOGS_DIRECTORY):].lstrip('/')
+            run_timestamp = run_timestamp[len(constants.SKY_LOGS_DIRECTORY
+                                             ):].lstrip('/')
         local_log_dir = ''
         if controller:  # download controller logs
             remote_log = os.path.join(managed_jobs.JOBS_CONTROLLER_LOGS_DIR,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR addresses an issue where downloading managed job logs would result in a malformed path on the client-side:
```
❯ sky jobs logs -s 1
Job 1 logs: ~/sky_logs/managed_jobs/~/sky_logs/1-long-logs-test
```

<!-- Describe the tests ran -->
This PR was tested by first verifying with a local api server that the log path now looks like `~/sky_logs/managed_jobs/1-long-logs-test` and ensuring that the behavior of `sky jobs logs 1`, `sky jobs logs --controller 1`, and in the dashboard are unaffected. I also tested the change with a remote api server running in k8s to ensure the commands listed above all yield the expected behavior.

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
