### PR TITLE
[UX] Download button for managed jobs logs

### DIFF
--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -642,3 +642,59 @@ export async function handleJobAction(action, jobId, cluster) {
     );
   }
 }
+
+/**
+ * Downloads managed job logs as a zip via the API server.
+ * Flow:
+ * 1) POST /jobs/download_logs to fetch logs from the remote cluster to API server
+ * 2) POST /download to stream a zip back to the browser and trigger download
+ */
+export async function downloadManagedJobLogs({
+  jobId = null,
+  name = null,
+  controller = false,
+}) {
+  try {
+    // Step 1: schedule server-side download; result is a mapping job_id -> folder path on API server
+    const mapping = await apiClient.fetch('/jobs/download_logs', {
+      job_id: jobId,
+      name: name,
+      controller: controller,
+      refresh: false,
+    });
+
+    const folderPaths = Object.values(mapping || {});
+    if (!folderPaths.length) {
+      showToast('No logs found to download.', 'warning');
+      return;
+    }
+
+    // Step 2: request the zip and trigger browser download
+    const baseUrl = window.location.origin;
+    const fullUrl = `${baseUrl}${ENDPOINT}/download`;
+    const resp = await fetch(`${fullUrl}?relative=items`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ folder_paths: folderPaths }),
+    });
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(`Download failed: ${resp.status} ${text}`);
+    }
+    const blob = await resp.blob();
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const namePart = jobId ? `job-${jobId}` : name ? `job-${name}` : 'job';
+    const logType = controller ? 'controller-logs' : 'logs';
+    a.href = url;
+    a.download = `managed-${namePart}-${logType}-${ts}.zip`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    window.URL.revokeObjectURL(url);
+  } catch (error) {
+    console.error('Error downloading managed job logs:', error);
+    showToast(`Error downloading managed job logs: ${error.message}`, 'error');
+  }
+}

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -11,6 +11,7 @@ import {
   ChevronRightIcon,
   CopyIcon,
   CheckIcon,
+  Download,
 } from 'lucide-react';
 import {
   CustomTooltip as Tooltip,
@@ -18,7 +19,10 @@ import {
   renderPoolLink,
 } from '@/components/utils';
 import { LogFilter, formatLogs, stripAnsiCodes } from '@/components/utils';
-import { streamManagedJobLogs } from '@/data/connectors/jobs';
+import {
+  streamManagedJobLogs,
+  downloadManagedJobLogs,
+} from '@/data/connectors/jobs';
 import { StatusBadge } from '@/components/elements/StatusBadge';
 import { useMobile } from '@/hooks/useMobile';
 import Head from 'next/head';
@@ -250,20 +254,40 @@ function JobDetails() {
                       logs.)
                     </span>
                   </div>
-                  <Tooltip
-                    content="Refresh logs"
-                    className="text-muted-foreground"
-                  >
-                    <button
-                      onClick={handleLogsRefresh}
-                      disabled={isLoadingLogs}
-                      className="text-sky-blue hover:text-sky-blue-bright flex items-center"
+                  <div className="flex items-center space-x-3">
+                    <Tooltip
+                      content="Download full logs"
+                      className="text-muted-foreground"
                     >
-                      <RotateCwIcon
-                        className={`w-4 h-4 ${isLoadingLogs ? 'animate-spin' : ''}`}
-                      />
-                    </button>
-                  </Tooltip>
+                      <button
+                        onClick={() =>
+                          downloadManagedJobLogs({
+                            jobId: parseInt(
+                              Array.isArray(jobId) ? jobId[0] : jobId
+                            ),
+                            controller: false,
+                          })
+                        }
+                        className="text-sky-blue hover:text-sky-blue-bright flex items-center"
+                      >
+                        <Download className="w-4 h-4" />
+                      </button>
+                    </Tooltip>
+                    <Tooltip
+                      content="Refresh logs"
+                      className="text-muted-foreground"
+                    >
+                      <button
+                        onClick={handleLogsRefresh}
+                        disabled={isLoadingLogs}
+                        className="text-sky-blue hover:text-sky-blue-bright flex items-center"
+                      >
+                        <RotateCwIcon
+                          className={`w-4 h-4 ${isLoadingLogs ? 'animate-spin' : ''}`}
+                        />
+                      </button>
+                    </Tooltip>
+                  </div>
                 </div>
                 <div className="p-4">
                   <JobDetailsContent
@@ -291,20 +315,40 @@ function JobDetails() {
                       logs.)
                     </span>
                   </div>
-                  <Tooltip
-                    content="Refresh controller logs"
-                    className="text-muted-foreground"
-                  >
-                    <button
-                      onClick={handleControllerLogsRefresh}
-                      disabled={isLoadingControllerLogs}
-                      className="text-sky-blue hover:text-sky-blue-bright flex items-center"
+                  <div className="flex items-center space-x-3">
+                    <Tooltip
+                      content="Download full controller logs"
+                      className="text-muted-foreground"
                     >
-                      <RotateCwIcon
-                        className={`w-4 h-4 ${isLoadingControllerLogs ? 'animate-spin' : ''}`}
-                      />
-                    </button>
-                  </Tooltip>
+                      <button
+                        onClick={() =>
+                          downloadManagedJobLogs({
+                            jobId: parseInt(
+                              Array.isArray(jobId) ? jobId[0] : jobId
+                            ),
+                            controller: true,
+                          })
+                        }
+                        className="text-sky-blue hover:text-sky-blue-bright flex items-center"
+                      >
+                        <Download className="w-4 h-4" />
+                      </button>
+                    </Tooltip>
+                    <Tooltip
+                      content="Refresh controller logs"
+                      className="text-muted-foreground"
+                    >
+                      <button
+                        onClick={handleControllerLogsRefresh}
+                        disabled={isLoadingControllerLogs}
+                        className="text-sky-blue hover:text-sky-blue-bright flex items-center"
+                      >
+                        <RotateCwIcon
+                          className={`w-4 h-4 ${isLoadingControllerLogs ? 'animate-spin' : ''}`}
+                        />
+                      </button>
+                    </Tooltip>
+                  </div>
                 </div>
                 <div className="p-4">
                   <JobDetailsContent

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -1042,17 +1042,7 @@ def get_log_dir_for_jobs(job_ids: List[Optional[str]]) -> str:
     for row in rows:
         job_id = row[JobInfoLoc.JOB_ID.value]
         if row[JobInfoLoc.LOG_PATH.value]:
-            log_path = row[JobInfoLoc.LOG_PATH.value]
-            # If LOG_PATH contains the full path with SKY_LOGS_DIRECTORY,
-            # strip the prefix to get just the relative part.
-            # This allows callers to construct the appropriate path based on
-            # their context (local filesystem vs API server directory).
-            if log_path.startswith(constants.SKY_LOGS_DIRECTORY):
-                relative_path = log_path[len(constants.SKY_LOGS_DIRECTORY
-                                            ):].lstrip('/')
-                job_to_dir[str(job_id)] = relative_path
-            else:
-                job_to_dir[str(job_id)] = log_path
+            job_to_dir[str(job_id)] = row[JobInfoLoc.LOG_PATH.value]
         else:
             run_timestamp = row[JobInfoLoc.RUN_TIMESTAMP.value]
             job_to_dir[str(job_id)] = os.path.join(constants.SKY_LOGS_DIRECTORY,

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -1042,7 +1042,17 @@ def get_log_dir_for_jobs(job_ids: List[Optional[str]]) -> str:
     for row in rows:
         job_id = row[JobInfoLoc.JOB_ID.value]
         if row[JobInfoLoc.LOG_PATH.value]:
-            job_to_dir[str(job_id)] = row[JobInfoLoc.LOG_PATH.value]
+            log_path = row[JobInfoLoc.LOG_PATH.value]
+            # If LOG_PATH contains the full path with SKY_LOGS_DIRECTORY,
+            # strip the prefix to get just the relative part.
+            # This allows callers to construct the appropriate path based on
+            # their context (local filesystem vs API server directory).
+            if log_path.startswith(constants.SKY_LOGS_DIRECTORY):
+                relative_path = log_path[len(constants.SKY_LOGS_DIRECTORY
+                                            ):].lstrip('/')
+                job_to_dir[str(job_id)] = relative_path
+            else:
+                job_to_dir[str(job_id)] = log_path
         else:
             run_timestamp = row[JobInfoLoc.RUN_TIMESTAMP.value]
             job_to_dir[str(job_id)] = os.path.join(constants.SKY_LOGS_DIRECTORY,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR adds a download button for managed jobs logs similar to the one for cluster job logs. 


<!-- Describe the tests ran -->
I tested running a managed job and verifying that I could indeed download the logs as a zip file (`Managed Job Logs Aug 19 2025.zip`) which unzips to `1-long-logs-test/run.log`. 
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
