### PR TITLE
[Optimizer][SSH] Support ssh specific region launch

### DIFF
--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1262,12 +1262,13 @@ def _check_specified_clouds(dag: 'dag_lib.Dag') -> None:
 
 
 def _check_specified_regions(task: task_lib.Task) -> None:
-    """Check if specified regions (Kubernetes contexts) are enabled.
+    """Check if specified regions (Kubernetes/SSH contexts) are enabled.
 
     Args:
         task: The task to check.
     """
-    # Only check for Kubernetes now
+    # Only check for Kubernetes/SSH for now
+    # Below check works because SSH inherits Kubernetes cloud.
     if not all(
             isinstance(resources.cloud, clouds.Kubernetes)
             for resources in task.resources):
@@ -1276,12 +1277,21 @@ def _check_specified_regions(task: task_lib.Task) -> None:
     for resources in task.resources:
         if resources.region is None:
             continue
-        existing_contexts = clouds.Kubernetes.existing_allowed_contexts()
+
+        is_ssh = isinstance(resources.cloud, clouds.SSH)
+        if is_ssh:
+            existing_contexts = clouds.SSH.existing_allowed_contexts()
+        else:
+            existing_contexts = clouds.Kubernetes.existing_allowed_contexts()
+
         region = resources.region
         task_name = f' {task.name!r}' if task.name is not None else ''
         msg = f'Task{task_name} requires '
         if region not in existing_contexts:
-            infra_str = f'Kubernetes/{region}'
+            if is_ssh:
+                infra_str = f'SSH/{region.lstrip("ssh-")}'
+            else:
+                infra_str = f'Kubernetes/{region}'
             logger.warning(f'{infra_str} is not enabled.')
             volume_mounts_str = ''
             if task.volume_mounts:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

User had an issue with launching a skypilot cluster on ssh node pools when specifying a specific node pool via infra description (ie: `--infra ssh/mycluster`). This PR fixes that for the optimizer. 

```
sky launch -c somecluster --infra ssh/somesshnodepool
Kubernetes/ssh-somesshnodepool is not enabled.
sky.exceptions.ResourcesUnavailableError: Task 'sky-cmd' requires infra Kubernetes/ssh-somesshnodepool which is not enabled. To enable access, change the task infra requirement or run: sky check to ensure the infra is enabled.
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [X] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
