### PR TITLE
Fix docker name conflict 

### DIFF
--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -85,9 +85,6 @@ def check_docker_image(cname, docker_cmd):
 
 def maybe_remove_container_cmds(container_name, docker_cmd):
     """Remove the container if it exists. If not, it will be a no-op.
-
-    This is to prevent name collisions when the container is stopped 
-    but not removed.
     """
     docker_rm = [
         docker_cmd,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Attempts to resolve https://github.com/skypilot-org/skypilot/issues/6457 by attempting to remove `sky_container` if it exists right before attempting to start one. This was the new suggested fix by @Michaelvll.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

Note: this issue is very hard to repro and typically requires running many managed jobs in parallel. Ideally, this fix can be tested in production to ensure it actually resolves the issue over time (issue isn't seen again) before merging.

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
