### PR TITLE
[Policy] Skip applying volume policy to job/serve controller

### DIFF
--- a/examples/admin_policy/example_policy/example_policy/skypilot_policy.py
+++ b/examples/admin_policy/example_policy/example_policy/skypilot_policy.py
@@ -220,6 +220,9 @@ class AddVolumesPolicy(sky.AdminPolicy):
     def validate_and_mutate(
             cls, user_request: sky.UserRequest) -> sky.MutatedUserRequest:
         task = user_request.task
+        if task.is_controller_task():
+            # Skip applying admin policy to job/serve controller
+            return sky.MutatedUserRequest(task, user_request.skypilot_config)
         # Use `task.set_volumes` to set the volumes.
         # Or use `task.update_volumes` to update in-place
         # instead of overwriting.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Skip applying volume policy to job/serve controller

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Launch a cluster with volume admin policy enabled, volumes are updated
  - Launch a managed job  with volume admin policy enabled, volumes are updated to the job cluster but not to the job controller
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
