### PR TITLE
Fixed client http pool config

### DIFF
--- a/sky/server/rest.py
+++ b/sky/server/rest.py
@@ -34,6 +34,16 @@ F = TypeVar('F', bound=Callable[..., Any])
 _RETRY_CONTEXT = contextvars.ContextVar('retry_context', default=None)
 
 _session = requests.Session()
+# Tune connection pool size, otherwise the default max is just 10.
+adapter = requests.adapters.HTTPAdapter(
+    pool_connections=50,
+    pool_maxsize=200,
+    # We handle retries by ourselves in SDK.
+    max_retries=0,
+)
+_session.mount('http://', adapter)
+_session.mount('https://', adapter)
+
 _session.headers[constants.API_VERSION_HEADER] = str(constants.API_VERSION)
 _session.headers[constants.VERSION_HEADER] = (
     versions.get_local_readable_version())


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixes connection drops issue when a single SDK process initiates > 10 HTTP connections to the API server.

Tested manually in benchmark, now a single process can file up to 200 concurrent connections.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
