### PR TITLE
[pools] don't show None in sky status / sky jobs queue

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1494,7 +1494,7 @@ def format_job_table(
         'JOB DURATION',
         '#RECOVERIES',
         'STATUS',
-        'WORKER_POOL',
+        'POOL',
     ]
     if show_all:
         # TODO: move SCHED. STATE to a separate flag (e.g. --debug)
@@ -1597,6 +1597,10 @@ def format_job_table(
 
             user_values = get_user_column_values(job_tasks[0])
 
+            pool = job_tasks[0].get('pool')
+            if pool is None:
+                pool = '-'
+
             job_id = job_hash[1] if tasks_have_k8s_user else job_hash
             job_values = [
                 job_id,
@@ -1610,7 +1614,7 @@ def format_job_table(
                 job_duration,
                 recovery_cnt,
                 status_str,
-                job_tasks[0].get('pool', '-'),
+                pool,
             ]
             if show_all:
                 details = job_tasks[current_task_id].get('details')
@@ -1637,6 +1641,9 @@ def format_job_table(
             submitted = log_utils.readable_time_duration(task['submitted_at'])
             user_values = get_user_column_values(task)
             task_workspace = '-' if len(job_tasks) > 1 else workspace
+            pool = task.get('pool')
+            if pool is None:
+                pool = '-'
             values = [
                 task['job_id'] if len(job_tasks) == 1 else ' \u21B3',
                 task['task_id'] if len(job_tasks) > 1 else '-',
@@ -1653,7 +1660,7 @@ def format_job_table(
                 job_duration,
                 task['recovery_count'],
                 task['status'].colored_str(),
-                task.get('pool', '-'),
+                pool,
             ]
             if show_all:
                 # schedule_state is only set at the job level, so if we have


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Previously, if pools were supported by the jobs controller, but a job did not belong to a pool, the `None` value would be exposed to the user. Now, it just shows `-`.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
