### PR TITLE
[CORE] Fix parsing for config option

### DIFF
--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -805,7 +805,7 @@ def _compose_cli_config(cli_config: Optional[List[str]]) -> config_utils.Config:
             # cli_config is a path to a config file
             parsed_config = parse_and_validate_config_file(maybe_config_path)
         else:  # cli_config is a comma-separated list of key-value pairs
-            parsed_config = _parse_dotlist(cli_config)
+            parsed_config = _parse_dotlist(cli_config[0].split(','))
         _validate_config(parsed_config, config_source)
     except ValueError as e:
         raise ValueError(f'Invalid config override: {cli_config}. '

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -797,6 +797,26 @@ def test_parse_dotlist():
     assert config.get_nested(('key1',), None) == 'a,b,c=d'
 
 
+def test_compose_cli_config(tmp_path):
+    cli_config = ('aws.vpc_name=vpc-123,aws.security_group_name=sg-123',)
+    config = skypilot_config._compose_cli_config(cli_config)
+    assert config.get_nested(('aws', 'vpc_name'), None) == 'vpc-123'
+    assert config.get_nested(('aws', 'security_group_name'), None) == 'sg-123'
+
+    # Write to temp file and read it
+    config_path = tmp_path / 'config.yaml'
+    yaml_str = '''
+    aws:
+        vpc_name: vpc-123
+        security_group_name: sg-123
+    '''
+    with open(config_path, 'w') as f:
+        f.write(yaml_str)
+    config = skypilot_config._compose_cli_config([str(config_path)])
+    assert config.get_nested(('aws', 'vpc_name'), None) == 'vpc-123'
+    assert config.get_nested(('aws', 'security_group_name'), None) == 'sg-123'
+
+
 @mock.patch('sky.skylet.constants.SKIPPED_CLIENT_OVERRIDE_KEYS',
             [('aws', 'vpc_name')])
 def test_override_skypilot_config_with_disallowed_keys(monkeypatch, tmp_path):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This pr fixes nested parsing for the `--config` option.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

I added a unit test to ensure there is no regression.

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
