### PR TITLE
[UX] Explain --config option properly

### DIFF
--- a/sky/client/cli/flags.py
+++ b/sky/client/cli/flags.py
@@ -276,9 +276,9 @@ def config_option(expose_value: bool):
             multiple=True,
             expose_value=expose_value,
             callback=preprocess_config_options,
-            help=('Path to a config file or a comma-separated '
-                  'list of key-value pairs '
-                  '(e.g. "nested.key1=val1,another.key2=val2").'),
+            help=('Path to a config file or a single key-value pair. To add '
+                  'multiple key-value pairs add multiple flags (e.g. '
+                  '--config nested.key1=val1 --config nested.key2=val2).'),
         )(func)
 
     return return_option_decorator

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -514,10 +514,10 @@ def parse_and_validate_config_file(config_path: str) -> config_utils.Config:
 
 
 def _parse_dotlist(dotlist: List[str]) -> config_utils.Config:
-    """Parse a comma-separated list of key-value pairs into a dictionary.
+    """Parse a single key-value pair into a dictionary.
 
     Args:
-        dotlist: A comma-separated list of key-value pairs.
+        dotlist: A single key-value pair.
 
     Returns:
         A config_utils.Config object with the parsed key-value pairs.
@@ -788,7 +788,7 @@ def _compose_cli_config(cli_config: Optional[List[str]]) -> config_utils.Config:
     """Composes the skypilot CLI config.
     CLI config can either be:
     - A path to a config file
-    - A comma-separated list of key-value pairs
+    - A single key-value pair
     """
 
     if not cli_config:
@@ -804,7 +804,7 @@ def _compose_cli_config(cli_config: Optional[List[str]]) -> config_utils.Config:
             config_source = maybe_config_path
             # cli_config is a path to a config file
             parsed_config = parse_and_validate_config_file(maybe_config_path)
-        else:  # cli_config is a comma-separated list of key-value pairs
+        else:  # cli_config is a single key-value pair
             parsed_config = _parse_dotlist(cli_config)
         _validate_config(parsed_config, config_source)
     except ValueError as e:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR updates the message describing the --config option to reflect the fact that --config only accepts a single nested key value pair.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
