### PR TITLE
[UX] Add jobs_controller prefix to avoid overwriting downloaded logs

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4364,7 +4364,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         if controller:  # download controller logs
             remote_log = os.path.join(managed_jobs.JOBS_CONTROLLER_LOGS_DIR,
                                       f'{job_id}.log')
-            local_log_dir = os.path.join(local_dir, run_timestamp)
+            local_log_dir = os.path.join(local_dir, 'jobs_controller',
+                                         run_timestamp)
             os.makedirs(os.path.dirname(os.path.expanduser(local_log_dir)),
                         exist_ok=True)
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4364,7 +4364,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         if controller:  # download controller logs
             remote_log = os.path.join(managed_jobs.JOBS_CONTROLLER_LOGS_DIR,
                                       f'{job_id}.log')
-            local_log_dir = os.path.join(local_dir, 'jobs_controller',
+            local_log_dir = os.path.join(local_dir, 'managed_jobs',
                                          run_timestamp)
             os.makedirs(os.path.dirname(os.path.expanduser(local_log_dir)),
                         exist_ok=True)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR adds a `managed_jobs/` prefix to managed jobs controller logs that are downloaded by the client. Previously this prefix was not being used and was resulting in the following confusing behavior:
```
❯ sky logs -s sky-475f-rsonecha 1
Job 1 logs: ~/sky_logs/1-long-logs-test
```
```
❯ sky jobs logs -s --controller 1
Job 1 logs (controller): ~/sky_logs/1-long-logs-test
```
where cluster job logs and managed jobs controller logs for jobs with the same job id and name would get downloaded to the same local directory.

<!-- Describe the tests ran -->
I manually verified that downloading managed jobs controller logs now uses the `~/sky_logs/managed_jobs/` prefix:
```
❯ sky jobs logs -s --controller 1
Job 1 logs (controller): ~/sky_logs/managed_jobs/1-long-logs-test
```

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
