### PR TITLE
Add Helm Lint in Pre-Commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,3 +74,8 @@ repos:
             - --load-plugins=pylint_quotes  # Load the pylint-quotes plugin
         files: ^sky/  # Only include files from the 'sky/' directory
         exclude: (^sky/skylet/providers/ibm/|^sky/schemas/generated/)
+
+-   repo: https://github.com/gruntwork-io/pre-commit
+    rev: v0.1.30  # Match the version from requirements
+    hooks:
+    -   id: helmlint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
+        exclude: ^charts/
     -   id: check-added-large-files
 
 -   repo: https://github.com/psf/black


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The `check-yaml` hook was throwing errors on our Helm templates because it doesn't understand Go template syntax (`{{ .Values... }}`). 
This PR swaps it out for helmlint, which is the right tool for the job.
- Excluded Helm chart paths from check-yaml.
- Added the helmlint hook to properly lint our charts.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
