### PR TITLE
Fix missing auth.oauth in grafana-auted ingress

### DIFF
--- a/charts/skypilot/templates/grafana-ingress.yaml
+++ b/charts/skypilot/templates/grafana-ingress.yaml
@@ -5,10 +5,15 @@ metadata:
   name: {{ .Release.Name }}-grafana-authed
   namespace: {{ .Release.Namespace }}
   annotations:
-    {{- if index .Values.ingress "oauth2-proxy" "enabled" }}
+    {{- if or .Values.auth.oauth.enabled (and .Values.ingress.enabled (index .Values.ingress "oauth2-proxy" "enabled")) }}
     # OAuth2 Proxy authentication for browser-based access
-    nginx.ingress.kubernetes.io/auth-signin: {{ if index .Values.ingress "oauth2-proxy" "use-https" | default false }}https{{ else }}http{{ end }}://$host/oauth2/start?rd=$escaped_request_uri
-    nginx.ingress.kubernetes.io/auth-url: {{ if index .Values.ingress "oauth2-proxy" "use-https" | default false }}https{{ else }}http{{ end }}://$host/oauth2/auth
+    {{- $oauth2 := .Values.auth.oauth -}}
+    {{- if not .Values.auth.oauth.enabled -}}
+    {{- $oauth2 = index .Values.ingress "oauth2-proxy" -}}
+    {{- end }}
+    nginx.ingress.kubernetes.io/auth-signin: {{ if index $oauth2 "use-https" | default false }}https{{ else }}http{{ end }}://$host/oauth2/start?rd=$escaped_request_uri
+    nginx.ingress.kubernetes.io/auth-url: {{ if index $oauth2 "use-https" | default false }}https{{ else }}http{{ end }}://$host/oauth2/auth
+    nginx.ingress.kubernetes.io/auth-response-headers: {{ index .Values.grafana "grafana.ini" "auth.proxy" "header_name" }}
     {{- else }}
     # Basic authentication
     nginx.ingress.kubernetes.io/auth-type: basic


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR updates the `grafana-authed` Ingress to support the newer `auth.oauth` configuration, while still handling the deprecated `ingress.oauth2-proxy`. It also adds dynamic configuration of the `auth-response-headers` annotation based on the `auth.proxy` settings in `grafana.ini`.

The main objective is to fix an issue where Grafana did not properly apply the OAuth2 Proxy when using Google OAuth with the auth.oauth values.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
