### PR TITLE
Add to helm lint for github's' workflow

### DIFF
--- a/.github/workflows/helm-unittest.yaml
+++ b/.github/workflows/helm-unittest.yaml
@@ -14,25 +14,29 @@ on:
 jobs:
   helm-unittest:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
+
     - name: Set up Helm
       uses: azure/setup-helm@v4
       with:
         version: '3.14.0'
-        
+
     - name: Install helm unittest plugin
       run: |
         helm plugin install https://github.com/helm-unittest/helm-unittest.git
-        
+
     - name: Update chart dependencies
       run: |
         cd charts/skypilot
         helm dependency update
-        
+
+    - name: Run helm lint
+      run: |
+        helm lint charts/skypilot
+
     - name: Run helm unit tests
       run: |
         helm unittest charts/skypilot


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

As requested by @aylei in #6798, this PR adds `helm lint` to the helm unittest workflow.

See review comment: https://github.com/skypilot-org/skypilot/pull/6798#pullrequestreview-3139662653

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
