### PR TITLE
api server: add proper hashing support for internal basic auth

### DIFF
--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -23,6 +23,7 @@ import uuid
 import cachetools
 import colorama
 import filelock
+from passlib.context import CryptContext
 from typing_extensions import ParamSpec
 
 from sky import exceptions
@@ -102,6 +103,7 @@ logger = sky_logging.init_logger(__name__)
 
 hinted_for_server_install_version_mismatch = False
 
+crypt_ctx = CryptContext(["bcrypt", "sha256_crypt", "sha512_crypt", "des_crypt", "apr_md5_crypt", "ldap_sha1"])
 
 class ApiServerStatus(enum.Enum):
     HEALTHY = 'healthy'

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -23,7 +23,7 @@ import uuid
 import cachetools
 import colorama
 import filelock
-from passlib.context import CryptContext
+from passlib import context as passlib_context
 from typing_extensions import ParamSpec
 
 from sky import exceptions
@@ -103,7 +103,7 @@ logger = sky_logging.init_logger(__name__)
 
 hinted_for_server_install_version_mismatch = False
 
-crypt_ctx = CryptContext([
+crypt_ctx = passlib_context.CryptContext([
     'bcrypt', 'sha256_crypt', 'sha512_crypt', 'des_crypt', 'apr_md5_crypt',
     'ldap_sha1'
 ])

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -104,8 +104,8 @@ logger = sky_logging.init_logger(__name__)
 hinted_for_server_install_version_mismatch = False
 
 crypt_ctx = CryptContext([
-    "bcrypt", "sha256_crypt", "sha512_crypt", "des_crypt", "apr_md5_crypt",
-    "ldap_sha1"
+    'bcrypt', 'sha256_crypt', 'sha512_crypt', 'des_crypt', 'apr_md5_crypt',
+    'ldap_sha1'
 ])
 
 

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -108,6 +108,7 @@ crypt_ctx = CryptContext([
     "ldap_sha1"
 ])
 
+
 class ApiServerStatus(enum.Enum):
     HEALTHY = 'healthy'
     UNHEALTHY = 'unhealthy'

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -103,7 +103,10 @@ logger = sky_logging.init_logger(__name__)
 
 hinted_for_server_install_version_mismatch = False
 
-crypt_ctx = CryptContext(["bcrypt", "sha256_crypt", "sha512_crypt", "des_crypt", "apr_md5_crypt", "ldap_sha1"])
+crypt_ctx = CryptContext([
+    "bcrypt", "sha256_crypt", "sha512_crypt", "des_crypt", "apr_md5_crypt",
+    "ldap_sha1"
+])
 
 class ApiServerStatus(enum.Enum):
     HEALTHY = 'healthy'

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -24,7 +24,6 @@ import zipfile
 import aiofiles
 import fastapi
 from fastapi.middleware import cors
-from passlib.hash import apr_md5_crypt
 import starlette.middleware.base
 import uvloop
 
@@ -148,7 +147,7 @@ def _try_set_basic_auth_user(request: fastapi.Request):
         username_encoded = username.encode('utf8')
         db_username_encoded = user.name.encode('utf8')
         if (username_encoded == db_username_encoded and
-                apr_md5_crypt.verify(password, user.password)):
+                common.crypt_ctx.verify(password, user.password)):
             request.state.auth_user = user
             break
 
@@ -248,7 +247,7 @@ class BasicAuthMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             username_encoded = username.encode('utf8')
             db_username_encoded = user.name.encode('utf8')
             if (username_encoded == db_username_encoded and
-                    apr_md5_crypt.verify(password, user.password)):
+                    common.crypt_ctx.verify(password, user.password)):
                 valid_user = True
                 request.state.auth_user = user
                 await authn.override_user_info_in_request_body(request, user)

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -65,6 +65,7 @@ install_requires = [
     # Required for API server metrics
     'prometheus_client>=0.8.0',
     'passlib',
+    'bcrypt',
     'pyjwt',
     'gitpython',
     'types-paramiko',

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -14,8 +14,8 @@ import filelock
 from sky import global_user_state
 from sky import models
 from sky import sky_logging
-from sky.server.requests import payloads
 from sky.server.common import crypt_ctx
+from sky.server.requests import payloads
 from sky.skylet import constants
 from sky.users import permission
 from sky.users import rbac

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -10,12 +10,12 @@ from typing import Any, Dict, Generator, List
 
 import fastapi
 import filelock
-from passlib.hash import apr_md5_crypt
 
 from sky import global_user_state
 from sky import models
 from sky import sky_logging
 from sky.server.requests import payloads
+from sky.server.common import crypt_ctx
 from sky.skylet import constants
 from sky.users import permission
 from sky.users import rbac
@@ -86,7 +86,7 @@ async def user_create(user_create_body: payloads.UserCreateBody) -> None:
         role = rbac.get_default_role()
 
     # Create user
-    password_hash = apr_md5_crypt.hash(password)
+    password_hash = crypt_ctx.hash(password)
     user_hash = hashlib.md5(
         username.encode()).hexdigest()[:common_utils.USER_HASH_LENGTH]
     with _user_lock(user_hash):
@@ -146,7 +146,7 @@ async def user_update(request: fastapi.Request,
 
     with _user_lock(user_info.id):
         if password:
-            password_hash = apr_md5_crypt.hash(password)
+            password_hash = crypt_ctx.hash(password)
             global_user_state.add_or_update_user(
                 models.User(id=user_info.id,
                             name=user_info.name,
@@ -271,13 +271,13 @@ async def user_import(
                 creation_errors.append(f'{username}: User already exists')
                 continue
 
-            # Check if password is already hashed (APR1 hash)
-            if password.startswith('$apr1$'):
+            # Check if password is already hashed
+            if crypt_ctx.identify(password) is not None:
                 # Password is already hashed, use it directly
                 password_hash = password
             else:
                 # Password is plain text, hash it
-                password_hash = apr_md5_crypt.hash(password)
+                password_hash = crypt_ctx.hash(password)
 
             user_hash = hashlib.md5(
                 username.encode()).hexdigest()[:common_utils.USER_HASH_LENGTH]

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -14,7 +14,7 @@ import filelock
 from sky import global_user_state
 from sky import models
 from sky import sky_logging
-from sky.server.common import crypt_ctx
+from sky.server import common as server_common
 from sky.server.requests import payloads
 from sky.skylet import constants
 from sky.users import permission
@@ -86,7 +86,7 @@ async def user_create(user_create_body: payloads.UserCreateBody) -> None:
         role = rbac.get_default_role()
 
     # Create user
-    password_hash = crypt_ctx.hash(password)
+    password_hash = server_common.crypt_ctx.hash(password)
     user_hash = hashlib.md5(
         username.encode()).hexdigest()[:common_utils.USER_HASH_LENGTH]
     with _user_lock(user_hash):
@@ -146,7 +146,7 @@ async def user_update(request: fastapi.Request,
 
     with _user_lock(user_info.id):
         if password:
-            password_hash = crypt_ctx.hash(password)
+            password_hash = server_common.crypt_ctx.hash(password)
             global_user_state.add_or_update_user(
                 models.User(id=user_info.id,
                             name=user_info.name,
@@ -272,12 +272,12 @@ async def user_import(
                 continue
 
             # Check if password is already hashed
-            if crypt_ctx.identify(password) is not None:
+            if server_common.crypt_ctx.identify(password) is not None:
                 # Password is already hashed, use it directly
                 password_hash = password
             else:
                 # Password is plain text, hash it
-                password_hash = crypt_ctx.hash(password)
+                password_hash = server_common.crypt_ctx.hash(password)
 
             user_hash = hashlib.md5(
                 username.encode()).hexdigest()[:common_utils.USER_HASH_LENGTH]

--- a/tests/unit_tests/test_sky/users/test_server.py
+++ b/tests/unit_tests/test_sky/users/test_server.py
@@ -7,7 +7,7 @@ import fastapi
 import pytest
 
 from sky import models
-from sky.server.common import crypt_ctx
+from sky.server import common as server_common
 from sky.server.requests import payloads
 from sky.skylet import constants
 from sky.users import rbac
@@ -210,7 +210,7 @@ class TestUsersEndpoints:
         user_obj = args[0]
         assert user_obj.id == 'test_user'
         assert user_obj.name == 'Test User'
-        assert crypt_ctx.identify(user_obj.password) is not None
+        assert server_common.crypt_ctx.identify(user_obj.password) is not None
         assert user_obj.password != new_password
 
     @mock.patch('sky.users.rbac.get_supported_roles')
@@ -381,7 +381,7 @@ class TestUsersEndpoints:
         args, kwargs = mock_add_or_update_user.call_args
         user_obj = args[0]
         assert user_obj.name == 'alice'
-        assert crypt_ctx.identify(user_obj.password) is not None
+        assert server_common.crypt_ctx.identify(user_obj.password) is not None
         assert user_obj.password != password
 
     @mock.patch('sky.global_user_state.get_user_by_name')
@@ -516,7 +516,7 @@ class TestUsersEndpoints:
         user_obj = args[0]
         assert user_obj.id == 'test_user'
         assert user_obj.name == 'Test User'
-        assert crypt_ctx.identify(user_obj.password) is not None
+        assert server_common.crypt_ctx.identify(user_obj.password) is not None
         assert user_obj.password != new_password
 
     @mock.patch('sky.users.rbac.get_supported_roles')
@@ -554,7 +554,7 @@ class TestUsersEndpoints:
         user_obj = args[0]
         assert user_obj.id == 'test_user'
         assert user_obj.name == 'Test User'
-        assert crypt_ctx.identify(user_obj.password) is not None
+        assert server_common.crypt_ctx.identify(user_obj.password) is not None
         assert user_obj.password != new_password
 
     @mock.patch('sky.users.rbac.get_supported_roles')
@@ -679,7 +679,7 @@ class TestUsersEndpoints:
         user_obj = args[0]
         assert user_obj.id == 'test_user'
         assert user_obj.name == 'Test User'
-        assert crypt_ctx.identify(user_obj.password) is not None
+        assert server_common.crypt_ctx.identify(user_obj.password) is not None
         assert user_obj.password != new_password
 
     @mock.patch('sky.global_user_state.get_user')

--- a/tests/unit_tests/test_sky/users/test_server.py
+++ b/tests/unit_tests/test_sky/users/test_server.py
@@ -7,6 +7,7 @@ import fastapi
 import pytest
 
 from sky import models
+from sky.server.common import crypt_ctx
 from sky.server.requests import payloads
 from sky.skylet import constants
 from sky.users import rbac
@@ -191,10 +192,11 @@ class TestUsersEndpoints:
                                 password='old_password')
         mock_get_user.return_value = test_user
         mock_request.state.auth_user = None
+        new_password = 'new_password'
 
         update_body = payloads.UserUpdateBody(user_id='test_user',
                                               role='admin',
-                                              password='new_password')
+                                              password=new_password)
 
         # Execute
         result = await server.user_update(mock_request, update_body)
@@ -208,7 +210,8 @@ class TestUsersEndpoints:
         user_obj = args[0]
         assert user_obj.id == 'test_user'
         assert user_obj.name == 'Test User'
-        assert user_obj.password.startswith('$apr1$')
+        assert crypt_ctx.identify(user_obj.password) is not None
+        assert user_obj.password != new_password
 
     @mock.patch('sky.users.rbac.get_supported_roles')
     @pytest.mark.asyncio
@@ -360,8 +363,9 @@ class TestUsersEndpoints:
         mock_get_user_by_name.return_value = None
         mock_get_supported_roles.return_value = ['admin', 'user']
         mock_get_default_role.return_value = 'user'
+        password = 'pw123'
         create_body = payloads.UserCreateBody(username='alice',
-                                              password='pw123',
+                                              password=password,
                                               role=None)
 
         # Execute
@@ -377,7 +381,8 @@ class TestUsersEndpoints:
         args, kwargs = mock_add_or_update_user.call_args
         user_obj = args[0]
         assert user_obj.name == 'alice'
-        assert user_obj.password.startswith('$apr1$')
+        assert crypt_ctx.identify(user_obj.password) is not None
+        assert user_obj.password != password
 
     @mock.patch('sky.global_user_state.get_user_by_name')
     @pytest.mark.asyncio
@@ -494,9 +499,10 @@ class TestUsersEndpoints:
         mock_request.state.auth_user = models.User(id='admin_user',
                                                    name='Admin')
         mock_get_user_roles.return_value = ['admin']
+        new_password = 'new_password'
 
         update_body = payloads.UserUpdateBody(user_id='test_user',
-                                              password='new_password')
+                                              password=new_password)
 
         # Execute
         result = await server.user_update(mock_request, update_body)
@@ -510,7 +516,8 @@ class TestUsersEndpoints:
         user_obj = args[0]
         assert user_obj.id == 'test_user'
         assert user_obj.name == 'Test User'
-        assert user_obj.password.startswith('$apr1$')
+        assert crypt_ctx.identify(user_obj.password) is not None
+        assert user_obj.password != new_password
 
     @mock.patch('sky.users.rbac.get_supported_roles')
     @mock.patch('sky.global_user_state.get_user')
@@ -530,9 +537,10 @@ class TestUsersEndpoints:
         # Mock current user as the same user
         mock_request.state.auth_user = test_user
         mock_get_user_roles.return_value = ['user']
+        new_password = 'new_password'
 
         update_body = payloads.UserUpdateBody(user_id='test_user',
-                                              password='new_password')
+                                              password=new_password)
 
         # Execute
         result = await server.user_update(mock_request, update_body)
@@ -546,7 +554,8 @@ class TestUsersEndpoints:
         user_obj = args[0]
         assert user_obj.id == 'test_user'
         assert user_obj.name == 'Test User'
-        assert user_obj.password.startswith('$apr1$')
+        assert crypt_ctx.identify(user_obj.password) is not None
+        assert user_obj.password != new_password
 
     @mock.patch('sky.users.rbac.get_supported_roles')
     @mock.patch('sky.global_user_state.get_user')
@@ -651,10 +660,11 @@ class TestUsersEndpoints:
         mock_request.state.auth_user = models.User(id='admin_user',
                                                    name='Admin')
         mock_get_user_roles.return_value = ['admin']
+        new_password = 'new_password'
 
         update_body = payloads.UserUpdateBody(user_id='test_user',
                                               role='user',
-                                              password='new_password')
+                                              password=new_password)
 
         # Execute
         result = await server.user_update(mock_request, update_body)
@@ -669,7 +679,8 @@ class TestUsersEndpoints:
         user_obj = args[0]
         assert user_obj.id == 'test_user'
         assert user_obj.name == 'Test User'
-        assert user_obj.password.startswith('$apr1$')
+        assert crypt_ctx.identify(user_obj.password) is not None
+        assert user_obj.password != new_password
 
     @mock.patch('sky.global_user_state.get_user')
     @mock.patch('sky.users.permission.permission_service.get_user_roles')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Internal basic auth supported only `apr_md5_crypt` hashing, which is [deprecated](https://passlib.readthedocs.io/en/stable/lib/passlib.hash.html#deprecated-hashes).

I switched it to`passlib`'s `CryptContext` which is a tool to support multiple hash types at once, thus basic auth can use either legacy `apr_md5` hashes or something more modern. It also uses `bcrypt` by default (e.g. when users are created in UI) which gives pretty robust hashes.

I tested:
 * creating user via UI and INITIAL_BASIC_AUTH env (k8s);
 * importing/exporting user list from UI;
 * creating users and changing their passwords in UI.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
