### PR TITLE
Retry on transient error when streaming API request

### DIFF
--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1944,6 +1944,7 @@ def stream_and_get(request_id: None = None,
 @usage_lib.entrypoint
 @server_common.check_server_healthy_or_start
 @annotations.client_api
+@rest.retry_transient_errors()
 def stream_and_get(
     request_id: Optional[server_common.RequestId[T]] = None,
     log_path: Optional[str] = None,
@@ -1995,7 +1996,7 @@ def stream_and_get(
     if response.status_code in [404, 400]:
         detail = response.json().get('detail')
         with ux_utils.print_exception_no_traceback():
-            raise RuntimeError(f'Failed to stream logs: {detail}')
+            raise exceptions.ClientError(f'Failed to stream logs: {detail}')
     elif response.status_code != 200:
         # TODO(syang): handle the case where the requestID is not provided
         # see https://github.com/skypilot-org/skypilot/issues/6549

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -661,3 +661,11 @@ class RequestInterruptedError(Exception):
 class SkyletInternalError(Exception):
     """Raised when a Skylet internal error occurs."""
     pass
+
+
+class ClientError(Exception):
+    """Raised when a there is a client error occurs.
+
+    If a request encounters a ClientError, it will not be retried to the server.
+    """
+    pass

--- a/sky/server/rest.py
+++ b/sky/server/rest.py
@@ -76,6 +76,8 @@ def retry_transient_errors(max_retries: int = 3,
         if isinstance(e, requests.exceptions.HTTPError):
             # Only server error is considered as transient.
             return e.response.status_code >= 500
+        if isinstance(e, exceptions.ClientError):
+            return False
         # It is hard to enumerate all other errors that are transient, e.g.
         # broken pipe, connection refused, etc. Instead, it is safer to assume
         # all other errors might be transient since we only retry for 3 times


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Test:

Launch with network issue, can be recovered by retry:

```bash
$ SKYPILOT_DEBUG=1 sky launch --infra aws -c bastion --cpus 4+ -y
...
Running on cluster: bastion
D 08-21 23:47:01 rest.py:119] Retry stream_and_get due to ("Connection broken: InvalidChunkLength(got length b'', 0 bytes read)", InvalidChunkLength(got length b'', 0 bytes read)), attempt 1/5
I 08-21 15:49:35 optimizer.py:918] Considered resources (1 node):
I 08-21 15:49:35 optimizer.py:986] -----------------------------------------------------------------------------
I 08-21 15:49:35 optimizer.py:986]  INFRA             INSTANCE     vCPUs   Mem(GB)   GPUS   COST ($)   CHOSEN
I 08-21 15:49:35 optimizer.py:986] -----------------------------------------------------------------------------
I 08-21 15:49:35 optimizer.py:986]  AWS (us-east-1)   m6i.xlarge   4       16        -      0.19          ✔
I 08-21 15:49:35 optimizer.py:986] -----------------------------------------------------------------------------
....
```

- [x] Normal launch
- [x] `sky status`
- [x] `sky api logs xxx` (will not retry)

```
sky.exceptions.ClientError: Failed to stream logs: Request 'xxx' not found 
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
