### PR TITLE
[SDK] reset transient failure count if function made progress on latest retry

### DIFF
--- a/sky/server/rest.py
+++ b/sky/server/rest.py
@@ -94,7 +94,7 @@ def retry_transient_errors(max_retries: int = 3,
             failed_retry_cnt = 0
 
             with _retry_in_context() as context:
-                previous_line_processed = context.line_processed # should be 0
+                previous_line_processed = context.line_processed  # should be 0
 
                 def _handle_exception():
                     # If the function made progress on a retry,
@@ -102,7 +102,8 @@ def retry_transient_errors(max_retries: int = 3,
                     # Otherwise, increments the failed retry count.
                     nonlocal backoff, failed_retry_cnt, previous_line_processed
                     if context.line_processed > previous_line_processed:
-                        backoff = common_utils.Backoff(initial_backoff, max_backoff_factor)
+                        backoff = common_utils.Backoff(initial_backoff,
+                                                       max_backoff_factor)
                         previous_line_processed = context.line_processed
                         failed_retry_cnt = 0
                     else:
@@ -126,8 +127,9 @@ def retry_transient_errors(max_retries: int = 3,
                         if not is_transient_error(e):
                             # Permanent error, no need to retry.
                             raise
-                        logger.debug(f'Retry {func.__name__} due to {e}, '
-                                     f'attempt {failed_retry_cnt}/{max_retries}')
+                        logger.debug(
+                            f'Retry {func.__name__} due to {e}, '
+                            f'attempt {failed_retry_cnt}/{max_retries}')
                         time.sleep(backoff.current_backoff())
 
         return cast(F, wrapper)

--- a/sky/server/rest.py
+++ b/sky/server/rest.py
@@ -130,7 +130,12 @@ def retry_transient_errors(max_retries: int = 3,
                         logger.debug(
                             f'Retry {func.__name__} due to {e}, '
                             f'attempt {failed_retry_cnt}/{max_retries}')
-                        time.sleep(backoff.current_backoff())
+                        # Only sleep if this is not the first retry.
+                        # The idea is that if the function made progress on a
+                        # retry, we should try again immediately to reduce the
+                        # waiting time.
+                        if failed_retry_cnt > 0:
+                            time.sleep(backoff.current_backoff())
 
         return cast(F, wrapper)
 

--- a/tests/unit_tests/test_sky/server/test_rest.py
+++ b/tests/unit_tests/test_sky/server/test_rest.py
@@ -206,7 +206,8 @@ class TestRetryTransientErrorsDecorator:
         assert mock_logger.debug.call_count == 11
         debug_calls = mock_logger.debug.call_args_list
         for call in debug_calls:
-            assert 'Retry function_failing_after_making_progress due to' in call[0][0]
+            assert 'Retry function_failing_after_making_progress due to' in call[
+                0][0]
 
     def test_different_http_error_status_codes(self):
         """Test behavior with different HTTP error status codes."""

--- a/tests/unit_tests/test_sky/server/test_rest.py
+++ b/tests/unit_tests/test_sky/server/test_rest.py
@@ -156,6 +156,58 @@ class TestRetryTransientErrorsDecorator:
         for call in debug_calls:
             assert 'Retry failing_then_succeeding_function due to' in call[0][0]
 
+    @mock.patch('sky.server.rest.logger')
+    def test_retry_context_is_reset_when_progress_is_made(self, mock_logger):
+        """Test that retry context is reset when progress is made."""
+        call_count = 0
+
+        @rest.retry_transient_errors(max_retries=3, initial_backoff=0.1)
+        def function_making_progress():
+            nonlocal call_count
+            retry_context = rest.get_retry_context()
+            call_count += 1
+            if call_count < 10:
+                retry_context.line_processed += 1
+                raise ValueError("Test error")
+            return "success"
+
+        with mock.patch('time.sleep'):
+            result = function_making_progress()
+            assert result == "success"
+
+        # Check that debug logging was called
+        assert mock_logger.debug.call_count == 9  # 9 retries
+        debug_calls = mock_logger.debug.call_args_list
+        for call in debug_calls:
+            assert 'Retry function_making_progress due to' in call[0][0]
+
+    @mock.patch('sky.server.rest.logger')
+    def test_repeated_failure_after_progress(self, mock_logger):
+        """Test that retry_transient_errors fails if function fails after making progress."""
+        call_count = 0
+
+        @rest.retry_transient_errors(max_retries=3, initial_backoff=0.1)
+        def function_failing_after_making_progress():
+            nonlocal call_count
+            retry_context = rest.get_retry_context()
+            call_count += 1
+            if call_count < 10:
+                retry_context.line_processed += 1
+                raise ValueError("Test error")
+
+            raise ValueError("Test error")
+
+        with mock.patch('time.sleep'):
+            with pytest.raises(ValueError):
+                function_failing_after_making_progress()
+
+        # Check that debug logging was called
+        # 11 retries, 9 retries after progress, 2 retries after failure
+        assert mock_logger.debug.call_count == 11
+        debug_calls = mock_logger.debug.call_args_list
+        for call in debug_calls:
+            assert 'Retry function_failing_after_making_progress due to' in call[0][0]
+
     def test_different_http_error_status_codes(self):
         """Test behavior with different HTTP error status codes."""
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
On transient retries - if we determine the retry to have succeeded, then reset the retry count. This allows the function decorator to deal with any number of transient errors that the function can recover from.

To determine if a retry has succeeded, we use the `line_processed` field as a proxy for progress. The idea is that if the function, on retry, were able to process more lines, the function must have overcome whatever transient error was thrown before.

This PR has no effect on functions that don't interact with `line_processed` field, preserving the current behavior where requests are retried `max_retries` times.
<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
