### PR TITLE
Revert "[Core] Pool Job Consolidation"

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1,5 +1,4 @@
 """Util constants/functions for the backends."""
-import asyncio
 from datetime import datetime
 import enum
 import fnmatch
@@ -18,9 +17,6 @@ from typing import (Any, Callable, Dict, List, Optional, Sequence, Set, Tuple,
                     TypeVar, Union)
 import uuid
 
-import aiohttp
-from aiohttp import ClientTimeout
-from aiohttp import TCPConnector
 import colorama
 from packaging import version
 import psutil
@@ -1679,32 +1675,6 @@ def check_network_connection():
     # Assume network connection is down
     raise exceptions.NetworkError('Could not refresh the cluster. '
                                   'Network seems down.')
-
-
-async def async_check_network_connection():
-    """Check if the network connection is available.
-
-    Tolerates 3 retries as it is observed that connections can fail.
-    Uses aiohttp for async HTTP requests.
-    """
-    # Create a session with retry logic
-    timeout = ClientTimeout(total=15)
-    connector = TCPConnector(limit=1)  # Limit to 1 connection at a time
-
-    async with aiohttp.ClientSession(timeout=timeout,
-                                     connector=connector) as session:
-        for i, ip in enumerate(_TEST_IP_LIST):
-            try:
-                async with session.head(ip) as response:
-                    if response.status < 400:  # Any 2xx or 3xx status is good
-                        return
-            except (aiohttp.ClientError, asyncio.TimeoutError) as e:
-                if i == len(_TEST_IP_LIST) - 1:
-                    raise exceptions.NetworkError(
-                        'Could not refresh the cluster. '
-                        'Network seems down.') from e
-                # If not the last IP, continue to try the next one
-                continue
 
 
 @timeline.event

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -31,7 +31,6 @@ from sky import skypilot_config
 from sky.adaptors import common as adaptors_common
 from sky.client import common as client_common
 from sky.client import oauth as oauth_lib
-from sky.jobs import scheduler
 from sky.schemas.api import responses
 from sky.server import common as server_common
 from sky.server import rest
@@ -2258,25 +2257,6 @@ def api_stop() -> None:
             raise RuntimeError(
                 f'Cannot kill the API server at {server_url} because it is not '
                 f'the default SkyPilot API server started locally.')
-
-    try:
-        with open(os.path.expanduser(scheduler.JOB_CONTROLLER_PID_PATH),
-                  'r',
-                  encoding='utf-8') as f:
-            pids = f.read().split('\n')[:-1]
-            for pid in pids:
-                if subprocess_utils.is_process_alive(int(pid.strip())):
-                    subprocess_utils.kill_children_processes(
-                        parent_pids=[int(pid.strip())], force=True)
-        os.remove(os.path.expanduser(scheduler.JOB_CONTROLLER_PID_PATH))
-    except FileNotFoundError:
-        # its fine we will create it
-        pass
-    except Exception as e:  # pylint: disable=broad-except
-        # in case we get perm issues or something is messed up, just ignore it
-        # and assume the process is dead
-        logger.error(f'Error looking at job controller pid file: {e}')
-        pass
 
     found = _local_api_server_running(kill=True)
 

--- a/sky/client/sdk_async.py
+++ b/sky/client/sdk_async.py
@@ -19,16 +19,20 @@ import aiohttp
 import colorama
 
 from sky import admin_policy
+from sky import backends
 from sky import catalog
 from sky import exceptions
+from sky import models
 from sky import sky_logging
 from sky.client import common as client_common
 from sky.client import sdk
+from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.schemas.api import responses
 from sky.server import common as server_common
 from sky.server import rest
 from sky.server.requests import payloads
 from sky.server.requests import requests as requests_lib
+from sky.skylet import job_lib
 from sky.usage import usage_lib
 from sky.utils import annotations
 from sky.utils import common
@@ -41,11 +45,6 @@ if typing.TYPE_CHECKING:
     import io
 
     import sky
-    from sky import backends
-    from sky import models
-    from sky.provision.kubernetes import utils as kubernetes_utils
-    from sky.skylet import autostop_lib
-    from sky.skylet import job_lib
 
 logger = sky_logging.init_logger(__name__)
 logging.getLogger('httpx').setLevel(logging.CRITICAL)
@@ -378,10 +377,9 @@ async def launch(
     cluster_name: Optional[str] = None,
     retry_until_up: bool = False,
     idle_minutes_to_autostop: Optional[int] = None,
-    wait_for: Optional['autostop_lib.AutostopWaitFor'] = None,
     dryrun: bool = False,
     down: bool = False,  # pylint: disable=redefined-outer-name
-    backend: Optional['backends.Backend'] = None,
+    backend: Optional[backends.Backend] = None,
     optimize_target: common.OptimizeTarget = common.OptimizeTarget.COST,
     no_setup: bool = False,
     clone_disk_from: Optional[str] = None,
@@ -393,12 +391,12 @@ async def launch(
     _is_launched_by_sky_serve_controller: bool = False,
     _disable_controller_check: bool = False,
     stream_logs: Optional[StreamConfig] = DEFAULT_STREAM_CONFIG,
-) -> Tuple[Optional[int], Optional['backends.ResourceHandle']]:
+) -> Tuple[Optional[int], Optional[backends.ResourceHandle]]:
     """Async version of launch() that launches a cluster or task."""
     request_id = await context_utils.to_thread(
         sdk.launch, task, cluster_name, retry_until_up,
-        idle_minutes_to_autostop, wait_for, dryrun, down, backend,
-        optimize_target, no_setup, clone_disk_from, fast, _need_confirmation,
+        idle_minutes_to_autostop, dryrun, down, backend, optimize_target,
+        no_setup, clone_disk_from, fast, _need_confirmation,
         _is_launched_by_jobs_controller, _is_launched_by_sky_serve_controller,
         _disable_controller_check)
     if stream_logs is not None:
@@ -414,9 +412,9 @@ async def exec(  # pylint: disable=redefined-builtin
     cluster_name: Optional[str] = None,
     dryrun: bool = False,
     down: bool = False,  # pylint: disable=redefined-outer-name
-    backend: Optional['backends.Backend'] = None,
+    backend: Optional[backends.Backend] = None,
     stream_logs: Optional[StreamConfig] = DEFAULT_STREAM_CONFIG,
-) -> Tuple[Optional[int], Optional['backends.ResourceHandle']]:
+) -> Tuple[Optional[int], Optional[backends.ResourceHandle]]:
     """Async version of exec() that executes a task on an existing cluster."""
     request_id = await context_utils.to_thread(sdk.exec, task, cluster_name,
                                                dryrun, down, backend)
@@ -456,7 +454,7 @@ async def start(
     down: bool = False,  # pylint: disable=redefined-outer-name
     force: bool = False,
     stream_logs: Optional[StreamConfig] = DEFAULT_STREAM_CONFIG,
-) -> 'backends.CloudVmRayResourceHandle':
+) -> backends.CloudVmRayResourceHandle:
     """Async version of start() that restarts a cluster."""
     request_id = await context_utils.to_thread(sdk.start, cluster_name,
                                                idle_minutes_to_autostop,
@@ -536,7 +534,7 @@ async def job_status(
     cluster_name: str,
     job_ids: Optional[List[int]] = None,
     stream_logs: Optional[StreamConfig] = DEFAULT_STREAM_CONFIG
-) -> Dict[Optional[int], Optional['job_lib.JobStatus']]:
+) -> Dict[Optional[int], Optional[job_lib.JobStatus]]:
     """Async version of job_status() that gets the status of jobs on a
       cluster."""
     request_id = await context_utils.to_thread(sdk.job_status, cluster_name,
@@ -710,7 +708,7 @@ async def realtime_kubernetes_gpu_availability(
     quantity_filter: Optional[int] = None,
     is_ssh: Optional[bool] = None,
     stream_logs: Optional[StreamConfig] = DEFAULT_STREAM_CONFIG
-) -> List[Tuple[str, List['models.RealtimeGpuAvailability']]]:
+) -> List[Tuple[str, List[models.RealtimeGpuAvailability]]]:
     """Async version of realtime_kubernetes_gpu_availability() that gets the
       real-time Kubernetes GPU availability."""
     request_id = await context_utils.to_thread(
@@ -727,7 +725,7 @@ async def realtime_kubernetes_gpu_availability(
 async def kubernetes_node_info(
     context: Optional[str] = None,
     stream_logs: Optional[StreamConfig] = DEFAULT_STREAM_CONFIG
-) -> 'models.KubernetesNodesInfo':
+) -> models.KubernetesNodesInfo:
     """Async version of kubernetes_node_info() that gets the resource
     information for all the nodes in the cluster."""
     request_id = await context_utils.to_thread(sdk.kubernetes_node_info,
@@ -742,8 +740,8 @@ async def kubernetes_node_info(
 @annotations.client_api
 async def status_kubernetes(
     stream_logs: Optional[StreamConfig] = DEFAULT_STREAM_CONFIG
-) -> Tuple[List['kubernetes_utils.KubernetesSkyPilotClusterInfoPayload'],
-           List['kubernetes_utils.KubernetesSkyPilotClusterInfoPayload'],
+) -> Tuple[List[kubernetes_utils.KubernetesSkyPilotClusterInfoPayload],
+           List[kubernetes_utils.KubernetesSkyPilotClusterInfoPayload],
            List[Dict[str, Any]], Optional[str]]:
     """Async version of status_kubernetes() that gets all SkyPilot clusters
       and jobs in the Kubernetes cluster."""

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -3,7 +3,6 @@
 See `Stage` for a Task's life cycle.
 """
 import enum
-import logging
 import typing
 from typing import List, Optional, Tuple, Union
 
@@ -121,7 +120,6 @@ def _execute(
     _quiet_optimizer: bool = False,
     _is_launched_by_jobs_controller: bool = False,
     _is_launched_by_sky_serve_controller: bool = False,
-    job_logger: logging.Logger = logger,
 ) -> Tuple[Optional[int], Optional[backends.ResourceHandle]]:
     """Execute an entrypoint.
 
@@ -223,8 +221,7 @@ def _execute(
             _quiet_optimizer=_quiet_optimizer,
             _is_launched_by_jobs_controller=_is_launched_by_jobs_controller,
             _is_launched_by_sky_serve_controller=
-            _is_launched_by_sky_serve_controller,
-            job_logger=job_logger)
+            _is_launched_by_sky_serve_controller)
 
 
 def _execute_dag(
@@ -246,7 +243,6 @@ def _execute_dag(
     _quiet_optimizer: bool,
     _is_launched_by_jobs_controller: bool,
     _is_launched_by_sky_serve_controller: bool,
-    job_logger: logging.Logger = logger,
 ) -> Tuple[Optional[int], Optional[backends.ResourceHandle]]:
     """Execute a DAG.
 
@@ -257,7 +253,7 @@ def _execute_dag(
     task = dag.tasks[0]
 
     if any(r.job_recovery is not None for r in task.resources):
-        job_logger.warning(
+        logger.warning(
             f'{colorama.Style.DIM}The task has `job_recovery` specified, '
             'but is launched as an unmanaged job. It will be ignored.'
             'To enable job recovery, use managed jobs: sky jobs launch.'
@@ -338,10 +334,10 @@ def _execute_dag(
                 # itself have no task running and start the auto{stop,down}
                 # process, before the task is submitted in the EXEC stage.
                 verb = 'torn down' if down else 'stopped'
-                job_logger.info(f'{colorama.Style.DIM}The cluster will '
-                                f'be {verb} after 1 minutes of idleness '
-                                '(after all jobs finish).'
-                                f'{colorama.Style.RESET_ALL}')
+                logger.info(f'{colorama.Style.DIM}The cluster will '
+                            f'be {verb} after 1 minutes of idleness '
+                            '(after all jobs finish).'
+                            f'{colorama.Style.RESET_ALL}')
                 idle_minutes_to_autostop = 1
             if Stage.DOWN in stages:
                 stages.remove(Stage.DOWN)
@@ -370,7 +366,7 @@ def _execute_dag(
             yellow = colorama.Fore.YELLOW
             bold = colorama.Style.BRIGHT
             reset = colorama.Style.RESET_ALL
-            job_logger.info(
+            logger.info(
                 f'{yellow}Launching a spot job that does not '
                 f'automatically recover from preemptions. To '
                 'get automatic recovery, use managed job instead: '
@@ -389,7 +385,7 @@ def _execute_dag(
                     controller = controller_utils.Controllers.from_name(
                         cluster_name)
                     if controller is not None:
-                        job_logger.info(
+                        logger.info(
                             f'Choosing resources for {controller.value.name}...'
                         )
                     dag = optimizer.Optimizer.optimize(dag,
@@ -431,7 +427,7 @@ def _execute_dag(
         if handle is None:
             assert dryrun, ('If not dryrun, handle must be set or '
                             'Stage.PROVISION must be included in stages.')
-            job_logger.info('Dryrun finished.')
+            logger.info('Dryrun finished.')
             return None, None
 
         do_workdir = (Stage.SYNC_WORKDIR in stages and not dryrun and
@@ -440,7 +436,7 @@ def _execute_dag(
                           (task.file_mounts is not None or
                            task.storage_mounts is not None))
         if do_workdir or do_file_mounts:
-            job_logger.info(ux_utils.starting_message('Syncing files.'))
+            logger.info(ux_utils.starting_message('Syncing files.'))
 
         if do_workdir:
             if cluster_name is not None:
@@ -460,11 +456,11 @@ def _execute_dag(
                                      task.storage_mounts)
 
         if no_setup:
-            job_logger.info('Setup commands skipped.')
+            logger.info('Setup commands skipped.')
         elif Stage.SETUP in stages and not dryrun:
             if skip_unnecessary_provisioning and provisioning_skipped:
-                job_logger.debug('Unnecessary provisioning was skipped, so '
-                                 'skipping setup as well.')
+                logger.debug('Unnecessary provisioning was skipped, so '
+                             'skipping setup as well.')
             else:
                 if cluster_name is not None:
                     global_user_state.add_cluster_event(
@@ -525,7 +521,6 @@ def launch(
     _is_launched_by_jobs_controller: bool = False,
     _is_launched_by_sky_serve_controller: bool = False,
     _disable_controller_check: bool = False,
-    job_logger: logging.Logger = logger,
 ) -> Tuple[Optional[int], Optional[backends.ResourceHandle]]:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Launches a cluster or task.
@@ -693,7 +688,7 @@ def launch(
         _is_launched_by_jobs_controller=_is_launched_by_jobs_controller,
         _is_launched_by_sky_serve_controller=
         _is_launched_by_sky_serve_controller,
-        job_logger=job_logger)
+    )
 
 
 @usage_lib.entrypoint
@@ -704,7 +699,6 @@ def exec(  # pylint: disable=redefined-builtin
     down: bool = False,
     stream_logs: bool = True,
     backend: Optional[backends.Backend] = None,
-    job_logger: logging.Logger = logger,
 ) -> Tuple[Optional[int], Optional[backends.ResourceHandle]]:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Executes a task on an existing cluster.
@@ -780,5 +774,4 @@ def exec(  # pylint: disable=redefined-builtin
         ],
         cluster_name=cluster_name,
         detach_run=True,
-        job_logger=job_logger,
     )

--- a/sky/jobs/constants.py
+++ b/sky/jobs/constants.py
@@ -1,5 +1,4 @@
 """Constants used for Managed Jobs."""
-import os
 from typing import Any, Dict, Union
 
 from sky.skylet import constants as skylet_constants
@@ -10,8 +9,6 @@ JOBS_CONTROLLER_LOGS_DIR = '~/sky_logs/jobs_controller'
 
 JOBS_TASK_YAML_PREFIX = '~/.sky/managed_jobs'
 
-CONSOLIDATED_SIGNAL_PATH = os.path.expanduser('~/.sky/signals/')
-SIGNAL_FILE_PREFIX = '/tmp/sky_jobs_controller_signal_{}'
 # Resources as a dict for the jobs controller.
 # Use smaller CPU instance type for jobs controller, but with more memory, i.e.
 # r6i.xlarge (4vCPUs, 32 GB) for AWS, Standard_E4s_v5 (4vCPUs, 32 GB) for Azure,

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1,27 +1,31 @@
-"""Controller: handles scheduling and the life cycle of a managed job.
+"""Controller: handles the life cycle of a managed job.
+
+TODO(cooperc): Document lifecycle, and multiprocess layout.
 """
-import asyncio
-import logging
+import argparse
+import multiprocessing
 import os
-import resource
+import pathlib
 import shutil
-import sys
 import time
 import traceback
 import typing
-from typing import Dict, Optional, Set, Tuple
+from typing import Optional, Tuple
 
-import dotenv
-import psutil
+import filelock
 
-import sky
+# This import ensures backward compatibility. Controller processes may not have
+# imported this module initially, but will attempt to import it during job
+# termination on the fly. If a job was launched with an old SkyPilot runtime
+# and a new job is launched with a newer runtime, the old job's termination
+# will try to import code from a different SkyPilot runtime, causing exceptions.
+# pylint: disable=unused-import
 from sky import core
 from sky import exceptions
 from sky import sky_logging
 from sky.backends import backend_utils
 from sky.backends import cloud_vm_ray_backend
 from sky.data import data_utils
-from sky.jobs import constants as jobs_constants
 from sky.jobs import recovery_strategy
 from sky.jobs import scheduler
 from sky.jobs import state as managed_job_state
@@ -31,33 +35,19 @@ from sky.skylet import job_lib
 from sky.usage import usage_lib
 from sky.utils import common
 from sky.utils import common_utils
-from sky.utils import context
-from sky.utils import context_utils
 from sky.utils import controller_utils
 from sky.utils import dag_utils
 from sky.utils import status_lib
+from sky.utils import subprocess_utils
 from sky.utils import ux_utils
 
+if typing.TYPE_CHECKING:
+    import sky
+
+# Use the explicit logger name so that the logger is under the
+# `sky.jobs.controller` namespace when executed directly, so as
+# to inherit the setup from the `sky` logger.
 logger = sky_logging.init_logger('sky.jobs.controller')
-
-_background_tasks: Set[asyncio.Task] = set()
-_background_tasks_lock: asyncio.Lock = asyncio.Lock()
-
-
-async def create_background_task(coro: typing.Coroutine) -> None:
-    """Create a background task and add it to the set of background tasks.
-
-    Main reason we do this is since tasks are only held as a weak reference in
-    the executor, we need to keep a strong reference to the task to avoid it
-    being garbage collected.
-
-    Args:
-        coro: The coroutine to create a task for.
-    """
-    async with _background_tasks_lock:
-        task = asyncio.create_task(coro)
-        _background_tasks.add(task)
-        task.add_done_callback(_background_tasks.discard)
 
 
 def _get_dag_and_name(dag_yaml: str) -> Tuple['sky.Dag', str]:
@@ -68,79 +58,13 @@ def _get_dag_and_name(dag_yaml: str) -> Tuple['sky.Dag', str]:
 
 
 class JobsController:
-    """Controls the lifecycle of a single managed job.
+    """Each jobs controller manages the life cycle of one managed job."""
 
-    This controller executes a chain DAG defined in ``dag_yaml`` by:
-    - Loading the DAG and preparing per-task environment variables so each task
-      has a stable global job identifier across recoveries.
-    - Launching the task on the configured backend (``CloudVmRayBackend``),
-      optionally via a cluster pool.
-    - Persisting state transitions to the managed jobs state store
-      (e.g., STARTING → RUNNING → SUCCEEDED/FAILED/CANCELLED).
-    - Monitoring execution, downloading/streaming logs, detecting failures or
-      preemptions, and invoking recovery through
-      ``recovery_strategy.StrategyExecutor``.
-    - Cleaning up clusters and ephemeral resources when tasks finish.
-
-    Concurrency and coordination:
-    - Runs inside an ``asyncio`` event loop.
-    - Shares a ``starting`` set, guarded by ``starting_lock`` and signaled via
-      ``starting_signal``, to throttle concurrent launches across jobs that the
-      top-level ``Controller`` manages.
-
-    Key attributes:
-    - ``_job_id``: Integer identifier of this managed job.
-    - ``_dag_yaml`` / ``_dag`` / ``_dag_name``: The job definition and metadata.
-    - ``_backend``: Backend used to launch and manage clusters.
-    - ``_pool``: Optional pool name if using a cluster pool.
-    - ``_logger``: Job-scoped logger for progress and diagnostics.
-    - ``starting`` / ``starting_lock`` / ``starting_signal``: Shared scheduler
-      coordination primitives. ``starting_lock`` must be used for accessing
-      ``starting_signal`` and ``starting``
-    - ``_strategy_executor``: Recovery/launch strategy executor (created per
-      task).
-    """
-
-    def __init__(
-        self,
-        job_id: int,
-        dag_yaml: str,
-        job_logger: logging.Logger,
-        starting: Set[int],
-        starting_lock: asyncio.Lock,
-        starting_signal: asyncio.Condition,
-        pool: Optional[str] = None,
-    ) -> None:
-        """Initialize a ``JobsController``.
-
-        Args:
-            job_id: Integer ID of the managed job.
-            dag_yaml: Path to the YAML file containing the chain DAG to run.
-            job_logger: Logger instance dedicated to this job.
-            starting: Shared set of job IDs currently in the STARTING phase,
-                used to limit concurrent launches.
-            starting_lock: ``asyncio.Lock`` guarding access to the shared
-                scheduler state (e.g., the ``starting`` set).
-            starting_signal: ``asyncio.Condition`` used to notify when a job
-                exits STARTING so more jobs can be admitted.
-            pool: Optional cluster pool name. When provided, the job is
-                submitted to the pool rather than launching a dedicated
-                cluster.
-        """
-
-        self.starting = starting
-        self.starting_lock = starting_lock
-        self.starting_signal = starting_signal
-
-        self._logger = job_logger
-        self._logger.info(f'Initializing JobsController for job_id={job_id}, '
-                          f'dag_yaml={dag_yaml}')
-
+    def __init__(self, job_id: int, dag_yaml: str, pool: Optional[str]) -> None:
         self._job_id = job_id
-        self._dag_yaml = dag_yaml
         self._dag, self._dag_name = _get_dag_and_name(dag_yaml)
-        self._logger.info(f'Loaded DAG: {self._dag}')
-
+        logger.info(self._dag)
+        # TODO(zhwu): this assumes the specific backend.
         self._backend = cloud_vm_ray_backend.CloudVmRayBackend()
         self._pool = pool
 
@@ -160,7 +84,6 @@ class JobsController:
                 # dag_utils.maybe_infer_and_fill_dag_and_task_names.
                 assert task_name is not None, self._dag
                 task_name = f'{self._dag_name}_{task_name}'
-
             job_id_env_var = common_utils.get_global_job_id(
                 self._backend.run_timestamp,
                 f'{task_name}',
@@ -179,7 +102,7 @@ class JobsController:
     def _download_log_and_stream(
         self,
         task_id: Optional[int],
-        handle: Optional['cloud_vm_ray_backend.CloudVmRayResourceHandle'],
+        handle: Optional[cloud_vm_ray_backend.CloudVmRayResourceHandle],
         job_id_on_pool_cluster: Optional[int],
     ) -> None:
         """Downloads and streams the logs of the current job with given task ID.
@@ -189,10 +112,9 @@ class JobsController:
         preemptions or ssh disconnection during the streaming.
         """
         if handle is None:
-            self._logger.info(f'Cluster for job {self._job_id} is not found. '
-                              'Skipping downloading and streaming the logs.')
+            logger.info(f'Cluster for job {self._job_id} is not found. '
+                        'Skipping downloading and streaming the logs.')
             return
-
         managed_job_logs_dir = os.path.join(constants.SKY_LOGS_DIRECTORY,
                                             'managed_jobs',
                                             f'job-id-{self._job_id}')
@@ -203,25 +125,19 @@ class JobsController:
             job_ids=[str(job_id_on_pool_cluster)]
             if job_id_on_pool_cluster is not None else None)
         if log_file is not None:
-            # Set the path of the log file for the current task, so it can
-            # be accessed even after the job is finished
+            # Set the path of the log file for the current task, so it can be
+            # accessed even after the job is finished
             managed_job_state.set_local_log_file(self._job_id, task_id,
                                                  log_file)
-        else:
-            self._logger.warning(
-                f'No log file was downloaded for job {self._job_id}, '
-                f'task {task_id}')
+        logger.info(f'\n== End of logs (ID: {self._job_id}) ==')
 
-        self._logger.info(f'\n== End of logs (ID: {self._job_id}) ==')
-
-    async def _cleanup_cluster(self, cluster_name: Optional[str]) -> None:
+    def _cleanup_cluster(self, cluster_name: Optional[str]) -> None:
         if cluster_name is None:
             return
         if self._pool is None:
-            await context_utils.to_thread(managed_job_utils.terminate_cluster,
-                                          cluster_name)
+            managed_job_utils.terminate_cluster(cluster_name)
 
-    async def _run_one_task(self, task_id: int, task: 'sky.Task') -> bool:
+    def _run_one_task(self, task_id: int, task: 'sky.Task') -> bool:
         """Busy loop monitoring cluster status and handling recovery.
 
         When the task is successfully completed, this function returns True,
@@ -256,52 +172,38 @@ class JobsController:
                 3. Any unexpected error happens during the `sky.launch`.
         Other exceptions may be raised depending on the backend.
         """
-        task_start_time = time.time()
-        self._logger.info(
-            f'Starting task {task_id} ({task.name}) for job {self._job_id}')
 
         latest_task_id, last_task_prev_status = (
-            await
-            managed_job_state.get_latest_task_id_status_async(self._job_id))
-
+            managed_job_state.get_latest_task_id_status(self._job_id))
         is_resume = False
         if (latest_task_id is not None and last_task_prev_status !=
                 managed_job_state.ManagedJobStatus.PENDING):
             assert latest_task_id >= task_id, (latest_task_id, task_id)
             if latest_task_id > task_id:
-                self._logger.info(f'Task {task_id} ({task.name}) has already '
-                                  'been executed. Skipping...')
+                logger.info(f'Task {task_id} ({task.name}) has already '
+                            'been executed. Skipping...')
                 return True
             if latest_task_id == task_id:
                 # Start recovery.
                 is_resume = True
-                self._logger.info(
-                    f'Resuming task {task_id} from previous execution')
 
         callback_func = managed_job_utils.event_callback_func(
             job_id=self._job_id, task_id=task_id, task=task)
-
         if task.run is None:
-            self._logger.info(
-                f'Skip running task {task_id} ({task.name}) due to its '
-                'run commands being empty.')
+            logger.info(f'Skip running task {task_id} ({task.name}) due to its '
+                        'run commands being empty.')
             # Call set_started first to initialize columns in the state table,
             # including start_at and last_recovery_at to avoid issues for
             # uninitialized columns.
-            await managed_job_state.set_started_async(
-                job_id=self._job_id,
-                task_id=task_id,
-                start_time=time.time(),
-                callback_func=callback_func)
-            await managed_job_state.set_succeeded_async(
-                job_id=self._job_id,
-                task_id=task_id,
-                end_time=time.time(),
-                callback_func=callback_func)
-            self._logger.info(
-                f'Empty task {task_id} marked as succeeded immediately')
+            managed_job_state.set_started(job_id=self._job_id,
+                                          task_id=task_id,
+                                          start_time=time.time(),
+                                          callback_func=callback_func)
+            managed_job_state.set_succeeded(job_id=self._job_id,
+                                            task_id=task_id,
+                                            end_time=time.time(),
+                                            callback_func=callback_func)
             return True
-
         usage_lib.messages.usage.update_task_id(task_id)
         task_id_env_var = task.envs[constants.TASK_ID_ENV_VAR]
         assert task.name is not None, task
@@ -312,97 +214,61 @@ class JobsController:
             task.name, self._job_id) if self._pool is None else None
         self._strategy_executor = recovery_strategy.StrategyExecutor.make(
             cluster_name, self._backend, task, self._job_id, task_id,
-            self._logger, self._pool, self.starting, self.starting_lock,
-            self.starting_signal)
+            self._pool)
         if not is_resume:
             submitted_at = time.time()
             if task_id == 0:
                 submitted_at = backend_utils.get_timestamp_from_run_timestamp(
                     self._backend.run_timestamp)
-
-            resources_str = backend_utils.get_task_resources_str(
-                task, is_managed_job=True)
-
-            await managed_job_state.set_starting_async(
+            managed_job_state.set_starting(
                 self._job_id,
                 task_id,
                 self._backend.run_timestamp,
                 submitted_at,
-                resources_str=resources_str,
+                resources_str=backend_utils.get_task_resources_str(
+                    task, is_managed_job=True),
                 specs={
                     'max_restarts_on_errors':
                         self._strategy_executor.max_restarts_on_errors
                 },
                 callback_func=callback_func)
-            self._logger.info(f'Submitted managed job {self._job_id} '
-                              f'(task: {task_id}, name: {task.name!r}); '
-                              f'{constants.TASK_ID_ENV_VAR}: {task_id_env_var}')
+            logger.info(f'Submitted managed job {self._job_id} '
+                        f'(task: {task_id}, name: {task.name!r}); '
+                        f'{constants.TASK_ID_ENV_VAR}: {task_id_env_var}')
 
-        self._logger.info('Started monitoring.')
+        logger.info('Started monitoring.')
 
         # Only do the initial cluster launch if not resuming from a controller
         # failure. Otherwise, we will transit to recovering immediately.
         remote_job_submitted_at = time.time()
         if not is_resume:
-            launch_start = time.time()
-
-            # Run the launch in a separate thread to avoid blocking the event
-            # loop. The scheduler functions used internally already have their
-            # own file locks.
-            remote_job_submitted_at = await self._strategy_executor.launch()
-
-            launch_time = time.time() - launch_start
-            self._logger.info(f'Cluster launch completed in {launch_time:.2f}s')
+            remote_job_submitted_at = self._strategy_executor.launch()
             assert remote_job_submitted_at is not None, remote_job_submitted_at
         if self._pool is None:
             job_id_on_pool_cluster = None
         else:
             # Update the cluster name when using cluster pool.
             cluster_name, job_id_on_pool_cluster = (
-                await
-                managed_job_state.get_pool_submit_info_async(self._job_id))
+                managed_job_state.get_pool_submit_info(self._job_id))
         assert cluster_name is not None, (cluster_name, job_id_on_pool_cluster)
 
         if not is_resume:
-            await managed_job_state.set_started_async(
-                job_id=self._job_id,
-                task_id=task_id,
-                start_time=remote_job_submitted_at,
-                callback_func=callback_func)
-
-        monitoring_start_time = time.time()
-        status_check_count = 0
-
-        async with self.starting_lock:
-            try:
-                self.starting.remove(self._job_id)
-                # its fine if we notify again, better to wake someone up
-                # and have them go to sleep again, then have some stuck
-                # sleeping.
-                # ps. this shouldn't actually happen because if its been
-                # removed from the set then we would get a key error.
-                self.starting_signal.notify()
-            except KeyError:
-                pass
+            managed_job_state.set_started(job_id=self._job_id,
+                                          task_id=task_id,
+                                          start_time=remote_job_submitted_at,
+                                          callback_func=callback_func)
 
         while True:
-            status_check_count += 1
-
             # NOTE: if we are resuming from a controller failure, we only keep
             # monitoring if the job is in RUNNING state. For all other cases,
             # we will directly transit to recovering since we have no idea what
             # the cluster status is.
             force_transit_to_recovering = False
             if is_resume:
-                prev_status = await (
-                    managed_job_state.get_job_status_with_task_id_async(
-                        job_id=self._job_id, task_id=task_id))
-
+                prev_status = managed_job_state.get_job_status_with_task_id(
+                    job_id=self._job_id, task_id=task_id)
                 if prev_status is not None:
                     if prev_status.is_terminal():
-                        self._logger.info(
-                            f'Task {task_id} already in terminal state: '
-                            f'{prev_status}')
                         return (prev_status ==
                                 managed_job_state.ManagedJobStatus.SUCCEEDED)
                     if (prev_status ==
@@ -410,26 +276,23 @@ class JobsController:
                         # If the controller is down when cancelling the job,
                         # we re-raise the error to run the `_cleanup` function
                         # again to clean up any remaining resources.
-                        self._logger.info(
-                            f'Task {task_id} was being cancelled, '
-                            're-raising cancellation')
-                        raise asyncio.CancelledError()
+                        raise exceptions.ManagedJobUserCancelledError(
+                            'Recovering cancel signal.')
                 if prev_status != managed_job_state.ManagedJobStatus.RUNNING:
                     force_transit_to_recovering = True
                 # This resume logic should only be triggered once.
                 is_resume = False
 
-            await asyncio.sleep(managed_job_utils.JOB_STATUS_CHECK_GAP_SECONDS)
+            time.sleep(managed_job_utils.JOB_STATUS_CHECK_GAP_SECONDS)
 
             # Check the network connection to avoid false alarm for job failure.
             # Network glitch was observed even in the VM.
             try:
-                await backend_utils.async_check_network_connection()
+                backend_utils.check_network_connection()
             except exceptions.NetworkError:
-                self._logger.info(
-                    'Network is not available. Retrying again in '
-                    f'{managed_job_utils.JOB_STATUS_CHECK_GAP_SECONDS} '
-                    'seconds.')
+                logger.info('Network is not available. Retrying again in '
+                            f'{managed_job_utils.JOB_STATUS_CHECK_GAP_SECONDS} '
+                            'seconds.')
                 continue
 
             # NOTE: we do not check cluster status first because race condition
@@ -440,47 +303,32 @@ class JobsController:
             job_status = None
             if not force_transit_to_recovering:
                 try:
-                    job_status = await managed_job_utils.get_job_status(
+                    job_status = managed_job_utils.get_job_status(
                         self._backend,
                         cluster_name,
-                        job_id=job_id_on_pool_cluster,
-                        job_logger=self._logger,
-                    )
+                        job_id=job_id_on_pool_cluster)
                 except exceptions.FetchClusterInfoError as fetch_e:
-                    self._logger.info(
+                    logger.info(
                         'Failed to fetch the job status. Start recovery.\n'
                         f'Exception: {common_utils.format_exception(fetch_e)}\n'
                         f'Traceback: {traceback.format_exc()}')
 
             if job_status == job_lib.JobStatus.SUCCEEDED:
-                self._logger.info(f'Task {task_id} succeeded! '
-                                  'Getting end time and cleaning up')
-                try:
-                    success_end_time = await context_utils.to_thread(
-                        managed_job_utils.try_to_get_job_end_time,
-                        self._backend, cluster_name, job_id_on_pool_cluster)
-                except Exception as e:  # pylint: disable=broad-except
-                    self._logger.warning(
-                        f'Failed to get job end time: '
-                        f'{common_utils.format_exception(e)}',
-                        exc_info=True)
-                    success_end_time = 0
-
+                success_end_time = managed_job_utils.try_to_get_job_end_time(
+                    self._backend, cluster_name, job_id_on_pool_cluster)
                 # The job is done. Set the job to SUCCEEDED first before start
                 # downloading and streaming the logs to make it more responsive.
-                await managed_job_state.set_succeeded_async(
-                    self._job_id,
-                    task_id,
-                    end_time=success_end_time,
-                    callback_func=callback_func)
-                self._logger.info(
+                managed_job_state.set_succeeded(self._job_id,
+                                                task_id,
+                                                end_time=success_end_time,
+                                                callback_func=callback_func)
+                logger.info(
                     f'Managed job {self._job_id} (task: {task_id}) SUCCEEDED. '
                     f'Cleaning up the cluster {cluster_name}.')
                 try:
                     logger.info(f'Downloading logs on cluster {cluster_name} '
                                 f'and job id {job_id_on_pool_cluster}.')
-                    clusters = await context_utils.to_thread(
-                        backend_utils.get_clusters,
+                    clusters = backend_utils.get_clusters(
                         cluster_names=[cluster_name],
                         refresh=common.StatusRefreshMode.NONE,
                         all_users=True,
@@ -489,25 +337,17 @@ class JobsController:
                         assert len(clusters) == 1, (clusters, cluster_name)
                         handle = clusters[0].get('handle')
                         # Best effort to download and stream the logs.
-                        await context_utils.to_thread(
-                            self._download_log_and_stream, task_id, handle,
-                            job_id_on_pool_cluster)
+                        self._download_log_and_stream(task_id, handle,
+                                                      job_id_on_pool_cluster)
                 except Exception as e:  # pylint: disable=broad-except
                     # We don't want to crash here, so just log and continue.
-                    self._logger.warning(
+                    logger.warning(
                         f'Failed to download and stream logs: '
                         f'{common_utils.format_exception(e)}',
                         exc_info=True)
                 # Only clean up the cluster, not the storages, because tasks may
                 # share storages.
-                await self._cleanup_cluster(cluster_name)
-
-                task_total_time = time.time() - task_start_time
-                monitoring_time = time.time() - monitoring_start_time
-                self._logger.info(f'Task {task_id} completed successfully in '
-                                  f'{task_total_time:.2f}s '
-                                  f'(monitoring time: {monitoring_time:.2f}s, '
-                                  f'status checks: {status_check_count})')
+                self._cleanup_cluster(cluster_name)
                 return True
 
             # For single-node jobs, non-terminated job_status indicates a
@@ -523,7 +363,7 @@ class JobsController:
             if job_status in job_lib.JobStatus.user_code_failure_states():
                 # Add a grace period before the check of preemption to avoid
                 # false alarm for job failure.
-                await asyncio.sleep(5)
+                time.sleep(5)
 
             # Pull the actual cluster status from the cloud provider to
             # determine whether the cluster is preempted or failed.
@@ -543,7 +383,7 @@ class JobsController:
                 # code).
                 cluster_status_str = ('' if cluster_status is None else
                                       f' (status: {cluster_status.value})')
-                self._logger.info(
+                logger.info(
                     f'Cluster is preempted or failed{cluster_status_str}. '
                     'Recovering...')
             else:
@@ -554,18 +394,14 @@ class JobsController:
                       in job_lib.JobStatus.user_code_failure_states() or
                       job_status == job_lib.JobStatus.FAILED_DRIVER):
                     # The user code has probably crashed, fail immediately.
-                    self._logger.info(
-                        f'Task {task_id} failed with status: {job_status}')
-                    end_time = await context_utils.to_thread(
-                        managed_job_utils.try_to_get_job_end_time,
+                    end_time = managed_job_utils.try_to_get_job_end_time(
                         self._backend, cluster_name, job_id_on_pool_cluster)
-                    self._logger.info(
+                    logger.info(
                         f'The user job failed ({job_status}). Please check the '
                         'logs below.\n'
                         f'== Logs of the user job (ID: {self._job_id}) ==\n')
 
-                    await context_utils.to_thread(self._download_log_and_stream,
-                                                  task_id, handle,
+                    self._download_log_and_stream(task_id, handle,
                                                   job_id_on_pool_cluster)
 
                     failure_reason = (
@@ -594,7 +430,7 @@ class JobsController:
                     if should_restart_on_failure:
                         max_restarts = (
                             self._strategy_executor.max_restarts_on_errors)
-                        self._logger.info(
+                        logger.info(
                             f'User program crashed '
                             f'({managed_job_status.value}). '
                             f'Retry the job as max_restarts_on_errors is '
@@ -602,9 +438,7 @@ class JobsController:
                             f'[{self._strategy_executor.restart_cnt_on_failure}'
                             f'/{max_restarts}]')
                     else:
-                        self._logger.info(
-                            f'Task {task_id} failed and will not be retried')
-                        await managed_job_state.set_failed_async(
+                        managed_job_state.set_failed(
                             self._job_id,
                             task_id,
                             failure_type=managed_job_status,
@@ -615,11 +449,11 @@ class JobsController:
                 elif job_status is not None:
                     # Either the job is cancelled (should not happen) or in some
                     # unknown new state that we do not handle.
-                    self._logger.error(f'Unknown job status: {job_status}')
+                    logger.error(f'Unknown job status: {job_status}')
                     failure_reason = (
                         f'Unknown job status {job_status}. To see the details, '
                         f'run: sky jobs logs --controller {self._job_id}')
-                    await managed_job_state.set_failed_async(
+                    managed_job_state.set_failed(
                         self._job_id,
                         task_id,
                         failure_type=managed_job_state.ManagedJobStatus.
@@ -632,10 +466,9 @@ class JobsController:
                     # job status. Try to recover the job (will not restart the
                     # cluster, if the cluster is healthy).
                     assert job_status is None, job_status
-                    self._logger.info(
-                        'Failed to fetch the job status while the '
-                        'cluster is healthy. Try to recover the job '
-                        '(the cluster will not be restarted).')
+                    logger.info('Failed to fetch the job status while the '
+                                'cluster is healthy. Try to recover the job '
+                                '(the cluster will not be restarted).')
             # When the handle is None, the cluster should be cleaned up already.
             if handle is not None:
                 resources = handle.launched_resources
@@ -654,121 +487,86 @@ class JobsController:
                     # Some spot resource (e.g., Spot TPU VM) may need to be
                     # cleaned up after preemption, as running launch again on
                     # those clusters again may fail.
-                    self._logger.info(
-                        'Cleaning up the preempted or failed cluster'
-                        '...')
-                    await self._cleanup_cluster(cluster_name)
+                    logger.info('Cleaning up the preempted or failed cluster'
+                                '...')
+                    self._cleanup_cluster(cluster_name)
 
             # Try to recover the managed jobs, when the cluster is preempted or
             # failed or the job status is failed to be fetched.
-            self._logger.info(f'Starting recovery for task {task_id}, '
-                              f'it is currently {job_status}')
-            await managed_job_state.set_recovering_async(
+            managed_job_state.set_recovering(
                 job_id=self._job_id,
                 task_id=task_id,
                 force_transit_to_recovering=force_transit_to_recovering,
                 callback_func=callback_func)
-
-            recovered_time = await self._strategy_executor.recover()
-
+            recovered_time = self._strategy_executor.recover()
             if self._pool is not None:
                 cluster_name, job_id_on_pool_cluster = (
-                    await
-                    managed_job_state.get_pool_submit_info_async(self._job_id))
+                    managed_job_state.get_pool_submit_info(self._job_id))
                 assert cluster_name is not None
-            await managed_job_state.set_recovered_async(
-                self._job_id,
-                task_id,
-                recovered_time=recovered_time,
-                callback_func=callback_func)
+            managed_job_state.set_recovered(self._job_id,
+                                            task_id,
+                                            recovered_time=recovered_time,
+                                            callback_func=callback_func)
 
-    async def run(self):
+    def run(self):
         """Run controller logic and handle exceptions."""
-        self._logger.info(f'Starting JobsController run for job {self._job_id}')
         task_id = 0
-        cancelled = False
-
         try:
             succeeded = True
             # We support chain DAGs only for now.
             for task_id, task in enumerate(self._dag.tasks):
-                self._logger.info(
-                    f'Processing task {task_id}/{len(self._dag.tasks)-1}: '
-                    f'{task.name}')
-                task_start = time.time()
-                succeeded = await self._run_one_task(task_id, task)
-                task_time = time.time() - task_start
-                self._logger.info(
-                    f'Task {task_id} completed in {task_time:.2f}s '
-                    f'with success={succeeded}')
-
+                succeeded = self._run_one_task(task_id, task)
                 if not succeeded:
-                    self._logger.info(
-                        f'Task {task_id} failed, stopping execution')
                     break
-
         except exceptions.ProvisionPrechecksError as e:
             # Please refer to the docstring of self._run for the cases when
             # this exception can occur.
-            self._logger.error(f'Provision prechecks failed for task {task_id}')
             failure_reason = ('; '.join(
                 common_utils.format_exception(reason, use_bracket=True)
                 for reason in e.reasons))
-            self._logger.error(failure_reason)
-            await self._update_failed_task_state(
+            logger.error(failure_reason)
+            self._update_failed_task_state(
                 task_id, managed_job_state.ManagedJobStatus.FAILED_PRECHECKS,
                 failure_reason)
         except exceptions.ManagedJobReachedMaxRetriesError as e:
             # Please refer to the docstring of self._run for the cases when
             # this exception can occur.
-            self._logger.error(
-                f'Managed job reached max retries for task {task_id}')
             failure_reason = common_utils.format_exception(e)
-            self._logger.error(failure_reason)
+            logger.error(failure_reason)
             # The managed job should be marked as FAILED_NO_RESOURCE, as the
             # managed job may be able to launch next time.
-            await self._update_failed_task_state(
+            self._update_failed_task_state(
                 task_id, managed_job_state.ManagedJobStatus.FAILED_NO_RESOURCE,
                 failure_reason)
-        except asyncio.CancelledError:  # pylint: disable=try-except-raise
-            # have this here to avoid getting caught by the general except block
-            # below.
-            cancelled = True
-            raise
         except (Exception, SystemExit) as e:  # pylint: disable=broad-except
-            self._logger.error(
-                f'Unexpected error in JobsController run for task {task_id}')
             with ux_utils.enable_traceback():
-                self._logger.error(traceback.format_exc())
+                logger.error(traceback.format_exc())
             msg = ('Unexpected error occurred: ' +
                    common_utils.format_exception(e, use_bracket=True))
-            self._logger.error(msg)
-            await self._update_failed_task_state(
+            logger.error(msg)
+            self._update_failed_task_state(
                 task_id, managed_job_state.ManagedJobStatus.FAILED_CONTROLLER,
                 msg)
         finally:
+            # This will set all unfinished tasks to CANCELLING, and will not
+            # affect the jobs in terminal states.
+            # We need to call set_cancelling before set_cancelled to make sure
+            # the table entries are correctly set.
             callback_func = managed_job_utils.event_callback_func(
                 job_id=self._job_id,
                 task_id=task_id,
                 task=self._dag.tasks[task_id])
-            await managed_job_state.set_cancelling_async(
-                job_id=self._job_id, callback_func=callback_func)
-            if not cancelled:
-                # the others haven't been run yet so we can set them to
-                # cancelled immediately (no resources to clean up).
-                # if we are running and get cancelled, we need to clean up the
-                # resources first so this will be done later.
-                await managed_job_state.set_cancelled_async(
-                    job_id=self._job_id, callback_func=callback_func)
+            managed_job_state.set_cancelling(job_id=self._job_id,
+                                             callback_func=callback_func)
+            managed_job_state.set_cancelled(job_id=self._job_id,
+                                            callback_func=callback_func)
 
-    async def _update_failed_task_state(
+    def _update_failed_task_state(
             self, task_id: int,
             failure_type: managed_job_state.ManagedJobStatus,
             failure_reason: str):
         """Update the state of the failed task."""
-        self._logger.info(f'Updating failed task state: task_id={task_id}, '
-                          f'failure_type={failure_type}')
-        await managed_job_state.set_failed_async(
+        managed_job_state.set_failed(
             self._job_id,
             task_id=task_id,
             failure_type=failure_type,
@@ -779,439 +577,199 @@ class JobsController:
                 task=self._dag.tasks[task_id]))
 
 
-class Controller:
-    """Controller for managing jobs."""
+def _run_controller(job_id: int, dag_yaml: str, pool: Optional[str]):
+    """Runs the controller in a remote process for interruption."""
+    # The controller needs to be instantiated in the remote process, since
+    # the controller is not serializable.
+    jobs_controller = JobsController(job_id, dag_yaml, pool)
+    jobs_controller.run()
 
-    def __init__(self):
-        # Global state for active jobs
-        self.job_tasks: Dict[int, asyncio.Task] = {}
-        self.starting: Set[int] = set()
 
-        # Lock for synchronizing access to global state dictionary
-        # Must always hold _job_tasks_lock when accessing the _starting_signal.
-        self._job_tasks_lock = asyncio.Lock()
-        # We signal whenever a job leaves the api server launching state. Feel
-        # free to signal as much as you want to be safe from leaks (if you
-        # do not signal enough there may be some jobs forever waiting to
-        # launch).
-        self._starting_signal = asyncio.Condition(lock=self._job_tasks_lock)
-
-    async def _cleanup(self,
-                       job_id: int,
-                       dag_yaml: str,
-                       job_logger: logging.Logger,
-                       pool: Optional[str] = None):
-        """Clean up the cluster(s) and storages.
-
-        (1) Clean up the succeeded task(s)' ephemeral storage. The storage has
-            to be cleaned up after the whole job is finished, as the tasks
-            may share the same storage.
-        (2) Clean up the cluster(s) that are not cleaned up yet, which can
-            happen when the task failed or cancelled. At most one cluster
-            should be left when reaching here, as we currently only support
-            chain DAGs, and only one task is executed at a time.
-        """
-        # Cleanup the HA recovery script first as it is possible that some error
-        # was raised when we construct the task object (e.g.,
-        # sky.exceptions.ResourcesUnavailableError).
-        await managed_job_state.remove_ha_recovery_script_async(job_id)
-
-        def task_cleanup(task: 'sky.Task', job_id: int):
-            assert task.name is not None, task
-            error = None
-
-            try:
-                if pool is None:
-                    cluster_name = (
-                        managed_job_utils.generate_managed_job_cluster_name(
-                            task.name, job_id))
-                    managed_job_utils.terminate_cluster(cluster_name,
-                                                        _logger=job_logger)
-                    status = core.status(cluster_names=[cluster_name],
-                                         all_users=True)
-                    assert (len(status) == 0 or
-                            status[0]['status'] == sky.ClusterStatus.STOPPED), (
-                                f'{cluster_name} is not down: {status}')
-                    job_logger.info(f'{cluster_name} is down')
-                else:
-                    cluster_name, job_id_on_pool_cluster = (
-                        managed_job_state.get_pool_submit_info(job_id))
-                    if cluster_name is not None:
-                        if job_id_on_pool_cluster is not None:
-                            core.cancel(cluster_name=cluster_name,
-                                        job_ids=[job_id_on_pool_cluster],
-                                        _try_cancel_if_cluster_is_init=True)
-            except Exception as e:  # pylint: disable=broad-except
-                error = e
-                job_logger.warning(
-                    f'Failed to terminate cluster {cluster_name}: {e}')
-                # we continue to try cleaning up whatever else we can.
-            # Clean up Storages with persistent=False.
-            # TODO(zhwu): this assumes the specific backend.
-            backend = cloud_vm_ray_backend.CloudVmRayBackend()
-            # Need to re-construct storage object in the controller process
-            # because when SkyPilot API server machine sends the yaml config to
-            # the controller machine, only storage metadata is sent, not the
-            # storage object itself.
-            for storage in task.storage_mounts.values():
-                storage.construct()
-            try:
-                backend.teardown_ephemeral_storage(task)
-            except Exception as e:  # pylint: disable=broad-except
-                error = e
-                job_logger.warning(f'Failed to teardown ephemeral storage: {e}')
-                # we continue to try cleaning up whatever else we can.
-
-            # Clean up any files mounted from the local disk, such as two-hop
-            # file mounts.
-            for file_mount in (task.file_mounts or {}).values():
+def _handle_signal(job_id):
+    """Handle the signal if the user sent it."""
+    signal_file = pathlib.Path(
+        managed_job_utils.SIGNAL_FILE_PREFIX.format(job_id))
+    user_signal = None
+    if signal_file.exists():
+        # Filelock is needed to prevent race condition with concurrent
+        # signal writing.
+        with filelock.FileLock(str(signal_file) + '.lock'):
+            with signal_file.open(mode='r', encoding='utf-8') as f:
+                user_signal = f.read().strip()
                 try:
-                    # For consolidation mode, there is no two-hop file mounts
-                    # and the file path here represents the real user data.
-                    # We skip the cleanup for consolidation mode.
-                    if (not data_utils.is_cloud_store_url(file_mount) and
-                            not managed_job_utils.is_consolidation_mode()):
-                        path = os.path.expanduser(file_mount)
-                        if os.path.isdir(path):
-                            shutil.rmtree(path)
-                        else:
-                            os.remove(path)
-                except Exception as e:  # pylint: disable=broad-except
-                    job_logger.warning(
-                        f'Failed to clean up file mount {file_mount}: {e}')
+                    user_signal = managed_job_utils.UserSignal(user_signal)
+                except ValueError:
+                    logger.warning(
+                        f'Unknown signal received: {user_signal}. Ignoring.')
+                    user_signal = None
+            # Remove the signal file, after reading the signal.
+            signal_file.unlink()
+    if user_signal is None:
+        # None or empty string.
+        return
+    assert user_signal == managed_job_utils.UserSignal.CANCEL, (
+        f'Only cancel signal is supported, but {user_signal} got.')
+    raise exceptions.ManagedJobUserCancelledError(
+        f'User sent {user_signal.value} signal.')
 
-            if error is not None:
-                raise error
 
+def _cleanup(job_id: int, dag_yaml: str, pool: Optional[str]):
+    """Clean up the cluster(s) and storages.
+
+    (1) Clean up the succeeded task(s)' ephemeral storage. The storage has
+        to be cleaned up after the whole job is finished, as the tasks
+        may share the same storage.
+    (2) Clean up the cluster(s) that are not cleaned up yet, which can happen
+        when the task failed or cancelled. At most one cluster should be left
+        when reaching here, as we currently only support chain DAGs, and only
+        task is executed at a time.
+    """
+    # Cleanup the HA recovery script first as it is possible that some error
+    # was raised when we construct the task object (e.g.,
+    # sky.exceptions.ResourcesUnavailableError).
+    managed_job_state.remove_ha_recovery_script(job_id)
+    dag, _ = _get_dag_and_name(dag_yaml)
+    for task in dag.tasks:
+        assert task.name is not None, task
+        if pool is None:
+            cluster_name = managed_job_utils.generate_managed_job_cluster_name(
+                task.name, job_id)
+            managed_job_utils.terminate_cluster(cluster_name)
+        else:
+            cluster_name, job_id_on_pool_cluster = (
+                managed_job_state.get_pool_submit_info(job_id))
+            if cluster_name is not None:
+                if job_id_on_pool_cluster is not None:
+                    core.cancel(cluster_name=cluster_name,
+                                job_ids=[job_id_on_pool_cluster],
+                                _try_cancel_if_cluster_is_init=True)
+
+        # Clean up Storages with persistent=False.
+        # TODO(zhwu): this assumes the specific backend.
+        backend = cloud_vm_ray_backend.CloudVmRayBackend()
+        # Need to re-construct storage object in the controller process
+        # because when SkyPilot API server machine sends the yaml config to the
+        # controller machine, only storage metadata is sent, not the storage
+        # object itself.
+        for storage in task.storage_mounts.values():
+            storage.construct()
+        backend.teardown_ephemeral_storage(task)
+
+        # Clean up any files mounted from the local disk, such as two-hop file
+        # mounts.
+        for file_mount in (task.file_mounts or {}).values():
+            try:
+                # For consolidation mode, there is no two-hop file mounts
+                # and the file path here represents the real user data.
+                # We skip the cleanup for consolidation mode.
+                if (not data_utils.is_cloud_store_url(file_mount) and
+                        not managed_job_utils.is_consolidation_mode()):
+                    path = os.path.expanduser(file_mount)
+                    if os.path.isdir(path):
+                        shutil.rmtree(path)
+                    else:
+                        os.remove(path)
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning(
+                    f'Failed to clean up file mount {file_mount}: {e}')
+
+
+def start(job_id, dag_yaml, pool):
+    """Start the controller."""
+    controller_process = None
+    cancelling = False
+    task_id = None
+    try:
+        _handle_signal(job_id)
+        # TODO(suquark): In theory, we should make controller process a
+        #  daemon process so it will be killed after this process exits,
+        #  however daemon process cannot launch subprocesses, explained here:
+        #  https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process.daemon  # pylint: disable=line-too-long
+        #  So we can only enable daemon after we no longer need to
+        #  start daemon processes like Ray.
+        controller_process = multiprocessing.Process(target=_run_controller,
+                                                     args=(job_id, dag_yaml,
+                                                           pool))
+        controller_process.start()
+        while controller_process.is_alive():
+            _handle_signal(job_id)
+            time.sleep(1)
+    except exceptions.ManagedJobUserCancelledError:
         dag, _ = _get_dag_and_name(dag_yaml)
-        error = None
-        for task in dag.tasks:
-            # most things in this function are blocking
-            try:
-                await context_utils.to_thread(task_cleanup, task, job_id)
-            except Exception as e:  # pylint: disable=broad-except
-                error = e
+        task_id, _ = managed_job_state.get_latest_task_id_status(job_id)
+        assert task_id is not None, job_id
+        logger.info(
+            f'Cancelling managed job, job_id: {job_id}, task_id: {task_id}')
+        managed_job_state.set_cancelling(
+            job_id=job_id,
+            callback_func=managed_job_utils.event_callback_func(
+                job_id=job_id, task_id=task_id, task=dag.tasks[task_id]))
+        cancelling = True
+    finally:
+        if controller_process is not None:
+            logger.info(f'Killing controller process {controller_process.pid}.')
+            # NOTE: it is ok to kill or join a killed process.
+            # Kill the controller process first; if its child process is
+            # killed first, then the controller process will raise errors.
+            # Kill any possible remaining children processes recursively.
+            subprocess_utils.kill_children_processes(
+                parent_pids=[controller_process.pid], force=True)
+            controller_process.join()
+            logger.info(f'Controller process {controller_process.pid} killed.')
 
-        if error is not None:
-            # we only raise the last error that occurred, but its fine to lose
-            # some data here.
-            raise error
+        logger.info(f'Cleaning up any cluster for job {job_id}.')
+        # NOTE: Originally, we send an interruption signal to the controller
+        # process and the controller process handles cleanup. However, we
+        # figure out the behavior differs from cloud to cloud
+        # (e.g., GCP ignores 'SIGINT'). A possible explanation is
+        # https://unix.stackexchange.com/questions/356408/strange-problem-with-trap-and-sigint
+        # But anyway, a clean solution is killing the controller process
+        # directly, and then cleanup the cluster job_state.
+        _cleanup(job_id, dag_yaml=dag_yaml, pool=pool)
+        logger.info(f'Cluster of managed job {job_id} has been cleaned up.')
 
-    async def run_job_loop(self,
-                           job_id: int,
-                           dag_yaml: str,
-                           job_logger: logging.Logger,
-                           log_file: str,
-                           env_file_path: Optional[str] = None,
-                           pool: Optional[str] = None):
-        """Background task that runs the job loop."""
-        # Replace os.environ with ContextualEnviron to enable per-job
-        # environment isolation. This allows each job to have its own
-        # environment variables without affecting other jobs or the main
-        # process.
-        context.initialize()
-        ctx = context.get()
-        ctx.redirect_log(log_file)  # type: ignore
-
-        # Load and apply environment variables from the job's environment file
-        if env_file_path and os.path.exists(env_file_path):
-            try:
-                # Load environment variables from the file
-                env_vars = dotenv.dotenv_values(env_file_path)
-                job_logger.info(f'Loading environment from {env_file_path}: '
-                                f'{list(env_vars.keys())}')
-
-                # Apply environment variables to the job's context
-                ctx = context.get()
-                if ctx is not None:
-                    for key, value in env_vars.items():
-                        if value is not None:
-                            ctx.override_envs({key: value})
-                            job_logger.debug(
-                                f'Set environment variable: {key}={value}')
-                else:
-                    job_logger.error(
-                        'Context is None, cannot set environment variables')
-            except Exception as e:  # pylint: disable=broad-except
-                job_logger.error(
-                    f'Failed to load environment file {env_file_path}: {e}')
-        elif env_file_path:
-            job_logger.error(f'Environment file not found: {env_file_path}')
-
-        cancelling = False
-        try:
-            job_logger.info(f'Starting job loop for {job_id}')
-
-            controller = JobsController(job_id, dag_yaml, job_logger,
-                                        self.starting, self._job_tasks_lock,
-                                        self._starting_signal, pool)
-
-            async with self._job_tasks_lock:
-                if job_id in self.job_tasks:
-                    job_logger.error(
-                        f'Job {job_id} already exists in job_tasks')
-                    raise ValueError(f'Job {job_id} already exists')
-
-                # Create the task and store it
-                # This function should return instantly and run the job loop in
-                # the background.
-                task = asyncio.create_task(controller.run())
-                self.job_tasks[job_id] = task
-            await task
-        except asyncio.CancelledError:
-            job_logger.info(f'Job {job_id} was cancelled')
-            dag, _ = _get_dag_and_name(dag_yaml)
-            task_id, _ = await (
-                managed_job_state.get_latest_task_id_status_async(job_id))
-            assert task_id is not None, job_id
-            job_logger.info(f'Cancelling managed job, job_id: {job_id}, '
-                            f'task_id: {task_id}')
-            await managed_job_state.set_cancelling_async(
+        if cancelling:
+            assert task_id is not None, job_id  # Since it's set with cancelling
+            managed_job_state.set_cancelled(
                 job_id=job_id,
                 callback_func=managed_job_utils.event_callback_func(
                     job_id=job_id, task_id=task_id, task=dag.tasks[task_id]))
-            cancelling = True
-            raise
-        except Exception as e:
-            job_logger.error(f'Unexpected error in job loop for {job_id}: '
-                             f'{common_utils.format_exception(e)}')
-            raise
-        finally:
-            try:
-                await self._cleanup(job_id,
-                                    dag_yaml=dag_yaml,
-                                    job_logger=job_logger,
-                                    pool=pool)
-                job_logger.info(
-                    f'Cluster of managed job {job_id} has been cleaned up.')
-            except Exception as e:  # pylint: disable=broad-except
-                await managed_job_state.set_failed_async(
-                    job_id,
-                    task_id=None,
-                    failure_type=managed_job_state.ManagedJobStatus.
-                    FAILED_CONTROLLER,
-                    failure_reason=e,
-                    override_terminal=True)
 
-            if cancelling:
-                # Since it's set with cancelling
-                assert task_id is not None, job_id
-                await managed_job_state.set_cancelled_async(
-                    job_id=job_id,
-                    callback_func=managed_job_utils.event_callback_func(
-                        job_id=job_id, task_id=task_id,
-                        task=dag.tasks[task_id]))
+        # We should check job status after 'set_cancelled', otherwise
+        # the job status is not terminal.
+        job_status = managed_job_state.get_status(job_id)
+        assert job_status is not None
+        # The job can be non-terminal if the controller exited abnormally,
+        # e.g. failed to launch cluster after reaching the MAX_RETRY.
+        if not job_status.is_terminal():
+            logger.info(f'Previous job status: {job_status.value}')
+            managed_job_state.set_failed(
+                job_id,
+                task_id=None,
+                failure_type=managed_job_state.ManagedJobStatus.
+                FAILED_CONTROLLER,
+                failure_reason=('Unexpected error occurred. For details, '
+                                f'run: sky jobs logs --controller {job_id}'))
 
-            # We should check job status after 'set_cancelled', otherwise
-            # the job status is not terminal.
-            job_status = await managed_job_state.get_status_async(job_id)
-            assert job_status is not None
-            # The job can be non-terminal if the controller exited abnormally,
-            # e.g. failed to launch cluster after reaching the MAX_RETRY.
-            if not job_status.is_terminal():
-                job_logger.info(f'Previous job status: {job_status.value}')
-                await managed_job_state.set_failed_async(
-                    job_id,
-                    task_id=None,
-                    failure_type=managed_job_state.ManagedJobStatus.
-                    FAILED_CONTROLLER,
-                    failure_reason=(
-                        'Unexpected error occurred. For details, '
-                        f'run: sky jobs logs --controller {job_id}'))
-
-            await scheduler.job_done_async(job_id)
-
-            async with self._job_tasks_lock:
-                try:
-                    # just in case we were cancelled or some other error
-                    # occurred during launch
-                    self.starting.remove(job_id)
-                    # its fine if we notify again, better to wake someone up
-                    # and have them go to sleep again, then have some stuck
-                    # sleeping.
-                    self._starting_signal.notify()
-                except KeyError:
-                    pass
-
-            # Remove the job from the job_tasks dictionary.
-            async with self._job_tasks_lock:
-                if job_id in self.job_tasks:
-                    del self.job_tasks[job_id]
-
-    async def start_job(
-        self,
-        job_id: int,
-        dag_yaml: str,
-        env_file_path: Optional[str] = None,
-        pool: Optional[str] = None,
-    ):
-        """Start a new job.
-
-        Args:
-            job_id: The ID of the job to start.
-            dag_yaml: Path to the YAML file containing the DAG definition.
-            env_file_path: Optional path to environment file for the job.
-        """
-        # Create a job-specific logger
-        log_dir = os.path.expanduser(jobs_constants.JOBS_CONTROLLER_LOGS_DIR)
-        os.makedirs(log_dir, exist_ok=True)
-        log_file = os.path.join(log_dir, f'{job_id}.log')
-
-        job_logger = logging.getLogger(f'sky.jobs.{job_id}')
-        job_logger.setLevel(logging.DEBUG)
-
-        # Create file handler
-        file_handler = logging.FileHandler(log_file)
-        file_handler.setLevel(logging.DEBUG)
-
-        # Use Sky's standard formatter
-        file_handler.setFormatter(sky_logging.FORMATTER)
-
-        # Add the handler to the logger
-        job_logger.addHandler(file_handler)
-
-        # Prevent log propagation to avoid duplicate logs
-        job_logger.propagate = False
-
-        job_logger.info(f'Starting job {job_id} with dag_yaml={dag_yaml}, '
-                        f'env_file_path={env_file_path}')
-
-        async with self._job_tasks_lock:
-            self.starting.add(job_id)
-        await create_background_task(
-            self.run_job_loop(job_id, dag_yaml, job_logger, log_file,
-                              env_file_path, pool))
-
-        job_logger.info(f'Job {job_id} started successfully')
-
-    async def cancel_job(self):
-        """Cancel an existing job."""
-        while True:
-            cancels = os.listdir(jobs_constants.CONSOLIDATED_SIGNAL_PATH)
-            for cancel in cancels:
-                async with self._job_tasks_lock:
-                    job_id = int(cancel)
-                    if job_id in self.job_tasks:
-                        logger.info(f'Cancelling job {job_id}')
-
-                        task = self.job_tasks[job_id]
-
-                        # Run the cancellation in the background, so we can
-                        # return immediately.
-                        task.cancel()
-                        logger.info(f'Job {job_id} cancelled successfully')
-
-                        os.remove(f'{jobs_constants.CONSOLIDATED_SIGNAL_PATH}/'
-                                  f'{job_id}')
-            await asyncio.sleep(15)
-
-    async def monitor_loop(self):
-        """Monitor the job loop."""
-        logger.info(f'Starting monitor loop for pid {os.getpid()}...')
-
-        while True:
-            async with self._job_tasks_lock:
-                running_tasks = [
-                    task for task in self.job_tasks.values() if not task.done()
-                ]
-
-            async with self._job_tasks_lock:
-                starting_count = len(self.starting)
-
-            if starting_count >= scheduler.LAUNCHES_PER_WORKER:
-                # launching a job takes around 1 minute, so lets wait half that
-                # time
-                await asyncio.sleep(30)
-                continue
-
-            if len(running_tasks) >= scheduler.JOBS_PER_WORKER:
-                await asyncio.sleep(60)
-                continue
-
-            # Check if there are any jobs that are waiting to launch
-            try:
-                waiting_job = await managed_job_state.get_waiting_job_async(
-                    pid=-os.getpid())
-            except Exception as e:  # pylint: disable=broad-except
-                logger.error(f'Failed to get waiting job: {e}')
-                await asyncio.sleep(5)
-                continue
-
-            if waiting_job is None:
-                await asyncio.sleep(10)
-                continue
-
-            schedule_state = waiting_job['schedule_state']
-            if (schedule_state !=
-                    managed_job_state.ManagedJobScheduleState.WAITING):
-                # in this case it is already currently being restarted
-
-                # two options, old_pid is > 0 meaning it is an old job, in which
-                # case we do not support taking it over
-                # if old_pid is < 0, that means it was started by the new
-                # consolidated controller, in which case we can take it over if
-                # the controller managing it is dead. if it is not dead, the
-                # other process will handle restarting it.
-                if waiting_job['old_pid'] < 0:
-                    try:
-                        process = psutil.Process(-waiting_job['old_pid'])
-                        if process.is_running():
-                            continue
-                    except psutil.NoSuchProcess:
-                        pass
-
-            job_id = waiting_job['job_id']
-            dag_yaml_path = waiting_job['dag_yaml_path']
-            env_file_path = waiting_job.get('env_file_path')
-            pool = waiting_job.get('pool', None)
-
-            cancels = os.listdir(jobs_constants.CONSOLIDATED_SIGNAL_PATH)
-            if str(job_id) in cancels:
-                status = await managed_job_state.get_status_async(job_id)
-                if status == managed_job_state.ManagedJobStatus.PENDING:
-                    logger.info(f'Job {job_id} cancelled')
-                    os.remove(f'{jobs_constants.CONSOLIDATED_SIGNAL_PATH}/'
-                              f'{job_id}')
-                    await managed_job_state.set_cancelling_async(
-                        job_id=job_id,
-                        callback_func=managed_job_utils.event_callback_func(
-                            job_id=job_id, task_id=None, task=None))
-                    await managed_job_state.set_cancelled_async(
-                        job_id=job_id,
-                        callback_func=managed_job_utils.event_callback_func(
-                            job_id=job_id, task_id=None, task=None))
-                    continue
-
-            await self.start_job(job_id, dag_yaml_path, env_file_path, pool)
-
-
-async def main():
-    context_utils.hijack_sys_attrs()
-
-    controller = Controller()
-
-    # Will happen multiple times, who cares though
-    os.makedirs(jobs_constants.CONSOLIDATED_SIGNAL_PATH, exist_ok=True)
-
-    # Increase number of files we can open
-    soft = None
-    try:
-        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
-        resource.setrlimit(resource.RLIMIT_NOFILE, (hard, hard))
-    except OSError as e:
-        logger.warning(f'Failed to increase number of files we can open: {e}\n'
-                       f'Current soft limit: {soft}, hard limit: {hard}')
-
-    # Will loop forever, do it in the background
-    cancel_job_task = asyncio.create_task(controller.cancel_job())
-    monitor_loop_task = asyncio.create_task(controller.monitor_loop())
-
-    try:
-        await asyncio.gather(cancel_job_task, monitor_loop_task)
-    except Exception as e:  # pylint: disable=broad-except
-        logger.error(f'Controller server crashed: {e}')
-        sys.exit(1)
+        scheduler.job_done(job_id)
 
 
 if __name__ == '__main__':
-    asyncio.run(main())
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--job-id',
+                        required=True,
+                        type=int,
+                        help='Job id for the controller job.')
+    parser.add_argument('dag_yaml',
+                        type=str,
+                        help='The path to the user job yaml file.')
+    parser.add_argument('--pool',
+                        required=False,
+                        default=None,
+                        type=str,
+                        help='The pool to use for the controller job.')
+    args = parser.parse_args()
+    # We start process with 'spawn', because 'fork' could result in weird
+    # behaviors; 'spawn' is also cross-platform.
+    multiprocessing.set_start_method('spawn', force=True)
+    start(args.job_id, args.dag_yaml, args.pool)

--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -5,19 +5,18 @@ In the YAML file, the user can specify the strategy to use for managed jobs.
 resources:
     job_recovery: EAGER_NEXT_REGION
 """
-import asyncio
-import logging
+import time
 import traceback
 import typing
-from typing import Optional, Set
+from typing import Optional
 
 from sky import backends
 from sky import dag as dag_lib
 from sky import exceptions
+from sky import execution
 from sky import global_user_state
 from sky import sky_logging
 from sky.backends import backend_utils
-from sky.client import sdk
 from sky.jobs import scheduler
 from sky.jobs import state
 from sky.jobs import utils as managed_job_utils
@@ -25,7 +24,6 @@ from sky.serve import serve_utils
 from sky.skylet import job_lib
 from sky.usage import usage_lib
 from sky.utils import common_utils
-from sky.utils import context_utils
 from sky.utils import registry
 from sky.utils import status_lib
 from sky.utils import ux_utils
@@ -43,7 +41,7 @@ MAX_JOB_CHECKING_RETRY = 10
 # Minutes to job cluster autodown. This should be significantly larger than
 # managed_job_utils.JOB_STATUS_CHECK_GAP_SECONDS, to avoid tearing down the
 # cluster before its status can be updated by the job controller.
-_AUTODOWN_MINUTES = 10
+_AUTODOWN_MINUTES = 5
 
 
 class StrategyExecutor:
@@ -51,33 +49,15 @@ class StrategyExecutor:
 
     RETRY_INIT_GAP_SECONDS = 60
 
-    def __init__(
-        self,
-        cluster_name: Optional[str],
-        backend: 'backends.Backend',
-        task: 'task_lib.Task',
-        max_restarts_on_errors: int,
-        job_id: int,
-        task_id: int,
-        job_logger: logging.Logger,
-        pool: Optional[str],
-        starting: Set[int],
-        starting_lock: asyncio.Lock,
-        starting_signal: asyncio.Condition,
-    ) -> None:
+    def __init__(self, cluster_name: Optional[str], backend: 'backends.Backend',
+                 task: 'task_lib.Task', max_restarts_on_errors: int,
+                 job_id: int, task_id: int, pool: Optional[str]) -> None:
         """Initialize the strategy executor.
 
         Args:
             cluster_name: The name of the cluster.
             backend: The backend to use. Only CloudVMRayBackend is supported.
             task: The task to execute.
-            max_restarts_on_errors: Maximum number of restarts on errors.
-            job_id: The ID of the job.
-            task_id: The ID of the task.
-            job_logger: Logger instance for this specific job.
-            starting: Set of job IDs that are currently starting.
-            starting_lock: Lock to synchronize starting jobs.
-            starting_signal: Condition to signal when a job can start.
         """
         assert isinstance(backend, backends.CloudVmRayBackend), (
             'Only CloudVMRayBackend is supported.')
@@ -94,26 +74,12 @@ class StrategyExecutor:
         self.task_id = task_id
         self.pool = pool
         self.restart_cnt_on_failure = 0
-        self._logger = job_logger
         self.job_id_on_pool_cluster: Optional[int] = None
-        self.starting = starting
-        self.starting_lock = starting_lock
-        self.starting_signal = starting_signal
 
     @classmethod
-    def make(
-        cls,
-        cluster_name: Optional[str],
-        backend: 'backends.Backend',
-        task: 'task_lib.Task',
-        job_id: int,
-        task_id: int,
-        job_logger: logging.Logger,
-        pool: Optional[str],
-        starting: Set[int],
-        starting_lock: asyncio.Lock,
-        starting_signal: asyncio.Condition,
-    ) -> 'StrategyExecutor':
+    def make(cls, cluster_name: Optional[str], backend: 'backends.Backend',
+             task: 'task_lib.Task', job_id: int, task_id: int,
+             pool: Optional[str]) -> 'StrategyExecutor':
         """Create a strategy from a task."""
 
         resource_list = list(task.resources)
@@ -145,10 +111,9 @@ class StrategyExecutor:
         assert job_recovery_strategy is not None, job_recovery_name
         return job_recovery_strategy(cluster_name, backend, task,
                                      max_restarts_on_errors, job_id, task_id,
-                                     job_logger, pool, starting, starting_lock,
-                                     starting_signal)
+                                     pool)
 
-    async def launch(self) -> float:
+    def launch(self) -> float:
         """Launch the cluster for the first time.
 
         It can fail if resource is not available. Need to check the cluster
@@ -160,11 +125,11 @@ class StrategyExecutor:
         Raises: Please refer to the docstring of self._launch().
         """
 
-        job_submit_at = await self._launch(max_retry=None)
+        job_submit_at = self._launch(max_retry=None)
         assert job_submit_at is not None
         return job_submit_at
 
-    async def recover(self) -> float:
+    def recover(self) -> float:
         """Relaunch the cluster after failure and wait until job starts.
 
         When recover() is called the cluster should be in STOPPED status (i.e.
@@ -174,11 +139,13 @@ class StrategyExecutor:
         """
         raise NotImplementedError
 
-    async def _try_cancel_jobs(self):
+    def _try_cancel_jobs(self):
+        from sky import core  # pylint: disable=import-outside-toplevel
+
         if self.cluster_name is None:
             return
-        handle = await context_utils.to_thread(
-            global_user_state.get_handle_from_cluster_name, self.cluster_name)
+        handle = global_user_state.get_handle_from_cluster_name(
+            self.cluster_name)
         if handle is None or self.pool is not None:
             return
         try:
@@ -207,16 +174,9 @@ class StrategyExecutor:
                 kwargs = dict(all=True)
             else:
                 kwargs = dict(job_ids=[self.job_id_on_pool_cluster])
-            request_id = await context_utils.to_thread(
-                sdk.cancel,
-                cluster_name=self.cluster_name,
-                **kwargs,
-                _try_cancel_if_cluster_is_init=True,
-            )
-            await context_utils.to_thread(
-                sdk.get,
-                request_id,
-            )
+            core.cancel(cluster_name=self.cluster_name,
+                        **kwargs,
+                        _try_cancel_if_cluster_is_init=True)
         except Exception as e:  # pylint: disable=broad-except
             logger.info('Failed to cancel the job on the cluster. The cluster '
                         'might be already down or the head node is preempted.'
@@ -224,9 +184,9 @@ class StrategyExecutor:
                         f'{common_utils.format_exception(e)}\n'
                         'Terminating the cluster explicitly to ensure no '
                         'remaining job process interferes with recovery.')
-            await context_utils.to_thread(self._cleanup_cluster)
+            self._cleanup_cluster()
 
-    async def _wait_until_job_starts_on_cluster(self) -> Optional[float]:
+    def _wait_until_job_starts_on_cluster(self) -> Optional[float]:
         """Wait for MAX_JOB_CHECKING_RETRY times until job starts on the cluster
 
         Returns:
@@ -240,34 +200,32 @@ class StrategyExecutor:
             # Avoid the infinite loop, if any bug happens.
             job_checking_retry_cnt += 1
             try:
-                cluster_status, _ = (await context_utils.to_thread(
-                    backend_utils.refresh_cluster_status_handle,
-                    self.cluster_name,
-                    force_refresh_statuses=set(status_lib.ClusterStatus)))
+                cluster_status, _ = (
+                    backend_utils.refresh_cluster_status_handle(
+                        self.cluster_name,
+                        force_refresh_statuses=set(status_lib.ClusterStatus)))
             except Exception as e:  # pylint: disable=broad-except
                 # If any unexpected error happens, retry the job checking
                 # loop.
                 # TODO(zhwu): log the unexpected error to usage collection
                 # for future debugging.
-                self._logger.info(
-                    f'Unexpected exception: {e}\nFailed to get the '
-                    'refresh the cluster status. Retrying.')
+                logger.info(f'Unexpected exception: {e}\nFailed to get the '
+                            'refresh the cluster status. Retrying.')
                 continue
             if cluster_status != status_lib.ClusterStatus.UP:
                 # The cluster can be preempted before the job is
                 # launched.
                 # Break to let the retry launch kick in.
-                self._logger.info('The cluster is preempted before the job '
-                                  'is submitted.')
+                logger.info('The cluster is preempted before the job '
+                            'is submitted.')
                 # TODO(zhwu): we should recover the preemption with the
                 # recovery strategy instead of the current while loop.
                 break
 
             try:
-                status = await managed_job_utils.get_job_status(
+                status = managed_job_utils.get_job_status(
                     self.backend,
                     self.cluster_name,
-                    job_logger=self._logger,
                     job_id=self.job_id_on_pool_cluster)
             except Exception as e:  # pylint: disable=broad-except
                 # If any unexpected error happens, retry the job checking
@@ -276,16 +234,14 @@ class StrategyExecutor:
                 # get_job_status, so it should not happen here.
                 # TODO(zhwu): log the unexpected error to usage collection
                 # for future debugging.
-                self._logger.info(
-                    f'Unexpected exception: {e}\nFailed to get the '
-                    'job status. Retrying.')
+                logger.info(f'Unexpected exception: {e}\nFailed to get the '
+                            'job status. Retrying.')
                 continue
 
             # Check the job status until it is not in initialized status
             if status is not None and status > job_lib.JobStatus.INIT:
                 try:
-                    job_submitted_at = await context_utils.to_thread(
-                        managed_job_utils.get_job_timestamp,
+                    job_submitted_at = managed_job_utils.get_job_timestamp(
                         self.backend,
                         self.cluster_name,
                         self.job_id_on_pool_cluster,
@@ -294,13 +250,11 @@ class StrategyExecutor:
                 except Exception as e:  # pylint: disable=broad-except
                     # If we failed to get the job timestamp, we will retry
                     # job checking loop.
-                    self._logger.info(
-                        f'Unexpected Exception: {e}\nFailed to get '
-                        'the job start timestamp. Retrying.')
+                    logger.info(f'Unexpected Exception: {e}\nFailed to get '
+                                'the job start timestamp. Retrying.')
                     continue
             # Wait for the job to be started
-            await asyncio.sleep(
-                managed_job_utils.JOB_STARTED_STATUS_CHECK_GAP_SECONDS)
+            time.sleep(managed_job_utils.JOB_STARTED_STATUS_CHECK_GAP_SECONDS)
         return None
 
     def _cleanup_cluster(self) -> None:
@@ -309,10 +263,10 @@ class StrategyExecutor:
         if self.pool is None:
             managed_job_utils.terminate_cluster(self.cluster_name)
 
-    async def _launch(self,
-                      max_retry: Optional[int] = 3,
-                      raise_on_failure: bool = True,
-                      recovery: bool = False) -> Optional[float]:
+    def _launch(self,
+                max_retry: Optional[int] = 3,
+                raise_on_failure: bool = True,
+                recovery: bool = False) -> Optional[float]:
         """Implementation of launch().
 
         The function will wait until the job starts running, but will leave the
@@ -353,98 +307,51 @@ class StrategyExecutor:
         while True:
             retry_cnt += 1
             try:
-                async with scheduler.scheduled_launch(
-                        self.job_id,
-                        self.starting,
-                        self.starting_lock,
-                        self.starting_signal,
-                        self._logger,
-                ):
+                with scheduler.scheduled_launch(self.job_id):
                     # The job state may have been PENDING during backoff -
                     # update to STARTING or RECOVERING.
                     # On the first attempt (when retry_cnt is 1), we should
                     # already be in STARTING or RECOVERING.
                     if retry_cnt > 1:
-                        await state.set_restarting_async(
-                            self.job_id, self.task_id, recovery)
+                        state.set_restarting(self.job_id, self.task_id,
+                                             recovery)
                     try:
                         usage_lib.messages.usage.set_internal()
                         if self.pool is None:
                             assert self.cluster_name is not None
-
-                            log_file = _get_logger_file(self._logger)
-                            request_id = None
-                            try:
-                                request_id = await context_utils.to_thread(
-                                    sdk.launch,
-                                    self.dag,
-                                    cluster_name=self.cluster_name,
-                                    idle_minutes_to_autostop=_AUTODOWN_MINUTES,
-                                    down=True,
-                                    _is_launched_by_jobs_controller=True,
-                                )
-                                if log_file is None:
-                                    raise OSError('Log file is None')
-                                with open(log_file, 'a', encoding='utf-8') as f:
-                                    await context_utils.to_thread(
-                                        sdk.stream_and_get,
-                                        request_id,
-                                        output_stream=f,
-                                    )
-                            except asyncio.CancelledError:
-                                if request_id:
-                                    req = await context_utils.to_thread(
-                                        sdk.api_cancel, request_id)
-                                    try:
-                                        await context_utils.to_thread(
-                                            sdk.get, req)
-                                    except Exception as e:  # pylint: disable=broad-except
-                                        # we must still return a CancelledError
-                                        self._logger.error(
-                                            f'Failed to cancel the job: {e}')
-                                raise
-                            self._logger.info('Managed job cluster launched.')
+                            # Detach setup, so that the setup failure can be
+                            # detected by the controller process (job_status ->
+                            # FAILED_SETUP).
+                            execution.launch(
+                                self.dag,
+                                cluster_name=self.cluster_name,
+                                # We expect to tear down the cluster as soon as
+                                # the job is finished. However, in case the
+                                # controller dies, set autodown to try and avoid
+                                # a resource leak.
+                                idle_minutes_to_autostop=_AUTODOWN_MINUTES,
+                                down=True,
+                                _is_launched_by_jobs_controller=True)
                         else:
-                            self.cluster_name = await (context_utils.to_thread(
-                                serve_utils.get_next_cluster_name, self.pool,
-                                self.job_id))
+                            self.cluster_name = (
+                                serve_utils.get_next_cluster_name(
+                                    self.pool, self.job_id))
                             if self.cluster_name is None:
                                 raise exceptions.NoClusterLaunchedError(
                                     'No cluster name found in the pool.')
-                            request_id = None
-                            try:
-                                request_id = await context_utils.to_thread(
-                                    sdk.exec,
-                                    self.dag,
-                                    cluster_name=self.cluster_name,
-                                )
-                                job_id_on_pool_cluster, _ = (
-                                    await context_utils.to_thread(
-                                        sdk.get, request_id))
-                            except asyncio.CancelledError:
-                                if request_id:
-                                    req = await context_utils.to_thread(
-                                        sdk.api_cancel, request_id)
-                                    try:
-                                        await context_utils.to_thread(
-                                            sdk.get, req)
-                                    except Exception as e:  # pylint: disable=broad-except
-                                        # we must still return a CancelledError
-                                        self._logger.error(
-                                            f'Failed to cancel the job: {e}')
-                                raise
+                            job_id_on_pool_cluster, _ = execution.exec(
+                                self.dag, cluster_name=self.cluster_name)
                             assert job_id_on_pool_cluster is not None, (
                                 self.cluster_name, self.job_id)
                             self.job_id_on_pool_cluster = job_id_on_pool_cluster
-                            await state.set_job_id_on_pool_cluster_async(
+                            state.set_job_id_on_pool_cluster(
                                 self.job_id, job_id_on_pool_cluster)
-                        self._logger.info('Managed job cluster launched.')
+                        logger.info('Managed job cluster launched.')
                     except (exceptions.InvalidClusterNameError,
                             exceptions.NoCloudAccessError,
                             exceptions.ResourcesMismatchError) as e:
-                        self._logger.error(
-                            'Failure happened before provisioning. '
-                            f'{common_utils.format_exception(e)}')
+                        logger.error('Failure happened before provisioning. '
+                                     f'{common_utils.format_exception(e)}')
                         if raise_on_failure:
                             raise exceptions.ProvisionPrechecksError(
                                 reasons=[e])
@@ -472,30 +379,28 @@ class StrategyExecutor:
                             reasons_str = '; '.join(
                                 common_utils.format_exception(err)
                                 for err in reasons)
-                            self._logger.error(
+                            logger.error(
                                 'Failure happened before provisioning. '
                                 f'Failover reasons: {reasons_str}')
                             if raise_on_failure:
                                 raise exceptions.ProvisionPrechecksError(
                                     reasons)
                             return None
-                        self._logger.info(
-                            'Failed to launch a cluster with error: '
-                            f'{common_utils.format_exception(e)})')
+                        logger.info('Failed to launch a cluster with error: '
+                                    f'{common_utils.format_exception(e)})')
                     except Exception as e:  # pylint: disable=broad-except
                         # If the launch fails, it will be recovered by the
                         # following code.
-                        self._logger.info(
-                            'Failed to launch a cluster with error: '
-                            f'{common_utils.format_exception(e)})')
+                        logger.info('Failed to launch a cluster with error: '
+                                    f'{common_utils.format_exception(e)})')
                         with ux_utils.enable_traceback():
-                            self._logger.info(
+                            logger.info(
                                 f'  Traceback: {traceback.format_exc()}')
                     else:  # No exception, the launch succeeds.
                         # At this point, a sky.launch() has succeeded. Cluster
                         # may be UP (no preemption since) or DOWN (newly
                         # preempted).
-                        job_submitted_at = await (
+                        job_submitted_at = (
                             self._wait_until_job_starts_on_cluster())
                         if job_submitted_at is not None:
                             return job_submitted_at
@@ -503,7 +408,7 @@ class StrategyExecutor:
                         # launch.
                         # TODO(zhwu): log the unexpected error to usage
                         # collection for future debugging.
-                        self._logger.info(
+                        logger.info(
                             'Failed to successfully submit the job to the '
                             'launched cluster, due to unexpected submission '
                             'errors or the cluster being preempted during '
@@ -511,7 +416,7 @@ class StrategyExecutor:
 
                     # If we get here, the launch did not succeed. Tear down the
                     # cluster and retry.
-                    await context_utils.to_thread(self._cleanup_cluster)
+                    self._cleanup_cluster()
                     if max_retry is not None and retry_cnt >= max_retry:
                         # Retry forever if max_retry is None.
                         if raise_on_failure:
@@ -534,13 +439,15 @@ class StrategyExecutor:
 
             except exceptions.NoClusterLaunchedError:
                 # Update the status to PENDING during backoff.
-                state.set_backoff_pending_async(self.job_id, self.task_id)
+                state.set_backoff_pending(self.job_id, self.task_id)
                 # Calculate the backoff time and sleep.
+                # We retry immediately for worker pool, since no sky.launch()
+                # is called and the overhead is minimal.
                 gap_seconds = (backoff.current_backoff()
                                if self.pool is None else 1)
-                self._logger.info('Retrying to launch the cluster in '
-                                  f'{gap_seconds:.1f} seconds.')
-                await asyncio.sleep(gap_seconds)
+                logger.info('Retrying to launch the cluster in '
+                            f'{gap_seconds:.1f} seconds.')
+                time.sleep(gap_seconds)
                 continue
             else:
                 # The inner loop should either return or throw
@@ -566,39 +473,26 @@ class FailoverStrategyExecutor(StrategyExecutor):
 
     _MAX_RETRY_CNT = 240  # Retry for 4 hours.
 
-    def __init__(
-        self,
-        cluster_name: Optional[str],
-        backend: 'backends.Backend',
-        task: 'task_lib.Task',
-        max_restarts_on_errors: int,
-        job_id: int,
-        task_id: int,
-        job_logger: logging.Logger,
-        pool: Optional[str],
-        starting: Set[int],
-        starting_lock: asyncio.Lock,
-        starting_signal: asyncio.Condition,
-    ) -> None:
+    def __init__(self, cluster_name: Optional[str], backend: 'backends.Backend',
+                 task: 'task_lib.Task', max_restarts_on_errors: int,
+                 job_id: int, task_id: int, pool: Optional[str]) -> None:
         super().__init__(cluster_name, backend, task, max_restarts_on_errors,
-                         job_id, task_id, job_logger, pool, starting,
-                         starting_lock, starting_signal)
+                         job_id, task_id, pool)
         # Note down the cloud/region of the launched cluster, so that we can
         # first retry in the same cloud/region. (Inside recover() we may not
         # rely on cluster handle, as it can be None if the cluster is
         # preempted.)
         self._launched_resources: Optional['resources.Resources'] = None
 
-    async def _launch(self,
-                      max_retry: Optional[int] = 3,
-                      raise_on_failure: bool = True,
-                      recovery: bool = False) -> Optional[float]:
-        job_submitted_at = await super()._launch(max_retry, raise_on_failure,
-                                                 recovery)
+    def _launch(self,
+                max_retry: Optional[int] = 3,
+                raise_on_failure: bool = True,
+                recovery: bool = False) -> Optional[float]:
+        job_submitted_at = super()._launch(max_retry, raise_on_failure,
+                                           recovery)
         if job_submitted_at is not None and self.cluster_name is not None:
             # Only record the cloud/region if the launch is successful.
-            handle = await context_utils.to_thread(
-                global_user_state.get_handle_from_cluster_name,
+            handle = global_user_state.get_handle_from_cluster_name(
                 self.cluster_name)
             assert isinstance(handle, backends.CloudVmRayResourceHandle), (
                 'Cluster should be launched.', handle)
@@ -608,7 +502,7 @@ class FailoverStrategyExecutor(StrategyExecutor):
             self._launched_resources = None
         return job_submitted_at
 
-    async def recover(self) -> float:
+    def recover(self) -> float:
         # 1. Cancel the jobs and launch the cluster with the STOPPED status,
         #    so that it will try on the current region first until timeout.
         # 2. Tear down the cluster, if the step 1 failed to launch the cluster.
@@ -616,7 +510,7 @@ class FailoverStrategyExecutor(StrategyExecutor):
         #    original user specification.
 
         # Step 1
-        await self._try_cancel_jobs()
+        self._try_cancel_jobs()
 
         while True:
             # Add region constraint to the task, to retry on the same region
@@ -630,32 +524,31 @@ class FailoverStrategyExecutor(StrategyExecutor):
                     cloud=launched_cloud, region=launched_region, zone=None)
                 task.set_resources({new_resources})
                 # Not using self.launch to avoid the retry until up logic.
-                job_submitted_at = await self._launch(raise_on_failure=False,
-                                                      recovery=True)
+                job_submitted_at = self._launch(raise_on_failure=False,
+                                                recovery=True)
                 # Restore the original dag, i.e. reset the region constraint.
                 task.set_resources(original_resources)
                 if job_submitted_at is not None:
                     return job_submitted_at
 
             # Step 2
-            self._logger.debug('Terminating unhealthy cluster and reset cloud '
-                               'region.')
-            await context_utils.to_thread(self._cleanup_cluster)
+            logger.debug('Terminating unhealthy cluster and reset cloud '
+                         'region.')
+            self._cleanup_cluster()
 
             # Step 3
-            self._logger.debug(
-                'Relaunch the cluster  without constraining to prior '
-                'cloud/region.')
+            logger.debug('Relaunch the cluster  without constraining to prior '
+                         'cloud/region.')
             # Not using self.launch to avoid the retry until up logic.
-            job_submitted_at = await self._launch(max_retry=self._MAX_RETRY_CNT,
-                                                  raise_on_failure=False,
-                                                  recovery=True)
+            job_submitted_at = self._launch(max_retry=self._MAX_RETRY_CNT,
+                                            raise_on_failure=False,
+                                            recovery=True)
             if job_submitted_at is None:
                 # Failed to launch the cluster.
                 gap_seconds = self.RETRY_INIT_GAP_SECONDS
-                self._logger.info('Retrying to recover the cluster in '
-                                  f'{gap_seconds:.1f} seconds.')
-                await asyncio.sleep(gap_seconds)
+                logger.info('Retrying to recover the cluster in '
+                            f'{gap_seconds:.1f} seconds.')
+                time.sleep(gap_seconds)
                 continue
 
             return job_submitted_at
@@ -687,7 +580,7 @@ class EagerFailoverStrategyExecutor(FailoverStrategyExecutor):
                                                   -> R1Z1 (success)
     """
 
-    async def recover(self) -> float:
+    def recover(self) -> float:
         # 1. Terminate the current cluster
         # 2. Launch again by explicitly blocking the previously launched region
         # (this will failover through the entire search space except the
@@ -699,14 +592,12 @@ class EagerFailoverStrategyExecutor(FailoverStrategyExecutor):
         # task.resources.
 
         # Step 1
-        self._logger.debug(
-            'Terminating unhealthy cluster and reset cloud region.')
-        await context_utils.to_thread(self._cleanup_cluster)
+        logger.debug('Terminating unhealthy cluster and reset cloud region.')
+        self._cleanup_cluster()
 
         # Step 2
-        self._logger.debug(
-            'Relaunch the cluster skipping the previously launched '
-            'cloud/region.')
+        logger.debug('Relaunch the cluster skipping the previously launched '
+                     'cloud/region.')
         if self._launched_resources is not None:
             task = self.dag.tasks[0]
             requested_resources = self._launched_resources
@@ -723,35 +614,26 @@ class EagerFailoverStrategyExecutor(FailoverStrategyExecutor):
                                              region=launched_region)
                 }
                 # Not using self.launch to avoid the retry until up logic.
-                job_submitted_at = await self._launch(raise_on_failure=False,
-                                                      recovery=True)
+                job_submitted_at = self._launch(raise_on_failure=False,
+                                                recovery=True)
                 task.blocked_resources = None
                 if job_submitted_at is not None:
                     return job_submitted_at
 
         while True:
             # Step 3
-            self._logger.debug(
-                'Relaunch the cluster without constraining to prior '
-                'cloud/region.')
+            logger.debug('Relaunch the cluster without constraining to prior '
+                         'cloud/region.')
             # Not using self.launch to avoid the retry until up logic.
-            job_submitted_at = await self._launch(max_retry=self._MAX_RETRY_CNT,
-                                                  raise_on_failure=False,
-                                                  recovery=True)
+            job_submitted_at = self._launch(max_retry=self._MAX_RETRY_CNT,
+                                            raise_on_failure=False,
+                                            recovery=True)
             if job_submitted_at is None:
                 # Failed to launch the cluster.
                 gap_seconds = self.RETRY_INIT_GAP_SECONDS
-                self._logger.info('Retrying to recover the cluster in '
-                                  f'{gap_seconds:.1f} seconds.')
-                await asyncio.sleep(gap_seconds)
+                logger.info('Retrying to recover the cluster in '
+                            f'{gap_seconds:.1f} seconds.')
+                time.sleep(gap_seconds)
                 continue
 
             return job_submitted_at
-
-
-def _get_logger_file(file_logger: logging.Logger) -> Optional[str]:
-    """Gets the file path that the logger writes to."""
-    for handler in file_logger.handlers:
-        if isinstance(handler, logging.FileHandler):
-            return handler.baseFilename
-    return None

--- a/sky/jobs/scheduler.py
+++ b/sky/jobs/scheduler.py
@@ -42,209 +42,145 @@ Nomenclature:
 """
 
 from argparse import ArgumentParser
-import asyncio
 import contextlib
 import os
-import pathlib
-import shutil
 import sys
-import typing
-from typing import Set
-import uuid
+import time
+from typing import Optional
 
 import filelock
 
+from sky import exceptions
 from sky import sky_logging
-from sky import skypilot_config
-from sky.adaptors import common as adaptors_common
-from sky.client import sdk
 from sky.jobs import constants as managed_job_constants
 from sky.jobs import state
-from sky.jobs import utils as managed_job_utils
-from sky.server import config as server_config
+from sky.serve import serve_utils
 from sky.skylet import constants
 from sky.utils import common_utils
+from sky.utils import controller_utils
 from sky.utils import subprocess_utils
-
-if typing.TYPE_CHECKING:
-    import logging
-
-    import psutil
-else:
-    psutil = adaptors_common.LazyImport('psutil')
 
 logger = sky_logging.init_logger('sky.jobs.controller')
 
-# Job controller lock. This is used to synchronize writing/reading the
-# controller pid file.
-JOB_CONTROLLER_PID_LOCK = os.path.expanduser(
-    '~/.sky/locks/job_controller_pid.lock')
-
-JOB_CONTROLLER_PID_PATH = os.path.expanduser('~/.sky/job_controller_pid')
-JOB_CONTROLLER_ENV_PATH = os.path.expanduser('~/.sky/job_controller_env')
-
-# Based on testing, each worker takes around 200-300MB memory. Keeping it
-# higher to be safe.
-JOB_MEMORY_MB = 400
-# Number of ongoing launches launches allowed per worker. Can probably be
-# increased a bit to around 16 but keeping it lower to just to be safe
-LAUNCHES_PER_WORKER = 8
-# this can probably be increased to around 300-400 but keeping it lower to just
-# to be safe
-JOBS_PER_WORKER = 200
-
-# keep 1GB reserved after the controllers
-MAXIMUM_CONTROLLER_RESERVED_MEMORY_MB = 2048
-
-CURRENT_HASH = os.path.expanduser('~/.sky/wheels/current_sky_wheel_hash')
-
-# Maximum values for above constants. There will start to be lagging issues
-# at these numbers already.
-# JOB_MEMORY_MB = 200
-# LAUNCHES_PER_WORKER = 16
-# JOBS_PER_WORKER = 400
+_ALIVE_JOB_LAUNCH_WAIT_INTERVAL = 0.5
 
 
-def get_number_of_controllers() -> int:
-    """Returns the number of controllers that should be running.
+def _start_controller(job_id: int, dag_yaml_path: str, env_file_path: str,
+                      pool: Optional[str]) -> None:
+    activate_python_env_cmd = (f'{constants.ACTIVATE_SKY_REMOTE_PYTHON_ENV};')
+    source_environment_cmd = (f'source {env_file_path};'
+                              if env_file_path else '')
+    maybe_pool_arg = (f'--pool {pool}' if pool is not None else '')
+    run_controller_cmd = (
+        f'{sys.executable} -u -m sky.jobs.controller '
+        f'{dag_yaml_path} --job-id {job_id} {maybe_pool_arg};')
 
-    This is the number of controllers that should be running to maximize
-    resource utilization.
+    # If the command line here is changed, please also update
+    # utils._controller_process_alive. The substring `--job-id X`
+    # should be in the command.
+    run_cmd = (f'{activate_python_env_cmd}'
+               f'{source_environment_cmd}'
+               f'{run_controller_cmd}')
 
-    In consolidation mode, we use the existing API server so our resource
-    requirements are just for the job controllers. We try taking up as much
-    much memory as possible left over from the API server.
-
-    In non-consolidation mode, we have to take into account the memory of the
-    API server workers. We limit to only 8 launches per worker, so our logic is
-    each controller will take CONTROLLER_MEMORY_MB + 8 * WORKER_MEMORY_MB. We
-    leave some leftover room for ssh codegen and ray status overhead.
-    """
-    consolidation_mode = skypilot_config.get_nested(
-        ('jobs', 'controller', 'consolidation_mode'), default_value=False)
-
-    total_memory_mb = common_utils.get_mem_size_gb() * 1024
-    if consolidation_mode:
-        config = server_config.compute_server_config(deploy=True, quiet=True)
-
-        used = 0.0
-        used += MAXIMUM_CONTROLLER_RESERVED_MEMORY_MB
-        used += (config.long_worker_config.garanteed_parallelism +
-                    config.long_worker_config.burstable_parallelism) * \
-            server_config.LONG_WORKER_MEM_GB * 1024
-        used += (config.short_worker_config.garanteed_parallelism +
-                    config.short_worker_config.burstable_parallelism) * \
-            server_config.SHORT_WORKER_MEM_GB * 1024
-
-        return max(1, int((total_memory_mb - used) // JOB_MEMORY_MB))
-    else:
-        return max(
-            1,
-            int((total_memory_mb - MAXIMUM_CONTROLLER_RESERVED_MEMORY_MB) /
-                ((LAUNCHES_PER_WORKER * server_config.LONG_WORKER_MEM_GB) * 1024
-                 + JOB_MEMORY_MB)))
-
-
-def start_controller() -> None:
-    """Start the job controller process.
-
-    This requires that the env file is already set up.
-    """
-    os.environ[constants.OVERRIDE_CONSOLIDATION_MODE] = 'true'
     logs_dir = os.path.expanduser(
         managed_job_constants.JOBS_CONTROLLER_LOGS_DIR)
     os.makedirs(logs_dir, exist_ok=True)
-    log_path = os.path.join(logs_dir, f'controller_{uuid.uuid4()}.log')
-
-    activate_python_env_cmd = (f'{constants.ACTIVATE_SKY_REMOTE_PYTHON_ENV};')
-    run_controller_cmd = (f'{sys.executable} -u -m'
-                          'sky.jobs.controller')
-
-    run_cmd = (f'{activate_python_env_cmd}'
-               f'{run_controller_cmd}')
-
-    logger.info(f'Running controller with command: {run_cmd}')
+    log_path = os.path.join(logs_dir, f'{job_id}.log')
 
     pid = subprocess_utils.launch_new_process_tree(run_cmd, log_output=log_path)
-    with open(JOB_CONTROLLER_PID_PATH, 'a', encoding='utf-8') as f:
-        f.write(str(pid) + '\n')
+    state.set_job_controller_pid(job_id, pid)
+
+    logger.debug(f'Job {job_id} started with pid {pid}')
 
 
-def get_alive_controllers() -> typing.Optional[int]:
-    if not os.path.exists(JOB_CONTROLLER_PID_PATH):
-        # if the file doesn't exist, it means the controller server is not
-        # running, so we return 0
-        return 0
+def maybe_schedule_next_jobs() -> None:
+    """Determine if any managed jobs can be scheduled, and if so, schedule them.
 
-    try:
-        with open(JOB_CONTROLLER_PID_PATH, 'r', encoding='utf-8') as f:
-            pids = f.read().split('\n')[:-1]
-    except OSError:
-        # if the file is corrupted, or any issues with reading it, we just
-        # return None to be safe and not over start
-        return None
+    Here, "schedule" means to select job that is waiting, and allow it to
+    proceed. It does NOT mean to submit a job to the scheduler.
 
-    alive = 0
-    for pid in pids:
-        try:
-            # TODO(luca) there is a chance that the process that is alive is
-            # not the same controller process. a better solution is to also
-            # include a random UUID with each controller and store that in the
-            # db as well/in the command that spawns it.
-            if subprocess_utils.is_process_alive(int(pid.strip())):
-                alive += 1
-        except ValueError:
-            # if the pid is not an integer, let's assume it's alive to not
-            # over start new processes
-            alive += 1
-    return alive
+    For newly submitted jobs, scheduling means updating the state of the jobs,
+    and starting the job controller process. For jobs that are already alive but
+    are waiting to launch a new task or recover, just update the state of the
+    job to indicate that the launch can proceed.
 
+    This function transitions jobs into LAUNCHING on a best-effort basis. That
+    is, if we can start any jobs, we will, but if not, we will exit (almost)
+    immediately. It's expected that if some WAITING or ALIVE_WAITING jobs cannot
+    be started now (either because the lock is held, or because there are not
+    enough resources), another call to this function will be made whenever that
+    situation is resolved. (If the lock is held, the lock holder should start
+    the jobs. If there aren't enough resources, the next controller to exit and
+    free up resources should start the jobs.)
 
-def maybe_start_controllers(from_scheduler: bool = False) -> None:
-    """Start the job controller process.
+    If this function obtains the lock, it will launch as many jobs as possible
+    before releasing the lock. This is what allows other calls to exit
+    immediately if the lock is held, while ensuring that all jobs are started as
+    soon as possible.
 
-    If the process is already running, it will not start a new one.
-    Will also add the job_id, dag_yaml_path, and env_file_path to the
-    controllers list of processes.
+    This uses subprocess_utils.launch_new_process_tree() to start the controller
+    processes, which should be safe to call from pretty much any code running on
+    the jobs controller instance. New job controller processes will be detached
+    from the current process and there will not be a parent/child relationship.
+    See launch_new_process_tree for more.
+
+    After adding the pool support, this function will be called in a per-pool
+    basis. We employ resources limitation for each pool given the number of
+    ready workers in the pool. Each pool will have its own scheduler queue,
+    indicating by the argument `pool`. Finished job in pool 1 will only trigger
+    another jobs in pool 1, but the job in pool 2 will still be waiting. When
+    the `pool` argument is None, it schedules a job regardless of the pool.
     """
     try:
-        with filelock.FileLock(JOB_CONTROLLER_PID_LOCK, blocking=False):
-            if from_scheduler and not managed_job_utils.is_consolidation_mode():
-                cur = pathlib.Path(CURRENT_HASH)
-                old = pathlib.Path(f'{CURRENT_HASH}.old')
+        # We must use a global lock rather than a per-job lock to ensure correct
+        # parallelism control. If we cannot obtain the lock, exit immediately.
+        # The current lock holder is expected to launch any jobs it can before
+        # releasing the lock.
+        with filelock.FileLock(controller_utils.get_resources_lock_path(),
+                               blocking=False):
+            while True:
+                maybe_next_job = state.get_waiting_job()
+                if maybe_next_job is None:
+                    # Nothing left to start, break from scheduling loop
+                    break
+                actual_pool = maybe_next_job['pool']
 
-                if old.exists() and cur.exists():
-                    if (old.read_text(encoding='utf-8') !=
-                            cur.read_text(encoding='utf-8')):
-                        # TODO(luca): there is a 1/2^160 chance that there will
-                        # be a collision. using a geometric distribution and
-                        # assuming one update a day, we expect a bug slightly
-                        # before the heat death of the universe. should get
-                        # this fixed before then.
-                        try:
-                            # this will stop all the controllers and the api
-                            # server.
-                            sdk.api_stop()
-                        except Exception as e:  # pylint: disable=broad-except
-                            logger.error(f'Failed to stop the api server: {e}')
-                            pass
-                        else:
-                            shutil.copyfile(cur, old)
-                if not old.exists():
-                    shutil.copyfile(cur, old)
+                current_state = maybe_next_job['schedule_state']
 
-            alive = get_alive_controllers()
-            if alive is None:
-                return
-            wanted = get_number_of_controllers()
-            started = 0
+                assert current_state in (
+                    state.ManagedJobScheduleState.ALIVE_WAITING,
+                    state.ManagedJobScheduleState.WAITING), maybe_next_job
 
-            while alive + started < wanted:
-                start_controller()
-                started += 1
+                # Note: we expect to get ALIVE_WAITING jobs before WAITING jobs,
+                # since they will have been submitted and therefore started
+                # first. The requirements to launch in an alive job are more
+                # lenient, so there is no way that we wouldn't be able to launch
+                # an ALIVE_WAITING job, but we would be able to launch a WAITING
+                # job.
+                if current_state == state.ManagedJobScheduleState.ALIVE_WAITING:
+                    if not controller_utils.can_provision():
+                        # Can't schedule anything, break from scheduling loop.
+                        break
+                elif current_state == state.ManagedJobScheduleState.WAITING:
+                    if not _can_start_new_job(actual_pool):
+                        # Can't schedule anything, break from scheduling loop.
+                        break
 
-            if started > 0:
-                logger.info(f'Started {started} controllers')
+                logger.debug(f'Scheduling job {maybe_next_job["job_id"]}')
+                state.scheduler_set_launching(maybe_next_job['job_id'],
+                                              current_state)
+
+                if current_state == state.ManagedJobScheduleState.WAITING:
+                    # The job controller has not been started yet. We must start
+                    # it.
+
+                    job_id = maybe_next_job['job_id']
+                    dag_yaml_path = maybe_next_job['dag_yaml_path']
+                    env_file_path = maybe_next_job['env_file_path']
+
+                    _start_controller(job_id, dag_yaml_path, env_file_path,
+                                      actual_pool)
+
     except filelock.Timeout:
         # If we can't get the lock, just exit. The process holding the lock
         # should launch any pending jobs.
@@ -252,42 +188,30 @@ def maybe_start_controllers(from_scheduler: bool = False) -> None:
 
 
 def submit_job(job_id: int, dag_yaml_path: str, original_user_yaml_path: str,
-               env_file_path: str, priority: int) -> None:
+               env_file_path: str, priority: int, pool: Optional[str]) -> None:
     """Submit an existing job to the scheduler.
 
     This should be called after a job is created in the `spot` table as
     PENDING. It will tell the scheduler to try and start the job controller, if
-    there are resources available.
+    there are resources available. It may block to acquire the lock, so it
+    should not be on the critical path for `sky jobs launch -d`.
 
     The user hash should be set (e.g. via SKYPILOT_USER_ID) before calling this.
     """
-    controller_pid = state.get_job_controller_pid(job_id)
-    if controller_pid is not None:
-        if managed_job_utils.controller_process_alive(controller_pid, job_id):
-            maybe_start_controllers(from_scheduler=True)
-            return
-
-    state.scheduler_set_waiting(job_id, dag_yaml_path,
-                                original_user_yaml_path, env_file_path,
-                                common_utils.get_user_hash(), priority)
-    if state.get_ha_recovery_script(job_id) is None:
-        # the run command is just the command that called scheduler
-        run = (f'{sys.executable} -m sky.jobs.scheduler {dag_yaml_path} '
-               f'--job-id {job_id} --env-file {env_file_path} '
-               f'--user-yaml-path {original_user_yaml_path} '
-               f'--priority {priority}')
-        state.set_ha_recovery_script(job_id, run)
-    maybe_start_controllers(from_scheduler=True)
+    with filelock.FileLock(controller_utils.get_resources_lock_path()):
+        is_resume = state.scheduler_set_waiting(job_id, dag_yaml_path,
+                                                original_user_yaml_path,
+                                                env_file_path,
+                                                common_utils.get_user_hash(),
+                                                priority)
+    if is_resume:
+        _start_controller(job_id, dag_yaml_path, env_file_path, pool)
+    else:
+        maybe_schedule_next_jobs()
 
 
-@contextlib.asynccontextmanager
-async def scheduled_launch(
-    job_id: int,
-    starting: Set[int],
-    starting_lock: asyncio.Lock,
-    starting_signal: asyncio.Condition,
-    job_logger: 'logging.Logger',
-):
+@contextlib.contextmanager
+def scheduled_launch(job_id: int):
     """Launch as part of an ongoing job.
 
     A newly started job will already be LAUNCHING, and this will immediately
@@ -316,34 +240,30 @@ async def scheduled_launch(
         yield
         return
 
-    assert starting_lock == starting_signal._lock, (  # type: ignore #pylint: disable=protected-access
-        'starting_lock and starting_signal must use the same lock')
+    # If we're already in LAUNCHING schedule_state, we don't need to wait.
+    # This may be the case for the first launch of a job.
+    if (state.get_job_schedule_state(job_id) !=
+            state.ManagedJobScheduleState.LAUNCHING):
+        # Since we aren't LAUNCHING, we need to wait to be scheduled.
+        _set_alive_waiting(job_id)
 
-    while True:
-        async with starting_lock:
-            starting_count = len(starting)
-            if starting_count < LAUNCHES_PER_WORKER:
-                break
-            job_logger.info('Too many jobs starting, waiting for a slot')
-            await starting_signal.wait()
-
-    job_logger.info(f'Starting job {job_id}')
-
-    async with starting_lock:
-        starting.add(job_id)
-
-    await state.scheduler_set_launching_async(job_id)
+        while (state.get_job_schedule_state(job_id) !=
+               state.ManagedJobScheduleState.LAUNCHING):
+            time.sleep(_ALIVE_JOB_LAUNCH_WAIT_INTERVAL)
 
     try:
         yield
-    except Exception as e:
-        raise e
+    except exceptions.NoClusterLaunchedError:
+        # NoClusterLaunchedError is indicates that the job is in retry backoff.
+        # We should transition to ALIVE_BACKOFF instead of ALIVE.
+        with filelock.FileLock(controller_utils.get_resources_lock_path()):
+            state.scheduler_set_alive_backoff(job_id)
+        raise
     else:
-        await state.scheduler_set_alive_async(job_id)
+        with filelock.FileLock(controller_utils.get_resources_lock_path()):
+            state.scheduler_set_alive(job_id)
     finally:
-        async with starting_lock:
-            starting.remove(job_id)
-            starting_signal.notify()
+        maybe_schedule_next_jobs()
 
 
 def job_done(job_id: int, idempotent: bool = False) -> None:
@@ -354,23 +274,38 @@ def job_done(job_id: int, idempotent: bool = False) -> None:
 
     The job could be in any terminal ManagedJobStatus. However, once DONE, it
     should never transition back to another state.
-
-    This is only called by utils.update_managed_jobs_statuses which is sync.
     """
     if idempotent and (state.get_job_schedule_state(job_id)
                        == state.ManagedJobScheduleState.DONE):
         return
 
-    state.scheduler_set_done(job_id, idempotent)
+    with filelock.FileLock(controller_utils.get_resources_lock_path()):
+        state.scheduler_set_done(job_id, idempotent)
+    maybe_schedule_next_jobs()
 
 
-async def job_done_async(job_id: int, idempotent: bool = False):
-    """Async version of job_done."""
-    if idempotent and (await state.get_job_schedule_state_async(job_id)
-                       == state.ManagedJobScheduleState.DONE):
-        return
+def _set_alive_waiting(job_id: int) -> None:
+    """Should use wait_until_launch_okay() to transition to this state."""
+    with filelock.FileLock(controller_utils.get_resources_lock_path()):
+        state.scheduler_set_alive_waiting(job_id)
+    maybe_schedule_next_jobs()
 
-    await state.scheduler_set_done_async(job_id, idempotent)
+
+def _can_start_new_job(pool: Optional[str]) -> bool:
+    # Check basic resource limits
+    # Pool jobs don't need to provision resources, so we skip the check.
+    if not ((controller_utils.can_provision() or pool is not None) and
+            controller_utils.can_start_new_process()):
+        return False
+
+    # Check if there are available workers in the pool
+    if pool is not None:
+        alive_jobs_in_pool = state.get_num_alive_jobs(pool)
+        if alive_jobs_in_pool >= len(serve_utils.get_ready_replicas(pool)):
+            logger.debug(f'No READY workers available in pool {pool}')
+            return False
+
+    return True
 
 
 if __name__ == '__main__':
@@ -402,4 +337,4 @@ if __name__ == '__main__':
         f' Default: {constants.DEFAULT_PRIORITY}.')
     args = parser.parse_args()
     submit_job(args.job_id, args.dag_yaml, args.user_yaml_path, args.env_file,
-               args.priority)
+               args.priority, args.pool)

--- a/sky/jobs/server/utils.py
+++ b/sky/jobs/server/utils.py
@@ -11,6 +11,7 @@ logger = sky_logging.init_logger(__name__)
 
 def check_version_mismatch_and_non_terminal_jobs() -> None:
     """Check if controller has version mismatch and non-terminal jobs exist.
+
     Raises:
         ValueError: If there's a version mismatch and non-terminal jobs exist.
         sky.exceptions.ClusterNotUpError: If the controller is not accessible.
@@ -58,8 +59,7 @@ def check_version_mismatch_and_non_terminal_jobs() -> None:
     job_table_payload = output_parts[1]
 
     # Process locally: check version match and filter non-terminal jobs
-    version_matches = (controller_version == local_version or
-                       int(controller_version) > 17)
+    version_matches = controller_version == local_version
 
     # Load and filter jobs locally using existing method
     jobs, _, _, _, _ = managed_job_utils.load_managed_job_queue(

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -4,11 +4,9 @@ NOTE: whenever an API change is made in this file, we need to bump the
 jobs.constants.MANAGED_JOBS_VERSION and handle the API change in the
 ManagedJobCodeGen.
 """
-import asyncio
 import collections
 import datetime
 import enum
-import logging
 import os
 import pathlib
 import shlex
@@ -16,11 +14,11 @@ import textwrap
 import time
 import traceback
 import typing
-from typing import (Any, Deque, Dict, List, Literal, Optional, Set, TextIO,
-                    Tuple, Union)
+from typing import Any, Deque, Dict, List, Optional, Set, TextIO, Tuple, Union
 
 import colorama
 import filelock
+from typing_extensions import Literal
 
 from sky import backends
 from sky import exceptions
@@ -39,7 +37,6 @@ from sky.usage import usage_lib
 from sky.utils import annotations
 from sky.utils import command_runner
 from sky.utils import common_utils
-from sky.utils import context_utils
 from sky.utils import controller_utils
 from sky.utils import infra_utils
 from sky.utils import log_utils
@@ -59,9 +56,9 @@ else:
 
 logger = sky_logging.init_logger(__name__)
 
+SIGNAL_FILE_PREFIX = '/tmp/sky_jobs_controller_signal_{}'
 # Controller checks its job's status every this many seconds.
-# This is a tradeoff between the latency and the resource usage.
-JOB_STATUS_CHECK_GAP_SECONDS = 15
+JOB_STATUS_CHECK_GAP_SECONDS = 20
 
 # Controller checks if its job has started every this many seconds.
 JOB_STARTED_STATUS_CHECK_GAP_SECONDS = 5
@@ -85,7 +82,7 @@ _JOB_CANCELLED_MESSAGE = (
 # blocking for a long time. This should be significantly longer than the
 # JOB_STATUS_CHECK_GAP_SECONDS to avoid timing out before the controller can
 # update the state.
-_FINAL_JOB_STATUS_WAIT_TIMEOUT_SECONDS = 120
+_FINAL_JOB_STATUS_WAIT_TIMEOUT_SECONDS = 40
 
 
 class ManagedJobQueueResultType(enum.Enum):
@@ -102,11 +99,7 @@ class UserSignal(enum.Enum):
 
 
 # ====== internal functions ======
-def terminate_cluster(
-        cluster_name: str,
-        max_retry: int = 6,
-        _logger: logging.Logger = logger,  # pylint: disable=invalid-name
-) -> None:
+def terminate_cluster(cluster_name: str, max_retry: int = 6) -> None:
     """Terminate the cluster."""
     from sky import core  # pylint: disable=import-outside-toplevel
     retry_cnt = 0
@@ -129,18 +122,18 @@ def terminate_cluster(
             return
         except exceptions.ClusterDoesNotExist:
             # The cluster is already down.
-            _logger.debug(f'The cluster {cluster_name} is already down.')
+            logger.debug(f'The cluster {cluster_name} is already down.')
             return
         except Exception as e:  # pylint: disable=broad-except
             retry_cnt += 1
             if retry_cnt >= max_retry:
                 raise RuntimeError(
                     f'Failed to terminate the cluster {cluster_name}.') from e
-            _logger.error(
+            logger.error(
                 f'Failed to terminate the cluster {cluster_name}. Retrying.'
                 f'Details: {common_utils.format_exception(e)}')
             with ux_utils.enable_traceback():
-                _logger.error(f'  Traceback: {traceback.format_exc()}')
+                logger.error(f'  Traceback: {traceback.format_exc()}')
             time.sleep(backoff.current_backoff())
 
 
@@ -190,9 +183,6 @@ def _validate_consolidation_mode_config(
 # Use LRU Cache so that the check is only done once.
 @annotations.lru_cache(scope='request', maxsize=1)
 def is_consolidation_mode() -> bool:
-    if os.environ.get(constants.OVERRIDE_CONSOLIDATION_MODE) is not None:
-        return True
-
     consolidation_mode = skypilot_config.get_nested(
         ('jobs', 'controller', 'consolidation_mode'), default_value=False)
     # We should only do this check on API server, as the controller will not
@@ -209,7 +199,6 @@ def ha_recovery_for_consolidation_mode():
     # already has all runtime installed. Directly start jobs recovery here.
     # Refers to sky/templates/kubernetes-ray.yml.j2 for more details.
     runner = command_runner.LocalProcessCommandRunner()
-    scheduler.maybe_start_controllers()
     with open(constants.HA_PERSISTENT_RECOVERY_LOG_PATH.format('jobs_'),
               'w',
               encoding='utf-8') as f:
@@ -225,7 +214,7 @@ def ha_recovery_for_consolidation_mode():
             # just keep running.
             if controller_pid is not None:
                 try:
-                    if controller_process_alive(controller_pid, job_id):
+                    if _controller_process_alive(controller_pid, job_id):
                         f.write(f'Controller pid {controller_pid} for '
                                 f'job {job_id} is still running. '
                                 'Skipping recovery.\n')
@@ -238,7 +227,7 @@ def ha_recovery_for_consolidation_mode():
 
             if job['schedule_state'] not in [
                     managed_job_state.ManagedJobScheduleState.DONE,
-                    managed_job_state.ManagedJobScheduleState.WAITING,
+                    managed_job_state.ManagedJobScheduleState.WAITING
             ]:
                 script = managed_job_state.get_ha_recovery_script(job_id)
                 if script is None:
@@ -253,66 +242,56 @@ def ha_recovery_for_consolidation_mode():
         f.write(f'Total recovery time: {time.time() - start} seconds\n')
 
 
-async def get_job_status(
-        backend: 'backends.CloudVmRayBackend', cluster_name: str,
-        job_id: Optional[int],
-        job_logger: logging.Logger) -> Optional['job_lib.JobStatus']:
+def get_job_status(backend: 'backends.CloudVmRayBackend', cluster_name: str,
+                   job_id: Optional[int]) -> Optional['job_lib.JobStatus']:
     """Check the status of the job running on a managed job cluster.
 
     It can be None, INIT, RUNNING, SUCCEEDED, FAILED, FAILED_DRIVER,
     FAILED_SETUP or CANCELLED.
     """
-    # TODO(luca) make this async
-    handle = await context_utils.to_thread(
-        global_user_state.get_handle_from_cluster_name, cluster_name)
+    handle = global_user_state.get_handle_from_cluster_name(cluster_name)
     if handle is None:
         # This can happen if the cluster was preempted and background status
         # refresh already noticed and cleaned it up.
-        job_logger.info(f'Cluster {cluster_name} not found.')
+        logger.info(f'Cluster {cluster_name} not found.')
         return None
     assert isinstance(handle, backends.CloudVmRayResourceHandle), handle
     job_ids = None if job_id is None else [job_id]
     for i in range(_JOB_STATUS_FETCH_MAX_RETRIES):
         try:
-            job_logger.info('=== Checking the job status... ===')
-            statuses = await context_utils.to_thread(backend.get_job_status,
-                                                     handle,
-                                                     job_ids=job_ids,
-                                                     stream_logs=False)
+            logger.info('=== Checking the job status... ===')
+            statuses = backend.get_job_status(handle,
+                                              job_ids=job_ids,
+                                              stream_logs=False)
             status = list(statuses.values())[0]
             if status is None:
-                job_logger.info('No job found.')
+                logger.info('No job found.')
             else:
-                job_logger.info(f'Job status: {status}')
-            job_logger.info('=' * 34)
+                logger.info(f'Job status: {status}')
+            logger.info('=' * 34)
             return status
         except exceptions.CommandError as e:
             # Retry on k8s transient network errors. This is useful when using
             # coreweave which may have transient network issue sometimes.
             if (e.detailed_reason is not None and
                     _JOB_K8S_TRANSIENT_NW_MSG in e.detailed_reason):
-                job_logger.info('Failed to connect to the cluster. Retrying '
-                                f'({i + 1}/{_JOB_STATUS_FETCH_MAX_RETRIES})...')
-                job_logger.info('=' * 34)
-                await asyncio.sleep(1)
+                logger.info('Failed to connect to the cluster. Retrying '
+                            f'({i + 1}/{_JOB_STATUS_FETCH_MAX_RETRIES})...')
+                logger.info('=' * 34)
+                time.sleep(1)
             else:
-                job_logger.info(
-                    f'Failed to get job status: {e.detailed_reason}')
-                job_logger.info('=' * 34)
+                logger.info(f'Failed to get job status: {e.detailed_reason}')
+                logger.info('=' * 34)
                 return None
     return None
 
 
-def controller_process_alive(pid: int, job_id: int) -> bool:
+def _controller_process_alive(pid: int, job_id: int) -> bool:
     """Check if the controller process is alive."""
     try:
-        if pid < 0:
-            # new job controller process will always be negative
-            pid = -pid
         process = psutil.Process(pid)
         cmd_str = ' '.join(process.cmdline())
-        return process.is_running() and ((f'--job-id {job_id}' in cmd_str) or
-                                         ('controller' in cmd_str))
+        return process.is_running() and f'--job-id {job_id}' in cmd_str
     except psutil.NoSuchProcess:
         return False
 
@@ -487,7 +466,7 @@ def update_managed_jobs_statuses(job_id: Optional[int] = None):
             failure_reason = f'No controller pid set for {schedule_state.value}'
         else:
             logger.debug(f'Checking controller pid {pid}')
-            if controller_process_alive(pid, job_id):
+            if _controller_process_alive(pid, job_id):
                 # The controller is still running, so this job is fine.
                 continue
 
@@ -625,17 +604,7 @@ def event_callback_func(job_id: int, task_id: int, task: 'sky.Task'):
             f'Bash:{event_callback},log_path:{log_path},result:{result}')
         logger.info(f'=== END: event callback for {status!r} ===')
 
-    try:
-        asyncio.get_running_loop()
-
-        # In async context
-        async def async_callback_func(status: str):
-            return await context_utils.to_thread(callback_func, status)
-
-        return async_callback_func
-    except RuntimeError:
-        # Not in async context
-        return callback_func
+    return callback_func
 
 
 # ======== user functions ========
@@ -682,32 +651,8 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]],
             logger.info(f'Job {job_id} is already in terminal state '
                         f'{job_status.value}. Skipped.')
             continue
-        elif job_status == managed_job_state.ManagedJobStatus.PENDING:
-            # the if is a short circuit, this will be atomic.
-            cancelled = managed_job_state.set_pending_cancelled(job_id)
-            if cancelled:
-                cancelled_job_ids.append(job_id)
-                continue
 
         update_managed_jobs_statuses(job_id)
-
-        job_controller_pid = managed_job_state.get_job_controller_pid(job_id)
-        if job_controller_pid is not None and job_controller_pid < 0:
-            # This is a consolidated job controller, so we need to cancel the
-            # with the controller server API
-            try:
-                # we create a file as a signal to the controller server
-                signal_file = pathlib.Path(
-                    managed_job_constants.CONSOLIDATED_SIGNAL_PATH, f'{job_id}')
-                signal_file.touch()
-                cancelled_job_ids.append(job_id)
-            except OSError as e:
-                logger.error(f'Failed to cancel job {job_id} '
-                             f'with controller server: {e}')
-                # don't add it to the to be cancelled job ids, since we don't
-                # know for sure yet.
-                continue
-            continue
 
         job_workspace = managed_job_state.get_workspace(job_id)
         if current_workspace is not None and job_workspace != current_workspace:
@@ -715,8 +660,7 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]],
             continue
 
         # Send the signal to the jobs controller.
-        signal_file = (pathlib.Path(
-            managed_job_constants.SIGNAL_FILE_PREFIX.format(job_id)))
+        signal_file = pathlib.Path(SIGNAL_FILE_PREFIX.format(job_id))
         # Filelock is needed to prevent race condition between signal
         # check/removal and signal writing.
         with filelock.FileLock(str(signal_file) + '.lock'):
@@ -1215,7 +1159,8 @@ def dump_managed_job_queue(
                 # It's possible for a WAITING/ALIVE_WAITING job to be ready to
                 # launch, but the scheduler just hasn't run yet.
                 managed_job_state.ManagedJobScheduleState.WAITING,
-                managed_job_state.ManagedJobScheduleState.ALIVE_WAITING):
+                managed_job_state.ManagedJobScheduleState.ALIVE_WAITING,
+        ):
             # This job will not block others.
             continue
 

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -526,7 +526,6 @@ def _post_provision_setup(
             status.update(
                 ux_utils.spinner_message(
                     'Checking controller version compatibility'))
-
             try:
                 server_jobs_utils.check_version_mismatch_and_non_terminal_jobs()
             except exceptions.ClusterNotUpError:

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -294,11 +294,6 @@ def is_consolidation_mode(pool: bool = False) -> bool:
     # We should only do this check on API server, as the controller will not
     # have related config and will always seemingly disabled for consolidation
     # mode. Check #6611 for more details.
-    if (os.environ.get(skylet_constants.OVERRIDE_CONSOLIDATION_MODE) is not None
-            and controller.controller_type == 'jobs'):
-        # if we are in the job controller, we must always be in consolidation
-        # mode.
-        return True
     if os.environ.get(skylet_constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
         _validate_consolidation_mode_config(consolidation_mode, pool)
     return consolidation_mode

--- a/sky/serve/server/impl.py
+++ b/sky/serve/server/impl.py
@@ -279,7 +279,8 @@ def up(
             ]
             run_script = '\n'.join(env_cmds + [run_script])
             # Dump script for high availability recovery.
-            serve_state.set_ha_recovery_script(service_name, run_script)
+            if controller_utils.high_availability_specified(controller_name):
+                serve_state.set_ha_recovery_script(service_name, run_script)
             backend.run_on_head(controller_handle, run_script)
 
         style = colorama.Style

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -21,6 +21,7 @@ from sky import task as task_lib
 from sky.backends import backend_utils
 from sky.backends import cloud_vm_ray_backend
 from sky.data import data_utils
+from sky.jobs import scheduler as jobs_scheduler
 from sky.serve import constants
 from sky.serve import controller
 from sky.serve import load_balancer
@@ -277,6 +278,7 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
                 pool=service_spec.pool,
                 controller_pid=os.getpid(),
                 entrypoint=entrypoint)
+        jobs_scheduler.maybe_schedule_next_jobs()
         # Directly throw an error here. See sky/serve/api.py::up
         # for more details.
         if not success:

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -531,17 +531,12 @@ def _start_api_server(deploy: bool = False,
 
         # Check available memory before starting the server.
         avail_mem_size_gb: float = common_utils.get_mem_size_gb()
-        # pylint: disable=import-outside-toplevel
-        import sky.jobs.utils as job_utils
-        max_memory = (server_constants.MIN_AVAIL_MEM_GB_CONSOLIDATION_MODE
-                      if job_utils.is_consolidation_mode() else
-                      server_constants.MIN_AVAIL_MEM_GB)
-        if avail_mem_size_gb <= max_memory:
+        if avail_mem_size_gb <= server_constants.MIN_AVAIL_MEM_GB:
             logger.warning(
                 f'{colorama.Fore.YELLOW}Your SkyPilot API server machine only '
                 f'has {avail_mem_size_gb:.1f}GB memory available. '
-                f'At least {max_memory}GB is recommended to support higher '
-                'load with better performance.'
+                f'At least {server_constants.MIN_AVAIL_MEM_GB}GB is '
+                'recommended to support higher load with better performance.'
                 f'{colorama.Style.RESET_ALL}')
 
         args = [sys.executable, *API_SERVER_CMD.split()]

--- a/sky/server/config.py
+++ b/sky/server/config.py
@@ -18,9 +18,8 @@ from sky.utils import common_utils
 # TODO(aylei): maintaining these constants is error-prone, we may need to
 # automatically tune parallelism at runtime according to system usage stats
 # in the future.
-# TODO(luca): The future is now! ^^^
-LONG_WORKER_MEM_GB = 0.4
-SHORT_WORKER_MEM_GB = 0.25
+_LONG_WORKER_MEM_GB = 0.4
+_SHORT_WORKER_MEM_GB = 0.25
 # To control the number of long workers.
 _CPU_MULTIPLIER_FOR_LONG_WORKERS = 2
 # Limit the number of long workers of local API server, since local server is
@@ -72,7 +71,7 @@ class ServerConfig:
     queue_backend: QueueBackend
 
 
-def compute_server_config(deploy: bool, quiet: bool = False) -> ServerConfig:
+def compute_server_config(deploy: bool) -> ServerConfig:
     """Compute the server config based on environment.
 
     We have different assumptions for the resources in different deployment
@@ -126,12 +125,7 @@ def compute_server_config(deploy: bool, quiet: bool = False) -> ServerConfig:
         burstable_parallel_for_short = _BURSTABLE_WORKERS_FOR_LOCAL
         # Runs in low resource mode if the available memory is less than
         # server_constants.MIN_AVAIL_MEM_GB.
-        # pylint: disable=import-outside-toplevel
-        import sky.jobs.utils as job_utils
-        max_memory = (server_constants.MIN_AVAIL_MEM_GB_CONSOLIDATION_MODE
-                      if job_utils.is_consolidation_mode() else
-                      server_constants.MIN_AVAIL_MEM_GB)
-        if not deploy and mem_size_gb < max_memory:
+        if not deploy and mem_size_gb < server_constants.MIN_AVAIL_MEM_GB:
             # Permanent worker process may have significant memory consumption
             # (~350MB per worker) after running commands like `sky check`, so we
             # don't start any permanent workers in low resource local mode. This
@@ -142,20 +136,15 @@ def compute_server_config(deploy: bool, quiet: bool = False) -> ServerConfig:
             # permanently because it never exits.
             max_parallel_for_long = 0
             max_parallel_for_short = 0
-            if not quiet:
-                logger.warning(
-                    'SkyPilot API server will run in low resource mode because '
-                    'the available memory is less than '
-                    f'{max_memory}GB.')
-    if not quiet:
-        logger.info(
-            f'SkyPilot API server will start {num_server_workers} server '
-            f'processes with {max_parallel_for_long} background workers for '
-            f'long requests and will allow at max {max_parallel_for_short} '
-            'short requests in parallel. SkyPilot API server will start '
-            f'{burstable_parallel_for_long} burstable workers for long '
-            f' requests and {burstable_parallel_for_short} burstable workers '
-            'for short requests.')
+            logger.warning(
+                'SkyPilot API server will run in low resource mode because '
+                'the available memory is less than '
+                f'{server_constants.MIN_AVAIL_MEM_GB}GB.')
+    logger.info(
+        f'SkyPilot API server will start {num_server_workers} server processes '
+        f'with {max_parallel_for_long} background workers for long requests '
+        f'and will allow at max {max_parallel_for_short} short requests in '
+        f'parallel.')
     return ServerConfig(
         num_server_workers=num_server_workers,
         queue_backend=queue_backend,
@@ -173,15 +162,10 @@ def _max_long_worker_parallism(cpu_count: int,
                                local=False) -> int:
     """Max parallelism for long workers."""
     # Reserve min available memory to avoid OOM.
-    # pylint: disable=import-outside-toplevel
-    import sky.jobs.utils as job_utils
-    max_memory = (server_constants.MIN_AVAIL_MEM_GB_CONSOLIDATION_MODE
-                  if job_utils.is_consolidation_mode() else
-                  server_constants.MIN_AVAIL_MEM_GB)
-    available_mem = max(0, mem_size_gb - max_memory)
+    available_mem = max(0, mem_size_gb - server_constants.MIN_AVAIL_MEM_GB)
     cpu_based_max_parallel = cpu_count * _CPU_MULTIPLIER_FOR_LONG_WORKERS
     mem_based_max_parallel = int(available_mem * _MAX_MEM_PERCENT_FOR_BLOCKING /
-                                 LONG_WORKER_MEM_GB)
+                                 _LONG_WORKER_MEM_GB)
     n = max(_MIN_LONG_WORKERS,
             min(cpu_based_max_parallel, mem_based_max_parallel))
     if local:
@@ -193,12 +177,8 @@ def _max_short_worker_parallism(mem_size_gb: float,
                                 long_worker_parallism: int) -> int:
     """Max parallelism for short workers."""
     # Reserve memory for long workers and min available memory.
-    # pylint: disable=import-outside-toplevel
-    import sky.jobs.utils as job_utils
-    max_memory = (server_constants.MIN_AVAIL_MEM_GB_CONSOLIDATION_MODE
-                  if job_utils.is_consolidation_mode() else
-                  server_constants.MIN_AVAIL_MEM_GB)
-    reserved_mem = max_memory + (long_worker_parallism * LONG_WORKER_MEM_GB)
+    reserved_mem = server_constants.MIN_AVAIL_MEM_GB + (long_worker_parallism *
+                                                        _LONG_WORKER_MEM_GB)
     available_mem = max(0, mem_size_gb - reserved_mem)
-    n = max(_MIN_SHORT_WORKERS, int(available_mem / SHORT_WORKER_MEM_GB))
+    n = max(_MIN_SHORT_WORKERS, int(available_mem / _SHORT_WORKER_MEM_GB))
     return n

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -34,7 +34,6 @@ VERSION_HEADER = 'X-SkyPilot-Version'
 REQUEST_NAME_PREFIX = 'sky.'
 # The memory (GB) that SkyPilot tries to not use to prevent OOM.
 MIN_AVAIL_MEM_GB = 2
-MIN_AVAIL_MEM_GB_CONSOLIDATION_MODE = 4
 # Default encoder/decoder handler name.
 DEFAULT_HANDLER_NAME = 'default'
 # The path to the API request database.

--- a/sky/server/daemons.py
+++ b/sky/server/daemons.py
@@ -115,15 +115,18 @@ def managed_job_status_refresh_event():
     """Refresh the managed job status for controller consolidation mode."""
     # pylint: disable=import-outside-toplevel
     from sky.jobs import utils as managed_job_utils
+    from sky.utils import controller_utils
 
     # We run the recovery logic before starting the event loop as those two are
     # conflicting. Check PERSISTENT_RUN_RESTARTING_SIGNAL_FILE for details.
-    managed_job_utils.ha_recovery_for_consolidation_mode()
+    if controller_utils.high_availability_specified(
+            controller_utils.Controllers.JOBS_CONTROLLER.value.cluster_name):
+        managed_job_utils.ha_recovery_for_consolidation_mode()
 
     # After recovery, we start the event loop.
     from sky.skylet import events
     refresh_event = events.ManagedJobEvent()
-    scheduling_event = events.ManagedJobEvent()
+    scheduling_event = events.ManagedJobSchedulingEvent()
     logger.info('=== Running managed job event ===')
     refresh_event.run()
     scheduling_event.run()
@@ -141,10 +144,14 @@ def _serve_status_refresh_event(pool: bool):
     """Refresh the sky serve status for controller consolidation mode."""
     # pylint: disable=import-outside-toplevel
     from sky.serve import serve_utils
+    from sky.utils import controller_utils
 
     # We run the recovery logic before starting the event loop as those two are
     # conflicting. Check PERSISTENT_RUN_RESTARTING_SIGNAL_FILE for details.
-    serve_utils.ha_recovery_for_consolidation_mode(pool=pool)
+    controller = controller_utils.get_controller_for_pool(pool)
+    if controller_utils.high_availability_specified(
+            controller.value.cluster_name):
+        serve_utils.ha_recovery_for_consolidation_mode(pool=pool)
 
     # After recovery, we start the event loop.
     from sky.skylet import events

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -624,9 +624,6 @@ app.include_router(volumes_rest.router, prefix='/volumes', tags=['volumes'])
 app.include_router(ssh_node_pools_rest.router,
                    prefix='/ssh_node_pools',
                    tags=['ssh_node_pools'])
-# increase the resource limit for the server
-soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
-resource.setrlimit(resource.RLIMIT_NOFILE, (hard, hard))
 
 # Increase the limit of files we can open to our hard limit. This fixes bugs
 # where we can not aquire file locks or open enough logs and the API server

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -58,8 +58,6 @@ install_requires = [
     'setproctitle',
     'sqlalchemy',
     'psycopg2-binary',
-    'aiosqlite',
-    'asyncpg',
     # TODO(hailong): These three dependencies should be removed after we make
     # the client-side actually not importing them.
     'casbin',

--- a/sky/skylet/attempt_skylet.py
+++ b/sky/skylet/attempt_skylet.py
@@ -12,7 +12,6 @@ def restart_skylet():
     # Kills old skylet if it is running.
     # TODO(zhwu): make the killing graceful, e.g., use a signal to tell
     # skylet to exit, instead of directly killing it.
-
     subprocess.run(
         # We use -m to grep instead of {constants.SKY_PYTHON_CMD} -m to grep
         # because need to handle the backward compatibility of the old skylet

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -90,7 +90,7 @@ TASK_ID_LIST_ENV_VAR = f'{SKYPILOT_ENV_VAR_PREFIX}TASK_IDS'
 # cluster yaml is updated.
 #
 # TODO(zongheng,zhanghao): make the upgrading of skylet automatic?
-SKYLET_VERSION = '18'
+SKYLET_VERSION = '17'
 # The version of the lib files that skylet/jobs use. Whenever there is an API
 # change for the job_lib or log_lib, we need to bump this version, so that the
 # user can be notified to update their SkyPilot version on the remote cluster.
@@ -419,7 +419,6 @@ SKY_USER_FILE_PATH = '~/.sky/generated'
 
 # Environment variable that is set to 'true' if this is a skypilot server.
 ENV_VAR_IS_SKYPILOT_SERVER = 'IS_SKYPILOT_SERVER'
-OVERRIDE_CONSOLIDATION_MODE = 'IS_SKYPILOT_JOB_CONTROLLER'
 
 # Environment variable that is set to 'true' if metrics are enabled.
 ENV_VAR_SERVER_METRICS_ENABLED = 'SKY_API_SERVER_METRICS_ENABLED'

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -12,7 +12,7 @@ import yaml
 from sky import clouds
 from sky import sky_logging
 from sky.backends import cloud_vm_ray_backend
-from sky.jobs import scheduler
+from sky.jobs import scheduler as managed_job_scheduler
 from sky.jobs import state as managed_job_state
 from sky.jobs import utils as managed_job_utils
 from sky.serve import serve_utils
@@ -77,7 +77,15 @@ class ManagedJobEvent(SkyletEvent):
     def _run(self):
         logger.info('=== Updating managed job status ===')
         managed_job_utils.update_managed_jobs_statuses()
-        scheduler.maybe_start_controllers()
+
+
+class ManagedJobSchedulingEvent(SkyletEvent):
+    """Skylet event for scheduling managed jobs."""
+    EVENT_INTERVAL_SECONDS = 20
+
+    def _run(self):
+        logger.info('=== Scheduling next jobs ===')
+        managed_job_scheduler.maybe_schedule_next_jobs()
 
 
 class ServiceUpdateEvent(SkyletEvent):

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -227,11 +227,6 @@ def get_controller_for_pool(pool: bool) -> Controllers:
 def high_availability_specified(cluster_name: Optional[str]) -> bool:
     """Check if the controller high availability is specified in user config.
     """
-    # pylint: disable=import-outside-toplevel
-    from sky.jobs import utils as managed_job_utils
-    if managed_job_utils.is_consolidation_mode():
-        return True
-
     controller = Controllers.from_name(cluster_name)
     if controller is None:
         return False

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -10,7 +10,6 @@ from alembic.config import Config
 from alembic.runtime import migration
 import filelock
 import sqlalchemy
-from sqlalchemy.ext import asyncio as sqlalchemy_async
 
 from sky import sky_logging
 from sky.skylet import constants
@@ -32,29 +31,17 @@ SERVE_VERSION = '001'
 SERVE_LOCK_PATH = '~/.sky/locks/.serve_db.lock'
 
 
-def get_engine(db_name: str, async_engine: bool = False):
+def get_engine(db_name: str):
     conn_string = None
     if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
         conn_string = os.environ.get(constants.ENV_VAR_DB_CONNECTION_URI)
     if conn_string:
-        logger.debug(f'using db URI from {conn_string}')
-        if async_engine:
-            conn_string = conn_string.replace('postgresql://',
-                                              'postgresql+asyncpg://')
-            engine = sqlalchemy_async.create_async_engine(
-                conn_string, poolclass=sqlalchemy.NullPool)
-        else:
-            engine = sqlalchemy.create_engine(conn_string,
-                                              poolclass=sqlalchemy.NullPool)
+        engine = sqlalchemy.create_engine(conn_string,
+                                          poolclass=sqlalchemy.NullPool)
     else:
         db_path = os.path.expanduser(f'~/.sky/{db_name}.db')
         pathlib.Path(db_path).parents[0].mkdir(parents=True, exist_ok=True)
-        if async_engine:
-            engine = sqlalchemy_async.create_async_engine(
-                'sqlite+aiosqlite:///' + db_path, connect_args={'timeout': 30})
-        else:
-            engine = sqlalchemy.create_engine('sqlite:///' + db_path,
-                                              connect_args={'timeout': 30})
+        engine = sqlalchemy.create_engine('sqlite:///' + db_path)
     return engine
 
 

--- a/sky/utils/rich_utils.py
+++ b/sky/utils/rich_utils.py
@@ -421,7 +421,7 @@ async def decode_rich_status_async(
         undecoded_buffer = b''
 
         # Iterate over the response content in chunks
-        async for chunk, _ in response.content.iter_chunks():
+        async for chunk in response.content.iter_chunked(8192):
             if chunk is None:
                 return
 
@@ -481,8 +481,6 @@ async def decode_rich_status_async(
                     line = line[:-2] + '\n'
                 is_payload, line = message_utils.decode_payload(
                     line, raise_for_mismatch=False)
-                if line is None:
-                    continue
                 control = None
                 if is_payload:
                     control, encoded_status = Control.decode(line)

--- a/sky/utils/subprocess_utils.py
+++ b/sky/utils/subprocess_utils.py
@@ -437,12 +437,3 @@ def slow_start_processes(processes: List[Startable],
             break
         batch_size = min(batch_size * 2, max_batch_size)
         time.sleep(delay)
-
-
-def is_process_alive(pid: int) -> bool:
-    """Check if a process is alive."""
-    try:
-        process = psutil.Process(pid)
-        return process.is_running()
-    except psutil.NoSuchProcess:
-        return False


### PR DESCRIPTION
Reverts skypilot-org/skypilot#6459

During the upgrade path, there is a short period of time between killing the old controllers and starting the new ones. If, during this time, we check the status of the job (e.g. by running `sky jobs cancel`, which calls `utils.update_managed_jobs_statuses`) then the job may incorrectly transition to FAILED_CONTROLLER.

There's a few possible fixes but I need to think more and I don't want this to go into nightly as-is.