### PR TITLE
Fixed provision log smoke test

### DIFF
--- a/tests/smoke_tests/test_provision_logs.py
+++ b/tests/smoke_tests/test_provision_logs.py
@@ -30,7 +30,6 @@ def test_provision_logs_streaming(generic_cloud: str):
                 'done; [ $ok -eq 1 ]')
 
     commands = [
-        smoke_tests_utils.SKY_API_RESTART,
         # Launch detached so we can immediately query provision logs.
         (f'sky launch --infra {generic_cloud} -d -y '
          f'{smoke_tests_utils.LOW_RESOURCE_ARG} -c {name} examples/minimal.yaml'
@@ -45,13 +44,9 @@ def test_provision_logs_streaming(generic_cloud: str):
         wait_stream_ok(tail_cmd),
     ]
 
-    # Ensure we also clear any global config override and restart API.
-    teardown = (f'export {skypilot_config.ENV_VAR_GLOBAL_CONFIG}= && '
-                'export SKYPILOT_DEBUG=0; '
-                f'{smoke_tests_utils.SKY_API_RESTART}')
     test = smoke_tests_utils.Test(
         'provision_logs_streaming',
         commands,
-        teardown=teardown,
+        teardown=f'sky down -y {name}',
         timeout=smoke_tests_utils.get_timeout(generic_cloud))
     smoke_tests_utils.run_one_test(test)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixed the case when running on remote API server && avoid potential inter-case interleave since the cases may share a same local API server

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
