### PR TITLE
Support `no_remote_server` mark on smoke tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -256,10 +256,15 @@ def pytest_collection_modifyitems(config, items):
         reason='skipped, because --tpu option is set')
     skip_marks['local'] = pytest.mark.skip(
         reason='test requires local API server')
+    skip_marks['no_remote_server'] = pytest.mark.skip(
+        reason='skip tests marked as no_remote_server if --remote-server is set'
+    )
     skip_marks['no_resource_heavy'] = pytest.mark.skip(
-        reason='skipped, because --no-resource-heavy option is set')
+        reason=
+        'skip tests marked as resource_heavy if --no-resource-heavy is set')
     skip_marks['resource_heavy'] = pytest.mark.skip(
-        reason='skipped, because --resource-heavy option is set')
+        reason=
+        'skip tests not marked as resource_heavy if --resource-heavy is set')
     for cloud in all_clouds_in_smoke_tests:
         skip_marks[cloud] = pytest.mark.skip(
             reason=f'tests for {cloud} is skipped, try setting --{cloud}')
@@ -309,6 +314,9 @@ def pytest_collection_modifyitems(config, items):
         if 'resource_heavy' not in marks and config.getoption(
                 '--resource-heavy'):
             item.add_marker(skip_marks['resource_heavy'])
+        # Skip tests marked as no_remote_server if --remote-server is set
+        if 'no_remote_server' in marks and config.getoption('--remote-server'):
+            item.add_marker(skip_marks['no_remote_server'])
 
     # Check if tests need to be run serially for Kubernetes and Lambda Cloud
     # We run Lambda Cloud tests serially because Lambda Cloud rate limits its

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -421,6 +421,7 @@ def test_docker_preinstalled_package(generic_cloud: str):
 @pytest.mark.no_nebius  # Nebius does not have T4 gpus
 @pytest.mark.no_hyperbolic  # Hyperbolic has low availability of T4 GPUs
 @pytest.mark.resource_heavy
+@pytest.mark.no_remote_server
 def test_multi_echo(generic_cloud: str):
     name = smoke_tests_utils.get_cluster_name()
     use_spot = True
@@ -700,6 +701,7 @@ def test_azure_http_server_with_custom_ports():
 
 # ---------- Web apps with custom ports on Kubernetes. ----------
 @pytest.mark.kubernetes
+@pytest.mark.no_remote_server
 def test_kubernetes_http_server_with_custom_ports():
     name = smoke_tests_utils.get_cluster_name()
     test = smoke_tests_utils.Test(

--- a/tests/smoke_tests/test_provision_logs.py
+++ b/tests/smoke_tests/test_provision_logs.py
@@ -12,7 +12,6 @@ from sky import skypilot_config
 
 
 @pytest.mark.no_vast
-@pytest.mark.no_remote_server
 def test_provision_logs_streaming(generic_cloud: str):
     name = smoke_tests_utils.get_cluster_name()
 

--- a/tests/smoke_tests/test_provision_logs.py
+++ b/tests/smoke_tests/test_provision_logs.py
@@ -12,6 +12,7 @@ from sky import skypilot_config
 
 
 @pytest.mark.no_vast
+@pytest.mark.no_remote_server
 def test_provision_logs_streaming(generic_cloud: str):
     name = smoke_tests_utils.get_cluster_name()
 

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -318,6 +318,7 @@ def test_skyserve_azure_http():
 
 @pytest.mark.kubernetes
 @pytest.mark.serve
+@pytest.mark.no_remote_server
 def test_skyserve_kubernetes_http():
     """Test skyserve on Kubernetes"""
     name = _get_service_name()
@@ -497,6 +498,7 @@ def test_skyserve_dynamic_ondemand_fallback():
 @pytest.mark.serve
 @pytest.mark.no_vast  # Vast doesn't support opening ports
 @pytest.mark.no_hyperbolic  # Hyperbolic doesn't support opening ports for skypilot yet
+@pytest.mark.no_remote_server
 def test_skyserve_user_bug_restart(generic_cloud: str):
     """Tests that we restart the service after user bug."""
     # TODO(zhwu): this behavior needs some rethinking.
@@ -615,6 +617,7 @@ def test_skyserve_auto_restart():
 @pytest.mark.no_vast  # Vast doesn't support opening ports
 @pytest.mark.no_hyperbolic  # Hyperbolic doesn't support opening ports for skypilot yet
 @pytest.mark.serve
+@pytest.mark.no_remote_server
 def test_skyserve_cancel(generic_cloud: str):
     """Test skyserve with cancel"""
     name = _get_service_name()
@@ -643,6 +646,7 @@ def test_skyserve_cancel(generic_cloud: str):
 @pytest.mark.no_vast  # Vast doesn't support opening ports
 @pytest.mark.no_hyperbolic  # Hyperbolic doesn't support opening ports for skypilot yet
 @pytest.mark.serve
+@pytest.mark.no_remote_server
 def test_skyserve_streaming(generic_cloud: str):
     """Test skyserve with streaming"""
     resource_arg, env = smoke_tests_utils.get_cloud_specific_resource_config(
@@ -693,6 +697,7 @@ def test_skyserve_readiness_timeout_fail(generic_cloud: str):
 @pytest.mark.no_vast  # Vast doesn't support opening ports
 @pytest.mark.no_hyperbolic  # Hyperbolic doesn't support opening ports for skypilot yet
 @pytest.mark.serve
+@pytest.mark.no_remote_server
 def test_skyserve_large_readiness_timeout(generic_cloud: str):
     """Test skyserve with customized large readiness timeout"""
     name = _get_service_name()
@@ -717,6 +722,7 @@ def test_skyserve_large_readiness_timeout(generic_cloud: str):
 @pytest.mark.no_vast  # Vast doesn't support opening ports
 @pytest.mark.no_hyperbolic  # Hyperbolic doesn't support opening ports for skypilot yet
 @pytest.mark.serve
+@pytest.mark.no_remote_server
 def test_skyserve_update(generic_cloud: str):
     """Test skyserve with update"""
     resource_arg, env = smoke_tests_utils.get_cloud_specific_resource_config(
@@ -754,6 +760,7 @@ def test_skyserve_update(generic_cloud: str):
 @pytest.mark.no_vast  # Vast doesn't support opening ports
 @pytest.mark.no_hyperbolic  # Hyperbolic doesn't support opening ports for skypilot yet
 @pytest.mark.serve
+@pytest.mark.no_remote_server
 def test_skyserve_rolling_update(generic_cloud: str):
     """Test skyserve with rolling update"""
     resource_arg, env = smoke_tests_utils.get_cloud_specific_resource_config(
@@ -814,6 +821,7 @@ def test_skyserve_rolling_update(generic_cloud: str):
 @pytest.mark.no_vast  # Vast doesn't support opening ports
 @pytest.mark.serve
 @pytest.mark.no_hyperbolic  # Hyperbolic doesn't support opening ports for skypilot yet
+@pytest.mark.no_remote_server
 def test_skyserve_fast_update(generic_cloud: str):
     """Test skyserve with fast update (Increment version of old replicas)"""
     name = _get_service_name()
@@ -858,6 +866,7 @@ def test_skyserve_fast_update(generic_cloud: str):
 @pytest.mark.no_vast  # Vast doesn't support opening ports
 @pytest.mark.no_hyperbolic  # Hyperbolic doesn't support opening ports for skypilot yet
 @pytest.mark.serve
+@pytest.mark.no_remote_server
 def test_skyserve_update_autoscale(generic_cloud: str):
     """Test skyserve update with autoscale"""
     resource_arg, env = smoke_tests_utils.get_cloud_specific_resource_config(
@@ -986,6 +995,7 @@ def test_skyserve_new_autoscaler_update(mode: str, generic_cloud: str):
 @pytest.mark.no_vast  # Vast doesn't support opening ports
 @pytest.mark.no_hyperbolic  # Hyperbolic doesn't support opening ports for skypilot yet
 @pytest.mark.serve
+@pytest.mark.no_remote_server
 def test_skyserve_failures(generic_cloud: str):
     """Test replica failure statuses"""
     resource_arg, env = smoke_tests_utils.get_cloud_specific_resource_config(
@@ -1082,6 +1092,7 @@ def test_skyserve_https(generic_cloud: str):
 
 @pytest.mark.serve
 @pytest.mark.no_hyperbolic  # Hyperbolic doesn't support opening ports for skypilot yet
+@pytest.mark.no_remote_server
 def test_skyserve_multi_ports(generic_cloud: str):
     """Test skyserve with multiple ports"""
     name = _get_service_name()

--- a/tests/smoke_tests/test_workspaces.py
+++ b/tests/smoke_tests/test_workspaces.py
@@ -12,6 +12,7 @@ from sky import skypilot_config
 
 
 # ---------- Test workspace switching ----------
+@pytest.mark.no_remote_server
 def test_workspace_switching(generic_cloud: str):
     # Test switching between workspaces by modifying .sky.yaml.
     #
@@ -25,9 +26,6 @@ def test_workspace_switching(generic_cloud: str):
         pytest.skip(
             'Skipping workspace switching test when not in Buildkite environment'
         )
-    if smoke_tests_utils.is_remote_server_test():
-        pytest.skip('Skipping workspace switching test since we do not support '
-                    'restarting clusters in remote server')
     ws1_name = 'ws-1'
     ws2_name = 'ws-2'
     server_config_content = textwrap.dedent(f"""\


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
