### PR TITLE
[Core] Add a new use_ssm flag instead of relying on proxy command

### DIFF
--- a/docs/source/cloud-setup/cloud-permissions/aws.rst
+++ b/docs/source/cloud-setup/cloud-permissions/aws.rst
@@ -59,7 +59,7 @@ Using AWS Systems Manager (SSM)
 
 `AWS Systems Manager Session Manager <https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager.html>`_ provides secure shell access to EC2 instances without requiring direct network access through SSH ports or bastion hosts.
 
-SkyPilot can be configured to use SSM for SSH connections by setting the ``ssh_proxy_command`` in your :ref:`config.yaml <config-yaml>` file.
+SkyPilot can be configured to use SSM for SSH connections by setting ``use_ssm`` to true in your :ref:`config.yaml <config-yaml>` file under the ``aws`` section.
 
 Prerequisites
 ~~~~~~~~~~~~~
@@ -92,14 +92,10 @@ Add the following to your ``~/.sky/config.yaml`` file:
 .. code-block:: yaml
 
     aws:
-      ssh_proxy_command:
-        us-east-1: aws ssm start-session --target "$(aws ec2 describe-instances --filter Name=ip-address,Values=%h --region us-east-1 --profile sky | jq -r '.Reservations[].Instances[]|.InstanceId')" --region us-east-1 --profile sky --document-name AWS-StartSSHSession --parameters portNumber=%p
-        us-east-2: aws ssm start-session --target "$(aws ec2 describe-instances --filter Name=ip-address,Values=%h --region us-east-2 --profile sky | jq -r '.Reservations[].Instances[]|.InstanceId')" --region us-east-2 --profile sky --document-name AWS-StartSSHSession --parameters portNumber=%p
+        use_ssm: true
 
 .. note::
 
-    - Replace ``sky`` with your actual AWS profile name if different.
-    - Add additional regions as needed following the same pattern.
     - The ``jq`` command-line JSON processor must be installed on your system.
 
 Once configured, SkyPilot will automatically use SSM for all SSH connections to your AWS instances in the specified regions.

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -777,11 +777,12 @@ def write_cluster_config(
             keys=('use_ssm',),
             default_value=False)
         if not use_ssm and use_internal_ips and ssh_proxy_command is None:
-            logger.warning('use_internal_ips is set to true, ' +
-            'but ssh_proxy_command is not set. Defaulting to using SSM. ' +
-            'Specify ssh_proxy_command to use a different proxy command: ' +
-            'https://docs.skypilot.co/en/latest/reference/config.html#' +
-            'aws.ssh_proxy_command.')
+            logger.warning(
+                'use_internal_ips is set to true, '
+                'but ssh_proxy_command is not set. Defaulting to '
+                'using SSM. Specify ssh_proxy_command to use a different '
+                'https://docs.skypilot.co/en/latest/reference/config.html#'
+                'aws.ssh_proxy_command.')
             use_ssm = True
         if use_ssm:
             if ssh_proxy_command is None:
@@ -790,11 +791,12 @@ def write_cluster_config(
                 ip_address_filter = ('Name=private-ip-address,Values=%h'
                                      if use_internal_ips else
                                      'Name=ip-address,Values=%h')
-                ssm_proxy_command = 'aws ssm start-session --target \"' + \
-                    '$(aws ec2 describe-instances --filter ' + \
-                    f'{ip_address_filter} --region {region_name} ' + \
-                    f'{profile_str} ' + \
-                    '| jq -r \'.Reservations[].Instances[]|.InstanceId\')\" ' + \
+                get_instance_id_command = 'aws ec2 describe-instances ' + \
+                    f'--region {region_name} --filters {ip_address_filter} ' + \
+                    '--query \"Reservations[].Instances[].InstanceId\" ' + \
+                    f'{profile_str} --output text'
+                ssm_proxy_command = 'aws ssm start-session --target ' + \
+                    f'\"$({get_instance_id_command})\" ' + \
                     f'--region {region_name} {profile_str} ' + \
                     '--document-name AWS-StartSSHSession ' + \
                     '--parameters portNumber=%p'

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -778,11 +778,12 @@ def write_cluster_config(
             default_value=False)
         if not use_ssm and use_internal_ips and ssh_proxy_command is None:
             logger.warning(
+                f'{colorama.Fore.YELLOW}'
                 'use_internal_ips is set to true, '
                 'but ssh_proxy_command is not set. Defaulting to '
                 'using SSM. Specify ssh_proxy_command to use a different '
                 'https://docs.skypilot.co/en/latest/reference/config.html#'
-                'aws.ssh_proxy_command.')
+                f'aws.ssh_proxy_command.{colorama.Style.RESET_ALL}')
             use_ssm = True
         if use_ssm:
             if ssh_proxy_command is None:
@@ -803,9 +804,10 @@ def write_cluster_config(
                 ssh_proxy_command = ssm_proxy_command
                 region_name = 'ssm-session'  # TODO: change this to a random string
             else:
-                logger.warning('use_ssm is set to true, but ssh_proxy_command '
+                logger.warning(f'{colorama.Fore.YELLOW}'
+                               'use_ssm is set to true, but ssh_proxy_command '
                                f'is already set to {ssh_proxy_command!r}.'
-                               'Ignoring use_ssm.')
+                               f'Ignoring use_ssm. {colorama.Style.RESET_ALL}')
     logger.debug(f'Using ssh_proxy_command: {ssh_proxy_command!r}')
 
     # User-supplied global instance tags from ~/.sky/config.yaml.

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -765,10 +765,10 @@ def write_cluster_config(
             ssh_proxy_command = ssh_proxy_command_config[region_name]
 
     use_internal_ips = skypilot_config.get_effective_region_config(
-                    cloud=str(cloud).lower(),
-                    region=region.name,
-                    keys=('use_internal_ips',),
-                    default_value=False)
+        cloud=str(cloud).lower(),
+        region=region.name,
+        keys=('use_internal_ips',),
+        default_value=False)
     if isinstance(cloud, clouds.AWS):
         # If the use_ssm flag is set to true, we use the ssm proxy command.
         use_ssm = skypilot_config.get_effective_region_config(
@@ -779,27 +779,22 @@ def write_cluster_config(
         if use_ssm:
             if ssh_proxy_command is None:
                 aws_profile = os.environ.get('AWS_PROFILE', 'default')
-                ip_address_filter = (
-                    "Name=private-ip-address,Values=%h"
-                    if use_internal_ips else
-                    "Name=ip-address,Values=%h"
-                )
-                ssm_proxy_command = "aws ssm start-session --target \"" + \
-                    "$(aws ec2 describe-instances --filter " + \
-                    f"{ip_address_filter} --region {region_name} " + \
-                    f"--profile {aws_profile} " + \
-                    "| jq -r '.Reservations[].Instances[]|.InstanceId')\" " + \
-                    f"--region {region_name} --profile {aws_profile} " + \
-                    "--document-name AWS-StartSSHSession " + \
-                    "--parameters portNumber=%p"
-                logger.warning('Using ssm proxy command: ' +
-                               f'{ssm_proxy_command!r}')
+                ip_address_filter = ('Name=private-ip-address,Values=%h'
+                                     if use_internal_ips else
+                                     'Name=ip-address,Values=%h')
+                ssm_proxy_command = 'aws ssm start-session --target \"' + \
+                    '$(aws ec2 describe-instances --filter ' + \
+                    f'{ip_address_filter} --region {region_name} ' + \
+                    f'--profile {aws_profile} ' + \
+                    '| jq -r \'.Reservations[].Instances[]|.InstanceId\')\" ' + \
+                    f'--region {region_name} --profile {aws_profile} ' + \
+                    '--document-name AWS-StartSSHSession ' + \
+                    '--parameters portNumber=%p'
                 ssh_proxy_command = ssm_proxy_command
-                region_name = 'ssm-session' # TODO: change this to a random string
+                region_name = 'ssm-session'  # TODO: change this to a random string
             else:
-                logger.warning('use_ssm is set to true, but ssh_proxy_command' +
-                               ' is already set to ' +
-                               f'{ssh_proxy_command!r}')
+                logger.warning('use_ssm is set to true, but ssh_proxy_command '
+                               f'is already set to {ssh_proxy_command!r}')
     logger.debug(f'Using ssh_proxy_command: {ssh_proxy_command!r}')
 
     # User-supplied global instance tags from ~/.sky/config.yaml.

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -776,6 +776,13 @@ def write_cluster_config(
             region=region.name,
             keys=('use_ssm',),
             default_value=False)
+        if not use_ssm and use_internal_ips and ssh_proxy_command is None:
+            logger.warning('use_internal_ips is set to true, ' +
+            'but ssh_proxy_command is not set. Defaulting to using SSM. ' +
+            'Specify ssh_proxy_command to use a different proxy command: ' +
+            'https://docs.skypilot.co/en/latest/reference/config.html#' +
+            'aws.ssh_proxy_command.')
+            use_ssm = True
         if use_ssm:
             if ssh_proxy_command is None:
                 aws_profile = os.environ.get('AWS_PROFILE', 'default')
@@ -794,8 +801,9 @@ def write_cluster_config(
                 region_name = 'ssm-session'  # TODO: change this to a random string
             else:
                 logger.warning('use_ssm is set to true, but ssh_proxy_command '
-                               f'is already set to {ssh_proxy_command!r}')
-    logger.warning(f'Using ssh_proxy_command: {ssh_proxy_command!r}')
+                               f'is already set to {ssh_proxy_command!r}.'
+                               'Ignoring use_ssm.')
+    logger.debug(f'Using ssh_proxy_command: {ssh_proxy_command!r}')
 
     # User-supplied global instance tags from ~/.sky/config.yaml.
     labels = skypilot_config.get_effective_region_config(

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -795,7 +795,7 @@ def write_cluster_config(
             else:
                 logger.warning('use_ssm is set to true, but ssh_proxy_command '
                                f'is already set to {ssh_proxy_command!r}')
-    logger.debug(f'Using ssh_proxy_command: {ssh_proxy_command!r}')
+    logger.warning(f'Using ssh_proxy_command: {ssh_proxy_command!r}')
 
     # User-supplied global instance tags from ~/.sky/config.yaml.
     labels = skypilot_config.get_effective_region_config(

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -785,16 +785,17 @@ def write_cluster_config(
             use_ssm = True
         if use_ssm:
             if ssh_proxy_command is None:
-                aws_profile = os.environ.get('AWS_PROFILE', 'default')
+                aws_profile = os.environ.get('AWS_PROFILE', None)
+                profile_str = f'--profile {aws_profile}' if aws_profile else ''
                 ip_address_filter = ('Name=private-ip-address,Values=%h'
                                      if use_internal_ips else
                                      'Name=ip-address,Values=%h')
                 ssm_proxy_command = 'aws ssm start-session --target \"' + \
                     '$(aws ec2 describe-instances --filter ' + \
                     f'{ip_address_filter} --region {region_name} ' + \
-                    f'--profile {aws_profile} ' + \
+                    f'{profile_str} ' + \
                     '| jq -r \'.Reservations[].Instances[]|.InstanceId\')\" ' + \
-                    f'--region {region_name} --profile {aws_profile} ' + \
+                    f'--region {region_name} {profile_str} ' + \
                     '--document-name AWS-StartSSHSession ' + \
                     '--parameters portNumber=%p'
                 ssh_proxy_command = ssm_proxy_command

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -954,9 +954,6 @@ _NETWORK_CONFIG_SCHEMA = {
     'use_internal_ips': {
         'type': 'boolean',
     },
-    'use_ssm': {
-        'type': 'boolean',
-    },
     'ssh_proxy_command': {
         'oneOf': [{
             'type': 'string',

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -954,6 +954,9 @@ _NETWORK_CONFIG_SCHEMA = {
     'use_internal_ips': {
         'type': 'boolean',
     },
+    'use_ssm': {
+        'type': 'boolean',
+    },
     'ssh_proxy_command': {
         'oneOf': [{
             'type': 'string',

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1221,6 +1221,9 @@ def get_config_schema():
                         'type': 'null',
                     }],
                 },
+                'use_ssm': {
+                    'type': 'boolean',
+                },
                 'post_provision_runcmd': {
                     'type': 'array',
                     'items': {

--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -457,8 +457,6 @@ def run_one_test(test: Test, check_sky_status: bool = True) -> None:
     if check_sky_status:
         test.commands.insert(0, 'sky status')
 
-    outputs = []
-
     log_to_stdout = os.environ.get('LOG_TO_STDOUT', None)
     if log_to_stdout:
         write = test.echo
@@ -485,18 +483,14 @@ def run_one_test(test: Test, check_sky_status: bool = True) -> None:
             flush()
             proc = subprocess.Popen(
                 command,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                stdout=subprocess_out,
+                stderr=subprocess.STDOUT,
                 shell=True,
                 executable='/bin/bash',
                 env=env_dict,
             )
             try:
                 proc.wait(timeout=test.timeout)
-                output = proc.stdout.read().decode('utf-8')
-                outputs.append(output)
-                # Also send output to log file.
-                subprocess_out.write(output)
             except subprocess.TimeoutExpired as e:
                 flush()
                 test.echo(f'Timeout after {test.timeout} seconds.')
@@ -642,49 +636,6 @@ VALIDATE_LAUNCH_OUTPUT = (
     'echo "==Validating task output ending 2==" && '
     'echo "$s" | grep -A 5 "Job finished (status: SUCCEEDED)" | '
     'grep "Job ID:" && '
-    'echo "$s" | grep -A 1 "Useful Commands" | grep "Job ID:"')
-
-VALIDATE_LAUNCH_OUTPUT_EXPORTED = (
-    # Validate the output of the job submission:
-    # ⚙️ Launching on Kubernetes.
-    #   Pod is up.
-    # ✓ Cluster launched: test. View logs at: ~/sky_logs/sky-2024-10-07-19-44-18-177288/provision.log
-    # ✓ Setup Detached.
-    # ⚙️ Job submitted, ID: 1.
-    # ├── Waiting for task resources on 1 node.
-    # └── Job started. Streaming logs... (Ctrl-C to exit log streaming; job will not be killed)
-    # (setup pid=1277) running setup
-    # (min, pid=1277) # conda environments:
-    # (min, pid=1277) #
-    # (min, pid=1277) base                  *  /opt/conda
-    # (min, pid=1277)
-    # (min, pid=1277) task run finish
-    # ✓ Job finished (status: SUCCEEDED).
-    #
-    # Job ID: 1
-    # 📋 Useful Commands
-    # ├── To cancel the job:          sky cancel test 1
-    # ├── To stream job logs:         sky logs test 1
-    # └── To view job queue:          sky queue test
-    #
-    # Cluster name: test
-    # ├── To log into the head VM:    ssh test
-    # ├── To submit a job:            sky exec test yaml_file
-    # ├── To stop the cluster:        sky stop test
-    # └── To teardown the cluster:    sky down test
-    'echo "$s" && echo "\n==Validating launching=="',
-    'echo "$s" | grep -A 1 "Launching on" | grep "is up."',
-    'echo "$s" && echo "==Validating setup output=="',
-    'echo "$s" | grep -A 1 "Setup detached" | grep "Job submitted"',
-    'echo "==Validating running output hints=="',
-    'echo "$s" | grep -A 1 "Job submitted, ID:" | grep "Waiting for task resources on "',
-    'echo "==Validating task setup/run output starting=="',
-    'echo "$s" | grep -A 1 "Job started. Streaming logs..." | grep "(setup" | grep "running setup"',
-    'echo "$s" | grep -A 1 "(setup" | grep "(min, pid="',
-    'echo "==Validating task output ending=="',
-    'echo "$s" | grep -A 1 "task run finish" | grep "Job finished (status: SUCCEEDED)"',
-    'echo "==Validating task output ending 2=="',
-    'echo "$s" | grep -A 5 "Job finished (status: SUCCEEDED)" | grep "Job ID:"',
     'echo "$s" | grep -A 1 "Useful Commands" | grep "Job ID:"')
 
 _CLOUD_CMD_CLUSTER_NAME_SUFFIX = '-cloud-cmd'

--- a/tests/smoke_tests/test_ssm.py
+++ b/tests/smoke_tests/test_ssm.py
@@ -7,24 +7,8 @@
 # Terminate failed clusters after test finishes
 # > pytest tests/smoke_tests/test_ssm.py --terminate-on-failure
 
-from ast import Name
-import json
-import os
-import pathlib
-import subprocess
-import sys
-import tempfile
-import textwrap
-import time
-
 import pytest
 from smoke_tests import smoke_tests_utils
-
-import sky
-from sky import skypilot_config
-from sky.skylet import constants
-from sky.skylet import events
-from sky.utils import common_utils
 
 
 @pytest.mark.aws

--- a/tests/smoke_tests/test_ssm.py
+++ b/tests/smoke_tests/test_ssm.py
@@ -76,10 +76,36 @@ def test_ssm_private_no_ssh_proxy_command():
                   f'--config aws.security_group_name=lloyd-airgap-gw-sg '
                   f'--config aws.use_internal_ips=true')
 
+    warning_message = 'use_internal_ips is set to true, but ' \
+        'ssh_proxy_command is not set. Defaulting to using SSM. ' \
+        'Specify ssh_proxy_command to use a different ' \
+        'https://docs.skypilot.co/en/latest/reference/config.html#aws.ssh_proxy_command.'
+
+    VALIDATE_SSM_OUTPUT = (
+        'echo "$s" && echo "==Validating launching==" && '
+        f'echo "$s" | grep "{warning_message}" && '
+        'echo "$s" | grep -A 1 "Launching on" | grep "is up." && '
+        'echo "$s" && echo "==Validating setup output==" && '
+        'echo "$s" | grep -A 1 "Setup detached" | grep "Job submitted" && '
+        'echo "==Validating running output hints==" && echo "$s" | '
+        'grep -A 1 "Job submitted, ID:" | '
+        'grep "Waiting for task resources on " && '
+        'echo "==Validating task setup/run output starting==" && echo "$s" | '
+        'grep -A 1 "Job started. Streaming logs..." | grep "(setup" | '
+        'grep "running setup" && '
+        'echo "$s" | grep -A 1 "(setup" | grep "(min, pid=" && '
+        'echo "==Validating task output ending==" && '
+        'echo "$s" | grep -A 1 "task run finish" | '
+        'grep "Job finished (status: SUCCEEDED)" && '
+        'echo "==Validating task output ending 2==" && '
+        'echo "$s" | grep -A 5 "Job finished (status: SUCCEEDED)" | '
+        'grep "Job ID:" && '
+        'echo "$s" | grep -A 1 "Useful Commands" | grep "Job ID:"')
+
     test = smoke_tests_utils.Test(
-        'ssm_private',
+        'ssm_private_no_ssh_proxy_command',
         [
-            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml | tee /dev/stderr) && {smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
+            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml | tee /dev/stderr) && {VALIDATE_SSM_OUTPUT}',
         ],
         teardown=f'sky down -y {name}',
         timeout=smoke_tests_utils.get_timeout('aws'),
@@ -114,6 +140,80 @@ def test_ssm_private_custom_ami():
             'ssm_private_custom_ami',
             [
                 f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} --image-id {ami_id} tests/test_yamls/minimal.yaml) && {smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
+            ],
+            teardown=f'sky down -y {name}',
+            timeout=smoke_tests_utils.get_timeout('aws'),
+            env={
+                skypilot_config.ENV_VAR_GLOBAL_CONFIG: f.name,
+                constants.SKY_API_SERVER_URL_ENV_VAR:
+                    sky.server.common.get_server_url()
+            },
+        )
+        smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.aws
+def test_ssm_private_proxy_command_and_use_ssm():
+    """Test that ssm works with private IP addresses.
+
+    Because we turn on use_internal_ips SkyPilot will automatically
+    use the private subnet to create the cluster.
+    """
+    name = smoke_tests_utils.get_cluster_name()
+
+    warning_message = 'use_ssm is set to true, ' \
+        'but ssh_proxy_command is already set to'
+
+    VALIDATE_SSM_OUTPUT = (
+        'echo "$s" && echo "==Validating launching==" && '
+        f'echo "$s" | grep "{warning_message}" && '
+        'echo "$s" | grep -A 1 "Launching on" | grep "is up." && '
+        'echo "$s" && echo "==Validating setup output==" && '
+        'echo "$s" | grep -A 1 "Setup detached" | grep "Job submitted" && '
+        'echo "==Validating running output hints==" && echo "$s" | '
+        'grep -A 1 "Job submitted, ID:" | '
+        'grep "Waiting for task resources on " && '
+        'echo "==Validating task setup/run output starting==" && echo "$s" | '
+        'grep -A 1 "Job started. Streaming logs..." | grep "(setup" | '
+        'grep "running setup" && '
+        'echo "$s" | grep -A 1 "(setup" | grep "(min, pid=" && '
+        'echo "==Validating task output ending==" && '
+        'echo "$s" | grep -A 1 "task run finish" | '
+        'grep "Job finished (status: SUCCEEDED)" && '
+        'echo "==Validating task output ending 2==" && '
+        'echo "$s" | grep -A 5 "Job finished (status: SUCCEEDED)" | '
+        'grep "Job ID:" && '
+        'echo "$s" | grep -A 1 "Useful Commands" | grep "Job ID:"')
+
+    get_instance_id_command = 'aws ec2 describe-instances ' + \
+        '--region us-west-1 --filters Name=private-ip-address,Values=%h ' + \
+                    '--query \"Reservations[].Instances[].InstanceId\" ' + \
+                    '--output text'
+    ssm_proxy_command = 'aws ssm start-session --target ' + \
+        '\"$(' + get_instance_id_command + ')\" ' + \
+        '--region us-west-1 ' + \
+        '--document-name AWS-StartSSHSession ' + \
+        '--parameters portNumber=%p'
+
+    vpc = "DO_NOT_DELETE_lloyd-airgapped-plus-gateway"
+
+    config = textwrap.dedent(f"""
+    aws:
+        use_internal_ips: true
+        vpc_name: {vpc}
+        use_ssm: true
+        ssh_proxy_command: {ssm_proxy_command!r}
+        security_group_name: lloyd-airgap-gw-sg
+    """)
+
+    with tempfile.NamedTemporaryFile(delete=True) as f:
+        f.write(config.encode('utf-8'))
+        f.flush()
+
+        test = smoke_tests_utils.Test(
+            'ssm_private_proxy_command_and_use_ssm',
+            [
+                f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} tests/test_yamls/minimal.yaml | tee /dev/stderr) && {VALIDATE_SSM_OUTPUT}',
             ],
             teardown=f'sky down -y {name}',
             timeout=smoke_tests_utils.get_timeout('aws'),

--- a/tests/smoke_tests/test_ssm.py
+++ b/tests/smoke_tests/test_ssm.py
@@ -81,8 +81,8 @@ def test_ssm_private():
         [
             f's=$(SKYPILOT_DEBUG=1 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml) && echo "$s"',
         ],
-        teardown=f'sky down -y {name}',
-        timeout=smoke_tests_utils.get_timeout('aws'),
+        # teardown=f'sky down -y {name}',
+        timeout=120,
     )
     smoke_tests_utils.run_one_test(test)
 

--- a/tests/smoke_tests/test_ssm.py
+++ b/tests/smoke_tests/test_ssm.py
@@ -154,36 +154,15 @@ def test_ssm_private_custom_ami():
 
 @pytest.mark.aws
 def test_ssm_private_proxy_command_and_use_ssm():
-    """Test that ssm works with private IP addresses.
-
-    Because we turn on use_internal_ips SkyPilot will automatically
-    use the private subnet to create the cluster.
+    """Test that ssm errors if ssh_proxy_command and use_ssm are set.
     """
     name = smoke_tests_utils.get_cluster_name()
 
     warning_message = 'use_ssm is set to true, ' \
         'but ssh_proxy_command is already set to'
 
-    VALIDATE_SSM_OUTPUT = (
-        'echo "$s" && echo "==Validating launching==" && '
-        f'echo "$s" | grep "{warning_message}" && '
-        'echo "$s" | grep -A 1 "Launching on" | grep "is up." && '
-        'echo "$s" && echo "==Validating setup output==" && '
-        'echo "$s" | grep -A 1 "Setup detached" | grep "Job submitted" && '
-        'echo "==Validating running output hints==" && echo "$s" | '
-        'grep -A 1 "Job submitted, ID:" | '
-        'grep "Waiting for task resources on " && '
-        'echo "==Validating task setup/run output starting==" && echo "$s" | '
-        'grep -A 1 "Job started. Streaming logs..." | grep "(setup" | '
-        'grep "running setup" && '
-        'echo "$s" | grep -A 1 "(setup" | grep "(min, pid=" && '
-        'echo "==Validating task output ending==" && '
-        'echo "$s" | grep -A 1 "task run finish" | '
-        'grep "Job finished (status: SUCCEEDED)" && '
-        'echo "==Validating task output ending 2==" && '
-        'echo "$s" | grep -A 5 "Job finished (status: SUCCEEDED)" | '
-        'grep "Job ID:" && '
-        'echo "$s" | grep -A 1 "Useful Commands" | grep "Job ID:"')
+    VALIDATE_SSM_OUTPUT = ('echo "$s" && echo "==Validating launching==" && '
+                           f'echo "$s" | grep "{warning_message}"')
 
     get_instance_id_command = 'aws ec2 describe-instances ' + \
         '--region us-west-1 --filters Name=private-ip-address,Values=%h ' + \

--- a/tests/smoke_tests/test_ssm.py
+++ b/tests/smoke_tests/test_ssm.py
@@ -30,9 +30,7 @@ def test_ssm_public():
     test = smoke_tests_utils.Test(
         'ssm_public',
         [
-            f's=$(SKYPILOT_DEBUG=1 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml | tee /dev/stderr)',
-            f'aws ec2 describe-instances --debug --region us-west-1 --filters "Name=instance-state-name,Values=running,pending" --query "Reservations[].Instances[].InstanceId" --output text',
-            f'aws ssm start-session --debug --region us-west-1 --target "$(aws ec2 describe-instances --region us-west-1 --filters "Name=instance-state-name,Values=running,pending" --query "Reservations[].Instances[].InstanceId" --output text)" --document-name AWS-StartInteractiveCommand --parameters "command=[\"echo hi\"]"',
+            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml | tee /dev/stderr) && {smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
         ],
         teardown=f'sky down -y {name}',
         timeout=smoke_tests_utils.get_timeout('aws'),

--- a/tests/smoke_tests/test_ssm.py
+++ b/tests/smoke_tests/test_ssm.py
@@ -79,7 +79,7 @@ def test_ssm_private():
     test = smoke_tests_utils.Test(
         'ssm_private',
         [
-            f's=$(SKYPILOT_DEBUG=1 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml | tee /dev/stderr) && echo "$s"',
+            f's=$(SKYPILOT_DEBUG=1 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml | tee /dev/stderr) && {smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
         ],
         # teardown=f'sky down -y {name}',
         timeout=smoke_tests_utils.get_timeout('aws'),

--- a/tests/smoke_tests/test_ssm.py
+++ b/tests/smoke_tests/test_ssm.py
@@ -79,10 +79,10 @@ def test_ssm_private():
     test = smoke_tests_utils.Test(
         'ssm_private',
         [
-            f's=$(SKYPILOT_DEBUG=1 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml) && echo "$s"',
+            f's=$(SKYPILOT_DEBUG=1 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml | tee /dev/stderr) && echo "$s"',
         ],
         # teardown=f'sky down -y {name}',
-        timeout=120,
+        timeout=smoke_tests_utils.get_timeout('aws'),
     )
     smoke_tests_utils.run_one_test(test)
 

--- a/tests/smoke_tests/test_ssm.py
+++ b/tests/smoke_tests/test_ssm.py
@@ -32,15 +32,40 @@ def test_ssm_public():
     """Test that ssm works with public IP addresses."""
     name = smoke_tests_utils.get_cluster_name()
     vpc = "DO_NOT_DELETE_lloyd-airgapped-plus-gateway"
-    vpc_config = f'aws.vpc_name={vpc},aws.use_ssm=true,aws.security_group_name=lloyd-airgap-gw-sg'
+    vpc_config = f'--config aws.vpc_name={vpc} ' \
+        f'--config aws.use_ssm=true ' \
+        f'--config aws.security_group_name=lloyd-airgap-gw-sg'
 
     test = smoke_tests_utils.Test(
         'ssm_public',
         [
-            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} --config {vpc_config} tests/test_yamls/minimal.yaml) && {smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
+            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml) && {smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
         ],
         teardown=f'sky down -y {name}',
         timeout=smoke_tests_utils.get_timeout('aws'),
     )
-    print(test.commands)
+    smoke_tests_utils.run_one_test(test)
+
+@pytest.mark.aws
+def test_ssm_private():
+    """Test that ssm works with private IP addresses.
+
+    Because we turn on use_internal_ips SkyPilot will automatically
+    use the private subnet to create the cluster.
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    vpc = "DO_NOT_DELETE_lloyd-airgapped-plus-gateway"
+    vpc_config = f'--config aws.vpc_name={vpc} ' \
+        f'--config aws.use_ssm=true ' \
+        f'--config aws.security_group_name=lloyd-airgap-gw-sg' \
+        f'--config aws.use_internal_ips=true'
+
+    test = smoke_tests_utils.Test(
+        'ssm_private',
+        [
+            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml) && {smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
+        ],
+        teardown=f'sky down -y {name}',
+        timeout=smoke_tests_utils.get_timeout('aws'),
+    )
     smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_ssm.py
+++ b/tests/smoke_tests/test_ssm.py
@@ -79,7 +79,30 @@ def test_ssm_private():
     test = smoke_tests_utils.Test(
         'ssm_private',
         [
-            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml) && echo "$s"',
+            f's=$(SKYPILOT_DEBUG=1 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml) && echo "$s"',
+        ],
+        teardown=f'sky down -y {name}',
+        timeout=smoke_tests_utils.get_timeout('aws'),
+    )
+    smoke_tests_utils.run_one_test(test)
+
+@pytest.mark.aws
+def test_ssm_private_no_ssh_proxy_command():
+    """Test that ssm works with private IP addresses.
+
+    Because we turn on use_internal_ips SkyPilot will automatically
+    use the private subnet to create the cluster.
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    vpc = "DO_NOT_DELETE_lloyd-airgapped-plus-gateway"
+    vpc_config = (f'--config aws.vpc_name={vpc} '
+                  f'--config aws.security_group_name=lloyd-airgap-gw-sg '
+                  f'--config aws.use_internal_ips=true')
+
+    test = smoke_tests_utils.Test(
+        'ssm_private',
+        [
+            f's=$(SKYPILOT_DEBUG=1 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml) && echo "$s"',
         ],
         teardown=f'sky down -y {name}',
         timeout=smoke_tests_utils.get_timeout('aws'),

--- a/tests/smoke_tests/test_ssm.py
+++ b/tests/smoke_tests/test_ssm.py
@@ -32,19 +32,22 @@ def test_ssm_public():
     """Test that ssm works with public IP addresses."""
     name = smoke_tests_utils.get_cluster_name()
     vpc = "DO_NOT_DELETE_lloyd-airgapped-plus-gateway"
-    vpc_config = f'--config aws.vpc_name={vpc} ' \
-        f'--config aws.use_ssm=true ' \
+    vpc_config = (
+        f'--config aws.vpc_name={vpc} '
+        f'--config aws.use_ssm=true '
         f'--config aws.security_group_name=lloyd-airgap-gw-sg'
+    )
 
     test = smoke_tests_utils.Test(
         'ssm_public',
         [
-            f'export s=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml)',
-        ] + list(smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT_EXPORTED),
+            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml) && {smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
+        ],
         teardown=f'sky down -y {name}',
         timeout=smoke_tests_utils.get_timeout('aws'),
     )
     smoke_tests_utils.run_one_test(test)
+
 
 @pytest.mark.aws
 def test_ssm_private():
@@ -55,20 +58,19 @@ def test_ssm_private():
     """
     name = smoke_tests_utils.get_cluster_name()
     vpc = "DO_NOT_DELETE_lloyd-airgapped-plus-gateway"
-    vpc_config = f'--config aws.vpc_name={vpc} ' \
-        f'--config aws.use_ssm=true ' \
-        f'--config aws.security_group_name=lloyd-airgap-gw-sg ' \
+    vpc_config = (
+        f'--config aws.vpc_name={vpc} '
+        f'--config aws.use_ssm=true '
+        f'--config aws.security_group_name=lloyd-airgap-gw-sg '
         f'--config aws.use_internal_ips=true'
+    )
 
     test = smoke_tests_utils.Test(
         'ssm_private',
         [
-            f'SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml',
+            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml) && {smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
         ],
         teardown=f'sky down -y {name}',
         timeout=smoke_tests_utils.get_timeout('aws'),
     )
-    outputs = smoke_tests_utils.run_one_test(test)
-    for output in outputs:
-        print(output)
     smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_ssm.py
+++ b/tests/smoke_tests/test_ssm.py
@@ -32,11 +32,9 @@ def test_ssm_public():
     """Test that ssm works with public IP addresses."""
     name = smoke_tests_utils.get_cluster_name()
     vpc = "DO_NOT_DELETE_lloyd-airgapped-plus-gateway"
-    vpc_config = (
-        f'--config aws.vpc_name={vpc} '
-        f'--config aws.use_ssm=true '
-        f'--config aws.security_group_name=lloyd-airgap-gw-sg'
-    )
+    vpc_config = (f'--config aws.vpc_name={vpc} '
+                  f'--config aws.use_ssm=true '
+                  f'--config aws.security_group_name=lloyd-airgap-gw-sg')
 
     test = smoke_tests_utils.Test(
         'ssm_public',
@@ -58,12 +56,10 @@ def test_ssm_private():
     """
     name = smoke_tests_utils.get_cluster_name()
     vpc = "DO_NOT_DELETE_lloyd-airgapped-plus-gateway"
-    vpc_config = (
-        f'--config aws.vpc_name={vpc} '
-        f'--config aws.use_ssm=true '
-        f'--config aws.security_group_name=lloyd-airgap-gw-sg '
-        f'--config aws.use_internal_ips=true'
-    )
+    vpc_config = (f'--config aws.vpc_name={vpc} '
+                  f'--config aws.use_ssm=true '
+                  f'--config aws.security_group_name=lloyd-airgap-gw-sg '
+                  f'--config aws.use_internal_ips=true')
 
     test = smoke_tests_utils.Test(
         'ssm_private',

--- a/tests/smoke_tests/test_ssm.py
+++ b/tests/smoke_tests/test_ssm.py
@@ -39,8 +39,8 @@ def test_ssm_public():
     test = smoke_tests_utils.Test(
         'ssm_public',
         [
-            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml) && {smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
-        ],
+            f'export s=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml)',
+        ] + list(smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT_EXPORTED),
         teardown=f'sky down -y {name}',
         timeout=smoke_tests_utils.get_timeout('aws'),
     )
@@ -57,15 +57,18 @@ def test_ssm_private():
     vpc = "DO_NOT_DELETE_lloyd-airgapped-plus-gateway"
     vpc_config = f'--config aws.vpc_name={vpc} ' \
         f'--config aws.use_ssm=true ' \
-        f'--config aws.security_group_name=lloyd-airgap-gw-sg' \
+        f'--config aws.security_group_name=lloyd-airgap-gw-sg ' \
         f'--config aws.use_internal_ips=true'
 
     test = smoke_tests_utils.Test(
         'ssm_private',
         [
-            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml) && {smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
+            f'SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml',
         ],
         teardown=f'sky down -y {name}',
         timeout=smoke_tests_utils.get_timeout('aws'),
     )
+    outputs = smoke_tests_utils.run_one_test(test)
+    for output in outputs:
+        print(output)
     smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_ssm.py
+++ b/tests/smoke_tests/test_ssm.py
@@ -38,6 +38,30 @@ def test_ssm_public():
     smoke_tests_utils.run_one_test(test)
 
 
+# @pytest.mark.aws
+# def test_ssm_private():
+#     """Test that ssm works with private IP addresses.
+
+#     Because we turn on use_internal_ips SkyPilot will automatically
+#     use the private subnet to create the cluster.
+#     """
+#     name = smoke_tests_utils.get_cluster_name()
+#     vpc = "DO_NOT_DELETE_lloyd-airgapped-plus-gateway"
+#     vpc_config = (f'--config aws.vpc_name={vpc} '
+#                   f'--config aws.use_ssm=true '
+#                   f'--config aws.security_group_name=lloyd-airgap-gw-sg '
+#                   f'--config aws.use_internal_ips=true')
+
+#     test = smoke_tests_utils.Test(
+#         'ssm_private',
+#         [
+#             f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml) && {smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
+#         ],
+#         teardown=f'sky down -y {name}',
+#         timeout=smoke_tests_utils.get_timeout('aws'),
+#     )
+#     smoke_tests_utils.run_one_test(test)
+
 @pytest.mark.aws
 def test_ssm_private():
     """Test that ssm works with private IP addresses.
@@ -55,7 +79,7 @@ def test_ssm_private():
     test = smoke_tests_utils.Test(
         'ssm_private',
         [
-            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml) && {smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
+            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml) && echo "$s"',
         ],
         teardown=f'sky down -y {name}',
         timeout=smoke_tests_utils.get_timeout('aws'),

--- a/tests/smoke_tests/test_ssm.py
+++ b/tests/smoke_tests/test_ssm.py
@@ -7,8 +7,15 @@
 # Terminate failed clusters after test finishes
 # > pytest tests/smoke_tests/test_ssm.py --terminate-on-failure
 
+import tempfile
+import textwrap
+
 import pytest
 from smoke_tests import smoke_tests_utils
+
+import sky
+from sky import skypilot_config
+from sky.skylet import constants
 
 
 @pytest.mark.aws
@@ -54,3 +61,42 @@ def test_ssm_private():
         timeout=smoke_tests_utils.get_timeout('aws'),
     )
     smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.aws
+def test_ssm_private_custom_ami():
+    """Test that ssm works with private IP addresses and a custom AMI.
+    """
+
+    ami_id = "ami-04b95a57b104f3c92"
+
+    config = textwrap.dedent(f"""
+    aws:
+        ssh_user: my-own-user-name
+        use_internal_ips: true
+        vpc_name: DO_NOT_DELETE_lloyd-airgapped-plus-gateway
+        use_ssm: true
+        post_provision_runcmd:
+            - systemctl enable amazon-ssm-agent
+            - systemctl start amazon-ssm-agent
+    """)
+
+    with tempfile.NamedTemporaryFile(delete=True) as f:
+        f.write(config.encode('utf-8'))
+        f.flush()
+
+        name = smoke_tests_utils.get_cluster_name()
+        test = smoke_tests_utils.Test(
+            'ssm_private_custom_ami',
+            [
+                f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} --image-id {ami_id} tests/test_yamls/minimal.yaml) && {smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
+            ],
+            teardown=f'sky down -y {name}',
+            timeout=smoke_tests_utils.get_timeout('aws'),
+            env={
+                skypilot_config.ENV_VAR_GLOBAL_CONFIG: f.name,
+                constants.SKY_API_SERVER_URL_ENV_VAR:
+                    sky.server.common.get_server_url()
+            },
+        )
+        smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_ssm.py
+++ b/tests/smoke_tests/test_ssm.py
@@ -30,7 +30,8 @@ def test_ssm_public():
     test = smoke_tests_utils.Test(
         'ssm_public',
         [
-            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml) && {smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
+            f's=$(SKYPILOT_DEBUG=1 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml)',
+            f'aws ec2 describe-instances --debug --region us-west-1 --query "Reservations[].Instances[].InstanceId" --output text',
         ],
         teardown=f'sky down -y {name}',
         timeout=smoke_tests_utils.get_timeout('aws'),

--- a/tests/smoke_tests/test_ssm.py
+++ b/tests/smoke_tests/test_ssm.py
@@ -30,8 +30,9 @@ def test_ssm_public():
     test = smoke_tests_utils.Test(
         'ssm_public',
         [
-            f's=$(SKYPILOT_DEBUG=1 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml)',
-            f'aws ec2 describe-instances --debug --region us-west-1 --query "Reservations[].Instances[].InstanceId" --output text',
+            f's=$(SKYPILOT_DEBUG=1 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml | tee /dev/stderr)',
+            f'aws ec2 describe-instances --debug --region us-west-1 --filters "Name=instance-state-name,Values=running,pending" --query "Reservations[].Instances[].InstanceId" --output text',
+            f'aws ssm start-session --debug --region us-west-1 --target "$(aws ec2 describe-instances --region us-west-1 --filters "Name=instance-state-name,Values=running,pending" --query "Reservations[].Instances[].InstanceId" --output text)" --document-name AWS-StartInteractiveCommand --parameters "command=[\"echo hi\"]"',
         ],
         teardown=f'sky down -y {name}',
         timeout=smoke_tests_utils.get_timeout('aws'),

--- a/tests/smoke_tests/test_ssm.py
+++ b/tests/smoke_tests/test_ssm.py
@@ -38,30 +38,6 @@ def test_ssm_public():
     smoke_tests_utils.run_one_test(test)
 
 
-# @pytest.mark.aws
-# def test_ssm_private():
-#     """Test that ssm works with private IP addresses.
-
-#     Because we turn on use_internal_ips SkyPilot will automatically
-#     use the private subnet to create the cluster.
-#     """
-#     name = smoke_tests_utils.get_cluster_name()
-#     vpc = "DO_NOT_DELETE_lloyd-airgapped-plus-gateway"
-#     vpc_config = (f'--config aws.vpc_name={vpc} '
-#                   f'--config aws.use_ssm=true '
-#                   f'--config aws.security_group_name=lloyd-airgap-gw-sg '
-#                   f'--config aws.use_internal_ips=true')
-
-#     test = smoke_tests_utils.Test(
-#         'ssm_private',
-#         [
-#             f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml) && {smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
-#         ],
-#         teardown=f'sky down -y {name}',
-#         timeout=smoke_tests_utils.get_timeout('aws'),
-#     )
-#     smoke_tests_utils.run_one_test(test)
-
 @pytest.mark.aws
 def test_ssm_private():
     """Test that ssm works with private IP addresses.
@@ -79,19 +55,20 @@ def test_ssm_private():
     test = smoke_tests_utils.Test(
         'ssm_private',
         [
-            f's=$(SKYPILOT_DEBUG=1 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml | tee /dev/stderr) && {smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
+            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml | tee /dev/stderr) && {smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
         ],
-        # teardown=f'sky down -y {name}',
+        teardown=f'sky down -y {name}',
         timeout=smoke_tests_utils.get_timeout('aws'),
     )
     smoke_tests_utils.run_one_test(test)
 
+
 @pytest.mark.aws
 def test_ssm_private_no_ssh_proxy_command():
-    """Test that ssm works with private IP addresses.
+    """Test that ssm will run by default if use_internal_ips is set.
 
-    Because we turn on use_internal_ips SkyPilot will automatically
-    use the private subnet to create the cluster.
+    This security group does not allow ssh access so if this test passes
+    it means that SkyPilot is using SSM to connect to the cluster.
     """
     name = smoke_tests_utils.get_cluster_name()
     vpc = "DO_NOT_DELETE_lloyd-airgapped-plus-gateway"
@@ -102,7 +79,7 @@ def test_ssm_private_no_ssh_proxy_command():
     test = smoke_tests_utils.Test(
         'ssm_private',
         [
-            f's=$(SKYPILOT_DEBUG=1 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml) && echo "$s"',
+            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml | tee /dev/stderr) && {smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
         ],
         teardown=f'sky down -y {name}',
         timeout=smoke_tests_utils.get_timeout('aws'),

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -36,3 +36,4 @@ from smoke_tests.test_mount_and_storage import *
 from smoke_tests.test_region_and_zone import *
 from smoke_tests.test_sky_serve import *
 from smoke_tests.test_workspaces import *
+from smoke_tests.test_ssm import *

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -35,5 +35,5 @@ from smoke_tests.test_managed_job import *
 from smoke_tests.test_mount_and_storage import *
 from smoke_tests.test_region_and_zone import *
 from smoke_tests.test_sky_serve import *
-from smoke_tests.test_workspaces import *
 from smoke_tests.test_ssm import *
+from smoke_tests.test_workspaces import *


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR adds the use_ssm flag (default false) to turn on SSM for clusters.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

I added multiple smoke tests for this PR:
- One to test that the flag works with public instances
- One to test that the flag works with private instances
- One to test that if the user sets use_internal_ips to True but doesn't specify a proxy command we default to ssm. In that case the user will see the following message
```
use_internal_ips is set to true, but ssh_proxy_command is not set. Defaulting to using SSM. Specify ssh_proxy_command to use a different https://docs.skypilot.co/en/latest/reference/config.html#aws.ssh_proxy_command.
```
- One to test that the flag is compatible with a custom AMI and ssh user name
- One to test that if the user has both `use_internal_ips` set to true and `ssh_proxy_command` we will default to the ssh_proxy_command but warn the user we are not using ssm with the following message
```
use_ssm is set to true, but ssh_proxy_command is already set to <CURRENT_CMD>. Ignoring use_ssm.
```

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
