### PR TITLE
[SDK] cluster job queue return type improvements

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -59,6 +59,7 @@ from sky import task as task_lib
 from sky.adaptors import common as adaptors_common
 from sky.client import sdk
 from sky.client.cli import flags
+from sky.client.cli import table_utils
 from sky.data import storage_utils
 from sky.provision.kubernetes import constants as kubernetes_constants
 from sky.provision.kubernetes import utils as kubernetes_utils
@@ -2123,7 +2124,7 @@ def queue(clusters: List[str], skip_finished: bool, all_users: bool):
                        f'cluster {cluster!r}.{colorama.Style.RESET_ALL}\n'
                        f'  {common_utils.format_exception(e)}')
             return
-        job_tables[cluster] = job_lib.format_job_queue(job_table)
+        job_tables[cluster] = table_utils.format_job_queue(job_table)
 
     subprocess_utils.run_in_parallel(_get_job_queue, clusters)
     user_str = 'all users' if all_users else 'current user'

--- a/sky/client/cli/table_utils.py
+++ b/sky/client/cli/table_utils.py
@@ -1,3 +1,4 @@
+"""Utilities for formatting tables for CLI output."""
 from typing import List
 
 from sky.schemas.api import responses

--- a/sky/client/cli/table_utils.py
+++ b/sky/client/cli/table_utils.py
@@ -17,17 +17,17 @@ def format_job_queue(jobs: List[responses.ClusterJobRecord]):
     ])
     for job in jobs:
         job_table.add_row([
-            job['job_id'],
-            job['job_name'],
-            job['username'],
-            log_utils.readable_time_duration(job['submitted_at']),
-            log_utils.readable_time_duration(job['start_at']),
-            log_utils.readable_time_duration(job['start_at'],
-                                             job['end_at'],
+            job.job_id,
+            job.job_name,
+            job.username,
+            log_utils.readable_time_duration(job.submitted_at),
+            log_utils.readable_time_duration(job.start_at),
+            log_utils.readable_time_duration(job.start_at,
+                                             job.end_at,
                                              absolute=True),
-            job['resources'],
-            job['status'].colored_str(),
-            job['log_path'],
-            job.get('metadata', {}).get('git_commit', '-'),
+            job.resources,
+            job.status.colored_str(),
+            job.log_path,
+            job.metadata.get('git_commit', '-'),
         ])
     return job_table

--- a/sky/client/cli/table_utils.py
+++ b/sky/client/cli/table_utils.py
@@ -1,0 +1,33 @@
+from typing import List
+
+from sky.schemas.api import responses
+from sky.utils import log_utils
+
+
+def format_job_queue(jobs: List[responses.ClusterJobRecord]):
+    """Format the job queue for display.
+
+    Usage:
+        jobs = get_job_queue()
+        print(format_job_queue(jobs))
+    """
+    job_table = log_utils.create_table([
+        'ID', 'NAME', 'USER', 'SUBMITTED', 'STARTED', 'DURATION', 'RESOURCES',
+        'STATUS', 'LOG', 'GIT COMMIT'
+    ])
+    for job in jobs:
+        job_table.add_row([
+            job['job_id'],
+            job['job_name'],
+            job['username'],
+            log_utils.readable_time_duration(job['submitted_at']),
+            log_utils.readable_time_duration(job['start_at']),
+            log_utils.readable_time_duration(job['start_at'],
+                                             job['end_at'],
+                                             absolute=True),
+            job['resources'],
+            job['status'].colored_str(),
+            job['log_path'],
+            job.get('metadata', {}).get('git_commit', '-'),
+        ])
+    return job_table

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1284,8 +1284,8 @@ def queue(
         The request ID of the queue request.
 
     Request Returns:
-        job_records (List[responses.ClusterJobRecord]): A list of dicts for each job in the
-            queue.
+        job_records (List[responses.ClusterJobRecord]): A list of job records
+            for each job in the queue.
 
             .. code-block:: python
 

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1267,9 +1267,11 @@ def autostop(
 @usage_lib.entrypoint
 @server_common.check_server_healthy_or_start
 @annotations.client_api
-def queue(cluster_name: str,
-          skip_finished: bool = False,
-          all_users: bool = False) -> server_common.RequestId[List[dict]]:
+def queue(
+    cluster_name: str,
+    skip_finished: bool = False,
+    all_users: bool = False
+) -> server_common.RequestId[List[responses.ClusterJobRecord]]:
     """Gets the job queue of a cluster.
 
     Args:
@@ -1282,7 +1284,7 @@ def queue(cluster_name: str,
         The request ID of the queue request.
 
     Request Returns:
-        job_records (List[Dict[str, Any]]): A list of dicts for each job in the
+        job_records (List[responses.ClusterJobRecord]): A list of dicts for each job in the
             queue.
 
             .. code-block:: python

--- a/sky/client/sdk_async.py
+++ b/sky/client/sdk_async.py
@@ -523,11 +523,11 @@ async def autostop(
 @usage_lib.entrypoint
 @annotations.client_api
 async def queue(
-        cluster_name: str,
-        skip_finished: bool = False,
-        all_users: bool = False,
-        stream_logs: Optional[StreamConfig] = DEFAULT_STREAM_CONFIG
-) -> List[dict]:
+    cluster_name: str,
+    skip_finished: bool = False,
+    all_users: bool = False,
+    stream_logs: Optional[StreamConfig] = DEFAULT_STREAM_CONFIG
+) -> List[responses.ClusterJobRecord]:
     """Async version of queue() that gets the job queue of a cluster."""
     request_id = await context_utils.to_thread(sdk.queue, cluster_name,
                                                skip_finished, all_users)

--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -133,6 +133,7 @@ class ClusterJobRecord(ResponseBaseModel):
     resources: str
     status: job_lib.JobStatus
     log_path: str
+    metadata: Dict[str, Any] = {}
 
 
 class UploadStatus(enum.Enum):

--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -126,9 +126,9 @@ class ClusterJobRecord(ResponseBaseModel):
     job_name: str
     username: str
     user_hash: str
-    submitted_at: int
-    start_at: int
-    end_at: int
+    submitted_at: float
+    start_at: float
+    end_at: float
     resources: str
     status: str
     log_path: str

--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -7,6 +7,7 @@ import pydantic
 
 from sky import models
 from sky.server import common
+from sky.skylet import job_lib
 from sky.utils import status_lib
 
 
@@ -130,7 +131,7 @@ class ClusterJobRecord(ResponseBaseModel):
     start_at: float
     end_at: float
     resources: str
-    status: str
+    status: job_lib.JobStatus
     log_path: str
 
 

--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -128,8 +128,10 @@ class ClusterJobRecord(ResponseBaseModel):
     username: str
     user_hash: str
     submitted_at: float
-    start_at: float
-    end_at: float
+    # None if the job has not started yet.
+    start_at: Optional[float] = None
+    # None if the job has not ended yet.
+    end_at: Optional[float] = None
     resources: str
     status: job_lib.JobStatus
     log_path: str

--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -120,6 +120,20 @@ class StatusResponse(ResponseBaseModel):
     accelerators: Optional[str] = None
 
 
+class ClusterJobRecord(ResponseBaseModel):
+    """Response for the cluster job queue endpoint."""
+    job_id: int
+    job_name: str
+    username: str
+    user_hash: str
+    submitted_at: int
+    start_at: int
+    end_at: int
+    resources: str
+    status: str
+    log_path: str
+
+
 class UploadStatus(enum.Enum):
     """Status of the upload."""
     UPLOADING = 'uploading'

--- a/sky/server/requests/serializers/decoders.py
+++ b/sky/server/requests/serializers/decoders.py
@@ -105,7 +105,7 @@ def decode_queue(return_value: List[dict],) -> List[responses.ClusterJobRecord]:
     jobs = return_value
     for job in jobs:
         job['status'] = job_lib.JobStatus(job['status'])
-    return jobs
+    return [responses.ClusterJobRecord.model_validate(job) for job in jobs]
 
 
 @register_decoders('jobs.queue')

--- a/sky/server/requests/serializers/decoders.py
+++ b/sky/server/requests/serializers/decoders.py
@@ -101,7 +101,7 @@ def decode_start(return_value: str) -> 'backends.CloudVmRayResourceHandle':
 
 
 @register_decoders('queue')
-def decode_queue(return_value: List[dict],) -> List[Dict[str, Any]]:
+def decode_queue(return_value: List[dict],) -> List[responses.ClusterJobRecord]:
     jobs = return_value
     for job in jobs:
         job['status'] = job_lib.JobStatus(job['status'])

--- a/sky/server/requests/serializers/encoders.py
+++ b/sky/server/requests/serializers/encoders.py
@@ -92,7 +92,8 @@ def encode_start(resource_handle: 'backends.CloudVmRayResourceHandle') -> str:
 
 
 @register_encoder('queue')
-def encode_queue(jobs: List[responses.ClusterJobRecord],) -> List[Dict[str, Any]]:
+def encode_queue(
+    jobs: List[responses.ClusterJobRecord],) -> List[Dict[str, Any]]:
     response = []
     for job in jobs:
         response_job = job.model_dump()

--- a/sky/server/requests/serializers/encoders.py
+++ b/sky/server/requests/serializers/encoders.py
@@ -92,10 +92,13 @@ def encode_start(resource_handle: 'backends.CloudVmRayResourceHandle') -> str:
 
 
 @register_encoder('queue')
-def encode_queue(jobs: List[dict],) -> List[Dict[str, Any]]:
+def encode_queue(jobs: List[responses.ClusterJobRecord],) -> List[Dict[str, Any]]:
+    response = []
     for job in jobs:
-        job['status'] = job['status'].value
-    return jobs
+        response_job = job.model_dump()
+        response_job['status'] = job['status'].value
+        response.append(response_job)
+    return response
 
 
 @register_encoder('status_kubernetes')

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -24,7 +24,6 @@ from sky import sky_logging
 from sky.adaptors import common as adaptors_common
 from sky.skylet import constants
 from sky.utils import common_utils
-from sky.utils import log_utils
 from sky.utils import message_utils
 from sky.utils import subprocess_utils
 from sky.utils.db import db_utils
@@ -612,8 +611,8 @@ def get_job_submitted_or_ended_timestamp_payload(job_id: int,
     PENDING state.
 
     The normal job duration will use `start_at` instead of `submitted_at` (in
-    `format_job_queue()`), because the job may stay in PENDING if the cluster is
-    busy.
+    `table_utils.format_job_queue()`), because the job may stay in PENDING if
+    the cluster is busy.
     """
     return message_utils.encode_payload(
         get_job_submitted_or_ended_timestamp(job_id, get_ended_time))
@@ -939,35 +938,6 @@ def is_cluster_idle() -> bool:
     for (count,) in rows:
         return count == 0
     assert False, 'Should not reach here'
-
-
-def format_job_queue(jobs: List[Dict[str, Any]]):
-    """Format the job queue for display.
-
-    Usage:
-        jobs = get_job_queue()
-        print(format_job_queue(jobs))
-    """
-    job_table = log_utils.create_table([
-        'ID', 'NAME', 'USER', 'SUBMITTED', 'STARTED', 'DURATION', 'RESOURCES',
-        'STATUS', 'LOG', 'GIT COMMIT'
-    ])
-    for job in jobs:
-        job_table.add_row([
-            job['job_id'],
-            job['job_name'],
-            job['username'],
-            log_utils.readable_time_duration(job['submitted_at']),
-            log_utils.readable_time_duration(job['start_at']),
-            log_utils.readable_time_duration(job['start_at'],
-                                             job['end_at'],
-                                             absolute=True),
-            job['resources'],
-            job['status'].colored_str(),
-            job['log_path'],
-            job.get('metadata', {}).get('git_commit', '-'),
-        ])
-    return job_table
 
 
 def dump_job_queue(user_hash: Optional[str], all_jobs: bool) -> str:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Improve the return type of `queue` SDK call. currently this call returns a list of dictionaries and it is unclear what fields are in each dictionary. By returning a concrete type, the user can better understand what is returned when cluster queue endpoint is called.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
