### PR TITLE
Fixed retry on non-transient errors

### DIFF
--- a/sky/server/rest.py
+++ b/sky/server/rest.py
@@ -48,6 +48,13 @@ _session.headers[constants.API_VERSION_HEADER] = str(constants.API_VERSION)
 _session.headers[constants.VERSION_HEADER] = (
     versions.get_local_readable_version())
 
+# Enumerate error types that might be transient and can be addressed by
+# retrying.
+_transient_errors = [
+    requests.exceptions.RequestException,
+    ConnectionError,
+]
+
 
 class RetryContext:
 
@@ -87,14 +94,10 @@ def retry_transient_errors(max_retries: int = 3,
         if isinstance(e, requests.exceptions.HTTPError):
             # Only server error is considered as transient.
             return e.response.status_code >= 500
-        if isinstance(e, exceptions.ClientError):
-            return False
-        # It is hard to enumerate all other errors that are transient, e.g.
-        # broken pipe, connection refused, etc. Instead, it is safer to assume
-        # all other errors might be transient since we only retry for 3 times
-        # by default. For permanent errors that we do not know now, we can
-        # exclude them here in the future.
-        return True
+        for error in _transient_errors:
+            if isinstance(e, error):
+                return True
+        return False
 
     def decorator(func: F) -> F:
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR limits the error types that will be retried for streaming request to avoid unnecessary retries when there is an application error like https://buildkite.com/skypilot-1/full-smoke-tests-run/builds/63#0198d571-b764-4dbb-8136-bf6524367ce0

Tested locally:

```bash
$ SKYPILOT_DEBUG=1 sky launch -c c -y --cpus 1+ 'for i in {1..100}; do echo "$i" && sleep 1; done' --cloud kubernetes
(simulate network error)
(sky-cmd, pid=1561) 1
(sky-cmd, pid=1561) 2
(sky-cmd, pid=1561) 3
(sky-cmd, pid=1561) 4
(sky-cmd, pid=1561) 5
(sky-cmd, pid=1561) 6
(sky-cmd, pid=1561) 7
(sky-cmd, pid=1561) 8
(sky-cmd, pid=1561) 9
D 08-25 11:53:53 sdk.py:151] To stream request logs: sky api logs e13a8439-b723-4017-a75e-ab100d332df6
D 08-25 11:53:53 rest.py:144] Retry tail_logs due to ("Connection broken: InvalidChunkLength(got length b'', 0 bytes read)", InvalidChunkLength(got length b'', 0 bytes read)), attempt 0/3
D 08-25 11:53:53 rest.py:144] Retry tail_logs due to HTTPConnectionPool(host='127.0.0.1', port=7890): Max retries exceeded with url: http://api.skypilot.co/logs (Caused by ProxyError('Cannot connect to proxy.', NewConnectionError('<urllib3.connection.HTTPConnection object at 0x121d0e200>: Failed to establish a new connection: [Errno 61] Connection refused'))), attempt 1/3
(sky-cmd, pid=1561) 10
(sky-cmd, pid=1561) 11
(sky-cmd, pid=1561) 12
(sky-cmd, pid=1561) 13
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
