### PR TITLE
[SDK] storage ls typing improvement

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -59,9 +59,7 @@ from sky import task as task_lib
 from sky.adaptors import common as adaptors_common
 from sky.client import sdk
 from sky.client.cli import flags
-from sky.client.cli import git
 from sky.client.cli import table_utils
-from sky.data import storage_utils
 from sky.provision.kubernetes import constants as kubernetes_constants
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.schemas.api import responses

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -59,6 +59,7 @@ from sky import task as task_lib
 from sky.adaptors import common as adaptors_common
 from sky.client import sdk
 from sky.client.cli import flags
+from sky.client.cli import git
 from sky.client.cli import table_utils
 from sky.data import storage_utils
 from sky.provision.kubernetes import constants as kubernetes_constants
@@ -4027,8 +4028,7 @@ def storage_ls(verbose: bool):
     """List storage objects managed by SkyPilot."""
     request_id = sdk.storage_ls()
     storages = sdk.stream_and_get(request_id)
-    storage_table = storage_utils.format_storage_table(storages,
-                                                       show_all=verbose)
+    storage_table = table_utils.format_storage_table(storages, show_all=verbose)
     click.echo(storage_table)
 
 

--- a/sky/client/cli/table_utils.py
+++ b/sky/client/cli/table_utils.py
@@ -2,6 +2,8 @@
 from typing import List
 
 from sky.schemas.api import responses
+from sky.skylet import constants
+from sky.utils import common_utils
 from sky.utils import log_utils
 
 
@@ -32,3 +34,46 @@ def format_job_queue(jobs: List[responses.ClusterJobRecord]):
             job.metadata.get('git_commit', '-'),
         ])
     return job_table
+
+
+def format_storage_table(storages: List[responses.StorageRecord],
+                         show_all: bool = False) -> str:
+    """Format the storage table for display.
+
+    Args:
+        storage_table (dict): The storage table.
+
+    Returns:
+        str: The formatted storage table.
+    """
+    storage_table = log_utils.create_table([
+        'NAME',
+        'UPDATED',
+        'STORE',
+        'COMMAND',
+        'STATUS',
+    ])
+
+    for row in storages:
+        launched_at = row.launched_at
+        if show_all:
+            command = row.last_use
+        else:
+            command = common_utils.truncate_long_string(
+                row.last_use, constants.LAST_USE_TRUNC_LENGTH)
+        storage_table.add_row([
+            # NAME
+            row.name,
+            # LAUNCHED
+            log_utils.readable_time_duration(launched_at),
+            # CLOUDS
+            ', '.join([s.value for s in row.store]),
+            # COMMAND,
+            command,
+            # STATUS
+            row.status.value,
+        ])
+    if storages:
+        return str(storage_table)
+    else:
+        return 'No existing storage.'

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1618,26 +1618,15 @@ def cost_report(
 @usage_lib.entrypoint
 @server_common.check_server_healthy_or_start
 @annotations.client_api
-def storage_ls() -> server_common.RequestId[List[Dict[str, Any]]]:
+def storage_ls() -> server_common.RequestId[List[responses.StorageRecord]]:
     """Gets the storages.
 
     Returns:
         The request ID of the storage list request.
 
     Request Returns:
-        storage_records (List[Dict[str, Any]]): A list of dicts, with each dict
-            containing the information of a storage.
-
-            .. code-block:: python
-
-                {
-                    'name': (str) storage name,
-                    'launched_at': (int) timestamp of creation,
-                    'store': (List[sky.StoreType]) storage type,
-                    'last_use': (int) timestamp of last use,
-                    'status': (sky.StorageStatus) storage status,
-                }
-        ]
+        storage_records (List[responses.StorageRecord]):
+            A list of storage records.
     """
     response = server_common.make_authenticated_request('GET', '/storage/ls')
     return server_common.get_request_id(response)

--- a/sky/core.py
+++ b/sky/core.py
@@ -1130,25 +1130,25 @@ def job_status(cluster_name: str,
 # = Storage Management =
 # ======================
 @usage_lib.entrypoint
-def storage_ls() -> List[Dict[str, Any]]:
+def storage_ls() -> List[responses.StorageRecord]:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Gets the storages.
 
     Returns:
-        [
-            {
-                'name': str,
-                'launched_at': int timestamp of creation,
-                'store': List[sky.StoreType],
-                'last_use': int timestamp of last use,
-                'status': sky.StorageStatus,
-            }
-        ]
+        List[responses.StorageRecord]: A list of storage records.
     """
     storages = global_user_state.get_storage()
+    storage_records = []
     for storage in storages:
-        storage['store'] = list(storage.pop('handle').sky_stores.keys())
-    return storages
+        storage_records.append(
+            responses.StorageRecord(
+                name=storage['name'],
+                launched_at=storage['launched_at'],
+                store=storage['handle'],
+                last_use=storage['last_use'],
+                status=storage['status'],
+            ))
+    return storage_records
 
 
 @usage_lib.entrypoint

--- a/sky/core.py
+++ b/sky/core.py
@@ -1144,7 +1144,7 @@ def storage_ls() -> List[responses.StorageRecord]:
             responses.StorageRecord(
                 name=storage['name'],
                 launched_at=storage['launched_at'],
-                store=storage['handle'],
+                store=list(storage.pop('handle').sky_stores.keys()),
                 last_use=storage['last_use'],
                 status=storage['status'],
             ))

--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -5,7 +5,7 @@ import pathlib
 import shlex
 import stat
 import subprocess
-from typing import Any, Dict, List, Optional, Set, TextIO, Union
+from typing import List, Optional, Set, TextIO, Union
 import warnings
 import zipfile
 
@@ -15,55 +15,11 @@ from sky import exceptions
 from sky import sky_logging
 from sky.skylet import constants
 from sky.utils import common_utils
-from sky.utils import log_utils
 
 logger = sky_logging.init_logger(__name__)
 
 _USE_SKYIGNORE_HINT = (
     'To avoid using .gitignore, you can create a .skyignore file instead.')
-
-
-def format_storage_table(storages: List[Dict[str, Any]],
-                         show_all: bool = False) -> str:
-    """Format the storage table for display.
-
-    Args:
-        storage_table (dict): The storage table.
-
-    Returns:
-        str: The formatted storage table.
-    """
-    storage_table = log_utils.create_table([
-        'NAME',
-        'UPDATED',
-        'STORE',
-        'COMMAND',
-        'STATUS',
-    ])
-
-    for row in storages:
-        launched_at = row['launched_at']
-        if show_all:
-            command = row['last_use']
-        else:
-            command = common_utils.truncate_long_string(
-                row['last_use'], constants.LAST_USE_TRUNC_LENGTH)
-        storage_table.add_row([
-            # NAME
-            row['name'],
-            # LAUNCHED
-            log_utils.readable_time_duration(launched_at),
-            # CLOUDS
-            ', '.join([s.value for s in row['store']]),
-            # COMMAND,
-            command,
-            # STATUS
-            row['status'].value,
-        ])
-    if storages:
-        return str(storage_table)
-    else:
-        return 'No existing storage.'
 
 
 def get_excluded_files_from_skyignore(src_dir_path: str) -> List[str]:

--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 
 import pydantic
 
+from sky import data
 from sky import models
 from sky.server import common
 from sky.skylet import job_lib
@@ -143,3 +144,12 @@ class UploadStatus(enum.Enum):
     """Status of the upload."""
     UPLOADING = 'uploading'
     COMPLETED = 'completed'
+
+
+class StorageRecord(ResponseBaseModel):
+    """Response for the storage list endpoint."""
+    name: str
+    launched_at: int
+    store: List[data.StoreType]
+    last_use: str
+    status: status_lib.StorageStatus

--- a/sky/server/requests/serializers/decoders.py
+++ b/sky/server/requests/serializers/decoders.py
@@ -181,14 +181,16 @@ def decode_list_accelerators(
 
 @register_decoders('storage_ls')
 def decode_storage_ls(
-        return_value: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        return_value: List[Dict[str, Any]]) -> List[responses.StorageRecord]:
     for storage_info in return_value:
         storage_info['status'] = status_lib.StorageStatus(
             storage_info['status'])
         storage_info['store'] = [
             storage.StoreType(store) for store in storage_info['store']
         ]
-    return return_value
+    return [
+        responses.StorageRecord(**storage_info) for storage_info in return_value
+    ]
 
 
 @register_decoders('job_status')

--- a/sky/server/requests/serializers/encoders.py
+++ b/sky/server/requests/serializers/encoders.py
@@ -203,11 +203,11 @@ def encode_enabled_clouds(clouds: List['clouds.Cloud']) -> List[str]:
 
 @register_encoder('storage_ls')
 def encode_storage_ls(
-        return_value: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        return_value: List[responses.StorageRecord]) -> List[Dict[str, Any]]:
     for storage_info in return_value:
         storage_info['status'] = storage_info['status'].value
         storage_info['store'] = [store.value for store in storage_info['store']]
-    return return_value
+    return [storage_info.model_dump() for storage_info in return_value]
 
 
 @register_encoder('job_status')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Add proper typing to storage ls endpoint, allowing users to better understand the response.
In addition, move the storage table formatting code to table_utils.py

Changes:

- Add a response schema at `schemas/api/responses.py`. Have the server (`sky/core.py`) return said response type, and have the SDK (`sky/client/sdk.py`) return the said response type to user.
- Change the encoder/decoder for this endpoint to encode and decode `StorageRecord` response properly.
- Move the volume table formatting utility (used for pretty print CLI response) from `sky/data/storage_utils.py` to `sky/client/cli/table_utils.py` and have the table formatting utility accept `StorageRecord` as argument.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
