### PR TITLE
[Client] Retry all chunk uploads if no upload displays completed status

### DIFF
--- a/sky/client/common.py
+++ b/sky/client/common.py
@@ -19,6 +19,7 @@ from sky.adaptors import common as adaptors_common
 from sky.client import service_account_auth
 from sky.data import data_utils
 from sky.data import storage_utils
+from sky.schemas.api import responses as api_responses
 from sky.server import common as server_common
 from sky.server.requests import payloads
 from sky.skylet import constants
@@ -201,7 +202,7 @@ def _upload_chunk_with_retry(params: UploadChunkParams) -> str:
                 msg = ('Uploaded chunk: '
                        f'{params.chunk_index + 1} / {params.total_chunks} '
                        f'(Status: {status})')
-                if status == 'uploading':
+                if status == api_responses.UploadStatus.UPLOADING.value:
                     missing_chunks = data.get('missing_chunks')
                     if missing_chunks:
                         msg += f' - Waiting for chunks: {missing_chunks}'
@@ -371,7 +372,8 @@ def upload_mounts_to_api_server(dag: 'sky.Dag',
                     ]
                     statuses = subprocess_utils.run_in_parallel(
                         _upload_chunk_with_retry, chunk_params)
-                    if any(status == 'completed' for status in statuses):
+                    if any(status == api_responses.UploadStatus.COMPLETED.value
+                           for status in statuses):
                         upload_completed = True
                         break
                     else:

--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -1,5 +1,6 @@
 """Responses for the API server."""
 
+import enum
 from typing import Any, Dict, List, Optional
 
 import pydantic
@@ -117,3 +118,9 @@ class StatusResponse(ResponseBaseModel):
     cpus: Optional[str] = None
     memory: Optional[str] = None
     accelerators: Optional[str] = None
+
+
+class UploadStatus(enum.Enum):
+    """Status of the upload."""
+    UPLOADING = 'uploading'
+    COMPLETED = 'completed'

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -928,8 +928,9 @@ async def upload_zip_file(request: fastapi.Request, user_hash: str,
         zip_file_path.rename(zip_file_path.with_suffix(''))
         missing_chunks = get_missing_chunks(total_chunks)
         if missing_chunks:
-            return payloads.UploadZipFileResponse(status='uploading',
-                                                  missing_chunks=missing_chunks)
+            return payloads.UploadZipFileResponse(
+                status=responses.UploadStatus.UPLOADING.value,
+                missing_chunks=missing_chunks)
         zip_file_path = client_file_mounts_dir / f'{upload_id}.zip'
         async with aiofiles.open(zip_file_path, 'wb') as zip_file:
             for chunk in range(total_chunks):
@@ -946,7 +947,8 @@ async def upload_zip_file(request: fastapi.Request, user_hash: str,
     unzip_file(zip_file_path, client_file_mounts_dir)
     if total_chunks > 1:
         shutil.rmtree(chunk_dir)
-    return payloads.UploadZipFileResponse(status='completed')
+    return payloads.UploadZipFileResponse(
+        status=responses.UploadStatus.COMPLETED.value)
 
 
 def _is_relative_to(path: pathlib.Path, parent: pathlib.Path) -> bool:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
I was debugging this error where a file that should have been uploaded does not exist in the remote server:
```
sky launch workdir.yaml -c sjtest
YAML to run: workdir.yaml
⚙︎ Uploading files to API server
✓ Files uploaded  View logs: ~/sky_logs/file_uploads/sky-2025-08-25-12-07-20-327404-aa0e49a9.log
ValueError: File mount source '/root/.sky/api_server/clients/1dcc8143/file_mounts/Users/seungjinyang/.netrc' does not exist locally. To fix: check if it exists, and correct the path.
```

The file upload log shows the following:
```
I 08-25 12:07:20 common.py:334] Zipping files to be uploaded: ['/Users/seungjinyang/.netrc', '/Users/seungjinyang/largefile']
I 08-25 12:07:21 common.py:338] Zipped files to: /var/folders/4t/b03l11jx2lz6krkxv815mhmm0000gn/T/tmpd1fnckgd.zip
I 08-25 12:07:21 common.py:171] Uploading chunk: 1 / 3
I 08-25 12:07:21 common.py:171] Uploading chunk: 2 / 3
I 08-25 12:07:21 common.py:171] Uploading chunk: 3 / 3
I 08-25 12:08:01 common.py:203] Uploaded chunk: 3 / 3 - Waiting for chunks: ['part1', 'part0']
I 08-25 12:08:11 common.py:203] Uploaded chunk: 2 / 3 - Waiting for chunks: ['part0']
E 08-25 12:08:32 common.py:206] Failed to upload chunk: 1 / 3: <html>
E 08-25 12:08:32 common.py:206] <head><title>502 Bad Gateway</title></head>
E 08-25 12:08:32 common.py:206] <body>
E 08-25 12:08:32 common.py:206] <center><h1>502 Bad Gateway</h1></center>
E 08-25 12:08:32 common.py:206] <hr><center>nginx</center>
E 08-25 12:08:32 common.py:206] </body>
E 08-25 12:08:32 common.py:206] </html>
E 08-25 12:08:32 common.py:206] 
I 08-25 12:08:32 common.py:210] Retrying... (1 / 3)
E 08-25 12:09:03 common.py:206] Failed to upload chunk: 1 / 3: <html>
E 08-25 12:09:03 common.py:206] <head><title>503 Service Temporarily Unavailable</title></head>
E 08-25 12:09:03 common.py:206] <body>
E 08-25 12:09:03 common.py:206] <center><h1>503 Service Temporarily Unavailable</h1></center>
E 08-25 12:09:03 common.py:206] <hr><center>nginx</center>
E 08-25 12:09:03 common.py:206] </body>
E 08-25 12:09:03 common.py:206] </html>
E 08-25 12:09:03 common.py:206] 
I 08-25 12:09:03 common.py:210] Retrying... (2 / 3)
I 08-25 12:09:30 common.py:203] Uploaded chunk: 1 / 3 - Waiting for chunks: ['part2', 'part1']
```
What is happening here is very interesting:
1. Client starts upload three chunks in parallel, retrying until each chunk is uploaded
2. Server dies and restarts after two chunks are uploaded. When the third chunk is uploaded, the server is still waiting for the two chunks that were uploaded before the server died.
3. On client side, since all three chunks succeeded uploading, it moves on to the launch stage where it discovered the file mounts were not unzipped.

The learning here is that the client cannot take "all chunks were uploaded without error" to mean the file upload succeeded, as the server may have suffered issues inbetween the chunk uploads.

What I do here instead is check for an explicit "completed" status in the response, and if no response exists, retry the whole upload again.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
