### PR TITLE
[logs] show a better error when server logs are not available

### DIFF
--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1508,6 +1508,12 @@ async def stream(
         if log_path == constants.API_SERVER_LOGS:
             resolved_log_path = pathlib.Path(
                 constants.API_SERVER_LOGS).expanduser()
+            if not resolved_log_path.exists():
+                raise fastapi.HTTPException(
+                    status_code=404,
+                    detail=f'Server log file does not exist. The API server '
+                    'have been started using foreground logging mode - check '
+                    'the external log location such as `kubectl logs`.')
         else:
             # This should be a log path under ~/sky_logs.
             resolved_logs_directory = pathlib.Path(

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1512,8 +1512,10 @@ async def stream(
                 raise fastapi.HTTPException(
                     status_code=404,
                     detail='Server log file does not exist. The API server may '
-                    'have been started using foreground logging mode - check '
-                    'the external log location such as `kubectl logs`.')
+                    'have been started with `--foreground` - check the '
+                    'stdout of API server process, such as: '
+                    '`kubectl logs -n api-server-namespace '
+                    'api-server-pod-name`')
         else:
             # This should be a log path under ~/sky_logs.
             resolved_logs_directory = pathlib.Path(

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1511,7 +1511,7 @@ async def stream(
             if not resolved_log_path.exists():
                 raise fastapi.HTTPException(
                     status_code=404,
-                    detail=f'Server log file does not exist. The API server '
+                    detail='Server log file does not exist. The API server may '
                     'have been started using foreground logging mode - check '
                     'the external log location such as `kubectl logs`.')
         else:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
If you start the API server with `sky api start --foreground`, as in our Helm chart, `sky api logs --server-logs` will not work (TODO: make it work).

Before this change, `sky api logs --server-logs` would silently return nothing. Now, it should return a somewhat more helpful error message.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
