### PR TITLE
[Nebius] Implement can_credential_expire

### DIFF
--- a/sky/adaptors/nebius.py
+++ b/sky/adaptors/nebius.py
@@ -67,17 +67,17 @@ def credentials_path() -> str:
         'credentials_file_path', None)
     if workspace_path is not None:
         return workspace_path
-    return _get_default_credentials_path()
+    return get_default_credentials_path()
 
 
-def _get_workspace_credentials_path() -> Optional[str]:
+def get_workspace_credentials_path() -> Optional[str]:
     """Get credentials path if explicitly set in workspace config."""
     workspace_cred_path = skypilot_config.get_workspace_cloud('nebius').get(
         'credentials_file_path', None)
     return workspace_cred_path
 
 
-def _get_default_credentials_path() -> str:
+def get_default_credentials_path() -> str:
     """Get the default credentials path."""
     return '~/.nebius/credentials.json'
 
@@ -189,7 +189,7 @@ def sdk():
     3. Default credentials path
     """
     # 1. Check if credentials path is set in workspace config (highest priority)
-    workspace_cred_path = _get_workspace_credentials_path()
+    workspace_cred_path = get_workspace_credentials_path()
     if workspace_cred_path is not None:
         # Check if token is also available and warn
         token = get_iam_token()
@@ -206,7 +206,7 @@ def sdk():
         return _sdk(token, None)
 
     # 3. Fall back to default credentials path (lowest priority)
-    default_cred_path = _get_default_credentials_path()
+    default_cred_path = get_default_credentials_path()
     return _sdk(None, default_cred_path)
 
 
@@ -308,10 +308,10 @@ def get_credential_file_paths() -> List[str]:
     }
 
     # Add workspace-specific credentials path if set
-    workspace_cred_path = _get_workspace_credentials_path()
+    workspace_cred_path = get_workspace_credentials_path()
     if workspace_cred_path is not None:
         paths.add(workspace_cred_path)
     # Always add default path in case it's needed for fallback
-    paths.add(_get_default_credentials_path())
+    paths.add(get_default_credentials_path())
 
     return list(paths)


### PR DESCRIPTION
We have a code path that logs a warning message if the credentials you're using is expirable: https://github.com/skypilot-org/skypilot/blob/b351b9f5e1e5d81264a886e522db40ec1a29aa03/sky/backends/cloud_vm_ray_backend.py#L2070-L2082

`backend_utils.get_expirable_clouds()` calls `cloud.can_credential_expire()`, which defaults to False if the cloud's implementation does not implement the method, which is the case for Nebius.

This PR implements `can_credential_expire` for Nebius. It returns True if the user is using [IAM tokens](https://docs.nebius.com/iam/authorization/access-tokens) (`~/.nebius/NEBIUS_IAM_TOKEN.txt`), and False if a service account is used instead.

TODOs:
- Write tests

Follow up:
Right now this warning is logged only if `task.is_controller_task()` is True, but clusters may leak too in the case of normal clusters. For example if Autostop/down is set, but the credentials expire by the time the remote cluster tries to stop itself through the cloud API.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
