### PR TITLE
[Volume] Validate volume name for k8s

### DIFF
--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -396,6 +396,21 @@ class Cloud:
         del label_key, label_value
         return True, None
 
+    @classmethod
+    def is_volume_name_valid(cls,
+                             volume_name: str) -> Tuple[bool, Optional[str]]:
+        """Validates that the volume name is valid for this cloud.
+
+        Returns:
+            A tuple of a boolean indicating whether the volume name is valid
+            and an optional string describing the reason if the volume name
+            is invalid.
+        """
+        # If a cloud does not support volume, they are ignored. Only clouds
+        # that support volume implement this method.
+        del volume_name
+        return True, None
+
     @timeline.event
     def get_feasible_launchable_resources(
             self,

--- a/sky/volumes/volume.py
+++ b/sky/volumes/volume.py
@@ -125,14 +125,19 @@ class Volume:
 
     def _validate_config(self) -> None:
         """Validate the volume config."""
+        assert self.cloud is not None, 'Cloud must be specified'
+        cloud_obj = registry.CLOUD_REGISTRY.from_str(self.cloud)
+        assert cloud_obj is not None
+
+        valid, err_msg = cloud_obj.is_volume_name_valid(self.name)
+        if not valid:
+            raise ValueError(f'{err_msg}')
+
         if not self.resource_name and not self.size:
             raise ValueError('Size is required for new volumes. '
                              'Please specify the size in the YAML file or '
                              'use the --size flag.')
         if self.labels:
-            assert self.cloud is not None, 'Cloud must be specified'
-            cloud_obj = registry.CLOUD_REGISTRY.from_str(self.cloud)
-            assert cloud_obj is not None
             for key, value in self.labels.items():
                 valid, err_msg = cloud_obj.is_label_valid(key, value)
                 if not valid:

--- a/tests/unit_tests/test_sky/volumes/test_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_volume.py
@@ -75,6 +75,7 @@ class TestVolume:
     def test_volume_validate_config_valid_with_size(self):
         """Test Volume._validate_config with valid size."""
         volume = volume_lib.Volume(name='test', type='k8s-pvc', size='100Gi')
+        volume.cloud = 'kubernetes'
         volume._validate_config()  # Should not raise
 
     def test_volume_validate_config_valid_with_resource_name(self):
@@ -82,6 +83,7 @@ class TestVolume:
         volume = volume_lib.Volume(name='test',
                                    type='k8s-pvc',
                                    resource_name='existing-pvc')
+        volume.cloud = 'kubernetes'
         volume._validate_config()  # Should not raise
 
     def test_volume_validate_config_valid_with_both(self):
@@ -90,12 +92,13 @@ class TestVolume:
                                    type='k8s-pvc',
                                    size='100Gi',
                                    resource_name='existing-pvc')
+        volume.cloud = 'kubernetes'
         volume._validate_config()  # Should not raise
 
     def test_volume_validate_config_missing_size_and_resource_name(self):
         """Test Volume._validate_config with missing size and resource_name."""
         volume = volume_lib.Volume(name='test', type='k8s-pvc')
-
+        volume.cloud = 'kubernetes'
         with pytest.raises(ValueError) as exc_info:
             volume._validate_config()
         assert 'Size is required for new volumes' in str(exc_info.value)
@@ -103,6 +106,7 @@ class TestVolume:
     def test_volume_validate_config_empty_config(self):
         """Test Volume._validate_config with empty config."""
         volume = volume_lib.Volume(name='test', type='k8s-pvc', config={})
+        volume.cloud = 'kubernetes'
 
         with pytest.raises(ValueError) as exc_info:
             volume._validate_config()
@@ -113,16 +117,28 @@ class TestVolume:
         volume = volume_lib.Volume(name='test', type='k8s-pvc')
         volume.size = None
         volume.resource_name = None
+        volume.cloud = 'kubernetes'
 
         with pytest.raises(ValueError) as exc_info:
             volume._validate_config()
         assert 'Size is required for new volumes' in str(exc_info.value)
+
+    def test_volume_validate_config_invalid_name(self):
+        """Test Volume._validate_config with invalid name."""
+        volume = volume_lib.Volume(name='test_xyz', type='k8s-pvc')
+        volume.cloud = 'kubernetes'
+
+        with pytest.raises(ValueError) as exc_info:
+            volume._validate_config()
+        assert 'Volume name must be a valid DNS-1123 subdomain' in str(
+            exc_info.value)
 
     def test_volume_validate_config_empty_strings(self):
         """Test Volume._validate_config with empty strings."""
         volume = volume_lib.Volume(name='test', type='k8s-pvc')
         volume.size = ''
         volume.resource_name = ''
+        volume.cloud = 'kubernetes'
 
         with pytest.raises(ValueError) as exc_info:
             volume._validate_config()
@@ -131,6 +147,7 @@ class TestVolume:
     def test_volume_adjust_and_validate_config_integration(self):
         """Test integration of adjust and validate config."""
         volume = volume_lib.Volume(name='test', type='k8s-pvc', size='100Gi')
+        volume.cloud = 'kubernetes'
 
         # Should work together
         volume._adjust_config()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Validate volume name for k8s

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Create volumes with valid and invalid names 
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
