### PR TITLE
Fixed memory usage in file upload

### DIFF
--- a/sky/server/auth/authn.py
+++ b/sky/server/auth/authn.py
@@ -14,6 +14,10 @@ logger = sky_logging.init_logger(__name__)
 # TODO(hailong): Remove this function and use request.state.auth_user instead.
 async def override_user_info_in_request_body(request: fastapi.Request,
                                              auth_user: Optional[models.User]):
+    # Skip for upload requests to avoid consuming the body prematurely, which
+    # will break the streaming upload.
+    if request.url.path.startswith('/upload'):
+        return
     if auth_user is None:
         return
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -852,6 +852,15 @@ async def upload_zip_file(request: fastapi.Request, user_hash: str,
         chunk_index: The chunk index, starting from 0.
         total_chunks: The total number of chunks.
     """
+    # Field _body would be set if the request body has been received, fail fast
+    # to surface potential memory issues, i.e. catch the issue in our smoke
+    # test.
+    # pylint: disable=protected-access
+    if hasattr(request, '_body'):
+        raise fastapi.HTTPException(
+            status_code=500,
+            detail='Upload request body should not be received before streaming'
+        )
     # Add the upload id to the cleanup list.
     upload_ids_to_cleanup[(upload_id,
                            user_hash)] = (datetime.datetime.now() +


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Reduce memory usage in file upload.

The regression is introduced by `override_user_info_in_request_body`, which consume the request body without streaming. This PR skips that middleware for `/upload` API. As a follow-up, we should remove this middleware cc @DanielZhangQD 

Tests: **launch with 3GiB file mounts**

Before:

Takes ~2GiB mem to process the request:

<img width="957" height="326" alt="image" src="https://github.com/user-attachments/assets/27879db2-32fe-480f-9715-ad78c44924e0" />

After:

No obvious mem peaks when process the request

<img width="957" height="326" alt="image" src="https://github.com/user-attachments/assets/c3725af0-6475-4dab-b84f-c24beff82f61" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
