### PR TITLE
[ManagedJobs] Disable autodown on worker clusters for now

### DIFF
--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -327,10 +327,16 @@ class StrategyExecutor:
                                 cluster_name=self.cluster_name,
                                 # We expect to tear down the cluster as soon as
                                 # the job is finished. However, in case the
-                                # controller dies, set autodown to try and avoid
+                                # controller dies, set autostop to try and avoid
                                 # a resource leak.
                                 idle_minutes_to_autostop=_AUTODOWN_MINUTES,
-                                down=True,
+                                # Ideally, we should autodown to be safe, but
+                                # it's fine to just autostop for now, as
+                                # Nebius doesn't support autodown yet
+                                # and this is just a safety net.
+                                # TODO(kevin): set down=True once Nebius
+                                # supports autodown.
+                                down=False,
                                 _is_launched_by_jobs_controller=True)
                         else:
                             self.cluster_name = (


### PR DESCRIPTION
Closes #6633.

Currently, the managed jobs controller will set autodown on the worker cluster it launches as a safety precaution, as the controller might die and not be able to tear down the clusters.

But this means Nebius we can't run managed jobs on Nebius, which is also causing the majority of remaining smoke test failures on #6856.

This PR temporarily disables autodown, as it's just a safety precaution and it's important to get managed jobs working for Nebius right now.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
