### PR TITLE
[logs] add additional debug logs for terminated k8s pods

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1441,6 +1441,12 @@ def query_instances(
         phase = pod.status.phase
         pod_status = status_map[phase]
         if non_terminated_only and pod_status is None:
+            logger.debug(f'Pod {pod.metadata.name} is terminated, but '
+                         'query_instances is called with '
+                         f'non_terminated_only=True. Phase: {phase}')
+            if phase == 'Failed':
+                reason_for_debug = _get_pod_termination_reason(pod)
+                logger.debug(f'Termination reason: {reason_for_debug}')
             continue
         reason = None
         if phase == 'Failed':


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This will help us debug some issues in flaky k8s environments.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
