### PR TITLE
chore: fix typos in comment

### DIFF
--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -571,7 +571,7 @@ def launch(
                     idle_minutes=idle_minutes_to_autostop,
                     wait_for=wait_for)
             if resource.autostop_config is not None:
-                # For backward-compatbility, get the final autostop config for
+                # For backward-compatibility, get the final autostop config for
                 # admin policy.
                 # TODO(aylei): remove this after 0.12.0
                 down = resource.autostop_config.down

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -933,7 +933,7 @@ class AWS(clouds.Cloud):
         # `aws configure list` as cache key. Different `aws configure list` output
         # can have same aws identity, our assumption is the output would be stable
         # in real world, so the number of cache files would be limited.
-        # TODO(aylei): consider using a more stable cache key and evalute eviction.
+        # TODO(aylei): consider using a more stable cache key and evaluate eviction.
         cache_path = catalog_common.get_catalog_path(
             f'aws/.cache/user-identity-{config_hash}.txt')
         if os.path.exists(cache_path):

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -61,7 +61,7 @@ AVAILABLE_LOCAL_API_SERVER_URLS = [
 
 API_SERVER_CMD = '-m sky.server.server'
 # The client dir on the API server for storing user-specific data, such as file
-# mounts, logs, etc. This dir is empheral and will be cleaned up when the API
+# mounts, logs, etc. This dir is ephemeral and will be cleaned up when the API
 # server is restarted.
 API_SERVER_CLIENT_DIR = pathlib.Path('~/.sky/api_server/clients')
 RETRY_COUNT_ON_TIMEOUT = 3


### PR DESCRIPTION
Corrected misspellings in comment:

- `compatbility` → `compatibility`
- `evalute` → `evaluate`
- `empheral` → `ephemeral`