### PR TITLE
[core] sky status optimization - cache private key content

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -3033,11 +3033,10 @@ def get_clusters(
                     expanded_private_key_path]
             else:
                 with open(expanded_private_key_path, 'r',
-                            encoding='utf-8') as f:
+                          encoding='utf-8') as f:
                     credential['ssh_private_key_content'] = f.read()
-                    cached_private_keys[
-                        expanded_private_key_path] = credential[
-                            'ssh_private_key_content']
+                    cached_private_keys[expanded_private_key_path] = credential[
+                        'ssh_private_key_content']
             record['credentials'] = credential
 
     def _update_records_with_resources(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
By cacheing the private key content during `_update_records_with_credentials_and_resources_str`, we avoid the need to re-read the file we've already read. This happens when there are multiple clusters belonging to the same user.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
