### PR TITLE
[chore] move yaml utilities to yaml_utils.py

### DIFF
--- a/sky/admin_policy.py
+++ b/sky/admin_policy.py
@@ -13,6 +13,7 @@ from sky.adaptors import common as adaptors_common
 from sky.utils import common_utils
 from sky.utils import config_utils
 from sky.utils import ux_utils
+from sky.utils import yaml_utils
 
 if typing.TYPE_CHECKING:
     import requests
@@ -80,9 +81,9 @@ class UserRequest:
 
     def encode(self) -> str:
         return _UserRequestBody(
-            task=common_utils.dump_yaml_str(self.task.to_yaml_config()),
-            skypilot_config=common_utils.dump_yaml_str(
-                dict(self.skypilot_config)),
+            task=yaml_utils.dump_yaml_str(self.task.to_yaml_config()),
+            skypilot_config=yaml_utils.dump_yaml_str(dict(
+                self.skypilot_config)),
             request_options=self.request_options,
             at_client_side=self.at_client_side,
         ).model_dump_json()
@@ -92,9 +93,9 @@ class UserRequest:
         user_request_body = _UserRequestBody.model_validate_json(body)
         return cls(
             task=sky.Task.from_yaml_config(
-                common_utils.read_yaml_all_str(user_request_body.task)[0]),
+                yaml_utils.read_yaml_all_str(user_request_body.task)[0]),
             skypilot_config=config_utils.Config.from_dict(
-                common_utils.read_yaml_all_str(
+                yaml_utils.read_yaml_all_str(
                     user_request_body.skypilot_config)[0]),
             request_options=user_request_body.request_options,
             at_client_side=user_request_body.at_client_side,
@@ -116,9 +117,9 @@ class MutatedUserRequest:
 
     def encode(self) -> str:
         return _MutatedUserRequestBody(
-            task=common_utils.dump_yaml_str(self.task.to_yaml_config()),
-            skypilot_config=common_utils.dump_yaml_str(
-                dict(self.skypilot_config),)).model_dump_json()
+            task=yaml_utils.dump_yaml_str(self.task.to_yaml_config()),
+            skypilot_config=yaml_utils.dump_yaml_str(dict(
+                self.skypilot_config),)).model_dump_json()
 
     @classmethod
     def decode(cls, mutated_user_request_body: str,
@@ -126,14 +127,14 @@ class MutatedUserRequest:
         mutated_user_request_body = _MutatedUserRequestBody.model_validate_json(
             mutated_user_request_body)
         task = sky.Task.from_yaml_config(
-            common_utils.read_yaml_all_str(mutated_user_request_body.task)[0])
+            yaml_utils.read_yaml_all_str(mutated_user_request_body.task)[0])
         # Some internal Task fields are not serialized. We need to manually
         # restore them from the original request.
         task.managed_job_dag = original_request.task.managed_job_dag
         task.service_name = original_request.task.service_name
         return cls(task=task,
                    skypilot_config=config_utils.Config.from_dict(
-                       common_utils.read_yaml_all_str(
+                       yaml_utils.read_yaml_all_str(
                            mutated_user_request_body.skypilot_config)[0],))
 
 

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -198,7 +198,7 @@ def configure_ssh_info(config: Dict[str, Any]) -> Dict[str, Any]:
     _, public_key_path = get_or_generate_keys()
     with open(public_key_path, 'r', encoding='utf-8') as f:
         public_key = f.read().strip()
-    config_str = common_utils.dump_yaml_str(config)
+    config_str = yaml_utils.dump_yaml_str(config)
     config_str = config_str.replace('skypilot:ssh_user',
                                     config['auth']['ssh_user'])
     config_str = config_str.replace('skypilot:ssh_public_key_content',

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -241,7 +241,7 @@ def _optimize_file_mounts(tmp_yaml_path: str) -> None:
         subprocess.CalledProcessError: If the file mounts are failed to be
             copied.
     """
-    yaml_config = common_utils.read_yaml(tmp_yaml_path)
+    yaml_config = yaml_utils.read_yaml(tmp_yaml_path)
 
     file_mounts = yaml_config.get('file_mounts', {})
     # Remove the file mounts added by the newline.
@@ -325,7 +325,7 @@ def _optimize_file_mounts(tmp_yaml_path: str) -> None:
             shell=True,
             check=True)
 
-    common_utils.dump_yaml(tmp_yaml_path, yaml_config)
+    yaml_utils.dump_yaml(tmp_yaml_path, yaml_config)
 
 
 def path_size_megabytes(path: str) -> int:
@@ -510,7 +510,7 @@ def _replace_yaml_dicts(
         for key in exclude_restore_key_name[:-1]:
             curr = curr[key]
         curr[exclude_restore_key_name[-1]] = value
-    return common_utils.dump_yaml_str(new_config)
+    return yaml_utils.dump_yaml_str(new_config)
 
 
 def get_expirable_clouds(
@@ -937,7 +937,7 @@ def write_cluster_config(
             tmp_yaml_path,
             cluster_config_overrides=cluster_config_overrides,
             context=region.name)
-        yaml_obj = common_utils.read_yaml(tmp_yaml_path)
+        yaml_obj = yaml_utils.read_yaml(tmp_yaml_path)
         pod_config: Dict[str, Any] = yaml_obj['available_node_types'][
             'ray_head_default']['node_config']
 
@@ -976,7 +976,7 @@ def write_cluster_config(
     # Read the cluster name from the tmp yaml file, to take the backward
     # compatbility restortion above into account.
     # TODO: remove this after 2 minor releases, 0.10.0.
-    yaml_config = common_utils.read_yaml(tmp_yaml_path)
+    yaml_config = yaml_utils.read_yaml(tmp_yaml_path)
     config_dict['cluster_name_on_cloud'] = yaml_config['cluster_name']
 
     # Make sure to do this before we optimize file mounts. Optimization is
@@ -1022,7 +1022,7 @@ def _add_auth_to_cluster_config(cloud: clouds.Cloud, tmp_yaml_path: str):
 
     This function's output removes comments included in the jinja2 template.
     """
-    config = common_utils.read_yaml(tmp_yaml_path)
+    config = yaml_utils.read_yaml(tmp_yaml_path)
     # Check the availability of the cloud type.
     if isinstance(cloud, (
             clouds.AWS,
@@ -1054,7 +1054,7 @@ def _add_auth_to_cluster_config(cloud: clouds.Cloud, tmp_yaml_path: str):
         config = auth.setup_hyperbolic_authentication(config)
     else:
         assert False, cloud
-    common_utils.dump_yaml(tmp_yaml_path, config)
+    yaml_utils.dump_yaml(tmp_yaml_path, config)
 
 
 def get_timestamp_from_run_timestamp(run_timestamp: str) -> float:
@@ -1156,7 +1156,7 @@ def _deterministic_cluster_yaml_hash(tmp_yaml_path: str) -> str:
     """
 
     # Load the yaml contents so that we can directly remove keys.
-    yaml_config = common_utils.read_yaml(tmp_yaml_path)
+    yaml_config = yaml_utils.read_yaml(tmp_yaml_path)
     for key_list in _RAY_YAML_KEYS_TO_REMOVE_FOR_HASH:
         dict_to_remove_from = yaml_config
         found_key = True
@@ -1175,7 +1175,7 @@ def _deterministic_cluster_yaml_hash(tmp_yaml_path: str) -> str:
     config_hash = hashlib.sha256()
 
     yaml_hash = hashlib.sha256(
-        common_utils.dump_yaml_str(yaml_config).encode('utf-8'))
+        yaml_utils.dump_yaml_str(yaml_config).encode('utf-8'))
     config_hash.update(yaml_hash.digest())
 
     file_mounts = yaml_config.get('file_mounts', {})

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1972,7 +1972,7 @@ class RetryingVmProvisioner(object):
                 ray_config = global_user_state.get_cluster_yaml_dict(
                     cluster_config_file)
                 ray_config['upscaling_speed'] = 0
-                common_utils.dump_yaml(cluster_config_file, ray_config)
+                yaml_utils.dump_yaml(cluster_config_file, ray_config)
                 start = time.time()
                 returncode, stdout, stderr = ray_up()
                 logger.debug(
@@ -4649,7 +4649,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                                              prefix='sky_',
                                              delete=False,
                                              suffix='.yml') as f:
-                common_utils.dump_yaml(f.name, config)
+                yaml_utils.dump_yaml(f.name, config)
                 f.flush()
 
                 teardown_verb = 'Terminating' if terminate else 'Stopping'

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -53,6 +53,7 @@ from sky.utils import rich_utils
 from sky.utils import status_lib
 from sky.utils import subprocess_utils
 from sky.utils import ux_utils
+from sky.utils import yaml_utils
 from sky.utils.kubernetes import ssh_utils
 
 if typing.TYPE_CHECKING:
@@ -2332,7 +2333,7 @@ def _save_config_updates(endpoint: Optional[str] = None,
             config['api_server'][
                 'service_account_token'] = service_account_token
 
-        common_utils.dump_yaml(str(config_path), config)
+        yaml_utils.dump_yaml(str(config_path), config)
         skypilot_config.reload_config()
 
 
@@ -2348,7 +2349,7 @@ def _clear_api_server_config() -> None:
         config = dict(config)
         del config['api_server']
 
-        common_utils.dump_yaml(str(config_path), config, blank=True)
+        yaml_utils.dump_yaml(str(config_path), config, blank=True)
         skypilot_config.reload_config()
 
 

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -595,7 +595,7 @@ def add_or_update_cluster(cluster_name: str,
         if (is_launch and not cluster_row or
                 cluster_row.status != status_lib.ClusterStatus.UP.value):
             conditional_values.update({
-                'last_creation_yaml': common_utils.dump_yaml_str(task_config)
+                'last_creation_yaml': yaml_utils.dump_yaml_str(task_config)
                                       if task_config else None,
                 'last_creation_command': last_use,
             })

--- a/sky/logs/agent.py
+++ b/sky/logs/agent.py
@@ -5,8 +5,8 @@ import shlex
 from typing import Any, Dict
 
 from sky.skylet import constants
-from sky.utils import common_utils
 from sky.utils import resources_utils
+from sky.utils import yaml_utils
 
 
 class LoggingAgent(abc.ABC):
@@ -65,7 +65,7 @@ class FluentbitAgent(LoggingAgent):
                 'outputs': [self.fluentbit_output_config(cluster_name)],
             }
         }
-        return common_utils.dump_yaml_str(cfg_dict)
+        return yaml_utils.dump_yaml_str(cfg_dict)
 
     @abc.abstractmethod
     def fluentbit_output_config(

--- a/sky/logs/aws.py
+++ b/sky/logs/aws.py
@@ -6,8 +6,8 @@ import pydantic
 
 from sky.logs.agent import FluentbitAgent
 from sky.skylet import constants
-from sky.utils import common_utils
 from sky.utils import resources_utils
+from sky.utils import yaml_utils
 
 EC2_MD_URL = '"${AWS_EC2_METADATA_SERVICE_ENDPOINT:-http://169.254.169.254/}"'
 
@@ -213,7 +213,7 @@ class CloudwatchLoggingAgent(FluentbitAgent):
             }
         }
 
-        return common_utils.dump_yaml_str(cfg_dict)
+        return yaml_utils.dump_yaml_str(cfg_dict)
 
     def fluentbit_output_config(
             self, cluster_name: resources_utils.ClusterName) -> Dict[str, Any]:

--- a/sky/provision/do/utils.py
+++ b/sky/provision/do/utils.py
@@ -17,6 +17,7 @@ from sky.provision import constants as provision_constants
 from sky.provision.do import constants
 from sky.utils import annotations
 from sky.utils import common_utils
+from sky.utils import yaml_utils
 
 logger = sky_logging.init_logger(__name__)
 
@@ -61,7 +62,7 @@ def _init_client():
     if get_credentials_path() is None:
         raise DigitalOceanError(
             'No credentials found, please run `doctl auth init`')
-    credentials = common_utils.read_yaml(get_credentials_path())
+    credentials = yaml_utils.read_yaml(get_credentials_path())
     default_token = credentials.get('access-token', None)
     if default_token is not None:
         try:

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2782,7 +2782,7 @@ def combine_pod_config_fields(
         kubernetes_config)
 
     # Write the updated YAML back to the file
-    common_utils.dump_yaml(cluster_yaml_path, yaml_obj)
+    yaml_utils.dump_yaml(cluster_yaml_path, yaml_obj)
 
 
 def combine_metadata_fields(cluster_yaml_path: str,
@@ -2834,7 +2834,7 @@ def combine_metadata_fields(cluster_yaml_path: str,
         config_utils.merge_k8s_configs(destination, custom_metadata)
 
     # Write the updated YAML back to the file
-    common_utils.dump_yaml(cluster_yaml_path, yaml_obj)
+    yaml_utils.dump_yaml(cluster_yaml_path, yaml_obj)
 
 
 def merge_custom_metadata(

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -37,6 +37,7 @@ from sky.utils import env_options
 from sky.utils import resources_utils
 from sky.utils import status_lib
 from sky.utils import ux_utils
+from sky.utils import yaml_utils
 
 if typing.TYPE_CHECKING:
     from sky.serve import service_spec
@@ -79,7 +80,7 @@ def launch_cluster(replica_id: int,
                     f'{cluster_name} with resources override: '
                     f'{resources_override}')
     try:
-        config = common_utils.read_yaml(
+        config = yaml_utils.read_yaml(
             os.path.expanduser(service_task_yaml_path))
         task = task_lib.Task.from_yaml_config(config)
         if resources_override is not None:
@@ -1397,7 +1398,7 @@ class SkyPilotReplicaManager(ReplicaManager):
         # the latest version. This can significantly improve the speed
         # for updating an existing service with only config changes to the
         # service specs, e.g. scale down the service.
-        new_config = common_utils.read_yaml(
+        new_config = yaml_utils.read_yaml(
             os.path.expanduser(service_task_yaml_path))
         # Always create new replicas and scale down old ones when file_mounts
         # are not empty.
@@ -1414,7 +1415,7 @@ class SkyPilotReplicaManager(ReplicaManager):
                 old_service_task_yaml_path = (
                     serve_utils.generate_task_yaml_file_name(
                         self._service_name, info.version))
-                old_config = common_utils.read_yaml(
+                old_config = yaml_utils.read_yaml(
                     os.path.expanduser(old_service_task_yaml_path))
                 for key in ['service', 'pool', '_user_specified_yaml']:
                     old_config.pop(key, None)

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -699,7 +699,7 @@ def _get_service_status(
     if record['pool']:
         latest_yaml_path = generate_task_yaml_file_name(service_name,
                                                         record['version'])
-        raw_yaml_config = common_utils.read_yaml(latest_yaml_path)
+        raw_yaml_config = yaml_utils.read_yaml(latest_yaml_path)
         original_config = raw_yaml_config.get('_user_specified_yaml')
         if original_config is None:
             # Fall back to old display format.
@@ -711,7 +711,7 @@ def _get_service_status(
                 original_config['pool'] = svc  # Add pool to root config
         else:
             original_config = yaml_utils.safe_load(original_config)
-        record['pool_yaml'] = common_utils.dump_yaml_str(original_config)
+        record['pool_yaml'] = yaml_utils.dump_yaml_str(original_config)
 
     record['target_num_replicas'] = 0
     try:

--- a/sky/serve/server/impl.py
+++ b/sky/serve/server/impl.py
@@ -34,6 +34,7 @@ from sky.utils import dag_utils
 from sky.utils import rich_utils
 from sky.utils import subprocess_utils
 from sky.utils import ux_utils
+from sky.utils import yaml_utils
 
 logger = sky_logging.init_logger(__name__)
 
@@ -179,7 +180,7 @@ def up(
         controller = controller_utils.get_controller_for_pool(pool)
         controller_name = controller.value.cluster_name
         task_config = task.to_yaml_config()
-        common_utils.dump_yaml(service_file.name, task_config)
+        yaml_utils.dump_yaml(service_file.name, task_config)
         remote_tmp_task_yaml_path = (
             serve_utils.generate_remote_tmp_task_yaml_file_name(service_name))
         remote_config_yaml_path = (
@@ -531,7 +532,7 @@ def update(
             prefix=f'{service_name}-v{current_version}',
             mode='w') as service_file:
         task_config = task.to_yaml_config()
-        common_utils.dump_yaml(service_file.name, task_config)
+        yaml_utils.dump_yaml(service_file.name, task_config)
         remote_task_yaml_path = serve_utils.generate_task_yaml_file_name(
             service_name, current_version, expand_user=False)
 

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -41,6 +41,7 @@ from sky.utils import annotations
 from sky.utils import common_utils
 from sky.utils import rich_utils
 from sky.utils import ux_utils
+from sky.utils import yaml_utils
 
 if typing.TYPE_CHECKING:
     import aiohttp
@@ -816,7 +817,7 @@ def process_mounts_in_task_on_api_server(task: str, env_vars: Dict[str, str],
         return str(client_file_mounts_dir /
                    file_mounts_mapping[original_path].lstrip('/'))
 
-    task_configs = common_utils.read_yaml_all(str(client_task_path))
+    task_configs = yaml_utils.read_yaml_all(str(client_task_path))
     for task_config in task_configs:
         if task_config is None:
             continue
@@ -869,7 +870,7 @@ def process_mounts_in_task_on_api_server(task: str, env_vars: Dict[str, str],
     # We can switch to using string, but this is to make it easier to debug, by
     # persisting the translated task yaml file.
     translated_client_task_path = client_dir / f'{task_id}_translated.yaml'
-    common_utils.dump_yaml(str(translated_client_task_path), task_configs)
+    yaml_utils.dump_yaml(str(translated_client_task_path), task_configs)
 
     dag = dag_utils.load_chain_dag_from_yaml(str(translated_client_task_path))
     return dag

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -55,6 +55,7 @@ from sky.utils import context_utils
 from sky.utils import subprocess_utils
 from sky.utils import tempstore
 from sky.utils import timeline
+from sky.utils import yaml_utils
 from sky.workspaces import core as workspaces_core
 
 if typing.TYPE_CHECKING:
@@ -387,7 +388,7 @@ def _request_execution_wrapper(request_id: str,
                 if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
                     config = skypilot_config.to_dict()
                     logger.debug(f'request config: \n'
-                                 f'{common_utils.dump_yaml_str(dict(config))}')
+                                 f'{yaml_utils.dump_yaml_str(dict(config))}')
                 return_value = func(**request_body.to_kwargs())
                 f.flush()
         except KeyboardInterrupt:

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -20,7 +20,6 @@ from sky.skylet import constants
 from sky.skylet import job_lib
 from sky.usage import usage_lib
 from sky.utils import cluster_utils
-from sky.utils import common_utils
 from sky.utils import registry
 from sky.utils import ux_utils
 from sky.utils import yaml_utils
@@ -181,7 +180,7 @@ class AutostopEvent(SkyletEvent):
 
             config_path = os.path.abspath(
                 os.path.expanduser(cluster_utils.SKY_CLUSTER_YAML_REMOTE_PATH))
-            config = common_utils.read_yaml(config_path)
+            config = yaml_utils.read_yaml(config_path)
             provider_name = cluster_utils.get_provider_name(config)
             cloud = registry.CLOUD_REGISTRY.from_str(provider_name)
             assert cloud is not None, f'Unknown cloud: {provider_name}'
@@ -326,5 +325,5 @@ class AutostopEvent(SkyletEvent):
         config['auth'].pop('ssh_proxy_command', None)
         # Empty the file_mounts.
         config['file_mounts'] = {}
-        common_utils.dump_yaml(yaml_path, config)
+        yaml_utils.dump_yaml(yaml_path, config)
         logger.debug('Replaced upscaling speed to 0.')

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -494,7 +494,7 @@ def reload_config() -> None:
 def parse_and_validate_config_file(config_path: str) -> config_utils.Config:
     config = config_utils.Config()
     try:
-        config_dict = common_utils.read_yaml(config_path)
+        config_dict = yaml_utils.read_yaml(config_path)
         config = config_utils.Config.from_dict(config_dict)
         # pop the db url from the config, and set it to the env var.
         # this is to avoid db url (considered a sensitive value)
@@ -504,7 +504,7 @@ def parse_and_validate_config_file(config_path: str) -> config_utils.Config:
             os.environ[constants.ENV_VAR_DB_CONNECTION_URI] = db_url
         if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
             logger.debug(f'Config loaded from {config_path}:\n'
-                         f'{common_utils.dump_yaml_str(dict(config))}')
+                         f'{yaml_utils.dump_yaml_str(dict(config))}')
     except yaml.YAMLError as e:
         logger.error(f'Error in loading config file ({config_path}):', e)
     if config:
@@ -600,7 +600,7 @@ def _reload_config_as_server() -> None:
             sqlalchemy_engine.dispose()
     if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
         logger.debug(f'server config: \n'
-                     f'{common_utils.dump_yaml_str(dict(server_config))}')
+                     f'{yaml_utils.dump_yaml_str(dict(server_config))}')
     _set_loaded_config(server_config)
     _set_loaded_config_path(server_config_path)
 
@@ -628,7 +628,7 @@ def _reload_config_as_client() -> None:
     if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
         logger.debug(
             f'client config (before task and CLI overrides): \n'
-            f'{common_utils.dump_yaml_str(dict(overlaid_client_config))}')
+            f'{yaml_utils.dump_yaml_str(dict(overlaid_client_config))}')
     _set_loaded_config(overlaid_client_config)
     _set_loaded_config_path([user_config_path, project_config_path])
 
@@ -738,9 +738,9 @@ def override_skypilot_config(
                 'Failed to override the SkyPilot config on API '
                 'server with your local SkyPilot config:\n'
                 '=== SkyPilot config on API server ===\n'
-                f'{common_utils.dump_yaml_str(dict(original_config))}\n'
+                f'{yaml_utils.dump_yaml_str(dict(original_config))}\n'
                 '=== Your local SkyPilot config ===\n'
-                f'{common_utils.dump_yaml_str(dict(override_configs))}\n'
+                f'{yaml_utils.dump_yaml_str(dict(override_configs))}\n'
                 f'Details: {e}') from e
     finally:
         _set_loaded_config(original_config)
@@ -767,7 +767,7 @@ def replace_skypilot_config(new_configs: config_utils.Config) -> Iterator[None]:
                                          mode='w',
                                          prefix='mutated-skypilot-config-',
                                          suffix='.yaml') as temp_file:
-            common_utils.dump_yaml(temp_file.name, dict(**new_configs))
+            yaml_utils.dump_yaml(temp_file.name, dict(**new_configs))
         # Modify the env var of current process or context so that the
         # new config will be used by spawned sub-processes.
         # Note that this code modifies os.environ directly because it
@@ -831,7 +831,7 @@ def apply_cli_config(cli_config: Optional[List[str]]) -> Dict[str, Any]:
     parsed_config = _compose_cli_config(cli_config)
     if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
         logger.debug(f'applying following CLI overrides: \n'
-                     f'{common_utils.dump_yaml_str(dict(parsed_config))}')
+                     f'{yaml_utils.dump_yaml_str(dict(parsed_config))}')
     _set_loaded_config(
         overlay_skypilot_config(original_config=_get_loaded_config(),
                                 override_configs=parsed_config))
@@ -875,7 +875,7 @@ def update_api_server_config_no_lock(config: config_utils.Config) -> None:
                 def _set_config_yaml_to_db(key: str,
                                            config: config_utils.Config):
                     assert sqlalchemy_engine is not None
-                    config_str = common_utils.dump_yaml_str(dict(config))
+                    config_str = yaml_utils.dump_yaml_str(dict(config))
                     with orm.Session(sqlalchemy_engine) as session:
                         if (sqlalchemy_engine.dialect.name ==
                                 db_utils.SQLAlchemyDialect.SQLITE.value):
@@ -901,7 +901,7 @@ def update_api_server_config_no_lock(config: config_utils.Config) -> None:
 
     if not db_updated:
         # save to the local file (PVC in Kubernetes, local file otherwise)
-        common_utils.dump_yaml(global_config_path, dict(config))
+        yaml_utils.dump_yaml(global_config_path, dict(config))
 
         if config_map_utils.is_running_in_kubernetes():
             # In Kubernetes, sync the PVC config to ConfigMap for user

--- a/sky/task.py
+++ b/sky/task.py
@@ -564,7 +564,7 @@ class Task:
         secrets_overrides: Optional[List[Tuple[str, str]]] = None,
     ) -> 'Task':
         user_specified_yaml = config.pop('_user_specified_yaml',
-                                         common_utils.dump_yaml_str(config))
+                                         yaml_utils.dump_yaml_str(config))
         # More robust handling for 'envs': explicitly convert keys and values to
         # str, since users may pass '123' as keys/values which will get parsed
         # as int causing validate_schema() to fail.

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -19,6 +19,7 @@ from sky.usage import constants
 from sky.utils import common_utils
 from sky.utils import env_options
 from sky.utils import ux_utils
+from sky.utils import yaml_utils
 
 if typing.TYPE_CHECKING:
     import inspect
@@ -402,7 +403,7 @@ def _clean_yaml(yaml_info: Dict[str, Optional[str]]):
                     contents = inspect.getsource(contents)
 
                 if type(contents) in constants.USAGE_MESSAGE_REDACT_TYPES:
-                    lines = common_utils.dump_yaml_str({
+                    lines = yaml_utils.dump_yaml_str({
                         redact_type: contents
                     }).strip().split('\n')
                     message = (f'{len(lines)} lines {redact_type.upper()}'
@@ -431,7 +432,7 @@ def prepare_json_from_yaml_config(
         with open(yaml_config_or_path, 'r', encoding='utf-8') as f:
             lines = f.readlines()
             comment_lines = [line for line in lines if line.startswith('#')]
-        yaml_info = common_utils.read_yaml_all(yaml_config_or_path)
+        yaml_info = yaml_utils.read_yaml_all(yaml_config_or_path)
 
     for i in range(len(yaml_info)):
         if yaml_info[i] is None:

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -6,7 +6,6 @@ import functools
 import getpass
 import hashlib
 import inspect
-import io
 import os
 import platform
 import random
@@ -30,16 +29,13 @@ from sky.usage import constants as usage_constants
 from sky.utils import annotations
 from sky.utils import ux_utils
 from sky.utils import validator
-from sky.utils import yaml_utils
 
 if typing.TYPE_CHECKING:
     import jinja2
     import psutil
-    import yaml
 else:
     jinja2 = adaptors_common.LazyImport('jinja2')
     psutil = adaptors_common.LazyImport('psutil')
-    yaml = adaptors_common.LazyImport('yaml')
 
 USER_HASH_FILE = os.path.expanduser('~/.sky/user_hash')
 USER_HASH_LENGTH = 8
@@ -572,92 +568,6 @@ def user_and_hostname_hash() -> str:
     """
     hostname_hash = hashlib.md5(socket.gethostname().encode()).hexdigest()[-4:]
     return f'{getpass.getuser()}-{hostname_hash}'
-
-
-def read_yaml(path: Optional[str]) -> Dict[str, Any]:
-    if path is None:
-        raise ValueError('Attempted to read a None YAML.')
-    with open(path, 'r', encoding='utf-8') as f:
-        config = yaml_utils.safe_load(f)
-    return config
-
-
-def read_yaml_all_str(yaml_str: str) -> List[Dict[str, Any]]:
-    stream = io.StringIO(yaml_str)
-    config = yaml_utils.safe_load_all(stream)
-    configs = list(config)
-    if not configs:
-        # Empty YAML file.
-        return [{}]
-    return configs
-
-
-def read_yaml_all(path: str) -> List[Dict[str, Any]]:
-    with open(path, 'r', encoding='utf-8') as f:
-        return read_yaml_all_str(f.read())
-
-
-def dump_yaml(path: str,
-              config: Union[List[Dict[str, Any]], Dict[str, Any]],
-              blank: bool = False) -> None:
-    """Dumps a YAML file.
-
-    Args:
-        path: the path to the YAML file.
-        config: the configuration to dump.
-    """
-    with open(path, 'w', encoding='utf-8') as f:
-        contents = dump_yaml_str(config)
-        if blank and isinstance(config, dict) and len(config) == 0:
-            # when dumping to yaml, an empty dict will go in as {}.
-            contents = ''
-        f.write(contents)
-
-
-def dump_yaml_str(config: Union[List[Dict[str, Any]], Dict[str, Any]]) -> str:
-    """Dumps a YAML string.
-
-    Args:
-        config: the configuration to dump.
-
-    Returns:
-        The YAML string.
-    """
-
-    if isinstance(config, list):
-        dump_func = yaml.dump_all  # type: ignore
-    else:
-        dump_func = yaml.dump  # type: ignore
-
-    try:
-        # pylint: disable=import-outside-toplevel
-        from yaml import CSafeDumper
-
-        # https://github.com/yaml/pyyaml/issues/127
-        class CLineBreakDumper(CSafeDumper):
-
-            def write_line_break(self, data=None):
-                super().write_line_break(data)
-                if len(self.indents) == 1:
-                    super().write_line_break()
-
-        return dump_func(config,
-                         Dumper=CLineBreakDumper,
-                         sort_keys=False,
-                         default_flow_style=False)
-    except ImportError:
-        # https://github.com/yaml/pyyaml/issues/127
-        class LineBreakDumper(yaml.SafeDumper):
-
-            def write_line_break(self, data=None):
-                super().write_line_break(data)
-                if len(self.indents) == 1:
-                    super().write_line_break()
-
-        return dump_func(config,
-                         Dumper=LineBreakDumper,
-                         sort_keys=False,
-                         default_flow_style=False)
 
 
 def make_decorator(cls, name_or_fn: Union[str, Callable],

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -38,6 +38,7 @@ from sky.utils import env_options
 from sky.utils import registry
 from sky.utils import rich_utils
 from sky.utils import ux_utils
+from sky.utils import yaml_utils
 
 if typing.TYPE_CHECKING:
     import psutil
@@ -497,7 +498,7 @@ def shared_controller_vars_to_fill(
         with tempfile.NamedTemporaryFile(
                 delete=False,
                 suffix=_LOCAL_SKYPILOT_CONFIG_PATH_SUFFIX) as temp_file:
-            common_utils.dump_yaml(temp_file.name, dict(**local_user_config))
+            yaml_utils.dump_yaml(temp_file.name, dict(**local_user_config))
         local_user_config_path = temp_file.name
 
     vars_to_fill: Dict[str, Any] = {
@@ -786,9 +787,9 @@ def replace_skypilot_config_path_in_file_mounts(
             continue
         if local_path.endswith(_LOCAL_SKYPILOT_CONFIG_PATH_SUFFIX):
             with tempfile.NamedTemporaryFile('w', delete=False) as f:
-                user_config = common_utils.read_yaml(local_path)
+                user_config = yaml_utils.read_yaml(local_path)
                 config = _setup_proxy_command_on_controller(cloud, user_config)
-                common_utils.dump_yaml(f.name, dict(**config))
+                yaml_utils.dump_yaml(f.name, dict(**config))
                 file_mounts[remote_path] = f.name
                 replaced = True
     if replaced:

--- a/sky/utils/dag_utils.py
+++ b/sky/utils/dag_utils.py
@@ -6,9 +6,9 @@ from sky import dag as dag_lib
 from sky import sky_logging
 from sky import task as task_lib
 from sky.utils import cluster_utils
-from sky.utils import common_utils
 from sky.utils import registry
 from sky.utils import ux_utils
+from sky.utils import yaml_utils
 
 logger = sky_logging.init_logger(__name__)
 
@@ -117,7 +117,7 @@ def load_chain_dag_from_yaml(
       A chain Dag with 1 or more tasks (an empty entrypoint would create a
       trivial task).
     """
-    configs = common_utils.read_yaml_all(path)
+    configs = yaml_utils.read_yaml_all(path)
     return _load_chain_dag(configs, env_overrides, secret_overrides)
 
 
@@ -143,7 +143,7 @@ def load_chain_dag_from_yaml_str(
       A chain Dag with 1 or more tasks (an empty entrypoint would create a
       trivial task).
     """
-    configs = common_utils.read_yaml_all_str(yaml_str)
+    configs = yaml_utils.read_yaml_all_str(yaml_str)
     return _load_chain_dag(configs, env_overrides, secrets_overrides)
 
 
@@ -164,7 +164,7 @@ def dump_chain_dag_to_yaml_str(dag: dag_lib.Dag,
         configs.append(
             task.to_yaml_config(
                 use_user_specified_yaml=use_user_specified_yaml))
-    return common_utils.dump_yaml_str(configs)
+    return yaml_utils.dump_yaml_str(configs)
 
 
 def dump_chain_dag_to_yaml(dag: dag_lib.Dag, path: str) -> None:

--- a/sky/utils/kubernetes/config_map_utils.py
+++ b/sky/utils/kubernetes/config_map_utils.py
@@ -4,7 +4,7 @@ import os
 from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import kubernetes
-from sky.utils import common_utils
+from sky.utils import yaml_utils
 
 logger = sky_logging.init_logger(__name__)
 
@@ -69,7 +69,7 @@ def initialize_configmap_sync_on_startup(config_file_path: str) -> None:
 
         current_config = skypilot_config.parse_and_validate_config_file(
             config_file_path)
-        config_yaml = common_utils.dump_yaml_str(dict(current_config))
+        config_yaml = yaml_utils.dump_yaml_str(dict(current_config))
 
         configmap_body = {
             'apiVersion': 'v1',
@@ -111,7 +111,7 @@ def patch_configmap_with_config(config, config_file_path: str) -> None:
     try:
         namespace = _get_kubernetes_namespace()
         configmap_name = _get_configmap_name()
-        config_yaml = common_utils.dump_yaml_str(dict(config))
+        config_yaml = yaml_utils.dump_yaml_str(dict(config))
         patch_body = {'data': {'config.yaml': config_yaml}}
 
         try:

--- a/sky/utils/yaml_utils.py
+++ b/sky/utils/yaml_utils.py
@@ -78,19 +78,11 @@ def dump_yaml(path: str,
 
 def dump_yaml_str(config: Union[List[Dict[str, Any]], Dict[str, Any]]) -> str:
     """Dumps a YAML string.
-
     Args:
         config: the configuration to dump.
-
     Returns:
         The YAML string.
     """
-    global _c_extension_unavailable
-
-    if isinstance(config, list):
-        dump_func = yaml.dump_all  # type: ignore
-    else:
-        dump_func = yaml.dump  # type: ignore
 
     # https://github.com/yaml/pyyaml/issues/127
     class LineBreakDumper(yaml.SafeDumper):
@@ -100,28 +92,11 @@ def dump_yaml_str(config: Union[List[Dict[str, Any]], Dict[str, Any]]) -> str:
             if len(self.indents) == 1:
                 super().write_line_break()
 
-    if _c_extension_unavailable:
-        return dump_func(config,
-                         Dumper=LineBreakDumper,
-                         sort_keys=False,
-                         default_flow_style=False)
-
-    try:
-        # https://github.com/yaml/pyyaml/issues/127
-        class CLineBreakDumper(yaml.CSafeDumper):
-
-            def write_line_break(self, data=None):
-                super().write_line_break(data)
-                if len(self.indents) == 1:
-                    super().write_line_break()
-
-        return dump_func(config,
-                         Dumper=CLineBreakDumper,
-                         sort_keys=False,
-                         default_flow_style=False)
-    except AttributeError:
-        _c_extension_unavailable = True
-        return dump_func(config,
-                         Dumper=LineBreakDumper,
-                         sort_keys=False,
-                         default_flow_style=False)
+    if isinstance(config, list):
+        dump_func = yaml.dump_all  # type: ignore
+    else:
+        dump_func = yaml.dump  # type: ignore
+    return dump_func(config,
+                     Dumper=LineBreakDumper,
+                     sort_keys=False,
+                     default_flow_style=False)

--- a/sky/utils/yaml_utils.py
+++ b/sky/utils/yaml_utils.py
@@ -1,5 +1,6 @@
 """YAML utilities."""
-from typing import Any, TYPE_CHECKING
+import io
+from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
 
 from sky.adaptors import common
 
@@ -8,28 +9,119 @@ if TYPE_CHECKING:
 else:
     yaml = common.LazyImport('yaml')
 
-_csafe_loader_unavailable = False
+_c_extension_unavailable = False
 
 
 def safe_load(stream) -> Any:
-    global _csafe_loader_unavailable
-    if _csafe_loader_unavailable:
+    global _c_extension_unavailable
+    if _c_extension_unavailable:
         return yaml.load(stream, Loader=yaml.SafeLoader)
 
     try:
         return yaml.load(stream, Loader=yaml.CSafeLoader)
     except AttributeError:
-        _csafe_loader_unavailable = True
+        _c_extension_unavailable = True
         return yaml.load(stream, Loader=yaml.SafeLoader)
 
 
 def safe_load_all(stream) -> Any:
-    global _csafe_loader_unavailable
-    if _csafe_loader_unavailable:
+    global _c_extension_unavailable
+    if _c_extension_unavailable:
         return yaml.load_all(stream, Loader=yaml.SafeLoader)
 
     try:
         return yaml.load_all(stream, Loader=yaml.CSafeLoader)
     except AttributeError:
-        _csafe_loader_unavailable = True
+        _c_extension_unavailable = True
         return yaml.load_all(stream, Loader=yaml.SafeLoader)
+
+
+def read_yaml(path: Optional[str]) -> Dict[str, Any]:
+    if path is None:
+        raise ValueError('Attempted to read a None YAML.')
+    with open(path, 'r', encoding='utf-8') as f:
+        config = safe_load(f)
+    return config
+
+
+def read_yaml_all_str(yaml_str: str) -> List[Dict[str, Any]]:
+    stream = io.StringIO(yaml_str)
+    config = safe_load_all(stream)
+    configs = list(config)
+    if not configs:
+        # Empty YAML file.
+        return [{}]
+    return configs
+
+
+def read_yaml_all(path: str) -> List[Dict[str, Any]]:
+    with open(path, 'r', encoding='utf-8') as f:
+        return read_yaml_all_str(f.read())
+
+
+def dump_yaml(path: str,
+              config: Union[List[Dict[str, Any]], Dict[str, Any]],
+              blank: bool = False) -> None:
+    """Dumps a YAML file.
+
+    Args:
+        path: the path to the YAML file.
+        config: the configuration to dump.
+    """
+    with open(path, 'w', encoding='utf-8') as f:
+        contents = dump_yaml_str(config)
+        if blank and isinstance(config, dict) and len(config) == 0:
+            # when dumping to yaml, an empty dict will go in as {}.
+            contents = ''
+        f.write(contents)
+
+
+def dump_yaml_str(config: Union[List[Dict[str, Any]], Dict[str, Any]]) -> str:
+    """Dumps a YAML string.
+
+    Args:
+        config: the configuration to dump.
+
+    Returns:
+        The YAML string.
+    """
+    global _c_extension_unavailable
+
+    if isinstance(config, list):
+        dump_func = yaml.dump_all  # type: ignore
+    else:
+        dump_func = yaml.dump  # type: ignore
+
+    # https://github.com/yaml/pyyaml/issues/127
+    class LineBreakDumper(yaml.SafeDumper):
+
+        def write_line_break(self, data=None):
+            super().write_line_break(data)
+            if len(self.indents) == 1:
+                super().write_line_break()
+
+    if _c_extension_unavailable:
+        return dump_func(config,
+                         Dumper=LineBreakDumper,
+                         sort_keys=False,
+                         default_flow_style=False)
+
+    try:
+        # https://github.com/yaml/pyyaml/issues/127
+        class CLineBreakDumper(yaml.CSafeDumper):
+
+            def write_line_break(self, data=None):
+                super().write_line_break(data)
+                if len(self.indents) == 1:
+                    super().write_line_break()
+
+        return dump_func(config,
+                         Dumper=CLineBreakDumper,
+                         sort_keys=False,
+                         default_flow_style=False)
+    except AttributeError:
+        _c_extension_unavailable = True
+        return dump_func(config,
+                         Dumper=LineBreakDumper,
+                         sort_keys=False,
+                         default_flow_style=False)

--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -33,6 +33,7 @@ from sky.utils import common_utils
 from sky.utils import config_utils
 from sky.utils import env_options
 from sky.utils import subprocess_utils
+from sky.utils import yaml_utils
 
 # To avoid the second smoke test reusing the cluster launched in the first
 # smoke test. Also required for test_managed_jobs_recovery to make sure the
@@ -450,7 +451,7 @@ def override_sky_config(
         original_config = skypilot_config.config_utils.Config()
     overlay_config = skypilot_config.overlay_skypilot_config(
         original_config, override_sky_config_dict)
-    temp_config_file.write(common_utils.dump_yaml_str(dict(overlay_config)))
+    temp_config_file.write(yaml_utils.dump_yaml_str(dict(overlay_config)))
     temp_config_file.flush()
     # Update the environment variable to use the temporary file
     env_dict[skypilot_config.ENV_VAR_GLOBAL_CONFIG] = temp_config_file.name

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -36,6 +36,7 @@ from sky import skypilot_config
 from sky.skylet import constants
 from sky.skylet import events
 from sky.utils import common_utils
+from sky.utils import yaml_utils
 
 
 # ---------- Dry run: 2 Tasks in a chain. ----------
@@ -625,7 +626,7 @@ class TestYamlSpecs:
 
     def _check_equivalent(self, yaml_path):
         """Check if the yaml is equivalent after load and dump again."""
-        origin_task_config = common_utils.read_yaml(yaml_path)
+        origin_task_config = yaml_utils.read_yaml(yaml_path)
 
         task = sky.Task.from_yaml(yaml_path)
         new_task_config = task.to_yaml_config()

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -39,6 +39,7 @@ from sky.data import storage as storage_lib
 from sky.skylet import constants
 from sky.utils import common_utils
 from sky.utils import controller_utils
+from sky.utils import yaml_utils
 
 
 # ---------- Testing managed job ----------
@@ -786,13 +787,13 @@ def test_managed_jobs_retry_logs(generic_cloud: str):
         timeout *= 2
     name = smoke_tests_utils.get_cluster_name()
     yaml_path = 'tests/test_yamls/test_managed_jobs_retry.yaml'
-    yaml_config = common_utils.read_yaml_all(yaml_path)
+    yaml_config = yaml_utils.read_yaml_all(yaml_path)
     for task_config in yaml_config:
         task_config['resources'] = task_config.get('resources', {})
         task_config['resources']['cloud'] = generic_cloud
 
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as yaml_file:
-        common_utils.dump_yaml(yaml_file.name, yaml_config)
+        yaml_utils.dump_yaml(yaml_file.name, yaml_config)
         yaml_path = yaml_file.name
         with tempfile.NamedTemporaryFile(mode='w', suffix='.log') as log_file:
             test = smoke_tests_utils.Test(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,9 +14,9 @@ from sky.server.requests import payloads
 from sky.sky_logging import INFO
 from sky.skylet import constants
 from sky.utils import annotations
-from sky.utils import common_utils
 from sky.utils import config_utils
 from sky.utils import kubernetes_enums
+from sky.utils import yaml_utils
 
 DISK_ENCRYPTED = True
 VPC_NAME = 'vpc-12345678'
@@ -333,7 +333,7 @@ def test_config_get_set_nested(monkeypatch, tmp_path) -> None:
     # Check that dumping the config to a file with the new None can be reloaded
     new_config2 = skypilot_config.set_nested(('aws', 'ssh_proxy_command'), None)
     new_config_path = tmp_path / 'new_config.yaml'
-    common_utils.dump_yaml(new_config_path, new_config2)
+    yaml_utils.dump_yaml(new_config_path, new_config2)
     monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH', new_config_path)
     skypilot_config.reload_config()
     assert skypilot_config.get_nested(('aws', 'vpc_name'), None) == VPC_NAME
@@ -348,7 +348,7 @@ def test_config_get_set_nested(monkeypatch, tmp_path) -> None:
     del new_config3['aws']['ssh_proxy_command']
     del new_config3['aws']['use_internal_ips']
     new_config_path = tmp_path / 'new_config3.yaml'
-    common_utils.dump_yaml(new_config_path, new_config3)
+    yaml_utils.dump_yaml(new_config_path, new_config3)
     monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH', new_config_path)
     skypilot_config.reload_config()
     assert skypilot_config.get_nested(('aws', 'vpc_name'), None) == VPC_NAME
@@ -411,7 +411,7 @@ def test_k8s_config_with_override(monkeypatch, tmp_path,
             tmp_path / (cluster_name + '.yml'))
 
     # Load the cluster YAML
-    cluster_config = common_utils.read_yaml(cluster_yaml)
+    cluster_config = yaml_utils.read_yaml(cluster_yaml)
     head_node_type = cluster_config['head_node_type']
     cluster_pod_config = cluster_config['available_node_types'][head_node_type][
         'node_config']
@@ -468,7 +468,7 @@ def test_gcp_config_with_override(monkeypatch, tmp_path,
             tmp_path / (cluster_name + '.yml'))
 
     # Load the cluster YAML
-    cluster_config = common_utils.read_yaml(cluster_yaml)
+    cluster_config = yaml_utils.read_yaml(cluster_yaml)
     assert cluster_config['provider']['vpc_name'] == VPC_NAME
     assert '-v /tmp:/tmp' in cluster_config['docker'][
         'run_options'], cluster_config

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes.py
@@ -625,7 +625,7 @@ class TestKubernetesSecurityContextMerging(unittest.TestCase):
         self.assertFalse(deploy_vars['tpu_requested'])  # H100 is GPU, not TPU
 
     @patch('sky.utils.yaml_utils.safe_load')
-    @patch('sky.utils.common_utils.dump_yaml')
+    @patch('sky.utils.yaml_utils.dump_yaml')
     @patch('sky.skypilot_config.get_effective_region_config')
     def test_user_security_context_merged_with_ipc_lock_capability(
             self, mock_get_cloud_config_value, mock_dump_yaml, mock_safe_load):
@@ -714,7 +714,7 @@ class TestKubernetesSecurityContextMerging(unittest.TestCase):
                 os.unlink(tmp_path)
 
     @patch('sky.utils.yaml_utils.safe_load')
-    @patch('sky.utils.common_utils.dump_yaml')
+    @patch('sky.utils.yaml_utils.dump_yaml')
     @patch('sky.skypilot_config.get_effective_region_config')
     def test_user_security_context_without_ipc_lock_capability(
             self, mock_get_cloud_config_value, mock_dump_yaml, mock_safe_load):
@@ -797,7 +797,7 @@ class TestKubernetesVolumeMerging(unittest.TestCase):
     """Test cases for merging user-specified volume mounts and volumes with pod_config."""
 
     @patch('sky.utils.yaml_utils.safe_load')
-    @patch('sky.utils.common_utils.dump_yaml')
+    @patch('sky.utils.yaml_utils.dump_yaml')
     @patch('sky.skypilot_config.get_effective_region_config')
     def test_user_volume_mounts_merged_correctly(self,
                                                  mock_get_cloud_config_value,

--- a/tests/unit_tests/test_sky/utils/kubernetes/test_skypilot_config_configmap_sync.py
+++ b/tests/unit_tests/test_sky/utils/kubernetes/test_skypilot_config_configmap_sync.py
@@ -82,7 +82,7 @@ class TestConfigMapSync(unittest.TestCase):
     @mock.patch('sky.utils.kubernetes.config_map_utils.'
                 '_get_kubernetes_namespace')
     @mock.patch('sky.utils.kubernetes.config_map_utils._get_configmap_name')
-    @mock.patch('sky.utils.common_utils.dump_yaml_str')
+    @mock.patch('sky.utils.yaml_utils.dump_yaml_str')
     @mock.patch('sky.utils.kubernetes.config_map_utils.kubernetes')
     def test_patch_configmap_success(self, mock_k8s, mock_dump_yaml,
                                      mock_get_name, mock_get_ns, mock_is_k8s):
@@ -158,7 +158,7 @@ class TestConfigMapSync(unittest.TestCase):
         from sky import skypilot_config
         with mock.patch.object(skypilot_config, 'get_user_config_path',
                                return_value=config_path), \
-             mock.patch('sky.utils.common_utils.dump_yaml') as mock_dump_yaml, \
+             mock.patch('sky.utils.yaml_utils.dump_yaml') as mock_dump_yaml, \
              mock.patch('sky.skypilot_config.reload_config'):
 
             config = config_utils.Config({'test': 'value'})
@@ -185,7 +185,7 @@ class TestConfigMapSync(unittest.TestCase):
         from sky import skypilot_config
         with mock.patch.object(skypilot_config, 'get_user_config_path',
                                return_value=config_path), \
-             mock.patch('sky.utils.common_utils.dump_yaml') as mock_dump_yaml, \
+             mock.patch('sky.utils.yaml_utils.dump_yaml') as mock_dump_yaml, \
              mock.patch('sky.skypilot_config.reload_config'):
 
             config = config_utils.Config({'test': 'value'})
@@ -203,7 +203,7 @@ class TestConfigMapSync(unittest.TestCase):
                 '_get_kubernetes_namespace')
     @mock.patch('sky.utils.kubernetes.config_map_utils._get_configmap_name')
     @mock.patch('sky.skypilot_config.parse_and_validate_config_file')
-    @mock.patch('sky.utils.common_utils.dump_yaml_str')
+    @mock.patch('sky.utils.yaml_utils.dump_yaml_str')
     @mock.patch('sky.utils.kubernetes.config_map_utils.kubernetes')
     def test_initialize_configmap_sync_on_startup_creates_configmap(
             self, mock_k8s, mock_dump_yaml, mock_parse_config, mock_get_name,

--- a/tests/unit_tests/test_sky/workspaces/test_workspace_config_concurrency.py
+++ b/tests/unit_tests/test_sky/workspaces/test_workspace_config_concurrency.py
@@ -12,6 +12,7 @@ import pytest
 
 from sky import skypilot_config
 from sky.utils import common_utils
+from sky.utils import yaml_utils
 from sky.workspaces import core
 
 
@@ -36,7 +37,7 @@ class TestWorkspaceConfigConcurrency(unittest.TestCase):
                 }
             }
         }
-        common_utils.dump_yaml(self.temp_config_file, self.initial_config)
+        yaml_utils.dump_yaml(self.temp_config_file, self.initial_config)
 
         # Patch the config path to use our temporary file
         self.config_path_patcher = mock.patch(
@@ -47,7 +48,7 @@ class TestWorkspaceConfigConcurrency(unittest.TestCase):
         # Mock skypilot_config.to_dict to read from our temp file
         def mock_to_dict():
             if os.path.exists(self.temp_config_file):
-                return common_utils.read_yaml(self.temp_config_file)
+                return yaml_utils.read_yaml(self.temp_config_file)
             return {}
 
         self.to_dict_patcher = mock.patch('sky.skypilot_config.to_dict',
@@ -125,7 +126,7 @@ class TestWorkspaceConfigConcurrency(unittest.TestCase):
         self.assertEqual(len(results), num_threads)
 
         # Verify final config contains all workspaces
-        final_config = common_utils.read_yaml(self.temp_config_file)
+        final_config = yaml_utils.read_yaml(self.temp_config_file)
         final_workspaces = final_config['workspaces']
 
         # Should have default + test + num_threads new workspaces
@@ -203,7 +204,7 @@ class TestWorkspaceConfigConcurrency(unittest.TestCase):
         self.assertEqual(result1, expected_workspaces1)
 
         # Verify first update was written
-        config_after_first = common_utils.read_yaml(self.temp_config_file)
+        config_after_first = yaml_utils.read_yaml(self.temp_config_file)
         self.assertEqual(config_after_first['workspaces'], expected_workspaces1)
 
         # Second update (should preserve workspace1)
@@ -213,7 +214,7 @@ class TestWorkspaceConfigConcurrency(unittest.TestCase):
         result2 = core._update_workspaces_config(second_modifier)
 
         # Verify second update was written and first workspace preserved
-        config_after_second = common_utils.read_yaml(self.temp_config_file)
+        config_after_second = yaml_utils.read_yaml(self.temp_config_file)
         final_workspaces = config_after_second['workspaces']
         self.assertEqual(len(final_workspaces), 3)
         self.assertEqual(final_workspaces['workspace1'],
@@ -251,7 +252,7 @@ class TestWorkspaceConfigConcurrency(unittest.TestCase):
 
                 def mock_to_dict():
                     if os.path.exists(self.temp_config_file):
-                        return common_utils.read_yaml(self.temp_config_file)
+                        return yaml_utils.read_yaml(self.temp_config_file)
                     return {}
 
                 with mock.patch('sky.skypilot_config.to_dict',
@@ -289,7 +290,7 @@ class TestWorkspaceConfigConcurrency(unittest.TestCase):
         self.assertEqual(len(results), 3)
 
         # Check final state
-        final_config = common_utils.read_yaml(self.temp_config_file)
+        final_config = yaml_utils.read_yaml(self.temp_config_file)
         final_workspaces = final_config['workspaces']
 
         # Should have default + test + 3 process workspaces

--- a/tests/unit_tests/test_sky/workspaces/test_workspace_management.py
+++ b/tests/unit_tests/test_sky/workspaces/test_workspace_management.py
@@ -44,7 +44,7 @@ class TestWorkspaceManagement(unittest.TestCase):
 
     @mock.patch('sky.skypilot_config.get_user_config_path')
     @mock.patch('sky.skypilot_config.to_dict')
-    @mock.patch('sky.utils.common_utils.dump_yaml')
+    @mock.patch('sky.utils.yaml_utils.dump_yaml')
     @mock.patch('sky.skypilot_config.reload_config')
     def test_internal_update_workspaces_config(self, mock_reload_config,
                                                mock_dump_yaml, mock_to_dict,

--- a/tests/unit_tests/test_sky/workspaces/test_workspace_race_condition_demo.py
+++ b/tests/unit_tests/test_sky/workspaces/test_workspace_race_condition_demo.py
@@ -6,7 +6,7 @@ import time
 import unittest
 from unittest import mock
 
-from sky.utils import common_utils
+from sky.utils import yaml_utils
 from sky.workspaces import core
 
 
@@ -30,7 +30,7 @@ class TestWorkspaceRaceConditionDemo(unittest.TestCase):
                 }
             }
         }
-        common_utils.dump_yaml(self.temp_config_file, self.initial_config)
+        yaml_utils.dump_yaml(self.temp_config_file, self.initial_config)
 
         # Patch the config path to use our temporary file
         self.config_path_patcher = mock.patch(
@@ -41,7 +41,7 @@ class TestWorkspaceRaceConditionDemo(unittest.TestCase):
         # Mock skypilot_config.to_dict to read from our temp file
         def mock_to_dict():
             if os.path.exists(self.temp_config_file):
-                return common_utils.read_yaml(self.temp_config_file)
+                return yaml_utils.read_yaml(self.temp_config_file)
             return {}
 
         self.to_dict_patcher = mock.patch('sky.skypilot_config.to_dict',
@@ -117,7 +117,7 @@ class TestWorkspaceRaceConditionDemo(unittest.TestCase):
                 results.append(result)
 
         # Verify both updates succeeded and no data was lost
-        final_config = common_utils.read_yaml(self.temp_config_file)
+        final_config = yaml_utils.read_yaml(self.temp_config_file)
         final_workspaces = final_config['workspaces']
 
         # Should have default + workspace_alpha + workspace_beta = 3 workspaces
@@ -230,7 +230,7 @@ class TestWorkspaceRaceConditionDemo(unittest.TestCase):
                 future.result()  # This will raise any exceptions
 
         # Verify final state is consistent
-        final_config = common_utils.read_yaml(self.temp_config_file)
+        final_config = yaml_utils.read_yaml(self.temp_config_file)
         final_workspaces = final_config['workspaces']
 
         # Should have: default, workspace_1 (updated), workspace_2, new_workspace


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Now that we have a file for yaml related functions, move yaml utility functions from common_utils to yaml_utils. This PR contains no logic changes.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
