### PR TITLE
nebius: make Nebius API domain customizable

### DIFF
--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1410,6 +1410,9 @@ def get_config_schema():
                 **_NETWORK_CONFIG_SCHEMA, 'tenant_id': {
                     'type': 'string',
                 },
+                'domain': {
+                    'type': 'string',
+                },
                 'region_configs': {
                     'type': 'object',
                     'required': [],
@@ -1663,6 +1666,9 @@ def get_config_schema():
                             'type': 'string',
                         },
                         'tenant_id': {
+                            'type': 'string',
+                        },
+                        'domain': {
                             'type': 'string',
                         },
                         'disabled': {


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR makes changing Nebius API domain possible. It is not really necessary for regular users, but gives some flexibility for Nebius developers.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
