### PR TITLE
Request DB asyncio support

### DIFF
--- a/sky/jobs/server/server.py
+++ b/sky/jobs/server/server.py
@@ -79,7 +79,8 @@ async def logs(
         if jobs_logs_body.refresh else api_requests.ScheduleType.SHORT,
         request_cluster_name=common.JOB_CONTROLLER_NAME,
     )
-    request_task = api_requests.get_request(request.state.request_id)
+    request_task = await api_requests.get_request_async(request.state.request_id
+                                                       )
 
     return stream_utils.stream_response(
         request_id=request_task.request_id,

--- a/sky/serve/server/server.py
+++ b/sky/serve/server/server.py
@@ -107,7 +107,8 @@ async def tail_logs(
         request_cluster_name=common.SKY_SERVE_CONTROLLER_NAME,
     )
 
-    request_task = api_requests.get_request(request.state.request_id)
+    request_task = await api_requests.get_request_async(request.state.request_id
+                                                       )
 
     return stream_utils.stream_response(
         request_id=request_task.request_id,

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -451,7 +451,7 @@ async def execute_request_coroutine(request: api_requests.Request):
                                                   **request_body.to_kwargs())
 
     async def poll_task(request_id: str) -> bool:
-        request = api_requests.get_request(request_id)
+        request = await api_requests.get_request_async(request_id)
         if request is None:
             raise RuntimeError('Request not found')
 

--- a/sky/server/requests/preconditions.py
+++ b/sky/server/requests/preconditions.py
@@ -98,7 +98,7 @@ class Precondition(abc.ABC):
                 return False
 
             # Check if the request has been cancelled
-            request = api_requests.get_request(self.request_id)
+            request = await api_requests.get_request_async(self.request_id)
             if request is None:
                 logger.error(f'Request {self.request_id} not found')
                 return False
@@ -112,7 +112,8 @@ class Precondition(abc.ABC):
                     return True
                 if status_msg is not None and status_msg != last_status_msg:
                     # Update the status message if it has changed.
-                    with api_requests.update_request(self.request_id) as req:
+                    async with api_requests.update_request_async(
+                            self.request_id) as req:
                         assert req is not None, self.request_id
                         req.status_msg = status_msg
                     last_status_msg = status_msg

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -402,22 +402,42 @@ _DB = None
 _init_db_lock = threading.Lock()
 
 
+def _init_db_within_lock():
+    global _DB
+    if _DB is None:
+        db_path = os.path.expanduser(
+            server_constants.API_SERVER_REQUEST_DB_PATH)
+        pathlib.Path(db_path).parents[0].mkdir(parents=True, exist_ok=True)
+        _DB = db_utils.SQLiteConn(db_path, create_table)
+
+
 def init_db(func):
     """Initialize the database."""
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        global _DB
         if _DB is not None:
             return func(*args, **kwargs)
         with _init_db_lock:
-            if _DB is None:
-                db_path = os.path.expanduser(
-                    server_constants.API_SERVER_REQUEST_DB_PATH)
-                pathlib.Path(db_path).parents[0].mkdir(parents=True,
-                                                       exist_ok=True)
-                _DB = db_utils.SQLiteConn(db_path, create_table)
+            _init_db_within_lock()
         return func(*args, **kwargs)
+
+    return wrapper
+
+
+def init_db_async(func):
+    """Async version of init_db."""
+
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs):
+        if _DB is not None:
+            return await func(*args, **kwargs)
+        # If _DB is not initialized, init_db_async will be blocked if there
+        # is a thread initializing _DB, this is fine since it occurs on process
+        # startup.
+        with _init_db_lock:
+            _init_db_within_lock()
+        return await func(*args, **kwargs)
 
     return wrapper
 
@@ -440,23 +460,45 @@ def request_lock_path(request_id: str) -> str:
 @contextlib.contextmanager
 @init_db
 def update_request(request_id: str) -> Generator[Optional[Request], None, None]:
-    """Get a SkyPilot API request."""
+    """Get and update a SkyPilot API request."""
     request = _get_request_no_lock(request_id)
     yield request
     if request is not None:
         _add_or_update_request_no_lock(request)
 
 
+@contextlib.asynccontextmanager
+@init_db_async
+async def update_request_async(request_id: str):
+    """Async version of update_request."""
+    request = await _get_request_no_lock_async(request_id)
+    yield request
+    if request is not None:
+        await _add_or_update_request_no_lock_async(request)
+
+
+_get_request_sql = (f'SELECT {", ".join(REQUEST_COLUMNS)} FROM {REQUEST_TABLE} '
+                    'WHERE request_id LIKE ?')
+
+
 def _get_request_no_lock(request_id: str) -> Optional[Request]:
     """Get a SkyPilot API request."""
     assert _DB is not None
-    columns_str = ', '.join(REQUEST_COLUMNS)
     with _DB.conn:
         cursor = _DB.conn.cursor()
-        cursor.execute(
-            f'SELECT {columns_str} FROM {REQUEST_TABLE} '
-            'WHERE request_id LIKE ?', (request_id + '%',))
+        cursor.execute(_get_request_sql, (request_id + '%',))
         row = cursor.fetchone()
+        if row is None:
+            return None
+    return Request.from_row(row)
+
+
+async def _get_request_no_lock_async(request_id: str) -> Optional[Request]:
+    """Async version of _get_request_no_lock."""
+    assert _DB is not None
+    conn = await _DB.async_conn()
+    async with conn.execute(_get_request_sql, (request_id + '%',)) as cursor:
+        row = await cursor.fetchone()
         if row is None:
             return None
     return Request.from_row(row)
@@ -481,6 +523,13 @@ def get_request(request_id: str) -> Optional[Request]:
         return _get_request_no_lock(request_id)
 
 
+@init_db_async
+async def get_request_async(request_id: str) -> Optional[Request]:
+    """Async version of get_request."""
+    async with filelock.AsyncFileLock(request_lock_path(request_id)):
+        return await _get_request_no_lock_async(request_id)
+
+
 @init_db
 def create_if_not_exists(request: Request) -> bool:
     """Create a SkyPilot API request if it does not exist."""
@@ -488,6 +537,16 @@ def create_if_not_exists(request: Request) -> bool:
         if _get_request_no_lock(request.request_id) is not None:
             return False
         _add_or_update_request_no_lock(request)
+        return True
+
+
+@init_db_async
+async def create_if_not_exists_async(request: Request) -> bool:
+    """Async version of create_if_not_exists."""
+    async with filelock.AsyncFileLock(request_lock_path(request.request_id)):
+        if await _get_request_no_lock_async(request.request_id) is not None:
+            return False
+        await _add_or_update_request_no_lock_async(request)
         return True
 
 
@@ -565,17 +624,25 @@ def get_request_tasks(
     return requests
 
 
+_add_or_update_request_sql = (f'INSERT OR REPLACE INTO {REQUEST_TABLE} '
+                              f'({", ".join(REQUEST_COLUMNS)}) VALUES '
+                              f'({", ".join(["?"] * len(REQUEST_COLUMNS))})')
+
+
 def _add_or_update_request_no_lock(request: Request):
     """Add or update a REST request into the database."""
-    row = request.to_row()
-    key_str = ', '.join(REQUEST_COLUMNS)
-    fill_str = ', '.join(['?'] * len(row))
     assert _DB is not None
     with _DB.conn:
         cursor = _DB.conn.cursor()
-        cursor.execute(
-            f'INSERT OR REPLACE INTO {REQUEST_TABLE} ({key_str}) '
-            f'VALUES ({fill_str})', row)
+        cursor.execute(_add_or_update_request_sql, request.to_row())
+
+
+async def _add_or_update_request_no_lock_async(request: Request):
+    """Async version of _add_or_update_request_no_lock."""
+    assert _DB is not None
+    conn = await _DB.async_conn()
+    await conn.execute(_add_or_update_request_sql, request.to_row())
+    await conn.commit()
 
 
 def set_request_failed(request_id: str, e: BaseException) -> None:

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1388,7 +1388,7 @@ async def local_down(request: fastapi.Request) -> None:
 async def api_get(request_id: str) -> payloads.RequestPayload:
     """Gets a request with a given request ID prefix."""
     while True:
-        request_task = requests_lib.get_request(request_id)
+        request_task = await requests_lib.get_request_async(request_id)
         if request_task is None:
             print(f'No task with request ID {request_id}', flush=True)
             raise fastapi.HTTPException(
@@ -1474,7 +1474,7 @@ async def stream(
 
     # Original plain text streaming logic
     if request_id is not None:
-        request_task = requests_lib.get_request(request_id)
+        request_task = await requests_lib.get_request_async(request_id)
         if request_task is None:
             print(f'No task with request ID {request_id}')
             raise fastapi.HTTPException(
@@ -1561,7 +1561,7 @@ async def api_status(
     else:
         encoded_request_tasks = []
         for request_id in request_ids:
-            request_task = requests_lib.get_request(request_id)
+            request_task = await requests_lib.get_request_async(request_id)
             if request_task is None:
                 continue
             encoded_request_tasks.append(request_task.readable_encode())

--- a/sky/server/stream_utils.py
+++ b/sky/server/stream_utils.py
@@ -56,7 +56,7 @@ async def log_streamer(request_id: Optional[str],
     if request_id is not None:
         status_msg = rich_utils.EncodedStatusMessage(
             f'[dim]Checking request: {request_id}[/dim]')
-        request_task = requests_lib.get_request(request_id)
+        request_task = await requests_lib.get_request_async(request_id)
 
         if request_task is None:
             raise fastapi.HTTPException(
@@ -89,7 +89,7 @@ async def log_streamer(request_id: Optional[str],
             # coroutines to run. This busy waiting loop is performance critical
             # for short-running requests, so we do not want to yield too long.
             await asyncio.sleep(0.1)
-            request_task = requests_lib.get_request(request_id)
+            request_task = await requests_lib.get_request_async(request_id)
             if not follow:
                 break
         if show_request_waiting_spinner:
@@ -151,7 +151,7 @@ async def _tail_log_file(f: aiofiles.threadpool.binary.AsyncBufferedReader,
         line: Optional[bytes] = await f.readline()
         if not line:
             if request_id is not None:
-                request_task = requests_lib.get_request(request_id)
+                request_task = await requests_lib.get_request_async(request_id)
                 if request_task.status > requests_lib.RequestStatus.RUNNING:
                     if (request_task.status ==
                             requests_lib.RequestStatus.CANCELLED):

--- a/sky/server/stream_utils.py
+++ b/sky/server/stream_utils.py
@@ -86,9 +86,11 @@ async def log_streamer(request_id: Optional[str],
                 # Use smaller padding (1024 bytes) to force browser rendering
                 yield f'{waiting_msg}' + ' ' * 4096 + '\n'
             # Sleep shortly to avoid storming the DB and CPU and allow other
-            # coroutines to run. This busy waiting loop is performance critical
-            # for short-running requests, so we do not want to yield too long.
-            await asyncio.sleep(0.1)
+            # coroutines to run.
+            # TODO(aylei): we should use a better mechanism to avoid busy
+            # polling the DB, which can be a bottleneck for high-concurrency
+            # requests.
+            await asyncio.sleep(0.5)
             request_task = await requests_lib.get_request_async(request_id)
             if not follow:
                 break
@@ -179,7 +181,7 @@ async def _tail_log_file(f: aiofiles.threadpool.binary.AsyncBufferedReader,
             # Sleep shortly to avoid storming the DB and CPU, this has
             # little impact on the responsivness here since we are waiting
             # for a new line to come in.
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(0.5)
             continue
 
         # Refresh the heartbeat time, this is a trivial optimization for

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -35,7 +35,8 @@ install_requires = [
     # Light weight requirement, can be replaced with "typing" once
     # we deprecate Python 3.7 (this will take a while).
     'typing_extensions',
-    'filelock >= 3.6.0',
+    # filelock 3.15.0 or higher is required for async file locking.
+    'filelock >= 3.15.0',
     'packaging',
     'psutil',
     'pulp',
@@ -71,6 +72,7 @@ install_requires = [
     'types-paramiko',
     'alembic',
     'aiohttp',
+    'aiosqlite',
 ]
 
 # See requirements-dev.txt for the version of grpc and protobuf
@@ -94,6 +96,7 @@ server_dependencies = [
     'aiohttp',
     GRPC,
     PROTOBUF,
+    'aiosqlite',
 ]
 
 local_ray = [

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -1,4 +1,5 @@
 """Utils for sky databases."""
+import asyncio
 import contextlib
 import enum
 import sqlite3
@@ -6,6 +7,7 @@ import threading
 import typing
 from typing import Any, Callable, Optional
 
+import aiosqlite
 import sqlalchemy
 from sqlalchemy import exc as sqlalchemy_exc
 
@@ -283,3 +285,12 @@ class SQLiteConn(threading.local):
         self.conn = sqlite3.connect(db_path, timeout=_DB_TIMEOUT_S)
         self.cursor = self.conn.cursor()
         create_table(self.cursor, self.conn)
+        self._async_conn: Optional[aiosqlite.Connection] = None
+        self._async_conn_lock = asyncio.Lock()
+
+    async def async_conn(self) -> aiosqlite.Connection:
+        if self._async_conn is None:
+            async with self._async_conn_lock:
+                if self._async_conn is None:
+                    self._async_conn = await aiosqlite.connect(self.db_path)
+        return self._async_conn

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -91,7 +91,7 @@ def test_api_stream_heartbeat(monkeypatch):
                     except Exception:
                         pass
 
-                    if current_time - start_time > 0.55:
+                    if current_time - start_time > 3.0:
                         break
             finally:
                 # Properly close the async generator to avoid pending task errors
@@ -180,7 +180,7 @@ def test_heartbeat_not_displayed_to_users(monkeypatch):
                         # Non-control messages should be displayed
                         user_visible_messages.append(item)
 
-                    if current_time - start_time > 0.55:
+                    if current_time - start_time > 2.0:
                         break
             finally:
                 await log_stream.aclose()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -59,10 +59,10 @@ def test_api_stream_heartbeat(monkeypatch):
                 self.schedule_type = requests_lib.ScheduleType.LONG
                 self.status_msg = None
 
-        def mock_get_request(request_id):
+        async def mock_get_request(request_id):
             return MockRequest()
 
-        monkeypatch.setattr('sky.server.requests.requests.get_request',
+        monkeypatch.setattr('sky.server.requests.requests.get_request_async',
                             mock_get_request)
 
         log_path = pathlib.Path(temp_log_path)
@@ -144,10 +144,10 @@ def test_heartbeat_not_displayed_to_users(monkeypatch):
                 self.schedule_type = requests_lib.ScheduleType.LONG
                 self.status_msg = None
 
-        def mock_get_request(request_id):
+        async def mock_get_request(request_id):
             return MockRequest()
 
-        monkeypatch.setattr('sky.server.requests.requests.get_request',
+        monkeypatch.setattr('sky.server.requests.requests.get_request_async',
                             mock_get_request)
 
         log_path = pathlib.Path(temp_log_path)

--- a/tests/unit_tests/test_sky/server/requests/test_precond.py
+++ b/tests/unit_tests/test_sky/server/requests/test_precond.py
@@ -14,7 +14,7 @@ class TestPrecondition(unittest.TestCase):
     def setUp(self):
         self.request_id = 'test-request'
 
-    @mock.patch('sky.server.requests.requests.get_request')
+    @mock.patch('sky.server.requests.requests.get_request_async')
     async def test_precondition_timeout(self, mock_get_request):
         """Test Precondition timeout behavior."""
 
@@ -34,7 +34,7 @@ class TestPrecondition(unittest.TestCase):
         self.assertIsInstance(api_requests.set_request_failed.call_args[0][1],
                               exceptions.RequestCancelled)
 
-    @mock.patch('sky.server.requests.requests.get_request')
+    @mock.patch('sky.server.requests.requests.get_request_async')
     async def test_precondition_cancelled(self, mock_get_request):
         """Test Precondition cancellation behavior."""
 
@@ -51,7 +51,7 @@ class TestPrecondition(unittest.TestCase):
 
         self.assertFalse(result)
 
-    @mock.patch('sky.server.requests.requests.get_request')
+    @mock.patch('sky.server.requests.requests.get_request_async')
     async def test_precondition_check_exception(self, mock_get_request):
         """Test Precondition behavior when check raises exception."""
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR add asyncio support for request DB to avoid sync operations block the uvicorn event loop.

Test:

**Before this PR**, 

<img width="2234" height="1756" alt="image" src="https://github.com/user-attachments/assets/600c833a-3d00-4545-b729-6598afa50041" />


**After this PR**, slow request operations now longer affect the event loop:

<img width="812" height="606" alt="image" src="https://github.com/user-attachments/assets/a331ed46-4acf-4103-afe0-048b31ff3737" />

Note that there is a significant diff on the duration of `get_request` and `get_request_async`, because previously `get_request` was executed in uvicorn's event loop, which has a fixed concurrency (equal to CPU cores, 4 in my test) and will not be affected by coroutine scheduling once `get_request` start. The async version has the same concurrency with client requests (30 in my test) and with the coroutine scheduling time. The final throughput is same as before.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] See above
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
