### PR TITLE
Use `generic_cloud` as infra in `test_job_pipeline`

### DIFF
--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -26,6 +26,7 @@ import re
 import tempfile
 import time
 
+import jinja2
 import pytest
 from smoke_tests import smoke_tests_utils
 from smoke_tests import test_mount_and_storage
@@ -149,37 +150,48 @@ def test_managed_jobs_cli_exit_codes(generic_cloud: str):
 def test_job_pipeline(generic_cloud: str):
     """Test a job pipeline."""
     name = smoke_tests_utils.get_cluster_name()
-    test = smoke_tests_utils.Test(
-        'job_pipeline',
-        [
-            f'sky jobs launch -n {name} {smoke_tests_utils.LOW_RESOURCE_ARG} --infra {generic_cloud} tests/test_yamls/pipeline.yaml -y -d',
-            # Need to wait for setup and job initialization.
-            'sleep 30',
-            rf'{smoke_tests_utils.GET_JOB_QUEUE} | grep {name} | head -n1 | grep "STARTING\|RUNNING"',
-            # `grep -A 4 {name}` finds the job with {name} and the 4 lines
-            # after it, i.e. the 4 tasks within the job.
-            # `sed -n 2p` gets the second line of the 4 lines, i.e. the first
-            # task within the job.
-            rf'{smoke_tests_utils.GET_JOB_QUEUE} | grep -A 4 {name}| sed -n 2p | grep "STARTING\|RUNNING"',
-            f'{smoke_tests_utils.GET_JOB_QUEUE} | grep -A 4 {name}| sed -n 3p | grep "PENDING"',
+
+    # Use Jinja templating to generate the pipeline YAML with the specific cloud
+    template_str = pathlib.Path('tests/test_yamls/pipeline.yaml.j2').read_text()
+    template = jinja2.Template(template_str)
+    content = template.render(cloud=generic_cloud)
+
+    with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
+        f.write(content)
+        f.flush()
+        file_path = f.name
+
+        test = smoke_tests_utils.Test(
+            'job_pipeline',
+            [
+                f'sky jobs launch -n {name} {smoke_tests_utils.LOW_RESOURCE_ARG} --infra {generic_cloud} {file_path} -y -d',
+                # Need to wait for setup and job initialization.
+                'sleep 30',
+                rf'{smoke_tests_utils.GET_JOB_QUEUE} | grep {name} | head -n1 | grep "STARTING\|RUNNING"',
+                # `grep -A 4 {name}` finds the job with {name} and the 4 lines
+                # after it, i.e. the 4 tasks within the job.
+                # `sed -n 2p` gets the second line of the 4 lines, i.e. the first
+                # task within the job.
+                rf'{smoke_tests_utils.GET_JOB_QUEUE} | grep -A 4 {name}| sed -n 2p | grep "STARTING\|RUNNING"',
+                f'{smoke_tests_utils.GET_JOB_QUEUE} | grep -A 4 {name}| sed -n 3p | grep "PENDING"',
+                f'sky jobs cancel -y -n {name}',
+                'sleep 5',
+                rf'{smoke_tests_utils.GET_JOB_QUEUE} | grep -A 4 {name}| sed -n 2p | grep "CANCELLING\|CANCELLED"',
+                rf'{smoke_tests_utils.GET_JOB_QUEUE} | grep -A 4 {name}| sed -n 3p | grep "CANCELLING\|CANCELLED"',
+                rf'{smoke_tests_utils.GET_JOB_QUEUE} | grep -A 4 {name}| sed -n 4p | grep "CANCELLING\|CANCELLED"',
+                rf'{smoke_tests_utils.GET_JOB_QUEUE} | grep -A 4 {name}| sed -n 5p | grep "CANCELLING\|CANCELLED"',
+                'sleep 200',
+                f'{smoke_tests_utils.GET_JOB_QUEUE} | grep -A 4 {name}| sed -n 2p | grep "CANCELLED"',
+                f'{smoke_tests_utils.GET_JOB_QUEUE} | grep -A 4 {name}| sed -n 3p | grep "CANCELLED"',
+                f'{smoke_tests_utils.GET_JOB_QUEUE} | grep -A 4 {name}| sed -n 4p | grep "CANCELLED"',
+                f'{smoke_tests_utils.GET_JOB_QUEUE} | grep -A 4 {name}| sed -n 5p | grep "CANCELLED"',
+            ],
             f'sky jobs cancel -y -n {name}',
-            'sleep 5',
-            rf'{smoke_tests_utils.GET_JOB_QUEUE} | grep -A 4 {name}| sed -n 2p | grep "CANCELLING\|CANCELLED"',
-            rf'{smoke_tests_utils.GET_JOB_QUEUE} | grep -A 4 {name}| sed -n 3p | grep "CANCELLING\|CANCELLED"',
-            rf'{smoke_tests_utils.GET_JOB_QUEUE} | grep -A 4 {name}| sed -n 4p | grep "CANCELLING\|CANCELLED"',
-            rf'{smoke_tests_utils.GET_JOB_QUEUE} | grep -A 4 {name}| sed -n 5p | grep "CANCELLING\|CANCELLED"',
-            'sleep 200',
-            f'{smoke_tests_utils.GET_JOB_QUEUE} | grep -A 4 {name}| sed -n 2p | grep "CANCELLED"',
-            f'{smoke_tests_utils.GET_JOB_QUEUE} | grep -A 4 {name}| sed -n 3p | grep "CANCELLED"',
-            f'{smoke_tests_utils.GET_JOB_QUEUE} | grep -A 4 {name}| sed -n 4p | grep "CANCELLED"',
-            f'{smoke_tests_utils.GET_JOB_QUEUE} | grep -A 4 {name}| sed -n 5p | grep "CANCELLED"',
-        ],
-        f'sky jobs cancel -y -n {name}',
-        env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
-        # Increase timeout since sky jobs queue -r can be blocked by other spot tests.
-        timeout=30 * 60,
-    )
-    smoke_tests_utils.run_one_test(test)
+            env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
+            # Increase timeout since sky jobs queue -r can be blocked by other spot tests.
+            timeout=30 * 60,
+        )
+        smoke_tests_utils.run_one_test(test)
 
 
 @pytest.mark.no_fluidstack  #fluidstack does not support spot instances

--- a/tests/test_yamls/pipeline.yaml.j2
+++ b/tests/test_yamls/pipeline.yaml.j2
@@ -7,9 +7,7 @@ resources:
   cpus: 2+
   memory: 4+
   use_spot: true
-  any_of:
-    - infra: aws
-    - infra: gcp
+  infra: {{cloud}}
 
 setup: |
   echo setup for train
@@ -26,9 +24,7 @@ name: b
 resources:
   cpus: 2+
   memory: 4+
-  any_of:
-    - infra: aws
-    - infra: gcp
+  infra: {{cloud}}
 
 setup: |
   echo setup for train
@@ -46,6 +42,8 @@ name: eval1
 resources:
   cpus: 2+
   memory: 4+
+  infra: {{cloud}}
+
 setup: |
   echo setup for eval
   sleep 20
@@ -62,6 +60,8 @@ name: eval2
 resources:
   cpus: 2+
   memory: 4+
+  infra: {{cloud}}
+
 setup: |
   echo setup for eval
   sleep 20


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Currently `--aws -k job_pipeline` will use nebius to run the `test_job_pipeline`, see [logs](https://buildkite.com/skypilot-1/smoke-tests/builds/2826#0198e838-b522-49d9-9af4-d0f8c3f7dcaf)

```bash
job_pipeline] + sky jobs launch -n t-job-pipeline-00 --cpus 2+ --memory 4+ --infra aws tests/test_yamls/pipeline.yaml -y -d
  | [job_pipeline]
  | D 08-26 21:12:04 skypilot_config.py:233] using user config file specified by SKYPILOT_GLOBAL_CONFIG: tests/test_yamls/low_resource_sky_config.yaml
  | D 08-26 21:12:04 skypilot_config.py:505] Config loaded from tests/test_yamls/low_resource_sky_config.yaml:
  | D 08-26 21:12:04 skypilot_config.py:505] jobs:
  | D 08-26 21:12:04 skypilot_config.py:505]   controller:
  | D 08-26 21:12:04 skypilot_config.py:505]     resources:
  | D 08-26 21:12:04 skypilot_config.py:505]       cpus: 2+
  | D 08-26 21:12:04 skypilot_config.py:505]       memory: 4+
  | D 08-26 21:12:04 skypilot_config.py:505]
  | D 08-26 21:12:04 skypilot_config.py:505] serve:
  | D 08-26 21:12:04 skypilot_config.py:505]   controller:
  | D 08-26 21:12:04 skypilot_config.py:505]     resources:
  | D 08-26 21:12:04 skypilot_config.py:505]       cpus: 2+
  | D 08-26 21:12:04 skypilot_config.py:505]       memory: 4+
  | D 08-26 21:12:04 skypilot_config.py:505]
  | D 08-26 21:12:04 skypilot_config.py:512] Config syntax check passed for path: tests/test_yamls/low_resource_sky_config.yaml
  | D 08-26 21:12:04 skypilot_config.py:272] using default project config file: .sky.yaml
  | D 08-26 21:12:04 skypilot_config.py:627] client config (before task and CLI overrides):
  | D 08-26 21:12:04 skypilot_config.py:627] jobs:
  | D 08-26 21:12:04 skypilot_config.py:627]   controller:
  | D 08-26 21:12:04 skypilot_config.py:627]     resources:
  | D 08-26 21:12:04 skypilot_config.py:627]       cpus: 2+
  | D 08-26 21:12:04 skypilot_config.py:627]       memory: 4+
  | D 08-26 21:12:04 skypilot_config.py:627]
  | D 08-26 21:12:04 skypilot_config.py:627] serve:
  | D 08-26 21:12:04 skypilot_config.py:627]   controller:
  | D 08-26 21:12:04 skypilot_config.py:627]     resources:
  | D 08-26 21:12:04 skypilot_config.py:627]       cpus: 2+
  | D 08-26 21:12:04 skypilot_config.py:627]       memory: 4+
  | D 08-26 21:12:04 skypilot_config.py:627]
  | YAML to run: tests/test_yamls/pipeline.yaml
  | WARNING: override params {'cloud': AWS, 'region': None, 'zone': None, 'cpus': '2+', 'memory': '4+'} are ignored, since the yaml file contains multiple tasks.
  | D 08-26 21:12:05 common.py:415] Health check status: 200
  |  

<br class="Apple-interchange-newline">
```

With this PR's change, we configure the yaml with the `generic_cloud` so that its consistent with pytest parameter.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
