### PR TITLE
fix: catch FileNotFoundError when pip3 is missing in UV-only environments

### DIFF
--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -143,9 +143,13 @@ def _build_sky_wheel() -> pathlib.Path:
                            stdout=subprocess.DEVNULL,
                            stderr=subprocess.PIPE,
                            check=True)
-        except subprocess.CalledProcessError as e:
-            raise RuntimeError('Failed to build pip wheel for SkyPilot. '
-                               f'Error message: {e.stderr.decode()}') from e
+        except (subprocess.CalledProcessError, FileNotFoundError) as e:
+            if isinstance(e, FileNotFoundError):
+                msg = 'pip3 not found. Please install pip3.'
+            else:
+                msg = f'Error message: {e.stderr.decode()}'
+            raise RuntimeError('Failed to build pip wheel for SkyPilot. ' +
+                               msg) from e
 
         try:
             wheel_path = next(tmp_dir.glob(_WHEEL_PATTERN))


### PR DESCRIPTION
Fixes #5046

## Summary
This PR fixes an uncaught `FileNotFoundError` that occurs when pip3 is not available in UV-only environments.

## Root Cause
When SkyPilot tries to build a wheel using `pip3 wheel`, it only caught `CalledProcessError` but not `FileNotFoundError`. In environments where pip3 doesn't exist (like pure UV environments), this causes an unhandled exception.

## Solution
Added `FileNotFoundError` to the exception handling in `wheel_utils.py:_build_sky_wheel()`. Now the code properly catches both exceptions and provides appropriate error messages:
- For `FileNotFoundError`: "pip3 not found. Please install pip3."
- For `CalledProcessError`: Shows the actual pip error message

## Test Plan
Tested with mock to simulate both error conditions:
1. ✅ `FileNotFoundError` when pip3 is missing - properly caught with clear error message
2. ✅ `CalledProcessError` when pip3 fails - still works as before

The fix allows UV-only environments to fail gracefully with a clear error message instead of crashing with an uncaught exception.

## Note on UV Support
Currently not adding native UV support for building wheels because:
- The current fix solves the immediate problem
- pip3 is the standard tool across all Python environments
- Users can install pip3 in UV environments if needed (`uv pip install pip`)
- Native UV support would add maintenance complexity without clear demand