### PR TITLE
[Coreweave] Add Coreweave autoscaler support

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -1143,6 +1143,7 @@ Can be one of:
 
 - ``gke``: Google Kubernetes Engine
 - ``karpenter``: Karpenter
+- ``coreweave``: `CoreWeave autoscaler <https://docs.coreweave.com/docs/products/cks/nodes/autoscaling>`_
 - ``generic``: Generic autoscaler, assumes nodes are labelled with ``skypilot.co/accelerator``.
 
 .. _config-yaml-kubernetes-pod-config:

--- a/docs/source/reference/kubernetes/kubernetes-getting-started.rst
+++ b/docs/source/reference/kubernetes/kubernetes-getting-started.rst
@@ -348,7 +348,7 @@ FAQs
       # ~/.sky/config.yaml
       kubernetes:
         provision_timeout: 900  # Wait 15 minutes for nodes to get provisioned before failover. Set to -1 to wait indefinitely.
-        autoscaler: gke  # [gke, karpenter, generic]; required if using GPUs/TPUs in scale-to-zero setting
+        autoscaler: gke  # [gke, karpenter, coreweave, generic]; required if using GPUs/TPUs in scale-to-zero setting
 
 * **Can SkyPilot provision a Kubernetes cluster for me? Will SkyPilot add more nodes to my Kubernetes clusters?**
 

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1082,7 +1082,6 @@ class KarpenterAutoscaler(Autoscaler):
     can_query_backend: bool = False
 
 
-
 class CoreweaveAutoscaler(Autoscaler):
     """CoreWeave autoscaler
     """

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1082,6 +1082,15 @@ class KarpenterAutoscaler(Autoscaler):
     can_query_backend: bool = False
 
 
+
+class CoreweaveAutoscaler(Autoscaler):
+    """CoreWeave autoscaler
+    """
+
+    label_formatter: Any = CoreWeaveLabelFormatter
+    can_query_backend: bool = False
+
+
 class GenericAutoscaler(Autoscaler):
     """Generic autoscaler
     """
@@ -1094,6 +1103,7 @@ class GenericAutoscaler(Autoscaler):
 AUTOSCALER_TYPE_TO_AUTOSCALER = {
     kubernetes_enums.KubernetesAutoscalerType.GKE: GKEAutoscaler,
     kubernetes_enums.KubernetesAutoscalerType.KARPENTER: KarpenterAutoscaler,
+    kubernetes_enums.KubernetesAutoscalerType.COREWEAVE: CoreweaveAutoscaler,
     kubernetes_enums.KubernetesAutoscalerType.GENERIC: GenericAutoscaler,
 }
 

--- a/sky/utils/kubernetes_enums.py
+++ b/sky/utils/kubernetes_enums.py
@@ -42,4 +42,5 @@ class KubernetesAutoscalerType(enum.Enum):
     """Enum for the different types of cluster autoscalers for Kubernetes."""
     GKE = 'gke'
     KARPENTER = 'karpenter'
+    COREWEAVE = 'coreweave'
     GENERIC = 'generic'

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -982,19 +982,19 @@ spec:
 
 def test_coreweave_autoscaler():
     """Test that CoreweaveAutoscaler is properly configured."""
+    from sky.provision.kubernetes.utils import AUTOSCALER_TYPE_TO_AUTOSCALER
+    from sky.provision.kubernetes.utils import CoreweaveAutoscaler
+    from sky.provision.kubernetes.utils import CoreWeaveLabelFormatter
     from sky.utils import kubernetes_enums
-    from sky.provision.kubernetes.utils import (AUTOSCALER_TYPE_TO_AUTOSCALER,
-                                                CoreweaveAutoscaler,
-                                                CoreWeaveLabelFormatter)
-    
+
     # Test that COREWEAVE autoscaler type is mapped correctly
     autoscaler_class = AUTOSCALER_TYPE_TO_AUTOSCALER.get(
         kubernetes_enums.KubernetesAutoscalerType.COREWEAVE)
     assert autoscaler_class is not None
     assert autoscaler_class == CoreweaveAutoscaler
-    
+
     # Test that CoreweaveAutoscaler uses the correct label formatter
     assert CoreweaveAutoscaler.label_formatter == CoreWeaveLabelFormatter
-    
+
     # Test that CoreweaveAutoscaler cannot query backend (like other simple autoscalers)
     assert CoreweaveAutoscaler.can_query_backend == False

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -978,3 +978,23 @@ spec:
 '''
 
         self._check_pod_config(comprehensive_pod_config, True)
+
+
+def test_coreweave_autoscaler():
+    """Test that CoreweaveAutoscaler is properly configured."""
+    from sky.utils import kubernetes_enums
+    from sky.provision.kubernetes.utils import (AUTOSCALER_TYPE_TO_AUTOSCALER,
+                                                CoreweaveAutoscaler,
+                                                CoreWeaveLabelFormatter)
+    
+    # Test that COREWEAVE autoscaler type is mapped correctly
+    autoscaler_class = AUTOSCALER_TYPE_TO_AUTOSCALER.get(
+        kubernetes_enums.KubernetesAutoscalerType.COREWEAVE)
+    assert autoscaler_class is not None
+    assert autoscaler_class == CoreweaveAutoscaler
+    
+    # Test that CoreweaveAutoscaler uses the correct label formatter
+    assert CoreweaveAutoscaler.label_formatter == CoreWeaveLabelFormatter
+    
+    # Test that CoreweaveAutoscaler cannot query backend (like other simple autoscalers)
+    assert CoreweaveAutoscaler.can_query_backend == False


### PR DESCRIPTION
Adds support for CW cluster autoscaler: https://docs.coreweave.com/docs/products/cks/nodes/autoscaling

Users need to add this to config.yaml to make it work:
```
# ~/.sky/config.yaml
kubernetes:
  provision_timeout: 3600 # Wait 1 hour for nodes to get provisioned before failover. Set to -1 to wait indefinitely.
  autoscaler: coreweave
```

~Do not merge - testing on CW cluster~
Tested on CW H200 cluster. Scaled up from 0->1 in ~20 min.