### PR TITLE
[Nebius] Remove redundant AllowTcpForwarding configurations for Nebius setup

### DIFF
--- a/docs/source/cloud-setup/cloud-permissions/nebius.rst
+++ b/docs/source/cloud-setup/cloud-permissions/nebius.rst
@@ -68,10 +68,3 @@ To do so, you can use SkyPilot's global config file ``~/.sky/config.yaml`` to sp
       ssh_proxy_command: ssh -W %h:%p -o StrictHostKeyChecking=no myself@my.proxy
 
 The ``nebius.ssh_proxy_command`` field is optional. If SkyPilot is run on a machine that can directly access the internal IPs of the instances, it can be omitted. Otherwise, it should be set to a command that can be used to proxy SSH connections to the internal IPs of the instances.
-
-When using a proxy machine, don't forget to enable `AllowTcpForwarding` on the proxy host:
-
-.. code-block:: bash
-
-    sudo sed -i 's/^#\?AllowTcpForwarding.*/AllowTcpForwarding yes/' /etc/ssh/sshd_config
-    sudo systemctl restart sshd

--- a/sky/templates/nebius-ray.yml.j2
+++ b/sky/templates/nebius-ray.yml.j2
@@ -56,10 +56,6 @@ available_node_types:
           filesystem_mount_path: {{ fs.filesystem_mount_path }}
         {%- endfor %}
       UserData: |
-        runcmd:
-          - sudo sed -i 's/^#\?AllowTcpForwarding.*/AllowTcpForwarding yes/' /etc/ssh/sshd_config
-          - systemctl restart sshd
-
         {# Two available OS images:
                1. ubuntu24.04-driverless - requires Docker installation
                2. ubuntu24.04-cuda12 - comes with Docker pre-installed


### PR DESCRIPTION
Remove redundant AllowTcpForwarding configurations for Nebius setup

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
Run Docker and several nodes

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
