### PR TITLE
[db] reuse db engine across databases, API server process uses QueuePool for postgres

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -299,7 +299,9 @@ def create_table(engine: sqlalchemy.engine.Engine):
 # a session has already been created with _SQLALCHEMY_ENGINE = e1,
 # and then another thread overwrites _SQLALCHEMY_ENGINE = e2
 # which could result in e1 being garbage collected unexpectedly.
-def initialize_and_get_db() -> sqlalchemy.engine.Engine:
+def initialize_and_get_db(
+    pg_pool_class: Optional[sqlalchemy.pool.Pool] = None
+) -> sqlalchemy.engine.Engine:
     global _SQLALCHEMY_ENGINE
 
     if _SQLALCHEMY_ENGINE is not None:
@@ -308,7 +310,8 @@ def initialize_and_get_db() -> sqlalchemy.engine.Engine:
         if _SQLALCHEMY_ENGINE is not None:
             return _SQLALCHEMY_ENGINE
         # get an engine to the db
-        engine = migration_utils.get_engine('state')
+        engine = migration_utils.get_engine('state',
+                                            pg_pool_class=pg_pool_class)
 
         # run migrations if needed
         create_table(engine)

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -24,6 +24,7 @@ import aiofiles
 import anyio
 import fastapi
 from fastapi.middleware import cors
+from sqlalchemy import pool
 import starlette.middleware.base
 import uvloop
 
@@ -1902,7 +1903,7 @@ if __name__ == '__main__':
     skyuvicorn.add_timestamp_prefix_for_server_logs()
 
     # Initialize global user state db
-    global_user_state.initialize_and_get_db()
+    global_user_state.initialize_and_get_db(pool.QueuePool)
     # Initialize request db
     requests_lib.reset_db_and_logs()
     # Restore the server user hash

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -36,7 +36,9 @@ _sqlite_engine_cache: Dict[str, sqlalchemy.engine.Engine] = {}
 
 def get_engine(db_name: str):
     global _postgres_engine_cache, _sqlite_engine_cache
-    conn_string = os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER)
+    conn_string = None
+    if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
+        conn_string = os.environ.get(constants.ENV_VAR_DB_CONNECTION_URI)
     if conn_string:
         if conn_string not in _postgres_engine_cache:
             _postgres_engine_cache[conn_string] = sqlalchemy.create_engine(

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -36,9 +36,6 @@ _sqlite_engine_cache: Dict[str, sqlalchemy.engine.Engine] = {}
 
 
 def get_engine(db_name: str):
-    # pylint does not count dictionary element assignment as an assignment.
-    # pylint: disable=global-variable-not-assigned
-    global _postgres_engine_cache, _sqlite_engine_cache
     conn_string = None
     if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
         conn_string = os.environ.get(constants.ENV_VAR_DB_CONNECTION_URI)

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -32,7 +32,6 @@ SERVE_VERSION = '001'
 SERVE_LOCK_PATH = '~/.sky/locks/.serve_db.lock'
 
 _postgres_engine: Optional[sqlalchemy.engine.Engine] = None
-_sqlite_engine: Optional[sqlalchemy.engine.Engine] = None
 
 
 def get_engine(db_name: str):
@@ -48,9 +47,7 @@ def get_engine(db_name: str):
     else:
         db_path = os.path.expanduser(f'~/.sky/{db_name}.db')
         pathlib.Path(db_path).parents[0].mkdir(parents=True, exist_ok=True)
-        if _sqlite_engine is None:
-            _sqlite_engine = sqlalchemy.create_engine('sqlite:///' + db_path)
-        engine = _sqlite_engine
+        engine = sqlalchemy.create_engine('sqlite:///' + db_path)
     return engine
 
 

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -4,7 +4,7 @@ import contextlib
 import logging
 import os
 import pathlib
-from typing import Optional
+from typing import Dict
 
 from alembic import command as alembic_command
 from alembic.config import Config
@@ -31,23 +31,24 @@ SERVE_DB_NAME = 'serve_db'
 SERVE_VERSION = '001'
 SERVE_LOCK_PATH = '~/.sky/locks/.serve_db.lock'
 
-_postgres_engine: Optional[sqlalchemy.engine.Engine] = None
-
+_postgres_engine_cache: Dict[str, sqlalchemy.engine.Engine] = {}
+_sqlite_engine_cache: Dict[str, sqlalchemy.engine.Engine] = {}
 
 def get_engine(db_name: str):
-    global _postgres_engine, _sqlite_engine
-    conn_string = None
-    if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
-        conn_string = os.environ.get(constants.ENV_VAR_DB_CONNECTION_URI)
+    global _postgres_engine_cache, _sqlite_engine_cache
+    conn_string = os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER)
     if conn_string:
-        if _postgres_engine is None:
-            _postgres_engine = sqlalchemy.create_engine(
+        if conn_string not in _postgres_engine_cache:
+            _postgres_engine_cache[conn_string] = sqlalchemy.create_engine(
                 conn_string, poolclass=sqlalchemy.NullPool)
-        engine = _postgres_engine
+        engine = _postgres_engine_cache[conn_string]
     else:
         db_path = os.path.expanduser(f'~/.sky/{db_name}.db')
         pathlib.Path(db_path).parents[0].mkdir(parents=True, exist_ok=True)
-        engine = sqlalchemy.create_engine('sqlite:///' + db_path)
+        if db_path not in _sqlite_engine_cache:
+            _sqlite_engine_cache[db_path] = sqlalchemy.create_engine(
+                'sqlite:///' + db_path)
+        engine = _sqlite_engine_cache[db_path]
     return engine
 
 

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -34,7 +34,10 @@ SERVE_LOCK_PATH = '~/.sky/locks/.serve_db.lock'
 _postgres_engine_cache: Dict[str, sqlalchemy.engine.Engine] = {}
 _sqlite_engine_cache: Dict[str, sqlalchemy.engine.Engine] = {}
 
+
 def get_engine(db_name: str):
+    # pylint does not count dictionary element assignment as an assignment.
+    # pylint: disable=global-variable-not-assigned
     global _postgres_engine_cache, _sqlite_engine_cache
     conn_string = None
     if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -2,9 +2,9 @@
 
 import contextlib
 import logging
-import threading
 import os
 import pathlib
+import threading
 from typing import Dict, Optional
 
 from alembic import command as alembic_command
@@ -35,8 +35,8 @@ SERVE_LOCK_PATH = '~/.sky/locks/.serve_db.lock'
 _postgres_engine_cache: Dict[str, sqlalchemy.engine.Engine] = {}
 _sqlite_engine_cache: Dict[str, sqlalchemy.engine.Engine] = {}
 
-
 _db_creation_lock = threading.Lock()
+
 
 def get_engine(db_name: str,
                pg_pool_class: Optional[sqlalchemy.pool.Pool] = None):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR allows `get_engine` to cache and reuse engines across databases.

Additionally, have the main API server process use QueuePool instead of NullPool, which is more efficient when the process is expected to submit db requests frequently and concurrently.

I am still unsure on whether each executor process should get a QueuePool for itself, because large API server deployments can have many dozens of executors and each executor being able to have ~5 concurrent connections may put quite a bit of pressure on the DB. However, we know the main API server will be interacting with the DB frequently, so giving that process access to persistent reusable connections make sense.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
