### PR TITLE
[k8s] better logs for pod missing events analysis

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1293,6 +1293,8 @@ def _get_pod_missing_reason(context: Optional[str], namespace: str,
     last_scheduled_node = None
     insert_new_pod_event = True
     new_event_inserted = False
+    inserted_pod_events = 0
+
     for event in pod_events:
         if event.reason == 'Scheduled':
             pattern = r'Successfully assigned (\S+) to (\S+)'
@@ -1317,6 +1319,11 @@ def _get_pod_missing_reason(context: Optional[str], namespace: str,
                 insert_new_pod_event = False
             else:
                 new_event_inserted = True
+                inserted_pod_events += 1
+
+    logger.debug(f'[pod {pod_name}] processed {len(pod_events)} pod events and '
+                 f'inserted {inserted_pod_events} new pod events '
+                 'previously unseen')
 
     if last_scheduled_node is not None:
         node_field_selector = ('involvedObject.kind=Node,'
@@ -1331,6 +1338,7 @@ def _get_pod_missing_reason(context: Optional[str], namespace: str,
             # latest event appears first
             reverse=True)
         insert_new_node_event = True
+        inserted_node_events = 0
         for event in node_events:
             if insert_new_node_event:
                 # Try inserting the latest events first. If the event is a
@@ -1349,6 +1357,15 @@ def _get_pod_missing_reason(context: Optional[str], namespace: str,
                     insert_new_node_event = False
                 else:
                     new_event_inserted = True
+                    inserted_node_events += 1
+
+        logger.debug(f'[pod {pod_name}: node {last_scheduled_node}] '
+                    f'processed {len(node_events)} node events and '
+                    f'inserted {inserted_node_events} new node events '
+                    'previously unseen')
+    else:
+        logger.debug(f'[pod {pod_name}] could not determine the node '
+                     'the pod was scheduled to')
 
     if not new_event_inserted:
         # If new event is not inserted, there is no useful information to

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1315,6 +1315,9 @@ def _get_pod_missing_reason(context: Optional[str], namespace: str,
                     transitioned_at=int(
                         event.metadata.creation_timestamp.timestamp()),
                     expose_duplicate_error=True)
+                logger.debug(f'[pod {pod_name}] encountered new pod event: '
+                             f'{event.metadata.creation_timestamp} '
+                             f'{event.reason} {event.message}')
             except db_utils.UniqueConstraintViolationError:
                 insert_new_pod_event = False
             else:
@@ -1353,6 +1356,10 @@ def _get_pod_missing_reason(context: Optional[str], namespace: str,
                         transitioned_at=int(
                             event.metadata.creation_timestamp.timestamp()),
                         expose_duplicate_error=True)
+                    logger.debug(
+                        f'[pod {pod_name}] encountered new node event: '
+                        f'{event.metadata.creation_timestamp} '
+                        f'{event.reason} {event.message}')
                 except db_utils.UniqueConstraintViolationError:
                     insert_new_node_event = False
                 else:
@@ -1360,9 +1367,9 @@ def _get_pod_missing_reason(context: Optional[str], namespace: str,
                     inserted_node_events += 1
 
         logger.debug(f'[pod {pod_name}: node {last_scheduled_node}] '
-                    f'processed {len(node_events)} node events and '
-                    f'inserted {inserted_node_events} new node events '
-                    'previously unseen')
+                     f'processed {len(node_events)} node events and '
+                     f'inserted {inserted_node_events} new node events '
+                     'previously unseen')
     else:
         logger.debug(f'[pod {pod_name}] could not determine the node '
                      'the pod was scheduled to')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Include some stats regarding the number of k8s events processed and inserted for debugging purposes

Prints the following loglines:
```
I 08-27 15:27:31 daemons.py:86] === Refreshing cluster status ===
D 08-27 15:27:31 instance.py:1281] Analyzing events for pod <pod-name>
D 08-27 15:27:31 instance.py:1318] [pod <pod-name>] encountered new event: 2025-08-27 21:57:13+00:00 TaintManagerEviction Cancelling deletion of Pod default/<pod-name>
D 08-27 15:27:31 instance.py:1318] [pod <pod-name>] encountered new event: 2025-08-27 21:55:19+00:00 NodeNotReady Node is not ready
D 08-27 15:27:31 instance.py:1318] [pod <pod-name>] encountered new event: 2025-08-27 21:53:53+00:00 Pulled Successfully pulled image "us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:latest" in 16.629s (16.629s including waiting). Image size: 446331120 bytes.
D 08-27 15:27:31 instance.py:1318] [pod <pod-name>] encountered new event: 2025-08-27 21:53:53+00:00 Created Created container: ray-node
D 08-27 15:27:31 instance.py:1318] [pod <pod-name>] encountered new event: 2025-08-27 21:53:53+00:00 Started Started container ray-node
D 08-27 15:27:31 instance.py:1318] [pod <pod-name>] encountered new event: 2025-08-27 21:53:36+00:00 Scheduled Successfully assigned default/<pod-name> to <node-name>
D 08-27 15:27:31 instance.py:1318] [pod <pod-name>] encountered new event: 2025-08-27 21:53:36+00:00 Pulling Pulling image "us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:latest"
D 08-27 15:27:31 instance.py:1327] [pod <pod-name>] processed 7 pod events and inserted 7 new pod events previously unseen
D 08-27 15:27:31 instance.py:1359] [pod <pod-name>] encountered new node event: 2025-08-27 21:56:25+00:00 RemovingNode Node <node-name> event: Removing Node <node-name> from Controller
D 08-27 15:27:31 instance.py:1359] [pod <pod-name>] encountered new node event: 2025-08-27 21:56:23+00:00 DeletingNode Deleting node <node-name> because it does not exist in the cloud provider
D 08-27 15:27:31 instance.py:1359] [pod <pod-name>] encountered new node event: 2025-08-27 21:55:19+00:00 NodeNotReady Node <node-name> status is now: NodeNotReady
D 08-27 15:27:31 instance.py:1359] [pod <pod-name>] encountered new node event: 2025-08-27 21:30:23+00:00 NodeRegistrationCheckerDidNotRunChecks Wed Aug 27 21:30:23 UTC 2025 - **     Node ready and registered. **
D 08-27 15:27:31 instance.py:1368] [pod <pod-name>: node <node-name>] processed 4 node events and inserted 4 new node events previously unseen
D 08-27 15:27:31 backend_utils.py:1813] Querying Kubernetes cluster 'sky-99ec-seungjinyang' status:
D 08-27 15:27:31 backend_utils.py:1813] {'sky-99ec-seungjinyang-3639d895-head': (<ClusterStatus.UP: 'UP'>, None)}
D 08-27 15:27:31 backend_utils.py:2276] The cluster is abnormal. Setting to INIT status. node_statuses: [(<ClusterStatus.UP: 'UP'>, None)]

I 08-27 15:27:31 daemons.py:91] Status refreshed. Sleeping 60 seconds for the next refresh...
I 08-27 15:27:31 daemons.py:91] 
D 08-27 15:28:31 skypilot_config.py:298] using default server config file: ~/.sky/config.yaml
D 08-27 15:28:31 skypilot_config.py:602] server config: 
D 08-27 15:28:31 skypilot_config.py:602] {}
D 08-27 15:28:31 skypilot_config.py:602] 
I 08-27 15:28:31 daemons.py:86] === Refreshing cluster status ===
D 08-27 15:28:31 instance.py:1281] Analyzing events for pod <pod-name>
D 08-27 15:28:31 instance.py:1327] [pod <pod-name>] processed 7 pod events and inserted 0 new pod events previously unseen
D 08-27 15:28:32 instance.py:1368] [pod <pod-name>: node <node-name>] processed 4 node events and inserted 0 new node events previously unseen
D 08-27 15:28:32 backend_utils.py:1813] Querying Kubernetes cluster 'sky-99ec-seungjinyang' status:
D 08-27 15:28:32 backend_utils.py:1813] {'sky-99ec-seungjinyang-3639d895-head': (<ClusterStatus.UP: 'UP'>, None)}
D 08-27 15:28:32 backend_utils.py:2276] The cluster is abnormal. Setting to INIT status. node_statuses: [(<ClusterStatus.UP: 'UP'>, None)]
```
<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
