### PR TITLE
[Core] Add separate cluster event retention for events with type DEBUG

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -30,7 +30,7 @@ Below is the configuration syntax and some example values. See detailed explanat
     :ref:`service_account_token <config-yaml-api-server-service-account-token>`: sky_xxx
     :ref:`requests_retention_hours <config-yaml-api-server-requests-gc-retention-hours>`: 24
     :ref:`cluster_event_retention_hours <config-yaml-api-server-cluster-event-retention-hours>`: 24
-    :ref:`cluster_debug_event_retention_hours <config-yaml-api-server-cluster-debug-event-retention-hours>`: 168
+    :ref:`cluster_debug_event_retention_hours <config-yaml-api-server-cluster-debug-event-retention-hours>`: 720
 
   :ref:`allowed_clouds <config-yaml-allowed-clouds>`:
     - aws

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -255,10 +255,10 @@ Example:
   api_server:
     cluster_event_retention_hours: -1 # Disable all cluster event GC
   
-.. _config-yaml-api-server-cluster-event-retention-hours:
+.. _config-yaml-api-server-cluster-event-retention-hours-debug:
 
 ``api_server.cluster_event_retention_hours_debug``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Retention period for cluster events in hours (optional). Set to a negative value to disable cluster event GC.
 

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -30,6 +30,7 @@ Below is the configuration syntax and some example values. See detailed explanat
     :ref:`service_account_token <config-yaml-api-server-service-account-token>`: sky_xxx
     :ref:`requests_retention_hours <config-yaml-api-server-requests-gc-retention-hours>`: 24
     :ref:`cluster_event_retention_hours <config-yaml-api-server-cluster-event-retention-hours>`: 24
+    :ref:`cluster_event_retention_hours_debug <config-yaml-api-server-cluster-event-retention-hours-debug>`: 168
 
   :ref:`allowed_clouds <config-yaml-allowed-clouds>`:
     - aws
@@ -252,7 +253,25 @@ Example:
 .. code-block:: yaml
 
   api_server:
-    cluster_event_retention_hours: -1 # Disable cluster event GC
+    cluster_event_retention_hours: -1 # Disable all cluster event GC
+  
+.. _config-yaml-api-server-cluster-event-retention-hours:
+
+``api_server.cluster_event_retention_hours_debug``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Retention period for cluster events in hours (optional). Set to a negative value to disable cluster event GC.
+
+Cluster event GC will remove debug cluster event entries in `sky status -v`, i.e., the logs and status of the cluster events.
+
+Default: ``168.0`` (7 days).
+
+Example:
+
+.. code-block:: yaml
+
+  api_server:
+    cluster_event_retention_hours_debug: -1 # Disable all cluster event GC
 
 .. _config-yaml-jobs:
 

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -30,7 +30,7 @@ Below is the configuration syntax and some example values. See detailed explanat
     :ref:`service_account_token <config-yaml-api-server-service-account-token>`: sky_xxx
     :ref:`requests_retention_hours <config-yaml-api-server-requests-gc-retention-hours>`: 24
     :ref:`cluster_event_retention_hours <config-yaml-api-server-cluster-event-retention-hours>`: 24
-    :ref:`cluster_event_retention_hours_debug <config-yaml-api-server-cluster-event-retention-hours-debug>`: 168
+    :ref:`cluster_debug_event_retention_hours <config-yaml-api-server-cluster-debug-event-retention-hours>`: 168
 
   :ref:`allowed_clouds <config-yaml-allowed-clouds>`:
     - aws

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -255,23 +255,23 @@ Example:
   api_server:
     cluster_event_retention_hours: -1 # Disable all cluster event GC
   
-.. _config-yaml-api-server-cluster-event-retention-hours-debug:
+.. _config-yaml-api-server-cluster-debug-event-retention-hours:
 
-``api_server.cluster_event_retention_hours_debug``
+``api_server.cluster_debug_event_retention_hours``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Retention period for cluster events in hours (optional). Set to a negative value to disable cluster event GC.
 
 Cluster event GC will remove debug cluster event entries in `sky status -v`, i.e., the logs and status of the cluster events.
 
-Default: ``168.0`` (7 days).
+Default: ``720.0`` (30 days).
 
 Example:
 
 .. code-block:: yaml
 
   api_server:
-    cluster_event_retention_hours_debug: -1 # Disable all cluster event GC
+    cluster_debug_event_retention_hours: -1 # Disable all cluster event GC
 
 .. _config-yaml-jobs:
 

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -53,7 +53,7 @@ _SQLALCHEMY_ENGINE: Optional[sqlalchemy.engine.Engine] = None
 _SQLALCHEMY_ENGINE_LOCK = threading.Lock()
 
 DEFAULT_CLUSTER_EVENT_RETENTION_HOURS = 24.0
-DEBUG_CLUSTER_EVENT_RETENTION_HOURS = 7 * 24.0
+DEBUG_CLUSTER_EVENT_RETENTION_HOURS = 30 * 24.0
 MIN_CLUSTER_EVENT_DAEMON_INTERVAL_SECONDS = 3600
 
 _UNIQUE_CONSTRAINT_FAILED_ERROR_MSGS = [
@@ -832,7 +832,7 @@ async def cluster_event_retention_daemon():
             ('api_server', 'cluster_event_retention_hours'),
             DEFAULT_CLUSTER_EVENT_RETENTION_HOURS)
         debug_retention_hours = skypilot_config.get_nested(
-            ('api_server', 'cluster_event_retention_hours_debug'),
+            ('api_server', 'cluster_debug_event_retention_hours'),
             DEBUG_CLUSTER_EVENT_RETENTION_HOURS)
         try:
             if retention_hours >= 0:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1555,6 +1555,9 @@ def get_config_schema():
             'cluster_event_retention_hours': {
                 'type': 'number',
             },
+            'cluster_event_retention_hours_debug': {
+                'type': 'number',
+            },
         }
     }
 

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1555,7 +1555,7 @@ def get_config_schema():
             'cluster_event_retention_hours': {
                 'type': 'number',
             },
-            'cluster_event_retention_hours_debug': {
+            'cluster_debug_event_retention_hours': {
                 'type': 'number',
             },
         }

--- a/tests/test_global_user_state.py
+++ b/tests/test_global_user_state.py
@@ -46,7 +46,10 @@ async def test_cluster_event_retention_daemon():
                     await sky.global_user_state.cluster_event_retention_daemon()
 
                 # Verify cleanup was called with the correct retention.
-                mock_clean.assert_called_with(2)
+                mock_clean.assert_any_call(
+                    2, sky.global_user_state.ClusterEventType.STATUS_CHANGE)
+                mock_clean.assert_any_call(
+                    2, sky.global_user_state.ClusterEventType.DEBUG)
 
                 # Verify sleep was called with max(2 * 3600, 3600) = 7200
                 assert mock_sleep.call_count == 5


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR separates the retention of `STATUS_CHANGE` and `DEBUG` events. There is a new option `api_server.cluster_debug_event_retention_hours` that solely configures the retention of debug events. The default is set to 30 days.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

I tested this by setting the regular retention setting very low (60 seconds) while leaving the debug retention setting alone, starting a GKE cluster, killing some nodes, verifying that the table had entries for both event types, waiting for 60 seconds and seeing that only debug events remain.

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
