### PR TITLE
[Core] During multi-node setup + stall improve UX

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -621,7 +621,7 @@ class RayCodeGen:
                             placement_group_bundle_index=i)
                     ) \\
                     .remote(
-                        setup_cmd,
+                        setup_cmd + " && echo 'Setup complete'",
                         os.path.expanduser({setup_log_path!r}),
                         env_vars={setup_envs!r},
                         stream_logs=True,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4892,6 +4892,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             tail: int = 0,
             require_outputs: bool = False,
             stream_logs: bool = True,
+            setup_spinner: bool = False,
             process_stream: bool = False) -> Union[int, Tuple[int, str, str]]:
         """Tail the logs of a job.
 
@@ -4932,10 +4933,15 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     return last_exit_code
                 raise e
 
+        num_nodes = (handle.launched_nodes
+                     if handle.launched_nodes is not None else 0)
         code = job_lib.JobLibCodeGen.tail_logs(job_id,
                                                managed_job_id=managed_job_id,
                                                follow=follow,
-                                               tail=tail)
+                                               tail=tail,
+                                               setup_spinner=setup_spinner,
+                                               cluster_name=handle.cluster_name,
+                                               num_nodes=num_nodes)
         if job_id is None and managed_job_id is None:
             logger.info(
                 'Job ID not provided. Streaming the logs of the latest job.')

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -1156,7 +1156,8 @@ def launch(
         if not detach_run and job_id is not None:
             returncode = sdk.tail_logs(handle.get_cluster_name(),
                                        job_id,
-                                       follow=True)
+                                       follow=True,
+                                       setup_spinner=True)
         click.secho(
             ux_utils.command_hint_messages(ux_utils.CommandHintType.CLUSTER_JOB,
                                            job_id, handle.get_cluster_name()))

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -852,15 +852,14 @@ def tail_logs(cluster_name: str,
 @annotations.client_api
 @rest.retry_transient_errors()
 def tail_logs(
-    cluster_name: str,
-    job_id: Optional[int],
-    follow: bool,
-    tail: int = 0,
-    output_stream: Optional['io.TextIOBase'] = None,
-    *,  # keyword only separator
-    preload_content: bool = True,
-    setup_spinner: bool = False
-) -> Union[int, Iterator[Optional[str]]]:
+        cluster_name: str,
+        job_id: Optional[int],
+        follow: bool,
+        tail: int = 0,
+        output_stream: Optional['io.TextIOBase'] = None,
+        *,  # keyword only separator
+        preload_content: bool = True,
+        setup_spinner: bool = False) -> Union[int, Iterator[Optional[str]]]:
     """Tails the logs of a job.
 
     Args:
@@ -901,13 +900,11 @@ def tail_logs(
         raise ValueError(
             'output_stream cannot be specified when preload_content is False')
 
-    body = payloads.ClusterJobBody(
-        cluster_name=cluster_name,
-        job_id=job_id,
-        follow=follow,
-        tail=tail,
-        setup_spinner=setup_spinner
-    )
+    body = payloads.ClusterJobBody(cluster_name=cluster_name,
+                                   job_id=job_id,
+                                   follow=follow,
+                                   tail=tail,
+                                   setup_spinner=setup_spinner)
     response = server_common.make_authenticated_request(
         'POST',
         '/logs',

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -828,7 +828,8 @@ def tail_logs(
         tail: int = 0,
         output_stream: Optional['io.TextIOBase'] = None,
         *,  # keyword only separator
-        preload_content: Literal[True] = True) -> int:
+        preload_content: Literal[True] = True,
+        setup_spinner: bool = False) -> int:
     ...
 
 
@@ -839,7 +840,8 @@ def tail_logs(cluster_name: str,
               tail: int = 0,
               output_stream: None = None,
               *,
-              preload_content: Literal[False]) -> Iterator[Optional[str]]:
+              preload_content: Literal[False],
+              setup_spinner: bool = False) -> Iterator[Optional[str]]:
     ...
 
 
@@ -856,7 +858,8 @@ def tail_logs(
     tail: int = 0,
     output_stream: Optional['io.TextIOBase'] = None,
     *,  # keyword only separator
-    preload_content: bool = True
+    preload_content: bool = True,
+    setup_spinner: bool = False
 ) -> Union[int, Iterator[Optional[str]]]:
     """Tails the logs of a job.
 
@@ -903,6 +906,7 @@ def tail_logs(
         job_id=job_id,
         follow=follow,
         tail=tail,
+        setup_spinner=setup_spinner
     )
     response = server_common.make_authenticated_request(
         'POST',

--- a/sky/core.py
+++ b/sky/core.py
@@ -997,7 +997,8 @@ def cancel(
 def tail_logs(cluster_name: str,
               job_id: Optional[int],
               follow: bool = True,
-              tail: int = 0) -> int:
+              tail: int = 0,
+              setup_spinner: bool = False) -> int:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Tails the logs of a job.
 
@@ -1030,7 +1031,7 @@ def tail_logs(cluster_name: str,
     usage_lib.record_cluster_name_for_current_operation(cluster_name)
     # Although tail_logs returns an int when require_outputs=False (default),
     # we need to check returnval as an int to avoid type checking errors.
-    returnval = backend.tail_logs(handle, job_id, follow=follow, tail=tail)
+    returnval = backend.tail_logs(handle, job_id, follow=follow, tail=tail, setup_spinner=setup_spinner)
     assert isinstance(returnval,
                       int), (f'returnval must be an int, but got {returnval}')
     return returnval

--- a/sky/core.py
+++ b/sky/core.py
@@ -1031,7 +1031,11 @@ def tail_logs(cluster_name: str,
     usage_lib.record_cluster_name_for_current_operation(cluster_name)
     # Although tail_logs returns an int when require_outputs=False (default),
     # we need to check returnval as an int to avoid type checking errors.
-    returnval = backend.tail_logs(handle, job_id, follow=follow, tail=tail, setup_spinner=setup_spinner)
+    returnval = backend.tail_logs(handle,
+                                  job_id,
+                                  follow=follow,
+                                  tail=tail,
+                                  setup_spinner=setup_spinner)
     assert isinstance(returnval,
                       int), (f'returnval must be an int, but got {returnval}')
     return returnval

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -380,6 +380,7 @@ class ClusterJobBody(RequestBody):
     job_id: Optional[int]
     follow: bool = True
     tail: int = 0
+    setup_spinner: bool = False
 
 
 class ClusterJobsBody(RequestBody):

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -104,7 +104,7 @@ SKYLET_VERSION = '26'
 # The version of the lib files that skylet/jobs use. Whenever there is an API
 # change for the job_lib or log_lib, we need to bump this version, so that the
 # user can be notified to update their SkyPilot version on the remote cluster.
-SKYLET_LIB_VERSION = 4
+SKYLET_LIB_VERSION = 5
 SKYLET_VERSION_FILE = '~/.sky/skylet_version'
 SKYLET_GRPC_PORT = 46590
 SKYLET_GRPC_TIMEOUT_SECONDS = 10

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -1248,9 +1248,9 @@ class JobLibCodeGen:
                   follow: bool = True,
                   tail: int = 0,
                   setup_spinner: bool = False,
-                  cluster_name: Optional[str] = None) -> str:
+                  cluster_name: Optional[str] = None,
+                  num_nodes: int = 0) -> str:
         # pylint: disable=line-too-long
-
         code = [
             # We use != instead of is not because 1 is not None will print a warning:
             # <stdin>:1: SyntaxWarning: "is not" with a literal. Did you mean "!="?
@@ -1265,7 +1265,7 @@ class JobLibCodeGen:
              f'  log_dir = None if run_timestamp is None else os.path.join({constants.SKY_LOGS_DIRECTORY!r}, run_timestamp)'
             ),
             # Add a newline to leave the if indent block above.
-            f'\ntail_log_kwargs = {{"job_id": job_id, "log_dir": log_dir, "managed_job_id": {managed_job_id!r}, "follow": {follow}, "setup_spinner": {setup_spinner}, "cluster_name": {cluster_name!r}}}',
+            f'\ntail_log_kwargs = {{"job_id": job_id, "log_dir": log_dir, "managed_job_id": {managed_job_id!r}, "follow": {follow}, "setup_spinner": {setup_spinner}, "cluster_name": {cluster_name!r}, "num_nodes": {num_nodes}}}',
             f'{_LINUX_NEW_LINE}if getattr(constants, "SKYLET_LIB_VERSION", 1) > 1: tail_log_kwargs["tail"] = {tail}',
             f'{_LINUX_NEW_LINE}log_lib.tail_logs(**tail_log_kwargs)',
             # After tailing, check the job status and exit with appropriate code

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -1246,7 +1246,9 @@ class JobLibCodeGen:
                   job_id: Optional[int],
                   managed_job_id: Optional[int],
                   follow: bool = True,
-                  tail: int = 0) -> str:
+                  tail: int = 0,
+                  setup_spinner: bool = False,
+                  cluster_name: Optional[str] = None) -> str:
         # pylint: disable=line-too-long
 
         code = [
@@ -1263,7 +1265,7 @@ class JobLibCodeGen:
              f'  log_dir = None if run_timestamp is None else os.path.join({constants.SKY_LOGS_DIRECTORY!r}, run_timestamp)'
             ),
             # Add a newline to leave the if indent block above.
-            f'\ntail_log_kwargs = {{"job_id": job_id, "log_dir": log_dir, "managed_job_id": {managed_job_id!r}, "follow": {follow}}}',
+            f'\ntail_log_kwargs = {{"job_id": job_id, "log_dir": log_dir, "managed_job_id": {managed_job_id!r}, "follow": {follow}, "setup_spinner": {setup_spinner}, "cluster_name": {cluster_name!r}}}',
             f'{_LINUX_NEW_LINE}if getattr(constants, "SKYLET_LIB_VERSION", 1) > 1: tail_log_kwargs["tail"] = {tail}',
             f'{_LINUX_NEW_LINE}log_lib.tail_logs(**tail_log_kwargs)',
             # After tailing, check the job status and exit with appropriate code

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -1265,8 +1265,11 @@ class JobLibCodeGen:
              f'  log_dir = None if run_timestamp is None else os.path.join({constants.SKY_LOGS_DIRECTORY!r}, run_timestamp)'
             ),
             # Add a newline to leave the if indent block above.
-            f'\ntail_log_kwargs = {{"job_id": job_id, "log_dir": log_dir, "managed_job_id": {managed_job_id!r}, "follow": {follow}, "setup_spinner": {setup_spinner}, "cluster_name": {cluster_name!r}, "num_nodes": {num_nodes}}}',
+            f'\ntail_log_kwargs = {{"job_id": job_id, "log_dir": log_dir, "managed_job_id": {managed_job_id!r}, "follow": {follow}}}',
             f'{_LINUX_NEW_LINE}if getattr(constants, "SKYLET_LIB_VERSION", 1) > 1: tail_log_kwargs["tail"] = {tail}',
+            f'{_LINUX_NEW_LINE}if getattr(constants, "SKYLET_LIB_VERSION", 1) > 4: tail_log_kwargs["setup_spinner"] = {setup_spinner}',
+            f'{_LINUX_NEW_LINE}if getattr(constants, "SKYLET_LIB_VERSION", 1) > 4: tail_log_kwargs["cluster_name"] = {cluster_name!r}',
+            f'{_LINUX_NEW_LINE}if getattr(constants, "SKYLET_LIB_VERSION", 1) > 4: tail_log_kwargs["num_nodes"] = {num_nodes}',
             f'{_LINUX_NEW_LINE}log_lib.tail_logs(**tail_log_kwargs)',
             # After tailing, check the job status and exit with appropriate code
             'job_status = job_lib.get_status(job_id)',

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -534,7 +534,7 @@ def _setup_watcher(log_file: TextIO, job_id: int, start_streaming: bool,
             return
 
     # Step 2: parse using a spinner until setup is complete.
-    setup_timeout = 3
+    setup_timeout = 60
     pids = set()
     completed_pids = set()
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR adds a new spinner that will tell the user which node is blocking and how to get the logs for that specific node when setup is being blocked. The approach was to modify the setup_cmd in the cloudvm backend to display a key message when setup is complete and then parsing these messages as they come in to determine what node is stalling. After a timeout the new code will display the number of workers that are complete, and messages to check stalled workers as shown in the screenshot below.

<img width="1744" height="740" alt="image" src="https://github.com/user-attachments/assets/21405588-e8e2-4fa2-8632-487d263261a2" />


This required modifying tail_logs to take in a new option `setup_spinner` which when set will call a new function to handle incoming lines that need to be printed. This PR also modified tail_logs to take in `num_nodes` supplied by the cluster handle to prevent us from having to guess at the number of workers we should be waiting for to deem setup complete.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

I tested this using a config yaml that stalls 2 of 3 nodes and verifying that the output conveys the state to the user and the given commands allow looking at the logs for each worker.

```config.yaml
num_nodes: 3

setup: |
  echo "Running setup."
  if [ "$SKYPILOT_SETUP_NODE_RANK" -eq 1 ]; then
    echo "I'm a slow worker, sleeping..."
    sleep 5
  fi
  if [ "$SKYPILOT_SETUP_NODE_RANK" -eq 2 ]; then
    echo "I'm a slow worker, sleeping..."
    sleep 10
  fi

# Typical use: make use of resources, such as running training.
# Invoked under the workdir (i.e., can use its files).
run: |
  echo "Running"
  sleep 1
  echo "Finished"
```

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
