### PR TITLE
[ux] avoid showing "blocked by other requests" after we obtain lock

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3087,10 +3087,6 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
         while True:
             try:
-                # Reset spinner message to remove any mention of being blocked
-                # by other requests.
-                rich_utils.force_update_status(
-                    ux_utils.spinner_message('Launching'))
                 return self._locked_provision(lock_id, task, to_provision,
                                               dryrun, stream_logs, cluster_name,
                                               retry_until_up,
@@ -3117,6 +3113,11 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         skip_unnecessary_provisioning: bool = False,
     ) -> Tuple[Optional[CloudVmRayResourceHandle], bool]:
         with timeline.DistributedLockEvent(lock_id, _CLUSTER_LOCK_TIMEOUT):
+            # Reset spinner message to remove any mention of being blocked
+            # by other requests.
+            rich_utils.force_update_status(
+                ux_utils.spinner_message('Launching'))
+
             # Try to launch the exiting cluster first. If no existing
             # cluster, this function will create a to_provision_config
             # with required resources.

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3087,6 +3087,10 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
         while True:
             try:
+                # Reset spinner message to remove any mention of being blocked
+                # by other requests.
+                rich_utils.force_update_status(
+                    ux_utils.spinner_message('Launching'))
                 return self._locked_provision(lock_id, task, to_provision,
                                               dryrun, stream_logs, cluster_name,
                                               retry_until_up,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Currently, the spinner will show `Launching - blocked by other requests` for a short period of time after we actually obtain the cluster lock and start doing stuff. This will reset the spinner message immediately upon obtaining the lock.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Manual test: add a sleep right after lock acquisition, validate expected behavior.
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
