### PR TITLE
remove global cacheing of get_command_runner

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -56,6 +56,7 @@ from sky.skylet import job_lib
 from sky.skylet import log_lib
 from sky.usage import usage_lib
 from sky.utils import accelerator_registry
+from sky.utils import annotations
 from sky.utils import cluster_utils
 from sky.utils import command_runner
 from sky.utils import common
@@ -2498,6 +2499,12 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
         self.stable_internal_external_ips = stable_internal_external_ips
 
     @context_utils.cancellation_guard
+    # we expect different request to be acting on different clusters
+    # (= different handles) so we have no real expectation of cache hit
+    # across requests.
+    # Do not change this cache to global scope
+    # without understanding https://github.com/skypilot-org/skypilot/pull/6908
+    @annotations.lru_cache(scope='request', maxsize=10)
     @timeline.event
     def get_command_runners(self,
                             force_cached: bool = False,
@@ -2853,6 +2860,12 @@ class LocalResourcesHandle(CloudVmRayResourceHandle):
         self.is_grpc_enabled = False
 
     @context_utils.cancellation_guard
+    # we expect different request to be acting on different clusters
+    # (= different handles) so we have no real expectation of cache hit
+    # across requests.
+    # Do not change this cache to global scope
+    # without understanding https://github.com/skypilot-org/skypilot/pull/6908
+    @annotations.lru_cache(scope='request', maxsize=10)
     @timeline.event
     def get_command_runners(self,
                             force_cached: bool = False,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -56,7 +56,6 @@ from sky.skylet import job_lib
 from sky.skylet import log_lib
 from sky.usage import usage_lib
 from sky.utils import accelerator_registry
-from sky.utils import annotations
 from sky.utils import cluster_utils
 from sky.utils import command_runner
 from sky.utils import common

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2499,7 +2499,7 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
         self.stable_internal_external_ips = stable_internal_external_ips
 
     @context_utils.cancellation_guard
-    @annotations.lru_cache(scope='global')
+    # @annotations.lru_cache(scope='global') # PROBLEM
     @timeline.event
     def get_command_runners(self,
                             force_cached: bool = False,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2499,7 +2499,6 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
         self.stable_internal_external_ips = stable_internal_external_ips
 
     @context_utils.cancellation_guard
-    # @annotations.lru_cache(scope='global') # PROBLEM
     @timeline.event
     def get_command_runners(self,
                             force_cached: bool = False,
@@ -2855,7 +2854,6 @@ class LocalResourcesHandle(CloudVmRayResourceHandle):
         self.is_grpc_enabled = False
 
     @context_utils.cancellation_guard
-    @annotations.lru_cache(scope='global')
     @timeline.event
     def get_command_runners(self,
                             force_cached: bool = False,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
TL;DR this global cacheing causes a memory leak on the status refresh daemon.

- When the cluster is fetched from the DB, the handle is re-created on every read from the DB:
```1293:1315:sky/global_user_state.py
        'handle': pickle.loads(row.handle),
```
- When status refresh=FORCE runs, we eventually do a Ray health check that calls a method on the handle:
```2065:2073:sky/backends/backend_utils.py
            runners = handle.get_command_runners(force_cached=True)
```
- That method is globally lru-cached on the instance (self), which retains a strong reference to the handle in the cache key:
```2501:2507:sky/backends/cloud_vm_ray_backend.py
    @context_utils.cancellation_guard
    @annotations.lru_cache(scope='global')
    @timeline.event
    def get_command_runners(self,
                            force_cached: bool = False,
                            avoid_ssh_control: bool = False) -> List[command_runner.CommandRunner]:
```
Why this leaks
- Each forced status call unpickles a fresh `CloudVmRayResourceHandle` instance (above).
- The first time we call `get_command_runners(self, ...)` on that instance, the global LRU cache stores an entry whose key includes `self`. Because `functools.lru_cache` holds strong references to arguments, the cache keeps those handle objects alive.
- On an API server, caches with scope='global' are never cleared per request (only scope='request' caches are cleared in `reload_for_new_request()`), so repeated status calls accumulate unique handle instances in the cache.
- The same decoration exists on the `LocalResourcesHandle.get_command_runners` override too.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
