### PR TITLE
long running request daemon memory hygiene

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -65,6 +65,7 @@ from sky.utils import context_utils
 from sky.utils import controller_utils
 from sky.utils import directory_utils
 from sky.utils import env_options
+from sky.utils import lock_events
 from sky.utils import locks
 from sky.utils import log_utils
 from sky.utils import message_utils
@@ -3112,7 +3113,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         retry_until_up: bool = False,
         skip_unnecessary_provisioning: bool = False,
     ) -> Tuple[Optional[CloudVmRayResourceHandle], bool]:
-        with timeline.DistributedLockEvent(lock_id, _CLUSTER_LOCK_TIMEOUT):
+        with lock_events.DistributedLockEvent(lock_id, _CLUSTER_LOCK_TIMEOUT):
             # Try to launch the exiting cluster first. If no existing
             # cluster, this function will create a to_provision_config
             # with required resources.

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -911,8 +911,7 @@ def reload_for_new_request(client_entrypoint: Optional[str],
 
     # Clear cache should be called before reload_logger and usage reset,
     # otherwise, the latest env var will not be used.
-    for func in annotations.FUNCTIONS_NEED_RELOAD_CACHE:
-        func.cache_clear()
+    annotations.clear_request_level_cache()
 
     # We need to reset usage message, so that the message is up-to-date with the
     # latest information in the context, e.g. client entrypoint and run id.

--- a/sky/server/daemons.py
+++ b/sky/server/daemons.py
@@ -4,12 +4,14 @@ import os
 import time
 from typing import Callable
 
+from sky.utils import annotations
 from sky import sky_logging
 from sky import skypilot_config
 from sky.server import constants as server_constants
 from sky.utils import common
 from sky.utils import env_options
 from sky.utils import ux_utils
+from sky.utils import timeline
 
 logger = sky_logging.init_logger(__name__)
 
@@ -67,6 +69,11 @@ class InternalRequestDaemon:
                     sky_logging.reload_logger()
                     level = self.refresh_log_level()
                     self.event_fn()
+                # Clear cache should be called before reload_logger and usage reset,
+                # otherwise, the latest env var will not be used.
+                for func in annotations.FUNCTIONS_NEED_RELOAD_CACHE:
+                    func.cache_clear()
+                timeline.save_timeline()
             except Exception:  # pylint: disable=broad-except
                 # It is OK to fail to run the event, as the event is not
                 # critical, but we should log the error.

--- a/sky/server/daemons.py
+++ b/sky/server/daemons.py
@@ -4,14 +4,14 @@ import os
 import time
 from typing import Callable
 
-from sky.utils import annotations
 from sky import sky_logging
 from sky import skypilot_config
 from sky.server import constants as server_constants
+from sky.utils import annotations
 from sky.utils import common
 from sky.utils import env_options
-from sky.utils import ux_utils
 from sky.utils import timeline
+from sky.utils import ux_utils
 
 logger = sky_logging.init_logger(__name__)
 
@@ -69,8 +69,8 @@ class InternalRequestDaemon:
                     sky_logging.reload_logger()
                     level = self.refresh_log_level()
                     self.event_fn()
-                # Clear cache should be called before reload_logger and usage reset,
-                # otherwise, the latest env var will not be used.
+                # Clear request level cache after each run to avoid
+                # using too much memory.
                 for func in annotations.FUNCTIONS_NEED_RELOAD_CACHE:
                     func.cache_clear()
                 timeline.save_timeline()

--- a/sky/server/daemons.py
+++ b/sky/server/daemons.py
@@ -71,8 +71,7 @@ class InternalRequestDaemon:
                     self.event_fn()
                 # Clear request level cache after each run to avoid
                 # using too much memory.
-                for func in annotations.FUNCTIONS_NEED_RELOAD_CACHE:
-                    func.cache_clear()
+                annotations.clear_request_level_cache()
                 timeline.save_timeline()
             except Exception:  # pylint: disable=broad-except
                 # It is OK to fail to run the event, as the event is not

--- a/sky/utils/annotations.py
+++ b/sky/utils/annotations.py
@@ -7,7 +7,7 @@ from typing_extensions import ParamSpec
 
 # Whether the current process is a SkyPilot API server process.
 is_on_api_server = True
-FUNCTIONS_NEED_RELOAD_CACHE = []
+_FUNCTIONS_NEED_RELOAD_CACHE = []
 
 T = TypeVar('T')
 P = ParamSpec('P')
@@ -50,7 +50,12 @@ def lru_cache(scope: Literal['global', 'request'], *lru_cache_args,
         else:
             cached_func = functools.lru_cache(*lru_cache_args,
                                               **lru_cache_kwargs)(func)
-            FUNCTIONS_NEED_RELOAD_CACHE.append(cached_func)
+            _FUNCTIONS_NEED_RELOAD_CACHE.append(cached_func)
             return cached_func
 
     return decorator
+
+def clear_request_level_cache():
+    """Clear the request-level cache."""
+    for func in _FUNCTIONS_NEED_RELOAD_CACHE:
+        func.cache_clear()

--- a/sky/utils/annotations.py
+++ b/sky/utils/annotations.py
@@ -55,6 +55,7 @@ def lru_cache(scope: Literal['global', 'request'], *lru_cache_args,
 
     return decorator
 
+
 def clear_request_level_cache():
     """Clear the request-level cache."""
     for func in _FUNCTIONS_NEED_RELOAD_CACHE:

--- a/sky/utils/cluster_utils.py
+++ b/sky/utils/cluster_utils.py
@@ -11,7 +11,7 @@ import uuid
 from sky.skylet import constants
 from sky.utils import command_runner
 from sky.utils import common_utils
-from sky.utils import timeline
+from sky.utils import lock_events
 
 # The cluster yaml used to create the current cluster where the module is
 # called.
@@ -107,7 +107,7 @@ class SSHConfigHelper(object):
         return auth_config['ssh_private_key']
 
     @classmethod
-    @timeline.FileLockEvent(ssh_conf_lock_path)
+    @lock_events.FileLockEvent(ssh_conf_lock_path)
     def add_cluster(
         cls,
         cluster_name: str,
@@ -334,7 +334,7 @@ class SSHConfigHelper(object):
             cluster_name: Cluster name.
         """
 
-        with timeline.FileLockEvent(
+        with lock_events.FileLockEvent(
                 cls.ssh_conf_per_cluster_lock_path.format(cluster_name)):
             cluster_config_path = os.path.expanduser(
                 cls.ssh_cluster_path.format(cluster_name))

--- a/sky/utils/lock_events.py
+++ b/sky/utils/lock_events.py
@@ -1,0 +1,94 @@
+"""Lock events."""
+
+import functools
+import os
+from typing import Optional, Union
+
+import filelock
+
+from sky.utils import locks
+from sky.utils import timeline
+
+
+class DistributedLockEvent:
+    """Serve both as a distributed lock and event for the lock."""
+
+    def __init__(self, lock_id: str, timeout: Optional[float] = None):
+        self._lock_id = lock_id
+        self._lock = locks.get_lock(lock_id, timeout)
+        self._hold_lock_event = timeline.Event(
+            f'[DistributedLock.hold]:{lock_id}')
+
+    def acquire(self):
+        was_locked = self._lock.is_locked
+        with timeline.Event(f'[DistributedLock.acquire]:{self._lock_id}'):
+            self._lock.acquire()
+        if not was_locked and self._lock.is_locked:
+            # start holding the lock after initial acquiring
+            self._hold_lock_event.begin()
+
+    def release(self):
+        was_locked = self._lock.is_locked
+        self._lock.release()
+        if was_locked and not self._lock.is_locked:
+            # stop holding the lock after initial releasing
+            self._hold_lock_event.end()
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.release()
+
+    def __call__(self, f):
+
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            with self:
+                return f(*args, **kwargs)
+
+        return wrapper
+
+
+class FileLockEvent:
+    """Serve both as a file lock and event for the lock."""
+
+    def __init__(self, lockfile: Union[str, os.PathLike], timeout: float = -1):
+        self._lockfile = lockfile
+        os.makedirs(os.path.dirname(os.path.abspath(self._lockfile)),
+                    exist_ok=True)
+        self._lock = filelock.FileLock(self._lockfile, timeout)
+        self._hold_lock_event = timeline.Event(
+            f'[FileLock.hold]:{self._lockfile}')
+
+    def acquire(self):
+        was_locked = self._lock.is_locked
+        with timeline.Event(f'[FileLock.acquire]:{self._lockfile}'):
+            self._lock.acquire()
+        if not was_locked and self._lock.is_locked:
+            # start holding the lock after initial acquiring
+            self._hold_lock_event.begin()
+
+    def release(self):
+        was_locked = self._lock.is_locked
+        self._lock.release()
+        if was_locked and not self._lock.is_locked:
+            # stop holding the lock after initial releasing
+            self._hold_lock_event.end()
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.release()
+
+    def __call__(self, f):
+        # Make this class callable as a decorator.
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            with self:
+                return f(*args, **kwargs)
+
+        return wrapper

--- a/sky/utils/timeline.py
+++ b/sky/utils/timeline.py
@@ -20,6 +20,7 @@ from sky.utils import locks
 _events = []
 _events_file_path = os.environ.get('SKYPILOT_TIMELINE_FILE_PATH')
 
+
 class Event:
     """Record an event.
 
@@ -169,17 +170,16 @@ def save_timeline():
     if not _events_file_path:
         return
     json_output = {
-        'traceEvents': events_to_write,
+        'traceEvents': _events,
         'displayTimeUnit': 'ms',
         'otherData': {
             'log_dir': os.path.dirname(os.path.abspath(_events_file_path)),
         }
     }
-    os.makedirs(os.path.dirname(os.path.abspath(_events_file_path)), exist_ok=True)
+    os.makedirs(os.path.dirname(os.path.abspath(_events_file_path)),
+                exist_ok=True)
     with open(_events_file_path, 'w', encoding='utf-8') as f:
         json.dump(json_output, f)
-    # After saving, drop our reference to the old list so it can be GC'd.
-    del events_to_write
 
 
 if _events_file_path:

--- a/sky/utils/timeline.py
+++ b/sky/utils/timeline.py
@@ -4,7 +4,6 @@ The timeline follows the trace event format defined here:
 https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
 """  # pylint: disable=line-too-long
 import atexit
-import functools
 import json
 import os
 import threading
@@ -12,10 +11,7 @@ import time
 import traceback
 from typing import Callable, Optional, Union
 
-import filelock
-
 from sky.utils import common_utils
-from sky.utils import locks
 
 _events = []
 
@@ -87,88 +83,6 @@ class Event:
 
 def event(name_or_fn: Union[str, Callable], message: Optional[str] = None):
     return common_utils.make_decorator(Event, name_or_fn, message=message)
-
-
-class DistributedLockEvent:
-    """Serve both as a distributed lock and event for the lock."""
-
-    def __init__(self, lock_id: str, timeout: Optional[float] = None):
-        self._lock_id = lock_id
-        self._lock = locks.get_lock(lock_id, timeout)
-        self._hold_lock_event = Event(f'[DistributedLock.hold]:{lock_id}')
-
-    def acquire(self):
-        was_locked = self._lock.is_locked
-        with Event(f'[DistributedLock.acquire]:{self._lock_id}'):
-            self._lock.acquire()
-        if not was_locked and self._lock.is_locked:
-            # start holding the lock after initial acquiring
-            self._hold_lock_event.begin()
-
-    def release(self):
-        was_locked = self._lock.is_locked
-        self._lock.release()
-        if was_locked and not self._lock.is_locked:
-            # stop holding the lock after initial releasing
-            self._hold_lock_event.end()
-
-    def __enter__(self):
-        self.acquire()
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.release()
-
-    def __call__(self, f):
-
-        @functools.wraps(f)
-        def wrapper(*args, **kwargs):
-            with self:
-                return f(*args, **kwargs)
-
-        return wrapper
-
-
-class FileLockEvent:
-    """Serve both as a file lock and event for the lock."""
-
-    def __init__(self, lockfile: Union[str, os.PathLike], timeout: float = -1):
-        self._lockfile = lockfile
-        os.makedirs(os.path.dirname(os.path.abspath(self._lockfile)),
-                    exist_ok=True)
-        self._lock = filelock.FileLock(self._lockfile, timeout)
-        self._hold_lock_event = Event(f'[FileLock.hold]:{self._lockfile}')
-
-    def acquire(self):
-        was_locked = self._lock.is_locked
-        with Event(f'[FileLock.acquire]:{self._lockfile}'):
-            self._lock.acquire()
-        if not was_locked and self._lock.is_locked:
-            # start holding the lock after initial acquiring
-            self._hold_lock_event.begin()
-
-    def release(self):
-        was_locked = self._lock.is_locked
-        self._lock.release()
-        if was_locked and not self._lock.is_locked:
-            # stop holding the lock after initial releasing
-            self._hold_lock_event.end()
-
-    def __enter__(self):
-        self.acquire()
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.release()
-
-    def __call__(self, f):
-        # Make this class callable as a decorator.
-        @functools.wraps(f)
-        def wrapper(*args, **kwargs):
-            with self:
-                return f(*args, **kwargs)
-
-        return wrapper
 
 
 def save_timeline():

--- a/tests/unit_tests/test_catalog.py
+++ b/tests/unit_tests/test_catalog.py
@@ -62,8 +62,7 @@ def test_read_catalog_triggers_update_on_stale_file(mock_get):
         pd.testing.assert_frame_equal(df._df, pd.read_csv(abs_catalog_path))
 
         # Clear the cache.
-        for func in annotations.FUNCTIONS_NEED_RELOAD_CACHE:
-            func.cache_clear()
+        annotations.clear_request_level_cache()
 
         # Now update_if_stale_func should be called and should trigger a new fetch.
         df.head()

--- a/tests/unit_tests/test_sky/utils/test_timeline.py
+++ b/tests/unit_tests/test_sky/utils/test_timeline.py
@@ -1,13 +1,15 @@
 """Test for sky.utils.timeline."""
 
-from unittest import mock
-import pytest
 import os
+from unittest import mock
+
+import pytest
 
 from sky.utils import timeline
 
 
 def test_save_timeline():
+
     @timeline.event("test_save_timeline")
     def test_save_timeline():
         pass

--- a/tests/unit_tests/test_sky/utils/test_timeline.py
+++ b/tests/unit_tests/test_sky/utils/test_timeline.py
@@ -1,0 +1,30 @@
+"""Test for sky.utils.timeline."""
+
+from unittest import mock
+import pytest
+import os
+
+from sky.utils import timeline
+
+
+def test_save_timeline():
+    @timeline.event("test_save_timeline")
+    def test_save_timeline():
+        pass
+
+    with mock.patch('sky.utils.timeline._get_events_file_path',
+                    return_value='/tmp/sky/timeline.json'):
+        test_save_timeline()
+        # one entry for function entry and
+        # one entry for function exit
+        assert len(timeline._events) == 2
+        timeline.save_timeline()
+        # after saving, the events should be empty
+        assert len(timeline._events) == 0
+        os.remove('/tmp/sky/timeline.json')
+
+    with mock.patch('sky.utils.timeline._get_events_file_path',
+                    return_value=None):
+        test_save_timeline()
+        # no timeline file path, so no events should be recorded
+        assert len(timeline._events) == 0


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Problem 1: Since the daemon is a single request that runs a while, the request level cache is not cleared after each periodic run of the daemon. Treat each run as a request in cacheing terms by clearing out request level cache after each run of the daemon.

Problem 2: timeline events can grow without bound. Do not store timeline events if the events won't be used for anything.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
