### PR TITLE
Fix coreweave k8s cluster smoke tests failures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -685,6 +685,7 @@ def prepare_env_file(request):
     if os.path.exists(expanded_path):
         # It's a local file/directory, use it directly
         logger.info(f'Using local env file: {expanded_path}')
+        os.environ['PYTEST_SKYPILOT_CONFIG_FILE_OVERRIDE'] = expanded_path
         yield expanded_path
         return
 

--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -765,8 +765,9 @@ def increase_initial_delay_seconds_for_slow_cloud(cloud: str):
 
 
 def is_remote_server_test() -> bool:
-    return os.environ.get('PYTEST_SKYPILOT_REMOTE_SERVER_TEST',
-                          None) is not None
+    return os.environ.get(
+        'PYTEST_SKYPILOT_REMOTE_SERVER_TEST',
+        None) is not None or api_server_endpoint_configured_in_env_file()
 
 
 def pytest_controller_cloud() -> Optional[str]:

--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -785,6 +785,16 @@ def pytest_config_file_override() -> Optional[str]:
     return os.environ.get('PYTEST_SKYPILOT_CONFIG_FILE_OVERRIDE', None)
 
 
+def services_account_token_configured() -> bool:
+    file_path = pytest_config_file_override()
+    if file_path is not None:
+        with open(file_path, 'r') as f:
+            content = f.read()
+            print(content, file=sys.stderr, flush=True)
+            return 'service_account_token' in content
+    return False
+
+
 def pytest_override_env_config_file(config: Dict[str, str]):
     """Override the environment variable for the test."""
     for key, value in config.items():

--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -785,7 +785,16 @@ def pytest_config_file_override() -> Optional[str]:
     return os.environ.get('PYTEST_SKYPILOT_CONFIG_FILE_OVERRIDE', None)
 
 
-def services_account_token_configured() -> bool:
+def api_server_endpoint_configured_in_env_file() -> bool:
+    file_path = pytest_config_file_override()
+    if file_path is not None:
+        with open(file_path, 'r') as f:
+            content = f.read()
+            return 'endpoint' in content
+    return False
+
+
+def services_account_token_configured_in_env_file() -> bool:
     file_path = pytest_config_file_override()
     if file_path is not None:
         with open(file_path, 'r') as f:

--- a/tests/smoke_tests/test_api_server.py
+++ b/tests/smoke_tests/test_api_server.py
@@ -18,6 +18,12 @@ def set_user(user_id: str, user_name: str, commands: List[str]) -> List[str]:
 # ---------- Test multi-tenant ----------
 @pytest.mark.no_hyperbolic  # Hyperbolic does not support multi-tenant jobs
 def test_multi_tenant(generic_cloud: str):
+    if smoke_tests_utils.services_account_token_configured():
+        pytest.skip(
+            'Skipping multi-tenant test because a service account token is '
+            'configured. The service account token represents a unique user, '
+            'so USER_ENV_VAR cannot be used to simulate multiple users.')
+
     name = smoke_tests_utils.get_cluster_name()
     user_1 = 'abcdef12'
     user_1_name = 'user1'
@@ -101,6 +107,12 @@ def test_multi_tenant(generic_cloud: str):
 
 @pytest.mark.no_hyperbolic  # Hyperbolic does not support multi-tenant jobs
 def test_multi_tenant_managed_jobs(generic_cloud: str):
+    if smoke_tests_utils.services_account_token_configured():
+        pytest.skip(
+            'Skipping multi-tenant test because a service account token is '
+            'configured. The service account token represents a unique user, '
+            'so USER_ENV_VAR cannot be used to simulate multiple users.')
+
     name = smoke_tests_utils.get_cluster_name()
     user_1 = 'abcdef12'
     user_1_name = 'user1'

--- a/tests/smoke_tests/test_api_server.py
+++ b/tests/smoke_tests/test_api_server.py
@@ -18,7 +18,7 @@ def set_user(user_id: str, user_name: str, commands: List[str]) -> List[str]:
 # ---------- Test multi-tenant ----------
 @pytest.mark.no_hyperbolic  # Hyperbolic does not support multi-tenant jobs
 def test_multi_tenant(generic_cloud: str):
-    if smoke_tests_utils.services_account_token_configured():
+    if smoke_tests_utils.services_account_token_configured_in_env_file():
         pytest.skip(
             'Skipping multi-tenant test because a service account token is '
             'configured. The service account token represents a unique user, '
@@ -107,7 +107,7 @@ def test_multi_tenant(generic_cloud: str):
 
 @pytest.mark.no_hyperbolic  # Hyperbolic does not support multi-tenant jobs
 def test_multi_tenant_managed_jobs(generic_cloud: str):
-    if smoke_tests_utils.services_account_token_configured():
+    if smoke_tests_utils.services_account_token_configured_in_env_file():
         pytest.skip(
             'Skipping multi-tenant test because a service account token is '
             'configured. The service account token represents a unique user, '

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -53,7 +53,10 @@ from sky.utils import resources_utils
 @pytest.mark.resource_heavy
 @pytest.mark.parametrize('accelerator', [{'do': 'H100', 'nebius': 'H100'}])
 def test_job_queue(generic_cloud: str, accelerator: Dict[str, str]):
-    accelerator = accelerator.get(generic_cloud, 'T4')
+    if generic_cloud == 'kubernetes':
+        accelerator = smoke_tests_utils.get_avaliabe_gpus_for_k8s_tests()
+    else:
+        accelerator = accelerator.get(generic_cloud, 'T4')
     name = smoke_tests_utils.get_cluster_name()
     test = smoke_tests_utils.Test(
         'job_queue',
@@ -477,7 +480,10 @@ def test_multi_echo(generic_cloud: str):
 @pytest.mark.resource_heavy
 @pytest.mark.parametrize('accelerator', [{'do': 'H100', 'nebius': 'H100'}])
 def test_huggingface(generic_cloud: str, accelerator: Dict[str, str]):
-    accelerator = accelerator.get(generic_cloud, 'T4')
+    if generic_cloud == 'kubernetes':
+        accelerator = smoke_tests_utils.get_avaliabe_gpus_for_k8s_tests()
+    else:
+        accelerator = accelerator.get(generic_cloud, 'T4')
     name = smoke_tests_utils.get_cluster_name()
     test = smoke_tests_utils.Test(
         'huggingface_glue_imdb_app',
@@ -1439,7 +1445,10 @@ def test_cancel_azure():
 @pytest.mark.resource_heavy
 @pytest.mark.parametrize('accelerator', [{'do': 'H100', 'nebius': 'H100'}])
 def test_cancel_pytorch(generic_cloud: str, accelerator: Dict[str, str]):
-    accelerator = accelerator.get(generic_cloud, 'T4')
+    if generic_cloud == 'kubernetes':
+        accelerator = smoke_tests_utils.get_avaliabe_gpus_for_k8s_tests()
+    else:
+        accelerator = accelerator.get(generic_cloud, 'T4')
     name = smoke_tests_utils.get_cluster_name()
     test = smoke_tests_utils.Test(
         'cancel-pytorch',
@@ -1935,6 +1944,7 @@ def test_long_setup_run_script(generic_cloud: str):
 @pytest.mark.kubernetes
 @pytest.mark.resource_heavy
 def test_min_gpt_kubernetes():
+    accelerator = smoke_tests_utils.get_avaliabe_gpus_for_k8s_tests()
     name = smoke_tests_utils.get_cluster_name()
     original_yaml_path = 'examples/distributed-pytorch/train.yaml'
 
@@ -1945,8 +1955,8 @@ def test_min_gpt_kubernetes():
     modified_content = content.replace('main.py',
                                        'main.py trainer_config.max_epochs=1')
 
-    modified_content = re.sub(r'accelerators:\s*[^\n]+', 'accelerators: T4',
-                              modified_content)
+    modified_content = re.sub(r'accelerators:\s*[^\n]+',
+                              f'accelerators: {accelerator}', modified_content)
 
     # Create a temporary YAML file with the modified content
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as f:

--- a/tests/smoke_tests/test_logs.py
+++ b/tests/smoke_tests/test_logs.py
@@ -9,12 +9,9 @@ import textwrap
 import pytest
 from smoke_tests import smoke_tests_utils
 
-from sky import skypilot_config
 
-
-@pytest.mark.no_vast  # Requires GCP
-@pytest.mark.no_fluidstack  # Requires GCP to be enabled
-def test_log_collection_to_gcp(generic_cloud: str):
+@pytest.mark.gcp
+def test_log_collection_to_gcp():
     name = smoke_tests_utils.get_cluster_name()
     # Calculate timestamp 1 hour ago in ISO format
     one_hour_ago = (datetime.now(timezone.utc) -

--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -1262,6 +1262,7 @@ class TestStorageWithCredentials:
     @pytest.mark.no_fluidstack
     @pytest.mark.no_hyperbolic
     @pytest.mark.no_postgres
+    @pytest.mark.no_kubernetes
     @pytest.mark.parametrize('store_type', [
         storage_lib.StoreType.S3, storage_lib.StoreType.GCS,
         pytest.param(storage_lib.StoreType.AZURE, marks=pytest.mark.azure),
@@ -1354,6 +1355,7 @@ class TestStorageWithCredentials:
     @pytest.mark.no_fluidstack
     @pytest.mark.no_hyperbolic
     @pytest.mark.no_postgres
+    @pytest.mark.no_kubernetes
     @pytest.mark.xdist_group('multiple_bucket_deletion')
     @pytest.mark.parametrize('store_type', [
         storage_lib.StoreType.S3, storage_lib.StoreType.GCS,
@@ -1400,6 +1402,7 @@ class TestStorageWithCredentials:
     @pytest.mark.no_fluidstack
     @pytest.mark.no_hyperbolic
     @pytest.mark.no_postgres
+    @pytest.mark.no_kubernetes
     @pytest.mark.parametrize('store_type', [
         storage_lib.StoreType.S3, storage_lib.StoreType.GCS,
         pytest.param(storage_lib.StoreType.AZURE, marks=pytest.mark.azure),
@@ -1430,6 +1433,7 @@ class TestStorageWithCredentials:
     @pytest.mark.no_fluidstack
     @pytest.mark.no_hyperbolic
     @pytest.mark.no_postgres
+    @pytest.mark.no_kubernetes
     @pytest.mark.parametrize('store_type', [
         storage_lib.StoreType.S3, storage_lib.StoreType.GCS,
         pytest.param(storage_lib.StoreType.AZURE, marks=pytest.mark.azure),
@@ -1679,6 +1683,7 @@ class TestStorageWithCredentials:
     @pytest.mark.no_fluidstack
     @pytest.mark.no_hyperbolic
     @pytest.mark.no_postgres
+    @pytest.mark.no_kubernetes
     def test_copy_mount_existing_storage(self,
                                          tmp_copy_mnt_existing_storage_obj):
         # Creates a bucket with no source in MOUNT mode (empty bucket), and

--- a/tests/smoke_tests/test_region_and_zone.py
+++ b/tests/smoke_tests/test_region_and_zone.py
@@ -273,7 +273,14 @@ def test_docker_storage_mounts(generic_cloud: str, image_id: str):
     # created in the centralus region when getting the storage account. We
     # should set the cluster to be launched in the same region.
     region_str = f'/centralus' if generic_cloud == 'azure' else ''
-    if azure_mount_unsupported_ubuntu_version in image_id:
+    if smoke_tests_utils.api_server_endpoint_configured_in_env_file():
+        # Assume only AWS is used for storage when using a remote API server.
+        # TODO: Find a better way to decide which cloud to use for storage
+        # when using a remote API server.
+        content = template.render(storage_name=storage_name,
+                                  include_gcs_mount=False,
+                                  include_azure_mount=False)
+    elif azure_mount_unsupported_ubuntu_version in image_id:
         # The store for mount_private_mount is not specified in the template.
         # If we're running on Azure, the private mount will be created on
         # azure blob. Also, if we're running on Kubernetes, the private mount

--- a/tests/smoke_tests/test_region_and_zone.py
+++ b/tests/smoke_tests/test_region_and_zone.py
@@ -273,7 +273,7 @@ def test_docker_storage_mounts(generic_cloud: str, image_id: str):
     # created in the centralus region when getting the storage account. We
     # should set the cluster to be launched in the same region.
     region_str = f'/centralus' if generic_cloud == 'azure' else ''
-    if smoke_tests_utils.api_server_endpoint_configured_in_env_file():
+    if smoke_tests_utils.is_remote_server_test():
         # Assume only AWS is used for storage when using a remote API server.
         # TODO: Find a better way to decide which cloud to use for storage
         # when using a remote API server.

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -343,7 +343,11 @@ def test_skyserve_oci_http():
 @pytest.mark.resource_heavy
 def test_skyserve_llm(generic_cloud: str, accelerator: Dict[str, str]):
     """Test skyserve with real LLM usecase"""
-    accelerator = accelerator.get(generic_cloud, 'T4')
+    if generic_cloud == 'kubernetes':
+        accelerator = smoke_tests_utils.get_avaliabe_gpus_for_k8s_tests()
+    else:
+        accelerator = accelerator.get(generic_cloud, 'T4')
+
     name = _get_service_name()
     auth_token = '123456'
 

--- a/tests/smoke_tests/test_workspaces.py
+++ b/tests/smoke_tests/test_workspaces.py
@@ -26,7 +26,7 @@ def test_workspace_switching(generic_cloud: str):
         pytest.skip(
             'Skipping workspace switching test when not in Buildkite environment'
         )
-    if smoke_tests_utils.api_server_endpoint_configured_in_env_file():
+    if smoke_tests_utils.is_remote_server_test():
         pytest.skip(
             'This test requires a local API server and needs to restart the server during execution. '
             'If the API server endpoint is set in the environment file, restarting is not supported, '

--- a/tests/smoke_tests/test_workspaces.py
+++ b/tests/smoke_tests/test_workspaces.py
@@ -26,6 +26,12 @@ def test_workspace_switching(generic_cloud: str):
         pytest.skip(
             'Skipping workspace switching test when not in Buildkite environment'
         )
+    if smoke_tests_utils.api_server_endpoint_configured_in_env_file():
+        pytest.skip(
+            'This test requires a local API server and needs to restart the server during execution. '
+            'If the API server endpoint is set in the environment file, restarting is not supported, '
+            'so the test will be skipped.')
+
     ws1_name = 'ws-1'
     ws2_name = 'ws-2'
     server_config_content = textwrap.dedent(f"""\


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

* Skip tests that require server restart or changing `USER_ENV`, which is not supported via API endpoints and service accounts token(The user will fixed if we use that, `USER_ENV` won't work then)  
* Change some GPU types
* Still working on it, PR for sync and convenience tests.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
