### PR TITLE
[API server] fix /upload endpoint from blocking the event loop

### DIFF
--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -916,7 +916,7 @@ async def upload_zip_file(request: fastapi.Request, user_hash: str,
                         await zip_file.write(data)
 
     logger.info(f'Uploaded zip file: {zip_file_path}')
-    unzip_file(zip_file_path, client_file_mounts_dir)
+    await unzip_file(zip_file_path, client_file_mounts_dir)
     if total_chunks > 1:
         shutil.rmtree(chunk_dir)
     return payloads.UploadZipFileResponse(
@@ -933,61 +933,65 @@ def _is_relative_to(path: pathlib.Path, parent: pathlib.Path) -> bool:
         return False
 
 
-def unzip_file(zip_file_path: pathlib.Path,
-               client_file_mounts_dir: pathlib.Path) -> None:
-    """Unzips a zip file."""
-    try:
-        with zipfile.ZipFile(zip_file_path, 'r') as zipf:
-            for member in zipf.infolist():
-                # Determine the new path
-                original_path = os.path.normpath(member.filename)
-                new_path = client_file_mounts_dir / original_path.lstrip('/')
+async def unzip_file(zip_file_path: pathlib.Path,
+                     client_file_mounts_dir: pathlib.Path) -> None:
+    """Unzips a zip file without blocking the event loop."""
 
-                if (member.external_attr >> 28) == 0xA:
-                    # Symlink. Read the target path and create a symlink.
+    def _do_unzip() -> None:
+        try:
+            with zipfile.ZipFile(zip_file_path, 'r') as zipf:
+                for member in zipf.infolist():
+                    # Determine the new path
+                    original_path = os.path.normpath(member.filename)
+                    new_path = client_file_mounts_dir / original_path.lstrip('/')
+
+                    if (member.external_attr >> 28) == 0xA:
+                        # Symlink. Read the target path and create a symlink.
+                        new_path.parent.mkdir(parents=True, exist_ok=True)
+                        target = zipf.read(member).decode()
+                        assert not os.path.isabs(target), target
+                        # Since target is a relative path, we need to check that it
+                        # is under `client_file_mounts_dir` for security.
+                        full_target_path = (new_path.parent / target).resolve()
+                        if not _is_relative_to(full_target_path,
+                                               client_file_mounts_dir):
+                            raise ValueError(
+                                f'Symlink target {target} leads to a file not in userspace. Aborted.')
+
+                        if new_path.exists() or new_path.is_symlink():
+                            new_path.unlink(missing_ok=True)
+                        new_path.symlink_to(
+                            target,
+                            target_is_directory=member.filename.endswith('/'))
+                        continue
+
+                    # Handle directories
+                    if member.filename.endswith('/'):
+                        new_path.mkdir(parents=True, exist_ok=True)
+                        continue
+
+                    # Handle files
                     new_path.parent.mkdir(parents=True, exist_ok=True)
-                    target = zipf.read(member).decode()
-                    assert not os.path.isabs(target), target
-                    # Since target is a relative path, we need to check that it
-                    # is under `client_file_mounts_dir` for security.
-                    full_target_path = (new_path.parent / target).resolve()
-                    if not _is_relative_to(full_target_path,
-                                           client_file_mounts_dir):
-                        raise ValueError(f'Symlink target {target} leads to a '
-                                         'file not in userspace. Aborted.')
+                    with zipf.open(member) as member_file, new_path.open('wb') as f:
+                        # Use shutil.copyfileobj to copy files in chunks, so it does
+                        # not load the entire file into memory.
+                        shutil.copyfileobj(member_file, f)
+        except zipfile.BadZipFile as e:
+            logger.error(f'Bad zip file: {zip_file_path}')
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=f'Invalid zip file: {common_utils.format_exception(e)}')
+        except Exception as e:
+            logger.error(f'Error unzipping file: {zip_file_path}')
+            raise fastapi.HTTPException(
+                status_code=500,
+                detail=(f'Error unzipping file: '
+                        f'{common_utils.format_exception(e)}'))
+        finally:
+            # Cleanup the temporary file regardless of success/failure handling above
+            zip_file_path.unlink(missing_ok=True)
 
-                    if new_path.exists() or new_path.is_symlink():
-                        new_path.unlink(missing_ok=True)
-                    new_path.symlink_to(
-                        target,
-                        target_is_directory=member.filename.endswith('/'))
-                    continue
-
-                # Handle directories
-                if member.filename.endswith('/'):
-                    new_path.mkdir(parents=True, exist_ok=True)
-                    continue
-
-                # Handle files
-                new_path.parent.mkdir(parents=True, exist_ok=True)
-                with zipf.open(member) as member_file, new_path.open('wb') as f:
-                    # Use shutil.copyfileobj to copy files in chunks, so it does
-                    # not load the entire file into memory.
-                    shutil.copyfileobj(member_file, f)
-    except zipfile.BadZipFile as e:
-        logger.error(f'Bad zip file: {zip_file_path}')
-        raise fastapi.HTTPException(
-            status_code=400,
-            detail=f'Invalid zip file: {common_utils.format_exception(e)}')
-    except Exception as e:
-        logger.error(f'Error unzipping file: {zip_file_path}')
-        raise fastapi.HTTPException(
-            status_code=500,
-            detail=(f'Error unzipping file: '
-                    f'{common_utils.format_exception(e)}'))
-
-    # Cleanup the temporary file
-    zip_file_path.unlink()
+    await context_utils.to_thread(_do_unzip)
 
 
 @app.post('/launch')

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -943,20 +943,22 @@ async def unzip_file(zip_file_path: pathlib.Path,
                 for member in zipf.infolist():
                     # Determine the new path
                     original_path = os.path.normpath(member.filename)
-                    new_path = client_file_mounts_dir / original_path.lstrip('/')
+                    new_path = client_file_mounts_dir / original_path.lstrip(
+                        '/')
 
                     if (member.external_attr >> 28) == 0xA:
                         # Symlink. Read the target path and create a symlink.
                         new_path.parent.mkdir(parents=True, exist_ok=True)
                         target = zipf.read(member).decode()
                         assert not os.path.isabs(target), target
-                        # Since target is a relative path, we need to check that it
-                        # is under `client_file_mounts_dir` for security.
+                        # Since target is a relative path, we need to check that
+                        # it is under `client_file_mounts_dir` for security.
                         full_target_path = (new_path.parent / target).resolve()
                         if not _is_relative_to(full_target_path,
                                                client_file_mounts_dir):
                             raise ValueError(
-                                f'Symlink target {target} leads to a file not in userspace. Aborted.')
+                                f'Symlink target {target} leads to a '
+                                'file not in userspace. Aborted.')
 
                         if new_path.exists() or new_path.is_symlink():
                             new_path.unlink(missing_ok=True)
@@ -972,9 +974,10 @@ async def unzip_file(zip_file_path: pathlib.Path,
 
                     # Handle files
                     new_path.parent.mkdir(parents=True, exist_ok=True)
-                    with zipf.open(member) as member_file, new_path.open('wb') as f:
-                        # Use shutil.copyfileobj to copy files in chunks, so it does
-                        # not load the entire file into memory.
+                    with zipf.open(member) as member_file, new_path.open(
+                            'wb') as f:
+                        # Use shutil.copyfileobj to copy files in chunks,
+                        # so it does not load the entire file into memory.
                         shutil.copyfileobj(member_file, f)
         except zipfile.BadZipFile as e:
             logger.error(f'Bad zip file: {zip_file_path}')
@@ -988,7 +991,8 @@ async def unzip_file(zip_file_path: pathlib.Path,
                 detail=(f'Error unzipping file: '
                         f'{common_utils.format_exception(e)}'))
         finally:
-            # Cleanup the temporary file regardless of success/failure handling above
+            # Cleanup the temporary file regardless of
+            # success/failure handling above
             zip_file_path.unlink(missing_ok=True)
 
     await context_utils.to_thread(_do_unzip)

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -71,6 +71,7 @@ install_requires = [
     'types-paramiko',
     'alembic',
     'aiohttp',
+    'anyio',
 ]
 
 # See requirements-dev.txt for the version of grpc and protobuf
@@ -92,6 +93,7 @@ server_dependencies = [
     'passlib',
     'pyjwt',
     'aiohttp',
+    'anyio',
     GRPC,
     PROTOBUF,
 ]

--- a/tests/unit_tests/test_zip_and_unzip.py
+++ b/tests/unit_tests/test_zip_and_unzip.py
@@ -1,3 +1,4 @@
+import asyncio
 import io
 import os
 import pathlib
@@ -57,7 +58,7 @@ def test_unzip_file(skyignore_dir, tmp_path):
         temp_dir_path = pathlib.Path(temp_dir)
 
         # Call server.unzip_file
-        server.unzip_file(zip_path, temp_dir_path)
+        asyncio.run(server.unzip_file(zip_path, temp_dir_path))
 
         # Verify the zip file was deleted
         assert not zip_path.exists()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This code turns IO intensive synchronous codepaths in `/upload` endpoint to be asynchronous.

Empirically, the `unzip_file` call can take dozens of seconds (for file mounts with many GBs) to complete. This call currently blocks the event loop, manifesting in hangs in, for example, k8s ssh (which is proxied through the API server).

This PR changes some IO intensive calls to be asynchronous.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
