### PR TITLE
[Dev] Introduce Performance Measure Annotation

### DIFF
--- a/sky/utils/annotations.py
+++ b/sky/utils/annotations.py
@@ -1,7 +1,9 @@
 """Annotations for public APIs."""
 
 import functools
-from typing import Callable, Literal, TypeVar
+import logging
+import time
+from typing import Callable, Literal, Optional, TypeVar
 
 from typing_extensions import ParamSpec
 
@@ -60,3 +62,54 @@ def clear_request_level_cache():
     """Clear the request-level cache."""
     for func in _FUNCTIONS_NEED_RELOAD_CACHE:
         func.cache_clear()
+
+
+def log_execution_time(func: Optional[Callable] = None,
+                       *,
+                       name: Optional[str] = None,
+                       level: int = logging.DEBUG,
+                       precision: int = 4) -> Callable:
+    """Mark a function and log its execution time.
+
+    Args:
+        func: Function to decorate.
+        name: Name of the function.
+        level: Logging level.
+        precision: Number of decimal places (default: 4).
+
+    Usage:
+        @log_execution_time
+        def my_function():
+            pass
+
+        @log_execution_time(name='my_module.my_function2')
+        def my_function2():
+            pass
+    """
+
+    def decorator(f: Callable) -> Callable:
+
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            nonlocal name
+            name = name or f.__name__
+            start_time = time.perf_counter()
+            try:
+                result = f(*args, **kwargs)
+                return result
+            finally:
+                from sky import sky_logging  # pylint: disable=all
+
+                end_time = time.perf_counter()
+                execution_time = end_time - start_time
+                log = (f'Method {name} executed in '
+                       f'{execution_time:.{precision}f}')
+                logger = sky_logging.init_logger(__name__)
+                logger.log(level, log)
+
+        return wrapper
+
+    if func is None:
+        return decorator
+    else:
+        return decorator(func)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Had some situations where I needed to measure performance, which is just a lot of manual coding. Added in an annotation to automatically log execution time with some configurations.

usage:

``` python
@log_execution_time
def my_function():
    pass

@log_execution_time(name='my_module.my_function2')
def my_function2():
    pass
```

ps: used pylint disable=all because the top level import thingy wouldn't work. Had to import in the specific location to fix circular imports

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
