### PR TITLE
[Dashboard] Add AMD GPU and system metrics to the dashboard

### DIFF
--- a/charts/skypilot/manifests/dcgm-cluster-dashboard.json
+++ b/charts/skypilot/manifests/dcgm-cluster-dashboard.json
@@ -90,6 +90,18 @@
           "legendFormat": "",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg(avg by (hostname, gpu_id, cluster) (amd_gpu_junction_temperature{hostname=~\"$host\", gpu_id=~\"$gpu\", cluster=~\"$cluster\"}))",
+          "interval": "",
+          "legendFormat": "",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "GPU Avgerage Temperature",
@@ -163,6 +175,19 @@
           "legendFormat": "",
           "range": false,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(avg by (hostname, gpu_id, cluster) (amd_gpu_average_package_power{hostname=~\"$host\", gpu_id=~\"$gpu\", cluster=~\"$cluster\"}))",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "range": false,
+          "refId": "B"
         }
       ],
       "title": "GPU Power Total",
@@ -277,6 +302,33 @@
           "legendFormat": "Last 24h",
           "range": true,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(rate(amd_gpu_energy_consumed{hostname=~\"$host\", gpu_id=~\"$gpu\", cluster=~\"$cluster\"}[1h])) / 3600000",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Last 1h",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(amd_gpu_energy_consumed{hostname=~\"$host\", gpu_id=~\"$gpu\", cluster=~\"$cluster\"}[24h])) / 3600000",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Last 24h",
+          "range": true,
+          "refId": "D"
         }
       ],
       "title": "GPU Energy Draw Total",
@@ -381,6 +433,17 @@
           "legendFormat": "{{node}} - GPU {{gpu}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg by (hostname, gpu_id, cluster) (amd_gpu_average_package_power{hostname=~\"$host\", gpu_id=~\"$gpu\", cluster=~\"$cluster\"})",
+          "interval": "",
+          "legendFormat": "{{hostname}} - GPU {{gpu_id}}",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "GPU Power Usage",
@@ -485,6 +548,17 @@
           "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg by (hostname, gpu_id, cluster) (amd_gpu_used_vram{hostname=~\"$host\", gpu_id=~\"$gpu\", cluster=~\"$cluster\"})",
+          "interval": "",
+          "legendFormat": "{{hostname}} - {{card_series}} GPU {{gpu_id}}",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "GPU Memory Utilization",
@@ -591,6 +665,17 @@
           "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg by (hostname, gpu_id, cluster) (amd_gpu_used_vram{hostname=~\"$host\", gpu_id=~\"$gpu\", cluster=~\"$cluster\"}) / avg by (hostname, gpu_id, cluster) (amd_gpu_total_vram{hostname=~\"$host\", gpu_id=~\"$gpu\", cluster=~\"$cluster\"})",
+          "interval": "",
+          "legendFormat": "{{hostname}} - {{card_series}} GPU {{gpu_id}}",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "GPU Memory Used Percentage",
@@ -697,6 +782,17 @@
           "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg by (hostname, gpu_id, cluster) (amd_gpu_gfx_activity{hostname=~\"$host\", gpu_id=~\"$gpu\", cluster=~\"$cluster\"})",
+          "interval": "",
+          "legendFormat": "{{hostname}} - {{card_series}} GPU {{gpu_id}}",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "GPU Utilization",
@@ -803,6 +899,17 @@
           "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "",
+          "interval": "",
+          "legendFormat": "{{hostname}} - {{card_series}} GPU {{gpu_id}}",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Tensor Core Utilization",
@@ -907,6 +1014,17 @@
           "interval": "",
           "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg by (hostname, gpu_id, cluster) (amd_gpu_junction_temperature{hostname=~\"$host\", gpu_id=~\"$gpu\", cluster=~\"$cluster\"})",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{hostname}} - {{card_series}} GPU {{gpu_id}}",
+          "refId": "B"
         }
       ],
       "title": "GPU Temperature",
@@ -1013,9 +1131,232 @@
           "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg by (hostname, gpu_id, cluster) (amd_gpu_clock{hostname=~\"$host\", gpu_id=~\"$gpu\", cluster=~\"$cluster\"})",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{hostname}} - {{card_series}} GPU {{gpu_id}}",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "GPU SM Clocks",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 21,
+      "options": {
+        "dataLinks": [],
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (node) ((1 - (node_memory_MemAvailable_bytes{node=~\"$host\"} / node_memory_MemTotal_bytes{node=~\"$host\"})))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Usage Percentage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 22,
+      "options": {
+        "dataLinks": [],
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(1 - avg by (node) (rate(node_cpu_seconds_total{mode=\"idle\", node=~\"$host\"}[2m])))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage Percentage",
       "type": "timeseries"
     }
   ],
@@ -1048,19 +1389,19 @@
             "$__all"
           ]
         },
-        "definition": "label_values(DCGM_FI_DEV_GPU_TEMP,node)",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "query_result(label_replace(DCGM_FI_DEV_GPU_UTIL, \"host\", \"$1\", \"node\", \"(.*)\") or label_replace(amd_gpu_gfx_activity, \"host\", \"$1\", \"hostname\", \"(.*)\"))",
         "includeAll": true,
         "label": "Host",
         "multi": true,
         "name": "host",
         "options": [],
-        "query": {
-          "qryType": 1,
-          "query": "label_values(DCGM_FI_DEV_GPU_TEMP,node)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
+        "query": "query_result(label_replace(DCGM_FI_DEV_GPU_UTIL, \"host\", \"$1\", \"node\", \"(.*)\") or label_replace(amd_gpu_gfx_activity, \"host\", \"$1\", \"hostname\", \"(.*)\"))",
         "refresh": 1,
-        "regex": "",
+        "regex": "/host=\"([^\"]+)\"/",
         "type": "query"
       },
       {
@@ -1076,15 +1417,15 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(DCGM_FI_DEV_GPU_TEMP, gpu)",
+        "definition": "query_result(label_replace(DCGM_FI_DEV_GPU_UTIL{node=~\"$host\"}, \"gpu\", \"$1\", \"gpu\", \"(.*)\") or label_replace(amd_gpu_gfx_activity{hostname=~\"$host\"}, \"gpu\", \"$1\", \"gpu_id\", \"(.*)\"))",
         "includeAll": true,
         "label": "GPU ID",
         "multi": true,
         "name": "gpu",
         "options": [],
-        "query": "label_values(DCGM_FI_DEV_GPU_TEMP, gpu)",
+        "query": "query_result(label_replace(DCGM_FI_DEV_GPU_UTIL{node=~\"$host\"}, \"gpu\", \"$1\", \"gpu\", \"(.*)\") or label_replace(amd_gpu_gfx_activity{hostname=~\"$host\"}, \"gpu\", \"$1\", \"gpu_id\", \"(.*)\"))",
         "refresh": 1,
-        "regex": "",
+        "regex": "/gpu=\"([^\"]+)/",
         "sort": 3,
         "type": "query"
       },
@@ -1105,7 +1446,7 @@
             "value": ".*"
           }
         ],
-                  "query": ".*",
+        "query": ".*",
         "refresh": 0,
         "regex": "",
         "skipUrlSync": false,

--- a/charts/skypilot/manifests/dcgm-cluster-dashboard.json
+++ b/charts/skypilot/manifests/dcgm-cluster-dashboard.json
@@ -1251,7 +1251,7 @@
           "refId": "A"
         }
       ],
-      "title": "Memory Usage Percentage",
+      "title": "Memory Utilization",
       "type": "timeseries"
     },
     {
@@ -1356,7 +1356,7 @@
           "refId": "A"
         }
       ],
-      "title": "CPU Usage Percentage",
+      "title": "CPU Utilization",
       "type": "timeseries"
     }
   ],

--- a/charts/skypilot/manifests/dcgm-cluster-filter-dashboard.json
+++ b/charts/skypilot/manifests/dcgm-cluster-filter-dashboard.json
@@ -120,6 +120,19 @@
             "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
             "range": true,
             "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "amd_gpu_gfx_activity{hostname=~\"$node\", gpu_id=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster) kube_pod_labels{label_skypilot_cluster=~\"$cluster\"}",
+            "hide": false,
+            "instant": false,
+            "legendFormat": "{{hostname}} - {{card_series}} GPU {{gpu_id}}",
+            "range": true,
+            "refId": "B"
           }
         ],
         "title": "GPU Utilization",
@@ -223,6 +236,19 @@
             "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
             "range": true,
             "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "amd_gpu_used_vram{hostname=~\"$node\", gpu_id=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster) kube_pod_labels{label_skypilot_cluster=~\"$cluster\"}",
+            "hide": false,
+            "instant": false,
+            "legendFormat": "{{hostname}} - {{card_series}} GPU {{gpu_id}}",
+            "range": true,
+            "refId": "B"
           }
         ],
         "title": "GPU Memory Utilization",
@@ -326,6 +352,19 @@
             "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
             "range": true,
             "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "amd_gpu_junction_temperature{hostname=~\"$node\", gpu_id=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster) kube_pod_labels{label_skypilot_cluster=~\"$cluster\"}",
+            "hide": false,
+            "instant": false,
+            "legendFormat": "{{hostname}} - {{card_series}} GPU {{gpu_id}}",
+            "range": true,
+            "refId": "B"
           }
         ],
         "title": "GPU Temperature",
@@ -429,6 +468,19 @@
             "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
             "range": true,
             "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "amd_gpu_average_package_power{hostname=~\"$node\", gpu_id=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster) kube_pod_labels{label_skypilot_cluster=~\"$cluster\"}",
+            "hide": false,
+            "instant": false,
+            "legendFormat": "{{hostname}} - {{card_series}} GPU {{gpu_id}}",
+            "range": true,
+            "refId": "B"
           }
         ],
         "title": "GPU Power Usage",
@@ -475,14 +527,14 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "definition": "label_values(DCGM_FI_DEV_GPU_UTIL, node)",
+          "definition": "query_result(label_replace(DCGM_FI_DEV_GPU_UTIL, \"_node\", \"$1\", \"node\", \"(.*)\") or label_replace(amd_gpu_gfx_activity, \"_node\", \"$1\", \"hostname\", \"(.*)\"))",
           "includeAll": true,
           "multi": true,
           "name": "node",
           "options": [],
-          "query": "label_values(DCGM_FI_DEV_GPU_UTIL, node)",
+          "query": "query_result(label_replace(DCGM_FI_DEV_GPU_UTIL, \"_node\", \"$1\", \"node\", \"(.*)\") or label_replace(amd_gpu_gfx_activity, \"_node\", \"$1\", \"hostname\", \"(.*)\"))",
           "refresh": 1,
-          "regex": "",
+          "regex": "/_node=\"([^\"]+)\"/",
           "type": "query"
         },
         {
@@ -495,14 +547,14 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "definition": "label_values(DCGM_FI_DEV_GPU_UTIL{node=~\"$node\"}, gpu)",
+          "definition": "query_result(label_replace(DCGM_FI_DEV_GPU_UTIL{node=~\"$node\"}, \"gpu\", \"$1\", \"gpu\", \"(.*)\") or label_replace(amd_gpu_gfx_activity{hostname=~\"$node\"}, \"gpu\", \"$1\", \"gpu_id\", \"(.*)\"))",
           "includeAll": true,
           "multi": true,
           "name": "gpu",
           "options": [],
-          "query": "label_values(DCGM_FI_DEV_GPU_UTIL{node=~\"$node\"}, gpu)",
+          "query": "query_result(label_replace(DCGM_FI_DEV_GPU_UTIL{node=~\"$node\"}, \"gpu\", \"$1\", \"gpu\", \"(.*)\") or label_replace(amd_gpu_gfx_activity{hostname=~\"$node\"}, \"gpu\", \"$1\", \"gpu_id\", \"(.*)\"))",
           "refresh": 1,
-          "regex": "",
+          "regex": "/gpu=\"([^\"]+)/",
           "sort": 1,
           "type": "query"
         }

--- a/charts/skypilot/manifests/dcgm-cluster-filter-dashboard.json
+++ b/charts/skypilot/manifests/dcgm-cluster-filter-dashboard.json
@@ -527,14 +527,14 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "definition": "query_result(label_replace(DCGM_FI_DEV_GPU_UTIL, \"_node\", \"$1\", \"node\", \"(.*)\") or label_replace(amd_gpu_gfx_activity, \"_node\", \"$1\", \"hostname\", \"(.*)\"))",
+          "definition": "query_result(label_replace(DCGM_FI_DEV_GPU_UTIL, \"node\", \"$1\", \"node\", \"(.*)\") or label_replace(amd_gpu_gfx_activity, \"node\", \"$1\", \"hostname\", \"(.*)\"))",
           "includeAll": true,
           "multi": true,
           "name": "node",
           "options": [],
-          "query": "query_result(label_replace(DCGM_FI_DEV_GPU_UTIL, \"_node\", \"$1\", \"node\", \"(.*)\") or label_replace(amd_gpu_gfx_activity, \"_node\", \"$1\", \"hostname\", \"(.*)\"))",
+          "query": "query_result(label_replace(DCGM_FI_DEV_GPU_UTIL, \"node\", \"$1\", \"node\", \"(.*)\") or label_replace(amd_gpu_gfx_activity, \"node\", \"$1\", \"hostname\", \"(.*)\"))",
           "refresh": 1,
-          "regex": "/_node=\"([^\"]+)\"/",
+          "regex": "/node=\"([^\"]+)\"/",
           "type": "query"
         },
         {

--- a/sky/dashboard/server.js
+++ b/sky/dashboard/server.js
@@ -24,6 +24,15 @@ app
       })
     );
 
+    // Proxy Grafana requests
+    server.use(
+      '/grafana',
+      createProxyMiddleware({
+        target: `${process.env.SKYPILOT_API_SERVER_ENDPOINT || 'http://localhost:46580'}/grafana`,
+        changeOrigin: true,
+      })
+    );
+
     server.all('*', (req, res) => {
       return handle(req, res);
     });

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -382,7 +382,7 @@ export function ContextDetails({ contextName, gpusInContext, nodesInContext }) {
       const query =
         'query=' +
         encodeURIComponent(
-          `group by (node) (DCGM_FI_DEV_GPU_TEMP{cluster=~"${clusterParam}"})`
+          `group by (node) (DCGM_FI_DEV_GPU_TEMP{cluster=~"${clusterParam}"} or label_replace(amd_gpu_gfx_activity{cluster=~"${clusterParam}"}, "node", "$1", "hostname", "(.*)"))`
         );
 
       const endpoint = `/api/datasources/proxy/1/api/v1/query?${query}`;
@@ -712,6 +712,51 @@ export function ContextDetails({ contextName, gpusInContext, nodesInContext }) {
                         title="GPU Power Consumption"
                         className="rounded"
                         key={`gpu-power-${selectedHosts}-${timeRange.from}-${timeRange.to}`}
+                      />
+                    </div>
+                  </div>
+
+                  {/* GPU Temperature */}
+                  <div className="bg-white rounded-md border border-gray-200 shadow-sm">
+                    <div className="p-2">
+                      <iframe
+                        src={buildGrafanaUrlForContext('12')}
+                        width="100%"
+                        height="400"
+                        frameBorder="0"
+                        title="GPU Temperature"
+                        className="rounded"
+                        key={`gpu-temp-${selectedHosts}-${timeRange.from}-${timeRange.to}`}
+                      />
+                    </div>
+                  </div>
+
+                  {/* CPU Usage Percentage */}
+                  <div className="bg-white rounded-md border border-gray-200 shadow-sm">
+                    <div className="p-2">
+                      <iframe
+                        src={buildGrafanaUrlForContext('22')}
+                        width="100%"
+                        height="400"
+                        frameBorder="0"
+                        title="CPU Usage Percentage"
+                        className="rounded"
+                        key={`cpu-usage-${selectedHosts}-${timeRange.from}-${timeRange.to}`}
+                      />
+                    </div>
+                  </div>
+
+                  {/* Memory Usage Percentage */}
+                  <div className="bg-white rounded-md border border-gray-200 shadow-sm">
+                    <div className="p-2">
+                      <iframe
+                        src={buildGrafanaUrlForContext('21')}
+                        width="100%"
+                        height="400"
+                        frameBorder="0"
+                        title="Memory Usage Percentage"
+                        className="rounded"
+                        key={`memory-usage-${selectedHosts}-${timeRange.from}-${timeRange.to}`}
                       />
                     </div>
                   </div>

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -731,7 +731,7 @@ export function ContextDetails({ contextName, gpusInContext, nodesInContext }) {
                     </div>
                   </div>
 
-                  {/* CPU Usage Percentage */}
+                  {/* CPU Utilization */}
                   <div className="bg-white rounded-md border border-gray-200 shadow-sm">
                     <div className="p-2">
                       <iframe
@@ -739,14 +739,14 @@ export function ContextDetails({ contextName, gpusInContext, nodesInContext }) {
                         width="100%"
                         height="400"
                         frameBorder="0"
-                        title="CPU Usage Percentage"
+                        title="CPU Utilization"
                         className="rounded"
-                        key={`cpu-usage-${selectedHosts}-${timeRange.from}-${timeRange.to}`}
+                        key={`cpu-util-${selectedHosts}-${timeRange.from}-${timeRange.to}`}
                       />
                     </div>
                   </div>
 
-                  {/* Memory Usage Percentage */}
+                  {/* Memory Utilization */}
                   <div className="bg-white rounded-md border border-gray-200 shadow-sm">
                     <div className="p-2">
                       <iframe
@@ -754,9 +754,9 @@ export function ContextDetails({ contextName, gpusInContext, nodesInContext }) {
                         width="100%"
                         height="400"
                         frameBorder="0"
-                        title="Memory Usage Percentage"
+                        title="Memory Utilization"
                         className="rounded"
-                        key={`memory-usage-${selectedHosts}-${timeRange.from}-${timeRange.to}`}
+                        key={`memory-util-${selectedHosts}-${timeRange.from}-${timeRange.to}`}
                       />
                     </div>
                   </div>


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

## Overview

Currently, the dashboard only provides metrics for NVIDIA GPUs. This PR adds support for AMD GPU metrics and basic system metrics.

<img width="3810" height="3340" alt="image" src="https://github.com/user-attachments/assets/bc377143-6da3-44c0-88c9-93d26ba642c9" />

## Details

- (feat) Add AMD GPU metrics to Grafana dashboard
  - Displayed alongside existing NVIDIA GPU metrics
  - Enabled AMD GPU node selection
- (feat) Add system metrics to Grafana dashboard
  - CPU utilization
  - Memory utilization
- (feat) Add additional Grafana panels to Skypilot dashboard
  - GPU temperature
  - CPU utilization
  - Memory utilization
- (feat) Add a middleware proxy to enable the use of Grafana for Skypilot dashboard development.

The container image has been built and tested.
https://hub.docker.com/layers/ibparkmoreh/skypilot-moreh/support-amd-dashboard/images/sha256-4d7b6708c5b88a581607fe41c331c7e4ee1c9229c2580715e10c80a587cf4c30

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
