### PR TITLE
Reverted poll interval when waiting request status

### DIFF
--- a/sky/server/stream_utils.py
+++ b/sky/server/stream_utils.py
@@ -22,7 +22,6 @@ logger = sky_logging.init_logger(__name__)
 _BUFFER_SIZE = 8 * 1024  # 8KB
 _BUFFER_TIMEOUT = 0.02  # 20ms
 _HEARTBEAT_INTERVAL = 30
-_REFRESH_INTERVAL = 1
 
 
 async def _yield_log_file_with_payloads_skipped(
@@ -91,7 +90,7 @@ async def log_streamer(request_id: Optional[str],
             # TODO(aylei): we should use a better mechanism to avoid busy
             # polling the DB, which can be a bottleneck for high-concurrency
             # requests.
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(0.1)
             request_task = await requests_lib.get_request_async(request_id)
             if not follow:
                 break
@@ -139,7 +138,6 @@ async def _tail_log_file(f: aiofiles.threadpool.binary.AsyncBufferedReader,
             buffer_bytes = 0
             last_flush_time = asyncio.get_event_loop().time()
 
-    last_refresh_time = asyncio.get_event_loop().time()
     while True:
         # Sleep 0 to yield control to allow other coroutines to run,
         # while keeps the loop tight to make log stream responsive.
@@ -154,10 +152,7 @@ async def _tail_log_file(f: aiofiles.threadpool.binary.AsyncBufferedReader,
 
         line: Optional[bytes] = await f.readline()
         if not line:
-            if (request_id is not None and
-                    current_time - last_refresh_time >= _REFRESH_INTERVAL):
-                # Refresh the request status from DB every _REFRESH_INTERVAL
-                last_refresh_time = current_time
+            if request_id is not None:
                 request_task = await requests_lib.get_request_async(request_id)
                 if request_task.status > requests_lib.RequestStatus.RUNNING:
                     if (request_task.status ==

--- a/tests/load_tests/test_load_on_server.py
+++ b/tests/load_tests/test_load_on_server.py
@@ -121,7 +121,7 @@ def run_single_api_request(idx, fn, kind):
 
 def test_launch_requests(num_requests, cloud, is_async=True):
     print(f"Testing {num_requests} launch requests")
-    cmd = f'sky launch --cloud={cloud} --cpus=2 -y --dryrun'
+    cmd = f'sky launch --cloud={cloud} --cpus=2 -y'
     if is_async:
         cmd += ' --async'
     run_concurrent_requests(num_requests, cmd)

--- a/tests/load_tests/test_load_on_server.py
+++ b/tests/load_tests/test_load_on_server.py
@@ -121,7 +121,7 @@ def run_single_api_request(idx, fn, kind):
 
 def test_launch_requests(num_requests, cloud, is_async=True):
     print(f"Testing {num_requests} launch requests")
-    cmd = f'sky launch --cloud={cloud} --cpus=2 -y'
+    cmd = f'sky launch --cloud={cloud} --cpus=2 -y --dryrun'
     if is_async:
         cmd += ' --async'
     run_concurrent_requests(num_requests, cmd)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Increase the poll interval in https://github.com/skypilot-org/skypilot/pull/6889 introduce high latency for short requests, should consider other potential solution to reduce the CPU usage.

Master: 

```
multitime -n 5 sky status
            Mean        Std.Dev.    Min         Median      Max
real        3.889       0.163       3.656       3.831       4.117
user        1.084       0.136       0.881       1.122       1.277
sys         0.743       0.197       0.518       0.670       1.103
```

This PR:

```
multitime -n 5 sky status
1: sky status
            Mean        Std.Dev.    Min         Median      Max
real        1.610       0.261       1.353       1.459       2.025
user        0.841       0.085       0.775       0.785       1.000
sys         0.811       0.151       0.618       0.763       0.993
```

Before #6889

```
multitime -n 5 sky status
1: sky status
            Mean        Std.Dev.    Min         Median      Max
real        1.981       0.894       1.251       1.598       3.702
user        1.023       0.216       0.857       0.922       1.438
sys         0.737       0.093       0.658       0.674       0.880
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
