### PR TITLE
[Core] add --no-owner --no-group to CommandRunner._rsync

### DIFF
--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -41,7 +41,7 @@ RSYNC_FILTER_GITIGNORE = f'--filter=\'dir-merge,- {constants.GIT_IGNORE_FILE}\''
 # The git exclude file to support.
 GIT_EXCLUDE = '.git/info/exclude'
 RSYNC_EXCLUDE_OPTION = '--exclude-from={}'
-# Owner and group metadata is not needed.
+# Owner and group metadata is not needed for downloads.
 RSYNC_NO_OWNER_NO_GROUP_OPTION = '--no-owner --no-group'
 
 _HASH_MAX_LENGTH = 10

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -41,6 +41,8 @@ RSYNC_FILTER_GITIGNORE = f'--filter=\'dir-merge,- {constants.GIT_IGNORE_FILE}\''
 # The git exclude file to support.
 GIT_EXCLUDE = '.git/info/exclude'
 RSYNC_EXCLUDE_OPTION = '--exclude-from={}'
+# Owner and group metadata is not needed.
+RSYNC_NO_OWNER_NO_GROUP_OPTION = '--no-owner --no-group'
 
 _HASH_MAX_LENGTH = 10
 _DEFAULT_CONNECT_TIMEOUT = 30
@@ -285,7 +287,9 @@ class CommandRunner:
         rsync_command = []
         if prefix_command is not None:
             rsync_command.append(prefix_command)
-        rsync_command += ['rsync', RSYNC_DISPLAY_OPTION]
+        rsync_command += [
+            'rsync', RSYNC_DISPLAY_OPTION, RSYNC_NO_OWNER_NO_GROUP_OPTION
+        ]
 
         # --filter
         # The source is a local path, so we need to resolve it.

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -287,9 +287,9 @@ class CommandRunner:
         rsync_command = []
         if prefix_command is not None:
             rsync_command.append(prefix_command)
-        rsync_command += [
-            'rsync', RSYNC_DISPLAY_OPTION, RSYNC_NO_OWNER_NO_GROUP_OPTION
-        ]
+        rsync_command += ['rsync', RSYNC_DISPLAY_OPTION]
+        if not up:
+            rsync_command.append(RSYNC_NO_OWNER_NO_GROUP_OPTION)
 
         # --filter
         # The source is a local path, so we need to resolve it.


### PR DESCRIPTION
Came across this while testing on the Coreweave Kubernetes cluster. On Kubernetes, we were getting partial errors (return code 23) from rsync due to the default securityContext on our helm charts which drops all capabilities:
```bash
I 08-29 06:55:36 command_runner.py:369] rsync: [generator] chown "/root/.sky/api_server/clients/de1a4b69/sky_logs/1-sky-cmd/." failed: Operation not permitted (1)
I 08-29 06:55:36 command_runner.py:369] rsync: [generator] chown "/root/.sky/api_server/clients/de1a4b69/sky_logs/1-sky-cmd/tasks" failed: Operation not permitted (1)
I 08-29 06:55:36 command_runner.py:369] rsync: [receiver] chown "/root/.sky/api_server/clients/de1a4b69/sky_logs/1-sky-cmd/.run.log.tGvrAf" failed: Operation not permitted (1)
I 08-29 06:55:36 command_runner.py:369] rsync: [receiver] chown "/root/.sky/api_server/clients/de1a4b69/sky_logs/1-sky-cmd/tasks/.run.log.DvPfgA" failed: Operation not permitted (1)
I 08-29 06:55:36 command_runner.py:369] rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1852) [generator=3.4.1]
```

This was causing `--sync-down` to take very long (>40s) because it retries for three times, even though the files were successfully fetched the first time around.

This is because we use `-a` on rsync, which is an alias to `-rlptgoD` ([reference](https://linux.die.net/man/1/rsync)):
- r = recursive
- l = preserve symlinks
- p = preserve permissions
- t = preserve times
- g = preserve group
- o = preserve owner

The problematic flag is g and o, which requires permissions to chown plus some other fs operations. But we actually don't really need to retain these two informations, we only care about the contents, so this PR adds `--no-owner --no-group` so that we don't require added permissions on the containers/host running the API server.

Note:
The alternative would be to specify these added capabilities, but I think it's better to just prevent the operation from happening since it's not needed.
```yaml
securityContext:
  capabilities:
    add:
    - CHOWN
    - FOWNER
    - DAC_OVERRIDE
```

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

Also manually tested that:
1. The rsync version on Mac OS supports these flags
2. In local API server case, the logs should be able to open after being downloaded from a remote cluster (including with a root user on the remote cluster)