### PR TITLE
[SDK] Use `make_authenticated_request` instead of `requests.post` when calling POST /download

### DIFF
--- a/sky/client/common.py
+++ b/sky/client/common.py
@@ -82,10 +82,11 @@ def download_logs_from_api_server(
             local_machine_prefix) for remote_path in paths_on_api_server
     }
     body = payloads.DownloadBody(folder_paths=list(paths_on_api_server),)
-    response = requests.post(f'{server_common.get_server_url()}/download',
-                             json=json.loads(body.model_dump_json()),
-                             stream=True,
-                             cookies=server_common.get_api_cookie_jar())
+    response = server_common.make_authenticated_request(
+        'POST',
+        '/download',
+        json=json.loads(body.model_dump_json()),
+        stream=True)
     if response.status_code == 200:
         remote_home_path = response.headers.get('X-Home-Path')
         assert remote_home_path is not None, response.headers


### PR DESCRIPTION
Before, calling `sky logs --sync-down` while using a service account token would error with:
```bash
% sky logs sky-102a-kevin 1 --sync-down
Syncing down logs to local...
...
  File "/Users/kevin/git/skypilot/sky/client/sdk.py", line 998, in download_logs
    remote2local_path_dict = client_common.download_logs_from_api_server(
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kevin/git/skypilot/sky/client/common.py", line 132, in download_logs_from_api_server
    raise Exception(
Exception: Failed to download logs: 400 {"detail":"Invalid folder path: ~/.sky/api_server/clients/sa-8b5cf11ca1481511/sky_logs/1-sky-cmd; ~/.sky/api_server/clients/de1a4b69/sky_logs"}
```

So I added some debug logs on the server and found something interesting:
```
I 08-29 17:25:59 authn.py:19] request.url.path: /download_logs
I 08-29 17:25:59 authn.py:20] auth_user: User(id='sa-8b5cf11ca1481511', name='dev', password=None, created_at=None)
I 08-29 17:25:59 authn.py:25] auth_user: sa-8b5cf11ca1481511
I 08-29 17:25:59 authn.py:26] auth_user: dev
...
I 08-29 17:26:07 authn.py:19] request.url.path: /download
I 08-29 17:26:07 authn.py:20] auth_user: User(id='de1a4b69', name='kevin.mingtarja@gmail.com', password=None, created_at=None)
I 08-29 17:26:07 authn.py:25] auth_user: de1a4b69
I 08-29 17:26:07 authn.py:26] auth_user: kevin.mingtarja@gmail.com'
```

The request to `/download_logs` got to the server with the correct service account credential, but the `/download` request which immediately follows, does not, it gets the user's credential. Which is why the server was complaining about invalid folder path, because the user hash was different between the two requests.

It seems it was because we are still using `requests.post` instead of `server_common.make_authenticated_request`. So this PR fixes this.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Tested manually using a service account token and it works with this patch
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
