### PR TITLE
Redo aiosqlite for requests and fix race condition

### DIFF
--- a/sky/jobs/server/server.py
+++ b/sky/jobs/server/server.py
@@ -79,7 +79,8 @@ async def logs(
         if jobs_logs_body.refresh else api_requests.ScheduleType.SHORT,
         request_cluster_name=common.JOB_CONTROLLER_NAME,
     )
-    request_task = api_requests.get_request(request.state.request_id)
+    request_task = await api_requests.get_request_async(request.state.request_id
+                                                       )
 
     return stream_utils.stream_response(
         request_id=request_task.request_id,

--- a/sky/serve/server/server.py
+++ b/sky/serve/server/server.py
@@ -107,7 +107,8 @@ async def tail_logs(
         request_cluster_name=common.SKY_SERVE_CONTROLLER_NAME,
     )
 
-    request_task = api_requests.get_request(request.state.request_id)
+    request_task = await api_requests.get_request_async(request.state.request_id
+                                                       )
 
     return stream_utils.stream_response(
         request_id=request_task.request_id,

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -453,7 +453,7 @@ async def execute_request_coroutine(request: api_requests.Request):
                                                   **request_body.to_kwargs())
 
     async def poll_task(request_id: str) -> bool:
-        request = api_requests.get_request(request_id)
+        request = await api_requests.get_request_async(request_id)
         if request is None:
             raise RuntimeError('Request not found')
 

--- a/sky/server/requests/preconditions.py
+++ b/sky/server/requests/preconditions.py
@@ -98,7 +98,7 @@ class Precondition(abc.ABC):
                 return False
 
             # Check if the request has been cancelled
-            request = api_requests.get_request(self.request_id)
+            request = await api_requests.get_request_async(self.request_id)
             if request is None:
                 logger.error(f'Request {self.request_id} not found')
                 return False
@@ -112,7 +112,8 @@ class Precondition(abc.ABC):
                     return True
                 if status_msg is not None and status_msg != last_status_msg:
                     # Update the status message if it has changed.
-                    with api_requests.update_request(self.request_id) as req:
+                    async with api_requests.update_request_async(
+                            self.request_id) as req:
                         assert req is not None, self.request_id
                         req.status_msg = status_msg
                     last_status_msg = status_msg

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -13,7 +13,8 @@ import sqlite3
 import threading
 import time
 import traceback
-from typing import Any, Callable, Dict, Generator, List, Optional, Tuple
+from typing import (Any, AsyncContextManager, Callable, Dict, Generator, List,
+                    Optional, Tuple)
 
 import colorama
 import filelock
@@ -402,22 +403,42 @@ _DB = None
 _init_db_lock = threading.Lock()
 
 
+def _init_db_within_lock():
+    global _DB
+    if _DB is None:
+        db_path = os.path.expanduser(
+            server_constants.API_SERVER_REQUEST_DB_PATH)
+        pathlib.Path(db_path).parents[0].mkdir(parents=True, exist_ok=True)
+        _DB = db_utils.SQLiteConn(db_path, create_table)
+
+
 def init_db(func):
     """Initialize the database."""
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        global _DB
         if _DB is not None:
             return func(*args, **kwargs)
         with _init_db_lock:
-            if _DB is None:
-                db_path = os.path.expanduser(
-                    server_constants.API_SERVER_REQUEST_DB_PATH)
-                pathlib.Path(db_path).parents[0].mkdir(parents=True,
-                                                       exist_ok=True)
-                _DB = db_utils.SQLiteConn(db_path, create_table)
+            _init_db_within_lock()
         return func(*args, **kwargs)
+
+    return wrapper
+
+
+def init_db_async(func):
+    """Async version of init_db."""
+
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs):
+        if _DB is not None:
+            return await func(*args, **kwargs)
+        # If _DB is not initialized, init_db_async will be blocked if there
+        # is a thread initializing _DB, this is fine since it occurs on process
+        # startup.
+        with _init_db_lock:
+            _init_db_within_lock()
+        return await func(*args, **kwargs)
 
     return wrapper
 
@@ -440,23 +461,56 @@ def request_lock_path(request_id: str) -> str:
 @contextlib.contextmanager
 @init_db
 def update_request(request_id: str) -> Generator[Optional[Request], None, None]:
-    """Get a SkyPilot API request."""
+    """Get and update a SkyPilot API request."""
     request = _get_request_no_lock(request_id)
     yield request
     if request is not None:
         _add_or_update_request_no_lock(request)
 
 
+@init_db
+def update_request_async(
+        request_id: str) -> AsyncContextManager[Optional[Request]]:
+    """Async version of update_request.
+
+    Returns an async context manager that yields the request record and
+    persists any in-place updates upon exit.
+    """
+
+    @contextlib.asynccontextmanager
+    async def _cm():
+        request = await _get_request_no_lock_async(request_id)
+        try:
+            yield request
+        finally:
+            if request is not None:
+                await _add_or_update_request_no_lock_async(request)
+
+    return _cm()
+
+
+_get_request_sql = (f'SELECT {", ".join(REQUEST_COLUMNS)} FROM {REQUEST_TABLE} '
+                    'WHERE request_id LIKE ?')
+
+
 def _get_request_no_lock(request_id: str) -> Optional[Request]:
     """Get a SkyPilot API request."""
     assert _DB is not None
-    columns_str = ', '.join(REQUEST_COLUMNS)
     with _DB.conn:
         cursor = _DB.conn.cursor()
-        cursor.execute(
-            f'SELECT {columns_str} FROM {REQUEST_TABLE} '
-            'WHERE request_id LIKE ?', (request_id + '%',))
+        cursor.execute(_get_request_sql, (request_id + '%',))
         row = cursor.fetchone()
+        if row is None:
+            return None
+    return Request.from_row(row)
+
+
+async def _get_request_no_lock_async(request_id: str) -> Optional[Request]:
+    """Async version of _get_request_no_lock."""
+    assert _DB is not None
+    conn = await _DB.async_conn()
+    async with conn.execute(_get_request_sql, (request_id + '%',)) as cursor:
+        row = await cursor.fetchone()
         if row is None:
             return None
     return Request.from_row(row)
@@ -481,6 +535,13 @@ def get_request(request_id: str) -> Optional[Request]:
         return _get_request_no_lock(request_id)
 
 
+@init_db_async
+async def get_request_async(request_id: str) -> Optional[Request]:
+    """Async version of get_request."""
+    async with filelock.AsyncFileLock(request_lock_path(request_id)):
+        return await _get_request_no_lock_async(request_id)
+
+
 @init_db
 def create_if_not_exists(request: Request) -> bool:
     """Create a SkyPilot API request if it does not exist."""
@@ -488,6 +549,16 @@ def create_if_not_exists(request: Request) -> bool:
         if _get_request_no_lock(request.request_id) is not None:
             return False
         _add_or_update_request_no_lock(request)
+        return True
+
+
+@init_db_async
+async def create_if_not_exists_async(request: Request) -> bool:
+    """Async version of create_if_not_exists."""
+    async with filelock.AsyncFileLock(request_lock_path(request.request_id)):
+        if await _get_request_no_lock_async(request.request_id) is not None:
+            return False
+        await _add_or_update_request_no_lock_async(request)
         return True
 
 
@@ -565,16 +636,15 @@ def get_request_tasks(
     return requests
 
 
-@init_db
-def get_api_request_ids_start_with(incomplete: str) -> List[str]:
+@init_db_async
+async def get_api_request_ids_start_with(incomplete: str) -> List[str]:
     """Get a list of API request ids for shell completion."""
     assert _DB is not None
-    with _DB.conn:
-        cursor = _DB.conn.cursor()
-        # Prioritize alive requests (PENDING, RUNNING) over finished ones,
-        # then order by creation time (newest first) within each category.
-        cursor.execute(
-            f"""SELECT request_id FROM {REQUEST_TABLE}
+    conn = await _DB.async_conn()
+    # Prioritize alive requests (PENDING, RUNNING) over finished ones,
+    # then order by creation time (newest first) within each category.
+    async with conn.execute(
+        f"""SELECT request_id FROM {REQUEST_TABLE}
                 WHERE request_id LIKE ?
                 ORDER BY
                     CASE
@@ -582,21 +652,32 @@ def get_api_request_ids_start_with(incomplete: str) -> List[str]:
                         ELSE 1
                     END,
                     created_at DESC
-                LIMIT 1000""", (f'{incomplete}%',))
-        return [row[0] for row in cursor.fetchall()]
+                LIMIT 1000""", (f'{incomplete}%',)) as cursor:
+        rows = await cursor.fetchall()
+        if rows is None:
+            return []
+    return [row[0] for row in rows]
+
+
+_add_or_update_request_sql = (f'INSERT OR REPLACE INTO {REQUEST_TABLE} '
+                              f'({", ".join(REQUEST_COLUMNS)}) VALUES '
+                              f'({", ".join(["?"] * len(REQUEST_COLUMNS))})')
 
 
 def _add_or_update_request_no_lock(request: Request):
     """Add or update a REST request into the database."""
-    row = request.to_row()
-    key_str = ', '.join(REQUEST_COLUMNS)
-    fill_str = ', '.join(['?'] * len(row))
     assert _DB is not None
     with _DB.conn:
         cursor = _DB.conn.cursor()
-        cursor.execute(
-            f'INSERT OR REPLACE INTO {REQUEST_TABLE} ({key_str}) '
-            f'VALUES ({fill_str})', row)
+        cursor.execute(_add_or_update_request_sql, request.to_row())
+
+
+async def _add_or_update_request_no_lock_async(request: Request):
+    """Async version of _add_or_update_request_no_lock."""
+    assert _DB is not None
+    conn = await _DB.async_conn()
+    await conn.execute(_add_or_update_request_sql, request.to_row())
+    await conn.commit()
 
 
 def set_request_failed(request_id: str, e: BaseException) -> None:

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1397,7 +1397,7 @@ async def local_down(request: fastapi.Request) -> None:
 async def api_get(request_id: str) -> payloads.RequestPayload:
     """Gets a request with a given request ID prefix."""
     while True:
-        request_task = requests_lib.get_request(request_id)
+        request_task = await requests_lib.get_request_async(request_id)
         if request_task is None:
             print(f'No task with request ID {request_id}', flush=True)
             raise fastapi.HTTPException(
@@ -1486,7 +1486,7 @@ async def stream(
 
     # Original plain text streaming logic
     if request_id is not None:
-        request_task = requests_lib.get_request(request_id)
+        request_task = await requests_lib.get_request_async(request_id)
         if request_task is None:
             print(f'No task with request ID {request_id}')
             raise fastapi.HTTPException(
@@ -1581,7 +1581,7 @@ async def api_status(
     else:
         encoded_request_tasks = []
         for request_id in request_ids:
-            request_task = requests_lib.get_request(request_id)
+            request_task = await requests_lib.get_request_async(request_id)
             if request_task is None:
                 continue
             encoded_request_tasks.append(request_task.readable_encode())
@@ -1791,7 +1791,7 @@ async def complete_volume_name(incomplete: str,) -> List[str]:
 
 @app.get('/api/completion/api_request')
 async def complete_api_request(incomplete: str,) -> List[str]:
-    return requests_lib.get_api_request_ids_start_with(incomplete)
+    return await requests_lib.get_api_request_ids_start_with(incomplete)
 
 
 @app.get('/dashboard/{full_path:path}')

--- a/sky/server/stream_utils.py
+++ b/sky/server/stream_utils.py
@@ -56,7 +56,7 @@ async def log_streamer(request_id: Optional[str],
     if request_id is not None:
         status_msg = rich_utils.EncodedStatusMessage(
             f'[dim]Checking request: {request_id}[/dim]')
-        request_task = requests_lib.get_request(request_id)
+        request_task = await requests_lib.get_request_async(request_id)
 
         if request_task is None:
             raise fastapi.HTTPException(
@@ -86,10 +86,12 @@ async def log_streamer(request_id: Optional[str],
                 # Use smaller padding (1024 bytes) to force browser rendering
                 yield f'{waiting_msg}' + ' ' * 4096 + '\n'
             # Sleep shortly to avoid storming the DB and CPU and allow other
-            # coroutines to run. This busy waiting loop is performance critical
-            # for short-running requests, so we do not want to yield too long.
+            # coroutines to run.
+            # TODO(aylei): we should use a better mechanism to avoid busy
+            # polling the DB, which can be a bottleneck for high-concurrency
+            # requests.
             await asyncio.sleep(0.1)
-            request_task = requests_lib.get_request(request_id)
+            request_task = await requests_lib.get_request_async(request_id)
             if not follow:
                 break
         if show_request_waiting_spinner:
@@ -151,7 +153,7 @@ async def _tail_log_file(f: aiofiles.threadpool.binary.AsyncBufferedReader,
         line: Optional[bytes] = await f.readline()
         if not line:
             if request_id is not None:
-                request_task = requests_lib.get_request(request_id)
+                request_task = await requests_lib.get_request_async(request_id)
                 if request_task.status > requests_lib.RequestStatus.RUNNING:
                     if (request_task.status ==
                             requests_lib.RequestStatus.CANCELLED):

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -39,7 +39,8 @@ install_requires = [
     # Light weight requirement, can be replaced with "typing" once
     # we deprecate Python 3.7 (this will take a while).
     'typing_extensions',
-    'filelock >= 3.6.0',
+    # filelock 3.15.0 or higher is required for async file locking.
+    'filelock >= 3.15.0',
     'packaging',
     'psutil',
     'pulp',
@@ -75,6 +76,7 @@ install_requires = [
     'types-paramiko',
     'alembic',
     'aiohttp',
+    'aiosqlite',
     'anyio',
 ]
 
@@ -100,6 +102,7 @@ server_dependencies = [
     'anyio',
     GRPC,
     PROTOBUF,
+    'aiosqlite',
 ]
 
 local_ray = [

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -5,9 +5,10 @@ import enum
 import sqlite3
 import threading
 import typing
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Iterable, Optional
 
 import aiosqlite
+import aiosqlite.context
 import sqlalchemy
 from sqlalchemy import exc as sqlalchemy_exc
 
@@ -288,9 +289,54 @@ class SQLiteConn(threading.local):
         self._async_conn: Optional[aiosqlite.Connection] = None
         self._async_conn_lock = asyncio.Lock()
 
-    async def async_conn(self) -> aiosqlite.Connection:
+    async def _get_async_conn(self) -> aiosqlite.Connection:
+        """Get the shared aiosqlite connection for current thread.
+
+        Typically, external caller should not get the connection directly,
+        instead, SQLiteConn.{operation}_async methods should be used. This
+        is to avoid txn interleaving on the shared aiosqlite connection.
+        E.g.
+        coroutine 1:
+            A: await write(row1)
+            B: cursor = await conn.execute(read_row1)
+            C: await cursor.fetchall()
+        coroutine 2:
+            D: await write(row2)
+            E: cursor = await conn.execute(read_row2)
+            F: await cursor.fetchall()
+        The A -> B -> D -> E -> C time sequence will cause B and D read at the
+        same snapshot point when B started, thus cause coroutine2 lost the
+        read-after-write consistency. When you are adding new async operations
+        to SQLiteConn, make sure the txn pattern does not cause this issue.
+        """
         if self._async_conn is None:
             async with self._async_conn_lock:
                 if self._async_conn is None:
+                    # Init logic like requests.init_db_within_lock will handle
+                    # initialization like setting the WAL mode, so we do not
+                    # duplicate that logic here.
                     self._async_conn = await aiosqlite.connect(self.db_path)
         return self._async_conn
+
+    async def execute_and_commit_async(self,
+                                       sql: str,
+                                       parameters: Optional[
+                                           Iterable[Any]] = None) -> None:
+        """Execute the sql and commit the transaction in a sync block."""
+        conn = await self._get_async_conn()
+
+        def exec_and_commit(sql: str, parameters: Optional[Iterable[Any]]):
+            # pylint: disable=protected-access
+            conn._conn.execute(sql, parameters)
+            conn._conn.commit()
+
+        # pylint: disable=protected-access
+        await conn._execute(exec_and_commit, sql, parameters)
+
+    @aiosqlite.context.contextmanager
+    async def execute_fetchall_async(self,
+                                     sql: str,
+                                     parameters: Optional[Iterable[Any]] = None
+                                    ) -> Iterable[sqlite3.Row]:
+        conn = await self._get_async_conn()
+        return await conn.execute_fetchall(sql, parameters)

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -1,4 +1,5 @@
 """Utils for sky databases."""
+import asyncio
 import contextlib
 import enum
 import sqlite3
@@ -6,6 +7,7 @@ import threading
 import typing
 from typing import Any, Callable, Optional
 
+import aiosqlite
 import sqlalchemy
 from sqlalchemy import exc as sqlalchemy_exc
 
@@ -283,3 +285,12 @@ class SQLiteConn(threading.local):
         self.conn = sqlite3.connect(db_path, timeout=_DB_TIMEOUT_S)
         self.cursor = self.conn.cursor()
         create_table(self.cursor, self.conn)
+        self._async_conn: Optional[aiosqlite.Connection] = None
+        self._async_conn_lock = asyncio.Lock()
+
+    async def async_conn(self) -> aiosqlite.Connection:
+        if self._async_conn is None:
+            async with self._async_conn_lock:
+                if self._async_conn is None:
+                    self._async_conn = await aiosqlite.connect(self.db_path)
+        return self._async_conn

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -59,10 +59,10 @@ def test_api_stream_heartbeat(monkeypatch):
                 self.schedule_type = requests_lib.ScheduleType.LONG
                 self.status_msg = None
 
-        def mock_get_request(request_id):
+        async def mock_get_request(request_id):
             return MockRequest()
 
-        monkeypatch.setattr('sky.server.requests.requests.get_request',
+        monkeypatch.setattr('sky.server.requests.requests.get_request_async',
                             mock_get_request)
 
         log_path = pathlib.Path(temp_log_path)
@@ -91,7 +91,7 @@ def test_api_stream_heartbeat(monkeypatch):
                     except Exception:
                         pass
 
-                    if current_time - start_time > 0.55:
+                    if current_time - start_time > 3.0:
                         break
             finally:
                 # Properly close the async generator to avoid pending task errors
@@ -144,10 +144,10 @@ def test_heartbeat_not_displayed_to_users(monkeypatch):
                 self.schedule_type = requests_lib.ScheduleType.LONG
                 self.status_msg = None
 
-        def mock_get_request(request_id):
+        async def mock_get_request(request_id):
             return MockRequest()
 
-        monkeypatch.setattr('sky.server.requests.requests.get_request',
+        monkeypatch.setattr('sky.server.requests.requests.get_request_async',
                             mock_get_request)
 
         log_path = pathlib.Path(temp_log_path)
@@ -180,7 +180,7 @@ def test_heartbeat_not_displayed_to_users(monkeypatch):
                         # Non-control messages should be displayed
                         user_visible_messages.append(item)
 
-                    if current_time - start_time > 0.55:
+                    if current_time - start_time > 2.0:
                         break
             finally:
                 await log_stream.aclose()

--- a/tests/unit_tests/test_sky/server/requests/test_precond.py
+++ b/tests/unit_tests/test_sky/server/requests/test_precond.py
@@ -14,7 +14,7 @@ class TestPrecondition(unittest.TestCase):
     def setUp(self):
         self.request_id = 'test-request'
 
-    @mock.patch('sky.server.requests.requests.get_request')
+    @mock.patch('sky.server.requests.requests.get_request_async')
     async def test_precondition_timeout(self, mock_get_request):
         """Test Precondition timeout behavior."""
 
@@ -34,7 +34,7 @@ class TestPrecondition(unittest.TestCase):
         self.assertIsInstance(api_requests.set_request_failed.call_args[0][1],
                               exceptions.RequestCancelled)
 
-    @mock.patch('sky.server.requests.requests.get_request')
+    @mock.patch('sky.server.requests.requests.get_request_async')
     async def test_precondition_cancelled(self, mock_get_request):
         """Test Precondition cancellation behavior."""
 
@@ -51,7 +51,7 @@ class TestPrecondition(unittest.TestCase):
 
         self.assertFalse(result)
 
-    @mock.patch('sky.server.requests.requests.get_request')
+    @mock.patch('sky.server.requests.requests.get_request_async')
     async def test_precondition_check_exception(self, mock_get_request):
         """Test Precondition behavior when check raises exception."""
 

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -275,7 +275,129 @@ async def test_requests_gc_daemon_disabled(isolated_database):
                 mock_sleep.assert_any_call(3600)
 
 
-def test_get_api_request_ids_start_with(isolated_database):
+@pytest.mark.asyncio
+async def test_get_request_async(isolated_database):
+    """Test getting a request asynchronously."""
+    request = requests.Request(request_id='test-request-async-1',
+                               name='test-request',
+                               entrypoint=dummy,
+                               request_body=payloads.RequestBody(),
+                               status=RequestStatus.PENDING,
+                               created_at=time.time(),
+                               user_id='test-user')
+
+    # Create the request
+    requests.create_if_not_exists(request)
+
+    # Get the request asynchronously
+    retrieved_request = await requests.get_request_async('test-request-async-1')
+
+    # Verify the request was retrieved correctly
+    assert retrieved_request is not None
+    assert retrieved_request.request_id == 'test-request-async-1'
+    assert retrieved_request.name == 'test-request'
+    assert retrieved_request.status == RequestStatus.PENDING
+    assert retrieved_request.user_id == 'test-user'
+
+
+@pytest.mark.asyncio
+async def test_get_request_async_nonexistent(isolated_database):
+    """Test getting a non-existent request asynchronously."""
+    retrieved_request = await requests.get_request_async('nonexistent-request')
+    assert retrieved_request is None
+
+
+@pytest.mark.asyncio
+async def test_create_if_not_exists_async(isolated_database):
+    """Test creating a request asynchronously if it doesn't exist."""
+    request = requests.Request(request_id='test-request-async-create-1',
+                               name='test-request',
+                               entrypoint=dummy,
+                               request_body=payloads.RequestBody(),
+                               status=RequestStatus.PENDING,
+                               created_at=time.time(),
+                               user_id='test-user')
+
+    # Create the request asynchronously
+    created = await requests.create_if_not_exists_async(request)
+
+    # Verify the request was created
+    assert created is True
+
+    # Verify we can retrieve it
+    retrieved_request = await requests.get_request_async(
+        'test-request-async-create-1')
+    assert retrieved_request is not None
+    assert retrieved_request.request_id == 'test-request-async-create-1'
+    assert retrieved_request.name == 'test-request'
+    assert retrieved_request.status == RequestStatus.PENDING
+
+
+@pytest.mark.asyncio
+async def test_create_if_not_exists_async_already_exists(isolated_database):
+    """Test creating a request asynchronously when it already exists."""
+    request = requests.Request(request_id='test-request-async-create-2',
+                               name='test-request',
+                               entrypoint=dummy,
+                               request_body=payloads.RequestBody(),
+                               status=RequestStatus.PENDING,
+                               created_at=time.time(),
+                               user_id='test-user')
+
+    # Create the request first time
+    created_first = await requests.create_if_not_exists_async(request)
+    assert created_first is True
+
+    # Try to create the same request again
+    created_second = await requests.create_if_not_exists_async(request)
+    assert created_second is False
+
+
+@pytest.mark.asyncio
+async def test_async_database_operations(isolated_database):
+    """Test async database operations work together correctly."""
+    # Create a request asynchronously
+    request = requests.Request(request_id='test-async-ops-1',
+                               name='test-request',
+                               entrypoint=dummy,
+                               request_body=payloads.RequestBody(),
+                               status=RequestStatus.PENDING,
+                               created_at=time.time(),
+                               user_id='test-user')
+
+    # Test create and get operations work together
+    created = await requests.create_if_not_exists_async(request)
+    assert created is True
+
+    retrieved = await requests.get_request_async('test-async-ops-1')
+    assert retrieved is not None
+    assert retrieved.request_id == 'test-async-ops-1'
+    assert retrieved.status == RequestStatus.PENDING
+
+    # Test that we can create a new request and get both
+    request2 = requests.Request(request_id='test-async-ops-2',
+                                name='test-request-2',
+                                entrypoint=dummy,
+                                request_body=payloads.RequestBody(),
+                                status=RequestStatus.RUNNING,
+                                created_at=time.time(),
+                                user_id='test-user-2')
+
+    created2 = await requests.create_if_not_exists_async(request2)
+    assert created2 is True
+
+    # Verify both requests exist
+    retrieved1 = await requests.get_request_async('test-async-ops-1')
+    retrieved2 = await requests.get_request_async('test-async-ops-2')
+
+    assert retrieved1 is not None
+    assert retrieved2 is not None
+    assert retrieved1.user_id == 'test-user'
+    assert retrieved2.user_id == 'test-user-2'
+
+
+@pytest.mark.asyncio
+async def test_get_api_request_ids_start_with(isolated_database):
     """Test request ID completion prioritizes alive requests and orders correctly."""
     current_time = time.time()
 
@@ -316,14 +438,15 @@ def test_get_api_request_ids_start_with(isolated_database):
         requests.create_if_not_exists(request)
 
     # Test completion with prefix that matches multiple requests
-    result = requests.get_api_request_ids_start_with('pen')  # matches pending-*
+    result = await requests.get_api_request_ids_start_with('pen'
+                                                          )  # matches pending-*
 
     # Should return only pending requests, ordered by newest first
     expected = ['pending-new', 'pending-old']
     assert result == expected
 
     # Test completion with broader prefix
-    result = requests.get_api_request_ids_start_with(
+    result = await requests.get_api_request_ids_start_with(
         '')  # matches all except 'other-request'
 
     # Should return alive requests first (newest first), then finished (newest first)
@@ -338,7 +461,7 @@ def test_get_api_request_ids_start_with(isolated_database):
     assert result_filtered == expected_all
 
     # Test empty result for non-matching prefix
-    result = requests.get_api_request_ids_start_with('nonexistent')
+    result = await requests.get_api_request_ids_start_with('nonexistent')
     assert result == []
 
     # Test limit functionality by creating many requests
@@ -355,5 +478,5 @@ def test_get_api_request_ids_start_with(isolated_database):
         requests.create_if_not_exists(request)
 
     # Test that limit is respected
-    bulk_result = requests.get_api_request_ids_start_with('bulk-')
+    bulk_result = await requests.get_api_request_ids_start_with('bulk-')
     assert len(bulk_result) == 1000  # Should be limited to 1000


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Redo https://github.com/skypilot-org/skypilot/pull/6889 and fix the race issue

Test:

1. Manual test passed:

```
$ sky launch -c c1 -y --cpus 2+ --cloud kubernetes
$ python test.py
$ cat test.py
from sky.client import sdk
import threading

threads = []
for i in range(30):
    thread = threading.Thread(target=sdk.tail_logs, args=('c1', None, True), daemon=True)
    threads.append(thread)
    thread.start()

for thread in threads:
    thread.join()
```

2. Unit test case: 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
