### PR TITLE
backcompat for 6940

### DIFF
--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -309,7 +309,8 @@ class StatusBody(RequestBody):
     cluster_names: Optional[List[str]] = None
     refresh: common_lib.StatusRefreshMode = common_lib.StatusRefreshMode.NONE
     all_users: bool = True
-    include_credentials: bool = False
+    # TODO (kyuds): default to False post 0.11.0
+    include_credentials: bool = True
 
 
 class StartBody(RequestBody):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Related to #6976, this happened because we defaulted to not fetch ssh credentials, but the older sdk doesn't know about the existence of the new flag `_include_credentials` to set it to `True`. 

Need to test, so please dont merge yet


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
