### PR TITLE
[db] Optimized request polling cost

### DIFF
--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -575,7 +575,7 @@ async def get_request_status_async(
         columns += ', status_msg'
     sql = f'SELECT {columns} FROM {REQUEST_TABLE} WHERE request_id LIKE ?'
     async with _DB.execute_fetchall_async(sql, (request_id + '%',)) as rows:
-        if rows is None:
+        if rows is None or len(rows) == 0:
             return None
         status = RequestStatus(rows[0][0])
         status_msg = rows[0][1] if include_msg else None

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -14,7 +14,7 @@ import threading
 import time
 import traceback
 from typing import (Any, AsyncContextManager, Callable, Dict, Generator, List,
-                    Optional, Tuple)
+                    NamedTuple, Optional, Tuple)
 
 import colorama
 import filelock
@@ -546,6 +546,40 @@ async def get_request_async(request_id: str) -> Optional[Request]:
     """Async version of get_request."""
     async with filelock.AsyncFileLock(request_lock_path(request_id)):
         return await _get_request_no_lock_async(request_id)
+
+
+class StatusWithMsg(NamedTuple):
+    status: RequestStatus
+    status_msg: Optional[str] = None
+
+
+@init_db_async
+@metrics_lib.time_me_async
+async def get_request_status_async(
+    request_id: str,
+    include_msg: bool = False,
+) -> Optional[StatusWithMsg]:
+    """Get the status of a request.
+
+    Args:
+        request_id: The ID of the request.
+        include_msg: Whether to include the status message.
+
+    Returns:
+        The status of the request. If the request is not found, returns
+        None.
+    """
+    assert _DB is not None
+    columns = 'status'
+    if include_msg:
+        columns += ', status_msg'
+    sql = f'SELECT {columns} FROM {REQUEST_TABLE} WHERE request_id LIKE ?'
+    async with _DB.execute_fetchall_async(sql, (request_id + '%',)) as rows:
+        if rows is None:
+            return None
+        status = RequestStatus(rows[0][0])
+        status_msg = rows[0][1] if include_msg else None
+        return StatusWithMsg(status, status_msg)
 
 
 @init_db

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1429,27 +1429,29 @@ async def local_down(request: fastapi.Request) -> None:
 async def api_get(request_id: str) -> payloads.RequestPayload:
     """Gets a request with a given request ID prefix."""
     while True:
-        request_task = await requests_lib.get_request_async(request_id)
-        if request_task is None:
+        req_status = await requests_lib.get_request_status_async(request_id)
+        if req_status is None:
             print(f'No task with request ID {request_id}', flush=True)
             raise fastapi.HTTPException(
                 status_code=404, detail=f'Request {request_id!r} not found')
-        if request_task.status > requests_lib.RequestStatus.RUNNING:
-            if request_task.should_retry:
-                raise fastapi.HTTPException(
-                    status_code=503,
-                    detail=f'Request {request_id!r} should be retried')
-            request_error = request_task.get_error()
-            if request_error is not None:
-                raise fastapi.HTTPException(
-                    status_code=500, detail=request_task.encode().model_dump())
-            return request_task.encode()
-        elif (request_task.status == requests_lib.RequestStatus.RUNNING and
-              daemons.is_daemon_request_id(request_id)):
-            return request_task.encode()
+        if (req_status.status == requests_lib.RequestStatus.RUNNING and
+                daemons.is_daemon_request_id(request_id)):
+            # Daemon requests run forever, break without waiting for complete.
+            break
+        if req_status.status > requests_lib.RequestStatus.RUNNING:
+            break
         # yield control to allow other coroutines to run, sleep shortly
         # to avoid storming the DB and CPU in the meantime
         await asyncio.sleep(0.1)
+    request_task = await requests_lib.get_request_async(request_id)
+    if request_task.should_retry:
+        raise fastapi.HTTPException(
+            status_code=503, detail=f'Request {request_id!r} should be retried')
+    request_error = request_task.get_error()
+    if request_error is not None:
+        raise fastapi.HTTPException(status_code=500,
+                                    detail=request_task.encode().model_dump())
+    return request_task.encode()
 
 
 @app.get('/api/stream')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -62,8 +62,15 @@ def test_api_stream_heartbeat(monkeypatch):
         async def mock_get_request(request_id):
             return MockRequest()
 
+        async def mock_get_request_status(request_id):
+            return requests_lib.StatusWithMsg(MockRequest().status,
+                                              MockRequest().status_msg)
+
         monkeypatch.setattr('sky.server.requests.requests.get_request_async',
                             mock_get_request)
+        monkeypatch.setattr(
+            'sky.server.requests.requests.get_request_status_async',
+            mock_get_request_status)
 
         log_path = pathlib.Path(temp_log_path)
 
@@ -147,9 +154,15 @@ def test_heartbeat_not_displayed_to_users(monkeypatch):
         async def mock_get_request(request_id):
             return MockRequest()
 
+        async def mock_get_request_status(request_id):
+            return requests_lib.StatusWithMsg(MockRequest().status,
+                                              MockRequest().status_msg)
+
         monkeypatch.setattr('sky.server.requests.requests.get_request_async',
                             mock_get_request)
-
+        monkeypatch.setattr(
+            'sky.server.requests.requests.get_request_status_async',
+            mock_get_request_status)
         log_path = pathlib.Path(temp_log_path)
 
         try:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/6945

According profile, there is a non-trivial CPU cost of `get_request_async` call since it is called in busy loops (`/api/get`, `/api/stream`), this PR simplifies the SQL to check status.

Test:

```bash
python test.py
10000 times get_request_status Time taken: 3.0183849334716797
10000 times get_request_status_async Time taken: 0.4276120662689209
```

About 7x improvement.

```python
$ cat test.py
import asyncio
import time
from sky.server.requests import requests

async def main():
    now = time.time()
    for _ in range(10000):
        req_status = await requests.get_request_async('skypilot-status-refresh-daemon')
    end = time.time()
    print(f'10000 times get_request_async Time taken: {end - now}')

    now = time.time()
    for _ in range(10000):
        req_status = await requests.get_request_status_async('skypilot-status-refresh-daemon')
    end = time.time()
    print(f'10000 times get_request_status_async Time taken: {end - now}')


if __name__ == '__main__':
    asyncio.run(main())
```

Also, `sky status` does not have regression:

```bash
# PR branch
$ multitime sky status
===> multitime results
1: sky status
            Mean        Std.Dev.    Min         Median      Max
real        1.793       0.524       1.394       1.559       2.827
user        1.373       0.316       1.012       1.309       1.952
sys         0.848       0.247       0.527       1.005       1.085
# master branch
$ multitime sky status
===> multitime results
1: sky status
            Mean        Std.Dev.    Min         Median      Max
real        1.800       0.680       1.401       1.496       3.158
user        1.168       0.176       0.952       1.232       1.430
sys         0.911       0.283       0.594       0.751       1.356
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
