### PR TITLE
[UX] Fix repeated sky launch shows cluster belongs to other users 

### DIFF
--- a/tests/unit_tests/test_sky/server/test_sdk.py
+++ b/tests/unit_tests/test_sky/server/test_sdk.py
@@ -1,7 +1,9 @@
 # Tests for the sky/client/sdk.py file
+import base64
 from http.cookiejar import Cookie
 from http.cookiejar import MozillaCookieJar
 import io
+import json
 import os
 from pathlib import Path
 import time
@@ -271,6 +273,234 @@ def test_api_login(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
             mock.call("http://localhost:8080"),
             mock.call("http://localhost:8080")
         ])
+
+
+def test_api_login_user_hash_token(monkeypatch: pytest.MonkeyPatch,
+                                   tmp_path: Path):
+    # Test that we set the user hash when we have a service account token.
+    config_path = tmp_path / "config.yaml"
+    user_hash_path = tmp_path / "user_hash"
+    monkeypatch.setattr('sky.utils.common_utils.USER_HASH_FILE',
+                        str(user_hash_path))
+    monkeypatch.setattr('sky.skypilot_config.get_user_config_path',
+                        lambda: str(config_path))
+
+    user_hash = '11111111'
+
+    user = mock.MagicMock()
+    user.get.return_value = user_hash
+
+    test_endpoint = "http://test.skypilot.co"
+
+    # Test with service account token.
+    with mock.patch('sky.server.common.check_server_healthy') as mock_check:
+        mock_check.return_value = (
+            server_common.ApiServerStatus.HEALTHY,
+            server_common.ApiServerInfo(
+                status=server_common.ApiServerStatus.HEALTHY,
+                basic_auth_enabled=False,
+                user=user))
+        client_sdk.api_login(test_endpoint, service_account_token="sky_test")
+
+        # Verify the user hash is written to the file.
+        assert user_hash_path.exists()
+        assert user_hash_path.read_text() == user_hash
+
+
+def test_api_login_user_hash_needs_auth(monkeypatch: pytest.MonkeyPatch,
+                                        tmp_path: Path):
+    # Test that we set the user hash when we need auth.
+    config_path = tmp_path / "config.yaml"
+    user_hash_path = tmp_path / "user_hash"
+    monkeypatch.setattr('sky.utils.common_utils.USER_HASH_FILE',
+                        str(user_hash_path))
+    monkeypatch.setattr('sky.skypilot_config.get_user_config_path',
+                        lambda: str(config_path))
+
+    user_hash = '11111111'
+
+    user = mock.MagicMock()
+    user.get.return_value = user_hash
+
+    test_endpoint = "http://test.skypilot.co"
+
+    # Test needs auth.
+    auth_token = base64.b64encode(
+        json.dumps({
+            'v': 1,
+            'user': user_hash,
+            'cookies': {}
+        }).encode('utf-8')).decode('utf-8')
+
+    with mock.patch('sky.server.common.check_server_healthy') as mock_check:
+        # On first call, return needs auth.
+        first_return_value = (
+            server_common.ApiServerStatus.NEEDS_AUTH,
+            server_common.ApiServerInfo(
+                status=server_common.ApiServerStatus.NEEDS_AUTH,
+                basic_auth_enabled=False))
+
+        # On second call, auth has succeeded.
+        second_return_value = (server_common.ApiServerStatus.HEALTHY,
+                               server_common.ApiServerInfo(
+                                   status=server_common.ApiServerStatus.HEALTHY,
+                                   basic_auth_enabled=False))
+
+        mock_check.side_effect = [first_return_value, second_return_value]
+
+        def _fake_start_local_auth_server(callback_port, token_container,
+                                          remote_endpoint):
+            token_container['token'] = auth_token
+            return None
+
+        # Set the token container manually.
+        monkeypatch.setattr('sky.client.oauth.start_local_auth_server',
+                            _fake_start_local_auth_server)
+        monkeypatch.setattr('webbrowser.open', lambda url: True)
+        client_sdk.api_login(test_endpoint)
+
+        # Verify the user hash is written to the file.
+        assert user_hash_path.exists()
+        assert user_hash_path.read_text() == user_hash
+
+
+def test_api_login_user_hash_needs_auth_both(monkeypatch: pytest.MonkeyPatch,
+                                             tmp_path: Path):
+    # Test that we set the user hash with the token returned from the
+    # api server even if we negotiate a new hash.
+    config_path = tmp_path / "config.yaml"
+    user_hash_path = tmp_path / "user_hash"
+    monkeypatch.setattr('sky.utils.common_utils.USER_HASH_FILE',
+                        str(user_hash_path))
+    monkeypatch.setattr('sky.skypilot_config.get_user_config_path',
+                        lambda: str(config_path))
+
+    user_hash = '11111111'
+
+    new_user_hash = '22222222'
+
+    user = mock.MagicMock()
+    user.get.return_value = user_hash
+
+    test_endpoint = "http://test.skypilot.co"
+
+    # Test needs auth.
+    auth_token = base64.b64encode(
+        json.dumps({
+            'v': 1,
+            'user': new_user_hash,
+            'cookies': {}
+        }).encode('utf-8')).decode('utf-8')
+
+    with mock.patch('sky.server.common.check_server_healthy') as mock_check:
+        # On first call, return needs auth.
+        first_return_value = (
+            server_common.ApiServerStatus.NEEDS_AUTH,
+            server_common.ApiServerInfo(
+                status=server_common.ApiServerStatus.NEEDS_AUTH,
+                basic_auth_enabled=False,
+                user=user))
+
+        # On second call, auth has succeeded.
+        second_return_value = (server_common.ApiServerStatus.HEALTHY,
+                               server_common.ApiServerInfo(
+                                   status=server_common.ApiServerStatus.HEALTHY,
+                                   basic_auth_enabled=False))
+
+        mock_check.side_effect = [first_return_value, second_return_value]
+
+        def _fake_start_local_auth_server(callback_port, token_container,
+                                          remote_endpoint):
+            token_container['token'] = auth_token
+            return None
+
+        # Set the token container manually.
+        monkeypatch.setattr('sky.client.oauth.start_local_auth_server',
+                            _fake_start_local_auth_server)
+        monkeypatch.setattr('webbrowser.open', lambda url: True)
+        client_sdk.api_login(test_endpoint)
+
+        # Verify the user hash is written to the file.
+        assert user_hash_path.exists()
+        # We should use the old user hash from the api server.
+        assert user_hash_path.read_text() == user_hash
+
+
+def test_api_login_user_hash_server_healthy(monkeypatch: pytest.MonkeyPatch,
+                                            tmp_path: Path):
+    # Test that we set the user hash when we need auth.
+    config_path = tmp_path / "config.yaml"
+    user_hash_path = tmp_path / "user_hash"
+    monkeypatch.setattr('sky.utils.common_utils.USER_HASH_FILE',
+                        str(user_hash_path))
+    monkeypatch.setattr('sky.skypilot_config.get_user_config_path',
+                        lambda: str(config_path))
+
+    user_hash = '11111111'
+
+    user = mock.MagicMock()
+    user.get.return_value = user_hash
+
+    test_endpoint = "http://test.skypilot.co"
+
+    # Test needs auth.
+    auth_token = base64.b64encode(
+        json.dumps({
+            'v': 1,
+            'user': user_hash,
+            'cookies': {}
+        }).encode('utf-8')).decode('utf-8')
+    with mock.patch('sky.server.common.check_server_healthy') as mock_check:
+        mock_check.return_value = (
+            server_common.ApiServerStatus.HEALTHY,
+            server_common.ApiServerInfo(
+                status=server_common.ApiServerStatus.HEALTHY,
+                user=user,
+                basic_auth_enabled=False))
+
+        def _fake_start_local_auth_server(callback_port, token_container,
+                                          remote_endpoint):
+            token_container['token'] = auth_token
+            return None
+
+        # Set the token container manually.
+        monkeypatch.setattr('sky.client.oauth.start_local_auth_server',
+                            _fake_start_local_auth_server)
+        monkeypatch.setattr('webbrowser.open', lambda url: True)
+        client_sdk.api_login(test_endpoint)
+
+        # Verify the user hash is written to the file.
+        assert user_hash_path.exists()
+        assert user_hash_path.read_text() == user_hash
+
+
+def test_api_login_user_hash_fail(monkeypatch: pytest.MonkeyPatch,
+                                  tmp_path: Path):
+    # Test that we don't set the user hash if we fail to login.
+    config_path = tmp_path / "config.yaml"
+    user_hash_path = tmp_path / "user_hash"
+    monkeypatch.setattr('sky.utils.common_utils.USER_HASH_FILE',
+                        str(user_hash_path))
+    monkeypatch.setattr('sky.skypilot_config.get_user_config_path',
+                        lambda: str(config_path))
+
+    user_hash = '11111111'
+
+    user = mock.MagicMock()
+    user.get.return_value = user_hash
+
+    test_endpoint = "http://test.skypilot.co"
+
+    # Make sure if we fail in the try block, the user hash is not written to
+    # the file.
+    # Make get_dashboard_url raise an exception.
+    monkeypatch.setattr('sky.server.common.get_dashboard_url',
+                        lambda *args, **kwargs: None)
+    with pytest.raises(Exception):
+        client_sdk.api_login(test_endpoint, service_account_token="sky_test")
+
+    # Verify the user hash is not written to the file.
+    assert not user_hash_path.exists()
 
 
 class MockRetryContext:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR aims to address the following issue:
- A user has previously logged into a remote API server, launches some cluster and eventually logs out
- Some time later they log back and in doing so have a new user hash as negotiated by the authentication
- As a result if they attempt to launch the same cluster they will see `Cluster <NAME> was created by another user <EMAIL>`. 

We fix this by enforcing that on `sky api login` if the api server responds with an old user hash we will store the old hash in `~/.sky/user_hash` instead of the new hash.

Another way to do this could have been to somehow update the server of the new hash and have it go through its cluster records and replace all entries with the old one with a new entry with the new hash. This seemed to require a lot more extra work on the server.

This PR also addresses issue #6975

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

I added 5 unit tests addressing this issue in the cases of: authentication with service account token, authentication with oauth with no reauth required, authentication with oauth with reauth required.

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
