### PR TITLE
[test] update unit test python version

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -80,12 +80,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.13"]
+        python-version: ["3.8", "3.13"]
         test-path:
           - tests/test_jobs_and_serve.py tests/test_cli.py
         include:
           - test-path: tests/test_jobs_and_serve.py tests/test_cli.py
-            test-name: "Limited Deps - Jobs, Serve & CLI"
+            test-name: "Limited Deps - Jobs, Serve & CLI (${{ matrix.python-version }})"
     name: "Python Tests - ${{ matrix.test-name }}"
     steps:
       - name: Checkout repository

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -85,8 +85,8 @@ jobs:
           - tests/test_jobs_and_serve.py tests/test_cli.py
         include:
           - test-path: tests/test_jobs_and_serve.py tests/test_cli.py
-            test-name: "Limited Deps - Jobs, Serve & CLI (${{ matrix.python-version }})"
-    name: "Python Tests - ${{ matrix.test-name }}"
+            test-name: "Limited Deps - Jobs, Serve & CLI"
+    name: "Python Tests - ${{ matrix.test-name }} (${{ matrix.python-version }})"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.7", "3.8", "3.13"]
         test-path:
           - tests/test_jobs_and_serve.py tests/test_cli.py
         include:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Run pytest (limited deps) check on both 3.8 (oldest version possible) and also 3.13 (latest compatible version) to make sure we aren't breaking compatibility with either python version.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
