### PR TITLE
[db] connection pool optimization - 2x speedup in remote postgres environment

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -2315,3 +2315,24 @@ def set_system_config(config_key: str, config_value: str) -> None:
             })
         session.execute(upsert_stmnt)
         session.commit()
+
+
+@_init_db
+def get_max_db_connections() -> Optional[int]:
+    """Get the maximum number of connections for the engine."""
+    assert _SQLALCHEMY_ENGINE is not None
+    if _SQLALCHEMY_ENGINE.dialect.name == db_utils.SQLAlchemyDialect.SQLITE.value:
+        return None
+    with sqlalchemy.orm.Session(_SQLALCHEMY_ENGINE) as session:
+        max_connections = session.execute(sqlalchemy.text('SHOW max_connections')).scalar()
+        print(f'Max connections: {max_connections}')
+        if max_connections is None:
+            return None
+        return int(max_connections)
+
+
+@_init_db
+def get_max_engine_connections() -> int:
+    """Get the current number of connections for the engine."""
+    assert _SQLALCHEMY_ENGINE is not None
+    return _SQLALCHEMY_ENGINE.pool.size() + _SQLALCHEMY_ENGINE.pool._max_overflow

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -299,9 +299,7 @@ def create_table(engine: sqlalchemy.engine.Engine):
 # a session has already been created with _SQLALCHEMY_ENGINE = e1,
 # and then another thread overwrites _SQLALCHEMY_ENGINE = e2
 # which could result in e1 being garbage collected unexpectedly.
-def initialize_and_get_db(
-    pg_pool_class: Optional[sqlalchemy.pool.Pool] = None
-) -> sqlalchemy.engine.Engine:
+def initialize_and_get_db() -> sqlalchemy.engine.Engine:
     global _SQLALCHEMY_ENGINE
 
     if _SQLALCHEMY_ENGINE is not None:
@@ -310,8 +308,7 @@ def initialize_and_get_db(
         if _SQLALCHEMY_ENGINE is not None:
             return _SQLALCHEMY_ENGINE
         # get an engine to the db
-        engine = migration_utils.get_engine('state',
-                                            pg_pool_class=pg_pool_class)
+        engine = db_utils.get_engine('state')
 
         # run migrations if needed
         create_table(engine)
@@ -2321,20 +2318,12 @@ def set_system_config(config_key: str, config_value: str) -> None:
 def get_max_db_connections() -> Optional[int]:
     """Get the maximum number of connections for the engine."""
     assert _SQLALCHEMY_ENGINE is not None
-    if _SQLALCHEMY_ENGINE.dialect.name == db_utils.SQLAlchemyDialect.SQLITE.value:
+    if (_SQLALCHEMY_ENGINE.dialect.name ==
+            db_utils.SQLAlchemyDialect.SQLITE.value):
         return None
     with sqlalchemy.orm.Session(_SQLALCHEMY_ENGINE) as session:
         max_connections = session.execute(
             sqlalchemy.text('SHOW max_connections')).scalar()
-        print(f'Max connections: {max_connections}')
         if max_connections is None:
             return None
         return int(max_connections)
-
-
-@_init_db
-def get_max_engine_connections() -> int:
-    """Get the current number of connections for the engine."""
-    assert _SQLALCHEMY_ENGINE is not None
-    return _SQLALCHEMY_ENGINE.pool.size(
-    ) + _SQLALCHEMY_ENGINE.pool._max_overflow

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -2324,7 +2324,8 @@ def get_max_db_connections() -> Optional[int]:
     if _SQLALCHEMY_ENGINE.dialect.name == db_utils.SQLAlchemyDialect.SQLITE.value:
         return None
     with sqlalchemy.orm.Session(_SQLALCHEMY_ENGINE) as session:
-        max_connections = session.execute(sqlalchemy.text('SHOW max_connections')).scalar()
+        max_connections = session.execute(
+            sqlalchemy.text('SHOW max_connections')).scalar()
         print(f'Max connections: {max_connections}')
         if max_connections is None:
             return None
@@ -2335,4 +2336,5 @@ def get_max_db_connections() -> Optional[int]:
 def get_max_engine_connections() -> int:
     """Get the current number of connections for the engine."""
     assert _SQLALCHEMY_ENGINE is not None
-    return _SQLALCHEMY_ENGINE.pool.size() + _SQLALCHEMY_ENGINE.pool._max_overflow
+    return _SQLALCHEMY_ENGINE.pool.size(
+    ) + _SQLALCHEMY_ENGINE.pool._max_overflow

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -157,7 +157,7 @@ def initialize_and_get_db() -> sqlalchemy.engine.Engine:
         if _SQLALCHEMY_ENGINE is not None:
             return _SQLALCHEMY_ENGINE
         # get an engine to the db
-        engine = migration_utils.get_engine('spot_jobs')
+        engine = db_utils.get_engine('spot_jobs')
 
         # run migrations if needed
         create_table(engine)

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -130,7 +130,7 @@ def initialize_and_get_db() -> sqlalchemy.engine.Engine:
         if _SQLALCHEMY_ENGINE is not None:
             return _SQLALCHEMY_ENGINE
         # get an engine to the db
-        engine = migration_utils.get_engine('serve/services')
+        engine = db_utils.get_engine('serve/services')
 
         # run migrations if needed
         create_table(engine)

--- a/sky/server/config.py
+++ b/sky/server/config.py
@@ -62,6 +62,7 @@ class QueueBackend(enum.Enum):
 class WorkerConfig:
     garanteed_parallelism: int
     burstable_parallelism: int
+    num_db_connections_per_worker: int
 
 
 @dataclasses.dataclass
@@ -174,10 +175,12 @@ def compute_server_config(deploy: bool,
         queue_backend=queue_backend,
         long_worker_config=WorkerConfig(
             garanteed_parallelism=max_parallel_for_long,
-            burstable_parallelism=burstable_parallel_for_long),
+            burstable_parallelism=burstable_parallel_for_long,
+            num_db_connections_per_worker=num_db_connections_per_worker),
         short_worker_config=WorkerConfig(
             garanteed_parallelism=max_parallel_for_short,
-            burstable_parallelism=burstable_parallel_for_short),
+            burstable_parallelism=burstable_parallel_for_short,
+            num_db_connections_per_worker=num_db_connections_per_worker),
         num_db_connections_per_worker=num_db_connections_per_worker,
     )
 

--- a/sky/server/config.py
+++ b/sky/server/config.py
@@ -71,7 +71,7 @@ class ServerConfig:
     queue_backend: QueueBackend
 
 
-def compute_server_config(deploy: bool) -> ServerConfig:
+def compute_server_config(deploy: bool, max_db_connections: Optional[int]) -> ServerConfig:
     """Compute the server config based on environment.
 
     We have different assumptions for the resources in different deployment

--- a/sky/server/config.py
+++ b/sky/server/config.py
@@ -161,8 +161,7 @@ def compute_server_config(deploy: bool,
                 'Increase the number of max db connections to '
                 f'at least {max_parallel_all_workers} for optimal performance.')
         else:
-            num_db_connections_per_worker = (max_db_connections //
-                                             max_parallel_all_workers)
+            num_db_connections_per_worker = 1
 
     logger.info(
         f'SkyPilot API server will start {num_server_workers} server processes '

--- a/sky/server/config.py
+++ b/sky/server/config.py
@@ -74,7 +74,8 @@ class ServerConfig:
 
 
 def compute_server_config(deploy: bool,
-                          max_db_connections: Optional[int] = None) -> ServerConfig:
+                          max_db_connections: Optional[int] = None
+                         ) -> ServerConfig:
     """Compute the server config based on environment.
 
     We have different assumptions for the resources in different deployment

--- a/sky/server/config.py
+++ b/sky/server/config.py
@@ -74,7 +74,7 @@ class ServerConfig:
 
 
 def compute_server_config(deploy: bool,
-                          max_db_connections: Optional[int]) -> ServerConfig:
+                          max_db_connections: Optional[int] = None) -> ServerConfig:
     """Compute the server config based on environment.
 
     We have different assumptions for the resources in different deployment

--- a/sky/server/config.py
+++ b/sky/server/config.py
@@ -2,6 +2,7 @@
 
 import dataclasses
 import enum
+from typing import Optional
 
 from sky import sky_logging
 from sky.server import constants as server_constants
@@ -68,10 +69,12 @@ class ServerConfig:
     num_server_workers: int
     long_worker_config: WorkerConfig
     short_worker_config: WorkerConfig
+    num_db_connections_per_worker: int
     queue_backend: QueueBackend
 
 
-def compute_server_config(deploy: bool, max_db_connections: Optional[int]) -> ServerConfig:
+def compute_server_config(deploy: bool,
+                          max_db_connections: Optional[int]) -> ServerConfig:
     """Compute the server config based on environment.
 
     We have different assumptions for the resources in different deployment
@@ -114,7 +117,17 @@ def compute_server_config(deploy: bool, max_db_connections: Optional[int]) -> Se
     queue_backend = QueueBackend.MULTIPROCESSING
     burstable_parallel_for_long = 0
     burstable_parallel_for_short = 0
+    # if num_db_connections_per_worker is 0, server will use NullPool
+    # to conserve the number of concurrent db connections.
+    # This could lead to performance degradation.
+    num_db_connections_per_worker = 0
     num_server_workers = cpu_count
+
+    # +1 for the event loop running the main process
+    # and gc daemons in the '__main__' body of sky/server/server.py
+    max_parallel_all_workers = (max_parallel_for_long + max_parallel_for_short +
+                                num_server_workers + 1)
+
     if not deploy:
         # For local mode, use local queue backend since we only run 1 uvicorn
         # worker in local mode and no multiprocessing is needed.
@@ -140,6 +153,17 @@ def compute_server_config(deploy: bool, max_db_connections: Optional[int]) -> Se
                 'SkyPilot API server will run in low resource mode because '
                 'the available memory is less than '
                 f'{server_constants.MIN_AVAIL_MEM_GB}GB.')
+    elif max_db_connections is not None:
+        if max_parallel_all_workers > max_db_connections:
+            logger.warning(
+                f'Max parallel all workers ({max_parallel_all_workers}) '
+                f'is greater than max db connections ({max_db_connections}). '
+                'Increase the number of max db connections to '
+                f'at least {max_parallel_all_workers} for optimal performance.')
+        else:
+            num_db_connections_per_worker = (max_db_connections //
+                                             max_parallel_all_workers)
+
     logger.info(
         f'SkyPilot API server will start {num_server_workers} server processes '
         f'with {max_parallel_for_long} background workers for long requests '
@@ -154,6 +178,7 @@ def compute_server_config(deploy: bool, max_db_connections: Optional[int]) -> Se
         short_worker_config=WorkerConfig(
             garanteed_parallelism=max_parallel_for_short,
             burstable_parallelism=burstable_parallel_for_short),
+        num_db_connections_per_worker=num_db_connections_per_worker,
     )
 
 

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -354,7 +354,8 @@ def _sigterm_handler(signum: int, frame: Optional['types.FrameType']) -> None:
     raise KeyboardInterrupt
 
 
-def _request_execution_wrapper(request_id: str, ignore_return_value: bool,
+def _request_execution_wrapper(request_id: str,
+                               ignore_return_value: bool,
                                num_db_connections_per_worker: int = 0) -> None:
     """Wrapper for a request execution.
 

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -355,7 +355,7 @@ def _sigterm_handler(signum: int, frame: Optional['types.FrameType']) -> None:
 
 
 def _request_execution_wrapper(request_id: str, ignore_return_value: bool,
-                               num_db_connections_per_worker: int) -> None:
+                               num_db_connections_per_worker: int = 0) -> None:
     """Wrapper for a request execution.
 
     It wraps the execution of a request to:

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -24,7 +24,6 @@ import aiofiles
 import anyio
 import fastapi
 from fastapi.middleware import cors
-from sqlalchemy import pool
 import starlette.middleware.base
 import uvloop
 
@@ -1925,13 +1924,15 @@ if __name__ == '__main__':
     usage_lib.maybe_show_privacy_policy()
 
     # Initialize global user state db
-    global_user_state.initialize_and_get_db(pool.StaticPool)
+    db_utils.set_max_connections(1)
+    global_user_state.initialize_and_get_db()
     # Initialize request db
     requests_lib.reset_db_and_logs()
     # Restore the server user hash
     _init_or_restore_server_user_hash()
     max_db_connections = global_user_state.get_max_db_connections()
-    config = server_config.compute_server_config(cmd_args.deploy, max_db_connections)
+    config = server_config.compute_server_config(cmd_args.deploy,
+                                                 max_db_connections)
 
     num_workers = config.num_server_workers
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1958,11 +1958,12 @@ if __name__ == '__main__':
         logger.info(f'Starting SkyPilot API server, workers={num_workers}')
         # We don't support reload for now, since it may cause leakage of request
         # workers or interrupt running requests.
-        config = uvicorn.Config('sky.server.server:app',
-                                host=cmd_args.host,
-                                port=cmd_args.port,
-                                workers=num_workers)
-        skyuvicorn.run(config)
+        uvicorn_config = uvicorn.Config('sky.server.server:app',
+                                        host=cmd_args.host,
+                                        port=cmd_args.port,
+                                        workers=num_workers)
+        skyuvicorn.run(uvicorn_config,
+                       max_db_connections=config.num_db_connections_per_worker)
     except Exception as exc:  # pylint: disable=broad-except
         logger.error(f'Failed to start SkyPilot API server: '
                      f'{common_utils.format_exception(exc, use_bracket=True)}')

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -574,8 +574,13 @@ def _reload_config_as_server() -> None:
                 'If db config is specified, no other config is allowed')
         logger.debug('retrieving config from database')
         with _DB_USE_LOCK:
-            sqlalchemy_engine = sqlalchemy.create_engine(db_url,
-                                                         poolclass=NullPool)
+            dispose_engine = False
+            if db_utils.get_max_connections() == 0:
+                dispose_engine = True
+                sqlalchemy_engine = sqlalchemy.create_engine(db_url,
+                                                             poolclass=NullPool)
+            else:
+                sqlalchemy_engine = db_utils.get_engine('config')
             db_utils.add_all_tables_to_db_sqlalchemy(Base.metadata,
                                                      sqlalchemy_engine)
 
@@ -597,7 +602,8 @@ def _reload_config_as_server() -> None:
                 server_config = overlay_skypilot_config(server_config,
                                                         db_config)
             # Close the engine to avoid connection leaks
-            sqlalchemy_engine.dispose()
+            if dispose_engine:
+                sqlalchemy_engine.dispose()
     if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
         logger.debug(f'server config: \n'
                      f'{yaml_utils.dump_yaml_str(dict(server_config))}')
@@ -867,8 +873,13 @@ def update_api_server_config_no_lock(config: config_utils.Config) -> None:
             raise ValueError('Cannot change db url while server is running')
         if existing_db_url:
             with _DB_USE_LOCK:
-                sqlalchemy_engine = sqlalchemy.create_engine(existing_db_url,
+                dispose_engine = False
+                if db_utils.get_max_connections() == 0:
+                    dispose_engine = True
+                    sqlalchemy_engine = sqlalchemy.create_engine(existing_db_url,
                                                              poolclass=NullPool)
+                else:
+                    sqlalchemy_engine = db_utils.get_engine('config')
                 db_utils.add_all_tables_to_db_sqlalchemy(
                     Base.metadata, sqlalchemy_engine)
 
@@ -897,7 +908,8 @@ def update_api_server_config_no_lock(config: config_utils.Config) -> None:
                 _set_config_yaml_to_db(API_SERVER_CONFIG_KEY, config)
                 db_updated = True
                 # Close the engine to avoid connection leaks
-                sqlalchemy_engine.dispose()
+                if dispose_engine:
+                    sqlalchemy_engine.dispose()
 
     if not db_updated:
         # save to the local file (PVC in Kubernetes, local file otherwise)

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -876,8 +876,8 @@ def update_api_server_config_no_lock(config: config_utils.Config) -> None:
                 dispose_engine = False
                 if db_utils.get_max_connections() == 0:
                     dispose_engine = True
-                    sqlalchemy_engine = sqlalchemy.create_engine(existing_db_url,
-                                                             poolclass=NullPool)
+                    sqlalchemy_engine = sqlalchemy.create_engine(
+                        existing_db_url, poolclass=NullPool)
                 else:
                     sqlalchemy_engine = db_utils.get_engine('config')
                 db_utils.add_all_tables_to_db_sqlalchemy(

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -370,6 +370,9 @@ def set_max_connections(max_connections: int):
     global _max_connections
     _max_connections = max_connections
 
+def get_max_connections():
+    return _max_connections
+
 
 def get_engine(db_name: str):
     conn_string = None

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -277,6 +277,14 @@ def drop_column_from_table_alembic(
             raise
 
 
+def get_max_connections(engine: sqlalchemy.engine.Engine) -> Optional[int]:
+    """Get the maximum number of connections for the engine."""
+    if engine.dialect.name == SQLAlchemyDialect.SQLITE.value:
+        return None
+    with sqlalchemy.orm.Session(engine) as session:
+        return session.execute(sqlalchemy.text('SHOW max_connections')).scalar()
+
+
 class SQLiteConn(threading.local):
     """Thread-local connection to the sqlite3 database."""
 

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -2,10 +2,12 @@
 import asyncio
 import contextlib
 import enum
+import os
+import pathlib
 import sqlite3
 import threading
 import typing
-from typing import Any, Callable, Iterable, Optional
+from typing import Any, Callable, Dict, Iterable, Optional
 
 import aiosqlite
 import aiosqlite.context
@@ -13,6 +15,7 @@ import sqlalchemy
 from sqlalchemy import exc as sqlalchemy_exc
 
 from sky import sky_logging
+from sky.skylet import constants
 
 logger = sky_logging.init_logger(__name__)
 if typing.TYPE_CHECKING:
@@ -354,3 +357,48 @@ class SQLiteConn(threading.local):
                                     ) -> Iterable[sqlite3.Row]:
         conn = await self._get_async_conn()
         return await conn.execute_fetchall(sql, parameters)
+
+
+_max_connections = 0
+_postgres_engine_cache: Dict[str, sqlalchemy.engine.Engine] = {}
+_sqlite_engine_cache: Dict[str, sqlalchemy.engine.Engine] = {}
+
+_db_creation_lock = threading.Lock()
+
+
+def set_max_connections(max_connections: int):
+    global _max_connections
+    _max_connections = max_connections
+
+
+def get_engine(db_name: str):
+    conn_string = None
+    if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
+        conn_string = os.environ.get(constants.ENV_VAR_DB_CONNECTION_URI)
+    if conn_string:
+        with _db_creation_lock:
+            if conn_string not in _postgres_engine_cache:
+                if _max_connections == 0:
+                    _postgres_engine_cache[conn_string] = (
+                        sqlalchemy.create_engine(
+                            conn_string, poolclass=sqlalchemy.pool.NullPool))
+                elif _max_connections == 1:
+                    _postgres_engine_cache[conn_string] = (
+                        sqlalchemy.create_engine(
+                            conn_string, poolclass=sqlalchemy.pool.StaticPool))
+                else:
+                    _postgres_engine_cache[conn_string] = (
+                        sqlalchemy.create_engine(
+                            conn_string,
+                            poolclass=sqlalchemy.pool.QueuePool,
+                            size=_max_connections,
+                            max_overflow=0))
+            engine = _postgres_engine_cache[conn_string]
+    else:
+        db_path = os.path.expanduser(f'~/.sky/{db_name}.db')
+        pathlib.Path(db_path).parents[0].mkdir(parents=True, exist_ok=True)
+        if db_path not in _sqlite_engine_cache:
+            _sqlite_engine_cache[db_path] = sqlalchemy.create_engine(
+                'sqlite:///' + db_path)
+        engine = _sqlite_engine_cache[db_path]
+    return engine

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -280,14 +280,6 @@ def drop_column_from_table_alembic(
             raise
 
 
-def get_max_connections(engine: sqlalchemy.engine.Engine) -> Optional[int]:
-    """Get the maximum number of connections for the engine."""
-    if engine.dialect.name == SQLAlchemyDialect.SQLITE.value:
-        return None
-    with sqlalchemy.orm.Session(engine) as session:
-        return session.execute(sqlalchemy.text('SHOW max_connections')).scalar()
-
-
 class SQLiteConn(threading.local):
     """Thread-local connection to the sqlite3 database."""
 
@@ -369,6 +361,7 @@ _db_creation_lock = threading.Lock()
 def set_max_connections(max_connections: int):
     global _max_connections
     _max_connections = max_connections
+
 
 def get_max_connections():
     return _max_connections

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -3,9 +3,6 @@
 import contextlib
 import logging
 import os
-import pathlib
-import threading
-from typing import Dict, Optional
 
 from alembic import command as alembic_command
 from alembic.config import Config
@@ -14,7 +11,6 @@ import filelock
 import sqlalchemy
 
 from sky import sky_logging
-from sky.skylet import constants
 
 logger = sky_logging.init_logger(__name__)
 
@@ -31,34 +27,6 @@ SPOT_JOBS_LOCK_PATH = '~/.sky/locks/.spot_jobs_db.lock'
 SERVE_DB_NAME = 'serve_db'
 SERVE_VERSION = '001'
 SERVE_LOCK_PATH = '~/.sky/locks/.serve_db.lock'
-
-_postgres_engine_cache: Dict[str, sqlalchemy.engine.Engine] = {}
-_sqlite_engine_cache: Dict[str, sqlalchemy.engine.Engine] = {}
-
-_db_creation_lock = threading.Lock()
-
-
-def get_engine(db_name: str,
-               pg_pool_class: Optional[sqlalchemy.pool.Pool] = None):
-    conn_string = None
-    if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
-        conn_string = os.environ.get(constants.ENV_VAR_DB_CONNECTION_URI)
-    if conn_string:
-        if pg_pool_class is None:
-            pg_pool_class = sqlalchemy.NullPool
-        with _db_creation_lock:
-            if conn_string not in _postgres_engine_cache:
-                _postgres_engine_cache[conn_string] = sqlalchemy.create_engine(
-                    conn_string, poolclass=pg_pool_class)
-            engine = _postgres_engine_cache[conn_string]
-    else:
-        db_path = os.path.expanduser(f'~/.sky/{db_name}.db')
-        pathlib.Path(db_path).parents[0].mkdir(parents=True, exist_ok=True)
-        if db_path not in _sqlite_engine_cache:
-            _sqlite_engine_cache[db_path] = sqlalchemy.create_engine(
-                'sqlite:///' + db_path)
-        engine = _sqlite_engine_cache[db_path]
-    return engine
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
If postgres DB supports enough connections for every process (executor, uvicorn worker, main loop), use a persistent connection instead of NullPool (which does connection setup/teardown for every DB op) to save on connection setup/teardown time.

We have been using NullPools to save on total # of connections at any given time because we didn't have visibility on the number of connections a PSQL instance supports. Now that we are able to get this number, we're able to make smart choices in the trade-offs to make.

Testing:

Running `sky status` on a remote API server on GKE with GCP cloud SQL backend, using IAM auth.

Initial few runs of `sky status` are discarded to fully load modules and initialize the db connections.

this PR
2.921
2.810
2.874
2.970
2.850
avg: 2.885

master
5.515
5.492
6.008
5.590
6.111
avg: 5.7432

This PR is approx. 2X faster.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
