### PR TITLE
[Dashboard] Fix cluster detail page job log download

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -1069,6 +1069,7 @@ export function ManagedJobsTable({
                             jobParent="/jobs"
                             jobId={item.id}
                             managed={true}
+                            workspace={item.workspace}
                           />
                         </TableCell>
                       </TableRow>
@@ -1257,6 +1258,7 @@ export function Status2Actions({
   jobParent,
   jobId,
   managed,
+  workspace = 'default',
 }) {
   const router = useRouter();
 
@@ -1287,7 +1289,7 @@ export function Status2Actions({
         downloadJobLogs({
           clusterName: clusterName,
           jobIds: [jobId],
-          workspace: 'default', // TODO: Get actual workspace from context
+          workspace: workspace,
         });
       }
     }
@@ -1362,6 +1364,7 @@ export function ClusterJobs({
   refreshClusterJobsOnly,
   userFilter = null,
   nameFilter = null,
+  workspace = 'default',
 }) {
   const [expandedRowId, setExpandedRowId] = useState(null);
   const [sortConfig, setSortConfig] = useState({
@@ -1602,6 +1605,7 @@ export function ClusterJobs({
                         jobParent={`/clusters/${clusterName}`}
                         jobId={item.id}
                         managed={false}
+                        workspace={workspace}
                       />
                     </TableCell>
                   </TableRow>

--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -219,7 +219,7 @@ export async function downloadJobLogs({
     // Step 1: schedule server-side download; result is a mapping job_id -> folder path on API server
     const mapping = await apiClient.fetch('/download_logs', {
       cluster_name: clusterName,
-      job_ids: jobIds,
+      job_ids: jobIds ? jobIds.map(String) : null, // Convert to strings as expected by server
       override_skypilot_config: {
         active_workspace: workspace || 'default',
       },

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -795,6 +795,7 @@ function ActiveTab({
             clusterJobData={clusterJobData}
             loading={clusterJobsLoading}
             refreshClusterJobsOnly={refreshClusterJobsOnly}
+            workspace={clusterData.workspace}
           />
         </div>
       )}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR converts the job IDs passed to the server to strings in the download logs request from the cluster detail page. This fixes an issue where the download button works from the cluster job detail page but not the cluster detail page. The reason why it works for the cluster job detail page is that we were parsing the job id from the url which by default will be a string.


<!-- Describe the tests ran -->
I manually verified that the download logs button from the cluster detail page is now working. 

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
