### PR TITLE
[Dashboard] Deduplicate Managed Jobs Download Button

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -1323,36 +1323,6 @@ export function Status2Actions({
           {withLabel && <span className="ml-1.5">Download</span>}
         </button>
       </Tooltip>
-      {managed && (
-        <>
-          <Tooltip
-            key="controllerlogs"
-            content="View Controller Logs"
-            className="capitalize text-sm text-muted-foreground"
-          >
-            <button
-              onClick={(e) => handleLogsClick(e, 'controllerlogs')}
-              className="text-sky-blue hover:text-sky-blue-bright font-medium inline-flex items-center h-8"
-            >
-              <MonitorPlay className="w-4 h-4" />
-              {withLabel && <span className="ml-2">Controller Logs</span>}
-            </button>
-          </Tooltip>
-          <Tooltip
-            key="downloadcontrollerlogs"
-            content="Download Controller Logs"
-            className="capitalize text-sm text-muted-foreground"
-          >
-            <button
-              onClick={(e) => handleDownloadLogs(e, true)}
-              className="text-sky-blue hover:text-sky-blue-bright font-medium inline-flex items-center h-8"
-            >
-              <Download className="w-4 h-4" />
-              {withLabel && <span className="ml-1.5">Download Controller</span>}
-            </button>
-          </Tooltip>
-        </>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The managed jobs page in the dashboard currently shows four buttons under the logs column:
1. view job logs
2. download job logs
3. view controller logs
4. download controller logs

This PR removes 3 and 4, making for a cleaner and less confusing UX. Users can still view/download controller logs from the managed jobs detail page. 

<!-- Describe the tests ran -->
Manually verified that buttons 3 and 4 are no longer there and 1 and 2 still work as expected. 

<img width="1481" height="287" alt="Screenshot 2025-09-03 at 12 49 39 PM" src="https://github.com/user-attachments/assets/cf333586-d3e9-4894-99a3-90b03d1574dd" />

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
