### PR TITLE
[Dashboard] Fix api server metrics app parameter

### DIFF
--- a/sky/dashboard/next.config.mjs
+++ b/sky/dashboard/next.config.mjs
@@ -7,6 +7,7 @@ const nextConfig = {
   },
   env: {
     SKYPILOT_API_SERVER_ENDPOINT: process.env.SKYPILOT_API_SERVER_ENDPOINT,
+    SKYPILOT_RELEASE_NAME: process.env.SKYPILOT_RELEASE_NAME,
     INFRA_CACHE_DURATION_MINUTES:
       process.env.INFRA_CACHE_DURATION_MINUTES || '10',
     INFRA_CACHE_DEBUG: process.env.INFRA_CACHE_DEBUG || 'false',

--- a/sky/dashboard/src/components/config.js
+++ b/sky/dashboard/src/components/config.js
@@ -171,9 +171,17 @@ export function Config() {
             <button
               onClick={() => {
                 const grafanaUrl = getGrafanaUrl();
-                const host = window.location.hostname;
+                // Get app name from environment variable
+                const releaseName =
+                  process.env.SKYPILOT_RELEASE_NAME || 'skypilot';
+                const appName = `${releaseName}-api`;
+                // Fallback to hostname if environment variable is not available
+                const appParam =
+                  appName !== 'skypilot-api'
+                    ? appName
+                    : window.location.hostname;
                 window.open(
-                  `${grafanaUrl}/d/skypilot-apiserver-overview/skypilot-api-server?orgId=1&from=now-1h&to=now&timezone=browser&var-app=${host}`,
+                  `${grafanaUrl}/d/skypilot-apiserver-overview/skypilot-api-server?orgId=1&from=now-1h&to=now&timezone=browser&var-app=${appParam}`,
                   '_blank'
                 );
               }}

--- a/sky/dashboard/src/components/config.js
+++ b/sky/dashboard/src/components/config.js
@@ -175,13 +175,8 @@ export function Config() {
                 const releaseName =
                   process.env.SKYPILOT_RELEASE_NAME || 'skypilot';
                 const appName = `${releaseName}-api`;
-                // Fallback to hostname if environment variable is not available
-                const appParam =
-                  appName !== 'skypilot-api'
-                    ? appName
-                    : window.location.hostname;
                 window.open(
-                  `${grafanaUrl}/d/skypilot-apiserver-overview/skypilot-api-server?orgId=1&from=now-1h&to=now&timezone=browser&var-app=${appParam}`,
+                  `${grafanaUrl}/d/skypilot-apiserver-overview/skypilot-api-server?orgId=1&from=now-1h&to=now&timezone=browser&var-app=${appName}`,
                   '_blank'
                 );
               }}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR addresses an issue where the "View API Server Metrics" button in the config page of the dashboard injects an incorrect app into the grafana url. Previously, we were using the api server hostname as the app name. However, the app name should actually be set to `"$SKYPILOT_RELEASE_NAME"-api`. 


<!-- Describe the tests ran -->
I tested this PR by first reproducing the issue by deploying an api server on a kubernetes cluster with api server metrics enabled and verified that when I click on the "View API Server Metrics" it opened the api server metrics grafana dashboard with app set to `89.169.110.123` which is the api server hostname. As you can see, this shows no data:
<img width="1512" height="982" alt="Screenshot 2025-09-03 at 2 26 15 PM" src="https://github.com/user-attachments/assets/4cd2cbe2-f151-4ff8-bb94-5db79355abe1" />


Then I redeployed the api server using the following docker image: `rohanskypilot/skypilot:api-metrics-v1` which I built with the changes in this PR and see that the same button now opens the dashboard with app correctly set to `skypilot-test-api`:
<img width="1512" height="982" alt="Screenshot 2025-09-03 at 2 29 20 PM" src="https://github.com/user-attachments/assets/0c4420f4-85d6-405d-b757-d6302edb78ca" />

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
