### PR TITLE
Add B200 to common accelerators in `sky show-gpus`

### DIFF
--- a/sky/catalog/__init__.py
+++ b/sky/catalog/__init__.py
@@ -326,6 +326,7 @@ def get_common_gpus() -> List[str]:
         'A10G',
         'A100',
         'A100-80GB',
+        'B200',
         'H100',
         'H200',
         'L4',


### PR DESCRIPTION
Currently need to run `sky show-gpus -a` to see B200s. This PR fixes it to show in regular `sky show-gpus`.