### PR TITLE
[API server] OOMkill executors that exceeded memory limit

### DIFF
--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -448,7 +448,7 @@ def _request_execution_wrapper(request_id: str,
             if rss_gb > mem_limit:
                 logger.warning(
                     f'Request {request_id} used more memory than the limit. '
-                    f'RSS: {rss_gb} GB. '
+                    f'RSS: {rss_gb:.3f} GB. '
                     f'Limit: {mem_limit} GB. '
                     f'OOMKilling the executor (pid {pid}).')
                 sys.exit(1)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
We've seen cases where a short executor (which is supposed to only use up to 0.25G) use up to 0.7G. If multiple short executors do that, the entire pod (in case of remote API server) may be OOMkilled.

The idea is that we OOMkill individual executors before the executors OOMkill the pod.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
