### PR TITLE
[Storage] Fix arm64 rclone download

### DIFF
--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -75,6 +75,23 @@ def test_file_mounts(generic_cloud: str):
     smoke_tests_utils.run_one_test(test)
 
 
+@pytest.mark.aws
+def test_aws_arm64_file_mounts():
+    name = smoke_tests_utils.get_cluster_name()
+    test_commands = [
+        *smoke_tests_utils.STORAGE_SETUP_COMMANDS,
+        f'sky launch -y -c {name} --infra aws/us-west-2 --image-id ami-03ac43540bf1c63c0 -t t4g.large examples/using_file_mounts.yaml',
+        f'sky logs {name} 1 --status',  # Ensure the job succeeded.
+    ]
+    test = smoke_tests_utils.Test(
+        'aws_arm64_using_file_mounts',
+        test_commands,
+        f'sky down -y {name}',
+        timeout=20 * 60,  # 20 mins
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
 @pytest.mark.scp
 def test_scp_file_mounts():
     name = smoke_tests_utils.get_cluster_name()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Our previous rclone download script seems downloading `rclone` for the 32 bit version instead of 64 bit, which is likely not matching most cloud images.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
