### PR TITLE
[Dashboard] Fix enabled clouds not showing up on first load

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -1460,7 +1460,7 @@ export function GPUs() {
         // Use the shared getInfraData function
         // If forceRefresh is true, call getInfraData directly to bypass cache
         const infraData = forceRefresh
-          ? await getInfraData(true)
+          ? await getInfraData()
           : await dashboardCache.get(getInfraData);
 
         const { gpuData, cloudData } = infraData || {};

--- a/sky/dashboard/src/data/connectors/infra.jsx
+++ b/sky/dashboard/src/data/connectors/infra.jsx
@@ -6,7 +6,7 @@ import { apiClient } from '@/data/connectors/client';
 export async function getCloudInfrastructure(
   clusters,
   jobs,
-  forceRefresh = false
+  forceRefresh = true
 ) {
   try {
     // Get enabled clouds

--- a/sky/dashboard/src/data/connectors/infra.jsx
+++ b/sky/dashboard/src/data/connectors/infra.jsx
@@ -120,7 +120,7 @@ export async function getCloudInfrastructure(
  * Main function to get all infrastructure data.
  * Uses cached data from clusters and jobs to avoid redundant API calls.
  */
-export async function getInfraData(forceRefresh = false) {
+export async function getInfraData(forceRefresh = true) {
   // Import here to avoid circular dependencies
   const { getClusters } = await import('@/data/connectors/clusters');
   const { getManagedJobs } = await import('@/data/connectors/jobs');


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR addresses an issue on fresh deployments where no enabled clouds show up in the dashboard until the user refreshes the page or the page auto-refreshes in 30s. We fix the issue by setting forceRefresh to true in the `getInfraData` and `getCloudInfrastructure` functions.


<!-- Describe the tests ran -->
I manually verified that this works by removing my `~/.sky/` directory, restarting the api server, and checking that all my enabled clouds show up in the infra page on first load. Previously, it showed no enabled clouds. 

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
