### PR TITLE
[API server] introduce separate executor pool for short requests requiring catalog

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -3007,6 +3007,7 @@ def get_clusters(
         """Add resource str to record"""
         for record in _get_records_with_handle(records):
             handle = record['handle']
+            # info: get_readable_resources_repr requires catalog access.
             record[
                 'resources_str'] = resources_utils.get_readable_resources_repr(
                     handle, simplify=True)

--- a/sky/server/config.py
+++ b/sky/server/config.py
@@ -137,7 +137,8 @@ def compute_server_config(deploy: bool,
     # +1 for the event loop running the main process
     # and gc daemons in the '__main__' body of sky/server/server.py
     max_parallel_all_workers = (max_parallel_for_long + max_parallel_for_short +
-                                max_parallel_for_short_catalog + num_server_workers + 1)
+                                max_parallel_for_short_catalog +
+                                num_server_workers + 1)
 
     if not deploy:
         # For local mode, use local queue backend since we only run 1 uvicorn
@@ -228,15 +229,17 @@ def _max_short_worker_parallism(mem_size_gb: float,
     n = max(_MIN_SHORT_WORKERS, int(available_mem / _SHORT_WORKER_MEM_GB))
     return n
 
+
 def _max_short_catalog_worker_parallism(mem_size_gb: float,
                                         long_worker_parallism: int,
                                         short_worker_parallism: int) -> int:
     """Max parallelism for short catalog workers."""
     # Reserve memory for long workers and min available memory.
-    reserved_mem = server_constants.MIN_AVAIL_MEM_GB
+    reserved_mem: float = server_constants.MIN_AVAIL_MEM_GB
     reserved_mem += (long_worker_parallism * _LONG_WORKER_MEM_GB)
     reserved_mem += (short_worker_parallism * _SHORT_WORKER_MEM_GB)
     # divide by 2 to reserve memory for regular short workers
     available_mem = max(0, mem_size_gb - reserved_mem) / 2
-    n = max(_MIN_SHORT_CATALOG_WORKERS, int(available_mem / _SHORT_CATALOG_WORKER_MEM_GB))
+    n = max(_MIN_SHORT_CATALOG_WORKERS,
+            int(available_mem / _SHORT_CATALOG_WORKER_MEM_GB))
     return n

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -644,4 +644,11 @@ def start(
                                  config=config.short_worker_config)
     short_worker.run_in_background()
     workers.append(short_worker)
+
+    # Start a worker for short catalog requests.
+    short_catalog_worker = RequestWorker(schedule_type=api_requests.ScheduleType.SHORT_WITH_CATALOG,
+                                         config=config.short_catalog_worker_config)
+    short_catalog_worker.run_in_background()
+    workers.append(short_catalog_worker)
+
     return queue_server, workers

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -646,8 +646,9 @@ def start(
     workers.append(short_worker)
 
     # Start a worker for short catalog requests.
-    short_catalog_worker = RequestWorker(schedule_type=api_requests.ScheduleType.SHORT_WITH_CATALOG,
-                                         config=config.short_catalog_worker_config)
+    short_catalog_worker = RequestWorker(
+        schedule_type=api_requests.ScheduleType.SHORT_WITH_CATALOG,
+        config=config.short_catalog_worker_config)
     short_catalog_worker.run_in_background()
     workers.append(short_catalog_worker)
 

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -109,6 +109,9 @@ class ScheduleType(enum.Enum):
     LONG = 'long'
     # Queue for requests that should be executed quickly for a quick response.
     SHORT = 'short'
+    # Queue for requests that should be executed quickly for a quick response,
+    # and needs to access the catalog.
+    SHORT_WITH_CATALOG = 'short_with_catalog'
 
 
 @dataclasses.dataclass

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -715,7 +715,7 @@ async def realtime_kubernetes_gpu_availability(
         request_name='realtime_kubernetes_gpu_availability',
         request_body=realtime_gpu_availability_body,
         func=core.realtime_kubernetes_gpu_availability,
-        schedule_type=requests_lib.ScheduleType.SHORT,
+        schedule_type=requests_lib.ScheduleType.SHORT_WITH_CATALOG,
     )
 
 
@@ -756,7 +756,7 @@ async def list_accelerators(
         request_name='list_accelerators',
         request_body=list_accelerator_counts_body,
         func=catalog.list_accelerators,
-        schedule_type=requests_lib.ScheduleType.SHORT,
+        schedule_type=requests_lib.ScheduleType.SHORT_WITH_CATALOG,
     )
 
 
@@ -771,7 +771,7 @@ async def list_accelerator_counts(
         request_name='list_accelerator_counts',
         request_body=list_accelerator_counts_body,
         func=catalog.list_accelerator_counts,
-        schedule_type=requests_lib.ScheduleType.SHORT,
+        schedule_type=requests_lib.ScheduleType.SHORT_WITH_CATALOG,
     )
 
 
@@ -786,6 +786,9 @@ async def validate(validate_body: payloads.ValidateBody) -> None:
     # in each step, which may be an expensive operation. We should consolidate
     # these into a single call or have a TTL cache for (task, admin_policy)
     # pairs.
+
+    # TODO: this request needs catalog access. We should run this in a
+    # separate worker using SHORT_WITH_CATALOG executor.
     logger.debug(f'Validating tasks: {validate_body.dag}')
 
     context.initialize()
@@ -1094,7 +1097,7 @@ async def status(
         func=core.status,
         schedule_type=(requests_lib.ScheduleType.LONG if
                        status_body.refresh != common_lib.StatusRefreshMode.NONE
-                       else requests_lib.ScheduleType.SHORT),
+                       else requests_lib.ScheduleType.SHORT_WITH_CATALOG),
     )
 
 
@@ -1372,7 +1375,7 @@ async def cost_report(request: fastapi.Request,
         request_name='cost_report',
         request_body=cost_report_body,
         func=core.cost_report,
-        schedule_type=requests_lib.ScheduleType.SHORT,
+        schedule_type=requests_lib.ScheduleType.SHORT_WITH_CATALOG,
     )
 
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -685,7 +685,7 @@ async def check(request: fastapi.Request,
         request_name='check',
         request_body=check_body,
         func=sky_check.check,
-        schedule_type=requests_lib.ScheduleType.SHORT,
+        schedule_type=requests_lib.ScheduleType.SHORT_WITH_CATALOG,
     )
 
 
@@ -829,7 +829,7 @@ async def optimize(optimize_body: payloads.OptimizeBody,
         request_body=optimize_body,
         ignore_return_value=True,
         func=core.optimize,
-        schedule_type=requests_lib.ScheduleType.SHORT,
+        schedule_type=requests_lib.ScheduleType.SHORT_WITH_CATALOG,
     )
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Reading (and cacheing) the catalog is memory intensive. Introduce a new pool of workers with higher memory usage expectation and direct requests using catalog to those workers.

A good side effect of this change is that we increase the 'cache hit rate' of requests that need catalog, as they will be directed to a smaller pool of workers that have a higher chance of catalog already being loaded.

Also increase the memory given to long executors (who also need catalog for launches) as we've added more SKUs, clouds, etc making catalog heavier than when this number was last calculated.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
