### PR TITLE
[sso] add use-https to auth.oauth values

### DIFF
--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -154,9 +154,6 @@
                                 "null"
                             ]
                         },
-                        "use-https": {
-                            "type": "boolean"
-                        },
                         "cookie-refresh": {
                             "type": [
                                 "string",
@@ -190,6 +187,9 @@
                         },
                         "session-store-type": {
                             "type": "string"
+                        },
+                        "use-https": {
+                            "type": "boolean"
                         }
                     }
                 },

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -154,6 +154,9 @@
                                 "null"
                             ]
                         },
+                        "use-https": {
+                            "type": "boolean"
+                        },
                         "cookie-refresh": {
                             "type": [
                                 "string",

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -195,6 +195,7 @@ auth:
     cookie-refresh: null  # refresh tokens after this duration (Access token lifespan minus 1 min)
     # @schema type: [string, number, null]
     cookie-expire: null  # cookie expiration time (should match refresh token lifespan)
+    use-https: false
 
   # Service account token based authentication for the API server
   # @schema type: [object, null]


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Azure requires an `https` redirect uri unless the endpoint is localhost. This PR adds a `use-https` field to the values file which should be set to `true` if using Azure or another SSO provider that requires an `https` redirect uri.

This works because we already have the following handling of `use-https` in `charts/skypilot/templates/oauth2-proxy-deployment.yaml`:
```
{{- if not (index $oauth2 "use-https" | default false) }}
        - --cookie-secure=false
{{- end }}
```
By setting `use-https=true` we don't set `--cookie-secure=false` and since `--cookie-secure` has a default value of true according to the oauth [docs](https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview?_highlight=cookie&_highlight=secure#cookie-options), `cookie-secure` will be set to `true`. Then, by [this](https://github.com/oauth2-proxy/oauth2-proxy/blob/8afb047e01906a20d73f7578ef5d54b592e2a4ef/oauthproxy.go#L1092-L1097) snippet of code in the oauth2-proxy implementation, the scheme will be correctly set to https.

TODO:
- [ ] update docs

original set up command:
```
helm install skypilot skypilot/skypilot-nightly --devel \
  --namespace skypilot --create-namespace \
  --set auth.oauth.enabled=true \
  --set auth.oauth.oidc-issuer-url=https://login.microsoftonline.com/f39eb076-3f2b-4818-afc1-bb1bb92fcd2d/v2.0 \
  --set auth.oauth.client-id=cf322169-6b5b-44b9-b542-40c94a648cfc \
  --set auth.oauth.client-secret='e6C8Q~BvWIdsr6esL9P5cH3mkKUrE19bRVjZda2H' \
```
now, we also run this:
```
helm upgrade -n skypilot skypilot ./charts/skypilot \
  --reuse-values \
  --set auth.oauth.use-https=true
```

<!-- Describe the tests ran -->
This PR was tested 
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
