### PR TITLE
[Core] Improve speed of volume list

### DIFF
--- a/sky/provision/__init__.py
+++ b/sky/provision/__init__.py
@@ -140,12 +140,12 @@ def get_volume_usedby(
 
 @_route_to_cloud_impl
 def get_all_volumes_usedby(
-    provider_name: str,
-    configs: List[models.VolumeConfig]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    provider_name: str, configs: List[models.VolumeConfig]
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """Get the usedby of a volume.
 
     Returns:
-        usedby_pods: List of dictionaries, each containing the config keys for 
+        usedby_pods: List of dictionaries, each containing the config keys for
                      a volume and a key containing pods using the volume.
                      These may include pods not created by SkyPilot.
         usedby_clusters: List of dictionaries, each containing the config keys
@@ -154,12 +154,12 @@ def get_all_volumes_usedby(
     """
     raise NotImplementedError
 
+
 @_route_to_cloud_impl
 def map_all_volumes_usedby(
-    provider_name: str,
-    used_by_pods: Dict[str, Any],
-    used_by_clusters: Dict[str, Any],
-    config: models.VolumeConfig) -> Tuple[List[str], List[str]]:
+        provider_name: str, used_by_pods: Dict[str, Any],
+        used_by_clusters: Dict[str, Any],
+        config: models.VolumeConfig) -> Tuple[List[str], List[str]]:
     """Map the usedby resources of a volume."""
     raise NotImplementedError
 

--- a/sky/provision/__init__.py
+++ b/sky/provision/__init__.py
@@ -138,6 +138,7 @@ def get_volume_usedby(
     """
     raise NotImplementedError
 
+
 @_route_to_cloud_impl
 def get_all_volumes_usedby(
     provider_name: str, configs: List[models.VolumeConfig]

--- a/sky/provision/__init__.py
+++ b/sky/provision/__init__.py
@@ -138,6 +138,31 @@ def get_volume_usedby(
     """
     raise NotImplementedError
 
+@_route_to_cloud_impl
+def get_all_volumes_usedby(
+    provider_name: str,
+    configs: List[models.VolumeConfig]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Get the usedby of a volume.
+
+    Returns:
+        usedby_pods: List of dictionaries, each containing the config keys for 
+                     a volume and a key containing pods using the volume.
+                     These may include pods not created by SkyPilot.
+        usedby_clusters: List of dictionaries, each containing the config keys
+                         for a volume and a key containing clusters using
+                         the volume.
+    """
+    raise NotImplementedError
+
+@_route_to_cloud_impl
+def map_all_volumes_usedby(
+    provider_name: str,
+    used_by_pods: Dict[str, Any],
+    used_by_clusters: Dict[str, Any],
+    config: models.VolumeConfig) -> Tuple[List[str], List[str]]:
+    """Map the usedby resources of a volume."""
+    raise NotImplementedError
+
 
 @_route_to_cloud_impl
 def run_instances(provider_name: str, region: str, cluster_name_on_cloud: str,

--- a/sky/provision/kubernetes/__init__.py
+++ b/sky/provision/kubernetes/__init__.py
@@ -14,3 +14,5 @@ from sky.provision.kubernetes.network import query_ports
 from sky.provision.kubernetes.volume import apply_volume
 from sky.provision.kubernetes.volume import delete_volume
 from sky.provision.kubernetes.volume import get_volume_usedby
+from sky.provision.kubernetes.volume import get_all_volumes_usedby
+from sky.provision.kubernetes.volume import map_all_volumes_usedby

--- a/sky/provision/kubernetes/__init__.py
+++ b/sky/provision/kubernetes/__init__.py
@@ -13,6 +13,6 @@ from sky.provision.kubernetes.network import open_ports
 from sky.provision.kubernetes.network import query_ports
 from sky.provision.kubernetes.volume import apply_volume
 from sky.provision.kubernetes.volume import delete_volume
-from sky.provision.kubernetes.volume import get_volume_usedby
 from sky.provision.kubernetes.volume import get_all_volumes_usedby
+from sky.provision.kubernetes.volume import get_volume_usedby
 from sky.provision.kubernetes.volume import map_all_volumes_usedby

--- a/sky/provision/kubernetes/volume.py
+++ b/sky/provision/kubernetes/volume.py
@@ -162,12 +162,10 @@ def get_volume_usedby(
 def get_all_volumes_usedby(
     configs: List[models.VolumeConfig],) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """Gets the usedby resources of all volumes."""
-    logger.warning(f'LLOYD: get_all_volumes_usedby configs: {configs}')
     field_selector = ','.join([
         f'status.phase!={phase}'
         for phase in k8s_constants.PVC_NOT_HOLD_POD_PHASES
     ])
-    logger.warning(f'LLOYD: get_all_volumes_usedby configs: {configs}')
     context_to_namespaces = {}
     pvc_names = set()
     for config in configs:

--- a/sky/provision/runpod/volume.py
+++ b/sky/provision/runpod/volume.py
@@ -156,3 +156,25 @@ def get_volume_usedby(
             cluster_names.append(matched)
 
     return usedby_pod_names, cluster_names
+
+
+def get_all_volumes_usedby(
+    configs: List[models.VolumeConfig],
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Gets the usedby resources of all volumes."""
+    used_by_results = [get_volume_usedby(config) for config in configs]
+    used_by_pods, used_by_clusters = {}, {}
+    for i in range(len(configs)):
+        config = configs[i]
+        used_by_pods[config.name_on_cloud] = used_by_results[i][0]
+        used_by_clusters[config.name_on_cloud] = used_by_results[i][1]
+    return used_by_pods, used_by_clusters
+
+
+def map_all_volumes_usedby(
+        used_by_pods: Dict[str, Any], used_by_clusters: Dict[str, Any],
+        config: models.VolumeConfig) -> Tuple[List[str], List[str]]:
+    """Maps the usedby resources of a volume."""
+    return (used_by_pods.get(config.name_on_cloud,
+                             []), used_by_clusters.get(config.name_on_cloud,
+                                                       []))

--- a/sky/volumes/server/core.py
+++ b/sky/volumes/server/core.py
@@ -83,7 +83,6 @@ def volume_list() -> List[Dict[str, Any]]:
     """
     with rich_utils.safe_status(ux_utils.spinner_message('Listing volumes')):
         volumes = global_user_state.get_volumes()
-        logger.warning(f'LLOYD: volumes: {volumes}')
         cloud_to_configs = {}
         for volume in volumes:
             config = volume.get('handle')
@@ -95,16 +94,12 @@ def volume_list() -> List[Dict[str, Any]]:
             if cloud not in cloud_to_configs:
                 cloud_to_configs[cloud] = []
             cloud_to_configs[cloud].append(config)
-        logger.warning(f'LLOYD: cloud_to_configs: {cloud_to_configs}')
 
         cloud_to_used_by_pods, cloud_to_used_by_clusters = {}, {}
         for cloud, configs in cloud_to_configs.items():
-            logger.warning(f'LLOYD: cloud: {cloud}, configs: {configs}')
             used_by_pods, used_by_clusters = provision.get_all_volumes_usedby(cloud, configs)
             cloud_to_used_by_pods[cloud] = used_by_pods
             cloud_to_used_by_clusters[cloud] = used_by_clusters
-        logger.warning(f'LLOYD: cloud_to_used_by_pods: {cloud_to_used_by_pods}')
-        logger.warning(f'LLOYD: cloud_to_used_by_clusters: {cloud_to_used_by_clusters}')
 
         all_users = global_user_state.get_all_users()
         user_map = {user.id: user.name for user in all_users}

--- a/sky/volumes/server/core.py
+++ b/sky/volumes/server/core.py
@@ -83,7 +83,7 @@ def volume_list() -> List[Dict[str, Any]]:
     """
     with rich_utils.safe_status(ux_utils.spinner_message('Listing volumes')):
         volumes = global_user_state.get_volumes()
-        cloud_to_configs = {}
+        cloud_to_configs: Dict[str, List[models.VolumeConfig]] = {}
         for volume in volumes:
             config = volume.get('handle')
             if config is None:
@@ -97,7 +97,8 @@ def volume_list() -> List[Dict[str, Any]]:
 
         cloud_to_used_by_pods, cloud_to_used_by_clusters = {}, {}
         for cloud, configs in cloud_to_configs.items():
-            used_by_pods, used_by_clusters = provision.get_all_volumes_usedby(cloud, configs)
+            used_by_pods, used_by_clusters = provision.get_all_volumes_usedby(
+                cloud, configs)
             cloud_to_used_by_pods[cloud] = used_by_pods
             cloud_to_used_by_clusters[cloud] = used_by_clusters
 
@@ -127,9 +128,12 @@ def volume_list() -> List[Dict[str, Any]]:
                 logger.warning(f'Volume {volume_name} has no handle.')
                 continue
             cloud = config.cloud
-            # usedby_pods, usedby_clusters = provision.get_volume_usedby(
-            #     cloud, config)
-            usedby_pods, usedby_clusters = provision.map_all_volumes_usedby(cloud, cloud_to_used_by_pods[cloud], cloud_to_used_by_clusters[cloud], config)
+            usedby_pods, usedby_clusters = provision.map_all_volumes_usedby(
+                cloud,
+                cloud_to_used_by_pods[cloud],
+                cloud_to_used_by_clusters[cloud],
+                config,
+            )
             record['type'] = config.type
             record['cloud'] = config.cloud
             record['region'] = config.region

--- a/tests/unit_tests/test_sky/volumes/test_core.py
+++ b/tests/unit_tests/test_sky/volumes/test_core.py
@@ -215,16 +215,18 @@ class TestVolumeCore:
         monkeypatch.setattr(global_user_state, 'get_volumes', mock_get_volumes)
         # Mock provision.get_all_volumes_usedby
         config_name = 'mock-config'
-        mock_get_all_usedby = mock.MagicMock(
-            return_value=({config_name: ['pod1', 'pod2']}, 
-                          {config_name: ['cluster1', 'cluster2']}))
-        monkeypatch.setattr(
-            provision, 'get_all_volumes_usedby', mock_get_all_usedby)
+        mock_get_all_usedby = mock.MagicMock(return_value=({
+            config_name: ['pod1', 'pod2']
+        }, {
+            config_name: ['cluster1', 'cluster2']
+        }))
+        monkeypatch.setattr(provision, 'get_all_volumes_usedby',
+                            mock_get_all_usedby)
 
         mock_map_all_usedby = mock.MagicMock(
             return_value=(['pod1', 'pod2'], ['cluster1', 'cluster2']))
-        monkeypatch.setattr(
-            provision, 'map_all_volumes_usedby', mock_map_all_usedby)
+        monkeypatch.setattr(provision, 'map_all_volumes_usedby',
+                            mock_map_all_usedby)
 
         # Call the function
         result = core.volume_list()

--- a/tests/unit_tests/test_sky/volumes/test_core.py
+++ b/tests/unit_tests/test_sky/volumes/test_core.py
@@ -213,10 +213,18 @@ class TestVolumeCore:
         # Mock global_user_state
         mock_get_volumes = mock.MagicMock(return_value=mock_volumes)
         monkeypatch.setattr(global_user_state, 'get_volumes', mock_get_volumes)
-        # Mock provision.get_volume_usedby
-        mock_get_usedby = mock.MagicMock(
+        # Mock provision.get_all_volumes_usedby
+        config_name = 'mock-config'
+        mock_get_all_usedby = mock.MagicMock(
+            return_value=({config_name: ['pod1', 'pod2']}, 
+                          {config_name: ['cluster1', 'cluster2']}))
+        monkeypatch.setattr(
+            provision, 'get_all_volumes_usedby', mock_get_all_usedby)
+
+        mock_map_all_usedby = mock.MagicMock(
             return_value=(['pod1', 'pod2'], ['cluster1', 'cluster2']))
-        monkeypatch.setattr(provision, 'get_volume_usedby', mock_get_usedby)
+        monkeypatch.setattr(
+            provision, 'map_all_volumes_usedby', mock_map_all_usedby)
 
         # Call the function
         result = core.volume_list()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR modifies the way we list volumes for a speedup. In running `volume_list()` we get the pod information with the ultimate goal of linking each volume to the cluster associated with it. 

With this change instead of going through each volume and then using `list_namespaced_pod()` to get all of the pods associated with the volume we first get all of the namespaces associated with each of the pods, then get all of the pods in each of the namespaces by calling `list_namespaced_pod()`. This way we only make one call per-context, per-namespace.

Another approach would have been to call `list_pod_for_all_namespaces()`. This would allow us to only make one API call. The issue is you can't filter this call based on namespace, that means if the user has a large amount of pods we have to parse all of the pod information in-memory for many pods even if they have nothing to do with the created volumes.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

Tested by running `sky volumes ls` and comparing the speed before and after the fix. Also added a unit test for runpod.

For example, with 20 volumes and 1 cluster attached to each cluster I ran volumes 10 times and got averages:
- Before 4.20 seconds
- After 1.36 seconds

Here is a graph showing the time it takes at different numbers of PVCs before and after the change.
<img width="1376" height="770" alt="image" src="https://github.com/user-attachments/assets/8992b434-ef35-437b-a8b6-36d6ccd25d34" />



<!-- CI commands (/-prefixed) can only be triggered by repo members -->
