### PR TITLE
Fixed request retention daemon

### DIFF
--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -17,6 +17,7 @@ import traceback
 from typing import (Any, AsyncContextManager, Callable, Dict, Generator, List,
                     NamedTuple, Optional, Tuple)
 
+import anyio
 import colorama
 import filelock
 
@@ -32,7 +33,6 @@ from sky.server.requests import payloads
 from sky.server.requests.serializers import decoders
 from sky.server.requests.serializers import encoders
 from sky.utils import common_utils
-from sky.utils import subprocess_utils
 from sky.utils import ux_utils
 from sky.utils.db import db_utils
 
@@ -784,17 +784,15 @@ def set_request_cancelled(request_id: str) -> None:
 
 @init_db
 @metrics_lib.time_me
-def _delete_requests(requests: List[Request]):
+async def _delete_requests(requests: List[Request]):
     """Clean up requests by their IDs."""
     id_list_str = ','.join(repr(req.request_id) for req in requests)
     assert _DB is not None
-    with _DB.conn:
-        cursor = _DB.conn.cursor()
-        cursor.execute(
-            f'DELETE FROM {REQUEST_TABLE} WHERE request_id IN ({id_list_str})')
+    await _DB.execute_and_commit_async(
+        f'DELETE FROM {REQUEST_TABLE} WHERE request_id IN ({id_list_str})')
 
 
-def clean_finished_requests_with_retention(retention_seconds: int):
+async def clean_finished_requests_with_retention(retention_seconds: int):
     """Clean up finished requests older than the retention period.
 
     This function removes old finished requests (SUCCEEDED, FAILED, CANCELLED)
@@ -804,17 +802,19 @@ def clean_finished_requests_with_retention(retention_seconds: int):
         retention_seconds: Requests older than this many seconds will be
             deleted.
     """
-    reqs = get_request_tasks(
+    reqs = await get_request_tasks_async(
         req_filter=RequestTaskFilter(status=RequestStatus.finished_status(),
                                      finished_before=time.time() -
                                      retention_seconds))
 
-    subprocess_utils.run_in_parallel(
-        func=lambda req: req.log_path.unlink(missing_ok=True),
-        args=reqs,
-        num_threads=len(reqs))
+    futs = []
+    for req in reqs:
+        futs.append(
+            asyncio.create_task(
+                anyio.Path(req.log_path.absolute()).unlink(missing_ok=True)))
+    await asyncio.gather(*futs)
 
-    _delete_requests(reqs)
+    await _delete_requests(reqs)
 
     # To avoid leakage of the log file, logs must be deleted before the
     # request task in the database.
@@ -839,7 +839,8 @@ async def requests_gc_daemon():
             logger.info('Requests GC daemon cancelled')
             break
         except Exception as e:  # pylint: disable=broad-except
-            logger.error(f'Error running requests GC daemon: {e}')
+            logger.error(f'Error running requests GC daemon: {e}'
+                         f'traceback: {traceback.format_exc()}')
         # Run the daemon at most once every hour to avoid too frequent
         # cleanup.
         await asyncio.sleep(max(retention_seconds, 3600))

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -334,6 +334,9 @@ class SQLiteConn(threading.local):
         """Execute the sql and commit the transaction in a sync block."""
         conn = await self._get_async_conn()
 
+        if parameters is None:
+            parameters = []
+
         def exec_and_commit(sql: str, parameters: Optional[Iterable[Any]]):
             # pylint: disable=protected-access
             conn._conn.execute(sql, parameters)

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -172,7 +172,8 @@ async def test_clean_finished_requests_with_retention_no_old_requests(
 
 
 @pytest.mark.asyncio
-async def test_clean_finished_requests_with_retention_all_statuses(isolated_database):
+async def test_clean_finished_requests_with_retention_all_statuses(
+        isolated_database):
     """Test cleanup works for all finished statuses."""
     current_time = time.time()
     retention_seconds = 60
@@ -211,7 +212,8 @@ async def test_clean_finished_requests_with_retention_all_statuses(isolated_data
 
     with mock.patch.object(pathlib.Path, 'unlink'):
         with mock.patch('sky.server.requests.requests.logger') as mock_logger:
-            await requests.clean_finished_requests_with_retention(retention_seconds)
+            await requests.clean_finished_requests_with_retention(
+                retention_seconds)
 
     # Verify all finished requests were deleted
     assert requests.get_request('old-succeeded-1') is None

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -73,7 +73,8 @@ def test_set_request_failed_nonexistent_request(isolated_database):
                                     ValueError('Test error'))
 
 
-def test_clean_finished_requests_with_retention(isolated_database):
+@pytest.mark.asyncio
+async def test_clean_finished_requests_with_retention(isolated_database):
     """Test cleaning up old finished requests."""
     current_time = time.time()
     retention_seconds = 60  # 1 minute retention
@@ -117,7 +118,8 @@ def test_clean_finished_requests_with_retention(isolated_database):
     # Mock log file unlinking
     with mock.patch.object(pathlib.Path, 'unlink') as mock_unlink:
         with mock.patch('sky.server.requests.requests.logger') as mock_logger:
-            requests.clean_finished_requests_with_retention(retention_seconds)
+            await requests.clean_finished_requests_with_retention(
+                retention_seconds)
 
     # Verify old finished request was deleted
     assert requests.get_request('old-finished-1') is None
@@ -137,7 +139,8 @@ def test_clean_finished_requests_with_retention(isolated_database):
     assert 'Cleaned up 1 finished requests' in log_message
 
 
-def test_clean_finished_requests_with_retention_no_old_requests(
+@pytest.mark.asyncio
+async def test_clean_finished_requests_with_retention_no_old_requests(
         isolated_database):
     """Test cleanup when there are no old requests to clean."""
     current_time = time.time()
@@ -157,7 +160,7 @@ def test_clean_finished_requests_with_retention_no_old_requests(
     requests.create_if_not_exists(recent_request)
 
     with mock.patch('sky.server.requests.requests.logger') as mock_logger:
-        requests.clean_finished_requests_with_retention(retention_seconds)
+        await requests.clean_finished_requests_with_retention(retention_seconds)
 
     # Verify request was NOT deleted
     assert requests.get_request('recent-test-1') is not None
@@ -168,7 +171,8 @@ def test_clean_finished_requests_with_retention_no_old_requests(
     assert 'Cleaned up 0 finished requests' in log_message
 
 
-def test_clean_finished_requests_with_retention_all_statuses(isolated_database):
+@pytest.mark.asyncio
+async def test_clean_finished_requests_with_retention_all_statuses(isolated_database):
     """Test cleanup works for all finished statuses."""
     current_time = time.time()
     retention_seconds = 60
@@ -207,7 +211,7 @@ def test_clean_finished_requests_with_retention_all_statuses(isolated_database):
 
     with mock.patch.object(pathlib.Path, 'unlink'):
         with mock.patch('sky.server.requests.requests.logger') as mock_logger:
-            requests.clean_finished_requests_with_retention(retention_seconds)
+            await requests.clean_finished_requests_with_retention(retention_seconds)
 
     # Verify all finished requests were deleted
     assert requests.get_request('old-succeeded-1') is None
@@ -222,30 +226,93 @@ def test_clean_finished_requests_with_retention_all_statuses(isolated_database):
 
 @pytest.mark.asyncio
 async def test_requests_gc_daemon(isolated_database):
-    """Test the garbage collection daemon runs correctly."""
+    """Test the garbage collection daemon runs correctly with real cleanup."""
+    current_time = time.time()
+
+    # Create test requests: some old finished, some recent, some running
+    old_finished_request = requests.Request(
+        request_id='old-finished-gc-1',
+        name='test-request',
+        entrypoint=dummy,
+        request_body=payloads.RequestBody(),
+        status=RequestStatus.SUCCEEDED,
+        created_at=current_time - 180,
+        finished_at=current_time - 150,  # Finished 150 seconds ago
+        user_id='test-user')
+
+    recent_finished_request = requests.Request(
+        request_id='recent-finished-gc-1',
+        name='test-request',
+        entrypoint=dummy,
+        request_body=payloads.RequestBody(),
+        status=RequestStatus.FAILED,
+        created_at=current_time - 60,
+        finished_at=current_time - 30,  # Finished 30 seconds ago
+        user_id='test-user')
+
+    running_request = requests.Request(request_id='running-gc-1',
+                                       name='test-request',
+                                       entrypoint=dummy,
+                                       request_body=payloads.RequestBody(),
+                                       status=RequestStatus.RUNNING,
+                                       created_at=current_time - 180,
+                                       user_id='test-user')
+
+    # Create the requests in the database
+    requests.create_if_not_exists(old_finished_request)
+    requests.create_if_not_exists(recent_finished_request)
+    requests.create_if_not_exists(running_request)
+
+    # Verify all requests exist before cleanup
+    assert requests.get_request('old-finished-gc-1') is not None
+    assert requests.get_request('recent-finished-gc-1') is not None
+    assert requests.get_request('running-gc-1') is not None
+
+    # Mock the entire daemon to run only one iteration by patching the loop
+    async def single_iteration_daemon():
+        """Modified daemon that runs only one iteration."""
+        logger = requests.logger
+        logger.info('Running requests GC daemon...')
+        # Use the latest config.
+        requests.skypilot_config.reload_config()
+        retention_seconds = requests.skypilot_config.get_nested(
+            ('api_server', 'requests_retention_hours'),
+            requests.DEFAULT_REQUESTS_RETENTION_HOURS) * 3600
+        try:
+            # Negative value disables the requests GC
+            if retention_seconds >= 0:
+                await requests.clean_finished_requests_with_retention(
+                    retention_seconds)
+        except Exception as e:  # pylint: disable=broad-except
+            import traceback
+            logger.error(f'Error running requests GC daemon: {e}'
+                         f'traceback: {traceback.format_exc()}')
+        # Don't loop - just return after one iteration
+
     with mock.patch(
             'sky.server.requests.requests.skypilot_config') as mock_config:
-        with mock.patch(
-                'sky.server.requests.requests.clean_finished_requests_with_retention'
-        ) as mock_clean:
-            with mock.patch('asyncio.sleep') as mock_sleep:
-                # Configure retention seconds
-                mock_config.get_nested.return_value = 120  # 2 minutes
+        # Configure retention to 2 minutes (0.033 hours)
+        # This will be converted to 0.033 * 3600 = ~120 seconds
+        mock_config.get_nested.return_value = 120 / 3600  # 2 minutes in hours
+        mock_config.reload_config.return_value = None
 
-                # Make sleep raise CancelledError after first iteration
-                # to exit loop
-                mock_sleep.side_effect = [None, asyncio.CancelledError()]
+        # Run the single iteration daemon
+        await single_iteration_daemon()
 
-                # Run the daemon
-                with pytest.raises(asyncio.CancelledError):
-                    await requests.requests_gc_daemon()
+        # Verify config was called
+        mock_config.reload_config.assert_called_once()
+        mock_config.get_nested.assert_called_once_with(
+            ('api_server', 'requests_retention_hours'), 24)
 
-                # Verify cleanup was called
-                mock_clean.assert_called_with(120 * 3600)
+        # Verify cleanup was actually performed on old finished requests
+        # Old finished request should be deleted (finished 150s ago > 120s)
+        assert requests.get_request('old-finished-gc-1') is None
 
-                # Verify sleep was called with max(retention, 3600)
-                assert mock_sleep.call_count == 2
-                mock_sleep.assert_any_call(120 * 3600)
+        # Recent finished request should still exist (finished 30s ago < 120s)
+        assert requests.get_request('recent-finished-gc-1') is not None
+
+        # Running request should still exist (not finished)
+        assert requests.get_request('running-gc-1') is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

```
E 09-05 15:44:34 requests.py:842] Error running requests GC daemon: object NoneType can't be used in 'await' expression
Running cluster event retention daemon...
```

This PR fixes the request retention daemon and make it non-blocking. The UT failed to capture this regression since `clean_finished_requests_with_retention` is mocked in `test_requests_gc_daemon` , this PR also refines the UT to cover such case.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
