### PR TITLE
[sso] add redis image value

### DIFF
--- a/charts/skypilot/templates/oauth2-proxy-redis.yaml
+++ b/charts/skypilot/templates/oauth2-proxy-redis.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: redis
-        image: redis:7-alpine
+        image: {{ index $oauth2 "redis-image" | default "redis:7-alpine" }}
         ports:
         - containerPort: 6379
         resources:

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -173,6 +173,12 @@
                                 "null"
                             ]
                         },
+                        "redis-image": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
                         "redis-secret": {
                             "type": [
                                 "string",
@@ -475,6 +481,12 @@
                             "type": "string"
                         },
                         "oidc-issuer-url": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "redis-image": {
                             "type": [
                                 "string",
                                 "null"

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -190,6 +190,9 @@ auth:
     # Refer to redis-url for more details.
     # @schema type: [string, null]
     redis-secret: null
+    # Redis container image for session storage
+    # @schema type: [string, null]
+    redis-image: "redis:7-alpine"
     # Cookie timing settings (in seconds)
     # @schema type: [string, number, null]
     cookie-refresh: null  # refresh tokens after this duration (Access token lifespan minus 1 min)
@@ -312,6 +315,9 @@ ingress:
     # If set, this external Redis instance will be used
     # @schema type: [string, null]
     redis-url: null
+    # Redis container image for session storage
+    # @schema type: [string, null]
+    redis-image: "redis:7-alpine"
     # Cookie timing settings (in seconds)
     # @schema type: [string, number, null]
     cookie-refresh: null  # refresh tokens after this duration (Access token lifespan minus 1 min)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR adds `redis-image` to values.yaml in the oauth sections to enable specifying a speific redis image. This is useful for users who want to can't pull public images or just want more flexibility. 


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
