### PR TITLE
[DNM] [API server] Unload lazy modules in executors after each request run

### DIFF
--- a/sky/adaptors/common.py
+++ b/sky/adaptors/common.py
@@ -165,10 +165,7 @@ def get_lazy_modules_info():
             is_loaded = (hasattr(module, '_module') and
                          getattr(module, '_module', None) is not None)
             module_name = getattr(module, '_module_name', '<unknown>')
-            info['modules'].append({
-                'name': module_name,
-                'loaded': is_loaded
-            })
+            info['modules'].append({'name': module_name, 'loaded': is_loaded})
             if is_loaded:
                 info['loaded_count'] += 1
             info['total_count'] += 1

--- a/sky/adaptors/common.py
+++ b/sky/adaptors/common.py
@@ -139,7 +139,7 @@ def unload_all_lazy_modules():
         try:
             module.unload_module()
             unloaded_count += 1
-        except Exception:
+        except (ImportError, KeyError, AttributeError):
             # Continue unloading other modules even if one fails
             pass
 
@@ -162,15 +162,17 @@ def get_lazy_modules_info():
 
     for module in modules:
         try:
-            is_loaded = module._module is not None
+            is_loaded = (hasattr(module, '_module') and
+                         getattr(module, '_module', None) is not None)
+            module_name = getattr(module, '_module_name', '<unknown>')
             info['modules'].append({
-                'name': module._module_name,
+                'name': module_name,
                 'loaded': is_loaded
             })
             if is_loaded:
                 info['loaded_count'] += 1
             info['total_count'] += 1
-        except Exception:
+        except (AttributeError, TypeError):
             # Skip modules that might be in an invalid state
             pass
 

--- a/sky/adaptors/common.py
+++ b/sky/adaptors/common.py
@@ -1,4 +1,6 @@
 """Lazy import for modules to avoid import error when not used."""
+from __future__ import annotations
+
 import functools
 import importlib
 import sys
@@ -9,7 +11,7 @@ import weakref
 
 # Global registry to track all LazyImport instances using weak references
 # This prevents circular references and allows instances to be garbage collected
-_LAZY_IMPORT_REGISTRY: weakref.WeakSet['LazyImport'] = weakref.WeakSet()
+_LAZY_IMPORT_REGISTRY: weakref.WeakSet[LazyImport] = weakref.WeakSet()
 _REGISTRY_LOCK = threading.RLock()
 
 

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -38,6 +38,7 @@ from sky import global_user_state
 from sky import models
 from sky import sky_logging
 from sky import skypilot_config
+from sky.adaptors import common as adaptors_common
 from sky.server import common as server_common
 from sky.server import config as server_config
 from sky.server import constants as server_constants
@@ -402,6 +403,7 @@ def _request_execution_wrapper(request_id: str,
                                          group='request_execution'):
                     return_value = func(**request_body.to_kwargs())
                 f.flush()
+                adaptors_common.unload_all_lazy_modules()
         except KeyboardInterrupt:
             logger.info(f'Request {request_id} cancelled by user')
             # Kill all children processes related to this request.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Profiling RSS and largest sources of heap allocation

Before:
```
RSS: 313.671875 MB for 83720

/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:55: size=86.9 KiB, count=412, average=216 B
/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:53: size=32.2 KiB, count=824, average=40 B
/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:46: size=25.8 KiB, count=412, average=64 B
/Users/seungjinyang/assemble/skypilot/sky/provision/kubernetes/utils.py:690: size=3424 B, count=54, average=63 B
/Users/seungjinyang/assemble/skypilot/sky/server/requests/serializers/decoders.py:26: size=2539 B, count=25, average=102 B
/Users/seungjinyang/assemble/skypilot/sky/utils/annotations.py:62: size=1120 B, count=2, average=560 B
/Users/seungjinyang/assemble/skypilot/sky/check.py:111: size=960 B, count=2, average=480 B
/Users/seungjinyang/assemble/skypilot/sky/server/requests/requests.py:172: size=816 B, count=2, average=408 B
/Users/seungjinyang/assemble/skypilot/sky/clouds/gcp.py:836: size=704 B, count=1, average=704 B
/Users/seungjinyang/assemble/skypilot/sky/usage/usage_lib.py:56: size=680 B, count=1, average=680 B
/Users/seungjinyang/assemble/skypilot/sky/utils/yaml_utils.py:88: size=672 B, count=4, average=168 B
/Users/seungjinyang/assemble/skypilot/sky/utils/tempstore.py:26: size=624 B, count=3, average=208 B
RSS: 317.703125 MB for 83720

/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:55: size=86.9 KiB, count=412, average=216 B
/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:53: size=32.2 KiB, count=824, average=40 B
/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:46: size=25.8 KiB, count=412, average=64 B
/Users/seungjinyang/assemble/skypilot/sky/server/requests/serializers/decoders.py:26: size=2667 B, count=27, average=99 B
/Users/seungjinyang/assemble/skypilot/sky/clouds/cloud.py:611: size=1160 B, count=4, average=290 B
/Users/seungjinyang/assemble/skypilot/sky/utils/annotations.py:62: size=1120 B, count=2, average=560 B
/Users/seungjinyang/assemble/skypilot/sky/check.py:111: size=960 B, count=2, average=480 B
/Users/seungjinyang/assemble/skypilot/sky/clouds/aws.py:801: size=928 B, count=1, average=928 B
/Users/seungjinyang/assemble/skypilot/sky/provision/kubernetes/utils.py:1995: size=912 B, count=1, average=912 B
/Users/seungjinyang/assemble/skypilot/sky/clouds/gcp.py:861: size=912 B, count=1, average=912 B
/Users/seungjinyang/assemble/skypilot/sky/clouds/aws.py:1054: size=912 B, count=1, average=912 B
/Users/seungjinyang/assemble/skypilot/sky/server/requests/requests.py:172: size=816 B, count=2, average=408 B
/Users/seungjinyang/assemble/skypilot/sky/utils/yaml_utils.py:88: size=800 B, count=4, average=200 B
/Users/seungjinyang/assemble/skypilot/sky/usage/usage_lib.py:56: size=744 B, count=2, average=372 B
/Users/seungjinyang/assemble/skypilot/sky/clouds/gcp.py:836: size=704 B, count=1, average=704 B
RSS: 320.109375 MB for 83720

/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:55: size=86.9 KiB, count=412, average=216 B
/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:53: size=32.2 KiB, count=824, average=40 B
/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:46: size=25.8 KiB, count=412, average=64 B
/Users/seungjinyang/assemble/skypilot/sky/server/requests/serializers/decoders.py:26: size=2667 B, count=27, average=99 B
/Users/seungjinyang/assemble/skypilot/sky/clouds/cloud.py:611: size=1160 B, count=4, average=290 B
/Users/seungjinyang/assemble/skypilot/sky/utils/annotations.py:62: size=1120 B, count=2, average=560 B
/Users/seungjinyang/assemble/skypilot/sky/check.py:111: size=960 B, count=2, average=480 B
/Users/seungjinyang/assemble/skypilot/sky/clouds/gcp.py:941: size=928 B, count=1, average=928 B
/Users/seungjinyang/assemble/skypilot/sky/clouds/aws.py:801: size=928 B, count=1, average=928 B
/Users/seungjinyang/assemble/skypilot/sky/clouds/gcp.py:861: size=912 B, count=1, average=912 B
/Users/seungjinyang/assemble/skypilot/sky/clouds/aws.py:1054: size=912 B, count=1, average=912 B
/Users/seungjinyang/assemble/skypilot/sky/server/requests/requests.py:172: size=816 B, count=2, average=408 B
/Users/seungjinyang/assemble/skypilot/sky/usage/usage_lib.py:56: size=744 B, count=2, average=372 B
RSS: 320.59375 MB for 83720

/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:55: size=86.9 KiB, count=412, average=216 B
/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:53: size=32.2 KiB, count=824, average=40 B
/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:46: size=25.8 KiB, count=412, average=64 B
/Users/seungjinyang/assemble/skypilot/sky/server/requests/serializers/decoders.py:26: size=2667 B, count=27, average=99 B
/Users/seungjinyang/assemble/skypilot/sky/utils/annotations.py:62: size=1120 B, count=2, average=560 B
/Users/seungjinyang/assemble/skypilot/sky/clouds/cloud.py:611: size=1096 B, count=4, average=274 B
/Users/seungjinyang/assemble/skypilot/sky/utils/yaml_utils.py:88: size=968 B, count=5, average=194 B
/Users/seungjinyang/assemble/skypilot/sky/check.py:111: size=960 B, count=2, average=480 B
/Users/seungjinyang/assemble/skypilot/sky/clouds/gcp.py:941: size=928 B, count=1, average=928 B
/Users/seungjinyang/assemble/skypilot/sky/clouds/gcp.py:861: size=912 B, count=1, average=912 B
/Users/seungjinyang/assemble/skypilot/sky/clouds/aws.py:1054: size=912 B, count=1, average=912 B
/Users/seungjinyang/assemble/skypilot/sky/server/requests/requests.py:172: size=816 B, count=2, average=408 B
/Users/seungjinyang/assemble/skypilot/sky/server/requests/requests.py:744: size=768 B, count=9, average=85 B
/Users/seungjinyang/assemble/skypilot/sky/usage/usage_lib.py:56: size=744 B, count=2, average=372 B
/Users/seungjinyang/assemble/skypilot/sky/catalog/common.py:506: size=728 B, count=1, average=728 B
RSS: 321.1875 MB for 83720
```

After:
```
RSS: 311.328125 MB for 80499

/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:55: size=86.9 KiB, count=412, average=216 B
/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:53: size=32.2 KiB, count=824, average=40 B
/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:46: size=25.8 KiB, count=412, average=64 B
/Users/seungjinyang/assemble/skypilot/sky/provision/kubernetes/utils.py:690: size=3200 B, count=50, average=64 B
/Users/seungjinyang/assemble/skypilot/sky/server/requests/serializers/decoders.py:26: size=2539 B, count=25, average=102 B
/Users/seungjinyang/assemble/skypilot/sky/clouds/gcp.py:896: size=928 B, count=1, average=928 B
RSS: 314.859375 MB for 80499

/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:55: size=86.9 KiB, count=412, average=216 B
/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:53: size=32.2 KiB, count=824, average=40 B
/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:46: size=25.8 KiB, count=412, average=64 B
/Users/seungjinyang/assemble/skypilot/sky/server/requests/serializers/decoders.py:26: size=2667 B, count=27, average=99 B
/Users/seungjinyang/assemble/skypilot/sky/utils/yaml_utils.py:88: size=1136 B, count=6, average=189 B
RSS: 281.734375 MB for 80499

Dumping memory trace for process 80499 request 22a39c0e-9153-45e1-89c6-7924b66c0c2d
/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:55: size=86.9 KiB, count=412, average=216 B
/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:53: size=32.2 KiB, count=824, average=40 B
/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:46: size=25.8 KiB, count=412, average=64 B
/Users/seungjinyang/assemble/skypilot/sky/server/requests/serializers/decoders.py:26: size=2667 B, count=27, average=99 B
/Users/seungjinyang/assemble/skypilot/sky/utils/yaml_utils.py:88: size=1304 B, count=7, average=186 B
RSS: 282.265625 MB for 80499

/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:55: size=86.9 KiB, count=412, average=216 B
/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:53: size=32.2 KiB, count=824, average=40 B
/Users/seungjinyang/assemble/skypilot/sky/adaptors/kubernetes.py:46: size=25.8 KiB, count=412, average=64 B
/Users/seungjinyang/assemble/skypilot/sky/server/requests/serializers/decoders.py:26: size=2667 B, count=27, average=99 B
RSS: 283.40625 MB for 80499
```
The important thing to note is that the memory allocations from aws.py and gcp.py has disappeared with changes introduced in this PR, which suggests the cloud specific modules indeed are being unloaded.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
