### PR TITLE
[aws] do not import catalog during check

### DIFF
--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -859,11 +859,11 @@ class AWS(clouds.Cloud):
 
         # Fetch the AWS catalogs
         # pylint: disable=import-outside-toplevel
-        from sky.catalog import aws_catalog
+        from sky.catalog.data_fetchers import fetch_aws
 
         # Trigger the fetch of the availability zones mapping.
         try:
-            aws_catalog.get_default_instance_type()
+            fetch_aws.fetch_availability_zone_mappings()
         except RuntimeError as e:
             return False, (
                 'Failed to fetch the availability zones for the account '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
We were calling `aws_catalog.get_default_instance_type()` to implicitly trigger the fetch of AZ mappings, but this has the side effect of ingesting the catalog CSV when the cloud might not even be enabled. Fix the code to call the AZ fetch directly, preventing the side effect of importing catalog.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
