### PR TITLE
[UX] Remove unnecessary line in doc for SSM

### DIFF
--- a/docs/source/cloud-setup/cloud-permissions/aws.rst
+++ b/docs/source/cloud-setup/cloud-permissions/aws.rst
@@ -94,10 +94,6 @@ Add the following to your ``~/.sky/config.yaml`` file:
     aws:
         use_ssm: true
 
-.. note::
-
-    - The ``jq`` command-line JSON processor must be installed on your system.
-
 Once configured, SkyPilot will automatically use SSM for all SSH connections to your AWS instances in the specified regions.
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This line removes the jq line from the doc for SSM since the new command doesn't use it.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
