### PR TITLE
[API server] use k8s resource requests to compute number of workers

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -126,6 +126,16 @@ spec:
         - name: SKYPILOT_AUTH_OAUTH2_PROXY_BASE_URL
           value: {{ include "skypilot.oauth2ProxyURL" . }}
         {{- end }}
+        - name: SKYPILOT_POD_CPU_CORE_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: skypilot-api
+              resource: requests.cpu
+        - name: SKYPILOT_POD_MEMORY_BYTES_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: skypilot-api
+              resource: requests.memory
         # Use tini as the init process
         command: ["tini", "--"]
         # Start API server in foreground (if supported) to:

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -994,7 +994,8 @@ def get_mem_size_gb() -> float:
         except ValueError as e:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
-                    f'Failed to parse the memory size from {mem_size} (GB)') from e
+                    f'Failed to parse the memory size from {mem_size} (GB)'
+                ) from e
     mem_size = os.getenv('SKYPILOT_POD_MEMORY_BYTES_LIMIT')
     if mem_size is not None:
         try:
@@ -1002,7 +1003,8 @@ def get_mem_size_gb() -> float:
         except ValueError as e:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
-                    f'Failed to parse the memory size from {mem_size} (bytes)') from e
+                    f'Failed to parse the memory size from {mem_size} (bytes)'
+                ) from e
     return _mem_size_gb()
 
 

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -994,7 +994,15 @@ def get_mem_size_gb() -> float:
         except ValueError as e:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
-                    f'Failed to parse the memory size from {mem_size}') from e
+                    f'Failed to parse the memory size from {mem_size} (GB)') from e
+    mem_size = os.getenv('SKYPILOT_POD_MEMORY_BYTES_LIMIT')
+    if mem_size is not None:
+        try:
+            return float(mem_size) / (1024**3)
+        except ValueError as e:
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(
+                    f'Failed to parse the memory size from {mem_size} (bytes)') from e
     return _mem_size_gb()
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR handle the case where resource request and limit are far apart. Currently k8s deployed API server uses resource limits to calculate the number of workers. In this case, the pod can easily blow past resource requests if it's set too low compared to the limit, and get throttled.

Verified the environment variable is populated with the expected value.
<img width="738" height="220" alt="Screenshot 2025-09-05 at 9 40 32 PM" src="https://github.com/user-attachments/assets/eea5d118-6b28-4ece-9238-3e75230f7892" />
<img width="644" height="61" alt="Screenshot 2025-09-05 at 9 41 00 PM" src="https://github.com/user-attachments/assets/dfb450a5-8a0b-4c68-8675-1a0f2cd37826" />


Testing:
I've tested the current behavior of the API server in three cases.

Case 1: Request = Limit
```
     Limits:       
       cpu:     4  
       memory:  8Gi
     Requests:     
       cpu:      4 
       memory:   8Gi 
SkyPilot API server will start 4 server processes with 8 background workers for long requests and will allow at max 11 short requests in parallel.
```
API server follows request/limit.

Case 2: Request < Limit
```
     Limits:
       cpu:     8
       memory:  16Gi
     Requests:
       cpu:      4
       memory:   8Gi  
SkyPilot API server will start 4 server processes with 8 background workers for long requests and will allow at max 43 short requests in parallel.
```
API server follows limit.

Case 3: No limit
```
(underlying node resources: 16 CPUs, 32GB mem)
     Requests:     
       cpu:      4 
       memory:   8Gi 
SkyPilot API server will start 8 server processes with 16 background workers for long requests and will allow at max 91 short requests in parallel.
```
API server follows underlying node config.


---

I've tested the behavior of the API Server in this branch in the same three cases - in all cases the server uses the following config based on requests.
```
SkyPilot API server will start 4 server processes with 8 background workers for long requests and will allow at max 11 short requests in parallel.
```
<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
