### PR TITLE
[Core] Add backward compatibility for jobs queue api

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -313,7 +313,9 @@ from the client and return an error during validation.
 
 #### Adding new fields to API response body
 
-When adding new fields to objects that are serialized in API response bodies (such as resource handles), special care must be taken to ensure older clients can deserialize objects from newer servers. This commonly occurs with objects that are pickled and sent over the API.
+##### Adding new fields to the existing objects in the API response body
+
+When adding new fields to the existing objects that are serialized in API response bodies (such as resource handles), special care must be taken to ensure older clients can deserialize objects from newer servers. This commonly occurs with objects that are pickled and sent over the API.
 
 For example, if you add a new field like `SSHTunnelInfo` to `CloudVmRayResourceHandle`, older clients without this class definition will fail during deserialization with errors like:
 ```
@@ -330,9 +332,13 @@ backwards compatibility processing.
 
 See the `prepare_handle_for_backwards_compatibility` function and its usage for a concrete example of this.
 
+##### Adding new fields to the API response body
+
+When you need to add a brand-new field to the response body or change the response type (e.g., from `List` to `Dict`), prefer introducing a new API instead. See [Refactoring existing APIs](#refactoring-existing-apis) for details.
+
 #### Refactoring existing APIs
 
-Refactoring existing APIs can be tricky. It is recommended to add an new API instead. Then the compatibility issue can be addressed in the same way as [Adding new APIs](#adding-new-apis), e.g.:
+Refactoring existing APIs can be tricky. It is recommended to add a new API instead. Then the compatibility issue can be addressed in the same way as [Adding new APIs](#adding-new-apis), e.g.:
 
 - `constants.py`:
 

--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -37,7 +37,7 @@ export async function getManagedJobs(options = {}) {
     if (limit !== undefined) body.limit = limit;
     if (statuses !== undefined && statuses.length > 0) body.statuses = statuses;
 
-    const response = await apiClient.post(`/jobs/queue`, body);
+    const response = await apiClient.post(`/jobs/queue/v2`, body);
     const id = response.headers.get('X-Skypilot-Request-ID');
     const fetchedData = await apiClient.get(`/api/get?request_id=${id}`);
     if (fetchedData.status === 500) {
@@ -541,7 +541,7 @@ export async function handleJobAction(action, jobId, cluster) {
     case 'restartcontroller':
       logStarter = 'Restarting';
       logMiddle = 'restarted';
-      apiPath = 'jobs/queue';
+      apiPath = 'jobs/queue/v2';
       requestBody = { all_users: true, refresh: true };
       jobId = 'controller';
       break;

--- a/sky/jobs/server/server.py
+++ b/sky/jobs/server/server.py
@@ -46,6 +46,21 @@ async def queue(request: fastapi.Request,
     )
 
 
+@router.post('/queue/v2')
+async def queue_v2(request: fastapi.Request,
+                   jobs_queue_body_v2: payloads.JobsQueueV2Body) -> None:
+    executor.schedule_request(
+        request_id=request.state.request_id,
+        request_name='jobs.queue_v2',
+        request_body=jobs_queue_body_v2,
+        func=core.queue_v2,
+        schedule_type=(api_requests.ScheduleType.LONG
+                       if jobs_queue_body_v2.refresh else
+                       api_requests.ScheduleType.SHORT),
+        request_cluster_name=common.JOB_CONTROLLER_NAME,
+    )
+
+
 @router.post('/cancel')
 async def cancel(request: fastapi.Request,
                  jobs_cancel_body: payloads.JobsCancelBody) -> None:

--- a/sky/jobs/server/server.py
+++ b/sky/jobs/server/server.py
@@ -32,6 +32,8 @@ async def launch(request: fastapi.Request,
     )
 
 
+# For backwards compatibility
+# TODO(hailong): Remove before 0.12.0.
 @router.post('/queue')
 async def queue(request: fastapi.Request,
                 jobs_queue_body: payloads.JobsQueueBody) -> None:

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -10,7 +10,7 @@ from sky.skylet import constants
 # based on version info is needed.
 # For more details and code guidelines, refer to:
 # https://docs.skypilot.co/en/latest/developers/CONTRIBUTING.html#backward-compatibility-guidelines
-API_VERSION = 17
+API_VERSION = 18
 
 # The minimum peer API version that the code should still work with.
 # Notes (dev):

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -512,6 +512,14 @@ class JobsQueueBody(RequestBody):
     skip_finished: bool = False
     all_users: bool = False
     job_ids: Optional[List[int]] = None
+
+
+class JobsQueueV2Body(RequestBody):
+    """The request body for the jobs queue endpoint."""
+    refresh: bool = False
+    skip_finished: bool = False
+    all_users: bool = False
+    job_ids: Optional[List[int]] = None
     user_match: Optional[str] = None
     workspace_match: Optional[str] = None
     name_match: Optional[str] = None

--- a/sky/server/requests/serializers/decoders.py
+++ b/sky/server/requests/serializers/decoders.py
@@ -110,14 +110,12 @@ def decode_queue(return_value: List[dict],) -> List[Dict[str, Any]]:
 
 @register_decoders('jobs.queue')
 def decode_jobs_queue(return_value: List[dict],) -> List[Dict[str, Any]]:
-    jobs = return_value
-    for job in jobs:
-        job['status'] = managed_jobs.ManagedJobStatus(job['status'])
-    return jobs
+    # To keep backward compatibility with v0.10.2
+    return decode_jobs_queue_v2(return_value)
 
 
 @register_decoders('jobs.queue_v2')
-def decode_jobs_queue_v2(return_value):
+def decode_jobs_queue_v2(return_value) -> List[Dict[str, Any]]:
     """Decode jobs queue response.
 
     Supports legacy list, or a dict {jobs, total}.

--- a/sky/server/requests/serializers/decoders.py
+++ b/sky/server/requests/serializers/decoders.py
@@ -109,7 +109,15 @@ def decode_queue(return_value: List[dict],) -> List[Dict[str, Any]]:
 
 
 @register_decoders('jobs.queue')
-def decode_jobs_queue(return_value):
+def decode_jobs_queue(return_value: List[dict],) -> List[Dict[str, Any]]:
+    jobs = return_value
+    for job in jobs:
+        job['status'] = managed_jobs.ManagedJobStatus(job['status'])
+    return jobs
+
+
+@register_decoders('jobs.queue_v2')
+def decode_jobs_queue_v2(return_value):
     """Decode jobs queue response.
 
     Supports legacy list, or a dict {jobs, total}.

--- a/sky/server/requests/serializers/encoders.py
+++ b/sky/server/requests/serializers/encoders.py
@@ -6,7 +6,7 @@ import base64
 import dataclasses
 import pickle
 import typing
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from sky.schemas.api import responses
 from sky.server import constants as server_constants
@@ -128,7 +128,8 @@ def encode_jobs_queue(jobs: List[dict],) -> List[Dict[str, Any]]:
 
 
 @register_encoder('jobs.queue_v2')
-def encode_jobs_queue_v2(jobs_or_tuple):
+def encode_jobs_queue_v2(
+        jobs_or_tuple) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
     # Support returning either a plain jobs list or a (jobs, total) tuple
     status_counts = {}
     if isinstance(jobs_or_tuple, tuple):

--- a/sky/server/requests/serializers/encoders.py
+++ b/sky/server/requests/serializers/encoders.py
@@ -121,7 +121,14 @@ def encode_status_kubernetes(
 
 
 @register_encoder('jobs.queue')
-def encode_jobs_queue(jobs_or_tuple):
+def encode_jobs_queue(jobs: List[dict],) -> List[Dict[str, Any]]:
+    for job in jobs:
+        job['status'] = job['status'].value
+    return jobs
+
+
+@register_encoder('jobs.queue_v2')
+def encode_jobs_queue_v2(jobs_or_tuple):
     # Support returning either a plain jobs list or a (jobs, total) tuple
     status_counts = {}
     if isinstance(jobs_or_tuple, tuple):

--- a/sky/utils/resource_checker.py
+++ b/sky/utils/resource_checker.py
@@ -276,9 +276,8 @@ def _get_active_resources(
         # pylint: disable=import-outside-toplevel
         from sky.jobs.server import core as managed_jobs_core
         try:
-            filtered_jobs, _, _, _ = managed_jobs_core.queue(refresh=False,
-                                                             skip_finished=True,
-                                                             all_users=True)
+            filtered_jobs, _, _, _ = managed_jobs_core.queue_v2(
+                refresh=False, skip_finished=True, all_users=True)
             return filtered_jobs
         except exceptions.ClusterNotUpError:
             logger.warning('All jobs should be finished.')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,7 +145,7 @@ def pytest_addoption(parser):
     parser.addoption(
         '--base-branch',
         type=str,
-        default='',
+        default=None,
         help='Base branch to test backward compatibility against',
     )
     parser.addoption(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,7 +145,7 @@ def pytest_addoption(parser):
     parser.addoption(
         '--base-branch',
         type=str,
-        default='master',
+        default='',
         help='Base branch to test backward compatibility against',
     )
     parser.addoption(

--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 import re
 import subprocess
+import sys
 import tempfile
 import textwrap
 from typing import Sequence
@@ -99,6 +100,7 @@ class TestBackwardCompatibility:
         if not base_branch:
             # Default to the minimum compatible version as the base branch
             base_branch = f'v{constants.MIN_COMPATIBLE_VERSION}'
+        print(f'base_branch: {base_branch}', file=sys.stderr, flush=True)
 
         # Check if gcloud is installed
         if subprocess.run('gcloud --version', shell=True).returncode != 0:

--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -96,6 +96,9 @@ class TestBackwardCompatibility:
         """Session-wide setup that runs exactly once (concurrency limited to 1)."""
         # No locking mechanism needed since concurrency is limited to 1
         base_branch = request.config.getoption("--base-branch")
+        if not base_branch:
+            # Default to the minimum compatible version as the base branch
+            base_branch = f'v{constants.MIN_COMPATIBLE_VERSION}'
 
         # Check if gcloud is installed
         if subprocess.run('gcloud --version', shell=True).returncode != 0:

--- a/tests/unit_tests/test_sky/jobs/test_server_queue.py
+++ b/tests/unit_tests/test_sky/jobs/test_server_queue.py
@@ -328,7 +328,7 @@ class TestQueue:
                             lambda pattern: [type('U', (), {'id': 'hashA'})()])
 
         # Filter by user match 'a', page 1, limit 10
-        filtered, total, status_counts, total_no_filter = jobs_core.queue(
+        filtered, total, status_counts, total_no_filter = jobs_core.queue_v2(
             refresh=False,
             skip_finished=False,
             all_users=True,
@@ -353,7 +353,7 @@ class TestQueue:
         monkeypatch.setattr(jobs_core.global_user_state,
                             'get_user_by_name_match', lambda pattern: [])
 
-        filtered, total, status_counts, total_no_filter = jobs_core.queue(
+        filtered, total, status_counts, total_no_filter = jobs_core.queue_v2(
             refresh=False,
             skip_finished=False,
             all_users=True,
@@ -375,7 +375,7 @@ class TestQueue:
         self._patch_backend_and_utils(monkeypatch, jobs)
 
         # Page 2, limit 10
-        filtered, total, status_counts, total_no_filter = jobs_core.queue(
+        filtered, total, status_counts, total_no_filter = jobs_core.queue_v2(
             refresh=False,
             skip_finished=False,
             all_users=True,
@@ -396,7 +396,7 @@ class TestQueue:
         self._patch_backend_and_utils(monkeypatch, jobs)
         # page without limit
         with pytest.raises(ValueError):
-            jobs_core.queue(refresh=False,
+            jobs_core.queue_v2(refresh=False,
                             skip_finished=False,
                             all_users=True,
                             job_ids=None,
@@ -408,7 +408,7 @@ class TestQueue:
                             limit=None)
         # invalid page
         with pytest.raises(ValueError):
-            jobs_core.queue(refresh=False,
+            jobs_core.queue_v2(refresh=False,
                             skip_finished=False,
                             all_users=True,
                             job_ids=None,
@@ -420,7 +420,7 @@ class TestQueue:
                             limit=10)
         # invalid limit
         with pytest.raises(ValueError):
-            jobs_core.queue(refresh=False,
+            jobs_core.queue_v2(refresh=False,
                             skip_finished=False,
                             all_users=True,
                             job_ids=None,
@@ -475,7 +475,7 @@ class TestQueue:
         # Only my hash and None should pass when all_users=False
         monkeypatch.setattr(jobs_core.common_utils, 'get_user_hash',
                             lambda: 'me')
-        filtered, total, status_counts, total_no_filter = jobs_core.queue(
+        filtered, total, status_counts, total_no_filter = jobs_core.queue_v2(
             refresh=False,
             skip_finished=False,
             all_users=False,
@@ -503,7 +503,7 @@ class TestQueue:
         self._patch_backend_and_utils(monkeypatch, jobs)
         monkeypatch.setattr(jobs_core.workspaces_core, 'get_workspaces',
                             fake_get_workspaces_only_w1)
-        filtered, total, status_counts, total_no_filter = jobs_core.queue(
+        filtered, total, status_counts, total_no_filter = jobs_core.queue_v2(
             refresh=False,
             skip_finished=False,
             all_users=True,
@@ -566,7 +566,7 @@ class TestQueue:
             },
         ]
         self._patch_backend_and_utils(monkeypatch, jobs)
-        filtered, total, status_counts, total_no_filter = jobs_core.queue(
+        filtered, total, status_counts, total_no_filter = jobs_core.queue_v2(
             refresh=False,
             skip_finished=True,
             all_users=True,
@@ -585,7 +585,7 @@ class TestQueue:
     def test_queue_filter_by_job_ids(self, monkeypatch):
         jobs = [_make_job(1), _make_job(2), _make_job(3)]
         self._patch_backend_and_utils(monkeypatch, jobs)
-        filtered, total, status_counts, total_no_filter = jobs_core.queue(
+        filtered, total, status_counts, total_no_filter = jobs_core.queue_v2(
             refresh=False,
             skip_finished=False,
             all_users=True,

--- a/tests/unit_tests/test_sky/jobs/test_server_queue.py
+++ b/tests/unit_tests/test_sky/jobs/test_server_queue.py
@@ -397,39 +397,39 @@ class TestQueue:
         # page without limit
         with pytest.raises(ValueError):
             jobs_core.queue_v2(refresh=False,
-                            skip_finished=False,
-                            all_users=True,
-                            job_ids=None,
-                            user_match=None,
-                            workspace_match=None,
-                            name_match=None,
-                            pool_match=None,
-                            page=1,
-                            limit=None)
+                               skip_finished=False,
+                               all_users=True,
+                               job_ids=None,
+                               user_match=None,
+                               workspace_match=None,
+                               name_match=None,
+                               pool_match=None,
+                               page=1,
+                               limit=None)
         # invalid page
         with pytest.raises(ValueError):
             jobs_core.queue_v2(refresh=False,
-                            skip_finished=False,
-                            all_users=True,
-                            job_ids=None,
-                            user_match=None,
-                            workspace_match=None,
-                            name_match=None,
-                            pool_match=None,
-                            page=0,
-                            limit=10)
+                               skip_finished=False,
+                               all_users=True,
+                               job_ids=None,
+                               user_match=None,
+                               workspace_match=None,
+                               name_match=None,
+                               pool_match=None,
+                               page=0,
+                               limit=10)
         # invalid limit
         with pytest.raises(ValueError):
             jobs_core.queue_v2(refresh=False,
-                            skip_finished=False,
-                            all_users=True,
-                            job_ids=None,
-                            user_match=None,
-                            workspace_match=None,
-                            name_match=None,
-                            pool_match=None,
-                            page=1,
-                            limit=0)
+                               skip_finished=False,
+                               all_users=True,
+                               job_ids=None,
+                               user_match=None,
+                               workspace_match=None,
+                               name_match=None,
+                               pool_match=None,
+                               page=1,
+                               limit=0)
 
     def test_queue_all_users_filtering(self, monkeypatch):
         # Create jobs with user_hash values

--- a/tests/unit_tests/test_sky/utils/test_resource_checker.py
+++ b/tests/unit_tests/test_sky/utils/test_resource_checker.py
@@ -86,7 +86,7 @@ class TestResourceChecker:
         }]
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     def test_check_no_active_resources_for_users_no_resources(
             self, mock_queue, mock_get_clusters):
         """Test resource check passes when user has no active resources."""
@@ -105,7 +105,7 @@ class TestResourceChecker:
                                            all_users=True)
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     def test_check_no_active_resources_for_users_with_clusters(
             self, mock_queue, mock_get_clusters, sample_clusters):
         """Test resource check fails when user has active clusters."""
@@ -124,7 +124,7 @@ class TestResourceChecker:
         assert "Please terminate these resources first" in error_message
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     def test_check_no_active_resources_for_users_with_jobs(
             self, mock_queue, mock_get_clusters, sample_managed_jobs):
         """Test resource check fails when user has active managed jobs."""
@@ -144,7 +144,7 @@ class TestResourceChecker:
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
     @mock.patch('sky.utils.resource_checker.global_user_state.get_user')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     def test_check_no_active_resources_for_users_with_mixed_resources(
             self, mock_queue, mock_get_user, mock_get_clusters, sample_clusters,
             sample_managed_jobs, sample_user):
@@ -166,7 +166,7 @@ class TestResourceChecker:
         assert "Please terminate these resources first" in error_message
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     def test_check_no_active_resources_for_service_account(
             self, mock_queue, mock_get_clusters, sample_clusters,
             sample_managed_jobs):
@@ -187,7 +187,7 @@ class TestResourceChecker:
         assert "1 active managed job(s): job-002" in error_message
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     def test_check_no_active_resources_for_multiple_users(
             self, mock_queue, mock_get_clusters, sample_clusters,
             sample_managed_jobs):
@@ -211,7 +211,7 @@ class TestResourceChecker:
         # userclean should not appear in errors since it has no resources
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     def test_check_no_active_resources_jobs_controller_down(
             self, mock_queue, mock_get_clusters, sample_clusters):
         """Test resource check when jobs controller is down."""
@@ -231,7 +231,7 @@ class TestResourceChecker:
         # Should not mention jobs since controller is down
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     def test_check_no_active_resources_for_workspaces(self, mock_queue,
                                                       mock_get_clusters,
                                                       sample_clusters,
@@ -253,7 +253,7 @@ class TestResourceChecker:
         assert "1 active managed job(s): job-002" in error_message
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     def test_check_no_active_resources_empty_operations(self, mock_queue,
                                                         mock_get_clusters):
         """Test resource check with empty operations list."""
@@ -266,7 +266,7 @@ class TestResourceChecker:
         mock_queue.assert_not_called()
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     def test_check_no_active_resources_update_operation(self, mock_queue,
                                                         mock_get_clusters,
                                                         sample_clusters):
@@ -285,7 +285,7 @@ class TestResourceChecker:
         assert "1 active cluster(s): cluster-1" in error_message
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     def test_check_no_active_resources_mixed_operations(self, mock_queue,
                                                         mock_get_clusters,
                                                         sample_clusters,
@@ -306,7 +306,7 @@ class TestResourceChecker:
         assert "Cannot update user 'user456'" in error_message
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     @mock.patch('sky.utils.resource_checker.global_user_state.get_all_users')
     def test_check_users_workspaces_active_resources_all_authorized(
             self, mock_get_all_users, mock_queue, mock_get_clusters,
@@ -337,7 +337,7 @@ class TestResourceChecker:
         assert missed_users == []
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     @mock.patch('sky.utils.resource_checker.global_user_state.get_all_users')
     def test_check_users_workspaces_active_resources_unauthorized_users(
             self, mock_get_all_users, mock_queue, mock_get_clusters,
@@ -375,7 +375,7 @@ class TestResourceChecker:
         assert len(missed_users) == 2
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     @mock.patch('sky.utils.resource_checker.global_user_state.get_all_users')
     def test_check_users_workspaces_active_resources_no_resources(
             self, mock_get_all_users, mock_queue, mock_get_clusters):
@@ -395,7 +395,7 @@ class TestResourceChecker:
         assert missed_users == []
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     @mock.patch('sky.utils.resource_checker.global_user_state.get_all_users')
     def test_check_users_workspaces_active_resources_clusters_only(
             self, mock_get_all_users, mock_queue, mock_get_clusters,
@@ -428,7 +428,7 @@ class TestResourceChecker:
         assert 'bob@company.com' in missed_users
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     @mock.patch('sky.utils.resource_checker.global_user_state.get_all_users')
     def test_check_users_workspaces_active_resources_jobs_only(
             self, mock_get_all_users, mock_queue, mock_get_clusters,
@@ -461,7 +461,7 @@ class TestResourceChecker:
         assert 'service-account-1' in missed_users
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     def test_get_active_resources_for_workspaces_multiple_workspaces(
             self, mock_queue, mock_get_clusters, sample_clusters,
             sample_managed_jobs):
@@ -486,7 +486,7 @@ class TestResourceChecker:
             assert job['workspace'] in workspaces
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     def test_get_active_resources_for_workspaces_single_workspace(
             self, mock_queue, mock_get_clusters, sample_clusters,
             sample_managed_jobs):
@@ -518,7 +518,7 @@ class TestResourceChecker:
             assert job['workspace'] == 'default'
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     def test_get_active_resources_for_workspaces_empty_list(
             self, mock_queue, mock_get_clusters):
         """Test getting active resources for empty workspace list."""
@@ -534,7 +534,7 @@ class TestResourceChecker:
         mock_queue.assert_not_called()
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     def test_get_active_resources_for_workspaces_nonexistent_workspace(
             self, mock_queue, mock_get_clusters, sample_clusters,
             sample_managed_jobs):
@@ -553,7 +553,7 @@ class TestResourceChecker:
         assert jobs == []
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     @mock.patch('sky.utils.resource_checker.global_user_state.get_all_users')
     def test_check_users_workspaces_active_resources_user_without_name(
             self, mock_get_all_users, mock_queue, mock_get_clusters,
@@ -586,7 +586,7 @@ class TestResourceChecker:
         assert 'service-account-1' in missed_users  # Use name when available
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     def test_get_active_resources_for_workspaces_jobs_controller_down(
             self, mock_queue, mock_get_clusters, sample_clusters):
         """Test handling when jobs controller is down."""
@@ -608,7 +608,7 @@ class TestResourceChecker:
         assert jobs == []  # Should be empty due to controller being down
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     def test_get_active_resources_by_names_filter_functionality(
             self, mock_queue, mock_get_clusters, sample_clusters,
             sample_managed_jobs):
@@ -646,7 +646,7 @@ class TestResourceChecker:
             assert job['user_hash'] in user_ids
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     @mock.patch('sky.utils.resource_checker.global_user_state.get_all_users')
     def test_check_users_workspaces_active_resources_empty_workspaces(
             self, mock_get_all_users, mock_queue, mock_get_clusters):
@@ -667,7 +667,7 @@ class TestResourceChecker:
         mock_get_all_users.assert_not_called()
 
     @mock.patch('sky.utils.resource_checker.global_user_state.get_clusters')
-    @mock.patch('sky.jobs.server.core.queue')
+    @mock.patch('sky.jobs.server.core.queue_v2')
     @mock.patch('sky.utils.resource_checker.global_user_state.get_all_users')
     def test_check_users_workspaces_active_resources_mixed_workspace_resources(
             self, mock_get_all_users, mock_queue, mock_get_clusters):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Add backward compatibility for jobs queue api

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- controller 0.10.1, server 0.10.1,       Client 0.10.2,       - success
- controller 0.10.1, server 0.10.1,       Client branch 7052,  - success
- controller 0.10.1, server 0.10.2,       Client 0.10.1,        - fail
- controller 0.10.1, server 0.10.2,       Client 0.10.2,       - success
- controller 0.10.1, server 0.10.2,       Client branch 7052,  - success
- controller 0.10.1, server branch 7052,  Client 0.10.1,         - success
- controller 0.10.1, server branch 7052,  Client 0.10.2,        - success
- controller 0.10.1, server branch 7052,  Client branch 7052,   - success
- controller 0.10.2, server 0.10.2,       Client 0.10.1,        - fail
- controller 0.10.2, server 0.10.2,       Client 0.10.2,        - success
- controller 0.10.2, server 0.10.2,       Client branch 7052,   - success
- controller 0.10.2, server branch 7052,  Client 0.10.1,         - success
- controller 0.10.2, server branch 7052,  Client 0.10.2,         - success
- controller 0.10.2, server branch 7052,  Client branch 7052,    - success
 - controller 7052  , server branch 7052,  Client 0.10.1,         - success
- controller 7052  , server branch 7052,  Client 0.10.2,         - success
- controller 7052  , server branch 7052,  Client branch 7052,    - success
 - controller master, server master,       Client branch 7052,  - success
- Dashboard:
  - Managed jobs page (large number of jobs)
  - Restart job controller
  - Delete user with active resources
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
