### PR TITLE
[Core] comprehensive deactivation for default UV environment

### DIFF
--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -62,11 +62,13 @@ SKY_UV_INSTALL_CMD = (f'{SKY_UV_CMD} -V >/dev/null 2>&1 || '
                       'curl -LsSf https://astral.sh/uv/install.sh '
                       f'| UV_INSTALL_DIR={SKY_UV_INSTALL_DIR} sh')
 SKY_UV_PIP_CMD: str = (f'VIRTUAL_ENV={SKY_REMOTE_PYTHON_ENV} {SKY_UV_CMD} pip')
-# Deleting the SKY_REMOTE_PYTHON_ENV_NAME from the PATH to deactivate the
-# environment. `deactivate` command does not work when conda is used.
+# Deleting the SKY_REMOTE_PYTHON_ENV_NAME from the PATH and unsetting relevant
+# VIRTUAL_ENV envvars to deactivate the environment. `deactivate` command does
+# not work when conda is used.
 DEACTIVATE_SKY_REMOTE_PYTHON_ENV = (
     'export PATH='
-    f'$(echo $PATH | sed "s|$(echo ~)/{SKY_REMOTE_PYTHON_ENV_NAME}/bin:||")')
+    f'$(echo $PATH | sed "s|$(echo ~)/{SKY_REMOTE_PYTHON_ENV_NAME}/bin:||") && '
+    'unset VIRTUAL_ENV && unset VIRTUAL_ENV_PROMPT')
 
 # Prefix for SkyPilot environment variables
 SKYPILOT_ENV_VAR_PREFIX = 'SKYPILOT_'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #6705 

So basically, what happens is we never actually explicitly activate the `uv` environment, but it seems that there is a discrepancy between how containerization and ray workers work in kubernetes and non-kubernetes environments. The `uv` environment is essentially inherited when the `ray.remote` function is called to invoke `log_lib.py::run_bash_command_with_log` on the cluster.

I was able to intercept some relevant information and logged its output:

```
Env vars: {'HOME': '/home/sky', 'HOSTNAME': 'mycluster-5b9e2381-head', 'KUBERNETES_PORT': 'tcp://34.118.224.1:443', 'KUBERNETES_PORT_443_TCP': 'tcp://34.118.224.1:443', 'KUBERNETES_PORT_443_TCP_ADDR': '34.118.224.1', 'KUBERNETES_PORT_443_TCP_PORT': '443', 'KUBERNETES_PORT_443_TCP_PROTO': 'tcp', 'KUBERNETES_SERVICE_HOST': '34.118.224.1', 'KUBERNETES_SERVICE_PORT': '443', 'KUBERNETES_SERVICE_PORT_HTTPS': '443', 'LANG': 'C.UTF-8', 'LC_ALL': 'C.UTF-8', 'MYCLUSTER_5B9E2381_HEAD_SSH_PORT': 'tcp://34.118.239.99:22', 'MYCLUSTER_5B9E2381_HEAD_SSH_PORT_22_TCP': 'tcp://34.118.239.99:22', 'MYCLUSTER_5B9E2381_HEAD_SSH_PORT_22_TCP_ADDR': '34.118.239.99', 'MYCLUSTER_5B9E2381_HEAD_SSH_PORT_22_TCP_PORT': '22', 'MYCLUSTER_5B9E2381_HEAD_SSH_PORT_22_TCP_PROTO': 'tcp', 'MYCLUSTER_5B9E2381_HEAD_SSH_SERVICE_HOST': '34.118.239.99', 'MYCLUSTER_5B9E2381_HEAD_SSH_SERVICE_PORT': '22', 'NVIDIA_VISIBLE_DEVICES': 'none', 'PATH': '/home/sky/skypilot-runtime/bin:/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/sky/.local/bin', 'PS1': '(skypilot-runtime) ', 'PWD': '/home/sky', 'PYTHONUNBUFFERED': '1', 'RAY_CLIENT_MODE': '0', 'RAY_DEDUP_LOGS': '0', 'RAY_JOB_ID': 'ffffffff', 'RAY_LD_PRELOAD': '1', 'RAY_RAYLET_PID': '728', 'RAY_SCHEDULER_EVENTS': '0', 'RAY_USAGE_STATS_ENABLED': '0', 'RAY_worker_maximum_startup_concurrency': '24', 'SHLVL': '1', 'SKYPILOT_IN_CLUSTER_CONTEXT_NAME': 'gke_sandbox-446922_us-central1-c_skytest', 'SKYPILOT_POD_NODE_TYPE': 'head', 'SPT_NOENV': '1', 'VIRTUAL_ENV': '/home/sky/skypilot-runtime', 'VIRTUAL_ENV_PROMPT': '(skypilot-runtime) ', '_': '/home/sky/skypilot-runtime/bin/python', 'PYTHONBREAKPOINT': 'ray.util.rpdb.set_trace', 'NEURON_RT_VISIBLE_CORES': '', 'CUDA_VISIBLE_DEVICES': '', 'HABANA_VISIBLE_MODULES': '', 'ASCEND_VISIBLE_DEVICES': '', 'TPU_VISIBLE_CHIPS': '', 'OMP_NUM_THREADS': '1'}

Current command: /home/sky/skypilot-runtime/lib/python3.10/site-packages/ray/_private/workers/default_worker.py --node-ip-address=10.100.0.25 --node-manager-port=35655 --object-store-name=/tmp/ray_skypilot/session_2025-09-08_04-49-13_555249_584/sockets/plasma_store --raylet-name=/tmp/ray_skypilot/session_2025-09-08_04-49-13_555249_584/sockets/raylet --redis-address=None --temp-dir=/tmp/ray_skypilot --metrics-agent-port=62573 --runtime-env-agent-port=55780 --logging-rotate-bytes=536870912 --logging-rotate-backup-count=5 --runtime-env-agent-port=55780 --gcs-address=10.100.0.25:6380 --session-name=session_2025-09-08_04-49-13_555249_584 --temp-dir=/tmp/ray_skypilot --webui=127.0.0.1:8266 --cluster-id=401b5e4102479e10d4da9d607b4d6de2c139cda3d59a26721cd74250 --startup-token=1 --worker-launch-time-ms=1757306985733
```

We can see that ray python code is executed. Ray is started in the `uv` environment (`skypilot-runtime`), and while ray tasks are supposed to be executed in an isolated environment, this does not occur and we end up inheriting the `VIRTUAL_ENV` and related envvars, which is then directly inherited to our subprocess. So, the only way to sensibly fix this is in `DEACTIVATE_SKY_REMOTE_PYTHON_ENV`, we have to unset the remaining relevant envvars. 

For other clouds, (tested on AWS), it seems that ray is able to successfully sanitize environments before running a ray task. Regardless, the following fix is sufficient to prevent `uv` from auto-detecting, and it is safe as well because the `VIRTUAL_ENV` and `VIRTUAL_ENV_PROMPT` is not set for non-k8s clouds anyways. 

~~**IMPORTANT**: this code changes will break kubernetes at this moment. I don't think changes from #6766 is applied in our default docker images yet. After those are published and we push new docker images, I think we can try and merge this code. Otherwise, for the default k8s docker images that we have published right now, we will get a permission denied error as only `root` is able to write to `/opt/conda`.~~(image pushed)

~~** also need some more manual testing. Tested to see that `uv pip install` attempts to write to `/opt/conda`, which is the conda base environment, though I get permission denied due to above reasons.~~(works)

** Another attempt I did was to not activate the uv environment in the k8s docker image (using VIRTUAL_ENV= like we do in the rest of the codebase, in hopes that maybe the process of copying over environment variables was the problem. It wasn't, and I was able to confirm this by both using the normal docker image and my hand-crafted one)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
