### PR TITLE
More metrics per process

### DIFF
--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -23,7 +23,6 @@ import concurrent.futures
 import contextlib
 import multiprocessing
 import os
-import psutil
 import queue as queue_lib
 import signal
 import sys
@@ -132,7 +131,8 @@ def executor_initializer(proc_group: str):
     setproctitle.setproctitle(f'SkyPilot:executor:{proc_group}:'
                               f'{multiprocessing.current_process().pid}')
     threading.Thread(target=metrics_lib.process_monitor,
-                     args=(f'worker:{proc_group}',), daemon=True).start()
+                     args=(f'worker:{proc_group}',),
+                     daemon=True).start()
 
 
 class RequestWorker:

--- a/sky/server/uvicorn.py
+++ b/sky/server/uvicorn.py
@@ -19,9 +19,9 @@ from uvicorn.supervisors import multiprocess
 
 from sky import sky_logging
 from sky.server import daemons
+from sky.server import metrics as metrics_lib
 from sky.server import state
 from sky.server.requests import requests as requests_lib
-from sky.server import metrics as metrics_lib
 from sky.skylet import constants
 from sky.utils import context_utils
 from sky.utils import env_options
@@ -214,7 +214,8 @@ class Server(uvicorn.Server):
             event_loop.set_debug(True)
             event_loop.slow_callback_duration = lag_threshold
         threading.Thread(target=metrics_lib.process_monitor,
-                         args=('server',), daemon=True).start()
+                         args=('server',),
+                         daemon=True).start()
         with self.capture_signals():
             asyncio.run(self.serve(*args, **kwargs))
 

--- a/sky/server/uvicorn.py
+++ b/sky/server/uvicorn.py
@@ -21,6 +21,7 @@ from sky import sky_logging
 from sky.server import daemons
 from sky.server import state
 from sky.server.requests import requests as requests_lib
+from sky.server import metrics as metrics_lib
 from sky.skylet import constants
 from sky.utils import context_utils
 from sky.utils import env_options
@@ -212,6 +213,8 @@ class Server(uvicorn.Server):
             # Same as set PYTHONASYNCIODEBUG=1, but with custom threshold.
             event_loop.set_debug(True)
             event_loop.slow_callback_duration = lag_threshold
+        threading.Thread(target=metrics_lib.process_monitor,
+                         args=('server',), daemon=True).start()
         with self.capture_signals():
             asyncio.run(self.serve(*args, **kwargs))
 

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -1098,13 +1098,15 @@ def release_memory():
     """Release the process memory"""
     # Do the best effort to release the python heap and let malloc_trim
     # be more efficient.
-    gc.collect()
-    if sys.platform.startswith('linux'):
-        try:
+    try:
+        gc.collect()
+        if sys.platform.startswith('linux'):
             # Will fail on musl (alpine), but at least it works on our
             # offical docker images.
             libc = ctypes.CDLL('libc.so.6')
             return libc.malloc_trim(0)
-        except (AttributeError, OSError):
-            return 0
-    return 0
+        return 0
+    except Exception as e:  # pylint: disable=broad-except
+        logger.error(f'Failed to release memory: '
+                     f'{format_exception(e)}')
+        return 0


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Add more metrics per process, like a continuous top view:

<img width="1622" height="966" alt="image" src="https://github.com/user-attachments/assets/aaff0249-d31a-4605-80c4-db0d701457cd" />

I expect this to help us locate issues when there is a CPU saturation or OOM.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
