### PR TITLE
minor: image generation docs fix

### DIFF
--- a/sky/catalog/images/README.md
+++ b/sky/catalog/images/README.md
@@ -3,12 +3,12 @@
 ## Prerequisites
 You only need to do this once.
 1. Install [Packer](https://developer.hashicorp.com/packer/tutorials/aws-get-started/get-started-install-cli)
-2. Download plugins used by Packer
+2. Setup cloud credentials
+3. `cd sky/catalog/images/`
+4. Download plugins used by Packer
 ```bash
 packer init plugins.pkr.hcl
 ```
-3. Setup cloud credentials
-4. `cd sky/catalog/images/`
 
 ## Generate Images
 FYI time to packer build images:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Turns out you need to be in `sky/catalog/images` for `packer init plugins.pkr.hcl` to work.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
