### PR TITLE
[API server] executor correctly restores env var in case of `override_request_env_and_config` failure

### DIFF
--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -285,20 +285,20 @@ def override_request_env_and_config(
     """Override the environment and SkyPilot config for a request."""
     original_env = os.environ.copy()
     try:
-        # Unset SKYPILOT_DEBUG by default, to avoid the value set on the API server
-        # affecting client requests. If set on the client side, it will be
-        # overridden by the request body.
+        # Unset SKYPILOT_DEBUG by default, to avoid the value set on the API
+        # server affecting client requests. If set on the client side, it will
+        # be overridden by the request body.
         os.environ.pop('SKYPILOT_DEBUG', None)
         # Remove the db connection uri from client supplied env vars, as the
         # client should not set the db string on server side.
         request_body.env_vars.pop(constants.ENV_VAR_DB_CONNECTION_URI, None)
         os.environ.update(request_body.env_vars)
         # Note: may be overridden by AuthProxyMiddleware.
-        # TODO(zhwu): we need to make the entire request a context available to the
-        # entire request execution, so that we can access info like user through
-        # the execution.
+        # TODO(zhwu): we need to make the entire request a context available to
+        # the entire request execution, so that we can access info like user
+        # through the execution.
         user = models.User(id=request_body.env_vars[constants.USER_ID_ENV_VAR],
-                        name=request_body.env_vars[constants.USER_ENV_VAR])
+                           name=request_body.env_vars[constants.USER_ENV_VAR])
         global_user_state.add_or_update_user(user)
         # Refetch the user to get the latest user info, including the created_at
         # field.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
If any error happens in the codeblock that is now moved into the try block, the request environment variables were not being restored. This PR fixes the issue.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
