### PR TITLE
revert PR 6766 for k8s GPU image

### DIFF
--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -25,10 +25,6 @@ RUN sudo useradd -m -s /bin/bash sky && \
     sudo /bin/bash -c 'echo "sky ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers' && \
     sudo /bin/bash -c "echo 'Defaults        secure_path=\"/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"' > /etc/sudoers.d/sky"
 
-# give sky group write permission to /opt/conda
-RUN chown -R :sky /opt/conda && \
-    chmod -R g+w /opt/conda
-
 # Switch to sky user
 USER sky
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
In https://github.com/skypilot-org/skypilot/pull/6766 I made the same change for gpu and non gpu images (and only tested non gpu image back then).

Turns out, the non GPU image's base image comes with conda preinstalled in system directory so this change was needed. For GPU image, the base image does not come with conda preinstalled, and we install conda in the dockerfile as sky user, making the conda directory a user directory.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
