### PR TITLE
[Dependencies] Upgrade Ray version and remove Apple Silicon grpcio workaround

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -5,7 +5,7 @@ Installation
 
 .. note::
 
-    For Macs, macOS >= 10.15 is required to install SkyPilot. Apple Silicon-based devices (e.g. Apple M1) must run :code:`pip uninstall grpcio; conda install -c conda-forge grpcio=1.43.0` prior to installing SkyPilot.
+    For Macs, macOS >= 10.15 is required to install SkyPilot.
 
 Install SkyPilot using pip:
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -3,10 +3,6 @@
 Installation
 ==================
 
-.. note::
-
-    For Macs, macOS >= 10.15 is required to install SkyPilot.
-
 Install SkyPilot using pip:
 
 .. tab-set::

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -108,9 +108,9 @@ server_dependencies = [
 local_ray = [
     # Lower version of ray will cause dependency conflict for
     # click/grpcio/protobuf.
-    # Excluded 2.6.0 as it has a bug in the cluster launcher:
+    # Ray 2.6.1+ resolved cluster launcher bugs and grpcio issues on Apple Silicon.
     # https://github.com/ray-project/ray/releases/tag/ray-2.6.1
-    'ray[default] >= 2.2.0, != 2.6.0',
+    'ray[default] >= 2.6.1',
 ]
 
 remote = [


### PR DESCRIPTION
## Summary
- Upgrade local Ray requirement from >= 2.2.0 to >= 2.6.1
- Remove outdated Apple Silicon grpcio installation instructions
- Better version consistency with remote Ray (2.9.3)

## Context
Ray 2.6.0+ (July 2023) resolved grpcio issues on Apple Silicon, making the special installation steps unnecessary.

**Ray team confirmation**: Ray's documentation removed Apple Silicon grpcio workarounds in [PR #36029](https://github.com/ray-project/ray/pull/36029) (June 29, 2023), indicating the issue was resolved.

## Changes
- `sky/setup_files/dependencies.py`: Update Ray version requirement and comments
- `docs/source/getting-started/installation.rst`: Remove Apple Silicon grpcio instructions

Fixes #7072