### PR TITLE
Fix release body creation failure

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -127,7 +127,14 @@ jobs:
         with:
           name: "Release v${{ needs.extract-version.outputs.version }}"
           tag_name: "v${{ needs.extract-version.outputs.version }}"
-          generate_release_notes: true
+          body: |
+            ## SkyPilot v${{ needs.extract-version.outputs.version }}
+
+            Get it now with:
+
+            ```bash
+            uv pip install "skypilot>=${{ needs.extract-version.outputs.version }}"
+            ```
           draft: true
           token: ${{ secrets.GH_PAT_FOR_RELEASE }}
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

See failure [here](https://github.com/skypilot-org/skypilot/actions/runs/17260643036/job/48981481111)

```bash
Error: Validation Failed: {"resource":"Release","code":"custom","field":"body","message":"body is too long (maximum is 125000 characters)"} - https://docs.github.com/rest/releases/releases#create-a-release
```

We leave the release notes to blank and let human fill it later.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
