### PR TITLE
[Pools] Add support for num_gpus in setup.

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -248,6 +248,17 @@ def write_ray_up_script_with_patched_launch_hash_fn(
     return f.name
 
 
+def _get_num_gpus(ray_resources_dict: Dict[str, float]) -> int:
+    dict_copy = copy.copy(ray_resources_dict)
+    try:
+        dict_copy.pop('CPU')
+    except KeyError:
+        pass
+    if len(dict_copy) == 0:
+        return 0
+    return int(list(dict_copy.values())[0])
+
+
 class RayCodeGen:
     """Code generator of a Ray program that executes a sky.Task.
 
@@ -601,7 +612,7 @@ class RayCodeGen:
             assert len(ray_resources_dict) == 1, (
                 'There can only be one type of accelerator per instance. '
                 f'Found: {ray_resources_dict}.')
-            num_gpus = list(ray_resources_dict.values())[0]
+            num_gpus = _get_num_gpus(ray_resources_dict)
             options.append(f'resources={json.dumps(ray_resources_dict)}')
 
             resources_key = list(ray_resources_dict.keys())[0]
@@ -3637,6 +3648,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             setup_envs.update(self._skypilot_predefined_env_vars(handle))
             setup_envs['SKYPILOT_SETUP_NODE_IPS'] = '\n'.join(internal_ips)
             setup_envs['SKYPILOT_SETUP_NODE_RANK'] = str(node_id)
+            setup_envs[constants.SKYPILOT_NUM_GPUS_PER_NODE] = (str(
+                _get_num_gpus(backend_utils.get_task_demands_dict(task))))
+
             runner = runners[node_id]
             setup_script = log_lib.make_task_bash_script(setup,
                                                          env_vars=setup_envs)

--- a/tests/smoke_tests/test_pools.py
+++ b/tests/smoke_tests/test_pools.py
@@ -1,0 +1,71 @@
+import tempfile
+import textwrap
+
+import pytest
+from smoke_tests import smoke_tests_utils
+
+import sky
+from sky import skypilot_config
+from sky.skylet import constants
+from sky.skylet import events
+from sky.utils import common_utils
+from sky.utils import yaml_utils
+
+
+@pytest.mark.gcp
+def test_pools_setup_num_gpus():
+    """Test that the number of GPUs is set correctly in the setup script."""
+
+    setup_yaml = textwrap.dedent(f"""
+    pool:
+        workers: 1
+
+    resources:
+        accelerators: {{L4:2}}
+
+    setup: |
+        echo "SKYPILOT_NUM_GPUS_PER_NODE is $SKYPILOT_NUM_GPUS_PER_NODE"
+        if [[ "$SKYPILOT_NUM_GPUS_PER_NODE" != "2" ]]; then
+            exit 1
+        fi
+    """)
+
+    with tempfile.NamedTemporaryFile(delete=True) as f:
+        f.write(setup_yaml.encode('utf-8'))
+        f.flush()
+        name = smoke_tests_utils.get_cluster_name()+'-lloyd'
+        pool = f'{name}-pool'
+
+        wait_until_pool_ready = (
+            'start_time=$SECONDS; '
+            'while true; do '
+            'if (( $SECONDS - $start_time > {timeout} )); then '
+            '  echo "Timeout after {timeout} seconds waiting for job to succeed"; exit 1; '
+            'fi; '
+            f's=$(sky jobs pool status {pool}); '
+            'echo "$s"; '
+            'if echo "$s" | grep "FAILED"; then '
+            '  exit 1; '
+            'fi; '
+            'if echo "$s" | grep "SHUTTING_DOWN"; then '
+            '  exit 1; '
+            'fi; '
+            'if echo "$s" | grep "READY"; then '
+            '  break; '
+            'fi; '
+            'echo "Waiting for pool to be ready..."; '
+            'sleep 5; '
+            'done')
+
+
+        test = smoke_tests_utils.Test(
+            'test_pools_setup_num_gpus',
+            [
+                f's=$(sky jobs pool apply -p {pool} {f.name} -y); echo "$s"; echo; echo; echo "$s" | grep "Successfully created pool"',
+                # Wait for the pool to be created.
+                wait_until_pool_ready.format(timeout=smoke_tests_utils.get_timeout('gcp')),
+            ],
+            timeout=smoke_tests_utils.get_timeout('gcp'),
+            teardown=f'sky jobs pool down {pool} -y && sleep 5 && controller=$(sky status -u | grep sky-jobs-controller- | awk \'NR==1{{print $1}}\') && echo "$controller" && echo delete | sky down "$controller" && exit 1 || true'
+        )
+        smoke_tests_utils.run_one_test(test)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -34,6 +34,7 @@ from smoke_tests.test_images import *
 from smoke_tests.test_logs import *
 from smoke_tests.test_managed_job import *
 from smoke_tests.test_mount_and_storage import *
+from smoke_tests.test_pools import *
 from smoke_tests.test_region_and_zone import *
 from smoke_tests.test_sky_serve import *
 from smoke_tests.test_ssm import *


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR adds support for using `SKYPILOT_NUM_GPUS_PER_NODE` in the setup portion of cluster and job configuration files.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

This was tested with two new smoke tests in both the cluster and pools case that verify that the environment variable exists in setup and holds the correct value.

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
