### PR TITLE
[SSH] Use relative paths (~) in SSH config files for better portability

### DIFF
--- a/sky/utils/cluster_utils.py
+++ b/sky/utils/cluster_utils.py
@@ -144,6 +144,9 @@ class SSHConfigHelper(object):
             username = docker_user
 
         key_path = cls.generate_local_key_file(cluster_name, auth_config)
+        # Keep the unexpanded path for SSH config (with ~)
+        key_path_for_config = key_path
+        # Expand the path for internal operations that need absolute path
         key_path = os.path.expanduser(key_path)
         sky_autogen_comment = ('# Added by sky (use `sky stop/down '
                                f'{cluster_name}` to remove)')
@@ -208,8 +211,9 @@ class SSHConfigHelper(object):
             node_name = cluster_name if i == 0 else cluster_name + f'-worker{i}'
             # TODO(romilb): Update port number when k8s supports multinode
             codegen += cls._get_generated_config(
-                sky_autogen_comment, node_name, ip, username, key_path,
-                proxy_command, port, docker_proxy_command) + '\n'
+                sky_autogen_comment, node_name, ip, username,
+                key_path_for_config, proxy_command, port,
+                docker_proxy_command) + '\n'
 
         cluster_config_path = os.path.expanduser(
             cls.ssh_cluster_path.format(cluster_name))


### PR DESCRIPTION
Fixes #7093

<!-- Describe the changes in this PR -->
This PR modifies SSH config generation to use relative paths (with `~`) instead of absolute paths for SSH key files, improving portability across different environments.

## Problem
SSH configs generated by SkyPilot contain absolute paths like `/home/username/.sky/generated/ssh-keys/cluster.key`, which break when:
- Copying configs between machines with different home directories
- Using configs from dev server on local machine (e.g., for IDE connections)
- Home directory changes in containerized environments

## Solution
- Keep the unexpanded path (with `~`) for writing to SSH config files
- Still use expanded absolute path for internal operations that require it (e.g., docker proxy command generation)
- Modified `sky/utils/cluster_utils.py` to preserve both versions of the path

<!-- Describe the tests ran -->
Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Manual test: `sky launch --dryrun` to verify basic functionality
- [ ] All smoke tests: `pytest tests/test_smoke.py` (to be run)
- [ ] Backward compatibility test with existing clusters

## Example
Before:
```
Host cluster-name
  IdentityFile /home/username/.sky/generated/ssh-keys/cluster.key
```

After:
```
Host cluster-name
  IdentityFile ~/.sky/generated/ssh-keys/cluster.key
```

This makes SSH configs portable - you can now copy them between machines without manual path adjustments.