### PR TITLE
[Docs] Reorder installation guide to prioritize environment setup with native uv support

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -3,179 +3,283 @@
 Installation
 ==================
 
-Install SkyPilot using pip:
+Set up environment
+-------------------
+
+Before installing SkyPilot, we recommend creating a new environment to avoid package conflicts. SkyPilot requires Python 3.7 <= version <= 3.13.
 
 .. tab-set::
 
-    .. tab-item:: Latest Release
-        :sync: latest-release-tab
+    .. tab-item:: uv
+        :sync: uv-env
 
         .. code-block:: shell
 
-          # Recommended: use a new conda env to avoid package conflicts.
-          # SkyPilot requires 3.7 <= python <= 3.13.
-          conda create -y -n sky python=3.10
-          conda activate sky
-
-          # Choose your infra:
-
-          pip install "skypilot[kubernetes]"
-          pip install "skypilot[aws]"
-          pip install "skypilot[gcp]"
-          pip install "skypilot[azure]"
-          pip install "skypilot[oci]"
-          pip install "skypilot[nebius]"
-          pip install "skypilot[lambda]"
-          pip install "skypilot[runpod]"
-          pip install "skypilot[fluidstack]"
-          pip install "skypilot[paperspace]"
-          pip install "skypilot[cudo]"
-          # IBM is only supported for Python <= 3.11
-          pip install "skypilot[ibm]"
-          # SCP is only supported for Python <= 3.11
-          pip install "skypilot[scp]"
-          pip install "skypilot[vsphere]"
-          # Nebius is only supported for Python >= 3.10
-
-          pip install "skypilot[all]"
-
-
-    .. tab-item:: Nightly
-        :sync: nightly-tab
-
-        .. code-block:: shell
-
-          # Recommended: use a new conda env to avoid package conflicts.
-          # SkyPilot requires 3.7 <= python <= 3.13.
-          conda create -y -n sky python=3.10
-          conda activate sky
-
-          # Choose your infra:
-
-          pip install "skypilot-nightly[kubernetes]"
-          pip install "skypilot-nightly[aws]"
-          pip install "skypilot-nightly[gcp]"
-          pip install "skypilot-nightly[azure]"
-          pip install "skypilot-nightly[oci]"
-          pip install "skypilot-nightly[nebius]"
-          pip install "skypilot-nightly[lambda]"
-          pip install "skypilot-nightly[runpod]"
-          pip install "skypilot-nightly[fluidstack]"
-          pip install "skypilot-nightly[paperspace]"
-          pip install "skypilot-nightly[do]"
-          pip install "skypilot-nightly[cudo]"
-          pip install "skypilot-nightly[ibm]"
-          pip install "skypilot-nightly[scp]"
-          pip install "skypilot-nightly[vsphere]"
-          pip install "skypilot-nightly[all]"
-
-
-    .. tab-item:: From Source
-        :sync: from-source-tab
-
-        .. code-block:: shell
-
-          # Recommended: use a new conda env to avoid package conflicts.
-          # SkyPilot requires 3.7 <= python <= 3.13.
-          conda create -y -n sky python=3.10
-          conda activate sky
-
-          git clone https://github.com/skypilot-org/skypilot.git
-          cd skypilot
-
-          # Choose your infra:
-
-          pip install -e ".[kubernetes]"
-          pip install -e ".[aws]"
-          pip install -e ".[gcp]"
-          pip install -e ".[azure]"
-          pip install -e ".[oci]"
-          pip install -e ".[nebius]"
-          pip install -e ".[lambda]"
-          pip install -e ".[runpod]"
-          pip install -e ".[fluidstack]"
-          pip install -e ".[paperspace]"
-          pip install -e ".[cudo]"
-          pip install -e ".[ibm]"
-          pip install -e ".[scp]"
-          pip install -e ".[vsphere]"
-          pip install -e ".[all]"
-
-To use more than one cloud, combine the pip extras:
-
-.. tab-set::
-
-    .. tab-item:: Latest Release
-        :sync: latest-release-tab
-
-        .. code-block:: shell
-
-          pip install -U "skypilot[kubernetes,aws,gcp]"
-
-    .. tab-item:: Nightly
-        :sync: nightly-tab
-
-        .. code-block:: shell
-
-          pip install -U "skypilot-nightly[kubernetes,aws,gcp]"
-
-    .. tab-item:: From Source
-        :sync: from-source-tab
-
-        .. code-block:: shell
-
-          pip install -e ".[kubernetes,aws,gcp]"
-
-
-Installing via ``uv``
-----------------------
-
-SkyPilot can be installed using `uv <https://github.com/astral-sh/uv>`_, a fast Python package installer:
-
-.. tab-set::
-
-    .. tab-item:: uv venv
-        :sync: uv-venv-tab
-
-        .. code-block:: shell
-
+          # Install uv if you haven't already
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          
           # Create a virtual environment with pip pre-installed (required for SkyPilot)
           uv venv --seed --python 3.10
           source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-          
-          # Install SkyPilot with your chosen cloud providers
-          uv pip install "skypilot[kubernetes,aws,gcp]"
-          
-          # Azure CLI has an issue with uv, and requires '--prerelease allow'.
-          uv pip install --prerelease allow azure-cli
-          uv pip install "skypilot[azure]"
 
         .. note::
           
           The ``--seed`` flag is **required** as it ensures ``pip`` is installed in the virtual environment. 
           SkyPilot needs ``pip`` to build wheels for remote cluster setup.
 
-    .. tab-item:: uv tool
-        :sync: uv-tool-tab
+    .. tab-item:: venv
+        :sync: venv-env
 
         .. code-block:: shell
 
-          # Install as a globally available tool with pip included
-          uv tool install --with pip "skypilot[aws,gcp]"
-          
-          # Or with all cloud providers
-          uv tool install --with pip "skypilot[all]"
-          
-          # Now you can use sky directly
-          sky check
+          # Create a virtual environment
+          python3 -m venv sky-env
+          source sky-env/bin/activate  # On Windows: sky-env\Scripts\activate
 
-        .. note::
-          
-          The ``--with pip`` flag is **required** when using ``uv tool install``. 
-          Without it, SkyPilot will fail when building wheels for remote clusters.
+    .. tab-item:: conda
+        :sync: conda-env
+
+        .. code-block:: shell
+
+          # Create a new conda environment
+          conda create -y -n sky python=3.10
+          conda activate sky
+
+Install SkyPilot
+----------------
+
+After setting up your environment, install SkyPilot:
+
+.. tab-set::
+
+    .. tab-item:: pip / venv / conda
+        :sync: venv-env conda-env
+
+        .. tab-set::
+
+            .. tab-item:: Latest Release
+
+                .. code-block:: shell
+
+                  # Choose your infra:
+                  pip install "skypilot[kubernetes]"
+                  pip install "skypilot[aws]"
+                  pip install "skypilot[gcp]"
+                  pip install "skypilot[azure]"
+                  pip install "skypilot[oci]"
+                  pip install "skypilot[nebius]"
+                  pip install "skypilot[lambda]"
+                  pip install "skypilot[runpod]"
+                  pip install "skypilot[fluidstack]"
+                  pip install "skypilot[paperspace]"
+                  pip install "skypilot[cudo]"
+                  # IBM is only supported for Python <= 3.11
+                  pip install "skypilot[ibm]"
+                  # SCP is only supported for Python <= 3.11
+                  pip install "skypilot[scp]"
+                  pip install "skypilot[vsphere]"
+                  # Nebius is only supported for Python >= 3.10
+
+                  pip install "skypilot[all]"
+
+            .. tab-item:: Nightly
+
+                .. code-block:: shell
+
+                  # Choose your infra:
+                  pip install "skypilot-nightly[kubernetes]"
+                  pip install "skypilot-nightly[aws]"
+                  pip install "skypilot-nightly[gcp]"
+                  pip install "skypilot-nightly[azure]"
+                  pip install "skypilot-nightly[oci]"
+                  pip install "skypilot-nightly[nebius]"
+                  pip install "skypilot-nightly[lambda]"
+                  pip install "skypilot-nightly[runpod]"
+                  pip install "skypilot-nightly[fluidstack]"
+                  pip install "skypilot-nightly[paperspace]"
+                  pip install "skypilot-nightly[do]"
+                  pip install "skypilot-nightly[cudo]"
+                  pip install "skypilot-nightly[ibm]"
+                  pip install "skypilot-nightly[scp]"
+                  pip install "skypilot-nightly[vsphere]"
+                  pip install "skypilot-nightly[all]"
+
+            .. tab-item:: From Source
+
+                .. code-block:: shell
+
+                  git clone https://github.com/skypilot-org/skypilot.git
+                  cd skypilot
+
+                  # Choose your infra:
+                  pip install -e ".[kubernetes]"
+                  pip install -e ".[aws]"
+                  pip install -e ".[gcp]"
+                  pip install -e ".[azure]"
+                  pip install -e ".[oci]"
+                  pip install -e ".[nebius]"
+                  pip install -e ".[lambda]"
+                  pip install -e ".[runpod]"
+                  pip install -e ".[fluidstack]"
+                  pip install -e ".[paperspace]"
+                  pip install -e ".[cudo]"
+                  pip install -e ".[ibm]"
+                  pip install -e ".[scp]"
+                  pip install -e ".[vsphere]"
+                  pip install -e ".[all]"
+
+    .. tab-item:: uv
+        :sync: uv-env
+
+        .. tab-set::
+
+            .. tab-item:: Latest Release
+
+                .. code-block:: shell
+
+                  # Choose your infra:
+                  uv pip install "skypilot[kubernetes]"
+                  uv pip install "skypilot[aws]"
+                  uv pip install "skypilot[gcp]"
+                  # Azure CLI requires '--prerelease allow' with uv
+                  uv pip install --prerelease allow azure-cli
+                  uv pip install "skypilot[azure]"
+                  uv pip install "skypilot[oci]"
+                  uv pip install "skypilot[nebius]"
+                  uv pip install "skypilot[lambda]"
+                  uv pip install "skypilot[runpod]"
+                  uv pip install "skypilot[fluidstack]"
+                  uv pip install "skypilot[paperspace]"
+                  uv pip install "skypilot[cudo]"
+                  # IBM is only supported for Python <= 3.11
+                  uv pip install "skypilot[ibm]"
+                  # SCP is only supported for Python <= 3.11
+                  uv pip install "skypilot[scp]"
+                  uv pip install "skypilot[vsphere]"
+                  # Nebius is only supported for Python >= 3.10
+
+                  uv pip install "skypilot[all]"
+
+            .. tab-item:: Nightly
+
+                .. code-block:: shell
+
+                  # Choose your infra:
+                  uv pip install "skypilot-nightly[kubernetes]"
+                  uv pip install "skypilot-nightly[aws]"
+                  uv pip install "skypilot-nightly[gcp]"
+                  # Azure CLI requires '--prerelease allow' with uv
+                  uv pip install --prerelease allow azure-cli
+                  uv pip install "skypilot-nightly[azure]"
+                  uv pip install "skypilot-nightly[oci]"
+                  uv pip install "skypilot-nightly[nebius]"
+                  uv pip install "skypilot-nightly[lambda]"
+                  uv pip install "skypilot-nightly[runpod]"
+                  uv pip install "skypilot-nightly[fluidstack]"
+                  uv pip install "skypilot-nightly[paperspace]"
+                  uv pip install "skypilot-nightly[do]"
+                  uv pip install "skypilot-nightly[cudo]"
+                  uv pip install "skypilot-nightly[ibm]"
+                  uv pip install "skypilot-nightly[scp]"
+                  uv pip install "skypilot-nightly[vsphere]"
+                  uv pip install "skypilot-nightly[all]"
+
+            .. tab-item:: From Source
+
+                .. code-block:: shell
+
+                  git clone https://github.com/skypilot-org/skypilot.git
+                  cd skypilot
+
+                  # Choose your infra:
+                  uv pip install -e ".[kubernetes]"
+                  uv pip install -e ".[aws]"
+                  uv pip install -e ".[gcp]"
+                  # Azure CLI requires '--prerelease allow' with uv
+                  uv pip install --prerelease allow azure-cli
+                  uv pip install -e ".[azure]"
+                  uv pip install -e ".[oci]"
+                  uv pip install -e ".[nebius]"
+                  uv pip install -e ".[lambda]"
+                  uv pip install -e ".[runpod]"
+                  uv pip install -e ".[fluidstack]"
+                  uv pip install -e ".[paperspace]"
+                  uv pip install -e ".[cudo]"
+                  uv pip install -e ".[ibm]"
+                  uv pip install -e ".[scp]"
+                  uv pip install -e ".[vsphere]"
+                  uv pip install -e ".[all]"
+
+To use more than one cloud, combine the pip extras:
+
+.. tab-set::
+
+    .. tab-item:: pip / venv / conda
+        :sync: venv-env conda-env
+
+        .. tab-set::
+
+            .. tab-item:: Latest Release
+
+                .. code-block:: shell
+
+                  pip install -U "skypilot[kubernetes,aws,gcp]"
+
+            .. tab-item:: Nightly
+
+                .. code-block:: shell
+
+                  pip install -U "skypilot-nightly[kubernetes,aws,gcp]"
+
+            .. tab-item:: From Source
+
+                .. code-block:: shell
+
+                  pip install -e ".[kubernetes,aws,gcp]"
+
+    .. tab-item:: uv
+        :sync: uv-env
+
+        .. tab-set::
+
+            .. tab-item:: Latest Release
+
+                .. code-block:: shell
+
+                  uv pip install "skypilot[kubernetes,aws,gcp]"
+
+            .. tab-item:: Nightly
+
+                .. code-block:: shell
+
+                  uv pip install "skypilot-nightly[kubernetes,aws,gcp]"
+
+            .. tab-item:: From Source
+
+                .. code-block:: shell
+
+                  uv pip install -e ".[kubernetes,aws,gcp]"
 
 
-Alternatively, we also provide a :ref:`Docker image <docker-image>` as a quick way to try out SkyPilot.
+Alternative installation methods
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**uv tool (global installation)**: You can install SkyPilot globally without creating a virtual environment:
+
+.. code-block:: shell
+
+  # Install as a globally available tool with pip included
+  uv tool install --with pip "skypilot[aws,gcp]"
+  
+  # Now you can use sky directly
+  sky check
+
+.. note::
+  
+  The ``--with pip`` flag is **required** when using ``uv tool install``. 
+  Without it, SkyPilot will fail when building wheels for remote clusters.
+
+**Docker**: We also provide a :ref:`Docker image <docker-image>` as a quick way to try out SkyPilot.
 
 .. note::
 
@@ -319,7 +423,7 @@ GCP
     Here some commonly encountered errors and their fixes:
 
     * ``RemoveError: 'requests' is a dependency of conda and cannot be removed from conda's operating environment`` when running :code:`conda install -c conda-forge google-cloud-sdk` --- run :code:`conda update --force conda` first and rerun the command.
-    * ``Authorization Error (Error 400: invalid_request)`` with the url generated by :code:`gcloud auth login` --- install the latest version of the `Google Cloud SDK <https://cloud.google.com/sdk/docs/install>`_ (e.g., with :code:`conda install -c conda-forge google-cloud-sdk`) on your local machine (which opened the browser) and rerun the command.
+    * ``Authorization Error (Error 400: invalid_request)`` with the url generated by :code:`gcloud auth login` --- install the latest version of the `Google Cloud SDK <https://cloud.google.com/sdk/docs/install>`__ (e.g., with :code:`conda install -c conda-forge google-cloud-sdk`) on your local machine (which opened the browser) and rerun the command.
 
 **Optional**: To create and use a long-lived service account on your local machine, see :ref:`here<gcp-service-account>`.
 
@@ -360,7 +464,7 @@ To use `Nebius Managed Kubernetes <https://nebius.com/services/managed-kubernete
 
   nebius mk8s cluster get-credentials --id <cluster_id> --external --kubeconfig $HOME/.kube/config
 
-Nebius also offers `Object Storage <https://nebius.com/services/storage>`_, an S3-compatible object storage without any egress charges.
+Nebius also offers `Object Storage <https://nebius.com/services/storage>`__, an S3-compatible object storage without any egress charges.
 SkyPilot can download/upload data to Nebius buckets and mount them as local filesystem on clusters launched by SkyPilot. To set up Nebius support, run:
 
 .. code-block:: shell


### PR DESCRIPTION
Motivated by #7073 which enabled native uv support in SkyPilot.

This PR reorganizes the installation documentation to improve user experience:

## Changes
1. **Environment setup comes first**: Users now choose their environment tool (uv/venv/conda) before seeing installation commands
2. **Native uv support highlighted**: uv is now the first option, reflecting the native support added in #7073
3. **Consistent command presentation**: Installation commands now match the chosen environment tool (e.g., `uv pip install` for uv users)
4. **Reduced redundancy**: Removed duplicate environment creation steps from each installation method

## Structure
The new flow is:
1. Choose and create environment (uv → venv → conda)
2. Install SkyPilot with commands appropriate to your environment
3. Optional: Alternative installation methods (uv tool, Docker)

This makes the installation process more intuitive, especially for users adopting uv as their package manager.

Tested (run the relevant ones):
- [x] Code formatting: `bash format.sh`
- [x] Documentation builds correctly