### PR TITLE
[test] retry event loop lag tests

### DIFF
--- a/tests/test_ssh_proxy_lag.py
+++ b/tests/test_ssh_proxy_lag.py
@@ -230,8 +230,8 @@ async def run_endpoint_test(
             test_tasks.append(task)
 
         results = await asyncio.gather(*test_tasks,
-                                    ssh_task,
-                                    return_exceptions=True)
+                                       ssh_task,
+                                       return_exceptions=True)
         for result in results:
             if isinstance(result, Exception):
                 raise result
@@ -244,7 +244,8 @@ async def run_endpoint_test(
         # Report results
         status = "❌ BLOCKING" if degradation > expected_degradation_threshold else "✅ OK"
         print(
-            f"   Latency: {avg_latency*1000:.1f}ms ({degradation:.1f}x) - {status}")
+            f"   Latency: {avg_latency*1000:.1f}ms ({degradation:.1f}x) - {status}"
+        )
 
         blocking = degradation > expected_degradation_threshold
         if not blocking:

--- a/tests/test_ssh_proxy_lag.py
+++ b/tests/test_ssh_proxy_lag.py
@@ -221,34 +221,39 @@ async def run_endpoint_test(
 
     monitor.clear()
 
-    # Run concurrent requests while monitoring SSH
-    ssh_task = asyncio.create_task(monitor.monitor_during_operation())
-    test_tasks = []
-    for _ in range(num_concurrent):
-        task = asyncio.create_task(endpoint_func())
-        test_tasks.append(task)
+    for _ in range(3):
+        # Run concurrent requests while monitoring SSH
+        ssh_task = asyncio.create_task(monitor.monitor_during_operation())
+        test_tasks = []
+        for _ in range(num_concurrent):
+            task = asyncio.create_task(endpoint_func())
+            test_tasks.append(task)
 
-    results = await asyncio.gather(*test_tasks,
-                                   ssh_task,
-                                   return_exceptions=True)
-    for result in results:
-        if isinstance(result, Exception):
-            raise result
+        results = await asyncio.gather(*test_tasks,
+                                    ssh_task,
+                                    return_exceptions=True)
+        for result in results:
+            if isinstance(result, Exception):
+                raise result
 
-    # Calculate results
-    avg_latency = sum(monitor.latencies) / len(
-        monitor.latencies) if monitor.latencies else 0
-    degradation = monitor.get_degradation(avg_latency)
+        # Calculate results
+        avg_latency = sum(monitor.latencies) / len(
+            monitor.latencies) if monitor.latencies else 0
+        degradation = monitor.get_degradation(avg_latency)
 
-    # Report results
-    status = "❌ BLOCKING" if degradation > expected_degradation_threshold else "✅ OK"
-    print(
-        f"   Latency: {avg_latency*1000:.1f}ms ({degradation:.1f}x) - {status}")
+        # Report results
+        status = "❌ BLOCKING" if degradation > expected_degradation_threshold else "✅ OK"
+        print(
+            f"   Latency: {avg_latency*1000:.1f}ms ({degradation:.1f}x) - {status}")
+
+        blocking = degradation > expected_degradation_threshold
+        if not blocking:
+            break
 
     return {
         'latency': avg_latency,
         'degradation': degradation,
-        'blocking': degradation > expected_degradation_threshold
+        'blocking': blocking
     }
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
tests that are based on empirical performance are always flaky. Add some retries on event loop lag tests to only flag endpoints that are consistently laggy.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
