### PR TITLE
[Catalog] Add method to download catalog from custom url

### DIFF
--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -162,11 +162,10 @@ class LazyDataFrame:
         self._load_df()[key] = value
 
 
-def _update_catalog(
-        filename: str,
-        url: str,
-        url_fallback: Optional[str] = None,
-        pull_frequency_hours: Optional[int] = None) -> bool:
+def _update_catalog(filename: str,
+                    url: str,
+                    url_fallback: Optional[str] = None,
+                    pull_frequency_hours: Optional[int] = None) -> bool:
 
     catalog_path = get_catalog_path(filename)
     cloud = os.path.dirname(filename)
@@ -202,8 +201,7 @@ def _update_catalog(
         headers = {'User-Agent': 'SkyPilot/0.7'}
         update_frequency_str = ''
         if pull_frequency_hours is not None:
-            update_frequency_str = (
-                f' (every {pull_frequency_hours} hours)')
+            update_frequency_str = (f' (every {pull_frequency_hours} hours)')
         with rich_utils.safe_status(
                 ux_utils.spinner_message(
                     f'Updating {cloud} catalog: {filename}') +
@@ -220,13 +218,12 @@ def _update_catalog(
             except requests.exceptions.RequestException as e:
                 error_str = (f'Failed to fetch {cloud} catalog {filename}. ')
                 if os.path.exists(catalog_path):
-                    logger.warning(
-                        f'{error_str}Using cached catalog files.')
+                    logger.warning(f'{error_str}Using cached catalog files.')
                     # Update catalog file modification time.
                     os.utime(catalog_path, None)  # Sets to current time
                 else:
                     logger.error(f'{error_str}Please check your internet '
-                                    'connection.')
+                                 'connection.')
                     with ux_utils.print_exception_no_traceback():
                         raise e
             else:
@@ -260,16 +257,18 @@ def read_catalog(filename: str,
     url_fallback = f'{constants.HOSTED_CATALOG_DIR_URL_S3_MIRROR}/{constants.CATALOG_SCHEMA_VERSION}/{filename}'  # pylint: disable=line-too-long
 
     def update_catalog_wrapper():
-        return _update_catalog(
-            filename=filename,
-            url=url,
-            url_fallback=url_fallback,
-            pull_frequency_hours=pull_frequency_hours)
+        return _update_catalog(filename=filename,
+                               url=url,
+                               url_fallback=url_fallback,
+                               pull_frequency_hours=pull_frequency_hours)
 
-    return LazyDataFrame(catalog_path, update_if_stale_func=update_catalog_wrapper)
+    return LazyDataFrame(catalog_path,
+                         update_if_stale_func=update_catalog_wrapper)
 
 
-def read_catalog_from_url(filename: str, url: str, pull_frequency_hours: Optional[int] = None):
+def read_catalog_from_url(filename: str,
+                          url: str,
+                          pull_frequency_hours: Optional[int] = None):
     """Reads the catalog from a local CSV file. Development purposes only.
 
     If the file does not exist, download the up-to-date catalog from the
@@ -284,12 +283,12 @@ def read_catalog_from_url(filename: str, url: str, pull_frequency_hours: Optiona
     catalog_path = get_catalog_path(filename)
 
     def update_catalog_wrapper():
-        return _update_catalog(
-            filename=filename,
-            url=url,
-            pull_frequency_hours=pull_frequency_hours)
+        return _update_catalog(filename=filename,
+                               url=url,
+                               pull_frequency_hours=pull_frequency_hours)
 
-    return LazyDataFrame(catalog_path, update_if_stale_func=update_catalog_wrapper) 
+    return LazyDataFrame(catalog_path,
+                         update_if_stale_func=update_catalog_wrapper)
 
 
 def _get_instance_type(

--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -275,6 +275,11 @@ def read_catalog_from_url(filename: str,
     a csv file that doesn't match with the current catalog. This function
     is designed to be used by cloud providers adding their cloud to SkyPilot
     to allow testing before the catalog is merged into `skypilot-catalog`.
+
+    Recommendations:
+        filename: pass in the exact same value to be passed to `read_catalog`.
+            Refer to other cloud implementations for an idea.
+        pull_frequency_hours: just set to None.
     """
     assert filename.endswith('.csv'), 'The catalog file must be a CSV file.'
     assert (pull_frequency_hours is None or

--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -248,10 +248,10 @@ def read_catalog(filename: str,
     # https://github.com/skypilot-org/skypilot/issues/5438 for details.
     url_fallback = f'{constants.HOSTED_CATALOG_DIR_URL_S3_MIRROR}/{constants.CATALOG_SCHEMA_VERSION}/{filename}'  # pylint: disable=line-too-long
 
-    return read_catalog_from_url(filename,
-                                 url,
-                                 url_fallback,
-                                 pull_frequency_hours)
+    return read_catalog_from_url(filename=filename,
+                                 url=url,
+                                 url_fallback=url_fallback,
+                                 pull_frequency_hours=pull_frequency_hours)
 
 
 def read_catalog_from_url(filename: str,

--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -166,7 +166,6 @@ def _update_catalog(filename: str,
                     url: str,
                     url_fallback: Optional[str] = None,
                     pull_frequency_hours: Optional[int] = None) -> bool:
-
     catalog_path = get_catalog_path(filename)
     cloud = os.path.dirname(filename)
     if cloud != 'common':

--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -208,10 +208,6 @@ def _update_catalog(filename: str,
             try:
                 r = requests.get(url=url, headers=headers)
                 if r.status_code == 429 and url_fallback is not None:
-                    # fallback to s3 mirror, github introduced rate
-                    # limit after 2025-05, see
-                    # https://github.com/skypilot-org/skypilot/issues/5438
-                    # for more details
                     r = requests.get(url=url_fallback, headers=headers)
                 r.raise_for_status()
             except requests.exceptions.RequestException as e:
@@ -253,6 +249,8 @@ def read_catalog(filename: str,
     catalog_path = get_catalog_path(filename)
 
     url = f'{constants.HOSTED_CATALOG_DIR_URL}/{constants.CATALOG_SCHEMA_VERSION}/{filename}'  # pylint: disable=line-too-long
+    # fallback to s3 mirror, github introduced rate limit after 2025-05, see
+    # https://github.com/skypilot-org/skypilot/issues/5438 for details.
     url_fallback = f'{constants.HOSTED_CATALOG_DIR_URL_S3_MIRROR}/{constants.CATALOG_SCHEMA_VERSION}/{filename}'  # pylint: disable=line-too-long
 
     def update_catalog_wrapper():


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolves #7106.

Intended use:

Before:
```
_df = common.read_catalog('<cloud>/vms.csv')
```

After:
```
_df = common.read_catalog_from_url('<cloud>/vms.csv`, 'https://your-domain.com/static/your-csv.csv')
```

Note that this is ONLY FOR ADDING NEW CLOUDS. This should give users an easy way to go test their implementations before the catalog is officially merged to `skypilot-catalog` (also gives them an opportunity to see if their catalog csv file is actually proper too).

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
