### PR TITLE
[AWS] Fix catalog wrt p4de instances

### DIFF
--- a/sky/catalog/data_fetchers/fetch_aws.py
+++ b/sky/catalog/data_fetchers/fetch_aws.py
@@ -206,7 +206,7 @@ def _get_spot_pricing_table(region: str) -> 'pd.DataFrame':
         ret = ret + response['SpotPriceHistory']
     df = pd.DataFrame(ret)[['InstanceType', 'AvailabilityZone', 'SpotPrice']]
     df = df.rename(columns={'AvailabilityZone': 'AvailabilityZoneName'})
-    df = df.set_index(['InstanceType', 'AvailabilityZoneName'])    
+    df = df.set_index(['InstanceType', 'AvailabilityZoneName'])
     return df
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Not sure what the context is, but p4de instances are now sometimes returned by AWS, so _patch_p4de needs to check if an instance was returned for that AvailabilityZone.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

I manually ran `fetch_aws.py` and diffed it against the published catalog on github. See snippet: https://www.diffchecker.com/4DQ9R4pD

As you can see, there are no repeats of `use1-az4` for example.

<!-- CI commands (/-prefixed) can only be triggered by repo members -->

Closes https://github.com/skypilot-org/skypilot/issues/7091