### PR TITLE
docs: fix default Nebius API domain

### DIFF
--- a/docs/source/admin/workspaces.rst
+++ b/docs/source/admin/workspaces.rst
@@ -85,7 +85,7 @@ The above is achieved by configuring the following section in the config file:
              disabled: false
              tenant_id: Nebius tenant ID (tenant-xxxxxxxx)
              credentials_file_path: ~/.nebius/credentials-file-name.json
-             domain: api.nebius.com:443
+             domain: api.nebius.cloud:443
 
 To apply the configuration, follow the following steps:
 

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -170,7 +170,7 @@ Below is the configuration syntax and some example values. See detailed explanat
     :ref:`use_static_ip_address <config-yaml-nebius-use-static-ip-address>`: true
     :ref:`ssh_proxy_command <config-yaml-nebius-ssh-proxy-command>`: ssh -W %h:%p user@host
     :ref:`tenant_id <config-yaml-nebius-tenant-id>`: tenant-1234567890
-    :ref:`domain <config-yaml-nebius-domain>`: api.nebius.com:443
+    :ref:`domain <config-yaml-nebius-domain>`: api.nebius.cloud:443
 
   :ref:`rbac <config-yaml-rbac>`:
     :ref:`default_role <config-yaml-rbac-default-role>`: admin
@@ -1493,7 +1493,7 @@ Example:
 .. code-block:: yaml
 
   nebius:
-    domain: api.nebius.com:443
+    domain: api.nebius.cloud:443
 
 
 .. _config-yaml-rbac:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Just noticed that I used wrong default API domain for Nebius, changing it to the correct one to make less noise.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
