### PR TITLE
Fix env file shared API server smoke tests failures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -759,4 +759,6 @@ def prepare_env_file(request):
 
     logger.info(f'Using env file: {local_file_path}')
     os.environ['PYTEST_SKYPILOT_CONFIG_FILE_OVERRIDE'] = local_file_path
+    if has_api_server:
+        os.environ['PYTEST_SKYPILOT_REMOTE_SERVER_TEST'] = '1'
     yield local_file_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import socket
 import subprocess
 import tempfile
 import time
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import filelock
 import pytest
@@ -280,6 +280,9 @@ def pytest_collection_modifyitems(config, items):
     generic_cloud = _generic_cloud(config)
     generic_cloud_keyword = cloud_to_pytest_keyword[generic_cloud]
 
+    # Check if we need to dynamically add no_remote_server mark
+    should_add_no_remote_server_mark = _should_add_no_remote_server_mark(config)
+
     for item in items:
         if 'smoke_tests' not in item.location[0]:
             # Only mark smoke test cases
@@ -319,6 +322,12 @@ def pytest_collection_modifyitems(config, items):
         if 'resource_heavy' not in marks and config.getoption(
                 '--resource-heavy'):
             item.add_marker(skip_marks['resource_heavy'])
+        # Dynamically add no_remote_server mark if api_server is configured in env file
+        if should_add_no_remote_server_mark:
+            item.add_marker(pytest.mark.no_remote_server)
+            marks.append(
+                'no_remote_server')  # Update marks list for subsequent checks
+
         # Skip tests marked as no_remote_server if --remote-server is set
         if 'no_remote_server' in marks and config.getoption('--remote-server'):
             item.add_marker(skip_marks['no_remote_server'])
@@ -367,6 +376,70 @@ def _generic_cloud(config) -> str:
     if generic_cloud_option is not None:
         return generic_cloud_option
     return _get_cloud_to_run(config)[0]
+
+
+@common_utils.lru_cache(maxsize=1)
+def _get_and_check_env_file(env_file_path: str) -> Tuple[bool, Optional[str]]:
+    """Download/get env file and check if it contains api_server configuration.
+
+    Returns:
+        tuple: (has_api_server_config, local_file_path)
+    """
+    assert isinstance(
+        env_file_path,
+        str), f'env_file_path must be a string, got {type(env_file_path)}'
+
+    # Check if it's a local file or directory (same logic as prepare_env_file)
+    expanded_path = os.path.expanduser(env_file_path)
+    if os.path.exists(expanded_path):
+        # It's a local file
+        local_file_path = expanded_path
+    else:
+        # It's a cloud storage URL - download it (same logic as prepare_env_file)
+        logger.info(
+            f'Downloading env file from cloud storage for collection: {env_file_path}'
+        )
+
+        # Create temporary directory for downloaded files
+        temp_dir = tempfile.mkdtemp(prefix='skypilot_env_collection_')
+
+        # Get the appropriate CloudStorage handler for the URL
+        cloud_storage = cloud_stores.get_storage_from_path(env_file_path)
+
+        # Generate the download command - assert it's a file
+        assert not cloud_storage.is_directory(env_file_path), (
+            f'Expected file but got directory: {env_file_path}')
+        download_cmd = cloud_storage.make_sync_file_command(
+            env_file_path, temp_dir)
+
+        # Execute the download command
+        subprocess.run(download_cmd, shell=True, check=True)
+
+        # Get the filename from the original URL
+        file_name = os.path.basename(env_file_path)
+        local_file_path = os.path.join(temp_dir, file_name)
+
+    # Check if the file contains api_server configuration
+    with open(local_file_path, 'r') as f:
+        content = f.read()
+        has_api_server = 'endpoint' in content and ('api_server' in content)
+
+    return has_api_server, local_file_path
+
+
+def _should_add_no_remote_server_mark(config) -> bool:
+    """Check if we should dynamically add no_remote_server mark to tests.
+
+    Returns True if --env-file option is set and the config file contains
+    api_server configuration.
+    """
+    # Get the --env-file option directly from pytest config during collection
+    env_file_path = config.getoption('--env-file')
+    if env_file_path is None:
+        return False
+
+    has_api_server, _ = _get_and_check_env_file(env_file_path)
+    return has_api_server
 
 
 @pytest.fixture
@@ -680,46 +753,10 @@ def prepare_env_file(request):
         yield
         return
 
-    # Check if it's a local file or directory
-    expanded_path = os.path.expanduser(env_file_path)
-    if os.path.exists(expanded_path):
-        # It's a local file/directory, use it directly
-        logger.info(f'Using local env file: {expanded_path}')
-        os.environ['PYTEST_SKYPILOT_CONFIG_FILE_OVERRIDE'] = expanded_path
-        yield expanded_path
-        return
+    # Use the cached function to get/download the env file
+    # This avoids duplicate downloads if collection phase already downloaded it
+    has_api_server, local_file_path = _get_and_check_env_file(env_file_path)
 
-    # Not a local file, treat as cloud storage URL (e.g., s3://bucket/path)
-
-    logger.info(
-        f'Attempting to download env file from cloud storage: {env_file_path}')
-
-    # Create temporary directory for downloaded files
-    temp_dir = tempfile.mkdtemp(prefix='skypilot_env_')
-
-    try:
-        # Get the appropriate CloudStorage handler for the URL
-        cloud_storage = cloud_stores.get_storage_from_path(env_file_path)
-
-        # Generate the download command - assert it's a file
-        assert not cloud_storage.is_directory(env_file_path), (
-            f'Expected file but got directory: {env_file_path}')
-        download_cmd = cloud_storage.make_sync_file_command(
-            env_file_path, temp_dir)
-
-        logger.info(f'Executing download command: {download_cmd}')
-
-        # Execute the download command
-        subprocess.run(download_cmd, shell=True, check=True)
-
-        # Get the filename from the original URL
-        file_name = os.path.basename(env_file_path)
-        file_path = os.path.join(temp_dir, file_name)
-
-        logger.info(f'Downloaded env file to: {file_path}')
-        os.environ['PYTEST_SKYPILOT_CONFIG_FILE_OVERRIDE'] = file_path
-        yield file_path
-    finally:
-        # Clean up temporary directory
-        if os.path.exists(temp_dir):
-            shutil.rmtree(temp_dir, ignore_errors=True)
+    logger.info(f'Using env file: {local_file_path}')
+    os.environ['PYTEST_SKYPILOT_CONFIG_FILE_OVERRIDE'] = local_file_path
+    yield local_file_path

--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -781,9 +781,8 @@ def increase_initial_delay_seconds_for_slow_cloud(cloud: str):
 
 
 def is_remote_server_test() -> bool:
-    return os.environ.get(
-        'PYTEST_SKYPILOT_REMOTE_SERVER_TEST',
-        None) is not None or api_server_endpoint_configured_in_env_file()
+    return os.environ.get('PYTEST_SKYPILOT_REMOTE_SERVER_TEST',
+                          None) is not None
 
 
 def pytest_controller_cloud() -> Optional[str]:
@@ -800,15 +799,6 @@ def is_grpc_enabled_test() -> bool:
 
 def pytest_config_file_override() -> Optional[str]:
     return os.environ.get('PYTEST_SKYPILOT_CONFIG_FILE_OVERRIDE', None)
-
-
-def api_server_endpoint_configured_in_env_file() -> bool:
-    file_path = pytest_config_file_override()
-    if file_path is not None:
-        with open(file_path, 'r') as f:
-            content = f.read()
-            return 'endpoint' in content
-    return False
 
 
 def services_account_token_configured_in_env_file() -> bool:
@@ -830,12 +820,13 @@ def pytest_override_env_config_file(config: Dict[str, str]):
 def get_api_server_url() -> str:
     """Get the API server URL in the test environment."""
     if is_remote_server_test():
-        if api_server_endpoint_configured_in_env_file():
-            config_file = pytest_config_file_override()
-            config = skypilot_config.parse_and_validate_config_file(config_file)
-            return config.get_nested(('api_server', 'endpoint'), 'UNKNOWN')
-        else:
-            return docker_utils.get_api_server_endpoint_inside_docker()
+        file_path = pytest_config_file_override()
+        if file_path is not None:
+            config = skypilot_config.parse_and_validate_config_file(file_path)
+            endpoint = config.get_nested(('api_server', 'endpoint'), None)
+            if endpoint is not None:
+                return endpoint
+        return docker_utils.get_api_server_endpoint_inside_docker()
     return server_common.get_server_url()
 
 

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -433,9 +433,7 @@ def test_multi_echo(generic_cloud: str):
     if generic_cloud == 'kubernetes':
         # EKS does not support spot instances
         # Assume tests using a remote api server endpoint do not support spot instances
-        use_spot = not smoke_tests_utils.is_eks_cluster(
-        ) and not smoke_tests_utils.api_server_endpoint_configured_in_env_file(
-        )
+        use_spot = not smoke_tests_utils.is_eks_cluster()
         accelerator = smoke_tests_utils.get_avaliabe_gpus_for_k8s_tests()
     test = smoke_tests_utils.Test(
         'multi_echo',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

* If  `api_server` specific in `--env-file`, pytest collection should skip those mark as `--no-remote-server` tests. We fetch the env file ahead in pytest collection phrase in this PR.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
