### PR TITLE
Tune short worker memory estimation

### DIFF
--- a/docs/source/reference/api-server/api-server-tunning.rst
+++ b/docs/source/reference/api-server/api-server-tunning.rst
@@ -75,19 +75,19 @@ The following table shows the maximum concurrency for different resource configu
      - Max concurrency
    * - 4
      - 8Gi
-     - 8 Long requests, 11 Short requests
+     - 8 Long requests, 9 Short requests
    * - 16
      - 32Gi
-     - 32 Long requests, 60 Short requests
+     - 32 Long requests, 57 Short requests
    * - 32
      - 64Gi
-     - 64 Long requests, 145 Short requests
+     - 64 Long requests, 121 Short requests
    * - 64
      - 128Gi
-     - 128 Long requests, 299 Short requests
+     - 128 Long requests, 249 Short requests
    * - 128
      - 256Gi
-     - 256 Long requests, 589 Short requests
+     - 256 Long requests, 505 Short requests
 
 Use asynchronous requests to avoid blocking
 -------------------------------------------


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

New estimation from our load test:

```bash
python tests/load_tests/workload_benchmark.py -t 8 -r 10 -s workloads/basic.sh --cloud kubernetes
```

Despite the outlier (status refresh daemon, which is tracked by other issues), the max stable RSS of each short worker is now about 300MB, this PR update the estimation in code accordingly.

<img width="1903" height="777" alt="image" src="https://github.com/user-attachments/assets/741e0e61-3f22-4998-b1d8-b248a43b01f1" />

Also, this PR update the min short workers to make sure there are always idle short workers.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
