### PR TITLE
[Dashboard] show infra for workspaces

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -215,9 +215,10 @@ export function InfrastructureSection({
 
                       // Get workspace information for this context
                       const workspaces = contextWorkspaceMap[context] || [];
-                      const workspaceDisplay = workspaces.length > 0 
-                        ? ` (${workspaces.join(', ')})` 
-                        : '';
+                      const workspaceDisplay =
+                        workspaces.length > 0
+                          ? ` (${workspaces.join(', ')})`
+                          : '';
 
                       return (
                         <tr key={context} className="hover:bg-gray-50">
@@ -279,9 +280,15 @@ export function InfrastructureSection({
                                 <CircularProgress size={16} />
                               </div>
                             ) : (
-                              <span 
-                                className={nodes.length === 0 ? 'text-gray-400' : ''}
-                                title={nodes.length === 0 ? 'Context may be unavailable or timed out' : ''}
+                              <span
+                                className={
+                                  nodes.length === 0 ? 'text-gray-400' : ''
+                                }
+                                title={
+                                  nodes.length === 0
+                                    ? 'Context may be unavailable or timed out'
+                                    : ''
+                                }
                               >
                                 {nodes.length === 0 ? '0*' : nodes.length}
                               </span>
@@ -302,11 +309,21 @@ export function InfrastructureSection({
                                 <CircularProgress size={16} />
                               </div>
                             ) : (
-                              <span 
-                                className={totalGpus === 0 && nodes.length === 0 ? 'text-gray-400' : ''}
-                                title={totalGpus === 0 && nodes.length === 0 ? 'Context may be unavailable or timed out' : ''}
+                              <span
+                                className={
+                                  totalGpus === 0 && nodes.length === 0
+                                    ? 'text-gray-400'
+                                    : ''
+                                }
+                                title={
+                                  totalGpus === 0 && nodes.length === 0
+                                    ? 'Context may be unavailable or timed out'
+                                    : ''
+                                }
                               >
-                                {totalGpus === 0 && nodes.length === 0 ? '0*' : totalGpus}
+                                {totalGpus === 0 && nodes.length === 0
+                                  ? '0*'
+                                  : totalGpus}
                               </span>
                             )}
                           </td>
@@ -1650,7 +1667,7 @@ export function GPUs() {
       const infraData = forceRefresh
         ? await getWorkspaceInfrastructure()
         : await dashboardCache.get(getWorkspaceInfrastructure);
-      
+
       if (infraData) {
         const {
           workspaces: fetchedWorkspaceInfrastructure,
@@ -1669,11 +1686,13 @@ export function GPUs() {
         setPerNodeGPUs(fetchedPerNodeGPUs || []);
         setContextStats(fetchedContextStats || {});
         setContextWorkspaceMap(fetchedContextWorkspaceMap || {});
-        
+
         // Extract available workspaces from the workspace infrastructure data
-        const workspaceNames = Object.keys(fetchedWorkspaceInfrastructure || {});
+        const workspaceNames = Object.keys(
+          fetchedWorkspaceInfrastructure || {}
+        );
         setAvailableWorkspaces(workspaceNames.sort());
-        
+
         setKubeDataLoaded(true);
         setKubeLoading(false);
       } else if (infraData === null) {
@@ -1923,15 +1942,18 @@ export function GPUs() {
   }, [perContextGPUs]);
 
   // Filter contexts based on selected workspace
-  const filterContextsByWorkspace = React.useCallback((contexts) => {
-    if (selectedWorkspace === 'all') {
-      return contexts;
-    }
-    return contexts.filter(context => {
-      const workspaces = contextWorkspaceMap[context] || [];
-      return workspaces.includes(selectedWorkspace);
-    });
-  }, [selectedWorkspace, contextWorkspaceMap]);
+  const filterContextsByWorkspace = React.useCallback(
+    (contexts) => {
+      if (selectedWorkspace === 'all') {
+        return contexts;
+      }
+      return contexts.filter((context) => {
+        const workspaces = contextWorkspaceMap[context] || [];
+        return workspaces.includes(selectedWorkspace);
+      });
+    },
+    [selectedWorkspace, contextWorkspaceMap]
+  );
 
   // Separate SSH contexts from Kubernetes contexts using allKubeContextNames
   const sshContexts = React.useMemo(() => {
@@ -2344,7 +2366,10 @@ export function GPUs() {
           {/* Workspace Selector */}
           {availableWorkspaces.length > 0 && (
             <div className="flex items-center mr-4">
-              <label htmlFor="workspace-selector" className="text-sm font-medium text-gray-700 mr-2">
+              <label
+                htmlFor="workspace-selector"
+                className="text-sm font-medium text-gray-700 mr-2"
+              >
                 Workspace:
               </label>
               <select
@@ -2362,7 +2387,7 @@ export function GPUs() {
               </select>
             </div>
           )}
-          
+
           {isAnyLoading && (
             <div className="flex items-center mr-2">
               <CircularProgress size={15} className="mt-0" />


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR addresses issue https://github.com/skypilot-org/skypilot/issues/7095 where a user who is a member of a workspace (say "team-a") would see no k8s clusters/clouds enabled in the Infra page. 

This PR adds workspace-aware infrastructure fetching and adds a drop-down for users to view infrastructure associated with each of the workspaces they are a part of.


<!-- Describe the tests ran -->
<img width="1466" height="503" alt="Screenshot 2025-09-10 at 5 37 33 PM" src="https://github.com/user-attachments/assets/a7930a2e-bdc1-4644-abff-c9b6a20604e1" />
<img width="1471" height="374" alt="Screenshot 2025-09-10 at 5 37 53 PM" src="https://github.com/user-attachments/assets/cba31705-7830-442d-8830-0a0844dede59" />

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
