### PR TITLE
[Dependency] Fix FastAPI dependency

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -49,7 +49,7 @@ install_requires = [
     # <= 3.13 may encounter https://github.com/ultralytics/yolov5/issues/414
     'pyyaml > 3.13, != 5.4.*',
     'requests',
-    'fastapi',
+    'fastapi >= 0.116.0',
     'uvicorn[standard]',
     # Some pydantic versions are not compatible with ray. Adopted from ray's
     # setup.py:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

FastAPI 0.115.0 is not compatible with `sky api start`. Pinning it to `0.116.0` or larger helps fix it.

```bash
I 09-11 13:13:38 server.py:214] Uvicorn running on http://127.0.0.1:46580 (Press CTRL+C to quit)
E 09-11 13:13:38 httptools_impl.py:406] Exception in ASGI application
E 09-11 13:13:38 httptools_impl.py:406] Traceback (most recent call last):
E 09-11 13:13:38 httptools_impl.py:406]   File "/Users/tianxia/miniconda3/envs/sky/lib/python3.9/site-packages/uvicorn/protocols/http/httptools_impl.py", line 401, in run_asgi
E 09-11 13:13:38 httptools_impl.py:406]     result = await app(  # type: ignore[func-returns-value]
E 09-11 13:13:38 httptools_impl.py:406]   File "/Users/tianxia/miniconda3/envs/sky/lib/python3.9/site-packages/uvicorn/middleware/proxy_headers.py", line 70, in __call__
E 09-11 13:13:38 httptools_impl.py:406]     return await self.app(scope, receive, send)
E 09-11 13:13:38 httptools_impl.py:406]   File "/Users/tianxia/miniconda3/envs/sky/lib/python3.9/site-packages/fastapi/applications.py", line 1054, in __call__
E 09-11 13:13:38 httptools_impl.py:406]     await super().__call__(scope, receive, send)
E 09-11 13:13:38 httptools_impl.py:406]   File "/Users/tianxia/miniconda3/envs/sky/lib/python3.9/site-packages/starlette/applications.py", line 112, in __call__
E 09-11 13:13:38 httptools_impl.py:406]     self.middleware_stack = self.build_middleware_stack()
E 09-11 13:13:38 httptools_impl.py:406]   File "/Users/tianxia/miniconda3/envs/sky/lib/python3.9/site-packages/starlette/applications.py", line 99, in build_middleware_stack
E 09-11 13:13:38 httptools_impl.py:406]     app = cls(app=app, *args, **kwargs)
E 09-11 13:13:38 httptools_impl.py:406] TypeError: __init__() got an unexpected keyword argument 'app'
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
