### PR TITLE
[k8s] scale default cpu / memory numbers based on number of gpus requested

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -841,6 +841,8 @@ class Kubernetes(clouds.Cloud):
                                  from_instance_type(default_instance_type))
 
             gpu_task_cpus = k8s_instance_type.cpus
+            if resources.cpus is None:
+                gpu_task_cpus = gpu_task_cpus * acc_count
             # Special handling to bump up memory multiplier for GPU instances
             gpu_task_memory = (float(resources.memory.strip('+')) if
                                resources.memory is not None else gpu_task_cpus *


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Before:
```
sky launch -c gpgpu --gpus H100_NVLINK_80GB:1
Considered resources (1 node):
-----------------------------------------------------------------------------------------------------
 INFRA                         INSTANCE   vCPUs   Mem(GB)   GPUS                 COST ($)   CHOSEN   
-----------------------------------------------------------------------------------------------------
 Kubernetes (coreweave-prod)   -          2       8         H100_NVLINK_80GB:1   0.00          ✔     
-----------------------------------------------------------------------------------------------------
sky launch -c gpgpu --gpus H100_NVLINK_80GB:2
Considered resources (1 node):
-----------------------------------------------------------------------------------------------------
 INFRA                         INSTANCE   vCPUs   Mem(GB)   GPUS                 COST ($)   CHOSEN   
-----------------------------------------------------------------------------------------------------
 Kubernetes (coreweave-prod)   -          2       8         H100_NVLINK_80GB:1   0.00          ✔     
-----------------------------------------------------------------------------------------------------
sky launch -c gpgpu --gpus H100_NVLINK_80GB:4
Considered resources (1 node):
-----------------------------------------------------------------------------------------------------
 INFRA                         INSTANCE   vCPUs   Mem(GB)   GPUS                 COST ($)   CHOSEN   
-----------------------------------------------------------------------------------------------------
 Kubernetes (coreweave-prod)   -          2       8         H100_NVLINK_80GB:1   0.00          ✔     
-----------------------------------------------------------------------------------------------------
sky launch -c gpgpu --gpus H100_NVLINK_80GB:8
Considered resources (1 node):
-----------------------------------------------------------------------------------------------------
 INFRA                         INSTANCE   vCPUs   Mem(GB)   GPUS                 COST ($)   CHOSEN   
-----------------------------------------------------------------------------------------------------
 Kubernetes (coreweave-prod)   -          2       8         H100_NVLINK_80GB:1   0.00          ✔     
-----------------------------------------------------------------------------------------------------
```

After
```
sky launch -c gpgpu --gpus H100_NVLINK_80GB:1
Considered resources (1 node):
-----------------------------------------------------------------------------------------------------
 INFRA                         INSTANCE   vCPUs   Mem(GB)   GPUS                 COST ($)   CHOSEN   
-----------------------------------------------------------------------------------------------------
 Kubernetes (coreweave-prod)   -          2       8         H100_NVLINK_80GB:1   0.00          ✔     
-----------------------------------------------------------------------------------------------------
sky launch -c gpgpu --gpus H100_NVLINK_80GB:2
Considered resources (1 node):
-----------------------------------------------------------------------------------------------------
 INFRA                         INSTANCE   vCPUs   Mem(GB)   GPUS                 COST ($)   CHOSEN   
-----------------------------------------------------------------------------------------------------
 Kubernetes (coreweave-prod)   -          4       16        H100_NVLINK_80GB:2   0.00          ✔     
-----------------------------------------------------------------------------------------------------
sky launch -c gpgpu --gpus H100_NVLINK_80GB:4
Considered resources (1 node):
-----------------------------------------------------------------------------------------------------
 INFRA                         INSTANCE   vCPUs   Mem(GB)   GPUS                 COST ($)   CHOSEN   
-----------------------------------------------------------------------------------------------------
 Kubernetes (coreweave-prod)   -          8       32        H100_NVLINK_80GB:4   0.00          ✔     
-----------------------------------------------------------------------------------------------------
sky launch -c gpgpu --gpus H100_NVLINK_80GB:8
Considered resources (1 node):
-----------------------------------------------------------------------------------------------------
 INFRA                         INSTANCE   vCPUs   Mem(GB)   GPUS                 COST ($)   CHOSEN   
-----------------------------------------------------------------------------------------------------
 Kubernetes (coreweave-prod)   -          16      64        H100_NVLINK_80GB:8   0.00          ✔     
-----------------------------------------------------------------------------------------------------
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
