### PR TITLE
Fix token authentication for git workdirs

### DIFF
--- a/sky/utils/git.py
+++ b/sky/utils/git.py
@@ -272,7 +272,7 @@ class GitRepo:
                 logger.info(
                     f'Successfully validated repository {https_url} access '
                     'using token authentication')
-                return GitCloneInfo(url=auth_url, token=self.git_token)
+                return GitCloneInfo(url=https_url, token=self.git_token)
             except Exception as e:
                 logger.info(f'Token access failed: {str(e)}')
                 raise exceptions.GitError(
@@ -488,7 +488,10 @@ class GitRepo:
 
         try:
             # Get all remote refs
-            refs = git_cmd.ls_remote(clone_info.url).split('\n')
+            url = clone_info.url
+            if clone_info.token:
+                url = self.get_https_url(with_token=True)
+            refs = git_cmd.ls_remote(url).split('\n')
 
             # Collect all commit hashes from refs
             all_commit_hashes = set()


### PR DESCRIPTION
Previously, when launching using a private git repo as workdir, using `GIT_TOKEN`, validation would succeed, but a user would still get prompted for username and password.

```bash
YAML to run: example_skypilot_yamls/git_private.sky.yaml
# --- get_repo_clone_info ---
D 09-11 14:19:44 git.py:234] Validating access to github.com/kevinmingtarja/test-kevinm
D 09-11 14:19:44 git.py:240] Trying public HTTPS access to https://github.com/kevinmingtarja/test-kevinm.git
D 09-11 14:19:44 git.py:269] Trying token authentication to https://github.com/kevinmingtarja/test-kevinm.git
I 09-11 14:19:45 git.py:272] Successfully validated repository https://github.com/kevinmingtarja/test-kevinm.git access using token authentication
# --- get_ref_type ---
D 09-11 14:19:45 git.py:234] Validating access to github.com/kevinmingtarja/test-kevinm
D 09-11 14:19:45 git.py:240] Trying public HTTPS access to https://github.com/kevinmingtarja/test-kevinm.git
D 09-11 14:19:45 git.py:269] Trying token authentication to https://github.com/kevinmingtarja/test-kevinm.git
I 09-11 14:19:46 git.py:272] Successfully validated repository https://github.com/kevinmingtarja/test-kevinm.git access using token authentication
Username for 'https://github.com':
```

So what is happening is in get_ref_type: https://github.com/skypilot-org/skypilot/blob/50f8acc208a7453333ac4d8fdd663b40984c031c/sky/utils/git.py#L473-L491

We do another `ls_remote(clone_info.url)`, but when using token auth, `clone_info.url` doesn't point to the URL containing the token (`https://{token}@github.com/...`), which is why git is prompting the user for username and password, because it did not see the token.

This PR fixes this by checking if `clone_info.token` is true, if so, call `ls_remote` with `self.get_https_url(with_token=True)`, otherwise use `clone_info.url` as is.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below):
   - Manually tested with a private github repo and `GIT_TOKEN=$(gh auth token)`
