### PR TITLE
best-effort sky status if model validation fails for a cluster

### DIFF
--- a/sky/core.py
+++ b/sky/core.py
@@ -183,8 +183,10 @@ def status(
         try:
             status_responses.append(
                 responses.StatusResponse.model_validate(cluster))
-        except Exception as e:
-            logger.error(f'Failed to validate status responses for cluster {cluster.get("name")}: {e}')
+        except Exception as e: # pylint: disable=broad-except
+            logger.error(
+                f'Failed to validate status responses for cluster {cluster.get("name")}: {e}'
+            )
     return status_responses
 
 

--- a/sky/core.py
+++ b/sky/core.py
@@ -183,10 +183,9 @@ def status(
         try:
             status_responses.append(
                 responses.StatusResponse.model_validate(cluster))
-        except Exception as e: # pylint: disable=broad-except
-            logger.error(
-                f'Failed to validate status responses for cluster {cluster.get("name")}: {e}'
-            )
+        except Exception as e:  # pylint: disable=broad-except
+            logger.error('Failed to validate status responses for cluster '
+                         f'{cluster.get("name")}: {e}')
     return status_responses
 
 

--- a/sky/core.py
+++ b/sky/core.py
@@ -177,9 +177,19 @@ def status(
         cluster_names=cluster_names,
         all_users=all_users,
         include_credentials=include_credentials)
-    return [
-        responses.StatusResponse.model_validate(cluster) for cluster in clusters
-    ]
+
+    status_responses = []
+    exceptions = []
+    for cluster in clusters:
+        try:
+            status_responses.append(
+                responses.StatusResponse.model_validate(cluster))
+        except Exception as e:
+            logger.error(f'Failed to validate status responses for cluster {cluster.name}: {e}')
+            exceptions.append(e)
+    if exceptions:
+        raise exceptions[0]
+    return status_responses
 
 
 def status_kubernetes(

--- a/sky/core.py
+++ b/sky/core.py
@@ -179,16 +179,12 @@ def status(
         include_credentials=include_credentials)
 
     status_responses = []
-    exceptions = []
     for cluster in clusters:
         try:
             status_responses.append(
                 responses.StatusResponse.model_validate(cluster))
         except Exception as e:
-            logger.error(f'Failed to validate status responses for cluster {cluster.name}: {e}')
-            exceptions.append(e)
-    if exceptions:
-        raise exceptions[0]
+            logger.error(f'Failed to validate status responses for cluster {cluster.get("name")}: {e}')
     return status_responses
 
 

--- a/sky/core.py
+++ b/sky/core.py
@@ -184,8 +184,8 @@ def status(
             status_responses.append(
                 responses.StatusResponse.model_validate(cluster))
         except Exception as e:  # pylint: disable=broad-except
-            logger.error('Failed to validate status responses for cluster '
-                         f'{cluster.get("name")}: {e}')
+            logger.warning('Failed to validate status responses for cluster '
+                           f'{cluster.get("name")}: {e}')
     return status_responses
 
 

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -1,8 +1,10 @@
 from unittest import mock
 
+from sky import core
 from sky.backends.cloud_vm_ray_backend import CloudVmRayResourceHandle
-from sky.core import cancel
+from sky.utils import common
 from sky.utils import common_utils
+from sky.utils import status_lib
 
 
 @mock.patch('sky.backends.backend_utils.check_cluster_available')
@@ -11,7 +13,7 @@ def test_cancel_jobs_for_current_user(mock_cancel_jobs,
                                       mock_check_cluster_available) -> None:
     mock_handle = mock.create_autospec(CloudVmRayResourceHandle, instance=True)
     mock_check_cluster_available.return_value = mock_handle
-    cancel('test-cluster', all=True)
+    core.cancel('test-cluster', all=True)
     mock_cancel_jobs.assert_called_once_with(
         mock_handle,
         None,
@@ -26,10 +28,53 @@ def test_cancel_jobs_for_all_users(mock_cancel_jobs,
                                    mock_check_cluster_available) -> None:
     mock_handle = mock.create_autospec(CloudVmRayResourceHandle, instance=True)
     mock_check_cluster_available.return_value = mock_handle
-    cancel('test-cluster', all_users=True)
+    core.cancel('test-cluster', all_users=True)
     mock_cancel_jobs.assert_called_once_with(
         mock_handle,
         None,
         cancel_all=True,
         user_hash=None,
     )
+
+
+@mock.patch(
+    'sky.backends.backend_utils.get_clusters',
+    return_value=[
+        {
+            # properly formatted cluster record
+            'name': 'test-cluster',
+            'launched_at': '0',
+            'handle': None,
+            'last_use': 'sky launch',
+            'status': status_lib.ClusterStatus.UP,
+            'autostop': 0,
+            'to_down': False,
+            'cluster_hash': '00000',
+            'cluster_ever_up': True,
+            'status_updated_at': 0,
+            'user_hash': '00000',
+            'user_name': 'pilot',
+            'workspace': 'default',
+            'is_managed': False,
+            'nodes': 0,
+        },
+        {
+            # cluster record with missing fields
+            'name': 'malformed-cluster',
+        }
+    ])
+def test_status_best_effort(mock_get_clusters) -> None:
+    with mock.patch('sky.core.logger') as mock_logger:
+        core.status()
+    mock_get_clusters.assert_called_once_with(
+        refresh=common.StatusRefreshMode.NONE,
+        cluster_names=None,
+        all_users=False,
+        include_credentials=False,
+    )
+    assert len(core.status()) == 1
+    # Verify logging shows 0 cleaned requests
+    mock_logger.warning.assert_called_once()
+    log_message = mock_logger.warning.call_args[0][0]
+    assert ('Failed to validate status responses for cluster malformed-cluster'
+            in log_message)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
For sky status, if validation fails for a cluster, still return other clusters and emit a log for failed cluster - allowing best effort result.



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
