### PR TITLE
Fixed flaky UT test_backoff_progression

### DIFF
--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -4,6 +4,7 @@ import contextlib
 import functools
 import multiprocessing
 import os
+import threading
 import time
 
 import fastapi
@@ -208,12 +209,12 @@ def time_me_async(func):
     return async_wrapper
 
 
-def process_monitor(process_type: str):
+def process_monitor(process_type: str, stop: threading.Event):
     pid = multiprocessing.current_process().pid
     proc = psutil.Process(pid)
     peak_rss = 0
     last_bucket_end = time.time()
-    while True:
+    while not stop.is_set():
         if time.time() - last_bucket_end >= 30:
             # Reset peak RSS every 30 seconds.
             last_bucket_end = time.time()

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -130,8 +130,9 @@ queue_backend = server_config.QueueBackend.MULTIPROCESSING
 def executor_initializer(proc_group: str):
     setproctitle.setproctitle(f'SkyPilot:executor:{proc_group}:'
                               f'{multiprocessing.current_process().pid}')
+    # Executor never stops, unless the whole process is killed.
     threading.Thread(target=metrics_lib.process_monitor,
-                     args=(f'worker:{proc_group}',),
+                     args=(f'worker:{proc_group}', threading.Event()),
                      daemon=True).start()
 
 

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -220,6 +220,8 @@ def test_server_run_uses_uvloop(mock_asyncio_run, mock_hijack_sys_attrs):
     """Test that Server.run uses uvloop event loop policy."""
     from sky.server.uvicorn import Server
 
+    threads_before = len(threading.enumerate())
+
     config = uvicorn.Config(app='sky.server.server:app',
                             host='127.0.0.1',
                             port=8000)
@@ -250,6 +252,8 @@ def test_server_run_uses_uvloop(mock_asyncio_run, mock_hijack_sys_attrs):
         server_instance.run()
 
     mock_asyncio_run.assert_called_once()
+    threads_after = len(threading.enumerate())
+    assert threads_after == threads_before
 
     # Check uvloop policy was set (if uvloop is available)
     if uvloop_available:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

`test_backoff_progression` can be flaky it is scheduled to the same pytest process of `test_server_run_uses_uvloop` and run after it. The root cause is that `server.run()` does not stop the process monitor thread properly, which runs in the background and calls `time.sleep()`.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
