### PR TITLE
[Dashboard] Fix workspace page when default workspace is private

### DIFF
--- a/sky/dashboard/src/components/workspaces.jsx
+++ b/sky/dashboard/src/components/workspaces.jsx
@@ -55,7 +55,9 @@ import Link from 'next/link';
 
 // Workspace-aware API functions (cacheable)
 export async function getWorkspaceClusters(workspaceName) {
-  console.error(`[WORKSPACE DEBUG] getWorkspaceClusters called for workspace: ${workspaceName}`);
+  console.error(
+    `[WORKSPACE DEBUG] getWorkspaceClusters called for workspace: ${workspaceName}`
+  );
   try {
     const clusters = await apiClient.fetch('/status', {
       cluster_names: null,
@@ -63,7 +65,11 @@ export async function getWorkspaceClusters(workspaceName) {
       include_credentials: false,
       override_skypilot_config: { active_workspace: workspaceName },
     });
-    console.error(`[WORKSPACE DEBUG] getWorkspaceClusters raw response for ${workspaceName}:`, clusters.length, 'clusters');
+    console.error(
+      `[WORKSPACE DEBUG] getWorkspaceClusters raw response for ${workspaceName}:`,
+      clusters.length,
+      'clusters'
+    );
 
     const mappedClusters = clusters.map((cluster) => ({
       status:
@@ -90,14 +96,19 @@ export async function getWorkspaceClusters(workspaceName) {
       resources_str: cluster.resources_str,
       workspace: cluster.workspace || 'default', // Preserve workspace info
     }));
-    
+
     // Filter clusters to only include those that belong to the requested workspace
-    const filteredClusters = mappedClusters.filter(cluster => 
-      cluster.workspace === workspaceName
+    const filteredClusters = mappedClusters.filter(
+      (cluster) => cluster.workspace === workspaceName
     );
-    
-    console.error(`[WORKSPACE DEBUG] getWorkspaceClusters for ${workspaceName}: ${mappedClusters.length} total -> ${filteredClusters.length} filtered`);
-    console.error(`[WORKSPACE DEBUG] Filtered clusters:`, filteredClusters.map(c => ({name: c.cluster, workspace: c.workspace})));
+
+    console.error(
+      `[WORKSPACE DEBUG] getWorkspaceClusters for ${workspaceName}: ${mappedClusters.length} total -> ${filteredClusters.length} filtered`
+    );
+    console.error(
+      `[WORKSPACE DEBUG] Filtered clusters:`,
+      filteredClusters.map((c) => ({ name: c.cluster, workspace: c.workspace }))
+    );
     return filteredClusters;
   } catch (error) {
     console.error(
@@ -119,22 +130,28 @@ export async function getWorkspaceManagedJobs(workspaceName) {
     const id = response.headers.get('X-Skypilot-Request-ID');
     const fetchedData = await apiClient.get(`/api/get?request_id=${id}`);
     const data = await fetchedData.json();
-    const jobsData = data.return_value ? JSON.parse(data.return_value) : { jobs: [] };
-    
+    const jobsData = data.return_value
+      ? JSON.parse(data.return_value)
+      : { jobs: [] };
+
     // Ensure workspace information is preserved and filter by workspace
     if (jobsData.jobs) {
-      jobsData.jobs = jobsData.jobs.map(job => ({
+      jobsData.jobs = jobsData.jobs.map((job) => ({
         ...job,
-        workspace: job.workspace || 'default'
+        workspace: job.workspace || 'default',
       }));
-      
+
       // Filter jobs to only include those that belong to the requested workspace
       const originalJobCount = jobsData.jobs.length;
-      jobsData.jobs = jobsData.jobs.filter(job => job.workspace === workspaceName);
-      
-      console.error(`[WORKSPACE DEBUG] getWorkspaceManagedJobs for ${workspaceName}: ${originalJobCount} total -> ${jobsData.jobs.length} filtered`);
+      jobsData.jobs = jobsData.jobs.filter(
+        (job) => job.workspace === workspaceName
+      );
+
+      console.error(
+        `[WORKSPACE DEBUG] getWorkspaceManagedJobs for ${workspaceName}: ${originalJobCount} total -> ${jobsData.jobs.length} filtered`
+      );
     }
-    
+
     return jobsData;
   } catch (error) {
     console.error(
@@ -435,10 +452,23 @@ export function Workspaces() {
       workspaceDataArray.forEach(
         ({ workspaceName, enabledClouds, clusters, managedJobs }) => {
           // Debug logging
-          console.error(`[WORKSPACE DEBUG] Processing workspace ${workspaceName}:`);
-          console.error(`[WORKSPACE DEBUG] - Clusters:`, clusters.length, clusters.map(c => ({name: c.cluster, workspace: c.workspace})));
-          console.error(`[WORKSPACE DEBUG] - Jobs:`, managedJobs.jobs.length, managedJobs.jobs.map(j => ({name: j.name, workspace: j.workspace})));
-          
+          console.error(
+            `[WORKSPACE DEBUG] Processing workspace ${workspaceName}:`
+          );
+          console.error(
+            `[WORKSPACE DEBUG] - Clusters:`,
+            clusters.length,
+            clusters.map((c) => ({ name: c.cluster, workspace: c.workspace }))
+          );
+          console.error(
+            `[WORKSPACE DEBUG] - Jobs:`,
+            managedJobs.jobs.length,
+            managedJobs.jobs.map((j) => ({
+              name: j.name,
+              workspace: j.workspace,
+            }))
+          );
+
           // Clusters and jobs already have workspace info from API calls
           clusters.forEach((cluster) => {
             clustersResponse.push(cluster);
@@ -473,11 +503,15 @@ export function Workspaces() {
 
       // Process clusters
       let totalRunningClusters = 0;
-      console.error(`[WORKSPACE DEBUG] Processing ${clustersResponse.length} total clusters for stats:`);
+      console.error(
+        `[WORKSPACE DEBUG] Processing ${clustersResponse.length} total clusters for stats:`
+      );
       clustersResponse.forEach((cluster) => {
         const wsName = cluster.workspace || 'default';
-        console.error(`[WORKSPACE DEBUG] Cluster ${cluster.cluster} -> workspace ${wsName} (original: ${cluster.workspace})`);
-        
+        console.error(
+          `[WORKSPACE DEBUG] Cluster ${cluster.cluster} -> workspace ${wsName} (original: ${cluster.workspace})`
+        );
+
         if (!workspaceStatsAggregator[wsName]) {
           workspaceStatsAggregator[wsName] = {
             name: wsName,

--- a/sky/dashboard/src/components/workspaces.jsx
+++ b/sky/dashboard/src/components/workspaces.jsx
@@ -380,23 +380,23 @@ export function Workspaces() {
       setRawWorkspacesData(fetchedWorkspacesConfig);
       const configuredWorkspaceNames = Object.keys(fetchedWorkspacesConfig);
 
-        // Fetch data for each workspace in parallel using workspace-aware API calls
-        const workspaceDataPromises = configuredWorkspaceNames.map(
-          async (wsName) => {
-            const [enabledClouds, clusters, managedJobs] = await Promise.all([
-              dashboardCache.get(getEnabledClouds, [wsName]),
-              dashboardCache.get(getWorkspaceClusters, [wsName]),
-              dashboardCache.get(getWorkspaceManagedJobs, [wsName]),
-            ]);
+      // Fetch data for each workspace in parallel using workspace-aware API calls
+      const workspaceDataPromises = configuredWorkspaceNames.map(
+        async (wsName) => {
+          const [enabledClouds, clusters, managedJobs] = await Promise.all([
+            dashboardCache.get(getEnabledClouds, [wsName]),
+            dashboardCache.get(getWorkspaceClusters, [wsName]),
+            dashboardCache.get(getWorkspaceManagedJobs, [wsName]),
+          ]);
 
-            return {
-              workspaceName: wsName,
-              enabledClouds,
-              clusters: clusters || [],
-              managedJobs: managedJobs || { jobs: [] },
-            };
-          }
-        );
+          return {
+            workspaceName: wsName,
+            enabledClouds,
+            clusters: clusters || [],
+            managedJobs: managedJobs || { jobs: [] },
+          };
+        }
+      );
 
       const workspaceDataArray = await Promise.all(workspaceDataPromises);
 
@@ -646,7 +646,7 @@ export function Workspaces() {
     // Invalidate cache to ensure fresh data is fetched
     dashboardCache.invalidate(getWorkspaces);
     dashboardCache.invalidateFunction(getEnabledClouds); // This function has arguments
-    
+
     // Invalidate workspace-specific caches
     dashboardCache.invalidateFunction(getWorkspaceClusters); // Invalidate all workspace clusters
     dashboardCache.invalidateFunction(getWorkspaceManagedJobs); // Invalidate all workspace jobs

--- a/sky/dashboard/src/data/connectors/workspaces.jsx
+++ b/sky/dashboard/src/data/connectors/workspaces.jsx
@@ -311,7 +311,7 @@ export async function getEnabledClouds(workspaceName = null, expand = false) {
         // which is also a JSON string.
         enabledCloudsData = JSON.parse(resultData.return_value);
         console.log(
-          'Successfully parsed enabled_clouds data from return_value:',
+          `Successfully parsed enabled_clouds data for workspace ${workspaceName}:`,
           enabledCloudsData
         );
       } catch (parseError) {

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -328,7 +328,9 @@ def override_request_env_and_config(
                     workspaces_core.reject_request_for_unauthorized_workspace(
                         user)
                 else:
-                    logger.debug(f'{request_id} permission granted to sky.workspaces.get request')
+                    logger.debug(
+                        f'{request_id} permission granted to sky.workspaces.get request'
+                    )
             except exceptions.PermissionDeniedError as e:
                 logger.debug(
                     f'{request_id} permission denied to workspace: {skypilot_config.get_active_workspace()}: {e}'

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -323,8 +323,8 @@ def override_request_env_and_config(
             try:
                 if (request_name is not None and
                         request_name != 'sky.workspaces.get'):
-                    # Rejecting requests to workspaces that the user does not have
-                    # permission to access.
+                    # Rejecting requests to workspaces that the user does not
+                    # have permission to access.
                     workspaces_core.reject_request_for_unauthorized_workspace(
                         user)
                 else:

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -319,12 +319,11 @@ def override_request_env_and_config(
         with skypilot_config.override_skypilot_config(
                 request_body.override_skypilot_config,
                 request_body.override_skypilot_config_path):
-            # Rejecting requests to workspaces that the user does not have
-            # permission to access.
-            if request_name is not None:
-                logger.debug(f'{request_id} request name: {request_name}')
+
             try:
                 if request_name is not None and request_name != 'sky.workspaces.get':
+                    # Rejecting requests to workspaces that the user does not have
+                    # permission to access.
                     workspaces_core.reject_request_for_unauthorized_workspace(
                         user)
                 else:

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -321,22 +321,26 @@ def override_request_env_and_config(
                 request_body.override_skypilot_config_path):
 
             try:
-                if request_name is not None and request_name != 'sky.workspaces.get':
+                if (request_name is not None and 
+                    request_name != 'sky.workspaces.get'):
                     # Rejecting requests to workspaces that the user does not have
                     # permission to access.
                     workspaces_core.reject_request_for_unauthorized_workspace(
                         user)
                 else:
                     logger.debug(
-                        f'{request_id} permission granted to sky.workspaces.get request'
+                        f'{request_id} permission granted to '
+                        f'sky.workspaces.get request'
                     )
             except exceptions.PermissionDeniedError as e:
                 logger.debug(
-                    f'{request_id} permission denied to workspace: {skypilot_config.get_active_workspace()}: {e}'
+                    f'{request_id} permission denied to workspace: '
+                    f'{skypilot_config.get_active_workspace()}: {e}'
                 )
                 raise e
             logger.debug(
-                f'{request_id} permission granted to workspace: {skypilot_config.get_active_workspace()}'
+                f'{request_id} permission granted to workspace: '
+                f'{skypilot_config.get_active_workspace()}'
             )
             yield
     finally:
@@ -418,7 +422,8 @@ def _request_execution_wrapper(request_id: str,
         # captured in the log file.
         try:
             with sky_logging.add_debug_log_handler(request_id), \
-                override_request_env_and_config(request_body, request_id, request_name), \
+                override_request_env_and_config(
+                    request_body, request_id, request_name), \
                 tempstore.tempdir():
                 if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
                     config = skypilot_config.to_dict()

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -321,27 +321,21 @@ def override_request_env_and_config(
                 request_body.override_skypilot_config_path):
 
             try:
-                if (request_name is not None and 
-                    request_name != 'sky.workspaces.get'):
+                if (request_name is not None and
+                        request_name != 'sky.workspaces.get'):
                     # Rejecting requests to workspaces that the user does not have
                     # permission to access.
                     workspaces_core.reject_request_for_unauthorized_workspace(
                         user)
                 else:
-                    logger.debug(
-                        f'{request_id} permission granted to '
-                        f'sky.workspaces.get request'
-                    )
+                    logger.debug(f'{request_id} permission granted to '
+                                 f'sky.workspaces.get request')
             except exceptions.PermissionDeniedError as e:
-                logger.debug(
-                    f'{request_id} permission denied to workspace: '
-                    f'{skypilot_config.get_active_workspace()}: {e}'
-                )
+                logger.debug(f'{request_id} permission denied to workspace: '
+                             f'{skypilot_config.get_active_workspace()}: {e}')
                 raise e
-            logger.debug(
-                f'{request_id} permission granted to workspace: '
-                f'{skypilot_config.get_active_workspace()}'
-            )
+            logger.debug(f'{request_id} permission granted to workspace: '
+                         f'{skypilot_config.get_active_workspace()}')
             yield
     finally:
         # We need to call the save_timeline() since atexit will not be

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -329,10 +329,12 @@ def override_request_env_and_config(
                     workspaces_core.reject_request_for_unauthorized_workspace(
                         user)
                 except exceptions.PermissionDeniedError as e:
-                    logger.debug(f'{request_id} permission denied to workspace: '
-                                 f'{skypilot_config.get_active_workspace()}: {e}')
+                    logger.debug(
+                        f'{request_id} permission denied to workspace: '
+                        f'{skypilot_config.get_active_workspace()}: {e}')
                     raise e
-            logger.debug(f'{request_id} permission granted to {request_name} request')
+            logger.debug(
+                f'{request_id} permission granted to {request_name} request')
             yield
     finally:
         # We need to call the save_timeline() since atexit will not be

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -420,10 +420,8 @@ def get_active_workspace(force_user_workspace: bool = False) -> str:
     active_workspace = get_nested(keys=('active_workspace',),
                                   default_value=None)
     if active_workspace is None:
-        logger.debug(
-            f'No active workspace found, using default workspace: '
-            f'{constants.SKYPILOT_DEFAULT_WORKSPACE}'
-        )
+        logger.debug(f'No active workspace found, using default workspace: '
+                     f'{constants.SKYPILOT_DEFAULT_WORKSPACE}')
         active_workspace = constants.SKYPILOT_DEFAULT_WORKSPACE
     else:
         logger.debug(f'Got active workspace: {active_workspace}')

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -415,10 +415,18 @@ def local_active_workspace_ctx(workspace: str) -> Iterator[None]:
 def get_active_workspace(force_user_workspace: bool = False) -> str:
     context_workspace = getattr(_active_workspace_context, 'workspace', None)
     if not force_user_workspace and context_workspace is not None:
-        logger.debug(f'Get context workspace: {context_workspace}')
+        logger.debug(f'Got context workspace: {context_workspace}')
         return context_workspace
-    return get_nested(keys=('active_workspace',),
-                      default_value=constants.SKYPILOT_DEFAULT_WORKSPACE)
+    active_workspace = get_nested(keys=('active_workspace',),
+                                  default_value=None)
+    if active_workspace is None:
+        logger.debug(
+            f'No active workspace found, using default workspace: {constants.SKYPILOT_DEFAULT_WORKSPACE}'
+        )
+        active_workspace = constants.SKYPILOT_DEFAULT_WORKSPACE
+    else:
+        logger.debug(f'Got active workspace: {active_workspace}')
+    return active_workspace
 
 
 def set_nested(keys: Tuple[str, ...], value: Any) -> Dict[str, Any]:

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -421,7 +421,8 @@ def get_active_workspace(force_user_workspace: bool = False) -> str:
                                   default_value=None)
     if active_workspace is None:
         logger.debug(
-            f'No active workspace found, using default workspace: {constants.SKYPILOT_DEFAULT_WORKSPACE}'
+            f'No active workspace found, using default workspace: '
+            f'{constants.SKYPILOT_DEFAULT_WORKSPACE}'
         )
         active_workspace = constants.SKYPILOT_DEFAULT_WORKSPACE
     else:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR allows users to hit the `GET /workspaces` endpoint without checking workspace credentials. This is safe because the `/workspaces` endpoint only returns workspaces that are accessible by the caller. 

This PR also adds some more debug logging around the workspace authorization codepath and revamps the workspaces page in the dashboard to first determine which workspaces are accessible by the current user and then pass this information to subsequent server requests to determine the number of clusters/managed jobs as well as enabled infra for each workspace. 

This PR addresses https://github.com/skypilot-org/skypilot/issues/7131 for the workspaces page and will be followed by a few other PRs that update the other pages in the dashboard to be more workspace-aware.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
