### PR TITLE
Fix k8s gpu status

### DIFF
--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -978,6 +978,10 @@ def test_kubernetes_context_failover(unreachable_context):
                 f'sky launch -y -c {name}-4 --gpus H100 --cpus 1 --infra kubernetes/{unreachable_context} echo hi && exit 1 || true',
                 # Test failover from unreachable context
                 f'sky launch -y -c {name}-5 --cpus 1 echo hi',
+                # switch back to kind-skypilot where GPU cluster is launched
+                f'kubectl config use-context kind-skypilot',
+                # test if sky status --kubernetes shows H100
+                f'sky status --kubernetes',
             ],
             f'sky down -y {name}-1 {name}-3 {name}-5',
             env={

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -981,7 +981,8 @@ def test_kubernetes_context_failover(unreachable_context):
                 # switch back to kind-skypilot where GPU cluster is launched
                 f'kubectl config use-context kind-skypilot',
                 # test if sky status --kubernetes shows H100
-                f'sky status --kubernetes',
+                f'sky status --kubernetes | grep H100 || '
+                '{ echo "sky status --kubernetes does not show H100." && exit 1; }',
             ],
             f'sky down -y {name}-1 {name}-3 {name}-5',
             env={


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
we moved the GPU matching from node selector to affinity; this PR updates the `status_kubernetes` code to reflect this change.


before:
```
sky status --kubernetes
SkyPilot clusters
USER          NAME                   RESOURCES                                  STATUS  LAUNCHED  
seungjinyang  sky-903a-seungjinyang  1x Kubernetes(cpus=2, mem=2)               UP      1 hr ago  
seungjinyang  sky-dbaa-seungjinyang  1x Kubernetes(cpus=2, mem=8, {'None': 1})  UP      1 hr ago
```

after:
```
sky status --kubernetes
SkyPilot clusters
USER          NAME                   RESOURCES                                STATUS  LAUNCHED  
seungjinyang  sky-903a-seungjinyang  1x Kubernetes(cpus=2, mem=2)             UP      1 hr ago  
seungjinyang  sky-dbaa-seungjinyang  1x Kubernetes(cpus=2, mem=8, {'L4': 1})  UP      1 hr ago 
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
