### PR TITLE
[k8s] Fix login MOTD contamination in Kubernetes command execution

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1280,10 +1280,14 @@ def get_cluster_info(
     assert head_pod_name is not None
     runner = command_runner.KubernetesCommandRunner(
         ((namespace, context), head_pod_name))
+    # Use whoami without login shell to avoid MOTD output.
+    # Some container images (like CUDA-Q) print MOTD when using login shells,
+    # which can contaminate the whoami output.
     rc, stdout, stderr = runner.run(get_k8s_ssh_user_cmd,
                                     require_outputs=True,
                                     separate_stderr=True,
-                                    stream_logs=False)
+                                    stream_logs=False,
+                                    use_login=False)
     _raise_command_running_error('get ssh user', get_k8s_ssh_user_cmd,
                                  head_pod_name, rc, stdout + stderr)
     ssh_user = stdout.strip()

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1293,7 +1293,7 @@ def get_cluster_info(
                                     stream_logs=False)
     _raise_command_running_error('get ssh user', get_k8s_ssh_user_cmd,
                                  head_pod_name, rc, stdout + stderr)
-    
+
     # Extract SSH user using pattern matching
     ssh_user_match = _SSH_USER_PATTERN.search(stdout)
     if ssh_user_match:

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -35,6 +35,9 @@ _TIMEOUT_FOR_POD_TERMINATION = 60  # 1 minutes
 _MAX_RETRIES = 3
 _NUM_THREADS = subprocess_utils.get_parallel_threads('kubernetes')
 
+# Pattern to extract SSH user from command output, handling MOTD contamination
+_SSH_USER_PATTERN = re.compile(r'SKYPILOT_SSH_USER: ([^\s\n]+)')
+
 logger = sky_logging.init_logger(__name__)
 
 
@@ -1276,21 +1279,28 @@ def get_cluster_info(
     assert cpu_request is not None, 'cpu_request should not be None'
 
     ssh_user = 'sky'
-    get_k8s_ssh_user_cmd = 'echo $(whoami)'
+    # Use pattern matching to extract SSH user, handling MOTD contamination.
+    # Some container images (like CUDA-Q) print MOTD when login shells start,
+    # which can contaminate command output. We use a unique pattern to extract
+    # the actual username reliably.
+    get_k8s_ssh_user_cmd = 'echo "SKYPILOT_SSH_USER: $(whoami)"'
     assert head_pod_name is not None
     runner = command_runner.KubernetesCommandRunner(
         ((namespace, context), head_pod_name))
-    # Use whoami without login shell to avoid MOTD output.
-    # Some container images (like CUDA-Q) print MOTD when using login shells,
-    # which can contaminate the whoami output.
     rc, stdout, stderr = runner.run(get_k8s_ssh_user_cmd,
                                     require_outputs=True,
                                     separate_stderr=True,
-                                    stream_logs=False,
-                                    use_login=False)
+                                    stream_logs=False)
     _raise_command_running_error('get ssh user', get_k8s_ssh_user_cmd,
                                  head_pod_name, rc, stdout + stderr)
-    ssh_user = stdout.strip()
+    
+    # Extract SSH user using pattern matching
+    ssh_user_match = _SSH_USER_PATTERN.search(stdout)
+    if ssh_user_match:
+        ssh_user = ssh_user_match.group(1)
+    else:
+        raise ValueError('Failed to find SSH user identifier: '
+                         f'{stdout + stderr}')
     logger.debug(
         f'Using ssh user {ssh_user} for cluster {cluster_name_on_cloud}')
 

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -1163,7 +1163,8 @@ class LocalProcessCommandRunner(CommandRunner):
                                                process_stream,
                                                separate_stderr,
                                                skip_num_lines=skip_num_lines,
-                                               source_bashrc=source_bashrc)
+                                               source_bashrc=source_bashrc,
+                                               use_login=False)
 
         log_dir = os.path.expanduser(os.path.dirname(log_path))
         os.makedirs(log_dir, exist_ok=True)

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -186,20 +186,12 @@ class CommandRunner:
         # Use `echo ~` to get the remote home directory, instead of pwd or
         # echo $HOME, because pwd can be `/` when the remote user is root
         # and $HOME is not always set.
-        # For command runners that support use_login parameter, avoid login shell
-        # to prevent MOTD output contamination.
-        extra_kwargs = {}
-        if hasattr(self, 'run'):
-            import inspect
-            sig = inspect.signature(self.run)
-            if 'use_login' in sig.parameters:
-                extra_kwargs['use_login'] = False
-        
+        # Use use_login=False to prevent MOTD output contamination.
         rc, remote_home_dir, stderr = self.run('echo ~',
                                                require_outputs=True,
                                                separate_stderr=True,
                                                stream_logs=False,
-                                               **extra_kwargs)
+                                               use_login=False)
         if rc != 0:
             raise ValueError('Failed to get remote home directory: '
                              f'{remote_home_dir + stderr}')
@@ -405,6 +397,7 @@ class CommandRunner:
             connect_timeout: Optional[int] = None,
             source_bashrc: bool = False,
             skip_num_lines: int = 0,
+            use_login: bool = True,
             **kwargs) -> Union[int, Tuple[int, str, str]]:
         """Runs the command on the cluster.
 
@@ -423,7 +416,8 @@ class CommandRunner:
                 output. This is used when the output is not processed by
                 SkyPilot but we still want to get rid of some warning messages,
                 such as SSH warnings.
-
+            use_login: Whether to use login shell. If False, avoids login shell
+                MOTD output that can contaminate command output.
 
         Returns:
             returncode
@@ -765,6 +759,7 @@ class SSHCommandRunner(CommandRunner):
             connect_timeout: Optional[int] = None,
             source_bashrc: bool = False,
             skip_num_lines: int = 0,
+            use_login: bool = True,
             **kwargs) -> Union[int, Tuple[int, str, str]]:
         """Uses 'ssh' to run 'cmd' on a node with ip.
 
@@ -809,7 +804,8 @@ class SSHCommandRunner(CommandRunner):
                                                process_stream,
                                                separate_stderr,
                                                skip_num_lines=skip_num_lines,
-                                               source_bashrc=source_bashrc)
+                                               source_bashrc=source_bashrc,
+                                               use_login=use_login)
         command = base_ssh_command + [shlex.quote(command_str)]
 
         log_dir = os.path.expanduser(os.path.dirname(log_path))
@@ -1159,6 +1155,7 @@ class LocalProcessCommandRunner(CommandRunner):
             connect_timeout: Optional[int] = None,
             source_bashrc: bool = False,
             skip_num_lines: int = 0,
+            use_login: bool = True,
             **kwargs) -> Union[int, Tuple[int, str, str]]:
         """Use subprocess to run the command."""
         del port_forward, ssh_mode, connect_timeout  # Unused.
@@ -1168,7 +1165,7 @@ class LocalProcessCommandRunner(CommandRunner):
                                                separate_stderr,
                                                skip_num_lines=skip_num_lines,
                                                source_bashrc=source_bashrc,
-                                               use_login=False)
+                                               use_login=use_login)
 
         log_dir = os.path.expanduser(os.path.dirname(log_path))
         os.makedirs(log_dir, exist_ok=True)

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -919,7 +919,6 @@ class KubernetesCommandRunner(CommandRunner):
         else:
             return f'pod/{self.pod_name}'
 
-
     def port_forward_command(
             self,
             port_forward: List[Tuple[int, int]],

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -23,7 +23,7 @@ from sky.utils import timeline
 
 logger = sky_logging.init_logger(__name__)
 
-# Pattern to extract home directory from command output, handling MOTD contamination
+# Pattern to extract home directory from command output
 _HOME_DIR_PATTERN = re.compile(r'SKYPILOT_HOME_DIR: ([^\s\n]+)')
 
 # Rsync options
@@ -187,7 +187,7 @@ class CommandRunner:
         return '-'.join(str(x) for x in self.node)
 
     def _get_remote_home_dir(self) -> str:
-        # Use pattern matching to extract home directory, handling MOTD contamination.
+        # Use pattern matching to extract home directory.
         # Some container images print MOTD when login shells start, which can
         # contaminate command output. We use a unique pattern to extract the
         # actual home directory reliably.
@@ -198,7 +198,7 @@ class CommandRunner:
         if rc != 0:
             raise ValueError('Failed to get remote home directory: '
                              f'{output + stderr}')
-        
+
         # Extract home directory using pattern matching
         home_dir_match = _HOME_DIR_PATTERN.search(output)
         if home_dir_match:

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1733,6 +1733,9 @@ def test_aws_custom_image():
         # Test python>=3.12 where SkyPilot should automatically create a separate
         # conda env for runtime with python 3.10.
         'docker:continuumio/miniconda3:latest',
+        # Test image with custom MOTD that can potentially interfere with
+        # SSH user/rsync path detection.
+        'docker:nvcr.io/nvidia/quantum/cuda-quantum:cu12-0.10.0',
     ])
 def test_kubernetes_custom_image(image_id):
     """Test Kubernetes custom image"""


### PR DESCRIPTION
Container images with a login MOTD (like `nvcr.io/nvidia/quantum/cuda-quantum:cu12-0.10.0`) break SkyPilot on Kubernetes due to contaminated command output:

```
D 09-13 09:54:06 command_runner.py:356] Running rsync command: chmod +x /Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/utils/kubernetes/rsync_helper.sh &&  rsync -Pavz --filter='dir-merge,- .gitignore' -e /Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/utils/kubernetes/rsync_helper.sh '/private/var/folders/98/hhq8wrtx6y13196q61xphjsm0000gn/T/sky-tmphgkn98ck/tmp7ucqa_p0/' test-2ea485ef-head@default%2Bcoreweave-dev:'=========================\n      NVIDIA CUDA-Q      \n=========================\n\nVersion: cu12-0.10.0\n\nCopyright (c) 2025 NVIDIA Corporation & Affiliates \nAll rights reserved.\n\nTo run a command as administrator (user `root`), use `sudo <command>`.\n\n\n/home/cudaq/.sky/.runtime_files'
D 09-13 09:54:45 subprocess_utils.py:158] building file list ... 
D 09-13 09:54:45 subprocess_utils.py:158]  0 files...
42 files to consider
D 09-13 09:54:45 subprocess_utils.py:158] pod: test-2ea485ef-head
D 09-13 09:54:45 subprocess_utils.py:158] namespace_context: default+coreweave-dev
D 09-13 09:54:45 subprocess_utils.py:158] namespace: default
D 09-13 09:54:45 subprocess_utils.py:158] context: coreweave-dev
D 09-13 09:54:45 subprocess_utils.py:158] Assuming resource is a pod: test-2ea485ef-head
D 09-13 09:54:45 subprocess_utils.py:158] rsync: [Receiver] ERROR: cannot stat destination "/home/cudaq/=========================\n      NVIDIA CUDA-Q      \n=========================\n\nVersion: cu12-0.10.0\n\nCopyright (c) 2025 NVIDIA Corporation & Affiliates \nAll rights reserved.\n\nTo run a command as administrator (user `root`), use `sudo <command>`.\n\n\n/home/cudaq/.sky/.runtime_files": File name too long (36)
```

This is because some login shells may print MOTD to stdout, messing up the `whoami` and `echo ~` outputs used for SSH user detection and rsync home path resolutin.