### PR TITLE
[Lambda] Fix Docker image validation error message and SSH port configuration

### DIFF
--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -367,7 +367,7 @@ class DockerInitializer:
         # pylint: disable=anomalous-backslash-in-string
         self._run(
             'sudo sed -i "/^Port .*/d" /etc/ssh/sshd_config;'
-            f'sudo echo "Port {port}" >> /etc/ssh/sshd_config;'
+            f'echo "Port {port}" | sudo tee -a /etc/ssh/sshd_config > /dev/null;'
             'mkdir -p ~/.ssh;'
             'cat /tmp/host_ssh_authorized_keys >> ~/.ssh/authorized_keys;'
             'sudo service ssh start;'

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1331,10 +1331,18 @@ class Resources:
                     clouds.CloudImplementationFeatures.IMAGE_ID
                 })
         except exceptions.NotSupportedError as e:
+            # Provide a more helpful error message for Lambda cloud
+            if self.cloud.is_same_cloud(clouds.Lambda()):
+                with ux_utils.print_exception_no_traceback():
+                    raise ValueError(
+                        'Lambda cloud only supports Docker images. '
+                        'Please prefix your image with "docker:" '
+                        '(e.g., image_id: docker:your-image-name).') from e
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
                     'image_id is only supported for AWS/GCP/Azure/IBM/OCI/'
-                    'Kubernetes, please explicitly specify the cloud.') from e
+                    'Kubernetes. For Lambda cloud, use "docker:" prefix for '
+                    'Docker images.') from e
 
         if self._region is not None:
             # If the image_id has None as key (region-agnostic),


### PR DESCRIPTION
Fixes #6792

This PR addresses two issues with Docker image support on Lambda cloud:
1. Improves error message when users specify image_id without the required `docker:` prefix
2. Fixes SSH port configuration in Docker containers by using proper sudo redirection

## Problem
When using Lambda cloud with Docker images, users encountered two issues:
1. **Misleading error message**: When specifying `image_id` without `docker:` prefix, the error message was generic and didn't explain that Lambda requires the prefix
2. **SSH connection failures**: Even with correct `docker:` prefix, SSH connections failed because the port configuration command used incorrect sudo redirection

## Solution
1. **Error message improvement**: Added Lambda-specific error message in `resources.py` that clearly states the requirement for `docker:` prefix
2. **SSH port fix**: Changed `sudo echo "Port X" >> file` to `echo "Port X" | sudo tee -a file` in `docker_utils.py` to properly handle sudo file redirection

Tested (run the relevant ones):
- [x] Code formatting: `bash format.sh`
- [x] Manual test with Lambda cloud Docker images
- [x] Verified SSH connection works after the fix

## Example
Before (error message):
```
ValueError: image_id is only supported for AWS/GCP/Azure/IBM/OCI/Kubernetes.
```

After (error message):
```
ValueError: Lambda cloud only supports Docker images. Please prefix your image with "docker:" (e.g., image_id: docker:your-image-name).
```

SSH port configuration fix ensures proper port 10022 setup in Docker containers.