### PR TITLE
[Docker] Fix `RAY_RUNTIME_ENV_HOOK` causing `FAILED_DRIVER` errors

### DIFF
--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -15,6 +15,10 @@ logger = sky_logging.init_logger(__name__)
 # Configure environment variables. A docker image can have environment variables
 # set in the Dockerfile with `ENV``. We need to export these variables to the
 # shell environment, so that our ssh session can access them.
+# Filter out RAY_RUNTIME_ENV_HOOK to prevent Ray version conflicts.
+# Docker images with Ray 2.48.0+ set this for UV package manager support,
+# but it causes FAILED_DRIVER errors with SkyPilot's Ray 2.9.3.
+# See: https://github.com/skypilot-org/skypilot/pull/7181
 SETUP_ENV_VARS_CMD = (
     'prefix_cmd() '
     '{ if [ $(id -u) -ne 0 ]; then echo "sudo"; else echo ""; fi; } && '

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -18,7 +18,7 @@ logger = sky_logging.init_logger(__name__)
 SETUP_ENV_VARS_CMD = (
     'prefix_cmd() '
     '{ if [ $(id -u) -ne 0 ]; then echo "sudo"; else echo ""; fi; } && '
-    'export -p > ~/container_env_var.sh && '
+    'export -p | grep -v RAY_RUNTIME_ENV_HOOK > ~/container_env_var.sh && '
     '$(prefix_cmd) '
     'mv ~/container_env_var.sh /etc/profile.d/container_env_var.sh;')
 


### PR DESCRIPTION
Fixes #7180

This PR fixes FAILED_DRIVER errors that occur when using Docker images containing `RAY_RUNTIME_ENV_HOOK` environment variable (common in images with Ray 2.48.0+).

## Problem
Docker images with Ray 2.48.0+ set `RAY_RUNTIME_ENV_HOOK=ray._private.runtime_env.uv_runtime_env_hook.hook` for UV package manager support. When SkyPilot exports container environment variables to `/etc/profile.d/container_env_var.sh`, this incompatible variable causes jobs to fail with:
```
ModuleNotFoundError: No module named 'ray._private.runtime_env.uv_runtime_env_hook'
```

## Solution
Filter out `RAY_RUNTIME_ENV_HOOK` when exporting Docker container environment variables to prevent version conflicts between container's Ray and SkyPilot's Ray 2.9.3.

Tested (run the relevant ones):
- [x] Code formatting: `bash format.sh`
- [x] Manual test with affected Docker images (e.g., skyrl/lambda-huggingface:v0.0.5)
- [x] Verified jobs run successfully after the fix

## Example
Before fix:
```bash
sky launch test.yaml  # Using docker:skyrl/lambda-huggingface:v0.0.5
# ✓ Job finished (status: FAILED_DRIVER).
```

After fix:
```bash
sky launch test.yaml  # Using docker:skyrl/lambda-huggingface:v0.0.5
# ✓ Job finished (status: SUCCEEDED).
```

## Test

Have a `test-lambda-docker-issue.yaml`:

```yaml
name: test-lambda-docker-issue

resources:
  accelerators: A10
  cloud: lambda
  image_id: docker:erictang000/skyrl-train-ray-2.48.0-py3.12-cu12.8

num_nodes: 1

setup: |
  echo "Setup phase starting"
  pwd

run: |
  echo "Hello from Lambda Docker container!"
```

and then launch it

```shell
(skypilot) andyl@andylizf-dev-server-us-west ~/skypilot (fix-docker-ray-env-hook)> sky launch test-lambda-docker-issue.yaml 
--cluster test-lambda-final-fix35 --yes
YAML to run: /tmp/test-lambda-docker-issue.yaml
Running on cluster: test-lambda-final-fix35
Considered resources (1 node):
---------------------------------------------------------------------------------
 INFRA                INSTANCE     vCPUs   Mem(GB)   GPUS    COST ($)   CHOSEN   
---------------------------------------------------------------------------------
 Lambda (us-east-1)   gpu_1x_a10   30      200       A10:1   0.75          ✔     
---------------------------------------------------------------------------------
⚙︎ Launching on Lambda us-east-1.
├── Instance is up.
└── Docker container is up.
✓ Cluster launched: test-lambda-final-fix35.  View logs: sky logs --provision test-lambda-final-fix35
⚙︎ Syncing files.
✓ Setup detached.
⚙︎ Job submitted, ID: 1
├── Waiting for task resources on 1 node.
└── Job started. Streaming logs... (Ctrl-C to exit log streaming; job will not be killed)
(setup pid=2019) Setup phase starting
(setup pid=2019) /home/ray/sky_workdir
(test-lambda-docker-issue, pid=2019) Hello from Lambda Docker container!
✓ Job finished (status: SUCCEEDED).

📋 Useful Commands
Job ID: 1
├── To cancel the job:          sky cancel test-lambda-final-fix35 1
├── To stream job logs:         sky logs test-lambda-final-fix35 1
└── To view job queue:          sky queue test-lambda-final-fix35
Cluster name: test-lambda-final-fix35
├── To log into the head VM:    ssh test-lambda-final-fix35
├── To submit a job:            sky exec test-lambda-final-fix35 yaml_file
├── To stop the cluster:        sky stop test-lambda-final-fix35
└── To teardown the cluster:    sky down test-lambda-final-fix35
```

while this does not affect the envs of user commands:

```shell
(skypilot) andyl@andylizf-dev-server-us-west ~/skypilot (fix-docker-ray-env-hook)> sky exec test-lambda-final-fix35 'env | grep RAY_RUNTIME_ENV_HOOK'
Command to run: env | grep RAY_RUNTIME_ENV_HOOK
Submitting job to cluster: test-lambda-final-fix35
⚙︎ Job submitted, ID: 2
├── Waiting for task resources on 1 node.
└── Job started. Streaming logs... (Ctrl-C to exit log streaming; job will not be killed)
(sky-cmd, pid=2018) RAY_RUNTIME_ENV_HOOK=ray._private.runtime_env.uv_runtime_env_hook.hook
✓ Job finished (status: SUCCEEDED).
```