### PR TITLE
[DO NOT MERGE] [Metrics] add values to configure metrics-related images

### DIFF
--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -548,11 +548,13 @@ prometheus:
     enabled: false
   alertmanager:
     enabled: false
-  image:
-    repository: quay.io/prometheus-operator/prometheus-config-reloader
-    tag: v0.83.0
-    digest: ""
-    pullPolicy: IfNotPresent
+  configmapReload:
+    prometheus: 
+      image:
+        repository: quay.io/prometheus-operator/prometheus-config-reloader
+        tag: v0.83.0
+        digest: ""
+        pullPolicy: IfNotPresent
 
 # Set configuration for Grafana helm chart
 # Refer to https://github.com/grafana/helm-charts/blob/main/charts/grafana/README.md for available values.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR adds relevant grafana, prometheus, and kube-state-metrics values to our values.yaml file to allow users to specify custom images rather than using the default hard coded images. 

Used the following sub-charts as reference:

1. Prometheus 27.20.0 (according to SkyPilot [Chart.yaml](https://github.com/skypilot-org/skypilot/blob/master/charts/skypilot/Chart.yaml)): https://github.com/prometheus-community/helm-charts/blob/prometheus (5.33.*)-27.20.0/charts/prometheus/values.yaml
2. Kube-state-metrics 5.33.* (according to Prometheus [Chart.yaml](https://github.com/prometheus-community/helm-charts/blob/prometheus-27.20.0/charts/prometheus/Chart.yaml)): https://github.com/prometheus-community/helm-charts/blob/kube-state-metrics-5.33.2/charts/kube-state-metrics/values.yaml
3. Grafana 9.2.2 (according to SkyPilot [Chart.yaml](https://github.com/skypilot-org/skypilot/blob/master/charts/skypilot/Chart.yaml)): https://github.com/grafana/helm-charts/blob/grafana-9.2.2/charts/grafana/values.yaml


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
