### PR TITLE
do not wait indefinitely if lock acquisition fails

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4394,7 +4394,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             else:
                 raise
         lock_id = backend_utils.cluster_status_lock_id(cluster_name)
-        lock = locks.get_lock(lock_id)
+        lock = locks.get_lock(lock_id, timeout=1)
         # Retry in case new cluster operation comes in and holds the lock
         # right after the lock is removed.
         n_attempts = 2
@@ -4421,7 +4421,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             # lock.
             lock.force_unlock()
             try:
-                with lock.acquire(blocking=False):
+                with lock:
                     self.teardown_no_lock(
                         handle,
                         terminate,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
1. move force unlock statement closer to lock acquisition to lessen the chance that the lock is grabbed inbetween.
2. add "blocking=False" argument to the lock acquisition. Since we force unlock the lock, we don't expect the lock to be acquired - so this makes sense. Currently there is no lock timeout - so if for some reason the lock is acquired at this time, this codepath may block indefinitely until the lock is released.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
