### PR TITLE
[core] kill subprocesses on ssh context exit

### DIFF
--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -146,7 +146,7 @@ class SSHThreadPoolExecutor(futures.ThreadPoolExecutor):
         # we need to kill the children processes
         # to avoid leakage.
         subprocess_utils.kill_children_processes()
-        self.shutdown(wait=True, cancel_futures=True)
+        self.shutdown()
         return False
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Currently, if one of the ssh sessions on the `_parallel_ssh_with_cache` function hangs, the entire executor hangs. This is because `futures.ThreadPoolExecutor`'s `__exit__` function calls `self.shutdown(wait=True)`, which waits for the thread that will never complete.

We could solve this problem by setting `wait=False` in the call, but simply makes the function nonblocking without actually cleaning up the threads. This results in a leak and we're not about that either.

the specific codepath `_parallel_ssh_with_cache` eventually calls `log_lib.run_with_log` with each thread. This codepath has some guard against request cancellation with this codepath:
```
        except KeyboardInterrupt:
            # Kill the subprocess directly, otherwise, the underlying
            # process will only be killed after the python program exits,
            # causing the stream handling stuck at `readline`.
            subprocess_utils.kill_children_processes()
            raise
```
but `KeyboardInterrupt` is only raised in the main thread, not in any of the threads in the `ThreadPoolExecutor`.

Therefore, I simply call `subprocess_utils.kill_children_processes()` on context exit instead, guaranteeing cleanup.

This has an additional benefit of letting the rest of the request cancel correctly, including releasing locks, which allows other requests (such as sky.down) to act on the cluster.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
