### PR TITLE
[db] when updating cluster, check the hash matches

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2331,12 +2331,14 @@ def _update_cluster_status(cluster_name: str) -> Optional[Dict[str, Any]]:
             'All nodes up; SkyPilot runtime healthy.',
             global_user_state.ClusterEventType.STATUS_CHANGE,
             nop_if_duplicate=True)
-        global_user_state.add_or_update_cluster(cluster_name,
-                                                handle,
-                                                requested_resources=None,
-                                                ready=True,
-                                                is_launch=False,
-                                                update_only=True)
+        global_user_state.add_or_update_cluster(
+            cluster_name,
+            handle,
+            requested_resources=None,
+            ready=True,
+            is_launch=False,
+            update_only=True,
+            update_cluster_hash_filter=record['cluster_hash'])
         return global_user_state.get_cluster_from_name(cluster_name)
 
     # All cases below are transitioning the cluster to non-UP states.
@@ -2542,12 +2544,14 @@ def _update_cluster_status(cluster_name: str) -> Optional[Dict[str, Any]]:
             global_user_state.ClusterEventType.STATUS_CHANGE,
             nop_if_duplicate=True,
             duplicate_regex=init_reason_regex)
-        global_user_state.add_or_update_cluster(cluster_name,
-                                                handle,
-                                                requested_resources=None,
-                                                ready=False,
-                                                is_launch=False,
-                                                update_only=True)
+        global_user_state.add_or_update_cluster(
+            cluster_name,
+            handle,
+            requested_resources=None,
+            ready=False,
+            is_launch=False,
+            update_only=True,
+            update_cluster_hash_filter=record['cluster_hash'])
         return global_user_state.get_cluster_from_name(cluster_name)
     # Now is_abnormal is False: either node_statuses is empty or all nodes are
     # STOPPED.

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2337,8 +2337,7 @@ def _update_cluster_status(cluster_name: str) -> Optional[Dict[str, Any]]:
             requested_resources=None,
             ready=True,
             is_launch=False,
-            update_only=True,
-            update_cluster_hash_filter=record['cluster_hash'])
+            existing_cluster_hash=record['cluster_hash'])
         return global_user_state.get_cluster_from_name(cluster_name)
 
     # All cases below are transitioning the cluster to non-UP states.
@@ -2550,8 +2549,7 @@ def _update_cluster_status(cluster_name: str) -> Optional[Dict[str, Any]]:
             requested_resources=None,
             ready=False,
             is_launch=False,
-            update_only=True,
-            update_cluster_hash_filter=record['cluster_hash'])
+            existing_cluster_hash=record['cluster_hash'])
         return global_user_state.get_cluster_from_name(cluster_name)
     # Now is_abnormal is False: either node_statuses is empty or all nodes are
     # STOPPED.

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -633,10 +633,9 @@ def add_or_update_cluster(cluster_name: str,
 
         if update_only:
             count = session.query(cluster_table).filter_by(
-                name=cluster_name).update({
+                name=cluster_name, cluster_hash=cluster_hash).update({
                     **conditional_values, cluster_table.c.handle: handle,
                     cluster_table.c.status: status.value,
-                    cluster_table.c.cluster_hash: cluster_hash,
                     cluster_table.c.status_updated_at: status_updated_at
                 })
             assert count <= 1

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -516,8 +516,7 @@ def add_or_update_cluster(cluster_name: str,
                           task_config: Optional[Dict[str, Any]] = None,
                           is_managed: bool = False,
                           provision_log_path: Optional[str] = None,
-                          update_only: bool = False,
-                          update_cluster_hash_filter: Optional[str] = None):
+                          existing_cluster_hash: Optional[str] = None):
     """Adds or updates cluster_name -> cluster_handle mapping.
 
     Args:
@@ -533,13 +532,11 @@ def add_or_update_cluster(cluster_name: str,
         is_managed: Whether the cluster is launched by the
             controller.
         provision_log_path: Absolute path to provision.log, if available.
-        update_only: Whether to update the cluster only. If True,
-            the cluster record will not be inserted if one does not exist.
+        existing_cluster_hash: If specified, the cluster will be updated
+            only if the cluster_hash matches. If a cluster does not exist,
+            it will not be inserted and an error will be raised.
     """
     assert _SQLALCHEMY_ENGINE is not None
-    if update_only and update_cluster_hash_filter is None:
-        raise ValueError(
-            'update_cluster_hash is required when update_only is True')
 
     # FIXME: launched_at will be changed when `sky launch -c` is called.
     handle = pickle.dumps(cluster_handle)
@@ -636,17 +633,17 @@ def add_or_update_cluster(cluster_name: str,
             session.rollback()
             raise ValueError('Unsupported database dialect')
 
-        if update_only:
+        if existing_cluster_hash is not None:
             count = session.query(cluster_table).filter_by(
-                name=cluster_name,
-                cluster_hash=update_cluster_hash_filter).update({
+                name=cluster_name, cluster_hash=existing_cluster_hash).update({
                     **conditional_values, cluster_table.c.handle: handle,
                     cluster_table.c.status: status.value,
                     cluster_table.c.status_updated_at: status_updated_at
                 })
             assert count <= 1
             if count == 0:
-                raise ValueError(f'Cluster {cluster_name} not found.')
+                raise ValueError(f'Cluster {cluster_name} with hash '
+                                 f'{existing_cluster_hash} not found.')
         else:
             insert_stmnt = insert_func(cluster_table).values(
                 name=cluster_name,

--- a/tests/test_global_user_state.py
+++ b/tests/test_global_user_state.py
@@ -91,11 +91,35 @@ def test_add_or_update_cluster_update_only(_mock_db_conn):
                       instance_type='p4d.24xlarge'),
         ready=True,
         update_only=False)
-    # now that a record exists, should update the record
+
+    with pytest.raises(ValueError):
+        # update_cluster_hash_filter is required when update_only is True
+        global_user_state.add_or_update_cluster(
+            'test-cluster',
+            'test-cluster',
+            sky.Resources(infra='aws/us-east-1/us-east-1a',
+                          instance_type='p4d.24xlarge'),
+            ready=True,
+            update_only=True)
+
+    with pytest.raises(ValueError):
+        # incorrect cluster hash filter
+        global_user_state.add_or_update_cluster(
+            'test-cluster',
+            'test-cluster',
+            sky.Resources(infra='aws/us-east-1/us-east-1a',
+                          instance_type='p4d.24xlarge'),
+            ready=True,
+            update_only=True,
+            update_cluster_hash_filter='01230123')
+
+    # correct cluster hash filter
+    record = global_user_state.get_cluster_from_name('test-cluster')
     global_user_state.add_or_update_cluster(
         'test-cluster',
         'test-cluster',
         sky.Resources(infra='aws/us-east-1/us-east-1a',
                       instance_type='p4d.24xlarge'),
         ready=True,
-        update_only=True)
+        update_only=True,
+        update_cluster_hash_filter=record['cluster_hash'])

--- a/tests/test_global_user_state.py
+++ b/tests/test_global_user_state.py
@@ -72,7 +72,7 @@ async def test_cluster_event_retention_daemon():
 
 
 def test_add_or_update_cluster_update_only(_mock_db_conn):
-    # if no record exists and update_only is True
+    # if no record exists and existing_cluster_hash is specified
     # should raise ValueError
     with pytest.raises(ValueError):
         global_user_state.add_or_update_cluster(
@@ -81,26 +81,15 @@ def test_add_or_update_cluster_update_only(_mock_db_conn):
             sky.Resources(infra='aws/us-east-1/us-east-1a',
                           instance_type='p4d.24xlarge'),
             ready=True,
-            update_only=True)
+            existing_cluster_hash='01230123')
 
-    # if update_only is False, should insert a new record
+    # if existing_cluster_hash is not specified, should insert a new record
     global_user_state.add_or_update_cluster(
         'test-cluster',
         'test-cluster',
         sky.Resources(infra='aws/us-east-1/us-east-1a',
                       instance_type='p4d.24xlarge'),
-        ready=True,
-        update_only=False)
-
-    with pytest.raises(ValueError):
-        # update_cluster_hash_filter is required when update_only is True
-        global_user_state.add_or_update_cluster(
-            'test-cluster',
-            'test-cluster',
-            sky.Resources(infra='aws/us-east-1/us-east-1a',
-                          instance_type='p4d.24xlarge'),
-            ready=True,
-            update_only=True)
+        ready=True)
 
     with pytest.raises(ValueError):
         # incorrect cluster hash filter
@@ -110,8 +99,7 @@ def test_add_or_update_cluster_update_only(_mock_db_conn):
             sky.Resources(infra='aws/us-east-1/us-east-1a',
                           instance_type='p4d.24xlarge'),
             ready=True,
-            update_only=True,
-            update_cluster_hash_filter='01230123')
+            existing_cluster_hash='01230123')
 
     # correct cluster hash filter
     record = global_user_state.get_cluster_from_name('test-cluster')
@@ -121,5 +109,4 @@ def test_add_or_update_cluster_update_only(_mock_db_conn):
         sky.Resources(infra='aws/us-east-1/us-east-1a',
                       instance_type='p4d.24xlarge'),
         ready=True,
-        update_only=True,
-        update_cluster_hash_filter=record['cluster_hash'])
+        existing_cluster_hash=record['cluster_hash'])


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
In routines such as status refresh, it is possible to encounter a TOCTTOU bug - between the time the cluster is gotten and the cluster is updated, the cluster record with given name may have been deleted and recreated by `sky down` and `sky launch` in quick succession.

This PR guards against such case by requiring the cluster hash be equal if cluster is being updated.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
