### PR TITLE
[Chart] support nameOverride and fullnameOverride in chart

### DIFF
--- a/charts/skypilot/templates/api-configmap.yaml
+++ b/charts/skypilot/templates/api-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-config
+  name: {{ include "skypilot.fullname" . }}-config
   namespace: {{ .Release.Namespace }}
 data:
   config.yaml: |-

--- a/charts/skypilot/templates/api-dashboard-grafana-configmap.yaml
+++ b/charts/skypilot/templates/api-dashboard-grafana-configmap.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-api-server-overview-dashboard
+  name: {{ include "skypilot.fullname" . }}-api-server-overview-dashboard
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name }}-api
+    app: {{ include "skypilot.fullname" . }}-api
     grafana_dashboard: "true"
 data:
   api-server-overview.json: |

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-api-server
+  name: {{ include "skypilot.fullname" . }}-api-server
   namespace: {{ .Release.Namespace }}
 spec:
   # Note: replicas > 1 is not well tested.
@@ -24,7 +24,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-api
+      app: {{ include "skypilot.fullname" . }}-api
   template:
     metadata:
       annotations:
@@ -38,7 +38,7 @@ spec:
         {{- toYaml .Values.apiService.annotations | nindent 8 }}
         {{- end }}
       labels:
-        app: {{ .Release.Name }}-api
+        app: {{ include "skypilot.fullname" . }}-api
         # This label indicates that the API server is ready to serve requests.
         skypilot.co/ready: "true"
     spec:
@@ -67,7 +67,7 @@ spec:
         - name: SKYPILOT_DEV
           value: {{ .Values.apiService.skypilotDev | quote }}
         - name: SKYPILOT_RELEASE_NAME
-          value: {{ .Release.Name | quote }}
+          value: {{ include "skypilot.fullname" . | quote }}
         {{- if include "skypilot.enableBasicAuthInAPIServer" . | trim | eq "true" }}
         - name: SKYPILOT_INITIAL_BASIC_AUTH
           valueFrom:
@@ -101,7 +101,7 @@ spec:
         - name: SKYPILOT_DB_CONNECTION_URI
           valueFrom:
             secretKeyRef:
-              name: {{ .Release.Name }}-db-connection
+              name: {{ include "skypilot.fullname" . }}-db-connection
               key: connection_string
         {{- end }}
         {{- if .Values.apiService.authUserHeaderName }}
@@ -521,7 +521,7 @@ spec:
       {{- if .Values.storage.enabled }}
       - name: state-volume
         persistentVolumeClaim:
-          claimName: {{ .Release.Name }}-state
+          claimName: {{ include "skypilot.fullname" . }}-state
       {{- else }}
       - name: state-volume
         emptyDir: {}
@@ -561,11 +561,11 @@ spec:
       {{- end }}
       - name: skypilot-config
         configMap:
-          name: {{ .Release.Name }}-config
+          name: {{ include "skypilot.fullname" . }}-config
       {{- if .Values.apiService.sshNodePools }}
       - name: skypilot-ssh-node-pools
         secret:
-          secretName: {{ .Release.Name }}-ssh-node-pools
+          secretName: {{ include "skypilot.fullname" . }}-ssh-node-pools
       {{- end }}
       {{- if .Values.apiService.sshKeySecret }}
       - name: skypilot-ssh-identity

--- a/charts/skypilot/templates/api-secrets.yaml
+++ b/charts/skypilot/templates/api-secrets.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-ssh-node-pools
+  name: {{ include "skypilot.fullname" . }}-ssh-node-pools
   namespace: {{ .Release.Namespace }}
 stringData:
   ssh_node_pools.yaml: |

--- a/charts/skypilot/templates/api-service.yaml
+++ b/charts/skypilot/templates/api-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-api-service
+  name: {{ include "skypilot.fullname" . }}-api-service
   namespace: {{ .Release.Namespace }}
 spec:
   type: ClusterIP  # Use clusterIP to allow ingress to authenticate
@@ -10,5 +10,5 @@ spec:
       targetPort: 46580  # Assuming your container listens on port 46580
       protocol: TCP
   selector:
-    app: {{ .Release.Name }}-api
+    app: {{ include "skypilot.fullname" . }}-api
     skypilot.co/ready: "true"

--- a/charts/skypilot/templates/auth.yaml
+++ b/charts/skypilot/templates/auth.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-basic-auth
+  name: {{ include "skypilot.fullname" . }}-basic-auth
   namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:

--- a/charts/skypilot/templates/datasource.yaml
+++ b/charts/skypilot/templates/datasource.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-prometheus-datasource
+  name: {{ include "skypilot.fullname" . }}-prometheus-datasource
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name }}-api
+    app: {{ include "skypilot.fullname" . }}-api
     grafana_datasource: "true"
 stringData:
   prometheus.yaml: |-
@@ -13,7 +13,7 @@ stringData:
     datasources:
       - name: Prometheus
         type: prometheus
-        url: http://{{ .Release.Name }}-prometheus-server:80
+        url: http://{{ include "skypilot.fullname" . }}-prometheus-server:80
         editable: false
         uid: prometheus
 {{- end }}

--- a/charts/skypilot/templates/db-secrets.yaml
+++ b/charts/skypilot/templates/db-secrets.yaml
@@ -7,7 +7,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-db-connection
+  name: {{ include "skypilot.fullname" . }}-db-connection
   namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:

--- a/charts/skypilot/templates/dcgm-cluster-dashboard-grafana-configmap.yaml
+++ b/charts/skypilot/templates/dcgm-cluster-dashboard-grafana-configmap.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-dcgm-cluster-dashboard
+  name: {{ include "skypilot.fullname" . }}-dcgm-cluster-dashboard
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name }}-api
+    app: {{ include "skypilot.fullname" . }}-api
     grafana_dashboard: "true"
 data:
   dcgm-cluster-dashboard.json: |

--- a/charts/skypilot/templates/dcgm-cluster-filtering-dashboard-grafana-configmap.yaml
+++ b/charts/skypilot/templates/dcgm-cluster-filtering-dashboard-grafana-configmap.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-dcgm-skycluster-dashboard
+  name: {{ include "skypilot.fullname" . }}-dcgm-skycluster-dashboard
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name }}-api
+    app: {{ include "skypilot.fullname" . }}-api
     grafana_dashboard: "true"
 data:
   dcgm-skycluster-dashboard.json: |

--- a/charts/skypilot/templates/dcgm-prometheus-scrape-service.yaml
+++ b/charts/skypilot/templates/dcgm-prometheus-scrape-service.yaml
@@ -2,17 +2,17 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-dcgm-exporter
+  name: {{ include "skypilot.fullname" . }}-dcgm-exporter
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name }}-dcgm-exporter
+    app: {{ include "skypilot.fullname" . }}-dcgm-exporter
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9400"
     prometheus.io/path: "/metrics"
 spec:
   selector:
-    app.kubernetes.io/name: {{ .Release.Name }}-dcgm-exporter
+    app.kubernetes.io/name: {{ include "skypilot.fullname" . }}-dcgm-exporter
   ports:
   - name: metrics
     port: 9400

--- a/charts/skypilot/templates/grafana-ingress.yaml
+++ b/charts/skypilot/templates/grafana-ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ .Release.Name }}-grafana-authed
+  name: {{ include "skypilot.fullname" . }}-grafana-authed
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- if or .Values.auth.oauth.enabled (and .Values.ingress.enabled (index .Values.ingress "oauth2-proxy" "enabled")) }}
@@ -18,7 +18,7 @@ metadata:
     # Basic authentication
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-realm: "SkyPilot API Server"
-    nginx.ingress.kubernetes.io/auth-secret: {{ .Values.ingress.authSecret | default (printf "%s-basic-auth" .Release.Name) }}
+    nginx.ingress.kubernetes.io/auth-secret: {{ .Values.ingress.authSecret | default (printf "%s-basic-auth" (include "skypilot.fullname" .)) }}
     {{- end }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header X-WEBAUTH-USER admin;
@@ -29,7 +29,7 @@ spec:
       paths:
       - backend:
           service:
-            name: {{ .Release.Name }}-grafana
+            name: {{ include "skypilot.fullname" . }}-grafana
             port:
               number: 80
         path: {{ .Values.grafana.ingress.path }}

--- a/charts/skypilot/templates/ingress-nodeport.yaml
+++ b/charts/skypilot/templates/ingress-nodeport.yaml
@@ -2,10 +2,10 @@
 {{- $createNodePort := false -}}
 {{- if eq .Values.ingress.nodePortEnabled nil -}}
   {{- /* Keep existing NodePort service if ingress.nodePortEnabled is not set */ -}}
-  {{- $existingService := lookup "v1" "Service" .Release.Namespace (printf "%s-ingress-controller-np" .Release.Name) -}}
+  {{- $existingService := lookup "v1" "Service" .Release.Namespace (printf "%s-ingress-controller-np" (include "skypilot.fullname" .)) -}}
   {{- if $existingService -}}
     {{- /* If there is an existing legacy NodePort service, error out and ask user to set ingress.nodePortEnabled explicitly */ -}}
-    {{- fail (printf "Service %s-ingress-controller-np is deprecated and will be removed in SkyPilot v0.10.0. Refer to https://docs.skypilot.co/en/latest/reference/api-server/api-server-admin-deploy.html#sky-migrate-legacy-service for migration steps." .Release.Name) -}}
+    {{- fail (printf "Service %s-ingress-controller-np is deprecated and will be removed in SkyPilot v0.10.0. Refer to https://docs.skypilot.co/en/latest/reference/api-server/api-server-admin-deploy.html#sky-migrate-legacy-service for migration steps." (include "skypilot.fullname" .)) -}}
   {{- end -}}
 {{- else -}}
   {{- /* Use explicitly set value */ -}}
@@ -16,7 +16,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-ingress-controller-np
+  name: {{ include "skypilot.fullname" . }}-ingress-controller-np
   namespace: {{ .Release.Namespace }}
 spec:
   type: NodePort

--- a/charts/skypilot/templates/ingress.yaml
+++ b/charts/skypilot/templates/ingress.yaml
@@ -7,7 +7,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ .Release.Name }}-ingress
+  name: {{ include "skypilot.fullname" . }}-ingress
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- if not $useNewIngressClass }}
@@ -43,7 +43,7 @@ metadata:
     # Basic authentication
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-realm: "SkyPilot API Server"
-    nginx.ingress.kubernetes.io/auth-secret: {{ .Values.ingress.authSecret | default (printf "%s-basic-auth" .Release.Name) }}
+    nginx.ingress.kubernetes.io/auth-secret: {{ .Values.ingress.authSecret | default (printf "%s-basic-auth" (include "skypilot.fullname" .)) }}
     {{- end }}
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
@@ -69,7 +69,7 @@ spec:
         path: {{ .Values.ingress.path }}{{ if ne .Values.ingress.path "/" }}(/|$)(.*){{ end }}
         backend:
           service:
-            name: {{ .Release.Name }}-api-service
+            name: {{ include "skypilot.fullname" . }}-api-service
             port:
               number: 80
 {{- end }}

--- a/charts/skypilot/templates/initial-auth.yaml
+++ b/charts/skypilot/templates/initial-auth.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-initial-basic-auth
+  name: {{ include "skypilot.fullname" . }}-initial-basic-auth
   namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:

--- a/charts/skypilot/templates/oauth2-proxy-deployment.yaml
+++ b/charts/skypilot/templates/oauth2-proxy-deployment.yaml
@@ -43,19 +43,19 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: {{ .Release.Name }}-oauth2-proxy
+    app: {{ include "skypilot.fullname" . }}-oauth2-proxy
     skypilot.co/component: oauth2-proxy
-  name: {{ .Release.Name }}-oauth2-proxy
+  name: {{ include "skypilot.fullname" . }}-oauth2-proxy
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-oauth2-proxy
+      app: {{ include "skypilot.fullname" . }}-oauth2-proxy
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}-oauth2-proxy
+        app: {{ include "skypilot.fullname" . }}-oauth2-proxy
         skypilot.co/component: oauth2-proxy
     spec:
       containers:
@@ -110,7 +110,7 @@ spec:
           value: {{ index $oauth2 "client-secret" | quote }}
           {{- end }}
         - name: SERVICE_NAME
-          value: {{ .Release.Name }}
+          value: {{ include "skypilot.fullname" . }}
         {{- if (index $oauth2 "redis-secret") }}
         - name: REDIS_URL
           valueFrom:
@@ -120,7 +120,7 @@ spec:
         {{- end }}
         - name: OAUTH2_PROXY_COOKIE_SECRET
           {{- /* Look up existing deployment to get the current cookie secret if available */}}
-          {{- $deploymentName := printf "%s-oauth2-proxy" .Release.Name }}
+          {{- $deploymentName := printf "%s-oauth2-proxy" (include "skypilot.fullname" .) }}
           {{- $existingDeployment := lookup "apps/v1" "Deployment" .Release.Namespace $deploymentName }}
           {{- if and $existingDeployment $existingDeployment.spec.template.spec.containers }}
             {{- range $container := $existingDeployment.spec.template.spec.containers }}

--- a/charts/skypilot/templates/oauth2-proxy-ingress.yaml
+++ b/charts/skypilot/templates/oauth2-proxy-ingress.yaml
@@ -6,10 +6,10 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ .Release.Name }}-oauth2-proxy
+  name: {{ include "skypilot.fullname" . }}-oauth2-proxy
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name }}-oauth2-proxy
+    app: {{ include "skypilot.fullname" . }}-oauth2-proxy
     skypilot.co/component: oauth2-proxy
   annotations:
     {{- if not $useNewIngressClass }}
@@ -27,7 +27,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: {{ .Release.Name }}-oauth2-proxy
+            name: {{ include "skypilot.fullname" . }}-oauth2-proxy
             port:
               number: 4180
 {{- end }}

--- a/charts/skypilot/templates/oauth2-proxy-redis.yaml
+++ b/charts/skypilot/templates/oauth2-proxy-redis.yaml
@@ -7,20 +7,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-oauth2-proxy-redis
+  name: {{ include "skypilot.fullname" . }}-oauth2-proxy-redis
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name }}-oauth2-proxy-redis
+    app: {{ include "skypilot.fullname" . }}-oauth2-proxy-redis
     skypilot.co/component: oauth2-proxy-redis
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-oauth2-proxy-redis
+      app: {{ include "skypilot.fullname" . }}-oauth2-proxy-redis
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}-oauth2-proxy-redis
+        app: {{ include "skypilot.fullname" . }}-oauth2-proxy-redis
         skypilot.co/component: oauth2-proxy-redis
     spec:
       containers:
@@ -39,10 +39,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-oauth2-proxy-redis
+  name: {{ include "skypilot.fullname" . }}-oauth2-proxy-redis
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name }}-oauth2-proxy-redis
+    app: {{ include "skypilot.fullname" . }}-oauth2-proxy-redis
     skypilot.co/component: oauth2-proxy-redis
 spec:
   type: ClusterIP
@@ -52,6 +52,6 @@ spec:
     protocol: TCP
     name: redis
   selector:
-    app: {{ .Release.Name }}-oauth2-proxy-redis
+    app: {{ include "skypilot.fullname" . }}-oauth2-proxy-redis
 {{- end -}}
 {{- end -}}

--- a/charts/skypilot/templates/oauth2-proxy-service.yaml
+++ b/charts/skypilot/templates/oauth2-proxy-service.yaml
@@ -3,9 +3,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: {{ .Release.Name }}-oauth2-proxy
+    app: {{ include "skypilot.fullname" . }}-oauth2-proxy
     skypilot.co/component: oauth2-proxy
-  name: {{ .Release.Name }}-oauth2-proxy
+  name: {{ include "skypilot.fullname" . }}-oauth2-proxy
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
@@ -14,5 +14,5 @@ spec:
     protocol: TCP
     targetPort: 4180
   selector:
-    app: {{ .Release.Name }}-oauth2-proxy
+    app: {{ include "skypilot.fullname" . }}-oauth2-proxy
 {{- end }}

--- a/charts/skypilot/templates/pvc.yaml
+++ b/charts/skypilot/templates/pvc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Release.Name }}-state
+  name: {{ include "skypilot.fullname" . }}-state
   namespace: {{ .Release.Namespace }}
   {{- with .Values.storage.annotations }}
   annotations:

--- a/charts/skypilot/templates/rbac.yaml
+++ b/charts/skypilot/templates/rbac.yaml
@@ -17,7 +17,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-api-role
+  name: {{ include "skypilot.fullname" . }}-api-role
 rules:
 {{ toYaml .Values.rbac.clusterRules | indent 2 }}
 {{- if .Values.rbac.manageRbacPolicies }}
@@ -32,14 +32,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}-api-role-binding
+  name: {{ include "skypilot.fullname" . }}-api-role-binding
 subjects:
 - kind: ServiceAccount
   name: {{ include "skypilot.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Release.Name }}-api-role
+  name: {{ include "skypilot.fullname" . }}-api-role
   apiGroup: rbac.authorization.k8s.io
 {{- $namespace := .Values.kubernetesCredentials.inclusterNamespace | default .Release.Namespace }}
 {{- if ne $namespace .Release.Namespace }}
@@ -50,7 +50,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Release.Name }}-api-role
+  name: {{ include "skypilot.fullname" . }}-api-role
   namespace: {{ $namespace }}
 rules:
 {{ toYaml .Values.rbac.namespaceRules | indent 2 }}
@@ -66,7 +66,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Release.Name }}-api-role-binding
+  name: {{ include "skypilot.fullname" . }}-api-role-binding
   namespace: {{ $namespace }}
 subjects:
 - kind: ServiceAccount
@@ -74,6 +74,6 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ .Release.Name }}-api-role
+  name: {{ include "skypilot.fullname" . }}-api-role
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/skypilot/templates/system-rbac.yaml
+++ b/charts/skypilot/templates/system-rbac.yaml
@@ -6,7 +6,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Release.Name }}-system-role
+  name: {{ include "skypilot.fullname" . }}-system-role
   namespace: {{ $namespace }}
 rules:
   - apiGroups: [ "apps" ]
@@ -24,7 +24,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Release.Name }}-system-role-binding
+  name: {{ include "skypilot.fullname" . }}-system-role-binding
   namespace: {{ $namespace }}
 subjects:
 - kind: ServiceAccount
@@ -32,7 +32,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ .Release.Name }}-system-role
+  name: {{ include "skypilot.fullname" . }}-system-role
   apiGroup: rbac.authorization.k8s.io
 ---
 {{/* If API server is going to configure RBAC policies for controllers, the permission to manage skypilot-system namespace is also needed */}}
@@ -40,7 +40,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-system-cluster-role
+  name: {{ include "skypilot.fullname" . }}-system-cluster-role
 rules:
   - apiGroups: [ "" ]
     resources: [ "namespaces" ]
@@ -50,14 +50,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}-system-cluster-role-binding
+  name: {{ include "skypilot.fullname" . }}-system-cluster-role-binding
 subjects:
 - kind: ServiceAccount
   name: {{ include "skypilot.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Release.Name }}-system-cluster-role
+  name: {{ include "skypilot.fullname" . }}-system-cluster-role
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
 {{- end }}

--- a/charts/skypilot/tests/db_secrets_test.yaml
+++ b/charts/skypilot/tests/db_secrets_test.yaml
@@ -13,7 +13,7 @@ tests:
           of: Secret
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-db-connection
+          value: RELEASE-NAME-skypilot-db-connection
       - equal:
           path: stringData.connection_string
           value: postgresql://user:pass@host:5432/db

--- a/charts/skypilot/tests/deployment_test.yaml
+++ b/charts/skypilot/tests/deployment_test.yaml
@@ -146,7 +146,7 @@ tests:
             name: SKYPILOT_DB_CONNECTION_URI
             valueFrom:
               secretKeyRef:
-                name: RELEASE-NAME-db-connection
+                name: RELEASE-NAME-skypilot-db-connection
                 key: connection_string
 
   - it: should not set database connection environment variables when neither secret nor string is configured

--- a/charts/skypilot/tests/ingress_test.yaml
+++ b/charts/skypilot/tests/ingress_test.yaml
@@ -13,7 +13,7 @@ tests:
           of: Ingress
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-ingress
+          value: RELEASE-NAME-skypilot-ingress
 
   - it: should not create ingress when disabled
     set:
@@ -135,7 +135,7 @@ tests:
           value: "SkyPilot API Server"
       - equal:
           path: metadata.annotations["nginx.ingress.kubernetes.io/auth-secret"]
-          value: "RELEASE-NAME-basic-auth"
+          value: "RELEASE-NAME-skypilot-basic-auth"
 
   - it: should not add basic auth annotations when user management is enabled
     set:
@@ -254,7 +254,7 @@ tests:
     asserts:
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.name
-          value: "RELEASE-NAME-api-service"
+          value: "RELEASE-NAME-skypilot-api-service"
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.port.number
           value: 80 

--- a/charts/skypilot/tests/oauth2_test.yaml
+++ b/charts/skypilot/tests/oauth2_test.yaml
@@ -65,7 +65,7 @@ tests:
           of: Deployment
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-oauth2-proxy
+          value: RELEASE-NAME-skypilot-oauth2-proxy
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--oidc-issuer-url=https://example.okta.com/oauth2/default"
@@ -211,7 +211,7 @@ tests:
           of: Ingress
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-oauth2-proxy
+          value: RELEASE-NAME-skypilot-oauth2-proxy
       - equal:
           path: spec.rules[0].host
           value: "api.example.com"
@@ -220,7 +220,7 @@ tests:
           value: "/oauth2"
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.name
-          value: RELEASE-NAME-oauth2-proxy
+          value: RELEASE-NAME-skypilot-oauth2-proxy
 
   - it: should create oauth2-proxy resources when new auth config is enabled
     set:
@@ -256,7 +256,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: SKYPILOT_AUTH_OAUTH2_PROXY_BASE_URL
-            value: "http://RELEASE-NAME-oauth2-proxy:4180"
+            value: "http://RELEASE-NAME-skypilot-oauth2-proxy:4180"
 
   - it: should not create oauth2-proxy ingress when using new auth config
     set:
@@ -339,7 +339,7 @@ tests:
           of: Service
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-oauth2-proxy
+          value: RELEASE-NAME-skypilot-oauth2-proxy
       - equal:
           path: spec.ports[0].port
           value: 4180
@@ -348,7 +348,7 @@ tests:
           value: 4180
       - equal:
           path: spec.selector.app
-          value: RELEASE-NAME-oauth2-proxy
+          value: RELEASE-NAME-skypilot-oauth2-proxy
 
   - it: should create redis deployment and service when session store is redis
     set:
@@ -368,7 +368,7 @@ tests:
         documentIndex: 1
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-oauth2-proxy-redis
+          value: RELEASE-NAME-skypilot-oauth2-proxy-redis
         documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].image

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -2,6 +2,18 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
+        "nameOverride": {
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        "fullnameOverride": {
+            "type": [
+                "string",
+                "null"
+            ]
+        },
         "apiService": {
             "type": "object",
             "properties": {

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -2,18 +2,6 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
-        "nameOverride": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "fullnameOverride": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
         "apiService": {
             "type": "object",
             "properties": {
@@ -253,6 +241,9 @@
                 "type": "object"
             }
         },
+        "fullnameOverride": {
+            "type": "string"
+        },
         "gcpCredentials": {
             "type": "object",
             "properties": {
@@ -449,6 +440,9 @@
                     "type": "string"
                 }
             }
+        },
+        "nameOverride": {
+            "type": "string"
         },
         "nebiusCredentials": {
             "type": "object",

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -1,3 +1,6 @@
+nameOverride: ""
+fullnameOverride: ""
+
 apiService:
   # Docker image to use for the API server. The default value will be updated by the release pipeline to be consistent with the SkyPilot release or nightly build.
   # Refer to https://docs.skypilot.co/en/latest/reference/api-server/helm-values-spec.html#helm-values-apiservice-image for more details.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Support the `nameOverride` and `fullnameOverride` values like those in the [official helm chart template](https://github.com/helm/helm/blob/e007c900ce5f2233c8583565d5ba1b0433b1a213/pkg/chartutil/create.go#L433). This allows users to override the names of the resources. Useful for some scenarios such as where you need a fixed name that doesn't change between chart releases.

<!-- Describe the tests ran -->

Changes to tests: 

The original helm tests checked for `RELEASE-NAME-*` but with the new format, the new names follow `RELEASE-NAME-skypilot-*`. If it's not desirable to change the name to this format, I can update the override to preserve the old format instead of appending `.Chart.Name`.

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
