### PR TITLE
[Dashboard] Speed up clusters page first load by 20x for long cluster history

### DIFF
--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -373,8 +373,11 @@ export function Clusters() {
   const handleRefresh = () => {
     // Invalidate cache to ensure fresh data is fetched
     dashboardCache.invalidate(getClusters);
-    dashboardCache.invalidate(getClusterHistory);
     dashboardCache.invalidate(getWorkspaces);
+    // Only invalidate cluster history if we're currently showing history
+    if (showHistory) {
+      dashboardCache.invalidate(getClusterHistory);
+    }
 
     // Reset preloading state so ClusterTable can fetch fresh data immediately
     setPreloadingComplete(false);
@@ -382,11 +385,11 @@ export function Clusters() {
     // Trigger a new preload cycle
     cachePreloader.preloadForPage('clusters', { force: true }).then(() => {
       setPreloadingComplete(true);
+      // Call refresh after preloading is complete
+      if (refreshDataRef.current) {
+        refreshDataRef.current();
+      }
     });
-
-    if (refreshDataRef.current) {
-      refreshDataRef.current();
-    }
   };
 
   return (
@@ -797,7 +800,7 @@ export function ClusterTable({
             </TableHeader>
 
             <TableBody>
-              {loading && isInitialLoad ? (
+              {loading || !preloadingComplete ? (
                 <TableRow>
                   <TableCell
                     colSpan={9}

--- a/sky/dashboard/src/lib/cache-preloader.js
+++ b/sky/dashboard/src/lib/cache-preloader.js
@@ -2,7 +2,7 @@
 // This utility manages background preloading of cache data to improve page switching performance
 
 import dashboardCache from './cache';
-import { getClusters, getClusterHistory } from '@/data/connectors/clusters';
+import { getClusters } from '@/data/connectors/clusters';
 import { getManagedJobsWithClientPagination } from '@/data/connectors/jobs';
 import { getWorkspaces, getEnabledClouds } from '@/data/connectors/workspaces';
 import { getUsers } from '@/data/connectors/users';
@@ -17,7 +17,6 @@ export const DASHBOARD_CACHE_FUNCTIONS = {
   // Base functions used across multiple pages (no arguments)
   base: {
     getClusters: { fn: getClusters, args: [] },
-    getClusterHistory: { fn: getClusterHistory, args: [] },
     getManagedJobs: {
       fn: getManagedJobsWithClientPagination,
       args: [{ allUsers: true }],
@@ -40,7 +39,7 @@ export const DASHBOARD_CACHE_FUNCTIONS = {
 
   // Page-specific function requirements
   pages: {
-    clusters: ['getClusters', 'getClusterHistory', 'getWorkspaces'],
+    clusters: ['getClusters', 'getWorkspaces'],
     jobs: ['getManagedJobs', 'getClusters', 'getWorkspaces', 'getUsers'],
     infra: [
       'getClusters',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR addresses an issue where a browser refresh (cmd/ctrl + r) causes the dashboard to fetch the cost report which calls the super [inefficient](https://github.com/skypilot-org/skypilot/issues/7190) `get_clusters_from_history` from the global user state db. When the cluster history table is long (~1000 clusters), this db query takes around 20 seconds. 

Currently, the dashboard cache preloader loads the cluster history regardless of whether or not the user has actually clicked the "Show history" toggle which means that loading the page takes 20 seconds. Worse yet, instead of showing a loading spinner on the clusters table, we show "No active clusters" during that loading period instead of a loading spinner which makes for a super confusing UX. This PR also addresses this issue by adding a loading spinner to the clusters table. 

<!-- Describe the tests ran -->
This PR was tested by spinning up a test api server with ~1000 clusters in the cluster history table and verified that the `/cost_report` endpoint is no longer being called on first load of the clusters page when the "Show history" toggle is set to false. 

Also benchmarked the load speed on master compared to this branch and saw the time go from ~20s to ~1s (20x speed up) empirically.


<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
