### PR TITLE
[Dashboard] Remove duplicate requests during refresh and query active jobs for pool status

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -216,9 +216,6 @@ export function ManagedJobs() {
     dashboardCache.invalidate(getWorkspaces);
     dashboardCache.invalidate(getUsers);
 
-    // Refresh parent component data (including poolsData for link matching)
-    fetchData(true); // Pass true to indicate it's a refresh button click
-
     // Trigger a re-fetch in both tables via their refreshDataRef
     if (jobsRefreshRef.current) {
       jobsRefreshRef.current();
@@ -784,10 +781,6 @@ export function ManagedJobsTable({
                 // Call the refresh function passed from parent
                 if (onRefresh) {
                   onRefresh();
-                }
-                // Also call the local refresh function to ensure loading state is set
-                if (refreshDataRef && refreshDataRef.current) {
-                  refreshDataRef.current();
                 }
               }}
               disabled={loading}

--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -16,6 +16,7 @@ export async function getManagedJobs(options = {}) {
   try {
     const {
       allUsers = true,
+      skipFinished = false,
       nameMatch,
       userMatch,
       workspaceMatch,
@@ -28,6 +29,7 @@ export async function getManagedJobs(options = {}) {
     const body = {
       all_users: allUsers,
       verbose: true,
+      skip_finished: skipFinished,
     };
     if (nameMatch !== undefined) body.name_match = nameMatch;
     if (userMatch !== undefined) body.user_match = userMatch;
@@ -286,7 +288,7 @@ export async function getPoolStatus() {
     // Also fetch managed jobs to get job counts by pool
     let jobsData = { jobs: [] };
     try {
-      const jobsResponse = await getManagedJobs({ allUsers: true });
+      const jobsResponse = await getManagedJobs({ allUsers: true, skipFinished: true });
       if (!jobsResponse.controllerStopped) {
         jobsData = jobsResponse;
       }

--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -288,7 +288,10 @@ export async function getPoolStatus() {
     // Also fetch managed jobs to get job counts by pool
     let jobsData = { jobs: [] };
     try {
-      const jobsResponse = await getManagedJobs({ allUsers: true, skipFinished: true });
+      const jobsResponse = await getManagedJobs({
+        allUsers: true,
+        skipFinished: true,
+      });
       if (!jobsResponse.controllerStopped) {
         jobsData = jobsResponse;
       }


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

- Remove duplicate requests during refresh
- Query active jobs only for pool status

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Refresh button can refresh the data
  - Job count in pool table works 
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
