### PR TITLE
Fix output handling when not all cluster stopping succeeds (Fixes #7123)

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -47,6 +47,7 @@ import sky
 from sky import backends
 from sky import catalog
 from sky import clouds
+from sky import core
 from sky import dag as dag_lib
 from sky import exceptions
 from sky import jobs as managed_jobs
@@ -3131,6 +3132,28 @@ def _controller_to_hint_or_raise(
     return _hint_or_raise_for_down_sky_serve_controller
 
 
+def _do_down_stop_autostop(
+    name: str,
+    *,
+    do_down: bool,
+    purge: bool,
+    idle_minutes_to_autostop: Optional[int],
+    wait_for: Optional[autostop_lib.AutostopWaitFor],
+) -> None:
+    """Executes down/stop/autostop for a single cluster."""
+    if do_down:
+        core.down(name, purge=purge)
+    elif idle_minutes_to_autostop is not None:
+        core.autostop(
+            name,
+            idle_minutes=idle_minutes_to_autostop,
+            wait_for=wait_for or autostop_lib.DEFAULT_AUTOSTOP_WAIT_FOR,
+            down=do_down,
+        )
+    else:
+        core.stop(name, purge=purge)
+
+
 def _down_or_stop_clusters(
         names: List[str],
         apply_to_all: bool = False,
@@ -3296,6 +3319,39 @@ def _down_or_stop_clusters(
         total=len(clusters))
 
     request_ids = []
+
+    successes: List[str] = []
+    failures: List[Tuple[str, BaseException]] = []
+
+    with progress:
+        for name in clusters:
+            try:
+                sky_logging.print(f'→ {operation.split()[0]} {name} ...', flush=True)
+                _do_down_stop_autostop(
+                    name,
+                    do_down=down,
+                    purge=purge,
+                    idle_minutes_to_autostop=idle_minutes_to_autostop,
+                    wait_for=wait_for,
+                )
+                sky_logging.print(f'✓ {name}', flush=True)
+                successes.append(name)
+            except BaseException as e:
+                e = exceptions.wrap_exception(e)
+                sky_logging.print(f'✗ {name}: {e}', flush=True)
+                failures.append((name, e))
+            finally:
+                progress.update(task, advance=1)
+
+    click.echo('\nSummary:')
+    if successes:
+        click.echo('  ✓ Succeeded: ' + ', '.join(successes))
+    if failures:
+        click.echo('  ✗ Failed: ' + ', '.join(n for (n, _) in failures))
+
+    if failures:
+        raise click.ClickException('Some clusters failed. See summary above.')
+
 
     def _down_or_stop(name: str):
         success_progress = False

--- a/tests/test_down_many.py
+++ b/tests/test_down_many.py
@@ -1,0 +1,106 @@
+import re
+import click
+import pytest
+
+from sky import exceptions
+from sky.client.cli import command as cli_mod
+from sky.client.cli.command import _down_or_stop_clusters
+
+
+def strip_ansi(s: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", s)
+
+
+class DummyCloudError(exceptions.CloudError):
+    def __init__(self):
+        super().__init__(
+            message="Request error UNAUTHENTICATED: Invalid token",
+            cloud_provider="nebius",
+            error_type="RequestError",
+        )
+
+
+@pytest.mark.parametrize("mode", ["down", "stop", "autostop"])
+def test_batch_continues_on_errors_helper(monkeypatch, capsys, mode):
+    monkeypatch.setenv("RICH_FORCE_TERMINAL", "1")
+    monkeypatch.setenv("RICH_PROGRESS_NO_CLEAR", "1")
+    monkeypatch.setenv("TERM", "xterm-256color")
+    monkeypatch.setenv("COLUMNS", "100")
+
+    names = ["sky-ok-1", "sky-nebius-fail", "sky-ok-2"]
+
+    def fake_down(name, purge=False):
+        if name == "sky-nebius-fail":
+            raise DummyCloudError()
+
+    def fake_stop(name, purge=False):
+        return fake_down(name, purge=purge)
+
+    def fake_autostop(name, idle_minutes, wait_for, down):
+        return fake_down(name)
+
+    monkeypatch.setattr(cli_mod.core, "down", fake_down, raising=True)
+    monkeypatch.setattr(cli_mod.core, "stop", fake_stop, raising=True)
+    monkeypatch.setattr(cli_mod.core, "autostop", fake_autostop, raising=True)
+
+    def fake_get_cluster_records_and_set_ssh_config(clusters=None, all_users=False):
+        clusters = clusters or names
+        return [{"name": n, "status": None} for n in clusters]
+
+    monkeypatch.setattr(
+        cli_mod,
+        "_get_cluster_records_and_set_ssh_config",
+        fake_get_cluster_records_and_set_ssh_config,
+        raising=True,
+    )
+
+    class FakeControllers:
+        @staticmethod
+        def from_name(name):
+            return None
+
+    monkeypatch.setattr(
+        cli_mod,
+        "controller_utils",
+        type("X", (), {"Controllers": FakeControllers}),
+        raising=True,
+    )
+
+    kwargs = dict(
+        names=names,
+        apply_to_all=False,
+        all_users=False,
+        down=(mode == "down"),
+        no_confirm=True,
+        purge=False,
+        idle_minutes_to_autostop=(10 if mode == "autostop" else None),
+        wait_for=None,
+        async_call=False,
+    )
+
+    with pytest.raises(click.ClickException):
+        _down_or_stop_clusters(**kwargs)
+
+    captured = capsys.readouterr()
+    out_raw = (captured.out + captured.err).replace("\r", "\n")
+
+    import sys
+
+    print("\n=== DEBUG: RAW OUTPUT ===", file=sys.stderr)
+    print(repr(out_raw), file=sys.stderr)
+    print("\n=== DEBUG: CLEAN OUTPUT ===", file=sys.stderr)
+    print(strip_ansi(out_raw), file=sys.stderr)
+    print("=" * 50, file=sys.stderr)
+
+    with capsys.disabled():
+        print("\n=== USER-VISIBLE OUTPUT (raw) ===\n")
+        print(out_raw)
+    out = strip_ansi(out_raw)
+
+    assert "✓ sky-ok-1" in out
+    assert "✓ sky-ok-2" in out
+    assert "✗ sky-nebius-fail" in out
+    assert re.search(r"nebius.*UNAUTHENTICATED", out, re.I)
+    assert "Summary:" in out
+    assert "Succeeded:" in out
+    assert "Failed:" in out


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
- Added `_do_down_stop_autostop()` helper in `command.py` to encapsulate down/stop/autostop logic for a single cluster.  
- Updated `_down_or_stop_clusters()` to track per-cluster successes/failures and print a clear summary at the end.  
- Adjusted behavior so a single cluster failure no longer makes the whole command appear to fail.

<!-- Describe the tests ran -->
Added a test with mocked clusters for all three operations (`down`, `stop`, `autostop`) using `pytest -s -v tests/test_down_many.py::test_batch_continues_on_errors_helper`. Verified:
- Success/failure logging works as expected.
- Partial failure no longer aborts the whole run.
- Summary output shows succeeded and failed clusters.
<img width="945" height="181" alt="Screenshot 2025-09-17 at 11 19 46" src="https://github.com/user-attachments/assets/8fc2c3e2-be9c-43b7-866b-a8e114161805" />