### PR TITLE
[test] make test_log_collection more robust

### DIFF
--- a/tests/smoke_tests/test_aws_logs.py
+++ b/tests/smoke_tests/test_aws_logs.py
@@ -45,10 +45,11 @@ def test_log_collection_to_aws_cloudwatch(generic_cloud: str):
                       skypilot_smoke_test_case: {name}-case
                 """))
         additional_tags.flush()
-        logs_cmd = 'for i in {1..10}; do echo $i; done'
+        logs_cmd = 'for i in {1..10}; do echo "test output $i"; done'
         validate_logs_cmd = (
             'echo $output && echo "===Validate logs from AWS CloudWatch===" && '
-            'for i in {1..10}; do echo $output | grep -q $i; done')
+            'for i in {1..10}; do echo $output | grep -q "test output $i"; done'
+        )
         test = smoke_tests_utils.Test(
             'log_collection_to_aws_cloudwatch',
             [

--- a/tests/smoke_tests/test_logs.py
+++ b/tests/smoke_tests/test_logs.py
@@ -37,10 +37,11 @@ def test_log_collection_to_gcp(generic_cloud: str):
                       skypilot_smoke_test_case: {name}-case
                 """))
         additional_labels.flush()
-        logs_cmd = 'for i in {1..10}; do echo $i; done'
+        logs_cmd = 'for i in {1..10}; do echo "test output $i"; done'
         validate_logs_cmd = (
             'echo $output && echo "===Validate logs from GCP Cloud Logging===" && '
-            'for i in {1..10}; do echo $output | grep -q $i; done')
+            'for i in {1..10}; do echo $output | grep -q "test output $i"; done'
+        )
         test = smoke_tests_utils.Test(
             'log_collection_to_gcp',
             [


### PR DESCRIPTION
The existing test will not just grep the actual job output, but also some setup log lines. In some case, those log lines can contain all the digits 1-9 as well as "10", which would cause the test to erroneously pass. This occured in #7135 with
test_log_collection_to_gcp, because this log line was present:
```
2025-09-17 21:53:46,296\tINFO worker.py:1719 -- Connected to Ray cluster. View the dashboard at \u001b[1m\u001b[32m127.0.0.1:8266 \u001b[39m\u001b[22m
```
Which matches all numbers from 1 to 10.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
