### PR TITLE
Clear cache after request

### DIFF
--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -465,6 +465,9 @@ def _request_execution_wrapper(request_id: str,
                 # Capture the peak RSS before GC.
                 peak_rss = max(proc.memory_info().rss,
                                metrics_lib.peak_rss_bytes)
+                # Clear request level cache to release all memory used by
+                # the request.
+                annotations.clear_request_level_cache()
                 with metrics_lib.time_it(name='release_memory',
                                          group='internal'):
                     common_utils.release_memory()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We saw a consistent RSS increment after a same request get executed multiple times, this PR clear cache after each request to:

1. Reduce memory footprint before the next cache clear (currently the cache is only cleared before a new request get executed on the executor);
2. Make RSS increment more meaningful by eliminating ephemeral memory usage from the statistics;

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
