### PR TITLE
[local up] support launching multiple kind clusters

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -5897,7 +5897,13 @@ def local():
     '--context-name',
     type=str,
     required=False,
-    help='Name to use for the kubeconfig context. Defaults to "default".')
+    help='Name to use for the kubeconfig context. Defaults to "default". '
+    'Used with the ip list.')
+@click.option(
+    '--name',
+    type=str,
+    required=False,
+    help='Name of the cluster. Defaults to "skypilot". Used without ip list.')
 @click.option('--password',
               type=str,
               required=False,
@@ -5908,7 +5914,7 @@ def local():
 @_add_click_options(flags.COMMON_OPTIONS)
 @usage_lib.entrypoint
 def local_up(gpus: bool, ips: str, ssh_user: str, ssh_key_path: str,
-             cleanup: bool, context_name: Optional[str],
+             cleanup: bool, context_name: Optional[str], name: Optional[str],
              password: Optional[str], async_call: bool):
     """Creates a local or remote cluster."""
 
@@ -5955,17 +5961,26 @@ def local_up(gpus: bool, ips: str, ssh_user: str, ssh_key_path: str,
                 f'Failed to read SSH key file {ssh_key_path}: {str(e)}')
 
     request_id = sdk.local_up(gpus, ip_list, ssh_user, ssh_key, cleanup,
-                              context_name, password)
+                              context_name, name, password)
     _async_call_or_wait(request_id, async_call, request_name='local up')
 
 
+@click.option('--name',
+              type=str,
+              required=False,
+              help='Name of the cluster to down. Defaults to "skypilot".')
 @local.command('down', cls=_DocumentedCodeCommand)
 @flags.config_option(expose_value=False)
 @_add_click_options(flags.COMMON_OPTIONS)
 @usage_lib.entrypoint
-def local_down(async_call: bool):
-    """Deletes a local cluster."""
-    request_id = sdk.local_down()
+def local_down(name: Optional[str], async_call: bool):
+    """Deletes a local cluster.
+
+    This will only delete a local cluster started without the ip list.
+    To clean up the local cluster started with a ip list, use `sky local up`
+    with the cleanup flag.
+    """
+    request_id = sdk.local_down(name)
     _async_call_or_wait(request_id, async_call, request_name='sky.local.down')
 
 

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1677,6 +1677,7 @@ def local_up(gpus: bool,
              ssh_key: Optional[str],
              cleanup: bool,
              context_name: Optional[str] = None,
+             name: Optional[str] = None,
              password: Optional[str] = None) -> server_common.RequestId[None]:
     """Launches a Kubernetes cluster on local machines.
 
@@ -1688,8 +1689,8 @@ def local_up(gpus: bool,
     # TODO: move this check to server.
     if not server_common.is_api_server_local():
         with ux_utils.print_exception_no_traceback():
-            raise ValueError(
-                'sky local up is only supported when running SkyPilot locally.')
+            raise ValueError('`sky local up` is only supported when '
+                             'running SkyPilot locally.')
 
     body = payloads.LocalUpBody(gpus=gpus,
                                 ips=ips,
@@ -1697,6 +1698,7 @@ def local_up(gpus: bool,
                                 ssh_key=ssh_key,
                                 cleanup=cleanup,
                                 context_name=context_name,
+                                name=name,
                                 password=password)
     response = server_common.make_authenticated_request(
         'POST', '/local_up', json=json.loads(body.model_dump_json()))
@@ -1706,16 +1708,19 @@ def local_up(gpus: bool,
 @usage_lib.entrypoint
 @server_common.check_server_healthy_or_start
 @annotations.client_api
-def local_down() -> server_common.RequestId[None]:
+def local_down(name: Optional[str]) -> server_common.RequestId[None]:
     """Tears down the Kubernetes cluster started by local_up."""
     # We do not allow local up when the API server is running remotely since it
     # will modify the kubeconfig.
     # TODO: move this check to remote server.
     if not server_common.is_api_server_local():
         with ux_utils.print_exception_no_traceback():
-            raise ValueError('sky local down is only supported when running '
+            raise ValueError('`sky local down` is only supported when running '
                              'SkyPilot locally.')
-    response = server_common.make_authenticated_request('POST', '/local_down')
+
+    body = payloads.LocalDownBody(name=name)
+    response = server_common.make_authenticated_request(
+        'POST', '/local_down', json=json.loads(body.model_dump_json()))
     return server_common.get_request_id(response)
 
 

--- a/sky/client/sdk_async.py
+++ b/sky/client/sdk_async.py
@@ -661,13 +661,14 @@ async def local_up(
         ssh_key: Optional[str],
         cleanup: bool,
         context_name: Optional[str] = None,
+        name: Optional[str] = None,
         password: Optional[str] = None,
         stream_logs: Optional[StreamConfig] = DEFAULT_STREAM_CONFIG) -> None:
     """Async version of local_up() that launches a Kubernetes cluster on
     local machines."""
     request_id = await context_utils.to_thread(sdk.local_up, gpus, ips,
                                                ssh_user, ssh_key, cleanup,
-                                               context_name, password)
+                                               context_name, name, password)
     if stream_logs is not None:
         return await _stream_and_get(request_id, stream_logs)
     else:
@@ -677,10 +678,11 @@ async def local_up(
 @usage_lib.entrypoint
 @annotations.client_api
 async def local_down(
+        name: Optional[str] = None,
         stream_logs: Optional[StreamConfig] = DEFAULT_STREAM_CONFIG) -> None:
     """Async version of local_down() that tears down the Kubernetes cluster
     started by local_up."""
-    request_id = await context_utils.to_thread(sdk.local_down)
+    request_id = await context_utils.to_thread(sdk.local_down, name)
     if stream_logs is not None:
         return await _stream_and_get(request_id, stream_logs)
     else:

--- a/sky/core.py
+++ b/sky/core.py
@@ -1,6 +1,4 @@
 """SDK functions for cluster/job management."""
-import os
-import shlex
 import typing
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -9,7 +7,6 @@ import colorama
 from sky import admin_policy
 from sky import backends
 from sky import catalog
-from sky import check as sky_check
 from sky import clouds
 from sky import dag as dag_lib
 from sky import data
@@ -31,7 +28,6 @@ from sky.schemas.api import responses
 from sky.skylet import autostop_lib
 from sky.skylet import constants
 from sky.skylet import job_lib
-from sky.skylet import log_lib
 from sky.usage import usage_lib
 from sky.utils import admin_policy_utils
 from sky.utils import common
@@ -1303,6 +1299,7 @@ def local_up(gpus: bool,
              ssh_key: Optional[str],
              cleanup: bool,
              context_name: Optional[str] = None,
+             name: Optional[str] = None,
              password: Optional[str] = None) -> None:
     """Creates a local or remote cluster."""
 
@@ -1333,57 +1330,12 @@ def local_up(gpus: bool,
                                                       password)
     else:
         # Run local deployment (kind) if no remote args are specified
-        kubernetes_deploy_utils.deploy_local_cluster(gpus)
+        kubernetes_deploy_utils.deploy_local_cluster(name, gpus)
 
 
-def local_down() -> None:
+def local_down(name: Optional[str] = None) -> None:
     """Tears down the Kubernetes cluster started by local_up."""
-    cluster_removed = False
-
-    path_to_package = os.path.dirname(__file__)
-    down_script_path = os.path.join(path_to_package, 'utils/kubernetes',
-                                    'delete_cluster.sh')
-
-    cwd = os.path.dirname(os.path.abspath(down_script_path))
-    run_command = shlex.split(down_script_path)
-
-    # Setup logging paths
-    run_timestamp = sky_logging.get_run_timestamp()
-    log_path = os.path.join(constants.SKY_LOGS_DIRECTORY, run_timestamp,
-                            'local_down.log')
-
-    with rich_utils.safe_status(
-            ux_utils.spinner_message('Removing local cluster',
-                                     log_path=log_path,
-                                     is_local=True)):
-
-        returncode, stdout, stderr = log_lib.run_with_log(cmd=run_command,
-                                                          log_path=log_path,
-                                                          require_outputs=True,
-                                                          stream_logs=False,
-                                                          cwd=cwd)
-        stderr = stderr.replace('No kind clusters found.\n', '')
-
-        if returncode == 0:
-            cluster_removed = True
-        elif returncode == 100:
-            logger.info(ux_utils.error_message('Local cluster does not exist.'))
-        else:
-            with ux_utils.print_exception_no_traceback():
-                raise RuntimeError('Failed to create local cluster. '
-                                   f'Stdout: {stdout}'
-                                   f'\nError: {stderr}')
-    if cluster_removed:
-        # Run sky check
-        with rich_utils.safe_status(
-                ux_utils.spinner_message('Running sky check...')):
-            sky_check.check_capability(sky_cloud.CloudCapability.COMPUTE,
-                                       clouds=['kubernetes'],
-                                       quiet=True)
-        logger.info(
-            ux_utils.finishing_message('Local cluster removed.',
-                                       log_path=log_path,
-                                       is_local=True))
+    kubernetes_deploy_utils.teardown_local_cluster(name)
 
 
 @usage_lib.entrypoint

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -672,7 +672,13 @@ class LocalUpBody(RequestBody):
     ssh_key: Optional[str] = None
     cleanup: bool = False
     context_name: Optional[str] = None
+    name: Optional[str] = None
     password: Optional[str] = None
+
+
+class LocalDownBody(RequestBody):
+    """The request body for the local down endpoint."""
+    name: Optional[str] = None
 
 
 class SSHUpBody(RequestBody):

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1438,12 +1438,13 @@ async def local_up(request: fastapi.Request,
 
 
 @app.post('/local_down')
-async def local_down(request: fastapi.Request) -> None:
+async def local_down(request: fastapi.Request,
+                     local_down_body: payloads.LocalDownBody) -> None:
     """Tears down the Kubernetes cluster started by local_up."""
     executor.schedule_request(
         request_id=request.state.request_id,
         request_name='local_down',
-        request_body=payloads.RequestBody(),
+        request_body=local_down_body,
         func=core.local_down,
         schedule_type=requests_lib.ScheduleType.LONG,
     )

--- a/sky/utils/kubernetes/delete_cluster.sh
+++ b/sky/utils/kubernetes/delete_cluster.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
-# Deletes the local kind cluster
-# Usage: ./delete_cluster.sh
-# Raises error code 100 if the local cluster does not exist
+# Deletes the local kind cluster of [name]
+# Usage: ./delete_cluster.sh [name]
+# Raises error code 100 if the specified local cluster does not exist
 
 set -e
+
+NAME="${1:-skypilot}"
+
 # Check if docker is running
 if ! docker info > /dev/null 2>&1; then
     >&2 echo "Docker is not running. Please start Docker and try again."
@@ -17,13 +20,13 @@ if ! kind version > /dev/null 2>&1; then
 fi
 
 # Check if the local cluster exists
-if ! kind get clusters | grep -q skypilot; then
-    echo "Local cluster does not exist. Exiting."
+if ! kind get clusters | grep -q $NAME; then
+    echo "Local cluster $NAME does not exist. Exiting."
     exit 100
 fi
 
-kind delete cluster --name skypilot
-echo "Local cluster deleted!"
+kind delete cluster --name $NAME
+echo "Local cluster $NAME deleted!"
 
 # Switch to the first available context
 AVAILABLE_CONTEXT=$(kubectl config get-contexts -o name | head -n 1)

--- a/sky/utils/kubernetes/generate_kind_config.py
+++ b/sky/utils/kubernetes/generate_kind_config.py
@@ -3,67 +3,8 @@
 Maps specified ports from host to cluster container.
 """
 import argparse
-import textwrap
 
-
-def generate_kind_config(path: str,
-                         port_start: int = 30000,
-                         port_end: int = 32768,
-                         num_nodes: int = 1,
-                         gpus: bool = False) -> None:
-    """Generate a kind cluster config with ports mapped from host to container
-
-    Args:
-        path: Path to generate the config file at
-        port_start: Port range start
-        port_end: Port range end
-        num_nodes: Number of nodes in the cluster
-        gpus: If true, initialize kind cluster with GPU support
-    """
-
-    preamble = textwrap.dedent(f"""
-    apiVersion: kind.x-k8s.io/v1alpha4
-    kind: Cluster
-    kubeadmConfigPatches:
-    - |
-      kind: ClusterConfiguration
-      apiServer:
-        extraArgs:
-          "service-node-port-range": {port_start}-{port_end}
-    nodes:
-    - role: control-plane
-      kubeadmConfigPatches:
-      - |
-        kind: InitConfiguration
-        nodeRegistration:
-          kubeletExtraArgs:
-            node-labels: "ingress-ready=true"
-    """)
-    if gpus:
-        preamble += textwrap.indent(
-            textwrap.dedent("""
-        extraMounts:
-        - hostPath: /dev/null
-          containerPath: /var/run/nvidia-container-devices/all"""), ' ' * 2)
-    preamble += textwrap.indent(
-        textwrap.dedent("""
-      extraPortMappings:"""), ' ' * 2)
-    suffix = ''
-    if num_nodes > 1:
-        for _ in range(1, num_nodes):
-            suffix += """- role: worker\n"""
-    with open(path, 'w', encoding='utf-8') as f:
-        f.write(preamble)
-        for port in range(port_start, port_end + 1):
-            f.write(f"""
-      - containerPort: {port}
-        hostPort: {port}
-        listenAddress: "0.0.0.0"
-        protocol: tcp""")
-        f.write('\n')
-        if suffix:
-            f.write(suffix)
-
+from sky.utils.kubernetes import kubernetes_deploy_utils
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Generate a kind cluster '
@@ -77,10 +18,6 @@ if __name__ == '__main__':
                         type=int,
                         default=30000,
                         help='Port range start')
-    parser.add_argument('--port-end',
-                        type=int,
-                        default=32768,
-                        help='Port range end')
     parser.add_argument('--num-nodes',
                         type=int,
                         default=1,
@@ -90,5 +27,8 @@ if __name__ == '__main__':
                         action='store_true',
                         help='Initialize kind cluster with GPU support')
     args = parser.parse_args()
-    generate_kind_config(args.path, args.port_start, args.port_end,
-                         args.num_nodes, args.gpus)
+
+    with open(args.path, 'w', encoding='utf-8') as f:
+        f.write(
+            kubernetes_deploy_utils.generate_kind_config(
+                args.port_start, args.num_nodes, args.gpus))

--- a/sky/utils/kubernetes/kubernetes_deploy_utils.py
+++ b/sky/utils/kubernetes/kubernetes_deploy_utils.py
@@ -1,9 +1,11 @@
 """Utility functions for deploying Kubernetes clusters."""
 import os
+import random
 import shlex
 import subprocess
 import sys
 import tempfile
+import textwrap
 from typing import List, Optional
 
 import colorama
@@ -24,6 +26,9 @@ logger = sky_logging.init_logger(__name__)
 
 # Default path for Kubernetes configuration file
 DEFAULT_KUBECONFIG_PATH = os.path.expanduser('~/.kube/config')
+DEFAULT_LOCAL_CLUSTER_NAME = 'skypilot'
+LOCAL_CLUSTER_PORT_RANGE = 100
+LOCAL_CLUSTER_INTERNAL_PORT_START = 30000
 
 
 def check_ssh_cluster_dependencies(
@@ -252,7 +257,68 @@ def deploy_remote_cluster(ip_list: List[str],
                         is_local=True))
 
 
-def deploy_local_cluster(gpus: bool):
+def generate_kind_config(port_start: int,
+                         num_nodes: int = 1,
+                         gpus: bool = False) -> str:
+    """Generate a kind cluster config with ports mapped from host to container
+
+    Port range will be [port_start, port_start + LOCAL_CLUSTER_PORT_RANGE)
+    Internally, this will map to ports 30000 - 30099
+
+    Args:
+        path: Path to generate the config file at
+        port_start: Port range start for mappings
+        num_nodes: Number of nodes in the cluster
+        gpus: If true, initialize kind cluster with GPU support
+
+    Returns:
+        The kind cluster config
+    """
+    internal_start = LOCAL_CLUSTER_INTERNAL_PORT_START
+    internal_end = internal_start + LOCAL_CLUSTER_PORT_RANGE - 1
+
+    config = textwrap.dedent(f"""
+    apiVersion: kind.x-k8s.io/v1alpha4
+    kind: Cluster
+    kubeadmConfigPatches:
+    - |
+      kind: ClusterConfiguration
+      apiServer:
+        extraArgs:
+          "service-node-port-range": {internal_start}-{internal_end}
+    nodes:
+    - role: control-plane
+      kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    """)
+    if gpus:
+        config += textwrap.indent(
+            textwrap.dedent("""
+        extraMounts:
+        - hostPath: /dev/null
+          containerPath: /var/run/nvidia-container-devices/all"""), ' ' * 2)
+    config += textwrap.indent(textwrap.dedent("""
+      extraPortMappings:"""), ' ' * 2)
+    for offset in range(LOCAL_CLUSTER_PORT_RANGE):
+        config += textwrap.indent(
+            textwrap.dedent(f"""
+        - containerPort: {internal_start + offset}
+          hostPort: {port_start + offset}
+          listenAddress: "0.0.0.0"
+          protocol: tcp
+        """), ' ' * 2)
+    if num_nodes > 1:
+        config += '- role: worker\n' * (num_nodes - 1)
+    return config
+
+
+def deploy_local_cluster(name: Optional[str], gpus: bool):
+    name = name or DEFAULT_LOCAL_CLUSTER_NAME
+    context_name = f'kind-{name}'
     cluster_created = False
 
     # Check if GPUs are available on the host
@@ -262,41 +328,54 @@ def deploy_local_cluster(gpus: bool):
     # Check if ~/.kube/config exists:
     if os.path.exists(os.path.expanduser('~/.kube/config')):
         curr_context = kubernetes_utils.get_current_kube_config_context_name()
-        skypilot_context = 'kind-skypilot'
-        if curr_context is not None and curr_context != skypilot_context:
+        if curr_context is not None and curr_context != context_name:
             logger.info(
                 f'Current context in kube config: {curr_context}'
-                '\nWill automatically switch to kind-skypilot after the local '
-                'cluster is created.')
-    message_str = 'Creating local cluster{}...'
-    message_str = message_str.format((' with GPU support (this may take up '
-                                      'to 15 minutes)') if gpus else '')
-    path_to_package = os.path.dirname(__file__)
-    up_script_path = os.path.join(path_to_package, 'create_cluster.sh')
+                f'\nWill automatically switch to {context_name} after the '
+                'local cluster is created.')
+    message_str = 'Creating local cluster {}{}...'
+    message_str = message_str.format(
+        name,
+        ' with GPU support (this may take up to 15 minutes)' if gpus else '')
 
-    # Get directory of script and run it from there
-    cwd = os.path.dirname(os.path.abspath(up_script_path))
-    run_command = up_script_path + ' --gpus' if gpus else up_script_path
-    run_command = shlex.split(run_command)
+    with tempfile.NamedTemporaryFile(mode='w+', suffix='.yaml',
+                                     delete=True) as f:
+        # Choose random port range to use on the host machine.
+        # Port range is port_start - port_start + 99 (exactly 100 ports).
+        port_start = random.randint(300, 399) * 100
+        port_end = port_start + LOCAL_CLUSTER_PORT_RANGE - 1
+        logger.debug(f'Using port range {port_start}-{port_end}')
+        f.write(generate_kind_config(port_start, gpus=gpus))
+        f.flush()
 
-    # Setup logging paths
-    run_timestamp = sky_logging.get_run_timestamp()
-    log_path = os.path.join(constants.SKY_LOGS_DIRECTORY, run_timestamp,
-                            'local_up.log')
-    logger.info(message_str)
+        path_to_package = os.path.dirname(__file__)
+        up_script_path = os.path.join(path_to_package, 'create_cluster.sh')
 
-    with rich_utils.safe_status(
-            ux_utils.spinner_message(message_str,
-                                     log_path=log_path,
-                                     is_local=True)):
-        returncode, _, stderr = log_lib.run_with_log(
-            cmd=run_command,
-            log_path=log_path,
-            require_outputs=True,
-            stream_logs=False,
-            line_processor=log_utils.SkyLocalUpLineProcessor(log_path=log_path,
-                                                             is_local=True),
-            cwd=cwd)
+        # Get directory of script and run it from there
+        cwd = os.path.dirname(os.path.abspath(up_script_path))
+        run_command = f'{up_script_path} {name} {f.name}'
+        if gpus:
+            run_command += ' --gpus'
+        run_command = shlex.split(run_command)
+
+        # Setup logging paths
+        run_timestamp = sky_logging.get_run_timestamp()
+        log_path = os.path.join(constants.SKY_LOGS_DIRECTORY, run_timestamp,
+                                'local_up.log')
+        logger.info(message_str)
+
+        with rich_utils.safe_status(
+                ux_utils.spinner_message(message_str,
+                                         log_path=log_path,
+                                         is_local=True)):
+            returncode, _, stderr = log_lib.run_with_log(
+                cmd=run_command,
+                log_path=log_path,
+                require_outputs=True,
+                stream_logs=False,
+                line_processor=log_utils.SkyLocalUpLineProcessor(
+                    log_path=log_path, is_local=True),
+                cwd=cwd)
 
     # Kind always writes to stderr even if it succeeds.
     # If the failure happens after the cluster is created, we need
@@ -309,11 +388,11 @@ def deploy_local_cluster(gpus: bool):
     elif returncode == 100:
         logger.info(
             ux_utils.finishing_message(
-                'Local cluster already exists.\n',
+                f'Local cluster {name} already exists.\n',
                 log_path=log_path,
                 is_local=True,
                 follow_up_message=
-                'If you want to delete it instead, run: sky local down'))
+                'If you want to delete it instead, run: `sky local down --name {name}`'))  # pylint: disable=line-too-long
     else:
         with ux_utils.print_exception_no_traceback():
             log_hint = ux_utils.log_path_hint(log_path, is_local=True)
@@ -339,7 +418,7 @@ def deploy_local_cluster(gpus: bool):
         if gpus:
             # Get GPU model by querying the node labels
             label_name_escaped = 'skypilot.co/accelerator'.replace('.', '\\.')
-            gpu_type_cmd = f'kubectl get node skypilot-control-plane -o jsonpath=\"{{.metadata.labels[\'{label_name_escaped}\']}}\"'  # pylint: disable=line-too-long
+            gpu_type_cmd = f'kubectl get node {name}-control-plane -o jsonpath=\"{{.metadata.labels[\'{label_name_escaped}\']}}\"'  # pylint: disable=line-too-long
             try:
                 # Run the command and capture the output
                 gpu_count_output = subprocess.check_output(gpu_type_cmd,
@@ -375,8 +454,9 @@ def deploy_local_cluster(gpus: bool):
                         'This may cause issues with running tasks.')
         logger.info(
             ux_utils.finishing_message(
-                message=(f'Local Kubernetes cluster created successfully with '
-                         f'{num_cpus} CPUs{gpu_message}.'),
+                message=(
+                    f'Local Kubernetes cluster {name} created successfully '
+                    f'with {num_cpus} CPUs{gpu_message}.'),
                 log_path=log_path,
                 is_local=True,
                 follow_up_message=(
@@ -384,3 +464,54 @@ def deploy_local_cluster(gpus: bool):
                     'Hint: To change the number of CPUs, change your docker '
                     'runtime settings. See https://kind.sigs.k8s.io/docs/user/quick-start/#settings-for-docker-desktop for more info.'  # pylint: disable=line-too-long
                     f'{gpu_hint}')))
+
+
+def teardown_local_cluster(name: Optional[str] = None):
+    name = name or DEFAULT_LOCAL_CLUSTER_NAME
+    cluster_removed = False
+
+    path_to_package = os.path.dirname(__file__)
+    down_script_path = os.path.join(path_to_package, 'delete_cluster.sh')
+
+    cwd = os.path.dirname(os.path.abspath(down_script_path))
+    run_command = f'{down_script_path} {name}'
+    run_command = shlex.split(run_command)
+
+    # Setup logging paths
+    run_timestamp = sky_logging.get_run_timestamp()
+    log_path = os.path.join(constants.SKY_LOGS_DIRECTORY, run_timestamp,
+                            'local_down.log')
+
+    with rich_utils.safe_status(
+            ux_utils.spinner_message(f'Removing local cluster {name}',
+                                     log_path=log_path,
+                                     is_local=True)):
+
+        returncode, stdout, stderr = log_lib.run_with_log(cmd=run_command,
+                                                          log_path=log_path,
+                                                          require_outputs=True,
+                                                          stream_logs=False,
+                                                          cwd=cwd)
+        stderr = stderr.replace('No kind clusters found.\n', '')
+
+        if returncode == 0:
+            cluster_removed = True
+        elif returncode == 100:
+            logger.info(
+                ux_utils.error_message(f'Local cluster {name} does not exist.'))
+        else:
+            with ux_utils.print_exception_no_traceback():
+                raise RuntimeError(f'Failed to down local cluster {name}. '
+                                   f'Stdout: {stdout}'
+                                   f'\nError: {stderr}')
+    if cluster_removed:
+        # Run sky check
+        with rich_utils.safe_status(
+                ux_utils.spinner_message('Running sky check...')):
+            sky_check.check_capability(sky_cloud.CloudCapability.COMPUTE,
+                                       clouds=['kubernetes'],
+                                       quiet=True)
+        logger.info(
+            ux_utils.finishing_message(f'Local cluster {name} removed.',
+                                       log_path=log_path,
+                                       is_local=True))


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #5704

** I know endpoint schema changed, but this won't break backwards compatibility as we don't allow using this command in the client/server model anyways

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
