### PR TITLE
Cost report optimization (2)

### DIFF
--- a/sky/core.py
+++ b/sky/core.py
@@ -302,7 +302,7 @@ def endpoints(cluster: str,
 @usage_lib.entrypoint
 def cost_report(
         days: Optional[int] = None,
-        dashboard_response: bool = False,
+        dashboard_summary_response: bool = False,
         cluster_hashes: Optional[List[str]] = None) -> List[Dict[str, Any]]:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Get all cluster cost reports, including those that have been downed.
@@ -349,7 +349,7 @@ def cost_report(
     if days is None:
         days = constants.COST_REPORT_DEFAULT_DAYS
 
-    abbreviate_response = dashboard_response and cluster_hashes is None
+    abbreviate_response = dashboard_summary_response and cluster_hashes is None
 
     cluster_reports = global_user_state.get_clusters_from_history(
         days=days,
@@ -397,7 +397,7 @@ def cost_report(
         resources = record.get('resources')
         if resources is None:
             return
-        if not dashboard_response:
+        if not dashboard_summary_response:
             fields = ['cloud', 'region', 'cpus', 'memory', 'accelerators']
         else:
             fields = ['cloud']
@@ -434,7 +434,7 @@ def cost_report(
 
     for report in cluster_reports:
         _update_record_with_resources(report)
-        if dashboard_response:
+        if dashboard_summary_response:
             report.pop('usage_intervals')
             report.pop('user_hash')
             report.pop('resources')

--- a/sky/core.py
+++ b/sky/core.py
@@ -434,10 +434,6 @@ def cost_report(
 
     for report in cluster_reports:
         _update_record_with_resources(report)
-        if abbreviate_response:
-            report.pop('last_creation_yaml')
-            report.pop('last_creation_command')
-            report.pop('last_event')
         if dashboard_response:
             report.pop('usage_intervals')
             report.pop('user_hash')

--- a/sky/core.py
+++ b/sky/core.py
@@ -397,7 +397,7 @@ def cost_report(
         resources = record.get('resources')
         if resources is None:
             return
-        if not abbreviate_response:
+        if not dashboard_response:
             fields = ['cloud', 'region', 'cpus', 'memory', 'accelerators']
         else:
             fields = ['cloud']
@@ -438,6 +438,7 @@ def cost_report(
             report.pop('last_creation_yaml')
             report.pop('last_creation_command')
             report.pop('last_event')
+        if dashboard_response:
             report.pop('usage_intervals')
             report.pop('user_hash')
             report.pop('resources')

--- a/sky/core.py
+++ b/sky/core.py
@@ -386,7 +386,7 @@ def cost_report(
     if not cluster_reports:
         return []
 
-    if not dashboard_response:
+    if not abbreviate_response:
         cluster_reports = subprocess_utils.run_in_parallel(
             _process_cluster_report, cluster_reports)
 

--- a/sky/core.py
+++ b/sky/core.py
@@ -300,7 +300,7 @@ def endpoints(cluster: str,
 
 
 @usage_lib.entrypoint
-def cost_report(days: Optional[int] = None) -> List[Dict[str, Any]]:
+def cost_report(days: Optional[int] = None, include_cost: bool = True) -> List[Dict[str, Any]]:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Get all cluster cost reports, including those that have been downed.
 
@@ -364,43 +364,6 @@ def cost_report(days: Optional[int] = None) -> List[Dict[str, Any]]:
             cost = (launched_resources.get_cost(duration) * launched_nodes)
             return cost
 
-        def _update_record_with_resources(record: Dict[str, Any]) -> None:
-            """Add resource fields for dashboard compatibility."""
-            if record is None:
-                return
-            resources = record.get('resources')
-            if resources is None:
-                return
-            fields = ['cloud', 'region', 'cpus', 'memory', 'accelerators']
-            for field in fields:
-                try:
-                    record[field] = str(getattr(resources, field))
-                except Exception as e:  # pylint: disable=broad-except
-                    # Ok to skip the fields as this is just for display
-                    # purposes.
-                    logger.debug(f'Failed to get resources.{field} for cluster '
-                                 f'{record["name"]}: {str(e)}')
-                    record[field] = None
-
-            # Add resources_str and resources_str_full for dashboard
-            # compatibility
-            num_nodes = record.get('num_nodes', 1)
-            try:
-                resource_str_simple = resources_utils.format_resource(
-                    resources, simplify=True)
-                resource_str_full = resources_utils.format_resource(
-                    resources, simplify=False)
-                record['resources_str'] = f'{num_nodes}x{resource_str_simple}'
-                record[
-                    'resources_str_full'] = f'{num_nodes}x{resource_str_full}'
-            except Exception as e:  # pylint: disable=broad-except
-                logger.debug(f'Failed to get resources_str for cluster '
-                             f'{record["name"]}: {str(e)}')
-                for field in fields:
-                    record[field] = None
-                record['resources_str'] = '-'
-                record['resources_str_full'] = '-'
-
         try:
             report['total_cost'] = get_total_cost(report)
         except Exception as e:  # pylint: disable=broad-except
@@ -409,17 +372,57 @@ def cost_report(days: Optional[int] = None) -> List[Dict[str, Any]]:
                            f'{report["name"]}: {str(e)}')
             report['total_cost'] = 0.0
 
-        _update_record_with_resources(report)
         return report
 
     # Process clusters in parallel
     if not cluster_reports:
         return []
 
-    processed_reports = subprocess_utils.run_in_parallel(
-        _process_cluster_report, cluster_reports)
+    if include_cost:
+        cluster_reports = subprocess_utils.run_in_parallel(
+            _process_cluster_report, cluster_reports)
 
-    return processed_reports
+    def _update_record_with_resources(record: Dict[str, Any]) -> None:
+        """Add resource fields for dashboard compatibility."""
+        if record is None:
+            return
+        resources = record.get('resources')
+        if resources is None:
+            return
+        fields = ['cloud', 'region', 'cpus', 'memory', 'accelerators']
+        for field in fields:
+            try:
+                record[field] = str(getattr(resources, field))
+            except Exception as e:  # pylint: disable=broad-except
+                # Ok to skip the fields as this is just for display
+                # purposes.
+                logger.debug(f'Failed to get resources.{field} for cluster '
+                                f'{record["name"]}: {str(e)}')
+                record[field] = None
+
+        # Add resources_str and resources_str_full for dashboard
+        # compatibility
+        num_nodes = record.get('num_nodes', 1)
+        try:
+            resource_str_simple = resources_utils.format_resource(
+                resources, simplify=True)
+            resource_str_full = resources_utils.format_resource(
+                resources, simplify=False)
+            record['resources_str'] = f'{num_nodes}x{resource_str_simple}'
+            record[
+                'resources_str_full'] = f'{num_nodes}x{resource_str_full}'
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Failed to get resources_str for cluster '
+                            f'{record["name"]}: {str(e)}')
+            for field in fields:
+                record[field] = None
+            record['resources_str'] = '-'
+            record['resources_str_full'] = '-'
+
+    for report in cluster_reports:
+        _update_record_with_resources(report)
+
+    return cluster_reports
 
 
 def _start(

--- a/sky/core.py
+++ b/sky/core.py
@@ -397,7 +397,10 @@ def cost_report(
         resources = record.get('resources')
         if resources is None:
             return
-        fields = ['cloud', 'region', 'cpus', 'memory', 'accelerators']
+        if not abbreviate_response:
+            fields = ['cloud', 'region', 'cpus', 'memory', 'accelerators']
+        else:
+            fields = ['cloud']
         for field in fields:
             try:
                 record[field] = str(getattr(resources, field))
@@ -414,17 +417,20 @@ def cost_report(
         try:
             resource_str_simple = resources_utils.format_resource(resources,
                                                                   simplify=True)
-            resource_str_full = resources_utils.format_resource(resources,
-                                                                simplify=False)
             record['resources_str'] = f'{num_nodes}x{resource_str_simple}'
-            record['resources_str_full'] = f'{num_nodes}x{resource_str_full}'
+            if not abbreviate_response:
+                resource_str_full = resources_utils.format_resource(
+                    resources, simplify=False)
+                record[
+                    'resources_str_full'] = f'{num_nodes}x{resource_str_full}'
         except Exception as e:  # pylint: disable=broad-except
             logger.debug(f'Failed to get resources_str for cluster '
                          f'{record["name"]}: {str(e)}')
             for field in fields:
                 record[field] = None
             record['resources_str'] = '-'
-            record['resources_str_full'] = '-'
+            if not abbreviate_response:
+                record['resources_str_full'] = '-'
 
     for report in cluster_reports:
         _update_record_with_resources(report)

--- a/sky/core.py
+++ b/sky/core.py
@@ -300,7 +300,8 @@ def endpoints(cluster: str,
 
 
 @usage_lib.entrypoint
-def cost_report(days: Optional[int] = None, include_cost: bool = True) -> List[Dict[str, Any]]:
+def cost_report(days: Optional[int] = None,
+                dashboard_response: bool = False) -> List[Dict[str, Any]]:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Get all cluster cost reports, including those that have been downed.
 
@@ -378,7 +379,7 @@ def cost_report(days: Optional[int] = None, include_cost: bool = True) -> List[D
     if not cluster_reports:
         return []
 
-    if include_cost:
+    if not dashboard_response:
         cluster_reports = subprocess_utils.run_in_parallel(
             _process_cluster_report, cluster_reports)
 
@@ -397,23 +398,22 @@ def cost_report(days: Optional[int] = None, include_cost: bool = True) -> List[D
                 # Ok to skip the fields as this is just for display
                 # purposes.
                 logger.debug(f'Failed to get resources.{field} for cluster '
-                                f'{record["name"]}: {str(e)}')
+                             f'{record["name"]}: {str(e)}')
                 record[field] = None
 
         # Add resources_str and resources_str_full for dashboard
         # compatibility
         num_nodes = record.get('num_nodes', 1)
         try:
-            resource_str_simple = resources_utils.format_resource(
-                resources, simplify=True)
-            resource_str_full = resources_utils.format_resource(
-                resources, simplify=False)
+            resource_str_simple = resources_utils.format_resource(resources,
+                                                                  simplify=True)
+            resource_str_full = resources_utils.format_resource(resources,
+                                                                simplify=False)
             record['resources_str'] = f'{num_nodes}x{resource_str_simple}'
-            record[
-                'resources_str_full'] = f'{num_nodes}x{resource_str_full}'
+            record['resources_str_full'] = f'{num_nodes}x{resource_str_full}'
         except Exception as e:  # pylint: disable=broad-except
             logger.debug(f'Failed to get resources_str for cluster '
-                            f'{record["name"]}: {str(e)}')
+                         f'{record["name"]}: {str(e)}')
             for field in fields:
                 record[field] = None
             record['resources_str'] = '-'

--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -112,11 +112,19 @@ export async function getClusters({ clusterNames = null } = {}) {
   }
 }
 
-export async function getClusterHistory() {
+export async function getClusterHistory(clusterHash = null) {
   try {
-    const history = await apiClient.fetch('/cost_report', {
+    const requestBody = {
       days: 30,
-    });
+      dashboard_response: true,
+    };
+    
+    // If a specific cluster hash is provided, include it in the request
+    if (clusterHash) {
+      requestBody.cluster_hashes = [clusterHash];
+    }
+    
+    const history = await apiClient.fetch('/cost_report', requestBody);
 
     console.log('Raw cluster history data:', history); // Debug log
 

--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -116,7 +116,7 @@ export async function getClusterHistory(clusterHash = null) {
   try {
     const requestBody = {
       days: 30,
-      dashboard_response: true,
+      dashboard_summary_response: true,
     };
 
     // If a specific cluster hash is provided, include it in the request

--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -118,12 +118,12 @@ export async function getClusterHistory(clusterHash = null) {
       days: 30,
       dashboard_response: true,
     };
-    
+
     // If a specific cluster hash is provided, include it in the request
     if (clusterHash) {
       requestBody.cluster_hashes = [clusterHash];
     }
-    
+
     const history = await apiClient.fetch('/cost_report', requestBody);
 
     console.log('Raw cluster history data:', history); // Debug log

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -167,7 +167,9 @@ function ClusterDetails() {
 
       setHistoryLoading(true);
       try {
-        const historyData = await dashboardCache.get(getClusterHistory, [cluster]);
+        const historyData = await dashboardCache.get(getClusterHistory, [
+          cluster,
+        ]);
         const foundHistoryCluster = historyData.find(
           (c) => c.cluster_hash === cluster || c.cluster === cluster
         );

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -167,7 +167,7 @@ function ClusterDetails() {
 
       setHistoryLoading(true);
       try {
-        const historyData = await dashboardCache.get(getClusterHistory);
+        const historyData = await dashboardCache.get(getClusterHistory, [cluster]);
         const foundHistoryCluster = historyData.find(
           (c) => c.cluster_hash === cluster || c.cluster === cluster
         );

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1645,12 +1645,11 @@ def get_clusters_from_history(
             'user_hash': user_hash,
             'user_name': user_name,
             'workspace': workspace,
-            'last_creation_yaml': None if abbreviate_response else
-                                  row.last_creation_yaml,
-            'last_creation_command': None if abbreviate_response else
-                                     row.last_creation_command,
-            'last_event': None if abbreviate_response else last_event,
         }
+        if not abbreviate_response:
+            record['last_creation_yaml'] = row.last_creation_yaml
+            record['last_creation_command'] = row.last_creation_command
+            record['last_event'] = last_event
 
         records.append(record)
 

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -792,7 +792,8 @@ class GetConfigBody(RequestBody):
 class CostReportBody(RequestBody):
     """The request body for the cost report endpoint."""
     days: Optional[int] = 30
-    include_cost: bool = True
+    # Only return fields that are needed for the dashboard
+    dashboard_response: bool = False
 
 
 class RequestPayload(BasePayload):

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -792,6 +792,7 @@ class GetConfigBody(RequestBody):
 class CostReportBody(RequestBody):
     """The request body for the cost report endpoint."""
     days: Optional[int] = 30
+    include_cost: bool = True
 
 
 class RequestPayload(BasePayload):

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -796,7 +796,8 @@ class CostReportBody(RequestBody):
     # the name is not unique
     cluster_hashes: Optional[List[str]] = None
     # Only return fields that are needed for the dashboard
-    dashboard_response: bool = False
+    # summary page
+    dashboard_summary_response: bool = False
 
 
 class RequestPayload(BasePayload):

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -792,6 +792,9 @@ class GetConfigBody(RequestBody):
 class CostReportBody(RequestBody):
     """The request body for the cost report endpoint."""
     days: Optional[int] = 30
+    # we use hashes instead of names to avoid the case where
+    # the name is not unique
+    cluster_hashes: Optional[List[str]] = None
     # Only return fields that are needed for the dashboard
     dashboard_response: bool = False
 

--- a/sky/server/requests/serializers/encoders.py
+++ b/sky/server/requests/serializers/encoders.py
@@ -185,8 +185,9 @@ def encode_cost_report(
     for cluster_report in cost_report:
         if cluster_report['status'] is not None:
             cluster_report['status'] = cluster_report['status'].value
-        cluster_report['resources'] = pickle_and_encode(
-            cluster_report['resources'])
+        if 'resources' in cluster_report:
+            cluster_report['resources'] = pickle_and_encode(
+                cluster_report['resources'])
     return cost_report
 
 

--- a/tests/unit_tests/test_sky/test_cost_report.py
+++ b/tests/unit_tests/test_sky/test_cost_report.py
@@ -21,7 +21,9 @@ class TestCostReportCore(unittest.TestCase):
             result = core.cost_report()
 
             # Should call with default 30 days
-            mock_get_history.assert_called_once_with(days=30)
+            mock_get_history.assert_called_once_with(days=30,
+                                                     abbreviate_response=False,
+                                                     cluster_hashes=None)
             self.assertEqual(result, [])
 
     def test_cost_report_custom_days(self):
@@ -33,7 +35,9 @@ class TestCostReportCore(unittest.TestCase):
             result = core.cost_report(days=7)
 
             # Should call with custom 7 days
-            mock_get_history.assert_called_once_with(days=7)
+            mock_get_history.assert_called_once_with(days=7,
+                                                     abbreviate_response=False,
+                                                     cluster_hashes=None)
             self.assertEqual(result, [])
 
     def test_cost_report_none_days(self):
@@ -45,7 +49,9 @@ class TestCostReportCore(unittest.TestCase):
             result = core.cost_report(days=None)
 
             # Should call with default 30 days when None is passed
-            mock_get_history.assert_called_once_with(days=30)
+            mock_get_history.assert_called_once_with(days=30,
+                                                     abbreviate_response=False,
+                                                     cluster_hashes=None)
             self.assertEqual(result, [])
 
     def test_cost_report_with_pickle_errors(self):
@@ -62,7 +68,9 @@ class TestCostReportCore(unittest.TestCase):
             result = core.cost_report(days=30)
 
             self.assertEqual(result, [])
-            mock_get_history.assert_called_once_with(days=30)
+            mock_get_history.assert_called_once_with(days=30,
+                                                     abbreviate_response=False,
+                                                     cluster_hashes=None)
 
 
 class TestCostReportStatusUtils(unittest.TestCase):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Improve speed of calling cost_report endpoint in dashboard by doing the minimal work necessary to serve the UI.

Tests:
Measured loading time of historical clusters on an API server with around 1200 terminated clusters - this change drops the loading time from 6 to 3 seconds.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
