### PR TITLE
[Dashboard] Show the result of the latest request and throw error when failed to get managed jobs

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -338,6 +338,8 @@ export function ManagedJobsTable({
     onConfirm: null,
   });
   const isMobile = useMobile();
+  // Guards multiple concurrent fetches: only latest response should commit
+  const requestSeqRef = useRef(0);
 
   const handleRestartController = async () => {
     setConfirmationModal({
@@ -364,6 +366,9 @@ export function ManagedJobsTable({
   const fetchData = React.useCallback(
     async (options = {}) => {
       const includeStatus = options.includeStatus !== false;
+      // Bump request sequence and capture a version for this fetch
+      const version = requestSeqRef.current + 1;
+      requestSeqRef.current = version;
       setLocalLoading(true);
       setLoading(true); // Set parent loading state
       try {
@@ -448,13 +453,16 @@ export function ManagedJobsTable({
           }
         }
 
-        setData(jobs);
-        setTotalCount(total || 0);
-        setTotalNoFilter(totalNoFilter || 0);
-        setControllerStopped(!!isControllerStopped);
-        setControllerLaunching(!!isLaunching);
-        setApiStatusCounts(statusCounts);
-        setIsInitialLoad(false);
+        // Only commit if this is still the latest request
+        if (version === requestSeqRef.current) {
+          setData(jobs);
+          setTotalCount(total || 0);
+          setTotalNoFilter(totalNoFilter || 0);
+          setControllerStopped(!!isControllerStopped);
+          setControllerLaunching(!!isLaunching);
+          setApiStatusCounts(statusCounts);
+          setIsInitialLoad(false);
+        }
 
         // Log cache status for debugging
         if (process.env.NODE_ENV === 'development') {
@@ -470,12 +478,16 @@ export function ManagedJobsTable({
       } catch (err) {
         console.error('Error fetching data:', err);
         // Still set data to empty array on error to show proper UI
-        setData([]);
-        setControllerStopped(false);
-        setIsInitialLoad(false);
+        if (version === requestSeqRef.current) {
+          setData([]);
+          setControllerStopped(false);
+          setIsInitialLoad(false);
+        }
       } finally {
-        setLocalLoading(false);
-        setLoading(false); // Clear parent loading state
+        if (version === requestSeqRef.current) {
+          setLocalLoading(false);
+          setLoading(false); // Clear parent loading state
+        }
       }
     },
     [

--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -12,45 +12,49 @@ import { apiClient } from './client';
 // Configuration
 const DEFAULT_TAIL_LINES = 10000;
 
-export async function getManagedJobs(options = {}) {
-  try {
-    const {
-      allUsers = true,
-      skipFinished = false,
-      nameMatch,
-      userMatch,
-      workspaceMatch,
-      poolMatch,
-      page,
-      limit,
-      statuses,
-    } = options;
+export async function getManagedJobs(options) {
+  const {
+    allUsers = true,
+    skipFinished = false,
+    nameMatch,
+    userMatch,
+    workspaceMatch,
+    poolMatch,
+    page,
+    limit,
+    statuses,
+  } = options || {};
 
-    const body = {
-      all_users: allUsers,
-      verbose: true,
-      skip_finished: skipFinished,
-    };
-    if (nameMatch !== undefined) body.name_match = nameMatch;
-    if (userMatch !== undefined) body.user_match = userMatch;
-    if (workspaceMatch !== undefined) body.workspace_match = workspaceMatch;
-    if (poolMatch !== undefined) body.pool_match = poolMatch;
-    if (page !== undefined) body.page = page;
-    if (limit !== undefined) body.limit = limit;
-    if (statuses !== undefined && statuses.length > 0) body.statuses = statuses;
+  const body = {
+    all_users: allUsers,
+    verbose: true,
+    skip_finished: skipFinished,
+  };
+  if (nameMatch !== undefined) body.name_match = nameMatch;
+  if (userMatch !== undefined) body.user_match = userMatch;
+  if (workspaceMatch !== undefined) body.workspace_match = workspaceMatch;
+  if (poolMatch !== undefined) body.pool_match = poolMatch;
+  if (page !== undefined) body.page = page;
+  if (limit !== undefined) body.limit = limit;
+  if (statuses !== undefined && statuses.length > 0) body.statuses = statuses;
 
-    const response = await apiClient.post(`/jobs/queue/v2`, body);
-    const id = response.headers.get('X-Skypilot-Request-ID');
-    const fetchedData = await apiClient.get(`/api/get?request_id=${id}`);
+  const response = await apiClient.post(`/jobs/queue/v2`, body);
+  if (!response.ok) {
+    throw new Error(`Failed to schedule jobs query: ${response.status}`);
+  }
+
+  const id = response.headers.get('X-Skypilot-Request-ID');
+  const fetchedData = await apiClient.get(`/api/get?request_id=${id}`);
+  if (fetchedData.status !== 200) {
+    // For 500, check CLUSTER_NOT_UP and throw to avoid caching erroneous data
     if (fetchedData.status === 500) {
       try {
         const data = await fetchedData.json();
         if (data.detail && data.detail.error) {
           try {
             const error = JSON.parse(data.detail.error);
-            // Handle specific error types
             if (error.type && error.type === CLUSTER_NOT_UP_ERROR) {
-              return { jobs: [], total: 0, controllerStopped: true };
+              throw new Error('CLUSTER_NOT_UP');
             }
           } catch (jsonError) {
             console.error('Error parsing JSON:', jsonError);
@@ -59,129 +63,118 @@ export async function getManagedJobs(options = {}) {
       } catch (parseError) {
         console.error('Error parsing JSON:', parseError);
       }
-      return { jobs: [], total: 0, controllerStopped: false };
     }
-    // print out the response for debugging
-    const data = await fetchedData.json();
-    const parsed = data.return_value ? JSON.parse(data.return_value) : [];
-    const managedJobs = Array.isArray(parsed) ? parsed : parsed?.jobs || [];
-    const total = Array.isArray(parsed)
-      ? managedJobs.length
-      : (parsed?.total ?? managedJobs.length);
-    const totalNoFilter = parsed?.total_no_filter || total;
-    const statusCounts = parsed?.status_counts || {};
-
-    // Process jobs data
-    const jobData = managedJobs.map((job) => {
-      let total_duration = 0;
-      if (job.end_at && job.submitted_at) {
-        total_duration = job.end_at - job.submitted_at;
-      } else if (job.submitted_at) {
-        total_duration = Date.now() / 1000 - job.submitted_at;
-      }
-
-      const events = [];
-      if (job.submitted_at) {
-        events.push({
-          type: 'PENDING',
-          timestamp: job.submitted_at,
-        });
-      }
-      if (job.start_at) {
-        events.push({
-          type: 'RUNNING',
-          timestamp: job.start_at,
-        });
-      }
-      if (job.end_at) {
-        events.push({
-          type: job.status,
-          timestamp: job.end_at,
-        });
-      }
-
-      let cloud = '';
-      let region = '';
-      let cluster_resources = '';
-      let infra = '';
-      let full_infra = '';
-
-      try {
-        cloud = job.cloud || '';
-        cluster_resources = job.cluster_resources;
-        region = job.region || '';
-
-        if (cloud) {
-          infra = cloud;
-          if (region) {
-            infra += `/${region}`;
-          }
-        }
-
-        full_infra = infra;
-        if (job.accelerators) {
-          const accel_str = Object.entries(job.accelerators)
-            .map(([key, value]) => `${value}x${key}`)
-            .join(', ');
-          if (accel_str) {
-            full_infra += ` (${accel_str})`;
-          }
-        }
-      } catch (e) {
-        cluster_resources = job.cluster_resources;
-      }
-
-      return {
-        id: job.job_id,
-        task_job_id: job._job_id,
-        task: job.task_name,
-        name: job.job_name,
-        job_duration: job.job_duration,
-        total_duration: total_duration,
-        workspace: job.workspace,
-        status: job.status,
-        requested_resources: job.resources,
-        resources_str: cluster_resources,
-        resources_str_full: job.cluster_resources_full || cluster_resources,
-        cloud: cloud,
-        region: job.region,
-        infra: infra,
-        full_infra: full_infra,
-        recoveries: job.recovery_count,
-        details: job.details || job.failure_reason,
-        user: job.user_name,
-        user_hash: job.user_hash,
-        submitted_at: job.submitted_at
-          ? new Date(job.submitted_at * 1000)
-          : null,
-        events: events,
-        dag_yaml: job.user_yaml,
-        entrypoint: job.entrypoint,
-        git_commit: job.metadata?.git_commit || '-',
-        pool: job.pool,
-        pool_hash: job.pool_hash,
-        current_cluster_name: job.current_cluster_name,
-        job_id_on_pool_cluster: job.job_id_on_pool_cluster,
-      };
-    });
-
-    return {
-      jobs: jobData,
-      total,
-      totalNoFilter,
-      controllerStopped: false,
-      statusCounts,
-    };
-  } catch (error) {
-    console.error('Error fetching managed job data:', error);
-    return {
-      jobs: [],
-      total: 0,
-      totalNoFilter: 0,
-      controllerStopped: false,
-      statusCounts: {},
-    };
+    throw new Error(`Jobs result not OK: ${fetchedData.status}`);
   }
+  // print out the response for debugging
+  const data = await fetchedData.json();
+  const parsed = data.return_value ? JSON.parse(data.return_value) : [];
+  const managedJobs = Array.isArray(parsed) ? parsed : parsed?.jobs || [];
+  const total = Array.isArray(parsed)
+    ? managedJobs.length
+    : (parsed?.total ?? managedJobs.length);
+  const totalNoFilter = parsed?.total_no_filter || total;
+  const statusCounts = parsed?.status_counts || {};
+
+  // Process jobs data
+  const jobData = managedJobs.map((job) => {
+    let total_duration = 0;
+    if (job.end_at && job.submitted_at) {
+      total_duration = job.end_at - job.submitted_at;
+    } else if (job.submitted_at) {
+      total_duration = Date.now() / 1000 - job.submitted_at;
+    }
+
+    const events = [];
+    if (job.submitted_at) {
+      events.push({
+        type: 'PENDING',
+        timestamp: job.submitted_at,
+      });
+    }
+    if (job.start_at) {
+      events.push({
+        type: 'RUNNING',
+        timestamp: job.start_at,
+      });
+    }
+    if (job.end_at) {
+      events.push({
+        type: job.status,
+        timestamp: job.end_at,
+      });
+    }
+
+    let cloud = '';
+    let region = '';
+    let cluster_resources = '';
+    let infra = '';
+    let full_infra = '';
+
+    try {
+      cloud = job.cloud || '';
+      cluster_resources = job.cluster_resources;
+      region = job.region || '';
+
+      if (cloud) {
+        infra = cloud;
+        if (region) {
+          infra += `/${region}`;
+        }
+      }
+
+      full_infra = infra;
+      if (job.accelerators) {
+        const accel_str = Object.entries(job.accelerators)
+          .map(([key, value]) => `${value}x${key}`)
+          .join(', ');
+        if (accel_str) {
+          full_infra += ` (${accel_str})`;
+        }
+      }
+    } catch (e) {
+      cluster_resources = job.cluster_resources;
+    }
+
+    return {
+      id: job.job_id,
+      task_job_id: job._job_id,
+      task: job.task_name,
+      name: job.job_name,
+      job_duration: job.job_duration,
+      total_duration: total_duration,
+      workspace: job.workspace,
+      status: job.status,
+      requested_resources: job.resources,
+      resources_str: cluster_resources,
+      resources_str_full: job.cluster_resources_full || cluster_resources,
+      cloud: cloud,
+      region: job.region,
+      infra: infra,
+      full_infra: full_infra,
+      recoveries: job.recovery_count,
+      details: job.details || job.failure_reason,
+      user: job.user_name,
+      user_hash: job.user_hash,
+      submitted_at: job.submitted_at ? new Date(job.submitted_at * 1000) : null,
+      events: events,
+      dag_yaml: job.user_yaml,
+      entrypoint: job.entrypoint,
+      git_commit: job.metadata?.git_commit || '-',
+      pool: job.pool,
+      pool_hash: job.pool_hash,
+      current_cluster_name: job.current_cluster_name,
+      job_id_on_pool_cluster: job.job_id_on_pool_cluster,
+    };
+  });
+
+  return {
+    jobs: jobData,
+    total,
+    totalNoFilter,
+    controllerStopped: false,
+    statusCounts,
+  };
 }
 
 /**
@@ -198,7 +191,7 @@ export async function getManagedJobs(options = {}) {
  * @param {boolean} options.useClientPagination - Whether to use client-side pagination (default: true)
  * @returns {Promise<{jobs: Array, total: number, controllerStopped: boolean}>}
  */
-export async function getManagedJobsWithClientPagination(options = {}) {
+export async function getManagedJobsWithClientPagination(options) {
   const {
     allUsers = true,
     nameMatch,
@@ -208,7 +201,7 @@ export async function getManagedJobsWithClientPagination(options = {}) {
     page = 1,
     limit = 10,
     useClientPagination = true,
-  } = options;
+  } = options || {};
 
   try {
     // If client pagination is disabled, fall back to server-side pagination


### PR DESCRIPTION

<!-- Describe the changes in this PR -->
Show the result of the latest request and throw error when failed to get managed jobs


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - For the case where there are a lot of managed jobs, when the cache is not ready, click the status filter to check jobs of different statuses, only the result of the last status will be shown in the jobs table
  - When failed to get the managed jobs list, the cache will not be overridden to be empty list
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
