### PR TITLE
Fix AWS Storage Mounting for profiles other than default

### DIFF
--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -94,7 +94,8 @@ def get_s3_mount_cmd(bucket_name: str,
     # Use rclone for ARM64 architectures since goofys doesn't support them
     rclone_mount = (
         f'{FUSERMOUNT3_SOFT_LINK_CMD} && '
-        f'AWS_PROFILE={os.getenv("AWS_PROFILE")} rclone mount :s3:{bucket_name}{_bucket_sub_path} {mount_path} '
+        f'AWS_PROFILE={os.getenv("AWS_PROFILE")} \
+         rclone mount :s3:{bucket_name}{_bucket_sub_path} {mount_path} '
         # Have to add --s3-env-auth=true to allow rclone to access private
         # buckets.
         '--daemon --allow-other --s3-env-auth=true')

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -94,8 +94,8 @@ def get_s3_mount_cmd(bucket_name: str,
     # Use rclone for ARM64 architectures since goofys doesn't support them
     rclone_mount = (
         f'{FUSERMOUNT3_SOFT_LINK_CMD} && '
-        f'AWS_PROFILE={os.getenv("AWS_PROFILE")} \
-         rclone mount :s3:{bucket_name}{_bucket_sub_path} {mount_path} '
+        f'AWS_PROFILE={os.getenv("AWS_PROFILE")} '
+        f'rclone mount :s3:{bucket_name}{_bucket_sub_path} {mount_path} '
         # Have to add --s3-env-auth=true to allow rclone to access private
         # buckets.
         '--daemon --allow-other --s3-env-auth=true')

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -92,10 +92,9 @@ def get_s3_mount_cmd(bucket_name: str,
         _bucket_sub_path = f':{_bucket_sub_path}'
 
     # Use rclone for ARM64 architectures since goofys doesn't support them
-    arch_check = 'ARCH=$(uname -m) && '
     rclone_mount = (
         f'{FUSERMOUNT3_SOFT_LINK_CMD} && '
-        f'rclone mount :s3:{bucket_name}{_bucket_sub_path} {mount_path} '
+        f'AWS_PROFILE={os.getenv("AWS_PROFILE")} rclone mount :s3:{bucket_name}{_bucket_sub_path} {mount_path} '
         # Have to add --s3-env-auth=true to allow rclone to access private
         # buckets.
         '--daemon --allow-other --s3-env-auth=true')
@@ -104,10 +103,11 @@ def get_s3_mount_cmd(bucket_name: str,
                     f'--type-cache-ttl {_TYPE_CACHE_TTL} '
                     f'{bucket_name}{_bucket_sub_path} {mount_path}')
 
-    mount_cmd = (f'{arch_check}'
+    mount_cmd = (f'ARCH=$(uname -m) ;'
                  f'if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then '
                  f'  {rclone_mount}; '
                  f'else '
+                 f'  export AWS_PROFILE={os.getenv("AWS_PROFILE")}; '
                  f'  {goofys_mount}; '
                  f'fi')
     return mount_cmd


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This introduces a way to mount AWS storage buckets (S3) using credentials which aren't default. Currently if you run `AWS_PROFILE=<some_profile> sky launch -c ....` it will error out on the storage mount step. This makes sure the correct env variable is passed through to the remote machine

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
