### PR TITLE
[Core] Handle null start_at and end_at properly in JobInfo proto

### DIFF
--- a/sky/core.py
+++ b/sky/core.py
@@ -847,8 +847,10 @@ def queue(cluster_name: str,
                     'submitted_at': job_info.submitted_at,
                     'status': job_lib.JobStatus.from_protobuf(job_info.status),
                     'run_timestamp': job_info.run_timestamp,
-                    'start_at': job_info.start_at,
-                    'end_at': job_info.end_at,
+                    'start_at': job_info.start_at
+                                if job_info.HasField('start_at') else None,
+                    'end_at': job_info.end_at
+                              if job_info.HasField('end_at') else None,
                     'resources': job_info.resources,
                     'log_path': job_info.log_path,
                     'user_hash': job_info.username,

--- a/sky/schemas/generated/jobsv1_pb2.py
+++ b/sky/schemas/generated/jobsv1_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\"sky/schemas/generated/jobsv1.proto\x12\x07jobs.v1\"\x85\x01\n\rAddJobRequest\x12\x15\n\x08job_name\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x10\n\x08username\x18\x02 \x01(\t\x12\x15\n\rrun_timestamp\x18\x03 \x01(\t\x12\x15\n\rresources_str\x18\x04 \x01(\t\x12\x10\n\x08metadata\x18\x05 \x01(\tB\x0b\n\t_job_name\"1\n\x0e\x41\x64\x64JobResponse\x12\x0e\n\x06job_id\x18\x01 \x01(\x03\x12\x0f\n\x07log_dir\x18\x02 \x01(\t\"\xb3\x01\n\x0fQueueJobRequest\x12\x0e\n\x06job_id\x18\x01 \x01(\x03\x12\x14\n\x07\x63odegen\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x13\n\x0bscript_path\x18\x03 \x01(\t\x12\x16\n\x0eremote_log_dir\x18\x04 \x01(\t\x12\x31\n\x0bmanaged_job\x18\x05 \x01(\x0b\x32\x17.jobs.v1.ManagedJobInfoH\x01\x88\x01\x01\x42\n\n\x08_codegenB\x0e\n\x0c_managed_job\"\x89\x01\n\x0eManagedJobInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\x04pool\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x11\n\tworkspace\x18\x03 \x01(\t\x12\x12\n\nentrypoint\x18\x04 \x01(\t\x12&\n\x05tasks\x18\x05 \x03(\x0b\x32\x17.jobs.v1.ManagedJobTaskB\x07\n\x05_pool\"]\n\x0eManagedJobTask\x12\x0f\n\x07task_id\x18\x01 \x01(\x05\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x15\n\rresources_str\x18\x03 \x01(\t\x12\x15\n\rmetadata_json\x18\x04 \x01(\t\"\x12\n\x10QueueJobResponse\"\x15\n\x13UpdateStatusRequest\"\x16\n\x14UpdateStatusResponse\"L\n\x12GetJobQueueRequest\x12\x16\n\tuser_hash\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x10\n\x08\x61ll_jobs\x18\x02 \x01(\x08\x42\x0c\n\n_user_hash\"\xf4\x01\n\x07JobInfo\x12\x0e\n\x06job_id\x18\x01 \x01(\x03\x12\x10\n\x08job_name\x18\x02 \x01(\t\x12\x10\n\x08username\x18\x03 \x01(\t\x12\x14\n\x0csubmitted_at\x18\x04 \x01(\x01\x12\"\n\x06status\x18\x05 \x01(\x0e\x32\x12.jobs.v1.JobStatus\x12\x15\n\rrun_timestamp\x18\x06 \x01(\t\x12\x10\n\x08start_at\x18\x07 \x01(\x01\x12\x0e\n\x06\x65nd_at\x18\x08 \x01(\x01\x12\x11\n\tresources\x18\t \x01(\t\x12\x0b\n\x03pid\x18\n \x01(\x03\x12\x10\n\x08log_path\x18\x0b \x01(\t\x12\x10\n\x08metadata\x18\x0c \x01(\t\"5\n\x13GetJobQueueResponse\x12\x1e\n\x04jobs\x18\x01 \x03(\x0b\x32\x10.jobs.v1.JobInfo\"^\n\x11\x43\x61ncelJobsRequest\x12\x0f\n\x07job_ids\x18\x01 \x03(\x03\x12\x12\n\ncancel_all\x18\x02 \x01(\x08\x12\x16\n\tuser_hash\x18\x03 \x01(\tH\x00\x88\x01\x01\x42\x0c\n\n_user_hash\"/\n\x12\x43\x61ncelJobsResponse\x12\x19\n\x11\x63\x61ncelled_job_ids\x18\x01 \x03(\x03\"\x1e\n\x1c\x46\x61ilAllInProgressJobsRequest\"\x1f\n\x1d\x46\x61ilAllInProgressJobsResponse\"\x7f\n\x0fTailLogsRequest\x12\x13\n\x06job_id\x18\x01 \x01(\x03H\x00\x88\x01\x01\x12\x1b\n\x0emanaged_job_id\x18\x02 \x01(\x03H\x01\x88\x01\x01\x12\x0e\n\x06\x66ollow\x18\x03 \x01(\x08\x12\x0c\n\x04tail\x18\x04 \x01(\x05\x42\t\n\x07_job_idB\x11\n\x0f_managed_job_id\"7\n\x10TailLogsResponse\x12\x10\n\x08log_line\x18\x01 \x01(\t\x12\x11\n\texit_code\x18\x02 \x01(\x05\"&\n\x13GetJobStatusRequest\x12\x0f\n\x07job_ids\x18\x01 \x03(\x03\"\xa4\x01\n\x14GetJobStatusResponse\x12\x44\n\x0cjob_statuses\x18\x01 \x03(\x0b\x32..jobs.v1.GetJobStatusResponse.JobStatusesEntry\x1a\x46\n\x10JobStatusesEntry\x12\x0b\n\x03key\x18\x01 \x01(\x03\x12!\n\x05value\x18\x02 \x01(\x0e\x32\x12.jobs.v1.JobStatus:\x02\x38\x01\"A\n\x1fGetJobSubmittedTimestampRequest\x12\x13\n\x06job_id\x18\x01 \x01(\x03H\x00\x88\x01\x01\x42\t\n\x07_job_id\"5\n GetJobSubmittedTimestampResponse\x12\x11\n\ttimestamp\x18\x01 \x01(\x02\"=\n\x1bGetJobEndedTimestampRequest\x12\x13\n\x06job_id\x18\x01 \x01(\x03H\x00\x88\x01\x01\x42\t\n\x07_job_id\"1\n\x1cGetJobEndedTimestampResponse\x12\x11\n\ttimestamp\x18\x01 \x01(\x02\"+\n\x18GetLogDirsForJobsRequest\x12\x0f\n\x07job_ids\x18\x01 \x03(\x03\"\x98\x01\n\x19GetLogDirsForJobsResponse\x12H\n\x0cjob_log_dirs\x18\x01 \x03(\x0b\x32\x32.jobs.v1.GetLogDirsForJobsResponse.JobLogDirsEntry\x1a\x31\n\x0fJobLogDirsEntry\x12\x0b\n\x03key\x18\x01 \x01(\x03\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01*\x8d\x02\n\tJobStatus\x12\x1a\n\x16JOB_STATUS_UNSPECIFIED\x10\x00\x12\x13\n\x0fJOB_STATUS_INIT\x10\x01\x12\x16\n\x12JOB_STATUS_PENDING\x10\x02\x12\x19\n\x15JOB_STATUS_SETTING_UP\x10\x03\x12\x16\n\x12JOB_STATUS_RUNNING\x10\x04\x12\x1c\n\x18JOB_STATUS_FAILED_DRIVER\x10\x05\x12\x18\n\x14JOB_STATUS_SUCCEEDED\x10\x06\x12\x15\n\x11JOB_STATUS_FAILED\x10\x07\x12\x1b\n\x17JOB_STATUS_FAILED_SETUP\x10\x08\x12\x18\n\x14JOB_STATUS_CANCELLED\x10\t2\x91\x07\n\x0bJobsService\x12\x39\n\x06\x41\x64\x64Job\x12\x16.jobs.v1.AddJobRequest\x1a\x17.jobs.v1.AddJobResponse\x12?\n\x08QueueJob\x12\x18.jobs.v1.QueueJobRequest\x1a\x19.jobs.v1.QueueJobResponse\x12K\n\x0cUpdateStatus\x12\x1c.jobs.v1.UpdateStatusRequest\x1a\x1d.jobs.v1.UpdateStatusResponse\x12H\n\x0bGetJobQueue\x12\x1b.jobs.v1.GetJobQueueRequest\x1a\x1c.jobs.v1.GetJobQueueResponse\x12\x45\n\nCancelJobs\x12\x1a.jobs.v1.CancelJobsRequest\x1a\x1b.jobs.v1.CancelJobsResponse\x12\x66\n\x15\x46\x61ilAllInProgressJobs\x12%.jobs.v1.FailAllInProgressJobsRequest\x1a&.jobs.v1.FailAllInProgressJobsResponse\x12\x41\n\x08TailLogs\x12\x18.jobs.v1.TailLogsRequest\x1a\x19.jobs.v1.TailLogsResponse0\x01\x12K\n\x0cGetJobStatus\x12\x1c.jobs.v1.GetJobStatusRequest\x1a\x1d.jobs.v1.GetJobStatusResponse\x12o\n\x18GetJobSubmittedTimestamp\x12(.jobs.v1.GetJobSubmittedTimestampRequest\x1a).jobs.v1.GetJobSubmittedTimestampResponse\x12\x63\n\x14GetJobEndedTimestamp\x12$.jobs.v1.GetJobEndedTimestampRequest\x1a%.jobs.v1.GetJobEndedTimestampResponse\x12Z\n\x11GetLogDirsForJobs\x12!.jobs.v1.GetLogDirsForJobsRequest\x1a\".jobs.v1.GetLogDirsForJobsResponseb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\"sky/schemas/generated/jobsv1.proto\x12\x07jobs.v1\"\x85\x01\n\rAddJobRequest\x12\x15\n\x08job_name\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x10\n\x08username\x18\x02 \x01(\t\x12\x15\n\rrun_timestamp\x18\x03 \x01(\t\x12\x15\n\rresources_str\x18\x04 \x01(\t\x12\x10\n\x08metadata\x18\x05 \x01(\tB\x0b\n\t_job_name\"1\n\x0e\x41\x64\x64JobResponse\x12\x0e\n\x06job_id\x18\x01 \x01(\x03\x12\x0f\n\x07log_dir\x18\x02 \x01(\t\"\xb3\x01\n\x0fQueueJobRequest\x12\x0e\n\x06job_id\x18\x01 \x01(\x03\x12\x14\n\x07\x63odegen\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x13\n\x0bscript_path\x18\x03 \x01(\t\x12\x16\n\x0eremote_log_dir\x18\x04 \x01(\t\x12\x31\n\x0bmanaged_job\x18\x05 \x01(\x0b\x32\x17.jobs.v1.ManagedJobInfoH\x01\x88\x01\x01\x42\n\n\x08_codegenB\x0e\n\x0c_managed_job\"\x89\x01\n\x0eManagedJobInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\x04pool\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x11\n\tworkspace\x18\x03 \x01(\t\x12\x12\n\nentrypoint\x18\x04 \x01(\t\x12&\n\x05tasks\x18\x05 \x03(\x0b\x32\x17.jobs.v1.ManagedJobTaskB\x07\n\x05_pool\"]\n\x0eManagedJobTask\x12\x0f\n\x07task_id\x18\x01 \x01(\x05\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x15\n\rresources_str\x18\x03 \x01(\t\x12\x15\n\rmetadata_json\x18\x04 \x01(\t\"\x12\n\x10QueueJobResponse\"\x15\n\x13UpdateStatusRequest\"\x16\n\x14UpdateStatusResponse\"L\n\x12GetJobQueueRequest\x12\x16\n\tuser_hash\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x10\n\x08\x61ll_jobs\x18\x02 \x01(\x08\x42\x0c\n\n_user_hash\"\xa3\x02\n\x07JobInfo\x12\x0e\n\x06job_id\x18\x01 \x01(\x03\x12\x10\n\x08job_name\x18\x02 \x01(\t\x12\x10\n\x08username\x18\x03 \x01(\t\x12\x14\n\x0csubmitted_at\x18\x04 \x01(\x01\x12\"\n\x06status\x18\x05 \x01(\x0e\x32\x12.jobs.v1.JobStatus\x12\x15\n\rrun_timestamp\x18\x06 \x01(\t\x12\x15\n\x08start_at\x18\x07 \x01(\x01H\x00\x88\x01\x01\x12\x13\n\x06\x65nd_at\x18\x08 \x01(\x01H\x01\x88\x01\x01\x12\x11\n\tresources\x18\t \x01(\t\x12\x10\n\x03pid\x18\n \x01(\x03H\x02\x88\x01\x01\x12\x10\n\x08log_path\x18\x0b \x01(\t\x12\x10\n\x08metadata\x18\x0c \x01(\tB\x0b\n\t_start_atB\t\n\x07_end_atB\x06\n\x04_pid\"5\n\x13GetJobQueueResponse\x12\x1e\n\x04jobs\x18\x01 \x03(\x0b\x32\x10.jobs.v1.JobInfo\"^\n\x11\x43\x61ncelJobsRequest\x12\x0f\n\x07job_ids\x18\x01 \x03(\x03\x12\x12\n\ncancel_all\x18\x02 \x01(\x08\x12\x16\n\tuser_hash\x18\x03 \x01(\tH\x00\x88\x01\x01\x42\x0c\n\n_user_hash\"/\n\x12\x43\x61ncelJobsResponse\x12\x19\n\x11\x63\x61ncelled_job_ids\x18\x01 \x03(\x03\"\x1e\n\x1c\x46\x61ilAllInProgressJobsRequest\"\x1f\n\x1d\x46\x61ilAllInProgressJobsResponse\"\x7f\n\x0fTailLogsRequest\x12\x13\n\x06job_id\x18\x01 \x01(\x03H\x00\x88\x01\x01\x12\x1b\n\x0emanaged_job_id\x18\x02 \x01(\x03H\x01\x88\x01\x01\x12\x0e\n\x06\x66ollow\x18\x03 \x01(\x08\x12\x0c\n\x04tail\x18\x04 \x01(\x05\x42\t\n\x07_job_idB\x11\n\x0f_managed_job_id\"7\n\x10TailLogsResponse\x12\x10\n\x08log_line\x18\x01 \x01(\t\x12\x11\n\texit_code\x18\x02 \x01(\x05\"&\n\x13GetJobStatusRequest\x12\x0f\n\x07job_ids\x18\x01 \x03(\x03\"\xa4\x01\n\x14GetJobStatusResponse\x12\x44\n\x0cjob_statuses\x18\x01 \x03(\x0b\x32..jobs.v1.GetJobStatusResponse.JobStatusesEntry\x1a\x46\n\x10JobStatusesEntry\x12\x0b\n\x03key\x18\x01 \x01(\x03\x12!\n\x05value\x18\x02 \x01(\x0e\x32\x12.jobs.v1.JobStatus:\x02\x38\x01\"A\n\x1fGetJobSubmittedTimestampRequest\x12\x13\n\x06job_id\x18\x01 \x01(\x03H\x00\x88\x01\x01\x42\t\n\x07_job_id\"5\n GetJobSubmittedTimestampResponse\x12\x11\n\ttimestamp\x18\x01 \x01(\x02\"=\n\x1bGetJobEndedTimestampRequest\x12\x13\n\x06job_id\x18\x01 \x01(\x03H\x00\x88\x01\x01\x42\t\n\x07_job_id\"1\n\x1cGetJobEndedTimestampResponse\x12\x11\n\ttimestamp\x18\x01 \x01(\x02\"+\n\x18GetLogDirsForJobsRequest\x12\x0f\n\x07job_ids\x18\x01 \x03(\x03\"\x98\x01\n\x19GetLogDirsForJobsResponse\x12H\n\x0cjob_log_dirs\x18\x01 \x03(\x0b\x32\x32.jobs.v1.GetLogDirsForJobsResponse.JobLogDirsEntry\x1a\x31\n\x0fJobLogDirsEntry\x12\x0b\n\x03key\x18\x01 \x01(\x03\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01*\x8d\x02\n\tJobStatus\x12\x1a\n\x16JOB_STATUS_UNSPECIFIED\x10\x00\x12\x13\n\x0fJOB_STATUS_INIT\x10\x01\x12\x16\n\x12JOB_STATUS_PENDING\x10\x02\x12\x19\n\x15JOB_STATUS_SETTING_UP\x10\x03\x12\x16\n\x12JOB_STATUS_RUNNING\x10\x04\x12\x1c\n\x18JOB_STATUS_FAILED_DRIVER\x10\x05\x12\x18\n\x14JOB_STATUS_SUCCEEDED\x10\x06\x12\x15\n\x11JOB_STATUS_FAILED\x10\x07\x12\x1b\n\x17JOB_STATUS_FAILED_SETUP\x10\x08\x12\x18\n\x14JOB_STATUS_CANCELLED\x10\t2\x91\x07\n\x0bJobsService\x12\x39\n\x06\x41\x64\x64Job\x12\x16.jobs.v1.AddJobRequest\x1a\x17.jobs.v1.AddJobResponse\x12?\n\x08QueueJob\x12\x18.jobs.v1.QueueJobRequest\x1a\x19.jobs.v1.QueueJobResponse\x12K\n\x0cUpdateStatus\x12\x1c.jobs.v1.UpdateStatusRequest\x1a\x1d.jobs.v1.UpdateStatusResponse\x12H\n\x0bGetJobQueue\x12\x1b.jobs.v1.GetJobQueueRequest\x1a\x1c.jobs.v1.GetJobQueueResponse\x12\x45\n\nCancelJobs\x12\x1a.jobs.v1.CancelJobsRequest\x1a\x1b.jobs.v1.CancelJobsResponse\x12\x66\n\x15\x46\x61ilAllInProgressJobs\x12%.jobs.v1.FailAllInProgressJobsRequest\x1a&.jobs.v1.FailAllInProgressJobsResponse\x12\x41\n\x08TailLogs\x12\x18.jobs.v1.TailLogsRequest\x1a\x19.jobs.v1.TailLogsResponse0\x01\x12K\n\x0cGetJobStatus\x12\x1c.jobs.v1.GetJobStatusRequest\x1a\x1d.jobs.v1.GetJobStatusResponse\x12o\n\x18GetJobSubmittedTimestamp\x12(.jobs.v1.GetJobSubmittedTimestampRequest\x1a).jobs.v1.GetJobSubmittedTimestampResponse\x12\x63\n\x14GetJobEndedTimestamp\x12$.jobs.v1.GetJobEndedTimestampRequest\x1a%.jobs.v1.GetJobEndedTimestampResponse\x12Z\n\x11GetLogDirsForJobs\x12!.jobs.v1.GetLogDirsForJobsRequest\x1a\".jobs.v1.GetLogDirsForJobsResponseb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -25,8 +25,8 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_GETJOBSTATUSRESPONSE_JOBSTATUSESENTRY']._serialized_options = b'8\001'
   _globals['_GETLOGDIRSFORJOBSRESPONSE_JOBLOGDIRSENTRY']._loaded_options = None
   _globals['_GETLOGDIRSFORJOBSRESPONSE_JOBLOGDIRSENTRY']._serialized_options = b'8\001'
-  _globals['_JOBSTATUS']._serialized_start=2138
-  _globals['_JOBSTATUS']._serialized_end=2407
+  _globals['_JOBSTATUS']._serialized_start=2185
+  _globals['_JOBSTATUS']._serialized_end=2454
   _globals['_ADDJOBREQUEST']._serialized_start=48
   _globals['_ADDJOBREQUEST']._serialized_end=181
   _globals['_ADDJOBRESPONSE']._serialized_start=183
@@ -46,41 +46,41 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_GETJOBQUEUEREQUEST']._serialized_start=718
   _globals['_GETJOBQUEUEREQUEST']._serialized_end=794
   _globals['_JOBINFO']._serialized_start=797
-  _globals['_JOBINFO']._serialized_end=1041
-  _globals['_GETJOBQUEUERESPONSE']._serialized_start=1043
-  _globals['_GETJOBQUEUERESPONSE']._serialized_end=1096
-  _globals['_CANCELJOBSREQUEST']._serialized_start=1098
-  _globals['_CANCELJOBSREQUEST']._serialized_end=1192
-  _globals['_CANCELJOBSRESPONSE']._serialized_start=1194
-  _globals['_CANCELJOBSRESPONSE']._serialized_end=1241
-  _globals['_FAILALLINPROGRESSJOBSREQUEST']._serialized_start=1243
-  _globals['_FAILALLINPROGRESSJOBSREQUEST']._serialized_end=1273
-  _globals['_FAILALLINPROGRESSJOBSRESPONSE']._serialized_start=1275
-  _globals['_FAILALLINPROGRESSJOBSRESPONSE']._serialized_end=1306
-  _globals['_TAILLOGSREQUEST']._serialized_start=1308
-  _globals['_TAILLOGSREQUEST']._serialized_end=1435
-  _globals['_TAILLOGSRESPONSE']._serialized_start=1437
-  _globals['_TAILLOGSRESPONSE']._serialized_end=1492
-  _globals['_GETJOBSTATUSREQUEST']._serialized_start=1494
-  _globals['_GETJOBSTATUSREQUEST']._serialized_end=1532
-  _globals['_GETJOBSTATUSRESPONSE']._serialized_start=1535
-  _globals['_GETJOBSTATUSRESPONSE']._serialized_end=1699
-  _globals['_GETJOBSTATUSRESPONSE_JOBSTATUSESENTRY']._serialized_start=1629
-  _globals['_GETJOBSTATUSRESPONSE_JOBSTATUSESENTRY']._serialized_end=1699
-  _globals['_GETJOBSUBMITTEDTIMESTAMPREQUEST']._serialized_start=1701
-  _globals['_GETJOBSUBMITTEDTIMESTAMPREQUEST']._serialized_end=1766
-  _globals['_GETJOBSUBMITTEDTIMESTAMPRESPONSE']._serialized_start=1768
-  _globals['_GETJOBSUBMITTEDTIMESTAMPRESPONSE']._serialized_end=1821
-  _globals['_GETJOBENDEDTIMESTAMPREQUEST']._serialized_start=1823
-  _globals['_GETJOBENDEDTIMESTAMPREQUEST']._serialized_end=1884
-  _globals['_GETJOBENDEDTIMESTAMPRESPONSE']._serialized_start=1886
-  _globals['_GETJOBENDEDTIMESTAMPRESPONSE']._serialized_end=1935
-  _globals['_GETLOGDIRSFORJOBSREQUEST']._serialized_start=1937
-  _globals['_GETLOGDIRSFORJOBSREQUEST']._serialized_end=1980
-  _globals['_GETLOGDIRSFORJOBSRESPONSE']._serialized_start=1983
-  _globals['_GETLOGDIRSFORJOBSRESPONSE']._serialized_end=2135
-  _globals['_GETLOGDIRSFORJOBSRESPONSE_JOBLOGDIRSENTRY']._serialized_start=2086
-  _globals['_GETLOGDIRSFORJOBSRESPONSE_JOBLOGDIRSENTRY']._serialized_end=2135
-  _globals['_JOBSSERVICE']._serialized_start=2410
-  _globals['_JOBSSERVICE']._serialized_end=3323
+  _globals['_JOBINFO']._serialized_end=1088
+  _globals['_GETJOBQUEUERESPONSE']._serialized_start=1090
+  _globals['_GETJOBQUEUERESPONSE']._serialized_end=1143
+  _globals['_CANCELJOBSREQUEST']._serialized_start=1145
+  _globals['_CANCELJOBSREQUEST']._serialized_end=1239
+  _globals['_CANCELJOBSRESPONSE']._serialized_start=1241
+  _globals['_CANCELJOBSRESPONSE']._serialized_end=1288
+  _globals['_FAILALLINPROGRESSJOBSREQUEST']._serialized_start=1290
+  _globals['_FAILALLINPROGRESSJOBSREQUEST']._serialized_end=1320
+  _globals['_FAILALLINPROGRESSJOBSRESPONSE']._serialized_start=1322
+  _globals['_FAILALLINPROGRESSJOBSRESPONSE']._serialized_end=1353
+  _globals['_TAILLOGSREQUEST']._serialized_start=1355
+  _globals['_TAILLOGSREQUEST']._serialized_end=1482
+  _globals['_TAILLOGSRESPONSE']._serialized_start=1484
+  _globals['_TAILLOGSRESPONSE']._serialized_end=1539
+  _globals['_GETJOBSTATUSREQUEST']._serialized_start=1541
+  _globals['_GETJOBSTATUSREQUEST']._serialized_end=1579
+  _globals['_GETJOBSTATUSRESPONSE']._serialized_start=1582
+  _globals['_GETJOBSTATUSRESPONSE']._serialized_end=1746
+  _globals['_GETJOBSTATUSRESPONSE_JOBSTATUSESENTRY']._serialized_start=1676
+  _globals['_GETJOBSTATUSRESPONSE_JOBSTATUSESENTRY']._serialized_end=1746
+  _globals['_GETJOBSUBMITTEDTIMESTAMPREQUEST']._serialized_start=1748
+  _globals['_GETJOBSUBMITTEDTIMESTAMPREQUEST']._serialized_end=1813
+  _globals['_GETJOBSUBMITTEDTIMESTAMPRESPONSE']._serialized_start=1815
+  _globals['_GETJOBSUBMITTEDTIMESTAMPRESPONSE']._serialized_end=1868
+  _globals['_GETJOBENDEDTIMESTAMPREQUEST']._serialized_start=1870
+  _globals['_GETJOBENDEDTIMESTAMPREQUEST']._serialized_end=1931
+  _globals['_GETJOBENDEDTIMESTAMPRESPONSE']._serialized_start=1933
+  _globals['_GETJOBENDEDTIMESTAMPRESPONSE']._serialized_end=1982
+  _globals['_GETLOGDIRSFORJOBSREQUEST']._serialized_start=1984
+  _globals['_GETLOGDIRSFORJOBSREQUEST']._serialized_end=2027
+  _globals['_GETLOGDIRSFORJOBSRESPONSE']._serialized_start=2030
+  _globals['_GETLOGDIRSFORJOBSRESPONSE']._serialized_end=2182
+  _globals['_GETLOGDIRSFORJOBSRESPONSE_JOBLOGDIRSENTRY']._serialized_start=2133
+  _globals['_GETLOGDIRSFORJOBSRESPONSE_JOBLOGDIRSENTRY']._serialized_end=2182
+  _globals['_JOBSSERVICE']._serialized_start=2457
+  _globals['_JOBSSERVICE']._serialized_end=3370
 # @@protoc_insertion_point(module_scope)

--- a/sky/schemas/proto/jobsv1.proto
+++ b/sky/schemas/proto/jobsv1.proto
@@ -94,10 +94,10 @@ message JobInfo {
   double submitted_at = 4;
   JobStatus status = 5;
   string run_timestamp = 6;
-  double start_at = 7;
-  double end_at = 8;
+  optional double start_at = 7;
+  optional double end_at = 8;
   string resources = 9;
-  int64 pid = 10;
+  optional int64 pid = 10;
   string log_path = 11;
   string metadata = 12;
 }

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -559,21 +559,20 @@ def get_jobs_info(user_hash: Optional[str] = None,
     jobs_info = []
     for job in jobs:
         jobs_info.append(
-            jobsv1_pb2.JobInfo(
-                job_id=job['job_id'],
-                job_name=job['job_name'],
-                username=job['username'],
-                submitted_at=job['submitted_at'],
-                status=job['status'].to_protobuf(),
-                run_timestamp=job['run_timestamp'],
-                start_at=job['start_at']
-                if job['start_at'] is not None else -1.0,
-                end_at=job['end_at'] if job['end_at'] is not None else 0.0,
-                resources=job['resources'] or '',
-                pid=job['pid'],
-                log_path=os.path.join(constants.SKY_LOGS_DIRECTORY,
-                                      job['run_timestamp']),
-                metadata=json.dumps(job['metadata'])))
+            jobsv1_pb2.JobInfo(job_id=job['job_id'],
+                               job_name=job['job_name'],
+                               username=job['username'],
+                               submitted_at=job['submitted_at'],
+                               status=job['status'].to_protobuf(),
+                               run_timestamp=job['run_timestamp'],
+                               start_at=job['start_at'],
+                               end_at=job['end_at'],
+                               resources=job['resources'],
+                               pid=job['pid'],
+                               log_path=os.path.join(
+                                   constants.SKY_LOGS_DIRECTORY,
+                                   job['run_timestamp']),
+                               metadata=json.dumps(job['metadata'])))
     return jobs_info
 
 

--- a/tests/unit_tests/test_sky/utils/test_log_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_log_utils.py
@@ -1,0 +1,80 @@
+"""Tests for sky.utils.log_utils module."""
+
+import sys
+import time
+
+import pytest
+
+from sky.utils import log_utils
+
+# Using time.time() results in different workers getting different values,
+# and apparently pytest-xdist cannot handle that.
+NOW = 1758240750.0
+
+
+@pytest.mark.parametrize(
+    "start,end,absolute",
+    [
+        # start=None cases
+        (None, None, False),
+        (None, NOW, False),
+        (None, None, True),
+        # start < 0 cases
+        (-1.0, None, False),
+        (-100.0, NOW, False),
+        (-1.0, None, True),
+        # start=0 and end=0 cases
+        (0.0, 0.0, False),
+        (0.0, 0.0, True),
+    ])
+def test_readable_time_duration_returns_dash(start, end, absolute):
+    """Test cases where readable_time_duration should return '-'."""
+    result = log_utils.readable_time_duration(start=start,
+                                              end=end,
+                                              absolute=absolute)
+    assert result == '-'
+
+
+@pytest.mark.parametrize(
+    "start_time,end_time,expected_relative,expected_absolute", [
+        (NOW, NOW + 10, 'a few secs before', '10s'),
+        (NOW, NOW + 60, '1 min before', '1m'),
+        (NOW, NOW + 3600, '1 hr before', '1h'),
+        (NOW, NOW + 3600 * 24, '1 day before', '1d'),
+        (NOW, NOW + 3600 * 24 * 7, '1 week before', '1w'),
+        (NOW, NOW + 3600 * 24 * 30, '1 month before', '1mo'),
+        (NOW, NOW + 3600 * 24 * 365, '1 year before', '1 year'),
+        (NOW, NOW + 3600 * 24 * 365 * 2, '2 years before', '2 years'),
+        (NOW, NOW + 0.5, '< 1 sec', '< 1s'),
+    ])
+def test_readable_time_duration_exact_cases(start_time, end_time,
+                                            expected_relative,
+                                            expected_absolute):
+    """Test time duration cases with exact expected results."""
+    # Test relative formatting
+    result = log_utils.readable_time_duration(start=start_time,
+                                              end=end_time,
+                                              absolute=False)
+    assert result == expected_relative
+
+    # Test absolute formatting
+    result_abs = log_utils.readable_time_duration(start=start_time,
+                                                  end=end_time,
+                                                  absolute=True)
+    assert result_abs == expected_absolute
+
+
+def test_readable_time_end_at_none():
+    """Test end_at defaults to current time when it is None."""
+    # Using time.time() with parametrize() results in different workers
+    # getting different values, and pytest-xdist doesn't like that.
+    # So we move this into a separate test.
+    now = time.time() - 50
+    result = log_utils.readable_time_duration(start=now,
+                                              end=None,
+                                              absolute=False)
+    assert result == '50 secs ago'
+    result_abs = log_utils.readable_time_duration(start=now,
+                                                  end=None,
+                                                  absolute=True)
+    assert result_abs == '50s'


### PR DESCRIPTION
On the jobs table, a job could have a null `start_at` and/or `end_at`, for example:
```bash
# submitted
sqlite> select job_id, submitted_at, start_at, end_at from jobs;
1|1758219031.71795|1758219033.75829|1758219036.19299        
2|1758219059.18512|1758219061.01168|1758219063.48955
3|1758219424.66382||
# running
sqlite> select job_id, submitted_at, start_at, end_at from jobs;
1|1758219031.71795|1758219033.75829|1758219036.19299        
2|1758219059.18512|1758219061.01168|1758219063.48955
3|1758219424.66382|1758219426.85203|   
# succeeded                     
sqlite> select job_id, submitted_at, start_at, end_at from jobs;
1|1758219031.71795|1758219033.75829|1758219036.19299        
2|1758219059.18512|1758219061.01168|1758219063.48955
3|1758219424.66382|1758219426.85203|1758219429.37502
```

But the JobInfo proto did not handle it properly. When serializing to protobuf, a field that is unset or set to the zero value is treated the same way, which is it will not be serialized to the wire (see https://protobuf.dev/programming-guides/proto3/#field-labels). In fact, if the field is implicit (not marked as `optional`) you cannot determine whether the zero value was set or parsed from the wire or not provided at all.

So this PR improves the proto to mark `start_at` and `end_at` as optional, so that the client (well, API server in our case) can call the `HasField` method on the field to differentiate between zero value or unset when deserializing from the protobuf message, and properly set it to None if unset.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
