### PR TITLE
[Logs] terminate provision log once provisioning is complete

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1056,12 +1056,14 @@ async def get_status_from_cluster_name_async(
     assert _SQLALCHEMY_ENGINE_ASYNC is not None
     assert cluster_name is not None, 'cluster_name cannot be None'
     async with sql_async.AsyncSession(_SQLALCHEMY_ENGINE_ASYNC) as session:
-        row = await session.query(cluster_table.c.status
-                                 ).filter_by(name=cluster_name).first()
+        result = await session.execute(
+            sqlalchemy.select(cluster_table.c.status).where(
+                cluster_table.c.name == cluster_name))
+        row = result.fetchone()
 
     if row is None:
         return None
-    return status_lib.ClusterStatus(row.status)
+    return status_lib.ClusterStatus(row[0])
 
 
 @_init_db

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1059,11 +1059,11 @@ async def get_status_from_cluster_name_async(
         result = await session.execute(
             sqlalchemy.select(cluster_table.c.status).where(
                 cluster_table.c.name == cluster_name))
-        row = result.fetchone()
+        row = result.first()
 
-    if row is None:
-        return None
-    return status_lib.ClusterStatus(row[0])
+        if row is None:
+            return None
+        return status_lib.ClusterStatus(row[0])
 
 
 @_init_db

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1048,6 +1048,22 @@ def get_handle_from_cluster_name(
     return pickle.loads(row.handle)
 
 
+@_init_db_async
+@metrics_lib.time_me
+async def get_status_from_cluster_name_async(
+        cluster_name: str) -> Optional[status_lib.ClusterStatus]:
+    """Get the status of a cluster."""
+    assert _SQLALCHEMY_ENGINE_ASYNC is not None
+    assert cluster_name is not None, 'cluster_name cannot be None'
+    async with sql_async.AsyncSession(_SQLALCHEMY_ENGINE_ASYNC) as session:
+        row = await session.query(cluster_table.c.status
+                                 ).filter_by(name=cluster_name).first()
+
+    if row is None:
+        return None
+    return status_lib.ClusterStatus(row.status)
+
+
 @_init_db
 @metrics_lib.time_me
 def get_glob_cluster_names(cluster_name: str) -> List[str]:

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -24,6 +24,7 @@ from sqlalchemy import exc as sqlalchemy_exc
 from sqlalchemy import orm
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects import sqlite
+from sqlalchemy.ext import asyncio as sql_async
 from sqlalchemy.ext import declarative
 
 from sky import models
@@ -51,6 +52,7 @@ _ENABLED_CLOUDS_KEY_PREFIX = 'enabled_clouds_'
 _ALLOWED_CLOUDS_KEY_PREFIX = 'allowed_clouds_'
 
 _SQLALCHEMY_ENGINE: Optional[sqlalchemy.engine.Engine] = None
+_SQLALCHEMY_ENGINE_ASYNC: Optional[sql_async.AsyncEngine] = None
 _SQLALCHEMY_ENGINE_LOCK = threading.Lock()
 
 DEFAULT_CLUSTER_EVENT_RETENTION_HOURS = 24.0
@@ -296,6 +298,20 @@ def create_table(engine: sqlalchemy.engine.Engine):
         migration_utils.GLOBAL_USER_STATE_VERSION)
 
 
+def initialize_and_get_db_async() -> sql_async.AsyncEngine:
+    global _SQLALCHEMY_ENGINE_ASYNC
+    if _SQLALCHEMY_ENGINE_ASYNC is not None:
+        return _SQLALCHEMY_ENGINE_ASYNC
+    with _SQLALCHEMY_ENGINE_LOCK:
+        if _SQLALCHEMY_ENGINE_ASYNC is not None:
+            return _SQLALCHEMY_ENGINE_ASYNC
+
+        _SQLALCHEMY_ENGINE_ASYNC = db_utils.get_engine('state',
+                                                       async_engine=True)
+    initialize_and_get_db()
+    return _SQLALCHEMY_ENGINE_ASYNC
+
+
 # We wrap the sqlalchemy engine initialization in a thread
 # lock to ensure that multiple threads do not initialize the
 # engine which could result in a rare race condition where
@@ -319,6 +335,22 @@ def initialize_and_get_db() -> sqlalchemy.engine.Engine:
         # return engine
         _SQLALCHEMY_ENGINE = engine
         return _SQLALCHEMY_ENGINE
+
+
+def _init_db_async(func):
+    """Initialize the async database."""
+
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs):
+        if _SQLALCHEMY_ENGINE_ASYNC is None:
+            # this may happen multiple times since there is no locking
+            # here but thats fine, this is just a short circuit for the
+            # common case.
+            await context_utils.to_thread(initialize_and_get_db_async)
+
+        return await func(*args, **kwargs)
+
+    return wrapper
 
 
 def _init_db(func):

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1354,10 +1354,12 @@ def provision_logs(cluster_body: payloads.ClusterNameBody,
     effective_tail = None if tail is None or tail <= 0 else tail
 
     return fastapi.responses.StreamingResponse(
-        content=stream_utils.log_streamer(None,
-                                          log_path,
-                                          tail=effective_tail,
-                                          follow=follow),
+        content=stream_utils.log_streamer(
+            None,
+            log_path,
+            tail=effective_tail,
+            follow=follow,
+            cluster_name=cluster_body.cluster_name),
         media_type='text/plain',
         headers={
             'Cache-Control': 'no-cache, no-transform',

--- a/sky/server/stream_utils.py
+++ b/sky/server/stream_utils.py
@@ -192,10 +192,11 @@ async def _tail_log_file(
             check_status = (current_time - last_cluster_status_check_time
                            ) >= _CLUSTER_STATUS_INTERVAL
             if cluster_name is not None and check_status:
-                cluster_record = global_user_state.get_cluster_from_name(
+                cluster_record = await global_user_state.get_status_from_cluster_name_async(
                     cluster_name)
-                if cluster_record is None or cluster_record[
-                        'status'] != status_lib.ClusterStatus.INIT:
+                logger.info(
+                    f'PROVISION LOG: getting cluster record for {cluster_name}')
+                if cluster_record is None or cluster_record != status_lib.ClusterStatus.INIT:
                     break
                 last_cluster_status_check_time = current_time
             if current_time - last_heartbeat_time >= _HEARTBEAT_INTERVAL:

--- a/sky/server/stream_utils.py
+++ b/sky/server/stream_utils.py
@@ -192,9 +192,11 @@ async def _tail_log_file(
             check_status = (current_time - last_cluster_status_check_time
                            ) >= _CLUSTER_STATUS_INTERVAL
             if cluster_name is not None and check_status:
-                cluster_record = await global_user_state.get_status_from_cluster_name_async(
-                    cluster_name)
-                if cluster_record is None or cluster_record != status_lib.ClusterStatus.INIT:
+                cluster_record = await (
+                    global_user_state.get_status_from_cluster_name_async(
+                        cluster_name))
+                if (cluster_record is None or
+                        cluster_record != status_lib.ClusterStatus.INIT):
                     break
                 last_cluster_status_check_time = current_time
             if current_time - last_heartbeat_time >= _HEARTBEAT_INTERVAL:

--- a/sky/server/stream_utils.py
+++ b/sky/server/stream_utils.py
@@ -183,13 +183,10 @@ async def _tail_log_file(
                                 ' cancelled\n')
                     break
             elif cluster_name is not None:
-                # For provision logs, terminate streaming if cluster is UP
+                # For provision logs, terminate streaming if
                 cluster_record = global_user_state.get_cluster_from_name(
                     cluster_name)
-                if (cluster_record and cluster_record['status'] in [
-                        status_lib.ClusterStatus.UP,
-                        status_lib.ClusterStatus.STOPPED
-                ]):
+                if cluster_record is None or cluster_record['status'] != status_lib.ClusterStatus.INIT:
                     break
             if not follow:
                 break

--- a/sky/server/stream_utils.py
+++ b/sky/server/stream_utils.py
@@ -184,15 +184,6 @@ async def _tail_log_file(
                                 f'{request_task.name!r} request {request_id}'
                                 ' cancelled\n')
                     break
-            elif cluster_name is not None:
-                # For provision logs, terminate streaming if
-                cluster_record = global_user_state.get_cluster_from_name(
-                    cluster_name)
-                logger.info(
-                    f'PROVISION LOG: getting cluster record for {cluster_name}')
-                if cluster_record is None or cluster_record[
-                        'status'] != status_lib.ClusterStatus.INIT:
-                    break
             if not follow:
                 break
             # Provision logs pass in cluster_name, check cluster status
@@ -201,6 +192,8 @@ async def _tail_log_file(
             check_status = (current_time - last_cluster_status_check_time
                            ) >= _CLUSTER_STATUS_INTERVAL
             if cluster_name is not None and check_status:
+                cluster_record = global_user_state.get_cluster_from_name(
+                    cluster_name)
                 if cluster_record is None or cluster_record[
                         'status'] != status_lib.ClusterStatus.INIT:
                     break

--- a/sky/server/stream_utils.py
+++ b/sky/server/stream_utils.py
@@ -194,8 +194,6 @@ async def _tail_log_file(
             if cluster_name is not None and check_status:
                 cluster_record = await global_user_state.get_status_from_cluster_name_async(
                     cluster_name)
-                logger.info(
-                    f'PROVISION LOG: getting cluster record for {cluster_name}')
                 if cluster_record is None or cluster_record != status_lib.ClusterStatus.INIT:
                     break
                 last_cluster_status_check_time = current_time

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -112,6 +112,7 @@ server_dependencies = [
     GRPC,
     PROTOBUF,
     'aiosqlite',
+    'greenlet',
 ]
 
 local_ray = [


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR makes it such that `sky logs --provision <CLUSTER_NAME>` terminates once the cluster is no longer in init state (ie either up or stopped). This improves the UX of using provision log because currently the command will not terminate even once the provisioning has completed.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
