### PR TITLE
[k8s] improved default resources for GPU VMs

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -62,6 +62,7 @@ class Kubernetes(clouds.Cloud):
     _SUPPORTS_SERVICE_ACCOUNT_ON_REMOTE = True
 
     _DEFAULT_NUM_VCPUS = 2
+    _DEFAULT_NUM_VCPUS_WITH_GPU = 4
     _DEFAULT_MEMORY_CPU_RATIO = 1
     _DEFAULT_MEMORY_CPU_RATIO_WITH_GPU = 4  # Allocate more memory for GPU tasks
     _REPR = 'Kubernetes'
@@ -842,7 +843,7 @@ class Kubernetes(clouds.Cloud):
 
             gpu_task_cpus = k8s_instance_type.cpus
             if resources.cpus is None:
-                gpu_task_cpus = gpu_task_cpus * acc_count
+                gpu_task_cpus = self._DEFAULT_NUM_VCPUS_WITH_GPU * acc_count
             # Special handling to bump up memory multiplier for GPU instances
             gpu_task_memory = (float(resources.memory.strip('+')) if
                                resources.memory is not None else gpu_task_cpus *


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Closes https://github.com/skypilot-org/skypilot/issues/7149

The current default resources given to a GPU enabled k8s pod is 2 CPU + 8 GB mem per GPU. I am reevaluating the default resources to see what a good default would be.

Long story short, I want to give the pods as much CPU / memory resources but not too much that CPU / memory becomes the constraining factor. To pick the right defaults, I tried our own optimizer on different cloud providers and different GPUs to see what resources clouds give to GPU instances.

Out of the common GPU types, L4s generally get the lowest CPU/mem resources per GPU, as demonstrated by this output
```
---------------------------------------------------------------------------------
 INFRA              INSTANCE        vCPUs   Mem(GB)   GPUS   COST ($)   CHOSEN   
---------------------------------------------------------------------------------
 RunPod (CA)        1x_L4_SECURE    4       24        L4:1   0.44          ✔     
 GCP (us-east4-a)   g2-standard-4   4       16        L4:1   0.70                
 AWS (us-east-1)    g6.xlarge       4       16        L4:1   0.80                
---------------------------------------------------------------------------------
```
Other GPUs get more resources per GPU.

I use this as the reference and choose 4 CPU and 16 GB of memory per GPU as the default for k8s pod.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
