### PR TITLE
[ux] cluster query glob improvements

### DIFF
--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -11,6 +11,7 @@ from sky.utils import common_utils
 from sky.utils import log_utils
 from sky.utils import resources_utils
 from sky.utils import status_lib
+from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
     from sky.provision.kubernetes import utils as kubernetes_utils
@@ -105,11 +106,8 @@ def show_status_table(cluster_records: List[responses.StatusResponse],
 
     if query_clusters:
         cluster_names = {record['name'] for record in cluster_records}
-        not_found_clusters = [
-            repr(cluster)
-            for cluster in query_clusters
-            if cluster not in cluster_names
-        ]
+        not_found_clusters = ux_utils.get_non_matched_query(
+            query_clusters, cluster_names)
         if not_found_clusters:
             cluster_str = 'Cluster'
             if len(not_found_clusters) > 1:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
1. in backend_utils, do not call `_get_glob_clusters` (a db operation) if none of the query strings is a glob string. This saves on some DB round trip times and makes the codepath more efficient, especially on single cluster queries which happens quite frequently.
2. Improve the UX such that `Cluster <pattern> not found.` is not emitted if the glob pattern did resolve to at least one cluster. Example:

before
```
$ sky status 'sky*' 'aaa*'
...
Clusters
NAME                   INFRA             RESOURCES               STATUS  AUTOSTOP  LAUNCHED     
sky-cab9-seungjinyang  Kubernetes (test) 1x(cpus=2, mem=2, ...)  UP      -         37 mins ago  
sky-bce0-seungjinyang  Kubernetes (test) 1x(cpus=2, mem=2, ...)  UP      -         4 hrs ago
Cluster sky*, aaa* not found.
```

this {R
```
$ sky status 'sky*' 'aaa*'
...
Clusters
NAME                   INFRA             RESOURCES               STATUS  AUTOSTOP  LAUNCHED     
sky-cab9-seungjinyang  Kubernetes (test) 1x(cpus=2, mem=2, ...)  UP      -         37 mins ago  
sky-bce0-seungjinyang  Kubernetes (test) 1x(cpus=2, mem=2, ...)  UP      -         4 hrs ago
Cluster aaa* not found.
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
