### PR TITLE
Fix compatibility issue with uvicorn 0.36.0

### DIFF
--- a/sky/server/uvicorn.py
+++ b/sky/server/uvicorn.py
@@ -206,7 +206,6 @@ class Server(uvicorn.Server):
         add_timestamp_prefix_for_server_logs()
         context_utils.hijack_sys_attrs()
         # Use default loop policy of uvicorn (use uvloop if available).
-        self.config.setup_event_loop()
         lag_threshold = perf_utils.get_loop_lag_threshold()
         if lag_threshold is not None:
             event_loop = asyncio.get_event_loop()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Tentative fix for https://github.com/skypilot-org/skypilot/issues/7287. Verified with:

```py
uv venv
uv pip install -U -e '.[all]' --prerelease=allow
.venv/bin/sky api atart
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
