### PR TITLE
Fix doc build script

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -44,10 +44,8 @@ if [ "$AUTO_BUILD" = true ]; then
 else
     rm -rf build docs
     
-    # Set build environment
-    if [ "$CI" = "true" ] || [ "$GITHUB_ACTIONS" = "true" ] || [ "$READTHEDOCS" = "True" ]; then
-        export SPHINX_BUILD_PRODUCTION=true
-    else
+    # Set build environment (only if not already set by GitHub Actions)
+    if [ -z "$SPHINX_BUILD_PRODUCTION" ]; then
         export SPHINX_BUILD_LOCAL=true
     fi
 


### PR DESCRIPTION
Fixing a bug where https://docs.skypilot.co/en/latest/llms.txt uses local URLs (`http://127.0.0.1:8000/...`) 

Related PR:  https://github.com/skypilot-org/skypilot/pull/6809