### PR TITLE
[Docs] Update docs to use `--endpoints`

### DIFF
--- a/docs/source/examples/ports.rst
+++ b/docs/source/examples/ports.rst
@@ -38,14 +38,21 @@ and look in for the logs for some output like:
         http://127.0.0.1:8888/lab?token=<token>
 
 
-To get the public IP address of the head node of the cluster, run :code:`sky status --ip jupyter`:
+To get the endpoint URL for the exposed port, run :code:`sky status --endpoint 8888 jupyter`:
 
 .. code-block:: console
 
-    $ sky status --ip jupyter
-    35.223.97.21
+    $ sky status --endpoint 8888 jupyter
+    http://35.223.97.21:8888
 
-In the jupyter server URL, replace :code:`127.0.0.1` with the public IP from :code:`sky status --ip jupyter` and open the URL in your browser.
+You can then directly open this URL in your browser, replacing the token with the one from the jupyter server logs.
+
+Alternatively, you can view all exposed endpoints at once using :code:`sky status --endpoints jupyter`:
+
+.. code-block:: console
+
+    $ sky status --endpoints jupyter
+    8888: http://35.223.97.21:8888
 
 If you want to expose multiple ports, you can specify a list of ports or port ranges in the :code:`resources` section:
 
@@ -57,11 +64,18 @@ If you want to expose multiple ports, you can specify a list of ports or port ra
         - 10020-10040
         - 20000-20010
 
-SkyPilot also support opening ports through the CLI:
+SkyPilot also supports opening ports through the CLI:
 
 .. code-block:: console
 
     $ sky launch -c jupyter --ports 8888 jupyter_lab.yaml
+
+You can then get the endpoint URL directly:
+
+.. code-block:: console
+
+    $ sky status --endpoint 8888 jupyter
+    http://35.223.97.21:8888
 
 Security and lifecycle considerations
 -------------------------------------

--- a/docs/source/examples/ports.rst
+++ b/docs/source/examples/ports.rst
@@ -70,13 +70,6 @@ SkyPilot also supports opening ports through the CLI:
 
     $ sky launch -c jupyter --ports 8888 jupyter_lab.yaml
 
-You can then get the endpoint URL directly:
-
-.. code-block:: console
-
-    $ sky status --endpoint 8888 jupyter
-    http://35.223.97.21:8888
-
 Security and lifecycle considerations
 -------------------------------------
 


### PR DESCRIPTION
[Opening ports](https://docs.skypilot.co/en/latest/examples/ports.html) page had dated instructions using `--ip`. This PR updates it to use `--endpoint` and `--endpoints`. 