### PR TITLE
Fix uvicorn dependency

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -50,7 +50,7 @@ install_requires = [
     'pyyaml > 3.13, != 5.4.*',
     'requests',
     'fastapi',
-    'uvicorn[standard]<=0.35.0',
+    'uvicorn[standard]<0.36.0',
     # Some pydantic versions are not compatible with ray. Adopted from ray's
     # setup.py:
     # https://github.com/ray-project/ray/blob/ray-2.9.3/python/setup.py#L254

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -50,7 +50,7 @@ install_requires = [
     'pyyaml > 3.13, != 5.4.*',
     'requests',
     'fastapi',
-    'uvicorn[standard]==0.33.0',
+    'uvicorn[standard]<=0.35.0',
     # Some pydantic versions are not compatible with ray. Adopted from ray's
     # setup.py:
     # https://github.com/ray-project/ray/blob/ray-2.9.3/python/setup.py#L254

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -50,7 +50,7 @@ install_requires = [
     'pyyaml > 3.13, != 5.4.*',
     'requests',
     'fastapi',
-    'uvicorn[standard]==0.35.0',
+    'uvicorn[standard]==0.33.0',
     # Some pydantic versions are not compatible with ray. Adopted from ray's
     # setup.py:
     # https://github.com/ray-project/ray/blob/ray-2.9.3/python/setup.py#L254

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -50,7 +50,7 @@ install_requires = [
     'pyyaml > 3.13, != 5.4.*',
     'requests',
     'fastapi',
-    'uvicorn[standard]',
+    'uvicorn[standard]==0.35.0',
     # Some pydantic versions are not compatible with ray. Adopted from ray's
     # setup.py:
     # https://github.com/ray-project/ray/blob/ray-2.9.3/python/setup.py#L254


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

#7287 is having a serious impact. 
`uvicorn` upgrade is breaking our nightly/release builds. 
Since our code doesn’t specify a uvicorn version in the requirements, any pip install will pull the latest version, causing the sky server to fail to launch.

This is a workaround and a patch to fix existing code to use the original dependency.  
We can patch the nightly/release using this PR.

We should deprecate this after #7289 is merged.

# Before this PR:

```bash
uv venv --seed --python=3.10 ~/test_sky
cd ~/test_sky && source ~/test_sky/bin/activate
# Same failure if we install: uv pip install "skypilot[all]" or uv pip install -e ".[all]"
uv pip install --prerelease=allow "azure-cli>=2.65.0" && uv pip install "skypilot-nightly[all]"
sky api stop && sky api start

SkyPilot API server is not running.
Failed to connect to SkyPilot API server at http://127.0.0.1:46580/. Starting a local server.
sky.exceptions.ApiServerConnectionError: Could not connect to SkyPilot API server at http://127.0.0.1:46580/. Please ensure that the server is running. Try: curl http://127.0.0.1:46580/api/health

During handling of the above exception, another exception occurred:

RuntimeError: SkyPilot API server process exited unexpectedly.
View logs at: ~/.sky/api_server/server.log
```

# After this PR

```bash
uv venv --seed --python=3.10 ~/test_sky
source ~/test_sky/bin/activate
uv pip install --prerelease=allow "azure-cli>=2.65.0" && uv pip install -e ".[all]"
(test_sky) (sky) zpoint:~/codes/skypilot (dev/zeping/uvicorn_dependency)$ sky api stop && sky api start
SkyPilot API server stopped.
Failed to connect to SkyPilot API server at http://127.0.0.1:46580. Starting a local server.
✓ SkyPilot API server started. 
├── Dashboard may be stale when installed from source, to rebuild: npm --prefix sky/dashboard install && npm --prefix sky/dashboard run build
├── SkyPilot API server and dashboard: http://127.0.0.1:46580
└── View API server logs at: ~/.sky/api_server/server.log
(test_sky) (sky) zpoint:~/codes/skypilot (dev/zeping/uvicorn_dependency)$ 
```




<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
