### PR TITLE
Fixed fastapi compatibility issue and pin uvicorn >= 0.33

### DIFF
--- a/docs/source/examples/ports.rst
+++ b/docs/source/examples/ports.rst
@@ -38,14 +38,21 @@ and look in for the logs for some output like:
         http://127.0.0.1:8888/lab?token=<token>
 
 
-To get the public IP address of the head node of the cluster, run :code:`sky status --ip jupyter`:
+To get the endpoint URL for the exposed port, run :code:`sky status --endpoint 8888 jupyter`:
 
 .. code-block:: console
 
-    $ sky status --ip jupyter
-    35.223.97.21
+    $ sky status --endpoint 8888 jupyter
+    http://35.223.97.21:8888
 
-In the jupyter server URL, replace :code:`127.0.0.1` with the public IP from :code:`sky status --ip jupyter` and open the URL in your browser.
+You can then directly open this URL in your browser, replacing the token with the one from the jupyter server logs.
+
+Alternatively, you can view all exposed endpoints at once using :code:`sky status --endpoints jupyter`:
+
+.. code-block:: console
+
+    $ sky status --endpoints jupyter
+    8888: http://35.223.97.21:8888
 
 If you want to expose multiple ports, you can specify a list of ports or port ranges in the :code:`resources` section:
 
@@ -57,7 +64,7 @@ If you want to expose multiple ports, you can specify a list of ports or port ra
         - 10020-10040
         - 20000-20010
 
-SkyPilot also support opening ports through the CLI:
+SkyPilot also supports opening ports through the CLI:
 
 .. code-block:: console
 

--- a/sky/server/auth/oauth2_proxy.py
+++ b/sky/server/auth/oauth2_proxy.py
@@ -37,8 +37,8 @@ OAUTH2_PROXY_ENABLED_ENV_VAR = 'SKYPILOT_AUTH_OAUTH2_PROXY_ENABLED'
 class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
     """Middleware to handle authentication by delegating to OAuth2 Proxy."""
 
-    def __init__(self, application: fastapi.FastAPI):
-        super().__init__(application)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.enabled: bool = (os.getenv(OAUTH2_PROXY_ENABLED_ENV_VAR,
                                         'false') == 'true')
         self.proxy_base: str = ''

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -49,8 +49,15 @@ install_requires = [
     # <= 3.13 may encounter https://github.com/ultralytics/yolov5/issues/414
     'pyyaml > 3.13, != 5.4.*',
     'requests',
+    # SkyPilot inherits from uvicorn.Server to customize the behavior of
+    # uvicorn, so we need to pin uvicorn version to avoid potential break
+    # changes.
+    # Notes for current version check:
+    # - uvicorn 0.33.0 is the latest version that supports Python 3.8
+    # - uvicorn 0.36.0 removes setup_event_loop thus breaks SkyPilot's custom
+    #   behavior.
+    'uvicorn[standard] >=0.33.0, <0.36.0',
     'fastapi',
-    'uvicorn[standard]',
     # Some pydantic versions are not compatible with ray. Adopted from ray's
     # setup.py:
     # https://github.com/ray-project/ray/blob/ray-2.9.3/python/setup.py#L254

--- a/tests/unit_tests/test_sky/server/auth/test_oauth2_proxy.py
+++ b/tests/unit_tests/test_sky/server/auth/test_oauth2_proxy.py
@@ -24,7 +24,7 @@ class TestOAuth2ProxyMiddleware:
                 'SKYPILOT_AUTH_OAUTH2_PROXY_ENABLED': 'true',
                 'SKYPILOT_AUTH_OAUTH2_PROXY_BASE_URL': 'http://oauth2-proxy:4180'
             }):
-            return OAuth2ProxyMiddleware(application=mock.Mock())
+            return OAuth2ProxyMiddleware(app=mock.Mock())
 
     @pytest.fixture
     def middleware_disabled(self):
@@ -32,7 +32,7 @@ class TestOAuth2ProxyMiddleware:
         with mock.patch.dict(os.environ,
                              {'SKYPILOT_AUTH_OAUTH2_PROXY_ENABLED': 'false'},
                              clear=True):
-            return OAuth2ProxyMiddleware(application=mock.Mock())
+            return OAuth2ProxyMiddleware(app=mock.Mock())
 
     @pytest.fixture
     def mock_request(self):
@@ -346,7 +346,7 @@ class TestOAuth2ProxyMiddleware:
             with pytest.raises(ValueError,
                                match='OAuth2 Proxy is enabled but base_url is '
                                'not set'):
-                OAuth2ProxyMiddleware(application=mock.Mock())
+                OAuth2ProxyMiddleware(app=mock.Mock())
 
     @pytest.mark.asyncio
     async def test_forward_to_oauth2_proxy_connection_error(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/7293

Tests:

```
# Branch new setup
> pip install -e .
> sky api stop; sky api start
# Works

> pip install fastapi==0.103.1
Successfully installed anyio-3.7.1 fastapi-0.103.1 starlette-0.27.0
> sky api stop; sky api start
# Works

> pip install fastapi==0.114.2
Successfully installed fastapi-0.114.2 starlette-0.38.6
> sky api stop; sky api start
# Works
```

For legacy uvicorn, warning raised:

```
> pip install uvicorn==0.28.0
Collecting uvicorn==0.28.0
  WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError(SSLEOFError(8, '[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1007)'))': /packages/25/bd/c20daf18824b1552d37579fc2f8cc147355c113d55aff21211443a2f89b9/uvicorn-0.28.0-py3-none-any.whl.metadata
  Downloading uvicorn-0.28.0-py3-none-any.whl.metadata (6.3 kB)
Requirement already satisfied: click>=7.0 in /opt/homebrew/anaconda3/envs/sky/lib/python3.10/site-packages (from uvicorn==0.28.0) (8.1.8)
Requirement already satisfied: h11>=0.8 in /opt/homebrew/anaconda3/envs/sky/lib/python3.10/site-packages (from uvicorn==0.28.0) (0.14.0)
Requirement already satisfied: typing-extensions>=4.0 in /opt/homebrew/anaconda3/envs/sky/lib/python3.10/site-packages (from uvicorn==0.28.0) (4.13.2)
Downloading uvicorn-0.28.0-py3-none-any.whl (60 kB)
Installing collected packages: uvicorn
  Attempting uninstall: uvicorn
    Found existing installation: uvicorn 0.35.0
    Uninstalling uvicorn-0.35.0:
      Successfully uninstalled uvicorn-0.35.0
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
skypilot 1.0.0.dev0 requires uvicorn[standard]<0.36.0,>=0.33.0, but you have uvicorn 0.28.0 which is incompatible.
Successfully installed uvicorn-0.28.0
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
