### PR TITLE
Revert "Workaround non-canonicalized L40S GPU name"

### DIFF
--- a/tests/test_optimizer_random_dag.py
+++ b/tests/test_optimizer_random_dag.py
@@ -71,9 +71,6 @@ def generate_random_dag(
 
             candidate_resources = set()
             for candidate in candidate_instance_types:
-                # TODO(aylei): remove this after #7177 get fixed
-                if candidate.accelerator_name == 'L40s':
-                    continue
                 instance_type = candidate.instance_type
                 if pd.isna(instance_type):
                     assert candidate.cloud == 'GCP', candidate


### PR DESCRIPTION
Since the issue has been fixed in https://github.com/skypilot-org/skypilot-catalog/commit/a459d8881e2c5bdacd56485709d4938ee0ed1bea, We can now revert skypilot-org/skypilot#7189