### PR TITLE
Fix backcompact on nightly 20250922

### DIFF
--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -152,6 +152,9 @@ class TestBackwardCompatibility:
             f'{self.ACTIVATE_BASE} && '
             'uv pip uninstall skypilot && '
             'uv pip install --prerelease=allow "azure-cli>=2.65.0" && '
+            # Fix https://github.com/skypilot-org/skypilot/issues/7287
+            # for legacy skypilot versions.
+            'uv pip install uvicorn==0.35.0 && '
             f'{pip_install_cmd}')
 
         # Install current version in current environment


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Copy of #7301, but set the base commt to [cdf2a96d2](https://github.com/skypilot-org/skypilot/commit/cdf2a96d298f86e944fc9bf49d53699566eb97db) which passes all nightly tests except backward compatiability.

If we manually pass on this PR. We can retrigger nightly build on this PR without tests.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
