### PR TITLE
Release 0.10.3.post1

### DIFF
--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -37,7 +37,7 @@ def _get_git_commit():
 
 
 __commit__ = _get_git_commit()
-__version__ = '0.10.3'
+__version__ = '0.10.3.post1'
 __root_dir__ = directory_utils.get_sky_dir()
 
 


### PR DESCRIPTION
Release 0.10.3.post1

Buildkite Test Links:
- [Full Smoke Tests](https://buildkite.com/skypilot-1/full-smoke-tests-run/builds/73) - ❌ 2 failures
  - custom gke deploy script failed so those tests were skipped
  - `test_cancel_pytorch on azure with param accelerator0` times out during setup - increasing setup timeout causes the test to pass
- [Quicktest Core](https://buildkite.com/skypilot-1/quicktest-core/builds/1309) - ❌ Failed due to #7301. Ignoring since there are no code changes since 0.10.3 so we can be pretty confident backcompat is okay.
- [Smoke Tests Remote Server Kubernetes](https://buildkite.com/skypilot-1/smoke-tests/builds/3554) - ✅ Success
- [Quicktest Core (vs Previous Minor)](https://buildkite.com/skypilot-1/quicktest-core/builds/1310) - ✅ Success
- [Release Tests](https://buildkite.com/skypilot-1/release/builds/96) - ⏳ (not waiting for completion)

*Release Tests may take up to 24 hours to complete and might fail due to resource constraints.*