### PR TITLE
[test] check for cache leak in get_clusters

### DIFF
--- a/tests/test_global_user_state.py
+++ b/tests/test_global_user_state.py
@@ -217,10 +217,8 @@ def test_get_clusters_cache_size(_mock_db_conn):
 
                 # Call multiple times - should hit cache
                 try:
-                    runners1 = first_handle.get_command_runners(
-                        force_cached=True)
-                    runners2 = first_handle.get_command_runners(
-                        force_cached=True)
+                    first_handle.get_command_runners()
+                    first_handle.get_command_runners()
 
                     # Verify cache behavior if cache_info is available
                     if hasattr(first_handle.get_command_runners, 'cache_info'):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Follow-up to https://github.com/skypilot-org/skypilot/pull/6908 - add a unit test for tracking any unbounded cache size increases when `get_clusters` is called.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
