### PR TITLE
[Docs] Add Docs to Explain Airgapped Setup

### DIFF
--- a/docs/source/cloud-setup/airgap.rst
+++ b/docs/source/cloud-setup/airgap.rst
@@ -1,34 +1,10 @@
 .. _airgap:
 
-Setting Up SkyPilot with Airgapping
-====================================
+Setting Up SkyPilot with Airgapped Environments
+================================================
 
 SkyPilot is compatible with any airgapped setup that allows downloading our required packages via a proxy (for example via an HTTP proxy or Amazon SSM).
 This guide details how to setup SkyPilot in these cases.
-
-.. _airgap-aws-ssm:
-
-AWS SSM
-~~~~~~~
-
-:ref:`AWS SSM <aws-ssm>` allows for secure shell access to EC2 instances without direct network access.
-This enables an airgapped setup where instances without public IP addresses can still be accessed.
-
-Given an airgapped AWS cluster with a private VPC ``private-vpc`` and a private security group ``private-sg``, a simple config can enable SkyPilot on the cluster.
-The following yaml is the SkyPilot config which can be edited at ``http://<api-server-url>/dashboard/config``. See the :ref:`yaml-spec` spec for more details. 
-
-.. code-block:: yaml
-
-    # ~/.sky/config.yaml
-    aws:
-        vpc_name: <private-vpc>
-        security_group_name: <private-sg>
-        use_internal_ips: true
-        use_ssm: true
-
-The above configuration directs SkyPilot to use SSM for connectivity to clusters, using the configured VPC and security group to create a cluster in AWS using private IPs (as a result of ``use_internal_ips: true``).
-
-See :ref:`Using AWS Systems Manager SSM <aws-ssm>` for further instructions on setting up SSM in SkyPilot, including required packages and permissions.
 
 .. _airgap-kubernetes:
 
@@ -65,3 +41,28 @@ The following yaml is the SkyPilot config which can be edited at ``http://<api-s
 Because different tools and libraries use different environment variable names we include all the possible names to ensure compatibility.
 
 This configuration directs SkyPilot pods to use the corporate proxy for outbound traffic.
+
+.. _airgap-aws-ssm:
+
+AWS SSM
+~~~~~~~
+
+:ref:`AWS SSM <aws-ssm>` allows for secure shell access to EC2 instances without direct network access.
+This enables an airgapped setup where instances without public IP addresses can still be accessed.
+
+Given an airgapped AWS cluster with a private VPC ``private-vpc`` and a private security group ``private-sg``, a simple config can enable SkyPilot on the cluster.
+The following yaml is the SkyPilot config which can be edited at ``http://<api-server-url>/dashboard/config``. See the :ref:`yaml-spec` spec for more details. 
+
+.. code-block:: yaml
+
+    # ~/.sky/config.yaml
+    aws:
+        vpc_name: <private-vpc>
+        security_group_name: <private-sg>
+        use_internal_ips: true
+        use_ssm: true
+
+The above configuration directs SkyPilot to use SSM for connectivity to clusters, using the configured VPC and security group to create a cluster in AWS using private IPs (as a result of ``use_internal_ips: true``).
+
+See :ref:`Using AWS Systems Manager SSM <aws-ssm>` for further instructions on setting up SSM in SkyPilot, including required packages and permissions.
+

--- a/docs/source/docs/index.rst
+++ b/docs/source/docs/index.rst
@@ -360,7 +360,7 @@ Read the research:
    ../cloud-setup/cloud-permissions/index
    Admin Policies <../cloud-setup/policy>
    External Logging Storage <../cloud-setup/external-logging>
-   Airgapped Clusters <../cloud-setup/airgap>
+   Airgapped Environments <../cloud-setup/airgap>
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR adds a new page describing how to to use SkyPilot with an airgapped AWS, or Kubernetes cluster under administrator guides.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
