### PR TITLE
[Docs] Refactor torchtitan example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 
 :fire: *News* :fire:
 - [Aug 2025] Serve and finetune **OpenAI GPT-OSS models** (gpt-oss-120b, gpt-oss-20b) with one command on any infra: [**serve**](./llm/gpt-oss/) + [**LoRA and full finetuning**](./llm/gpt-oss-finetuning/)
+- [Jul 2025] Run large-scale **LLM training with TorchTitan** on any cloud: [**example**](./llm/torchtitan/)
 - [Jul 2025] Run distributed **RL training for LLMs** with Verl (PPO, GRPO) on any cloud: [**example**](./llm/verl/)
 - [Jul 2025] 🎉 SkyPilot v0.10.0 released! [**blog post**](https://blog.skypilot.co/announcing-skypilot-0.10.0/), [**release notes**](https://github.com/skypilot-org/skypilot/releases/tag/v0.10.0)
 - [Jul 2025] Finetune **Llama4** on any distributed cluster/cloud: [**example**](./llm/llama-4-finetuning/)

--- a/docs/source/examples/training/index.rst
+++ b/docs/source/examples/training/index.rst
@@ -15,7 +15,7 @@ Training
    NeMo <nemo.md>
    NeMo RL <nemorl.md>
    Ray <ray.md>
-   TorchTitan <torchtitan/README.md>
+   TorchTitan <torchtitan.md>
    Training on TPUs <tpu.md>
    Unsloth <unsloth.md>
    Verl (RLHF) <verl.md>

--- a/docs/source/examples/training/torchtitan
+++ b/docs/source/examples/training/torchtitan
@@ -1,1 +1,0 @@
-../../../../examples/training/torchtitan

--- a/docs/source/examples/training/torchtitan.md
+++ b/docs/source/examples/training/torchtitan.md
@@ -1,0 +1,1 @@
+../../generated-examples/torchtitan.md

--- a/llm/torchtitan/README.md
+++ b/llm/torchtitan/README.md
@@ -1,0 +1,70 @@
+# TorchTitan: Large-Scale LLM Training with SkyPilot
+
+This example shows how to train [TorchTitan](https://github.com/pytorch/torchtitan) models using SkyPilot's multi-node capabilities.
+
+TorchTitan is a PyTorch native platform designed for rapid experimentation and large-scale training of generative AI models, featuring:
+- Multi-dimensional composable parallelisms (FSDP2, Tensor Parallel, Pipeline Parallel, Context Parallel)
+- Distributed checkpointing
+- torch.compile support
+- Float8 support
+- And many more optimizations for training LLMs at scale
+
+## Quick start
+
+```bash
+# Install SkyPilot (if not already installed)
+pip install "skypilot[kubernetes,aws]"  # or your cloud: [gcp], [azure], etc.
+
+# Launch a cluster and start training
+export HF_TOKEN=... # if using a gated model from the HF Hub
+sky launch -c torchtitan-multinode llm/torchtitan/torchtitan.yaml --env HF_TOKEN
+
+# Tail logs
+sky logs torchtitan-multinode
+
+# Stop the cluster when done
+sky down torchtitan-multinode
+```
+
+## Configuration
+
+The provided `torchtitan.yaml` configuration:
+- Sets up a 2-node cluster with 8 H100 (or H200) GPUs per node
+- Installs PyTorch nightly and TorchTitan requirements
+- Downloads the Llama 3.1 tokenizer
+- Runs distributed training using torchrun
+
+### Customizing the configuration
+
+You can override various parameters without editing the YAML file:
+
+```bash
+# Use 4 nodes and train a larger model
+sky launch -c torchtitan-multinode llm/torchtitan/torchtitan.yaml \
+   --num-nodes 4 \
+   --env HF_TOKEN \
+   --env CONFIG_FILE=./torchtitan/models/llama3/train_configs/llama3_70b.toml # relative to the torchtitan's repo
+```
+
+## Available model configurations
+
+TorchTitan includes pre-configured training recipes for:
+- Llama 3.1 8B: `llama3_8b.toml`
+- Llama 3.1 70B: `llama3_70b.toml`
+- Llama 3.1 405B: `llama3_405b.toml`
+
+Each configuration file specifies model architecture, parallelism strategies, and training hyperparameters optimized for different scales.
+
+## Multi-node training details
+
+The configuration automatically:
+- Detects the head node IP and sets it as the master address
+- Configures the correct node rank for each node
+- Sets up the distributed environment for PyTorch's torchrun
+
+## Cost optimization
+
+To reduce costs:
+- Use spot instances: Add `use_spot: true` to the resources section
+- Use smaller GPU types for experimentation (e.g., A100 instead of H100)
+- Adjust the number of nodes based on your training requirements

--- a/llm/torchtitan/torchtitan.yaml
+++ b/llm/torchtitan/torchtitan.yaml
@@ -1,0 +1,53 @@
+# SkyPilot configuration for TorchTitan multi-node training
+# This configuration reproduces the functionality of multinode_trainer.slurm
+#
+# To launch:
+#   sky launch -c torchtitan-cluster llm/torchtitan/torchtitan.yaml
+#
+# To stop:
+#   sky down torchtitan-cluster
+#
+# To monitor:
+#   sky status --refresh
+
+name: torchtitan-multinode
+
+resources:
+  accelerators: {H100:8, H200:8}
+  disk_size: 1024GB
+
+num_nodes: 2
+
+envs:
+  CONFIG_FILE: "./torchtitan/models/llama3/train_configs/llama3_8b.toml"
+  HF_TOKEN: ""
+
+setup: |
+  # Clone TorchTitan repository
+  git clone https://github.com/pytorch/torchtitan.git
+  cd torchtitan
+
+  # Install dependencies
+  pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu126 --force-reinstall
+  pip install -r requirements.txt
+
+  # Download tokenizer
+  python scripts/download_hf_assets.py --repo_id meta-llama/Llama-3.1-8B --assets tokenizer --hf_token=$HF_TOKEN
+
+run: |
+  cd torchtitan
+
+  # Get head node IP (first node in the list)
+  HEAD_NODE_IP=$(echo "$SKYPILOT_NODE_IPS" | head -n1)
+  echo "Head node IP: $HEAD_NODE_IP"
+
+  # SKYPILOT_NODE_RANK is automatically set by SkyPilot
+  torchrun \
+    --nnodes $SKYPILOT_NUM_NODES \
+    --nproc_per_node $SKYPILOT_NUM_GPUS_PER_NODE \
+    --node_rank $SKYPILOT_NODE_RANK \
+    --master_addr=$HEAD_NODE_IP \
+    --master_port=8008 \
+    -m torchtitan.train \
+    --job.config_file $CONFIG_FILE \
+    --training.dataset c4_test


### PR DESCRIPTION
Follow-up to https://github.com/skypilot-org/skypilot/pull/6677: 
Move torchtitan example to `llm/` directory and integrate with auto-generated docs.

Changes:
- moved torchtitan from `examples/training/` to `llm/torchtitan/` for consistency
- udpated YAML configuration to clone torchtitan repo during setup
- fixed documentation symlinks and auto-generation