### PR TITLE
[Docs] SDK example for pytorch quickstart

### DIFF
--- a/docs/source/getting-started/tutorial.rst
+++ b/docs/source/getting-started/tutorial.rst
@@ -68,7 +68,7 @@ This example uses SkyPilot to train a GPT-like model (inspired by Karpathy's `mi
   
   .. tab-item:: Python
 
-    We define a Python script with the resource requirements, the setup commands,
+    We use the :ref:`Python SDK <pythonapi>` to create a task with the resource requirements, the setup commands,
     and the commands to run:
 
     .. code-block:: python
@@ -113,6 +113,12 @@ This example uses SkyPilot to train a GPT-like model (inspired by Karpathy's `mi
       launch_request = sky.launch(task=minGPT_ddp_task, cluster_name=cluster_name)
       job_id, _ = sky.stream_and_get(launch_request)
       sky.tail_logs(cluster_name, job_id, follow=True)
+
+    .. tip::
+
+      In the code, the ``workdir`` and ``file_mounts`` fields are commented out. To
+      learn about how to use them to mount local dirs/files or object store buckets
+      (S3, GCS, R2) into your cluster, see :ref:`sync-code-artifacts`.
 
     .. tip::
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Add an SDK example for pytorch quickstart example
Link: https://docs.skypilot.co/en/pytorch-example-sdk/getting-started/tutorial.html

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
