### PR TITLE
[core] Align rsync ignore handling with Git semantics

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -42,6 +42,7 @@ install_requires = [
     # filelock 3.15.0 or higher is required for async file locking.
     'filelock >= 3.15.0',
     'packaging',
+    'pathspec',
     'psutil',
     'pulp',
     # Cython 3.0 release breaks PyYAML 5.4.*

--- a/tests/unit_tests/test_sky/utils/test_command_runner.py
+++ b/tests/unit_tests/test_sky/utils/test_command_runner.py
@@ -1,0 +1,44 @@
+"""Tests for command_runner utilities."""
+from pathlib import Path
+
+from sky.utils import command_runner
+
+
+class _DummyRunner(command_runner.CommandRunner):
+    """Minimal runner to exercise CommandRunner._rsync locally."""
+
+    def run(self, *args, **kwargs):  # pragma: no cover - not used in test
+        raise NotImplementedError
+
+    def rsync(self, *args, **kwargs):  # pragma: no cover - not used in test
+        raise NotImplementedError
+
+
+def test_rsync_respects_skyignore_negation(tmp_path):
+    src = tmp_path / 'src'
+    dst = tmp_path / 'dst'
+    src.mkdir()
+    dst.mkdir()
+
+    (src / '.skyignore').write_text('*.log\n!important.log\n',
+                                    encoding='utf-8')
+    (src / 'boring.log').write_text('boring', encoding='utf-8')
+    (src / 'important.log').write_text('important', encoding='utf-8')
+    (src / 'notes.txt').write_text('notes', encoding='utf-8')
+
+    runner = _DummyRunner(node=('local', 0))
+    log_path: Path = tmp_path / 'rsync.log'
+
+    runner._rsync(
+        source=str(src),
+        target=str(dst),
+        node_destination=None,
+        up=True,
+        rsh_option=None,
+        log_path=str(log_path),
+        stream_logs=False,
+    )
+
+    assert not (dst / 'boring.log').exists()
+    assert (dst / 'important.log').exists()
+    assert (dst / 'notes.txt').exists()

--- a/tests/unit_tests/test_sky/utils/test_command_runner.py
+++ b/tests/unit_tests/test_sky/utils/test_command_runner.py
@@ -20,8 +20,7 @@ def test_rsync_respects_skyignore_negation(tmp_path):
     src.mkdir()
     dst.mkdir()
 
-    (src / '.skyignore').write_text('*.log\n!important.log\n',
-                                    encoding='utf-8')
+    (src / '.skyignore').write_text('*.log\n!important.log\n', encoding='utf-8')
     (src / 'boring.log').write_text('boring', encoding='utf-8')
     (src / 'important.log').write_text('important', encoding='utf-8')
     (src / 'notes.txt').write_text('notes', encoding='utf-8')


### PR DESCRIPTION
Fixes #7262

This PR teaches rsync-based sync to respect Git-style ignore semantics and keeps .skyignore behavior consistent across storage utilities and rsync. It also unifies .skyignore handling so nested files and negations behave the same as gitignore.

## Problem
- rsync filters forced every .skyignore pattern to be an exclusion, so `!` negations never worked.
- Nested .skyignore files were ignored unless the repo root also had one, contradicting docs and storage-utils behavior.
- storage_utils and rsync used different ignore engines, so workdir/file_mount sync could disagree with archive uploads.

## Solution
- Parse all .skyignore files with `pathspec.GitIgnoreSpec` so nested files and negations behave like gitignore.
- Feed the storage_utils exclusion list into rsync via a temporary `--exclude-from`, keeping both code paths aligned and cleaning up the file afterwards.
- Added regression tests for .skyignore negations/nested files and ensured `_rsync` honours re-included files.

Tested (run the relevant ones):
- [x] Code formatting: `PATH=/home/andyl/.local/share/uv/python/cpython-3.11.11-linux-x86_64-gnu/bin:$PATH bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py`
- [x] Relevant individual tests: `PYTHONPATH=.venv/lib/python3.11/site-packages ~/.local/share/uv/python/cpython-3.11.11-linux-x86_64-gnu/bin/python3.11 -m pytest tests/unit_tests/test_sky/utils/test_command_runner.py`
- [x] Relevant individual tests: `PYTHONPATH=.venv/lib/python3.11/site-packages ~/.local/share/uv/python/cpython-3.11.11-linux-x86_64-gnu/bin/python3.11 -m pytest tests/unit_tests/test_sky/storage/test_storage_utils.py`
- [ ] Backward compatibility test with existing clusters

## Example
Before:
```
.skyignore:
  *.log
  !keep.log

Sync dropped keep.log when using rsync-based workdir/file_mount uploads.
```

After:
```
keep.log stays on the remote, matching gitignore semantics for storage mounts and rsync uploads.
```