### PR TITLE
use ssh tunneling instead of external http for load-balancer -> replica communication

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -3715,7 +3715,7 @@ def cluster_tunnel_lock_id(cluster_name: str) -> str:
 
 def open_ssh_tunnel(head_runner: Union[command_runner.SSHCommandRunner,
                                        command_runner.KubernetesCommandRunner],
-                    port_forward: Tuple[int, int]) -> subprocess.Popen:
+                    port_forward: Tuple[int, int]) -> subprocess.Popen[Any]:
     local_port, remote_port = port_forward
     if isinstance(head_runner, command_runner.SSHCommandRunner):
         # Disabling ControlMaster makes things easier to reason about

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -50,6 +50,7 @@ from sky import clouds
 from sky import dag as dag_lib
 from sky import exceptions
 from sky import jobs as managed_jobs
+from sky import global_user_state
 from sky import models
 from sky import resources as resources_lib
 from sky import serve as serve_lib
@@ -60,6 +61,7 @@ from sky.adaptors import common as adaptors_common
 from sky.client import sdk
 from sky.client.cli import flags
 from sky.data import storage_utils
+from sky.backends import backend_utils
 from sky.provision.kubernetes import constants as kubernetes_constants
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.schemas.api import responses
@@ -5783,6 +5785,110 @@ def serve_down(
                                     all=all,
                                     purge=purge)
     _async_call_or_wait(request_id, async_call, 'sky.serve.down')
+
+
+def _parse_port_mapping(port_mapping: str) -> Tuple[int, int]:
+    parts = port_mapping.split(':')
+    if len(parts) != 2:
+        raise click.UsageError(
+            'PORT must be in the format <local_port>:<remote_port>.')
+    local_part, remote_part = parts
+    try:
+        local_port = int(local_part)
+        remote_port = int(remote_part)
+    except ValueError as exc:
+        raise click.UsageError(
+            'PORT must be two integers separated by a colon.') from exc
+    for port, label in ((local_port, 'local'), (remote_port, 'remote')):
+        if port <= 0 or port >= 65536:
+            raise click.UsageError(
+                f'{label.capitalize()} port must be between 1 and 65535.')
+    return local_port, remote_port
+
+
+@serve.command('forward', cls=_DocumentedCodeCommand)
+@flags.config_option(expose_value=False)
+@click.argument('service_name', required=True, type=str)
+@click.argument('replica_id', required=True, type=int)
+@click.argument('port', required=True, type=str)
+@usage_lib.entrypoint
+def serve_forward(service_name: str, replica_id: int, port: str) -> None:
+    """Forward a local port to a service replica.
+
+    Example:
+
+    .. code-block:: bash
+
+        sky serve forward my-service 1 9000:8080
+
+    This listens on ``localhost:9000`` and forwards traffic to port 8080 on
+    replica 1. Press ``Ctrl+C`` to stop the session.
+    """
+
+    local_port, remote_port = _parse_port_mapping(port)
+    replica_cluster = serve_lib.generate_replica_cluster_name(
+        service_name, replica_id)
+
+    handle = global_user_state.get_handle_from_cluster_name(replica_cluster)
+    if handle is None:
+        raise click.UsageError(
+            f'Cluster {replica_cluster!r} not found. '
+            f'Use `sky serve status {service_name}` to verify the replica id.')
+    if not isinstance(handle, backends.CloudVmRayResourceHandle):
+        raise click.ClickException(
+            f'Unsupported handle type for cluster {replica_cluster!r}.')
+
+    try:
+        runners = handle.get_command_runners(force_cached=True)
+    except Exception as exc:  # pylint: disable=broad-except
+        raise click.ClickException(
+            f'Failed to fetch command runners for {replica_cluster!r}: '
+            f'{common_utils.format_exception(exc)}') from exc
+
+    if not runners:
+        raise click.ClickException(
+            f'No command runners available for cluster {replica_cluster!r}.')
+
+    if len(runners) > 1:
+        logger.warning(
+            f'Multiple command runners found for cluster '
+            f'{replica_cluster!r}. Using the first one.')
+    runner = runners[0]
+    try:
+        tunnel_process = backend_utils.open_ssh_tunnel(
+            runner, (local_port, remote_port))
+    except exceptions.CommandError as exc:
+        raise click.ClickException(
+            f'Failed to establish port forward: {exc.error_msg}') from exc
+    except Exception as exc:  # pylint: disable=broad-except
+        raise click.ClickException(
+            'Failed to establish port forward: '
+            f'{common_utils.format_exception(exc)}') from exc
+
+    click.echo(
+        f'Forwarding localhost:{local_port} -> '
+        f'{replica_cluster}:localhost:{remote_port}')
+    click.echo('Press Ctrl+C to stop forwarding.')
+
+    try:
+        tunnel_process.wait()
+    except KeyboardInterrupt:
+        click.echo('\nStopping port forward...')
+    finally:
+        if tunnel_process.poll() is None:
+            tunnel_process.terminate()
+            try:
+                tunnel_process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                tunnel_process.kill()
+                tunnel_process.wait()
+        for stream in (tunnel_process.stdout, tunnel_process.stderr,
+                       tunnel_process.stdin):
+            if stream:
+                try:
+                    stream.close()
+                except Exception:  # pylint: disable=broad-except
+                    pass
 
 
 @serve.command('logs', cls=_DocumentedCodeCommand)

--- a/sky/serve/constants.py
+++ b/sky/serve/constants.py
@@ -84,6 +84,9 @@ CONTROLLER_PORT_START = 20001
 LOAD_BALANCER_PORT_START = 30001
 LOAD_BALANCER_PORT_RANGE = '30001-30020'
 
+# Default starting port for local SSH tunnels to replicas.
+REPLICA_PORT_FORWARD_START = 40001
+
 # Initial version of service.
 INITIAL_VERSION = 1
 

--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -128,7 +128,7 @@ class SkyServeController:
             ready_replica_urls = self._replica_manager.get_active_replica_urls()
 
             # Use URL-to-info mapping to avoid duplication
-            replica_info = {}
+            replica_info: Dict[str, Dict[str, str]] = {}
             for info in replica_infos:
                 if info.url in ready_replica_urls:
                     # Get GPU type from handle.launched_resources.accelerators
@@ -145,7 +145,7 @@ class SkyServeController:
             # Check that all ready replica URLs are included in replica_info
             missing_urls = set(ready_replica_urls) - set(replica_info.keys())
             if missing_urls:
-                logger.warning(f'Ready replica URLs missing from replica_info: '
+                logger.warning('Ready replica URLs missing from replica_info: '
                                f'{missing_urls}')
                 # fallback: add missing URLs with unknown GPU type
                 for url in missing_urls:

--- a/tests/unit_tests/test_replica_port_forward_manager.py
+++ b/tests/unit_tests/test_replica_port_forward_manager.py
@@ -1,0 +1,181 @@
+"""Unit tests for the SkyServe replica port forward manager."""
+
+from __future__ import annotations
+
+import itertools
+
+from sky.serve import replica_managers
+
+
+class _DummyProcess:
+    """Simple process stub that mimics the Popen interface used in tests."""
+
+    def __init__(self) -> None:
+        self.stdout = None
+        self.stderr = None
+        self.stdin = None
+        self._terminated = False
+
+    def poll(self):
+        return None if not self._terminated else 0
+
+    def terminate(self):
+        self._terminated = True
+
+    def wait(self, timeout=None):  # pylint: disable=unused-argument
+        return 0
+
+    def kill(self):
+        self._terminated = True
+
+
+def _make_replica_info(replica_id: int = 1,
+                       replica_port: str = '8000') -> replica_managers.ReplicaInfo:
+    return replica_managers.ReplicaInfo(replica_id=replica_id,
+                                        cluster_name=f'cluster-{replica_id}',
+                                        replica_port=replica_port,
+                                        is_spot=False,
+                                        location=None,
+                                        version=1,
+                                        resources_override=None)
+
+
+def test_ensure_port_forward_sets_local_url_and_reuses_existing(monkeypatch):
+    manager = replica_managers._ReplicaPortForwardManager()
+    replica_info = _make_replica_info()
+
+    dummy_process = _DummyProcess()
+    call_count = {'value': 0}
+
+    def fake_find_free_port(_start: int) -> int:  # pylint: disable=unused-argument
+        return 45000
+
+    def fake_start(self, *, info, local_port, remote_port):  # noqa: D401
+        call_count['value'] += 1
+        assert info is replica_info
+        assert local_port == 45000
+        assert remote_port == 8000
+        return dummy_process
+
+    monkeypatch.setattr(replica_managers.common_utils, 'find_free_port',
+                        fake_find_free_port)
+    monkeypatch.setattr(replica_managers._ReplicaPortForwardManager,
+                        '_start_port_forward_process', fake_start)
+
+    url = manager.ensure_port_forward(replica_info)
+    assert url == 'http://127.0.0.1:45000'
+    assert replica_info.url == url
+    assert call_count['value'] == 1
+
+    # Reusing the tunnel should not trigger another start.
+    assert manager.ensure_port_forward(replica_info) == url
+    assert call_count['value'] == 1
+
+
+def test_ensure_port_forward_replaces_when_remote_port_changes(monkeypatch):
+    manager = replica_managers._ReplicaPortForwardManager()
+    replica_info = _make_replica_info()
+
+    first_process = _DummyProcess()
+    second_process = _DummyProcess()
+    ports = itertools.cycle([45000, 45001])
+    call_args = []
+    terminated = []
+
+    def fake_find_free_port(_start: int) -> int:  # pylint: disable=unused-argument
+        return next(ports)
+
+    def fake_start(self, *, info, local_port, remote_port):
+        call_args.append((local_port, remote_port))
+        assert info is replica_info
+        return first_process if len(call_args) == 1 else second_process
+
+    def fake_terminate(self, tunnel):
+        terminated.append(tunnel)
+
+    monkeypatch.setattr(replica_managers.common_utils, 'find_free_port',
+                        fake_find_free_port)
+    monkeypatch.setattr(replica_managers._ReplicaPortForwardManager,
+                        '_start_port_forward_process', fake_start)
+    monkeypatch.setattr(replica_managers._ReplicaPortForwardManager,
+                        '_terminate_port_forward_process', fake_terminate)
+
+    url_first = manager.ensure_port_forward(replica_info)
+    assert url_first == 'http://127.0.0.1:45000'
+
+    replica_info.replica_port = '9000'
+    url_second = manager.ensure_port_forward(replica_info)
+    assert url_second == 'http://127.0.0.1:45001'
+
+    assert call_args == [(45000, 8000), (45001, 9000)]
+    assert terminated and terminated[0].remote_port == 8000
+    assert replica_info.url == url_second
+
+    # The replacement tunnel should be reused without another start.
+    assert manager.ensure_port_forward(replica_info) == url_second
+    assert len(call_args) == 2
+
+
+def test_ensure_port_forward_handles_invalid_remote_port(monkeypatch):
+    manager = replica_managers._ReplicaPortForwardManager()
+    info = _make_replica_info(replica_port='invalid')
+
+    def fail_start(self, *args, **kwargs):  # pragma: no cover
+        raise AssertionError('Should not attempt to start tunnel')
+
+    monkeypatch.setattr(replica_managers._ReplicaPortForwardManager,
+                        '_start_port_forward_process', fail_start)
+
+    url = manager.ensure_port_forward(info)
+    assert url is None
+    assert info.url is None
+    assert not manager.ensure_port_forward(info)
+
+
+def test_cleanup_stale_invokes_stop_for_missing_replicas(monkeypatch):
+    manager = replica_managers._ReplicaPortForwardManager()
+    manager._replica_port_forwards[1] = replica_managers._ReplicaPortForward(  # pylint: disable=protected-access
+        local_port=45000,
+        remote_port=8000,
+        process=_DummyProcess(),
+        cluster_name='cluster-1')
+    manager._replica_port_forwards[2] = replica_managers._ReplicaPortForward(  # pylint: disable=protected-access
+        local_port=45001,
+        remote_port=8001,
+        process=_DummyProcess(),
+        cluster_name='cluster-2')
+
+    stopped = []
+
+    def fake_stop(self, replica_id):
+        stopped.append(replica_id)
+        manager._replica_port_forwards.pop(replica_id, None)  # pylint: disable=protected-access
+
+    monkeypatch.setattr(replica_managers._ReplicaPortForwardManager, 'stop',
+                        fake_stop)
+
+    manager.cleanup_stale({1})
+    assert stopped == [2]
+    assert 2 not in manager._replica_port_forwards  # pylint: disable=protected-access
+    assert 1 in manager._replica_port_forwards  # pylint: disable=protected-access
+
+
+def test_stop_terminates_and_removes_port_forward(monkeypatch):
+    manager = replica_managers._ReplicaPortForwardManager()
+    tunnel = replica_managers._ReplicaPortForward(local_port=45000,
+                                                  remote_port=8000,
+                                                  process=_DummyProcess(),
+                                                  cluster_name='cluster-1')
+    manager._replica_port_forwards[1] = tunnel  # pylint: disable=protected-access
+
+    terminated = []
+
+    def fake_terminate(self, forward):
+        terminated.append(forward)
+
+    monkeypatch.setattr(replica_managers._ReplicaPortForwardManager,
+                        '_terminate_port_forward_process', fake_terminate)
+
+    manager.stop(1)
+    assert terminated == [tunnel]
+    assert 1 not in manager._replica_port_forwards  # pylint: disable=protected-access


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

By default, the controller accesses replicas via HTTP. However, this is insecure. This PR proposes a concept for one way to solve this problem: ssh tunnels. The replica manager will tunnel into the replica and forward its port to some local port. Then the controller can call the local http port directly. This avoids insecure external communication.

The replica, therefore, does not require an HTTP endpoint to be compatible with skypilot. However, there are cases where it may be useful to make requests directly to a specific replica. For this purpose I've also implemented a new sky cli command `sky serve forward service_name replica_id local_port:remote_port` which will make it possible to access the HTTP endpoint of the replica remotely. 

In the interest of security it's probably a good idea to remove all forwarded ports / externally accessible entrypoints (i.e. the current HTTP server) on all replicas given that they are no longer necessary (as far as I can tell).

If all goes according to plan this should be a drop in replacement that is backwards compatible with existing infrastructure (with the exception of the existing HTTP servers remaining active).

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->
I created unit tests but have not run this code in my development setup, I would like more guidance on how to load my local code into the remote controller or to run one locally or something to check to see if it works properly.

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
