### PR TITLE
[Cluster] Resolve ingress-nginx-controller service not found in ingress mode

### DIFF
--- a/sky/provision/kubernetes/constants.py
+++ b/sky/provision/kubernetes/constants.py
@@ -24,3 +24,6 @@ TAG_SKYPILOT_DEPLOYMENT_NAME = 'skypilot-deployment-name'
 
 # Pod phases that are not holding PVCs
 PVC_NOT_HOLD_POD_PHASES = ['Succeeded', 'Failed']
+
+# Label selector for finding the ingress controller service
+INGRESS_SERVICE_LABEL_SELECTOR = 'app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/component=controller'  # pylint: disable=line-too-long

--- a/sky/provision/kubernetes/network_utils.py
+++ b/sky/provision/kubernetes/network_utils.py
@@ -9,6 +9,7 @@ from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import common as adaptors_common
 from sky.adaptors import kubernetes
+from sky.provision.kubernetes import constants
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.utils import directory_utils
 from sky.utils import kubernetes_enums
@@ -245,15 +246,15 @@ def ingress_controller_exists(context: Optional[str],
 
 
 def get_ingress_external_ip_and_ports(
-    context: Optional[str],
-    namespace: str = 'ingress-nginx'
+        context: Optional[str]
 ) -> Tuple[Optional[str], Optional[Tuple[int, int]]]:
     """Returns external ip and ports for the ingress controller."""
     core_api = kubernetes.core_api(context)
     ingress_services = [
-        item for item in core_api.list_namespaced_service(
-            namespace, _request_timeout=kubernetes.API_TIMEOUT).items
-        if item.metadata.name == 'ingress-nginx-controller'
+        item for item in core_api.list_service_for_all_namespaces(
+            label_selector=constants.INGRESS_SERVICE_LABEL_SELECTOR,
+            _request_timeout=kubernetes.API_TIMEOUT).items
+        if item.spec.type == 'LoadBalancer'
     ]
     if not ingress_services:
         return (None, None)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR fixes an issue where the installed ingress-nginx-controller could not be found, which prevented endpoint lookup.

- Related issue: [skypilot-org/skypilot#4915](https://github.com/skypilot-org/skypilot/issues/4915)

**Before (output):**
```
$ sky status --endpoints gpt-oss-20b
No endpoints exposed yet. If the cluster was recently started, please retry after a while. Additionally, make sure your Ingress is configured correctly.
To debug, run: kubectl describe ingress && kubectl describe ingressclass
Aborted!
```
**After (output):**
```
$ sky status --endpoints gpt-oss-20b
8000: http://192.168.2.232/skypilot/skypilot/gpt-oss-20b-cf9280d8/8000
```

### **Note:**
This may still cause issues if there are multiple `ingress-nginx-controller` instances installed.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
