### PR TITLE
add support for vastai docker config

### DIFF
--- a/sky/provision/vast/instance.py
+++ b/sky/provision/vast/instance.py
@@ -89,7 +89,7 @@ def run_instances(region: str, cluster_name: str, cluster_name_on_cloud: str,
                                           resumed_instance_ids=[],
                                           created_instance_ids=[])
 
-        docker_login_params = None
+        docker_login_params: Optional[str] = None
         docker_login_config = config.node_config.get('DockerLogin')
         if docker_login_config:
             username = docker_login_config.get('username', '').strip()

--- a/sky/provision/vast/instance.py
+++ b/sky/provision/vast/instance.py
@@ -89,6 +89,15 @@ def run_instances(region: str, cluster_name: str, cluster_name_on_cloud: str,
                                           resumed_instance_ids=[],
                                           created_instance_ids=[])
 
+        docker_login_params = None
+        docker_login_config = config.node_config.get('DockerLogin')
+        if docker_login_config:
+            username = docker_login_config.get('username', '').strip()
+            password = docker_login_config.get('password', '').strip()
+            server = docker_login_config.get('server', '').strip()
+            if username and password and server:
+                docker_login_params = f'-u {username} -p {password} {server}'
+
         for _ in range(to_start_count):
             node_type = 'head' if head_instance_id is None else 'worker'
             try:
@@ -99,7 +108,8 @@ def run_instances(region: str, cluster_name: str, cluster_name_on_cloud: str,
                     disk_size=config.node_config['DiskSize'],
                     preemptible=config.node_config['Preemptible'],
                     image_name=config.node_config['ImageId'],
-                    ports=config.ports_to_open_on_launch)
+                    ports=config.ports_to_open_on_launch,
+                    docker_login=docker_login_params)
             except Exception as e:  # pylint: disable=broad-except
                 logger.warning(f'run_instances error: {e}')
                 raise

--- a/sky/provision/vast/utils.py
+++ b/sky/provision/vast/utils.py
@@ -35,7 +35,8 @@ def list_instances() -> Dict[str, Dict[str, Any]]:
 
 def launch(name: str, instance_type: str, region: str, disk_size: int,
            image_name: str, ports: Optional[List[int]],
-           preemptible: bool) -> str:
+           preemptible: bool,
+           docker_login: Optional[str] = None) -> str:
     """Launches an instance with the given parameters.
 
     Converts the instance_type to the Vast GPU name, finds the specs for the
@@ -120,6 +121,9 @@ def launch(name: str, instance_type: str, region: str, disk_size: int,
         'image': image_name,
         'disk': disk_size
     }
+
+    if docker_login:
+        launch_params['login'] = docker_login
 
     if preemptible:
         launch_params['min_bid'] = instance_touse['min_bid']

--- a/sky/templates/vast-ray.yml.j2
+++ b/sky/templates/vast-ray.yml.j2
@@ -25,6 +25,15 @@ available_node_types:
       Preemptible: {{use_spot}}
       PublicKey: |-
         skypilot:ssh_public_key_content
+{%- if docker_login_config is not none %}
+      DockerLogin:
+        username: |-
+          {{docker_login_config.username}}
+        password: |-
+          {{docker_login_config.password}}
+        server: |-
+          {{docker_login_config.server}}
+{%- endif %}
 
 head_node_type: ray_head_default
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR adds support for importing docker config + env into vast ai 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
