### PR TITLE
[UX] move cluster name on cloud to hover drop down

### DIFF
--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -463,15 +463,18 @@ function ActiveTab({
                   Cluster
                 </div>
                 <div className="text-base mt-1">
-                  {clusterData.cluster || clusterData.name}
-                </div>
-              </div>
-              <div>
-                <div className="text-gray-600 font-medium text-base">
-                  Cluster Name on Cloud
-                </div>
-                <div className="text-base mt-1">
-                  {clusterData.cluster_name_on_cloud || '-'}
+                  {clusterData.cluster_name_on_cloud ? (
+                    <NonCapitalizedTooltip
+                      content={`Name on ${clusterData.cloud || clusterData.infra?.split('(')[0]?.trim() || 'cloud'}: ${clusterData.cluster_name_on_cloud}`}
+                      className="text-sm text-muted-foreground"
+                    >
+                      <span className="border-b border-dotted border-gray-400 cursor-help">
+                        {clusterData.cluster || clusterData.name}
+                      </span>
+                    </NonCapitalizedTooltip>
+                  ) : (
+                    clusterData.cluster || clusterData.name
+                  )}
                 </div>
               </div>
               <div>


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR moves the cluster name on cloud out of the detailed cluster page top-level to reduce clutter. Instead, we display a dotted underline under the SkyPilot cluster name and display the cluster name on cloud if the user hovers over it. 
<img width="1187" height="381" alt="Screenshot 2025-09-24 at 11 08 17 AM" src="https://github.com/user-attachments/assets/e59d9cb3-e225-4625-9624-e95f88ea8956" />
<img width="1230" height="366" alt="Screenshot 2025-09-24 at 11 09 09 AM" src="https://github.com/user-attachments/assets/b458fd63-dd90-4aad-be29-9b6f9ed13433" />



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
