### PR TITLE
[Test] Fail Explicitly if No GPUs

### DIFF
--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -963,10 +963,10 @@ def get_avaliabe_gpus_for_k8s_tests(default_gpu: str = 'T4') -> str:
             prefix = f'{skypilot_config.ENV_VAR_GLOBAL_CONFIG}={env_file}'
         show_gpus_command = f'{prefix} sky show-gpus --infra kubernetes'
         show_out = subprocess_utils.run(show_gpus_command,
-                                      shell=True,
-                                      check=True,
-                                      capture_output=True,
-                                      text=True)
+                                        shell=True,
+                                        check=True,
+                                        capture_output=True,
+                                        text=True)
         command = f'{prefix} sky show-gpus --infra kubernetes | grep -A1 "^GPU" | tail -1 | awk "{{print \$1}}"'
         Test.echo_without_prefix(command)
         result = subprocess_utils.run(command,
@@ -976,8 +976,9 @@ def get_avaliabe_gpus_for_k8s_tests(default_gpu: str = 'T4') -> str:
                                       text=True)
         gpu_name = result.stdout.strip()
         if gpu_name == '':
-            raise RuntimeError(f'No GPU found for kubernetes, test failing.'
-                            f'Output of {show_gpus_command}: {show_out.stdout}')
+            raise RuntimeError(
+                f'No GPU found for kubernetes, test failing.'
+                f'Output of {show_gpus_command}: {show_out.stdout}')
         return gpu_name
     return default_gpu
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Currently for smoke tests in Kubernetes that use an accelerator we attempt to retrieve an available gpu using `sky show-gpus --infra kubernetes`, however if there are no available GPUs then the grep will return the empty string and we end up passing whatever the next option is into --gpus. This causes kubernetes to fail on validating the instance name. This PR instead has the test fail immediately if we can't find a GPU.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
