### PR TITLE
[DB] add last activity time and launched at to cluster history

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -187,8 +187,12 @@ cluster_history_table = sqlalchemy.Table(
                       server_default=None),
     sqlalchemy.Column('last_activity_time',
                       sqlalchemy.Integer,
-                      server_default=None),
-    sqlalchemy.Column('launched_at', sqlalchemy.Integer, server_default=None),
+                      server_default=None,
+                      index=True),
+    sqlalchemy.Column('launched_at',
+                      sqlalchemy.Integer,
+                      server_default=None,
+                      index=True),
 )
 
 

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -188,9 +188,7 @@ cluster_history_table = sqlalchemy.Table(
     sqlalchemy.Column('last_activity_time',
                       sqlalchemy.Integer,
                       server_default=None),
-    sqlalchemy.Column('launched_at',
-                      sqlalchemy.Integer,
-                      server_default=None),
+    sqlalchemy.Column('launched_at', sqlalchemy.Integer, server_default=None),
 )
 
 
@@ -1375,7 +1373,7 @@ def _set_cluster_usage_intervals(
     # Calculate last_activity_time and launched_at from usage_intervals
     last_activity_time = _get_cluster_last_activity_time(usage_intervals)
     launched_at = _get_cluster_launch_time(usage_intervals)
-    
+
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         count = session.query(cluster_history_table).filter_by(
             cluster_hash=cluster_hash).update({
@@ -1753,8 +1751,8 @@ def get_clusters_from_history(
                 cluster_history_table.c.user_hash,
                 cluster_history_table.c.workspace.label('history_workspace'),
                 cluster_history_table.c.last_activity_time,
-                cluster_history_table.c.launched_at,
-                cluster_table.c.status, cluster_table.c.workspace)
+                cluster_history_table.c.launched_at, cluster_table.c.status,
+                cluster_table.c.workspace)
         else:
             query = session.query(
                 cluster_history_table.c.cluster_hash,
@@ -1766,16 +1764,14 @@ def get_clusters_from_history(
                 cluster_history_table.c.last_creation_command,
                 cluster_history_table.c.workspace.label('history_workspace'),
                 cluster_history_table.c.last_activity_time,
-                cluster_history_table.c.launched_at,
-                cluster_table.c.status, cluster_table.c.workspace)
+                cluster_history_table.c.launched_at, cluster_table.c.status,
+                cluster_table.c.workspace)
 
         query = query.select_from(
             cluster_history_table.join(cluster_table,
                                        cluster_history_table.c.cluster_hash ==
                                        cluster_table.c.cluster_hash,
                                        isouter=True))
-        # new filtering goes here
-
         if cluster_hashes is not None:
             query = query.filter(
                 cluster_history_table.c.cluster_hash.in_(cluster_hashes))
@@ -1827,11 +1823,10 @@ def get_clusters_from_history(
         user_name = user.name if user is not None else None
         if not abbreviate_response:
             last_event = last_cluster_event_dict.get(row.cluster_hash, None)
+        launched_at = row.launched_at
         usage_intervals: Optional[List[Tuple[
             int,
             Optional[int]]]] = usage_intervals_dict.get(row.cluster_hash, None)
-        # Use pre-computed launched_at from database instead of calculating from usage_intervals
-        launched_at = row.launched_at
         duration = _get_cluster_duration(usage_intervals)
 
         # Parse status

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1355,8 +1355,9 @@ def _get_cluster_last_activity_time(
     if usage_intervals:
         last_interval = usage_intervals[-1]
         last_activity_time = (last_interval[1] if last_interval[1] is not None
-                            else last_interval[0])
+                              else last_interval[0])
     return last_activity_time
+
 
 @_init_db
 @metrics_lib.time_me

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1372,7 +1372,6 @@ def _set_cluster_usage_intervals(
 
     # Calculate last_activity_time and launched_at from usage_intervals
     last_activity_time = _get_cluster_last_activity_time(usage_intervals)
-    launched_at = _get_cluster_launch_time(usage_intervals)
 
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         count = session.query(cluster_history_table).filter_by(
@@ -1380,7 +1379,6 @@ def _set_cluster_usage_intervals(
                 cluster_history_table.c.usage_intervals:
                     pickle.dumps(usage_intervals),
                 cluster_history_table.c.last_activity_time: last_activity_time,
-                cluster_history_table.c.launched_at: launched_at
             })
         session.commit()
     assert count <= 1, count

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -185,6 +185,9 @@ cluster_history_table = sqlalchemy.Table(
     sqlalchemy.Column('provision_log_path',
                       sqlalchemy.Text,
                       server_default=None),
+    sqlalchemy.Column('last_activity_time',
+                      sqlalchemy.Integer,
+                      server_default=None),
 )
 
 
@@ -720,6 +723,9 @@ def add_or_update_cluster(cluster_name: str,
                     conditional_values.get('last_creation_command'),
             }
 
+        # Calculate last_activity_time from usage_intervals
+        last_activity_time = _get_cluster_last_activity_time(usage_intervals)
+
         insert_stmnt = insert_func(cluster_history_table).values(
             cluster_hash=cluster_hash,
             name=cluster_name,
@@ -730,6 +736,7 @@ def add_or_update_cluster(cluster_name: str,
             user_hash=user_hash,
             workspace=history_workspace,
             provision_log_path=provision_log_path,
+            last_activity_time=last_activity_time,
             **creation_info,
         )
         do_update_stmt = insert_stmnt.on_conflict_do_update(
@@ -746,6 +753,7 @@ def add_or_update_cluster(cluster_name: str,
                 cluster_history_table.c.user_hash: history_hash,
                 cluster_history_table.c.workspace: history_workspace,
                 cluster_history_table.c.provision_log_path: provision_log_path,
+                cluster_history_table.c.last_activity_time: last_activity_time,
                 **creation_info,
             })
         session.execute(do_update_stmt)
@@ -1340,17 +1348,32 @@ def _get_cluster_duration(
     return total_duration
 
 
+def _get_cluster_last_activity_time(
+    usage_intervals: Optional[List[Tuple[int,
+                                         Optional[int]]]]) -> Optional[int]:
+    last_activity_time = None
+    if usage_intervals:
+        last_interval = usage_intervals[-1]
+        last_activity_time = (last_interval[1] if last_interval[1] is not None
+                            else last_interval[0])
+    return last_activity_time
+
 @_init_db
 @metrics_lib.time_me
 def _set_cluster_usage_intervals(
         cluster_hash: str, usage_intervals: List[Tuple[int,
                                                        Optional[int]]]) -> None:
     assert _SQLALCHEMY_ENGINE is not None
+
+    # Calculate last_activity_time from usage_intervals
+    last_activity_time = _get_cluster_last_activity_time(usage_intervals)
+
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         count = session.query(cluster_history_table).filter_by(
             cluster_hash=cluster_hash).update({
                 cluster_history_table.c.usage_intervals:
-                    pickle.dumps(usage_intervals)
+                    pickle.dumps(usage_intervals),
+                cluster_history_table.c.last_activity_time: last_activity_time
             })
         session.commit()
     assert count <= 1, count
@@ -1720,6 +1743,7 @@ def get_clusters_from_history(
                 cluster_history_table.c.usage_intervals,
                 cluster_history_table.c.user_hash,
                 cluster_history_table.c.workspace.label('history_workspace'),
+                cluster_history_table.c.last_activity_time,
                 cluster_table.c.status, cluster_table.c.workspace)
         else:
             query = session.query(
@@ -1731,6 +1755,7 @@ def get_clusters_from_history(
                 cluster_history_table.c.last_creation_yaml,
                 cluster_history_table.c.last_creation_command,
                 cluster_history_table.c.workspace.label('history_workspace'),
+                cluster_history_table.c.last_activity_time,
                 cluster_table.c.status, cluster_table.c.workspace)
 
         query = query.select_from(
@@ -1738,6 +1763,8 @@ def get_clusters_from_history(
                                        cluster_history_table.c.cluster_hash ==
                                        cluster_table.c.cluster_hash,
                                        isouter=True))
+        # new filtering goes here
+
         if cluster_hashes is not None:
             query = query.filter(
                 cluster_history_table.c.cluster_hash.in_(cluster_hashes))
@@ -1761,16 +1788,8 @@ def get_clusters_from_history(
         # ones by time
         if cutoff_time is not None and status is None:  # Historical cluster
             # For historical clusters, check if they were used recently
-            # Use the most recent activity from usage_intervals to determine
-            # last use
-            # Find the most recent activity time from usage_intervals
-            last_activity_time = None
-            if row_usage_intervals:
-                # Get the end time of the last interval (or start time if
-                # still running)
-                last_interval = row_usage_intervals[-1]
-                last_activity_time = (last_interval[1] if last_interval[1]
-                                      is not None else last_interval[0])
+            # Use the pre-computed last_activity_time from the database
+            last_activity_time = row.last_activity_time
 
             # Skip historical clusters that haven't been used recently
             if last_activity_time is None or last_activity_time < cutoff_time:

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1374,7 +1374,7 @@ def _set_cluster_usage_intervals(
                                                        Optional[int]]]) -> None:
     assert _SQLALCHEMY_ENGINE is not None
 
-    # Calculate last_activity_time and launched_at from usage_intervals
+    # Calculate last_activity_time from usage_intervals
     last_activity_time = _get_cluster_last_activity_time(usage_intervals)
 
     with orm.Session(_SQLALCHEMY_ENGINE) as session:

--- a/sky/schemas/db/global_user_state/009_last_activity_and_launched_at.py
+++ b/sky/schemas/db/global_user_state/009_last_activity_and_launched_at.py
@@ -24,16 +24,18 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade():
     """Add last_activity_time and launched_at columns to cluster history."""
     with op.get_context().autocommit_block():
-        # Add the columns first
+        # Add the columns with indices
         db_utils.add_column_to_table_alembic('cluster_history',
                                              'last_activity_time',
                                              sa.Integer(),
-                                             server_default=None)
+                                             server_default=None,
+                                             index=True)
 
         db_utils.add_column_to_table_alembic('cluster_history',
                                              'launched_at',
                                              sa.Integer(),
-                                             server_default=None)
+                                             server_default=None,
+                                             index=True)
 
         # Populate the columns for existing rows
         _populate_cluster_history_columns()

--- a/sky/schemas/db/global_user_state/009_last_activity_and_launched_at.py
+++ b/sky/schemas/db/global_user_state/009_last_activity_and_launched_at.py
@@ -29,12 +29,12 @@ def upgrade():
                                              'last_activity_time',
                                              sa.Integer(),
                                              server_default=None)
-        
+
         db_utils.add_column_to_table_alembic('cluster_history',
                                              'launched_at',
                                              sa.Integer(),
                                              server_default=None)
-        
+
         # Populate the columns for existing rows
         _populate_cluster_history_columns()
 
@@ -58,11 +58,12 @@ def _populate_cluster_history_columns():
             usage_intervals = pickle.loads(usage_intervals_blob)
 
             if usage_intervals:
-                # Calculate last_activity_time: end time of last interval (or start time if still running)
+                # Calculate last_activity_time: end time of last interval
+                # or start time if still running
                 last_interval = usage_intervals[-1]
                 last_activity_time = (last_interval[1] if last_interval[1]
                                       is not None else last_interval[0])
-                
+
                 # Calculate launched_at: start time of first interval
                 launched_at = usage_intervals[0][0]
 

--- a/sky/schemas/db/global_user_state/009_last_activity_time.py
+++ b/sky/schemas/db/global_user_state/009_last_activity_time.py
@@ -1,0 +1,78 @@
+"""Add last_activity_time to cluster history.
+
+Revision ID: 009
+Revises: 008
+Create Date: 2025-09-24
+
+"""
+# pylint: disable=invalid-name
+from typing import Sequence, Union
+import pickle
+
+from alembic import op
+import sqlalchemy as sa
+
+from sky.utils.db import db_utils
+
+# revision identifiers, used by Alembic.
+revision: str = '009'
+down_revision: Union[str, Sequence[str], None] = '008'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    """Add last_activity_time column to cluster history."""
+    with op.get_context().autocommit_block():
+        # Add the column first
+        db_utils.add_column_to_table_alembic('cluster_history',
+                                             'last_activity_time',
+                                             sa.Integer(),
+                                             server_default=None)
+        
+        # Populate the column for existing rows
+        _populate_last_activity_time()
+
+
+def _populate_last_activity_time():
+    """Populate last_activity_time for existing rows using usage_intervals logic."""
+    connection = op.get_bind()
+    
+    # Get all existing rows with usage_intervals
+    result = connection.execute(
+        sa.text("SELECT cluster_hash, usage_intervals FROM cluster_history "
+                "WHERE usage_intervals IS NOT NULL")
+    )
+    
+    for row in result:
+        cluster_hash = row[0]
+        usage_intervals_blob = row[1]
+        
+        try:
+            # Deserialize the usage_intervals
+            usage_intervals = pickle.loads(usage_intervals_blob)
+            
+            if usage_intervals:
+                # Apply the same logic as in the filtering code:
+                # Get the end time of the last interval (or start time if still running)
+                last_interval = usage_intervals[-1]
+                last_activity_time = (last_interval[1] if last_interval[1] is not None 
+                                    else last_interval[0])
+                
+                # Update the row with the calculated last_activity_time
+                connection.execute(
+                    sa.text("UPDATE cluster_history SET last_activity_time = :last_activity_time "
+                           "WHERE cluster_hash = :cluster_hash"),
+                    {
+                        'last_activity_time': last_activity_time,
+                        'cluster_hash': cluster_hash
+                    }
+                )
+        except (pickle.PickleError, AttributeError, IndexError):
+            # Skip rows with corrupted or invalid usage_intervals
+            continue
+
+
+def downgrade():
+    """No-op for backward compatibility."""
+    pass

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -201,6 +201,7 @@ def add_column_to_table_alembic(
     server_default: Optional[str] = None,
     copy_from: Optional[str] = None,
     value_to_replace_existing_entries: Optional[Any] = None,
+    index: Optional[bool] = None,
 ):
     """Add a column to a table using Alembic operations.
 
@@ -215,6 +216,8 @@ def add_column_to_table_alembic(
         copy_from: Column name to copy values from (for existing rows)
         value_to_replace_existing_entries: Default value for existing NULL
             entries
+        index: If True, create an index on this column. If None, no index
+            is created.
     """
     from alembic import op  # pylint: disable=import-outside-toplevel
 
@@ -222,7 +225,8 @@ def add_column_to_table_alembic(
         # Create the column with server_default if provided
         column = sqlalchemy.Column(column_name,
                                    column_type,
-                                   server_default=server_default)
+                                   server_default=server_default,
+                                   index=index)
         op.add_column(table_name, column)
 
         # Handle data migration

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -17,7 +17,7 @@ logger = sky_logging.init_logger(__name__)
 DB_INIT_LOCK_TIMEOUT_SECONDS = 10
 
 GLOBAL_USER_STATE_DB_NAME = 'state_db'
-GLOBAL_USER_STATE_VERSION = '008'
+GLOBAL_USER_STATE_VERSION = '009'
 GLOBAL_USER_STATE_LOCK_PATH = '~/.sky/locks/.state_db.lock'
 
 SPOT_JOBS_DB_NAME = 'spot_jobs_db'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR adds `last_activity_time` and `launched_at` columns to the `cluster_history` table in global user state. This is done in preparation to move the `last_activity-time`-based filtering out of the db client and into the db query itself. Similarly, we want to sort on `launched_at` in the db query rather than in code. We also add indices on these columns to make the previously mentioned db operations as efficient as possible. 


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
