### PR TITLE
[Pool] Test vllm Pool Parameterize Accelerators

### DIFF
--- a/tests/smoke_tests/test_pools.py
+++ b/tests/smoke_tests/test_pools.py
@@ -635,7 +635,7 @@ def test_pool_job_cancel_instant(generic_cloud: str):
 
 
 @pytest.mark.aws
-def test_pools_job_cancel_recovery(generic_cloud: str):
+def test_pool_job_cancel_recovery(generic_cloud: str):
     region = 'us-east-2'
     name = smoke_tests_utils.get_cluster_name()
     pool_name = f'{name}-pool'
@@ -656,7 +656,7 @@ def test_pools_job_cancel_recovery(generic_cloud: str):
             write_yaml(pool_yaml, pool_config)
             write_yaml(job_yaml, job_config)
             test = smoke_tests_utils.Test(
-                'test_pools_job_cancel_recovery',
+                'test_pool_job_cancel_recovery',
                 [
                     smoke_tests_utils.launch_cluster_for_cloud_cmd(
                         'aws', name, skip_remote_server_check=True),
@@ -693,7 +693,7 @@ def test_pools_job_cancel_recovery(generic_cloud: str):
             smoke_tests_utils.run_one_test(test)
 
 
-def test_pools_job_cancel_running_multiple(generic_cloud: str):
+def test_pool_job_cancel_running_multiple(generic_cloud: str):
     timeout = smoke_tests_utils.get_timeout(generic_cloud)
     pool_config = basic_pool_conf(num_workers=4, infra=generic_cloud)
     job_name = f'{smoke_tests_utils.get_cluster_name()}-job'
@@ -710,7 +710,7 @@ def test_pools_job_cancel_running_multiple(generic_cloud: str):
             pool_name = f'{name}-pool'
 
             test = smoke_tests_utils.Test(
-                'test_pools_job_cancel_running_multiple',
+                'test_pool_job_cancel_running_multiple',
                 [
                     _LAUNCH_POOL_AND_CHECK_SUCCESS.format(
                         pool_name=pool_name, pool_yaml=pool_yaml.name),
@@ -766,7 +766,7 @@ def test_pools_job_cancel_running_multiple(generic_cloud: str):
             smoke_tests_utils.run_one_test(test)
 
 
-def test_pools_job_cancel_running_multiple_simultaneous(generic_cloud: str):
+def test_pool_job_cancel_running_multiple_simultaneous(generic_cloud: str):
     timeout = smoke_tests_utils.get_timeout(generic_cloud)
     pool_config = basic_pool_conf(num_workers=4, infra=generic_cloud)
 
@@ -785,7 +785,7 @@ def test_pools_job_cancel_running_multiple_simultaneous(generic_cloud: str):
             pool_name = f'{name}-pool'
 
             test = smoke_tests_utils.Test(
-                'test_pools_job_cancel_running_multiple_simultaneous',
+                'test_pool_job_cancel_running_multiple_simultaneous',
                 [
                     _LAUNCH_POOL_AND_CHECK_SUCCESS.format(
                         pool_name=pool_name, pool_yaml=pool_yaml.name),
@@ -838,7 +838,7 @@ def test_pools_job_cancel_running_multiple_simultaneous(generic_cloud: str):
             smoke_tests_utils.run_one_test(test)
 
 
-def test_pools_job_cancel_instant_multiple(generic_cloud: str):
+def test_pool_job_cancel_instant_multiple(generic_cloud: str):
     timeout = smoke_tests_utils.get_timeout(generic_cloud)
     pool_config = basic_pool_conf(num_workers=4, infra=generic_cloud)
     job_name = f'{smoke_tests_utils.get_cluster_name()}-job'
@@ -855,7 +855,7 @@ def test_pools_job_cancel_instant_multiple(generic_cloud: str):
             pool_name = f'{name}-pool'
 
             test = smoke_tests_utils.Test(
-                'test_pools_job_cancel_instant_multiple',
+                'test_pool_job_cancel_instant_multiple',
                 [
                     _LAUNCH_POOL_AND_CHECK_SUCCESS.format(
                         pool_name=pool_name, pool_yaml=pool_yaml.name),
@@ -902,7 +902,7 @@ def test_pools_job_cancel_instant_multiple(generic_cloud: str):
             smoke_tests_utils.run_one_test(test)
 
 
-def test_pools_job_cancel_instant_multiple_simultaneous(generic_cloud: str):
+def test_pool_job_cancel_instant_multiple_simultaneous(generic_cloud: str):
     timeout = smoke_tests_utils.get_timeout(generic_cloud)
     pool_config = basic_pool_conf(num_workers=4, infra=generic_cloud)
     job_name = f'{smoke_tests_utils.get_cluster_name()}-job'
@@ -919,7 +919,7 @@ def test_pools_job_cancel_instant_multiple_simultaneous(generic_cloud: str):
             pool_name = f'{name}-pool'
 
             test = smoke_tests_utils.Test(
-                'test_pools_job_cancel_instant_multiple_simultaneous',
+                'test_pool_job_cancel_instant_multiple_simultaneous',
                 [
                     _LAUNCH_POOL_AND_CHECK_SUCCESS.format(
                         pool_name=pool_name, pool_yaml=pool_yaml.name),
@@ -961,3 +961,28 @@ def test_pools_job_cancel_instant_multiple_simultaneous(generic_cloud: str):
             )
 
             smoke_tests_utils.run_one_test(test)
+
+
+def test_pools_job_cancel_no_jobs(generic_cloud: str):
+    timeout = smoke_tests_utils.get_timeout(generic_cloud)
+    pool_config = basic_pool_conf(num_workers=1, infra=generic_cloud)
+
+    with tempfile.NamedTemporaryFile(delete=True) as pool_yaml:
+        write_yaml(pool_yaml, pool_config)
+
+        name = smoke_tests_utils.get_cluster_name()
+        pool_name = f'{name}-pool'
+
+        test = smoke_tests_utils.Test(
+            'test_pools_job_cancel_running',
+            [
+                _LAUNCH_POOL_AND_CHECK_SUCCESS.format(pool_name=pool_name,
+                                                      pool_yaml=pool_yaml.name),
+                # Cancel the job.
+                f's=$(sky jobs cancel --pool {pool_name} -y 2>&1); echo "$s"; echo; echo; echo "$s" | grep "No running job found in pool"',
+            ],
+            timeout=timeout,
+            teardown=cancel_jobs_and_teardown_pool(pool_name, timeout=5),
+        )
+
+        smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_pools.py
+++ b/tests/smoke_tests/test_pools.py
@@ -53,6 +53,7 @@ _TEARDOWN_POOL = ('sky jobs pool down {pool_name} -y')
 
 _CANCEL_POOL_JOBS = ('sky jobs cancel --pool {pool_name} -y')
 
+
 def cancel_job(job_name: str):
     return f'sky jobs cancel -n {job_name} -y'
 
@@ -116,11 +117,12 @@ def wait_until_worker_status(pool_name: str,
         'sleep 1')
 
 
-def wait_until_job_status(job_name: str,
-                          good_statuses: List[str],
-                          bad_statuses: List[str] = ['CANCELLED', 'FAILED_CONTROLLER'],
-                          timeout: int = 30,
-                          time_between_checks: int = 5):
+def wait_until_job_status(
+        job_name: str,
+        good_statuses: List[str],
+        bad_statuses: List[str] = ['CANCELLED', 'FAILED_CONTROLLER'],
+        timeout: int = 30,
+        time_between_checks: int = 5):
     s = 'start_time=$SECONDS; '
     s += 'while true; do '
     s += f'if (( $SECONDS - $start_time > {timeout} )); then '
@@ -489,7 +491,8 @@ def test_pool_queueing(generic_cloud: str):
                     _LAUNCH_JOB_AND_CHECK_SUCCESS.format(
                         pool_name=pool_name, job_yaml=job_yaml.name),
                     # Ensure the job is pending.
-                    wait_until_job_status(job_name, ['PENDING'], timeout=timeout),
+                    wait_until_job_status(job_name, ['PENDING'],
+                                          timeout=timeout),
                 ],
                 timeout=timeout,
                 teardown=cancel_jobs_and_teardown_pool(pool_name, timeout=5),
@@ -513,8 +516,7 @@ def test_pool_preemption(generic_cloud: str):
         run_cmd='echo "Hello, world!"; sleep infinity',
     )
     get_instance_id_cmd = smoke_tests_utils.AWS_GET_INSTANCE_ID.format(
-        region=region,
-        name_on_cloud=get_worker_cluster_name(pool_name, 1))
+        region=region, name_on_cloud=get_worker_cluster_name(pool_name, 1))
     timeout = smoke_tests_utils.get_timeout(generic_cloud)
     with tempfile.NamedTemporaryFile(delete=True) as pool_yaml:
         with tempfile.NamedTemporaryFile(delete=True) as job_yaml:
@@ -530,7 +532,8 @@ def test_pool_preemption(generic_cloud: str):
                     wait_until_pool_ready(pool_name, timeout=timeout),
                     _LAUNCH_JOB_AND_CHECK_SUCCESS.format(
                         pool_name=pool_name, job_yaml=job_yaml.name),
-                    wait_until_job_status(job_name, ['RUNNING'], timeout=timeout),
+                    wait_until_job_status(job_name, ['RUNNING'],
+                                          timeout=timeout),
                     # Restart the cluster manually.
                     smoke_tests_utils.run_cloud_cmd_on_cluster(
                         name,
@@ -540,7 +543,8 @@ def test_pool_preemption(generic_cloud: str):
                         skip_remote_server_check=True),
                     'sky status --refresh',
                     # # Wait until job is running.
-                    wait_until_job_status(job_name, ['RUNNING'], timeout=timeout),
+                    wait_until_job_status(job_name, ['RUNNING'],
+                                          timeout=timeout),
                 ],
                 timeout=smoke_tests_utils.get_timeout(generic_cloud),
                 teardown=
@@ -550,10 +554,10 @@ def test_pool_preemption(generic_cloud: str):
 
             smoke_tests_utils.run_one_test(test)
 
+
 def test_pool_job_cancel_running(generic_cloud: str):
     timeout = smoke_tests_utils.get_timeout(generic_cloud)
-    pool_config = basic_pool_conf(num_workers=1,
-                                  infra=generic_cloud)
+    pool_config = basic_pool_conf(num_workers=1, infra=generic_cloud)
 
     job_name = f'{smoke_tests_utils.get_cluster_name()}-job'
     job_config = basic_job_conf(
@@ -577,11 +581,13 @@ def test_pool_job_cancel_running(generic_cloud: str):
                     _LAUNCH_JOB_AND_CHECK_SUCCESS.format(
                         pool_name=pool_name, job_yaml=job_yaml.name),
                     # Ensure the job is running.
-                    wait_until_job_status(job_name, ['RUNNING'], timeout=timeout),
+                    wait_until_job_status(job_name, ['RUNNING'],
+                                          timeout=timeout),
                     # Cancel the job.
                     cancel_job(job_name),
                     # Ensure the job is cancelled.
-                    wait_until_job_status(job_name, ['CANCELLED'], bad_statuses=[], timeout=15),
+                    wait_until_job_status(
+                        job_name, ['CANCELLED'], bad_statuses=[], timeout=15),
                 ],
                 timeout=timeout,
                 teardown=cancel_jobs_and_teardown_pool(pool_name, timeout=5),
@@ -589,10 +595,10 @@ def test_pool_job_cancel_running(generic_cloud: str):
 
             smoke_tests_utils.run_one_test(test)
 
+
 def test_pool_job_cancel_instant(generic_cloud: str):
     timeout = smoke_tests_utils.get_timeout(generic_cloud)
-    pool_config = basic_pool_conf(num_workers=1,
-                                  infra=generic_cloud)
+    pool_config = basic_pool_conf(num_workers=1, infra=generic_cloud)
 
     job_name = f'{smoke_tests_utils.get_cluster_name()}-job'
     job_config = basic_job_conf(
@@ -618,13 +624,15 @@ def test_pool_job_cancel_instant(generic_cloud: str):
                     # Cancel the job.
                     cancel_job(job_name),
                     # Ensure the job is cancelled.
-                    wait_until_job_status(job_name, ['CANCELLED'], bad_statuses=[], timeout=15),
+                    wait_until_job_status(
+                        job_name, ['CANCELLED'], bad_statuses=[], timeout=15),
                 ],
                 timeout=timeout,
                 teardown=cancel_jobs_and_teardown_pool(pool_name, timeout=5),
             )
 
             smoke_tests_utils.run_one_test(test)
+
 
 @pytest.mark.aws
 def test_pools_job_cancel_recovery(generic_cloud: str):
@@ -641,8 +649,7 @@ def test_pools_job_cancel_recovery(generic_cloud: str):
         run_cmd='echo "Hello, world!"; sleep infinity',
     )
     get_instance_id_cmd = smoke_tests_utils.AWS_GET_INSTANCE_ID.format(
-        region=region,
-        name_on_cloud=get_worker_cluster_name(pool_name, 1))
+        region=region, name_on_cloud=get_worker_cluster_name(pool_name, 1))
     timeout = smoke_tests_utils.get_timeout(generic_cloud)
     with tempfile.NamedTemporaryFile(delete=True) as pool_yaml:
         with tempfile.NamedTemporaryFile(delete=True) as job_yaml:
@@ -658,7 +665,8 @@ def test_pools_job_cancel_recovery(generic_cloud: str):
                     wait_until_pool_ready(pool_name, timeout=timeout),
                     _LAUNCH_JOB_AND_CHECK_SUCCESS.format(
                         pool_name=pool_name, job_yaml=job_yaml.name),
-                    wait_until_job_status(job_name, ['RUNNING'], timeout=timeout),
+                    wait_until_job_status(job_name, ['RUNNING'],
+                                          timeout=timeout),
                     # Restart the cluster manually.
                     smoke_tests_utils.run_cloud_cmd_on_cluster(
                         name,
@@ -667,11 +675,14 @@ def test_pools_job_cancel_recovery(generic_cloud: str):
                             get_instance_id_cmd=get_instance_id_cmd),
                         skip_remote_server_check=True),
                     'sky status --refresh',
-                    wait_until_job_status(job_name, ['RUNNING', 'RECOVERING'], timeout=timeout, time_between_checks=1),
+                    wait_until_job_status(job_name, ['RUNNING', 'RECOVERING'],
+                                          timeout=timeout,
+                                          time_between_checks=1),
                     # Cancel the job.
                     cancel_job(job_name),
                     # Ensure the job is cancelled.
-                    wait_until_job_status(job_name, ['CANCELLED'], bad_statuses=[], timeout=15),
+                    wait_until_job_status(
+                        job_name, ['CANCELLED'], bad_statuses=[], timeout=15),
                 ],
                 timeout=smoke_tests_utils.get_timeout(generic_cloud),
                 teardown=
@@ -681,10 +692,10 @@ def test_pools_job_cancel_recovery(generic_cloud: str):
 
             smoke_tests_utils.run_one_test(test)
 
+
 def test_pools_job_cancel_running_multiple(generic_cloud: str):
     timeout = smoke_tests_utils.get_timeout(generic_cloud)
-    pool_config = basic_pool_conf(num_workers=1,
-                                  infra=generic_cloud)
+    pool_config = basic_pool_conf(num_workers=4, infra=generic_cloud)
     job_name = f'{smoke_tests_utils.get_cluster_name()}-job'
     job_config = basic_job_conf(
         job_name=job_name,
@@ -705,28 +716,48 @@ def test_pools_job_cancel_running_multiple(generic_cloud: str):
                         pool_name=pool_name, pool_yaml=pool_yaml.name),
                     # Immediately attempt to launch the job.
                     _LAUNCH_JOB_AND_CHECK_SUCCESS_WITH_NAME.format(
-                        pool_name=pool_name, job_yaml=job_yaml.name, job_name=f'{job_name}-1'),
+                        pool_name=pool_name,
+                        job_yaml=job_yaml.name,
+                        job_name=f'{job_name}-1'),
                     _LAUNCH_JOB_AND_CHECK_SUCCESS_WITH_NAME.format(
-                        pool_name=pool_name, job_yaml=job_yaml.name, job_name=f'{job_name}-2'),
+                        pool_name=pool_name,
+                        job_yaml=job_yaml.name,
+                        job_name=f'{job_name}-2'),
                     _LAUNCH_JOB_AND_CHECK_SUCCESS_WITH_NAME.format(
-                        pool_name=pool_name, job_yaml=job_yaml.name, job_name=f'{job_name}-3'),
+                        pool_name=pool_name,
+                        job_yaml=job_yaml.name,
+                        job_name=f'{job_name}-3'),
                     _LAUNCH_JOB_AND_CHECK_SUCCESS_WITH_NAME.format(
-                        pool_name=pool_name, job_yaml=job_yaml.name, job_name=f'{job_name}-4'),
+                        pool_name=pool_name,
+                        job_yaml=job_yaml.name,
+                        job_name=f'{job_name}-4'),
                     # Ensure the job is running.
-                    wait_until_job_status(f'{job_name}-1', ['RUNNING'], timeout=timeout),
-                    wait_until_job_status(f'{job_name}-2', ['RUNNING'], timeout=timeout),
-                    wait_until_job_status(f'{job_name}-3', ['RUNNING'], timeout=timeout),
-                    wait_until_job_status(f'{job_name}-4', ['RUNNING'], timeout=timeout),
+                    wait_until_job_status(f'{job_name}-1', ['RUNNING'],
+                                          timeout=timeout),
+                    wait_until_job_status(f'{job_name}-2', ['RUNNING'],
+                                          timeout=timeout),
+                    wait_until_job_status(f'{job_name}-3', ['RUNNING'],
+                                          timeout=timeout),
+                    wait_until_job_status(f'{job_name}-4', ['RUNNING'],
+                                          timeout=timeout),
                     # Cancel the job.
                     cancel_job(f'{job_name}-1'),
                     cancel_job(f'{job_name}-2'),
                     cancel_job(f'{job_name}-3'),
                     cancel_job(f'{job_name}-4'),
                     # Ensure the job is cancelled.
-                    wait_until_job_status(f'{job_name}-1', ['CANCELLED'], bad_statuses=[], timeout=15),
-                    wait_until_job_status(f'{job_name}-2', ['CANCELLED'], bad_statuses=[], timeout=15),
-                    wait_until_job_status(f'{job_name}-3', ['CANCELLED'], bad_statuses=[], timeout=15),
-                    wait_until_job_status(f'{job_name}-4', ['CANCELLED'], bad_statuses=[], timeout=15),
+                    wait_until_job_status(f'{job_name}-1', ['CANCELLED'],
+                                          bad_statuses=[],
+                                          timeout=15),
+                    wait_until_job_status(f'{job_name}-2', ['CANCELLED'],
+                                          bad_statuses=[],
+                                          timeout=15),
+                    wait_until_job_status(f'{job_name}-3', ['CANCELLED'],
+                                          bad_statuses=[],
+                                          timeout=15),
+                    wait_until_job_status(f'{job_name}-4', ['CANCELLED'],
+                                          bad_statuses=[],
+                                          timeout=15),
                 ],
                 timeout=timeout,
                 teardown=cancel_jobs_and_teardown_pool(pool_name, timeout=5),
@@ -734,10 +765,10 @@ def test_pools_job_cancel_running_multiple(generic_cloud: str):
 
             smoke_tests_utils.run_one_test(test)
 
+
 def test_pools_job_cancel_running_multiple_simultaneous(generic_cloud: str):
     timeout = smoke_tests_utils.get_timeout(generic_cloud)
-    pool_config = basic_pool_conf(num_workers=1,
-                                  infra=generic_cloud)
+    pool_config = basic_pool_conf(num_workers=4, infra=generic_cloud)
 
     launch_commands = []
     job_name = f'{smoke_tests_utils.get_cluster_name()}-job'
@@ -754,31 +785,176 @@ def test_pools_job_cancel_running_multiple_simultaneous(generic_cloud: str):
             pool_name = f'{name}-pool'
 
             test = smoke_tests_utils.Test(
-                'test_pools_job_cancel_running',
+                'test_pools_job_cancel_running_multiple_simultaneous',
                 [
                     _LAUNCH_POOL_AND_CHECK_SUCCESS.format(
                         pool_name=pool_name, pool_yaml=pool_yaml.name),
                     # Immediately attempt to launch the job.
                     _LAUNCH_JOB_AND_CHECK_SUCCESS_WITH_NAME.format(
-                        pool_name=pool_name, job_yaml=job_yaml.name, job_name=f'{job_name}-1'),
+                        pool_name=pool_name,
+                        job_yaml=job_yaml.name,
+                        job_name=f'{job_name}-1'),
                     _LAUNCH_JOB_AND_CHECK_SUCCESS_WITH_NAME.format(
-                        pool_name=pool_name, job_yaml=job_yaml.name, job_name=f'{job_name}-2'),
+                        pool_name=pool_name,
+                        job_yaml=job_yaml.name,
+                        job_name=f'{job_name}-2'),
                     _LAUNCH_JOB_AND_CHECK_SUCCESS_WITH_NAME.format(
-                        pool_name=pool_name, job_yaml=job_yaml.name, job_name=f'{job_name}-3'),
+                        pool_name=pool_name,
+                        job_yaml=job_yaml.name,
+                        job_name=f'{job_name}-3'),
                     _LAUNCH_JOB_AND_CHECK_SUCCESS_WITH_NAME.format(
-                        pool_name=pool_name, job_yaml=job_yaml.name, job_name=f'{job_name}-4'),
+                        pool_name=pool_name,
+                        job_yaml=job_yaml.name,
+                        job_name=f'{job_name}-4'),
                     # Ensure the job is running.
-                    wait_until_job_status(f'{job_name}-1', 'RUNNING', timeout=timeout),
-                    wait_until_job_status(f'{job_name}-2', 'RUNNING', timeout=timeout),
-                    wait_until_job_status(f'{job_name}-3', 'RUNNING', timeout=timeout),
-                    wait_until_job_status(f'{job_name}-4', 'RUNNING', timeout=timeout),
+                    wait_until_job_status(f'{job_name}-1', ['RUNNING'],
+                                          timeout=timeout),
+                    wait_until_job_status(f'{job_name}-2', ['RUNNING'],
+                                          timeout=timeout),
+                    wait_until_job_status(f'{job_name}-3', ['RUNNING'],
+                                          timeout=timeout),
+                    wait_until_job_status(f'{job_name}-4', ['RUNNING'],
+                                          timeout=timeout),
                     # Cancel all jobs at once.
                     _CANCEL_POOL_JOBS.format(pool_name=pool_name),
                     # Ensure the job is cancelled.
-                    wait_until_job_cancelled(f'{job_name}-1', timeout=15),
-                    wait_until_job_cancelled(f'{job_name}-2', timeout=15),
-                    wait_until_job_cancelled(f'{job_name}-3', timeout=15),
-                    wait_until_job_cancelled(f'{job_name}-4', timeout=15),
+                    wait_until_job_status(f'{job_name}-1', ['CANCELLED'],
+                                          bad_statuses=[],
+                                          timeout=15),
+                    wait_until_job_status(f'{job_name}-2', ['CANCELLED'],
+                                          bad_statuses=[],
+                                          timeout=15),
+                    wait_until_job_status(f'{job_name}-3', ['CANCELLED'],
+                                          bad_statuses=[],
+                                          timeout=15),
+                    wait_until_job_status(f'{job_name}-4', ['CANCELLED'],
+                                          bad_statuses=[],
+                                          timeout=15),
+                ],
+                timeout=timeout,
+                teardown=cancel_jobs_and_teardown_pool(pool_name, timeout=5),
+            )
+
+            smoke_tests_utils.run_one_test(test)
+
+
+def test_pools_job_cancel_instant_multiple(generic_cloud: str):
+    timeout = smoke_tests_utils.get_timeout(generic_cloud)
+    pool_config = basic_pool_conf(num_workers=4, infra=generic_cloud)
+    job_name = f'{smoke_tests_utils.get_cluster_name()}-job'
+    job_config = basic_job_conf(
+        job_name=job_name,
+        run_cmd='echo "Hello, world!"; sleep infinity',
+    )
+    with tempfile.NamedTemporaryFile(delete=True) as pool_yaml:
+        with tempfile.NamedTemporaryFile(delete=True) as job_yaml:
+            write_yaml(pool_yaml, pool_config)
+            write_yaml(job_yaml, job_config)
+
+            name = smoke_tests_utils.get_cluster_name()
+            pool_name = f'{name}-pool'
+
+            test = smoke_tests_utils.Test(
+                'test_pools_job_cancel_instant_multiple',
+                [
+                    _LAUNCH_POOL_AND_CHECK_SUCCESS.format(
+                        pool_name=pool_name, pool_yaml=pool_yaml.name),
+                    # Immediately attempt to launch the job.
+                    _LAUNCH_JOB_AND_CHECK_SUCCESS_WITH_NAME.format(
+                        pool_name=pool_name,
+                        job_yaml=job_yaml.name,
+                        job_name=f'{job_name}-1'),
+                    _LAUNCH_JOB_AND_CHECK_SUCCESS_WITH_NAME.format(
+                        pool_name=pool_name,
+                        job_yaml=job_yaml.name,
+                        job_name=f'{job_name}-2'),
+                    _LAUNCH_JOB_AND_CHECK_SUCCESS_WITH_NAME.format(
+                        pool_name=pool_name,
+                        job_yaml=job_yaml.name,
+                        job_name=f'{job_name}-3'),
+                    _LAUNCH_JOB_AND_CHECK_SUCCESS_WITH_NAME.format(
+                        pool_name=pool_name,
+                        job_yaml=job_yaml.name,
+                        job_name=f'{job_name}-4'),
+                    # Cancel the job.
+                    cancel_job(f'{job_name}-1'),
+                    cancel_job(f'{job_name}-2'),
+                    cancel_job(f'{job_name}-3'),
+                    cancel_job(f'{job_name}-4'),
+                    # Ensure the job is cancelled.
+                    wait_until_job_status(f'{job_name}-1', ['CANCELLED'],
+                                          bad_statuses=[],
+                                          timeout=15),
+                    wait_until_job_status(f'{job_name}-2', ['CANCELLED'],
+                                          bad_statuses=[],
+                                          timeout=15),
+                    wait_until_job_status(f'{job_name}-3', ['CANCELLED'],
+                                          bad_statuses=[],
+                                          timeout=15),
+                    wait_until_job_status(f'{job_name}-4', ['CANCELLED'],
+                                          bad_statuses=[],
+                                          timeout=15),
+                ],
+                timeout=timeout,
+                teardown=cancel_jobs_and_teardown_pool(pool_name, timeout=5),
+            )
+
+            smoke_tests_utils.run_one_test(test)
+
+
+def test_pools_job_cancel_instant_multiple_simultaneous(generic_cloud: str):
+    timeout = smoke_tests_utils.get_timeout(generic_cloud)
+    pool_config = basic_pool_conf(num_workers=4, infra=generic_cloud)
+    job_name = f'{smoke_tests_utils.get_cluster_name()}-job'
+    job_config = basic_job_conf(
+        job_name=job_name,
+        run_cmd='echo "Hello, world!"; sleep infinity',
+    )
+    with tempfile.NamedTemporaryFile(delete=True) as pool_yaml:
+        with tempfile.NamedTemporaryFile(delete=True) as job_yaml:
+            write_yaml(pool_yaml, pool_config)
+            write_yaml(job_yaml, job_config)
+
+            name = smoke_tests_utils.get_cluster_name()
+            pool_name = f'{name}-pool'
+
+            test = smoke_tests_utils.Test(
+                'test_pools_job_cancel_instant_multiple_simultaneous',
+                [
+                    _LAUNCH_POOL_AND_CHECK_SUCCESS.format(
+                        pool_name=pool_name, pool_yaml=pool_yaml.name),
+                    # Immediately attempt to launch the job.
+                    _LAUNCH_JOB_AND_CHECK_SUCCESS_WITH_NAME.format(
+                        pool_name=pool_name,
+                        job_yaml=job_yaml.name,
+                        job_name=f'{job_name}-1'),
+                    _LAUNCH_JOB_AND_CHECK_SUCCESS_WITH_NAME.format(
+                        pool_name=pool_name,
+                        job_yaml=job_yaml.name,
+                        job_name=f'{job_name}-2'),
+                    _LAUNCH_JOB_AND_CHECK_SUCCESS_WITH_NAME.format(
+                        pool_name=pool_name,
+                        job_yaml=job_yaml.name,
+                        job_name=f'{job_name}-3'),
+                    _LAUNCH_JOB_AND_CHECK_SUCCESS_WITH_NAME.format(
+                        pool_name=pool_name,
+                        job_yaml=job_yaml.name,
+                        job_name=f'{job_name}-4'),
+                    # Cancel all jobs at once.
+                    _CANCEL_POOL_JOBS.format(pool_name=pool_name),
+                    # Ensure the job is cancelled.
+                    wait_until_job_status(f'{job_name}-1', ['CANCELLED'],
+                                          bad_statuses=[],
+                                          timeout=15),
+                    wait_until_job_status(f'{job_name}-2', ['CANCELLED'],
+                                          bad_statuses=[],
+                                          timeout=15),
+                    wait_until_job_status(f'{job_name}-3', ['CANCELLED'],
+                                          bad_statuses=[],
+                                          timeout=15),
+                    wait_until_job_status(f'{job_name}-4', ['CANCELLED'],
+                                          bad_statuses=[],
+                                          timeout=15),
                 ],
                 timeout=timeout,
                 teardown=cancel_jobs_and_teardown_pool(pool_name, timeout=5),

--- a/tests/smoke_tests/test_pools.py
+++ b/tests/smoke_tests/test_pools.py
@@ -218,14 +218,19 @@ def get_worker_cluster_name(pool_name: str, worker_id: int):
 
 
 @pytest.mark.resource_heavy
+@pytest.mark.parametrize('accelerator', [{'do': 'H100', 'nebius': 'L40S'}])
 def test_vllm_pool(generic_cloud: str):
     name = smoke_tests_utils.get_cluster_name()
+    if generic_cloud == 'kubernetes':
+        accelerator = smoke_tests_utils.get_avaliabe_gpus_for_k8s_tests()
+    else:
+        accelerator = accelerator.get(generic_cloud, 'T4')
     pool_config = textwrap.dedent(f"""
     envs:
         MODEL_NAME: NousResearch/Meta-Llama-3-8B-Instruct
 
     resources:
-        accelerators: {{L4}}
+        accelerators: {{accelerator}}
         infra: {generic_cloud}
 
     setup: |
@@ -266,12 +271,6 @@ def test_vllm_pool(generic_cloud: str):
     name: t-test-vllm-pool
 
     resources:
-        cpus: 4
-        accelerators:
-            L4: 1
-        any_of:
-            - use_spot: true
-            - use_spot: false
         infra: {generic_cloud}
 
     envs:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR changes test_vllm_pool to use whatever accelerator is provided by Kubernetes to prevent test failures.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
