### PR TITLE
[Volume] Move volume validation to server side

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -4186,6 +4186,13 @@ def volumes_apply(
 
     logger.debug(f'Volume config: {volume.to_yaml_config()}')
 
+    # TODO(kevin): remove the try block in v0.13.0
+    try:
+        volumes_sdk.validate(volume)
+    except exceptions.APINotSupportedError:
+        # Do best-effort client-side validation.
+        volume.validate(skip_cloud_compatibility=True)
+
     if not yes:
         click.confirm(f'Proceed to create volume {volume.name!r}?',
                       default=True,

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -10,7 +10,7 @@ from sky.skylet import constants
 # based on version info is needed.
 # For more details and code guidelines, refer to:
 # https://docs.skypilot.co/en/latest/developers/CONTRIBUTING.html#backward-compatibility-guidelines
-API_VERSION = 19
+API_VERSION = 20
 
 # The minimum peer API version that the code should still work with.
 # Notes (dev):

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -478,6 +478,17 @@ class VolumeListBody(RequestBody):
     pass
 
 
+class VolumeValidateBody(RequestBody):
+    """The request body for the volume validate endpoint."""
+    name: Optional[str] = None
+    volume_type: Optional[str] = None
+    infra: Optional[str] = None
+    size: Optional[str] = None
+    labels: Optional[Dict[str, str]] = None
+    resource_name: Optional[str] = None
+    config: Optional[Dict[str, Any]] = None
+
+
 class EndpointsBody(RequestBody):
     """The request body for the endpoint."""
     cluster: str

--- a/sky/volumes/client/sdk.py
+++ b/sky/volumes/client/sdk.py
@@ -3,13 +3,16 @@ import json
 import typing
 from typing import Any, Dict, List
 
+from sky import exceptions
 from sky import sky_logging
 from sky.adaptors import common as adaptors_common
 from sky.server import common as server_common
+from sky.server import versions
 from sky.server.requests import payloads
 from sky.usage import usage_lib
 from sky.utils import annotations
 from sky.utils import context
+from sky.utils import ux_utils
 from sky.volumes import volume as volume_lib
 
 if typing.TYPE_CHECKING:
@@ -71,10 +74,42 @@ def apply(volume: volume_lib.Volume) -> server_common.RequestId[None]:
         config=volume.config,
         labels=volume.labels,
     )
-    response = requests.post(f'{server_common.get_server_url()}/volumes/apply',
-                             json=json.loads(body.model_dump_json()),
-                             cookies=server_common.get_api_cookie_jar())
+    response = server_common.make_authenticated_request(
+        'POST', '/volumes/apply', json=json.loads(body.model_dump_json()))
     return server_common.get_request_id(response)
+
+
+@context.contextual
+@usage_lib.entrypoint
+@server_common.check_server_healthy_or_start
+@annotations.client_api
+@versions.minimal_api_version(20)
+def validate(volume: volume_lib.Volume) -> None:
+    """Validates the volume.
+
+    All validation is done on the server side.
+
+    Args:
+        volume: The volume to validate.
+
+    Raises:
+        ValueError: If the volume is invalid.
+    """
+    body = payloads.VolumeValidateBody(
+        name=volume.name,
+        volume_type=volume.type,
+        infra=volume.infra,
+        resource_name=volume.resource_name,
+        size=volume.size,
+        config=volume.config,
+        labels=volume.labels,
+    )
+    response = server_common.make_authenticated_request(
+        'POST', '/volumes/validate', json=json.loads(body.model_dump_json()))
+    if response.status_code == 400:
+        with ux_utils.print_exception_no_traceback():
+            raise exceptions.deserialize_exception(
+                response.json().get('detail'))
 
 
 @context.contextual
@@ -87,8 +122,10 @@ def ls() -> server_common.RequestId[List[Dict[str, Any]]]:
     Returns:
         The request ID of the list request.
     """
-    response = requests.get(f'{server_common.get_server_url()}/volumes',
-                            cookies=server_common.get_api_cookie_jar())
+    response = server_common.make_authenticated_request(
+        'GET',
+        '/volumes',
+    )
     return server_common.get_request_id(response)
 
 
@@ -106,7 +143,6 @@ def delete(names: List[str]) -> server_common.RequestId[None]:
         The request ID of the delete request.
     """
     body = payloads.VolumeDeleteBody(names=names)
-    response = requests.post(f'{server_common.get_server_url()}/volumes/delete',
-                             json=json.loads(body.model_dump_json()),
-                             cookies=server_common.get_api_cookie_jar())
+    response = server_common.make_authenticated_request(
+        'POST', '/volumes/delete', json=json.loads(body.model_dump_json()))
     return server_common.get_request_id(response)

--- a/sky/volumes/server/server.py
+++ b/sky/volumes/server/server.py
@@ -51,17 +51,17 @@ async def volume_delete(request: fastapi.Request,
 @router.post('/validate')
 async def volume_validate(
         _: fastapi.Request,
-        volume_apply_body: payloads.VolumeValidateBody) -> None:
+        volume_validate_body: payloads.VolumeValidateBody) -> None:
     """Validates a volume."""
     try:
         volume_config = {
-            'name': volume_apply_body.name,
-            'type': volume_apply_body.volume_type,
-            'infra': volume_apply_body.infra,
-            'size': volume_apply_body.size,
-            'labels': volume_apply_body.labels,
-            'config': volume_apply_body.config,
-            'resource_name': volume_apply_body.resource_name,
+            'name': volume_validate_body.name,
+            'type': volume_validate_body.volume_type,
+            'infra': volume_validate_body.infra,
+            'size': volume_validate_body.size,
+            'labels': volume_validate_body.labels,
+            'config': volume_validate_body.config,
+            'resource_name': volume_validate_body.resource_name,
         }
         volume = volume_lib.Volume.from_yaml_config(volume_config)
         volume.validate()

--- a/sky/volumes/server/server.py
+++ b/sky/volumes/server/server.py
@@ -10,7 +10,6 @@ from sky.server.requests import payloads
 from sky.server.requests import requests as requests_lib
 from sky.utils import registry
 from sky.utils import volume as volume_utils
-from sky.volumes import volume as volume_lib
 from sky.volumes.server import core
 
 logger = sky_logging.init_logger(__name__)
@@ -53,6 +52,9 @@ async def volume_validate(
         _: fastapi.Request,
         volume_validate_body: payloads.VolumeValidateBody) -> None:
     """Validates a volume."""
+    # pylint: disable=import-outside-toplevel
+    from sky.volumes import volume as volume_lib
+
     try:
         volume_config = {
             'name': volume_validate_body.name,

--- a/sky/volumes/server/server.py
+++ b/sky/volumes/server/server.py
@@ -3,12 +3,14 @@
 import fastapi
 
 from sky import clouds
+from sky import exceptions
 from sky import sky_logging
 from sky.server.requests import executor
 from sky.server.requests import payloads
 from sky.server.requests import requests as requests_lib
 from sky.utils import registry
-from sky.utils import volume
+from sky.utils import volume as volume_utils
+from sky.volumes import volume as volume_lib
 from sky.volumes.server import core
 
 logger = sky_logging.init_logger(__name__)
@@ -46,6 +48,28 @@ async def volume_delete(request: fastapi.Request,
     )
 
 
+@router.post('/validate')
+async def volume_validate(
+        _: fastapi.Request,
+        volume_apply_body: payloads.VolumeValidateBody) -> None:
+    """Validates a volume."""
+    try:
+        volume_config = {
+            'name': volume_apply_body.name,
+            'type': volume_apply_body.volume_type,
+            'infra': volume_apply_body.infra,
+            'size': volume_apply_body.size,
+            'labels': volume_apply_body.labels,
+            'config': volume_apply_body.config,
+            'resource_name': volume_apply_body.resource_name,
+        }
+        volume = volume_lib.Volume.from_yaml_config(volume_config)
+        volume.validate()
+    except Exception as e:
+        raise fastapi.HTTPException(status_code=400,
+                                    detail=exceptions.serialize_exception(e))
+
+
 @router.post('/apply')
 async def volume_apply(request: fastapi.Request,
                        volume_apply_body: payloads.VolumeApplyBody) -> None:
@@ -55,7 +79,7 @@ async def volume_apply(request: fastapi.Request,
     volume_config = volume_apply_body.config
 
     supported_volume_types = [
-        volume_type.value for volume_type in volume.VolumeType
+        volume_type.value for volume_type in volume_utils.VolumeType
     ]
     if volume_type not in supported_volume_types:
         raise fastapi.HTTPException(
@@ -64,24 +88,24 @@ async def volume_apply(request: fastapi.Request,
     if cloud is None:
         raise fastapi.HTTPException(status_code=400,
                                     detail=f'Invalid cloud: {volume_cloud}')
-    if volume_type == volume.VolumeType.PVC.value:
+    if volume_type == volume_utils.VolumeType.PVC.value:
         if not cloud.is_same_cloud(clouds.Kubernetes()):
             raise fastapi.HTTPException(
                 status_code=400,
                 detail='PVC storage is only supported on Kubernetes')
         supported_access_modes = [
-            access_mode.value for access_mode in volume.VolumeAccessMode
+            access_mode.value for access_mode in volume_utils.VolumeAccessMode
         ]
         if volume_config is None:
             volume_config = {}
         access_mode = volume_config.get('access_mode')
         if access_mode is None:
-            volume_config[
-                'access_mode'] = volume.VolumeAccessMode.READ_WRITE_ONCE.value
+            volume_config['access_mode'] = (
+                volume_utils.VolumeAccessMode.READ_WRITE_ONCE.value)
         elif access_mode not in supported_access_modes:
             raise fastapi.HTTPException(
                 status_code=400, detail=f'Invalid access mode: {access_mode}')
-    elif volume_type == volume.VolumeType.RUNPOD_NETWORK_VOLUME.value:
+    elif volume_type == volume_utils.VolumeType.RUNPOD_NETWORK_VOLUME.value:
         if not cloud.is_same_cloud(clouds.RunPod()):
             raise fastapi.HTTPException(
                 status_code=400,

--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -594,8 +594,8 @@ class TestBackwardCompatibility:
             f'{self.ACTIVATE_CURRENT} && sky volumes apply -y -n {cluster_name}-1 --infra {generic_cloud} --type k8s-pvc --size 1Gi',
             f'{self.ACTIVATE_CURRENT} && sky volumes ls | grep "{cluster_name}-0"',
             f'{self.ACTIVATE_CURRENT} && sky volumes ls | grep "{cluster_name}-1"',
-            f'{self.ACTIVATE_CURRENT} && sky volumes down {cluster_name}-0 -y',
-            f'{self.ACTIVATE_CURRENT} && sky volumes down {cluster_name}-1 -y',
+            f'{self.ACTIVATE_CURRENT} && sky volumes delete {cluster_name}-0 -y',
+            f'{self.ACTIVATE_CURRENT} && sky volumes delete {cluster_name}-1 -y',
         ]
 
         teardown = f'{self.ACTIVATE_BASE} && sky down {cluster_name} -y && sky serve down {cluster_name}* -y'
@@ -672,8 +672,8 @@ class TestBackwardCompatibility:
             f'{self.ACTIVATE_BASE} && sky volumes apply -y -n {cluster_name}-1 --infra {generic_cloud} --type k8s-pvc --size 1Gi',
             f'{self.ACTIVATE_BASE} && sky volumes ls | grep "{cluster_name}-0"',
             f'{self.ACTIVATE_BASE} && sky volumes ls | grep "{cluster_name}-1"',
-            f'{self.ACTIVATE_BASE} && sky volumes down {cluster_name}-0 -y',
-            f'{self.ACTIVATE_BASE} && sky volumes down {cluster_name}-1 -y',
+            f'{self.ACTIVATE_BASE} && sky volumes delete {cluster_name}-0 -y',
+            f'{self.ACTIVATE_BASE} && sky volumes delete {cluster_name}-1 -y',
         ]
 
         teardown = f'{self.ACTIVATE_CURRENT} && sky down {cluster_name} -y && sky serve down {cluster_name}* -y'

--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -587,18 +587,24 @@ class TestBackwardCompatibility:
             f'{self.ACTIVATE_CURRENT} && sky serve logs --controller {cluster_name}-0 --no-follow',
             f'{self.ACTIVATE_CURRENT} && sky serve logs --load-balancer {cluster_name}-0 --no-follow',
             f'{self.ACTIVATE_CURRENT} && sky serve down {cluster_name}-0 -y',
-            # volume test
-            f'{self.ACTIVATE_BASE} && {smoke_tests_utils.SKY_API_RESTART} && '
-            f'sky volumes apply -y -n {cluster_name}-0 --infra {generic_cloud} --type k8s-pvc --size 1Gi',
-            # No restart on switch to current, cli in current, server in bases
-            f'{self.ACTIVATE_CURRENT} && sky volumes apply -y -n {cluster_name}-1 --infra {generic_cloud} --type k8s-pvc --size 1Gi',
-            f'{self.ACTIVATE_CURRENT} && sky volumes ls | grep "{cluster_name}-0"',
-            f'{self.ACTIVATE_CURRENT} && sky volumes ls | grep "{cluster_name}-1"',
-            f'{self.ACTIVATE_CURRENT} && sky volumes delete {cluster_name}-0 -y',
-            f'{self.ACTIVATE_CURRENT} && sky volumes delete {cluster_name}-1 -y',
         ]
 
         teardown = f'{self.ACTIVATE_BASE} && sky down {cluster_name} -y && sky serve down {cluster_name}* -y'
+
+        if generic_cloud == 'kubernetes':
+            commands.extend([
+                # volume test
+                f'{self.ACTIVATE_BASE} && {smoke_tests_utils.SKY_API_RESTART} && '
+                f'sky volumes apply -y -n {cluster_name}-0 --infra {generic_cloud} --type k8s-pvc --size 1Gi',
+                # No restart on switch to current, cli in current, server in bases
+                f'{self.ACTIVATE_CURRENT} && sky volumes apply -y -n {cluster_name}-1 --infra {generic_cloud} --type k8s-pvc --size 1Gi',
+                f'{self.ACTIVATE_CURRENT} && sky volumes ls | grep "{cluster_name}-0"',
+                f'{self.ACTIVATE_CURRENT} && sky volumes ls | grep "{cluster_name}-1"',
+                f'{self.ACTIVATE_CURRENT} && sky volumes delete {cluster_name}-0 -y',
+                f'{self.ACTIVATE_CURRENT} && sky volumes delete {cluster_name}-1 -y',
+            ])
+            teardown += ' && sky volumes delete {cluster_name}* -y'
+
         self.run_compatibility_test(cluster_name, commands, teardown)
 
     def test_client_server_compatibility_new_server(self, generic_cloud: str):
@@ -665,18 +671,24 @@ class TestBackwardCompatibility:
             f'{self.ACTIVATE_BASE} && sky serve logs --controller {cluster_name}-0 --no-follow',
             f'{self.ACTIVATE_BASE} && sky serve logs --load-balancer {cluster_name}-0 --no-follow',
             f'{self.ACTIVATE_BASE} && sky serve down {cluster_name}-0 -y',
-            # volume test
-            f'{self.ACTIVATE_CURRENT} && {smoke_tests_utils.SKY_API_RESTART} && '
-            f'sky volumes apply -y -n {cluster_name}-0 --infra {generic_cloud} --type k8s-pvc --size 1Gi',
-            # No restart on switch to base, cli in base, server in current
-            f'{self.ACTIVATE_BASE} && sky volumes apply -y -n {cluster_name}-1 --infra {generic_cloud} --type k8s-pvc --size 1Gi',
-            f'{self.ACTIVATE_BASE} && sky volumes ls | grep "{cluster_name}-0"',
-            f'{self.ACTIVATE_BASE} && sky volumes ls | grep "{cluster_name}-1"',
-            f'{self.ACTIVATE_BASE} && sky volumes delete {cluster_name}-0 -y',
-            f'{self.ACTIVATE_BASE} && sky volumes delete {cluster_name}-1 -y',
         ]
 
         teardown = f'{self.ACTIVATE_CURRENT} && sky down {cluster_name} -y && sky serve down {cluster_name}* -y'
+
+        if generic_cloud == 'kubernetes':
+            commands.extend([
+                # volume test
+                f'{self.ACTIVATE_CURRENT} && {smoke_tests_utils.SKY_API_RESTART} && '
+                f'sky volumes apply -y -n {cluster_name}-0 --infra {generic_cloud} --type k8s-pvc --size 1Gi',
+                # No restart on switch to base, cli in base, server in current
+                f'{self.ACTIVATE_BASE} && sky volumes apply -y -n {cluster_name}-1 --infra {generic_cloud} --type k8s-pvc --size 1Gi',
+                f'{self.ACTIVATE_BASE} && sky volumes ls | grep "{cluster_name}-0"',
+                f'{self.ACTIVATE_BASE} && sky volumes ls | grep "{cluster_name}-1"',
+                f'{self.ACTIVATE_BASE} && sky volumes delete {cluster_name}-0 -y',
+                f'{self.ACTIVATE_BASE} && sky volumes delete {cluster_name}-1 -y',
+            ])
+            teardown += ' && sky volumes delete {cluster_name}* -y'
+
         self.run_compatibility_test(cluster_name, commands, teardown)
 
     def test_sdk_compatibility(self, generic_cloud: str):

--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -587,6 +587,15 @@ class TestBackwardCompatibility:
             f'{self.ACTIVATE_CURRENT} && sky serve logs --controller {cluster_name}-0 --no-follow',
             f'{self.ACTIVATE_CURRENT} && sky serve logs --load-balancer {cluster_name}-0 --no-follow',
             f'{self.ACTIVATE_CURRENT} && sky serve down {cluster_name}-0 -y',
+            # volume test
+            f'{self.ACTIVATE_BASE} && {smoke_tests_utils.SKY_API_RESTART} && '
+            f'sky volumes apply -y -n {cluster_name}-0 --infra {generic_cloud} --type k8s-pvc --size 1Gi',
+            # No restart on switch to current, cli in current, server in bases
+            f'{self.ACTIVATE_CURRENT} && sky volumes apply -y -n {cluster_name}-1 --infra {generic_cloud} --type k8s-pvc --size 1Gi',
+            f'{self.ACTIVATE_CURRENT} && sky volumes ls | grep "{cluster_name}-0"',
+            f'{self.ACTIVATE_CURRENT} && sky volumes ls | grep "{cluster_name}-1"',
+            f'{self.ACTIVATE_CURRENT} && sky volumes down {cluster_name}-0 -y',
+            f'{self.ACTIVATE_CURRENT} && sky volumes down {cluster_name}-1 -y',
         ]
 
         teardown = f'{self.ACTIVATE_BASE} && sky down {cluster_name} -y && sky serve down {cluster_name}* -y'
@@ -656,6 +665,15 @@ class TestBackwardCompatibility:
             f'{self.ACTIVATE_BASE} && sky serve logs --controller {cluster_name}-0 --no-follow',
             f'{self.ACTIVATE_BASE} && sky serve logs --load-balancer {cluster_name}-0 --no-follow',
             f'{self.ACTIVATE_BASE} && sky serve down {cluster_name}-0 -y',
+            # volume test
+            f'{self.ACTIVATE_CURRENT} && {smoke_tests_utils.SKY_API_RESTART} && '
+            f'sky volumes apply -y -n {cluster_name}-0 --infra {generic_cloud} --type k8s-pvc --size 1Gi',
+            # No restart on switch to base, cli in base, server in current
+            f'{self.ACTIVATE_BASE} && sky volumes apply -y -n {cluster_name}-1 --infra {generic_cloud} --type k8s-pvc --size 1Gi',
+            f'{self.ACTIVATE_BASE} && sky volumes ls | grep "{cluster_name}-0"',
+            f'{self.ACTIVATE_BASE} && sky volumes ls | grep "{cluster_name}-1"',
+            f'{self.ACTIVATE_BASE} && sky volumes down {cluster_name}-0 -y',
+            f'{self.ACTIVATE_BASE} && sky volumes down {cluster_name}-1 -y',
         ]
 
         teardown = f'{self.ACTIVATE_CURRENT} && sky down {cluster_name} -y && sky serve down {cluster_name}* -y'

--- a/tests/unit_tests/test_sky/server/requests/test_process.py
+++ b/tests/unit_tests/test_sky/server/requests/test_process.py
@@ -22,7 +22,7 @@ def failing_task():
     raise ValueError('Task failed')
 
 
-def wait_for_workers_cleanup(executor, timeout=10):
+def wait_for_workers_cleanup(executor, timeout=30):
     """Wait for workers to be cleaned up.
 
     Args:
@@ -41,7 +41,7 @@ def wait_for_workers_cleanup(executor, timeout=10):
     return False
 
 
-def wait_for_futures(futures, timeout=10):
+def wait_for_futures(futures, timeout=30):
     """Wait for futures to complete.
 
     Args:

--- a/tests/unit_tests/test_sky/server/requests/test_process.py
+++ b/tests/unit_tests/test_sky/server/requests/test_process.py
@@ -22,13 +22,13 @@ def failing_task():
     raise ValueError('Task failed')
 
 
-def wait_for_workers_cleanup(executor, timeout=5):
+def wait_for_workers_cleanup(executor, timeout=10):
     """Wait for workers to be cleaned up.
-    
+
     Args:
         executor: The DisposableExecutor instance
         timeout: Maximum time to wait in seconds
-    
+
     Returns:
         bool: True if workers are cleaned up, False if timeout
     """
@@ -41,13 +41,13 @@ def wait_for_workers_cleanup(executor, timeout=5):
     return False
 
 
-def wait_for_futures(futures, timeout=5):
+def wait_for_futures(futures, timeout=10):
     """Wait for futures to complete.
-    
+
     Args:
         futures: List of futures to wait for
         timeout: Maximum time to wait in seconds
-    
+
     Returns:
         bool: True if all futures completed, False if timeout
     """

--- a/tests/unit_tests/test_sky/server/requests/test_process.py
+++ b/tests/unit_tests/test_sky/server/requests/test_process.py
@@ -22,13 +22,13 @@ def failing_task():
     raise ValueError('Task failed')
 
 
-def wait_for_workers_cleanup(executor, timeout=5):
+def wait_for_workers_cleanup(executor, timeout=15):
     """Wait for workers to be cleaned up.
-    
+
     Args:
         executor: The DisposableExecutor instance
         timeout: Maximum time to wait in seconds
-    
+
     Returns:
         bool: True if workers are cleaned up, False if timeout
     """
@@ -41,13 +41,13 @@ def wait_for_workers_cleanup(executor, timeout=5):
     return False
 
 
-def wait_for_futures(futures, timeout=5):
+def wait_for_futures(futures, timeout=15):
     """Wait for futures to complete.
-    
+
     Args:
         futures: List of futures to wait for
         timeout: Maximum time to wait in seconds
-    
+
     Returns:
         bool: True if all futures completed, False if timeout
     """

--- a/tests/unit_tests/test_sky/server/requests/test_process.py
+++ b/tests/unit_tests/test_sky/server/requests/test_process.py
@@ -22,7 +22,7 @@ def failing_task():
     raise ValueError('Task failed')
 
 
-def wait_for_workers_cleanup(executor, timeout=30):
+def wait_for_workers_cleanup(executor, timeout=10):
     """Wait for workers to be cleaned up.
 
     Args:
@@ -41,7 +41,7 @@ def wait_for_workers_cleanup(executor, timeout=30):
     return False
 
 
-def wait_for_futures(futures, timeout=30):
+def wait_for_futures(futures, timeout=10):
     """Wait for futures to complete.
 
     Args:

--- a/tests/unit_tests/test_sky/server/requests/test_process.py
+++ b/tests/unit_tests/test_sky/server/requests/test_process.py
@@ -22,7 +22,7 @@ def failing_task():
     raise ValueError('Task failed')
 
 
-def wait_for_workers_cleanup(executor, timeout=15):
+def wait_for_workers_cleanup(executor, timeout=20):
     """Wait for workers to be cleaned up.
 
     Args:
@@ -41,7 +41,7 @@ def wait_for_workers_cleanup(executor, timeout=15):
     return False
 
 
-def wait_for_futures(futures, timeout=15):
+def wait_for_futures(futures, timeout=20):
     """Wait for futures to complete.
 
     Args:

--- a/tests/unit_tests/test_sky/server/requests/test_process.py
+++ b/tests/unit_tests/test_sky/server/requests/test_process.py
@@ -22,13 +22,13 @@ def failing_task():
     raise ValueError('Task failed')
 
 
-def wait_for_workers_cleanup(executor, timeout=10):
+def wait_for_workers_cleanup(executor, timeout=5):
     """Wait for workers to be cleaned up.
-
+    
     Args:
         executor: The DisposableExecutor instance
         timeout: Maximum time to wait in seconds
-
+    
     Returns:
         bool: True if workers are cleaned up, False if timeout
     """
@@ -41,13 +41,13 @@ def wait_for_workers_cleanup(executor, timeout=10):
     return False
 
 
-def wait_for_futures(futures, timeout=10):
+def wait_for_futures(futures, timeout=5):
     """Wait for futures to complete.
-
+    
     Args:
         futures: List of futures to wait for
         timeout: Maximum time to wait in seconds
-
+    
     Returns:
         bool: True if all futures completed, False if timeout
     """

--- a/tests/unit_tests/test_sky/volumes/test_runpod_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_runpod_volume.py
@@ -83,7 +83,8 @@ class TestRunPodVolume:
             'size': '100'
         }
         with pytest.raises(ValueError) as exc_info:
-            volume_lib.Volume.from_yaml_config(cfg)
+            vol = volume_lib.Volume.from_yaml_config(cfg)
+            vol.validate()
         assert 'RunPod DataCenterId is required to create a network volume' in str(
             exc_info.value)
 
@@ -98,7 +99,8 @@ class TestRunPodVolume:
             'size': str(too_small)
         }
         with pytest.raises(ValueError) as exc_info:
-            volume_lib.Volume.from_yaml_config(cfg)
+            vol = volume_lib.Volume.from_yaml_config(cfg)
+            vol.validate()
         assert 'RunPod network volume size must be at least' in str(
             exc_info.value)
 
@@ -124,7 +126,8 @@ class TestRunPodVolume:
             'size': '50Mi'  # invalid in our adjust (expects Gi or integer)
         }
         with pytest.raises(ValueError) as exc_info:
-            volume_lib.Volume.from_yaml_config(cfg)
+            vol = volume_lib.Volume.from_yaml_config(cfg)
+            vol.validate()
         assert 'Invalid size' in str(exc_info.value)
 
     def test_cloud_mismatch_raises(self, monkeypatch):
@@ -142,7 +145,8 @@ class TestRunPodVolume:
             'size': '100'
         }
         with pytest.raises(ValueError) as exc_info:
-            volume_lib.Volume.from_yaml_config(cfg)
+            vol = volume_lib.Volume.from_yaml_config(cfg)
+            vol.validate()
         assert 'Invalid cloud' in str(exc_info.value)
 
     def test_resource_name_without_size_ok(self, monkeypatch):
@@ -178,7 +182,8 @@ class TestRunPodVolume:
             'size': '100'
         }
         with pytest.raises(ValueError) as exc_info:
-            volume_lib.Volume.from_yaml_config(cfg)
+            vol = volume_lib.Volume.from_yaml_config(cfg)
+            vol.validate()
         assert 'Invalid volume name: Volume name exceeds' in str(exc_info.value)
         # Max length boundary (30) should pass
         ok_cfg = {

--- a/tests/unit_tests/test_sky/volumes/test_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_volume.py
@@ -181,16 +181,8 @@ class TestVolume:
         volume.validate_cloud_compatibility()  # Should not raise
         assert volume.cloud == 'kubernetes'
 
-    def test_volume_normalize_config_method(self, monkeypatch):
+    def test_volume_normalize_config_method(self):
         """Test Volume._normalize_config method."""
-        # Mock infra_utils.InfraInfo.from_str
-        mock_infra_info = MagicMock()
-        mock_infra_info.cloud = 'kubernetes'
-        mock_infra_info.region = None
-        mock_infra_info.zone = None
-        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
-                            lambda x: mock_infra_info)
-
         volume = volume_lib.Volume(name='test',
                                    type='k8s-pvc',
                                    size='100Gi',
@@ -281,14 +273,6 @@ class TestVolume:
 
     def test_volume_schema_validation_valid_configs(self, monkeypatch):
         """Test volume schema validation with valid configurations."""
-        # Mock infra_utils.InfraInfo.from_str
-        mock_infra_info = MagicMock()
-        mock_infra_info.cloud = 'kubernetes'
-        mock_infra_info.region = None
-        mock_infra_info.zone = None
-        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
-                            lambda x: mock_infra_info)
-
         valid_configs = [
             {
                 'name': 'test-volume',
@@ -324,14 +308,6 @@ class TestVolume:
         """Test volume schema validation with missing required fields."""
         from sky import exceptions
 
-        # Mock infra_utils.InfraInfo.from_str
-        mock_infra_info = MagicMock()
-        mock_infra_info.cloud = 'kubernetes'
-        mock_infra_info.region = None
-        mock_infra_info.zone = None
-        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
-                            lambda x: mock_infra_info)
-
         invalid_configs = [
             {
                 'type': 'k8s-pvc',
@@ -360,14 +336,6 @@ class TestVolume:
 
     def test_volume_schema_validation_invalid_type(self, monkeypatch):
         """Test volume schema validation with invalid type."""
-        # Mock infra_utils.InfraInfo.from_str
-        mock_infra_info = MagicMock()
-        mock_infra_info.cloud = 'kubernetes'
-        mock_infra_info.region = None
-        mock_infra_info.zone = None
-        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
-                            lambda x: mock_infra_info)
-
         invalid_configs = [
             {
                 'name': 'test-volume',
@@ -392,14 +360,6 @@ class TestVolume:
         """Test volume schema validation with invalid size pattern."""
         from sky import exceptions
 
-        # Mock infra_utils.InfraInfo.from_str
-        mock_infra_info = MagicMock()
-        mock_infra_info.cloud = 'kubernetes'
-        mock_infra_info.region = None
-        mock_infra_info.zone = None
-        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
-                            lambda x: mock_infra_info)
-
         invalid_configs = [
             {
                 'name': 'test-volume',
@@ -419,14 +379,6 @@ class TestVolume:
     def test_volume_schema_validation_invalid_config_object(self, monkeypatch):
         """Test volume schema validation with invalid config object."""
         from sky import exceptions
-
-        # Mock infra_utils.InfraInfo.from_str
-        mock_infra_info = MagicMock()
-        mock_infra_info.cloud = 'kubernetes'
-        mock_infra_info.region = None
-        mock_infra_info.zone = None
-        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
-                            lambda x: mock_infra_info)
 
         invalid_configs = [
             {
@@ -457,14 +409,6 @@ class TestVolume:
         from sky.utils import common_utils
         from sky.utils import schemas
 
-        # Mock infra_utils.InfraInfo.from_str
-        mock_infra_info = MagicMock()
-        mock_infra_info.cloud = 'kubernetes'
-        mock_infra_info.region = None
-        mock_infra_info.zone = None
-        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
-                            lambda x: mock_infra_info)
-
         config_with_extra = {
             'name': 'test-volume',
             'type': 'k8s-pvc',
@@ -481,14 +425,6 @@ class TestVolume:
     def test_volume_schema_validation_case_insensitive_enums(self, monkeypatch):
         """Test volume schema validation with case insensitive enums."""
         from sky import exceptions
-
-        # Mock infra_utils.InfraInfo.from_str
-        mock_infra_info = MagicMock()
-        mock_infra_info.cloud = 'kubernetes'
-        mock_infra_info.region = None
-        mock_infra_info.zone = None
-        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
-                            lambda x: mock_infra_info)
 
         invalid_configs = [
             {
@@ -520,14 +456,6 @@ class TestVolume:
 
     def test_volume_schema_validation_access_modes(self, monkeypatch):
         """Test volume schema validation with different access modes."""
-        # Mock infra_utils.InfraInfo.from_str
-        mock_infra_info = MagicMock()
-        mock_infra_info.cloud = 'kubernetes'
-        mock_infra_info.region = None
-        mock_infra_info.zone = None
-        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
-                            lambda x: mock_infra_info)
-
         valid_access_modes = [
             'ReadWriteOnce', 'ReadWriteOncePod', 'ReadWriteMany', 'ReadOnlyMany'
         ]
@@ -546,14 +474,6 @@ class TestVolume:
 
     def test_validate_with_valid_labels(self, monkeypatch):
         """Test Volume.validate with valid labels."""
-        # Mock infra_utils.InfraInfo.from_str
-        mock_infra_info = MagicMock()
-        mock_infra_info.cloud = 'kubernetes'
-        mock_infra_info.region = None
-        mock_infra_info.zone = None
-        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
-                            lambda x: mock_infra_info)
-
         volume_lib.Volume(name='test',
                           type='k8s-pvc',
                           infra=None,
@@ -580,14 +500,6 @@ class TestVolume:
 
     def test_validate_with_invalid_label_key(self, monkeypatch):
         """Test Volume.validate with invalid label key."""
-        # Mock infra_utils.InfraInfo.from_str
-        mock_infra_info = MagicMock()
-        mock_infra_info.cloud = 'kubernetes'
-        mock_infra_info.region = None
-        mock_infra_info.zone = None
-        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
-                            lambda x: mock_infra_info)
-
         volume = volume_lib.Volume(
             name='test',
             type='k8s-pvc',
@@ -603,14 +515,6 @@ class TestVolume:
 
     def test_validate_with_invalid_label_value(self, monkeypatch):
         """Test Volume.validate with invalid label value."""
-        # Mock infra_utils.InfraInfo.from_str
-        mock_infra_info = MagicMock()
-        mock_infra_info.cloud = 'kubernetes'
-        mock_infra_info.region = None
-        mock_infra_info.zone = None
-        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
-                            lambda x: mock_infra_info)
-
         volume = volume_lib.Volume(
             name='test',
             type='k8s-pvc',
@@ -633,16 +537,8 @@ class TestVolume:
                                    labels={})
         volume.validate()
 
-    def test_validate_with_none_labels(self, monkeypatch):
+    def test_validate_with_none_labels(self):
         """Test Volume.validate with None labels."""
-        # Mock infra_utils.InfraInfo.from_str
-        mock_infra_info = MagicMock()
-        mock_infra_info.cloud = 'kubernetes'
-        mock_infra_info.region = None
-        mock_infra_info.zone = None
-        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
-                            lambda x: mock_infra_info)
-
         volume = volume_lib.Volume(name='test',
                                    type='k8s-pvc',
                                    infra='k8s',

--- a/tests/unit_tests/test_sky/volumes/test_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_volume.py
@@ -181,8 +181,16 @@ class TestVolume:
         volume.validate_cloud_compatibility()  # Should not raise
         assert volume.cloud == 'kubernetes'
 
-    def test_volume_normalize_config_method(self):
+    def test_volume_normalize_config_method(self, monkeypatch):
         """Test Volume._normalize_config method."""
+        # Mock infra_utils.InfraInfo.from_str
+        mock_infra_info = MagicMock()
+        mock_infra_info.cloud = 'kubernetes'
+        mock_infra_info.region = None
+        mock_infra_info.zone = None
+        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
+                            lambda x: mock_infra_info)
+
         volume = volume_lib.Volume(name='test',
                                    type='k8s-pvc',
                                    size='100Gi',
@@ -273,6 +281,14 @@ class TestVolume:
 
     def test_volume_schema_validation_valid_configs(self, monkeypatch):
         """Test volume schema validation with valid configurations."""
+        # Mock infra_utils.InfraInfo.from_str
+        mock_infra_info = MagicMock()
+        mock_infra_info.cloud = 'kubernetes'
+        mock_infra_info.region = None
+        mock_infra_info.zone = None
+        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
+                            lambda x: mock_infra_info)
+
         valid_configs = [
             {
                 'name': 'test-volume',
@@ -308,6 +324,14 @@ class TestVolume:
         """Test volume schema validation with missing required fields."""
         from sky import exceptions
 
+        # Mock infra_utils.InfraInfo.from_str
+        mock_infra_info = MagicMock()
+        mock_infra_info.cloud = 'kubernetes'
+        mock_infra_info.region = None
+        mock_infra_info.zone = None
+        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
+                            lambda x: mock_infra_info)
+
         invalid_configs = [
             {
                 'type': 'k8s-pvc',
@@ -336,6 +360,14 @@ class TestVolume:
 
     def test_volume_schema_validation_invalid_type(self, monkeypatch):
         """Test volume schema validation with invalid type."""
+        # Mock infra_utils.InfraInfo.from_str
+        mock_infra_info = MagicMock()
+        mock_infra_info.cloud = 'kubernetes'
+        mock_infra_info.region = None
+        mock_infra_info.zone = None
+        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
+                            lambda x: mock_infra_info)
+
         invalid_configs = [
             {
                 'name': 'test-volume',
@@ -360,6 +392,14 @@ class TestVolume:
         """Test volume schema validation with invalid size pattern."""
         from sky import exceptions
 
+        # Mock infra_utils.InfraInfo.from_str
+        mock_infra_info = MagicMock()
+        mock_infra_info.cloud = 'kubernetes'
+        mock_infra_info.region = None
+        mock_infra_info.zone = None
+        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
+                            lambda x: mock_infra_info)
+
         invalid_configs = [
             {
                 'name': 'test-volume',
@@ -379,6 +419,14 @@ class TestVolume:
     def test_volume_schema_validation_invalid_config_object(self, monkeypatch):
         """Test volume schema validation with invalid config object."""
         from sky import exceptions
+
+        # Mock infra_utils.InfraInfo.from_str
+        mock_infra_info = MagicMock()
+        mock_infra_info.cloud = 'kubernetes'
+        mock_infra_info.region = None
+        mock_infra_info.zone = None
+        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
+                            lambda x: mock_infra_info)
 
         invalid_configs = [
             {
@@ -409,6 +457,14 @@ class TestVolume:
         from sky.utils import common_utils
         from sky.utils import schemas
 
+        # Mock infra_utils.InfraInfo.from_str
+        mock_infra_info = MagicMock()
+        mock_infra_info.cloud = 'kubernetes'
+        mock_infra_info.region = None
+        mock_infra_info.zone = None
+        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
+                            lambda x: mock_infra_info)
+
         config_with_extra = {
             'name': 'test-volume',
             'type': 'k8s-pvc',
@@ -425,6 +481,14 @@ class TestVolume:
     def test_volume_schema_validation_case_insensitive_enums(self, monkeypatch):
         """Test volume schema validation with case insensitive enums."""
         from sky import exceptions
+
+        # Mock infra_utils.InfraInfo.from_str
+        mock_infra_info = MagicMock()
+        mock_infra_info.cloud = 'kubernetes'
+        mock_infra_info.region = None
+        mock_infra_info.zone = None
+        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
+                            lambda x: mock_infra_info)
 
         invalid_configs = [
             {
@@ -456,6 +520,14 @@ class TestVolume:
 
     def test_volume_schema_validation_access_modes(self, monkeypatch):
         """Test volume schema validation with different access modes."""
+        # Mock infra_utils.InfraInfo.from_str
+        mock_infra_info = MagicMock()
+        mock_infra_info.cloud = 'kubernetes'
+        mock_infra_info.region = None
+        mock_infra_info.zone = None
+        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
+                            lambda x: mock_infra_info)
+
         valid_access_modes = [
             'ReadWriteOnce', 'ReadWriteOncePod', 'ReadWriteMany', 'ReadOnlyMany'
         ]
@@ -474,6 +546,14 @@ class TestVolume:
 
     def test_validate_with_valid_labels(self, monkeypatch):
         """Test Volume.validate with valid labels."""
+        # Mock infra_utils.InfraInfo.from_str
+        mock_infra_info = MagicMock()
+        mock_infra_info.cloud = 'kubernetes'
+        mock_infra_info.region = None
+        mock_infra_info.zone = None
+        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
+                            lambda x: mock_infra_info)
+
         volume_lib.Volume(name='test',
                           type='k8s-pvc',
                           infra=None,
@@ -500,6 +580,14 @@ class TestVolume:
 
     def test_validate_with_invalid_label_key(self, monkeypatch):
         """Test Volume.validate with invalid label key."""
+        # Mock infra_utils.InfraInfo.from_str
+        mock_infra_info = MagicMock()
+        mock_infra_info.cloud = 'kubernetes'
+        mock_infra_info.region = None
+        mock_infra_info.zone = None
+        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
+                            lambda x: mock_infra_info)
+
         volume = volume_lib.Volume(
             name='test',
             type='k8s-pvc',
@@ -515,6 +603,14 @@ class TestVolume:
 
     def test_validate_with_invalid_label_value(self, monkeypatch):
         """Test Volume.validate with invalid label value."""
+        # Mock infra_utils.InfraInfo.from_str
+        mock_infra_info = MagicMock()
+        mock_infra_info.cloud = 'kubernetes'
+        mock_infra_info.region = None
+        mock_infra_info.zone = None
+        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
+                            lambda x: mock_infra_info)
+
         volume = volume_lib.Volume(
             name='test',
             type='k8s-pvc',
@@ -537,8 +633,16 @@ class TestVolume:
                                    labels={})
         volume.validate()
 
-    def test_validate_with_none_labels(self):
+    def test_validate_with_none_labels(self, monkeypatch):
         """Test Volume.validate with None labels."""
+        # Mock infra_utils.InfraInfo.from_str
+        mock_infra_info = MagicMock()
+        mock_infra_info.cloud = 'kubernetes'
+        mock_infra_info.region = None
+        mock_infra_info.zone = None
+        monkeypatch.setattr('sky.utils.infra_utils.InfraInfo.from_str',
+                            lambda x: mock_infra_info)
+
         volume = volume_lib.Volume(name='test',
                                    type='k8s-pvc',
                                    infra='k8s',


### PR DESCRIPTION
Previously, a client using a remote API server would still have to install the `[kubernetes]` extra, because we validate the k8s context name on the client side. This is not ideal, since we want clients to not need any extra dependency when using a remote API server.

This PR fixes this by moving validation to a server side, on `POST /volumes/validate`. We also add a corresponding SDK function for it and call it from the CLI, before calling apply.

Backwards compatibility:
- New client <-> old server: Fallback to best-effort client-side validation, without validating k8s context
- Old client <-> new server: No issues, since old client will still be using client-side validation

Tested manually that with this change, clients using a remote API server don't need to have kubernetes installed.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
    - Added more `sky volumes` operations to existing backcompat tests
    - Refactored volume unit tests
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)
