### PR TITLE
[do not merge][local up] Port range to allocate 100 ports

### DIFF
--- a/sky/utils/kubernetes/kubernetes_deploy_utils.py
+++ b/sky/utils/kubernetes/kubernetes_deploy_utils.py
@@ -466,7 +466,8 @@ def deploy_local_cluster(name: Optional[str], gpus: bool):
             ux_utils.finishing_message(
                 message=(
                     f'Local Kubernetes cluster {name} created successfully '
-                    f'with {num_cpus} CPUs{gpu_message}.'),
+                    f'with {num_cpus} CPUs{gpu_message}. Port range '
+                    f'{port_start}-{port_end} allocated.'),
                 log_path=log_path,
                 is_local=True,
                 follow_up_message=(

--- a/sky/utils/kubernetes/kubernetes_deploy_utils.py
+++ b/sky/utils/kubernetes/kubernetes_deploy_utils.py
@@ -352,7 +352,8 @@ def deploy_local_cluster(name: Optional[str], gpus: bool):
                                      delete=True) as f:
         # Choose random port range to use on the host machine.
         # Port range is port_start - port_start + 99 (exactly 100 ports).
-        port_start = random.randint(300, 399) * 100
+        # port_start = random.randint(300, 399) * 100
+        port_start = 30000
         port_end = port_start + LOCAL_CLUSTER_PORT_RANGE - 1
         logger.debug(f'Using port range {port_start}-{port_end}')
         f.write(generate_kind_config(port_start, gpus=gpus))

--- a/sky/utils/kubernetes/kubernetes_deploy_utils.py
+++ b/sky/utils/kubernetes/kubernetes_deploy_utils.py
@@ -27,7 +27,7 @@ logger = sky_logging.init_logger(__name__)
 # Default path for Kubernetes configuration file
 DEFAULT_KUBECONFIG_PATH = os.path.expanduser('~/.kube/config')
 DEFAULT_LOCAL_CLUSTER_NAME = 'skypilot'
-LOCAL_CLUSTER_PORT_RANGE = 101
+LOCAL_CLUSTER_PORT_RANGE = 100
 LOCAL_CLUSTER_INTERNAL_PORT_START = 30000
 
 
@@ -263,7 +263,7 @@ def generate_kind_config(port_start: int,
     """Generate a kind cluster config with ports mapped from host to container
 
     Port range will be [port_start, port_start + LOCAL_CLUSTER_PORT_RANGE)
-    Internally, this will map to ports 30000 - 30100
+    Internally, this will map to ports 30000 - 30099.
 
     Args:
         path: Path to generate the config file at
@@ -274,6 +274,16 @@ def generate_kind_config(port_start: int,
     Returns:
         The kind cluster config
     """
+    # Why the weird numbers (ie: 30000 - 30099)? The range of ports from
+    # 30000 to 30099 gives us exactly 100 ports allocated to the container.
+    # Each created local up cluster has a 1:1 mapping between ports in the
+    # container and actual ports on the machine. Therefore, it is very
+    # important that these ports do not overlap. However, as local up is
+    # used primarily for development purposes, it makes no sense to have a
+    # state tracking mechanism. The solution, thus is to pick a random number
+    # between 300 and 399. That will be the three leading digits of our port
+    # range. Say, we pick 302, then the port range will be 30200 - 30299,
+    # allowing an easy way to allocate IPs with low likelihoods of collision.
     internal_start = LOCAL_CLUSTER_INTERNAL_PORT_START
     internal_end = internal_start + LOCAL_CLUSTER_PORT_RANGE - 1
 

--- a/tests/kubernetes/scripts/helm_okta.sh
+++ b/tests/kubernetes/scripts/helm_okta.sh
@@ -37,6 +37,9 @@ NODEPORT=30082
 HTTPS_NODEPORT=30099
 RELEASE_NAME=skypilot
 
+# NODEPORT and HOSTPORT are not the same. Endpoint requires HOSTPORT
+HOSTPORT=$(docker port skypilot-control-plane | grep $NODEPORT | sed 's/.*://;s/^[[:space:]]*//;s/[[:space:]]*$//')
+
 # Cleanup function to delete namespace and resources
 cleanup() {
     echo ""
@@ -378,7 +381,7 @@ deploy_and_login() {
 
     # Get the API server URL
     echo "Getting API server URL..."
-    ENDPOINT=http://${CLUSTER_HOST}:${NODEPORT}
+    ENDPOINT=http://${CLUSTER_HOST}:${HOSTPORT}
     echo "API server endpoint: $ENDPOINT"
 
     # Test the API server with retry logic

--- a/tests/kubernetes/scripts/helm_okta.sh
+++ b/tests/kubernetes/scripts/helm_okta.sh
@@ -39,6 +39,7 @@ RELEASE_NAME=skypilot
 
 # NODEPORT and HOSTPORT are not the same. Endpoint requires HOSTPORT
 HOSTPORT=$(docker port skypilot-control-plane | grep $NODEPORT | sed 's/.*://;s/^[[:space:]]*//;s/[[:space:]]*$//')
+echo "Found HOSTPORT: $HOSTPORT"
 
 # Cleanup function to delete namespace and resources
 cleanup() {

--- a/tests/kubernetes/scripts/helm_okta.sh
+++ b/tests/kubernetes/scripts/helm_okta.sh
@@ -39,6 +39,7 @@ RELEASE_NAME=skypilot
 
 # NODEPORT and HOSTPORT are not the same. Endpoint requires HOSTPORT
 HOSTPORT=$(docker port skypilot-control-plane | grep $NODEPORT | sed 's/.*://;s/^[[:space:]]*//;s/[[:space:]]*$//')
+HTTPS_HOSTPORT=$(docker port skypilot-control-plane | grep $HTTPS_NODEPORT | sed 's/.*://;s/^[[:space:]]*//;s/[[:space:]]*$//')
 echo "Found HOSTPORT: $HOSTPORT"
 
 # Cleanup function to delete namespace and resources

--- a/tests/kubernetes/scripts/helm_okta.sh
+++ b/tests/kubernetes/scripts/helm_okta.sh
@@ -34,7 +34,7 @@
 
 NAMESPACE=skypilot
 NODEPORT=30082
-HTTPS_NODEPORT=30100
+HTTPS_NODEPORT=30099
 RELEASE_NAME=skypilot
 
 # Cleanup function to delete namespace and resources


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Follow up to pr #7367. There was a specific reason why we allocate exactly 100 ports. Referencing my comment from #7367:

just one comment about this, originally the range was set as 30000 - 30099 for a specific reason: its exactly 100 ports. Because there is a one-to-one mapping between the container and the local machine, to have multiple local up clusters, there was a need to be able to allocate ports so the local up clusters would not overlap.

After discussion, we decided that we would 1) choose a random number between 300 - 399, and that would be the three leading digits for hte port range. ie, if we chose 301, then the port range would be from 30100 - 30199. This was done primarily because local up is used mostly for development, and we didn't want to introduce new state-tracking mechanisms.

Thus, changing the helm okta smoketest a bit

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
