### PR TITLE
Fixed skypilot config propagation in jobs launch

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -18,6 +18,7 @@ import sky
 from sky import core
 from sky import exceptions
 from sky import sky_logging
+from sky import skypilot_config
 from sky.backends import backend_utils
 from sky.backends import cloud_vm_ray_backend
 from sky.data import data_utils
@@ -928,6 +929,9 @@ class Controller:
                             ctx.override_envs({key: value})
                             job_logger.debug(
                                 f'Set environment variable: {key}={value}')
+                    # Reload the skypilot config for this context to make sure
+                    # the latest config is used.
+                    skypilot_config.reload_config()
                 else:
                     job_logger.error(
                         'Context is None, cannot set environment variables')

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -98,6 +98,8 @@ def get_override_skypilot_config_from_client() -> Dict[str, Any]:
     """Returns the override configs from the client."""
     if annotations.is_on_api_server:
         return {}
+    # Ensure the config is up to date.
+    skypilot_config.reload_config()
     config = skypilot_config.to_dict()
     # Remove the API server config, as we should not specify the SkyPilot
     # server endpoint on the server side. This avoids the warning at

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -98,8 +98,6 @@ def get_override_skypilot_config_from_client() -> Dict[str, Any]:
     """Returns the override configs from the client."""
     if annotations.is_on_api_server:
         return {}
-    # Ensure the config is up to date.
-    skypilot_config.reload_config()
     config = skypilot_config.to_dict()
     # Remove the API server config, as we should not specify the SkyPilot
     # server endpoint on the server side. This avoids the warning at

--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -335,6 +335,8 @@ class Test(NamedTuple):
     timeout: int = DEFAULT_CMD_TIMEOUT
     # Environment variables to set for each command.
     env: Optional[Dict[str, str]] = None
+    # Config dictionary to override the skypilot config.
+    config_dict: Optional[Dict[str, Any]] = None
 
     def echo(self, message: str):
         # pytest's xdist plugin captures stdout; print to stderr so that the
@@ -508,7 +510,7 @@ def run_one_test(test: Test, check_sky_status: bool = True) -> None:
     if test.env:
         env_dict.update(test.env)
 
-    with override_sky_config(test, env_dict):
+    with override_sky_config(test, env_dict, config_dict=test.config_dict):
         for command in test.commands:
             write(f'+ {command}\n')
             flush()

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -1218,6 +1218,55 @@ def test_managed_jobs_logs_sync_down(generic_cloud: str):
     smoke_tests_utils.run_one_test(test)
 
 
+# Only run this test on Kubernetes since this test relies on kubernetes.pod_config
+@pytest.mark.kubernetes
+@pytest.mark.managed_jobs
+def test_managed_jobs_env_isolation(generic_cloud: str):
+    """Test that the job controller execution env of jobs are isolated."""
+    base_name = smoke_tests_utils.get_cluster_name()
+    for i in range(2):
+        name = f'{base_name}-{i}'
+        # We want to verify job controller isolates the skypilot config for each job,
+        # kubernetes.pod_config is the easiest way to verify the correct skypilot config
+        # is used in job controller. We assume the job controller is cloud agnostic, thus
+        # this case will also cover the same case for other clouds.
+        test = smoke_tests_utils.Test(
+            'test-managed-jobs-env-isolation',
+            [
+                # Sleep 60 to workaround the issue that SUCCEED job cannot be tailed by name
+                f'sky jobs launch -n {name} --infra {generic_cloud} {smoke_tests_utils.LOW_RESOURCE_ARG} -y -d \'echo "$TEST_POD_ENV"; sleep 60\'',
+                smoke_tests_utils.
+                get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                    job_name=f'{name}',
+                    job_status=[sky.ManagedJobStatus.RUNNING],
+                    timeout=80),
+                f'sky jobs logs -n {name} --no-follow | grep "my name is {name}"',
+                smoke_tests_utils.
+                get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                    job_name=f'{name}',
+                    job_status=[sky.ManagedJobStatus.SUCCEEDED],
+                    timeout=80),
+            ],
+            f'sky jobs cancel -y -n {name}',
+            env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
+            timeout=20 * 60,
+            config_dict={
+                'kubernetes': {
+                    'pod_config': {
+                        'spec': {
+                            'containers': [{
+                                'env': [{
+                                    'name': 'TEST_POD_ENV',
+                                    'value': f'my name is {name}'
+                                }]
+                            }]
+                        }
+                    }
+                }
+            })
+        smoke_tests_utils.run_one_test(test)
+
+
 def _get_ha_kill_test(name: str, generic_cloud: str,
                       status: sky.ManagedJobStatus, first_timeout: int,
                       second_timeout: int) -> smoke_tests_utils.Test:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -560,9 +560,11 @@ def test_get_override_skypilot_config_from_client_get_latest_config(tmp_path):
             ports: ingress
         """))
     with mock.patch('os.environ.get', return_value=old_path):
+        skypilot_config.reload_config()
         result_old = payloads.get_override_skypilot_config_from_client()
         assert result_old['kubernetes']['ports'] == 'loadbalancer'
     with mock.patch('os.environ.get', return_value=new_path):
+        skypilot_config.reload_config()
         result_new = payloads.get_override_skypilot_config_from_client()
         assert result_new['kubernetes']['ports'] == 'ingress'
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -544,6 +544,29 @@ def test_get_override_skypilot_config_from_client(mock_to_dict, mock_logger,
         assert result['aws']['security_group'] == 'test-sg'
 
 
+@annotations.client_api
+def test_get_override_skypilot_config_from_client_get_latest_config(tmp_path):
+    """Test that get_override_skypilot_config_from_client returns the loaded config path."""
+    old_path = tmp_path / 'old_config.yaml'
+    old_path.write_text(
+        textwrap.dedent(f"""\
+        kubernetes:
+            ports: loadbalancer
+        """))
+    new_path = tmp_path / 'new_config.yaml'
+    new_path.write_text(
+        textwrap.dedent(f"""\
+        kubernetes:
+            ports: ingress
+        """))
+    with mock.patch('os.environ.get', return_value=old_path):
+        result_old = payloads.get_override_skypilot_config_from_client()
+        assert result_old['kubernetes']['ports'] == 'loadbalancer'
+    with mock.patch('os.environ.get', return_value=new_path):
+        result_new = payloads.get_override_skypilot_config_from_client()
+        assert result_new['kubernetes']['ports'] == 'ingress'
+
+
 def test_override_skypilot_config(monkeypatch, tmp_path):
     """Test that override_skypilot_config properly restores config and cleans up."""
     os.environ.pop(skypilot_config.ENV_VAR_SKYPILOT_CONFIG, None)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

After we unify the job controller process, `sdk.launch()`  is now called by job controller in a single process. So the skypilot config is not reloaded before each `sdk.launch()`, causing the tasks get stale skypilot config.

This PR fixes this issue by always reloading config before sending the client config to server.

The reload takes about 2ms, thus will not introduce visible overhead.

New smoke test cases and unit test cases are added to verify this change.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
