### PR TITLE
[Test][Serve] Fix sky serve smoke test cleanup

### DIFF
--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -100,7 +100,7 @@ _TEARDOWN_SERVICE = _SHOW_SERVE_STATUS + (
     '    status_output=$(sky serve status {name} 2>&1); '
     '    echo "Checking service termination status..."; '
     '    echo "$status_output"; '
-    '    echo "$status_output" | grep -q "Service \'{name}\' not found" && echo "Service terminated successfully" && exit 0; '
+    r'    echo "$status_output" | grep -q "Service \'{name}\' not found\|No live services" && echo "Service terminated successfully" && exit 0; '
     '    current_time=$(date +%s); '
     '    elapsed=$((current_time - start_time)); '
     '    if [ "$elapsed" -ge "$timeout" ]; then '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

<img width="674" height="114" alt="image" src="https://github.com/user-attachments/assets/915f2f73-baf6-4384-bc5b-9ea3aebd89e0" />

When controller is down, it is also possible to show an `No live services` output instead of the original service not found.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
