### PR TITLE
[Volume] Infer cloud from volume type on the client side if infra is unset

### DIFF
--- a/sky/volumes/server/core.py
+++ b/sky/volumes/server/core.py
@@ -213,6 +213,7 @@ def volume_apply(
         # generate the storage name on cloud.
         cloud_obj = registry.CLOUD_REGISTRY.from_str(cloud)
         assert cloud_obj is not None
+        region, zone = cloud_obj.validate_region_zone(region, zone)
         name_uuid = str(uuid.uuid4())[:6]
         name_on_cloud = common_utils.make_cluster_name_on_cloud(
             name, max_length=cloud_obj.max_cluster_name_length())

--- a/sky/volumes/server/server.py
+++ b/sky/volumes/server/server.py
@@ -77,8 +77,6 @@ async def volume_apply(request: fastapi.Request,
                        volume_apply_body: payloads.VolumeApplyBody) -> None:
     """Creates or registers a volume."""
     volume_cloud = volume_apply_body.cloud
-    volume_region = volume_apply_body.region
-    volume_zone = volume_apply_body.zone
     volume_type = volume_apply_body.volume_type
     volume_config = volume_apply_body.config
 
@@ -92,8 +90,6 @@ async def volume_apply(request: fastapi.Request,
     if cloud is None:
         raise fastapi.HTTPException(status_code=400,
                                     detail=f'Invalid cloud: {volume_cloud}')
-    volume_apply_body.region, volume_apply_body.zone = (
-        cloud.validate_region_zone(volume_region, volume_zone))
     if volume_type == volume_utils.VolumeType.PVC.value:
         if not cloud.is_same_cloud(clouds.Kubernetes()):
             raise fastapi.HTTPException(

--- a/sky/volumes/server/server.py
+++ b/sky/volumes/server/server.py
@@ -77,6 +77,8 @@ async def volume_apply(request: fastapi.Request,
                        volume_apply_body: payloads.VolumeApplyBody) -> None:
     """Creates or registers a volume."""
     volume_cloud = volume_apply_body.cloud
+    volume_region = volume_apply_body.region
+    volume_zone = volume_apply_body.zone
     volume_type = volume_apply_body.volume_type
     volume_config = volume_apply_body.config
 
@@ -90,6 +92,8 @@ async def volume_apply(request: fastapi.Request,
     if cloud is None:
         raise fastapi.HTTPException(status_code=400,
                                     detail=f'Invalid cloud: {volume_cloud}')
+    volume_apply_body.region, volume_apply_body.zone = (
+        cloud.validate_region_zone(volume_region, volume_zone))
     if volume_type == volume_utils.VolumeType.PVC.value:
         if not cloud.is_same_cloud(clouds.Kubernetes()):
             raise fastapi.HTTPException(

--- a/sky/volumes/volume.py
+++ b/sky/volumes/volume.py
@@ -166,9 +166,6 @@ class Volume:
         cloud_obj = registry.CLOUD_REGISTRY.from_str(self.cloud)
         assert cloud_obj is not None
 
-        self.region, self.zone = cloud_obj.validate_region_zone(
-            self.region, self.zone)
-
         valid, err_msg = cloud_obj.is_volume_name_valid(self.name)
         if not valid:
             raise ValueError(f'Invalid volume name: {err_msg}')

--- a/sky/volumes/volume.py
+++ b/sky/volumes/volume.py
@@ -100,7 +100,7 @@ class Volume:
         }
 
     def _normalize_config(self) -> None:
-        """Adjust and validate the config."""
+        """Normalize and validate the config."""
         # Validate schema
         common_utils.validate_schema(self.to_yaml_config(),
                                      schemas.get_volume_schema(),
@@ -114,6 +114,18 @@ class Volume:
         self.cloud = infra_info.cloud
         self.region = infra_info.region
         self.zone = infra_info.zone
+
+        # Set cloud from volume type if not specified
+        cloud_obj_from_type = VOLUME_TYPE_TO_CLOUD.get(
+            volume_lib.VolumeType(self.type))
+        if self.cloud:
+            cloud_obj = registry.CLOUD_REGISTRY.from_str(self.cloud)
+            assert cloud_obj is not None
+            if not cloud_obj.is_same_cloud(cloud_obj_from_type):
+                raise ValueError(
+                    f'Invalid cloud {self.cloud} for volume type {self.type}')
+        else:
+            self.cloud = str(cloud_obj_from_type)
 
     def _adjust_config(self) -> None:
         """Adjust the volume config (e.g., parse size)."""
@@ -150,19 +162,9 @@ class Volume:
                              'use the --size flag.')
 
     def validate_cloud_compatibility(self) -> None:
-        """Validates that the specified cloud is compatible with volume type."""
-        cloud_obj_from_type = VOLUME_TYPE_TO_CLOUD.get(
-            volume_lib.VolumeType(self.type))
-        if self.cloud:
-            cloud_obj = registry.CLOUD_REGISTRY.from_str(self.cloud)
-            assert cloud_obj is not None
-            if not cloud_obj.is_same_cloud(cloud_obj_from_type):
-                raise ValueError(
-                    f'Invalid cloud {self.cloud} for volume type {self.type}')
-        else:
-            self.cloud = str(cloud_obj_from_type)
-            cloud_obj = cloud_obj_from_type
-            assert cloud_obj is not None
+        """Validates region, zone, name, labels with the cloud."""
+        cloud_obj = registry.CLOUD_REGISTRY.from_str(self.cloud)
+        assert cloud_obj is not None
 
         self.region, self.zone = cloud_obj.validate_region_zone(
             self.region, self.zone)

--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -681,7 +681,8 @@ class TestBackwardCompatibility:
                 f'{self.ACTIVATE_CURRENT} && {smoke_tests_utils.SKY_API_RESTART} && '
                 f'sky volumes apply -y -n {cluster_name}-0 --infra {generic_cloud} --type k8s-pvc --size 1Gi',
                 # No restart on switch to base, cli in base, server in current
-                f'{self.ACTIVATE_BASE} && sky volumes apply -y -n {cluster_name}-1 --type k8s-pvc --size 1Gi',
+                # Base version might contain the bug in https://github.com/skypilot-org/skypilot/issues/7380, so we need to specify --infra
+                f'{self.ACTIVATE_BASE} && sky volumes apply -y -n {cluster_name}-1 --infra {generic_cloud} --type k8s-pvc --size 1Gi',
                 f'{self.ACTIVATE_BASE} && sky volumes ls | grep "{cluster_name}-0"',
                 f'{self.ACTIVATE_BASE} && sky volumes ls | grep "{cluster_name}-1"',
                 f'{self.ACTIVATE_BASE} && sky volumes delete {cluster_name}-0 -y',
@@ -767,7 +768,8 @@ class TestBackwardCompatibility:
             commands = [
                 # Create volume in base version
                 f'{self.ACTIVATE_BASE} && {smoke_tests_utils.SKY_API_RESTART} && '
-                f'sky volumes apply -y -n {volume_name} --type k8s-pvc --size 1Gi',
+                # Base version might contain the bug in https://github.com/skypilot-org/skypilot/issues/7380, so we need to specify --infra
+                f'sky volumes apply -y -n {volume_name} --infra k8s --type k8s-pvc --size 1Gi',
                 f'{self.ACTIVATE_BASE} && sky volumes ls | grep "{volume_name}"',
 
                 # Use volume in current version

--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -597,7 +597,7 @@ class TestBackwardCompatibility:
                 f'{self.ACTIVATE_BASE} && {smoke_tests_utils.SKY_API_RESTART} && '
                 f'sky volumes apply -y -n {cluster_name}-0 --infra {generic_cloud} --type k8s-pvc --size 1Gi',
                 # No restart on switch to current, cli in current, server in bases
-                f'{self.ACTIVATE_CURRENT} && sky volumes apply -y -n {cluster_name}-1 --infra {generic_cloud} --type k8s-pvc --size 1Gi',
+                f'{self.ACTIVATE_CURRENT} && sky volumes apply -y -n {cluster_name}-1 --type k8s-pvc --size 1Gi',
                 f'{self.ACTIVATE_CURRENT} && sky volumes ls | grep "{cluster_name}-0"',
                 f'{self.ACTIVATE_CURRENT} && sky volumes ls | grep "{cluster_name}-1"',
                 f'{self.ACTIVATE_CURRENT} && sky volumes delete {cluster_name}-0 -y',
@@ -681,7 +681,7 @@ class TestBackwardCompatibility:
                 f'{self.ACTIVATE_CURRENT} && {smoke_tests_utils.SKY_API_RESTART} && '
                 f'sky volumes apply -y -n {cluster_name}-0 --infra {generic_cloud} --type k8s-pvc --size 1Gi',
                 # No restart on switch to base, cli in base, server in current
-                f'{self.ACTIVATE_BASE} && sky volumes apply -y -n {cluster_name}-1 --infra {generic_cloud} --type k8s-pvc --size 1Gi',
+                f'{self.ACTIVATE_BASE} && sky volumes apply -y -n {cluster_name}-1 --type k8s-pvc --size 1Gi',
                 f'{self.ACTIVATE_BASE} && sky volumes ls | grep "{cluster_name}-0"',
                 f'{self.ACTIVATE_BASE} && sky volumes ls | grep "{cluster_name}-1"',
                 f'{self.ACTIVATE_BASE} && sky volumes delete {cluster_name}-0 -y',
@@ -767,7 +767,7 @@ class TestBackwardCompatibility:
             commands = [
                 # Create volume in base version
                 f'{self.ACTIVATE_BASE} && {smoke_tests_utils.SKY_API_RESTART} && '
-                f'sky volumes apply -y -n {volume_name} --infra k8s --type k8s-pvc --size 1Gi',
+                f'sky volumes apply -y -n {volume_name} --type k8s-pvc --size 1Gi',
                 f'{self.ACTIVATE_BASE} && sky volumes ls | grep "{volume_name}"',
 
                 # Use volume in current version

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1031,8 +1031,7 @@ def test_volumes_on_kubernetes():
     test = smoke_tests_utils.Test(
         'volumes_on_kubernetes',
         [
-            # TODO(hailong): cover no `--infra` case after https://github.com/skypilot-org/skypilot/issues/7380 is fixed.
-            f'sky volumes apply -y -n pvc0 --type k8s-pvc --size 2GB --infra kubernetes',
+            f'sky volumes apply -y -n pvc0 --type k8s-pvc --size 2GB',
             f'sky volumes ls | grep "pvc0"',
             f'sky launch -y -c {name} --infra kubernetes tests/test_yamls/pvc_volume.yaml',
             f'sky logs {name} 1 --status',  # Ensure the job succeeded.

--- a/tests/unit_tests/test_sky/volumes/test_core.py
+++ b/tests/unit_tests/test_sky/volumes/test_core.py
@@ -453,6 +453,8 @@ class TestVolumeCore:
         mock_cloud.max_cluster_name_length.return_value = 63
         mock_cloud_registry = mock.MagicMock()
         mock_cloud_registry.from_str.return_value = mock_cloud
+        mock_cloud.validate_region_zone.return_value = ('us-east-1',
+                                                        'us-east-1a')
         monkeypatch.setattr('sky.utils.registry.CLOUD_REGISTRY',
                             mock_cloud_registry)
 
@@ -508,6 +510,8 @@ class TestVolumeCore:
         mock_cloud.max_cluster_name_length.return_value = 63
         mock_cloud_registry = mock.MagicMock()
         mock_cloud_registry.from_str.return_value = mock_cloud
+        mock_cloud.validate_region_zone.return_value = ('us-east-1',
+                                                        'us-east-1a')
         monkeypatch.setattr('sky.utils.registry.CLOUD_REGISTRY',
                             mock_cloud_registry)
 
@@ -547,6 +551,8 @@ class TestVolumeCore:
         mock_cloud.max_cluster_name_length.return_value = 63
         mock_cloud_registry = mock.MagicMock()
         mock_cloud_registry.from_str.return_value = mock_cloud
+        mock_cloud.validate_region_zone.return_value = ('us-east-1',
+                                                        'us-east-1a')
         monkeypatch.setattr('sky.utils.registry.CLOUD_REGISTRY',
                             mock_cloud_registry)
 

--- a/tests/unit_tests/test_sky/volumes/test_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_volume.py
@@ -487,15 +487,13 @@ class TestVolume:
 
     def test_validate_with_invalid_cloud(self):
         """Test Volume.validate with invalid cloud."""
-        volume = volume_lib.Volume(
-            name='test',
-            type='k8s-pvc',
-            infra='runpod',
-            size='100Gi',
-        )
-
         with pytest.raises(ValueError) as exc_info:
-            volume.validate()
+            volume_lib.Volume(
+                name='test',
+                type='k8s-pvc',
+                infra='runpod',
+                size='100Gi',
+            )
         assert 'Invalid cloud' in str(exc_info.value)
 
     def test_validate_with_invalid_label_key(self, monkeypatch):
@@ -620,6 +618,15 @@ class TestVolume:
             volume.validate()
         assert 'RunPod network volume size must be at least' in str(
             exc_info.value)
+
+    def test_volume_infers_cloud_from_type_when_infra_none(self):
+        """Test that volume infers cloud from type when infra is None."""
+        volume = volume_lib.Volume(name='test',
+                                   type='k8s-pvc',
+                                   infra=None,
+                                   size='100Gi')
+        # Cloud should be inferred from volume type
+        assert volume.cloud == 'Kubernetes'
 
 
 class TestVolumeConfigModel:


### PR DESCRIPTION
Fixes #7380.

PR #7370 moved the volume validation to server side, but we missed keeping the logic to fallback to inferring `self.cloud` from `self.type` if `self.infra` is unset on the client side. So what happens is, if infra is unset, cloud will also be unset, and this gives a validation error during apply because `cloud` is required in `VolumeApplyBody`.

This PR fixes this by reverting that validation back to the client side, so that `cloud` is never null.

I've reverted the test workaround too from #7382.

Backwards compatibility:
- New client <-> PR 7370 server: Bug fixed on the client side, there's no need to upgrade the server
- PR 7370 client <-> new server: Still fail, as expected, client will need to upgrade to latest. Workaround by setting `--infra`


Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Tested that `sky volumes apply --name test-pvc --type k8s-pvc --size 1Gi` works
  - A new test case under `test_volume.py::TestVolume`
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
