### PR TITLE
[SSM] Only Default to SSM if not Explicitly Set

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -805,15 +805,6 @@ def write_cluster_config(
                 f'is already set to {ssh_proxy_command!r}. Please remove '
                 'ssh_proxy_command or set use_ssm to false.')
 
-        if not use_ssm and use_internal_ips and ssh_proxy_command is None:
-            logger.warning(
-                f'{colorama.Fore.YELLOW}'
-                'use_internal_ips is set to true, '
-                'but ssh_proxy_command is not set. Defaulting to '
-                'using SSM. Specify ssh_proxy_command to use a different '
-                'https://docs.skypilot.co/en/latest/reference/config.html#'
-                f'aws.ssh_proxy_command.{colorama.Style.RESET_ALL}')
-            use_ssm = True
         if use_ssm:
             aws_profile = os.environ.get('AWS_PROFILE', None)
             profile_str = f'--profile {aws_profile}' if aws_profile else ''

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -797,13 +797,25 @@ def write_cluster_config(
             cloud=str(cloud).lower(),
             region=region.name,
             keys=('use_ssm',),
-            default_value=False)
+            default_value=None)
 
         if use_ssm and ssh_proxy_command is not None:
             raise exceptions.InvalidCloudConfigs(
                 'use_ssm is set to true, but ssh_proxy_command '
                 f'is already set to {ssh_proxy_command!r}. Please remove '
                 'ssh_proxy_command or set use_ssm to false.')
+
+        if use_internal_ips and ssh_proxy_command is None:
+            # Only if use_ssm is explicitly not set, we default to using SSM.
+            if use_ssm is None:
+                logger.warning(
+                    f'{colorama.Fore.YELLOW}'
+                    'use_internal_ips is set to true, '
+                    'but ssh_proxy_command is not set. Defaulting to '
+                    'using SSM. Specify ssh_proxy_command to use a different '
+                    'https://docs.skypilot.co/en/latest/reference/config.html#'
+                    f'aws.ssh_proxy_command.{colorama.Style.RESET_ALL}')
+                use_ssm = True
 
         if use_ssm:
             aws_profile = os.environ.get('AWS_PROFILE', None)

--- a/tests/smoke_tests/test_ssm.py
+++ b/tests/smoke_tests/test_ssm.py
@@ -64,56 +64,6 @@ def test_ssm_private():
 
 
 @pytest.mark.aws
-def test_ssm_private_no_ssh_proxy_command():
-    """Test that ssm will run by default if use_internal_ips is set.
-
-    This security group does not allow ssh access so if this test passes
-    it means that SkyPilot is using SSM to connect to the cluster.
-    """
-    name = smoke_tests_utils.get_cluster_name()
-    vpc = "DO_NOT_DELETE_lloyd-airgapped-plus-gateway"
-    vpc_config = (f'--config aws.vpc_name={vpc} '
-                  f'--config aws.security_group_name=lloyd-airgap-gw-sg '
-                  f'--config aws.use_internal_ips=true')
-
-    warning_message = 'use_internal_ips is set to true, but ' \
-        'ssh_proxy_command is not set. Defaulting to using SSM. ' \
-        'Specify ssh_proxy_command to use a different ' \
-        'https://docs.skypilot.co/en/latest/reference/config.html#aws.ssh_proxy_command.'
-
-    VALIDATE_SSM_OUTPUT = (
-        'echo "$s" && echo "==Validating launching==" && '
-        f'echo "$s" | grep "{warning_message}" && '
-        'echo "$s" | grep -A 1 "Launching on" | grep "is up." && '
-        'echo "$s" && echo "==Validating setup output==" && '
-        'echo "$s" | grep -A 1 "Setup detached" | grep "Job submitted" && '
-        'echo "==Validating running output hints==" && echo "$s" | '
-        'grep -A 1 "Job submitted, ID:" | '
-        'grep "Waiting for task resources on " && '
-        'echo "==Validating task setup/run output starting==" && echo "$s" | '
-        'grep -A 1 "Job started. Streaming logs..." | grep "(setup" | '
-        'grep "running setup" && '
-        'echo "$s" | grep -A 1 "(setup" | grep "(min, pid=" && '
-        'echo "==Validating task output ending==" && '
-        'echo "$s" | grep -A 1 "task run finish" | '
-        'grep "Job finished (status: SUCCEEDED)" && '
-        'echo "==Validating task output ending 2==" && '
-        'echo "$s" | grep -A 5 "Job finished (status: SUCCEEDED)" | '
-        'grep "Job ID:" && '
-        'echo "$s" | grep -A 1 "Useful Commands" | grep "Job ID:"')
-
-    test = smoke_tests_utils.Test(
-        'ssm_private_no_ssh_proxy_command',
-        [
-            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra aws/us-west-1 {smoke_tests_utils.LOW_RESOURCE_ARG} {vpc_config} tests/test_yamls/minimal.yaml | tee /dev/stderr) && {VALIDATE_SSM_OUTPUT}',
-        ],
-        teardown=f'sky down -y {name}',
-        timeout=smoke_tests_utils.get_timeout('aws'),
-    )
-    smoke_tests_utils.run_one_test(test)
-
-
-@pytest.mark.aws
 def test_ssm_private_custom_ami():
     """Test that ssm works with private IP addresses and a custom AMI.
     """

--- a/tests/unit_tests/test_aws.py
+++ b/tests/unit_tests/test_aws.py
@@ -16,6 +16,7 @@ from sky.provision.aws import config
 from sky.utils import common_utils
 from sky.utils import config_utils
 
+
 def test_aws_label():
     aws = AWS()
     # Invalid - AWS prefix

--- a/tests/unit_tests/test_aws.py
+++ b/tests/unit_tests/test_aws.py
@@ -1,12 +1,20 @@
+import pathlib
 import typing
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
 
+from sky import logs
+from sky import resources
+from sky import skypilot_config
+from sky.backends import backend_utils
+from sky.clouds import Region
+from sky.clouds import Zone
 from sky.clouds.aws import AWS
 from sky.provision.aws import config
-
+from sky.utils import common_utils
+from sky.utils import config_utils
 
 def test_aws_label():
     aws = AWS()
@@ -106,3 +114,116 @@ def test_usable_subnets(monkeypatch):
 
     error_message = str(e.value)
     assert f"SKYPILOT_ERROR_NO_NODES_LAUNCHED: All candidate subnets are private, did you mean to set use_internal_ips to True?" == error_message
+
+
+def test_ssm_default(monkeypatch):
+    """Test that SSM is explicitly set to true if use_internal_ips is true
+    and ssh_proxy_command is not set.
+    """
+    monkeypatch.setattr(common_utils, 'make_cluster_name_on_cloud',
+                        lambda *args, **kwargs: args[0])
+    tmp_yaml_path = '/tmp/fake-yaml-path'
+    monkeypatch.setattr(backend_utils, '_get_yaml_path_from_cluster_name',
+                        lambda *args, **kwargs: tmp_yaml_path)
+    # Patch make_deploy_variables.
+    monkeypatch.setattr(resources.Resources, 'make_deploy_variables',
+                        lambda *args, **kwargs: {'region': 'us-east-1'})
+    monkeypatch.setattr(logs, 'get_logging_agent', lambda *args, **kwargs: None)
+    config_dict = {
+        'aws': {
+            'use_internal_ips': True
+        },
+    }
+    config_dict = config_utils.Config.from_dict(config_dict)
+
+    monkeypatch.setattr(skypilot_config, '_get_loaded_config',
+                        lambda *args, **kwargs: config_dict)
+
+    use_internal_ips = skypilot_config.get_effective_region_config(
+        cloud=str(AWS()).lower(),
+        region='us-east-1',
+        keys=('use_internal_ips',),
+        default_value=False)
+    loaded_config = skypilot_config._get_loaded_config()
+    print(f'_get_loaded_config: {loaded_config}')
+    assert use_internal_ips is True
+
+    def fill_template_side_effect(*args, **kwargs):
+        config_dict = args[1]
+        print(config_dict)
+        assert 'ssh_proxy_command' in config_dict
+        assert "ssm" in config_dict['ssh_proxy_command']
+        assert 'use_internal_ips' in config_dict
+        assert config_dict['use_internal_ips'] is True
+        raise RuntimeError('fake-error')
+
+    monkeypatch.setattr(common_utils, 'fill_template',
+                        fill_template_side_effect)
+    with pytest.raises(RuntimeError) as e:
+        backend_utils.write_cluster_config(
+            to_provision=resources.Resources(cloud=AWS(),
+                                             instance_type='c2.xlarge'),
+            num_nodes=1,
+            cluster_config_template='aws-ray.yml.j2',
+            cluster_name='fake-cluster',
+            local_wheel_path=pathlib.Path('fake-wheel-path'),
+            wheel_hash='fake-wheel-hash',
+            region=Region(name='fake-region'),
+            zones=[Zone(name='fake-zone')])
+
+
+def test_ssm_explicit_default(monkeypatch):
+    """Test that SSM is false if explicitly set to false even if 
+    use_internal_ips is true and ssh_proxy_command is not set.
+    """
+    monkeypatch.setattr(common_utils, 'make_cluster_name_on_cloud',
+                        lambda *args, **kwargs: args[0])
+    tmp_yaml_path = '/tmp/fake-yaml-path'
+    monkeypatch.setattr(backend_utils, '_get_yaml_path_from_cluster_name',
+                        lambda *args, **kwargs: tmp_yaml_path)
+    # Patch make_deploy_variables.
+    monkeypatch.setattr(resources.Resources, 'make_deploy_variables',
+                        lambda *args, **kwargs: {'region': 'us-east-1'})
+    monkeypatch.setattr(logs, 'get_logging_agent', lambda *args, **kwargs: None)
+    config_dict = {
+        'aws': {
+            'use_ssm': False,
+            'use_internal_ips': True
+        },
+    }
+    config_dict = config_utils.Config.from_dict(config_dict)
+
+    monkeypatch.setattr(skypilot_config, '_get_loaded_config',
+                        lambda *args, **kwargs: config_dict)
+
+    use_internal_ips = skypilot_config.get_effective_region_config(
+        cloud=str(AWS()).lower(),
+        region='us-east-1',
+        keys=('use_internal_ips',),
+        default_value=False)
+    loaded_config = skypilot_config._get_loaded_config()
+    print(f'_get_loaded_config: {loaded_config}')
+    assert use_internal_ips is True
+
+    def fill_template_side_effect(*args, **kwargs):
+        config_dict = args[1]
+        print(config_dict)
+        assert 'ssh_proxy_command' in config_dict
+        assert config_dict['ssh_proxy_command'] is None
+        assert 'use_internal_ips' in config_dict
+        assert config_dict['use_internal_ips'] is True
+        raise RuntimeError('fake-error')
+
+    monkeypatch.setattr(common_utils, 'fill_template',
+                        fill_template_side_effect)
+    with pytest.raises(RuntimeError) as e:
+        backend_utils.write_cluster_config(
+            to_provision=resources.Resources(cloud=AWS(),
+                                             instance_type='c2.xlarge'),
+            num_nodes=1,
+            cluster_config_template='aws-ray.yml.j2',
+            cluster_name='fake-cluster',
+            local_wheel_path=pathlib.Path('fake-wheel-path'),
+            wheel_hash='fake-wheel-hash',
+            region=Region(name='fake-region'),
+            zones=[Zone(name='fake-zone')])


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR removes defaulting to SSM if `use_internal_ips` is set to true but `ssh_proxy_command` is empty. If a user wants to use internal IPs without SSM that should be allowed.

I added a new unit test that tests
- We don't set use_ssm to true if it's explicitly set to False in the above case
- We do set it to true if not explicitly set in the above case

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
