### PR TITLE
[DB] move get clusters from history filtering and sorting to db

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1738,7 +1738,7 @@ def get_clusters_from_history(
     current_user_hash = common_utils.get_user_hash()
 
     # Prepare filtering parameters
-    cutoff_time = None
+    cutoff_time = 0
     if days is not None:
         cutoff_time = int(time.time()) - (days * 24 * 60 * 60)
 
@@ -1774,12 +1774,24 @@ def get_clusters_from_history(
                                        cluster_history_table.c.cluster_hash ==
                                        cluster_table.c.cluster_hash,
                                        isouter=True))
+
+        # Only include clusters that are either active (status is not None)
+        # or are within the cutoff time (cutoff_time <= last_activity_time).
+        # If days is not specified, we include all clusters by setting
+        # cutoff_time to 0.
+        query = query.filter(
+            (cluster_table.c.status.isnot(None) |
+             (cluster_history_table.c.last_activity_time >= cutoff_time)))
+
+        # Order by launched_at descending (most recent first)
+        query = query.order_by(
+            sqlalchemy.desc(cluster_history_table.c.launched_at))
+
         if cluster_hashes is not None:
             query = query.filter(
                 cluster_history_table.c.cluster_hash.in_(cluster_hashes))
         rows = query.all()
 
-    filtered_rows = []
     usage_intervals_dict = {}
     row_to_user_hash = {}
     for row in rows:
@@ -1789,28 +1801,11 @@ def get_clusters_from_history(
                 row_usage_intervals = pickle.loads(row.usage_intervals)
             except (pickle.PickleError, AttributeError):
                 pass
-        # Parse status
-        status = None
-        if row.status:
-            status = status_lib.ClusterStatus[row.status]
-        # Apply filtering: always include active clusters, filter historical
-        # ones by time
-        if cutoff_time is not None and status is None:  # Historical cluster
-            # For historical clusters, check if they were used recently
-            # Use the pre-computed last_activity_time from the database
-            last_activity_time = row.last_activity_time
-
-            # Skip historical clusters that haven't been used recently
-            if last_activity_time is None or last_activity_time < cutoff_time:
-                continue
-
-        filtered_rows.append(row)
         usage_intervals_dict[row.cluster_hash] = row_usage_intervals
         user_hash = (row.user_hash
                      if row.user_hash is not None else current_user_hash)
         row_to_user_hash[row.cluster_hash] = user_hash
 
-    rows = filtered_rows
     user_hashes = set(row_to_user_hash.values())
     user_hash_to_user = _get_users(user_hashes)
     cluster_hashes = set(row_to_user_hash.keys())


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR optimizes the `get_clusters_from_history` db query by moving the filtering and sorting operations to the database query. This saves us from querying all the clusters in the cluster history table and then iterating over all of them to filter records that are not within the time range of interest. We also avoid sorting these values in code by utilizing the index on the newly added `launched_at` field and sorting as part of the db query. 


<!-- Describe the tests ran -->
**Correctness:**
I tested this PR on an api server with a db with over 2000 clusters in the cluster history table. I verified that the clusters returned prior to this PR and on this feature branch are the same. 

**Performance:**
I also benchmarked the performance improvement of the server response times to load the historical clusters across a few different "# of days" filters. We see that just having the `last_activity_time` and `launched_at` columns (added in [this](https://github.com/skypilot-org/skypilot/pull/7366) PR) and the indices associated with them reduces the time to load ~1000 clusters from history by 6x from 3s to 600ms on average. The optimization in this PR is most evident when we have a cluster history table that has a significant # of clusters (on the order of thousands), but we only want to load a subset of those clusters. The benchmarking results are shown below (units are in ms):
<img width="703" height="107" alt="Screenshot 2025-09-25 at 3 46 57 PM" src="https://github.com/user-attachments/assets/ea0ba38b-64d0-4a86-bd6d-eb26b34dee4c" />


While the results for "# of days" filter of 5, 10, and 30 are comparable between the original and optimized server response times, we see that when the "# of days" filter is set to 1 and the # of clusters returned is orders of magnitude less than the number of clusters in the cluster history table as a whole, there is roughly a 2x performance improvement. Another note is that while the average server response time for the original query is lower than the optimized query for "# of days" filter 5 and 10, this is likely due to typical variance in the server response times and is not a significant difference. 

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
