### PR TITLE
pin bcrypt version

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -78,7 +78,7 @@ install_requires = [
     'sqlalchemy_adapter',
     # Required for API server metrics
     'prometheus_client>=0.8.0',
-    'passlib==1.7.4',
+    'passlib',
     'bcrypt==4.0.1',
     'pyjwt',
     'gitpython',
@@ -105,7 +105,7 @@ PROTOBUF = 'protobuf>=5.26.1, < 7.0.0'
 server_dependencies = [
     'casbin',
     'sqlalchemy_adapter',
-    'passlib==1.7.4',
+    'passlib',
     'pyjwt',
     'aiohttp',
     'anyio',

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -78,8 +78,8 @@ install_requires = [
     'sqlalchemy_adapter',
     # Required for API server metrics
     'prometheus_client>=0.8.0',
-    'passlib',
-    'bcrypt',
+    'passlib==1.7.4',
+    'bcrypt==4.0.1',
     'pyjwt',
     'gitpython',
     'types-paramiko',
@@ -105,7 +105,7 @@ PROTOBUF = 'protobuf>=5.26.1, < 7.0.0'
 server_dependencies = [
     'casbin',
     'sqlalchemy_adapter',
-    'passlib',
+    'passlib==1.7.4',
     'pyjwt',
     'aiohttp',
     'anyio',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
I noticed the CI is failing with the following error

<img width="719" height="402" alt="image_720" src="https://github.com/user-attachments/assets/0c3d8c45-c3ed-4005-8a2f-c2ad6185a37d" />

Apparently some other projects (e.g. https://github.com/langflow-ai/langflow/issues/1173) have encountered this and the fix was to pin bcrypt version, so here we go

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
