### PR TITLE
Reduce max upload chunk size to 100MiB to prevent 413 errors

### DIFF
--- a/sky/client/common.py
+++ b/sky/client/common.py
@@ -45,7 +45,7 @@ _DOWNLOAD_CHUNK_BYTES = 8192
 # The chunk size for the zip file to be uploaded to the API server. We split
 # the zip file into chunks to avoid network issues for large request body that
 # can be caused by NGINX's client_max_body_size or Cloudflare's upload limit.
-# As of 09/25/2025, the upload limit for Cloudflare's free plan is 100MB:
+# As of 09/25/2025, the upload limit for Cloudflare's free plan is 100MiB:
 # https://developers.cloudflare.com/support/troubleshooting/http-status-codes/4xx-client-error/error-413/
 _UPLOAD_CHUNK_BYTES = 100 * 1024 * 1024
 


### PR DESCRIPTION
We were getting 413 errors when uploading 1Gi file_mounts on a remote API server that is proxied through Cloudflare.

Apparently, Cloudflare's upload limit for free plan is 100MiB: https://developers.cloudflare.com/support/troubleshooting/http-status-codes/4xx-client-error/error-413/#cloudflare-specific-information

This PR reduces the max upload chunk size based on that number.

I measured the time it takes to upload the same 1Gi file_mounts, to a remote API server with no Cloudflare proxying (so that 512MiB chunk works), and 100MiB chunks are slightly faster. I tested it using a remote API server running on GKE us-east5, with 4 vCPUs and 8GB RAM.
- 100MiB chunks: [33s, 34s, 36s, 36s, 37s]
- 512MiB chunks: [35s, 37s, 43s, 43s, 45s]

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Tested `sky launch` using `file_mounts` with a 1Gi file on a remote API server
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
