### PR TITLE
[local up] better port allocation

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -5906,23 +5906,31 @@ def local():
     required=False,
     help='Name to use for the kubeconfig context. Defaults to "default". '
     'Used with the ip list.')
-@click.option(
-    '--name',
-    type=str,
-    required=False,
-    help='Name of the cluster. Defaults to "skypilot". Used without ip list.')
 @click.option('--password',
               type=str,
               required=False,
               help='Password for the ssh-user to execute sudo commands. '
               'Required only if passwordless sudo is not setup.')
+@click.option(
+    '--name',
+    type=str,
+    required=False,
+    help='Name of the cluster. Defaults to "skypilot". Used without ip list.')
+@click.option(
+    '--port-start',
+    type=int,
+    required=False,
+    help='Starting port range for the local kind cluster. Needs to be a '
+    'multiple of 100. If not given, a random range will be used. '
+    'Used without ip list.')
 @local.command('up', cls=_DocumentedCodeCommand)
 @flags.config_option(expose_value=False)
 @_add_click_options(flags.COMMON_OPTIONS)
 @usage_lib.entrypoint
 def local_up(gpus: bool, ips: str, ssh_user: str, ssh_key_path: str,
-             cleanup: bool, context_name: Optional[str], name: Optional[str],
-             password: Optional[str], async_call: bool):
+             cleanup: bool, context_name: Optional[str], 
+             password: Optional[str], name: Optional[str],
+             port_start: Optional[int], async_call: bool):
     """Creates a local or remote cluster."""
 
     def _validate_args(ips, ssh_user, ssh_key_path, cleanup):
@@ -5968,7 +5976,7 @@ def local_up(gpus: bool, ips: str, ssh_user: str, ssh_key_path: str,
                 f'Failed to read SSH key file {ssh_key_path}: {str(e)}')
 
     request_id = sdk.local_up(gpus, ip_list, ssh_user, ssh_key, cleanup,
-                              context_name, name, password)
+                              context_name, password, name, port_start)
     _async_call_or_wait(request_id, async_call, request_name='local up')
 
 

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1677,8 +1677,9 @@ def local_up(gpus: bool,
              ssh_key: Optional[str],
              cleanup: bool,
              context_name: Optional[str] = None,
+             password: Optional[str] = None,
              name: Optional[str] = None,
-             password: Optional[str] = None) -> server_common.RequestId[None]:
+             port_start: Optional[int] = None) -> server_common.RequestId[None]:
     """Launches a Kubernetes cluster on local machines.
 
     Returns:
@@ -1698,8 +1699,9 @@ def local_up(gpus: bool,
                                 ssh_key=ssh_key,
                                 cleanup=cleanup,
                                 context_name=context_name,
+                                password=password,
                                 name=name,
-                                password=password)
+                                port_start=port_start)
     response = server_common.make_authenticated_request(
         'POST', '/local_up', json=json.loads(body.model_dump_json()))
     return server_common.get_request_id(response)

--- a/sky/core.py
+++ b/sky/core.py
@@ -1299,8 +1299,9 @@ def local_up(gpus: bool,
              ssh_key: Optional[str],
              cleanup: bool,
              context_name: Optional[str] = None,
+             password: Optional[str] = None,
              name: Optional[str] = None,
-             password: Optional[str] = None) -> None:
+             port_start: Optional[int] = None) -> None:
     """Creates a local or remote cluster."""
 
     def _validate_args(ips, ssh_user, ssh_key, cleanup):
@@ -1330,7 +1331,7 @@ def local_up(gpus: bool,
                                                       password)
     else:
         # Run local deployment (kind) if no remote args are specified
-        kubernetes_deploy_utils.deploy_local_cluster(name, gpus)
+        kubernetes_deploy_utils.deploy_local_cluster(name, port_start, gpus)
 
 
 def local_down(name: Optional[str] = None) -> None:

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -683,8 +683,9 @@ class LocalUpBody(RequestBody):
     ssh_key: Optional[str] = None
     cleanup: bool = False
     context_name: Optional[str] = None
-    name: Optional[str] = None
     password: Optional[str] = None
+    name: Optional[str] = None
+    port_start: Optional[int] = None
 
 
 class LocalDownBody(RequestBody):

--- a/sky/utils/kubernetes/kubernetes_deploy_utils.py
+++ b/sky/utils/kubernetes/kubernetes_deploy_utils.py
@@ -1,5 +1,6 @@
 """Utility functions for deploying Kubernetes clusters."""
 import os
+import random
 import shlex
 import subprocess
 import sys
@@ -26,8 +27,9 @@ logger = sky_logging.init_logger(__name__)
 # Default path for Kubernetes configuration file
 DEFAULT_KUBECONFIG_PATH = os.path.expanduser('~/.kube/config')
 DEFAULT_LOCAL_CLUSTER_NAME = 'skypilot'
-LOCAL_CLUSTER_PORT_RANGE = 101
+LOCAL_CLUSTER_PORT_RANGE = 100
 LOCAL_CLUSTER_INTERNAL_PORT_START = 30000
+LOCAL_CLUSTER_INTERNAL_PORT_END = 30099
 
 
 def check_ssh_cluster_dependencies(
@@ -262,7 +264,7 @@ def generate_kind_config(port_start: int,
     """Generate a kind cluster config with ports mapped from host to container
 
     Port range will be [port_start, port_start + LOCAL_CLUSTER_PORT_RANGE)
-    Internally, this will map to ports 30000 - 30100
+    Internally, this will map to ports 30000 - 30099
 
     Args:
         path: Path to generate the config file at
@@ -274,7 +276,7 @@ def generate_kind_config(port_start: int,
         The kind cluster config
     """
     internal_start = LOCAL_CLUSTER_INTERNAL_PORT_START
-    internal_end = internal_start + LOCAL_CLUSTER_PORT_RANGE - 1
+    internal_end = LOCAL_CLUSTER_INTERNAL_PORT_END
 
     config = textwrap.dedent(f"""
     apiVersion: kind.x-k8s.io/v1alpha4
@@ -315,8 +317,29 @@ def generate_kind_config(port_start: int,
     return config
 
 
-def deploy_local_cluster(name: Optional[str], gpus: bool):
+def deploy_local_cluster(name: Optional[str], port_start: Optional[int], gpus: bool):
     name = name or DEFAULT_LOCAL_CLUSTER_NAME
+
+    if name == DEFAULT_LOCAL_CLUSTER_NAME:
+        if port_start is None:
+            port_start = LOCAL_CLUSTER_INTERNAL_PORT_START
+        if port_start != LOCAL_CLUSTER_INTERNAL_PORT_START:
+            raise ValueError('Default local cluster `skypilot` should have '
+                             'port range from 30000 to 30099. Current '
+                             f'port range: {port_start}-{port_end}.')
+        port_end = LOCAL_CLUSTER_INTERNAL_PORT_END
+    else:
+        if port_start is None:
+            port_start = random.randint(301, 399) * 100
+        if port_start == LOCAL_CLUSTER_INTERNAL_PORT_START:
+            raise ValueError('Port range 30000 to 30099 is reserved for '
+                             'default local cluster `skypilot`. Current '
+                             f'port range: {port_start}-{port_end}.')
+        port_end = port_start + LOCAL_CLUSTER_PORT_RANGE - 1
+    if port_start % 100 != 0:
+        raise ValueError('Local cluster port start must be a multiple of 100. '
+                         f'Current port range: {port_start}-{port_end}.')
+
     context_name = f'kind-{name}'
     cluster_created = False
 
@@ -341,12 +364,7 @@ def deploy_local_cluster(name: Optional[str], gpus: bool):
                                      delete=True) as f:
         # Choose random port range to use on the host machine.
         # Port range is port_start - port_start + 99 (exactly 100 ports).
-        # port_start = random.randint(300, 399) * 100
-        # TODO (kyuds): hard coding to pass smoketests. Need to figure out
-        # how to deal with this later.
-        port_start = LOCAL_CLUSTER_INTERNAL_PORT_START
-        port_end = port_start + LOCAL_CLUSTER_PORT_RANGE - 1
-        logger.debug(f'Using port range {port_start}-{port_end}')
+        logger.debug(f'Using host port range {port_start}-{port_end}')
         f.write(generate_kind_config(port_start, gpus=gpus))
         f.flush()
 
@@ -458,7 +476,8 @@ def deploy_local_cluster(name: Optional[str], gpus: bool):
             ux_utils.finishing_message(
                 message=(
                     f'Local Kubernetes cluster {name} created successfully '
-                    f'with {num_cpus} CPUs{gpu_message}.'),
+                    f'with {num_cpus} CPUs{gpu_message} on host port range '
+                    f'{port_start}-{port_end}.'),
                 log_path=log_path,
                 is_local=True,
                 follow_up_message=(

--- a/tests/kubernetes/scripts/helm_okta.sh
+++ b/tests/kubernetes/scripts/helm_okta.sh
@@ -34,7 +34,7 @@
 
 NAMESPACE=skypilot
 NODEPORT=30082
-HTTPS_NODEPORT=30100
+HTTPS_NODEPORT=30099
 RELEASE_NAME=skypilot
 
 # Cleanup function to delete namespace and resources


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #5704 

This is a follow up pr. We should merge only after local test for `helm_deploy_okta` passes.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
