### PR TITLE
[Core] Improve the job detail filling process

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1065,6 +1065,22 @@ def get_handle_from_cluster_name(
     return pickle.loads(row.handle)
 
 
+@_init_db
+@metrics_lib.time_me
+def get_cluster_name_to_handle_map(
+) -> Dict[str, Optional['backends.ResourceHandle']]:
+    assert _SQLALCHEMY_ENGINE is not None
+    with orm.Session(_SQLALCHEMY_ENGINE) as session:
+        rows = session.query(cluster_table.c.name, cluster_table.c.handle).all()
+    name_to_handle = {}
+    for row in rows:
+        if row.handle and len(row.handle) > 0:
+            name_to_handle[row.name] = pickle.loads(row.handle)
+        else:
+            name_to_handle[row.name] = None
+    return name_to_handle
+
+
 @_init_db_async
 @metrics_lib.time_me
 async def get_status_from_cluster_name_async(

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1244,6 +1244,7 @@ def dump_managed_job_queue(
     # Make sure to get all jobs - some logic below (e.g. high priority job
     # detection) requires a full view of the jobs table.
     jobs = managed_job_state.get_managed_jobs()
+    cluster_name_to_handle = global_user_state.get_cluster_name_to_handle_map()
 
     # Figure out what the highest priority blocking job is. We need to know in
     # order to determine if other jobs are blocked by a higher priority job, or
@@ -1317,15 +1318,12 @@ def dump_managed_job_queue(
         job['status'] = job['status'].value
         job['schedule_state'] = job['schedule_state'].value
 
-        pool = managed_job_state.get_pool_from_job_id(job['job_id'])
-        if pool is not None:
-            cluster_name, _ = managed_job_state.get_pool_submit_info(
-                job['job_id'])
-        else:
+        cluster_name = job.get('current_cluster_name', None)
+        if cluster_name is None:
             cluster_name = generate_managed_job_cluster_name(
                 job['task_name'], job['job_id'])
-        handle = global_user_state.get_handle_from_cluster_name(
-            cluster_name) if cluster_name is not None else None
+        handle = cluster_name_to_handle.get(
+            cluster_name, None) if cluster_name is not None else None
         if isinstance(handle, backends.CloudVmRayResourceHandle):
             resources_str = resources_utils.get_readable_resources_repr(
                 handle, simplify=True)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Improve the job detail filling process to reduce the time spent retrieving the jobs.
The time spent to fill the job details is reduced from 8-11s to less than 1s.
- Remove unnecessary db calls
- Fetch all the cluster to handle map in one db call

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Test with 5000 managed jobs
    - The API response is the same with that in master
    - The time spent to fill the job details is reduced from 8-11s to less than 1s
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
