### PR TITLE
[Pools] Prevent Heterogeneous Pools and Add Docs

### DIFF
--- a/docs/source/examples/managed-jobs.rst
+++ b/docs/source/examples/managed-jobs.rst
@@ -454,8 +454,14 @@ To submit the pipeline, the same command :code:`sky jobs launch` is used. The pi
 
 .. _pool:
 
-Using pools
------------
+Using pools [EXPERIMENTAL]
+--------------------------
+
+.. warning::
+
+  Pools are currently in alpha so some features are not currently supported:
+  * Pools does not currently support heterogeneous clusters (e.g., mixed H100 and H200 workers)
+  * Pools does not currently support multiple jobs running concurrently on the same worker
 
 SkyPilot supports spawning a **pool** for launching many jobs that share the same environment — for example, batch inference or large-scale data processing.
 
@@ -482,8 +488,8 @@ Here is a simple example of creating a pool:
     workers: 3
 
   resources:
-    # Specify the resources for each worker, e.g. use either H100 or H200.
-    accelerators: {H100:1, H200:1}
+    # Specify the resources for each worker.
+    accelerators: {H100:1}
 
   file_mounts:
     /my-data:

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -408,6 +408,22 @@ def validate_service_task(task: 'sky.Task', pool: bool) -> None:
                                  f'{sys_name} will replenish preempted spot '
                                  f'with {policy_description} instances.')
 
+    if pool:
+        accelerators = set()
+        for resource in task.resources:
+            if resource.accelerators is not None:
+                if isinstance(resource.accelerators, str):
+                    accelerators.add(resource.accelerators)
+                elif isinstance(resource.accelerators, dict):
+                    accelerators.update(resource.accelerators.keys())
+                elif isinstance(resource.accelerators, list):
+                    accelerators.update(resource.accelerators)
+        if len(accelerators) > 1:
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError('Heterogeneous clusters are not supported for '
+                                 'cluster pools please specify one accelerator '
+                                 'for all workers.')
+
     # Try to create a spot placer from the task yaml. Check if the task yaml
     # is valid for spot placer.
     spot_placer.SpotPlacer.from_task(task.service, task)

--- a/tests/smoke_tests/test_pools.py
+++ b/tests/smoke_tests/test_pools.py
@@ -1,6 +1,6 @@
 import tempfile
 import textwrap
-from typing import Dict
+from typing import Dict, Optional
 
 import pytest
 from smoke_tests import smoke_tests_utils
@@ -154,8 +154,10 @@ def check_for_setup_message(pool_name: str,
 def basic_pool_conf(
     num_workers: int,
     infra: str,
+    resource_string: Optional[str] = None,
     setup_cmd: str = 'echo "setup message"',
 ):
+    resource_string = '    accelerators: ' + resource_string if resource_string else ''
     return textwrap.dedent(f"""
     pool:
         workers: {num_workers}
@@ -164,6 +166,7 @@ def basic_pool_conf(
         cpus: 2+
         memory: 4GB+
         infra: {infra}
+    {resource_string}
 
     setup: |
         {setup_cmd}
@@ -533,3 +536,51 @@ def test_pool_preemption(generic_cloud: str):
             )
 
             smoke_tests_utils.run_one_test(test)
+
+
+#(TODO): Remove once heterogeneous pools are supported.
+def test_heterogeneous_pool(generic_cloud: str):
+    name = smoke_tests_utils.get_cluster_name()
+    pool_name = f'{name}-pool'
+    pool_name = common_utils.make_cluster_name_on_cloud(
+        pool_name, sky.AWS.max_cluster_name_length())
+    pool_config = basic_pool_conf(num_workers=1,
+                                  infra=generic_cloud,
+                                  resource_string='{"L4", "A10G"}')
+    print(pool_config)
+    print("eee")
+    with tempfile.NamedTemporaryFile(delete=True) as pool_yaml:
+        write_yaml(pool_yaml, pool_config)
+        test = smoke_tests_utils.Test(
+            'test_heterogeneous_pool_counts',
+            [
+                f's=$(sky jobs pool apply -p {pool_name} {pool_yaml.name} -y 2>&1); echo "$s"; echo; echo; echo "$s" | grep "Heterogeneous clusters are not supported"',
+            ],
+            timeout=smoke_tests_utils.get_timeout(generic_cloud),
+            teardown=_TEARDOWN_POOL.format(pool_name=pool_name),
+        )
+        smoke_tests_utils.run_one_test(test)
+
+
+#(TODO): Remove once heterogeneous pools are supported.
+def test_heterogeneous_pool_counts(generic_cloud: str):
+    name = smoke_tests_utils.get_cluster_name()
+    pool_name = f'{name}-pool'
+    pool_name = common_utils.make_cluster_name_on_cloud(
+        pool_name, sky.AWS.max_cluster_name_length())
+    pool_config = basic_pool_conf(num_workers=1,
+                                  infra=generic_cloud,
+                                  resource_string='{"H100":1, "L40S":1}')
+    print(pool_config)
+    print("eee")
+    with tempfile.NamedTemporaryFile(delete=True) as pool_yaml:
+        write_yaml(pool_yaml, pool_config)
+        test = smoke_tests_utils.Test(
+            'test_heterogeneous_pool_counts',
+            [
+                f's=$(sky jobs pool apply -p {pool_name} {pool_yaml.name} -y 2>&1); echo "$s"; echo; echo; echo "$s" | grep "Heterogeneous clusters are not supported"',
+            ],
+            timeout=smoke_tests_utils.get_timeout(generic_cloud),
+            teardown=_TEARDOWN_POOL.format(pool_name=pool_name),
+        )
+        smoke_tests_utils.run_one_test(test)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR updates the docs for pools to note that it is experimental and outlines that it does not support heterogeneous clusters or multiple jobs per worker.
<img width="821" height="236" alt="Screenshot 2025-09-26 at 9 22 38 AM" src="https://github.com/user-attachments/assets/048a52f9-3171-4b8e-940f-75514b6b4285" />

It also adds a new error when a pool user attempts to launch a heterogenous cluster.

```
sky jobs pool apply -p test heterogeneous.yaml
YAML to run: heterogeneous.yaml
Pool spec:
Worker policy:  Fixed-size (3 workers)

ValueError: Heterogeneous clusters are not supported for cluster pools please specify one accelerator for all workers.
```

I added smoke tests to make sure we throw this error when the cluster is heterogenous.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
