### PR TITLE
[SDK] managed jobs queue / status kubernetes typing improvements

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -1395,10 +1395,10 @@ def _handle_jobs_queue_request(
         msg += ('Failed to query managed jobs: '
                 f'{common_utils.format_exception(e, use_bracket=True)}')
     else:
-        msg = managed_jobs.format_job_table(managed_jobs_,
-                                            show_all=show_all,
-                                            show_user=show_user,
-                                            max_jobs=max_num_jobs_to_show)
+        msg = table_utils.format_job_table(managed_jobs_,
+                                           show_all=show_all,
+                                           show_user=show_user,
+                                           max_jobs=max_num_jobs_to_show)
     return num_in_progress_jobs, msg
 
 
@@ -1513,9 +1513,9 @@ def _status_kubernetes(show_all: bool):
         click.echo(f'\n{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
                    f'Managed jobs'
                    f'{colorama.Style.RESET_ALL}')
-        msg = managed_jobs.format_job_table(all_jobs,
-                                            show_all=show_all,
-                                            show_user=False)
+        msg = table_utils.format_job_table(all_jobs,
+                                           show_all=show_all,
+                                           show_user=False)
         click.echo(msg)
     if any(['sky-serve-controller' in c.cluster_name for c in all_clusters]):
         # TODO: Parse serve controllers and show services separately.
@@ -2963,9 +2963,9 @@ def _hint_or_raise_for_down_jobs_controller(controller_name: str,
            'jobs (output of `sky jobs queue`) will be lost.')
     click.echo(msg)
     if managed_jobs_:
-        job_table = managed_jobs.format_job_table(managed_jobs_,
-                                                  show_all=False,
-                                                  show_user=True)
+        job_table = table_utils.format_job_table(managed_jobs_,
+                                                 show_all=False,
+                                                 show_user=True)
         msg = controller.value.decline_down_for_dirty_controller_hint
         # Add prefix to each line to align with the bullet point.
         msg += '\n'.join(

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -1322,7 +1322,7 @@ def exec(
 
 
 def _handle_jobs_queue_request(
-        request_id: server_common.RequestId[List[Dict[str, Any]]],
+        request_id: server_common.RequestId[List[responses.ManagedJobRecord]],
         show_all: bool,
         show_user: bool,
         max_num_jobs_to_show: Optional[int],

--- a/sky/client/cli/table_utils.py
+++ b/sky/client/cli/table_utils.py
@@ -1,6 +1,7 @@
 """Utilities for formatting tables for CLI output."""
-from typing import List
+from typing import List, Optional
 
+from sky.jobs import utils as managed_jobs
 from sky.schemas.api import responses
 from sky.skylet import constants
 from sky.utils import common_utils
@@ -77,3 +78,14 @@ def format_storage_table(storages: List[responses.StorageRecord],
         return str(storage_table)
     else:
         return 'No existing storage.'
+
+
+def format_job_table(jobs: List[responses.ManagedJobRecord],
+                     show_all: bool,
+                     show_user: bool,
+                     max_jobs: Optional[int] = None):
+    jobs = [job.model_dump() for job in jobs]
+    return managed_jobs.format_job_table(jobs,
+                                         show_all=show_all,
+                                         show_user=show_user,
+                                         max_jobs=max_jobs)

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1901,10 +1901,10 @@ def kubernetes_node_info(
 @usage_lib.entrypoint
 @server_common.check_server_healthy_or_start
 @annotations.client_api
-def status_kubernetes() -> server_common.RequestId[Tuple[
-    List['kubernetes_utils.KubernetesSkyPilotClusterInfoPayload'],
-    List['kubernetes_utils.KubernetesSkyPilotClusterInfoPayload'], List[Dict[
-        str, Any]], Optional[str]]]:
+def status_kubernetes() -> server_common.RequestId[
+    Tuple[List['kubernetes_utils.KubernetesSkyPilotClusterInfoPayload'],
+          List['kubernetes_utils.KubernetesSkyPilotClusterInfoPayload'],
+          List[responses.ManagedJobRecord], Optional[str]]]:
     """Gets all SkyPilot clusters and jobs in the Kubernetes cluster.
 
     Managed jobs and services are also included in the clusters returned.

--- a/sky/core.py
+++ b/sky/core.py
@@ -195,7 +195,7 @@ def status(
 def status_kubernetes(
 ) -> Tuple[List['kubernetes_utils.KubernetesSkyPilotClusterInfoPayload'],
            List['kubernetes_utils.KubernetesSkyPilotClusterInfoPayload'],
-           List[Dict[str, Any]], Optional[str]]:
+           List[responses.ManagedJobRecord], Optional[str]]:
     """Gets all SkyPilot clusters and jobs in the Kubernetes cluster.
 
     Managed jobs and services are also included in the clusters returned.
@@ -270,6 +270,7 @@ all_clusters, unmanaged_clusters, all_jobs, context
         kubernetes_utils.KubernetesSkyPilotClusterInfoPayload.from_cluster(c)
         for c in unmanaged_clusters
     ]
+    all_jobs = [responses.ManagedJobRecord(**job) for job in all_jobs]
     return all_clusters, unmanaged_clusters, all_jobs, context
 
 

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -9,6 +9,7 @@ from sky import sky_logging
 from sky.adaptors import common as adaptors_common
 from sky.client import common as client_common
 from sky.client import sdk
+from sky.schemas.api import responses
 from sky.serve.client import impl
 from sky.server import common as server_common
 from sky.server import rest
@@ -130,7 +131,7 @@ def queue(
     skip_finished: bool = False,
     all_users: bool = False,
     job_ids: Optional[List[int]] = None
-) -> server_common.RequestId[List[Dict[str, Any]]]:
+) -> server_common.RequestId[List[responses.ManagedJobRecord]]:
     """Gets statuses of managed jobs.
 
     Please refer to sky.cli.job_queue for documentation.
@@ -145,7 +146,7 @@ def queue(
         The request ID of the queue request.
 
     Request Returns:
-        job_records (List[Dict[str, Any]]): A list of dicts, with each dict
+        job_records (List[responses.ManagedJobRecord]): A list of dicts, with each dict
           containing the information of a job.
 
           .. code-block:: python

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -28,6 +28,7 @@ from sky.jobs import constants as managed_job_constants
 from sky.jobs import state as managed_job_state
 from sky.jobs import utils as managed_job_utils
 from sky.provision import common as provision_common
+from sky.schemas.api import responses
 from sky.serve import serve_state
 from sky.serve import serve_utils
 from sky.serve.server import impl
@@ -643,6 +644,28 @@ def queue(refresh: bool,
 
 
 @usage_lib.entrypoint
+def queue_v2_api(
+    refresh: bool,
+    skip_finished: bool = False,
+    all_users: bool = False,
+    job_ids: Optional[List[int]] = None,
+    user_match: Optional[str] = None,
+    workspace_match: Optional[str] = None,
+    name_match: Optional[str] = None,
+    pool_match: Optional[str] = None,
+    page: Optional[int] = None,
+    limit: Optional[int] = None,
+    statuses: Optional[List[str]] = None,
+) -> Tuple[List[responses.ManagedJobRecord], int, Dict[str, int], int]:
+    """Gets statuses of managed jobs and parse the
+    jobs to responses.ManagedJobRecord."""
+    jobs, total, status_counts, total_no_filter = queue_v2(
+        refresh, skip_finished, all_users, job_ids, user_match, workspace_match,
+        name_match, pool_match, page, limit, statuses)
+    return [responses.ManagedJobRecord(**job) for job in jobs
+           ], total, status_counts, total_no_filter
+
+
 def queue_v2(
     refresh: bool,
     skip_finished: bool = False,

--- a/sky/jobs/server/server.py
+++ b/sky/jobs/server/server.py
@@ -68,7 +68,7 @@ async def queue_v2(request: fastapi.Request,
         request_id=request.state.request_id,
         request_name='jobs.queue_v2',
         request_body=jobs_queue_body_v2,
-        func=core.queue_v2,
+        func=core.queue_v2_api,
         schedule_type=(api_requests.ScheduleType.LONG
                        if jobs_queue_body_v2.refresh else
                        api_requests.ScheduleType.SHORT),

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1538,8 +1538,7 @@ def _get_job_status_from_tasks(
 
 
 @typing.overload
-def format_job_table(tasks: Union[List[responses.ManagedJobRecord],
-                                  List[Dict[str, Any]]],
+def format_job_table(tasks: List[Dict[str, Any]],
                      show_all: bool,
                      show_user: bool,
                      return_rows: Literal[False] = False,
@@ -1548,8 +1547,7 @@ def format_job_table(tasks: Union[List[responses.ManagedJobRecord],
 
 
 @typing.overload
-def format_job_table(tasks: Union[List[responses.ManagedJobRecord],
-                                  List[Dict[str, Any]]],
+def format_job_table(tasks: List[Dict[str, Any]],
                      show_all: bool,
                      show_user: bool,
                      return_rows: Literal[True],
@@ -1558,7 +1556,7 @@ def format_job_table(tasks: Union[List[responses.ManagedJobRecord],
 
 
 def format_job_table(
-        tasks: Union[List[responses.ManagedJobRecord], List[Dict[str, Any]]],
+        tasks: List[Dict[str, Any]],
         show_all: bool,
         show_user: bool,
         return_rows: bool = False,

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -33,6 +33,7 @@ from sky.backends import cloud_vm_ray_backend
 from sky.jobs import constants as managed_job_constants
 from sky.jobs import scheduler
 from sky.jobs import state as managed_job_state
+from sky.schemas.api import responses
 from sky.skylet import constants
 from sky.skylet import job_lib
 from sky.skylet import log_lib
@@ -1517,7 +1518,7 @@ def load_managed_job_queue(
 
 
 def _get_job_status_from_tasks(
-    job_tasks: List[Dict[str, Any]]
+    job_tasks: Union[List[responses.ManagedJobRecord], List[Dict[str, Any]]]
 ) -> Tuple[managed_job_state.ManagedJobStatus, int]:
     """Get the current task status and the current task id for a job."""
     managed_task_status = managed_job_state.ManagedJobStatus.SUCCEEDED
@@ -1537,7 +1538,8 @@ def _get_job_status_from_tasks(
 
 
 @typing.overload
-def format_job_table(tasks: List[Dict[str, Any]],
+def format_job_table(tasks: Union[List[responses.ManagedJobRecord],
+                                  List[Dict[str, Any]]],
                      show_all: bool,
                      show_user: bool,
                      return_rows: Literal[False] = False,
@@ -1546,7 +1548,8 @@ def format_job_table(tasks: List[Dict[str, Any]],
 
 
 @typing.overload
-def format_job_table(tasks: List[Dict[str, Any]],
+def format_job_table(tasks: Union[List[responses.ManagedJobRecord],
+                                  List[Dict[str, Any]]],
                      show_all: bool,
                      show_user: bool,
                      return_rows: Literal[True],
@@ -1555,7 +1558,7 @@ def format_job_table(tasks: List[Dict[str, Any]],
 
 
 def format_job_table(
-        tasks: List[Dict[str, Any]],
+        tasks: Union[List[responses.ManagedJobRecord], List[Dict[str, Any]]],
         show_all: bool,
         show_user: bool,
         return_rows: bool = False,

--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -157,24 +157,7 @@ class StorageRecord(ResponseBaseModel):
 
 
 class ManagedJobRecord(ResponseBaseModel):
-    """Response for the managed job queue endpoint.
-    {
-        'job_id': int,
-        'job_name': str,
-        'resources': str,
-        'submitted_at': (float) timestamp of submission,
-        'end_at': (float) timestamp of end,
-        'job_duration': (float) duration in seconds,
-        'recovery_count': (int) Number of retries,
-        'status': (sky.jobs.ManagedJobStatus) of the job,
-        'cluster_resources': (str) resources of the cluster,
-        'region': (str) region of the cluster,
-        'user_name': (Optional[str]) job creator's user name,
-        'user_hash': (str) job creator's user hash,
-        'task_id': (int), set to 0 (except in pipelines, which may have multiple tasks), # pylint: disable=line-too-long
-        'task_name': (str), same as job_name (except in pipelines, which may have multiple tasks), # pylint: disable=line-too-long
-    }
-    """
+    """A single managed job record."""
     job_id: Optional[int] = None
     task_id: Optional[int] = None
     job_name: Optional[str] = None
@@ -212,4 +195,4 @@ class ManagedJobRecord(ResponseBaseModel):
     pool_hash: Optional[str] = None
     current_cluster_name: Optional[str] = None
     job_id_on_pool_cluster: Optional[int] = None
-    accelerators: Optional[Dict[str, float]] = None
+    accelerators: Optional[Dict[str, int]] = None

--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -212,3 +212,4 @@ class ManagedJobRecord(ResponseBaseModel):
     pool_hash: Optional[str] = None
     current_cluster_name: Optional[str] = None
     job_id_on_pool_cluster: Optional[int] = None
+    accelerators: Optional[Dict[str, float]] = None

--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -176,19 +176,39 @@ class ManagedJobRecord(ResponseBaseModel):
     }
     """
     job_id: Optional[int] = None
+    task_id: Optional[int] = None
     job_name: Optional[str] = None
-    resources: Optional[str] = None
-    # None if the job has not been submitted yet.
-    submitted_at: Optional[float] = None
-    # None if the job has not ended yet.
-    end_at: Optional[float] = None
+    task_name: Optional[str] = None
     job_duration: Optional[float] = None
-    recovery_count: Optional[int] = None
+    workspace: Optional[str] = None
     status: Optional[job_state.ManagedJobStatus] = None
+    schedule_state: Optional[str] = None
+    resources: Optional[str] = None
     cluster_resources: Optional[str] = None
+    cluster_resources_full: Optional[str] = None
+    cloud: Optional[str] = None
     region: Optional[str] = None
+    zone: Optional[str] = None
+    infra: Optional[str] = None
+    recovery_count: Optional[int] = None
+    details: Optional[str] = None
+    failure_reason: Optional[str] = None
     user_name: Optional[str] = None
     user_hash: Optional[str] = None
-    task_id: Optional[int] = None
-    task_name: Optional[str] = None
-    schedule_state: Optional[str] = None
+    submitted_at: Optional[float] = None
+    start_at: Optional[float] = None
+    end_at: Optional[float] = None
+    user_yaml: Optional[str] = None
+    entrypoint: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    controller_pid: Optional[int] = None
+    dag_yaml_path: Optional[str] = None
+    env_file_path: Optional[str] = None
+    last_recovered_at: Optional[float] = None
+    run_timestamp: Optional[str] = None
+    priority: Optional[int] = None
+    original_user_yaml_path: Optional[str] = None
+    pool: Optional[str] = None
+    pool_hash: Optional[str] = None
+    current_cluster_name: Optional[str] = None
+    job_id_on_pool_cluster: Optional[int] = None

--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -7,6 +7,7 @@ import pydantic
 
 from sky import data
 from sky import models
+from sky.jobs import state as job_state
 from sky.server import common
 from sky.skylet import job_lib
 from sky.utils import status_lib
@@ -153,3 +154,40 @@ class StorageRecord(ResponseBaseModel):
     store: List[data.StoreType]
     last_use: str
     status: status_lib.StorageStatus
+
+
+class ManagedJobRecord(ResponseBaseModel):
+    """Response for the managed job queue endpoint.
+    {
+        'job_id': int,
+        'job_name': str,
+        'resources': str,
+        'submitted_at': (float) timestamp of submission,
+        'end_at': (float) timestamp of end,
+        'job_duration': (float) duration in seconds,
+        'recovery_count': (int) Number of retries,
+        'status': (sky.jobs.ManagedJobStatus) of the job,
+        'cluster_resources': (str) resources of the cluster,
+        'region': (str) region of the cluster,
+        'user_name': (Optional[str]) job creator's user name,
+        'user_hash': (str) job creator's user hash,
+        'task_id': (int), set to 0 (except in pipelines, which may have multiple tasks), # pylint: disable=line-too-long
+        'task_name': (str), same as job_name (except in pipelines, which may have multiple tasks), # pylint: disable=line-too-long
+    }
+    """
+    job_id: Optional[int] = None
+    job_name: Optional[str] = None
+    resources: Optional[str] = None
+    # None if the job has not been submitted yet.
+    submitted_at: Optional[float] = None
+    # None if the job has not ended yet.
+    end_at: Optional[float] = None
+    job_duration: Optional[float] = None
+    recovery_count: Optional[int] = None
+    status: Optional[job_state.ManagedJobStatus] = None
+    cluster_resources: Optional[str] = None
+    region: Optional[str] = None
+    user_name: Optional[str] = None
+    user_hash: Optional[str] = None
+    task_id: Optional[int] = None
+    task_name: Optional[str] = None

--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -156,6 +156,8 @@ class StorageRecord(ResponseBaseModel):
     status: status_lib.StorageStatus
 
 
+# TODO (syang) figure out which fields are always present
+# and therefore can be non-optional.
 class ManagedJobRecord(ResponseBaseModel):
     """A single managed job record."""
     job_id: Optional[int] = None

--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -191,3 +191,4 @@ class ManagedJobRecord(ResponseBaseModel):
     user_hash: Optional[str] = None
     task_id: Optional[int] = None
     task_name: Optional[str] = None
+    schedule_state: Optional[str] = None

--- a/sky/server/requests/serializers/decoders.py
+++ b/sky/server/requests/serializers/decoders.py
@@ -72,7 +72,7 @@ def decode_status_kubernetes(
                         List[Dict[str, Any]], Optional[str]]
 ) -> Tuple[List[kubernetes_utils.KubernetesSkyPilotClusterInfoPayload],
            List[kubernetes_utils.KubernetesSkyPilotClusterInfoPayload],
-           List[Dict[str, Any]], Optional[str]]:
+           List[responses.ManagedJobRecord], Optional[str]]:
     (encoded_all_clusters, encoded_unmanaged_clusters, all_jobs,
      context) = return_value
     all_clusters = []
@@ -85,6 +85,7 @@ def decode_status_kubernetes(
         cluster['status'] = status_lib.ClusterStatus(cluster['status'])
         unmanaged_clusters.append(
             kubernetes_utils.KubernetesSkyPilotClusterInfoPayload(**cluster))
+    all_jobs = [responses.ManagedJobRecord(**job) for job in all_jobs]
     return all_clusters, unmanaged_clusters, all_jobs, context
 
 
@@ -115,7 +116,7 @@ def decode_jobs_queue(return_value: List[dict],) -> List[Dict[str, Any]]:
 
 
 @register_decoders('jobs.queue_v2')
-def decode_jobs_queue_v2(return_value) -> List[Dict[str, Any]]:
+def decode_jobs_queue_v2(return_value) -> List[responses.ManagedJobRecord]:
     """Decode jobs queue response.
 
     Supports legacy list, or a dict {jobs, total}.
@@ -129,6 +130,7 @@ def decode_jobs_queue_v2(return_value) -> List[Dict[str, Any]]:
         jobs = return_value
     for job in jobs:
         job['status'] = managed_jobs.ManagedJobStatus(job['status'])
+    jobs = [responses.ManagedJobRecord(**job) for job in jobs]
     return jobs
 
 

--- a/sky/server/requests/serializers/encoders.py
+++ b/sky/server/requests/serializers/encoders.py
@@ -107,7 +107,7 @@ def encode_status_kubernetes(
     return_value: Tuple[
         List['kubernetes_utils.KubernetesSkyPilotClusterInfoPayload'],
         List['kubernetes_utils.KubernetesSkyPilotClusterInfoPayload'],
-        List[Dict[str, Any]], Optional[str]]
+        List[responses.ManagedJobRecord], Optional[str]]
 ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]],
            Optional[str]]:
     all_clusters, unmanaged_clusters, all_jobs, context = return_value
@@ -121,6 +121,7 @@ def encode_status_kubernetes(
         encoded_cluster = dataclasses.asdict(cluster)
         encoded_cluster['status'] = encoded_cluster['status'].value
         encoded_unmanaged_clusters.append(encoded_cluster)
+    all_jobs = [job.model_dump() for job in all_jobs]
     return encoded_all_clusters, encoded_unmanaged_clusters, all_jobs, context
 
 
@@ -150,9 +151,9 @@ def encode_jobs_queue_v2(
     for job in jobs:
         job['status'] = job['status'].value
     if total is None:
-        return jobs
+        return [job.model_dump() for job in jobs]
     return {
-        'jobs': jobs,
+        'jobs': [job.model_dump() for job in jobs],
         'total': total,
         'total_no_filter': total_no_filter,
         'status_counts': status_counts


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Instead of returning an ambiguous`Dict[str, Any]` to the user when managed job queue (or kubernetes status) is called, return a pydantic response which makes the response fields easier to use by the user.

Changes:
- Add a response schema at `schemas/api/responses.py`. 
- Have the server (`sky/jobs/server/core.py`) return said response type for jobs queue API, and have the SDK (`sky/jobs/client/sdk.py`) return the said response type to user.
- Have the server (`sky/core.py`) return said response type for status_kubernetes API, and have the SDK (`sky/client/sdk.py`) return the said response type to user.
- Add a jobs table formatting utility in `sky/client/cli/table_utils.py` which takes in the new `ManagedJobRecord` as argument.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
