### PR TITLE
[CLI] Handle missing instance types in sky cost-report

### DIFF
--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -6,6 +6,7 @@ import click
 import colorama
 
 from sky import backends
+from sky import sky_logging
 from sky.schemas.api import responses
 from sky.utils import common_utils
 from sky.utils import log_utils
@@ -26,6 +27,8 @@ NUM_COST_REPORT_LINES = 5
 _ClusterRecord = Dict[str, Any]
 # A record returned by core.cost_report(); see its docstr for all fields.
 _ClusterCostReportRecord = Dict[str, Any]
+
+logger = sky_logging.init_logger(__name__)
 
 
 class StatusColumn:
@@ -378,7 +381,12 @@ def _get_resources_for_cost_report(
     launched_nodes = cluster_cost_report_record['num_nodes']
     launched_resources = cluster_cost_report_record['resources']
 
-    launched_resource_str = str(launched_resources)
+    try:
+        launched_resource_str = str(launched_resources)
+    except ValueError as e:
+        logger.debug(f'Failed to get resources string: {e}')
+        launched_resource_str = (f'{launched_resources.cloud}'
+                                 f'({launched_resources.instance_type})')
     resources_str = (f'{launched_nodes}x '
                      f'{launched_resource_str}')
 
@@ -392,8 +400,12 @@ def _get_price_for_cost_report(
     launched_nodes = cluster_cost_report_record['num_nodes']
     launched_resources = cluster_cost_report_record['resources']
 
-    hourly_cost = (launched_resources.get_cost(3600) * launched_nodes)
-    price_str = f'$ {hourly_cost:.2f}'
+    try:
+        hourly_cost = (launched_resources.get_cost(3600) * launched_nodes)
+        price_str = f'$ {hourly_cost:.2f}'
+    except ValueError as e:
+        logger.debug(f'Failed to get price: {e}')
+        price_str = '[Price unavailable]'
     return price_str
 
 

--- a/tests/unit_tests/test_sky/test_cost_report.py
+++ b/tests/unit_tests/test_sky/test_cost_report.py
@@ -494,7 +494,7 @@ class TestCostReportMissingInstanceType(unittest.TestCase):
                                                             truncate=True)
 
         # Should return the fallback price string
-        self.assertEqual(price_str, '[Price unavailable]')
+        self.assertEqual(price_str, status_utils.PRICE_UNAVAILABLE)
 
         # Verify get_cost was called
         mock_resources.get_cost.assert_called_once_with(3600)


### PR DESCRIPTION
Fixes #7304.

`sky cost-report` was failing when an instance type is not found on the catalog, because it tries to lookup the accelerator and hourly price of the instance. Instance types could go missing because our catalogs are periodically updated, and instance types might be retired by cloud providers.

This PR fixes this by handling this error,  logs a warning, and displaying a minimal str representation, and `[Price unavailable]` for the hourly price, for those clusters with missing instance types.

Preview:
```
% SKYPILOT_DEBUG=0 sky cost-report --days 3 --all
WARNING: Pricing is not available for some clusters. Some instance types may be missing from the catalog.
Clusters (last 3 days)
NAME                       LAUNCHED     DURATION           RESOURCES                          STATUS      COST/hr              COST (est.)
sky-cmd-6                  14 hrs ago   1m 5s              1x Kubernetes(2CPU--2GB)           TERMINATED  $ 0.00               -
sky-b2be-kevin             14 hrs ago   2m 51s             1x Kubernetes(2CPU--2GB)           TERMINATED  $ 0.00               -
sky-cmd-2                  18 hrs ago   1m 3s              1x Kubernetes(2CPU--2GB)           TERMINATED  $ 0.00               -
sky-0a83-kevin             2 days ago   2d 4h 23m 50s      1x AWS(m6i.2xlarge, disk_size=20)  TERMINATED  $ 0.38               $ 20.12
sky-7d5c-kevin             2 days ago   2h 35m 30s         1x AWS(m6i.large)                  TERMINATED  [Price unavailable]  -
```

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Added unit tests
  - Tested manually by removing `m6i.large` from my local catalog (`~/.sky/catalogs/v8/aws/vms.csv`) and running `sky cost-report`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
