### PR TITLE
[Pools] Add Pool Version to Workers in Dashboard

### DIFF
--- a/sky/dashboard/src/pages/jobs/pools/[pool].js
+++ b/sky/dashboard/src/pages/jobs/pools/[pool].js
@@ -685,9 +685,7 @@ export default function PoolDetailPage() {
                         <TableCell>
                           <StatusBadge status={worker.status} />
                         </TableCell>
-                        <TableCell>
-                          {worker.version || '-'}
-                        </TableCell>
+                        <TableCell>{worker.version || '-'}</TableCell>
                         <TableCell>
                           {worker.used_by ? (
                             <Link

--- a/sky/dashboard/src/pages/jobs/pools/[pool].js
+++ b/sky/dashboard/src/pages/jobs/pools/[pool].js
@@ -556,6 +556,12 @@ export default function PoolDetailPage() {
                     </TableHead>
                     <TableHead
                       className="sortable whitespace-nowrap"
+                      onClick={() => requestSort('version')}
+                    >
+                      Pool Version{getSortDirection('version')}
+                    </TableHead>
+                    <TableHead
+                      className="sortable whitespace-nowrap"
                       onClick={() => requestSort('used_by')}
                     >
                       Used By{getSortDirection('used_by')}
@@ -680,6 +686,9 @@ export default function PoolDetailPage() {
                           <StatusBadge status={worker.status} />
                         </TableCell>
                         <TableCell>
+                          {worker.version || '-'}
+                        </TableCell>
+                        <TableCell>
                           {worker.used_by ? (
                             <Link
                               href={`/jobs/${worker.used_by}`}
@@ -696,7 +705,7 @@ export default function PoolDetailPage() {
                   ) : (
                     <TableRow>
                       <TableCell
-                        colSpan={6}
+                        colSpan={7}
                         className="text-center py-8 text-gray-500"
                       >
                         {showFailedWorkers


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR adds the version of the pool that the worker is on in the dashboard under `/jobs/pools` under 'Pool Version' addressing issue https://github.com/skypilot-org/skypilot/issues/6930.

<img width="3382" height="464" alt="image" src="https://github.com/user-attachments/assets/13857b54-62d5-4f8f-b01d-2adfdcb15fb0" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
