### PR TITLE
chore: fix typos in comment

### DIFF
--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -923,7 +923,7 @@ To reuse an existing ingress controller, you can set :ref:`ingress-nginx.enabled
 
     # The first API server, with niginx-ingress controller deployed
     # It is assumed that the first API server is already deployed. If it is not deployed yet,
-    # add neccessary values instead of specifying --reuse-values
+    # add necessary values instead of specifying --reuse-values
     helm upgrade --install $RELEASE_NAME skypilot/skypilot-nightly --devel \
         --namespace $NAMESPACE \
         --reuse-values \

--- a/docs/source/reference/api-server/api-server-upgrade.rst
+++ b/docs/source/reference/api-server/api-server-upgrade.rst
@@ -261,7 +261,7 @@ The SkyPilot helm chart automatically configures the ingress resource to achieve
 
 .. _sky-api-server-api-compatibility:
 
-API compatbility
+API compatibility
 ----------------
 
 SkyPilot maintain an internal API version which will be bumped when an incompatible API change is introduced. Client and server can only communicate when they run on the same API version.

--- a/docs/source/reference/api-server/api-server-upgrade.rst
+++ b/docs/source/reference/api-server/api-server-upgrade.rst
@@ -262,7 +262,7 @@ The SkyPilot helm chart automatically configures the ingress resource to achieve
 .. _sky-api-server-api-compatibility:
 
 API compatibility
-----------------
+-----------------
 
 SkyPilot maintain an internal API version which will be bumped when an incompatible API change is introduced. Client and server can only communicate when they run on the same API version.
 

--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -237,7 +237,7 @@ class TestBackwardCompatibility:
             f'{self.ACTIVATE_BASE} && sky autostop -i 10 -y {cluster_name}',
             f'{self.ACTIVATE_BASE} && sky exec -d --cloud {generic_cloud} --num-nodes 2 {cluster_name} sleep 120',
             # Must restart API server after switch the code base to ensure the client and server run in same version.
-            # Test coverage for client and server run in differnet verions should be done in test_client_server_compatibility.
+            # Test coverage for client and server run in differnet versions should be done in test_client_server_compatibility.
             f'{self.ACTIVATE_CURRENT} && {smoke_tests_utils.SKY_API_RESTART} && result="$(sky status {cluster_name})"; echo "$result"; echo "$result" | grep UP',
             f'{self.ACTIVATE_CURRENT} && result="$(sky status -r {cluster_name})"; echo "$result"; echo "$result" | grep UP',
             need_launch_cmd,


### PR DESCRIPTION
Corrected misspellings:

- `neccessary` → `necessary`
- `compatbility` → `compatibility`
- `verions` → `versions`