### PR TITLE
[core] support docker ssh proxy via jump host

### DIFF
--- a/sky/utils/cluster_utils.py
+++ b/sky/utils/cluster_utils.py
@@ -202,18 +202,17 @@ class SSHConfigHelper(object):
                 if inner_proxy is not None:
                     inner_proxy = inner_proxy.replace('%h', ip)
                     inner_proxy = inner_proxy.replace('%p', str(inner_port))
-                return ' '.join(
-                    ['ssh'] + command_runner.ssh_options_list(
-                        key_path,
-                        ssh_control_name=None,
-                        ssh_proxy_command=inner_proxy,
-                        port=inner_port,
-                        # ProxyCommand (ssh -W) is a forwarding tunnel, not an
-                        # interactive session. ControlMaster would cache these
-                        # processes, causing them to hang and block subsequent
-                        # connections. Each ProxyCommand should be ephemeral.
-                        disable_control_master=True) +
-                    ['-W', '%h:%p', f'{auth_config["ssh_user"]}@{ip}'])
+                return ' '.join(['ssh'] + command_runner.ssh_options_list(
+                    key_path,
+                    ssh_control_name=None,
+                    ssh_proxy_command=inner_proxy,
+                    port=inner_port,
+                    # ProxyCommand (ssh -W) is a forwarding tunnel, not an
+                    # interactive session. ControlMaster would cache these
+                    # processes, causing them to hang and block subsequent
+                    # connections. Each ProxyCommand should be ephemeral.
+                    disable_control_master=True
+                ) + ['-W', '%h:%p', f'{auth_config["ssh_user"]}@{ip}'])
 
             docker_proxy_command_generator = _docker_proxy_cmd
             proxy_command_for_nodes = None

--- a/sky/utils/cluster_utils.py
+++ b/sky/utils/cluster_utils.py
@@ -208,6 +208,10 @@ class SSHConfigHelper(object):
                         ssh_control_name=None,
                         ssh_proxy_command=inner_proxy,
                         port=inner_port,
+                        # ProxyCommand (ssh -W) is a forwarding tunnel, not an
+                        # interactive session. ControlMaster would cache these
+                        # processes, causing them to hang and block subsequent
+                        # connections. Each ProxyCommand should be ephemeral.
                         disable_control_master=True) +
                     ['-W', '%h:%p', f'{auth_config["ssh_user"]}@{ip}'])
 

--- a/sky/utils/cluster_utils.py
+++ b/sky/utils/cluster_utils.py
@@ -195,6 +195,7 @@ class SSHConfigHelper(object):
         docker_proxy_command_generator = None
         proxy_command_for_nodes = proxy_command
         if docker_user is not None:
+
             def _docker_proxy_cmd(ip: str, port: int) -> str:
                 inner_proxy = proxy_command
                 inner_port = port or 22

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -670,12 +670,12 @@ class SSHCommandRunner(CommandRunner):
                 inner_proxy_command = inner_proxy_command.replace(
                     '%p', str(inner_proxy_port))
             self._docker_ssh_proxy_command = lambda ssh: ' '.join(
-                ssh + ssh_options_list(
-                    ssh_private_key,
-                    None,
-                    ssh_proxy_command=inner_proxy_command,
-                    port=inner_proxy_port,
-                    disable_control_master=self.disable_control_master) +
+                ssh + ssh_options_list(ssh_private_key,
+                                       None,
+                                       ssh_proxy_command=inner_proxy_command,
+                                       port=inner_proxy_port,
+                                       disable_control_master=self.
+                                       disable_control_master) +
                 ['-W', '%h:%p', f'{ssh_user}@{ip}'])
         else:
             self.ip = ip

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -652,15 +652,31 @@ class SSHCommandRunner(CommandRunner):
         if docker_user is not None:
             assert port is None or port == 22, (
                 f'port must be None or 22 for docker_user, got {port}.')
-            # Already checked in resources
-            assert ssh_proxy_command is None, (
-                'ssh_proxy_command is not supported when using docker.')
+            # When connecting via docker, the outer SSH hop points to the
+            # container's sshd (localhost). Preserve the user proxy for the
+            # inner hop that reaches the host VM, and clear the outer proxy to
+            # avoid forwarding localhost through the jump host.
+            inner_proxy_command = ssh_proxy_command
+            inner_proxy_port = port or 22
+            self._ssh_proxy_command = None
             self.ip = 'localhost'
             self.ssh_user = docker_user
             self.port = constants.DEFAULT_DOCKER_PORT
+            if inner_proxy_command is not None:
+                # Replace %h/%p placeholders with actual host values, since the
+                # final destination from the perspective of the user proxy is
+                # the host VM (ip, inner_proxy_port).
+                inner_proxy_command = inner_proxy_command.replace('%h', ip)
+                inner_proxy_command = inner_proxy_command.replace(
+                    '%p', str(inner_proxy_port))
             self._docker_ssh_proxy_command = lambda ssh: ' '.join(
-                ssh + ssh_options_list(ssh_private_key, None
-                                      ) + ['-W', '%h:%p', f'{ssh_user}@{ip}'])
+                ssh + ssh_options_list(
+                    ssh_private_key,
+                    None,
+                    ssh_proxy_command=inner_proxy_command,
+                    port=inner_proxy_port,
+                    disable_control_master=self.disable_control_master) +
+                ['-W', '%h:%p', f'{ssh_user}@{ip}'])
         else:
             self.ip = ip
             self.ssh_user = ssh_user

--- a/sky/utils/command_runner.pyi
+++ b/sky/utils/command_runner.pyi
@@ -142,8 +142,10 @@ class SSHCommandRunner(CommandRunner):
         ssh_user: str,
         ssh_private_key: str,
         ssh_control_name: Optional[str] = ...,
+        ssh_proxy_command: Optional[str] = ...,
         docker_user: Optional[str] = ...,
         disable_control_master: Optional[bool] = ...,
+        port_forward_execute_remote_command: Optional[bool] = ...,
     ) -> None:
         ...
 
@@ -196,6 +198,15 @@ class SSHCommandRunner(CommandRunner):
             source_bashrc: bool = ...,
             skip_lines: int = ...,
             **kwargs) -> Union[Tuple[int, str, str], int]:
+        ...
+
+    def ssh_base_command(
+        self,
+        *,
+        ssh_mode: SshMode,
+        port_forward: Optional[List[Tuple[int, int]]],
+        connect_timeout: Optional[int],
+    ) -> List[str]:
         ...
 
     def rsync(self,

--- a/tests/unit_tests/test_sky/utils/test_command_runner.py
+++ b/tests/unit_tests/test_sky/utils/test_command_runner.py
@@ -19,7 +19,8 @@ def test_docker_runner_passes_proxy_command_to_inner_hop() -> None:
     assert runner._ssh_proxy_command is None  # type: ignore[attr-defined]
 
     # Inner hop must include the user proxy command before targeting the host VM.
-    inner_cmd = runner._docker_ssh_proxy_command(['ssh', '-T'])  # type: ignore[attr-defined]
+    inner_cmd = runner._docker_ssh_proxy_command(
+        ['ssh', '-T'])  # type: ignore[attr-defined]
     assert "ProxyCommand='ssh -W 10.0.0.5:22 jump@host'" in inner_cmd
     assert inner_cmd.endswith('ubuntu@10.0.0.5')
 

--- a/tests/unit_tests/test_sky/utils/test_command_runner.py
+++ b/tests/unit_tests/test_sky/utils/test_command_runner.py
@@ -1,0 +1,31 @@
+"""Unit tests for sky.utils.command_runner."""
+
+from sky.utils import command_runner
+
+
+def test_docker_runner_passes_proxy_command_to_inner_hop() -> None:
+    """Ensure docker-mode runners reuse user proxy for the host hop."""
+    proxy_cmd = 'ssh -W %h:%p jump@host'
+    runner = command_runner.SSHCommandRunner(
+        node=('10.0.0.5', 22),
+        ssh_user='ubuntu',
+        ssh_private_key='/tmp/fake-key',
+        ssh_proxy_command=proxy_cmd,
+        docker_user='container',
+        ssh_control_name='unit-test-control',
+    )
+
+    # Proxy command should be consumed by the docker bridge, not the outer hop.
+    assert runner._ssh_proxy_command is None  # type: ignore[attr-defined]
+
+    # Inner hop must include the user proxy command before targeting the host VM.
+    inner_cmd = runner._docker_ssh_proxy_command(['ssh', '-T'])  # type: ignore[attr-defined]
+    assert "ProxyCommand='ssh -W 10.0.0.5:22 jump@host'" in inner_cmd
+    assert inner_cmd.endswith('ubuntu@10.0.0.5')
+
+    outer_cmd = runner.ssh_base_command(
+        ssh_mode=command_runner.SshMode.NON_INTERACTIVE,
+        port_forward=None,
+        connect_timeout=None,
+    )
+    assert outer_cmd[-1] == 'container@localhost'


### PR DESCRIPTION
Fixes #7054

This PR lets the docker SSH tunnel honor users' jump-host proxy command so docker workloads can run on private IPs.

## Problem
- docker nodes run sshd on localhost:10022 inside the container. SkyPilot used to clear `ssh_proxy_command` whenever `docker_user` was set, because the outer hop incorrectly attempted to run through the jump host. That broke the connection for private-only nodes.
- cluster_utils wrote both `ProxyCommand` values into `~/.ssh/config`, triggering `AssertionError: Cannot specify both proxy_command and docker_proxy_command.` in recent builds.

## Solution
- Inject the user proxy into the inner hop only (`ssh -W host:port gcpuser@vm`), while the outer hop stays pointed at localhost. `%h`/`%p` placeholders are resolved before assembling the docker proxy string so the jump host sees the actual host IP/port.
- Update cluster_utils to generate a single ProxyCommand entry aligned with the new behaviour and add unit coverage for the resolved command string.

Tested (run the relevant ones):
- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR
      - `sky launch -y -c jump-host jump_host.yaml` (fresh bastion host)
      - `gcloud compute routers create sky-nat-router-benchmark` / `gcloud compute routers nats create sky-nat-benchmark` (Cloud NAT so the private VM can reach Debian/Docker registries)
      - `sky launch -y -c docker-proxy-test docker_proxy_test.yaml` using `docker:gcr.io/google.com/cloudsdktool/cloud-sdk:slim`
      - `sky exec docker-proxy-test -- bash -lc 'whoami && echo $HOSTNAME'`
      - Confirmed the generated entry `~/.sky/generated/ssh/docker-proxy-test` now contains a single nested `ProxyCommand='ssh ... -W 10.129.x.x:22 jump-host'` followed by `-W %h:%p`, matching the intended three-hop chain
- [ ] All smoke tests: `pytest tests/test_smoke.py`
- [ ] Relevant individual tests: `pytest tests/test_smoke.py::test_name`
- [ ] Backward compatibility test with existing clusters
