### PR TITLE
[Docs] Pools - Fix Indent and Tweak Wording

### DIFF
--- a/docs/source/examples/managed-jobs.rst
+++ b/docs/source/examples/managed-jobs.rst
@@ -454,14 +454,15 @@ To submit the pipeline, the same command :code:`sky jobs launch` is used. The pi
 
 .. _pool:
 
-Using pools [EXPERIMENTAL]
+Using pools (Experimental)
 --------------------------
 
 .. warning::
 
   Pools are currently in alpha so some features are not currently supported:
-  * Pools does not currently support heterogeneous clusters (e.g., mixed H100 and H200 workers)
-  * Pools does not currently support multiple jobs running concurrently on the same worker
+
+  - Pools does not currently support heterogeneous clusters (e.g., mixed H100 and H200 workers)
+  - Pools does not currently support multiple jobs running concurrently on the same worker
 
 SkyPilot supports spawning a **pool** for launching many jobs that share the same environment — for example, batch inference or large-scale data processing.
 

--- a/docs/source/examples/managed-jobs.rst
+++ b/docs/source/examples/managed-jobs.rst
@@ -454,7 +454,7 @@ To submit the pipeline, the same command :code:`sky jobs launch` is used. The pi
 
 .. _pool:
 
-Using pools (Experimental)
+Using pools (experimental)
 --------------------------
 
 .. warning::


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR updates the pools docs to say (Experimental) instead of [EXPERIMENTAL] and fixes the indentation inside the warning.

<img width="1630" height="442" alt="image" src="https://github.com/user-attachments/assets/f1b6d435-e598-4e9b-9843-fd9d4a388fe2" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
