### PR TITLE
[Pools] Add Cancelled Check to Prevent Transition to FAILED_CONTROLLER

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -363,6 +363,21 @@ class JobsController:
             cluster_name, job_id_on_pool_cluster = (
                 await
                 managed_job_state.get_pool_submit_info_async(self._job_id))
+        if cluster_name is None:
+            # Check if we have been cancelled here, in the case where a user
+            # quickly cancels the job we want to gracefully handle it here,
+            # otherwise we will end up in the FAILED_CONTROLLER state.
+            self._logger.info(f'Cluster name is None for job {self._job_id}, '
+                              f'task {task_id}. Checking if we have been '
+                              'cancelled.')
+            status = await (managed_job_state.get_job_status_with_task_id_async(
+                job_id=self._job_id, task_id=task_id))
+            self._logger.debug(f'Status for job {self._job_id}, task {task_id}:'
+                               f'{status}')
+            if status == managed_job_state.ManagedJobStatus.CANCELLED:
+                self._logger.info(f'Job {self._job_id}, task {task_id} has '
+                                  'been quickly cancelled.')
+                raise asyncio.CancelledError()
         assert cluster_name is not None, (cluster_name, job_id_on_pool_cluster)
 
         if not is_resume:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Before this PR if a user quickly cancelled a pools job as soon as launch succeeded then the launch process on the controller would error out trying to retrieve the cluster name (replica name) and the job id on the pool. The result is that the job would transition from the `CANCELLED` state to the `FAILED_CONTROLLER` rather than staying in `CANCELLED`. Instead we now check if the job is already in the `CANCELLED` state and raise the same error that we do when are resuming from a controller failure and the job happens to already be `CANCELLED`.

We saw this happen in the `test_pool_job_cancel_instant_multiple_simultaneous` smoke test. I verified manually that this code path caught this exact case and prevented us from going to the wrong state.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
