### PR TITLE
[test] smoke test for "Fix improper argument parsing in fusermount"

### DIFF
--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -340,11 +340,13 @@ def test_azure_storage_mounts_with_stop():
 @pytest.mark.kubernetes
 @pytest.mark.parametrize(
     'storage_name_prefix',
-    ['sky-test',
-    # split the alphabet into 2 parts
-    # to avoid the storage name being too long.
-    '0-a-b-c-d-e-f-g-h-i-j-k-l-m',
-    '0-n-o-p-q-r-s-t-u-v-w-x-y-z',])
+    [
+        'sky-test',
+        # split the alphabet into 2 parts
+        # to avoid the storage name being too long.
+        '0-a-b-c-d-e-f-g-h-i-j-k-l-m',
+        '0-n-o-p-q-r-s-t-u-v-w-x-y-z',
+    ])
 def test_kubernetes_storage_mounts(storage_name_prefix: str):
     # Tests bucket mounting on k8s, assuming S3 is configured.
     # S3 mounting now works on all architectures including ARM64

--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -340,7 +340,11 @@ def test_azure_storage_mounts_with_stop():
 @pytest.mark.kubernetes
 @pytest.mark.parametrize(
     'storage_name_prefix',
-    ['sky-test', '0-a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p-q-r-s-t-u-v-w-x-y-z'])
+    ['sky-test',
+    # split the alphabet into 2 parts
+    # to avoid the storage name being too long.
+    '0-a-b-c-d-e-f-g-h-i-j-k-l-m',
+    '0-n-o-p-q-r-s-t-u-v-w-x-y-z',])
 def test_kubernetes_storage_mounts(storage_name_prefix: str):
     # Tests bucket mounting on k8s, assuming S3 is configured.
     # S3 mounting now works on all architectures including ARM64

--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -338,12 +338,15 @@ def test_azure_storage_mounts_with_stop():
 
 
 @pytest.mark.kubernetes
-def test_kubernetes_storage_mounts():
+@pytest.mark.parametrize(
+    'storage_name_prefix',
+    ['sky-test', '0-a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p-q-r-s-t-u-v-w-x-y-z'])
+def test_kubernetes_storage_mounts(storage_name_prefix: str):
     # Tests bucket mounting on k8s, assuming S3 is configured.
     # S3 mounting now works on all architectures including ARM64
     # (uses rclone fallback for ARM64, goofys for x86_64).
     name = smoke_tests_utils.get_cluster_name()
-    storage_name = f'sky-test-{int(time.time())}'
+    storage_name = f'{storage_name_prefix}-{int(time.time())}'
 
     s3_ls_cmd = TestStorageWithCredentials.cli_ls_cmd(storage_lib.StoreType.S3,
                                                       storage_name, 'hello.txt')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This smoke test will fail until a nightly build including https://github.com/skypilot-org/skypilot/pull/7424 is published, hence it is on a separate PR.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
