### PR TITLE
Add kubernetes volume smoke test for skyserve

### DIFF
--- a/tests/skyserve/http/kubernetes_volumes.yaml
+++ b/tests/skyserve/http/kubernetes_volumes.yaml
@@ -1,0 +1,28 @@
+volumes:
+  /mnt/data: my-pvc
+
+service:
+  readiness_probe:
+    path: /health
+    initial_delay_seconds: 180  # Use a large delay for EKS LB to be ready
+  replica_policy:
+    min_replicas: 1
+    max_replicas: 1
+
+resources:
+  ports: 8080
+  infra: kubernetes
+
+workdir: examples/serve/http_server
+
+# Use 8080 to test jupyter service is terminated
+run: |
+  # Test volume mount by checking if we can access the mounted directory
+  echo "Testing volume mount at /mnt/data"
+  ls -la /mnt/data || (echo "Volume mount failed" && exit 1)
+  # Create a test file to verify write access
+  echo "Hello from skyserve volume test" > /mnt/data/skyserve_test.txt || (echo "Cannot write to volume" && exit 1)
+  cat /mnt/data/skyserve_test.txt || (echo "Cannot read from volume" && exit 1)
+  echo "Volume test successful"
+  # Start the HTTP server
+  python3 server.py --port 8080

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -326,6 +326,30 @@ def test_skyserve_kubernetes_http():
     smoke_tests_utils.run_one_test(test)
 
 
+@pytest.mark.kubernetes
+@pytest.mark.serve
+@pytest.mark.no_remote_server
+def test_skyserve_kubernetes_volumes():
+    """Test skyserve on Kubernetes with PVC volumes"""
+    name = _get_service_name()
+    test = smoke_tests_utils.Test(
+        f'test-skyserve-kubernetes-volumes',
+        [
+            f'sky serve up -n {name} -y {smoke_tests_utils.LOW_RESOURCE_ARG} tests/skyserve/http/kubernetes_volumes.yaml',
+            _SERVE_WAIT_UNTIL_READY.format(name=name, replica_num=1),
+            f'{_SERVE_ENDPOINT_WAIT.format(name=name)}; '
+            'curl $endpoint | grep "Hi, SkyPilot here"',
+            # Additional check to verify the volume test passed by checking logs
+            f'logs=$(sky serve logs {name} 1 --no-follow); '
+            'echo "$logs" | grep "Volume test successful" || (echo "Volume test not found in logs" && exit 1)',
+        ],
+        _TEARDOWN_SERVICE.format(name=name),
+        env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
+        timeout=30 * 60,
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
 @pytest.mark.oci
 @pytest.mark.serve
 def test_skyserve_oci_http():


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Adds a new smoke test for SkyServe on Kubernetes to verify Persistent Volume Claim (PVC) mounting and read/write operations. This ensures that services deployed with Kubernetes volumes function as expected.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
    - `pytest tests/smoke_tests/test_sky_serve.py::test_skyserve_kubernetes_volumes --kubernetes`
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->

---
<a href="https://cursor.com/background-agent?bcId=bc-356e7355-07bb-4121-b44e-48c0304796e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-356e7355-07bb-4121-b44e-48c0304796e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

