### PR TITLE
[Test] Add smoke test for Serve with kubernetes volumes

### DIFF
--- a/tests/skyserve/http/kubernetes_volume.yaml.j2
+++ b/tests/skyserve/http/kubernetes_volume.yaml.j2
@@ -1,0 +1,21 @@
+volumes:
+  /mnt/data: {{ pvc_name }}
+
+service:
+  readiness_probe:
+    path: /health
+    initial_delay_seconds: 180  # Use a large delay for EKS LB to be ready
+  replicas: 2
+
+resources:
+  ports: 8080
+  infra: kubernetes
+
+workdir: examples/serve/http_server
+
+# Use 8080 to test jupyter service is terminated
+run: |
+  # Verify volume is mounted and writable
+  echo "Hello from volume!" > /mnt/data/hello.txt
+  cat /mnt/data/hello.txt
+  python3 server.py --port 8080

--- a/tests/skyserve/http/kubernetes_volume.yaml.j2
+++ b/tests/skyserve/http/kubernetes_volume.yaml.j2
@@ -5,7 +5,11 @@ service:
   readiness_probe:
     path: /health
     initial_delay_seconds: 180  # Use a large delay for EKS LB to be ready
-  replicas: 2
+  replica_policy:
+    min_replicas: 1
+    max_replicas: 2
+    target_qps_per_replica: 1
+    upscale_delay_seconds: 5
 
 resources:
   ports: 8080

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -361,7 +361,7 @@ def test_skyserve_kubernetes_http_with_volume():
         test = smoke_tests_utils.Test(
             'test-skyserve-kubernetes-volume',
             [
-                f'sky volumes apply {volume_yaml_path}',
+                f'sky volumes apply {volume_yaml_path} -y',
                 f'sky volumes ls | grep "{pvc_name}"',
                 f'sky serve up -n {name} -y {smoke_tests_utils.LOW_RESOURCE_ARG} {service_yaml_path}',
                 _SERVE_WAIT_UNTIL_READY.format(name=name, replica_num=2),

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -331,6 +331,7 @@ def test_skyserve_kubernetes_http():
 @pytest.mark.kubernetes
 @pytest.mark.serve
 @pytest.mark.no_remote_server
+@pytest.mark.resource_heavy  # kind local-path-provisioner only supports ReadWriteOnce access mode
 def test_skyserve_kubernetes_http_autoscaling_with_volume():
     """Test skyserve on Kubernetes with PVC volume"""
     name = _get_service_name()

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -373,7 +373,6 @@ def test_skyserve_kubernetes_http_autoscaling_with_volume():
                 f'sky serve logs {name} 1 --no-follow | grep "Hello from volume!"',
                 f'sky serve logs {name} 2 --no-follow | grep "Hello from volume!"',
             ],
-            'echo done',
             f'{_TEARDOWN_SERVICE.format(name=name)}; '
             f'sky volumes delete {pvc_name} -y',
             env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,

--- a/tests/test_yamls/rwmany_volume.yaml.j2
+++ b/tests/test_yamls/rwmany_volume.yaml.j2
@@ -1,0 +1,6 @@
+name: {{ volume_name }}
+type: k8s-pvc
+infra: kubernetes
+size: 1Gi
+config:
+  access_mode: ReadWriteMany


### PR DESCRIPTION
This PR adds a smoke test for SkyServe service on kubernetes using PVCs (created using `sky volumes`).

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - `test_skyserve_kubernetes_http_autoscaling_with_volume`
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
