### PR TITLE
[Volumes] Add ENV Variable Parsing to Volumes

### DIFF
--- a/sky/task.py
+++ b/sky/task.py
@@ -649,6 +649,10 @@ class Task:
             config['workdir'] = _fill_in_env_vars(config['workdir'],
                                                   env_and_secrets)
 
+        if config.get('volumes') is not None:
+            config['volumes'] = _fill_in_env_vars(config['volumes'],
+                                                  env_and_secrets)
+
         task = Task(
             config.pop('name', None),
             run=config.pop('run', None),
@@ -843,27 +847,6 @@ class Task:
         config['_user_specified_yaml'] = user_specified_yaml
         return Task.from_yaml_config(config)
 
-    def _replace_env_vars_in_volume_paths(self, vol_str: str) -> str:
-        """Replace environment variables in the volume path."""
-        return re.sub(
-            r'\$\{(\w+)\}',
-            lambda match: self._envs.get(match.group(1), match.group(0)),
-            vol_str)
-
-    def _resolve_volume_paths_with_envs(self) -> None:
-        """If the user has specified a volume path with an environment variable,
-        resolve the path to the actual volume name.
-        """
-        for dst_path, vol in self._volumes.items():
-            if isinstance(vol, str):
-                vol = self._replace_env_vars_in_volume_paths(vol)
-                self._volumes[dst_path] = vol
-            elif isinstance(vol, dict):
-                vol = self._replace_env_vars_in_volume_paths(vol['name'])
-                self._volumes[dst_path]['name'] = vol
-            else:
-                raise ValueError(f'Invalid volume config: {dst_path}: {vol}')
-
     def resolve_and_validate_volumes(self) -> None:
         """Resolve volumes config to volume mounts and validate them.
 
@@ -879,7 +862,6 @@ class Task:
             return None
         if not self._volumes:
             return None
-        self._resolve_volume_paths_with_envs()
         volume_mounts: List[volume_lib.VolumeMount] = []
         for dst_path, vol in self._volumes.items():
             self._validate_mount_path(dst_path, location='volumes')

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1041,6 +1041,22 @@ def test_volumes_on_kubernetes():
     smoke_tests_utils.run_one_test(test)
 
 
+@pytest.mark.kubernetes
+def test_volume_env_mount_kubernetes():
+    name = smoke_tests_utils.get_cluster_name()
+    pvc_name = f'{name}-pvc'
+    test = smoke_tests_utils.Test(
+        'volume_env_mount_kubernetes',
+        [
+            f'sky volumes apply -y -n user-pvc --type k8s-pvc --size 2GB',
+            f'sky launch -y -c {name} --infra kubernetes tests/test_yamls/pvc_volume.yaml',
+            f'sky logs {name} 1 --status',  # Ensure the job succeeded.
+        ],
+        f'sky down -y {name} && sky volumes delete user-pvc -y && (vol=$(sky volumes ls | grep "user-pvc"); if [ -n "$vol" ]; then echo "user-pvc not deleted" && exit 1; else echo "user-pvc deleted"; fi)',
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
 # ---------- Container logs from task on Kubernetes ----------
 @pytest.mark.kubernetes
 def test_container_logs_multinode_kubernetes():

--- a/tests/unit_tests/test_sky/test_task.py
+++ b/tests/unit_tests/test_sky/test_task.py
@@ -820,32 +820,58 @@ def test_resolve_volumes_override_topology():
 
 
 def test_resolve_volumes_with_envs():
-    t = task.Task()
-    t._volumes = {'/mnt': '${VOLUME_NAME}'}
-    t._envs = {'VOLUME_NAME': 'vol1'}
-    t._resolve_volume_paths_with_envs()
+
+    config = {
+        'volumes': {
+            '/mnt': '${VOLUME_NAME}'
+        },
+        'envs': {
+            'VOLUME_NAME': 'vol1'
+        }
+    }
+    t = task.Task.from_yaml_config(config)
     assert t._volumes == {'/mnt': 'vol1'}
 
 
 def test_resolve_volumes_with_envs_two():
-    t = task.Task()
-    t._volumes = {'/mnt': '${VOLUME_NAME}_${VOLUME_SUFFIX}'}
-    t._envs = {'VOLUME_NAME': 'vol1', 'VOLUME_SUFFIX': 'suffix'}
-    t._resolve_volume_paths_with_envs()
+    config = {
+        'volumes': {
+            '/mnt': '${VOLUME_NAME}_${VOLUME_SUFFIX}'
+        },
+        'envs': {
+            'VOLUME_NAME': 'vol1',
+            'VOLUME_SUFFIX': 'suffix'
+        }
+    }
+    t = task.Task.from_yaml_config(config)
     assert t._volumes == {'/mnt': 'vol1_suffix'}
 
 
 def test_resolve_volumes_with_envs_none():
-    t = task.Task()
-    t._volumes = {'/mnt': 'vol_test'}
-    t._envs = {'VOLUME_NAME': 'vol1', 'VOLUME_SUFFIX': 'suffix'}
-    t._resolve_volume_paths_with_envs()
+    config = {
+        'volumes': {
+            '/mnt': 'vol_test'
+        },
+        'envs': {
+            'VOLUME_NAME': 'vol1',
+            'VOLUME_SUFFIX': 'suffix'
+        }
+    }
+    t = task.Task.from_yaml_config(config)
     assert t._volumes == {'/mnt': 'vol_test'}
 
 
 def test_resolve_volumes_with_envs_dict():
-    t = task.Task()
-    t._volumes = {'/mnt': {'name': '${VOLUME_NAME}_${VOLUME_SUFFIX}'}}
-    t._envs = {'VOLUME_NAME': 'vol1', 'VOLUME_SUFFIX': 'suffix'}
-    t._resolve_volume_paths_with_envs()
+    config = {
+        'volumes': {
+            '/mnt': {
+                'name': '${VOLUME_NAME}_${VOLUME_SUFFIX}'
+            }
+        },
+        'envs': {
+            'VOLUME_NAME': 'vol1',
+            'VOLUME_SUFFIX': 'suffix'
+        }
+    }
+    t = task.Task.from_yaml_config(config)
     assert t._volumes == {'/mnt': {'name': 'vol1_suffix'}}

--- a/tests/unit_tests/test_sky/test_task.py
+++ b/tests/unit_tests/test_sky/test_task.py
@@ -817,3 +817,35 @@ def test_resolve_volumes_override_topology():
             assert r.cloud == registry.CLOUD_REGISTRY.from_str('aws')
             assert r.region == 'us-west1'
             assert r.zone == 'a'
+
+
+def test_resolve_volumes_with_envs():
+    t = task.Task()
+    t._volumes = {'/mnt': '${VOLUME_NAME}'}
+    t._envs = {'VOLUME_NAME': 'vol1'}
+    t._resolve_volume_paths_with_envs()
+    assert t._volumes == {'/mnt': 'vol1'}
+
+
+def test_resolve_volumes_with_envs_two():
+    t = task.Task()
+    t._volumes = {'/mnt': '${VOLUME_NAME}_${VOLUME_SUFFIX}'}
+    t._envs = {'VOLUME_NAME': 'vol1', 'VOLUME_SUFFIX': 'suffix'}
+    t._resolve_volume_paths_with_envs()
+    assert t._volumes == {'/mnt': 'vol1_suffix'}
+
+
+def test_resolve_volumes_with_envs_none():
+    t = task.Task()
+    t._volumes = {'/mnt': 'vol_test'}
+    t._envs = {'VOLUME_NAME': 'vol1', 'VOLUME_SUFFIX': 'suffix'}
+    t._resolve_volume_paths_with_envs()
+    assert t._volumes == {'/mnt': 'vol_test'}
+
+
+def test_resolve_volumes_with_envs_dict():
+    t = task.Task()
+    t._volumes = {'/mnt': {'name': '${VOLUME_NAME}_${VOLUME_SUFFIX}'}}
+    t._envs = {'VOLUME_NAME': 'vol1', 'VOLUME_SUFFIX': 'suffix'}
+    t._resolve_volume_paths_with_envs()
+    assert t._volumes == {'/mnt': {'name': 'vol1_suffix'}}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR adds the ability for us to parse environment variables set by the task yaml and substitute these names into volume names.

I added multiple unit tests that test the parsing of volume names to ensure:
- When there is no valid substitution we don't change the name
- When there are one or more valid substitutions we change the name accordingly
- We handle cases where the volume is a dictionary instead of a string.

I added a smoke test testing end-to-end functionality of using `sky launch --env USERNAME=<username>` with a volume name such as `${USERNAME}-pvc`. 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
