### PR TITLE
clear cache before retrying server status

### DIFF
--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -780,7 +780,7 @@ def check_server_healthy_or_start_fn(deploy: bool = False,
                 os.path.expanduser(constants.API_SERVER_CREATION_LOCK_PATH)):
             # Check again if server is already running. Other processes may
             # have started the server while we were waiting for the lock.
-            get_api_server_status.cache_clear()
+            get_api_server_status.cache_clear()  # type: ignore[attr-defined]
             api_server_info = get_api_server_status(endpoint)
             if api_server_info.status == ApiServerStatus.UNHEALTHY:
                 _start_api_server(deploy, host, foreground, metrics,

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -780,6 +780,7 @@ def check_server_healthy_or_start_fn(deploy: bool = False,
                 os.path.expanduser(constants.API_SERVER_CREATION_LOCK_PATH)):
             # Check again if server is already running. Other processes may
             # have started the server while we were waiting for the lock.
+            get_api_server_status.cache_clear()
             api_server_info = get_api_server_status(endpoint)
             if api_server_info.status == ApiServerStatus.UNHEALTHY:
                 _start_api_server(deploy, host, foreground, metrics,

--- a/tests/unit_tests/test_sky/server/test_common.py
+++ b/tests/unit_tests/test_sky/server/test_common.py
@@ -70,6 +70,57 @@ def test_unhealthy_server(mock_get_status):
         common.check_server_healthy()
 
 
+@mock.patch('sky.server.common._start_api_server')
+@mock.patch('sky.server.common.set_api_cookie_jar')
+@mock.patch('sky.server.common.versions.check_compatibility_at_client')
+@mock.patch('sky.server.common.make_authenticated_request')
+@mock.patch('sky.server.common.filelock.FileLock')
+@mock.patch('sky.server.common.is_api_server_local', return_value=True)
+@mock.patch('sky.server.common.get_server_url',
+            return_value='http://127.0.0.1:1111')
+def test_check_server_healthy_or_start_rechecks_status(
+        unused_mock_server_url, unused_mock_is_local, mock_filelock,
+        mock_make_request, mock_check_compat, unused_set_cookie,
+        mock_start_server):
+    """Re-check should observe the fresh server status before starting.
+
+    The test keeps the real `get_api_server_status` cache in place to ensure
+    the cache is cleared before re-fetching the server status.
+    """
+    healthy_response = mock.Mock()
+    healthy_response.status_code = 200
+    healthy_response.headers = {}
+    healthy_response.history = []
+    healthy_response.cookies = requests.cookies.RequestsCookieJar()
+    healthy_response.json.return_value = {
+        'status': ApiServerStatus.HEALTHY.value,
+        'api_version': server_constants.API_VERSION,
+        'version': sky.__version__,
+        'version_on_disk': sky.__version__,
+        'commit': sky.__commit__,
+        'user': {},
+        'basic_auth_enabled': False,
+    }
+
+    mock_make_request.side_effect = [
+        requests.exceptions.ConnectionError(), healthy_response
+    ]
+    mock_check_compat.return_value = mock.Mock(error=None)
+    mock_filelock.return_value.__enter__.return_value = None
+    mock_filelock.return_value.__exit__.return_value = None
+
+    with mock.patch.object(common.get_api_server_status,
+                           'cache_clear',
+                           wraps=common.get_api_server_status.cache_clear
+                           ) as mock_cache_clear:
+        common.check_server_healthy_or_start_fn()
+
+    assert mock_cache_clear.call_count == 1
+    assert mock_make_request.call_count == 2
+    mock_start_server.assert_not_called()
+    common.get_api_server_status.cache_clear()
+
+
 @mock.patch('sky.server.common.get_api_server_status')
 @mock.patch('sky.server.common.is_api_server_local')
 def test_local_client_server_mismatch(mock_is_local, mock_get_status):

--- a/tests/unit_tests/test_sky/server/test_common.py
+++ b/tests/unit_tests/test_sky/server/test_common.py
@@ -109,10 +109,10 @@ def test_check_server_healthy_or_start_rechecks_status(
     mock_filelock.return_value.__enter__.return_value = None
     mock_filelock.return_value.__exit__.return_value = None
 
-    with mock.patch.object(common.get_api_server_status,
-                           'cache_clear',
-                           wraps=common.get_api_server_status.cache_clear
-                           ) as mock_cache_clear:
+    with mock.patch.object(
+            common.get_api_server_status,
+            'cache_clear',
+            wraps=common.get_api_server_status.cache_clear) as mock_cache_clear:
         common.check_server_healthy_or_start_fn()
 
     assert mock_cache_clear.call_count == 1


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixes #7407.

It is difficult to smoke test this because smoke tests do not expect to run in an isolated environment where they can start/stop the API server.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] new unit test
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
