### PR TITLE
[k8s] Optimize `/kubernetes_node_info` for clusters with no accelerators by 3x

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -3140,7 +3140,7 @@ def get_kubernetes_node_info(
             pods = get_all_pods_in_kubernetes_cluster(context=context)
         except kubernetes.api_exception() as e:
             if e.status == 403:
-                pods = None
+                pass
             else:
                 raise
 

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -32,23 +32,23 @@ def test_get_kubernetes_nodes():
 def test_get_kubernetes_node_info():
     """Tests get_kubernetes_node_info function."""
     # Mock node and pod objects
-    mock_node_1 = mock.MagicMock()
-    mock_node_1.metadata.name = 'node-1'
-    mock_node_1.metadata.labels = {
+    mock_gpu_node_1 = mock.MagicMock()
+    mock_gpu_node_1.metadata.name = 'node-1'
+    mock_gpu_node_1.metadata.labels = {
         'skypilot.co/accelerator': 'a100-80gb',
         'cloud.google.com/gke-accelerator-count': '4'
     }
-    mock_node_1.status.allocatable = {'nvidia.com/gpu': '4'}
+    mock_gpu_node_1.status.allocatable = {'nvidia.com/gpu': '4'}
 
-    mock_node_2 = mock.MagicMock()
-    mock_node_2.metadata.name = 'node-2'
-    mock_node_2.metadata.labels = {
+    mock_gpu_node_2 = mock.MagicMock()
+    mock_gpu_node_2.metadata.name = 'node-2'
+    mock_gpu_node_2.metadata.labels = {
         'skypilot.co/accelerator': 'tpu-v4-podslice',
         'cloud.google.com/gke-accelerator-count': '8',
         'cloud.google.com/gke-tpu-accelerator': 'tpu-v4-podslice',
         'cloud.google.com/gke-tpu-topology': '2x4'
     }
-    mock_node_2.status.allocatable = {'google.com/tpu': '8'}
+    mock_gpu_node_2.status.allocatable = {'google.com/tpu': '8'}
 
     mock_pod_1 = mock.MagicMock()
     mock_pod_1.spec.node_name = 'node-1'
@@ -68,7 +68,7 @@ def test_get_kubernetes_node_info():
 
     # Test case 1: Normal operation with GPU and TPU nodes
     with mock.patch('sky.provision.kubernetes.utils.get_kubernetes_nodes',
-                   return_value=[mock_node_1, mock_node_2]), \
+                   return_value=[mock_gpu_node_1, mock_gpu_node_2]), \
          mock.patch('sky.provision.kubernetes.utils.'
                    'get_all_pods_in_kubernetes_cluster',
                    return_value=[mock_pod_1, mock_pod_2]), \
@@ -92,7 +92,7 @@ def test_get_kubernetes_node_info():
 
     # Test case 2: No permission to list pods
     with mock.patch('sky.provision.kubernetes.utils.get_kubernetes_nodes',
-                   return_value=[mock_node_1, mock_node_2]), \
+                   return_value=[mock_gpu_node_1, mock_gpu_node_2]), \
          mock.patch('sky.provision.kubernetes.utils.'
                    'get_all_pods_in_kubernetes_cluster',
                    side_effect=utils.kubernetes.kubernetes.client.ApiException(
@@ -118,7 +118,7 @@ def test_get_kubernetes_node_info():
     mock_node_3.status.allocatable = {'google.com/tpu': '4'}
 
     with mock.patch('sky.provision.kubernetes.utils.get_kubernetes_nodes',
-                   return_value=[mock_node_1, mock_node_3]), \
+                   return_value=[mock_gpu_node_1, mock_node_3]), \
          mock.patch('sky.provision.kubernetes.utils.'
                    'get_all_pods_in_kubernetes_cluster',
                    return_value=[mock_pod_1]):
@@ -139,6 +139,65 @@ def test_get_kubernetes_node_info():
         assert isinstance(node_info, models.KubernetesNodesInfo)
         assert len(node_info.node_info_dict) == 0
         assert node_info.hint == ''
+
+    # Test case 5: CPU-only nodes
+    mock_cpu_node_1 = mock.MagicMock()
+    mock_cpu_node_1.metadata.name = 'cpu-node-1'
+    mock_cpu_node_1.metadata.labels = {}
+    mock_cpu_node_1.status.allocatable = {'cpu': '4', 'memory': '16Gi'}
+    mock_cpu_node_1.status.addresses = [
+        mock.MagicMock(type='InternalIP', address='10.0.0.1')
+    ]
+
+    mock_cpu_node_2 = mock.MagicMock()
+    mock_cpu_node_2.metadata.name = 'cpu-node-2'
+    mock_cpu_node_2.metadata.labels = {}
+    mock_cpu_node_2.status.allocatable = {'cpu': '8', 'memory': '32Gi'}
+    mock_cpu_node_2.status.addresses = [
+        mock.MagicMock(type='InternalIP', address='10.0.0.2')
+    ]
+
+    with mock.patch('sky.provision.kubernetes.utils.get_kubernetes_nodes',
+                   return_value=[mock_cpu_node_1, mock_cpu_node_2]), \
+         mock.patch('sky.provision.kubernetes.utils.'
+                   'get_all_pods_in_kubernetes_cluster') as mock_get_pods:
+        node_info = utils.get_kubernetes_node_info()
+
+        mock_get_pods.assert_not_called()
+        assert isinstance(node_info, models.KubernetesNodesInfo)
+        assert len(node_info.node_info_dict) == 2
+        assert node_info.node_info_dict['cpu-node-1'].accelerator_type is None
+        assert node_info.node_info_dict['cpu-node-1'].total[
+            'accelerator_count'] == 0
+        assert node_info.node_info_dict['cpu-node-1'].free[
+            'accelerators_available'] == 0
+        assert node_info.node_info_dict['cpu-node-2'].total[
+            'accelerator_count'] == 0
+        assert node_info.node_info_dict['cpu-node-2'].free[
+            'accelerators_available'] == 0
+
+    # Test case 6: Mixed CPU and GPU nodes
+    with mock.patch('sky.provision.kubernetes.utils.get_kubernetes_nodes',
+                   return_value=[mock_cpu_node_1, mock_gpu_node_1]), \
+         mock.patch('sky.provision.kubernetes.utils.'
+                   'get_all_pods_in_kubernetes_cluster',
+                   return_value=[mock_pod_1]) as mock_get_pods, \
+         mock.patch('sky.provision.kubernetes.utils.get_gpu_resource_key',
+                   return_value='nvidia.com/gpu'):
+        node_info = utils.get_kubernetes_node_info()
+
+        mock_get_pods.assert_called_once()
+        assert len(node_info.node_info_dict) == 2
+        # CPU node should have 0 accelerators
+        assert node_info.node_info_dict['cpu-node-1'].total[
+            'accelerator_count'] == 0
+        assert node_info.node_info_dict['cpu-node-1'].free[
+            'accelerators_available'] == 0
+        # GPU node should have correct allocation
+        assert node_info.node_info_dict['node-1'].total[
+            'accelerator_count'] == 4
+        assert node_info.node_info_dict['node-1'].free[
+            'accelerators_available'] == 2
 
 
 def test_get_all_kube_context_names():

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -106,19 +106,19 @@ def test_get_kubernetes_node_info():
             'accelerators_available'] == -1
 
     # Test case 3: Multi-host TPU node
-    mock_node_3 = mock.MagicMock()
-    mock_node_3.metadata.name = 'node-3'
-    mock_node_3.metadata.labels = {
+    mock_tpu_node_1 = mock.MagicMock()
+    mock_tpu_node_1.metadata.name = 'node-3'
+    mock_tpu_node_1.metadata.labels = {
         'skypilot.co/accelerator': 'tpu-v4-podslice',
         'cloud.google.com/gke-accelerator-count': '4',
         'cloud.google.com/gke-tpu-accelerator': 'tpu-v4-podslice',
         'cloud.google.com/gke-tpu-topology': '4x4',
         'cloud.google.com/gke-tpu-node-pool-type': 'multi-host'
     }
-    mock_node_3.status.allocatable = {'google.com/tpu': '4'}
+    mock_tpu_node_1.status.allocatable = {'google.com/tpu': '4'}
 
     with mock.patch('sky.provision.kubernetes.utils.get_kubernetes_nodes',
-                   return_value=[mock_gpu_node_1, mock_node_3]), \
+                   return_value=[mock_gpu_node_1, mock_tpu_node_1]), \
          mock.patch('sky.provision.kubernetes.utils.'
                    'get_all_pods_in_kubernetes_cluster',
                    return_value=[mock_pod_1]):
@@ -142,7 +142,7 @@ def test_get_kubernetes_node_info():
 
     # Test case 5: CPU-only nodes
     mock_cpu_node_1 = mock.MagicMock()
-    mock_cpu_node_1.metadata.name = 'cpu-node-1'
+    mock_cpu_node_1.metadata.name = 'node-4'
     mock_cpu_node_1.metadata.labels = {}
     mock_cpu_node_1.status.allocatable = {'cpu': '4', 'memory': '16Gi'}
     mock_cpu_node_1.status.addresses = [
@@ -150,7 +150,7 @@ def test_get_kubernetes_node_info():
     ]
 
     mock_cpu_node_2 = mock.MagicMock()
-    mock_cpu_node_2.metadata.name = 'cpu-node-2'
+    mock_cpu_node_2.metadata.name = 'node-5'
     mock_cpu_node_2.metadata.labels = {}
     mock_cpu_node_2.status.allocatable = {'cpu': '8', 'memory': '32Gi'}
     mock_cpu_node_2.status.addresses = [
@@ -166,14 +166,14 @@ def test_get_kubernetes_node_info():
         mock_get_pods.assert_not_called()
         assert isinstance(node_info, models.KubernetesNodesInfo)
         assert len(node_info.node_info_dict) == 2
-        assert node_info.node_info_dict['cpu-node-1'].accelerator_type is None
-        assert node_info.node_info_dict['cpu-node-1'].total[
+        assert node_info.node_info_dict['node-4'].accelerator_type is None
+        assert node_info.node_info_dict['node-4'].total[
             'accelerator_count'] == 0
-        assert node_info.node_info_dict['cpu-node-1'].free[
+        assert node_info.node_info_dict['node-4'].free[
             'accelerators_available'] == 0
-        assert node_info.node_info_dict['cpu-node-2'].total[
+        assert node_info.node_info_dict['node-5'].total[
             'accelerator_count'] == 0
-        assert node_info.node_info_dict['cpu-node-2'].free[
+        assert node_info.node_info_dict['node-5'].free[
             'accelerators_available'] == 0
 
     # Test case 6: Mixed CPU and GPU nodes
@@ -189,9 +189,9 @@ def test_get_kubernetes_node_info():
         mock_get_pods.assert_called_once()
         assert len(node_info.node_info_dict) == 2
         # CPU node should have 0 accelerators
-        assert node_info.node_info_dict['cpu-node-1'].total[
+        assert node_info.node_info_dict['node-4'].total[
             'accelerator_count'] == 0
-        assert node_info.node_info_dict['cpu-node-1'].free[
+        assert node_info.node_info_dict['node-4'].free[
             'accelerators_available'] == 0
         # GPU node should have correct allocation
         assert node_info.node_info_dict['node-1'].total[


### PR DESCRIPTION
In `get_kubernetes_node_info`, we call `get_all_pods_in_kubernetes_cluster`, which is expensive for clusters with a lot of pods. The reason we need to call this is to get the real-time resource usage of accelerators, which we get by reading each pod's `pod.spec.containers[*].resources.requests`.

But this is only relevant for clusters with accelerators, we can skip this otherwise. This PR optimizes for this case by moving the call to `get_all_pods_in_kubernetes_cluster` down, after we check that at least one node have `accelerator_count` > 0.

Tested on a CPU-only cluster with 1000 pods and 100 requests each to `/kubernetes_node_info`:
- Before: 
```
Min:  2836.28ms
p50:  2947.82ms
p95:  3849.55ms
p99:  7867.67ms
Max:  7896.89ms
```
- After: 
```
Min:  611.65ms
p50:  717.43ms
p95:  1115.72ms
p99:  1421.59ms
Max:  1423.58ms
```

Future note: There might also be room for optimization for heterogenous clusters with `number_of_cpu_nodes` >>> `number_of_gpu_nodes`, where instead of getting all pods, we can get the pods only in GPU nodes, using field or label selectors. But this needs more benchmarking and is unclear whether it's worth it.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
