### PR TITLE
[CLI/SDK] Ability to skip provisioning but still running setup

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -957,6 +957,13 @@ def _handle_infra_cloud_region_zone_options(infra: Optional[str],
     # which incorrectly recognizes the help string as a docstring.
     # pylint: disable=bad-docstring-quotes
     help='Skip confirmation prompt.')
+@click.option('--skip-unnecessary-provision',
+              is_flag=True,
+              default=False,
+              required=False,
+              help='Do not re-provision the cluster if it is already up '
+              'and available. Does not skip setup even if provisioning '
+              'is skipped.')
 @click.option('--no-setup',
               is_flag=True,
               default=False,
@@ -1017,6 +1024,7 @@ def launch(
     no_setup: bool,
     clone_disk_from: Optional[str],
     fast: bool,
+    skip_unnecessary_provision: bool,
     async_call: bool,
     config_override: Optional[Dict[str, Any]] = None,
     git_url: Optional[str] = None,
@@ -1116,6 +1124,7 @@ def launch(
         no_setup=no_setup,
         clone_disk_from=clone_disk_from,
         fast=fast,
+        skip_unnecessary_provision=skip_unnecessary_provision,
         _need_confirmation=not yes,
     )
     job_id_handle = _async_call_or_wait(request_id, async_call, 'sky.launch')

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -442,6 +442,7 @@ def launch(
     no_setup: bool = False,
     clone_disk_from: Optional[str] = None,
     fast: bool = False,
+    skip_unnecessary_provision: bool = False,
     # Internal only:
     # pylint: disable=invalid-name
     _need_confirmation: bool = False,
@@ -512,6 +513,8 @@ def launch(
           different availability zone or region.
         fast: [Experimental] If the cluster is already up and available,
           skip provisioning and setup steps.
+        skip_unnecessary_provision: Do not re-provision the cluster if it is already up
+          and available. Does not skip setup even if provisioning is skipped.
         _need_confirmation: (Internal only) If True, show the confirmation
             prompt.
 
@@ -605,6 +608,7 @@ def launch(
             no_setup,
             clone_disk_from,
             fast,
+            skip_unnecessary_provision,
             _need_confirmation,
             _is_launched_by_jobs_controller,
             _is_launched_by_sky_serve_controller,
@@ -625,6 +629,7 @@ def _launch(
     no_setup: bool = False,
     clone_disk_from: Optional[str] = None,
     fast: bool = False,
+    skip_unnecessary_provision: bool = False,
     # Internal only:
     # pylint: disable=invalid-name
     _need_confirmation: bool = False,
@@ -710,6 +715,7 @@ def _launch(
         no_setup=no_setup,
         clone_disk_from=clone_disk_from,
         fast=fast,
+        skip_unnecessary_provision=skip_unnecessary_provision,
         # For internal use
         quiet_optimizer=_need_confirmation,
         is_launched_by_jobs_controller=_is_launched_by_jobs_controller,

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -252,6 +252,7 @@ class LaunchBody(RequestBody):
     down: bool = False
     backend: Optional[str] = None
     optimize_target: common_lib.OptimizeTarget = common_lib.OptimizeTarget.COST
+    skip_unnecessary_provision: bool = False
     no_setup: bool = False
     clone_disk_from: Optional[str] = None
     fast: bool = False


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
