### PR TITLE
[Test] Only run test_big_file_upload_memory_usage on remote API servers in docker

### DIFF
--- a/tests/smoke_tests/metrics_utils.py
+++ b/tests/smoke_tests/metrics_utils.py
@@ -26,6 +26,7 @@ def collect_metrics(
         stop_event is not None
     ), "Exactly one of duration_seconds or stop_event must be provided"
 
+    metrics = {}
     start_time = time.time()
     while True:
         if duration_seconds is not None and time.time(

--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -853,6 +853,12 @@ def is_non_docker_remote_api_server() -> bool:
     return False
 
 
+def is_docker_remote_api_server() -> bool:
+    if is_remote_server_test():
+        return 'host.docker.internal' in get_api_server_url()
+    return False
+
+
 def get_dashboard_cluster_status_request_id() -> str:
     """Get the status of the cluster from the dashboard."""
     body = payloads.StatusBody(all_users=True,)

--- a/tests/smoke_tests/test_api_server.py
+++ b/tests/smoke_tests/test_api_server.py
@@ -350,8 +350,12 @@ def test_managed_jobs_force_disable_cloud_bucket(generic_cloud: str):
 
 
 def test_big_file_upload_memory_usage(generic_cloud: str):
-    if not smoke_tests_utils.is_remote_server_test():
-        pytest.skip('This test is only for remote server')
+    # TODO(kevin): Re-enable this once we have a standardized way to expose /metrics
+    # on the non-docker remote API servers used for smoke tests.
+    if not smoke_tests_utils.is_docker_remote_api_server():
+        pytest.skip(
+            'This test is only for remote server setup with setup_docker_container fixture'
+        )
 
     def compare_rss_metrics(baseline: Dict[Tuple[str, ...], List[Tuple[float,
                                                                        float]]],


### PR DESCRIPTION
This smoke test was introduced in #7413 and assumes that the remote server is running in Docker and exposes metrics at `:9090/metrics`. Thus it fails on real remote API servers deployed with helm charts that we use for testing, since our default ingress config doesn't expose /metrics. So let's disable it for now until we have a standardized way to expose /metrics for actual remote API servers we use for testing.

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
