### PR TITLE
[Core] Change worker threads to match CPU count

### DIFF
--- a/sky/server/config.py
+++ b/sky/server/config.py
@@ -228,7 +228,7 @@ def _get_min_short_workers() -> int:
 
 
 def _max_short_worker_parallism(cpu_count: int, mem_size_gb: float,
-                                long_worker_parallism: int) -> int:
+                                long_worker_parallelism: int) -> int:
     """Max parallelism for short workers."""
     # Reserve memory for long workers and min available memory.
     # pylint: disable=import-outside-toplevel
@@ -237,8 +237,8 @@ def _max_short_worker_parallism(cpu_count: int, mem_size_gb: float,
                   if job_utils.is_consolidation_mode() else
                   server_constants.MIN_AVAIL_MEM_GB)
     reserved_mem = (
-        max_memory + (long_worker_parallism * LONG_WORKER_MEM_GB) +
-        server_constants.PER_WORKER_THREAD_POOL_MEMORY_GB * cpu_count)
+        max_memory + (long_worker_parallelism * LONG_WORKER_MEM_GB) +
+        server_constants.PER_FAST_API_WORKER_THREAD_MEMORY_GB * cpu_count)
     available_mem = max(0, mem_size_gb - reserved_mem)
     n = max(_get_min_short_workers(), int(available_mem / SHORT_WORKER_MEM_GB))
     return n

--- a/sky/server/config.py
+++ b/sky/server/config.py
@@ -207,7 +207,7 @@ def _max_long_worker_parallism(cpu_count: int,
                   server_constants.MIN_AVAIL_MEM_GB)
     available_mem = max(
         0, mem_size_gb - max_memory -
-        server_constants.PER_WORKER_THREAD_POOL_MEMORY_GB * cpu_count)
+        server_constants.PER_FAST_API_WORKER_THREAD_MEMORY_GB * cpu_count)
     cpu_based_max_parallel = cpu_count * _CPU_MULTIPLIER_FOR_LONG_WORKERS
     mem_based_max_parallel = int(available_mem * _MAX_MEM_PERCENT_FOR_BLOCKING /
                                  LONG_WORKER_MEM_GB)

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -40,6 +40,8 @@ DEFAULT_HANDLER_NAME = 'default'
 # The path to the API request database.
 API_SERVER_REQUEST_DB_PATH = '~/.sky/api_server/requests.db'
 
+PER_WORKER_THREAD_POOL_MEMORY_GB = 8 / 1024  # 8MB
+
 # The interval (seconds) for the cluster status to be refreshed in the
 # background.
 CLUSTER_REFRESH_DAEMON_INTERVAL_SECONDS = 60

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -40,7 +40,9 @@ DEFAULT_HANDLER_NAME = 'default'
 # The path to the API request database.
 API_SERVER_REQUEST_DB_PATH = '~/.sky/api_server/requests.db'
 
-PER_WORKER_THREAD_POOL_MEMORY_GB = 8 / 1024  # 8MB
+# This is the memory we assume each background thread in the thread pool
+# for each fastapi worker consumes.
+PER_FAST_API_WORKER_THREAD_MEMORY_GB = 8 / 1024  # 8MB
 
 # The interval (seconds) for the cluster status to be refreshed in the
 # background.

--- a/tests/unit_tests/test_sky/server/test_config.py
+++ b/tests/unit_tests/test_sky/server/test_config.py
@@ -100,19 +100,19 @@ def test_parallel_size_short():
     blocking_size = 1
     mem_size_gb = 2
     expected = 3
-    assert config._max_short_worker_parallism(mem_size_gb,
+    assert config._max_short_worker_parallism(1, mem_size_gb,
                                               blocking_size) == expected
 
     # Test with sufficient memory
     blocking_size = 8
     mem_size_gb = 12.5
     expected = 24
-    assert config._max_short_worker_parallism(mem_size_gb,
+    assert config._max_short_worker_parallism(1, mem_size_gb,
                                               blocking_size) == expected
 
     # Test with limited memory
     blocking_size = 1
     mem_size_gb = 3
     expected = 3
-    assert config._max_short_worker_parallism(mem_size_gb,
+    assert config._max_short_worker_parallism(1, mem_size_gb,
                                               blocking_size) == expected

--- a/tests/unit_tests/test_sky/server/test_config.py
+++ b/tests/unit_tests/test_sky/server/test_config.py
@@ -26,7 +26,7 @@ def test_compute_server_config_on_large_deployment(cpu_count, mem_size_gb):
     assert c.num_server_workers == 196
     assert c.long_worker_config.garanteed_parallelism == 392
     assert c.long_worker_config.burstable_parallelism == 0
-    assert c.short_worker_config.garanteed_parallelism == 2084
+    assert c.short_worker_config.garanteed_parallelism == 2078
     assert c.short_worker_config.burstable_parallelism == 0
     assert c.queue_backend == config.QueueBackend.MULTIPROCESSING
 
@@ -39,7 +39,7 @@ def test_compute_server_config(cpu_count, mem_size_gb):
     assert c.num_server_workers == 4
     assert c.long_worker_config.garanteed_parallelism == 8
     assert c.long_worker_config.burstable_parallelism == 0
-    assert c.short_worker_config.garanteed_parallelism == 36
+    assert c.short_worker_config.garanteed_parallelism == 35
     assert c.short_worker_config.burstable_parallelism == 0
     assert c.queue_backend == config.QueueBackend.MULTIPROCESSING
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Before the number of threads the asyncio loop used was bounded by the default threadpool executor. This PR instead sets the cpu count of the machine to unblock requests in scenarios where we have more requests than the default threadpool executor can handle. This improves situations where kubernetes ssh requests were blocked behind other requests such as tail logs.

I tested this manually by launching a concurrent number of tail logs requests that would normally block the API server and verified that sshing into a kubernetes pod is possible.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
