### PR TITLE
[Test] Fix test_cli_auto_retry when using URL with basic auth credentials

### DIFF
--- a/tests/chaos/chaos_proxy.py
+++ b/tests/chaos/chaos_proxy.py
@@ -1,6 +1,7 @@
 """TCP proxy that brings chaos."""
 import argparse
 import asyncio
+from urllib import parse
 
 from sky.server import common
 
@@ -84,7 +85,9 @@ async def main(local_port, interval):
     global connection_counter
 
     server_url = common.get_server_url()
-    target_host, target_port = server_url.split('://')[1].split(':')
+    parsed = parse.urlparse(server_url)
+    target_host = parsed.hostname
+    target_port = parsed.port or 80  # Assume HTTP port if not specified
 
     async def client_handler(reader, writer):
         global connection_counter


### PR DESCRIPTION
This test was failing when using an API server URL that contains basic auth credentials, i.e. `http://username:password@host`.

This PR fixes it by parsing the URL correctly using urllib.parse and handle proxying the username and password properly.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
