### PR TITLE
[Core] optimize get_managed_job_queue from O(N) to O(1)

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1065,6 +1065,22 @@ def get_handle_from_cluster_name(
     return pickle.loads(row.handle)
 
 
+@_init_db
+@metrics_lib.time_me
+def get_handles_from_cluster_names(
+        cluster_names: Set[str]
+) -> Dict[str, Optional['backends.ResourceHandle']]:
+    assert _SQLALCHEMY_ENGINE is not None
+    with orm.Session(_SQLALCHEMY_ENGINE) as session:
+        rows = session.query(cluster_table.c.name,
+                             cluster_table.c.handle).filter(
+                                 cluster_table.c.name.in_(cluster_names)).all()
+        return {
+            row.name: pickle.loads(row.handle) if row is not None else None
+            for row in rows
+        }
+
+
 @_init_db_async
 @metrics_lib.time_me
 async def get_status_from_cluster_name_async(

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1325,6 +1325,23 @@ def get_managed_job_queue(
                                              page,
                                              limit,
                                              statuses=statuses)
+    # we need job ids for each job
+    job_ids = set(job['job_id'] for job in jobs)
+    job_id_to_pool_info = (
+        managed_job_state.get_pool_and_submit_info_from_job_ids(job_ids))
+    cluster_names: Dict[int, str] = {}
+    for job in jobs:
+        # pool info is (pool, cluster_name, job_id_on_pool_cluster)
+        pool_info = job_id_to_pool_info.get(job['job_id'], None)
+        if pool_info and pool_info[0]:
+            cluster_name = pool_info[1]
+        else:
+            cluster_name = generate_managed_job_cluster_name(
+                job['task_name'], job['job_id'])
+        cluster_names[job['job_id']] = cluster_name
+    cluster_name_to_handles = global_user_state.get_handles_from_cluster_names(
+        set(cluster_names.values()))
+
     for job in jobs:
         end_at = job['end_at']
         if end_at is None:
@@ -1344,18 +1361,8 @@ def get_managed_job_queue(
         job['status'] = job['status'].value
         job['schedule_state'] = job['schedule_state'].value
 
-        # TODO(rohan): pull into batch query
-        pool = managed_job_state.get_pool_from_job_id(job['job_id'])
-        if pool is not None:
-            # TODO(rohan): pull into batch query
-            cluster_name, _ = managed_job_state.get_pool_submit_info(
-                job['job_id'])
-        else:
-            cluster_name = generate_managed_job_cluster_name(
-                job['task_name'], job['job_id'])
-        # TODO(rohan): pull into batch query
-        handle = global_user_state.get_handle_from_cluster_name(
-            cluster_name) if cluster_name is not None else None
+        cluster_name = cluster_names[job['job_id']]
+        handle = cluster_name_to_handles.get(cluster_name, None)
         if isinstance(handle, backends.CloudVmRayResourceHandle):
             resources_str = resources_utils.get_readable_resources_repr(
                 handle, simplify=True)

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1325,7 +1325,7 @@ def get_managed_job_queue(
                                              page,
                                              limit,
                                              statuses=statuses)
-    # we need job ids for each job
+
     job_ids = set(job['job_id'] for job in jobs)
     job_id_to_pool_info = (
         managed_job_state.get_pool_and_submit_info_from_job_ids(job_ids))


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR optimizes the number of db queries made in `get_managed_job_queue` from O(N) to O(1). Instead of making the `get_pool_from_job_id`, `get_pool_submit_info`, and `get_handle_from_cluster_name` db queries on each job, we run  batch `get_pool_and_submit_info_from_job_ids` and `get_handles_from_cluster_names ` queries such that the number of db queries made by `get_managed_job_queue` does not scale linearly with the number of managed jobs. 


<!-- Describe the tests ran -->
I tested this with a local api server with 20,000 mock entries in the spot_jobs sqlite db and observed a 15x improvement (4.211s --> 0.289s).
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
