### PR TITLE
[Core/Dashboard] cache deduplication (6x jobs page load speedup and 5x server load reduction)

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -514,36 +514,40 @@ export function ManagedJobsTable({
     fetchDataRef.current = fetchData;
   }, [fetchData]);
 
-  // Track if this is the initial load to avoid duplicate fetches
-  const isInitialLoad = React.useRef(true);
+  // Prevent duplicate API requests on first load/page refresh
+  // Multiple useEffects below would normally all fire on mount with their default values,
+  // causing redundant requests to the same API server endpoints.
+  // This ref ensures only the initial fetch effect runs, and subsequent effects
+  // only trigger on actual user interactions (page change, filter change, etc.)
+  const isInitialFetch = React.useRef(true);
 
   // Initial load - only runs once on mount
   React.useEffect(() => {
     fetchData({ includeStatus: true });
-    // Mark that initial load is complete
-    isInitialLoad.current = false;
+    // Mark that initial fetch is complete so other effects can run
+    isInitialFetch.current = false;
   }, []);
 
   // Fetch on pagination (page) changes without status request
-  // Skip on initial load (page defaults to 1)
+  // Skip on initial fetch (page defaults to 1)
   React.useEffect(() => {
-    if (!isInitialLoad.current) {
+    if (!isInitialFetch.current) {
       fetchData({ includeStatus: false });
     }
   }, [currentPage]);
 
   // Fetch on filters or page size changes with status request
-  // Skip on initial load (filters default to [] and pageSize to 10)
+  // Skip on initial fetch (filters default to [] and pageSize to 10)
   React.useEffect(() => {
-    if (!isInitialLoad.current) {
+    if (!isInitialFetch.current) {
       fetchData({ includeStatus: true });
     }
   }, [filters, pageSize]);
 
   // Fetch on status filter changes (activeTab, selectedStatuses, showAllMode)
-  // Skip on initial load (these have default values)
+  // Skip on initial fetch (these have default values)
   React.useEffect(() => {
-    if (!isInitialLoad.current) {
+    if (!isInitialFetch.current) {
       fetchData({ includeStatus: true });
     }
   }, [activeTab, selectedStatuses, showAllMode]);

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -514,24 +514,38 @@ export function ManagedJobsTable({
     fetchDataRef.current = fetchData;
   }, [fetchData]);
 
-  // Initial load
+  // Track if this is the initial mount to avoid duplicate fetches
+  const isInitialMount = React.useRef(true);
+
+  // Initial load - only runs once on mount
   React.useEffect(() => {
     fetchData({ includeStatus: true });
+    // Mark that initial load is complete
+    isInitialMount.current = false;
   }, []);
 
   // Fetch on pagination (page) changes without status request
+  // Skip on initial mount (page defaults to 1)
   React.useEffect(() => {
-    fetchData({ includeStatus: false });
+    if (!isInitialMount.current) {
+      fetchData({ includeStatus: false });
+    }
   }, [currentPage]);
 
   // Fetch on filters or page size changes with status request
+  // Skip on initial mount (filters default to [] and pageSize to 10)
   React.useEffect(() => {
-    fetchData({ includeStatus: true });
+    if (!isInitialMount.current) {
+      fetchData({ includeStatus: true });
+    }
   }, [filters, pageSize]);
 
   // Fetch on status filter changes (activeTab, selectedStatuses, showAllMode)
+  // Skip on initial mount (these have default values)
   React.useEffect(() => {
-    fetchData({ includeStatus: true });
+    if (!isInitialMount.current) {
+      fetchData({ includeStatus: true });
+    }
   }, [activeTab, selectedStatuses, showAllMode]);
 
   useEffect(() => {

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -514,36 +514,36 @@ export function ManagedJobsTable({
     fetchDataRef.current = fetchData;
   }, [fetchData]);
 
-  // Track if this is the initial mount to avoid duplicate fetches
-  const isInitialMount = React.useRef(true);
+  // Track if this is the initial load to avoid duplicate fetches
+  const isInitialLoad = React.useRef(true);
 
   // Initial load - only runs once on mount
   React.useEffect(() => {
     fetchData({ includeStatus: true });
     // Mark that initial load is complete
-    isInitialMount.current = false;
+    isInitialLoad.current = false;
   }, []);
 
   // Fetch on pagination (page) changes without status request
-  // Skip on initial mount (page defaults to 1)
+  // Skip on initial load (page defaults to 1)
   React.useEffect(() => {
-    if (!isInitialMount.current) {
+    if (!isInitialLoad.current) {
       fetchData({ includeStatus: false });
     }
   }, [currentPage]);
 
   // Fetch on filters or page size changes with status request
-  // Skip on initial mount (filters default to [] and pageSize to 10)
+  // Skip on initial load (filters default to [] and pageSize to 10)
   React.useEffect(() => {
-    if (!isInitialMount.current) {
+    if (!isInitialLoad.current) {
       fetchData({ includeStatus: true });
     }
   }, [filters, pageSize]);
 
   // Fetch on status filter changes (activeTab, selectedStatuses, showAllMode)
-  // Skip on initial mount (these have default values)
+  // Skip on initial load (these have default values)
   React.useEffect(() => {
-    if (!isInitialMount.current) {
+    if (!isInitialLoad.current) {
       fetchData({ includeStatus: true });
     }
   }, [activeTab, selectedStatuses, showAllMode]);

--- a/sky/dashboard/src/lib/cache.test.js
+++ b/sky/dashboard/src/lib/cache.test.js
@@ -1,0 +1,270 @@
+/**
+ * Tests for DashboardCache request deduplication and caching behavior
+ */
+
+import { DashboardCache } from './cache';
+
+// Helper to create a mock async function that tracks calls
+function createMockFetch(returnValue, delay = 10) {
+  const calls = [];
+  const fn = jest.fn(async (...args) => {
+    calls.push({ args, timestamp: Date.now() });
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    return typeof returnValue === 'function' ? returnValue() : returnValue;
+  });
+  fn.calls = calls;
+  return fn;
+}
+
+describe('DashboardCache', () => {
+  let cache;
+
+  beforeEach(() => {
+    cache = new DashboardCache();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('Request Deduplication', () => {
+    test('should deduplicate concurrent identical requests', async () => {
+      const mockFetch = createMockFetch({ data: 'test' }, 100);
+
+      // Make 3 concurrent identical requests
+      const promises = [
+        cache.get(mockFetch, ['arg1']),
+        cache.get(mockFetch, ['arg1']),
+        cache.get(mockFetch, ['arg1']),
+      ];
+
+      // Fast-forward time to complete the request
+      jest.advanceTimersByTime(100);
+
+      const results = await Promise.all(promises);
+
+      // All should return the same data
+      expect(results[0]).toEqual({ data: 'test' });
+      expect(results[1]).toEqual({ data: 'test' });
+      expect(results[2]).toEqual({ data: 'test' });
+
+      // But the fetch function should only be called once
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch.calls.length).toBe(1);
+    });
+
+    test('should not deduplicate requests with different arguments', async () => {
+      const mockFetch = createMockFetch({ data: 'test' }, 100);
+
+      // Make concurrent requests with different arguments
+      const promises = [
+        cache.get(mockFetch, ['arg1']),
+        cache.get(mockFetch, ['arg2']),
+        cache.get(mockFetch, ['arg3']),
+      ];
+
+      jest.advanceTimersByTime(100);
+      await Promise.all(promises);
+
+      // Should call fetch 3 times (once for each unique argument set)
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    test('should handle sequential requests using cache', async () => {
+      const mockFetch = createMockFetch({ data: 'test' }, 50);
+
+      // First request
+      const promise1 = cache.get(mockFetch, ['arg1']);
+      jest.advanceTimersByTime(50);
+      await promise1;
+
+      // Second request after first completes (should use cache)
+      const promise2 = cache.get(mockFetch, ['arg1']);
+      await promise2;
+
+      // Should use cache for second request, but cache also triggers
+      // a background refresh, so we expect 2 calls total
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    test('should cleanup pending requests after completion', async () => {
+      const mockFetch = createMockFetch({ data: 'test' }, 100);
+
+      const promise = cache.get(mockFetch, ['arg1']);
+
+      // Before completion, pending request should exist
+      expect(cache.pendingRequests.size).toBe(1);
+
+      jest.advanceTimersByTime(100);
+      await promise;
+
+      // After completion, pending request should be cleaned up
+      expect(cache.pendingRequests.size).toBe(0);
+    });
+
+    test('should cleanup pending requests even on error', async () => {
+      const mockFetch = jest.fn(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        throw new Error('Test error');
+      });
+
+      const promise = cache.get(mockFetch, ['arg1']);
+
+      expect(cache.pendingRequests.size).toBe(1);
+
+      jest.advanceTimersByTime(100);
+
+      try {
+        await promise;
+      } catch (error) {
+        // Expected error
+      }
+
+      // Should cleanup even on error
+      expect(cache.pendingRequests.size).toBe(0);
+    });
+  });
+
+  describe('Cache Behavior', () => {
+    test('should return cached data when available and fresh', async () => {
+      jest.useRealTimers(); // Use real timers for this test
+      const mockFetch = createMockFetch({ data: 'test' }, 10);
+
+      // First request
+      const result1 = await cache.get(mockFetch, ['arg1']);
+
+      // Second request (should use cache)
+      const result2 = await cache.get(mockFetch, ['arg1']);
+
+      expect(result1).toEqual({ data: 'test' });
+      expect(result2).toEqual({ data: 'test' });
+      // First call is the initial fetch, second is background refresh
+      expect(mockFetch.mock.calls.length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('should fetch fresh data when cache is stale', async () => {
+      jest.useRealTimers(); // Use real timers for this test
+      const mockFetch = createMockFetch({ data: 'test' }, 10);
+      const ttl = 100; // Short TTL for test
+
+      // First request
+      await cache.get(mockFetch, ['arg1'], { ttl });
+
+      // Wait for cache to become stale
+      await new Promise((resolve) => setTimeout(resolve, ttl + 50));
+
+      // Second request (cache is now stale, should fetch fresh data)
+      await cache.get(mockFetch, ['arg1'], { ttl });
+
+      expect(mockFetch.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test('should invalidate cache correctly', async () => {
+      jest.useRealTimers(); // Use real timers for this test
+      const mockFetch = createMockFetch({ data: 'test' }, 10);
+
+      // First request
+      await cache.get(mockFetch, ['arg1']);
+
+      // Invalidate cache
+      cache.invalidate(mockFetch, ['arg1']);
+
+      // Second request (should fetch fresh data)
+      await cache.get(mockFetch, ['arg1']);
+
+      expect(mockFetch.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('Real-world scenario: Jobs page load', () => {
+    test('should handle multiple simultaneous calls from useEffect hooks', async () => {
+      // Simulate getManagedJobs function
+      const getManagedJobs = createMockFetch(
+        {
+          jobs: [
+            { id: 1, name: 'job1' },
+            { id: 2, name: 'job2' },
+          ],
+          total: 2,
+        },
+        200
+      );
+
+      // Simulate 4 concurrent calls (like the 4 useEffect hooks)
+      const params = { allUsers: true, page: 1, limit: 10 };
+      const promises = [
+        cache.get(getManagedJobs, [params]), // Initial load
+        cache.get(getManagedJobs, [params]), // Filters effect
+        cache.get(getManagedJobs, [params]), // Status filter effect
+        cache.get(getManagedJobs, [params]), // Page effect
+      ];
+
+      // All should be pending
+      expect(cache.pendingRequests.size).toBe(1);
+
+      jest.advanceTimersByTime(200);
+      const results = await Promise.all(promises);
+
+      // All should get the same data
+      results.forEach((result) => {
+        expect(result.jobs).toHaveLength(2);
+        expect(result.total).toBe(2);
+      });
+
+      // But only one actual API call should be made
+      expect(getManagedJobs).toHaveBeenCalledTimes(1);
+
+      // Pending requests should be cleaned up
+      expect(cache.pendingRequests.size).toBe(0);
+    });
+
+    test('should handle concurrent requests with different parameters', async () => {
+      const getManagedJobs = createMockFetch({ jobs: [], total: 0 }, 200);
+
+      // Simulate different filter combinations being requested concurrently
+      const promises = [
+        cache.get(getManagedJobs, [{ allUsers: true, page: 1 }]),
+        cache.get(getManagedJobs, [{ allUsers: true, page: 2 }]),
+        cache.get(getManagedJobs, [{ allUsers: false, page: 1 }]),
+      ];
+
+      expect(cache.pendingRequests.size).toBe(3);
+
+      jest.advanceTimersByTime(200);
+      await Promise.all(promises);
+
+      // Should make 3 separate calls (different parameters)
+      expect(getManagedJobs).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('Statistics', () => {
+    test('should track pending requests in stats', async () => {
+      const mockFetch = createMockFetch({ data: 'test' }, 100);
+
+      const promise = cache.get(mockFetch, ['arg1']);
+
+      const stats = cache.getStats();
+      expect(stats.pendingRequests).toBe(1);
+
+      jest.advanceTimersByTime(100);
+      await promise;
+
+      const statsAfter = cache.getStats();
+      expect(statsAfter.pendingRequests).toBe(0);
+    });
+
+    test('should clear pending requests on cache.clear()', async () => {
+      const mockFetch = createMockFetch({ data: 'test' }, 100);
+
+      cache.get(mockFetch, ['arg1']);
+
+      expect(cache.pendingRequests.size).toBe(1);
+
+      cache.clear();
+
+      expect(cache.pendingRequests.size).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR eliminates duplicate calls to the api server during jobs page load and also enforces request deduplication at the dashboard cache layer. I observed this eliminate many duplicate calls to `sky.status`, `sky.jobs.queue`, and `sky.jobs.pool_status`.

On a remote api server (jobs consolidation mode enabled) and remote postgres db, I found that this resulted in a 6x speedup (30s --> 5s) and also significantly reduces api server load. In particular, prior to this PR, by observing the network tab in the browser console, I found that loading the jobs page made:

```
5 calls to sky.status
9 calls to sky.jobs.queue
2 calls to sky.jobs.pool_status
```

With this PR we make:
```
1 call to sky.status
1 call to sky.jobs.queue
1 call to sky.jobs.pool_status
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
