### PR TITLE
[k8s] Use streaming json parser for listing nodes and pods: up to 2x speedup, 50% less memory for large clusters

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1216,7 +1216,7 @@ class V1PodStatus:
 
 @dataclasses.dataclass
 class V1ResourceRequirements:
-    requests: Dict[str, str]
+    requests: Optional[Dict[str, str]]
 
 
 @dataclasses.dataclass
@@ -1227,7 +1227,7 @@ class V1Container:
 @dataclasses.dataclass
 class V1PodSpec:
     containers: List[V1Container]
-    node_name: str
+    node_name: Optional[str]
 
 
 @dataclasses.dataclass
@@ -1242,15 +1242,15 @@ class V1Pod:
         return cls(metadata=V1ObjectMeta(
             name=data['metadata']['name'],
             labels=data['metadata'].get('labels', {}),
-            namespace=data['metadata'].get('namespace', ''),
+            namespace=data['metadata'].get('namespace'),
         ),
-                   status=V1PodStatus(phase=data['status'].get('phase', ''),),
+                   status=V1PodStatus(phase=data['status'].get('phase'),),
                    spec=V1PodSpec(
-                       node_name=data['spec'].get('nodeName', ''),
+                       node_name=data['spec'].get('nodeName'),
                        containers=[
                            V1Container(resources=V1ResourceRequirements(
                                requests=container.get('resources', {}).get(
-                                   'requests', {})))
+                                   'requests') or None))
                            for container in data['spec'].get('containers', [])
                        ]))
 

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1331,12 +1331,14 @@ def get_all_pods_in_kubernetes_cluster(*,
                     'items.item.spec.containers.item.resources.requests',
                     'start_map'):
                 current_requests = {}
+            elif (prefix, event) == (
+                    'items.item.spec.containers.item.resources.requests',
+                    'map_key'):
+                last_key = value
             elif prefix.startswith(
                     'items.item.spec.containers.item.resources.requests.'
             ) and event in ('string', 'number'):
-                # Extract the resource key from the prefix
-                resource_key = prefix.split('.')[-1]
-                current_requests[resource_key] = str(value)
+                current_requests[last_key] = str(value)
             elif (prefix, event) == (
                     'items.item.spec.containers.item.resources.requests',
                     'end_map'):

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -48,6 +48,7 @@ install_requires = [
     # (https://github.com/yaml/pyyaml/issues/601)
     # <= 3.13 may encounter https://github.com/ultralytics/yolov5/issues/414
     'pyyaml > 3.13, != 5.4.*',
+    'ijson',
     'requests',
     # SkyPilot inherits from uvicorn.Server to customize the behavior of
     # uvicorn, so we need to pin uvicorn version to avoid potential break

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -991,6 +991,55 @@ def test_kubernetes_context_failover(unreachable_context):
         smoke_tests_utils.run_one_test(test)
 
 
+@pytest.mark.kubernetes
+def test_kubernetes_get_nodes_and_pods():
+    """Test the correctness of get_kubernetes_nodes and get_all_pods_in_kubernetes_cluster,
+    as we parse the JSON ourselves and not using the Kubernetes Python client deserializer.
+    """
+    if smoke_tests_utils.is_non_docker_remote_api_server():
+        pytest.skip('Skipping test because the Kubernetes configs and '
+                    'credentials are located on the remote API server '
+                    'and not the machine where the test is running')
+    from sky.adaptors import kubernetes
+    from sky.provision.kubernetes import utils as kubernetes_utils
+
+    nodes = kubernetes_utils.get_kubernetes_nodes(context=None)
+    preloaded_nodes = kubernetes.core_api().list_node().items
+
+    for node, preloaded_node in zip(nodes, preloaded_nodes):
+        assert node.metadata.name == preloaded_node.metadata.name
+        assert node.metadata.labels == preloaded_node.metadata.labels
+
+        assert node.status.allocatable == preloaded_node.status.allocatable
+        assert node.status.capacity == preloaded_node.status.capacity
+        node_addresses = [{
+            'type': addr.type,
+            'address': addr.address
+        } for addr in node.status.addresses]
+        preloaded_addresses = [{
+            'type': addr.type,
+            'address': addr.address
+        } for addr in preloaded_node.status.addresses]
+        assert node_addresses == preloaded_addresses
+
+    pods = kubernetes_utils.get_all_pods_in_kubernetes_cluster(context=None)
+    preloaded_pods = kubernetes.core_api().list_pod_for_all_namespaces().items
+
+    for pod, preloaded_pod in zip(pods, preloaded_pods):
+        assert pod.metadata.name == preloaded_pod.metadata.name
+        assert pod.metadata.labels == preloaded_pod.metadata.labels
+        assert pod.metadata.namespace == preloaded_pod.metadata.namespace
+
+        assert pod.status.phase == preloaded_pod.status.phase
+
+        assert pod.spec.node_name == preloaded_pod.spec.node_name
+        assert len(pod.spec.containers) == len(preloaded_pod.spec.containers)
+
+        for container, preloaded_container in zip(
+                pod.spec.containers, preloaded_pod.spec.containers):
+            assert container.resources.requests == preloaded_container.resources.requests
+
+
 @pytest.mark.no_seeweb  # Seeweb fails to provision resources
 def test_launch_and_exec_async(generic_cloud: str):
     """Test if the launch and exec commands work correctly with --async."""


### PR DESCRIPTION
`get_kubernetes_node_info` calls the k8s API to list all nodes and pods. On large kubernetes clusters, this can be expensive in many ways, as the size of the response body can get really big. On a mock API server setup using [kwok](https://kwok.sigs.k8s.io/), I mocked 500 nodes and 5000 pods. The response size is 4MB for list nodes, and 34MB for list pods. I would expect real clusters to be bigger than this, as real nodes and pods would contain a lot more labels, annotations, etc.

This large response size contributes to both increased memory usage, as we have to load everything to memory to deserialize it into python objects, and also increased CPU usage and latency, which is mainly caused by a long standing [issue](https://github.com/kubernetes-client/python/issues/1921) on the kubernetes python client.

This PR is an attempt to improve this by using a streaming json parser ([ijson](https://github.com/ICRAR/ijson)), which should limit memory usage (as the streaming json parser will only keep BUFFER_SIZE bytes in memory at any given time, which we can configure). It should also improve the latency, as we won't incur the cost of deserializing to the kubernetes client's python objects.

The main trade-off here is we need to maintain our own schema which is a subset of the k8s API schema. The good thing is we only need to do it for two resources, Node and Pod, both of which are stable APIs at this point. Plus we only care about a few fields.

Preliminary results of Peak RSS + latency on the mock API server:

| Test Case | Master | This PR |
|-----------|--------------|-------------|
| 500 nodes + 5000 pods | 474.98 MB (6.7s) | 271.50 MB (2s) |
| 500 nodes + 1000 pods | 265.23 MB (2.4s)  | 218.45 MB (1.1s) |
| 100 nodes + 1000 pods | 229.33 MB (1.3s) | 187.80 MB (0.5s) |
| 50 nodes + 500 pods | 199.41 MB (0.8s) | 176.38 MB (0.3s) |

Note: For the latency improvements, I feel like we will see similar numbers if we just use `json.loads()`, because the main bottleneck is on the k8s client deserializer.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - New smoke test that compares our custom parsing with the original deserializer from the kubernetes client package
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
