### PR TITLE
[Core/DB] cluster yaml check for .debug file

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -2495,11 +2495,22 @@ def _set_cluster_yaml_from_file(cluster_yaml_path: str,
     # on the local file system and migrate it to the database.
     # TODO(syang): remove this check once we have a way to migrate the
     # cluster from file to database. Remove on v0.12.0.
-    if cluster_yaml_path is not None and os.path.exists(cluster_yaml_path):
-        with open(cluster_yaml_path, 'r', encoding='utf-8') as f:
-            yaml_str = f.read()
-        set_cluster_yaml(cluster_name, yaml_str)
-        return yaml_str
+    if cluster_yaml_path is not None:
+        # First try the exact path
+        path_to_read = None
+        if os.path.exists(cluster_yaml_path):
+            path_to_read = cluster_yaml_path
+        # Fallback: try with .debug suffix (when debug logging was enabled)
+        # Debug logging causes YAML files to be saved with .debug suffix
+        # but the path stored in the handle doesn't include it
+        debug_path = cluster_yaml_path + '.debug'
+        if os.path.exists(debug_path):
+            path_to_read = debug_path
+        if path_to_read is not None:
+            with open(path_to_read, 'r', encoding='utf-8') as f:
+                yaml_str = f.read()
+            set_cluster_yaml(cluster_name, yaml_str)
+            return yaml_str
     return None
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR addresses an issue where `sky status -u` can fail if a cluster does not have its generated yaml file stashed in the db in the `cluster_yaml` table or in the api server's local `/root/.sky/generated/` directory. 

When debug mode is enabled, the file in the `/root/.sky/generated/` directory will have a name like `cluster-name.yml.debug` rather than `cluster-name.yml` (which we currently look for). So, we add handling to be able to use either name. 


<!-- Describe the tests ran -->
I verified that a cluster that does not have the cluster yaml stashed in the db and whose local file follows the `.debug` naming schema no longer results in a `ValueError` being raised when calling `sky status`. Similarly, `sky down` works without error now (previously errored out in this scenario).
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
