### PR TITLE
[ux] add error details when --config is invalid

### DIFF
--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -825,7 +825,8 @@ def _compose_cli_config(cli_config: Optional[List[str]]) -> config_utils.Config:
     except ValueError as e:
         raise ValueError(f'Invalid config override: {cli_config}. '
                          f'Check if config file exists or if the dotlist '
-                         f'is formatted as: key1=value1,key2=value2') from e
+                         f'is formatted as: key1=value1,key2=value2.\n'
+                         f'Details: {e}') from e
     logger.debug('CLI overrides config syntax check passed.')
 
     return parsed_config

--- a/tests/smoke_tests/test_cli.py
+++ b/tests/smoke_tests/test_cli.py
@@ -129,8 +129,7 @@ def test_cli_invalid_config_details(generic_cloud: str):
         f'{invalid_override} tests/test_yamls/minimal.yaml 2>&1 | tee /dev/stderr) && '
         'echo "\\n===Validating config error details===\\n" && '
         f'echo "$s" | grep "{details_msg}" && '
-        f'echo "$s" | grep "{suggestion_msg}"'
-    )
+        f'echo "$s" | grep "{suggestion_msg}"')
 
     test = smoke_tests_utils.Test(
         'cli_invalid_config_details', [command],

--- a/tests/smoke_tests/test_cli.py
+++ b/tests/smoke_tests/test_cli.py
@@ -118,6 +118,26 @@ def test_sky_login_wih_env_endpoint(generic_cloud: str):
     smoke_tests_utils.run_one_test(test, check_sky_status=False)
 
 
+@pytest.mark.no_remote_server
+def test_cli_invalid_config_details(generic_cloud: str):
+    """Test that invalid config overrides surface detailed CLI errors."""
+    invalid_override = 'gcp.label.smoke-test=test-value'
+    details_msg = 'Details: Invalid config YAML from (CLI).'
+    suggestion_msg = "Instead of 'label', did you mean 'labels'?"
+    command = (
+        's=$(SKYPILOT_DEBUG=0 sky launch --config '
+        f'{invalid_override} tests/test_yamls/minimal.yaml 2>&1 | tee /dev/stderr) && '
+        'echo "\\n===Validating config error details===\\n" && '
+        f'echo "$s" | grep "{details_msg}" && '
+        f'echo "$s" | grep "{suggestion_msg}"'
+    )
+
+    test = smoke_tests_utils.Test(
+        'cli_invalid_config_details', [command],
+        timeout=smoke_tests_utils.get_timeout(generic_cloud))
+    smoke_tests_utils.run_one_test(test, check_sky_status=False)
+
+
 def test_cli_auto_retry(generic_cloud: str):
     """Test that cli auto retry works."""
     name = smoke_tests_utils.get_cluster_name()


### PR DESCRIPTION
Example from my use
Before:
```
Error: Invalid value for '--config': Invalid config override: ('gcp.label.cooperc-label-test=test-value',). Check if config file exists or if the dotlist is formatted as: key1=value1,key2=value2
```

After:
```
Error: Invalid value for '--config': Invalid config override: ('gcp.label.cooperc-label-test=test-value',). Check if config file exists or if the dotlist is formatted as: key1=value1,key2=value2.
Details: Invalid config YAML from (CLI). See: https://docs.skypilot.co/en/latest/reference/config.html. Error: Instead of 'label', did you mean 'labels'?
```

Latter message is way more helpful.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
