### PR TITLE
[jobs] adjust default controller size

### DIFF
--- a/docs/source/examples/managed-jobs.rst
+++ b/docs/source/examples/managed-jobs.rst
@@ -878,9 +878,9 @@ To set up credentials:
 Customizing jobs controller resources
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You may want to customize the resources of the jobs controller for several reasons:
+You may want to customize the jobs controller resources for several reasons:
 
-#. Increasing the maximum number of jobs that can be run concurrently, which is based on the instance size of the controller. (Default: 90, see :ref:`best practices <jobs-controller-sizing>`)
+#. Increasing the maximum number of jobs that can be run concurrently, which is based on the controller's memory allocation. (Default: ~600, see :ref:`best practices <jobs-controller-sizing>`)
 #. Use a lower-cost controller (if you have a low number of concurrent managed jobs).
 #. Enforcing the jobs controller to run on a specific location. (Default: cheapest location)
 #. Changing the disk_size of the jobs controller to store more logs. (Default: 50GB)
@@ -900,7 +900,7 @@ To achieve the above, you can specify custom configs in :code:`~/.sky/config.yam
         # Bump cpus to allow more managed jobs to be launched concurrently. (Default: 4+)
         cpus: 8+
         # Bump memory to allow more managed jobs to be running at once.
-        # By default, it scales with CPU (8x).
+        # By default, it scales with CPU (4x).
         memory: 64+
         # Specify the disk_size in GB of the jobs controller.
         disk_size: 100
@@ -922,7 +922,7 @@ To see your current jobs controller, use :code:`sky status`.
   NAME                          INFRA             RESOURCES                                  STATUS   AUTOSTOP  LAUNCHED
   my-cluster-1                  AWS (us-east-1)   1x(cpus=16, m6i.4xlarge, ...)              STOPPED  -         1 week ago
   my-other-cluster              GCP (us-central1) 1x(cpus=16, n2-standard-16, ...)           STOPPED  -         1 week ago
-  sky-jobs-controller-919df126  AWS (us-east-1)   1x(cpus=2, r6i.xlarge, disk_size=50)       STOPPED  10m       1 day ago
+  sky-jobs-controller-919df126  AWS (us-east-1)   1x(cpus=4, m6i.xlarge, disk_size=50)       STOPPED  10m       1 day ago
 
   Managed jobs
   No in-progress managed jobs.
@@ -930,7 +930,7 @@ To see your current jobs controller, use :code:`sky status`.
   Services
   No live services.
 
-In this example, you can see the jobs controller (:code:`sky-jobs-controller-919df126`) is an r6i.xlarge on AWS, which is the default size.
+In this example, you can see the jobs controller (:code:`sky-jobs-controller-919df126`) is an m6i.xlarge on AWS, which is the default size.
 
 To tear down the current controller, so that new resource config is picked up, use :code:`sky down`.
 
@@ -958,31 +958,59 @@ Best practices for scaling up the jobs controller
 
 The number of active jobs that the controller supports is based on the controller size. There are two limits that apply:
 
-- **Actively launching job count**: maxes out at ``4 * vCPU count``.
+- **Actively launching job count**: maxes out at ``8 * floor((memory - 2GiB) / 3.59GiB)``.
   A job counts towards this limit when it is first starting, launching instances, or recovering.
 
-  - The default controller size has 4 CPUs, meaning **16 jobs** can be actively launching at once.
+  - The default controller size has 16 GiB memory, meaning **24 jobs** can be actively launching at once.
 
-- **Running job count**: maxes out at ``memory / 350MiB``, up to a max of ``2000`` jobs.
+- **Running job count**: maxes out at ``200 * floor((memory - 2GiB) / 3.59GiB)``.
 
-  - The default controller size has 32GiB of memory, meaning around **90 jobs** can be running in parallel.
+  - The default controller size supports up to **600 jobs** running in parallel.
 
-The default size is appropriate for most moderate use cases, but if you need to run hundreds or thousands of jobs at once, you should increase the controller size.
+The default size is appropriate for most moderate use cases, but if you need to run hundreds or thousands of jobs at once, you should increase the controller size. Each additional ~3.6 GiB of controller memory adds capacity for 8 concurrent launches and 200 concurrently running jobs.
 
-For maximum parallelism, the following configuration is recommended:
+Increase CPU modestly as memory grows to keep controller responsiveness high, but note that the hard parallelism limits are driven by available memory.
+A ratio of 4 GiB memory per CPU works well in our testing.
 
-.. code-block:: yaml
+For absolute maximum parallelism, the following per-cloud configurations are recommended:
 
-  jobs:
-    controller:
-      resources:
-        # In our testing, aws > gcp > azure
-        infra: aws
-        cpus: 128
-        # Azure does not have 128+ CPU instances, so use 96 instead
-        # cpus: 96
-        memory: 600+
-        disk_size: 500
+.. tab-set::
+
+    .. tab-item:: AWS
+
+        .. code-block:: yaml
+
+            jobs:
+              controller:
+                resources:
+                  infra: aws
+                  cpus: 192
+                  memory: 4x
+                  disk_size: 500
+
+    .. tab-item:: GCP
+
+        .. code-block:: yaml
+
+            jobs:
+              controller:
+                resources:
+                  infra: gcp
+                  cpus: 128
+                  memory: 4x
+                  disk_size: 500
+
+    .. tab-item:: Azure
+
+        .. code-block:: yaml
+
+            jobs:
+              controller:
+                resources:
+                  infra: azure
+                  cpus: 96
+                  memory: 4x
+                  disk_size: 500
 
 .. note::
   Remember to tear down your controller to apply these changes, as described above.
@@ -995,17 +1023,17 @@ With this configuration, you'll get the following performance:
 
    * - Cloud
      - Instance type
-     - Launching jobs
+     - Launches at once
      - Running jobs
    * - AWS
-     - r6i.32xlarge
-     - **512 launches at once**
-     - **2000 running at once**
+     - m7i.48xlarge (~768GiB RAM)
+     - **~1,704**
+     - **~42,600**
    * - GCP
-     - n2-highmem-128
-     - **512 launches at once**
-     - **2000 running at once**
+     - n2-standard-128 (~512GiB RAM)
+     - **~1,136**
+     - **~28,400**
    * - Azure
-     - Standard_E96s_v5
-     - **384 launches at once**
-     - **1930 running at once**
+     - Standard_D96s_v5 (~384GiB RAM)
+     - **~848**
+     - **~21,200**

--- a/docs/source/running-jobs/many-jobs.rst
+++ b/docs/source/running-jobs/many-jobs.rst
@@ -374,4 +374,4 @@ Then, submit all jobs by iterating over the config files and calling ``sky jobs 
 Best practices for scaling
 --------------------------
 
-By default, around 90 jobs can be managed at once. However, with some simple configuration, SkyPilot can reliably support **2000 jobs running in parallel**. See :ref:`the best practices <jobs-controller-sizing>` for more info.
+By default, roughly 600 jobs can run in parallel (with about 24 launching at once). Increasing the controller's resources bumps those ceilings proportionally, and large controllers can reliably manage thousands of jobs in parallel. See :ref:`the best practices <jobs-controller-sizing>` for more info.

--- a/sky/jobs/constants.py
+++ b/sky/jobs/constants.py
@@ -15,15 +15,9 @@ JOB_CONTROLLER_INDICATOR_FILE = '~/.sky/is_jobs_controller'
 CONSOLIDATED_SIGNAL_PATH = os.path.expanduser('~/.sky/signals/')
 SIGNAL_FILE_PREFIX = '/tmp/sky_jobs_controller_signal_{}'
 # Resources as a dict for the jobs controller.
-# Use smaller CPU instance type for jobs controller, but with more memory, i.e.
-# r6i.xlarge (4vCPUs, 32 GB) for AWS, Standard_E4s_v5 (4vCPUs, 32 GB) for Azure,
-# and n2-highmem-4 (4 vCPUs, 32 GB) for GCP, etc.
-# Concurrently limits are set based on profiling. 4x num vCPUs is the launch
-# parallelism limit, and memory / 350MB is the limit to concurrently running
-# jobs. See _get_launch_parallelism and _get_job_parallelism in scheduler.py.
 # We use 50 GB disk size to reduce the cost.
 CONTROLLER_RESOURCES: Dict[str, Union[str, int]] = {
-    'cpus': '8+',
+    'cpus': '4+',
     'memory': '4x',
     'disk_size': 50
 }

--- a/sky/jobs/constants.py
+++ b/sky/jobs/constants.py
@@ -23,8 +23,8 @@ SIGNAL_FILE_PREFIX = '/tmp/sky_jobs_controller_signal_{}'
 # jobs. See _get_launch_parallelism and _get_job_parallelism in scheduler.py.
 # We use 50 GB disk size to reduce the cost.
 CONTROLLER_RESOURCES: Dict[str, Union[str, int]] = {
-    'cpus': '4+',
-    'memory': '8x',
+    'cpus': '8+',
+    'memory': '4x',
     'disk_size': 50
 }
 

--- a/tests/unit_tests/test_controller_utils.py
+++ b/tests/unit_tests/test_controller_utils.py
@@ -23,16 +23,16 @@ _DEFAULT_AUTOSTOP = {
 @pytest.mark.parametrize(
     ('controller_type', 'custom_controller_resources_config', 'expected'), [
         ('jobs', {}, {
-            'cpus': '8+',
+            'cpus': '4+',
             'memory': '4x',
             'disk_size': 50,
             'autostop': _DEFAULT_AUTOSTOP,
         }),
         ('jobs', {
-            'cpus': '4+',
+            'cpus': '8+',
             'disk_size': 100,
         }, {
-            'cpus': '4+',
+            'cpus': '8+',
             'memory': '4x',
             'disk_size': 100,
             'autostop': _DEFAULT_AUTOSTOP,

--- a/tests/unit_tests/test_controller_utils.py
+++ b/tests/unit_tests/test_controller_utils.py
@@ -23,8 +23,8 @@ _DEFAULT_AUTOSTOP = {
 @pytest.mark.parametrize(
     ('controller_type', 'custom_controller_resources_config', 'expected'), [
         ('jobs', {}, {
-            'cpus': '4+',
-            'memory': '8x',
+            'cpus': '8+',
+            'memory': '4x',
             'disk_size': 50,
             'autostop': _DEFAULT_AUTOSTOP,
         }),
@@ -33,7 +33,7 @@ _DEFAULT_AUTOSTOP = {
             'disk_size': 100,
         }, {
             'cpus': '4+',
-            'memory': '8x',
+            'memory': '4x',
             'disk_size': 100,
             'autostop': _DEFAULT_AUTOSTOP,
         }),
@@ -66,6 +66,8 @@ def test_get_controller_resources(controller_type: str,
     monkeypatch.setattr('sky.skypilot_config.loaded', lambda: True)
     monkeypatch.setattr('sky.skypilot_config.get_nested',
                         get_custom_controller_resources)
+    monkeypatch.setattr('sky.global_user_state.get_handle_from_cluster_name',
+                        lambda _: None)
 
     controller_resources = list(
         controller_utils.get_controller_resources(


### PR DESCRIPTION
Now, we are way more CPU limited than memory. Change the controller so that the memory/cpu ratio is 4x.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
