### PR TITLE
[Kubernetes] Use Dedicated Threads for SSH

### DIFF
--- a/sky/server/config.py
+++ b/sky/server/config.py
@@ -205,7 +205,11 @@ def _max_long_worker_parallism(cpu_count: int,
     max_memory = (server_constants.MIN_AVAIL_MEM_GB_CONSOLIDATION_MODE
                   if job_utils.is_consolidation_mode() else
                   server_constants.MIN_AVAIL_MEM_GB)
-    available_mem = max(0, mem_size_gb - max_memory)
+    reserved_ssh_mem = (
+        server_constants.MAX_CONCURRENT_KUBE_SSH_CONNECTIONS * 
+        server_constants.GLIBC_PER_THREAD_STACK_SIZE_GB
+    )
+    available_mem = max(0, mem_size_gb - max_memory - reserved_ssh_mem)
     cpu_based_max_parallel = cpu_count * _CPU_MULTIPLIER_FOR_LONG_WORKERS
     mem_based_max_parallel = int(available_mem * _MAX_MEM_PERCENT_FOR_BLOCKING /
                                  LONG_WORKER_MEM_GB)
@@ -234,7 +238,14 @@ def _max_short_worker_parallism(mem_size_gb: float,
     max_memory = (server_constants.MIN_AVAIL_MEM_GB_CONSOLIDATION_MODE
                   if job_utils.is_consolidation_mode() else
                   server_constants.MIN_AVAIL_MEM_GB)
-    reserved_mem = max_memory + (long_worker_parallism * LONG_WORKER_MEM_GB)
+    reserved_ssh_mem = (
+        server_constants.MAX_CONCURRENT_KUBE_SSH_CONNECTIONS * 
+        server_constants.GLIBC_PER_THREAD_STACK_SIZE_GB
+    )
+    reserved_mem = (
+        max_memory + (long_worker_parallism * LONG_WORKER_MEM_GB) + 
+        reserved_ssh_mem
+    )
     available_mem = max(0, mem_size_gb - reserved_mem)
     n = max(_get_min_short_workers(), int(available_mem / SHORT_WORKER_MEM_GB))
     return n

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -48,6 +48,12 @@ CLUSTER_REFRESH_DAEMON_INTERVAL_SECONDS = 60
 # background.
 VOLUME_REFRESH_DAEMON_INTERVAL_SECONDS = 60
 
+# The assumed stack size per thread for glibc.
+GLIBC_PER_THREAD_STACK_SIZE_GB = 8 / 1024  # 8MB
+
+# The maximum number of concurrent kubernetes pod ssh connections.
+MAX_CONCURRENT_KUBE_SSH_CONNECTIONS = 1000
+
 # Environment variable for a file path to the API cookie file.
 # Keep in sync with websocket_proxy.py
 API_COOKIE_FILE_ENV_VAR = f'{constants.SKYPILOT_ENV_VAR_PREFIX}API_COOKIE_FILE'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR changes the handling for `/kubernetes-pod-ssh-proxy` to use dedicated threads to ferry information from the websocket to the kubernetes pod and from the kubernetes pod to the websocket. This prevent us from blocking ssh session when the asyncio loop is oversubscribed.

I do need to change the math to assume two threads per connection instead of one, but perhaps we should handle them both in a single thread.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
