### PR TITLE
fix(kubernetes): align accelerator dict keys during scaling (#7100)

### DIFF
--- a/sky/catalog/kubernetes_catalog.py
+++ b/sky/catalog/kubernetes_catalog.py
@@ -317,6 +317,26 @@ def _list_accelerators(
     qtys_map = common.list_accelerators_impl('Kubernetes', df, gpus_only,
                                              name_filter, region_filter,
                                              quantity_filter, case_sensitive)
+
+    # Align keys across counts, capacity, and available dictionaries.
+    # During cluster scaling events (e.g., node pool resizing), accelerators
+    # may be discovered but not yet have capacity/availability reported.
+    # We need to ensure all three dicts have the same keys to avoid assertion
+    # errors downstream.
+    all_keys = (set(qtys_map.keys()) | set(total_accelerators_capacity.keys()) |
+                set(total_accelerators_available.keys()))
+
+    for key in all_keys:
+        # Set default empty list for counts if key is missing
+        if key not in qtys_map:
+            qtys_map[key] = []
+        # Set default 0 for capacity if key is missing
+        if key not in total_accelerators_capacity:
+            total_accelerators_capacity[key] = 0
+        # Set default 0 for available if key is missing
+        if key not in total_accelerators_available:
+            total_accelerators_available[key] = 0
+
     return qtys_map, total_accelerators_capacity, total_accelerators_available
 
 

--- a/sky/core.py
+++ b/sky/core.py
@@ -1232,10 +1232,12 @@ def realtime_kubernetes_gpu_availability(
             quantity_filter=quantity_filter,
             case_sensitive=False)
         assert (set(counts.keys()) == set(capacity.keys()) == set(
-            available.keys())), (f'Keys of counts ({list(counts.keys())}), '
-                                 f'capacity ({list(capacity.keys())}), '
-                                 f'and available ({list(available.keys())}) '
-                                 'must be the same.')
+            available.keys())), (
+                f'Keys of counts ({list(counts.keys())}), '
+                f'capacity ({list(capacity.keys())}), '
+                f'and available ({list(available.keys())}) '
+                f'must be the same. This may occur during cluster scaling '
+                f'events. Context: {context}')
         realtime_gpu_availability_list: List[
             models.RealtimeGpuAvailability] = []
 


### PR DESCRIPTION
## Problem
`sky show-gpus --infra k8s` fails with:
AssertionError: Keys of counts ([]), capacity ([]), and available (['L4']) must be the same.

markdown
Copy code
This happens during Kubernetes cluster scaling (e.g., GKE node pool resizing).  
Accelerators are discovered by node labels before allocatable capacity/availability is reported, leading to mismatched keys.

## Change
- **sky/catalog/kubernetes_catalog.py**: Added key alignment logic to ensure counts, capacity, and available dicts have the same keys.  
- **sky/core.py**: Improved assertion message to include context for easier debugging.  
- **tests/unit_tests/kubernetes/test_kubernetes_utils.py**: Added test cases for:
  - Nodes scaling with 0-capacity accelerators
  - Mixed ready + scaling nodes

## Why
- Prevents `sky show-gpus` from crashing during cluster scaling.
- Handles transient states gracefully.
- Provides better debugging info if an error occurs in future.

## Tested
- Unit tests: `pytest tests/unit_tests/kubernetes/test_kubernetes_utils.py`
- All catalog-related tests: `pytest tests/unit_tests -k catalog`
- Only changed files formatted via pre-commit/format.sh
- Edge cases simulated (scaling-only, mixed nodes, no accelerators)

## Files Modified
- `sky/catalog/kubernetes_catalog.py`
- `sky/core.py`
- `tests/unit_tests/kubernetes/test_kubernetes_utils.py`

Fixes: #7100

## Note:
The second push rebases this branch on the latest upstream master, as the previous PR attempt was based on an older fork.

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->