### PR TITLE
[k8s] move filtering to stream time when calculating allocated GPU quantity by each node

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1256,26 +1256,45 @@ class V1Pod:
 
 
 @_retry_on_error(resource_type='pod')
-def get_all_pods_in_kubernetes_cluster(*,
-                                       context: Optional[str] = None
-                                      ) -> List[V1Pod]:
-    """Gets pods in all namespaces in kubernetes cluster indicated by context.
-
-    Used for computing cluster resource usage.
+def get_allocated_gpu_qty_by_node(
+    *,
+    context: Optional[str] = None,
+) -> Dict[str, int]:
+    """Gets allocated GPU quantity by each node by fetching pods in
+    all namespaces in kubernetes cluster indicated by context.
     """
     if context is None:
         context = get_current_kube_config_context_name()
+    non_included_pod_statuses = POD_STATUSES.copy()
+    status_filters = ['Running', 'Pending']
+    if status_filters is not None:
+        non_included_pod_statuses -= set(status_filters)
+        field_selector = ','.join(
+            [f'status.phase!={status}' for status in non_included_pod_statuses])
 
     # Return raw urllib3.HTTPResponse object so that we can parse the json
     # more efficiently.
     response = kubernetes.core_api(context).list_pod_for_all_namespaces(
-        _request_timeout=kubernetes.API_TIMEOUT, _preload_content=False)
-    pods = [
-        V1Pod.from_dict(item_dict) for item_dict in ijson.items(
-            response, 'items.item', buf_size=IJSON_BUFFER_SIZE)
-    ]
-
-    return pods
+        _request_timeout=kubernetes.API_TIMEOUT,
+        _preload_content=False,
+        field_selector=field_selector)
+    allocated_qty_by_node: Dict[str, int] = collections.defaultdict(int)
+    for item_dict in ijson.items(response,
+                                 'items.item',
+                                 buf_size=IJSON_BUFFER_SIZE):
+        pod = V1Pod.from_dict(item_dict)
+        if should_exclude_pod_from_gpu_allocation(pod):
+            logger.debug(f'Excluding pod {pod.metadata.name} from GPU count '
+                         f'calculations on node {pod.spec.node_name}')
+            continue
+        # Sum GPU requests across all containers
+        for container in pod.spec.containers:
+            if container.resources.requests:
+                allocated_qty = get_node_accelerator_count(
+                    context, container.resources.requests)
+                if allocated_qty > 0 and pod.spec.node_name:
+                    allocated_qty_by_node[pod.spec.node_name] += allocated_qty
+    return allocated_qty_by_node
 
 
 def check_instance_fits(context: Optional[str],
@@ -2964,31 +2983,12 @@ def get_kubernetes_node_info(
             has_accelerator_nodes = True
             break
 
-    # Get the pods to get the real-time resource usage
-    pods = None
+    # Get the allocated GPU quantity by each node
     allocated_qty_by_node: Dict[str, int] = collections.defaultdict(int)
     if has_accelerator_nodes:
         try:
-            pods = get_all_pods_in_kubernetes_cluster(context=context)
-            # Pre-compute allocated accelerator count per node
-            for pod in pods:
-                if pod.status.phase in ['Running', 'Pending']:
-                    # Skip pods that should not count against GPU count
-                    if should_exclude_pod_from_gpu_allocation(pod):
-                        logger.debug(f'Excluding low priority pod '
-                                     f'{pod.metadata.name} from GPU allocation '
-                                     f'calculations')
-                        continue
-                    # Iterate over all the containers in the pod and sum the
-                    # GPU requests
-                    pod_allocated_qty = 0
-                    for container in pod.spec.containers:
-                        if container.resources.requests:
-                            pod_allocated_qty += get_node_accelerator_count(
-                                context, container.resources.requests)
-                    if pod_allocated_qty > 0:
-                        allocated_qty_by_node[
-                            pod.spec.node_name] += pod_allocated_qty
+            allocated_qty_by_node = get_allocated_gpu_qty_by_node(
+                context=context)
         except kubernetes.api_exception() as e:
             if e.status == 403:
                 pass
@@ -3035,7 +3035,7 @@ def get_kubernetes_node_info(
                 ip_address=node_ip)
             continue
 
-        if pods is None:
+        if not has_accelerator_nodes:
             accelerators_available = -1
         else:
             allocated_qty = allocated_qty_by_node[node.metadata.name]


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The two users of `get_all_pods_in_kubernetes_cluster` does the same postprocessing of the pods
- filter out pods that are not in PENDING or RUNNING
- filter out pods according to `should_exclude_pod_from_gpu_allocation`
and then postprocesses the pods calculate a `collections.defaultdict(int)`.

By moving the filtering and postprocessing logic into the stream processing, we can reduce the memory needs of executing this call especially in larger k8s contexts with a lot of pods.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
