### PR TITLE
[k8s] reduce API calls during k8s check

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1689,6 +1689,8 @@ def check_credentials(context: Optional[str],
         namespace = get_kube_config_context_namespace(context)
         kubernetes.core_api(context).list_namespaced_pod(
             namespace, limit=1, _request_timeout=timeout)
+        # This call is "free" because this function is a cached call,
+        # and it will not be called again in this function.
         get_kubernetes_nodes(context=context)
     except ImportError:
         # TODO(romilb): Update these error strs to also include link to docs

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1671,7 +1671,6 @@ def get_port(svc_name: str, namespace: str, context: Optional[str]) -> int:
 
 
 def check_credentials(context: Optional[str],
-                      timeout: int = kubernetes.API_TIMEOUT,
                       run_optional_checks: bool = False) -> \
         Tuple[bool, Optional[str]]:
     """Check if the credentials in kubeconfig file are valid
@@ -1686,9 +1685,8 @@ def check_credentials(context: Optional[str],
         str: Error message if credentials are invalid, None otherwise
     """
     try:
-        namespace = get_kube_config_context_namespace(context)
-        kubernetes.core_api(context).list_namespaced_pod(
-            namespace, _request_timeout=timeout)
+        get_kube_config_context_namespace(context)
+        get_kubernetes_nodes(context=context)
     except ImportError:
         # TODO(romilb): Update these error strs to also include link to docs
         #  when docs are ready.

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1671,6 +1671,7 @@ def get_port(svc_name: str, namespace: str, context: Optional[str]) -> int:
 
 
 def check_credentials(context: Optional[str],
+                      timeout: int = kubernetes.API_TIMEOUT,
                       run_optional_checks: bool = False) -> \
         Tuple[bool, Optional[str]]:
     """Check if the credentials in kubeconfig file are valid
@@ -1685,7 +1686,9 @@ def check_credentials(context: Optional[str],
         str: Error message if credentials are invalid, None otherwise
     """
     try:
-        get_kube_config_context_namespace(context)
+        namespace = get_kube_config_context_namespace(context)
+        kubernetes.core_api(context).list_namespaced_pod(
+            namespace, limit=1, _request_timeout=timeout)
         get_kubernetes_nodes(context=context)
     except ImportError:
         # TODO(romilb): Update these error strs to also include link to docs


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This subtle change can reduce the credential check time of k8s by significant amount for following reasons:
1. `get_kubernetes_nodes` is a much cheaper call than `list_namespaced_pod`. Since the purpose of making a call here is that _a_ k8s API call succeeds, we should call a much cheaper API endpoint.
2. `get_kubernetes_nodes` is a cached call, and codepaths further down in `check_credentials` makes calls to `get_kubernetes_nodes`. Therefore, calling `get_kubernetes_nodes` is essentially free as future invocations will simply use a cached response from this call.

`get_kubernetes_nodes` implementation already sets the API timeout of `kubernetes.API_TIMEOUT`. Since no caller of `check_credentials` actually specifies a timeout different from default, the timeout logic stays identical.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
