### PR TITLE
[Volumes] make VolumeRecord region and size optional to match VolumeConfig

### DIFF
--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -206,9 +206,9 @@ class VolumeRecord(ResponseBaseModel):
     type: str
     launched_at: int
     cloud: str
-    region: str
+    region: Optional[str] = None
     zone: Optional[str] = None
-    size: str
+    size: Optional[str] = None
     config: Dict[str, Any]
     name_on_cloud: str
     user_hash: str


### PR DESCRIPTION
In `volume_list`, we read record['region'] and record['size'] from `VolumeConfig`, and in `VolumeConfig`, both of them are optional, so we should also make it optional in `VolumeRecord`.

https://github.com/skypilot-org/skypilot/blob/727ea9a60a919fd2ea477dea03a4096136355d20/sky/models.py#L101-L117

This was causing an issue on one of our older API server, where `sky volumes ls` failed with:
```
sky.exceptions.CloudError: pydantic_core error (ValidationError): 1 validation error for
VolumeRecord
region
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.11/v/string_type
```

The record that made it fail had `region` set to None:
```
{'name': 't-volume1', 'launched_at': 1757037347, 'user_hash': 'abcdef',
'user_name': 'bob', 'workspace': 'default', 'last_attached_at': None,
'last_use': 'sky volumes apply --infra k8s -n t-volume1 --size 10 --type k8s-pvc -y',
'usedby_pods': [], 'usedby_clusters': [], 'status': 'READY', 'type': 'k8s-pvc', 'cloud':
'Kubernetes', 'region': None, 'zone': None, 'size': '10', 'config': {'access_mode':
'ReadWriteOnce', 'namespace': 'skypilot'}, 'name_on_cloud': 't-volume1-a246a9e3-87f25e'}
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
