### PR TITLE
FIX (kubernetes): align accelerator dict keys during scaling (#7100)

### DIFF
--- a/sky/core.py
+++ b/sky/core.py
@@ -1232,10 +1232,12 @@ def realtime_kubernetes_gpu_availability(
             quantity_filter=quantity_filter,
             case_sensitive=False)
         assert (set(counts.keys()) == set(capacity.keys()) == set(
-            available.keys())), (f'Keys of counts ({list(counts.keys())}), '
-                                 f'capacity ({list(capacity.keys())}), '
-                                 f'and available ({list(available.keys())}) '
-                                 'must be the same.')
+            available.keys())), (
+                f'Keys of counts ({list(counts.keys())}), '
+                f'capacity ({list(capacity.keys())}), '
+                f'and available ({list(available.keys())}) '
+                f'must be the same. This may indicate a transient state '
+                f'during cluster scaling. Context: {context}')
         realtime_gpu_availability_list: List[
             models.RealtimeGpuAvailability] = []
 


### PR DESCRIPTION
## Problem
`sky show-gpus --infra k8s` fails with:
AssertionError: Keys of counts ([]), capacity ([]), and available (['L4']) must be the same.

This occurs during Kubernetes cluster scaling (e.g., when a GKE GPU node pool is resizing).  
Accelerators are discovered via node labels before their `status.allocatable` field reports capacity or availability, leading to mismatched accelerator dictionary keys.

---

## Change
- **sky/catalog/kubernetes_catalog.py**: Added key alignment logic to ensure `counts`, `capacity`, and `available` dictionaries always share the same keys.
- **sky/core.py**: Improved assertion message to include contextual information for easier debugging.
- **tests/unit_tests/kubernetes/test_kubernetes_utils.py**: Added comprehensive test cases covering:
  - Nodes scaling with 0-capacity accelerators  
  - Mixed ready + scaling nodes  
  - Edge scenarios with transient GPU states  

---

## Why
- Prevents `sky show-gpus --infra k8s` from crashing during cluster scaling operations.  
- Handles transient Kubernetes states gracefully.  
- Improves robustness and error transparency for GPU discovery.  
- Platform-agnostic — while first reported on GKE, this fix applies to **any** Kubernetes environment (EKS, AKS, on-prem, etc.).

---

## Tested
- Unit tests: `pytest tests/unit_tests/kubernetes/test_kubernetes_utils.py`  
- All catalog-related tests: `pytest tests/unit_tests -k catalog`  
- Pre-commit formatting and linting (`pre-commit run --files <changed-files>` or `./format.sh <changed-files>`)  
- Edge cases simulated (scaling-only, mixed-node clusters, no accelerators)  

---

## Files Modified
- `sky/catalog/kubernetes_catalog.py`  
- `sky/core.py`  
- `tests/unit_tests/kubernetes/test_kubernetes_utils.py`  

**Fixes:** #7100  

---

### Notes
- This branch rebases on the latest `upstream/master` to ensure a clean, up-to-date diff.  

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
