### PR TITLE
[jobs] catch some errors from get_job_status

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -324,11 +324,22 @@ async def get_job_status(
                 detailed_reason = 'Timeout'
             # TODO(cooperc): Gracefully handle these exceptions in the backend.
             elif isinstance(e, ValueError):
+                # If the cluster yaml is deleted in the middle of getting the
+                # SSH credentials, we could see this. See
+                # sky/global_user_state.py get_cluster_yaml_dict.
                 if re.search(r'Cluster yaml .* not found', str(e)):
                     detailed_reason = 'Cluster yaml was deleted'
                 else:
                     raise
             elif isinstance(e, TypeError):
+                # We will grab the SSH credentials from the cluster yaml, but if
+                # handle.cluster_yaml is None, we will just return an empty dict
+                # for the credentials. See
+                # backend_utils.ssh_credential_from_yaml. Then, the credentials
+                # are passed as kwargs to SSHCommandRunner.__init__ - see
+                # cloud_vm_ray_backend.get_command_runners. So we can hit this
+                # TypeError if the cluster yaml is removed from the handle right
+                # when we pull it before the cluster is fully deleted.
                 error_msg_to_check = (
                     'SSHCommandRunner.__init__() missing 2 required positional '
                     'arguments: \'ssh_user\' and \'ssh_private_key\'')


### PR DESCRIPTION
It's possible that backend.get_job_status throws a TypeError or ValueError in some rare cases. This just indicates that the cluster was cleaned up in the middle of the status check, probably by the skypilot-status-refresh-daemon. This is fine, and we should just treat the cluster is down and recover the managed jobs.

We should gracefully handle these errors within backend.get_job_status, but this will make sure that managed jobs aren't broken in the mean time.

<!-- Describe the changes in this PR -->

### Exception details:

I saw these two stacktraces in job controller tests:
```
I 10-02 06:44:58 utils.py:289] === Checking the job status... ===
E 10-02 06:45:21 controller.py:756] Unexpected error in JobsController run for task 0
E 10-02 06:45:21 controller.py:759] Traceback (most recent call last):
E 10-02 06:45:21 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/jobs/controller.py", line 716, in run
E 10-02 06:45:21 controller.py:759]     succeeded = await self._run_one_task(task_id, task)
E 10-02 06:45:21 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/jobs/controller.py", line 460, in _run_one_task
E 10-02 06:45:21 controller.py:759]     job_status = await managed_job_utils.get_job_status(
E 10-02 06:45:21 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/jobs/utils.py", line 290, in get_job_status
E 10-02 06:45:21 controller.py:759]     statuses = await context_utils.to_thread(backend.get_job_status,
E 10-02 06:45:21 controller.py:759]   File "/home/ubuntu/miniconda3/lib/python3.10/concurrent/futures/thread.py", line 58, in run
E 10-02 06:45:21 controller.py:759]     result = self.fn(*self.args, **self.kwargs)
E 10-02 06:45:21 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/backends/cloud_vm_ray_backend.py", line 4602, in get_job_status
E 10-02 06:45:21 controller.py:759]     returncode, stdout, stderr = self.run_on_head(handle,
E 10-02 06:45:21 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/utils/common_utils.py", line 618, in _record
E 10-02 06:45:21 controller.py:759]     return f(*args, **kwargs)
E 10-02 06:45:21 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/utils/context_utils.py", line 173, in wrapper
E 10-02 06:45:21 controller.py:759]     return func(*args, **kwargs)
E 10-02 06:45:21 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/backends/cloud_vm_ray_backend.py", line 5672, in run_on_head
E 10-02 06:45:21 controller.py:759]     runners = handle.get_command_runners()
E 10-02 06:45:21 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/utils/context_utils.py", line 173, in wrapper
E 10-02 06:45:21 controller.py:759]     return func(*args, **kwargs)
E 10-02 06:45:21 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/utils/common_utils.py", line 618, in _record
E 10-02 06:45:21 controller.py:759]     return f(*args, **kwargs)
E 10-02 06:45:21 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/backends/cloud_vm_ray_backend.py", line 2606, in get_command_runners
E 10-02 06:45:21 controller.py:759]     ssh_credentials = backend_utils.ssh_credential_from_yaml(
E 10-02 06:45:21 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/backends/backend_utils.py", line 1458, in ssh_credential_from_yaml
E 10-02 06:45:21 controller.py:759]     config = global_user_state.get_cluster_yaml_dict(cluster_yaml)
E 10-02 06:45:21 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/global_user_state.py", line 2497, in get_cluster_yaml_dict
E 10-02 06:45:21 controller.py:759]     raise ValueError(f'Cluster yaml {cluster_yaml_path} not found.')
E 10-02 06:45:21 controller.py:759] ValueError: Cluster yaml /home/ubuntu/.sky/generated/job-b-26-25.yml not found.
E 10-02 06:45:21 controller.py:759]
E 10-02 06:45:21 controller.py:762] Unexpected error occurred: [ValueError] Cluster yaml /home/ubuntu/.sky/generated/job-b-26-25.yml not found.
I 10-02 06:45:21 controller.py:786] Updating failed task state: task_id=0, failure_type=ManagedJobStatus.FAILED_CONTROLLER
D 10-02 06:45:49 utils.py:144] The cluster job-b-26-25 is already down.
I 10-02 06:45:50 controller.py:852] job-b-26-25 is down
I 10-02 06:45:51 controller.py:1003] Cluster of managed job 25 has been cleaned up.
I 10-02 06:45:42 state.py:1835] Unexpected error occurred: [ValueError] Cluster yaml /home/ubuntu/.sky/generated/job-b-26-25.yml not found.
I 10-02 06:45:44 state.py:1858] Cancellation skipped, job is already terminal
I 10-02 06:45:44 state.py:1882] Cancellation skipped, job is not CANCELLING
I 10-02 06:45:50 backend_utils.py:3225] Cluster(s) not found: job-b-26-25.
✓ Job finished (status: ManagedJobStatus.FAILED_CONTROLLER).
```

```
E 10-04 09:48:43 controller.py:756] Unexpected error in JobsController run for task 0
E 10-04 09:48:43 controller.py:759] Traceback (most recent call last):
E 10-04 09:48:43 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/jobs/controller.py", line 716, in run
E 10-04 09:48:43 controller.py:759]     succeeded = await self._run_one_task(task_id, task)
E 10-04 09:48:43 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/jobs/controller.py", line 460, in _run_one_task
E 10-04 09:48:43 controller.py:759]     job_status = await managed_job_utils.get_job_status(
E 10-04 09:48:43 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/jobs/utils.py", line 291, in get_job_status
E 10-04 09:48:43 controller.py:759]     statuses = await context_utils.to_thread(backend.get_job_status,
E 10-04 09:48:43 controller.py:759]   File "/home/ubuntu/miniconda3/lib/python3.10/concurrent/futures/thread.py", line 58, in run
E 10-04 09:48:43 controller.py:759]     result = self.fn(*self.args, **self.kwargs)
E 10-04 09:48:43 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/backends/cloud_vm_ray_backend.py", line 4602, in get_job_status
E 10-04 09:48:43 controller.py:759]     returncode, stdout, stderr = self.run_on_head(handle,
E 10-04 09:48:43 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/utils/common_utils.py", line 618, in _record
E 10-04 09:48:43 controller.py:759]     return f(*args, **kwargs)
E 10-04 09:48:43 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/utils/context_utils.py", line 173, in wrapper
E 10-04 09:48:43 controller.py:759]     return func(*args, **kwargs)
E 10-04 09:48:43 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/backends/cloud_vm_ray_backend.py", line 5672, in run_on_head
E 10-04 09:48:43 controller.py:759]     runners = handle.get_command_runners()
E 10-04 09:48:43 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/utils/context_utils.py", line 173, in wrapper
E 10-04 09:48:43 controller.py:759]     return func(*args, **kwargs)
E 10-04 09:48:43 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/utils/common_utils.py", line 618, in _record
E 10-04 09:48:43 controller.py:759]     return f(*args, **kwargs)
E 10-04 09:48:43 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/backends/cloud_vm_ray_backend.py", line 2667, in get_command_runners
E 10-04 09:48:43 controller.py:759]     runners = provision_lib.get_command_runners(
E 10-04 09:48:43 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/provision/__init__.py", line 66, in _wrapper
E 10-04 09:48:43 controller.py:759]     return func(provider_name, *args, **kwargs)
E 10-04 09:48:43 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/provision/__init__.py", line 284, in get_command_runners
E 10-04 09:48:43 controller.py:759]     return command_runner.SSHCommandRunner.make_runner_list(
E 10-04 09:48:43 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/utils/command_runner.py", line 472, in make_runner_list
E 10-04 09:48:43 controller.py:759]     return [cls(node, **kwargs) for node in node_list]
E 10-04 09:48:43 controller.py:759]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/utils/command_runner.py", line 472, in <listcomp>
E 10-04 09:48:43 controller.py:759]     return [cls(node, **kwargs) for node in node_list]
E 10-04 09:48:43 controller.py:759] TypeError: SSHCommandRunner.__init__() missing 2 required positional arguments: 'ssh_user' and 'ssh_private_key'
E 10-04 09:48:43 controller.py:759]
E 10-04 09:48:43 controller.py:762] Unexpected error occurred: [TypeError] SSHCommandRunner.__init__() missing 2 required positional arguments: 'ssh_user' and 'ssh_private_key'
```

These both stem from the cluster_yaml being deleted during the check.

The two errors seem to be related to the timing between pulling the handle and pulling the yaml

case 1 (ValueError):
```
status update                  | controller
---------------------------------------------------------------
                               | cluster seems to be up
cluster seems to be terminated |
                               | fetch handle
update handle to remove yaml   |
remove yaml from db            |
                               | get handle.cluster_yaml from db
                                 ^ it no longer exists, crashes
```
case 2 (TypeError):
```
status update                  | controller
---------------------------------------------------------------
                               | cluster seems to be up
cluster seems to be terminated |
update handle to remove yaml   |
                               | fetch handle
                               | handle.cluster_yaml unset
                                 ^ ssh_credential_from_yaml returns empty dict
                                 ^ get_command_runner crashes
```
<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

### Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - observed TypeError now caught in load test. couldn't repro ValueError
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
