### PR TITLE
[Dashboard] Only show the active jobs for a user

### DIFF
--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -1123,8 +1123,7 @@ function UsersTable({
           );
           const activeJobCount = (jobsData || []).filter(
             (j) =>
-              j.user_hash === user.userId &&
-              ACTIVE_JOB_STATUSES.has(j.status)
+              j.user_hash === user.userId && ACTIVE_JOB_STATUSES.has(j.status)
           ).length;
           return {
             ...user,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

TODO:
- [x] test locally with a managed job launched by current user and a completed job. The number user number shows 1 now, while on master it shows 2. 
<img width="1720" height="383" alt="image" src="https://github.com/user-attachments/assets/7fc742bc-ff34-4f0b-82e3-09e076243413" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
