### PR TITLE
[tests] Utility scripts for testing postgres operations at scale

### DIFF
--- a/tests/load_tests/db_scale_tests/README.md
+++ b/tests/load_tests/db_scale_tests/README.md
@@ -167,53 +167,75 @@ For manual testing and debugging, you can inject test data without automatic cle
 ### Inject Test Clusters
 
 ```bash
-# Inject 5 test clusters (default count)
-python tests/scale_tests/inject_test_clusters.py
+# Inject test clusters (default: 5 clusters)
+python tests/load_tests/db_scale_tests/inject_test_clusters.py
+
+# Inject with custom count and template cluster
+python tests/load_tests/db_scale_tests/inject_test_clusters.py \
+  --count 2000 \
+  --active-cluster scale-test-active
 
 # Verify with sky status
 sky status
 
 # Clean up when done
-python tests/scale_tests/cleanup_test_clusters.py
+python tests/load_tests/db_scale_tests/cleanup_test_clusters.py
 ```
 
-You can modify the `count` variable in `inject_test_clusters.py` to inject more clusters.
+**Options:**
+- `--count N` - Number of test clusters to inject (default: 5)
+- `--active-cluster NAME` - Name of active cluster to use as template (default: scale-test-active)
 
 ### Inject Test Cluster History
 
 ```bash
-# Inject test cluster history (5 recent + 5 old by default)
-python tests/scale_tests/inject_test_cluster_history.py
+# Inject test cluster history (default: 5 recent + 5 old)
+python tests/load_tests/db_scale_tests/inject_test_cluster_history.py
+
+# Inject with custom counts and template cluster
+python tests/load_tests/db_scale_tests/inject_test_cluster_history.py \
+  --recent-count 2000 \
+  --old-count 8000 \
+  --terminated-cluster scale-test-terminated
 
 # Verify programmatically
 python -c "from sky import global_user_state; print(len(global_user_state.get_clusters_from_history(days=10)))"
 
 # Clean up when done
-python tests/scale_tests/cleanup_test_cluster_history.py
+python tests/load_tests/db_scale_tests/cleanup_test_cluster_history.py
 ```
 
-You can modify the `recent_count` and `old_count` variables to inject more entries.
+**Options:**
+- `--recent-count N` - Number of recent terminated clusters to inject (default: 5)
+- `--old-count N` - Number of old terminated clusters to inject (default: 5)
+- `--terminated-cluster NAME` - Name of terminated cluster to use as template (default: scale-test-terminated)
 
 ### Inject Test Managed Jobs
 
 ```bash
-# Inject 10 test managed jobs (default count)
-python tests/scale_tests/inject_test_managed_jobs.py
+# Inject test managed jobs (default: 10 jobs)
+python tests/load_tests/db_scale_tests/inject_test_managed_jobs.py
+
+# Inject with custom count and template job
+python tests/load_tests/db_scale_tests/inject_test_managed_jobs.py \
+  --count 10000 \
+  --managed-job-id 2
 
 # Verify with sky jobs queue
 sky jobs queue
 
 # Clean up when done
-python tests/scale_tests/cleanup_test_managed_jobs.py
+python tests/load_tests/db_scale_tests/cleanup_test_managed_jobs.py
 ```
 
-You can modify the `count` variable in `inject_test_managed_jobs.py` to inject more jobs.
+**Options:**
+- `--count N` - Number of test managed jobs to inject (default: 10)
+- `--managed-job-id ID` - Job ID of managed job to use as template (default: 1)
 
 **Note**: These scripts inject data but do not clean it up automatically, allowing you to manually test SkyPilot commands against a scaled database. Remember to run the cleanup scripts when you're done testing.
 
 ## Future Enhancements
 
 - Remote PostgreSQL testing support
-- Configurable dataset sizes via command-line arguments for injection scripts
 - Integration with CI/CD performance benchmarking
 - Memory usage profiling

--- a/tests/load_tests/db_scale_tests/README.md
+++ b/tests/load_tests/db_scale_tests/README.md
@@ -224,13 +224,16 @@ python tests/load_tests/db_scale_tests/inject_test_managed_jobs.py \
 # Verify with sky jobs queue
 sky jobs queue
 
-# Clean up when done
-python tests/load_tests/db_scale_tests/cleanup_test_managed_jobs.py
+# Clean up when done (deletes all jobs with ID > 2)
+python tests/load_tests/db_scale_tests/cleanup_test_managed_jobs.py --managed-job-id 2
 ```
 
 **Options:**
 - `--count N` - Number of test managed jobs to inject (default: 10)
 - `--managed-job-id ID` - Job ID of managed job to use as template (default: 1)
+
+**Cleanup:**
+- `--managed-job-id ID` (required) - Deletes all jobs with job_id > this value
 
 **Note**: These scripts inject data but do not clean it up automatically, allowing you to manually test SkyPilot commands against a scaled database. Remember to run the cleanup scripts when you're done testing.
 

--- a/tests/load_tests/db_scale_tests/README_POSTGRES.md
+++ b/tests/load_tests/db_scale_tests/README_POSTGRES.md
@@ -1,0 +1,353 @@
+# PostgreSQL Scale Testing
+
+This directory contains scripts to inject mock data into a PostgreSQL database for performance and scale testing.
+
+## Overview
+
+The scripts adapt the existing SQLite-based test infrastructure to work with PostgreSQL by:
+- Replacing `sqlite3` calls with `psycopg2`
+- Running scripts from within a Kubernetes pod where PostgreSQL is accessible
+- Reusing the existing `SampleBasedGenerator` logic to create realistic test data
+
+## Files
+
+### Core Scripts (run in pod)
+- **`inject_postgres_clusters.py`** - Injects 2,000 active clusters + 10,000 cluster history entries into PostgreSQL
+- **`inject_postgres_managed_jobs.py`** - Injects 10,000 test managed jobs into PostgreSQL
+- **`cleanup_postgres_clusters.py`** - Removes test clusters and cluster history from PostgreSQL
+- **`cleanup_postgres_managed_jobs.py`** - Removes test managed jobs from PostgreSQL
+
+### Runner Scripts (run locally)
+- **`run_postgres_injection.py`** - Copies and runs both injection scripts in the pod (clusters + managed jobs)
+- **`run_postgres_cleanup.py`** - Copies and runs both cleanup scripts in the pod (clusters + managed jobs)
+
+### Existing SQLite Scripts
+- **`inject_test_managed_jobs.py`** - Injects test jobs into SQLite
+- **`cleanup_test_managed_jobs.py`** - Removes test jobs from SQLite
+- **`scale_test_utils.py`** - Contains TestScale class with injection logic
+- **`sample_based_generator.py`** - Contains SampleBasedGenerator for creating realistic test data
+- **`run_scale_test.py`** - Comprehensive scale test runner for SQLite
+
+## Prerequisites
+
+### In the Kubernetes Pod
+- Python 3 with `psycopg2` or `psycopg2-binary` installed
+- PostgreSQL database accessible at `localhost:5432`
+- Database credentials: `skypilot/skypilot@skypilot`
+- Sample clusters must exist:
+  - `scale-test-active` - An active cluster to use as template
+  - `scale-test-terminated` - A terminated cluster in cluster_history to use as template
+- A sample managed job (job_id=9) must exist in the database
+
+### Local Environment
+- `kubectl` configured with access to the cluster
+- Pod name (must be provided as CLI argument)
+- Namespace (defaults to `skypilot`, can be overridden with `-n` flag)
+
+## Usage
+
+### Quick Start
+
+1. **Inject test data (clusters + managed jobs):**
+   ```bash
+   cd /Users/rsonecha/Documents/assemble/skypilot/tests/load_tests/db_scale_tests
+   python3 run_postgres_injection.py --pod <pod-name>
+
+   # Or with custom namespace:
+   python3 run_postgres_injection.py --pod <pod-name> -n <namespace>
+   ```
+
+   This will inject:
+   - 2,000 active clusters (with cluster_yaml entries)
+   - 10,000 cluster history entries (2,000 recent + 8,000 old)
+   - 10,000 managed jobs
+
+2. **Verify the injection:**
+   ```bash
+   kubectl exec -n <namespace> <pod-name> -- python3 -c "
+   import psycopg2
+   conn = psycopg2.connect(host='localhost', port=5432, database='skypilot', user='skypilot', password='skypilot')
+   cursor = conn.cursor()
+   cursor.execute('SELECT COUNT(*) FROM clusters')
+   print(f'Total clusters: {cursor.fetchone()[0]}')
+   cursor.execute('SELECT COUNT(*) FROM cluster_yaml')
+   print(f'Total cluster_yaml entries: {cursor.fetchone()[0]}')
+   cursor.execute('SELECT COUNT(*) FROM cluster_history')
+   print(f'Total cluster history: {cursor.fetchone()[0]}')
+   cursor.execute('SELECT COUNT(*) FROM spot')
+   print(f'Total jobs: {cursor.fetchone()[0]}')
+   cursor.close()
+   conn.close()
+   "
+   ```
+
+3. **Clean up test data:**
+   ```bash
+   python3 run_postgres_cleanup.py --pod <pod-name>
+
+   # Or with custom namespace:
+   python3 run_postgres_cleanup.py --pod <pod-name> -n <namespace>
+   ```
+
+### Manual Execution
+
+If you prefer to run the scripts manually in the pod:
+
+1. **Copy the cluster injection script:**
+   ```bash
+   cat inject_postgres_clusters.py | kubectl exec -i -n <namespace> <pod-name> -- sh -c 'cat > /tmp/inject_postgres_clusters.py'
+   ```
+
+2. **Run the cluster injection:**
+   ```bash
+   kubectl exec -n <namespace> <pod-name> -- python3 /tmp/inject_postgres_clusters.py
+   ```
+
+3. **Copy the managed jobs injection script:**
+   ```bash
+   cat inject_postgres_managed_jobs.py | kubectl exec -i -n <namespace> <pod-name> -- sh -c 'cat > /tmp/inject_postgres_managed_jobs.py'
+   ```
+
+4. **Run the managed jobs injection:**
+   ```bash
+   kubectl exec -n <namespace> <pod-name> -- python3 /tmp/inject_postgres_managed_jobs.py
+   ```
+
+5. **Copy the cleanup scripts:**
+   ```bash
+   cat cleanup_postgres_clusters.py | kubectl exec -i -n <namespace> <pod-name> -- sh -c 'cat > /tmp/cleanup_postgres_clusters.py'
+   cat cleanup_postgres_managed_jobs.py | kubectl exec -i -n <namespace> <pod-name> -- sh -c 'cat > /tmp/cleanup_postgres_managed_jobs.py'
+   ```
+
+6. **Run the cleanup:**
+   ```bash
+   kubectl exec -n <namespace> <pod-name> -- python3 /tmp/cleanup_postgres_clusters.py
+   kubectl exec -n <namespace> <pod-name> -- python3 /tmp/cleanup_postgres_managed_jobs.py
+   ```
+
+## How It Works
+
+### Data Generation
+
+The scripts use a **sample-based approach** to create realistic test data:
+
+#### Clusters
+1. **Sample Cluster**: Load an existing active cluster (`scale-test-active`) as a template
+2. **Generate Copies**: Create 2,000 copies with:
+   - Unique cluster names (format: `test-cluster-NNNN-XXXXXXXX`)
+   - Unique `cluster_hash` values (UUIDs)
+   - Random timestamps for `launched_at` and `status_updated_at`
+   - cluster_yaml entries copied from sample cluster
+3. **Insert in Batches**: Insert into both `clusters` and `cluster_yaml` tables in batches of 100
+
+#### Cluster History
+1. **Sample Cluster**: Load a terminated cluster (`scale-test-terminated`) as a template
+2. **Generate Copies**: Create 10,000 copies (2,000 recent + 8,000 old) with:
+   - Unique cluster names (format: `test-cluster-recent-NNNN` or `test-cluster-old-NNNN`)
+   - Random timestamps (recent: 1-9 days ago, old: 15-30 days ago)
+3. **Insert in Batches**: Insert into `cluster_history` table in batches of 100
+
+#### Managed Jobs
+1. **Sample Job**: Load an existing managed job (job_id=9) as a template
+2. **Generate Copies**: Create 10,000 copies with:
+   - Unique `job_id` values (sequential from max_job_id + 1)
+   - Unique timestamps (`submitted_at`, `start_at`, `last_recovered_at`)
+   - Unique `run_timestamp` (format: `sky-YYYY-MM-DD-HH-MM-SS-XXXXXX`)
+   - Unique `controller_pid` (negative random values)
+   - Modified file paths (`dag_yaml_path`, `env_file_path`, `original_user_yaml_path`)
+3. **Insert in Batches**: Insert into both `spot` and `job_info` tables in batches of 100
+
+### Database Schema
+
+The scripts work with these tables:
+
+- **`clusters` table**: Active clusters with metadata
+- **`cluster_yaml` table**: YAML configuration for each cluster (linked by cluster_name)
+- **`cluster_history` table**: Terminated clusters with metadata
+- **`spot` table**: Main managed jobs table with job metadata
+- **`job_info` table**: Additional job information linked by `spot_job_id`
+
+### Cleanup Logic
+
+The cleanup scripts identify test data by:
+- **Clusters**: Names starting with `'test-cluster-'`
+- **Cluster history**: Names starting with `'test-cluster-recent-'` or `'test-cluster-old-'`
+- **Managed jobs**: `run_timestamp` starts with `'sky-'` and `job_id > 1`
+
+## Configuration
+
+### Customizing Cluster Count
+
+To inject a different number of clusters, edit `inject_postgres_clusters.py`:
+
+```python
+cluster_count = 2000  # Active clusters
+recent_history_count = 2000  # Recent cluster history (1-10 days)
+old_history_count = 8000  # Old cluster history (15-30 days)
+```
+
+### Customizing Template Clusters
+
+To use different sample clusters, edit `inject_postgres_clusters.py`:
+
+```python
+active_cluster_name = 'scale-test-active'  # Active cluster template
+terminated_cluster_name = 'scale-test-terminated'  # Terminated cluster template
+```
+
+### Customizing Job Count
+
+To inject a different number of jobs, edit `inject_postgres_managed_jobs.py`:
+
+```python
+count = 10000  # Change this value
+```
+
+### Customizing Template Job
+
+To use a different sample job, edit `inject_postgres_managed_jobs.py`:
+
+```python
+managed_job_id = 9  # Change this to your sample job ID
+```
+
+### Customizing Database Connection
+
+Edit the `db_params` in both injection and cleanup scripts:
+
+```python
+db_params = {
+    'host': 'localhost',
+    'port': 5432,
+    'database': 'skypilot',
+    'user': 'skypilot',
+    'password': 'skypilot'
+}
+```
+
+### Customizing Pod and Namespace
+
+Pass the pod name and namespace as command-line arguments:
+
+```bash
+python3 run_postgres_injection.py --pod my-custom-pod -n my-namespace
+python3 run_postgres_cleanup.py --pod my-custom-pod -n my-namespace
+```
+
+The `--pod` argument is required. The `-n/--namespace` argument is optional and defaults to `skypilot`.
+
+## Performance
+
+The injection scripts process data in batches of 100 for optimal performance:
+
+- **Batch size**: 100 items per batch
+- **Expected time**:
+  - Clusters: ~15-30 seconds for 2,000 clusters
+  - Cluster history: ~60-90 seconds for 10,000 entries
+  - Managed jobs: ~30-60 seconds for 10,000 jobs
+- **Progress output**:
+  - Clusters: Every 500 clusters
+  - Cluster history: Every 1,000 entries
+  - Jobs: Every 1,000 jobs
+
+## Troubleshooting
+
+### psycopg2 Not Installed
+
+If you get an import error for psycopg2:
+
+```bash
+kubectl exec -n <namespace> <pod-name> -- pip install psycopg2-binary
+```
+
+### Connection Failed
+
+Verify PostgreSQL is accessible:
+
+```bash
+kubectl exec -n <namespace> <pod-name> -- python3 -c "import psycopg2; conn = psycopg2.connect(host='localhost', port=5432, database='skypilot', user='skypilot', password='skypilot'); print('Connected!'); conn.close()"
+```
+
+### Sample Clusters Not Found
+
+Create sample clusters first:
+
+```bash
+# Create an active cluster
+sky launch --infra k8s -c scale-test-active -y "echo 'active cluster'"
+
+# Create and terminate a cluster for history
+sky launch --infra k8s -c scale-test-terminated -y "echo 'terminated cluster'"
+sky down scale-test-terminated -y
+```
+
+### Sample Job Not Found
+
+Create a sample managed job first:
+
+```bash
+sky jobs launch --infra k8s "sleep 10000000"
+```
+
+Then find its job_id and update the script.
+
+### kubectl cp Permission Errors
+
+If `kubectl cp` fails with permission errors, the runner scripts use stdin redirection as a workaround:
+
+```bash
+cat script.py | kubectl exec -i -n namespace pod -- sh -c 'cat > /tmp/script.py'
+```
+
+## Results
+
+After running the injection script, you should see output for both clusters and jobs:
+
+```
+============================================================
+INJECTION COMPLETE!
+============================================================
+Total active clusters injected: 2000
+Total cluster history injected: 10000
+  - Recent (1-10 days): 2000
+  - Old (15-30 days): 8000
+
+To clean up these clusters, run:
+  python cleanup_postgres_clusters.py
+
+============================================================
+INJECTION COMPLETE!
+============================================================
+Total jobs injected: 10000
+
+To clean up these jobs, run:
+  python cleanup_postgres_managed_jobs.py
+```
+
+Verify with:
+
+```bash
+kubectl exec -n <namespace> <pod-name> -- python3 -c "
+import psycopg2
+conn = psycopg2.connect(host='localhost', port=5432, database='skypilot', user='skypilot', password='skypilot')
+cursor = conn.cursor()
+cursor.execute('SELECT COUNT(*) FROM clusters')
+print(f'Total clusters: {cursor.fetchone()[0]}')
+cursor.execute('SELECT COUNT(*) FROM cluster_yaml')
+print(f'Total cluster_yaml: {cursor.fetchone()[0]}')
+cursor.execute('SELECT COUNT(*) FROM cluster_history')
+print(f'Total cluster history: {cursor.fetchone()[0]}')
+cursor.execute('SELECT COUNT(*) FROM spot')
+print(f'Total jobs: {cursor.fetchone()[0]}')
+cursor.close()
+conn.close()
+"
+```
+
+Expected output:
+```
+Total clusters: 2001 (2000 test + 1 sample)
+Total cluster_yaml: 2001
+Total cluster history: 10001 (10000 test + 1 sample)
+Total jobs: 10001 (10000 test + 1 sample)
+```

--- a/tests/load_tests/db_scale_tests/README_POSTGRES.md
+++ b/tests/load_tests/db_scale_tests/README_POSTGRES.md
@@ -1,353 +1,109 @@
 # PostgreSQL Scale Testing
 
-This directory contains scripts to inject mock data into a PostgreSQL database for performance and scale testing.
+This guide covers running scale tests against a PostgreSQL database (typically in a Kubernetes environment). For general information about scale testing, see [README.md](README.md).
 
 ## Overview
 
-The scripts adapt the existing SQLite-based test infrastructure to work with PostgreSQL by:
+The PostgreSQL scripts adapt the SQLite-based test infrastructure to work with PostgreSQL by:
 - Replacing `sqlite3` calls with `psycopg2`
 - Running scripts from within a Kubernetes pod where PostgreSQL is accessible
-- Reusing the existing `SampleBasedGenerator` logic to create realistic test data
+- Using the same sample-based data generation approach
 
 ## Files
 
 ### Core Scripts (run in pod)
-- **`inject_postgres_clusters.py`** - Injects 2,000 active clusters + 10,000 cluster history entries into PostgreSQL
-- **`inject_postgres_managed_jobs.py`** - Injects 10,000 test managed jobs into PostgreSQL
-- **`cleanup_postgres_clusters.py`** - Removes test clusters and cluster history from PostgreSQL
-- **`cleanup_postgres_managed_jobs.py`** - Removes test managed jobs from PostgreSQL
+- **`inject_postgres_clusters.py`** - Injects clusters and cluster history
+- **`inject_postgres_managed_jobs.py`** - Injects managed jobs
+- **`cleanup_postgres_clusters.py`** - Removes test clusters
+- **`cleanup_postgres_managed_jobs.py`** - Removes test jobs
 
 ### Runner Scripts (run locally)
-- **`run_postgres_injection.py`** - Copies and runs both injection scripts in the pod (clusters + managed jobs)
-- **`run_postgres_cleanup.py`** - Copies and runs both cleanup scripts in the pod (clusters + managed jobs)
-
-### Existing SQLite Scripts
-- **`inject_test_managed_jobs.py`** - Injects test jobs into SQLite
-- **`cleanup_test_managed_jobs.py`** - Removes test jobs from SQLite
-- **`scale_test_utils.py`** - Contains TestScale class with injection logic
-- **`sample_based_generator.py`** - Contains SampleBasedGenerator for creating realistic test data
-- **`run_scale_test.py`** - Comprehensive scale test runner for SQLite
+- **`run_postgres_injection.py`** - Copies and runs both injection scripts in the pod
+- **`run_postgres_cleanup.py`** - Copies and runs both cleanup scripts in the pod
 
 ## Prerequisites
 
-### In the Kubernetes Pod
-- Python 3 with `psycopg2` or `psycopg2-binary` installed
-- PostgreSQL database accessible at `localhost:5432`
-- Database credentials: `skypilot/skypilot@skypilot`
-- Sample clusters must exist:
-  - `scale-test-active` - An active cluster to use as template
-  - `scale-test-terminated` - A terminated cluster in cluster_history to use as template
-- A sample managed job (job_id=9) must exist in the database
+### Sample Data Setup
+See [README.md](README.md#required-sample-data-setup) for instructions on creating the required sample clusters and jobs.
 
-### Local Environment
+### Kubernetes Environment
 - `kubectl` configured with access to the cluster
-- Pod name (must be provided as CLI argument)
-- Namespace (defaults to `skypilot`, can be overridden with `-n` flag)
+- Python 3 with `psycopg2-binary` in the target pod (auto-installed by runner scripts)
+- PostgreSQL database accessible from the pod
 
 ## Usage
 
 ### Quick Start
 
-1. **Inject test data (clusters + managed jobs):**
+1. **Inject test data:**
    ```bash
-   cd /Users/rsonecha/Documents/assemble/skypilot/tests/load_tests/db_scale_tests
-   python3 run_postgres_injection.py --pod <pod-name>
-
-   # Or with custom namespace:
    python3 run_postgres_injection.py --pod <pod-name> -n <namespace>
    ```
 
-   This will inject:
-   - 2,000 active clusters (with cluster_yaml entries)
-   - 10,000 cluster history entries (2,000 recent + 8,000 old)
-   - 10,000 managed jobs
+   This injects the default test data (see [README.md](README.md) for scale details).
 
-2. **Verify the injection:**
+2. **Clean up test data:**
    ```bash
-   kubectl exec -n <namespace> <pod-name> -- python3 -c "
-   import psycopg2
-   conn = psycopg2.connect(host='localhost', port=5432, database='skypilot', user='skypilot', password='skypilot')
-   cursor = conn.cursor()
-   cursor.execute('SELECT COUNT(*) FROM clusters')
-   print(f'Total clusters: {cursor.fetchone()[0]}')
-   cursor.execute('SELECT COUNT(*) FROM cluster_yaml')
-   print(f'Total cluster_yaml entries: {cursor.fetchone()[0]}')
-   cursor.execute('SELECT COUNT(*) FROM cluster_history')
-   print(f'Total cluster history: {cursor.fetchone()[0]}')
-   cursor.execute('SELECT COUNT(*) FROM spot')
-   print(f'Total jobs: {cursor.fetchone()[0]}')
-   cursor.close()
-   conn.close()
-   "
-   ```
-
-3. **Clean up test data:**
-   ```bash
-   python3 run_postgres_cleanup.py --pod <pod-name>
-
-   # Or with custom namespace:
    python3 run_postgres_cleanup.py --pod <pod-name> -n <namespace>
    ```
 
-### Manual Execution
+### Customizing the Injection
 
-If you prefer to run the scripts manually in the pod:
+The injection scripts support various CLI arguments. To customize, run them manually in the pod:
 
-1. **Copy the cluster injection script:**
-   ```bash
-   cat inject_postgres_clusters.py | kubectl exec -i -n <namespace> <pod-name> -- sh -c 'cat > /tmp/inject_postgres_clusters.py'
-   ```
+```bash
+# Example: Inject 5000 clusters with custom template
+kubectl exec -n <namespace> <pod-name> -- python3 /tmp/inject_postgres_clusters.py \
+  --cluster-count 5000 \
+  --recent-history 3000 \
+  --old-history 12000 \
+  --active-cluster my-custom-active \
+  --terminated-cluster my-custom-terminated
 
-2. **Run the cluster injection:**
-   ```bash
-   kubectl exec -n <namespace> <pod-name> -- python3 /tmp/inject_postgres_clusters.py
-   ```
+# Example: Inject 20000 jobs from job ID 5
+kubectl exec -n <namespace> <pod-name> -- python3 /tmp/inject_postgres_managed_jobs.py \
+  --count 20000 \
+  --job-id 5
+```
 
-3. **Copy the managed jobs injection script:**
-   ```bash
-   cat inject_postgres_managed_jobs.py | kubectl exec -i -n <namespace> <pod-name> -- sh -c 'cat > /tmp/inject_postgres_managed_jobs.py'
-   ```
-
-4. **Run the managed jobs injection:**
-   ```bash
-   kubectl exec -n <namespace> <pod-name> -- python3 /tmp/inject_postgres_managed_jobs.py
-   ```
-
-5. **Copy the cleanup scripts:**
-   ```bash
-   cat cleanup_postgres_clusters.py | kubectl exec -i -n <namespace> <pod-name> -- sh -c 'cat > /tmp/cleanup_postgres_clusters.py'
-   cat cleanup_postgres_managed_jobs.py | kubectl exec -i -n <namespace> <pod-name> -- sh -c 'cat > /tmp/cleanup_postgres_managed_jobs.py'
-   ```
-
-6. **Run the cleanup:**
-   ```bash
-   kubectl exec -n <namespace> <pod-name> -- python3 /tmp/cleanup_postgres_clusters.py
-   kubectl exec -n <namespace> <pod-name> -- python3 /tmp/cleanup_postgres_managed_jobs.py
-   ```
+For all available options, run with `--help`:
+```bash
+kubectl exec -n <namespace> <pod-name> -- python3 /tmp/inject_postgres_clusters.py --help
+kubectl exec -n <namespace> <pod-name> -- python3 /tmp/inject_postgres_managed_jobs.py --help
+```
 
 ## How It Works
 
-### Data Generation
-
-The scripts use a **sample-based approach** to create realistic test data:
-
-#### Clusters
-1. **Sample Cluster**: Load an existing active cluster (`scale-test-active`) as a template
-2. **Generate Copies**: Create 2,000 copies with:
-   - Unique cluster names (format: `test-cluster-NNNN-XXXXXXXX`)
-   - Unique `cluster_hash` values (UUIDs)
-   - Random timestamps for `launched_at` and `status_updated_at`
-   - cluster_yaml entries copied from sample cluster
-3. **Insert in Batches**: Insert into both `clusters` and `cluster_yaml` tables in batches of 100
-
-#### Cluster History
-1. **Sample Cluster**: Load a terminated cluster (`scale-test-terminated`) as a template
-2. **Generate Copies**: Create 10,000 copies (2,000 recent + 8,000 old) with:
-   - Unique cluster names (format: `test-cluster-recent-NNNN` or `test-cluster-old-NNNN`)
-   - Random timestamps (recent: 1-9 days ago, old: 15-30 days ago)
-3. **Insert in Batches**: Insert into `cluster_history` table in batches of 100
-
-#### Managed Jobs
-1. **Sample Job**: Load an existing managed job (job_id=9) as a template
-2. **Generate Copies**: Create 10,000 copies with:
-   - Unique `job_id` values (sequential from max_job_id + 1)
-   - Unique timestamps (`submitted_at`, `start_at`, `last_recovered_at`)
-   - Unique `run_timestamp` (format: `sky-YYYY-MM-DD-HH-MM-SS-XXXXXX`)
-   - Unique `controller_pid` (negative random values)
-   - Modified file paths (`dag_yaml_path`, `env_file_path`, `original_user_yaml_path`)
-3. **Insert in Batches**: Insert into both `spot` and `job_info` tables in batches of 100
-
-### Database Schema
-
-The scripts work with these tables:
-
-- **`clusters` table**: Active clusters with metadata
-- **`cluster_yaml` table**: YAML configuration for each cluster (linked by cluster_name)
-- **`cluster_history` table**: Terminated clusters with metadata
-- **`spot` table**: Main managed jobs table with job metadata
-- **`job_info` table**: Additional job information linked by `spot_job_id`
-
-### Cleanup Logic
-
-The cleanup scripts identify test data by:
-- **Clusters**: Names starting with `'test-cluster-'`
-- **Cluster history**: Names starting with `'test-cluster-recent-'` or `'test-cluster-old-'`
-- **Managed jobs**: `run_timestamp` starts with `'sky-'` and `job_id > 1`
-
-## Configuration
-
-### Customizing Cluster Count
-
-To inject a different number of clusters, edit `inject_postgres_clusters.py`:
-
-```python
-cluster_count = 2000  # Active clusters
-recent_history_count = 2000  # Recent cluster history (1-10 days)
-old_history_count = 8000  # Old cluster history (15-30 days)
-```
-
-### Customizing Template Clusters
-
-To use different sample clusters, edit `inject_postgres_clusters.py`:
-
-```python
-active_cluster_name = 'scale-test-active'  # Active cluster template
-terminated_cluster_name = 'scale-test-terminated'  # Terminated cluster template
-```
-
-### Customizing Job Count
-
-To inject a different number of jobs, edit `inject_postgres_managed_jobs.py`:
-
-```python
-count = 10000  # Change this value
-```
-
-### Customizing Template Job
-
-To use a different sample job, edit `inject_postgres_managed_jobs.py`:
-
-```python
-managed_job_id = 9  # Change this to your sample job ID
-```
-
-### Customizing Database Connection
-
-Edit the `db_params` in both injection and cleanup scripts:
-
-```python
-db_params = {
-    'host': 'localhost',
-    'port': 5432,
-    'database': 'skypilot',
-    'user': 'skypilot',
-    'password': 'skypilot'
-}
-```
-
-### Customizing Pod and Namespace
-
-Pass the pod name and namespace as command-line arguments:
-
-```bash
-python3 run_postgres_injection.py --pod my-custom-pod -n my-namespace
-python3 run_postgres_cleanup.py --pod my-custom-pod -n my-namespace
-```
-
-The `--pod` argument is required. The `-n/--namespace` argument is optional and defaults to `skypilot`.
-
-## Performance
-
-The injection scripts process data in batches of 100 for optimal performance:
-
-- **Batch size**: 100 items per batch
-- **Expected time**:
-  - Clusters: ~15-30 seconds for 2,000 clusters
-  - Cluster history: ~60-90 seconds for 10,000 entries
-  - Managed jobs: ~30-60 seconds for 10,000 jobs
-- **Progress output**:
-  - Clusters: Every 500 clusters
-  - Cluster history: Every 1,000 entries
-  - Jobs: Every 1,000 jobs
+See [README.md](README.md#how-it-works) for details on the data generation approach. The PostgreSQL scripts use the same logic with `psycopg2` instead of `sqlite3`.
 
 ## Troubleshooting
 
 ### psycopg2 Not Installed
 
-If you get an import error for psycopg2:
+The runner scripts (`run_postgres_injection.py`) auto-install `psycopg2-binary` if needed. To install manually:
 
 ```bash
 kubectl exec -n <namespace> <pod-name> -- pip install psycopg2-binary
 ```
 
-### Connection Failed
+### Sample Data Not Found
 
-Verify PostgreSQL is accessible:
+See [README.md](README.md#required-sample-data-setup) for instructions on creating sample clusters and jobs.
 
+### Database Connection Issues
+
+Default connection assumes:
+- Host: `localhost`
+- Port: `5432`
+- Database: `skypilot`
+- User/Password: `skypilot/skypilot`
+
+To use different credentials, pass arguments to the injection scripts:
 ```bash
-kubectl exec -n <namespace> <pod-name> -- python3 -c "import psycopg2; conn = psycopg2.connect(host='localhost', port=5432, database='skypilot', user='skypilot', password='skypilot'); print('Connected!'); conn.close()"
-```
-
-### Sample Clusters Not Found
-
-Create sample clusters first:
-
-```bash
-# Create an active cluster
-sky launch --infra k8s -c scale-test-active -y "echo 'active cluster'"
-
-# Create and terminate a cluster for history
-sky launch --infra k8s -c scale-test-terminated -y "echo 'terminated cluster'"
-sky down scale-test-terminated -y
-```
-
-### Sample Job Not Found
-
-Create a sample managed job first:
-
-```bash
-sky jobs launch --infra k8s "sleep 10000000"
-```
-
-Then find its job_id and update the script.
-
-### kubectl cp Permission Errors
-
-If `kubectl cp` fails with permission errors, the runner scripts use stdin redirection as a workaround:
-
-```bash
-cat script.py | kubectl exec -i -n namespace pod -- sh -c 'cat > /tmp/script.py'
-```
-
-## Results
-
-After running the injection script, you should see output for both clusters and jobs:
-
-```
-============================================================
-INJECTION COMPLETE!
-============================================================
-Total active clusters injected: 2000
-Total cluster history injected: 10000
-  - Recent (1-10 days): 2000
-  - Old (15-30 days): 8000
-
-To clean up these clusters, run:
-  python cleanup_postgres_clusters.py
-
-============================================================
-INJECTION COMPLETE!
-============================================================
-Total jobs injected: 10000
-
-To clean up these jobs, run:
-  python cleanup_postgres_managed_jobs.py
-```
-
-Verify with:
-
-```bash
-kubectl exec -n <namespace> <pod-name> -- python3 -c "
-import psycopg2
-conn = psycopg2.connect(host='localhost', port=5432, database='skypilot', user='skypilot', password='skypilot')
-cursor = conn.cursor()
-cursor.execute('SELECT COUNT(*) FROM clusters')
-print(f'Total clusters: {cursor.fetchone()[0]}')
-cursor.execute('SELECT COUNT(*) FROM cluster_yaml')
-print(f'Total cluster_yaml: {cursor.fetchone()[0]}')
-cursor.execute('SELECT COUNT(*) FROM cluster_history')
-print(f'Total cluster history: {cursor.fetchone()[0]}')
-cursor.execute('SELECT COUNT(*) FROM spot')
-print(f'Total jobs: {cursor.fetchone()[0]}')
-cursor.close()
-conn.close()
-"
-```
-
-Expected output:
-```
-Total clusters: 2001 (2000 test + 1 sample)
-Total cluster_yaml: 2001
-Total cluster history: 10001 (10000 test + 1 sample)
-Total jobs: 10001 (10000 test + 1 sample)
+kubectl exec -n <namespace> <pod-name> -- python3 /tmp/inject_postgres_clusters.py \
+  --host my-db-host \
+  --port 5433 \
+  --database my-db \
+  --user my-user \
+  --password my-pass
 ```

--- a/tests/load_tests/db_scale_tests/cleanup_postgres_clusters.py
+++ b/tests/load_tests/db_scale_tests/cleanup_postgres_clusters.py
@@ -7,7 +7,9 @@ This script should be run from within the skypilot-api-server pod.
 try:
     import psycopg2
 except ImportError:
-    print("Error: psycopg2 not installed. Install with: pip install psycopg2-binary")
+    print(
+        "Error: psycopg2 not installed. Install with: pip install psycopg2-binary"
+    )
     exit(1)
 
 
@@ -33,24 +35,21 @@ def cleanup_clusters(conn):
     cluster_names = [cluster[0] for cluster in clusters]
 
     # Delete from cluster_yaml table first
-    cursor.execute(
-        "DELETE FROM cluster_yaml WHERE cluster_name = ANY(%s)",
-        (cluster_names,)
-    )
+    cursor.execute("DELETE FROM cluster_yaml WHERE cluster_name = ANY(%s)",
+                   (cluster_names,))
     deleted_yaml = cursor.rowcount
     print(f"Deleted {deleted_yaml} entries from cluster_yaml table")
 
     # Delete from clusters table
-    cursor.execute(
-        "DELETE FROM clusters WHERE name = ANY(%s)",
-        (cluster_names,)
-    )
+    cursor.execute("DELETE FROM clusters WHERE name = ANY(%s)",
+                   (cluster_names,))
     deleted_clusters = cursor.rowcount
 
     conn.commit()
     cursor.close()
 
-    print(f"Successfully deleted {deleted_clusters} clusters from clusters table")
+    print(
+        f"Successfully deleted {deleted_clusters} clusters from clusters table")
 
     return deleted_clusters, deleted_yaml
 
@@ -78,16 +77,16 @@ def cleanup_cluster_history(conn):
     cluster_names = [cluster[0] for cluster in history_clusters]
 
     # Delete from cluster_history table
-    cursor.execute(
-        "DELETE FROM cluster_history WHERE name = ANY(%s)",
-        (cluster_names,)
-    )
+    cursor.execute("DELETE FROM cluster_history WHERE name = ANY(%s)",
+                   (cluster_names,))
     deleted_history = cursor.rowcount
 
     conn.commit()
     cursor.close()
 
-    print(f"Successfully deleted {deleted_history} entries from cluster_history table")
+    print(
+        f"Successfully deleted {deleted_history} entries from cluster_history table"
+    )
 
     return deleted_history
 

--- a/tests/load_tests/db_scale_tests/cleanup_postgres_clusters.py
+++ b/tests/load_tests/db_scale_tests/cleanup_postgres_clusters.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Cleanup test clusters and cluster history from PostgreSQL database.
+This script should be run from within the skypilot-api-server pod.
+"""
+
+try:
+    import psycopg2
+except ImportError:
+    print("Error: psycopg2 not installed. Install with: pip install psycopg2-binary")
+    exit(1)
+
+
+def cleanup_clusters(conn):
+    """Cleanup test clusters from PostgreSQL database."""
+    cursor = conn.cursor()
+
+    # Find test clusters - they have names starting with 'test-cluster-'
+    cursor.execute("""
+        SELECT name, cluster_hash
+        FROM clusters
+        WHERE name LIKE 'test-cluster-%'
+        ORDER BY name
+    """)
+    clusters = cursor.fetchall()
+
+    if not clusters:
+        print("No test clusters found.")
+        cursor.close()
+        return 0, 0
+
+    print(f"Found {len(clusters)} test clusters")
+    cluster_names = [cluster[0] for cluster in clusters]
+
+    # Delete from cluster_yaml table first
+    cursor.execute(
+        "DELETE FROM cluster_yaml WHERE cluster_name = ANY(%s)",
+        (cluster_names,)
+    )
+    deleted_yaml = cursor.rowcount
+    print(f"Deleted {deleted_yaml} entries from cluster_yaml table")
+
+    # Delete from clusters table
+    cursor.execute(
+        "DELETE FROM clusters WHERE name = ANY(%s)",
+        (cluster_names,)
+    )
+    deleted_clusters = cursor.rowcount
+
+    conn.commit()
+    cursor.close()
+
+    print(f"Successfully deleted {deleted_clusters} clusters from clusters table")
+
+    return deleted_clusters, deleted_yaml
+
+
+def cleanup_cluster_history(conn):
+    """Cleanup test cluster history from PostgreSQL database."""
+    cursor = conn.cursor()
+
+    # Find test cluster history - they have names starting with 'test-cluster-recent-' or 'test-cluster-old-'
+    cursor.execute("""
+        SELECT name, cluster_hash
+        FROM cluster_history
+        WHERE name LIKE 'test-cluster-recent-%'
+           OR name LIKE 'test-cluster-old-%'
+        ORDER BY name
+    """)
+    history_clusters = cursor.fetchall()
+
+    if not history_clusters:
+        print("No test cluster history found.")
+        cursor.close()
+        return 0
+
+    print(f"Found {len(history_clusters)} test cluster history entries")
+    cluster_names = [cluster[0] for cluster in history_clusters]
+
+    # Delete from cluster_history table
+    cursor.execute(
+        "DELETE FROM cluster_history WHERE name = ANY(%s)",
+        (cluster_names,)
+    )
+    deleted_history = cursor.rowcount
+
+    conn.commit()
+    cursor.close()
+
+    print(f"Successfully deleted {deleted_history} entries from cluster_history table")
+
+    return deleted_history
+
+
+def main():
+    """Main function to cleanup test clusters from PostgreSQL."""
+    # Database connection parameters
+    db_params = {
+        'host': 'localhost',
+        'port': 5432,
+        'database': 'skypilot',
+        'user': 'skypilot',
+        'password': 'skypilot'
+    }
+
+    print("=" * 60)
+    print("PostgreSQL Cluster Cleanup")
+    print("=" * 60)
+    print(f"Database: {db_params['database']}@{db_params['host']}")
+    print("=" * 60)
+
+    try:
+        # Connect to PostgreSQL
+        print("\nConnecting to PostgreSQL...")
+        conn = psycopg2.connect(**db_params)
+        print("Connected successfully!")
+
+        # Cleanup clusters
+        print("\nCleaning up test clusters...")
+        deleted_clusters, deleted_yaml = cleanup_clusters(conn)
+
+        # Cleanup cluster history
+        print("\nCleaning up test cluster history...")
+        deleted_history = cleanup_cluster_history(conn)
+
+        # Close connection
+        conn.close()
+
+        print("\n" + "=" * 60)
+        print("CLEANUP COMPLETE!")
+        print("=" * 60)
+        print(f"Total clusters deleted: {deleted_clusters}")
+        print(f"Total cluster_yaml entries deleted: {deleted_yaml}")
+        print(f"Total cluster history deleted: {deleted_history}")
+
+    except psycopg2.Error as e:
+        print(f"\nPostgreSQL Error: {e}")
+        import traceback
+        traceback.print_exc()
+        exit(1)
+    except Exception as e:
+        print(f"\nError: {e}")
+        import traceback
+        traceback.print_exc()
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/load_tests/db_scale_tests/cleanup_postgres_managed_jobs.py
+++ b/tests/load_tests/db_scale_tests/cleanup_postgres_managed_jobs.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+Cleanup test managed jobs from PostgreSQL database.
+This script should be run from within the skypilot-api-server pod.
+"""
+
+try:
+    import psycopg2
+except ImportError:
+    print("Error: psycopg2 not installed. Install with: pip install psycopg2-binary")
+    exit(1)
+
+
+def cleanup_managed_jobs(conn):
+    """Cleanup test managed jobs from PostgreSQL database."""
+    cursor = conn.cursor()
+
+    # Find test jobs - they have run_timestamp starting with 'sky-'
+    # and were created by our test generator
+    cursor.execute("""
+        SELECT job_id, run_timestamp
+        FROM spot
+        WHERE run_timestamp LIKE 'sky-%'
+        AND job_id > 1
+        ORDER BY job_id
+    """)
+    jobs = cursor.fetchall()
+
+    if not jobs:
+        print("No test managed jobs found.")
+        cursor.close()
+        return 0
+
+    print(f"Found {len(jobs)} test managed jobs")
+    job_ids = [job[0] for job in jobs]
+
+    # Delete from both tables
+    cursor.execute(
+        "DELETE FROM spot WHERE job_id = ANY(%s)",
+        (job_ids,)
+    )
+    deleted_spot = cursor.rowcount
+
+    cursor.execute(
+        "DELETE FROM job_info WHERE spot_job_id = ANY(%s)",
+        (job_ids,)
+    )
+    deleted_job_info = cursor.rowcount
+
+    conn.commit()
+    cursor.close()
+
+    print(f"Successfully deleted {deleted_spot} jobs from spot table")
+    print(f"Successfully deleted {deleted_job_info} jobs from job_info table")
+
+    return deleted_spot
+
+
+def main():
+    """Main function to cleanup test managed jobs from PostgreSQL."""
+    # Database connection parameters
+    db_params = {
+        'host': 'localhost',
+        'port': 5432,
+        'database': 'skypilot',
+        'user': 'skypilot',
+        'password': 'skypilot'
+    }
+
+    print("=" * 60)
+    print("PostgreSQL Managed Job Cleanup")
+    print("=" * 60)
+    print(f"Database: {db_params['database']}@{db_params['host']}")
+    print("=" * 60)
+
+    try:
+        # Connect to PostgreSQL
+        print("\nConnecting to PostgreSQL...")
+        conn = psycopg2.connect(**db_params)
+        print("Connected successfully!")
+
+        # Cleanup jobs
+        deleted = cleanup_managed_jobs(conn)
+
+        # Close connection
+        conn.close()
+
+        print("\n" + "=" * 60)
+        print("CLEANUP COMPLETE!")
+        print("=" * 60)
+        print(f"Total jobs deleted: {deleted}")
+
+    except psycopg2.Error as e:
+        print(f"\nPostgreSQL Error: {e}")
+        import traceback
+        traceback.print_exc()
+        exit(1)
+    except Exception as e:
+        print(f"\nError: {e}")
+        import traceback
+        traceback.print_exc()
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/load_tests/db_scale_tests/cleanup_postgres_managed_jobs.py
+++ b/tests/load_tests/db_scale_tests/cleanup_postgres_managed_jobs.py
@@ -7,7 +7,9 @@ This script should be run from within the skypilot-api-server pod.
 try:
     import psycopg2
 except ImportError:
-    print("Error: psycopg2 not installed. Install with: pip install psycopg2-binary")
+    print(
+        "Error: psycopg2 not installed. Install with: pip install psycopg2-binary"
+    )
     exit(1)
 
 
@@ -35,16 +37,11 @@ def cleanup_managed_jobs(conn):
     job_ids = [job[0] for job in jobs]
 
     # Delete from both tables
-    cursor.execute(
-        "DELETE FROM spot WHERE job_id = ANY(%s)",
-        (job_ids,)
-    )
+    cursor.execute("DELETE FROM spot WHERE job_id = ANY(%s)", (job_ids,))
     deleted_spot = cursor.rowcount
 
-    cursor.execute(
-        "DELETE FROM job_info WHERE spot_job_id = ANY(%s)",
-        (job_ids,)
-    )
+    cursor.execute("DELETE FROM job_info WHERE spot_job_id = ANY(%s)",
+                   (job_ids,))
     deleted_job_info = cursor.rowcount
 
     conn.commit()

--- a/tests/load_tests/db_scale_tests/cleanup_test_clusters.py
+++ b/tests/load_tests/db_scale_tests/cleanup_test_clusters.py
@@ -37,8 +37,9 @@ def main():
 
         # Delete from cluster_yaml table first
         placeholders = ', '.join(['?' for _ in cluster_names])
-        cursor.execute(f"DELETE FROM cluster_yaml WHERE cluster_name IN ({placeholders})",
-                       cluster_names)
+        cursor.execute(
+            f"DELETE FROM cluster_yaml WHERE cluster_name IN ({placeholders})",
+            cluster_names)
         yaml_deleted = cursor.rowcount
 
         # Delete from clusters table

--- a/tests/load_tests/db_scale_tests/cleanup_test_clusters.py
+++ b/tests/load_tests/db_scale_tests/cleanup_test_clusters.py
@@ -35,13 +35,21 @@ def main():
         for name in cluster_names:
             print(f"  - {name}")
 
-        # Delete them
+        # Delete from cluster_yaml table first
         placeholders = ', '.join(['?' for _ in cluster_names])
+        cursor.execute(f"DELETE FROM cluster_yaml WHERE cluster_name IN ({placeholders})",
+                       cluster_names)
+        yaml_deleted = cursor.rowcount
+
+        # Delete from clusters table
         cursor.execute(f"DELETE FROM clusters WHERE name IN ({placeholders})",
                        cluster_names)
+        clusters_deleted = cursor.rowcount
+
         conn.commit()
 
-        print(f"\nSuccessfully deleted {len(cluster_names)} test clusters!")
+        print(f"\nSuccessfully deleted {clusters_deleted} test clusters!")
+        print(f"Successfully deleted {yaml_deleted} cluster_yaml entries!")
 
         cursor.close()
         conn.close()

--- a/tests/load_tests/db_scale_tests/cleanup_test_managed_jobs.py
+++ b/tests/load_tests/db_scale_tests/cleanup_test_managed_jobs.py
@@ -15,12 +15,14 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 def main():
     """Cleanup test managed jobs from database."""
     parser = argparse.ArgumentParser(
-        description='Cleanup test managed jobs injected after a specific job ID')
+        description='Cleanup test managed jobs injected after a specific job ID'
+    )
     parser.add_argument(
         '--managed-job-id',
         type=int,
         required=True,
-        help='Job ID of the template managed job. All jobs with ID > this will be deleted.'
+        help=
+        'Job ID of the template managed job. All jobs with ID > this will be deleted.'
     )
 
     args = parser.parse_args()
@@ -35,7 +37,8 @@ def main():
         cursor = conn.cursor()
 
         # Find test jobs - all jobs with job_id greater than the template job
-        cursor.execute("""
+        cursor.execute(
+            """
             SELECT job_id, run_timestamp
             FROM spot
             WHERE job_id > ?
@@ -44,7 +47,9 @@ def main():
         jobs = cursor.fetchall()
 
         if not jobs:
-            print(f"No test managed jobs found with job_id > {args.managed_job_id}.")
+            print(
+                f"No test managed jobs found with job_id > {args.managed_job_id}."
+            )
             return
 
         print(f"Found {len(jobs)} test managed jobs to delete")

--- a/tests/load_tests/db_scale_tests/cleanup_test_managed_jobs.py
+++ b/tests/load_tests/db_scale_tests/cleanup_test_managed_jobs.py
@@ -3,6 +3,7 @@
 Cleanup script to remove test managed jobs.
 """
 
+import argparse
 import os
 import sqlite3
 import sys
@@ -13,31 +14,41 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 
 def main():
     """Cleanup test managed jobs from database."""
+    parser = argparse.ArgumentParser(
+        description='Cleanup test managed jobs injected after a specific job ID')
+    parser.add_argument(
+        '--managed-job-id',
+        type=int,
+        required=True,
+        help='Job ID of the template managed job. All jobs with ID > this will be deleted.'
+    )
+
+    args = parser.parse_args()
+
     db_path = os.path.expanduser("~/.sky/spot_jobs.db")
 
-    print("Cleaning up test managed jobs...")
+    print(f"Cleaning up test managed jobs (job_id > {args.managed_job_id})...")
     print("=" * 60)
 
     try:
         conn = sqlite3.connect(db_path)
         cursor = conn.cursor()
 
-        # Find test jobs - they have run_timestamp starting with 'sky-'
-        # and were created by our test generator (look for recent ones with sky-cmd name)
+        # Find test jobs - all jobs with job_id greater than the template job
         cursor.execute("""
             SELECT job_id, run_timestamp
             FROM spot
-            WHERE run_timestamp LIKE 'sky-%'
-            AND job_id > 1
+            WHERE job_id > ?
             ORDER BY job_id
-        """)
+        """, (args.managed_job_id,))
         jobs = cursor.fetchall()
 
         if not jobs:
-            print("No test managed jobs found.")
+            print(f"No test managed jobs found with job_id > {args.managed_job_id}.")
             return
 
-        print(f"Found {len(jobs)} test managed jobs")
+        print(f"Found {len(jobs)} test managed jobs to delete")
+        print(f"Job ID range: {jobs[0][0]} - {jobs[-1][0]}")
         job_ids = [job[0] for job in jobs]
 
         # Delete from both tables

--- a/tests/load_tests/db_scale_tests/inject_minimal_test.py
+++ b/tests/load_tests/db_scale_tests/inject_minimal_test.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Inject a minimal number of test clusters to reproduce the YAML not found error.
+"""
+
+import os
+import pickle
+import sqlite3
+import sys
+import time
+
+# Add SkyPilot to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+
+from sky.utils import common_utils
+
+
+def main():
+    """Inject 2 test clusters to reproduce YAML issue."""
+    db_path = os.path.expanduser("~/.sky/state.db")
+
+    print("Injecting minimal test clusters to reproduce YAML error...")
+    print("=" * 60)
+
+    # First check if we have a real cluster to use as template
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    cursor = conn.cursor()
+
+    cursor.execute("SELECT * FROM clusters LIMIT 1")
+    sample = cursor.fetchone()
+
+    if not sample:
+        print("ERROR: No clusters found in database to use as template.")
+        print("Please create a cluster first with:")
+        print("  sky launch --infra k8s -c sample-cluster -y \"echo test\"")
+        conn.close()
+        return
+
+    # Convert sample to dict
+    sample_dict = dict(sample)
+    print(f"Using cluster '{sample_dict['name']}' as template")
+
+    # Deserialize the handle to modify it
+    original_handle = pickle.loads(sample_dict['handle'])
+    print(f"Original handle cluster_yaml: {original_handle.cluster_yaml}")
+
+    # Create 2 test clusters with missing YAML
+    test_clusters = []
+
+    for i in range(1, 3):
+        cluster_name = f'test-yaml-missing-{i}'
+
+        # Clone and modify the handle
+        handle = pickle.loads(sample_dict['handle'])
+        handle._cluster_name = cluster_name
+
+        # Set cluster_yaml path to a non-existent file
+        # This simulates the issue where the path is stored but file doesn't exist
+        yaml_path = os.path.expanduser(f'~/.sky/generated/{cluster_name}.yml')
+        handle._cluster_yaml = yaml_path
+
+        # Serialize the modified handle
+        handle_bytes = pickle.dumps(handle)
+
+        cluster = {
+            'name': cluster_name,
+            'launched_at': int(time.time()),
+            'handle': handle_bytes,
+            'last_use': sample_dict['last_use'],
+            'status': 'UP',
+            'autostop': -1,
+            'to_down': 0,
+            'metadata': '{}',
+            'owner': sample_dict.get('owner'),
+            'cluster_hash': sample_dict.get('cluster_hash'),
+            'storage_mounts_metadata': sample_dict.get('storage_mounts_metadata'),
+            'cluster_ever_up': 1,
+            'status_updated_at': int(time.time()),
+            'config_hash': sample_dict.get('config_hash'),
+            'user_hash': common_utils.get_user_hash(),
+            'workspace': sample_dict.get('workspace', 'default'),
+            'last_creation_yaml': sample_dict.get('last_creation_yaml'),
+            'last_creation_command': sample_dict.get('last_creation_command'),
+            'is_managed': 0,
+            'provision_log_path': sample_dict.get('provision_log_path'),
+            'skylet_ssh_tunnel_metadata': sample_dict.get('skylet_ssh_tunnel_metadata'),
+        }
+
+        test_clusters.append(cluster)
+        print(f"  Created test cluster: {cluster_name}")
+        print(f"    cluster_yaml path in handle: {yaml_path}")
+        print(f"    File exists: {os.path.exists(yaml_path)}")
+        print(f"    DB entry exists: <will check after insert>")
+
+    # Insert clusters into database
+    columns = list(test_clusters[0].keys())
+    columns_str = ', '.join(columns)
+    placeholders = ', '.join(['?' for _ in columns])
+    insert_sql = f"INSERT INTO clusters ({columns_str}) VALUES ({placeholders})"
+
+    for cluster in test_clusters:
+        row_data = tuple(cluster[col] for col in columns)
+        cursor.execute(insert_sql, row_data)
+
+    conn.commit()
+
+    # Check if cluster_yaml entries exist
+    print("\nChecking cluster_yaml table:")
+    for i in range(1, 3):
+        cluster_name = f'test-yaml-missing-{i}'
+        cursor.execute("SELECT * FROM cluster_yaml WHERE cluster_name = ?", (cluster_name,))
+        result = cursor.fetchone()
+        print(f"  {cluster_name}: {'FOUND' if result else 'NOT FOUND'}")
+
+    cursor.close()
+    conn.close()
+
+    print("\n" + "=" * 60)
+    print("Test clusters injected successfully!")
+    print("\nTo reproduce the error, run:")
+    print("  sky status")
+    print("\nExpected error:")
+    print("  ValueError: Cluster yaml ~/.sky/generated/test-yaml-missing-X.yml not found.")
+    print("\nTo clean up:")
+    print("  sqlite3 ~/.sky/state.db \"DELETE FROM clusters WHERE name LIKE 'test-yaml-missing-%';\"")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/load_tests/db_scale_tests/inject_minimal_test.py
+++ b/tests/load_tests/db_scale_tests/inject_minimal_test.py
@@ -74,7 +74,8 @@ def main():
             'metadata': '{}',
             'owner': sample_dict.get('owner'),
             'cluster_hash': sample_dict.get('cluster_hash'),
-            'storage_mounts_metadata': sample_dict.get('storage_mounts_metadata'),
+            'storage_mounts_metadata':
+                sample_dict.get('storage_mounts_metadata'),
             'cluster_ever_up': 1,
             'status_updated_at': int(time.time()),
             'config_hash': sample_dict.get('config_hash'),
@@ -84,7 +85,8 @@ def main():
             'last_creation_command': sample_dict.get('last_creation_command'),
             'is_managed': 0,
             'provision_log_path': sample_dict.get('provision_log_path'),
-            'skylet_ssh_tunnel_metadata': sample_dict.get('skylet_ssh_tunnel_metadata'),
+            'skylet_ssh_tunnel_metadata':
+                sample_dict.get('skylet_ssh_tunnel_metadata'),
         }
 
         test_clusters.append(cluster)
@@ -109,7 +111,8 @@ def main():
     print("\nChecking cluster_yaml table:")
     for i in range(1, 3):
         cluster_name = f'test-yaml-missing-{i}'
-        cursor.execute("SELECT * FROM cluster_yaml WHERE cluster_name = ?", (cluster_name,))
+        cursor.execute("SELECT * FROM cluster_yaml WHERE cluster_name = ?",
+                       (cluster_name,))
         result = cursor.fetchone()
         print(f"  {cluster_name}: {'FOUND' if result else 'NOT FOUND'}")
 
@@ -121,9 +124,13 @@ def main():
     print("\nTo reproduce the error, run:")
     print("  sky status")
     print("\nExpected error:")
-    print("  ValueError: Cluster yaml ~/.sky/generated/test-yaml-missing-X.yml not found.")
+    print(
+        "  ValueError: Cluster yaml ~/.sky/generated/test-yaml-missing-X.yml not found."
+    )
     print("\nTo clean up:")
-    print("  sqlite3 ~/.sky/state.db \"DELETE FROM clusters WHERE name LIKE 'test-yaml-missing-%';\"")
+    print(
+        "  sqlite3 ~/.sky/state.db \"DELETE FROM clusters WHERE name LIKE 'test-yaml-missing-%';\""
+    )
 
 
 if __name__ == "__main__":

--- a/tests/load_tests/db_scale_tests/inject_postgres_clusters.py
+++ b/tests/load_tests/db_scale_tests/inject_postgres_clusters.py
@@ -276,20 +276,48 @@ def inject_cluster_history(conn, recent_count, old_count,
 
 def main():
     """Main function to inject test clusters into PostgreSQL."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description='Inject test clusters into PostgreSQL database for scale testing'
+    )
+    parser.add_argument('--cluster-count', type=int, default=2000,
+                        help='Number of active clusters to inject (default: 2000)')
+    parser.add_argument('--recent-history', type=int, default=2000,
+                        help='Number of recent cluster history entries (1-10 days old) (default: 2000)')
+    parser.add_argument('--old-history', type=int, default=8000,
+                        help='Number of old cluster history entries (15-30 days old) (default: 8000)')
+    parser.add_argument('--active-cluster', type=str, default='scale-test-active',
+                        help='Name of active cluster to use as template (default: scale-test-active)')
+    parser.add_argument('--terminated-cluster', type=str, default='scale-test-terminated',
+                        help='Name of terminated cluster to use as template (default: scale-test-terminated)')
+    parser.add_argument('--host', type=str, default='localhost',
+                        help='Database host (default: localhost)')
+    parser.add_argument('--port', type=int, default=5432,
+                        help='Database port (default: 5432)')
+    parser.add_argument('--database', type=str, default='skypilot',
+                        help='Database name (default: skypilot)')
+    parser.add_argument('--user', type=str, default='skypilot',
+                        help='Database user (default: skypilot)')
+    parser.add_argument('--password', type=str, default='skypilot',
+                        help='Database password (default: skypilot)')
+
+    args = parser.parse_args()
+
     # Database connection parameters
     db_params = {
-        'host': 'localhost',
-        'port': 5432,
-        'database': 'skypilot',
-        'user': 'skypilot',
-        'password': 'skypilot'
+        'host': args.host,
+        'port': args.port,
+        'database': args.database,
+        'user': args.user,
+        'password': args.password
     }
 
-    cluster_count = 2000
-    recent_history_count = 2000
-    old_history_count = 8000
-    active_cluster_name = 'scale-test-active'
-    terminated_cluster_name = 'scale-test-terminated'
+    cluster_count = args.cluster_count
+    recent_history_count = args.recent_history
+    old_history_count = args.old_history
+    active_cluster_name = args.active_cluster
+    terminated_cluster_name = args.terminated_cluster
 
     print("=" * 60)
     print(f"PostgreSQL Cluster Injection Test")

--- a/tests/load_tests/db_scale_tests/inject_postgres_clusters.py
+++ b/tests/load_tests/db_scale_tests/inject_postgres_clusters.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""
+Inject test clusters and cluster history into PostgreSQL database for scale testing.
+This script should be run from within the skypilot-api-server pod.
+"""
+
+import copy
+import os
+import pickle
+import random
+import time
+import uuid
+
+try:
+    import psycopg2
+    from psycopg2.extras import execute_batch
+except ImportError:
+    print("Error: psycopg2 not installed. Install with: pip install psycopg2-binary")
+    exit(1)
+
+
+def load_active_cluster_sample(conn, cluster_name='scale-test-active'):
+    """Load an active cluster from PostgreSQL as a template."""
+    cursor = conn.cursor()
+
+    cursor.execute("SELECT * FROM clusters WHERE name = %s", (cluster_name,))
+    columns = [desc[0] for desc in cursor.description]
+    row = cursor.fetchone()
+
+    if not row:
+        raise ValueError(
+            f"Active cluster '{cluster_name}' not found in database. "
+            f"Please create it first."
+        )
+
+    sample = dict(zip(columns, row))
+    cursor.close()
+
+    return sample, columns
+
+
+def load_terminated_cluster_sample(conn, cluster_name='scale-test-terminated'):
+    """Load a terminated cluster from cluster_history as a template."""
+    cursor = conn.cursor()
+
+    cursor.execute("SELECT * FROM cluster_history WHERE name = %s", (cluster_name,))
+    columns = [desc[0] for desc in cursor.description]
+    row = cursor.fetchone()
+
+    if not row:
+        raise ValueError(
+            f"Terminated cluster '{cluster_name}' not found in cluster_history. "
+            f"Please create and terminate it first."
+        )
+
+    sample = dict(zip(columns, row))
+    cursor.close()
+
+    return sample, columns
+
+
+def update_handle_cluster_name(handle_blob, new_cluster_name):
+    """Update the cluster name in a pickled handle object."""
+    try:
+        handle = pickle.loads(handle_blob)
+        # Update cluster_name if it exists
+        if hasattr(handle, 'cluster_name'):
+            handle.cluster_name = new_cluster_name
+        # Re-pickle and return
+        return pickle.dumps(handle)
+    except Exception as e:
+        # If unpickling fails, just return the original blob
+        print(f"Warning: Failed to update handle cluster name: {e}")
+        return handle_blob
+
+
+def deep_copy_cluster(cluster_dict):
+    """Deep copy a cluster dict, handling memoryview objects."""
+    result = {}
+    for key, value in cluster_dict.items():
+        if isinstance(value, memoryview):
+            # Convert memoryview to bytes
+            result[key] = bytes(value)
+        else:
+            result[key] = copy.deepcopy(value)
+    return result
+
+
+def generate_cluster_data(active_cluster_sample, count):
+    """Generate test data for clusters table by cloning the sample cluster."""
+    clusters = []
+    current_time = time.time()
+
+    for i in range(count):
+        # Deep copy the sample cluster, handling memoryview objects
+        cluster = deep_copy_cluster(active_cluster_sample)
+
+        # Modify unique fields
+        cluster['name'] = f"test-cluster-{i+1:04d}-{uuid.uuid4().hex[:8]}"
+        cluster['cluster_hash'] = str(uuid.uuid4())
+        cluster['launched_at'] = int(
+            current_time - random.uniform(0, 7 * 24 * 3600))  # Last 7 days
+        cluster['status_updated_at'] = int(
+            current_time - random.uniform(0, 24 * 3600))  # Last day
+
+        # Update handle with new cluster name if handle exists
+        if cluster.get('handle'):
+            cluster['handle'] = update_handle_cluster_name(
+                cluster['handle'], cluster['name'])
+
+        clusters.append(cluster)
+
+    return clusters
+
+
+def generate_cluster_history_data(terminated_cluster_sample, recent_count, old_count):
+    """Generate cluster history data by cloning the terminated cluster sample."""
+    history_clusters = []
+    current_time = int(time.time())
+
+    # Generate recent clusters (within 10 days)
+    recent_min_days = 1 * 24 * 60 * 60  # 1 day ago
+    recent_max_days = 9 * 24 * 60 * 60  # 9 days ago
+
+    for i in range(recent_count):
+        cluster = deep_copy_cluster(terminated_cluster_sample)
+
+        # Modify unique fields
+        cluster['name'] = f"test-cluster-recent-{i+1:04d}-{uuid.uuid4().hex[:8]}"
+        cluster['cluster_hash'] = str(uuid.uuid4())
+
+        # Random timestamp 1-9 days ago
+        days_ago_seconds = random.randint(recent_min_days, recent_max_days)
+        cluster['last_activity_time'] = current_time - days_ago_seconds
+        cluster['launched_at'] = cluster['last_activity_time'] - random.randint(
+            3600, 86400)
+
+        history_clusters.append(cluster)
+
+    # Generate older clusters (15-30 days ago)
+    old_min_days = 15 * 24 * 60 * 60  # 15 days ago
+    old_max_days = 30 * 24 * 60 * 60  # 30 days ago
+
+    for i in range(old_count):
+        cluster = deep_copy_cluster(terminated_cluster_sample)
+
+        # Modify unique fields
+        cluster['name'] = f"test-cluster-old-{i+1:04d}-{uuid.uuid4().hex[:8]}"
+        cluster['cluster_hash'] = str(uuid.uuid4())
+
+        # Random timestamp 15-30 days ago
+        days_ago_seconds = random.randint(old_min_days, old_max_days)
+        cluster['last_activity_time'] = current_time - days_ago_seconds
+        cluster['launched_at'] = cluster['last_activity_time'] - random.randint(
+            3600, 86400)
+
+        history_clusters.append(cluster)
+
+    return history_clusters
+
+
+def inject_clusters(conn, count, active_cluster_name='scale-test-active'):
+    """Inject test clusters into PostgreSQL database."""
+    print(f"Injecting {count} test clusters...")
+
+    # Load sample data
+    print("Loading active cluster sample...")
+    active_cluster_sample, cluster_columns = load_active_cluster_sample(
+        conn, active_cluster_name
+    )
+
+    # Load cluster YAML for the sample
+    print("Loading cluster YAML...")
+    cursor = conn.cursor()
+    cursor.execute("SELECT yaml FROM cluster_yaml WHERE cluster_name = %s", (active_cluster_name,))
+    sample_yaml_row = cursor.fetchone()
+    sample_yaml = sample_yaml_row[0] if sample_yaml_row else None
+
+    if not sample_yaml:
+        print(f"Warning: No cluster_yaml found for {active_cluster_name}. Cluster YAML will not be injected.")
+
+    print(f"Generating {count} test clusters...")
+    clusters = generate_cluster_data(active_cluster_sample, count)
+
+    # Prepare insert statement for clusters table
+    columns_str = ', '.join(cluster_columns)
+    placeholders = ', '.join(['%s' for _ in cluster_columns])
+    insert_sql = f"INSERT INTO clusters ({columns_str}) VALUES ({placeholders})"
+
+    # Prepare insert statement for cluster_yaml table
+    yaml_insert_sql = """
+        INSERT INTO cluster_yaml (cluster_name, yaml)
+        VALUES (%s, %s)
+        ON CONFLICT (cluster_name) DO UPDATE SET yaml = EXCLUDED.yaml
+    """
+
+    # Insert in batches for performance
+    batch_size = 100
+    total_inserted = 0
+
+    print(f"Inserting clusters in batches of {batch_size}...")
+    for i in range(0, len(clusters), batch_size):
+        batch = clusters[i:i + batch_size]
+        batch_data = [tuple(cluster[col] for col in cluster_columns) for cluster in batch]
+
+        execute_batch(cursor, insert_sql, batch_data)
+        conn.commit()
+
+        # Also insert cluster_yaml entries if we have sample YAML
+        if sample_yaml:
+            yaml_batch_data = [(cluster['name'], sample_yaml) for cluster in batch]
+            execute_batch(cursor, yaml_insert_sql, yaml_batch_data)
+            conn.commit()
+
+        total_inserted += len(batch_data)
+        if total_inserted % 500 == 0:
+            print(f"  Inserted {total_inserted}/{count} clusters...")
+
+    cursor.close()
+
+    print(f"\nSuccessfully injected {total_inserted} test clusters!")
+    if sample_yaml:
+        print(f"Successfully injected {total_inserted} cluster_yaml entries!")
+
+    return total_inserted
+
+
+def inject_cluster_history(conn, recent_count, old_count,
+                           terminated_cluster_name='scale-test-terminated'):
+    """Inject test cluster history entries into PostgreSQL database."""
+    total_count = recent_count + old_count
+    print(f"\nInjecting {total_count} terminated cluster history entries...")
+    print(f"  - {recent_count} recent clusters (within 10 days)")
+    print(f"  - {old_count} older clusters (15-30 days ago)")
+
+    # Load sample data
+    print("Loading terminated cluster sample...")
+    terminated_cluster_sample, history_columns = load_terminated_cluster_sample(
+        conn, terminated_cluster_name
+    )
+
+    print(f"Generating {total_count} test cluster history entries...")
+    history_clusters = generate_cluster_history_data(
+        terminated_cluster_sample, recent_count, old_count
+    )
+
+    # Prepare insert statement
+    columns_str = ', '.join(history_columns)
+    placeholders = ', '.join(['%s' for _ in history_columns])
+    insert_sql = f"INSERT INTO cluster_history ({columns_str}) VALUES ({placeholders})"
+
+    # Insert in batches for performance
+    batch_size = 100
+    total_inserted = 0
+
+    cursor = conn.cursor()
+
+    print(f"Inserting cluster history in batches of {batch_size}...")
+    for i in range(0, len(history_clusters), batch_size):
+        batch = history_clusters[i:i + batch_size]
+        batch_data = [tuple(cluster[col] for col in history_columns) for cluster in batch]
+
+        execute_batch(cursor, insert_sql, batch_data)
+        conn.commit()
+
+        total_inserted += len(batch_data)
+        if total_inserted % 1000 == 0:
+            print(f"  Inserted {total_inserted}/{total_count} history entries...")
+
+    cursor.close()
+
+    print(f"\nSuccessfully injected {total_inserted} test cluster history entries!")
+
+    return total_inserted
+
+
+def main():
+    """Main function to inject test clusters into PostgreSQL."""
+    # Database connection parameters
+    db_params = {
+        'host': 'localhost',
+        'port': 5432,
+        'database': 'skypilot',
+        'user': 'skypilot',
+        'password': 'skypilot'
+    }
+
+    cluster_count = 2000
+    recent_history_count = 2000
+    old_history_count = 8000
+    active_cluster_name = 'scale-test-active'
+    terminated_cluster_name = 'scale-test-terminated'
+
+    print("=" * 60)
+    print(f"PostgreSQL Cluster Injection Test")
+    print("=" * 60)
+    print(f"Database: {db_params['database']}@{db_params['host']}")
+    print(f"Active clusters to inject: {cluster_count}")
+    print(f"Recent history (1-10 days): {recent_history_count}")
+    print(f"Old history (15-30 days): {old_history_count}")
+    print(f"Template active cluster: {active_cluster_name}")
+    print(f"Template terminated cluster: {terminated_cluster_name}")
+    print("=" * 60)
+
+    try:
+        # Connect to PostgreSQL
+        print("\nConnecting to PostgreSQL...")
+        conn = psycopg2.connect(**db_params)
+        print("Connected successfully!")
+
+        # Inject active clusters
+        clusters_injected = inject_clusters(conn, cluster_count, active_cluster_name)
+
+        # Inject cluster history
+        history_injected = inject_cluster_history(
+            conn, recent_history_count, old_history_count, terminated_cluster_name
+        )
+
+        # Close connection
+        conn.close()
+
+        print("\n" + "=" * 60)
+        print("INJECTION COMPLETE!")
+        print("=" * 60)
+        print(f"Total active clusters injected: {clusters_injected}")
+        print(f"Total cluster history injected: {history_injected}")
+        print(f"  - Recent (1-10 days): {recent_history_count}")
+        print(f"  - Old (15-30 days): {old_history_count}")
+        print("\nTo clean up these clusters, run:")
+        print("  python cleanup_postgres_clusters.py")
+
+    except psycopg2.Error as e:
+        print(f"\nPostgreSQL Error: {e}")
+        import traceback
+        traceback.print_exc()
+        exit(1)
+    except Exception as e:
+        print(f"\nError: {e}")
+        import traceback
+        traceback.print_exc()
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/load_tests/db_scale_tests/inject_postgres_managed_jobs.py
+++ b/tests/load_tests/db_scale_tests/inject_postgres_managed_jobs.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""
+Inject test managed jobs into PostgreSQL database for scale testing.
+This script should be run from within the skypilot-api-server pod.
+"""
+
+import copy
+import os
+import random
+import time
+
+try:
+    import psycopg2
+    from psycopg2.extras import execute_batch
+except ImportError:
+    print("Error: psycopg2 not installed. Install with: pip install psycopg2-binary")
+    exit(1)
+
+
+def load_managed_job_sample(conn, managed_job_id=9):
+    """Load a managed job from PostgreSQL as a template."""
+    cursor = conn.cursor()
+
+    # Load from spot table
+    cursor.execute("SELECT * FROM spot WHERE job_id = %s", (managed_job_id,))
+    spot_columns = [desc[0] for desc in cursor.description]
+    spot_row = cursor.fetchone()
+
+    if not spot_row:
+        raise ValueError(
+            f"Managed job with ID {managed_job_id} not found in spot table. "
+            f"Please create a sample job first."
+        )
+
+    spot_sample = dict(zip(spot_columns, spot_row))
+
+    # Load from job_info table
+    cursor.execute("SELECT * FROM job_info WHERE spot_job_id = %s",
+                   (spot_sample['spot_job_id'],))
+    job_info_columns = [desc[0] for desc in cursor.description]
+    job_info_row = cursor.fetchone()
+
+    if not job_info_row:
+        raise ValueError(
+            f"Job info for spot_job_id {spot_sample['spot_job_id']} not found."
+        )
+
+    job_info_sample = dict(zip(job_info_columns, job_info_row))
+    cursor.close()
+
+    return spot_sample, job_info_sample, spot_columns, job_info_columns
+
+
+def generate_managed_job_data(spot_sample, job_info_sample, count, max_job_id):
+    """Generate managed job data by cloning the sample job."""
+    spot_jobs = []
+    job_infos = []
+
+    current_time = time.time()
+    starting_job_id = max_job_id + 1
+
+    for i in range(count):
+        # Deep copy the samples
+        spot_job = copy.deepcopy(spot_sample)
+        job_info = copy.deepcopy(job_info_sample)
+
+        # Update unique IDs
+        job_id = starting_job_id + i
+        spot_job_id = starting_job_id + i
+
+        spot_job['job_id'] = job_id
+        spot_job['spot_job_id'] = spot_job_id
+        job_info['spot_job_id'] = spot_job_id
+
+        # Update timestamps
+        base_time = current_time - random.uniform(0, 3600)  # Within last hour
+        spot_job['submitted_at'] = base_time
+        spot_job['start_at'] = base_time + random.uniform(30, 120)
+        spot_job['last_recovered_at'] = spot_job['start_at']
+
+        # Update run_timestamp to be unique
+        timestamp_str = time.strftime('%Y-%m-%d-%H-%M-%S',
+                                      time.localtime(base_time))
+        spot_job['run_timestamp'] = f'sky-{timestamp_str}-{random.randint(100000, 999999)}'
+
+        # Update controller_pid to be unique
+        job_info['controller_pid'] = -(random.randint(1000, 99999))
+
+        # Update file paths to be unique
+        home_dir = os.path.expanduser('~')
+        job_hash = f'{i+1:04d}'
+        job_info['dag_yaml_path'] = f'{home_dir}/.sky/managed_jobs/test-job-{job_hash}.yaml'
+        job_info['env_file_path'] = f'{home_dir}/.sky/managed_jobs/test-job-{job_hash}.env'
+        job_info['original_user_yaml_path'] = f'{home_dir}/.sky/managed_jobs/test-job-{job_hash}.original_user_yaml'
+
+        spot_jobs.append(spot_job)
+        job_infos.append(job_info)
+
+    return spot_jobs, job_infos
+
+
+def inject_managed_jobs(conn, count=10000, managed_job_id=9):
+    """Inject test managed jobs into PostgreSQL database."""
+    print(f"Injecting {count} test managed jobs...")
+
+    # Load sample data
+    print("Loading sample managed job...")
+    spot_sample, job_info_sample, spot_columns, job_info_columns = load_managed_job_sample(
+        conn, managed_job_id
+    )
+
+    # Find max job_id
+    cursor = conn.cursor()
+    cursor.execute("SELECT MAX(job_id) FROM spot")
+    max_job_id = cursor.fetchone()[0] or 0
+    cursor.close()
+
+    print(f"Current max job_id: {max_job_id}")
+    print(f"Generating {count} test jobs starting from job_id {max_job_id + 1}...")
+
+    # Generate test data
+    spot_jobs, job_infos = generate_managed_job_data(
+        spot_sample, job_info_sample, count, max_job_id
+    )
+
+    # Prepare insert statements
+    spot_columns_str = ', '.join(spot_columns)
+    spot_placeholders = ', '.join(['%s' for _ in spot_columns])
+    job_info_columns_str = ', '.join(job_info_columns)
+    job_info_placeholders = ', '.join(['%s' for _ in job_info_columns])
+
+    spot_insert_sql = f"INSERT INTO spot ({spot_columns_str}) VALUES ({spot_placeholders})"
+    job_info_insert_sql = f"INSERT INTO job_info ({job_info_columns_str}) VALUES ({job_info_placeholders})"
+
+    # Insert in batches for performance
+    batch_size = 100
+    total_inserted = 0
+
+    cursor = conn.cursor()
+
+    print(f"Inserting jobs in batches of {batch_size}...")
+    for i in range(0, len(spot_jobs), batch_size):
+        spot_batch = spot_jobs[i:i + batch_size]
+        job_info_batch = job_infos[i:i + batch_size]
+
+        # Convert dicts to tuples in column order
+        spot_batch_data = [tuple(job[col] for col in spot_columns) for job in spot_batch]
+        job_info_batch_data = [tuple(job[col] for col in job_info_columns) for job in job_info_batch]
+
+        # Use execute_batch for better performance
+        execute_batch(cursor, spot_insert_sql, spot_batch_data)
+        execute_batch(cursor, job_info_insert_sql, job_info_batch_data)
+        conn.commit()
+
+        total_inserted += len(spot_batch_data)
+        if total_inserted % 1000 == 0:
+            print(f"  Inserted {total_inserted}/{count} jobs...")
+
+    cursor.close()
+
+    print(f"\nSuccessfully injected {total_inserted} test managed jobs!")
+    print(f"Job IDs: {max_job_id + 1} - {max_job_id + total_inserted}")
+
+    return total_inserted
+
+
+def main():
+    """Main function to inject test managed jobs into PostgreSQL."""
+    # Database connection parameters
+    db_params = {
+        'host': 'localhost',
+        'port': 5432,
+        'database': 'skypilot',
+        'user': 'skypilot',
+        'password': 'skypilot'
+    }
+
+    count = 10000
+    managed_job_id = 9  # Template job ID
+
+    print("=" * 60)
+    print(f"PostgreSQL Managed Job Injection Test")
+    print("=" * 60)
+    print(f"Database: {db_params['database']}@{db_params['host']}")
+    print(f"Jobs to inject: {count}")
+    print(f"Template job_id: {managed_job_id}")
+    print("=" * 60)
+
+    try:
+        # Connect to PostgreSQL
+        print("\nConnecting to PostgreSQL...")
+        conn = psycopg2.connect(**db_params)
+        print("Connected successfully!")
+
+        # Inject jobs
+        injected = inject_managed_jobs(conn, count, managed_job_id)
+
+        # Close connection
+        conn.close()
+
+        print("\n" + "=" * 60)
+        print("INJECTION COMPLETE!")
+        print("=" * 60)
+        print(f"Total jobs injected: {injected}")
+        print("\nTo clean up these jobs, run:")
+        print("  python cleanup_postgres_managed_jobs.py")
+
+    except psycopg2.Error as e:
+        print(f"\nPostgreSQL Error: {e}")
+        import traceback
+        traceback.print_exc()
+        exit(1)
+    except Exception as e:
+        print(f"\nError: {e}")
+        import traceback
+        traceback.print_exc()
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/load_tests/db_scale_tests/inject_postgres_managed_jobs.py
+++ b/tests/load_tests/db_scale_tests/inject_postgres_managed_jobs.py
@@ -13,7 +13,9 @@ try:
     import psycopg2
     from psycopg2.extras import execute_batch
 except ImportError:
-    print("Error: psycopg2 not installed. Install with: pip install psycopg2-binary")
+    print(
+        "Error: psycopg2 not installed. Install with: pip install psycopg2-binary"
+    )
     exit(1)
 
 
@@ -29,8 +31,7 @@ def load_managed_job_sample(conn, managed_job_id=9):
     if not spot_row:
         raise ValueError(
             f"Managed job with ID {managed_job_id} not found in spot table. "
-            f"Please create a sample job first."
-        )
+            f"Please create a sample job first.")
 
     spot_sample = dict(zip(spot_columns, spot_row))
 
@@ -42,8 +43,7 @@ def load_managed_job_sample(conn, managed_job_id=9):
 
     if not job_info_row:
         raise ValueError(
-            f"Job info for spot_job_id {spot_sample['spot_job_id']} not found."
-        )
+            f"Job info for spot_job_id {spot_sample['spot_job_id']} not found.")
 
     job_info_sample = dict(zip(job_info_columns, job_info_row))
     cursor.close()
@@ -81,7 +81,8 @@ def generate_managed_job_data(spot_sample, job_info_sample, count, max_job_id):
         # Update run_timestamp to be unique
         timestamp_str = time.strftime('%Y-%m-%d-%H-%M-%S',
                                       time.localtime(base_time))
-        spot_job['run_timestamp'] = f'sky-{timestamp_str}-{random.randint(100000, 999999)}'
+        spot_job[
+            'run_timestamp'] = f'sky-{timestamp_str}-{random.randint(100000, 999999)}'
 
         # Update controller_pid to be unique
         job_info['controller_pid'] = -(random.randint(1000, 99999))
@@ -89,9 +90,12 @@ def generate_managed_job_data(spot_sample, job_info_sample, count, max_job_id):
         # Update file paths to be unique
         home_dir = os.path.expanduser('~')
         job_hash = f'{i+1:04d}'
-        job_info['dag_yaml_path'] = f'{home_dir}/.sky/managed_jobs/test-job-{job_hash}.yaml'
-        job_info['env_file_path'] = f'{home_dir}/.sky/managed_jobs/test-job-{job_hash}.env'
-        job_info['original_user_yaml_path'] = f'{home_dir}/.sky/managed_jobs/test-job-{job_hash}.original_user_yaml'
+        job_info[
+            'dag_yaml_path'] = f'{home_dir}/.sky/managed_jobs/test-job-{job_hash}.yaml'
+        job_info[
+            'env_file_path'] = f'{home_dir}/.sky/managed_jobs/test-job-{job_hash}.env'
+        job_info[
+            'original_user_yaml_path'] = f'{home_dir}/.sky/managed_jobs/test-job-{job_hash}.original_user_yaml'
 
         spot_jobs.append(spot_job)
         job_infos.append(job_info)
@@ -106,8 +110,7 @@ def inject_managed_jobs(conn, count=10000, managed_job_id=9):
     # Load sample data
     print("Loading sample managed job...")
     spot_sample, job_info_sample, spot_columns, job_info_columns = load_managed_job_sample(
-        conn, managed_job_id
-    )
+        conn, managed_job_id)
 
     # Find max job_id
     cursor = conn.cursor()
@@ -116,12 +119,14 @@ def inject_managed_jobs(conn, count=10000, managed_job_id=9):
     cursor.close()
 
     print(f"Current max job_id: {max_job_id}")
-    print(f"Generating {count} test jobs starting from job_id {max_job_id + 1}...")
+    print(
+        f"Generating {count} test jobs starting from job_id {max_job_id + 1}..."
+    )
 
     # Generate test data
-    spot_jobs, job_infos = generate_managed_job_data(
-        spot_sample, job_info_sample, count, max_job_id
-    )
+    spot_jobs, job_infos = generate_managed_job_data(spot_sample,
+                                                     job_info_sample, count,
+                                                     max_job_id)
 
     # Prepare insert statements
     spot_columns_str = ', '.join(spot_columns)
@@ -144,8 +149,14 @@ def inject_managed_jobs(conn, count=10000, managed_job_id=9):
         job_info_batch = job_infos[i:i + batch_size]
 
         # Convert dicts to tuples in column order
-        spot_batch_data = [tuple(job[col] for col in spot_columns) for job in spot_batch]
-        job_info_batch_data = [tuple(job[col] for col in job_info_columns) for job in job_info_batch]
+        spot_batch_data = [
+            tuple(job[col] for col in spot_columns) for job in spot_batch
+        ]
+        job_info_batch_data = [
+            tuple(job[col]
+                  for col in job_info_columns)
+            for job in job_info_batch
+        ]
 
         # Use execute_batch for better performance
         execute_batch(cursor, spot_insert_sql, spot_batch_data)
@@ -169,21 +180,36 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser(
-        description='Inject test managed jobs into PostgreSQL database for scale testing'
-    )
-    parser.add_argument('--count', type=int, default=10000,
-                        help='Number of managed jobs to inject (default: 10000)')
-    parser.add_argument('--job-id', type=int, default=9,
+        description=
+        'Inject test managed jobs into PostgreSQL database for scale testing')
+    parser.add_argument(
+        '--count',
+        type=int,
+        default=10000,
+        help='Number of managed jobs to inject (default: 10000)')
+    parser.add_argument('--job-id',
+                        type=int,
+                        default=9,
                         help='Job ID of template managed job (default: 9)')
-    parser.add_argument('--host', type=str, default='localhost',
+    parser.add_argument('--host',
+                        type=str,
+                        default='localhost',
                         help='Database host (default: localhost)')
-    parser.add_argument('--port', type=int, default=5432,
+    parser.add_argument('--port',
+                        type=int,
+                        default=5432,
                         help='Database port (default: 5432)')
-    parser.add_argument('--database', type=str, default='skypilot',
+    parser.add_argument('--database',
+                        type=str,
+                        default='skypilot',
                         help='Database name (default: skypilot)')
-    parser.add_argument('--user', type=str, default='skypilot',
+    parser.add_argument('--user',
+                        type=str,
+                        default='skypilot',
                         help='Database user (default: skypilot)')
-    parser.add_argument('--password', type=str, default='skypilot',
+    parser.add_argument('--password',
+                        type=str,
+                        default='skypilot',
                         help='Database password (default: skypilot)')
 
     args = parser.parse_args()

--- a/tests/load_tests/db_scale_tests/inject_postgres_managed_jobs.py
+++ b/tests/load_tests/db_scale_tests/inject_postgres_managed_jobs.py
@@ -166,17 +166,39 @@ def inject_managed_jobs(conn, count=10000, managed_job_id=9):
 
 def main():
     """Main function to inject test managed jobs into PostgreSQL."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description='Inject test managed jobs into PostgreSQL database for scale testing'
+    )
+    parser.add_argument('--count', type=int, default=10000,
+                        help='Number of managed jobs to inject (default: 10000)')
+    parser.add_argument('--job-id', type=int, default=9,
+                        help='Job ID of template managed job (default: 9)')
+    parser.add_argument('--host', type=str, default='localhost',
+                        help='Database host (default: localhost)')
+    parser.add_argument('--port', type=int, default=5432,
+                        help='Database port (default: 5432)')
+    parser.add_argument('--database', type=str, default='skypilot',
+                        help='Database name (default: skypilot)')
+    parser.add_argument('--user', type=str, default='skypilot',
+                        help='Database user (default: skypilot)')
+    parser.add_argument('--password', type=str, default='skypilot',
+                        help='Database password (default: skypilot)')
+
+    args = parser.parse_args()
+
     # Database connection parameters
     db_params = {
-        'host': 'localhost',
-        'port': 5432,
-        'database': 'skypilot',
-        'user': 'skypilot',
-        'password': 'skypilot'
+        'host': args.host,
+        'port': args.port,
+        'database': args.database,
+        'user': args.user,
+        'password': args.password
     }
 
-    count = 10000
-    managed_job_id = 9  # Template job ID
+    count = args.count
+    managed_job_id = args.job_id
 
     print("=" * 60)
     print(f"PostgreSQL Managed Job Injection Test")

--- a/tests/load_tests/db_scale_tests/inject_test_cluster_history.py
+++ b/tests/load_tests/db_scale_tests/inject_test_cluster_history.py
@@ -21,7 +21,8 @@ def main():
         '--terminated-cluster',
         type=str,
         default='scale-test-terminated',
-        help='Name of the terminated cluster to use as template (default: scale-test-terminated)'
+        help=
+        'Name of the terminated cluster to use as template (default: scale-test-terminated)'
     )
     parser.add_argument(
         '--recent-count',

--- a/tests/load_tests/db_scale_tests/inject_test_cluster_history.py
+++ b/tests/load_tests/db_scale_tests/inject_test_cluster_history.py
@@ -3,6 +3,7 @@
 Simple script to inject test cluster history without cleanup for manual verification.
 """
 
+import argparse
 import os
 import sys
 
@@ -14,28 +15,46 @@ from scale_test_utils import TestScale
 
 def main():
     """Inject test cluster history without cleanup."""
-    recent_count = 5
-    old_count = 5
+    parser = argparse.ArgumentParser(
+        description='Inject test cluster history for manual verification')
+    parser.add_argument(
+        '--terminated-cluster',
+        type=str,
+        default='scale-test-terminated',
+        help='Name of the terminated cluster to use as template (default: scale-test-terminated)'
+    )
+    parser.add_argument(
+        '--recent-count',
+        type=int,
+        default=5,
+        help='Number of recent terminated clusters to inject (default: 5)')
+    parser.add_argument(
+        '--old-count',
+        type=int,
+        default=5,
+        help='Number of old terminated clusters to inject (default: 5)')
+
+    args = parser.parse_args()
 
     print(
-        f"Injecting {recent_count + old_count} test cluster history entries (no cleanup)..."
+        f"Injecting {args.recent_count + args.old_count} test cluster history entries (no cleanup)..."
     )
-    print(f"  - {recent_count} recent (within 10 days)")
-    print(f"  - {old_count} older (15-30 days ago)")
+    print(f"  - {args.recent_count} recent (within 10 days)")
+    print(f"  - {args.old_count} older (15-30 days ago)")
     print("=" * 60)
 
     # Create test instance
     test = TestScale()
     test.initialize(
         active_cluster_name='scale-test-active',
-        terminated_cluster_name='scale-test-terminated',
+        terminated_cluster_name=args.terminated_cluster,
         managed_job_id=1  # Not used
     )
 
     try:
         # Inject cluster history
-        injected = test.inject_cluster_history(recent_count=recent_count,
-                                               old_count=old_count)
+        injected = test.inject_cluster_history(recent_count=args.recent_count,
+                                               old_count=args.old_count)
         print(f"\nSuccessfully injected {injected} cluster history entries!")
         print(f"Total cluster hashes tracked: {len(test.test_cluster_hashes)}")
 

--- a/tests/load_tests/db_scale_tests/inject_test_clusters.py
+++ b/tests/load_tests/db_scale_tests/inject_test_clusters.py
@@ -21,13 +21,13 @@ def main():
         '--active-cluster',
         type=str,
         default='scale-test-active',
-        help='Name of the active cluster to use as template (default: scale-test-active)'
+        help=
+        'Name of the active cluster to use as template (default: scale-test-active)'
     )
-    parser.add_argument(
-        '--count',
-        type=int,
-        default=5,
-        help='Number of test clusters to inject (default: 5)')
+    parser.add_argument('--count',
+                        type=int,
+                        default=5,
+                        help='Number of test clusters to inject (default: 5)')
 
     args = parser.parse_args()
 

--- a/tests/load_tests/db_scale_tests/inject_test_clusters.py
+++ b/tests/load_tests/db_scale_tests/inject_test_clusters.py
@@ -3,6 +3,7 @@
 Simple script to inject test clusters without cleanup for manual verification.
 """
 
+import argparse
 import os
 import sys
 
@@ -14,22 +15,36 @@ from scale_test_utils import TestScale
 
 def main():
     """Inject test clusters without cleanup."""
-    count = 5
+    parser = argparse.ArgumentParser(
+        description='Inject test clusters for manual verification')
+    parser.add_argument(
+        '--active-cluster',
+        type=str,
+        default='scale-test-active',
+        help='Name of the active cluster to use as template (default: scale-test-active)'
+    )
+    parser.add_argument(
+        '--count',
+        type=int,
+        default=5,
+        help='Number of test clusters to inject (default: 5)')
 
-    print(f"Injecting {count} test clusters (no cleanup)...")
+    args = parser.parse_args()
+
+    print(f"Injecting {args.count} test clusters (no cleanup)...")
     print("=" * 60)
 
     # Create test instance
     test = TestScale()
     test.initialize(
-        active_cluster_name='scale-test-active',
+        active_cluster_name=args.active_cluster,
         terminated_cluster_name='scale-test-terminated',
         managed_job_id=1  # Not used
     )
 
     try:
         # Inject clusters
-        injected = test.inject_clusters(count)
+        injected = test.inject_clusters(args.count)
         print(f"\nSuccessfully injected {injected} test clusters!")
         print("\nCluster names:")
         for name in test.test_cluster_names:

--- a/tests/load_tests/db_scale_tests/inject_test_managed_jobs.py
+++ b/tests/load_tests/db_scale_tests/inject_test_managed_jobs.py
@@ -3,6 +3,7 @@
 Simple script to inject test managed jobs without cleanup for manual verification.
 """
 
+import argparse
 import os
 import sys
 
@@ -14,9 +15,22 @@ from scale_test_utils import TestScale
 
 def main():
     """Inject test managed jobs without cleanup."""
-    count = 10
+    parser = argparse.ArgumentParser(
+        description='Inject test managed jobs for manual verification')
+    parser.add_argument(
+        '--managed-job-id',
+        type=int,
+        default=1,
+        help='Job ID of the managed job to use as template (default: 1)')
+    parser.add_argument(
+        '--count',
+        type=int,
+        default=10,
+        help='Number of test managed jobs to inject (default: 10)')
 
-    print(f"Injecting {count} test managed jobs (no cleanup)...")
+    args = parser.parse_args()
+
+    print(f"Injecting {args.count} test managed jobs (no cleanup)...")
     print("=" * 60)
 
     # Create test instance
@@ -24,12 +38,12 @@ def main():
     test.initialize(
         active_cluster_name='scale-test-active',
         terminated_cluster_name='scale-test-terminated',
-        managed_job_id=1  # Required - must exist
+        managed_job_id=args.managed_job_id
     )
 
     try:
         # Inject managed jobs
-        injected = test.inject_managed_jobs(count)
+        injected = test.inject_managed_jobs(args.count)
         print(f"\nSuccessfully injected {injected} test managed jobs!")
         print(f"Job IDs: {min(test.test_job_ids)} - {max(test.test_job_ids)}")
 

--- a/tests/load_tests/db_scale_tests/inject_test_managed_jobs.py
+++ b/tests/load_tests/db_scale_tests/inject_test_managed_jobs.py
@@ -35,11 +35,9 @@ def main():
 
     # Create test instance
     test = TestScale()
-    test.initialize(
-        active_cluster_name='scale-test-active',
-        terminated_cluster_name='scale-test-terminated',
-        managed_job_id=args.managed_job_id
-    )
+    test.initialize(active_cluster_name='scale-test-active',
+                    terminated_cluster_name='scale-test-terminated',
+                    managed_job_id=args.managed_job_id)
 
     try:
         # Inject managed jobs

--- a/tests/load_tests/db_scale_tests/run_postgres_cleanup.py
+++ b/tests/load_tests/db_scale_tests/run_postgres_cleanup.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Runner script to execute PostgreSQL scale test cleanup from within the pod.
+This script copies cleanup scripts to the pod and executes them.
+Cleans up both clusters/cluster_history and managed jobs.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+
+
+def run_command(cmd, description):
+    """Run a shell command and print the output."""
+    print(f"\n{'='*60}")
+    print(f"{description}")
+    print(f"{'='*60}")
+    print(f"Running: {cmd}")
+
+    result = subprocess.run(
+        cmd,
+        shell=True,
+        capture_output=True,
+        text=True
+    )
+
+    if result.stdout:
+        print(result.stdout)
+    if result.stderr:
+        print("STDERR:", result.stderr, file=sys.stderr)
+
+    if result.returncode != 0:
+        print(f"Error: Command failed with exit code {result.returncode}")
+        return False
+
+    return True
+
+
+def copy_script_to_pod(script_path, pod_name, namespace, dest_filename):
+    """Copy a script to the pod using stdin."""
+    if not run_command(
+        f"cat {script_path} | kubectl exec -i -n {namespace} {pod_name} -- sh -c 'cat > /tmp/{dest_filename}'",
+        f"Copying {dest_filename} to pod"
+    ):
+        return False
+
+    # Verify the script was copied correctly
+    if not run_command(
+        f"kubectl exec -n {namespace} {pod_name} -- ls -lh /tmp/{dest_filename}",
+        f"Verifying {dest_filename} was copied"
+    ):
+        return False
+
+    return True
+
+
+def main():
+    """Main function to run the cleanup."""
+    parser = argparse.ArgumentParser(
+        description='Run PostgreSQL scale test cleanup (clusters + managed jobs) in a Kubernetes pod'
+    )
+    parser.add_argument(
+        '--pod',
+        type=str,
+        required=True,
+        help='Pod name (required)'
+    )
+    parser.add_argument(
+        '--namespace',
+        '-n',
+        type=str,
+        default='skypilot',
+        help='Namespace (default: skypilot)'
+    )
+
+    args = parser.parse_args()
+    pod_name = args.pod
+    namespace = args.namespace
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+
+    print("=" * 60)
+    print("PostgreSQL Cleanup Runner")
+    print("=" * 60)
+    print(f"Target pod: {pod_name}")
+    print(f"Namespace: {namespace}")
+    print("=" * 60)
+
+    # Step 1: Copy the cleanup scripts to the pod
+    clusters_script = os.path.join(script_dir, "cleanup_postgres_clusters.py")
+    jobs_script = os.path.join(script_dir, "cleanup_postgres_managed_jobs.py")
+
+    if not copy_script_to_pod(clusters_script, pod_name, namespace, "cleanup_postgres_clusters.py"):
+        print("Failed to copy clusters cleanup script. Exiting.")
+        return 1
+
+    if not copy_script_to_pod(jobs_script, pod_name, namespace, "cleanup_postgres_managed_jobs.py"):
+        print("Failed to copy managed jobs cleanup script. Exiting.")
+        return 1
+
+    # Step 2: Run the clusters cleanup script in the pod
+    if not run_command(
+        f"kubectl exec -n {namespace} {pod_name} -- python3 /tmp/cleanup_postgres_clusters.py",
+        "Running clusters cleanup script in pod"
+    ):
+        print("Failed to run clusters cleanup script. Exiting.")
+        return 1
+
+    # Step 3: Run the managed jobs cleanup script in the pod
+    if not run_command(
+        f"kubectl exec -n {namespace} {pod_name} -- python3 /tmp/cleanup_postgres_managed_jobs.py",
+        "Running managed jobs cleanup script in pod"
+    ):
+        print("Failed to run managed jobs cleanup script. Exiting.")
+        return 1
+
+    print("\n" + "=" * 60)
+    print("SUCCESS!")
+    print("=" * 60)
+    print("Cleanup completed successfully!")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/load_tests/db_scale_tests/run_postgres_injection.py
+++ b/tests/load_tests/db_scale_tests/run_postgres_injection.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+Runner script to execute PostgreSQL scale test injection from within the pod.
+This script copies injection scripts to the pod and executes them.
+Injects both clusters/cluster_history and managed jobs.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+
+
+def run_command(cmd, description):
+    """Run a shell command and print the output."""
+    print(f"\n{'='*60}")
+    print(f"{description}")
+    print(f"{'='*60}")
+    print(f"Running: {cmd}")
+
+    result = subprocess.run(
+        cmd,
+        shell=True,
+        capture_output=True,
+        text=True
+    )
+
+    if result.stdout:
+        print(result.stdout)
+    if result.stderr:
+        print("STDERR:", result.stderr, file=sys.stderr)
+
+    if result.returncode != 0:
+        print(f"Error: Command failed with exit code {result.returncode}")
+        return False
+
+    return True
+
+
+def copy_script_to_pod(script_path, pod_name, namespace, dest_filename):
+    """Copy a script to the pod using stdin."""
+    if not run_command(
+        f"cat {script_path} | kubectl exec -i -n {namespace} {pod_name} -- sh -c 'cat > /tmp/{dest_filename}'",
+        f"Copying {dest_filename} to pod"
+    ):
+        return False
+
+    # Verify the script was copied correctly
+    if not run_command(
+        f"kubectl exec -n {namespace} {pod_name} -- ls -lh /tmp/{dest_filename}",
+        f"Verifying {dest_filename} was copied"
+    ):
+        return False
+
+    return True
+
+
+def main():
+    """Main function to run the scale test."""
+    parser = argparse.ArgumentParser(
+        description='Run PostgreSQL scale test injection (clusters + managed jobs) in a Kubernetes pod'
+    )
+    parser.add_argument(
+        '--pod',
+        type=str,
+        required=True,
+        help='Pod name (required)'
+    )
+    parser.add_argument(
+        '--namespace',
+        '-n',
+        type=str,
+        default='skypilot',
+        help='Namespace (default: skypilot)'
+    )
+
+    args = parser.parse_args()
+    pod_name = args.pod
+    namespace = args.namespace
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+
+    print("=" * 60)
+    print("PostgreSQL Scale Test Runner")
+    print("=" * 60)
+    print(f"Target pod: {pod_name}")
+    print(f"Namespace: {namespace}")
+    print("=" * 60)
+
+    # Step 1: Check if psycopg2 is installed in the pod
+    if not run_command(
+        f"kubectl exec -n {namespace} {pod_name} -- python3 -c 'import psycopg2'",
+        "Checking if psycopg2 is installed in pod"
+    ):
+        print("\nInstalling psycopg2-binary in pod...")
+        if not run_command(
+            f"kubectl exec -n {namespace} {pod_name} -- pip install psycopg2-binary",
+            "Installing psycopg2-binary"
+        ):
+            print("Failed to install psycopg2-binary. Exiting.")
+            return 1
+
+    # Step 2: Copy the injection scripts to the pod
+    clusters_script = os.path.join(script_dir, "inject_postgres_clusters.py")
+    jobs_script = os.path.join(script_dir, "inject_postgres_managed_jobs.py")
+
+    if not copy_script_to_pod(clusters_script, pod_name, namespace, "inject_postgres_clusters.py"):
+        print("Failed to copy clusters injection script. Exiting.")
+        return 1
+
+    if not copy_script_to_pod(jobs_script, pod_name, namespace, "inject_postgres_managed_jobs.py"):
+        print("Failed to copy managed jobs injection script. Exiting.")
+        return 1
+
+    # Step 3: Run the clusters injection script in the pod
+    if not run_command(
+        f"kubectl exec -n {namespace} {pod_name} -- python3 /tmp/inject_postgres_clusters.py",
+        "Running clusters injection script in pod"
+    ):
+        print("Failed to run clusters injection script. Exiting.")
+        return 1
+
+    # Step 4: Run the managed jobs injection script in the pod
+    if not run_command(
+        f"kubectl exec -n {namespace} {pod_name} -- python3 /tmp/inject_postgres_managed_jobs.py",
+        "Running managed jobs injection script in pod"
+    ):
+        print("Failed to run managed jobs injection script. Exiting.")
+        return 1
+
+    print("\n" + "=" * 60)
+    print("SUCCESS!")
+    print("=" * 60)
+    print("Scale test injection completed successfully!")
+    print("\nTo clean up the test data, run:")
+    print(f"  python {os.path.join(script_dir, 'run_postgres_cleanup.py')} --pod {pod_name} -n {namespace}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/load_tests/db_scale_tests/run_postgres_injection.py
+++ b/tests/load_tests/db_scale_tests/run_postgres_injection.py
@@ -18,12 +18,7 @@ def run_command(cmd, description):
     print(f"{'='*60}")
     print(f"Running: {cmd}")
 
-    result = subprocess.run(
-        cmd,
-        shell=True,
-        capture_output=True,
-        text=True
-    )
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
 
     if result.stdout:
         print(result.stdout)
@@ -40,16 +35,14 @@ def run_command(cmd, description):
 def copy_script_to_pod(script_path, pod_name, namespace, dest_filename):
     """Copy a script to the pod using stdin."""
     if not run_command(
-        f"cat {script_path} | kubectl exec -i -n {namespace} {pod_name} -- sh -c 'cat > /tmp/{dest_filename}'",
-        f"Copying {dest_filename} to pod"
-    ):
+            f"cat {script_path} | kubectl exec -i -n {namespace} {pod_name} -- sh -c 'cat > /tmp/{dest_filename}'",
+            f"Copying {dest_filename} to pod"):
         return False
 
     # Verify the script was copied correctly
     if not run_command(
-        f"kubectl exec -n {namespace} {pod_name} -- ls -lh /tmp/{dest_filename}",
-        f"Verifying {dest_filename} was copied"
-    ):
+            f"kubectl exec -n {namespace} {pod_name} -- ls -lh /tmp/{dest_filename}",
+            f"Verifying {dest_filename} was copied"):
         return False
 
     return True
@@ -58,21 +51,18 @@ def copy_script_to_pod(script_path, pod_name, namespace, dest_filename):
 def main():
     """Main function to run the scale test."""
     parser = argparse.ArgumentParser(
-        description='Run PostgreSQL scale test injection (clusters + managed jobs) in a Kubernetes pod'
+        description=
+        'Run PostgreSQL scale test injection (clusters + managed jobs) in a Kubernetes pod'
     )
-    parser.add_argument(
-        '--pod',
-        type=str,
-        required=True,
-        help='Pod name (required)'
-    )
-    parser.add_argument(
-        '--namespace',
-        '-n',
-        type=str,
-        default='skypilot',
-        help='Namespace (default: skypilot)'
-    )
+    parser.add_argument('--pod',
+                        type=str,
+                        required=True,
+                        help='Pod name (required)')
+    parser.add_argument('--namespace',
+                        '-n',
+                        type=str,
+                        default='skypilot',
+                        help='Namespace (default: skypilot)')
 
     args = parser.parse_args()
     pod_name = args.pod
@@ -88,14 +78,12 @@ def main():
 
     # Step 1: Check if psycopg2 is installed in the pod
     if not run_command(
-        f"kubectl exec -n {namespace} {pod_name} -- python3 -c 'import psycopg2'",
-        "Checking if psycopg2 is installed in pod"
-    ):
+            f"kubectl exec -n {namespace} {pod_name} -- python3 -c 'import psycopg2'",
+            "Checking if psycopg2 is installed in pod"):
         print("\nInstalling psycopg2-binary in pod...")
         if not run_command(
-            f"kubectl exec -n {namespace} {pod_name} -- pip install psycopg2-binary",
-            "Installing psycopg2-binary"
-        ):
+                f"kubectl exec -n {namespace} {pod_name} -- pip install psycopg2-binary",
+                "Installing psycopg2-binary"):
             print("Failed to install psycopg2-binary. Exiting.")
             return 1
 
@@ -103,27 +91,27 @@ def main():
     clusters_script = os.path.join(script_dir, "inject_postgres_clusters.py")
     jobs_script = os.path.join(script_dir, "inject_postgres_managed_jobs.py")
 
-    if not copy_script_to_pod(clusters_script, pod_name, namespace, "inject_postgres_clusters.py"):
+    if not copy_script_to_pod(clusters_script, pod_name, namespace,
+                              "inject_postgres_clusters.py"):
         print("Failed to copy clusters injection script. Exiting.")
         return 1
 
-    if not copy_script_to_pod(jobs_script, pod_name, namespace, "inject_postgres_managed_jobs.py"):
+    if not copy_script_to_pod(jobs_script, pod_name, namespace,
+                              "inject_postgres_managed_jobs.py"):
         print("Failed to copy managed jobs injection script. Exiting.")
         return 1
 
     # Step 3: Run the clusters injection script in the pod
     if not run_command(
-        f"kubectl exec -n {namespace} {pod_name} -- python3 /tmp/inject_postgres_clusters.py",
-        "Running clusters injection script in pod"
-    ):
+            f"kubectl exec -n {namespace} {pod_name} -- python3 /tmp/inject_postgres_clusters.py",
+            "Running clusters injection script in pod"):
         print("Failed to run clusters injection script. Exiting.")
         return 1
 
     # Step 4: Run the managed jobs injection script in the pod
     if not run_command(
-        f"kubectl exec -n {namespace} {pod_name} -- python3 /tmp/inject_postgres_managed_jobs.py",
-        "Running managed jobs injection script in pod"
-    ):
+            f"kubectl exec -n {namespace} {pod_name} -- python3 /tmp/inject_postgres_managed_jobs.py",
+            "Running managed jobs injection script in pod"):
         print("Failed to run managed jobs injection script. Exiting.")
         return 1
 
@@ -132,7 +120,9 @@ def main():
     print("=" * 60)
     print("Scale test injection completed successfully!")
     print("\nTo clean up the test data, run:")
-    print(f"  python {os.path.join(script_dir, 'run_postgres_cleanup.py')} --pod {pod_name} -n {namespace}")
+    print(
+        f"  python {os.path.join(script_dir, 'run_postgres_cleanup.py')} --pod {pod_name} -n {namespace}"
+    )
 
     return 0
 

--- a/tests/load_tests/db_scale_tests/scale_test_utils.py
+++ b/tests/load_tests/db_scale_tests/scale_test_utils.py
@@ -120,14 +120,16 @@ class TestScale:
             cursor = conn.cursor()
 
             # Load cluster YAML for the sample cluster
-            cursor.execute("SELECT yaml FROM cluster_yaml WHERE cluster_name = ?",
-                          (self.generator.active_cluster_name,))
+            cursor.execute(
+                "SELECT yaml FROM cluster_yaml WHERE cluster_name = ?",
+                (self.generator.active_cluster_name,))
             sample_yaml_row = cursor.fetchone()
             sample_yaml = sample_yaml_row[0] if sample_yaml_row else None
 
             if not sample_yaml:
-                print(f"Warning: No cluster_yaml found for {self.generator.active_cluster_name}. "
-                      "Cluster YAML will not be injected.")
+                print(
+                    f"Warning: No cluster_yaml found for {self.generator.active_cluster_name}. "
+                    "Cluster YAML will not be injected.")
 
             # Get column names from first cluster dict
             cluster_columns = list(clusters[0].keys())
@@ -161,7 +163,9 @@ class TestScale:
 
                 # Also insert cluster_yaml entries if we have sample YAML
                 if sample_yaml:
-                    yaml_batch_data = [(cluster['name'], sample_yaml) for cluster in batch]
+                    yaml_batch_data = [
+                        (cluster['name'], sample_yaml) for cluster in batch
+                    ]
                     cursor.executemany(yaml_insert_sql, yaml_batch_data)
                     conn.commit()
 

--- a/tests/load_tests/db_scale_tests/scale_test_utils.py
+++ b/tests/load_tests/db_scale_tests/scale_test_utils.py
@@ -49,12 +49,22 @@ class TestScale:
         if self.test_cluster_names:
             try:
                 placeholders = ', '.join(['?' for _ in self.test_cluster_names])
+
+                # Delete from cluster_yaml table first
+                cursor.execute(
+                    f"DELETE FROM cluster_yaml WHERE cluster_name IN ({placeholders})",
+                    self.test_cluster_names)
+                yaml_deleted = cursor.rowcount
+
+                # Delete from clusters table
                 cursor.execute(
                     f"DELETE FROM clusters WHERE name IN ({placeholders})",
                     self.test_cluster_names)
+                clusters_deleted = cursor.rowcount
+
                 conn.commit()
-                print(
-                    f"Cleaned up {len(self.test_cluster_names)} test clusters")
+                print(f"Cleaned up {clusters_deleted} test clusters")
+                print(f"Cleaned up {yaml_deleted} cluster_yaml entries")
             except Exception as e:
                 print(f"Active clusters cleanup failed: {e}")
 
@@ -109,12 +119,29 @@ class TestScale:
             conn = sqlite3.connect(self.db_path)
             cursor = conn.cursor()
 
+            # Load cluster YAML for the sample cluster
+            cursor.execute("SELECT yaml FROM cluster_yaml WHERE cluster_name = ?",
+                          (self.generator.active_cluster_name,))
+            sample_yaml_row = cursor.fetchone()
+            sample_yaml = sample_yaml_row[0] if sample_yaml_row else None
+
+            if not sample_yaml:
+                print(f"Warning: No cluster_yaml found for {self.generator.active_cluster_name}. "
+                      "Cluster YAML will not be injected.")
+
             # Get column names from first cluster dict
             cluster_columns = list(clusters[0].keys())
             columns_str = ', '.join(cluster_columns)
             placeholders = ', '.join(['?' for _ in cluster_columns])
 
             insert_sql = f"INSERT INTO clusters ({columns_str}) VALUES ({placeholders})"
+
+            # Prepare cluster_yaml insert
+            yaml_insert_sql = """
+                INSERT INTO cluster_yaml (cluster_name, yaml)
+                VALUES (?, ?)
+                ON CONFLICT(cluster_name) DO UPDATE SET yaml = excluded.yaml
+            """
 
             # Insert in batches for performance
             batch_size = 100
@@ -132,11 +159,21 @@ class TestScale:
                 cursor.executemany(insert_sql, batch_data)
                 conn.commit()
 
+                # Also insert cluster_yaml entries if we have sample YAML
+                if sample_yaml:
+                    yaml_batch_data = [(cluster['name'], sample_yaml) for cluster in batch]
+                    cursor.executemany(yaml_insert_sql, yaml_batch_data)
+                    conn.commit()
+
                 total_inserted += len(batch_data)
 
             # Store names for cleanup
             self.test_cluster_names.extend(
                 [cluster['name'] for cluster in clusters])
+
+            print(f"Injected {total_inserted} clusters")
+            if sample_yaml:
+                print(f"Injected {total_inserted} cluster_yaml entries")
 
             cursor.close()
             conn.close()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR adds postgres equivalent scripts to run db scale testing by injecting active clusters, terminated clusters, and managed jobs into the database.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
