### PR TITLE
[DB] alembic cli wrapper script

### DIFF
--- a/docs/source/cloud-setup/policy.rst
+++ b/docs/source/cloud-setup/policy.rst
@@ -287,6 +287,7 @@ Always disable public IP for AWS tasks
 Use spot for all GPU tasks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+..
 .. literalinclude:: ../../../examples/admin_policy/example_policy/example_policy/skypilot_policy.py
     :language: python
     :pyobject: UseSpotForGpuPolicy

--- a/docs/source/cloud-setup/policy.rst
+++ b/docs/source/cloud-setup/policy.rst
@@ -287,7 +287,6 @@ Always disable public IP for AWS tasks
 Use spot for all GPU tasks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-..
 .. literalinclude:: ../../../examples/admin_policy/example_policy/example_policy/skypilot_policy.py
     :language: python
     :pyobject: UseSpotForGpuPolicy

--- a/docs/source/reference/api-server/api-server-upgrade.rst
+++ b/docs/source/reference/api-server/api-server-upgrade.rst
@@ -299,3 +299,66 @@ When the client and server are running on different minor versions, SkyPilot CLI
     pip install -U skypilot==X.X.X
 
 For a nightly build, its API compatibility is equivalent to its previous minor version, e.g., all nightly builds after ``0.10.0`` and before ``0.11.0`` have the same API compatibility guarantee as ``0.10.0``.
+
+.. _sky-api-server-database-migrations:
+
+Manual Database Migrations
+--------------------------
+
+The SkyPilot API server runs Alembic database migrations during startup if necessary to ensure the database schema is up to date.
+
+For advanced use cases such as expensive migrations or troubleshooting, SkyPilot exposes an Alembic wrapper that enables manual database operations. **Use this with caution** as these commands will directly interact with the database.
+
+The Alembic wrapper is located at ``sky/schemas/db/scripts/run_alembic.py``. It supports operations on three database sections:
+
+* ``state_db`` - Main state database (default)
+* ``spot_jobs_db`` - Spot jobs database
+* ``serve_db`` - Serve database
+
+Common Commands
+~~~~~~~~~~~~~~~
+
+Check current database version:
+
+.. code-block:: bash
+
+    python sky/schemas/db/scripts/run_alembic.py \
+      --url DB_URI \
+      --section state_db \
+      current
+
+View migration history:
+
+.. code-block:: bash
+
+    python sky/schemas/db/scripts/run_alembic.py \
+      --url DB_URI \
+      --section state_db \
+      history
+
+Manually upgrade to latest version:
+
+.. code-block:: bash
+
+    python sky/schemas/db/scripts/run_alembic.py \
+      --url DB_URI \
+      --section state_db \
+      upgrade head
+
+Upgrade to specific revision:
+
+.. code-block:: bash
+
+    python sky/schemas/db/scripts/run_alembic.py \
+      --url DB_URI \
+      --section state_db \
+      upgrade 009
+
+Show details of a specific revision:
+
+.. code-block:: bash
+
+    python sky/schemas/db/scripts/run_alembic.py \
+      --url DB_URI \
+      --section state_db \
+      show head

--- a/docs/source/reference/api-server/api-server-upgrade.rst
+++ b/docs/source/reference/api-server/api-server-upgrade.rst
@@ -302,7 +302,7 @@ For a nightly build, its API compatibility is equivalent to its previous minor v
 
 .. _sky-api-server-database-migrations:
 
-Manual Database Migrations
+Manual database migrations
 --------------------------
 
 The SkyPilot API server runs Alembic database migrations during startup if necessary to ensure the database schema is up to date.
@@ -315,7 +315,7 @@ The Alembic wrapper is located at ``sky/schemas/db/scripts/run_alembic.py``. It 
 * ``spot_jobs_db`` - Spot jobs database
 * ``serve_db`` - Serve database
 
-Common Commands
+Common commands
 ~~~~~~~~~~~~~~~
 
 Check current database version:

--- a/sky/schemas/db/scripts/run_alembic.py
+++ b/sky/schemas/db/scripts/run_alembic.py
@@ -11,7 +11,9 @@ from alembic.config import Config
 VALID_SECTIONS = ['state_db', 'spot_jobs_db', 'serve_db']
 
 # Valid commands
-VALID_COMMANDS = ['current', 'upgrade', 'history', 'downgrade', 'heads', 'branches', 'show']
+VALID_COMMANDS = [
+    'current', 'upgrade', 'history', 'downgrade', 'heads', 'branches', 'show'
+]
 
 
 def main():
@@ -34,36 +36,31 @@ Examples:
 
   # View history
   python run_alembic.py --url postgresql://user@localhost/sky --section state_db history
-        """
-    )
+        """)
 
     parser.add_argument(
         '--url',
         required=True,
-        help='Database URL (e.g., postgresql://user@localhost/sky or sqlite:////path/to/db.db)'
-    )
+        help='Database URL (e.g., postgresql://user@localhost/sky '
+        'or sqlite:////path/to/db.db)')
     parser.add_argument(
         '--section',
         choices=VALID_SECTIONS,
         default='state_db',
-        help='Database section to operate on (default: state_db)'
-    )
+        help='Database section to operate on (default: state_db)')
     parser.add_argument(
         '--config',
         default=None,
         help='Path to alembic.ini (default: auto-detected from script location)'
     )
-    parser.add_argument(
-        'command',
-        choices=VALID_COMMANDS,
-        help='Alembic command to run'
-    )
+    parser.add_argument('command',
+                        choices=VALID_COMMANDS,
+                        help='Alembic command to run')
     parser.add_argument(
         'revision',
         nargs='?',
         default=None,
-        help='Revision for upgrade/downgrade (e.g., head, 009, -1)'
-    )
+        help='Revision for upgrade/downgrade (e.g., head, 009, -1)')
 
     args = parser.parse_args()
 
@@ -71,15 +68,16 @@ Examples:
     if args.config:
         alembic_ini_path = args.config
     else:
-        # From sky/schemas/db/scripts/run_alembic.py -> sky/setup_files/alembic.ini
+        # From sky/schemas/db/scripts/run_alembic.py ->
+        #      sky/setup_files/alembic.ini
         script_dir = os.path.dirname(os.path.abspath(__file__))
-        alembic_ini_path = os.path.join(
-            script_dir, '..', '..', '..', 'setup_files', 'alembic.ini'
-        )
+        alembic_ini_path = os.path.join(script_dir, '..', '..', '..',
+                                        'setup_files', 'alembic.ini')
 
     # Validate config file exists
     if not os.path.exists(alembic_ini_path):
-        print(f"Error: alembic.ini not found at {alembic_ini_path}", file=sys.stderr)
+        print(f'Error: alembic.ini not found at {alembic_ini_path}',
+              file=sys.stderr)
         sys.exit(1)
 
     # Create alembic config
@@ -91,31 +89,34 @@ Examples:
 
     # Execute the command
     try:
-        if args.command == "current":
+        if args.command == 'current':
             command.current(alembic_cfg, verbose=True)
-        elif args.command == "upgrade":
-            revision = args.revision or "head"
+        elif args.command == 'upgrade':
+            revision = args.revision or 'head'
             command.upgrade(alembic_cfg, revision)
-        elif args.command == "downgrade":
+        elif args.command == 'downgrade':
             if not args.revision:
-                print("Error: revision required for downgrade (e.g., -1, base)", file=sys.stderr)
+                print('Error: revision required for downgrade (e.g., -1, base)',
+                      file=sys.stderr)
                 sys.exit(1)
             command.downgrade(alembic_cfg, args.revision)
-        elif args.command == "history":
+        elif args.command == 'history':
             command.history(alembic_cfg)
-        elif args.command == "heads":
+        elif args.command == 'heads':
             command.heads(alembic_cfg)
-        elif args.command == "branches":
+        elif args.command == 'branches':
             command.branches(alembic_cfg)
-        elif args.command == "show":
+        elif args.command == 'show':
             if not args.revision:
-                print("Error: revision required for show (e.g., head, 009)", file=sys.stderr)
+                print('Error: revision required for show (e.g., head, 009)',
+                      file=sys.stderr)
                 sys.exit(1)
             command.show(alembic_cfg, args.revision)
+    # pylint: disable=broad-except
     except Exception as e:
-        print(f"Error executing alembic command: {e}", file=sys.stderr)
+        print(f'Error executing alembic command: {e}', file=sys.stderr)
         sys.exit(1)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/sky/schemas/db/scripts/run_alembic.py
+++ b/sky/schemas/db/scripts/run_alembic.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Wrapper script to run alembic migrations manually with database URL."""
+import argparse
+import os
+import sys
+
+from alembic import command
+from alembic.config import Config
+
+# Valid sections from alembic.ini
+VALID_SECTIONS = ['state_db', 'spot_jobs_db', 'serve_db']
+
+# Valid commands
+VALID_COMMANDS = ['current', 'upgrade', 'history', 'downgrade', 'heads', 'branches', 'show']
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Run alembic migrations manually with database URL',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Check current version
+  python run_alembic.py --url postgresql://user@localhost/sky --section state_db current
+
+  # Upgrade to latest
+  python run_alembic.py --url postgresql://user@localhost/sky --section state_db upgrade head
+
+  # Upgrade to specific revision
+  python run_alembic.py --url postgresql://user@localhost/sky --section state_db upgrade 009
+
+  # Downgrade one revision
+  python run_alembic.py --url postgresql://user@localhost/sky --section state_db downgrade -1
+
+  # View history
+  python run_alembic.py --url postgresql://user@localhost/sky --section state_db history
+        """
+    )
+
+    parser.add_argument(
+        '--url',
+        required=True,
+        help='Database URL (e.g., postgresql://user@localhost/sky or sqlite:////path/to/db.db)'
+    )
+    parser.add_argument(
+        '--section',
+        choices=VALID_SECTIONS,
+        default='state_db',
+        help='Database section to operate on (default: state_db)'
+    )
+    parser.add_argument(
+        '--config',
+        default=None,
+        help='Path to alembic.ini (default: auto-detected from script location)'
+    )
+    parser.add_argument(
+        'command',
+        choices=VALID_COMMANDS,
+        help='Alembic command to run'
+    )
+    parser.add_argument(
+        'revision',
+        nargs='?',
+        default=None,
+        help='Revision for upgrade/downgrade (e.g., head, 009, -1)'
+    )
+
+    args = parser.parse_args()
+
+    # Determine alembic.ini path
+    if args.config:
+        alembic_ini_path = args.config
+    else:
+        # From sky/schemas/db/scripts/run_alembic.py -> sky/setup_files/alembic.ini
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        alembic_ini_path = os.path.join(
+            script_dir, '..', '..', '..', 'setup_files', 'alembic.ini'
+        )
+
+    # Validate config file exists
+    if not os.path.exists(alembic_ini_path):
+        print(f"Error: alembic.ini not found at {alembic_ini_path}", file=sys.stderr)
+        sys.exit(1)
+
+    # Create alembic config
+    alembic_cfg = Config(alembic_ini_path, ini_section=args.section)
+
+    # Set the database URL (escape % for configparser interpolation)
+    url = args.url.replace('%', '%%')
+    alembic_cfg.set_section_option(args.section, 'sqlalchemy.url', url)
+
+    # Execute the command
+    try:
+        if args.command == "current":
+            command.current(alembic_cfg, verbose=True)
+        elif args.command == "upgrade":
+            revision = args.revision or "head"
+            command.upgrade(alembic_cfg, revision)
+        elif args.command == "downgrade":
+            if not args.revision:
+                print("Error: revision required for downgrade (e.g., -1, base)", file=sys.stderr)
+                sys.exit(1)
+            command.downgrade(alembic_cfg, args.revision)
+        elif args.command == "history":
+            command.history(alembic_cfg)
+        elif args.command == "heads":
+            command.heads(alembic_cfg)
+        elif args.command == "branches":
+            command.branches(alembic_cfg)
+        elif args.command == "show":
+            if not args.revision:
+                print("Error: revision required for show (e.g., head, 009)", file=sys.stderr)
+                sys.exit(1)
+            command.show(alembic_cfg, args.revision)
+    except Exception as e:
+        print(f"Error executing alembic command: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR adds a utility script to allow users to manually run db migrations. While DB upgrades are handled automatically on api server start, this allows users greater flexibility in cases where expensive migrations cause api server start timeouts. This way, users can separately perform the db upgrade and the api server upgrade. 


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
