### PR TITLE
proper user hash calculation for ssh keys

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -65,10 +65,7 @@ MAX_TRIALS = 64
 _SSH_KEY_PATH_PREFIX = '~/.sky/clients/{user_hash}/ssh'
 
 
-def get_ssh_key_and_lock_path(
-        user_hash: Optional[str] = None) -> Tuple[str, str, str]:
-    if user_hash is None:
-        user_hash = common_utils.get_user_hash()
+def get_ssh_key_and_lock_path(user_hash: str) -> Tuple[str, str, str]:
     user_ssh_key_prefix = _SSH_KEY_PATH_PREFIX.format(user_hash=user_hash)
 
     os.makedirs(os.path.expanduser(user_ssh_key_prefix),
@@ -105,7 +102,7 @@ def _generate_rsa_key_pair() -> Tuple[str, str]:
     return public_key, private_key
 
 
-def _save_key_pair(private_key_path: str, public_key_path: str,
+def _save_key_pair(user_hash: str, private_key_path: str, public_key_path: str,
                    private_key: str, public_key: str) -> None:
     key_dir = os.path.dirname(private_key_path)
     os.makedirs(key_dir, exist_ok=True, mode=0o700)
@@ -124,13 +121,14 @@ def _save_key_pair(private_key_path: str, public_key_path: str,
               opener=functools.partial(os.open, mode=0o644)) as f:
         f.write(public_key)
 
-    global_user_state.set_ssh_keys(common_utils.get_user_hash(), public_key,
-                                   private_key)
+    global_user_state.set_ssh_keys(user_hash, public_key, private_key)
 
 
 def get_or_generate_keys() -> Tuple[str, str]:
     """Returns the absolute private and public key paths."""
-    private_key_path, public_key_path, lock_path = get_ssh_key_and_lock_path()
+    user_hash = common_utils.get_user_hash()
+    private_key_path, public_key_path, lock_path = get_ssh_key_and_lock_path(
+        user_hash)
     private_key_path = os.path.expanduser(private_key_path)
     public_key_path = os.path.expanduser(public_key_path)
     lock_path = os.path.expanduser(lock_path)
@@ -146,8 +144,8 @@ def get_or_generate_keys() -> Tuple[str, str]:
                 global_user_state.get_ssh_keys(common_utils.get_user_hash()))
             if not exists:
                 ssh_public_key, ssh_private_key = _generate_rsa_key_pair()
-            _save_key_pair(private_key_path, public_key_path, ssh_private_key,
-                           ssh_public_key)
+            _save_key_pair(user_hash, private_key_path, public_key_path,
+                           ssh_private_key, ssh_public_key)
     assert os.path.exists(public_key_path), (
         'Private key found, but associated public key '
         f'{public_key_path} does not exist.')
@@ -185,8 +183,8 @@ def create_ssh_key_files_from_db(private_key_path: Optional[str] = None):
                 global_user_state.get_ssh_keys(user_hash))
             if not exists:
                 raise RuntimeError(f'SSH keys not found for user {user_hash}')
-            _save_key_pair(private_key_path, public_key_path, ssh_private_key,
-                           ssh_public_key)
+            _save_key_pair(user_hash, private_key_path, public_key_path,
+                           ssh_private_key, ssh_public_key)
     assert os.path.exists(public_key_path), (
         'Private key found, but associated public key '
         f'{public_key_path} does not exist.')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR fixes a bug where sqlite -> postgres migration of ssh key files may be botched in multi-user cases.

`sky status -u` accesses cluster ssh key files, and in the process calls `create_ssh_key_files_from_db`. This codepath migrates any ssh keys that exist as a file on the local filesystem to the database.

When running `sky status -u`, the cluster listed may not belong to the user calling the command. We have code in `create_ssh_key_files_from_db` to determine the user hash of the cluster, which may be different from the caller, by looking at the filepath:
```
    if private_key_path is None:
        user_hash = common_utils.get_user_hash()
    else:
        # Assume private key path is in the format of
        # ~/.sky/clients/<user_hash>/ssh/sky-key
        separated_path = os.path.normpath(private_key_path).split(os.path.sep)
        assert separated_path[-1] == 'sky-key'
        assert separated_path[-2] == 'ssh'
        user_hash = separated_path[-3]
```
and the key is later saved to DB via `_save_key_pair` call.

The problem here is that `_save_key_pair` call does not take a user hash, and instead assumes the key belong to the user calling the command. While this assumption holds for normal `sky status`, it does not hold for `sky status -u` command.

This PR has `_save_key_pair` accept a user hash when storing the ssh key, associating the key with the correct user.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
