### PR TITLE
Fix `test_kubernetes_storage_mounts` flaky

### DIFF
--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -415,6 +415,8 @@ def test_kubernetes_storage_mounts(storage_name_prefix: str):
         storage_lib.StoreType.GCS, storage_name, 'hello.txt')
     azure_ls_cmd = TestStorageWithCredentials.cli_ls_cmd(
         storage_lib.StoreType.AZURE, storage_name, 'hello.txt')
+    nebius_ls_cmd = TestStorageWithCredentials.cli_ls_cmd(
+        storage_lib.StoreType.NEBIUS, storage_name, 'hello.txt')
 
     # For Azure, we need to check if the output is empty list, as it returns []
     # instead of a non-zero exit code when the file doesn't exist
@@ -425,7 +427,8 @@ def test_kubernetes_storage_mounts(storage_name_prefix: str):
 
     ls_hello_command = (f'{s3_ls_cmd} || {{ '
                         f'{gcs_ls_cmd}; }} || {{ '
-                        f'{azure_check_cmd}; }}')
+                        f'{azure_check_cmd}; }} || {{ '
+                        f'{nebius_ls_cmd}; }}')
     cloud_cmd_cluster_setup_cmd_list = controller_utils._get_cloud_dependencies_installation_commands(
         controller_utils.Controllers.JOBS_CONTROLLER)
     cloud_cmd_cluster_setup_cmd = ' && '.join(cloud_cmd_cluster_setup_cmd_list)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

After we introduce nebius credential, the nebius storage is auto selected sometime and the ls command does not include nebius causing flaky.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
