### PR TITLE
Fixed requests api cancel race condition

### DIFF
--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -399,6 +399,10 @@ def _request_execution_wrapper(request_id: str,
     logger.info(f'Running request {request_id} with pid {pid}')
     with api_requests.update_request(request_id) as request_task:
         assert request_task is not None, request_id
+        if request_task.status != api_requests.RequestStatus.PENDING:
+            logger.debug(f'Request is already {request_task.status.value}, '
+                         f'skipping execution')
+            return
         log_path = request_task.log_path
         request_task.pid = pid
         request_task.status = api_requests.RequestStatus.RUNNING

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -787,9 +787,12 @@ def set_request_succeeded(request_id: str, result: Optional[Any]) -> None:
 
 
 def set_request_cancelled(request_id: str) -> None:
-    """Set a request to cancelled."""
+    """Set a pending or running request to cancelled."""
     with update_request(request_id) as request_task:
         assert request_task is not None, request_id
+        # Already finished or cancelled.
+        if request_task.status > RequestStatus.RUNNING:
+            return
         request_task.finished_at = time.time()
         request_task.status = RequestStatus.CANCELLED
 

--- a/tests/common_test_fixtures.py
+++ b/tests/common_test_fixtures.py
@@ -54,7 +54,8 @@ def aws_config_region(monkeypatch: pytest.MonkeyPatch) -> str:
 
 @pytest.fixture
 def mock_client_requests(monkeypatch: pytest.MonkeyPatch, mock_queue,
-                         mock_stream_utils, mock_redirect_log_file) -> None:
+                         mock_stream_utils, mock_redirect_log_file,
+                         mock_execute_in_coroutine) -> None:
     """Fixture to mock HTTP requests using FastAPI's TestClient."""
     # This fixture automatically replaces `requests.get` and `requests.post`
     # with mocked versions that route requests through a FastAPI TestClient.
@@ -414,6 +415,22 @@ def mock_queue(monkeypatch):
 
     # Return the mock_queue_instance for use in tests
     return mock_queue_instance
+
+
+@pytest.fixture
+def mock_execute_in_coroutine(monkeypatch):
+
+    class MockCoroutineTask:
+
+        def cancel(self):
+            return
+
+    def mock_execute_in_coroutine(*args, **kwargs):
+        return MockCoroutineTask()
+
+    monkeypatch.setattr(
+        'sky.server.requests.executor.execute_request_in_coroutine',
+        mock_execute_in_coroutine)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ from common_test_fixtures import enable_all_clouds
 from common_test_fixtures import mock_aws_backend
 from common_test_fixtures import mock_client_requests
 from common_test_fixtures import mock_controller_accessible
+from common_test_fixtures import mock_execute_in_coroutine
 from common_test_fixtures import mock_job_table_no_job
 from common_test_fixtures import mock_job_table_one_job
 from common_test_fixtures import mock_queue

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -1538,22 +1538,23 @@ def test_loopback_access_with_basic_auth(generic_cloud: str):
 # concurrency issue in our code.
 def test_launch_and_cancel_race_condition(generic_cloud: str):
     """Test that launch and cancel race condition is handled correctly."""
+
     name = smoke_tests_utils.get_cluster_name()
-    launch_cmd = f'sky launch -y -c {name} --infra {generic_cloud} {smoke_tests_utils.LOW_RESOURCE_ARG} "sleep 120" --async'
+    launch_cmd = f'sky launch -y -c {name}-$i --infra {generic_cloud} {smoke_tests_utils.LOW_RESOURCE_ARG} "sleep 120" --async'
     extract_id = r'echo "$s" | sed -n "s/.*Submitted sky\.launch request: \([0-9a-f-]\{36\}\).*/\1/p"'
-    launch_then_cancel = f's=$({launch_cmd}) && echo $s && id=$({extract_id}) && sky api cancel $id'
+    launch_then_cancel = f's=$({launch_cmd}) && echo $s && id=$({extract_id}) && sky api cancel $id && sky down -y {name}-$i'
     test = smoke_tests_utils.Test(
         'launch_and_cancel_race_condition',
         [
             # Run multiple launch and cancel in parallel to introduce request queuing.
             # This can trigger race conditions more frequently.
-            f'for i in {{1..20}}; do ({launch_then_cancel}) & done',
-            # Wait and sleep shortly, so that if there is any leaked cluster it can be shown in sky status.
-            'wait && sleep 30',
+            f'for i in {{1..20}}; do ({launch_then_cancel}) & done; wait',
+            # Sleep shortly, so that if there is any leaked cluster it can be shown in sky status.
+            'sleep 10',
             # Verify the cluster is not created.
             f'sky status {name} | grep "not found"',
         ],
-        teardown=f'sky down -y {name} || true',
+        # teardown=f'sky down -y {name} || true',
         timeout=smoke_tests_utils.get_timeout(generic_cloud),
     )
     smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -1532,3 +1532,28 @@ def test_loopback_access_with_basic_auth(generic_cloud: str):
         timeout=smoke_tests_utils.get_timeout(generic_cloud),
     )
     smoke_tests_utils.run_one_test(test)
+
+
+# TODO(aylei): this test should not be retried in buildkite, failure indicates a
+# concurrency issue in our code.
+def test_launch_and_cancel_race_condition(generic_cloud: str):
+    """Test that launch and cancel race condition is handled correctly."""
+    name = smoke_tests_utils.get_cluster_name()
+    launch_cmd = f'sky launch -y -c {name} --infra {generic_cloud} {smoke_tests_utils.LOW_RESOURCE_ARG} "sleep 120" --async'
+    extract_id = r'echo "$s" | sed -n "s/.*Submitted sky\.launch request: \([0-9a-f-]\{36\}\).*/\1/p"'
+    launch_then_cancel = f's=$({launch_cmd}) && echo $s && id=$({extract_id}) && sky api cancel $id'
+    test = smoke_tests_utils.Test(
+        'launch_and_cancel_race_condition',
+        [
+            # Run multiple launch and cancel in parallel to introduce request queuing.
+            # This can trigger race conditions more frequently.
+            f'for i in {{1..20}}; do ({launch_then_cancel}) & done',
+            # Wait and sleep shortly, so that if there is any leaked cluster it can be shown in sky status.
+            'wait && sleep 30',
+            # Verify the cluster is not created.
+            f'sky status {name} | grep "not found"',
+        ],
+        teardown=f'sky down -y {name} || true',
+        timeout=smoke_tests_utils.get_timeout(generic_cloud),
+    )
+    smoke_tests_utils.run_one_test(test)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,8 +1,7 @@
+"""Unit tests for the SkyPilot API."""
 import asyncio
 import pathlib
 import tempfile
-import time
-from unittest import mock
 
 import sky
 from sky.clouds.cloud import Cloud

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -1,0 +1,59 @@
+"""Unit tests for sky.server.requests.executor module."""
+from unittest import mock
+
+import pytest
+
+from sky.server.requests import executor
+from sky.server.requests import payloads
+from sky.server.requests import requests as requests_lib
+
+CALLED_FLAG = [False]
+
+
+def dummy_entrypoint(called_flag):
+    CALLED_FLAG[0] = True
+    return 'ok'
+
+
+@pytest.fixture()
+def isolated_database(tmp_path):
+    """Create an isolated DB and logs directory per-test."""
+    temp_db_path = tmp_path / 'requests.db'
+    temp_log_path = tmp_path / 'logs'
+    temp_log_path.mkdir()
+
+    with mock.patch('sky.server.constants.API_SERVER_REQUEST_DB_PATH',
+                    str(temp_db_path)):
+        with mock.patch('sky.server.requests.requests.REQUEST_LOG_PATH_PREFIX',
+                        str(temp_log_path)):
+            requests_lib._DB = None
+            yield
+            requests_lib._DB = None
+
+
+def test_api_cancel_race_condition(isolated_database):
+    """Cancel before execution: wrapper must no-op and not run entrypoint."""
+    CALLED_FLAG[0] = False
+    req = requests_lib.Request(request_id='race-cancel-before',
+                               name='test-request',
+                               entrypoint=dummy_entrypoint,
+                               request_body=payloads.RequestBody(),
+                               status=requests_lib.RequestStatus.PENDING,
+                               created_at=0.0,
+                               user_id='test-user')
+
+    assert requests_lib.create_if_not_exists(req) is True
+
+    # Cancel the request before the executor starts.
+    cancelled = requests_lib.kill_requests(['race-cancel-before'])
+    assert cancelled == ['race-cancel-before']
+
+    # Execute wrapper should detect CANCELLED and return immediately.
+    executor._request_execution_wrapper('race-cancel-before',
+                                        ignore_return_value=False)
+
+    # Verify entrypoint was not invoked and status remains CANCELLED.
+    assert CALLED_FLAG[0] is False
+    updated = requests_lib.get_request('race-cancel-before')
+    assert updated is not None
+    assert updated.status == requests_lib.RequestStatus.CANCELLED


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

There is a race condition when `sky.launch` is executed asynchronously, below is the most common case that will cause the cluster get leaked.


| Timeline | launch  | api.cancel      | down                |
|----------|---------|-----------------|---------------------|
| T0       | Queued  |                 |                     |
| T1       |         | Cancel, success |                     |
| T2       |         |                 | no cluster, success |
| T3       | Executed |                 |                     |

IIUC, when launch is not queued, there is still a potential race condition with low probability, since `update_request` does not acquire a filelock, it is possible that the launch process read a stale request status that has been modified by an `api.cancel` request.

This PR fixes this issue by checking the status before execution and add lock in `update_request`. After this pull request, job cancellation is safe because:

- This PR ensures the launch process must be cancelled before `sky down` is called;
- When `sky down` is called, it either:
  - Observes a cluster left by the previous `sky launch` in `INIT` or `RUNNING` state and cleaned it;
  - Does not found any cluster, which is also fine.

Unit test and smoke test cases are added to avoid further regression.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
