### PR TITLE
Unit tests for PR 7502

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -25,7 +25,7 @@ import re
 import socket
 import subprocess
 import sys
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Tuple
 import uuid
 
 import colorama
@@ -152,22 +152,20 @@ def get_or_generate_keys() -> Tuple[str, str]:
     return private_key_path, public_key_path
 
 
-def create_ssh_key_files_from_db(private_key_path: Optional[str] = None):
-    if private_key_path is None:
-        user_hash = common_utils.get_user_hash()
-    else:
-        # Assume private key path is in the format of
-        # ~/.sky/clients/<user_hash>/ssh/sky-key
-        separated_path = os.path.normpath(private_key_path).split(os.path.sep)
-        assert separated_path[-1] == 'sky-key'
-        assert separated_path[-2] == 'ssh'
-        user_hash = separated_path[-3]
+def create_ssh_key_files_from_db(private_key_path: str):
+    # Assume private key path is in the format of
+    # ~/.sky/clients/<user_hash>/ssh/sky-key
+    separated_path = os.path.normpath(private_key_path).split(os.path.sep)
+    assert separated_path[-1] == 'sky-key'
+    assert separated_path[-2] == 'ssh'
+    user_hash = separated_path[-3]
 
     private_key_path_generated, public_key_path, lock_path = (
         get_ssh_key_and_lock_path(user_hash))
     assert private_key_path == os.path.expanduser(private_key_path_generated), (
         f'Private key path {private_key_path} does not '
-        f'match the generated path {private_key_path_generated}')
+        'match the generated path '
+        f'{os.path.expanduser(private_key_path_generated)}')
     private_key_path = os.path.expanduser(private_key_path)
     public_key_path = os.path.expanduser(public_key_path)
     lock_path = os.path.expanduser(lock_path)

--- a/tests/unit_tests/test_authentication.py
+++ b/tests/unit_tests/test_authentication.py
@@ -2,6 +2,7 @@
 
 """
 
+import os
 from unittest.mock import patch
 
 from google.auth import exceptions as google_exceptions
@@ -109,3 +110,38 @@ def test_gcp_project_metadata_parsing_malformed():
         # and should return 'False' (default)
         result = auth.parse_gcp_project_oslogin(malformed_project)
         assert result == 'False'
+
+
+def test_create_ssh_key_files_from_db():
+    """Test create_ssh_key_files_from_db with private_key_path."""
+    current_user_hash = 'current_user_hash_789'
+    path_user_hash = 'different_user_hash_abc'
+    mock_private_key = 'mock_private_key_content'
+    mock_public_key = 'mock_public_key_content'
+    # Use expanded path as input to match what the function expects
+    private_key_path = os.path.expanduser(
+        f'~/.sky/clients/{path_user_hash}/ssh/sky-key')
+
+    with patch('sky.authentication.global_user_state.get_ssh_keys') as mock_get_ssh_keys, \
+         patch('sky.authentication.os.path.exists') as mock_exists, \
+         patch('sky.authentication.filelock.FileLock') as mock_filelock, \
+         patch('sky.authentication._save_key_pair') as mock_save_key_pair, \
+         patch('sky.authentication.os.makedirs') as mock_makedirs:
+        # Setup mocks
+        mock_get_ssh_keys.return_value = (mock_public_key, mock_private_key,
+                                          True)
+        # Mock os.path.exists to return False for private key, True for public key
+        mock_exists.side_effect = lambda path: 'sky-key.pub' in path
+        mock_filelock.return_value.__enter__ = lambda x: None
+        mock_filelock.return_value.__exit__ = lambda x, y, z, w: None
+
+        # Call the function
+        auth.create_ssh_key_files_from_db(private_key_path=private_key_path)
+
+        # Verify _save_key_pair was called with the user_hash from the path.
+        mock_save_key_pair.assert_called_once()
+        args, kwargs = mock_save_key_pair.call_args
+        assert args[
+            0] == path_user_hash, f"Expected user_hash {path_user_hash}, got {args[0]}"
+        assert args[
+            0] != current_user_hash, f"Should not use current user hash {current_user_hash}"


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Add follow-up unit tests for https://github.com/skypilot-org/skypilot/pull/7502.

While writing this test I noticed that passing `private_key_path` of `None` is 1) never done and 2) broken, so I removed that from the argument typing.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
