### PR TITLE
[Test] Fix Container Logs Tests

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1072,9 +1072,11 @@ def test_volume_env_mount_kubernetes():
 
 def _check_container_logs(name, logs, range_start, range_end, count):
     """Check if the container logs contain the expected number of logging lines.
+
     Each line should be only one number in the given range and should show up 
     count number of times. We skip the messages that we see in the job from
-    running setup with set -x."""
+    running setup with set -x.
+    """
     output_cmd = f's=$({logs});'
     for num in range(range_start, range_end + 1):
         output_cmd += f' echo "$s" | grep -x "{num}" | wc -l | grep {count};'

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1068,6 +1068,20 @@ def test_volume_env_mount_kubernetes():
 
 
 # ---------- Container logs from task on Kubernetes ----------
+
+
+def _check_container_logs(name, logs, range_start, range_end, count):
+    """Check if the container logs contain the expected number of 
+    logging lines. Each line should be only one number in the given range.
+    and should show up count number of times."""
+    return [
+        smoke_tests_utils.run_cloud_cmd_on_cluster(
+            name,
+            f'{logs} | grep -x "{num}" | wc -l | grep {count}',
+        ) for num in range(range_start, range_end + 1)
+    ]
+
+
 @pytest.mark.kubernetes
 def test_container_logs_multinode_kubernetes():
     name = smoke_tests_utils.get_cluster_name()
@@ -1089,14 +1103,8 @@ def test_container_logs_multinode_kubernetes():
                 smoke_tests_utils.launch_cluster_for_cloud_cmd(
                     'kubernetes', name),
                 f'sky launch -y -c {name} {task_yaml} --num-nodes 2',
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    f'{head_logs} | wc -l | grep 9',
-                ),
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    f'{worker_logs} | wc -l | grep 9',
-                ),
+                *_check_container_logs(name, head_logs, 1, 9, 1),
+                *_check_container_logs(name, worker_logs, 1, 9, 1),
             ],
             f'sky down -y {name} && '
             f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}',
@@ -1122,51 +1130,8 @@ def test_container_logs_two_jobs_kubernetes():
                 smoke_tests_utils.launch_cluster_for_cloud_cmd(
                     'kubernetes', name),
                 f'sky launch -y -c {name} {task_yaml}',
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    f'{pod_logs} | wc -l | grep 9',
-                ),
                 f'sky launch -y -c {name} {task_yaml}',
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    f'{pod_logs} | wc -l | grep 18',
-                ),
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    f'{pod_logs} | grep 1 | wc -l | grep 2',
-                ),
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    f'{pod_logs} | grep 2 | wc -l | grep 2',
-                ),
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    f'{pod_logs} | grep 3 | wc -l | grep 2',
-                ),
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    f'{pod_logs} | grep 4 | wc -l | grep 2',
-                ),
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    f'{pod_logs} | grep 5 | wc -l | grep 2',
-                ),
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    f'{pod_logs} | grep 6 | wc -l | grep 2',
-                ),
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    f'{pod_logs} | grep 7 | wc -l | grep 2',
-                ),
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    f'{pod_logs} | grep 8 | wc -l | grep 2',
-                ),
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    f'{pod_logs} | grep 9 | wc -l | grep 2',
-                ),
+                *_check_container_logs(name, pod_logs, 1, 9, 2),
             ],
             f'sky down -y {name} && '
             f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}',
@@ -1195,46 +1160,7 @@ def test_container_logs_two_simultaneous_jobs_kubernetes():
                 f'sky exec -c {name} -d {task_yaml}',
                 f'sky exec -c {name} -d {task_yaml}',
                 'sleep 30',
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    f'{pod_logs} | wc -l | grep 18',
-                ),
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    f'{pod_logs} | grep 1 | wc -l | grep 2',
-                ),
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    f'{pod_logs} | grep 2 | wc -l | grep 2',
-                ),
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    f'{pod_logs} | grep 3 | wc -l | grep 2',
-                ),
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    f'{pod_logs} | grep 4 | wc -l | grep 2',
-                ),
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    f'{pod_logs} | grep 5 | wc -l | grep 2',
-                ),
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    f'{pod_logs} | grep 6 | wc -l | grep 2',
-                ),
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    f'{pod_logs} | grep 7 | wc -l | grep 2',
-                ),
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    f'{pod_logs} | grep 8 | wc -l | grep 2',
-                ),
-                smoke_tests_utils.run_cloud_cmd_on_cluster(
-                    name,
-                    f'{pod_logs} | grep 9 | wc -l | grep 2',
-                ),
+                *_check_container_logs(name, pod_logs, 1, 9, 2),
             ],
             f'sky down -y {name} && '
             f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}',

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1070,7 +1070,7 @@ def test_volume_env_mount_kubernetes():
 # ---------- Container logs from task on Kubernetes ----------
 
 
-def _check_container_logs(name, logs, range_start, range_end, count):
+def _check_container_logs(name, logs, total_lines, count):
     """Check if the container logs contain the expected number of logging lines.
 
     Each line should be only one number in the given range and should show up 
@@ -1078,7 +1078,7 @@ def _check_container_logs(name, logs, range_start, range_end, count):
     running setup with set -x.
     """
     output_cmd = f's=$({logs});'
-    for num in range(range_start, range_end + 1):
+    for num in range(1, total_lines + 1):
         output_cmd += f' echo "$s" | grep -x "{num}" | wc -l | grep {count};'
     return smoke_tests_utils.run_cloud_cmd_on_cluster(
         name,
@@ -1107,8 +1107,8 @@ def test_container_logs_multinode_kubernetes():
                 smoke_tests_utils.launch_cluster_for_cloud_cmd(
                     'kubernetes', name),
                 f'sky launch -y -c {name} {task_yaml} --num-nodes 2',
-                _check_container_logs(name, head_logs, 1, 9, 1),
-                _check_container_logs(name, worker_logs, 1, 9, 1),
+                _check_container_logs(name, head_logs, 9, 1),
+                _check_container_logs(name, worker_logs, 9, 1),
             ],
             f'sky down -y {name} && '
             f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}',
@@ -1135,7 +1135,7 @@ def test_container_logs_two_jobs_kubernetes():
                     'kubernetes', name),
                 f'sky launch -y -c {name} {task_yaml}',
                 f'sky launch -y -c {name} {task_yaml}',
-                _check_container_logs(name, pod_logs, 1, 9, 2),
+                _check_container_logs(name, pod_logs, 9, 2),
             ],
             f'sky down -y {name} && '
             f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}',
@@ -1164,7 +1164,7 @@ def test_container_logs_two_simultaneous_jobs_kubernetes():
                 f'sky exec -c {name} -d {task_yaml}',
                 f'sky exec -c {name} -d {task_yaml}',
                 'sleep 30',
-                _check_container_logs(name, pod_logs, 1, 9, 2),
+                _check_container_logs(name, pod_logs, 9, 2),
             ],
             f'sky down -y {name} && '
             f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}',

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1071,15 +1071,17 @@ def test_volume_env_mount_kubernetes():
 
 
 def _check_container_logs(name, logs, range_start, range_end, count):
-    """Check if the container logs contain the expected number of 
-    logging lines. Each line should be only one number in the given range.
-    and should show up count number of times."""
-    return [
-        smoke_tests_utils.run_cloud_cmd_on_cluster(
-            name,
-            f'{logs} | grep -x "{num}" | wc -l | grep {count}',
-        ) for num in range(range_start, range_end + 1)
-    ]
+    """Check if the container logs contain the expected number of logging lines.
+    Each line should be only one number in the given range and should show up 
+    count number of times. We skip the messages that we see in the job from
+    running setup with set -x."""
+    output_cmd = f's=$({logs});'
+    for num in range(range_start, range_end + 1):
+        output_cmd += f' echo "$s" | grep -x "{num}" | wc -l | grep {count};'
+    return smoke_tests_utils.run_cloud_cmd_on_cluster(
+        name,
+        output_cmd,
+    )
 
 
 @pytest.mark.kubernetes
@@ -1103,8 +1105,8 @@ def test_container_logs_multinode_kubernetes():
                 smoke_tests_utils.launch_cluster_for_cloud_cmd(
                     'kubernetes', name),
                 f'sky launch -y -c {name} {task_yaml} --num-nodes 2',
-                *_check_container_logs(name, head_logs, 1, 9, 1),
-                *_check_container_logs(name, worker_logs, 1, 9, 1),
+                _check_container_logs(name, head_logs, 1, 9, 1),
+                _check_container_logs(name, worker_logs, 1, 9, 1),
             ],
             f'sky down -y {name} && '
             f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}',
@@ -1131,7 +1133,7 @@ def test_container_logs_two_jobs_kubernetes():
                     'kubernetes', name),
                 f'sky launch -y -c {name} {task_yaml}',
                 f'sky launch -y -c {name} {task_yaml}',
-                *_check_container_logs(name, pod_logs, 1, 9, 2),
+                _check_container_logs(name, pod_logs, 1, 9, 2),
             ],
             f'sky down -y {name} && '
             f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}',
@@ -1160,7 +1162,7 @@ def test_container_logs_two_simultaneous_jobs_kubernetes():
                 f'sky exec -c {name} -d {task_yaml}',
                 f'sky exec -c {name} -d {task_yaml}',
                 'sleep 30',
-                *_check_container_logs(name, pod_logs, 1, 9, 2),
+                _check_container_logs(name, pod_logs, 1, 9, 2),
             ],
             f'sky down -y {name} && '
             f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR addresses a problem introduced in https://github.com/skypilot-org/skypilot/pull/7497 that changes the output of kubernetes jobs which caused some tests to fail due to the change in expected output. The previous PR adds the following lines due to `set -x`
```
+ '[' 1000 -eq 0 ']'
+ true
+ STEPS=("apt-ssh-setup" "runtime-setup" "env-setup")
+ set +x
+ '[' 0 -ne 0 ']'
+ '[' 0 -ne 0 ']'
+ '[' 0 -ne 0 ']'
```

I changed the tests to check explicitly for the lines it wants rather than test for exact line count.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
