### PR TITLE
[Tests] Don't Include Azure Mount if 18.04

### DIFF
--- a/tests/smoke_tests/test_region_and_zone.py
+++ b/tests/smoke_tests/test_region_and_zone.py
@@ -283,8 +283,9 @@ def test_docker_storage_mounts(generic_cloud: str, image_id: str):
                                                     enabled_cloud_storages)
         include_gcs_mount = clouds.cloud_in_iterable(clouds.GCP(),
                                                      enabled_cloud_storages)
-        include_azure_mount = clouds.cloud_in_iterable(clouds.Azure(),
-                                                       enabled_cloud_storages)
+        include_azure_mount = (
+            clouds.cloud_in_iterable(clouds.Azure(), enabled_cloud_storages) and
+            azure_mount_unsupported_ubuntu_version not in image_id)
         content = template.render(storage_name=storage_name,
                                   include_s3_mount=include_s3_mount,
                                   include_gcs_mount=include_gcs_mount,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixes two errors caused by attempting to use blobfuse2 with ubuntu 18.04 which does not support it. The following smoke tests show the error https://buildkite.com/skypilot-1/smoke-tests/builds/4096#0199bde8-a2c8-4c03-b5bb-72ee38aedbaf. 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
