### PR TITLE
[test] don't disable no_dependency tests by default

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -354,7 +354,8 @@ def pytest_collection_modifyitems(config, items):
             if has_api_server and 'no_remote_server' in marks:
                 item.add_marker(skip_marks['no_remote_server'])
         # Skip tests marked as no_dependency if --dependency is set
-        if 'no_dependency' in marks and config.getoption('--dependency') != 'all':
+        if 'no_dependency' in marks and config.getoption(
+                '--dependency') != 'all':
             item.add_marker(skip_marks['no_dependency'])
 
     # Check if tests need to be run serially for Kubernetes and Lambda Cloud

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -354,7 +354,7 @@ def pytest_collection_modifyitems(config, items):
             if has_api_server and 'no_remote_server' in marks:
                 item.add_marker(skip_marks['no_remote_server'])
         # Skip tests marked as no_dependency if --dependency is set
-        if 'no_dependency' in marks and config.getoption('--dependency'):
+        if 'no_dependency' in marks and config.getoption('--dependency') != 'all':
             item.add_marker(skip_marks['no_dependency'])
 
     # Check if tests need to be run serially for Kubernetes and Lambda Cloud


### PR DESCRIPTION
The default value for `--dependency` is `'all'`, not `None`. But when checking whether to skip tests marked with `no_dependency`, we just check the truthiness of the `--dependency` arg. This is regression from https://github.com/skypilot-org/skypilot/pull/7510. We should make sure to only skip these tests if the value is changed from the default.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
