### PR TITLE
Support empty `--dependency` flag

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -131,7 +131,7 @@ def _parse_args(args: Optional[str] = None):
     parser.add_argument('--jobs-consolidation', action="store_true")
     parser.add_argument('--grpc', action="store_true")
     parser.add_argument('--env-file')
-    parser.add_argument('--dependency')
+    parser.add_argument('--dependency', nargs='?', const='', default='all')
 
     parsed_args, _ = parser.parse_known_args(args_list)
 
@@ -175,8 +175,9 @@ def _parse_args(args: Optional[str] = None):
         extra_args.append('--grpc')
     if parsed_args.env_file:
         extra_args.append(f'--env-file {parsed_args.env_file}')
-    if parsed_args.dependency:
-        extra_args.append(f'--dependency {parsed_args.dependency}')
+    if parsed_args.dependency != 'all':
+        space = ' ' if parsed_args.dependency else ''
+        extra_args.append(f'--dependency{space}{parsed_args.dependency}')
 
     return default_clouds_to_run, parsed_args.k, extra_args
 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -208,9 +208,9 @@ jobs:
     with:
       commit: ${{ github.sha }}
       branch: ${{ github.ref_name }}
-      message: "nightly-build-pypi --kubernetes --no-resource-heavy --dependency kubernetes"
+      message: "nightly-build-pypi --kubernetes --no-resource-heavy --dependency"
       pipeline: "smoke-tests"
-      build_env_vars: '{"ARGS": "--kubernetes --no-resource-heavy --dependency kubernetes"}'
+      build_env_vars: '{"ARGS": "--kubernetes --no-resource-heavy --dependency"}'
       timeout_minutes: 60
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,12 +219,16 @@ def pytest_addoption(parser):
     parser.addoption(
         '--dependency',
         type=str,
+        nargs='?',
+        const='',
         default='all',
         help=
-        'Dependency for package install. For example, --dependency=aws will run '
-        'pip install "skypilot[aws]". --dependency=aws,azure will run '
-        'pip install "skypilot[aws,azure]". This parameter only works in the '
-        'Buildkite CI environment and will be ignored if run locally.',
+        ('Dependency for client-side package install. '
+         'E.g., --dependency=aws runs pip install "skypilot[aws]" on client. '
+         '--dependency=aws,azure runs pip install "skypilot[aws,azure]" on client. '
+         '--dependency (no value) installs base package only (no extras) on client. '
+         'This only affects client side; server side always installs all dependencies. '
+         'Only works in Buildkite CI; ignored if run locally.'),
     )
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
