### PR TITLE
[test]skip `--dependency` tests

### DIFF
--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -992,6 +992,7 @@ def test_kubernetes_context_failover(unreachable_context):
 
 
 @pytest.mark.kubernetes
+@pytest.mark.no_dependency
 def test_kubernetes_get_nodes_and_pods():
     """Test the correctness of get_kubernetes_nodes and get_all_pods_in_kubernetes_cluster,
     as we parse the JSON ourselves and not using the Kubernetes Python client deserializer.
@@ -1497,6 +1498,7 @@ def test_launch_with_failing_setup(generic_cloud: str):
 
 
 @pytest.mark.no_remote_server
+@pytest.mark.no_dependency
 def test_loopback_access_with_basic_auth(generic_cloud: str):
     """Test that loopback access works."""
     server_config_content = textwrap.dedent(f"""\

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -887,6 +887,7 @@ def unreachable_context():
 
 
 @pytest.mark.kubernetes
+@pytest.mark.no_dependency
 def test_kubernetes_context_failover(unreachable_context):
     """Test if the kubernetes context failover works.
 
@@ -985,7 +986,7 @@ def test_kubernetes_context_failover(unreachable_context):
             env={
                 skypilot_config.ENV_VAR_GLOBAL_CONFIG: f.name,
                 constants.SKY_API_SERVER_URL_ENV_VAR:
-                    sky.server.common.get_server_url()
+                    smoke_tests_utils.get_api_server_url()
             },
         )
         smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -986,7 +986,7 @@ def test_kubernetes_context_failover(unreachable_context):
             env={
                 skypilot_config.ENV_VAR_GLOBAL_CONFIG: f.name,
                 constants.SKY_API_SERVER_URL_ENV_VAR:
-                    smoke_tests_utils.get_api_server_url()
+                    sky.server.common.get_server_url()
             },
         )
         smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_workspaces.py
+++ b/tests/smoke_tests/test_workspaces.py
@@ -13,6 +13,7 @@ from sky import skypilot_config
 
 # ---------- Test workspace switching ----------
 @pytest.mark.no_remote_server
+@pytest.mark.no_dependency
 def test_workspace_switching(generic_cloud: str):
     # Test switching between workspaces by modifying .sky.yaml.
     #


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Skip tests that required client side sky restart or import kubernetes utils from client side

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
