### PR TITLE
Fixed potential gpu-metrics port-forawrd process leak

### DIFF
--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -11,7 +11,9 @@ from typing import List, Optional, Tuple
 import httpx
 import prometheus_client as prom
 
+from sky import sky_logging
 from sky.skylet import constants
+from sky.utils import common_utils
 from sky.utils import context_utils
 
 _SELECT_TIMEOUT = 1
@@ -34,6 +36,8 @@ _MEM_BUCKETS = [
     256 * _MB,
     float('inf'),
 ]
+
+logger = sky_logging.init_logger(__name__)
 
 # Whether the metrics are enabled, cannot be changed at runtime.
 METRICS_ENABLED = os.environ.get(constants.ENV_VAR_SERVER_METRICS_ENABLED,
@@ -310,6 +314,10 @@ async def send_metrics_request_with_port_forward(
             response.raise_for_status()
             return response.text
 
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        logger.error(f'Failed to send metrics request with port forward: '
+                     f'{common_utils.format_exception(e)}')
+        raise
     finally:
         # Always clean up port forward
         if port_forward_process:

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -188,53 +188,61 @@ def start_svc_port_forward(context: str, namespace: str, service: str,
     if 'KUBECONFIG' not in env:
         env['KUBECONFIG'] = os.path.expanduser('~/.kube/config')
 
-    # start the port forward process
-    port_forward_process = subprocess.Popen(cmd,
-                                            stdout=subprocess.PIPE,
-                                            stderr=subprocess.STDOUT,
-                                            text=True,
-                                            env=env)
-
+    port_forward_process = None
+    port_forward_exit = False
     local_port = None
-    start_time = time.time()
 
-    buffer = ''
-    # wait for the port forward to start and extract the local port
-    while time.time() - start_time < start_port_forward_timeout:
-        if port_forward_process.poll() is not None:
-            # port forward process has terminated
-            if port_forward_process.returncode != 0:
-                raise RuntimeError(
-                    f'Port forward failed for service {service} in namespace '
-                    f'{namespace} on context {context}')
-            break
+    try:
+        # start the port forward process
+        port_forward_process = subprocess.Popen(cmd,
+                                                stdout=subprocess.PIPE,
+                                                stderr=subprocess.STDOUT,
+                                                text=True,
+                                                env=env)
 
-        # read output line by line to find the local port
-        if port_forward_process.stdout:
-            # Wait up to 1s for data to be available without blocking
-            r, _, _ = select.select([port_forward_process.stdout], [], [],
-                                    _SELECT_TIMEOUT)
-            if r:
-                # Read available bytes from the FD without blocking
-                fd = port_forward_process.stdout.fileno()
-                raw = os.read(fd, _SELECT_BUFFER_SIZE)
-                chunk = raw.decode(errors='ignore')
-                buffer += chunk
-                match = re.search(r'Forwarding from 127\.0\.0\.1:(\d+)', buffer)
-                if match:
-                    local_port = int(match.group(1))
-                    break
+        start_time = time.time()
 
-        # sleep for 100ms to avoid busy-waiting
-        time.sleep(0.1)
+        buffer = ''
+        # wait for the port forward to start and extract the local port
+        while time.time() - start_time < start_port_forward_timeout:
+            if port_forward_process.poll() is not None:
+                # port forward process has terminated
+                if port_forward_process.returncode != 0:
+                    port_forward_exit = True
+                break
 
+            # read output line by line to find the local port
+            if port_forward_process.stdout:
+                # Wait up to 1s for data to be available without blocking
+                r, _, _ = select.select([port_forward_process.stdout], [], [],
+                                        _SELECT_TIMEOUT)
+                if r:
+                    # Read available bytes from the FD without blocking
+                    fd = port_forward_process.stdout.fileno()
+                    raw = os.read(fd, _SELECT_BUFFER_SIZE)
+                    chunk = raw.decode(errors='ignore')
+                    buffer += chunk
+                    match = re.search(r'Forwarding from 127\.0\.0\.1:(\d+)',
+                                      buffer)
+                    if match:
+                        local_port = int(match.group(1))
+                        break
+
+            # sleep for 100ms to avoid busy-waiting
+            time.sleep(0.1)
+    except BaseException:  # pylint: disable=broad-exception-caught
+        if port_forward_process:
+            stop_svc_port_forward(port_forward_process,
+                                  timeout=terminate_port_forward_timeout)
+        raise
+    if port_forward_exit:
+        raise RuntimeError(f'Port forward failed for service {service} in '
+                           f'namespace {namespace} on context {context}')
     if local_port is None:
         try:
-            port_forward_process.terminate()
-            port_forward_process.wait(timeout=terminate_port_forward_timeout)
-        except subprocess.TimeoutExpired:
-            port_forward_process.kill()
-            port_forward_process.wait()
+            if port_forward_process:
+                stop_svc_port_forward(port_forward_process,
+                                      timeout=terminate_port_forward_timeout)
         finally:
             raise RuntimeError(
                 f'Failed to extract local port for service {service} in '
@@ -243,14 +251,15 @@ def start_svc_port_forward(context: str, namespace: str, service: str,
     return port_forward_process, local_port
 
 
-def stop_svc_port_forward(port_forward_process: subprocess.Popen) -> None:
+def stop_svc_port_forward(port_forward_process: subprocess.Popen,
+                          timeout: int = 5) -> None:
     """Stops a port forward to a service in a Kubernetes cluster.
     Args:
         port_forward_process: The subprocess.Popen process to terminate
     """
     try:
         port_forward_process.terminate()
-        port_forward_process.wait(timeout=5)
+        port_forward_process.wait(timeout=timeout)
     except subprocess.TimeoutExpired:
         port_forward_process.kill()
         port_forward_process.wait()

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -24,8 +24,10 @@ logger = sky_logging.init_logger(__name__)
 metrics_app = fastapi.FastAPI()
 
 
+# Serve /metrics in dedicated thread to avoid blocking the event loop
+# of metrics server.
 @metrics_app.get('/metrics')
-async def metrics() -> fastapi.Response:
+def metrics() -> fastapi.Response:
     """Expose aggregated Prometheus metrics from all worker processes."""
     if os.environ.get('PROMETHEUS_MULTIPROC_DIR'):
         # In multiprocess mode, we need to collect metrics from all processes.

--- a/tests/unit_tests/test_sky/metrics/test_metrics_util.py
+++ b/tests/unit_tests/test_sky/metrics/test_metrics_util.py
@@ -1,0 +1,57 @@
+"""Unit tests for sky.metrics.utils."""
+import subprocess
+from unittest import mock
+
+import pytest
+
+from sky.metrics import utils
+
+
+def test_start_svc_port_forward_terminates_on_exception():
+    """Test subprocess is terminated when exception occurs."""
+    mock_process = mock.MagicMock(spec=subprocess.Popen)
+    mock_process.poll.return_value = None
+    mock_process.stdout = mock.MagicMock()
+    mock_process.stdout.fileno.return_value = 1
+
+    with mock.patch('subprocess.Popen',
+                    return_value=mock_process), \
+         mock.patch('time.time', side_effect=[0, 1, 2]), \
+         mock.patch('select.select',
+                    side_effect=Exception('Test error')), \
+         mock.patch('time.sleep'):
+
+        with pytest.raises(Exception, match='Test error'):
+            utils.start_svc_port_forward(context='test-context',
+                                         namespace='test-ns',
+                                         service='test-svc',
+                                         service_port=8080)
+
+        # Verify subprocess was terminated
+        mock_process.terminate.assert_called_once()
+        mock_process.wait.assert_called()
+
+
+def test_start_svc_port_forward_terminates_on_timeout():
+    """Test subprocess is terminated when no local port found."""
+    mock_process = mock.MagicMock(spec=subprocess.Popen)
+    mock_process.poll.return_value = None
+    mock_process.stdout = mock.MagicMock()
+    mock_process.stdout.fileno.return_value = 1
+
+    # Simulate timeout by advancing time past the timeout threshold
+    with mock.patch('subprocess.Popen',
+                    return_value=mock_process), \
+         mock.patch('time.time', side_effect=[0] + [11] * 10), \
+         mock.patch('select.select', return_value=([], [], [])), \
+         mock.patch('time.sleep'):
+
+        with pytest.raises(RuntimeError, match='Failed to extract local port'):
+            utils.start_svc_port_forward(context='test-context',
+                                         namespace='test-ns',
+                                         service='test-svc',
+                                         service_port=8080)
+
+        # Verify subprocess was terminated
+        mock_process.terminate.assert_called_once()
+        mock_process.wait.assert_called()

--- a/tests/unit_tests/test_sky/server/test_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_metrics.py
@@ -58,7 +58,7 @@ async def test_metrics_endpoint_without_multiprocess():
         with patch('sky.server.metrics.generate_latest') as mock_gen:
             mock_gen.return_value = b"# HELP test_metric Test metric\n"
 
-            response = await metrics.metrics()
+            response = metrics.metrics()
 
             assert isinstance(response, fastapi.Response)
             assert response.media_type == CONTENT_TYPE_LATEST
@@ -81,7 +81,7 @@ async def test_metrics_endpoint_with_multiprocess():
             mock_registry.return_value = mock_registry_instance
             mock_gen.return_value = b"# HELP multiproc_metric Test\n"
 
-            response = await metrics.metrics()
+            response = metrics.metrics()
 
             assert isinstance(response, fastapi.Response)
             mock_registry.assert_called_once()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

One of our user saw thousands of `kubectl port-forward` process to the prometheus server, I cannot repro this but according to the code, if there is any error raised in the `start_svc_port_forward` function, the process will never be cleaned. This PR fixes this potential issue.

A unit test is added.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
