### PR TITLE
Robustly parsing job controller name in smoke test

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -444,7 +444,7 @@ def _convert_quick_tests_core(test_files: List[str], args: str,
                         branch != 'master'):
                     continue
                 pipeline = _generate_pipeline(test_file,
-                                              args + f'--base-branch {branch}',
+                                              args + f' --base-branch {branch}',
                                               auto_retry=True)
                 output_file_pipelines.append(pipeline)
         else:

--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -480,7 +480,7 @@ class TestBackwardCompatibility:
         # and https://github.com/skypilot-org/skypilot/pull/7494
         check_controller_process_count = (
             's=$(sky status -u) && echo "$s" && '
-            'jobs_controller=$(echo "$s" | grep sky-jobs-controller- | awk \'{print $1}\') && '
+            'jobs_controller=$(echo "$s" | grep -oE \'sky-jobs-controller-[0-9a-f]+\' | head -n1) && '
             'if [ -z "$jobs_controller" ]; then echo "ERROR: jobs controller not found in sky status"; exit 1; fi && '
             'echo "Jobs controller: $jobs_controller" && '
             'num_controllers=$(ssh $jobs_controller "pgrep -f msky\\.jobs\\.controller | wc -l") && '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

`quicktest-core` fails on master, the parsing logic accidentally get `sky-jobs-controller-4a9ad66d\nD` thus break the bash script. This PR refines the parsing logic to unblock the test.

```
* To see all managed jobs: sky jobs queue
--
  | * 1 cluster has auto{stop,down} scheduled. Refresh statuses with: sky status --refresh
  | Jobs controller: sky-jobs-controller-4a9ad66d
  | D name ended
  | Warning: Permanently added '18.232.133.63' (ED25519) to the list of known hosts.
  | bash: line 1: D: command not found
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
