### PR TITLE
[Test] Fix Helm Okta Test

### DIFF
--- a/tests/smoke_tests/test_images.py
+++ b/tests/smoke_tests/test_images.py
@@ -719,6 +719,6 @@ def test_helm_deploy_eks(request):
 @pytest.mark.no_dependency  # This test is not related to dependency
 def test_helm_deploy_okta():
     test = smoke_tests_utils.Test('helm_deploy_okta', [
-        f'output=$(bash tests/kubernetes/scripts/helm_okta.sh 2>&1); echo "$output"; [ $? -eq 0 ] || exit 1',
+        f'output=$(bash tests/kubernetes/scripts/helm_okta.sh 2>&1); exit_code=$?; echo "$output"; exit $exit_code',
     ])
     smoke_tests_utils.run_one_test(test)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixes an error with the test_helm_okta test. The problem was that if the skypilot namespace was actively terminating due to a previous run we would try to deploy via helm and instantly fail. Now if the namespace is being terminated we wait until termination and then make our attempt. I also modified the test to print its output to make future debugging easier.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
