### PR TITLE
[Pools] Fix Logs Commands

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -5181,22 +5181,22 @@ def jobs_pool_logs(
     .. code-block:: bash
 
         # Tail the controller logs of a pool
-        sky pool logs --controller [POOL_NAME]
+        sky jobs pool logs --controller [POOL_NAME]
         \b
         # Print the worker logs so far and exit
-        sky pool logs --no-follow [POOL_NAME]
+        sky jobs pool logs --no-follow [POOL_NAME] 1
         \b
         # Tail the logs of worker 1
-        sky pool logs [POOL_NAME] 1
+        sky jobs pool logs [POOL_NAME] 1
         \b
         # Show the last 100 lines of the controller logs
-        sky pool logs --controller --tail 100 [POOL_NAME]
+        sky jobs pool logs --controller --tail 100 [POOL_NAME]
         \b
         # Sync down all logs of the pool (controller, all workers)
-        sky pool logs [POOL_NAME] --sync-down
+        sky jobs pool logs [POOL_NAME] --sync-down
         \b
         # Sync down controller logs and logs for workers 1 and 3
-        sky pool logs [POOL_NAME] 1 3 --controller --sync-down
+        sky jobs pool logs [POOL_NAME] 1 3 --controller --sync-down
     """
     _handle_serve_logs(pool_name,
                        follow=follow,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The help commands in jobs_logs for pools use the wrong prefix. Changed them and verified they all work as expected.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
