### PR TITLE
[Test] Remove Bad Output Logic for Okta test

### DIFF
--- a/tests/smoke_tests/test_images.py
+++ b/tests/smoke_tests/test_images.py
@@ -719,6 +719,6 @@ def test_helm_deploy_eks(request):
 @pytest.mark.no_dependency  # This test is not related to dependency
 def test_helm_deploy_okta():
     test = smoke_tests_utils.Test('helm_deploy_okta', [
-        f'output=$(bash tests/kubernetes/scripts/helm_okta.sh 2>&1); exit_code=$?; echo "$output"; exit $exit_code',
+        f'bash tests/kubernetes/scripts/helm_okta.sh',
     ])
     smoke_tests_utils.run_one_test(test)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR reverts a change introduced in https://github.com/skypilot-org/skypilot/pull/7535 that changed the output logic unnecessarily.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
