### PR TITLE
[Docs] Update docs title.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -158,7 +158,7 @@ html_sidebars = {
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # '<project> v<release> documentation'.
-html_title = 'SkyPilot documentation'
+html_title = 'SkyPilot Docs'
 
 # -- Options for EPUB output
 epub_show_urls = 'footnote'

--- a/docs/source/docs/index.rst
+++ b/docs/source/docs/index.rst
@@ -1,5 +1,5 @@
-Welcome to SkyPilot!
-====================
+SkyPilot: Run AI on Any Infrastructure
+======================================
 
 .. image:: /_static/SkyPilot_wide_dark.svg
   :width: 50%
@@ -13,10 +13,6 @@ Welcome to SkyPilot!
   :class: no-scaled-link, only-light
 
 .. raw:: html
-
-   <p style="text-align:center">
-   <strong>Simplify & scale any AI infrastructure</strong>
-   </p>
 
    <p></p>
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,5 @@
-Welcome to SkyPilot!
-====================
+SkyPilot: Run AI on Any Infrastructure
+======================================
 
 
 .. raw:: html


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This is to optimize how our docs show up in Google. It seems necessary to change index.rst's title because the rendered html's <title> is that h1 plus `html_title`.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
