### PR TITLE
Revert "[Pool] Reduce default setup timeout"

### DIFF
--- a/sky/serve/constants.py
+++ b/sky/serve/constants.py
@@ -76,9 +76,6 @@ CONTROLLER_AUTOSTOP = {
 # A period of time to initialize your service. Any readiness probe failures
 # during this period will be ignored.
 DEFAULT_INITIAL_DELAY_SECONDS = 1200
-# For pool, we shrink the initial delay to 300s to make the pool more
-# responsive to the failure that setup command starts a long-running server.
-DEFAULT_INITIAL_DELAY_SECONDS_POOL = 300
 DEFAULT_MIN_REPLICAS = 1
 
 # Default port range start for controller and load balancer. Ports will be

--- a/sky/serve/service_spec.py
+++ b/sky/serve/service_spec.py
@@ -126,12 +126,6 @@ class SkyServiceSpec:
                 self.base_ondemand_fallback_replicas > 0)
 
     @staticmethod
-    def _get_initial_delay_seconds(pool: bool) -> int:
-        if pool:
-            return constants.DEFAULT_INITIAL_DELAY_SECONDS_POOL
-        return constants.DEFAULT_INITIAL_DELAY_SECONDS
-
-    @staticmethod
     def from_yaml_config(config: Dict[str, Any]) -> 'SkyServiceSpec':
         common_utils.validate_schema(config, schemas.get_service_schema(),
                                      'Invalid service YAML: ')
@@ -159,8 +153,7 @@ class SkyServiceSpec:
                 'timeout_seconds', None)
             readiness_headers = readiness_section.get('headers', None)
         if initial_delay_seconds is None:
-            initial_delay_seconds = SkyServiceSpec._get_initial_delay_seconds(
-                config.get('pool', False))
+            initial_delay_seconds = constants.DEFAULT_INITIAL_DELAY_SECONDS
         service_config['initial_delay_seconds'] = initial_delay_seconds
         if readiness_timeout_seconds is None:
             readiness_timeout_seconds = (


### PR DESCRIPTION
Reverts skypilot-org/skypilot#7447 for a long running setup.