### PR TITLE
config to set custom uv_http_timout during dependency install

### DIFF
--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1562,6 +1562,13 @@ class Resources:
                 override_configs=self.cluster_config_overrides) and
                 self.accelerators is not None):
             initial_setup_commands = [constants.DISABLE_GPU_ECC_COMMAND]
+        uv_http_timeout = skypilot_config.get_nested(
+            ('provision', 'uv_http_timeout'),
+            None,
+            override_configs=self.cluster_config_overrides
+        )
+        if uv_http_timeout is not None:
+            initial_setup_commands.append(f"export UV_HTTP_TIMEOUT={uv_http_timeout}")
 
         docker_image = self.extract_docker_image()
 

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -635,6 +635,9 @@ available_node_types:
               # Set -x to print the commands and their arguments as they are executed.
               # Useful for debugging.
               set -x
+              {%- for initial_setup_command in initial_setup_commands %}
+              {{ initial_setup_command }}
+              {%- endfor %}
               # Helper function to conditionally use sudo
               # TODO(zhwu): consolidate the two prefix_cmd and sudo replacements
               prefix_cmd() { if [ $(id -u) -ne 0 ]; then echo "sudo"; else echo ""; fi; }
@@ -1328,9 +1331,6 @@ setup_commands:
   # commands in pod args are asynchronous and we cannot guarantee the failure indicators are created before the setup commands finish.
   - |
     mkdir -p ~/.ssh; touch ~/.ssh/config;
-    {%- for initial_setup_command in initial_setup_commands %}
-    {{ initial_setup_command }}
-    {%- endfor %}
     STEPS=("apt-ssh-setup" "runtime-setup" "env-setup")
     start_epoch=$(date +%s);
 

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1710,6 +1710,10 @@ def get_config_schema():
                 'type': 'integer',
                 'minimum': 1,
             },
+            'uv_http_timeout': {
+                'type': 'integer',
+                'minimum': 1,
+            },
         }
     }
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The idea here is to let users config the UV timeout for installing packaged. We already have an `initial_setup_commands` field where we can inject arbitrary commands to setup time, and do so with `disable_ecc` config value.

I've verified this works for at least GCP and k8s. One caveat about k8s is that I've had to move the place where `initial_setup_commands` is run to before when conda install commands are run, etc. I'm unsure why the initial setup commands were being run where it was being run, and if there is any side effects yet unknown to me by moving `initial_setup_commands` execution to the new place.

One piece of work that needs to be done is to either unset UV_HTTP_TIMEOUT at the end of setup, or set it to what the env var used to be in case the env var was set already.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
