### PR TITLE
Fix LazyImport TypeError in Nebius adaptor SDK initialization

### DIFF
--- a/sky/adaptors/nebius.py
+++ b/sky/adaptors/nebius.py
@@ -235,7 +235,7 @@ def _sdk(token: Optional[str], cred_path: Optional[str]):
     # Exactly one of token or cred_path must be provided
     assert (token is None) != (cred_path is None), (token, cred_path)
     # Load the LazyImport submodule to get the actual nebius.sdk module
-    # This is required because nebius is a LazyImport object, not the actual module
+    # This is required because nebius is a LazyImport object
     nebius_sdk = nebius.sdk.load_module()
     if token is not None:
         return nebius_sdk.SDK(credentials=token, domain=api_domain())

--- a/sky/adaptors/nebius.py
+++ b/sky/adaptors/nebius.py
@@ -234,10 +234,13 @@ def sdk():
 def _sdk(token: Optional[str], cred_path: Optional[str]):
     # Exactly one of token or cred_path must be provided
     assert (token is None) != (cred_path is None), (token, cred_path)
+    # Load the LazyImport submodule to get the actual nebius.sdk module
+    # This is required because nebius is a LazyImport object, not the actual module
+    nebius_sdk = nebius.sdk.load_module()
     if token is not None:
-        return nebius.sdk.SDK(credentials=token, domain=api_domain())
+        return nebius_sdk.SDK(credentials=token, domain=api_domain())
     if cred_path is not None:
-        return nebius.sdk.SDK(
+        return nebius_sdk.SDK(
             credentials_file_name=os.path.expanduser(cred_path),
             domain=api_domain(),
         )


### PR DESCRIPTION
## Problem

The `_sdk()` function in `sky/adaptors/nebius.py` was attempting to call `nebius.sdk.SDK()` directly on a LazyImport object without loading the underlying module first, causing:
`TypeError: 'LazyImport' object is not callable`

This error occurred during Nebius SDK initialization when using either IAM token or credentials file authentication.

## Solution

Load nebius.sdk module before calling SDK() to avoid TypeError when the LazyImport object is accessed. This fixes SDK initialization with both token and credentials file authentication methods.

The fix adds a call to `nebius.sdk.load_module()` to retrieve the actual `nebius.sdk` module before instantiating the SDK class. This pattern is consistent with other LazyImport usage throughout the SkyPilot codebase (e.g., `compute()`, `iam()`, `vpc()` functions in the same file).

## Changes

- Modified `_sdk()` function to load the LazyImport module before accessing SDK
- Added inline comments explaining the LazyImport requirement

## Testing

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Manual testing: Verified Nebius SDK initialization with IAM token authentication
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_nebius` (CI) or `pytest tests/test_smoke.py::test_nebius` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

Manual verification:
- Successfully initialized Nebius SDK with token authentication
- Successfully initialized Nebius SDK with credentials file
- Verified `sky check nebius` completes without errors