### PR TITLE
[deps] make sure server deps are always installed

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -10,6 +10,35 @@ from typing import Dict, List
 
 clouds_with_ray = ['ibm', 'docker', 'scp']
 
+# See requirements-dev.txt for the version of grpc and protobuf
+# used to generate the code during development.
+
+# The grpc version at runtime has to be newer than the version
+# used to generate the code.
+GRPC = 'grpcio>=1.63.0'
+# >= 5.26.1 because the runtime version can't be older than the version
+# used to generate the code.
+# < 7.0.0 because code generated for a major version V will be supported by
+# protobuf runtimes of version V and V+1.
+# https://protobuf.dev/support/cross-version-runtime-guarantee
+PROTOBUF = 'protobuf>=5.26.1, < 7.0.0'
+
+server_dependencies = [
+    'casbin',
+    'sqlalchemy_adapter',
+    'passlib',
+    'pyjwt',
+    'aiohttp',
+    'anyio',
+    GRPC,
+    PROTOBUF,
+    'aiosqlite',
+    'asyncpg',
+    'greenlet',
+    # Required for API server metrics
+    'prometheus_client>=0.8.0',
+]
+
 install_requires = [
     'wheel<0.46.0',  # https://github.com/skypilot-org/skypilot/issues/5153
     'setuptools',  # TODO: match version to pyproject.toml once #5153 is fixed
@@ -71,49 +100,14 @@ install_requires = [
     'setproctitle',
     'sqlalchemy',
     'psycopg2-binary',
-    'aiosqlite',
-    'asyncpg',
-    # TODO(hailong): These three dependencies should be removed after we make
-    # the client-side actually not importing them.
-    'casbin',
-    'sqlalchemy_adapter',
-    # Required for API server metrics
-    'prometheus_client>=0.8.0',
-    'passlib',
+    # TODO(hailong): These server_dependencies should be removed after we make
+    # the client-side actually not importing them, and we make sure that local
+    # API server installations will get them
+    *server_dependencies,
     'bcrypt==4.0.1',
-    'pyjwt',
     'gitpython',
     'types-paramiko',
     'alembic',
-    'aiohttp',
-    'aiosqlite',
-    'anyio',
-]
-
-# See requirements-dev.txt for the version of grpc and protobuf
-# used to generate the code during development.
-
-# The grpc version at runtime has to be newer than the version
-# used to generate the code.
-GRPC = 'grpcio>=1.63.0'
-# >= 5.26.1 because the runtime version can't be older than the version
-# used to generate the code.
-# < 7.0.0 because code generated for a major version V will be supported by
-# protobuf runtimes of version V and V+1.
-# https://protobuf.dev/support/cross-version-runtime-guarantee
-PROTOBUF = 'protobuf>=5.26.1, < 7.0.0'
-
-server_dependencies = [
-    'casbin',
-    'sqlalchemy_adapter',
-    'passlib',
-    'pyjwt',
-    'aiohttp',
-    'anyio',
-    GRPC,
-    PROTOBUF,
-    'aiosqlite',
-    'greenlet',
 ]
 
 local_ray = [
@@ -227,6 +221,7 @@ extras_require: Dict[str, List[str]] = {
 # Calculate which clouds should be included in the [all] installation.
 clouds_for_all = set(extras_require)
 clouds_for_all.remove('remote')
+clouds_for_all.remove('server')
 
 if sys.version_info < (3, 10):
     # Nebius needs python3.10. If python 3.9 [all] will not install nebius


### PR DESCRIPTION
Before this change, `pip install skypilot[aws]` could not correctly run a local API server in some cases, because the server dependencies were not installed.

We should have a way to install just the skypilot client without any of the server deps (#5500), but we don't have that at the moment.

Fixes #7286.
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `uv pip install .[aws]`, then `sky launch` with `SKYPILOT_ENABLE_GRPC=1`
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
