### PR TITLE
[debug] add details when managed jobs state transition fails

### DIFF
--- a/tests/test_jobs_state_async_vs_sync.py
+++ b/tests/test_jobs_state_async_vs_sync.py
@@ -473,8 +473,12 @@ async def test_set_backoff_pending_async_no_matching_rows(_mock_jobs_db_conn):
 
     # Call set_backoff_pending_async - should raise ManagedJobStatusError
     with pytest.raises(state.exceptions.ManagedJobStatusError,
-                       match='Failed to set the task back to pending'):
+                       match='Failed to set the task back to pending') as exc:
         await state.set_backoff_pending_async(job_id, 0)
+
+    message = str(exc.value)
+    assert 'rows matched job' in message
+    assert 'Status: RUNNING' in message
 
 
 @pytest.mark.asyncio
@@ -491,3 +495,38 @@ async def test_set_recovered_async_error_details(_seed_one_job: int):
     message = str(exc_info.value)
     assert 'rows matched job' in message
     assert 'Status: PENDING' in message
+
+
+@pytest.mark.asyncio
+async def test_transition_failures_surface_details_for_all_functions(
+        _seed_one_job: int):
+    """Every transition failure includes contextual task details."""
+    job_id = _seed_one_job
+    missing_task_id = 1
+
+    async def noop_callback(_):
+        return None
+
+    async def expect_failure(coro_factory):
+        with pytest.raises(state.exceptions.ManagedJobStatusError) as exc:
+            await coro_factory()
+        message = str(exc.value)
+        assert (f'0 rows matched job {job_id} and task {missing_task_id}'
+                in message)
+        return message
+
+    await expect_failure(
+        lambda: state.set_backoff_pending_async(job_id, missing_task_id))
+    await expect_failure(
+        lambda: state.set_restarting_async(job_id, missing_task_id, False))
+    await expect_failure(lambda: state.set_starting_async(
+        job_id, missing_task_id, 'run-id', time.time(), '{}', {}, noop_callback)
+                        )
+    await expect_failure(lambda: state.set_started_async(
+        job_id, missing_task_id, time.time(), noop_callback))
+    await expect_failure(lambda: state.set_recovering_async(
+        job_id, missing_task_id, False, noop_callback))
+    await expect_failure(lambda: state.set_recovered_async(
+        job_id, missing_task_id, time.time(), noop_callback))
+    await expect_failure(lambda: state.set_succeeded_async(
+        job_id, missing_task_id, time.time(), noop_callback))


### PR DESCRIPTION
Before, we would just get a cryptic "0 rows updated", but it wasn't clear why - usually because the job is in the wrong state, but what state?

Note that this approach isn't 100% race-proof as the status could change between the first and second query, but it seems like a big improvement anyway.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
