### PR TITLE
[db] Request database optimizations

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -3131,7 +3131,8 @@ def refresh_cluster_records() -> None:
     requests = requests_lib.get_request_tasks(
         req_filter=requests_lib.RequestTaskFilter(
             status=[requests_lib.RequestStatus.RUNNING],
-            include_request_names=['sky.launch']))
+            include_request_names=['sky.launch'],
+            fields=['cluster_name']))
     cluster_names_with_launch_request = {
         request.cluster_name for request in requests
     }
@@ -3360,7 +3361,8 @@ def get_clusters(
         req_filter=requests_lib.RequestTaskFilter(
             status=[requests_lib.RequestStatus.RUNNING],
             include_request_names=['sky.launch'],
-            cluster_names=cluster_names))
+            cluster_names=cluster_names,
+            fields=['cluster_name']))
     cluster_names_with_launch_request = {
         request.cluster_name for request in requests
     }

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -214,7 +214,7 @@ class RequestWorker:
                 time.sleep(0.1)
                 return
             request_id, ignore_return_value, _ = request_element
-            request = api_requests.get_request(request_id)
+            request = api_requests.get_request(request_id, exact_match=True)
             assert request is not None, f'Request with ID {request_id} is None'
             if request.status == api_requests.RequestStatus.CANCELLED:
                 return

--- a/sky/server/requests/preconditions.py
+++ b/sky/server/requests/preconditions.py
@@ -166,7 +166,10 @@ class ClusterStartCompletePrecondition(Precondition):
                     api_requests.RequestStatus.RUNNING
                 ],
                 include_request_names=['sky.launch', 'sky.start'],
-                cluster_names=[self.cluster_name]))
+                cluster_names=[self.cluster_name],
+                # Only get the request ID to avoid fetching the whole request.
+                # We're only interested in the count, not the whole request.
+                fields=['request_id']))
         if len(requests) == 0:
             # No running or pending tasks, the start process is done.
             return True, None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -61,7 +61,7 @@ def test_api_stream_heartbeat(monkeypatch):
         async def mock_get_request(request_id):
             return MockRequest()
 
-        async def mock_get_request_status(request_id):
+        async def mock_get_request_status(request_id, exact_match=False):
             return requests_lib.StatusWithMsg(MockRequest().status,
                                               MockRequest().status_msg)
 
@@ -153,7 +153,7 @@ def test_heartbeat_not_displayed_to_users(monkeypatch):
         async def mock_get_request(request_id):
             return MockRequest()
 
-        async def mock_get_request_status(request_id):
+        async def mock_get_request_status(request_id, exact_match=False):
             return requests_lib.StatusWithMsg(MockRequest().status,
                                               MockRequest().status_msg)
 

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -1404,7 +1404,7 @@ def test_update_request_row_fields_maintains_order():
 @pytest.mark.asyncio
 async def test_cancel_get_request_async():
 
-    async def mock_get_request_async_no_lock(id: str):
+    async def mock_get_request_async_no_lock(id: str, exact_match: bool = False):
         await asyncio.sleep(1)
         return None
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The PR introduces a series of changes to make accesses to request DB more efficient.

General changes
1. ~The database is given an index on `created_at`. This is because several queries in `requests.py` have `ORDER BY created_at` statements, which can be accelerated by an index.~
2. ~`RequestTaskFilter` now has a `sort` parameter that can toggle the inclusion of `ORDER BY created_at` statement. This allows callers that do not need the results to be sorted to benefit from not sorting the result.~
3. `RequestTaskFilter` had `fields` parameter introduced [2 days ago](https://github.com/skypilot-org/skypilot/pull/7576). This PR adds appropriate `fields` parameter to callers that do not need all of the parameters (especially request / response bodies) to perform their tasks.
4. ~`get_request_tasks_with_fields_async` is merged with `get_request_tasks_async`, allowing the latter function to handle an optional `fields` parameter if provided. Similarly, `get_request_tasks` is modified to handle an optional `fields` parameter.~
5. `exact_match` fields are added to some queries that acts on a request given a `request_id`. Since the API server wants to handle clients submitting a request ID prefix, query functions use `WHERE request_id LIKE <prefix>%` statement to handle prefixes. However, in cases where we know an exact request ID is supplied, using `WHERE request_id = <id>` is more efficient.


Case studies of specific codepaths

`sky api cancel -a`:
- Uses `kill_requests`. Since no request IDs are specified, the request IDs are retrieved from DB. This DB call now only returns request IDs (instead of whole requests) and does not sort. I expect this to be the bulk of the efficiency improvement.
- Since the request IDs are retrieved from DB, we can set `exact_match` to `True` on `update_request`. This uses an exact match query (`WHERE request_id = <id>` instead of `WHERE request_id LIKE <prefix>%`) making the operation more efficient.

`sky logs`
- uses `_tail_log_file`. We now establish an `exact_request_id` at the start of `_tail_log_file`, and use exact match query making the operation more efficient.



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
