### PR TITLE
[Test] skip `test_tail_jobs_logs_blocks_ssh --denepdency`

### DIFF
--- a/tests/smoke_tests/test_api_server.py
+++ b/tests/smoke_tests/test_api_server.py
@@ -491,10 +491,16 @@ def test_api_server_start_stop(generic_cloud: str):
 
 @pytest.mark.kubernetes  # We only run this test on Kubernetes to test its ssh.
 @pytest.mark.no_remote_server  # All blocking testing has been done for local server.
+@pytest.mark.no_dependency  # We can't restart the api server in the dependency test.
 def test_tail_jobs_logs_blocks_ssh(generic_cloud: str):
     """Test that we don't block ssh when we do a large amount
     of tail logs requests.
     """
+    if not smoke_tests_utils.is_in_buildkite_env():
+        pytest.skip(
+            'Skipping test: requires restarting API server, run only in '
+            'Buildkite.')
+
     name = smoke_tests_utils.get_cluster_name()
     job_name = name + '-job'
     timeout = smoke_tests_utils.get_timeout(generic_cloud)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolve #7608

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
