### PR TITLE
Fix `pydantic-core` install failre for arm

### DIFF
--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -228,7 +228,7 @@ RAY_INSTALLATION_COMMANDS = (
     f'|| {RAY_STATUS} || '
     # The pydantic-core==2.41.3 for arm seems corrupted
     # so we need to avoid that specific version.
-    f'{SKY_UV_PIP_CMD} install -U "ray[default]=={SKY_REMOTE_RAY_VERSION}" "pydantic-core==2.41.2"; '  # pylint: disable=line-too-long
+    f'{SKY_UV_PIP_CMD} install -U "ray[default]=={SKY_REMOTE_RAY_VERSION}" "pydantic-core==2.41.1"; '  # pylint: disable=line-too-long
     # In some envs, e.g. pip does not have permission to write under /opt/conda
     # ray package will be installed under ~/.local/bin. If the user's PATH does
     # not include ~/.local/bin (the pip install will have the output: `WARNING:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolve #7610 

Add a fallback to avoid specific version of `pydantic-core` 

This command

```bash
 time sky launch --instance-type m6g.large -y -c t-aws-storage-mou-2k-a2 --infra aws/us-west-2 --image-id ami-03ac43540bf1c63c0 --cpus 2+ --memory 4+

real    2m4.761s
user    0m2.135s
sys     0m0.261s
```

Now works

```bash
CondaKeyError: 'channels': 'https://aws-ml-conda-ec2.s3.us-west-2.amazonaws.com' is not in the 'channels' key of the config file

PATH=/home/ubuntu/miniconda3/bin:/home/ubuntu/miniconda3/condabin:/opt/amazon/openmpi/bin:/opt/amazon/efa/bin:/usr/local/cuda-12.8/bin:/usr/local/cuda-12.8/include:/usr/local/cuda-12.8/bin:/usr/local/cuda-12.8/include:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
Using Python 3.10.13 environment at: skypilot-runtime
Resolved 1 package in 31ms
Prepared 1 package in 62ms
Uninstalled 1 package in 7ms
Installed 1 package in 4ms
 - setuptools==80.9.0
 + setuptools==69.5.1
Using Python 3.10.13 environment at: skypilot-runtime
/home/ubuntu/skypilot-runtime/bin/python: can't open file '/home/ubuntu/status': [Errno 2] No such file or directory
Using Python 3.10.13 environment at: skypilot-runtime
Resolved 56 packages in 1.82s
Downloading grpcio (6.0MiB)
Downloading virtualenv (5.7MiB)
Downloading py-spy (1.9MiB)
Downloading aiohttp (1.6MiB)
Downloading pydantic-core (1.9MiB)
Downloading ray (61.0MiB)
  × Failed to download `pydantic-core==2.41.3`
  ├─▶ Failed to extract archive:
  │   pydantic_core-2.41.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  ├─▶ I/O operation failed during extraction
  ╰─▶ deflate decompression error: repeated call with bad state
  help: `pydantic-core` (v2.41.3) was included because `ray[default]` (v2.9.3)
        depends on `pydantic` (v2.12.1) which depends on `pydantic-core`
Using Python 3.10.13 environment at: skypilot-runtime
Resolved 56 packages in 231ms
Downloading py-spy (1.9MiB)
Downloading pydantic-core (1.9MiB)
Downloading aiohttp (1.6MiB)
Downloading grpcio (6.0MiB)
Downloading ray (61.0MiB)
Downloading virtualenv (5.7MiB)
   Building gpustat==1.1.1
 Downloading py-spy
 Downloading pydantic-core
 Downloading aiohttp
 Downloading grpcio
 Downloading virtualenv
      Built gpustat==1.1.1
 Downloading ray
Prepared 56 packages in 1.40s
Installed 56 packages in 54ms
 + aiohappyeyeballs==2.6.1
 + aiohttp==3.13.0
 + aiohttp-cors==0.8.1
 + aiosignal==1.4.0
 + annotated-types==0.7.0
 + async-timeout==5.0.1
 + attrs==25.4.0
 + blessed==1.22.0
 + cachetools==6.2.1
 + certifi==2025.10.5
 + charset-normalizer==3.4.4
 + click==8.3.0
 + colorful==0.5.7
 + distlib==0.4.0
 + filelock==3.20.0
 + frozenlist==1.8.0
 + google-api-core==2.26.0
 + google-auth==2.41.1
 + googleapis-common-protos==1.70.0
 + gpustat==1.1.1
 + grpcio==1.75.1
 + idna==3.11
 + jsonschema==4.25.1
 + jsonschema-specifications==2025.9.1
 + msgpack==1.1.2
 + multidict==6.7.0
 + nvidia-ml-py==13.580.82
 + opencensus==0.11.4
 + opencensus-context==0.1.3
 + packaging==25.0
 + platformdirs==4.5.0
 + prometheus-client==0.23.1
 + propcache==0.4.1
 + proto-plus==1.26.1
 + protobuf==6.32.1
 + psutil==7.1.0
 + py-spy==0.4.1
 + pyasn1==0.6.1
 + pyasn1-modules==0.4.2
 + pydantic==2.12.0
 + pydantic-core==2.41.1
 + pyyaml==6.0.3
 + ray==2.9.3
 + referencing==0.37.0
 + requests==2.32.5
 + rpds-py==0.27.1
 + rsa==4.9.1
 + six==1.17.0
 + smart-open==7.3.1
 + typing-extensions==4.15.0
 + typing-inspection==0.4.2
 + urllib3==2.5.0
 + virtualenv==20.35.3
 + wcwidth==0.2.14
 + wrapt==1.17.3
 + yarl==1.22.0
Using Python 3.10.13 environment at: skypilot-runtime
Using Python 3.10.13 environment at: skypilot-runtime
warning: Skipping skypilot as it is not installed
warning: No packages to uninstall
Using Python 3.10.13 environment at: skypilot-runtime
Resolved 105 packages in 462ms
Downloading pygments (1.2MiB)
Downloading awscli (4.5MiB)
Downloading botocore (13.4MiB)
Downloading pandas (11.6MiB)
Downloading sqlalchemy (3.1MiB)
Downloading asyncpg (2.8MiB)
Downloading numpy (13.6MiB)
Downloading networkx (1.6MiB)
Downloading pulp (15.6MiB)
Downloading uvloop (3.7MiB)
Downloading cryptography (4.1MiB)
Downloading psycopg2-binary (4.2MiB)
 Downloading pygments
 Downloading asyncpg
 Downloading sqlalchemy
 Downloading uvloop
 Downloading psycopg2-binary
 Downloading networkx
 Downloading cryptography
 Downloading numpy
 Downloading pulp
 Downloading botocore
 Downloading pandas
 Downloading awscli
Prepared 67 packages in 2.22s
Uninstalled 2 packages in 0.96ms
Installed 68 packages in 242ms
 + aiofiles==25.1.0
 + aiosqlite==0.21.0
 + alembic==1.17.0
 + anyio==4.11.0
 + asyncpg==0.30.0
 + awscli==1.42.51
 + bcrypt==4.0.1
 + boto3==1.40.51
 + botocore==1.40.51
 + bracex==2.6
 + casbin==1.43.0
 + cffi==2.0.0
 - click==8.3.0
 + click==8.1.8
 + colorama==0.4.4
 + cryptography==46.0.2
 + docutils==0.19
 + exceptiongroup==1.3.0
 + fastapi==0.119.0
 + gitdb==4.0.12
 + gitpython==3.1.45
 + greenlet==3.2.4
 + h11==0.16.0
 + httpcore==1.0.9
 + httptools==0.7.1
 + httpx==0.28.1
 + ijson==3.4.0.post0
 + jinja2==3.1.6
 + jmespath==1.0.1
 + mako==1.3.10
 + markdown-it-py==4.0.0
 + markupsafe==3.0.3
 + mdurl==0.1.2
 + networkx==3.4.2
 + numpy==2.2.6
 + pandas==2.3.3
 + passlib==1.7.4
 + pendulum==3.1.0
 + prettytable==3.16.0
 + psycopg2-binary==2.9.11
 + pulp==3.3.0
 + pycasbin==2.3.0
 + pycparser==2.23
 + pygments==2.19.2
 + pyjwt==2.10.1
 + python-dateutil==2.9.0.post0
 + python-dotenv==1.1.1
 + python-multipart==0.0.20
 + pytz==2025.2
 + rich==14.2.0
 - rsa==4.9.1
 + rsa==4.7.2
 + s3transfer==0.14.0
 + setproctitle==1.3.7
 + simpleeval==1.0.3
 + skypilot==1.0.0.dev0 (from file:///home/ubuntu/.sky/wheels/3f4e4a05e5168d61078562d54318597b/skypilot-1.0.0.dev0-py3-none-any.whl)
 + smmap==5.0.2
 + sniffio==1.3.1
 + sqlalchemy==2.0.44
 + sqlalchemy-adapter==1.7.0
 + starlette==0.48.0
 + tabulate==0.9.0
 + tomli==2.3.0
 + types-paramiko==4.0.0.20250822
 + tzdata==2025.2
 + uvicorn==0.35.0
 + uvloop==0.21.0
 + watchfiles==1.1.0
 + wcmatch==10.1
 + websockets==15.0.1
Using Python 3.10.13 environment at: skypilot-runtime
Create backup file /home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/ray/_private/log_monitor.py-v2.9.3.orig
patching file /home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/ray/_private/log_monitor.py (read from /home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/ray/_private/log_monitor.py-v2.9.3.orig)
Create backup file /home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/ray/_private/worker.py-v2.9.3.orig
patching file /home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/ray/_private/worker.py (read from /home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/ray/_private/worker.py-v2.9.3.orig)
Create backup file /home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/ray/dashboard/modules/job/cli.py-v2.9.3.orig
patching file /home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/ray/dashboard/modules/job/cli.py (read from /home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/ray/dashboard/modules/job/cli.py-v2.9.3.orig)
Create backup file /home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/ray/autoscaler/_private/autoscaler.py-v2.9.3.orig
patching file /home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/ray/autoscaler/_private/autoscaler.py (read from /home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/ray/autoscaler/_private/autoscaler.py-v2.9.3.orig)
Create backup file /home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/ray/autoscaler/_private/command_runner.py-v2.9.3.orig
patching file /home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/ray/autoscaler/_private/command_runner.py (read from /home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/ray/autoscaler/_private/command_runner.py-v2.9.3.orig)
Create backup file /home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/ray/autoscaler/_private/resource_demand_scheduler.py-v2.9.3.orig
patching file /home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/ray/autoscaler/_private/resource_demand_scheduler.py (read from /home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/ray/autoscaler/_private/resource_demand_scheduler.py-v2.9.3.orig)
Create backup file /home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/ray/autoscaler/_private/updater.py-v2.9.3.orig
patching file /home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/ray/autoscaler/_private/updater.py (read from /home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/ray/autoscaler/_private/updater.py-v2.9.3.orig)
I 10-14 13:58:50 common.py:303] --------------------End:   setup_runtime_on_cluster --------------------
I 10-14 13:58:50 common.py:303] 
D 10-14 13:58:50 provisioner.py:651] Starting Ray on the entire cluster.
I 10-14 13:58:50 common.py:299] 
I 10-14 13:58:50 common.py:299] --------------------Start: start_ray_on_head_node --------------------
I 10-14 13:58:50 instance_setup.py:386] Running command on head node: env -u PYTHONPATH $([ -s ~/.sky/python_path ] && cat ~/.sky/python_path 2> /dev/null || which python3) $([ -s ~/.sky/ray_path ] && cat ~/.sky/ray_path 2> /dev/null || which ray) stop; RAY_SCHEDULER_EVENTS=0 RAY_DEDUP_LOGS=0 RAY_worker_maximum_startup_concurrency=$(( 3 * $(nproc --all) )) env -u PYTHONPATH $([ -s ~/.sky/python_path ] && cat ~/.sky/python_path 2> /dev/null || which python3) $([ -s ~/.sky/ray_path ] && 
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
