### PR TITLE
[Doc] Add description to disable config to scrape gpu-metrics

### DIFF
--- a/docs/source/reference/api-server/examples/api-server-metrics-setup.rst
+++ b/docs/source/reference/api-server/examples/api-server-metrics-setup.rst
@@ -35,7 +35,7 @@ chart deploy everything for you with a single command:
       --set prometheus.enabled=true \
       --set grafana.enabled=true
 
-.. note::
+.. dropdown:: Turn off GPU metrics scraping
 
    The above command also configures Prometheus to scrape the SkyPilot API server's ``/gpu-metrics`` endpoint. To disable scraping of ``/gpu-metrics``, append ``--set prometheus.extraScrapeConfigs=""`` to the Helm command:
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Add description to disable config to scrape gpu-metrics

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
