### PR TITLE
[docs] fix sql deployment doc

### DIFF
--- a/docs/source/reference/api-server/examples/example-deploy-gcp-cloud-sql.rst
+++ b/docs/source/reference/api-server/examples/example-deploy-gcp-cloud-sql.rst
@@ -34,13 +34,13 @@ Create a GKE cluster
 
         **CLI:** 
         
-        Add ``--enable-workload-identity`` flag to ``gcloud container clusters create`` command as shown:
+        Add ``--workload-pool`` flag to ``gcloud container clusters create`` command as shown:
 
         .. code-block:: bash
 
             gcloud container clusters create <cluster-name> \
                 ...
-                --enable-workload-identity
+                --workload-pool=<project-id>.svc.id.goog
 
         **Web Console:**
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
While deploying a postgres connected API Server I noticed the docs are a little off.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
