### PR TITLE
fix test_kubernetes_storage_mounts

### DIFF
--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -187,6 +187,11 @@ def _storage_mounts_commands_generator(f: TextIO, cluster_name: str,
     f.flush()
     file_path = f.name
 
+    # stop is not supported on kubernetes
+    stop_command = ''
+    if cloud != 'kubernetes':
+        stop_command = f'sky stop -y {cluster_name}'
+
     test_commands = [
         smoke_tests_utils.launch_cluster_for_cloud_cmd(cloud, cluster_name),
         *smoke_tests_utils.STORAGE_SETUP_COMMANDS,
@@ -194,7 +199,7 @@ def _storage_mounts_commands_generator(f: TextIO, cluster_name: str,
         f'sky logs {cluster_name} 1 --status',  # Ensure job succeeded.
         smoke_tests_utils.run_cloud_cmd_on_cluster(cluster_name,
                                                    cmd=ls_hello_command),
-        f'sky stop -y {cluster_name}',
+        stop_command,
         f'sky start -y {cluster_name}',
         # Check if hello.txt from mounting bucket exists after restart in
         # the mounted directory


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The `stop` operation is not supported on kubernetes. This PR avoids calling `stop` on a cluster when it is hosted on kubernetes.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
