### PR TITLE
[Config] Only override `controller.consolidation_mode` config for now

### DIFF
--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -414,6 +414,12 @@ SKIPPED_CLIENT_OVERRIDE_KEYS: List[Tuple[str, ...]] = [
     ('daemons',),
     # TODO(kevin,tian): Override the whole controller config once our test
     # infrastructure supports setting dynamic server side configs.
+    # Tests that are affected:
+    # - test_managed_jobs_ha_kill_starting
+    # - test_managed_jobs_ha_kill_running
+    # - all tests that use LOW_CONTROLLER_RESOURCE_ENV or
+    #   LOW_CONTROLLER_RESOURCE_OVERRIDE_CONFIG (won't cause test failure,
+    #   but the configs won't be applied)
     ('jobs', 'controller', 'consolidation_mode'),
     ('serve', 'controller', 'consolidation_mode'),
 ]


### PR DESCRIPTION
This reverts parts of commit 40995a2a8b9b57535ea664d6d9fd14529d878093.

This change skipped the `('jobs', 'controller')` and `('serve', 'controller')` from the client config override, which is the right thing to do. But as a result, our existing `test_managed_jobs_ha_kill_*` broke, because it's overriding the high_availability config from the client, not the server.

We should properly fix our test setup such that these configs can be applied on the server side. But in the meantime to unblock nightly, let's ~~revert this change~~ instead skip just the consolidation_mode config, instead of the whole controller config, so that HA config is still allowed to override.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
