### PR TITLE
remove same length assumption between records and updated_records

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -3370,7 +3370,9 @@ def get_clusters(
         with progress:
             updated_records = subprocess_utils.run_in_parallel(
                 _refresh_cluster_record, cluster_names_without_launch_request)
-    updated_records_dict = {record['cluster_hash']: record for record in updated_records}
+    updated_records_dict = {
+        record['cluster_hash']: record for record in updated_records
+    }
     # Show information for removed clusters.
     kept_records = []
     autodown_clusters, remaining_clusters, failed_clusters = [], [], []
@@ -3386,8 +3388,7 @@ def get_clusters(
             else:
                 remaining_clusters.append(record['name'])
         elif updated_record['status'] == 'UNKNOWN':
-            failed_clusters.append(
-                (record['name'], updated_record['error']))
+            failed_clusters.append((record['name'], updated_record['error']))
             # Keep the original record if the status is unknown,
             # so that the user can still see the cluster.
             kept_records.append(record)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The culprit: https://github.com/skypilot-org/skypilot/pull/7076/files#diff-5d3b8c053073eef6241a9fc4439b8e97c680e73e6dbfe01a587eea2bf0000c4dL3236-R3342

<img width="681" height="881" alt="Screenshot 2025-10-14 at 9 28 41 PM" src="https://github.com/user-attachments/assets/ff8b02e5-d1aa-4e9b-be25-73f2baf204b2" />

Notice that before the offending change, `records` and `updated_records` are guaranteed to be the same length, but after the change these two lists do not have to be the same length (specifically, `updated_records` can be shorter than `records`). The codepath afterwards still assume the two lists are the same length, which can cause `list index out of range` issues.

The codepath is refactored to work when `updated_records` are shorter than `records`


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
