### PR TITLE
fix record matching logic

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -3378,8 +3378,9 @@ def get_clusters(
                     cluster_name
                     for _, cluster_name in cluster_names_without_launch_request
                 ])
-        # Preserve the index of the cluster name as it appears on "records"
-    updated_records_dict = {
+    # Preserve the index of the cluster name as it appears on "records"
+    # before filtering for clusters being launched.
+    updated_records_dict: Dict[int, Optional[Dict[str, Any]]] = {
         cluster_names_without_launch_request[i][0]: updated_records[i]
         for i in range(len(cluster_names_without_launch_request))
     }


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The previous PR https://github.com/skypilot-org/skypilot/pull/7623 was directionally correct but overlooked the fact that the returned `updated_records` may contain None records, causing `record['cluster_hash']: record for record in updated_records` to fail. This PR improves the matching logic to not rely on the returned record value to correlate between original and updated clusters.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
