### PR TITLE
[Logs] improve logging clarity in distributed postgres lock close connection failure case

### DIFF
--- a/sky/utils/locks.py
+++ b/sky/utils/locks.py
@@ -312,8 +312,11 @@ class PostgresLock(DistributedLock):
                 else:
                     self._connection.close()
             except Exception as e:  # pylint: disable=broad-except
-                logger.debug(
-                    f'Failed to invalidate or close postgres connection: {e}')
+                if invalidate:
+                    logger.debug(
+                        f'Failed to invalidate postgres connection: {e}')
+                else:
+                    logger.debug(f'Failed to close postgres connection: {e}')
             self._connection = None
 
     def is_locked(self) -> bool:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR adds a distinction between a failure in `invalidate()` and `close()` in the debug logs when an exception is raised when closing the postgres connection in the distributed postgres lock. 

The original log line was added in https://github.com/skypilot-org/skypilot/pull/7584.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
