### PR TITLE
[Docs] Update backwards compatibility instructions in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -290,6 +290,7 @@ However, when the value of the new field is taken from user input (e.g. CLI flag
 from sky.server import versions
 
 @click.option('--newflag', default=None)
+# Must have this or the version will be None!
 @server_common.check_server_healthy_or_start
 def cli_entry_point(newflag: Optional[str] = None):
     # The new flag is set but the server does not support the new field yet


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
I ran into an issue when working on https://github.com/skypilot-org/skypilot/pull/7617 where I tried to check the api server version in `sky/client/cli/command.py` but got `None` unless I added the `@server_common.check_server_healthy_or_start` decorator around the cli entrypoint. We should update the docs to reflect this.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
