### PR TITLE
[UX] show request waiting spinner for short requests

### DIFF
--- a/sky/server/stream_utils.py
+++ b/sky/server/stream_utils.py
@@ -25,6 +25,9 @@ logger = sky_logging.init_logger(__name__)
 _BUFFER_SIZE = 8 * 1024  # 8KB
 _BUFFER_TIMEOUT = 0.02  # 20ms
 _HEARTBEAT_INTERVAL = 30
+# If a SHORT request has been stuck in pending for
+# _SHORT_REQUEST_SPINNER_TIMEOUT seconds, we show the waiting spinner
+_SHORT_REQUEST_SPINNER_TIMEOUT = 2
 
 LONG_REQUEST_POLL_INTERVAL = 1
 DEFAULT_POLL_INTERVAL = 0.1
@@ -66,6 +69,7 @@ async def log_streamer(
     """
 
     if request_id is not None:
+        start_time = asyncio.get_event_loop().time()
         status_msg = rich_utils.EncodedStatusMessage(
             f'[dim]Checking request: {request_id}[/dim]')
         request_task = await requests_lib.get_request_async(request_id)
@@ -75,7 +79,12 @@ async def log_streamer(
                 status_code=404, detail=f'Request {request_id} not found')
         request_id = request_task.request_id
 
-        show_request_waiting_spinner = not plain_logs
+        # By default, do not show the waiting spinner for SHORT requests.
+        # If the request has been stuck in pending for
+        # _SHORT_REQUEST_SPINNER_TIMEOUT seconds, we show the waiting spinner
+        show_request_waiting_spinner = (not plain_logs and
+                                        request_task.schedule_type
+                                        == requests_lib.ScheduleType.LONG)
 
         if show_request_waiting_spinner:
             yield status_msg.init()
@@ -91,6 +100,14 @@ async def log_streamer(
                                        max_backoff_factor=10,
                                        multiplier=1.2)
         while req_status < requests_lib.RequestStatus.RUNNING:
+            current_time = asyncio.get_event_loop().time()
+            # Show the waiting spinner for a SHORT request if it has been stuck
+            # in pending for _SHORT_REQUEST_SPINNER_TIMEOUT seconds
+            if not show_request_waiting_spinner and (
+                    current_time - start_time > _SHORT_REQUEST_SPINNER_TIMEOUT):
+                show_request_waiting_spinner = True
+                yield status_msg.init()
+                yield status_msg.start()
             if req_msg is not None:
                 waiting_msg = request_task.status_msg
             if show_request_waiting_spinner:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR addresses an issue where certain cli commands including `sky launch` and `sky status` appear to hang when the server is under load. This could be due to SHORT requests being blocked. Previously, we only showed a spinner if the pending request was a LONG request. This PR changes the behavior to show a spinner for both SHORT and LONG requests. 

We add special handling to the `sky down` code path because it already has a spinner that prints "Terminating <num> clusters..." which interferes with our newly added "Waiting for 'sky.down' request to be scheduled", causing them to overwrite one another. 

<!-- Describe the tests ran -->
I tested by injecting a call to `time.sleep(10)` in `executor.py`'s `_request_execution_wrapper` function right before we set `request_task.status = api_requests.RequestStatus.RUNNING`. This makes every request stay stuck in `PENDING` state for at least 10s. 
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
