### PR TITLE
[db] Use uuid7 as request IDs

### DIFF
--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -162,6 +162,10 @@ class RequestIDMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
     """Middleware to add a request ID to each request."""
 
     async def dispatch(self, request: fastapi.Request, call_next):
+        # request ID is a primary key in the request table,
+        # so it gets an index.
+        # Use uuid7 to encourage sequential inserts,
+        # which is more efficient when inserting into an indexed column.
         request_id = str(uuid.uuid7())
         request.state.request_id = request_id
         response = await call_next(request)

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -89,6 +89,7 @@ install_requires = [
     'aiosqlite',
     'anyio',
     # we use this to get uuid7
+    # note: uuid7 support is added to stdlib in Python 3.14
     'uuid-utils',
 ]
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
request ID is a primary key in the requests table, and as primary key, request ID automatically gets an index.

Sequential inserts to index are more performant than random inserts to index. By using uuid7, the first component of which is a timestamp, we can ensure the inserts into the requests table are sequential inserts and improve the write performance of requests.

Normally we'd have to think about how this interacts with all the uuid4s that already exists in the database, but in this particular case we do not need to worry since the requests db is purged on API server restart.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
