### PR TITLE
Add default request for ephemeral storage in helm chart

### DIFF
--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -132,12 +132,6 @@ apiService:
     limits:
       cpu: "4"
       memory: "8Gi"
-      # not much ephemeral-storage is needed when 
-      # persistent storage is enabled.
-      # However, when ephemeral storage is used
-      # (e.g. to enable rollingUpdate), 
-      # it is recommended to set a larger value.
-      ephemeral-storage: "10Gi"
 
   # Extra environment variables to set before starting the API server. Example:
   # extraEnvs:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
In cases where PVCs are not being used (e.g. because rollingUpdate strategy is being used), API server pod can consume a modest - large amount of ephemeral storage. Add some sensible default value for ephemeral storage to requests to values.yaml file.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
