### PR TITLE
Revert "[db] Use uuid7 as request IDs (#7639)"

### DIFF
--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -19,6 +19,7 @@ import sys
 import threading
 import traceback
 from typing import Dict, List, Literal, Optional, Set, Tuple
+import uuid
 import zipfile
 
 import aiofiles
@@ -26,7 +27,6 @@ import anyio
 import fastapi
 from fastapi.middleware import cors
 import starlette.middleware.base
-import uuid_utils as uuid
 import uvloop
 
 import sky
@@ -162,11 +162,7 @@ class RequestIDMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
     """Middleware to add a request ID to each request."""
 
     async def dispatch(self, request: fastapi.Request, call_next):
-        # request ID is a primary key in the request table,
-        # so it gets an index.
-        # Use uuid7 to encourage sequential inserts,
-        # which is more efficient when inserting into an indexed column.
-        request_id = str(uuid.uuid7())
+        request_id = str(uuid.uuid4())
         request.state.request_id = request_id
         response = await call_next(request)
         # TODO(syang): remove X-Request-ID when v0.10.0 is released.

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -88,9 +88,6 @@ install_requires = [
     'aiohttp',
     'aiosqlite',
     'anyio',
-    # we use this to get uuid7
-    # note: uuid7 support is added to stdlib in Python 3.14
-    'uuid-utils',
 ]
 
 # See requirements-dev.txt for the version of grpc and protobuf


### PR DESCRIPTION
This reverts commit 240a49e1261b0a91c9224b087c494229cbda3459.

The problem with this PR is it makes request cancellation by prefix much harder, because the requests all have same prefix. I wouldn't inconvenience our users like that.
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
