### PR TITLE
[Logs] provision log termination debug logs

### DIFF
--- a/sky/server/stream_utils.py
+++ b/sky/server/stream_utils.py
@@ -215,11 +215,18 @@ async def _tail_log_file(
             # periodically to see if provisioning is done.
             if cluster_name is not None and should_check_status:
                 last_status_check_time = current_time
-                cluster_record = await (
+                cluster_status = await (
                     global_user_state.get_status_from_cluster_name_async(
                         cluster_name))
-                if (cluster_record is None or
-                        cluster_record != status_lib.ClusterStatus.INIT):
+                if cluster_status is None:
+                    logger.debug(
+                        'Stop tailing provision logs for cluster'
+                        f' status for cluster {cluster_name} not found')
+                    break
+                if cluster_status != status_lib.ClusterStatus.INIT:
+                    logger.debug(f'Stop tailing provision logs for cluster'
+                                 f' {cluster_name} has status {cluster_status} '
+                                 '(not in INIT state)')
                     break
             if current_time - last_heartbeat_time >= _HEARTBEAT_INTERVAL:
                 # Currently just used to keep the connection busy, refer to


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
We sometimes see provision logs terminating unexpectedly despite `--follow` being set explicitly (or by default). This PR adds debug logs in the provision log termination cases to provide more information in these situations.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
