### PR TITLE
[k8s] Disable compression for websocket proxy

### DIFF
--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2058,7 +2058,8 @@ if __name__ == '__main__':
         uvicorn_config = uvicorn.Config('sky.server.server:app',
                                         host=cmd_args.host,
                                         port=cmd_args.port,
-                                        workers=num_workers)
+                                        workers=num_workers,
+                                        ws_per_message_deflate=False)
         skyuvicorn.run(uvicorn_config,
                        max_db_connections=config.num_db_connections_per_worker)
     except Exception as exc:  # pylint: disable=broad-except


### PR DESCRIPTION
While profiling this code path, I noticed a good chunk of time was being spent on compressing ([permessage-deflate](https://datatracker.ietf.org/doc/html/rfc7692)) the websocket response:
https://kevinmingtarja.github.io/before.svg?s=deflate
https://kevinmingtarja.github.io/before.svg?s=websocket
<img width="1757" height="1124" alt="502434692-1823feb1-f975-430f-ad29-86210011aeed" src="https://github.com/user-attachments/assets/061090d5-de71-4e9d-a38f-05c8629c646b" />



But thinking about it, we are proxying SSH packets, which are encrypted, making it look practically random. So on paper, compression wouldn't do much to reduce the size of the packets anyways. Plus, the packets from the client are likely to be small (keystrokes), although the response from the remote server can be variable in size.

After this change, we spend noticeably less amount of work when sending websocket responses back to the client:
https://kevinmingtarja.github.io/after.svg?s=websocket

<img width="1757" height="1124" alt="502436166-4286ca0b-fff4-440d-97b2-1401d07733ec" src="https://github.com/user-attachments/assets/f95c073d-ee97-4ed4-bdf0-ebe91e4aff73" />


---
# Benchmarks

I used @lloyd-brown's benchmarking script and ran it with N clusters, 1 SSH connection each. The remote API server has 24 vCPUs and 48GiB memory. Overall, we see more improvements when the API server is under load, especially on the tail. The median and average does not differ too much for the no load case.

## With load: 8 status reqs/s + N SSH connections

## N=50

| | min_latency_ms | avg_latency_ms | median_latency_ms | p95_latency_ms | p99_latency_ms | max_latency_ms |
|---|---|---|---|---|---|---|
| Baseline | 59.405 | 197.260 | 181.865 | 345.478 | 438.527 | 1485.466 |
| PR | 56.766 | 169.420 | 158.872 | 297.857 | 388.576 | 631.886 |
| Difference | -2.639 | -27.840 | -22.993 | -47.621 | -49.951 | -853.580 |

## N=100

| | min_latency_ms | avg_latency_ms | median_latency_ms | p95_latency_ms | p99_latency_ms | max_latency_ms |
|---|---|---|---|---|---|---|
| Baseline | 60.475 | 283.945 | 258.847 | 534.755 | 722.586 | 2526.891 |
| PR | 60.524 | 268.084 | 249.900 | 489.536 | 624.133 | 1014.126 |
| Difference | +0.049 | -15.861 | -8.947 | -45.219 | -98.453 | -1512.765 |

## Without load: just N SSH connections

## N=50

| | min_latency_ms | avg_latency_ms | median_latency_ms | p95_latency_ms | p99_latency_ms | max_latency_ms |
|---|---|---|---|---|---|---|
| Baseline | 53.646 | 60.895 | 57.849 | 70.936 | 100.155 | 451.919 |
| PR | 53.413 | 62.707 | 57.932 | 86.303 | 139.413 | 388.313 |
| Difference | -0.233 | +1.812 | +0.083 | +15.367 | +39.258 | -63.606 |

## N=100

| | min_latency_ms | avg_latency_ms | median_latency_ms | p95_latency_ms | p99_latency_ms | max_latency_ms |
|---|---|---|---|---|---|---|
| Baseline | 51.860 | 75.117 | 68.485 | 99.113 | 214.206 | 612.903 |
| PR | 54.210 | 74.297 | 68.233 | 99.581 | 180.487 | 452.313 |
| Difference | +2.350 | -0.820 | -0.252 | +0.468 | -33.719 | -160.590 |

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
