### PR TITLE
Fixed lock leak on requests cancellation + GC

### DIFF
--- a/sky/utils/asyncio_utils.py
+++ b/sky/utils/asyncio_utils.py
@@ -2,17 +2,77 @@
 
 import asyncio
 import functools
+from typing import Set
+
+_background_tasks: Set[asyncio.Task] = set()
 
 
 def shield(func):
     """Shield the decorated async function from cancellation.
 
-    Note that filelock.AsyncFileLock is not cancellation safe, thus the
-    function calls filelock.AsyncFileLock must be shielded.
+    If the outter coroutine is cancelled, the inner decorated function
+    will be protected from cancellation by asyncio.shield(). And we will
+    maintain a reference to the the inner task to avoid it get GCed before
+    it is done.
+
+    For example, filelock.AsyncFileLock is not cancellation safe. The
+    following code:
+
+        async def fn_with_lock():
+            async with filelock.AsyncFileLock('lock'):
+                await asyncio.sleep(1)
+
+    is equivalent to:
+
+        # The lock may leak if the cancellation happens in
+        # lock.acquire() or lock.release()
+        async def fn_with_lock():
+            lock = filelock.AsyncFileLock('lock')
+            await lock.acquire()
+            try:
+                await asyncio.sleep(1)
+            finally:
+                await lock.release()
+
+    Shilding the function ensures there is no cancellation will happen in the
+    function, thus the lock will be released properly:
+
+        @shield
+        async def fn_with_lock()
+
+    Note that the resource acquisition and release should usually be protected
+    in one @shield block but not separately, e.g.:
+
+        lock = filelock.AsyncFileLock('lock')
+
+        @shield
+        async def acquire():
+            await lock.acquire()
+
+        @shield
+        async def release():
+            await lock.release()
+
+        async def fn_with_lock():
+            await acquire()
+            try:
+                do_something()
+            finally:
+                await release()
+
+    The above code is not safe because if `fn_with_lock` is cancelled,
+    `acquire()` and `release()` will be executed in the background
+    concurrently and causes race conditions.
     """
 
     @functools.wraps(func)
     async def async_wrapper(*args, **kwargs):
-        return await asyncio.shield(func(*args, **kwargs))
+        task = asyncio.create_task(func(*args, **kwargs))
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            _background_tasks.add(task)
+            task.add_done_callback(lambda _: _background_tasks.discard(task))
+            raise
 
     return async_wrapper

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -1194,6 +1194,7 @@ def test_update_request_row_fields_maintains_order():
 
 @pytest.mark.asyncio
 async def test_cancel_get_request_async():
+    import gc
 
     async def mock_get_request_async_no_lock(id: str):
         await asyncio.sleep(1)
@@ -1211,6 +1212,11 @@ async def test_cancel_get_request_async():
         await asyncio.sleep(0.2)
         for task in tasks:
             task.cancel()
+            # This is critical to proactively calls GC to ensure GC will not
+            # affect the lock release, refer to
+            # https://github.com/skypilot-org/skypilot/issues/7663
+            # for more details.
+            gc.collect()
         try:
             await asyncio.gather(*tasks, return_exceptions=True)
         except Exception:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/7663

I cannot repro this case on a real server with the following script (tried different sleep durations):

```
#!/usr/bin/env bash
set -euo pipefail

for j in {1..100}; do
    echo "Iteration $j"
    pids=()
    for i in {1..10}; do
        sky logs aylei5 > /tmp/logs_$i.txt &
        pid=$!
        pids+=("$pid")
        (
            sleep 10
            kill -s TERM "$pid" 2>/dev/null || true
        ) &
    done

    for pid in "${pids[@]}"; do
        wait "$pid" || true
    done
done
```

But the unit test do indicates we have a risk to leak the lock if the shielded task get GCed.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Unit test
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
