### PR TITLE
[DB] Optimize get_clusters by removing get_users query

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1620,8 +1620,10 @@ def get_clusters(
                 cluster_table.c.storage_mounts_metadata,
                 cluster_table.c.cluster_ever_up,
                 cluster_table.c.status_updated_at, cluster_table.c.user_hash,
-                cluster_table.c.config_hash, cluster_table.c.workspace,
-                cluster_table.c.is_managed)
+                cluster_table.c.config_hash,
+                cluster_table.c.workspace, cluster_table.c.is_managed,
+                user_table.c.name.label('user_name')).outerjoin(
+                    user_table, cluster_table.c.user_hash == user_table.c.id)
         else:
             query = session.query(
                 cluster_table.c.name,
@@ -1643,7 +1645,9 @@ def get_clusters(
                 cluster_table.c.is_managed,
                 # extra fields compared to above query
                 cluster_table.c.last_creation_yaml,
-                cluster_table.c.last_creation_command)
+                cluster_table.c.last_creation_command,
+                user_table.c.name.label('user_name')).outerjoin(
+                    user_table, cluster_table.c.user_hash == user_table.c.id)
         if exclude_managed_clusters:
             query = query.filter(cluster_table.c.is_managed == int(False))
         if workspaces_filter is not None:
@@ -1666,28 +1670,22 @@ def get_clusters(
         rows = query.all()
     records = []
 
-    # get user hash for each row
-    row_to_user_hash = {}
-    for row in rows:
-        user_hash = (row.user_hash
-                     if row.user_hash is not None else current_user_hash)
-        row_to_user_hash[row.cluster_hash] = user_hash
-
-    # get all users needed for the rows at once
-    user_hashes = set(row_to_user_hash.values())
-    user_hash_to_user = get_users(user_hashes)
+    # Check if we need to fetch the current user's name,
+    # for backwards compatibility, if user_hash is None.
+    current_user_name = None
+    needs_current_user = any(row.user_hash is None for row in rows)
+    if needs_current_user:
+        current_user = get_user(current_user_hash)
+        current_user_name = (current_user.name
+                             if current_user is not None else None)
 
     # get last cluster event for each row
-    cluster_hashes = set(row_to_user_hash.keys())
     if not summary_response:
+        cluster_hashes = {row.cluster_hash for row in rows}
         last_cluster_event_dict = _get_last_cluster_event_multiple(
             cluster_hashes, ClusterEventType.STATUS_CHANGE)
 
-    # get user for each row
     for row in rows:
-        user_hash = row_to_user_hash[row.cluster_hash]
-        user = user_hash_to_user.get(user_hash, None)
-        user_name = user.name if user is not None else None
         # TODO: use namedtuple instead of dict
         record = {
             'name': row.name,
@@ -1704,8 +1702,10 @@ def get_clusters(
                 row.storage_mounts_metadata),
             'cluster_ever_up': bool(row.cluster_ever_up),
             'status_updated_at': row.status_updated_at,
-            'user_hash': user_hash,
-            'user_name': user_name,
+            'user_hash': (row.user_hash
+                          if row.user_hash is not None else current_user_hash),
+            'user_name': (row.user_name
+                          if row.user_name is not None else current_user_name),
             'workspace': row.workspace,
             'is_managed': bool(row.is_managed),
             'config_hash': row.config_hash,


### PR DESCRIPTION
Instead of making a query to `get_users`, we should just do a LEFT OUTER JOIN with the users table to get the user_name, to reduce one RTT to the DB.

Benchmarked with `multitime -n 50 sky status --no-show-managed-jobs --no-show-services --no-show-pools`:
- Local API server
- GCP Cloud SQL Postgres, in us-west1 (oregon)
- 2k clusters, 100 users

Before:
```
            Mean        Std.Dev.    Min         Median      Max
real        9.331       1.812       7.404       8.909       19.367
```

After:
```
            Mean        Std.Dev.    Min         Median      Max
real        8.624       1.081       6.835       8.447       10.925
```

Saw some small improvements across the board.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
