### PR TITLE
strict checking for context-name in Node Pools to start with "ssh-"

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1480,6 +1480,7 @@ class RetryingVmProvisioner(object):
         elif to_provision.region is not None and to_provision.cloud is not None:
             # For public clouds, provision.region is always set.
             if clouds.SSH().is_same_cloud(to_provision.cloud):
+                assert to_provision.region.startswith("ssh-"), "SSH context must start with 'ssh-'"
                 message += (
                     f'in SSH Node Pool ({to_provision.region.lstrip("ssh-")}) '
                     f'for {requested_resources}. The SSH Node Pool may not '

--- a/sky/check.py
+++ b/sky/check.py
@@ -591,6 +591,7 @@ def _format_context_details(cloud: Union[str, sky_clouds.Cloud],
                                               'configuration.'))
                 else:
                     # Default case - not set up
+                    assert context.startswith("ssh-"), "SSH context must start with 'ssh-'"
                     text_suffix = (': ' + _red_color('disabled. ') +
                                    _dim_color('Reason: Not set up. Use '
                                               '`sky ssh up --infra '

--- a/sky/clouds/ssh.py
+++ b/sky/clouds/ssh.py
@@ -252,7 +252,7 @@ class SSH(kubernetes.Kubernetes):
     @classmethod
     def expand_infras(cls) -> List[str]:
         return [
-            f'{cls.canonical_name()}/{c.lstrip("ssh-")}'
+            f'{cls.canonical_name()}/{c.lstrip("ssh-")}' if c.startswith("ssh-") else "."
             for c in cls.existing_allowed_contexts(silent=True)
         ]
 

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1289,6 +1289,7 @@ def _check_specified_regions(task: task_lib.Task) -> None:
         msg = f'Task{task_name} requires '
         if region not in existing_contexts:
             if is_ssh:
+                assert region.startswith("ssh-"), "SSH context must start with 'ssh-'"
                 infra_str = f'SSH/{region.lstrip("ssh-")}'
             else:
                 infra_str = f'Kubernetes/{region}'


### PR DESCRIPTION
…th "ssh-"

<!-- Describe the changes in this PR -->
Assertions added for context-name to start with "ssh-" 

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
