### PR TITLE
[requests] Cleanup stale requests in batches

### DIFF
--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -962,6 +962,8 @@ async def clean_finished_requests_with_retention(retention_seconds: int,
 
         await _delete_requests(reqs)
         total_deleted += len(reqs)
+        if len(reqs) < batch_size:
+            break
 
     # To avoid leakage of the log file, logs must be deleted before the
     # request task in the database.

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -216,12 +216,11 @@ async def test_clean_finished_requests_with_retention_batch_size_functionality(
         assert requests.get_request(req.request_id) is not None
 
     # Verify batching occurred - should have made multiple calls with decreasing counts
-    # First call should return 10 (limited), second call should return 10, third call should return 5, fourth call should return 0
-    assert len(call_counts) >= 3  # At least 3 calls (10, 10, 5, 0)
+    # First call should return 10 (limited), second call should return 10, third call should return 5
+    assert len(call_counts) == 3  # At 3 calls (10, 10, 5)
     assert call_counts[0] == 10  # First batch
     assert call_counts[1] == 10  # Second batch
     assert call_counts[2] == 5  # Third batch (remaining)
-    assert call_counts[3] == 0  # Final call returns empty (loop termination)
 
     # Verify log file unlink was called for each deleted request
     assert mock_unlink.call_count == 25
@@ -276,10 +275,9 @@ async def test_clean_finished_requests_with_retention_limit_larger_than_total(
     for req in old_requests:
         assert requests.get_request(req.request_id) is None
 
-    # Should only need 2 calls: one returning 5 requests, one returning 0 (termination)
-    assert len(call_counts) == 2
-    assert call_counts[0] == 5  # All 5 requests in first batch
-    assert call_counts[1] == 0  # Empty result terminates loop
+    # Should only need 1 calls: one returning 5 requests(termination)
+    assert len(call_counts) == 1
+    assert call_counts[0] == 5  # All 5 requests in the batch
 
     # Verify logging
     mock_logger.info.assert_called_once()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
In `clean_finished_requests_with_retention`, delete stale requests in a batch of 1000 requests instead of deleting all stale requests (which can technically be unbounded)


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
