### PR TITLE
Update `bert_qa.yaml` example

### DIFF
--- a/examples/spot/bert_qa.yaml
+++ b/examples/spot/bert_qa.yaml
@@ -1,7 +1,7 @@
 name: bert_qa
 
 resources:
-    accelerators: V100:1
+    accelerators: H100:1
     
 file_mounts:
     /checkpoint:


### PR DESCRIPTION
Updating `bert_qa.yaml` example:
- Removing the need to clone the repo locally
- Setting `WANDB_API_KEY` as an env var
- To allow logging into the same wandb run, we need to set `WANDB_RESUME=allow` and `WANDB_RUN_ID=$SKYPILOT_TASK_ID`