### PR TITLE
[Tests] Debug 7624 Non-CI Failure

### DIFF
--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -246,4 +246,4 @@ def test_get_clusters_launch_refresh(monkeypatch):
                         get_request_tasks)
 
     assert len(
-        backend_utils.get_clusters(refresh=common.StatusRefreshMode.FORCE)) == 3
+        backend_utils.get_clusters(refresh=common.StatusRefreshMode.FORCE)) == 2


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Problem: #7624 introduced a new unit test called `test_get_clusters_launch_refresh` in `test_backend_utils.py`. When the test was first added, it was supposed to fail (as it was intended to catch a failure on that current master). This was commit [daad965](https://github.com/skypilot-org/skypilot/pull/7673/commits/daad965a1fea851c04096aa8cf3600f013759d8a).

The test failed successfully locally, but it was passing for some reason on CI. This PR resets to the point where the test should have failed in hopes of ci debugging.

Related: #7624


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
