### PR TITLE
Include cloud name in bucket creation errors

### DIFF
--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -2015,7 +2015,7 @@ class S3CompatibleStore(AbstractStore):
         except aws.botocore_exceptions().ClientError as e:
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.StorageBucketCreateError(
-                    f'Attempted to create a bucket {self.name} but failed.'
+                    f'Attempted to create S3 bucket {self.name} but failed.'
                 ) from e
         return self.config.resource_factory(bucket_name)
 
@@ -2554,7 +2554,7 @@ class GcsStore(AbstractStore):
         except Exception as e:  # pylint: disable=broad-except
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.StorageBucketCreateError(
-                    f'Attempted to create a bucket {self.name} but failed.'
+                    f'Attempted to create GCS bucket {self.name} but failed.'
                 ) from e
         logger.info(
             f'  {colorama.Style.DIM}Created GCS bucket {new_bucket.name!r} in '


### PR DESCRIPTION
There are two identical errors that say "Attempted to create a bucket _ but failed." but it's hard to tell what kind of bucket it refers to.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
