### PR TITLE
[Core] Cache check_workspace_permission per-request

### DIFF
--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -14,6 +14,7 @@ from sky import models
 from sky import sky_logging
 from sky.skylet import constants
 from sky.users import rbac
+from sky.utils import annotations
 from sky.utils import common_utils
 from sky.utils.db import db_utils
 
@@ -254,6 +255,9 @@ class PermissionService:
         with _policy_lock():
             self._load_policy_no_lock()
 
+    # Right now, not a lot of users are using multiple workspaces,
+    # so 5 should be more than enough.
+    @annotations.lru_cache(scope='request', maxsize=5)
     def check_workspace_permission(self, user_id: str,
                                    workspace_name: str) -> bool:
         """Check workspace permission.


### PR DESCRIPTION
In `POST /status`, `check_workspace_permission` is called twice:
1. In `override_request_env_and_config`, we call `reject_request_for_unauthorized_workspace`, which calls `check_workspace_permission` on the current active workspace (This is called for every request, not just status, so this PR should benefit other API endpoints too)
2. `get_clusters` calls `get_workspaces` calls `workspaces_for_user` calls `check_workspace_permission` for each available workspace


<p float="left">
<img width="400" alt="Screenshot 2025-10-21 at 12 01 05 AM" src="https://github.com/user-attachments/assets/d7506f5b-d544-4aa8-9565-184c704f0b39" />
<img width="400" alt="Screenshot 2025-10-21 at 12 00 48 AM" src="https://github.com/user-attachments/assets/b8ec9f57-3241-4089-8203-ac20bf671333" />
</p>


`check_workspace_permission` makes a network call to the DB, so we're wasting one network call here to get the same info we already fetched before.

This PR eliminates this by caching `check_workspace_permission` per-request.

Benchmarked with `multitime -n 50 sky status --no-show-managed-jobs --no-show-services --no-show-pools`:
- Local API server
- GCP Cloud SQL Postgres, in us-west1 (oregon)
- 2k clusters, 100 users

Before:
```
            Mean        Std.Dev.    Min         Median      Max
real        7.156       0.947       5.728       7.088       9.324
```

After:
```
            Mean        Std.Dev.    Min         Median      Max
real        6.311       0.825       5.152       6.320       7.888
```

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
