### PR TITLE
Add checkpoint persistence and WandB tracking to GPT-OSS fine-tuning examples

### DIFF
--- a/llm/gpt-oss-finetuning/README.md
+++ b/llm/gpt-oss-finetuning/README.md
@@ -29,17 +29,17 @@ For more details on how to setup your cloud credentials see [SkyPilot docs](http
 sky check
 ```
 
-### Configure checkpoint storage
+### Configure checkpoint storage (Optional)
 
-Before running training, update the YAML files to specify your S3 bucket for checkpoint persistence:
+Checkpoint storage is optional and only needed if you want to resume training from interruptions. By default, checkpoints are saved locally on the cluster.
+
+To enable checkpoint persistence across cluster restarts, uncomment and configure the S3 bucket in the YAML files:
 
 ```yaml
 file_mounts:
   /checkpoints:
     source: s3://my-skypilot-bucket  # change this to your bucket
 ```
-
-This enables automatic checkpoint saving and resuming from interruptions.
 
 ## Step 1: Run gpt-oss models
 

--- a/llm/gpt-oss-finetuning/gpt-oss-120b-lora.yaml
+++ b/llm/gpt-oss-finetuning/gpt-oss-120b-lora.yaml
@@ -1,11 +1,13 @@
 resources:
   accelerators: H100:8
+  disk_size: 1024
   network_tier: best
 
 file_mounts:
   /sft: ./sft
-  /checkpoints:
-    source: s3://my-skypilot-bucket # change this to your bucket
+  # Uncomment to enable checkpoint persistence across cluster restarts by saving them to S3
+  # /checkpoints:
+  #   source: s3://my-skypilot-bucket # change this to your bucket
 
 envs:
   WANDB_PROJECT: gpt-oss-120b-lora

--- a/llm/gpt-oss-finetuning/gpt-oss-120b-sft.yaml
+++ b/llm/gpt-oss-finetuning/gpt-oss-120b-sft.yaml
@@ -1,11 +1,13 @@
 resources:
   accelerators: H200:8
+  disk_size: 1024
   network_tier: best
 
 file_mounts:
   /sft: ./sft
-  /checkpoints:
-    source: s3://my-skypilot-bucket # change this to your bucket
+  # Uncomment to enable checkpoint persistence across cluster restarts by saving them to S3
+  # /checkpoints:
+  #   source: s3://my-skypilot-bucket # change this to your bucket
 
 envs:
   WANDB_PROJECT: gpt-oss-120b-sft

--- a/llm/gpt-oss-finetuning/gpt-oss-20b-lora.yaml
+++ b/llm/gpt-oss-finetuning/gpt-oss-20b-lora.yaml
@@ -1,11 +1,13 @@
 resources:
   accelerators: H100:2
+  disk_size: 512
   network_tier: best
 
 file_mounts:
   /sft: ./sft
-  /checkpoints:
-    source: s3://my-skypilot-bucket # change this to your bucket
+  # Uncomment to enable checkpoint persistence across cluster restarts by saving them to S3
+  # /checkpoints:
+  #   source: s3://my-skypilot-bucket # change this to your bucket
 
 envs:
   WANDB_PROJECT: gpt-oss-20b-lora

--- a/llm/gpt-oss-finetuning/gpt-oss-20b-sft.yaml
+++ b/llm/gpt-oss-finetuning/gpt-oss-20b-sft.yaml
@@ -2,12 +2,14 @@ name: gpt-oss-20b-sft-finetuning
 
 resources:
   accelerators: H100:8
+  disk_size: 512
   network_tier: best
 
 file_mounts:
   /sft: ./sft
-  /checkpoints:
-    source: s3://my-skypilot-bucket # change this to your bucket
+  # Uncomment to enable checkpoint persistence across cluster restarts by saving them to S3
+  # /checkpoints:
+  #   source: s3://my-skypilot-bucket # change this to your bucket
 
 envs:
   WANDB_PROJECT: gpt-oss-20b-sft

--- a/llm/gpt-oss-finetuning/sft/fsdp2.yaml
+++ b/llm/gpt-oss-finetuning/sft/fsdp2.yaml
@@ -8,6 +8,7 @@ fsdp_config:
   fsdp_activation_checkpointing: true
   fsdp_sharding_strategy: FULL_SHARD
   fsdp_transformer_layer_cls_to_wrap: GptOssDecoderLayer
+  fsdp_backward_prefetch: BACKWARD_PRE
   fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
   fsdp_cpu_ram_efficient_loading: false
   fsdp_offload_params: false

--- a/llm/gpt-oss-finetuning/sft/train.py
+++ b/llm/gpt-oss-finetuning/sft/train.py
@@ -81,6 +81,11 @@ def main():
         action="store_true",
         default=False,
         help="Enable resuming from the latest checkpoint (default: False)")
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default="/checkpoints",
+        help="Directory to save checkpoints (default: /checkpoints)")
     args = parser.parse_args()
 
     # Setup profiling if enabled
@@ -151,9 +156,13 @@ def main():
 
     report_to = "wandb" if os.environ.get("WANDB_API_KEY") else "none"
 
+    # Setup output directory for checkpoints
+    output_dir = os.path.join(args.output_dir, model_id.replace('/', '-'))
+    os.makedirs(output_dir, exist_ok=True)
+
     # Train model
     training_args = SFTConfig(
-        output_dir=f"/checkpoints/{model_id.replace('/', '-')}",
+        output_dir=output_dir,
         learning_rate=2e-4,
         num_train_epochs=1,
         logging_steps=1,


### PR DESCRIPTION
- Checkpoint persistence: mount `/checkpoints` from S3 for automatic checkpoint saving 
- Resume from checkpoint: all training jobs now support `--resume_from_checkpoint` to automatically resume from latest checkpoint
- WandB integration: (optional) experiment tracking with unique run IDs based on `SKYPILOT_TASK_ID`
