### PR TITLE
[core] avoid exception in k8s adaptor __del__

### DIFF
--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -196,9 +196,12 @@ class ClientWrapper:
             if real_client is not None:
                 real_client.close()
             else:
-                logger.debug(f'No client found for {self._client}')
+                # logger may already be cleaned up during __del__ at shutdown
+                if logger is not None:
+                    logger.debug(f'No client found for {self._client}')
         except Exception as e:  # pylint: disable=broad-except
-            logger.debug(f'Error closing Kubernetes client: {e}')
+            if logger is not None:
+                logger.debug(f'Error closing Kubernetes client: {e}')
 
 
 def wrap_kubernetes_client(func):


### PR DESCRIPTION
Before this change, you can see
```
Exception ignored in: <function ClientWrapper.__del__ at 0x7f5322771ea0>
Traceback (most recent call last):
  File "/skypilot/sky/adaptors/kubernetes.py", line 201, in __del__
AttributeError: 'NoneType' object has no attribute 'debug'
Exception ignored in: <function ClientWrapper.__del__ at 0x7f5322771ea0>
Traceback (most recent call last):
  File "/skypilot/sky/adaptors/kubernetes.py", line 201, in __del__
AttributeError: 'NoneType' object has no attribute 'debug'
```

This is due to [how `__del__` works](https://docs.python.org/3/reference/datamodel.html#object.__del__), where other globals may already be unloaded.

> `__del__()` can be executed during interpreter shutdown. As a consequence, the global variables it needs to access (including other modules) may already have been deleted or set to None.

In this case, we shouldn't worry too much about the exception and just continue.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
