### PR TITLE
[requests db] do not grab lock during get operations

### DIFF
--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -675,8 +675,7 @@ def get_latest_request_id() -> Optional[str]:
 def get_request(request_id: str,
                 fields: Optional[List[str]] = None) -> Optional[Request]:
     """Get a SkyPilot API request."""
-    with filelock.FileLock(request_lock_path(request_id)):
-        return _get_request_no_lock(request_id, fields)
+    return _get_request_no_lock(request_id, fields)
 
 
 @init_db_async
@@ -686,9 +685,7 @@ async def get_request_async(
         request_id: str,
         fields: Optional[List[str]] = None) -> Optional[Request]:
     """Async version of get_request."""
-    # TODO(aylei): figure out how to remove FileLock here to avoid the overhead
-    async with filelock.AsyncFileLock(request_lock_path(request_id)):
-        return await _get_request_no_lock_async(request_id, fields)
+    return await _get_request_no_lock_async(request_id, fields)
 
 
 class StatusWithMsg(NamedTuple):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Do not grab the request lock during get operations. The request lock is supposed to protect two updates from racing each other, and get requests aren't relevant.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
