### PR TITLE
[UX] include username and pass in dashboard url

### DIFF
--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -17,7 +17,6 @@ import time
 import typing
 from typing import (Any, Callable, cast, Dict, Generic, Literal, Optional,
                     Tuple, TypeVar, Union)
-from urllib import parse
 import uuid
 
 import cachetools
@@ -342,18 +341,7 @@ def get_server_url(host: Optional[str] = None) -> str:
 @annotations.lru_cache(scope='global')
 def get_dashboard_url(server_url: str,
                       starting_page: Optional[str] = None) -> str:
-    # The server_url may include username or password with the
-    # format of https://username:password@example.com:8080/path
-    # We need to remove the username and password and only
-    # return `https://example.com:8080/path`
-    parsed = parse.urlparse(server_url)
-    # Reconstruct the URL without credentials but keeping the scheme
-    dashboard_url = f'{parsed.scheme}://{parsed.hostname}'
-    if parsed.port:
-        dashboard_url = f'{dashboard_url}:{parsed.port}'
-    if parsed.path:
-        dashboard_url = f'{dashboard_url}{parsed.path}'
-    dashboard_url = dashboard_url.rstrip('/')
+    dashboard_url = server_url.rstrip('/')
     dashboard_url = f'{dashboard_url}/dashboard'
     if starting_page:
         dashboard_url = f'{dashboard_url}/{starting_page}'

--- a/tests/unit_tests/test_sky/server/test_common.py
+++ b/tests/unit_tests/test_sky/server/test_common.py
@@ -267,11 +267,12 @@ def test_get_dashboard_url():
     common.get_server_url.cache_clear()
     assert common.get_dashboard_url(
         server_url='https://user:pass@example.com:8080'
-    ) == 'https://example.com:8080/dashboard'
+    ) == 'https://user:pass@example.com:8080/dashboard'
     """Test get_dashboard_url with URL containing username."""
     common.get_server_url.cache_clear()
-    assert common.get_dashboard_url(server_url='https://user@example.com:8080'
-                                   ) == 'https://example.com:8080/dashboard'
+    assert common.get_dashboard_url(
+        server_url='https://user@example.com:8080'
+    ) == 'https://user@example.com:8080/dashboard'
     """Test get_dashboard_url with host parameter."""
     common.get_server_url.cache_clear()
     assert common.get_dashboard_url(server_url='http://custom-host:8080'
@@ -280,7 +281,7 @@ def test_get_dashboard_url():
     common.get_server_url.cache_clear()
     assert common.get_dashboard_url(
         server_url='https://user:pass@example.com:8080/api/v1'
-    ) == 'https://example.com:8080/api/v1/dashboard'
+    ) == 'https://user:pass@example.com:8080/api/v1/dashboard'
     """Test get_dashboard_url without port."""
     common.get_server_url.cache_clear()
     assert common.get_dashboard_url(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR makes it such that the dashboard url includes the username and password for the api server. This eliminates the need for users to manually login once they open the dashboard.


<!-- Describe the tests ran -->
I updated the related unit tests.

Tested with api server deployed on k8s with basic auth enabled and verified that `sky api login -e` as well as `sky dashboard` both function as expected:

```
❯ sky api login -e http://skypilot:yourpassword@34.69.137.211
Logged into SkyPilot API server at: http://skypilot:yourpassword@34.69.137.211
└── Dashboard: http://skypilot:yourpassword@34.69.137.211/dashboard
```
 and `sky dashboard` did not prompt me for a password (automatically logged in).

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
