### PR TITLE
[Dashboard] deduplicate users

### DIFF
--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -196,9 +196,12 @@ export function Users() {
   const getInitialDeduplicateUsers = () => {
     if (typeof window !== 'undefined' && router.isReady) {
       const deduplicateParam = router.query.deduplicate;
-      return deduplicateParam === 'true';
+      // If parameter is explicitly set, use it; otherwise default to true
+      if (deduplicateParam !== undefined) {
+        return deduplicateParam === 'true';
+      }
     }
-    return false;
+    return true; // Default to deduplicated view
   };
 
   const [deduplicateUsers, setDeduplicateUsers] = useState(
@@ -209,12 +212,19 @@ export function Users() {
   useEffect(() => {
     if (router.isReady) {
       const deduplicateParam = router.query.deduplicate;
-      const expectedState = deduplicateParam === 'true';
-      if (deduplicateUsers !== expectedState) {
-        setDeduplicateUsers(expectedState);
+
+      // If URL has no deduplicate parameter, set it to the default (true)
+      if (deduplicateParam === undefined) {
+        updateDeduplicateURL(true);
+      } else {
+        const expectedState = deduplicateParam === 'true';
+        if (deduplicateUsers !== expectedState) {
+          setDeduplicateUsers(expectedState);
+        }
       }
     }
-  }, [router.isReady, router.query.deduplicate, deduplicateUsers]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.isReady, router.query.deduplicate]);
 
   // Helper function to update deduplicate in URL
   const updateDeduplicateURL = (deduplicateValue) => {


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR adds a toggle to the users page to "Deduplicate users". This will consolidate entries in the users table that share the same "Name". The use case is for cases where the same user either has multiple devices that they use to log into the sky api server or if they have multiple emails they use to log in via sso. 

This is also a prerequisite to supporting a feature that shows the total # of GPUs used by a given user in our dashboard. 

<!-- Describe the tests ran -->
New users page (with "Deduplicate users" toggle unselected):
<img width="1512" height="982" alt="Screenshot 2025-10-21 at 2 16 55 PM" src="https://github.com/user-attachments/assets/6e502eb7-fe68-4f15-81e9-a35b666ce37f" />

New users page (with "Deduplicate users" toggle selected)
<img width="1512" height="982" alt="Screenshot 2025-10-21 at 3 39 45 PM (2)" src="https://github.com/user-attachments/assets/f111e919-75f1-49c3-8c22-a016a0ea2292" />




<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
