### PR TITLE
[Dashboard] Show Spinner During Node Loading

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -309,22 +309,7 @@ export function InfrastructureSection({
                                 <CircularProgress size={16} />
                               </div>
                             ) : (
-                              <span
-                                className={
-                                  totalGpus === 0 && nodes.length === 0
-                                    ? 'text-gray-400'
-                                    : ''
-                                }
-                                title={
-                                  totalGpus === 0 && nodes.length === 0
-                                    ? 'Context may be unavailable or timed out'
-                                    : ''
-                                }
-                              >
-                                {totalGpus === 0 && nodes.length === 0
-                                  ? '0*'
-                                  : totalGpus}
-                              </span>
+                              totalGpus
                             )}
                           </td>
                         </tr>


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixes an issue that if we have already managed to load the per context gpu data but not the node data we show 0* for the number of GPUs (indicating we are still loading GPU data) even though the GPU data is ready. I've removed the extra logic so now we either show a spinner if the data is still loading or just the number.

If we are still loading the GPU data we see:
<img width="1002" height="391" alt="image" src="https://github.com/user-attachments/assets/4869bfb1-aa7a-4c17-89ae-824972427846" />

Once loaded we see:
<img width="1318" height="396" alt="image" src="https://github.com/user-attachments/assets/e907a9e6-e642-4418-a17d-98a25a4eec84" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
