### PR TITLE
[Dashboard] adjust user deduplication button placement and only show for non-sso auth

### DIFF
--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -48,6 +48,7 @@ import {
 } from 'lucide-react';
 import { Layout } from '@/components/elements/layout';
 import { useMobile } from '@/hooks/useMobile';
+import { useSidebar } from '@/components/elements/sidebar';
 import { Card } from '@/components/ui/card';
 import { apiClient } from '@/data/connectors/client';
 import {
@@ -148,6 +149,7 @@ const SuccessDisplay = ({ message, onDismiss }) => {
 
 export function Users() {
   const router = useRouter();
+  const { userEmail } = useSidebar();
   const [loading, setLoading] = useState(false);
   const refreshDataRef = useRef(null);
   const isMobile = useMobile();
@@ -592,36 +594,6 @@ export function Users() {
               </button>
             )}
 
-          {/* Deduplicate Users Toggle - only show on users tab */}
-          {activeMainTab === 'users' && (
-            <label className="flex items-center cursor-pointer mr-2">
-              <input
-                type="checkbox"
-                checked={deduplicateUsers}
-                onChange={(e) => {
-                  const newValue = e.target.checked;
-                  setDeduplicateUsers(newValue);
-                  updateDeduplicateURL(newValue);
-                }}
-                className="sr-only"
-              />
-              <div
-                className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
-                  deduplicateUsers ? 'bg-sky-600' : 'bg-gray-300'
-                }`}
-              >
-                <span
-                  className={`inline-block h-3 w-3 transform rounded-full bg-white transition-transform ${
-                    deduplicateUsers ? 'translate-x-5' : 'translate-x-1'
-                  }`}
-                />
-              </div>
-              <span className="ml-2 text-sm text-gray-700">
-                Deduplicate users
-              </span>
-            </label>
-          )}
-
           <button
             onClick={handleRefresh}
             disabled={loading}
@@ -687,6 +659,36 @@ export function Users() {
             </button>
           )}
         </div>
+
+        {/* Deduplicate Users Toggle - only show on users tab when NOT using SSO/OAuth2 */}
+        {activeMainTab === 'users' && !userEmail && (
+          <label className="flex items-center cursor-pointer ml-4">
+            <input
+              type="checkbox"
+              checked={deduplicateUsers}
+              onChange={(e) => {
+                const newValue = e.target.checked;
+                setDeduplicateUsers(newValue);
+                updateDeduplicateURL(newValue);
+              }}
+              className="sr-only"
+            />
+            <div
+              className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+                deduplicateUsers ? 'bg-sky-600' : 'bg-gray-300'
+              }`}
+            >
+              <span
+                className={`inline-block h-3 w-3 transform rounded-full bg-white transition-transform ${
+                  deduplicateUsers ? 'translate-x-5' : 'translate-x-1'
+                }`}
+              />
+            </div>
+            <span className="ml-2 text-sm text-gray-700">
+              Deduplicate users
+            </span>
+          </label>
+        )}
 
         {/* Create Service Account Button for Service Accounts Tab */}
         {activeMainTab === 'service-accounts' && (


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
Verified that the "Deduplicate users" button only shows up when sso is not enabled and adjusted the placement to be in line with the "Search users by name, email, or role" bar because the toggle only applies to users and not service accounts.
<img width="1512" height="982" alt="Screenshot 2025-10-23 at 6 05 35 PM" src="https://github.com/user-attachments/assets/51eed745-4437-46cc-baa0-8760750a70dd" />

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
