### PR TITLE
[Tests] Fix Mocked Function to Match

### DIFF
--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -2,6 +2,7 @@
 import asyncio
 import pathlib
 import time
+from typing import List, Optional
 import unittest.mock as mock
 
 import filelock
@@ -1475,7 +1476,9 @@ def test_update_request_row_fields_maintains_order():
 async def test_cancel_get_request_async():
     import gc
 
-    async def mock_get_request_async_no_lock(id: str):
+    async def mock_get_request_async_no_lock(id: str,
+                                             fields: Optional[List[str]] = None
+                                            ):
         await asyncio.sleep(1)
         return None
 
@@ -1497,8 +1500,9 @@ async def test_cancel_get_request_async():
             # for more details.
             gc.collect()
         try:
-            await asyncio.gather(*tasks, return_exceptions=True)
-        except Exception:
+            await asyncio.gather(*tasks)
+        except asyncio.CancelledError:
+            # Expected when tasks are cancelled
             pass
         # Since get_request_async is shielded, task.cancel() will neither cancel or
         # wait the get_request_async coroutine. So we have to wait for a enough time


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

When we changed `get_request_no_lock_async` in https://github.com/skypilot-org/skypilot/commit/a91e4d302523bb49d9b15313fefa65a68c467b27 we didn't change the cancellation unit tests to match. I fixed it and changed exception handling so a similar change will not fail silently in the future.

The CI unit test output no longer has the errors.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
