### PR TITLE
[Pools] Add Parallel Launch

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -4665,7 +4665,8 @@ def jobs_launch(
         else:
             # TODO(tian): This can be very long. Considering have a "group id"
             # and query all job ids with the same group id.
-            job_ids_str = ','.join(map(str, job_ids))
+            # Sort job ids to ensure consistent ordering.
+            job_ids_str = ','.join(map(str, sorted(job_ids)))
             click.secho(
                 f'Jobs submitted with IDs: {colorama.Fore.CYAN}'
                 f'{job_ids_str}{colorama.Style.RESET_ALL}.'

--- a/tests/smoke_tests/test_pools.py
+++ b/tests/smoke_tests/test_pools.py
@@ -1062,11 +1062,18 @@ def test_pools_num_jobs_option(generic_cloud: str):
                     _LAUNCH_POOL_AND_CHECK_SUCCESS.format(
                         pool_name=pool_name, pool_yaml=pool_yaml.name),
                     # Test parallel job launching with --num-jobs 3
-                    ('s=$(sky jobs launch --pool {pool_name} {job_yaml} --num-jobs 3 -d -y); '
+                    ('s=$(sky jobs launch --pool {pool_name} {job_yaml} --num-jobs 10 -d -y); '
                      'echo "$s"; '
                      'echo; echo; echo "$s" | grep "Job submitted, ID: 1"; '
                      'echo "$s" | grep "Job submitted, ID: 2"; '
                      'echo "$s" | grep "Job submitted, ID: 3"; '
+                     'echo "$s" | grep "Job submitted, ID: 4"; '
+                     'echo "$s" | grep "Job submitted, ID: 5"; '
+                     'echo "$s" | grep "Job submitted, ID: 6"; '
+                     'echo "$s" | grep "Job submitted, ID: 7"; '
+                     'echo "$s" | grep "Job submitted, ID: 8"; '
+                     'echo "$s" | grep "Job submitted, ID: 9"; '
+                     'echo "$s" | grep "Job submitted, ID: 10"; '
                      'sleep 5').format(pool_name=pool_name,
                                        job_yaml=job_yaml.name)
                 ],


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR adds support for launching jobs in parallel using `--num-jobs`. Before one command would launch multiple jobs but the actual launching would happen serially, now we use multiple threads on the jobs controller to handle launching.

This may not be the right design. A single job launch is handled by scheduling a request and using a long executor normally and a short executor if we're in consolidation mode. What this means is that executor will launch multiple threads to handle this single request which seems to go against our idea of using executors. Another idea would be to spawn multiple requests when we specify `--num-jobs` but we reuse a lot (like the DAG) by launching multiple jobs in the launch function so it would likely take more resources and block other launch requests.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
