### PR TITLE
[SSH] set kubeconfig to /dev/null if in-cluster

### DIFF
--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -964,13 +964,15 @@ class KubernetesCommandRunner(CommandRunner):
         kubectl_args = [
             '--pod-running-timeout', f'{connect_timeout}s', '-n', self.namespace
         ]
+        # The same logic to either set `--context` to the k8s context where
+        # the sky cluster is hosted, or `--kubeconfig` to /dev/null for
+        # in-cluster k8s is used below in the `run()` method.
         if self.context:
             kubectl_args += ['--context', self.context]
-
         # If context is none, it means the cluster is hosted on in-cluster k8s.
-        # In this case, we need to set KUBECONFIG to /dev/null to avoid using
-        # kubeconfig file.
-        if self.context is None:
+        # In this case, we need to set KUBECONFIG to /dev/null to avoid looking
+        # for the cluster in whatever active context is set in the kubeconfig.
+        else:
             kubectl_args += ['--kubeconfig', '/dev/null']
         local_port, remote_port = port_forward[0]
         local_port_str = f'{local_port}' if local_port is not None else ''


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR addresses an [issue](https://github.com/skypilot-org/skypilot/issues/7727) that was causing ssh to a sky cluster running in-cluster (same k8s cluster where the api server is hosted) to fail after running `sky ssh up`.

The issue was that when we run `sky ssh up` we set the active kubernetes cluster in the api server pod to the ssh node pool k8s cluster. Then, in `port_forward_command` in `command_runner.py` which is used as part of the ssh flow, the api server was looking for the sky cluster pod in the ssh node pool k8s cluster. This PR adds a check to set `--kubeconfig /dev/null` as part of the port forward command when the sky cluster is hosted in-cluster.


<!-- Describe the tests ran -->
I reproduced the issue by:
1.  deploying an api server on kubernetes
2. launching a sky cluster in-cluster
3. ssh into the sky cluster works
4. running `sky ssh up`
5. ssh into the sky cluster does not work

Then, I redeployed the api server with the fix in this PR, ran through the same steps outlined above, and verified that ssh'ing into the sky cluster after running `sky ssh up` is succesful.

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
