### PR TITLE
make decoder for status response work in cases certain fields are absent

### DIFF
--- a/sky/server/requests/serializers/decoders.py
+++ b/sky/server/requests/serializers/decoders.py
@@ -56,10 +56,16 @@ def decode_status(
     clusters = return_value
     response = []
     for cluster in clusters:
-        cluster['handle'] = decode_and_unpickle(cluster['handle'])
+        # handle may not always be present in the response.
+        if 'handle' in cluster and cluster['handle'] is not None:
+            cluster['handle'] = decode_and_unpickle(cluster['handle'])
         cluster['status'] = status_lib.ClusterStatus(cluster['status'])
-        cluster['storage_mounts_metadata'] = decode_and_unpickle(
-            cluster['storage_mounts_metadata'])
+        # this field is to be deprecated in the future.
+        # do not decode this field if it is not present.
+        if ('storage_mounts_metadata' in cluster and
+                cluster['storage_mounts_metadata'] is not None):
+            cluster['storage_mounts_metadata'] = decode_and_unpickle(
+                cluster['storage_mounts_metadata'])
         if 'is_managed' not in cluster:
             cluster['is_managed'] = False
         response.append(responses.StatusResponse.model_validate(cluster))


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
https://github.com/skypilot-org/skypilot/pull/7653 works on removing `storage_mounts_metadata` from the response, and we have work ongoing to potentially avoid returning the cluster handle in certain circumstances. Ensure the client decoder is able to deal with these scenarios.



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
