### PR TITLE
[Volume] Improve log and add alias for volumes

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -4253,6 +4253,10 @@ def volumes():
     pass
 
 
+# Add 'volume' as an alias for 'volumes'
+cli.add_command(volumes, name='volume')
+
+
 @volumes.command('apply', cls=_DocumentedCodeCommand)
 @flags.config_option(expose_value=False)
 @click.argument('entrypoint',

--- a/sky/provision/kubernetes/volume.py
+++ b/sky/provision/kubernetes/volume.py
@@ -75,7 +75,6 @@ def delete_volume(config: models.VolumeConfig) -> models.VolumeConfig:
     """Deletes a volume."""
     context, namespace = _get_context_namespace(config)
     pvc_name = config.name_on_cloud
-    logger.info(f'Deleting PVC {pvc_name}')
     kubernetes_utils.delete_k8s_resource_with_retry(
         delete_func=lambda pvc_name=pvc_name: kubernetes.core_api(
             context).delete_namespaced_persistent_volume_claim(
@@ -84,6 +83,7 @@ def delete_volume(config: models.VolumeConfig) -> models.VolumeConfig:
                 _request_timeout=config_lib.DELETION_TIMEOUT),
         resource_type='pvc',
         resource_name=pvc_name)
+    logger.info(f'Deleted PVC {pvc_name} in namespace {namespace}')
     return config
 
 
@@ -242,9 +242,9 @@ def create_persistent_volume_claim(namespace: str, context: Optional[str],
     except kubernetes.api_exception() as e:
         if e.status != 404:  # Not found
             raise
-    logger.info(f'Creating PVC {pvc_name}')
     kubernetes.core_api(context).create_namespaced_persistent_volume_claim(
         namespace=namespace, body=pvc_spec)
+    logger.info(f'Created PVC {pvc_name} in namespace {namespace}')
 
 
 def _get_pvc_spec(namespace: str,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
- Improve log for creating and deleting volumes in k8s
- Add alias `sky volume` for `sky volumes`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
```
✗ sky volume apply -y -n pvc1 --type k8s-pvc --size 2GB --infra k8s
Created PVC pvc1-43dbb4ab-481fd3 in namespace default
✗ sky volume delete pvc1
Deleting 1 volume: pvc1. Proceed? [Y/n]:
Deleted PVC pvc1-43dbb4ab-481fd3 in namespace default
```
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
