### PR TITLE
[Test] Fix test_kubernetes_show_gpus for any k8s clusters

### DIFF
--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -1071,13 +1071,15 @@ def test_kubernetes_show_gpus(generic_cloud: str):
         [(
             's=$(SKYPILOT_DEBUG=0 sky show-gpus --infra kubernetes) && '
             'echo "$s" && '
-            # Grab the table header by querying for `REQUESTABLE_QTY_PER_NODE`
-            # using -A 1 to grab the next line as well.
-            # Then get the last line of the output
-            # (only the first line of values, exluding the table header.)
-            # Then, search for the correct utilization string.
-            'echo "$s" | grep "REQUESTABLE_QTY_PER_NODE" -A 1 | tail -n 1 | grep "8 of 8 free"'
-        )],
+            # Verify either:
+            # 1. We have at least one GPU entry with utilization info
+            #    Match pattern: "<GPU_TYPE>  <qty>  <X> of <Y> free"
+            #    Example      :    H100   1, 2, 4, 8   16 of 16 free
+            # OR
+            # 2. The cluster has no GPUs, and the expected message is shown
+            '(echo "$s" | grep -A 1 "REQUESTABLE_QTY_PER_NODE" | '
+            'grep -E "^[A-Z0-9]+[[:space:]]+[0-9, ]+[[:space:]]+[0-9]+ of [0-9]+ free" || '
+            'echo "$s" | grep "No GPUs found in any Kubernetes clusters")')],
     )
     smoke_tests_utils.run_one_test(test)
 


### PR DESCRIPTION
Previously, we were hardcoding the GPU count to be 8/8. But this is only true for the `kind` clusters in our test infra. This PR fixes it to use a regex pattern for matching, so that it can run on arbitrary k8s clusters with arbitrary amount of GPUs (or no GPUs too).

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
