### PR TITLE
[Dashboard] fix infra page workspace dropdown style

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -56,6 +56,13 @@ import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { NonCapitalizedTooltip } from '@/components/utils';
 import { Card } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 
 // Set the refresh interval to align with other pages
 const REFRESH_INTERVAL = REFRESH_INTERVALS.REFRESH_INTERVAL;
@@ -2415,25 +2422,25 @@ export function GPUs() {
           {/* Workspace Selector */}
           {availableWorkspaces.length > 0 && (
             <div className="flex items-center mr-4">
-              <label
-                htmlFor="workspace-selector"
-                className="text-sm font-medium text-gray-700 mr-2"
-              >
+              <label className="text-sm font-medium text-gray-700 mr-2">
                 Workspace:
               </label>
-              <select
-                id="workspace-selector"
+              <Select
                 value={selectedWorkspace}
-                onChange={(e) => setSelectedWorkspace(e.target.value)}
-                className="px-3 py-1 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-sky-blue focus:border-transparent"
+                onValueChange={setSelectedWorkspace}
               >
-                <option value="all">All Workspaces</option>
-                {availableWorkspaces.map((workspace) => (
-                  <option key={workspace} value={workspace}>
-                    {workspace}
-                  </option>
-                ))}
-              </select>
+                <SelectTrigger className="w-40 h-8 text-sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All Workspaces</SelectItem>
+                  {availableWorkspaces.map((workspace) => (
+                    <SelectItem key={workspace} value={workspace}>
+                      {workspace}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
           )}
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
New:
<img width="1512" height="982" alt="Screenshot 2025-10-27 at 2 51 49 PM" src="https://github.com/user-attachments/assets/fa6b620f-c258-46ca-83c5-06751c4cfe52" />

Old:
<img width="1512" height="982" alt="Screenshot 2025-10-27 at 2 53 08 PM" src="https://github.com/user-attachments/assets/b071650c-933c-4de5-9214-bb28b0307a4f" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
