### PR TITLE
[Dashboard] set deduplicate to default false for sso

### DIFF
--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -215,9 +215,11 @@ export function Users() {
     if (router.isReady) {
       const deduplicateParam = router.query.deduplicate;
 
-      // If URL has no deduplicate parameter, set it to the default (true)
+      // If URL has no deduplicate parameter, set it to the default
+      // Default to false for SSO (userEmail exists), true for non-SSO
       if (deduplicateParam === undefined) {
-        updateDeduplicateURL(true);
+        const defaultValue = !userEmail; // false for SSO, true for non-SSO
+        updateDeduplicateURL(defaultValue);
       } else {
         const expectedState = deduplicateParam === 'true';
         if (deduplicateUsers !== expectedState) {
@@ -226,7 +228,7 @@ export function Users() {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [router.isReady, router.query.deduplicate]);
+  }, [router.isReady, router.query.deduplicate, userEmail]);
 
   // Helper function to update deduplicate in URL
   const updateDeduplicateURL = (deduplicateValue) => {


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
We do not show the "Deduplicate users" toggle in the SSO case, but the deduplicate default value is set to true. So, we still deduplicate users in the SSO case but without showing the toggle.

Instead, we should have the default for SSO be false.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
