### PR TITLE
[Test] Workaround the min gpt case with rdzv

### DIFF
--- a/tests/smoke_tests/test_examples.py
+++ b/tests/smoke_tests/test_examples.py
@@ -43,6 +43,16 @@ def test_min_gpt(generic_cloud: str, train_file: str, accelerator: Dict[str,
             'git clone --depth 1 -b fix-mingpt https://github.com/michaelvll/examples || true',
             modified_content)
 
+        if generic_cloud == 'nebius' and train_file == 'examples/distributed-pytorch/train-rdzv.yaml':
+            nebius_fix = '''    # Nebius-specific fix: Add master's IP to /etc/hosts for proper hostname resolution
+    if [ ${SKYPILOT_NODE_RANK} == 0 ]; then
+        echo "$MASTER_ADDR $(hostname)" | sudo tee -a /etc/hosts
+    fi
+
+'''
+            modified_content = modified_content.replace(
+                '    torchrun \\', nebius_fix + '    torchrun \\')
+
         # Create a temporary YAML file with the modified content
         with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml',
                                          delete=False) as f:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Workaround the min gpt case with rdzv

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
