### PR TITLE
fix status encoder bw compatibility

### DIFF
--- a/sky/server/requests/serializers/encoders.py
+++ b/sky/server/requests/serializers/encoders.py
@@ -60,15 +60,14 @@ def encode_status(
         clusters: List[responses.StatusResponse]) -> List[Dict[str, Any]]:
     response = []
     for cluster in clusters:
+        response_cluster = cluster.model_dump(exclude_none=True)
         # These default setting is needed because last_use and status_updated_at
         # used to be not optional.
         # TODO(syang): remove this after v0.10.7 or v0.11.0
-        if 'last_use' not in cluster:
-            cluster['last_use'] = ''
-        if 'status_updated_at' not in cluster:
-            cluster['status_updated_at'] = 0
-
-        response_cluster = cluster.model_dump(exclude_none=True)
+        if 'last_use' not in response_cluster:
+            response_cluster['last_use'] = ''
+        if 'status_updated_at' not in response_cluster:
+            response_cluster['status_updated_at'] = 0
         response_cluster['status'] = cluster['status'].value
         handle = serialize_utils.prepare_handle_for_backwards_compatibility(
             cluster['handle'])


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The backwards compatibility code introduced for the encoder yesterday did not work in certain cases as evidenced by quick test core failures. This PR fixes the backwards compatibility code for the status 
encoder.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
