### PR TITLE
[Docs] Add section on using multiple GCP projects with Workspaces

### DIFF
--- a/docs/source/cloud-setup/cloud-permissions/gcp.rst
+++ b/docs/source/cloud-setup/cloud-permissions/gcp.rst
@@ -546,3 +546,47 @@ An alternative to setting up cloud NAT for instances that need to access the pub
       use_internal_ips: true
       vpc_name: my-vpc-name
       force_enable_external_ips: true
+
+
+Using multiple GCP projects
+----------------------------------
+
+Admins can isolate different teams to use separate GCP projects. This enables fine-grained resource tracking, billing separation, and access control per team.
+For more information on configuring workspaces, see `Workspaces <https://docs.skypilot.co/en/latest/admin/workspaces.html>`__.
+
+Prerequisites
+~~~~~~~~~~~~~
+
+The service account must have access to all GCP projects intended to be used. To grant the service account access to additional projects:
+
+1. Follow the :ref:`instructions <gcp-service-account-creation>` to create a service account with the appropriate roles/permissions.
+2. In the GCP Console, switch to the project you want to grant your service account to using the project dropdown at the top of the page, or use ``Cmd/Ctrl + O``.
+3. Navigate to the `IAM & Admin console <https://console.cloud.google.com/iam-admin/iam>`__ and click on the **IAM** tab.
+4. Click **GRANT ACCESS** at the top of the table:
+
+   - In the **Add principals** field, enter your service account email (e.g., ``my-service-account@main-project.iam.gserviceaccount.com``).
+   - In the **Assign roles** section, select the appropriate roles (see :ref:`Setting permissions <cloud-permissions-gcp>` for recommended roles).
+   - Click **SAVE**.
+
+5. Repeat steps 2-4 for each additional project you want to enable.
+
+Configuring workspaces with different projects
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once the service account has access to all the projects, configure the workspaces in the :ref:`SkyPilot config file <config-yaml>` to use different ``project_id`` values:
+
+.. code-block:: yaml
+
+    workspaces:
+      team-a:
+        gcp:
+          project_id: main-project-id
+      team-b:
+        gcp:
+          project_id: secondary-project-id
+
+You can then launch resources in a specific workspace:
+
+.. code-block:: console
+
+    $ sky launch --config active_workspace=team-a --infra gcp


### PR DESCRIPTION
This PR adds a new section under the GCP page of our docs, showcasing how to use our [Workspaces](https://docs.skypilot.co/en/latest/admin/workspaces.html) feature with multiple GCP projects.

<img width="2032" height="1167" alt="Screenshot 2025-10-28 at 3 20 43 PM" src="https://github.com/user-attachments/assets/b4c6bf1c-5399-4e1c-b256-21fae05a6075" />

Preview link: https://docs.skypilot.co/en/gcp-workspaces-docs/cloud-setup/cloud-permissions/gcp.html (not sure why it's still 404)

Tested manually:
1. Created a new GCP project `other-project`
2. Created a service account under `main-project`
3. On `other-project`, grant access to this service account
4. Download the service account key and `gcloud auth activate-service-account --key-file=./credentials.json`
5. Modify config.yaml to:
```
workspaces:
  team-a:
    gcp:
      project_id: main-project
  team-b:
    gcp:
      project_id: other-project
```
6. Verify it works

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
