### PR TITLE
Fix gpu label failure for "Too large resource version"

### DIFF
--- a/sky/utils/kubernetes/gpu_labeler.py
+++ b/sky/utils/kubernetes/gpu_labeler.py
@@ -3,7 +3,6 @@ import argparse
 import hashlib
 import os
 import subprocess
-import time
 from typing import Dict, Optional, Tuple
 
 import colorama
@@ -13,9 +12,6 @@ from sky.adaptors import kubernetes
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.utils import directory_utils
 from sky.utils import rich_utils
-
-# Polling interval in seconds for job completion checks
-JOB_COMPLETION_POLL_INTERVAL = 5
 
 
 def _format_string(str_to_format: str, colorama_format: str) -> str:
@@ -170,73 +166,6 @@ def label(context: Optional[str] = None, wait_for_completion: bool = True):
             '`skypilot.co/accelerator: <gpu_name>`. ')
 
 
-def _poll_jobs_completion(jobs_to_node_names: Dict[str, str],
-                          namespace: str,
-                          context: Optional[str] = None,
-                          timeout: int = 60 * 20) -> bool:
-    """Fallback polling method to check job completion status.
-
-    This method polls the Kubernetes API to check job status instead of using
-    the watch API. It's used as a fallback when the watch API fails due to
-    resource version mismatches.
-
-    Args:
-        jobs_to_node_names: A dictionary mapping job names to node names.
-        namespace: The namespace the jobs are in.
-        context: Optional Kubernetes context to use.
-        timeout: Timeout in seconds (default: 1200 seconds = 20 minutes).
-
-    Returns:
-        True if all jobs completed successfully, False if any failed
-        or timed out.
-    """
-    batch_v1 = kubernetes.batch_api(context=context)
-    start_time = time.time()
-    completed_jobs = []
-
-    print(
-        _format_string('Using polling method to check job completion...',
-                       colorama.Style.DIM))
-
-    while time.time() - start_time < timeout:
-        try:
-            jobs = batch_v1.list_namespaced_job(namespace=namespace)
-            for job in jobs.items:
-                job_name = job.metadata.name
-                if job_name in jobs_to_node_names:
-                    node_name = jobs_to_node_names[job_name]
-                    if job.status and job.status.completion_time:
-                        if job_name not in completed_jobs:
-                            print(
-                                _format_string(
-                                    f'GPU labeler job for node {node_name} '
-                                    'completed successfully',
-                                    colorama.Style.DIM))
-                            completed_jobs.append(job_name)
-                    elif job.status and job.status.failed:
-                        print(
-                            _format_string(
-                                f'GPU labeler job for node {node_name} failed',
-                                colorama.Style.DIM))
-                        return False
-
-            if len(completed_jobs) == len(jobs_to_node_names):
-                return True
-
-            time.sleep(JOB_COMPLETION_POLL_INTERVAL)
-        except kubernetes.api_exception() as poll_error:
-            print(
-                _format_string(f'Polling error: {str(poll_error)}',
-                               colorama.Fore.RED))
-            time.sleep(JOB_COMPLETION_POLL_INTERVAL)
-
-    print(
-        _format_string(
-            f'Timed out after waiting {timeout} seconds '
-            'for job to complete', colorama.Style.DIM))
-    return False
-
-
 def wait_for_jobs_completion(jobs_to_node_names: Dict[str, str],
                              namespace: str,
                              context: Optional[str] = None,
@@ -252,58 +181,41 @@ def wait_for_jobs_completion(jobs_to_node_names: Dict[str, str],
         True if the Job completed successfully, False if it failed or timed out.
     """
     batch_v1 = kubernetes.batch_api(context=context)
+    w = kubernetes.watch()
     completed_jobs = []
-
-    def _watch_jobs():
-        """Helper function to watch jobs with error handling."""
-        w = kubernetes.watch()
-        for event in w.stream(func=batch_v1.list_namespaced_job,
-                              namespace=namespace,
-                              timeout_seconds=timeout):
-            job = event['object']
-            job_name = job.metadata.name
-            if job_name in jobs_to_node_names:
-                node_name = jobs_to_node_names[job_name]
-                if job.status and job.status.completion_time:
-                    print(
-                        _format_string(
-                            f'GPU labeler job for node {node_name} '
-                            'completed successfully', colorama.Style.DIM))
-                    completed_jobs.append(job_name)
-                    num_remaining_jobs = len(jobs_to_node_names) - len(
-                        completed_jobs)
-                    if num_remaining_jobs == 0:
-                        w.stop()
-                        return True
-                elif job.status and job.status.failed:
-                    print(
-                        _format_string(
-                            f'GPU labeler job for node {node_name} failed',
-                            colorama.Style.DIM))
+    # Use resource_version="0" to start from the oldest available version.
+    # In multi-replica API server environments, replicas may be at different
+    # resource versions due to replication lag. Without specifying this, the
+    # watch may get version X from one replica but connect to another replica
+    # that only has up to version Y < X, causing "Too large resource version"
+    # errors. Using "0" ensures all replicas can serve the request from their
+    # oldest available version, avoiding version mismatches.
+    for event in w.stream(func=batch_v1.list_namespaced_job,
+                          namespace=namespace,
+                          timeout_seconds=timeout,
+                          resource_version='0'):
+        job = event['object']
+        job_name = job.metadata.name
+        if job_name in jobs_to_node_names:
+            node_name = jobs_to_node_names[job_name]
+            if job.status and job.status.completion_time:
+                print(
+                    _format_string(
+                        f'GPU labeler job for node {node_name} '
+                        'completed successfully', colorama.Style.DIM))
+                completed_jobs.append(job_name)
+                num_remaining_jobs = len(jobs_to_node_names) - len(
+                    completed_jobs)
+                if num_remaining_jobs == 0:
                     w.stop()
-                    return False
-        return None  # Timeout
-
-    try:
-        result = _watch_jobs()
-        if result is not None:
-            return result
-    except kubernetes.api_exception() as e:
-        if e.status == 504 and 'Too large resource version' in str(e):
-            print(
-                _format_string(
-                    'Watch failed due to resource version mismatch. '
-                    'Falling back to polling method...', colorama.Fore.YELLOW))
-            # Fall back to polling instead of watch API
-            # The watch API is unreliable when resource versions are changing
-            # rapidly or when there are multiple API server instances with
-            # different cache states
-            return _poll_jobs_completion(jobs_to_node_names, namespace, context,
-                                         timeout)
-        else:
-            # Re-raise other API exceptions
-            raise
-
+                    return True
+            elif job.status and job.status.failed:
+                print(
+                    _format_string(
+                        f'GPU labeler job for node {node_name} failed',
+                        colorama.Style.DIM))
+                w.stop()
+                return False
     print(
         _format_string(
             f'Timed out after waiting {timeout} seconds '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolve #7762

# Problem: GPU Labeler Fails with "Too large resource version" Error on nebius

## Root Cause
The Kubernetes Watch API fails with a 504 error when there's a resource version mismatch between the client and the k8s API server's watch cache:

```
python -m sky.utils.kubernetes.gpu_labeler

Found 5 unlabeled GPU nodes in the cluster
Using nvidia RuntimeClass for GPU labeling.
Created GPU labeler job for node computeinstance-e00c2pvvejrgxgp35g
Created GPU labeler job for node computeinstance-e00n7hs0fjmqqhk0y3
Created GPU labeler job for node computeinstance-e00sfp1hy7zkhv83r4
Created GPU labeler job for node computeinstance-e00t1t95cx9drjzr6g
Created GPU labeler job for node computeinstance-e00zpg9ntzyyy5w2qg
Traceback (most recent call last):
  File "/home/buildkite/miniconda3/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/buildkite/miniconda3/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/buildkite/sky_workdir/skypilot/sky/utils/kubernetes/gpu_labeler.py", line 256, in <module>
    main()
  File "/home/buildkite/sky_workdir/skypilot/sky/utils/kubernetes/gpu_labeler.py", line 252, in main
    label(context=context, wait_for_completion=not args.async_completion)
  File "/home/buildkite/sky_workdir/skypilot/sky/utils/kubernetes/gpu_labeler.py", line 147, in label
    success = wait_for_jobs_completion(jobs_to_node_names,
  File "/home/buildkite/sky_workdir/skypilot/sky/utils/kubernetes/gpu_labeler.py", line 186, in wait_for_jobs_completion
    for event in w.stream(func=batch_v1.list_namespaced_job,
  File "/home/buildkite/miniconda3/lib/python3.10/site-packages/kubernetes/watch/watch.py", line 202, in stream
    raise client.rest.ApiException(
kubernetes.client.exceptions.ApiException: (504)
Reason: Timeout: Timeout: Too large resource version: 4400, current: 4395
```

## Why the Watch API Fails

- **Watch API relies on sequential resource versions**: The Kubernetes watch mechanism requires the client's requested resource version to be within the range that the API server's watch cache holds.

- **Multiple API server instances cause version skew**: In managed Kubernetes clusters (GKE, EKS, Nebius, etc.), multiple API server instances exist for high availability. Each instance maintains its own watch cache that may be at different resource versions.

- **The watch stream automatically tracks resource versions**: When `watch.stream()` is called, the Kubernetes Python client:
  - First does a LIST operation to get the current state
  - The LIST response includes a resourceVersion from one API server instance
  - The watch then tries to stream events starting from that version
  - If the request is routed to a different API server instance whose watch cache hasn't reached that version yet, it returns a 504 error

- **Resource versions increment during the watch**: As the watch processes events, it automatically updates its internal `resource_version` field from each event's metadata. When the watch fails and is retried, even creating a new Watch object doesn't help because the new LIST call returns an even newer resource version.

## The Fix

This PR fixes the root cause by explicitly setting `resource_version='0'` when starting the watch:
- What `resource_version='0'` does: Tells Kubernetes to start watching from the oldest available version in the watch cache, rather than trying to use the latest version from a LIST operation.
- Why it works: All API server replicas can serve requests starting from their oldest available version (version 0), which is guaranteed to exist in all replicas' watch caches. This avoids the version mismatch where one replica has version X but another only has up to version Y < X.

## Test

<img width="3180" height="855" alt="image" src="https://github.com/user-attachments/assets/a05dfbb1-4d32-43a5-8450-2afc3f1a6557" />




<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
