### PR TITLE
[Dashboard] reorder users page filter drop down and table columns

### DIFF
--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -78,20 +78,20 @@ const PROPERTY_OPTIONS = [
     value: 'name',
   },
   {
+    label: 'GPU',
+    value: 'gpu type', // Match valueList key
+  },
+  {
+    label: 'Infra',
+    value: 'infra',
+  },
+  {
     label: 'User ID',
     value: 'user id', // Match valueList key
   },
   {
     label: 'Role',
     value: 'role',
-  },
-  {
-    label: 'GPU Type',
-    value: 'gpu type', // Match valueList key
-  },
-  {
-    label: 'Infra',
-    value: 'infra',
   },
 ];
 
@@ -334,7 +334,7 @@ export function Users() {
     ['name', 'Name'],
     ['user id', 'User ID'], // Note: lowercase with space to match URL encoding
     ['role', 'Role'],
-    ['gpu type', 'GPU Type'], // Note: lowercase with space to match URL encoding
+    ['gpu type', 'GPU'], // Note: lowercase with space to match URL encoding
     ['infra', 'Infra'],
   ]);
 
@@ -1577,11 +1577,11 @@ function UsersTable({
     let filtered = usersWithCounts;
 
     // Separate GPU type and infra filters from standard filters
-    // Note: filter.property contains the label (e.g., "GPU Type", "Infra"), not the value
+    // Note: filter.property contains the label (e.g., "GPU", "Infra"), not the value
     const standardFilters = filters.filter(
-      (f) => f.property !== 'GPU Type' && f.property !== 'Infra'
+      (f) => f.property !== 'GPU' && f.property !== 'Infra'
     );
-    const gpuTypeFilters = filters.filter((f) => f.property === 'GPU Type');
+    const gpuTypeFilters = filters.filter((f) => f.property === 'GPU');
     const infraFilters = filters.filter((f) => f.property === 'Infra');
 
     // Apply standard filters using the shared filter system
@@ -1853,7 +1853,7 @@ function UsersTable({
 
   // Check if we're still loading lookups for GPU/Infra filters
   const hasGpuOrInfraFilters = filters.some(
-    (f) => f.property === 'GPU Type' || f.property === 'Infra'
+    (f) => f.property === 'GPU' || f.property === 'Infra'
   );
   if (hasGpuOrInfraFilters && !lookupsReady) {
     return (
@@ -1916,6 +1916,12 @@ function UsersTable({
                 Joined{getSortDirection('created_at')}
               </TableHead>
               <TableHead
+                onClick={() => requestSort('gpuCount')}
+                className="sortable whitespace-nowrap cursor-pointer hover:bg-gray-50 w-1/6"
+              >
+                GPUs{getSortDirection('gpuCount')}
+              </TableHead>
+              <TableHead
                 onClick={() => requestSort('clusterCount')}
                 className="sortable whitespace-nowrap cursor-pointer hover:bg-gray-50 w-1/6"
               >
@@ -1926,12 +1932,6 @@ function UsersTable({
                 className="sortable whitespace-nowrap cursor-pointer hover:bg-gray-50 w-1/6"
               >
                 Jobs{getSortDirection('jobCount')}
-              </TableHead>
-              <TableHead
-                onClick={() => requestSort('gpuCount')}
-                className="sortable whitespace-nowrap cursor-pointer hover:bg-gray-50 w-1/6"
-              >
-                GPUs{getSortDirection('gpuCount')}
               </TableHead>
               {/* Show Actions column if basicAuthEnabled and not deduplicating */}
               {!deduplicateUsers &&
@@ -2013,6 +2013,25 @@ function UsersTable({
                   )}
                 </TableCell>
                 <TableCell>
+                  {user.gpuCount === -1 ? (
+                    <span className="px-2 py-0.5 bg-gray-100 text-gray-400 rounded text-xs font-medium flex items-center">
+                      <CircularProgress size={10} className="mr-1" />
+                      Loading...
+                    </span>
+                  ) : (
+                    <span
+                      className={`px-2 py-0.5 rounded text-xs font-medium ${
+                        user.gpuCount > 0
+                          ? 'bg-purple-100 text-purple-600'
+                          : 'bg-gray-100 text-gray-500'
+                      }`}
+                      title={`Total GPUs: ${user.gpuCount}`}
+                    >
+                      {user.gpuCount}
+                    </span>
+                  )}
+                </TableCell>
+                <TableCell>
                   {user.clusterCount === -1 ? (
                     <span className="px-2 py-0.5 bg-gray-100 text-gray-400 rounded text-xs font-medium flex items-center">
                       <CircularProgress size={10} className="mr-1" />
@@ -2050,25 +2069,6 @@ function UsersTable({
                     >
                       {user.jobCount}
                     </Link>
-                  )}
-                </TableCell>
-                <TableCell>
-                  {user.gpuCount === -1 ? (
-                    <span className="px-2 py-0.5 bg-gray-100 text-gray-400 rounded text-xs font-medium flex items-center">
-                      <CircularProgress size={10} className="mr-1" />
-                      Loading...
-                    </span>
-                  ) : (
-                    <span
-                      className={`px-2 py-0.5 rounded text-xs font-medium ${
-                        user.gpuCount > 0
-                          ? 'bg-purple-100 text-purple-600'
-                          : 'bg-gray-100 text-gray-500'
-                      }`}
-                      title={`Total GPUs: ${user.gpuCount}`}
-                    >
-                      {user.gpuCount}
-                    </span>
                   )}
                 </TableCell>
                 {/* Actions cell logic - hide when deduplicating */}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Make the information shown on the users page more gpu-centric.


Before:
<img width="1512" height="982" alt="Screenshot 2025-10-29 at 10 53 40 AM" src="https://github.com/user-attachments/assets/ed4b016b-aa97-4285-9516-72d077c0166b" />
After:
<img width="1512" height="982" alt="Screenshot 2025-10-29 at 10 54 41 AM" src="https://github.com/user-attachments/assets/aeb98ae1-4302-48f3-8ab4-764d6ceb3244" />

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
