### PR TITLE
Downgrade nebius CLI to mitigate CVE-2025-58187

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,8 @@ RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
     rm kubectl
 
 # Install Nebius CLI
-RUN curl -sSL https://storage.eu-north1.nebius.cloud/cli/install.sh | NEBIUS_INSTALL_FOLDER=/usr/local/bin bash
+# TODO(aylei): use the latest version of Nebius CLI after #7789 get resolved.
+RUN NEBIUS_CLI_VERSION=0.12.127 curl -sSL https://storage.eu-north1.nebius.cloud/cli/install.sh | NEBIUS_INSTALL_FOLDER=/usr/local/bin bash
 # Install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
     ~/.local/bin/uv pip install --prerelease allow azure-cli --system && \


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

https://github.com/skypilot-org/skypilot/issues/7789

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
