### PR TITLE
Refine trivy check

### DIFF
--- a/.github/workflows/image-vulnerability.yml
+++ b/.github/workflows/image-vulnerability.yml
@@ -45,9 +45,10 @@ jobs:
       - name: Evaluate Trivy scan results
         run: |
           mapfile -t high_vulns < <(jq -r '
-            .Results[]?.Vulnerabilities[]?
+            .Results[]? as $result
+            | $result.Vulnerabilities[]?
             | select(.Severity=="HIGH")
-            | "- \(.VulnerabilityID) | \(.PkgName) \(.InstalledVersion) -> \(.FixedVersion // "N/A")"
+            | "- \(.VulnerabilityID) | \(.PkgName) \(.InstalledVersion) -> \(.FixedVersion // "N/A") | component: \($result.Target // "unknown")"
           ' trivy-results.json)
           if [ "${#high_vulns[@]}" -gt 0 ]; then
             echo "::warning::Trivy found ${#high_vulns[@]} high severity vulnerabilities:"
@@ -55,9 +56,10 @@ jobs:
           fi
 
           mapfile -t critical_vulns < <(jq -r '
-            .Results[]?.Vulnerabilities[]?
+            .Results[]? as $result
+            | $result.Vulnerabilities[]?
             | select(.Severity=="CRITICAL")
-            | "- \(.VulnerabilityID) | \(.PkgName) \(.InstalledVersion) -> \(.FixedVersion // "N/A")"
+            | "- \(.VulnerabilityID) | \(.PkgName) \(.InstalledVersion) -> \(.FixedVersion // "N/A") | component: \($result.Target // "unknown")"
           ' trivy-results.json)
           if [ "${#critical_vulns[@]}" -gt 0 ]; then
             echo "Critical vulnerabilities detected (${#critical_vulns[@]}):"


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Vulnerabilities marked as `HIGH` priority in trivy might not be fixed in the upstream packages with high priority, e.g.

```
- CVE-2025-47912 | stdlib 1.24.4 -> 1.24.8, 1.25.2 | component: opt/google-cloud-sdk/bin/gcloud-crc32c
- CVE-2025-58183 | stdlib 1.24.4 -> 1.24.8, 1.25.2 | component: opt/google-cloud-sdk/bin/gcloud-crc32c
- CVE-2025-58185 | stdlib 1.24.4 -> 1.24.8, 1.25.2 | component: opt/google-cloud-sdk/bin/gcloud-crc32c
- CVE-2025-58186 | stdlib 1.24.4 -> 1.24.8, 1.25.2 | component: opt/google-cloud-sdk/bin/gcloud-crc32c
- CVE-2025-58187 | stdlib 1.24.4 -> 1.24.9, 1.25.3 | component: opt/google-cloud-sdk/bin/gcloud-crc32c
- CVE-2025-58188 | stdlib 1.24.4 -> 1.24.8, 1.25.2 | component: opt/google-cloud-sdk/bin/gcloud-crc32c
- CVE-2025-58189 | stdlib 1.24.4 -> 1.24.8, 1.25.2 | component: opt/google-cloud-sdk/bin/gcloud-crc32c
- CVE-2025-61723 | stdlib 1.24.4 -> 1.24.8, 1.25.2 | component: opt/google-cloud-sdk/bin/gcloud-crc32c
- CVE-2025-61724 | stdlib 1.24.4 -> 1.24.8, 1.25.2 | component: opt/google-cloud-sdk/bin/gcloud-crc32c
- CVE-2025-61725 | stdlib 1.24.4 -> 1.24.8, 1.25.2 | component: opt/google-cloud-sdk/bin/gcloud-crc32c
- CVE-2025-47912 | stdlib 1.24.6 -> 1.24.8, 1.25.2 | component: usr/local/bin/kubectl
- CVE-2025-58183 | stdlib 1.24.6 -> 1.24.8, 1.25.2 | component: usr/local/bin/kubectl
- CVE-2025-58185 | stdlib 1.24.6 -> 1.24.8, 1.25.2 | component: usr/local/bin/kubectl
- CVE-2025-58186 | stdlib 1.24.6 -> 1.24.8, 1.25.2 | component: usr/local/bin/kubectl
- CVE-2025-58187 | stdlib 1.24.6 -> 1.24.9, 1.25.3 | component: usr/local/bin/kubectl
- CVE-2025-58188 | stdlib 1.24.6 -> 1.24.8, 1.25.2 | component: usr/local/bin/kubectl
- CVE-2025-58189 | stdlib 1.24.6 -> 1.24.8, 1.25.2 | component: usr/local/bin/kubectl
- CVE-2025-61723 | stdlib 1.24.6 -> 1.24.8, 1.25.2 | component: usr/local/bin/kubectl
- CVE-2025-61724 | stdlib 1.24.6 -> 1.24.8, 1.25.2 | component: usr/local/bin/kubectl
- CVE-2025-61725 | stdlib 1.24.6 -> 1.24.8, 1.25.2 | component: usr/local/bin/kubectl
- CVE-2025-58187 | stdlib 1.25.2 -> 1.24.9, 1.25.3 | component: usr/local/bin/nebius
``` 

To avoid showing the red mark, this PR update our trivy scan pipeline to only fail on `CRITICAL` vulns and just print warning for `HIGH` vulns.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
