### PR TITLE
Make policy server in smoke test robust

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -532,12 +532,16 @@ def setup_policy_server(request, tmp_path_factory):
 
     def wait_server(port: int, timeout: int = 60):
         start_time = time.time()
+        success_count = 0
         while time.time() - start_time < timeout:
             try:
                 socket.create_connection(('127.0.0.1', port), timeout=1).close()
-                return True
+                success_count += 1
+                if success_count > 5:
+                    return True
             except (socket.error, OSError):
-                time.sleep(0.5)
+                pass
+            time.sleep(0.5)
         raise RuntimeError(f"Policy server not available after {timeout}s")
 
     try:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

after https://github.com/skypilot-org/skypilot/pull/7794, master get quite flaky on the policy server setup:

https://buildkite.com/skypilot-1/smoke-tests/builds/4981#_

<img width="984" height="396" alt="image" src="https://github.com/user-attachments/assets/46f76934-5ee3-4480-a803-36f217dbcdd5" />

I suspect it is because we disable the parallelism so now there will be only one process launch the server and run the test immediately after the server is ready, which may cause the first connection timed out.

This fix make the policy server setup by making 5 success probes.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
