### PR TITLE
Fix flaky policy server setup in smoke test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -515,7 +515,7 @@ def setup_policy_server(request, tmp_path_factory):
     # get the temp directory shared by all workers
     root_tmp_dir = tmp_path_factory.getbasetemp().parent / 'policy_server'
 
-    os.mkdir(root_tmp_dir, exist_ok=True)
+    pathlib.Path(root_tmp_dir).mkdir(parents=True, exist_ok=True)
     fn = root_tmp_dir / 'policy_server.txt'
     policy_server_url = ''
     # Reference count and pid for cleanup


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

After we switch to single parallelism in buildkite smoke test https://github.com/skypilot-org/skypilot/pull/7794, the `tmp_path_factory` fixture of pytest returns stable tmp path `/tmp/pytest-of-buildkite`, thus we have to cleanup the url file of policy server to avoid interleaving other test. 


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
