### PR TITLE
[Jobs][Controller] Fix the controller process check.

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -419,7 +419,7 @@ async def get_job_status(
     return None
 
 
-def controller_process_alive(pid: int, job_id: int) -> bool:
+def controller_process_alive(pid: int, job_id: Optional[int] = None) -> bool:
     """Check if the controller process is alive."""
     try:
         if pid < 0:
@@ -427,8 +427,11 @@ def controller_process_alive(pid: int, job_id: int) -> bool:
             pid = -pid
         process = psutil.Process(pid)
         cmd_str = ' '.join(process.cmdline())
-        return process.is_running() and ((f'--job-id {job_id}' in cmd_str) or
-                                         ('controller' in cmd_str))
+        if not process.is_running():
+            return False
+        if 'controller' in cmd_str:
+            return True
+        return job_id is not None and f'--job-id {job_id}' in cmd_str
     except psutil.NoSuchProcess:
         return False
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

In jobs controller, we have the file `~/.sky/job_controller_pid` to keep track of all alive controller pids. However, this file is persisted in PVC for a remote API server deployment and upon an API server upgrade, the process will be killed and the pid is possible to be reused by the OS.

Hence, we need to check whether the command that the PID runs is actually the jobs controller. Otherwise it will skip creating any job controller and all jobs stuck at pending.

```bash
# This should be a correct process cmdline
root@skypilot-api-server-7bbfcd6ff7-whxc6:/# cat /proc/30346/cmdline 
/usr/local/bin/python-u-msky.jobs.controllere74da74f-9c6b-40a8-b78a-91bf0cdbe10eroot@skypilot-api-server-7bbfcd6ff7-whxc
root@skypilot-api-server-7bbfcd6ff7-whxc6:/# cat ~/.sky/job_controller_pid
476
478
480
482
484
# Instead, this is what we see on a buggy server.
root@skypilot-api-server-7bbfcd6ff7-whxc6:/# cat /proc/476/cmdline 
/usr/local/bin/python-cfrom multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=20, pipe_handle=104)--multiprocessing-fork
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR: Tested on the buggy server and it fixes the problem.
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
