### PR TITLE
[CLI] Update help string for `sky api status -a`

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -6368,8 +6368,8 @@ INT_OR_NONE = IntOrNone()
               is_flag=True,
               default=False,
               required=False,
-              help=('Show requests of all statuses, including finished ones ',
-                    '(SUCCEEDED, FAILED, CANCELLED). By default, only active ',
+              help=('Show requests of all statuses, including finished ones '
+                    '(SUCCEEDED, FAILED, CANCELLED). By default, only active '
                     'requests (PENDING, RUNNING) are shown.'))
 @click.option(
     '--limit',


### PR DESCRIPTION
I was confused what the flag did and what the default behavior was.