### PR TITLE
[Dashboard] Group SSH Metric

### DIFF
--- a/charts/skypilot/manifests/api-server-overview.json
+++ b/charts/skypilot/manifests/api-server-overview.json
@@ -1475,8 +1475,8 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "histogram_quantile(\n  0.95,\n  sum by (pid, le) (\n    rate(sky_apiserver_websocket_ssh_latency_seconds_bucket{app=\"$app\"}[2m])\n  )\n)",
-          "legendFormat": "__auto",
+          "expr": "histogram_quantile(\n  0.95,\n  sum by (le) (\n    rate(sky_apiserver_websocket_ssh_latency_seconds_bucket{app=\"$app\"}[2m])\n  )\n)",
+          "legendFormat": "Latency",
           "range": true,
           "refId": "A"
         }


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Before we would display the SSH server latency and have one line per PID, now we aggregate all of the data into one metric.

<img width="1404" height="614" alt="image" src="https://github.com/user-attachments/assets/9804a1c0-3015-442d-82c5-18129a8b290a" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
