### PR TITLE
Fix typos in comments

### DIFF
--- a/sky/utils/auth_utils.py
+++ b/sky/utils/auth_utils.py
@@ -17,7 +17,7 @@ MAX_TRIALS = 64
 # We intentionally not have the ssh key pair to be stored in
 # ~/.sky/api_server/clients, i.e. sky.server.common.API_SERVER_CLIENT_DIR,
 # because ssh key pair need to persist across API server restarts, while
-# the former dir is empheral.
+# the former dir is ephemeral.
 _SSH_KEY_PATH_PREFIX = '~/.sky/clients/{user_hash}/ssh'
 
 

--- a/sky/utils/common.py
+++ b/sky/utils/common.py
@@ -31,7 +31,7 @@ JOB_CONTROLLER_NAME: str
 def refresh_server_id() -> None:
     """Refresh the server id.
 
-    This function is used to ensure the server id is read from the authorative
+    This function is used to ensure the server id is read from the authoritative
     source.
     """
     global SERVER_ID

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -1115,7 +1115,7 @@ def release_memory():
         gc.collect()
         if sys.platform.startswith('linux'):
             # Will fail on musl (alpine), but at least it works on our
-            # offical docker images.
+            # official docker images.
             libc = ctypes.CDLL('libc.so.6')
             return libc.malloc_trim(0)
         return 0

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -185,7 +185,7 @@ def add_column_to_table_sqlalchemy(
             pass
         else:
             raise
-    #postgressql
+    #postgresql
     except sqlalchemy_exc.ProgrammingError as e:
         if 'already exists' in str(e):
             pass

--- a/sky/utils/locks.py
+++ b/sky/utils/locks.py
@@ -274,7 +274,7 @@ class PostgresLock(DistributedLock):
             cursor.execute('SELECT pg_advisory_unlock(%s)', (self._lock_key,))
             result = cursor.fetchone()[0]
             if result:
-                # The lock is held by current routine and unlock suceed
+                # The lock is held by current routine and unlock succeed
                 self._connection.commit()
                 self._acquired = False
                 return


### PR DESCRIPTION
Corrected several spelling errors in code comments:

- `empheral` → `ephemeral`
- `offical` → `official`  
- `authorative` → `authoritative`
- `suceed` → `succeed`
- `postgressql` → `postgresql`

