### PR TITLE
[Storage] Fix Azure mount install cmd to not reinstall fuse3 when fusermount-shim is used

### DIFF
--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -235,8 +235,8 @@ def get_az_mount_install_cmd() -> str:
         'FUSE3_INSTALLED=0 && '
         # On Kubernetes, if FUSERMOUNT_SHARED_DIR is set, it means
         # fusermount and fusermount3 is symlinked to fusermount-shim.
-        # If we install fuse3, it will overwrite the fusermount-shim,
-        # so just install libfuse3, which is needed by blobfuse2.
+        # If we reinstall fuse3, it may overwrite the symlink, so
+        # just install libfuse3, which is needed by blobfuse2.
         'if [ -n "${FUSERMOUNT_SHARED_DIR:-}" ]; then '
         '  PACKAGES="libfuse3-3 libfuse3-dev"; '
         'else '


### PR DESCRIPTION
Failing on master: https://buildkite.com/skypilot-1/smoke-tests/builds/5076/steps/canvas?sid=019a3b52-536d-4eeb-affb-8b0f0ec808df

Related to #7531 

In `get_az_mount_install_cmd`, we install `fuse3`, `libfuse3-3`, `libfuse3-dev`. This is a problem when running in k8s, because we symlink fusermount and fusermount3 to our fusermount-shim (see https://github.com/skypilot-org/skypilot/tree/master/addons/fuse-proxy for details): https://github.com/skypilot-org/skypilot/blob/c2ddb3eeb0842c270055d5ec2e4282e42d816b31/sky/templates/kubernetes-ray.yml.j2#L814-L828

And re-installing `fuse3` will overwrite this symlink.

To illustrate what happens before and after `get_az_mount_install_cmd`:
```bash
# Initially, points to the shim
(base) sky@sky-b27a-kevin-7a2eebbf-head:~$ fusermount -V
fusermount3-shim version: 0.1.0
(base) sky@sky-b27a-kevin-7a2eebbf-head:~$ sudo apt-get update
...
(base) sky@sky-b27a-kevin-7a2eebbf-head:~$ sudo apt-get install fuse3 libfuse3-dev -y
...
# Overwritten, now points to the real fuse3 binary
(base) sky@sky-b27a-kevin-7a2eebbf-head:~$ fusermount -V
fusermount3 version: 3.10.3
```

This will lead to an error the next time we try to call fusermount:
```
fusermount: failed to open /dev/fuse: Operation not permitted
```

Because our skypilot pods by design do not have root privileges, it has to rely on the shim to talk to the fusermount-server (which is the one that has the privileges).

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
