### PR TITLE
[k8s] add more debug logs around k8s list_namespaced_pod

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1707,7 +1707,7 @@ def query_instances(
 
         # Log response metadata
         # pylint: disable=protected-access
-        logger.info(
+        logger.debug(
             f'Query response for skypilot cluster {cluster_name_on_cloud}: '
             f'resource_version={response.metadata.resource_version}, '
             f'pod_count={len(pods)}, '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR adds more debug logging around the `list_namespaced_pod` call to the k8s api to help diagnose issues where the k8s api returns an empty list of pods. These debug logs can help us determine whether this case is a bug on our end (we are passing in incorrect filtering values) or in the k8s api.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
