### PR TITLE
skip `test_managed_jobs_logs_gc` for dependency tests

### DIFF
--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -1598,6 +1598,7 @@ def test_managed_jobs_failed_precheck_storage_spec_error(
 
 @pytest.mark.no_remote_server  # Need an isolated API server for this test case
 @pytest.mark.managed_jobs
+@pytest.mark.no_dependency  # restart api server requires full dependency installed
 def test_managed_jobs_logs_gc(generic_cloud: str):
     name = smoke_tests_utils.get_cluster_name()
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We can't restart api server in the middle of tests in dependency tests, this scenario the server will have full dependency but client only partial installed.

If we restart, the server will be broken

See failure: https://buildkite.com/skypilot-1/smoke-tests/builds/5113#019a3dab-0a8d-4910-bb43-f304e22f0258

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
