### PR TITLE
Recover policy server from broken state

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -566,12 +566,13 @@ def setup_policy_server(request, tmp_path_factory):
                     launch_server = False
                 except RuntimeError:
                     # There is a broken state from previous crashed test, recover it
-                    print(f'Policy server {policy_server_url} is not running, launching new server',
-                          file=sys.stderr,
-                          flush=True)
+                    print(
+                        f'Policy server {policy_server_url} is not running, launching new server',
+                        file=sys.stderr,
+                        flush=True)
                     pathlib.Path(counter_file).unlink(missing_ok=True)
                     launch_server = True
-            
+
             if launch_server:
                 # Launch the policy server
                 port = common_utils.find_free_port(start_port=10000)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fix https://buildkite.com/skypilot-1/quicktest-core/builds/1779#019a3cde-4fc6-44ac-b571-07424b25fe1f

The policy server url file might left uncleaned if the previous test is crashed without the `finally` block executed, this PR adding guard to check the healthz of the policy server

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
