### PR TITLE
Allow configuring provisioner ssh socket timeout via environment variable

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -567,6 +567,11 @@ determines how long to wait for the connection to be established.
 
 Default: ``10``.
 
+The low-level socket connect timeout used for the raw SSH probe can be tuned
+with the ``SKYPILOT_SSH_SOCKET_CONNECT_TIMEOUT`` environment variable (seconds;
+default: ``1``). This controls how long each socket connection attempt waits
+before SkyPilot falls back to retrying.
+
 .. _config-yaml-aws:
 
 ``aws``

--- a/tests/unit_tests/test_provisioner.py
+++ b/tests/unit_tests/test_provisioner.py
@@ -1,0 +1,88 @@
+from unittest import mock
+
+import pytest
+
+from sky.provision import provisioner
+
+
+class _DummySocket:
+    """Simple context manager socket mock for SSH probing tests."""
+
+    def __init__(self, recv_payload: bytes = b'SSH'):
+        self._recv_payload = recv_payload
+
+    def recv(self, _num_bytes: int) -> bytes:
+        return self._recv_payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+
+def _setup_successful_socket(monkeypatch):
+    dummy_socket = _DummySocket()
+    create_connection_mock = mock.MagicMock(return_value=dummy_socket)
+    monkeypatch.setattr(provisioner.socket,
+                        'create_connection',
+                        create_connection_mock)
+    monkeypatch.setattr(provisioner,
+                        '_wait_ssh_connection_indirect',
+                        mock.MagicMock(return_value=(True, '')))
+    return create_connection_mock
+
+
+def test_wait_ssh_connection_direct_uses_default_timeout(monkeypatch):
+    monkeypatch.delenv('SKYPILOT_SSH_SOCKET_CONNECT_TIMEOUT', raising=False)
+    create_connection_mock = _setup_successful_socket(monkeypatch)
+
+    success, stderr = provisioner._wait_ssh_connection_direct(
+        '1.2.3.4',
+        22,
+        ssh_user='user',
+        ssh_private_key='key',
+        ssh_probe_timeout=5)
+
+    assert success
+    assert stderr == ''
+    assert create_connection_mock.call_args.kwargs['timeout'] == 1.0
+
+
+def test_wait_ssh_connection_direct_env_override(monkeypatch):
+    monkeypatch.setenv('SKYPILOT_SSH_SOCKET_CONNECT_TIMEOUT', '2.5')
+    create_connection_mock = _setup_successful_socket(monkeypatch)
+
+    success, _ = provisioner._wait_ssh_connection_direct(
+        '5.6.7.8',
+        22,
+        ssh_user='user',
+        ssh_private_key='key',
+        ssh_probe_timeout=5)
+
+    assert success
+    assert create_connection_mock.call_args.kwargs['timeout'] == pytest.approx(
+        2.5)
+
+
+@pytest.mark.parametrize('value', ['abc', '0', '-1'])
+def test_wait_ssh_connection_direct_invalid_env(monkeypatch, value):
+    monkeypatch.setenv('SKYPILOT_SSH_SOCKET_CONNECT_TIMEOUT', value)
+    create_connection_mock = mock.MagicMock()
+    monkeypatch.setattr(provisioner.socket,
+                        'create_connection',
+                        create_connection_mock)
+    monkeypatch.setattr(provisioner,
+                        '_wait_ssh_connection_indirect',
+                        mock.MagicMock(return_value=(True, '')))
+
+    success, stderr = provisioner._wait_ssh_connection_direct(
+        '9.9.9.9',
+        22,
+        ssh_user='user',
+        ssh_private_key='key',
+        ssh_probe_timeout=5)
+
+    assert not success
+    assert 'Invalid SKYPILOT_SSH_SOCKET_CONNECT_TIMEOUT' in stderr
+    create_connection_mock.assert_not_called()

--- a/tests/unit_tests/test_provisioner.py
+++ b/tests/unit_tests/test_provisioner.py
@@ -24,11 +24,9 @@ class _DummySocket:
 def _setup_successful_socket(monkeypatch):
     dummy_socket = _DummySocket()
     create_connection_mock = mock.MagicMock(return_value=dummy_socket)
-    monkeypatch.setattr(provisioner.socket,
-                        'create_connection',
+    monkeypatch.setattr(provisioner.socket, 'create_connection',
                         create_connection_mock)
-    monkeypatch.setattr(provisioner,
-                        '_wait_ssh_connection_indirect',
+    monkeypatch.setattr(provisioner, '_wait_ssh_connection_indirect',
                         mock.MagicMock(return_value=(True, '')))
     return create_connection_mock
 
@@ -53,12 +51,11 @@ def test_wait_ssh_connection_direct_env_override(monkeypatch):
     monkeypatch.setenv('SKYPILOT_SSH_SOCKET_CONNECT_TIMEOUT', '2.5')
     create_connection_mock = _setup_successful_socket(monkeypatch)
 
-    success, _ = provisioner._wait_ssh_connection_direct(
-        '5.6.7.8',
-        22,
-        ssh_user='user',
-        ssh_private_key='key',
-        ssh_probe_timeout=5)
+    success, _ = provisioner._wait_ssh_connection_direct('5.6.7.8',
+                                                         22,
+                                                         ssh_user='user',
+                                                         ssh_private_key='key',
+                                                         ssh_probe_timeout=5)
 
     assert success
     assert create_connection_mock.call_args.kwargs['timeout'] == pytest.approx(
@@ -69,11 +66,9 @@ def test_wait_ssh_connection_direct_env_override(monkeypatch):
 def test_wait_ssh_connection_direct_invalid_env(monkeypatch, value):
     monkeypatch.setenv('SKYPILOT_SSH_SOCKET_CONNECT_TIMEOUT', value)
     create_connection_mock = mock.MagicMock()
-    monkeypatch.setattr(provisioner.socket,
-                        'create_connection',
+    monkeypatch.setattr(provisioner.socket, 'create_connection',
                         create_connection_mock)
-    monkeypatch.setattr(provisioner,
-                        '_wait_ssh_connection_indirect',
+    monkeypatch.setattr(provisioner, '_wait_ssh_connection_indirect',
                         mock.MagicMock(return_value=(True, '')))
 
     success, stderr = provisioner._wait_ssh_connection_direct(


### PR DESCRIPTION
I found skypilot could fail due to timeout errors on slower connections (Starlink, high contention network). Added a defaults-preserving global environment variable so users don't need need to resort to per-cloud `ssh_proxy_command: 'none'` workarounds.

- Allow overriding the raw SSH socket probe timeout via `SKYPILOT_SSH_SOCKET_CONNECT_TIMEOUT`, keeping the 1 s default, and surface misconfigurations with clear errors.
- Document the new environment variable alongside the existing `provision.ssh_timeout` option.
- Add focused unit tests covering default, override, and invalid values for the new timeout path.

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - `PYTHONPATH=. uv run --no-project pytest tests/unit_tests/test_provisioner.py`
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)