### PR TITLE
[Helm] Remove unused Grafana default dashboard provider

### DIFF
--- a/charts/skypilot/DCGM_MONITORING.md
+++ b/charts/skypilot/DCGM_MONITORING.md
@@ -106,25 +106,15 @@ helm install skypilot ./charts/skypilot \
 
 ### Dashboard Configuration
 
-The NVIDIA DCGM dashboard is automatically provisioned using Grafana's dashboard import feature:
+The NVIDIA DCGM dashboards are automatically provisioned using Grafana's dashboards sidecar:
 
 ```yaml
 # In values.yaml
 grafana:
   enabled: true
-  dashboardProviders:
-    dashboardproviders.yaml:
-      apiVersion: 1
-      providers:
-      - name: 'default'
-        orgId: 1
-        folder: ''
-        type: file
-        disableDeletion: false
-        allowUiUpdates: false
-        updateIntervalSeconds: 30
-        options:
-          path: /var/lib/grafana/dashboards/default
+  sidecar:
+    dashboards:
+      enabled: true
 ```
 
 ## How It Works

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -618,17 +618,3 @@ grafana:
     # Enable dashboards discovery in grafana sidecar.
     dashboards:
       enabled: true
-  # Add dashboard provider configuration to load dashboards from default directory
-  dashboardProviders:
-    dashboardproviders.yaml:
-      apiVersion: 1
-      providers:
-      - name: 'default'
-        orgId: 1
-        folder: ''
-        type: file
-        disableDeletion: false
-        allowUiUpdates: false
-        updateIntervalSeconds: 30
-        options:
-          path: /var/lib/grafana/dashboards/default

--- a/docs/source/reference/api-server/helm-values-spec.rst
+++ b/docs/source/reference/api-server/helm-values-spec.rst
@@ -2209,19 +2209,6 @@ By default, Grafana is configured to work with the ingress controller and auth p
         enabled: true
       dashboards:
         enabled: true
-    dashboardProviders:
-      dashboardproviders.yaml:
-        apiVersion: 1
-        providers:
-        - name: 'default'
-          orgId: 1
-          folder: ''
-          type: file
-          disableDeletion: false
-          allowUiUpdates: false
-          updateIntervalSeconds: 30
-          options:
-            path: /var/lib/grafana/dashboards/default
 
 .. _helm-values-grafana-enabled:
 


### PR DESCRIPTION
This PR removes the redundant `dashboardProviders` configuration from the Grafana values that was causing these error logs to endlessly show up:

```
logger=provisioning.dashboard type=file name=default level=error msg="failed to search for dashboards" error="stat /var/lib/grafana/dashboards/default: no such file or directory"
```

This was caused by a manual `dashboardProviders` configuration in `values.yaml` that pointed to `/var/lib/grafana/dashboards/default` - a directory that doesn't exist in our default deployment.

So our Helm chart had two conflicting dashboard provisioning approaches:
1. **Sidecar-based provisioning** (enabled via `sidecar.dashboards.enabled: true`)
   - The Grafana Helm chart automatically creates a dashboard provider pointing to `/tmp/dashboards`
   - The sidecar containers watch for ConfigMaps/Secrets with label `grafana_dashboard: "true"`
   - Dashboards are written to `/tmp/dashboards` and loaded successfully
   - This is working correctly

2. **File-based provider** (our custom `dashboardProviders` config)
   - Pointed to `/var/lib/grafana/dashboards/default`
   - No volume or ConfigMap mounted at this location
   - Caused repeated errors as Grafana tried to scan a non-existent directory

---

### Extra: When is `/var/lib/grafana/dashboards/default` relevant?

The `/var/lib/grafana/dashboards/default` directory is only used when using the `dashboards` field in `values.yaml`:
```yaml
grafana:
  dashboards:
    default:
      my-dashboard:
        json: |
          { "dashboard": {...} }
      imported-dashboard:
        gnetId: 12345
        datasource: Prometheus
```
The Grafana Helm chart will create ConfigMaps and mounts them to `/var/lib/grafana/dashboards/default`.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Manually verified that the three dashboards we have by default is still present after the helm upgrade:
  ```
   % kubectl exec -it skypilot-grafana-5d654959c9-brj54 -- ls /tmp/dashboards
   api-server-overview.json        dcgm-skycluster-dashboard.json
   dcgm-cluster-dashboard.json
  ```
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
