### PR TITLE
[Test] Reduce memory usage of test_launch_and_cancel_race_condition

### DIFF
--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -37,7 +37,6 @@ from sky import skypilot_config
 from sky.skylet import constants
 from sky.skylet import events
 from sky.utils import common_utils
-from sky.utils import context
 from sky.utils import yaml_utils
 
 
@@ -1596,7 +1595,6 @@ def test_launch_and_cancel_race_condition(generic_cloud: str):
 
     def launch_and_cancel(idx: int):
         try:
-            context.initialize()
             cluster_name = f'{name}-{idx}'
 
             # Create a minimal task


### PR DESCRIPTION
Fixes #7809.

Previously, this test would allocate an additional 4.5-5GB of memory, since we were spawning 20 new processes to run the sky CLI in parallel.

This PR improves this by calling our SDK instead of CLI, which allows us to run them as threads, which are more lightweight than processes. As a result, the test now allocates much less memory, only ~1GB, even while increasing the parallelism from 20 to 30.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
