### PR TITLE
[Dashboard] Only show workspaces for the k8s contexts if there are more than 1 workspaces

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -223,8 +223,8 @@ export function InfrastructureSection({
                       // Get workspace information for this context
                       const workspaces = contextWorkspaceMap[context] || [];
                       const workspaceDisplay =
-                        workspaces.length > 0
-                          ? ` (${workspaces.join(', ')})`
+                        workspaces.length > 1
+                          ? ` (workspaces: ${workspaces.join(', ')})`
                           : '';
 
                       return (


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Only show workspaces for the k8s contexts if there are more than 1 workspaces

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
