### PR TITLE
[Pools] Change Run Wording.

### DIFF
--- a/sky/serve/server/impl.py
+++ b/sky/serve/server/impl.py
@@ -160,8 +160,8 @@ def up(
     if pool:
         if task.run is not None:
             logger.warning(
-                f'{colorama.Fore.YELLOW}The `run` section will be '
-                f'ignored for pool creation.{colorama.Style.RESET_ALL}')
+                f'{colorama.Fore.YELLOW}The `run` section will be ignored when '
+                f'creating the pool.{colorama.Style.RESET_ALL}')
         # Use dummy run script for cluster pool.
         task.run = serve_constants.POOL_DUMMY_RUN_COMMAND
 
@@ -547,8 +547,8 @@ def update(
     if pool:
         if task.run is not None:
             logger.warning(
-                f'{colorama.Fore.YELLOW}The `run` section will be '
-                f'ignored for pool creation.{colorama.Style.RESET_ALL}')
+                f'{colorama.Fore.YELLOW}The `run` section will be ignored when '
+                f'creating the pool.{colorama.Style.RESET_ALL}')
         # Use dummy run script for cluster pool.
         task.run = serve_constants.POOL_DUMMY_RUN_COMMAND
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR makes a small change to the message we display when the user specifies the run section in a pool which is not supported for pool creation. From "The `run` section will be ignored for pool." to "The `run` section will be ignored for pool creation."

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
