### PR TITLE
[k8s] add even more debug logs around k8s list_namespaced_pod

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1716,11 +1716,10 @@ def query_instances(
 
         pods = response.items
 
-        logger.debug(f'k8s api response for `{label_selector}`: '
-                     f'len(pods)={len(pods)}')
-
         # log detailed Pod info
         if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
+            logger.debug(f'k8s api response for `{label_selector}`: '
+                         f'len(pods)={len(pods)}')
             for pod in pods:
                 logger.debug(f'k8s pod info for `{label_selector}`: '
                              f'pod.apiVersion={pod.api_version}, '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Logged the entire response except for the `response.items` in case this fails for some reason. Then we grab `pods = response.items`, log a summary indicating how many pods were returned and then log detailed information about each pod. We log every field that the k8s `Pod` object has except for `PodSpec` which would not be very helpful for debugging here and is extremely verbose.


<!-- Describe the tests ran -->
Restarted the api server, observed the logs, and verified that they look as expected/useful. 

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
