### PR TITLE
[Dashboard] Show Succeeded Pools in Dropdown

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -612,7 +612,7 @@ export function ManagedJobsTable({
 
   // Populate valueList for filter dropdown
   useEffect(() => {
-    if (!data || data.length === 0 || !setValueList) {
+    if (!setValueList) {
       return;
     }
 
@@ -628,13 +628,41 @@ export function ManagedJobsTable({
       if (job.pool) pools.add(job.pool);
     });
 
+    // Extract pool names from poolsData, but only include pools that:
+    // 1. Have running jobs (non-terminal status jobs), OR
+    // 2. Were created in the last day (based on uptime)
+    if (poolsData && Array.isArray(poolsData)) {
+      const oneDayInSeconds = 24 * 60 * 60; // 24 hours in seconds
+
+      poolsData.forEach((pool) => {
+        if (!pool.name) return;
+
+        // Check if pool has running jobs (non-terminal status)
+        const hasRunningJobs =
+          pool.jobCounts && Object.keys(pool.jobCounts).length > 0;
+
+        // Check if pool was created in the last day
+        // uptime is seconds since pool was created
+        // If uptime is null/undefined, we can't determine creation time
+        const createdInLastDay =
+          pool.uptime !== null &&
+          pool.uptime !== undefined &&
+          pool.uptime > 0 &&
+          pool.uptime < oneDayInSeconds;
+
+        if (hasRunningJobs || createdInLastDay) {
+          pools.add(pool.name);
+        }
+      });
+    }
+
     setValueList({
       name: Array.from(names).sort(),
       user: Array.from(users).sort(),
       workspace: Array.from(workspaces).sort(),
       pool: Array.from(pools).sort(),
     });
-  }, [data, setValueList]);
+  }, [data, poolsData, setValueList]);
 
   const requestSort = (key) => {
     let direction = 'ascending';


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Before this change the managed jobs page in the dashboard would not autocomplete pools whose jobs had all succeeded. Now we have changed this so that the dropdown will show pools with running jobs and pools that have been created in the last day so that users can easily monitor the jobs from their pools.

<img width="1331" height="277" alt="Screenshot 2025-11-04 at 2 35 18 PM" src="https://github.com/user-attachments/assets/2af4a718-647e-48f6-8135-23e5338d6d26" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
