### PR TITLE
[examples] make ray example process check more robust

### DIFF
--- a/examples/distributed_ray_train/ray_train.yaml
+++ b/examples/distributed_ray_train/ray_train.yaml
@@ -25,12 +25,12 @@ run: |
   head_ip=`echo "$SKYPILOT_NODE_IPS" | head -n1`
   num_nodes=`echo "$SKYPILOT_NODE_IPS" | wc -l`
   if [ "$SKYPILOT_NODE_RANK" == "0" ]; then
-    ps aux | grep ray | grep 6379 &> /dev/null || ray start --head  --disable-usage-stats --port 6379
+    ps -eo cmd= | grep ray | grep 6379 &> /dev/null || ray start --head  --disable-usage-stats --port 6379
     sleep 5
     python train.py --num-workers $num_nodes
   else
     sleep 5
-    ps aux | grep ray | grep 6379 &> /dev/null || ray start --address $head_ip:6379 --disable-usage-stats
+    ps -eo cmd= | grep ray | grep 6379 &> /dev/null || ray start --address $head_ip:6379 --disable-usage-stats
     # Add sleep to after `ray start` to give ray enough time to daemonize 
     sleep 5
   fi


### PR DESCRIPTION
The ray-project/ray docker image uses the username `ray`, which causes every single line of `ps aux` to match `ray`. So the result of `ps aux | grep ray | grep 6379` is always
```
ray       192069  0.0  0.0   4060  2176 pts/0    S+   16:46   0:00 grep --color=auto 6379
```
or similar.
Then we will never call `ray start`.

Update the ps command so that it will only print the cmdline.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
