### PR TITLE
[SSH] Fix SSH with SSO

### DIFF
--- a/sky/templates/websocket_proxy.py
+++ b/sky/templates/websocket_proxy.py
@@ -239,14 +239,14 @@ if __name__ == '__main__':
 
     disable_latency_measurement = os.environ.get(
         skylet_constants.SSH_DISABLE_LATENCY_MEASUREMENT_ENV_VAR, '0') == '1'
-    if not disable_latency_measurement:
+    if disable_latency_measurement:
+        timestamps_are_supported = False
+    else:
         health_url = f'{server_url}/api/health'
         cookie_hdr = _get_cookie_header(health_url)
         health_response = requests.get(health_url, headers=cookie_hdr)
         health_data = health_response.json()
         timestamps_are_supported = int(health_data.get('api_version', 0)) > 21
-    else:
-        timestamps_are_supported = False
 
     server_proto, server_fqdn = server_url.split('://')
     websocket_proto = 'ws'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Before this PR we were not using the cookies to make the health request to check the version to see if ssh timestamping was supported. This would cause SSH to fail when oauth is used when we attempt to look up the api version.

We now:
- Pass the cookie in when making the check
- For whatever reason if we don't get the version we no longer error using `.get()`
- If the environment variable is set to disable timestamping we don't even make the check in the first place.

Verified this against a deployed API server with SSO.

Fixes #7860

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
