### PR TITLE
[SSH] Add Connectivity Test for Coverage

### DIFF
--- a/tests/kubernetes/scripts/helm_okta.sh
+++ b/tests/kubernetes/scripts/helm_okta.sh
@@ -451,3 +451,7 @@ kubectl delete namespace $NAMESPACE --ignore-not-found=true
 echo "✅ Namespace $NAMESPACE deleted"
 
 deploy_and_login "new"
+
+# Run basic tests.
+echo "Running basic tests..."
+pytest tests/smoke_tests/test_basic.py --kubernetes -k test_kubernetes_ssh_proxy_connection

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -1675,3 +1675,23 @@ def test_cancel_logs_request(generic_cloud: str):
         f'sky down -y {name} || true',
     )
     smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.kubernetes
+def test_kubernetes_ssh_proxy_connection():
+    """Test Kubernetes SSH proxy connection.
+    """
+    cluster_name = smoke_tests_utils.get_cluster_name()
+
+    test = smoke_tests_utils.Test(
+        'kubernetes_ssh_proxy_connection',
+        [
+            # Launch a minimal Kubernetes cluster for SSH proxy testing
+            f'sky launch -y -c {cluster_name} --infra kubernetes {smoke_tests_utils.LOW_RESOURCE_ARG} echo "SSH test cluster ready"',
+            # Run an SSH command on the cluster.
+            f'ssh {cluster_name} echo "SSH command executed"',
+        ],
+        f'sky down -y {cluster_name}',
+        timeout=15 * 60,  # 15 minutes timeout
+    )
+    smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2465,26 +2465,6 @@ def test_kubernetes_pod_config_change_detection():
         os.unlink(task_yaml_2_path)
 
 
-@pytest.mark.kubernetes
-def test_kubernetes_ssh_proxy_connection():
-    """Test Kubernetes SSH proxy connection.
-    """
-    cluster_name = smoke_tests_utils.get_cluster_name()
-
-    test = smoke_tests_utils.Test(
-        'kubernetes_ssh_proxy_connection',
-        [
-            # Launch a minimal Kubernetes cluster for SSH proxy testing
-            f'sky launch -y -c {cluster_name} --infra kubernetes {smoke_tests_utils.LOW_RESOURCE_ARG} echo "SSH test cluster ready"',
-            # Run an SSH command on the cluster.
-            f'ssh {cluster_name} echo "SSH command executed"',
-        ],
-        f'sky down -y {cluster_name}',
-        timeout=15 * 60,  # 15 minutes timeout
-    )
-    smoke_tests_utils.run_one_test(test)
-
-
 # ---------- SSH Proxy Performance Test ----------
 @pytest.mark.kubernetes
 @pytest.mark.no_remote_server


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR adds a new basic test to test ssh connectivity and invokes it at the end of `test_helm_deploy_okta` to ensure that ssh connectivity works in an SSO environment.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
