### PR TITLE
[Test] Reduce test_launch_and_cancel_race_condition parallelism to 20

### DIFF
--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -1620,10 +1620,10 @@ def test_launch_and_cancel_race_condition(generic_cloud: str):
             exceptions.append((idx, e))
 
     def run_parallel_launch_and_cancel() -> Generator[str, None, None]:
-        yield 'Running 30 parallel launch and cancel operations using SDK'
+        yield 'Running 20 parallel launch and cancel operations using SDK'
         # Run multiple launch and cancel in parallel to introduce request queuing.
         # This can trigger race conditions more frequently.
-        for i in range(30):
+        for i in range(20):
             thread = threading.Thread(target=launch_and_cancel,
                                       args=(i,),
                                       daemon=True)


### PR DESCRIPTION
This was a bit flaky on the last nightly test. 30 concurrent executor processes might get the CPU exhausted, since we recently limit the CPU of each buildkite agent container to 4.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
