### PR TITLE
[Dashboard] Return resources_str_full for cluster records of the dashboard requests

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -3243,11 +3243,10 @@ def get_clusters(
             handle = record['handle']
             resource_str_simple, resource_str_full = (
                 resources_utils.get_readable_resources_repr(
-                    handle, simplified_only=summary_response))
+                    handle, simplified_only=False))
             record['resources_str'] = resource_str_simple
+            record['resources_str_full'] = resource_str_full
             if not summary_response:
-                assert resource_str_full is not None
-                record['resources_str_full'] = resource_str_full
                 record['cluster_name_on_cloud'] = handle.cluster_name_on_cloud
 
     def _update_records_with_credentials(

--- a/sky/core.py
+++ b/sky/core.py
@@ -420,21 +420,17 @@ def cost_report(
         num_nodes = record.get('num_nodes', 1)
         try:
             resource_str_simple, resource_str_full = (
-                resources_utils.format_resource(
-                    resources, simplified_only=abbreviate_response))
+                resources_utils.format_resource(resources,
+                                                simplified_only=False))
             record['resources_str'] = f'{num_nodes}x{resource_str_simple}'
-            if not abbreviate_response:
-                assert resource_str_full is not None
-                record[
-                    'resources_str_full'] = f'{num_nodes}x{resource_str_full}'
+            record['resources_str_full'] = f'{num_nodes}x{resource_str_full}'
         except Exception as e:  # pylint: disable=broad-except
             logger.debug(f'Failed to get resources_str for cluster '
                          f'{record["name"]}: {str(e)}')
             for field in fields:
                 record[field] = None
             record['resources_str'] = '-'
-            if not abbreviate_response:
-                record['resources_str_full'] = '-'
+            record['resources_str_full'] = '-'
 
     for report in cluster_reports:
         _update_record_with_resources(report)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Return `resources_str_full` for cluster records of the dashboard requests

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Full resources can be shown when hovering on the `resources` column for running and terminated clusters in the cluster page.
  - `sky status` works for new client + new server, new client + old server, new server + old client
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
