### PR TITLE
[Test] Skip test_no_ssh_tunnel_process_leak_after_teardown for remote server tests

### DIFF
--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -1716,6 +1716,9 @@ def test_kubernetes_ssh_proxy_connection():
     smoke_tests_utils.run_one_test(test)
 
 
+# Only checks for processes in local machine, so skip remote server test.
+# TODO(kevin): Add metrics for number of open SSH tunnels and refactor this test to use it.
+@pytest.mark.no_remote_server
 def test_no_ssh_tunnel_process_leak_after_teardown(generic_cloud: str):
     """Test that no SSH tunnel process leaks after teardown."""
     cluster_name = smoke_tests_utils.get_cluster_name()


### PR DESCRIPTION
Failing on nightly build: https://buildkite.com/skypilot-1/smoke-tests/builds/5304/steps/canvas?sid=019a5d97-4b6d-47bb-ae61-3eb6961cabeb

This test checks for local processes and so should be skipped for remote server tests. In the future we can refactor this to use API server metrics (we'd need to add new metrics) instead of relying on `ps`.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
