### PR TITLE
Bugfix: add curl redirection for fluent-bit key download.

### DIFF
--- a/sky/logs/agent.py
+++ b/sky/logs/agent.py
@@ -38,7 +38,7 @@ class FluentbitAgent(LoggingAgent):
             'if ! command -v fluent-bit >/dev/null 2>&1 && [ ! -f /opt/fluent-bit/bin/fluent-bit ]; then '
             'sudo apt-get update; sudo apt-get install -y gnupg; '
             # pylint: disable=line-too-long
-            'sudo sh -c \'curl https://packages.fluentbit.io/fluentbit.key | gpg --dearmor > /usr/share/keyrings/fluentbit-keyring.gpg\'; '
+            'sudo sh -c \'curl -L https://packages.fluentbit.io/fluentbit.key | gpg --dearmor > /usr/share/keyrings/fluentbit-keyring.gpg\'; '
             # pylint: disable=line-too-long
             'os_id=$(grep -oP \'(?<=^ID=).*\' /etc/os-release 2>/dev/null || lsb_release -is 2>/dev/null | tr \'[:upper:]\' \'[:lower:]\'); '
             # pylint: disable=line-too-long


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR updates the fluent-bit key download to use `curl -L` instead of `curl`. This change fixes the following error from `sky logs --provision <cluster-name>` when using a sky config with GCP cloud logging set up: 
```
D 11-07 11:40:04 provisioner.py:740] ================================
D 11-07 11:40:04 provisioner.py:740]  Fluent Bit Installation Script 
D 11-07 11:40:04 provisioner.py:740] ================================
D 11-07 11:40:04 provisioner.py:740] This script requires superuser access to install packages.
D 11-07 11:40:04 provisioner.py:740] You will be prompted for your password by sudo.
D 11-07 11:40:04 provisioner.py:740]   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
D 11-07 11:40:04 provisioner.py:740]                                  Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
D 11-07 11:40:04 provisioner.py:740] gpg: no valid OpenPGP data found.
D 11-07 11:40:04 provisioner.py:740] deb [signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] https://packages.fluentbit.io/ubuntu/jammy jammy main
D 11-07 11:40:04 provisioner.py:740] Hit:1 http://archive.ubuntu.com/ubuntu jammy InRelease
D 11-07 11:40:04 provisioner.py:740] Hit:2 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64  InRelease
D 11-07 11:40:04 provisioner.py:740] Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
D 11-07 11:40:04 provisioner.py:740] Hit:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
D 11-07 11:40:04 provisioner.py:740] Ign:6 http://linux.mellanox.com/public/repo/mlnx_ofed/24.10-3.2.5.0/ubuntu22.04/amd64 ./ InRelease
D 11-07 11:40:04 provisioner.py:740] Hit:7 http://security.ubuntu.com/ubuntu jammy-security InRelease
D 11-07 11:40:04 provisioner.py:740] Hit:8 https://packages.cloud.google.com/apt cloud-sdk InRelease
D 11-07 11:40:04 provisioner.py:740] Get:5 https://s3.amazonaws.com/packages.fluentbit.io/ubuntu/jammy jammy InRelease [7565 B]
D 11-07 11:40:04 provisioner.py:740] Hit:9 http://linux.mellanox.com/public/repo/mlnx_ofed/24.10-3.2.5.0/ubuntu22.04/amd64 ./ Release
D 11-07 11:40:04 provisioner.py:740] Hit:10 https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy InRelease
D 11-07 11:40:04 provisioner.py:740] Err:5 https://s3.amazonaws.com/packages.fluentbit.io/ubuntu/jammy jammy InRelease
D 11-07 11:40:04 provisioner.py:740]   The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 9F9DDC083888C1CD
D 11-07 11:40:04 provisioner.py:740] Reading package lists...
D 11-07 11:40:04 provisioner.py:740] W: GPG error: https://s3.amazonaws.com/packages.fluentbit.io/ubuntu/jammy jammy InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 9F9DDC083888C1CD
D 11-07 11:40:04 provisioner.py:740] E: The repository 'https://packages.fluentbit.io/ubuntu/jammy jammy InRelease' is not signed.
D 11-07 11:40:04 provisioner.py:740] W: http://linux.mellanox.com/public/repo/mlnx_ofed/24.10-3.2.5.0/ubuntu22.04/amd64/./Release.gpg: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
D 11-07 11:40:04 provisioner.py:740] Reading package lists...
D 11-07 11:40:04 provisioner.py:740] Building dependency tree...
D 11-07 11:40:04 provisioner.py:740] Reading state information...
D 11-07 11:40:04 provisioner.py:740] E: Unable to locate package fluent-bit
D 11-07 11:40:04 provisioner.py:740] 
D 11-07 11:40:04 provisioner.py:740] ===== stderr =====
D 11-07 11:40:04 provisioner.py:740] 
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
