### PR TITLE
Add set autostop max minutes policy to public docs

### DIFF
--- a/docs/source/cloud-setup/policy.rst
+++ b/docs/source/cloud-setup/policy.rst
@@ -413,6 +413,19 @@ Enforce autostop for all tasks
     :caption: `Config YAML for using EnforceAutostopPolicy <https://github.com/skypilot-org/skypilot/blob/master/examples/admin_policy/enforce_autostop.yaml>`_
 
 
+Set max autostop idle minutes for all tasks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. literalinclude:: ../../../examples/admin_policy/example_policy/example_policy/skypilot_policy.py
+    :language: python
+    :pyobject: SetMaxAutostopIdleMinutesPolicy
+    :caption: `SetMaxAutostopIdleMinutesPolicy <https://github.com/skypilot-org/skypilot/blob/master/examples/admin_policy/example_policy/example_policy/skypilot_policy.py>`_
+
+.. literalinclude:: ../../../examples/admin_policy/set_max_autostop_idle_minutes.yaml
+    :language: yaml
+    :caption: `Config YAML for using SetMaxAutostopIdleMinutesPolicy <https://github.com/skypilot-org/skypilot/blob/master/examples/admin_policy/set_max_autostop_idle_minutes.yaml>`_
+
+
 .. _dynamic-kubernetes-contexts-update-policy:
 
 Dynamically update Kubernetes contexts to use


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We already have this policy in `example_policies` package, we were just not exposing it to the public docs.
<img width="827" height="649" alt="Screenshot 2025-11-07 at 12 45 26 PM" src="https://github.com/user-attachments/assets/58a281fb-5736-4b1f-b848-b3dd5e004a77" />



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
