### PR TITLE
improvements to rate limit policy documentation

### DIFF
--- a/docs/source/cloud-setup/policy.rst
+++ b/docs/source/cloud-setup/policy.rst
@@ -56,6 +56,12 @@ Then, set the :ref:`admin_policy <config-yaml-admin-policy>` field in :ref:`the 
 
     admin_policy: example_policy.DoNothingPolicy
 
+
+.. tip::
+
+   You can replace ``DoNothingPolicy`` with any of the :ref:`example policies <example-policies>`.
+
+
 Then, run a task:
 
 .. code-block:: bash
@@ -71,6 +77,9 @@ You should see the admin policy is applied to the task.
     Applying client admin policy: DoNothingPolicy
     Applying server admin policy: DoNothingPolicy
     ...
+
+
+You can also deploy an admin policy as a :ref:`RESTful server <host-admin-policy-as-server>`.
 
 Deploy an admin policy
 ----------------------
@@ -330,6 +339,8 @@ to set the modified resource configuration back to the task.
 Useful for:
 
 - Enforcing resource constraints (e.g. use spot instances for all GPU tasks, enforce autostop for all tasks).
+
+.. _example-policies:
 
 Example policies
 ----------------


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
1. Move the `RateLimitLaunchPolicy` code block closer to policy title and put `TokenBucketRateLimiter` class as a collapsible below `RateLimitLaunchPolicy`.
2. Add comment / docstring to `TokenBucketRateLimiter` class.
3. Improve helptext by suggesting users to try out different policies and to directly link to RESTful policy deployment option.



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
