### PR TITLE
[Deployment] Use recreate for grafana deployment to avoid PVC blocking upgrade

### DIFF
--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -570,6 +570,11 @@ prometheus:
 # @schema skipProperties:true
 grafana:
   enabled: false
+  # Use Recreate strategy to avoid PVC mount conflicts during upgrades
+  # Since Grafana uses ReadWriteOnce PVC, RollingUpdate would fail when
+  # trying to mount the same PVC on two pods simultaneously
+  deploymentStrategy:
+    type: Recreate
   persistence:
     enabled: true
     size: 10Gi


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

As the grafana deployment uses a PVC for persistence, but during upgrade, it could easily trigger restart (seems due to password change), and block the helm upgrade to succeed. Use Recreate for the grafana deployment for now to avoid it blocking the upgrade.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
