### PR TITLE
[Azure] Pin azcopy version

### DIFF
--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -202,7 +202,7 @@ class AzureBlobCloudStorage(CloudStorage):
         'if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then '
         '  ARCH="arm64"; '
         'fi && '
-        'curl -L https://github.com/Azure/azure-storage-azcopy/releases/download/v10.30.1/azcopy_linux_${ARCH}_10.30.1.tar.gz -o azcopy.tar.gz; ' # pylint: disable=line-too-long
+        'curl -L https://github.com/Azure/azure-storage-azcopy/releases/download/v10.30.1/azcopy_linux_${ARCH}_10.30.1.tar.gz -o azcopy.tar.gz; '  # pylint: disable=line-too-long
         'sudo tar -xvzf azcopy.tar.gz --strip-components=1 -C /usr/local/bin --exclude=*.txt; '  # pylint: disable=line-too-long
         'sudo chmod +x /usr/local/bin/azcopy; '
         'rm azcopy.tar.gz)'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

As of today, the original `https://aka.ms/downloadazcopy-v10-linux` points to a non-existence URL: `https://github.com/Azure/azure-storage-azcopy/releases/download/v10.31.0/azcopy_linux_amd64_10.31.0.tar.gz`. It should be more robust to pin the version.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
