### PR TITLE
Better HTML error parsing on reverse proxy 503

### DIFF
--- a/sky/server/rest.py
+++ b/sky/server/rest.py
@@ -4,6 +4,8 @@ import asyncio
 import contextlib
 import contextvars
 import functools
+import html
+import re
 import time
 import typing
 from typing import Any, Callable, cast, Optional, TypeVar
@@ -56,6 +58,9 @@ _transient_errors = [
     ConnectionError,
     urllib3.exceptions.HTTPError,
 ]
+
+_HTML_TITLE_RE = re.compile(r'<title[^>]*>(.*?)</title>',
+                            re.IGNORECASE | re.DOTALL)
 
 
 class RetryContext:
@@ -249,11 +254,42 @@ def handle_server_unavailable(response: 'requests.Response') -> None:
         if 'detail' in response_data:
             error_msg = response_data['detail']
     except Exception:  # pylint: disable=broad-except
-        if response.text:
-            error_msg = response.text
+        error_msg = handle_response_text(response)
 
     with ux_utils.print_exception_no_traceback():
         raise exceptions.ServerTemporarilyUnavailableError(error_msg)
+
+
+def handle_response_text(response: 'requests.Response') -> str:
+    """Handle the plaintext response to get the error message
+
+    There is a special handling for html content which might be returned
+    by the reverse proxy to make the error message more user-friendly.
+    """
+    error_msg = ''
+    if isinstance(response, str):
+        text, headers = response, {}
+    else:
+        text = getattr(response, 'text', '')
+        headers = getattr(response, 'headers', {}) or {}
+    if not isinstance(text, str):
+        text = str(text) if text is not None else ''
+    if not text:
+        return ''
+    content_type = headers.get('Content-Type', '')
+    is_html = isinstance(content_type, str) and 'html' in (content_type.lower())
+    if not is_html:
+        stripped = text.lstrip()
+        is_html = stripped.startswith('<') and '<title' in stripped.lower()
+    if is_html:
+        match = _HTML_TITLE_RE.search(text)
+        if match:
+            title = html.unescape(match.group(1)).strip()
+            if title:
+                error_msg = title
+    if not error_msg:
+        error_msg = text
+    return error_msg
 
 
 async def handle_server_unavailable_async(

--- a/tests/unit_tests/test_sky/server/test_rest.py
+++ b/tests/unit_tests/test_sky/server/test_rest.py
@@ -11,6 +11,28 @@ from sky.server import rest
 request_err = requests.exceptions.ChunkedEncodingError("Test error")
 
 
+class TestHandleResponseText:
+    """Test cases for handle_response_text helper."""
+
+    def test_plain_text_response_returns_text(self):
+        mock_response = mock.Mock()
+        mock_response.text = 'Plain error message'
+        mock_response.headers = {'Content-Type': 'text/plain'}
+
+        assert rest.handle_response_text(mock_response) == 'Plain error message'
+
+    def test_html_response_extracts_title(self):
+        mock_response = mock.Mock()
+        mock_response.text = (
+            '<head><title>503 Service Temporarily Unavailable</title></head>\n'
+            '<body>\n'
+            '<center><h1>503 Service Temporarily Unavailable</h1></center>')
+        mock_response.headers = {'Content-Type': 'text/html; charset=UTF-8'}
+
+        assert rest.handle_response_text(
+            mock_response) == '503 Service Temporarily Unavailable'
+
+
 class TestHandleServerUnavailable:
     """Test cases for handle_server_unavailable function."""
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Refine the UX when the reverse proxy returns an HTML error

Master branch:

<img width="646" height="204" alt="image" src="https://github.com/user-attachments/assets/cb74fdbe-be30-4d03-a9a8-82948208d143" />


This PR:

<img width="788" height="81" alt="image" src="https://github.com/user-attachments/assets/4115529b-c697-491b-b071-56840b0129df" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
