### PR TITLE
[Test] Fix `azcopy` install.

### DIFF
--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -201,10 +201,12 @@ class AzureBlobCloudStorage(CloudStorage):
         'ARCH=$(uname -m) && '
         'if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then '
         '  ARCH="arm64"; '
+        'elif [ "$ARCH" = "x86_64" ]; then '
+        '  ARCH="amd64"; '
         'fi && '
-        'curl -L https://github.com/Azure/azure-storage-azcopy/releases/download/v10.30.1/azcopy_linux_${ARCH}_10.30.1.tar.gz -o azcopy.tar.gz; '  # pylint: disable=line-too-long
-        'sudo tar -xvzf azcopy.tar.gz --strip-components=1 -C /usr/local/bin --exclude=*.txt; '  # pylint: disable=line-too-long
-        'sudo chmod +x /usr/local/bin/azcopy; '
+        'curl -fL https://github.com/Azure/azure-storage-azcopy/releases/download/v10.30.1/azcopy_linux_${ARCH}_10.30.1.tar.gz -o azcopy.tar.gz && '  # pylint: disable=line-too-long
+        'sudo tar -xvzf azcopy.tar.gz --strip-components=1 -C /usr/local/bin --exclude=*.txt && '  # pylint: disable=line-too-long
+        'sudo chmod +x /usr/local/bin/azcopy && '
         'rm azcopy.tar.gz)'
     ]
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixes an issue with test_docker_storage_mount where azcopy was not being properly installed due to an issue with creating the curl command based on the architecture.

Added `-f` so that if we fail to curl we actually see the 404 error instead of just continuing.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
