### PR TITLE
[Dashboard] enable filtering clusters and jobs by user

### DIFF
--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -2178,7 +2178,7 @@ function UsersTable({
                     </span>
                   ) : (
                     <Link
-                      href={`/clusters?user=${encodeURIComponent(user.userId)}`}
+                      href={`/clusters?property=user&operator=%3A&value=${encodeURIComponent(user.username)}`}
                       className={`px-2 py-0.5 rounded text-xs font-medium transition-colors duration-200 cursor-pointer inline-block ${
                         user.clusterCount > 0
                           ? 'bg-blue-100 text-blue-600 hover:bg-blue-200 hover:text-blue-700'
@@ -2198,7 +2198,7 @@ function UsersTable({
                     </span>
                   ) : (
                     <Link
-                      href={`/jobs?user=${encodeURIComponent(user.userId)}`}
+                      href={`/jobs?property=user&operator=%3A&value=${encodeURIComponent(user.username)}`}
                       className={`px-2 py-0.5 rounded text-xs font-medium transition-colors duration-200 cursor-pointer inline-block ${
                         user.jobCount > 0
                           ? 'bg-green-100 text-green-600 hover:bg-green-200 hover:text-green-700'
@@ -2731,7 +2731,7 @@ function ServiceAccountTokensView({
                     </TableCell>
                     <TableCell>
                       <Link
-                        href={`/clusters?user=${encodeURIComponent(token.service_account_user_id)}`}
+                        href={`/clusters?property=user&operator=%3A&value=${encodeURIComponent(token.service_account_name)}`}
                         className={`px-2 py-0.5 rounded text-xs font-medium transition-colors duration-200 cursor-pointer inline-block ${
                           token.clusterCount > 0
                             ? 'bg-blue-100 text-blue-600 hover:bg-blue-200 hover:text-blue-700'
@@ -2744,7 +2744,7 @@ function ServiceAccountTokensView({
                     </TableCell>
                     <TableCell>
                       <Link
-                        href={`/jobs?user=${encodeURIComponent(token.service_account_user_id)}`}
+                        href={`/jobs?property=user&operator=%3A&value=${encodeURIComponent(token.service_account_name)}`}
                         className={`px-2 py-0.5 rounded text-xs font-medium transition-colors duration-200 cursor-pointer inline-block ${
                           token.jobCount > 0
                             ? 'bg-green-100 text-green-600 hover:bg-green-200 hover:text-green-700'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR fixes an issue where previously clicking into a given user's cluster or job count, we would jump to the clusters/jobs page and try to filter by the user hash. However, the actual filtering mechanism in those pages uses the user name in the basic auth case and the user id (email address) in the sso case. 

<img width="1471" height="421" alt="Screenshot 2025-11-11 at 2 17 26 PM" src="https://github.com/user-attachments/assets/546b3e12-ca4b-4db4-ac01-e3ddfcd4cce9" />
<img width="1472" height="490" alt="Screenshot 2025-11-11 at 2 17 49 PM" src="https://github.com/user-attachments/assets/ec706580-70e6-4856-a176-2b2d56c25d34" />



<!-- Describe the tests ran -->
I tested that the filtering behavior was incorrect on master and correct on this branch on both a local api server as well as a shared api server with multiple users. 

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
