### PR TITLE
[Catalog] Revert catalog change for Trainium and Inferentia chips

### DIFF
--- a/sky/catalog/data_fetchers/fetch_aws.py
+++ b/sky/catalog/data_fetchers/fetch_aws.py
@@ -325,10 +325,6 @@ def _get_instance_types_df(region: str) -> Union[str, 'pd.DataFrame']:
             axis='columns')
         if 'GpuInfo' not in df.columns:
             df['GpuInfo'] = np.nan
-        if 'NeuronInfo' in df.columns:
-            df['GpuInfo'] = df['GpuInfo'].fillna(df['NeuronInfo'])
-        if 'InferenceAcceleratorInfo' in df.columns:
-            df['GpuInfo'] = df['GpuInfo'].fillna(df['InferenceAcceleratorInfo'])
         df = df[USEFUL_COLUMNS]
     except Exception as e:  # pylint: disable=broad-except
         print(traceback.format_exc())


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Revert catalog change for Trainium and Inferentia chips

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
