### PR TITLE
Properly display infra string in managed jobs when job is completed

### DIFF
--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -156,6 +156,9 @@ export async function getManagedJobs(options = {}) {
         cloud = job.cloud || '';
         cluster_resources = job.cluster_resources;
         region = job.region || '';
+        if (region === '-') {
+          region = '';
+        }
 
         if (cloud) {
           infra = cloud;


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Before:
<img width="1611" height="214" alt="Screenshot 2025-11-12 at 11 44 31 AM" src="https://github.com/user-attachments/assets/a0b833b0-16c1-4b62-867c-e54d741bfd09" />

After:
<img width="1614" height="222" alt="Screenshot 2025-11-12 at 11 40 35 AM" src="https://github.com/user-attachments/assets/17364a03-f59b-41f0-9d64-1b5ae8f26544" />

The "Before" state is a regression introduced on November 6th. This PR correctly identifies a "-" as not providing a valid region, making rest of the formatting work.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
