### PR TITLE
[Test] Fix Pools Unit Test in CI

### DIFF
--- a/tests/unit_tests/test_pool_validations.py
+++ b/tests/unit_tests/test_pool_validations.py
@@ -51,6 +51,7 @@ def test_pool_creation_with_run_section():
                 match='Pool creation does not support the `run` section'):
             serve_impl.up(task, service_name='test-pool', pool=True)
 
+
 @pytest.mark.skip(reason='CI does not seem to like sdk calls right now.')
 def test_pool_update_with_run_section():
     """Test that pool update errors out when using a run section."""


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR skips recently added pools tests that explicitly raise errors when pools is misconfigured. These tests are not working well with CLI and the pools interface is changing to not explicitly raise errors, so we can skip these tests.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
