### PR TITLE
fix broken `datetime` usages in ha_recovery_for_consolidation_mode

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -282,7 +282,7 @@ def ha_recovery_for_consolidation_mode():
               'w',
               encoding='utf-8') as f:
         start = time.time()
-        f.write(f'Starting HA recovery at {datetime.datetime.now()}\n')
+        f.write(f'Starting HA recovery at {datetime.now()}\n')
         jobs, _ = managed_job_state.get_managed_jobs_with_filters(
             fields=['job_id', 'controller_pid', 'schedule_state', 'status'])
         for job in jobs:
@@ -318,8 +318,8 @@ def ha_recovery_for_consolidation_mode():
                     continue
                 runner.run(script)
                 f.write(f'Job {job_id} completed recovery at '
-                        f'{datetime.datetime.now()}\n')
-        f.write(f'HA recovery completed at {datetime.datetime.now()}\n')
+                        f'{datetime.now()}\n')
+        f.write(f'HA recovery completed at {datetime.now()}\n')
         f.write(f'Total recovery time: {time.time() - start} seconds\n')
     signal_file.unlink()
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
A user reported this stacktrace in `managed-job-status-refresh-daemon`.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/sky/server/daemons.py", line 75, in run_event
    self.event_fn()
  File "/usr/local/lib/python3.10/site-packages/sky/server/daemons.py", line 136, in managed_job_status_refresh_event
    managed_job_utils.ha_recovery_for_consolidation_mode()
  File "/usr/local/lib/python3.10/site-packages/sky/jobs/utils.py", line 284, in ha_recovery_for_consolidation_mode
    f.write(f'Starting HA recovery at {datetime.datetime.now()}\n')
AttributeError: type object 'datetime.datetime' has no attribute 'datetime'
```

The import changed in #7716 but this usage did not get updated.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
