### PR TITLE
Do not use time based flushing in `passthrough_stream_handler`

### DIFF
--- a/sky/utils/context_utils.py
+++ b/sky/utils/context_utils.py
@@ -8,7 +8,6 @@ import multiprocessing
 import os
 import subprocess
 import sys
-import time
 import typing
 from typing import Any, Callable, IO, Optional, Tuple, TypeVar
 
@@ -54,6 +53,8 @@ def passthrough_stream_handler(in_stream: IO[Any], out_stream: IO[Any]) -> str:
                                errors='replace',
                                write_through=True)
     while True:
+        # can take a while to return
+        # if the task emits logs infrequently.
         line = wrapped.readline()
         if line:
             out_stream.write(line)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
I noticed a problem while running the jupyter lab example (a task that spins up a jupyter lab server, the task stays running indefinitely), where the log when using `--follow` mode would not print the most recent portion of logs that were available when using `--no-follow`.

It turns out this is because the modified code snippet assumes `wrapped.readline()` returns quicky - in reality, if the task prints out logs infrequently, `wrapped.readline()` can take a while to return (and in some cases where a task runs indefinitely but does not produce logs, behave like a hang). In such cases, the timing code written is useless because `wrapped.readline()` hanging means we never get a chance to execute the code block below to flush the last chunk of logs.

I don't have a good idea on how to fix it while also preserving the batch behavior, so just revert the code change for now.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
