### PR TITLE
Add type annotation to ha_recovery_for_consolidation_mode

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -265,7 +265,7 @@ def is_consolidation_mode(on_api_restart: bool = False) -> bool:
     return consolidation_mode
 
 
-def ha_recovery_for_consolidation_mode():
+def ha_recovery_for_consolidation_mode() -> None:
     """Recovery logic for HA mode."""
     # Touch the signal file here to avoid conflict with
     # update_managed_jobs_statuses. Although we run this first and then start


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously this function has no type annotation thus will be skipped by mypy ([it is default behavior](https://mypy.readthedocs.io/en/stable/config_file.html#confval-check_untyped_defs)), this PR add type annotation so that issues in this function can be properly caught, such as https://github.com/skypilot-org/skypilot/pull/7945

Test (based on commit before https://github.com/skypilot-org/skypilot/pull/7945):

```
$ mypy sky/jobs/utils.py
sky/jobs/utils.py:285: error: "Type[datetime]" has no attribute "datetime"  [attr-defined]
Found 1 error in 1 file (checked 1 source file)
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
