### PR TITLE
[Docs] Fix Ray start_cluster script name

### DIFF
--- a/examples/distributed_ray_train/README.md
+++ b/examples/distributed_ray_train/README.md
@@ -21,7 +21,7 @@ Under the hood, this script automatically:
 
 ## Customizing the Ray Cluster
 
-Customize the Ray cluster by setting environment variables before calling `start_cluster.sh`:
+Customize the Ray cluster by setting environment variables before calling `start_cluster`:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -42,7 +42,7 @@ Stop your Ray cluster with:
 
 Do not use `ray stop` directly, as it may interfere with SkyPilot's cluster management.
 
-To restart, simply run `start_cluster.sh` again. The script detects if Ray is already running and skips startup if the cluster is healthy.
+To restart, simply run `start_cluster` again. The script detects if Ray is already running and skips startup if the cluster is healthy.
 
 ## Running the Example
 

--- a/sky_templates/ray/start_cluster
+++ b/sky_templates/ray/start_cluster
@@ -15,16 +15,16 @@
 #   RAY_CMD=ray                            - (Optional) Command to invoke Ray (e.g., "uv run ray")
 #
 # Usage:
-#   ~/sky_templates/ray/start_cluster.sh
+#   ~/sky_templates/ray/start_cluster
 #
 #   # With custom configurations
 #   export RAY_DASHBOARD_HOST=0.0.0.0
 #   export RAY_DASHBOARD_PORT=8280
-#   ~/sky_templates/ray/start_cluster.sh
+#   ~/sky_templates/ray/start_cluster
 #
 #   # With uv
 #   export RAY_CMD="uv run ray"
-#   ~/sky_templates/ray/start_cluster.sh
+#   ~/sky_templates/ray/start_cluster
 
 set -e
 


### PR DESCRIPTION
Fixed some typos I missed in #7935 after removing the `.sh` extension from the script name.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
