### PR TITLE
Allow job controller specifying server config for local API server

### DIFF
--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -82,13 +82,12 @@ def request_body_env_vars() -> dict:
     env_vars[
         usage_constants.USAGE_RUN_ID_ENV_VAR] = usage_lib.messages.usage.run_id
     if not common.is_api_server_local():
-        # Remove the path to config file, as the config content is included in
-        # the request body and will be merged with the config on the remote
-        # server side.
+        # Used in job controller, for local API server, keep the
+        # SKYPILOT_CONFIG env var to use the config for the managed job.
         env_vars.pop(skypilot_config.ENV_VAR_SKYPILOT_CONFIG, None)
-        env_vars.pop(skypilot_config.ENV_VAR_GLOBAL_CONFIG, None)
-    # Project config is only loaded at client-side and merge with the server
-    # configs.
+    # Remove the path to config file, as the config content is included in the
+    # request body and will be merged with the config on the server side.
+    env_vars.pop(skypilot_config.ENV_VAR_GLOBAL_CONFIG, None)
     env_vars.pop(skypilot_config.ENV_VAR_PROJECT_CONFIG, None)
     # Remove the config related env vars, as the client config override
     # should be passed in the request body.

--- a/tests/unit_tests/test_sky/server/requests/test_payloads.py
+++ b/tests/unit_tests/test_sky/server/requests/test_payloads.py
@@ -24,6 +24,7 @@ def test_request_body_env_vars_includes_expected_keys(monkeypatch):
     assert local_env[
         skypilot_config.ENV_VAR_SKYPILOT_CONFIG] == '/tmp/config.yaml'
     assert constants.ENV_VAR_DB_CONNECTION_URI not in local_env
+    assert skypilot_config.ENV_VAR_GLOBAL_CONFIG not in local_env
     assert skypilot_config.ENV_VAR_PROJECT_CONFIG not in local_env
 
     payloads.request_body_env_vars.cache_clear()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/7957

Previously, we skipped `SKYPILOT_CONFIG` env var propagating to local api server to make the code path consistent with remote API server. For local API server clients, restarting the API server or modifying `~/.sky/config.yaml` was required to apply a new server config, which can be tricky to handle especially for automated clients like job controller.

This PR propagates `SKYPILOT_CONFIG` / `SKYPILOT_GLOBAL_CONFIG` env var to local API server to enable change the config location of the local API server instance without restarting.

Test:

**with the following config.yaml in API server**

```yaml
workspaces:
  default:
    kubernetes:
      allowed_contexts:
        - gke
  aylei:
    kubernetes:
      allowed_contexts:
        - gke
```

And the folliwng `.sky.yml` in working dir:

```
active_workspace: aylei
```

### Master branch

```
$ sky jobs launch 'echo hello' -y --async
$ sky jobs logs $ID --controller
...
I 11-14 07:53:48 recovery_strategy.py:530]   File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/utils/annotations.py", line 27, in wrapper
I 11-14 07:53:48 recovery_strategy.py:530]     return func(*args, **kwargs)
I 11-14 07:53:48 recovery_strategy.py:530]   File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/client/sdk.py", line 2025, in get
I 11-14 07:53:48 recovery_strategy.py:530]     raise error_obj
I 11-14 07:53:48 recovery_strategy.py:530] ValueError: Workspace aylei does not exist. Use `sky check` to see if it is defined on the API server and try again.
```

### PR branch

Same script succeed

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
