### PR TITLE
[Templates] Pin click to <8.3.0 in Ray start_cluster script

### DIFF
--- a/sky_templates/ray/start_cluster
+++ b/sky_templates/ray/start_cluster
@@ -63,7 +63,12 @@ else
     VERSION_SPEC=""
 fi
 
-uv pip install "ray[default]${VERSION_SPEC}" || uv pip install --system "ray[default]${VERSION_SPEC}"
+# Pin click<8.3.0 to avoid incompatibility with Ray on Python 3.10
+# click 8.3.0 and 8.3.1 breaks Ray CLI due to deepcopy issues with sentinel values
+# See: https://github.com/ray-project/ray/issues/56747
+# TODO(kevin): Remove this once the issue is fixed in a future click release
+RAY_INSTALL_SPEC="ray[default]${VERSION_SPEC} click<8.3.0"
+uv pip install ${RAY_INSTALL_SPEC} || uv pip install --system ${RAY_INSTALL_SPEC}
 
 # Verify Ray is working
 if ! run_ray --version > /dev/null; then


### PR DESCRIPTION
Was working fine yesterday and this morning. But failed this evening.

<img width="612" height="247" alt="Screenshot 2025-11-15 at 10 57 15 PM" src="https://github.com/user-attachments/assets/e63f19b2-a5e2-4f11-8512-9b83441ddb10" />

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
