### PR TITLE
Move `sky status --kubernetes` into a hidden command

### DIFF
--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1945,7 +1945,8 @@ def status_kubernetes() -> server_common.RequestId[
     Tuple[List['kubernetes_utils.KubernetesSkyPilotClusterInfoPayload'],
           List['kubernetes_utils.KubernetesSkyPilotClusterInfoPayload'],
           List[responses.ManagedJobRecord], Optional[str]]]:
-    """Gets all SkyPilot clusters and jobs in the Kubernetes cluster.
+    """[Experimental] Gets all SkyPilot clusters and jobs
+    in the Kubernetes cluster.
 
     Managed jobs and services are also included in the clusters returned.
     The caller must parse the controllers to identify which clusters are run

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -798,7 +798,8 @@ async def kubernetes_node_info(
 
 @app.get('/status_kubernetes')
 async def status_kubernetes(request: fastapi.Request) -> None:
-    """Gets Kubernetes status."""
+    """[Experimental] Get all SkyPilot resources (including from other '
+    'users) in the current Kubernetes context."""
     await executor.schedule_request_async(
         request_id=request.state.request_id,
         request_name=request_names.RequestName.STATUS_KUBERNETES,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Now that SkyPilot has been on client-server architecture for a while, this endpoint is no longer needed. It certainly has not been maintained for a while, and deprecating this endpoint can help reduce the support burden and user confusion.

~I choose to go with the "rip off the band-aid" approach as opposed to a more graceful deprecation scheme. This is as kubernetes status has been marked with `[Experimental]` all this time and therefore this endpoint is not subject to any guarantees of backward compatibility.~

Turns out this command is useful in cases where an API server needs to be migrated, due to its ability to see clusters from other API server deployments. To avoid user confusion but to retain the functionality, I move the functionality of kubernetes status out into a separate hidden command.

Before / After `sky` helptext (this view is unchanged)
```
$ sky -h
...
Commands:
  launch       Launch a cluster or task.
  exec         Execute a task or command on an existing cluster.
  status       Show clusters.
  cost-report  Show estimated costs for launched clusters.
  queue        Show the job queue for cluster(s).
  logs         Tail the log of a job.
  cancel       Cancel job(s).
  stop         Stop cluster(s).
  autostop     Schedule an autostop or autodown for cluster(s).
  start        Restart cluster(s).
  down         Tear down cluster(s).
  check        Check which clouds are available to use.
  show-gpus    Show supported GPU/TPU/accelerators and their prices.
  storage      SkyPilot Storage CLI.
  volumes      SkyPilot Volumes CLI.
  volume       SkyPilot Volumes CLI.
  jobs         Managed Jobs CLI (jobs with auto-recovery).
  dashboard    Opens the SkyPilot dashboard.
  serve        SkyServe CLI (multi-region, multi-cloud serving).
  api          SkyPilot API server commands.
  ssh          Commands for managing SSH Node Pools.
```

Before / After `sky status` helptext:
```diff
$ sky status -v
...
Options:
  --config TEXT                   Path to a config file or a single key-value
                                  pair. To add multiple key-value pairs add
                                  multiple flags (e.g. --config
                                  nested.key1=val1 --config nested.key2=val2).
  -v, --verbose                   Show all information in full.
  -r, --refresh                   Query the latest cluster statuses from the
                                  cloud provider(s).
  --ip                            Get the IP address of the head node of a
                                  cluster. This option will override all other
                                  options. For Kubernetes clusters, the
                                  returned IP address is the internal IP of
                                  the head pod, and may not be accessible from
                                  outside the cluster.
  --endpoints                     Get all exposed endpoints and corresponding
                                  URLs for acluster. This option will override
                                  all other options.
  --endpoint INTEGER              Get the endpoint URL for the specified port
                                  number on the cluster. This option will
                                  override all other options.
  --show-managed-jobs / --no-show-managed-jobs
                                  Also show recent in-progress managed jobs,
                                  if any.
  --show-services / --no-show-services
                                  Also show sky serve services, if any.
  --show-pools / --no-show-pools  Also show pools, if any.
- --kubernetes, --k8s             [Experimental] Show all SkyPilot resources
-                                 (including from other users) in the current
-                                 Kubernetes context.
  -u, --all-users                 Show all clusters, including those not owned
                                  by the current user.
  -h, --help                      Show this message and exit.
```

Newly introduced `sky status-kubernetes` helptext
```
$ sky status-kubernetes -h
Usage: sky status-kubernetes [OPTIONS]

  [Experimental] Show all SkyPilot resources (including from other ' 'users)
  in the current Kubernetes context.

Options:
  --config TEXT  Path to a config file or a single key-value pair. To add
                 multiple key-value pairs add multiple flags (e.g. --config
                 nested.key1=val1 --config nested.key2=val2).
  -v, --verbose  Show all information in full.
  -h, --help     Show this message and exit.
```
<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
