### PR TITLE
fix threadlocal AWS cache

### DIFF
--- a/sky/adaptors/aws.py
+++ b/sky/adaptors/aws.py
@@ -101,9 +101,12 @@ def _thread_local_lru_cache(maxsize=32):
             return local_cache.get_cache()(*args, **kwargs)
 
         def cache_info():
+            # Note that this will only give the cache info for the current
+            # thread's cache.
             return local_cache.get_cache().cache_info()
 
         def cache_clear():
+            # Note that this will only clear the cache for the current thread.
             local_cache.get_cache().cache_clear()
 
         wrapper.cache_info = cache_info


### PR DESCRIPTION
This partially reverts #5229, which incorrectly simplified the thread-local cache.

I just noticed the issue.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
