### PR TITLE
[Docs] Add server side debug logging instructions

### DIFF
--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -770,14 +770,14 @@ For detailed setup instructions (including how to set up external Prometheus and
 Optional: Set up server-side debug logging
 ------------------------------------------
 
-Debug logging can be turned on for individual requests by setting the
+Client-side debug logging can be turned on for individual requests by setting the
 ``SKYPILOT_DEBUG`` environment variable to ``1`` when submitting a request, e.g.
 
 .. code-block:: bash
 
     SKYPILOT_DEBUG=1 sky status
 
-To turn on debug logging for all requests, set
+To enable debug logging for all requests on server side, set
 ``SKYPILOT_SERVER_ENABLE_REQUEST_DEBUG_LOGGING`` to ``true`` in the Helm values:
 
 .. code-block:: bash
@@ -788,6 +788,9 @@ To turn on debug logging for all requests, set
       --set-string 'apiService.extraEnvs[0].name=SKYPILOT_SERVER_ENABLE_REQUEST_DEBUG_LOGGING' \
       --set-string 'apiService.extraEnvs[0].value=true'
 
+
+Debug level logs for each request are saved to ``~/.sky/logs/request_debug/<request_id>.log`` on the API server.
+Server-side debug logging does not affect output seen by the clients.
 
 Upgrade the API server
 -----------------------


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Add instructions to enable server-side debug logging when deploying API Server.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
