### PR TITLE
[Nebius] Handle disk cleanup on VM creation failure due to quota errors

### DIFF
--- a/sky/adaptors/nebius.py
+++ b/sky/adaptors/nebius.py
@@ -323,14 +323,6 @@ def botocore_exceptions():
     return exceptions
 
 
-@common.load_lazy_modules(_LAZY_MODULES)
-def nebius_request_error():
-    """Nebius exception request error."""
-    # pylint: disable=import-outside-toplevel
-    from nebius.aio.service_error import RequestError
-    return RequestError
-
-
 def get_credential_file_paths() -> List[str]:
     """Get the list of credential file paths based on current configuration."""
     paths = {

--- a/sky/provision/nebius/utils.py
+++ b/sky/provision/nebius/utils.py
@@ -373,9 +373,12 @@ def launch(cluster_name_on_cloud: str,
                 f'({nebius.MAX_RETRIES_TO_INSTANCE_READY * POLL_INTERVAL}'
                 f' seconds) while waiting for instance {instance_name}'
                 f' to be ready.')
-    except nebius.nebius_request_error() as e:
+    except nebius.request_error() as e:
         # Handle ResourceExhausted quota limit error. In this case, we need to
         # clean up the disk as VM creation failed and we can't proceed.
+        # It cannot be handled by the caller (provisioner)'s teardown logic,
+        # as we cannot retrieve the disk id, after the instance creation
+        # fails
         logger.warning(f'Failed to launch instance {instance_name}: {e}')
         service = nebius.compute().DiskServiceClient(nebius.sdk())
         nebius.sync_call(


### PR DESCRIPTION
Handle disk cleanup on VM creation failure due to quota errors to prevent resource leaks. 

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
Create vm in region where quota = 0 
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
