### PR TITLE
[DB] use queue pool for async db engine

### DIFF
--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -433,6 +433,9 @@ def get_engine(
             conn_string = conn_string.replace('postgresql://',
                                               'postgresql+asyncpg://')
         with _db_creation_lock:
+            # We use the same cache for both sync and async engines
+            # because we change the conn_string in the async case,
+            # so they would not overlap.
             if conn_string not in _postgres_engine_cache:
                 engine_type = 'sync' if not async_engine else 'async'
                 logger.debug(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Addresses https://github.com/skypilot-org/skypilot/pull/7829#pullrequestreview-3412531119. The main benefit for using `QueuePools` as compared to `NullPools` is that connection pooling allows maintaining long running connections in memory for efficient re-use ([ref](https://dokk.org/documentation/sqlalchemy/rel_1_2_19/core/pooling/#module-sqlalchemy.pool)). 

<!-- Describe the tests ran -->
Tested with local postgres (`NullPools`), initialized the sync engine as well as the async engine. Sync engine is initialized by most normal operations like `sky launch`, `sky status`, etc. Async engine is used by provision logs for checking the cluster status, so I ran provision logs during cluster launch to verify proper async engine initialization.

I ran the same tests described above with a remote api server and a beefy cloud sql instance to force using `QueuePools` and veriifed that both sync and async engine initialization works as expected. 
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
