### PR TITLE
[Dev UX] fix incorrect log-streamer comment for code clarity

### DIFF
--- a/sky/server/stream_utils.py
+++ b/sky/server/stream_utils.py
@@ -160,9 +160,10 @@ async def log_streamer(
                                                   polling_interval):
                     yield chunk
 
-    # head node provision logs
+    # api server request logs (if request_id is provided) or
+    # head node provision logs (if cluster_name is provided)
     else:
-        assert log_path is not None, (request_id, log_path)
+        assert log_path is not None, (request_id, cluster_name)
         async with aiofiles.open(log_path, 'rb') as f:
             async for chunk in _tail_log_file(f, request_id, plain_logs, tail,
                                               follow, cluster_name,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The existing comment incorrectly states that this code path is specifically used for head node provision logs. It is actually also used to stream regular api server request logs. This PR updates the comment and also adds `cluster_name` to the assertion message for more complete information in the case of an assertion failure.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
