### PR TITLE
[Pools/SkyServe] Change Update Message

### DIFF
--- a/sky/serve/server/impl.py
+++ b/sky/serve/server/impl.py
@@ -686,7 +686,7 @@ def update(
             f'to version {current_version}.',
             follow_up_message=
             f'\n{unit_noun} are updating, use {ux_utils.BOLD}{logs_cmd}'
-            f'{ux_utils.RESET_BOLD} to check.'))
+            f'{ux_utils.RESET_BOLD} to check their status.'))
 
 
 def apply(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Before this PR when a user updated their pool they would see a message saying that the pool was successfully updated. This is confusing because that message only indicates that the change to the new version is in flight not that it’s completed.

Added a follow-up message that clarifies the workers are still updating and provides guidance on how to check their status. The message now displays:
```
✓ Successfully updated pool <pool_name> to version 2.
Workers are updating, use `sky jobs pool logs <pool-name> <worker-id>` to check their status.
```

We similarly change the message when updating sky serve to be

```
✓ Successfully updated service <service_name> to version 2.
Replicas are updating, use `sky serve logs <service-name> <replica-id>` to check their status.
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
