### PR TITLE
adjust default TTL for aws sessions

### DIFF
--- a/sky/adaptors/aws.py
+++ b/sky/adaptors/aws.py
@@ -87,7 +87,15 @@ class _ThreadLocalTTLCache(threading.local):
         return self.cache
 
 
-def _thread_local_ttl_cache(maxsize=32, ttl=60 * 60):
+def _thread_local_ttl_cache(maxsize=32, ttl=60 * 55):
+    """Thread-local TTL cache decorator.
+
+    Args:
+        maxsize: Maximum size of the cache.
+        ttl: Time to live for the cache in seconds.
+             Default is 55 minutes, a bit less than 1 hour
+             default lifetime of an STS token.
+    """
 
     def decorator(func):
         # Create thread-local storage for the LRU cache


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The default lifetime of an STS token (and therefore a session) is 1 hour. Adjust the TTL timeout of AWS session cache to be a bit but definitely less than that, so there is no funny race condition we need to deal with.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
