### PR TITLE
Install tomli explicitly during Runpod setup

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -205,7 +205,10 @@ cloud_dependencies: Dict[str, List[str]] = {
     # https://github.com/runpod/runpod-python/releases/tag/1.6.1
     # RunPod needs a TOML parser to read ~/.runpod/config.toml. On Python 3.11+
     # stdlib provides tomllib; on lower versions we depend on tomli explicitly.
-    'runpod': ['runpod>=1.6.1', 'tomli; python_version < "3.11"'],
+    # Instead of installing tomli conditionally, we install it explicitly.
+    # This is because the conditional installation of tomli does not work
+    # with controller package installation code.
+    'runpod': ['runpod>=1.6.1', 'tomli'],
     'fluidstack': [],  # No dependencies needed for fluidstack
     'cudo': ['cudo-compute>=0.1.10'],
     'paperspace': [],  # No dependencies needed for paperspace


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The conditional install of tomli interferes with https://github.com/skypilot-org/skypilot/blob/64f419c0cd0d00ac09c2afe330d4565754253d4a/sky/utils/controller_utils.py#L411-L416 and disrupts python package installation in job controller when runpod is enabled.

I take the simple fix of installing tomli in all cases (even when it's not explicitly required) as a simple fix to this problem.

Tested manually.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
