### PR TITLE
[CoreWeave]: Adjust HPC networking env vars

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -109,8 +109,9 @@ class KubernetesHighPerformanceNetworkType(enum.Enum):
             return {
                 'NCCL_SOCKET_IFNAME': 'eth0',
                 'NCCL_IB_HCA': 'ibp',
-                'UCX_NET_DEVICES': ('ibp0:1,ibp1:1,ibp2:1,ibp3:1,'
-                                    'ibp4:1,ibp5:1,ibp6:1,ibp7:1')
+                # Restrict UCX to TCP to avoid unneccsary errors. NCCL doesn't use UCX
+                'UCX_TLS': 'tcp',
+                'UCX_NET_DEVICES': 'eth0',
             }
         else:
             # GCP clusters and generic clusters - environment variables are


### PR DESCRIPTION
Change the HPC networking environment variables used on CW clusters with `network_tier: best` to conform with their current standards.

Tested (run the relevant ones):

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [X] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

To test, I ran the `examples/coreweave_infiniband/coreweave_nccl_test.yaml` example against a CoreWeave Kubernetes Cluster. I confirmed that the two skypilot pods had the new environment variables and that the NCCL test perf was as expected.
```bash
❯ sky launch -c nccl examples/coreweave_infiniband/coreweave_nccl_test.yaml
...
(head, rank=0, pid=3388) [1,0]<stdout>:   536870912     134217728     float     sum      -1   2367.3  226.78  425.22      0   2386.5  224.96  421.80      0
(head, rank=0, pid=3388) [1,0]<stdout>:  1073741824     268435456     float     sum      -1   4498.5  238.69  447.54      0   4493.8  238.94  448.01      0
(head, rank=0, pid=3388) [1,0]<stdout>:  2147483648     536870912     float     sum      -1   8730.1  245.99  461.22      0   8754.9  245.29  459.92      0
(head, rank=0, pid=3388) [1,0]<stdout>:  4294967296    1073741824     float     sum      -1    17256  248.90  466.69      0    17205  249.64  468.08      0
(head, rank=0, pid=3388) [1,0]<stdout>:  8589934592    2147483648     float     sum      -1    34253  250.78  470.22      0    34234  250.92  470.48      0
(head, rank=0, pid=3388) [1,2]<stdout>:nccl-d28a9dc5-head:5737:16890 [2] NCCL INFO comm 0x642d0a53b5a0 rank 2 nranks 16 cudaDev 2 busId 4c000 - Destroy COMPLETE
(head, rank=0, pid=3388) [1,3]<stdout>:nccl-d28a9dc5-head:5740:16887 [3] NCCL INFO comm 0x614ff8bc21e0 rank 3 nranks 16 cudaDev 3 busId 5d000 - Destroy COMPLETE
(head, rank=0, pid=3388) [1,6]<stdout>:nccl-d28a9dc5-head:5750:16884 [6] NCCL INFO comm 0x640a525a19c0 rank 6 nranks 16 cudaDev 6 busId cb000 - Destroy COMPLETE
(head, rank=0, pid=3388) [1,5]<stdout>:nccl-d28a9dc5-head:5745:16886 [5] NCCL INFO comm 0x59748f4dde80 rank 5 nranks 16 cudaDev 5 busId bb000 - Destroy COMPLETE
(head, rank=0, pid=3388) [1,7]<stdout>:nccl-d28a9dc5-head:5752:16889 [7] NCCL INFO comm 0x6110a8237ab0 rank 7 nranks 16 cudaDev 7 busId db000 - Destroy COMPLETE
(head, rank=0, pid=3388) [1,4]<stdout>:nccl-d28a9dc5-head:5742:16883 [4] NCCL INFO comm 0x5a7f8f2f7440 rank 4 nranks 16 cudaDev 4 busId 9b000 - Destroy COMPLETE
(head, rank=0, pid=3388) [1,1]<stdout>:nccl-d28a9dc5-head:5735:16885 [1] NCCL INFO comm 0x576975fadbb0 rank 1 nranks 16 cudaDev 1 busId 3b000 - Destroy COMPLETE
(head, rank=0, pid=3388) [1,0]<stdout>:nccl-d28a9dc5-head:5733:16888 [0] NCCL INFO comm 0x568e2718cf80 rank 0 nranks 16 cudaDev 0 busId 19000 - Destroy COMPLETE
(head, rank=0, pid=3388) [1,0]<stdout>:# Out of bounds values : 0 OK
(head, rank=0, pid=3388) [1,0]<stdout>:# Avg bus bandwidth    : 453.917
```

