### PR TITLE
[K8s] Add Timeout for `rsync` Waiting

### DIFF
--- a/sky/utils/kubernetes/rsync_helper.sh
+++ b/sky/utils/kubernetes/rsync_helper.sh
@@ -58,4 +58,6 @@ fi
 # The waiting happens on the remote pod, not locally, which is more efficient
 # and reliable than polling from the local machine.
 # We wrap the command in a bash script that waits for rsync, then execs the original command.
-eval "${kubectl_cmd_base% --} -i -- bash -c 'until which rsync >/dev/null 2>&1; do sleep 0.5; done; exec \"\$@\"' -- \"\$@\""
+# Timeout after MAX_WAIT_TIME_SECONDS seconds.
+MAX_WAIT_TIME_SECONDS=300
+eval "${kubectl_cmd_base% --} -i -- bash -c 'count=0; max_count=$MAX_WAIT_TIME_SECONDS*2; until which rsync >/dev/null 2>&1; do if [ \$count -ge \$max_count ]; then echo \"Error when trying to rsync files to kubernetes cluster. Package installation may have failed.\" >&2; exit 1; fi; sleep 0.5; count=\$((count+1)); done; exec \"\$@\"' -- \"\$@\""


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

In https://github.com/skypilot-org/skypilot/pull/7844 we introduced code to wait for rsync to be installed on a k8s cluster so that we don't jump the gun to start mounting before rsync is available. We didn't add a timeout however so in the case where  the package installation just fails this command wouldn't return. We've added a 5 minute timeout to make sure we don't permanently wait.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
