### PR TITLE
[GPU Metrics] fix sky cluster gpu metrics fallback logic

### DIFF
--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -147,12 +147,7 @@ function ClusterDetails() {
   // Function to build Grafana panel URL with filters
   const buildGrafanaMetricsUrl = (panelId) => {
     const grafanaUrl = getGrafanaUrl();
-    // Use the matched cluster name if available, otherwise fall back to the display name
-    console.log('matchedClusterName', matchedClusterName);
-    console.log(
-      'clusterData?.cluster_name_on_cloud',
-      clusterData?.cluster_name_on_cloud
-    );
+    // Use the matched cluster name if available, otherwise fall back to the cluster name on cloud
     const clusterParam =
       matchedClusterName || clusterData?.cluster_name_on_cloud;
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR addresses an issue that was causing GPU metrics to not show up in the cluster detail page despite the same grafana panels showing data in the grafana dashboard. The issue is that in the case where there is an error in querying grafana for a list of skypilot clusters it has data for or `matchedClusterName` is not set for some other reason, we currently fall back to `clusterData?.cluster` while the label used in the prometheus metrics is `cluster_name_on_cloud`.

<!-- Describe the tests ran -->
I verified that on the api server where I noticed the issue described above, this PR fixes the issue and gpu metrics show up properly in the cluster detail page. 
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
