### PR TITLE
[k8s] Fix pod name and worker index mismatch

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -3162,21 +3162,23 @@ def filter_pods(namespace: str,
 
     # Sort pods by name, with workers sorted by their numeric suffix.
     # This ensures consistent ordering (e.g., cluster-head, cluster-worker1,
-    # worker2, worker3, ...) even when Kubernetes API returns them in
-    # arbitrary order. This works even if there were somehow pod names other
-    # than head/worker ones, but that may be overkill.
+    # cluster-worker2, cluster-worker3, ...) even when Kubernetes API
+    # returns them in arbitrary order. This works even if there were
+    # somehow pod names other than head/worker ones, and those end up at
+    # the end of the list.
     def get_pod_sort_key(
         pod: V1Pod
     ) -> Union[Tuple[Literal[0], str], Tuple[Literal[1], int], Tuple[Literal[2],
                                                                      str]]:
         name = pod.metadata.name
-        if '-worker' in name:
+        name_suffix = name.split('-')[-1]
+        if name_suffix == 'head':
+            return (0, name)
+        elif name_suffix.startswith('worker'):
             try:
-                return (1, int(name.split('-worker')[-1]))
+                return (1, int(name_suffix.split('worker')[-1]))
             except (ValueError, IndexError):
                 return (2, name)
-        elif '-head' in name:
-            return (0, name)
         else:
             return (2, name)
 

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -1916,41 +1916,60 @@ def test_combine_pod_config_fields_and_metadata_uses_correct_cloud():
             "custom_metadata should use SSH cloud"
 
 
-def test_filter_pods_sorts_by_name():
+@pytest.mark.parametrize('unsorted_pod_names, expected_sorted_pod_names', [
+    ([
+        'test-cluster-worker10', 'test-cluster-worker2', 'test-cluster-head',
+        'test-cluster-worker1', 'test-cluster-worker3'
+    ], [
+        'test-cluster-head', 'test-cluster-worker1', 'test-cluster-worker2',
+        'test-cluster-worker3', 'test-cluster-worker10'
+    ]),
+    ([
+        'test-cluster-worker1', 'test-cluster-worker20', 'test-cluster-head',
+        'test-cluster-worker3', 'test-cluster-worker2'
+    ], [
+        'test-cluster-head', 'test-cluster-worker1', 'test-cluster-worker2',
+        'test-cluster-worker3', 'test-cluster-worker20'
+    ]),
+    ([
+        'test-cluster-worker1', 'test-cluster-worker2', 'test-cluster-head',
+        'test-cluster-worker3', 'test-cluster-worker4'
+    ], [
+        'test-cluster-head', 'test-cluster-worker1', 'test-cluster-worker2',
+        'test-cluster-worker3', 'test-cluster-worker4'
+    ]),
+    ([
+        'test-cluster-head', 'test-cluster-worker1', 'test-cluster-worker2',
+        'test-cluster-worker3', 'test-cluster-worker4'
+    ], [
+        'test-cluster-head', 'test-cluster-worker1', 'test-cluster-worker2',
+        'test-cluster-worker3', 'test-cluster-worker4'
+    ]),
+    ([
+        'my-worker-head', 'my-worker-worker1', 'my-worker-worker2',
+        'my-worker-worker3', 'my-worker-worker4'
+    ], [
+        'my-worker-head', 'my-worker-worker1', 'my-worker-worker2',
+        'my-worker-worker3', 'my-worker-worker4'
+    ]),
+    ([
+        'my-worker-head', 'my-worker-worker1', 'extra-pod', 'my-worker-worker2',
+        'my-worker-worker3', 'my-worker-worker4'
+    ], [
+        'my-worker-head', 'my-worker-worker1', 'my-worker-worker2',
+        'my-worker-worker3', 'my-worker-worker4', 'extra-pod'
+    ]),
+])
+def test_filter_pods_sorts_by_name(unsorted_pod_names,
+                                   expected_sorted_pod_names):
     """Test that filter_pods returns pods sorted correctly"""
-    # Head pod should come first, then worker pods sorted by their numeric
-    # suffix, then any other pods alphabetically.
-
-    # Create mock pods with out-of-order names
-    mock_pod_worker4 = mock.MagicMock()
-    mock_pod_worker4.metadata.name = 'test-cluster-worker4'
-    mock_pod_worker4.metadata.deletion_timestamp = None
-
-    mock_pod_worker1 = mock.MagicMock()
-    mock_pod_worker1.metadata.name = 'test-cluster-worker1'
-    mock_pod_worker1.metadata.deletion_timestamp = None
-
-    mock_pod_head = mock.MagicMock()
-    mock_pod_head.metadata.name = 'test-cluster-head'
-    mock_pod_head.metadata.deletion_timestamp = None
-
-    mock_pod_worker3 = mock.MagicMock()
-    mock_pod_worker3.metadata.name = 'test-cluster-worker3'
-    mock_pod_worker3.metadata.deletion_timestamp = None
-
-    mock_pod_worker2 = mock.MagicMock()
-    mock_pod_worker2.metadata.name = 'test-cluster-worker2'
-    mock_pod_worker2.metadata.deletion_timestamp = None
-
-    # Mock pod list returned in arbitrary order
     mock_pod_list = mock.MagicMock()
-    mock_pod_list.items = [
-        mock_pod_worker4,
-        mock_pod_worker1,
-        mock_pod_worker3,
-        mock_pod_head,
-        mock_pod_worker2,
-    ]
+    mock_pod_list.items = []
+    for pod_name in unsorted_pod_names:
+        mock_pod = mock.MagicMock()
+        mock_pod.metadata.name = pod_name
+        mock_pod.metadata.deletion_timestamp = None
+        mock_pod_list.items.append(mock_pod)
 
     with patch('sky.provision.kubernetes.utils.kubernetes.core_api'
               ) as mock_core_api:
@@ -1962,56 +1981,4 @@ def test_filter_pods_sorts_by_name():
 
         # Verify the pods are returned in sorted order
         pod_names = list(result.keys())
-        assert pod_names == [
-            'test-cluster-head',
-            'test-cluster-worker1',
-            'test-cluster-worker2',
-            'test-cluster-worker3',
-            'test-cluster-worker4',
-        ]
-
-
-def test_filter_pods_handles_gaps_in_worker_numbers():
-    """Test that filter_pods correctly sorts workers even with gaps in numbering"""
-    # Create mock pods with gaps (worker1, worker2, worker5)
-    mock_pod_worker5 = mock.MagicMock()
-    mock_pod_worker5.metadata.name = 'test-cluster-worker5'
-    mock_pod_worker5.metadata.deletion_timestamp = None
-
-    mock_pod_worker2 = mock.MagicMock()
-    mock_pod_worker2.metadata.name = 'test-cluster-worker2'
-    mock_pod_worker2.metadata.deletion_timestamp = None
-
-    mock_pod_head = mock.MagicMock()
-    mock_pod_head.metadata.name = 'test-cluster-head'
-    mock_pod_head.metadata.deletion_timestamp = None
-
-    mock_pod_worker1 = mock.MagicMock()
-    mock_pod_worker1.metadata.name = 'test-cluster-worker1'
-    mock_pod_worker1.metadata.deletion_timestamp = None
-
-    # Mock pod list in arbitrary order
-    mock_pod_list = mock.MagicMock()
-    mock_pod_list.items = [
-        mock_pod_worker5,
-        mock_pod_worker2,
-        mock_pod_head,
-        mock_pod_worker1,
-    ]
-
-    with patch('sky.provision.kubernetes.utils.kubernetes.core_api'
-              ) as mock_core_api:
-        mock_core_api.return_value.list_namespaced_pod.return_value = mock_pod_list
-
-        result = utils.filter_pods(namespace='test-namespace',
-                                   context='test-context',
-                                   tag_filters={'test-label': 'test-value'})
-
-        # Verify the pods are returned in sorted order with gaps preserved
-        pod_names = list(result.keys())
-        assert pod_names == [
-            'test-cluster-head',
-            'test-cluster-worker1',
-            'test-cluster-worker2',
-            'test-cluster-worker5',
-        ]
+        assert pod_names == expected_sorted_pod_names


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #8024 by updating `filter_pods` to sort pods by name (and numeric worker suffix).

I believe the issue in #8024 was caused by inconsistent ordering of pods returned by the Kubernetes API and the lack of sorting for k8s clusters in [`CloudVmRayResourceHandle.update_cluster_ips`](https://github.com/skypilot-org/skypilot/blob/81c9a8aa002f5c121050a2e5ba45ef7757753131/sky/backends/cloud_vm_ray_backend.py#L2662-L2670).

The Kubernetes API makes no guarantees on the order of pods returned, so without explicit sorting, the ordering of pods could end up with the worker pods in a different order than expected. Because insertion order is preserved with dicts in Python 3.7+, this ordering was preserved all the way through to `SSHConfigHelper.add_cluster`.

This PR add logic to `filter_pods` to ensure that pods are always sorted by name, with worker pods sorted by their numeric suffix (`cluster-head`, `cluster-worker1`, `cluster-worker2`, etc.).

The reason I did not just enable sorting in `CloudVmRayResourceHandle.update_cluster_ips` is that that currently sorts based on IP addresses, which may not always correspond to the desired pod ordering, and it seems more natural to have `filter_pods` return pods in a consistent order to prevent other subtle issues like this one.

<!-- Describe the tests ran -->

I added tests to verify that `filter_pods` returns pods in the expected order. 

I also setup a 16-node GKE cluster that I launched via simple test template:

```yaml
resources:
  cpus: 2+
  
num_nodes: 16

setup: |
  echo "Setup on $(hostname)"

run: |
  echo "Running on $(hostname) - Node $SKYPILOT_NODE_RANK"
  echo "Node IP: $(hostname -I | awk '{print $1}')"
```

I ran `sky launch --infra k8s/gke_modern-rhythm-478817-v4_us-central1-c_skypilot-test-cluster test_multinode.yaml` and after the cluster was up I ran the following bash script to use the `ssh` aliases in the config to verify that all of the hostnames matched what expected:

```bash
#!/bin/bash

echo "Testing head node..."
remote_hostname=$(ssh sky-3795-danielblanchard "hostname")
if [[ "$remote_hostname" == *"head" ]]; then
    echo "MATCHED sky-3795-danielblanchard -> $remote_hostname"
else
    echo "FAILED sky-3795-danielblanchard -> $remote_hostname (expected suffix: head)"
fi

for i in {1..15}; do
    alias="sky-3795-danielblanchard-worker$i"
    expected_suffix="worker$i"
    echo "Testing $alias..."
    remote_hostname=$(ssh "$alias" "hostname")
    if [[ "$remote_hostname" == *"$expected_suffix" ]]; then
        echo "MATCHED $alias -> $remote_hostname"
    else
        echo "FAILED $alias -> $remote_hostname (expected suffix: $expected_suffix)"
    fi
done
```

The output of which showed everything was good:

```
Testing head node...
MATCHED sky-3795-danielblanchard -> sky-3795-danielblanchard-efc0a1e0-head
Testing sky-3795-danielblanchard-worker1...
MATCHED sky-3795-danielblanchard-worker1 -> sky-3795-danielblanchard-efc0a1e0-worker1
Testing sky-3795-danielblanchard-worker2...
MATCHED sky-3795-danielblanchard-worker2 -> sky-3795-danielblanchard-efc0a1e0-worker2
Testing sky-3795-danielblanchard-worker3...
MATCHED sky-3795-danielblanchard-worker3 -> sky-3795-danielblanchard-efc0a1e0-worker3
Testing sky-3795-danielblanchard-worker4...
MATCHED sky-3795-danielblanchard-worker4 -> sky-3795-danielblanchard-efc0a1e0-worker4
Testing sky-3795-danielblanchard-worker5...
MATCHED sky-3795-danielblanchard-worker5 -> sky-3795-danielblanchard-efc0a1e0-worker5
Testing sky-3795-danielblanchard-worker6...
MATCHED sky-3795-danielblanchard-worker6 -> sky-3795-danielblanchard-efc0a1e0-worker6
Testing sky-3795-danielblanchard-worker7...
MATCHED sky-3795-danielblanchard-worker7 -> sky-3795-danielblanchard-efc0a1e0-worker7
Testing sky-3795-danielblanchard-worker8...
MATCHED sky-3795-danielblanchard-worker8 -> sky-3795-danielblanchard-efc0a1e0-worker8
Testing sky-3795-danielblanchard-worker9...
MATCHED sky-3795-danielblanchard-worker9 -> sky-3795-danielblanchard-efc0a1e0-worker9
Testing sky-3795-danielblanchard-worker10...
MATCHED sky-3795-danielblanchard-worker10 -> sky-3795-danielblanchard-efc0a1e0-worker10
Testing sky-3795-danielblanchard-worker11...
MATCHED sky-3795-danielblanchard-worker11 -> sky-3795-danielblanchard-efc0a1e0-worker11
Testing sky-3795-danielblanchard-worker12...
MATCHED sky-3795-danielblanchard-worker12 -> sky-3795-danielblanchard-efc0a1e0-worker12
Testing sky-3795-danielblanchard-worker13...
MATCHED sky-3795-danielblanchard-worker13 -> sky-3795-danielblanchard-efc0a1e0-worker13
Testing sky-3795-danielblanchard-worker14...
MATCHED sky-3795-danielblanchard-worker14 -> sky-3795-danielblanchard-efc0a1e0-worker14
Testing sky-3795-danielblanchard-worker15...
MATCHED sky-3795-danielblanchard-worker15 -> sky-3795-danielblanchard-efc0a1e0-worker15
```



<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
