### PR TITLE
retain entrypoint function name to work with previous versions

### DIFF
--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -574,7 +574,7 @@ def kill_requests(request_ids: Optional[List[str]] = None,
     return _kill_requests(request_ids=expanded_request_ids, user_id=user_id)
 
 
-# needed for backward compatibility. Remove by v0.10.7 or v0.11.0
+# needed for backward compatibility. Remove by v0.10.7 or v0.12.0
 # and rename kill_requests to kill_requests_with_prefix.
 kill_requests_with_prefix = kill_requests
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The previous versions of sky (e.g. v0.10.3) used `kill_requests` as entrypoint, and did not have `kill_requests_with_prefix`. Newer versions of sky (e.g. v0.10.5) uses `kill_requests_with_prefix` as entrypoint with `kill_requests` aliased to `kill_requests_with_prefix`.

To make the code work with older clients which does not have `kill_requests_with_prefix`, use `kill_requests` (which exists in older versions) as entrypoint and alias `kill_requests_with_prefix` used by (v0.10.5, etc) to `kill_requests`. Once we have published enough versions that all supported clients have both `kill_requests` and `kill_requests_with_prefix` we can switch the entrypoint to use `kill_requests_with_prefix`.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
