### PR TITLE
fix helm command for rolling updates

### DIFF
--- a/docs/source/reference/api-server/api-server-upgrade.rst
+++ b/docs/source/reference/api-server/api-server-upgrade.rst
@@ -231,7 +231,7 @@ Here's an example of deploying the API server with the ``RollingUpdate`` strateg
 
 .. code-block:: bash
 
-    helm install -n $NAMESPACE $RELEASE_NAME skypilot/skypilot-nightly --devel --reuse-values \
+    helm upgrade --install -n $NAMESPACE $RELEASE_NAME skypilot/skypilot-nightly --devel --reuse-values \
       --set apiService.upgradeStrategy=RollingUpdate \
       --set storage.enabled=false \
       --set apiService.dbConnectionSecretName=my-db-secret


### PR DESCRIPTION
This seems to be what is intended. The given command fails with `Error: unknown flag: --reuse-values`

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
