### PR TITLE
[Metrics] change grafana data source for prometheus from secret to config map

### DIFF
--- a/charts/skypilot/templates/datasource.yaml
+++ b/charts/skypilot/templates/datasource.yaml
@@ -1,13 +1,13 @@
 {{- if and .Values.grafana.enabled .Values.grafana.sidecar.datasources.enabled }}
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-prometheus-datasource
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-api
     grafana_datasource: "true"
-stringData:
+data:
   prometheus.yaml: |-
     apiVersion: 1
     datasources:
@@ -16,4 +16,5 @@ stringData:
         url: http://{{ .Release.Name }}-prometheus-server:80
         editable: false
         uid: prometheus
+        access: proxy
 {{- end }}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR addresses an issue where deploying the api server with metrics enable shows no datasources configured. With this change, deploying the api server with metrics enabled has prometheus configured as a datasource for grafana and the metrics immediately show up. 


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
