### PR TITLE
Fix tls config on --reuse-values

### DIFF
--- a/charts/skypilot/templates/ingress.yaml
+++ b/charts/skypilot/templates/ingress.yaml
@@ -60,7 +60,8 @@ spec:
   {{- if $useNewIngressClass }}
   ingressClassName: {{ .Values.ingress.ingressClassName }}
   {{- end }}
-  {{- if .Values.ingress.tls.enabled | default false }}
+  {{- $tls := .Values.ingress.tls | default dict }}
+  {{- if $tls.enabled | default false }}
   tls:
   - hosts:
     - {{ .Values.ingress.host }}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Adding new nested fields with `--reuse-values` would cause issue like:

```
$ helm upgrade skypilot charts/skypilot --reuse-values --set prometheus.enabled=true --set grafana.enabled=true --set apiService.metrics.enabled=true
Error: UPGRADE FAILED: template: skypilot/templates/ingress.yaml:63:16: executing "skypilot/templates/ingress.yaml" at <.Values.ingress.tls.enabled>: nil pointer evaluating interface {}.enabled
```

This is because the stored values.yaml for `--reuse-values` do not have the new `ingress.tls.{}` struct, this PR add a compatible fix for this.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
