### PR TITLE
Fix `test_aws_region` failure

### DIFF
--- a/tests/smoke_tests/test_region_and_zone.py
+++ b/tests/smoke_tests/test_region_and_zone.py
@@ -192,8 +192,8 @@ def test_aws_zone():
     test = smoke_tests_utils.Test(
         'aws_zone',
         [
-            f'sky launch -y -c {name} examples/minimal.yaml {smoke_tests_utils.LOW_RESOURCE_ARG} --infra aws/*/us-east-2b',
-            f'sky exec {name} examples/minimal.yaml --infra aws/*/us-east-2b',
+            f'sky launch -y -c {name} examples/minimal.yaml {smoke_tests_utils.LOW_RESOURCE_ARG} --infra */*/us-east-2b',
+            f'sky exec {name} examples/minimal.yaml --infra */*/us-east-2b',
             f'sky logs {name} 1 --status',  # Ensure the job succeeded.
             f'sky status -v | grep {name} | grep us-east-2b',  # Ensure the zone is correct.
         ],


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

```bash
return func(*args, **kwargs)
--
File "/home/buildkite/.buildkite-agent/builds/generic_cloud/54-160-195-107-buildkite-generic9-1/skypilot-1/smoke-tests/sky/client/sdk.py", line 435, in validate
_raise_exception_object_on_client(
File "/home/buildkite/.buildkite-agent/builds/generic_cloud/54-160-195-107-buildkite-generic9-1/skypilot-1/smoke-tests/sky/client/sdk.py", line 392, in _raise_exception_object_on_client
raise e
ValueError: Cannot infer cloud from (region 'us-east-2', zone None). Multiple enabled clouds have region/zone of the same names: [Lambda, AWS]. To fix: explicitly specify `cloud`.
[aws_region] Failed (returned 1).
[aws_region] Reason: sky launch -y -c t-aws-region-05 --cpus 2+ --memory 4+ --infra */us-east-2 examples/minimal.yaml
```

After we enable lambda test in #8051, `test_aws_region` fail

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
