### PR TITLE
[Tests] Fix Tail Logs SSH Test

### DIFF
--- a/tests/smoke_tests/test_api_server.py
+++ b/tests/smoke_tests/test_api_server.py
@@ -550,7 +550,7 @@ def test_tail_jobs_logs_blocks_ssh(generic_cloud: str):
 
         # Wait for the job to start.
         def is_job_started(job_id: int):
-            req_id = jobs.queue(refresh=True, job_ids=[job_id])
+            req_id = jobs.queue_v2(refresh=True, job_ids=[job_id])
             job_records = sky.stream_and_get(req_id)[0]
             assert len(job_records) == 1
             return job_records[0]['status'] == sky.ManagedJobStatus.RUNNING


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

`test_tail_jobs_logs_blocks_ssh` uses the SDK to check whether the job it wants to tail has started. We changed the SDK in https://github.com/skypilot-org/skypilot/pull/8015 so we were incorrectly unpacking the return value. I changed the call to use `queue_v2`. The test is now passing.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
