### PR TITLE
[Test] Fix Pool Single Yaml Test

### DIFF
--- a/tests/smoke_tests/test_pools.py
+++ b/tests/smoke_tests/test_pools.py
@@ -1214,8 +1214,7 @@ def test_pools_single_yaml(generic_cloud: str):
                     pool_name=pool_name, pool_yaml=one_config_yaml.name),
                 (f's=$(sky jobs launch --pool {pool_name} {one_config_yaml.name} --name {job_name} -d -y); '
                  'echo "$s"; '
-                 'echo; echo; echo "$s" | grep "Job submitted"; '
-                 'echo "$s" | grep "Unified job"'),
+                 'echo; echo; echo "$s" | grep "Job submitted"'),
                 wait_until_job_status(job_name, ['SUCCEEDED'], timeout=timeout),
             ],
             timeout=smoke_tests_utils.get_timeout(generic_cloud),


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The `test_pools_single_yaml` test unnecessarily tried to check the job ID in the submission message when launching making it brittle to changes to the way we launch the jobs controller and the resulting ID space causing this failure https://buildkite.com/skypilot-1/smoke-tests/builds/5793#019aa90a-6ce3-4a9c-9d9b-a0d8bc8b1ee9. Now we just check that the job is submitted.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
