### PR TITLE
[GPU Metrics] use skypilot-cluster-name instead of skypilot-cluster

### DIFF
--- a/charts/skypilot/manifests/dcgm-cluster-filter-dashboard.json
+++ b/charts/skypilot/manifests/dcgm-cluster-filter-dashboard.json
@@ -115,7 +115,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_DEV_GPU_UTIL{node=~\"$node\", gpu=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster) kube_pod_labels{label_skypilot_cluster=~\"$cluster\"}",
+          "expr": "DCGM_FI_DEV_GPU_UTIL{node=~\"$node\", gpu=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster_name) kube_pod_labels{label_skypilot_cluster_name=~\"$cluster\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
@@ -128,7 +128,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "amd_gpu_gfx_activity{hostname=~\"$node\", gpu_id=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster) kube_pod_labels{label_skypilot_cluster=~\"$cluster\"}",
+          "expr": "amd_gpu_gfx_activity{hostname=~\"$node\", gpu_id=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster_name) kube_pod_labels{label_skypilot_cluster_name=~\"$cluster\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "{{hostname}} - {{card_series}} GPU {{gpu_id}}",
@@ -231,7 +231,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_DEV_FB_USED{node=~\"$node\", gpu=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster) kube_pod_labels{label_skypilot_cluster=~\"$cluster\"}",
+          "expr": "DCGM_FI_DEV_FB_USED{node=~\"$node\", gpu=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster_name) kube_pod_labels{label_skypilot_cluster_name=~\"$cluster\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
@@ -244,7 +244,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "amd_gpu_used_vram{hostname=~\"$node\", gpu_id=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster) kube_pod_labels{label_skypilot_cluster=~\"$cluster\"}",
+          "expr": "amd_gpu_used_vram{hostname=~\"$node\", gpu_id=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster_name) kube_pod_labels{label_skypilot_cluster_name=~\"$cluster\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "{{hostname}} - {{card_series}} GPU {{gpu_id}}",
@@ -347,7 +347,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_DEV_GPU_TEMP{node=~\"$node\", gpu=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster) kube_pod_labels{label_skypilot_cluster=~\"$cluster\"}",
+          "expr": "DCGM_FI_DEV_GPU_TEMP{node=~\"$node\", gpu=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster_name) kube_pod_labels{label_skypilot_cluster_name=~\"$cluster\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
@@ -360,7 +360,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "amd_gpu_junction_temperature{hostname=~\"$node\", gpu_id=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster) kube_pod_labels{label_skypilot_cluster=~\"$cluster\"}",
+          "expr": "amd_gpu_junction_temperature{hostname=~\"$node\", gpu_id=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster_name) kube_pod_labels{label_skypilot_cluster_name=~\"$cluster\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "{{hostname}} - {{card_series}} GPU {{gpu_id}}",
@@ -463,7 +463,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_DEV_POWER_USAGE{node=~\"$node\", gpu=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster) kube_pod_labels{label_skypilot_cluster=~\"$cluster\"}",
+          "expr": "DCGM_FI_DEV_POWER_USAGE{node=~\"$node\", gpu=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster_name) kube_pod_labels{label_skypilot_cluster_name=~\"$cluster\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
@@ -476,7 +476,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "amd_gpu_average_package_power{hostname=~\"$node\", gpu_id=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster) kube_pod_labels{label_skypilot_cluster=~\"$cluster\"}",
+          "expr": "amd_gpu_average_package_power{hostname=~\"$node\", gpu_id=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster_name) kube_pod_labels{label_skypilot_cluster_name=~\"$cluster\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "{{hostname}} - {{card_series}} GPU {{gpu_id}}",
@@ -571,7 +571,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "DCGM_FI_DEV_XID_ERRORS{node=~\"$node\", gpu=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster) kube_pod_labels{label_skypilot_cluster=~\"$cluster\"}",
+          "expr": "DCGM_FI_DEV_XID_ERRORS{node=~\"$node\", gpu=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster_name) kube_pod_labels{label_skypilot_cluster_name=~\"$cluster\"}",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -599,11 +599,11 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(kube_pod_labels, label_skypilot_cluster)",
+        "definition": "label_values(kube_pod_labels, label_skypilot_cluster_name)",
         "includeAll": true,
         "name": "cluster",
         "options": [],
-        "query": "label_values(kube_pod_labels, label_skypilot_cluster)",
+        "query": "label_values(kube_pod_labels, label_skypilot_cluster_name)",
         "refresh": 1,
         "regex": "",
         "sort": 1,

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -108,7 +108,7 @@ function ClusterDetails() {
     try {
       const grafanaUrl = getGrafanaUrl();
       const endpoint =
-        '/api/datasources/proxy/uid/prometheus/api/v1/label/label_skypilot_cluster/values';
+        '/api/datasources/proxy/uid/prometheus/api/v1/label/label_skypilot_cluster_name/values';
 
       const response = await fetch(`${grafanaUrl}${endpoint}`, {
         method: 'GET',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The `skypilot-cluster` label will be deprecated in `v0.11.0` in favor of `skypilot-cluster-name`. This PR updates prometheus queries in the sky and grafana dashboards to use `skypilot-cluster-name`.
<img width="798" height="620" alt="Screenshot 2025-11-21 at 6 03 51 PM" src="https://github.com/user-attachments/assets/20773954-d446-41f7-b960-8a7944328388" />


<!-- Describe the tests ran -->
I deployed a fresh api server and launched a sky cluster on k8s with gpus and verified that metrics are showing up properly in grafana and in the sky dashboard and show the `skypilot-cluster-name` label.
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
