### PR TITLE
[k8s] Dedup pending pod reason spinner updates

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -585,6 +585,7 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
         return False, reason
 
     missing_pods_retry = 0
+    last_status_msg: Optional[str] = None
     while True:
         # Get all pods in a single API call
         cluster_name_on_cloud = new_pods[0].metadata.labels[
@@ -645,15 +646,16 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
         if pending_reasons_count:
             msg = ', '.join([
                 f'{count} pod(s) pending due to {reason}'
-                for reason, count in pending_reasons_count.items()
+                for reason, count in sorted(pending_reasons_count.items())
             ])
-            rich_utils.force_update_status(
-                ux_utils.spinner_message(f'Launching ({msg})',
-                                         cluster_name=cluster_name))
+            status_text = f'Launching ({msg})'
         else:
-            rich_utils.force_update_status(
-                ux_utils.spinner_message('Launching',
-                                         cluster_name=cluster_name))
+            status_text = 'Launching'
+        new_status_msg = ux_utils.spinner_message(status_text,
+                                                  cluster_name=cluster_name)
+        if new_status_msg != last_status_msg:
+            rich_utils.force_update_status(new_status_msg)
+            last_status_msg = new_status_msg
         time.sleep(1)
 
 


### PR DESCRIPTION
Follow up to #7959, #8002.

Previously, we were always updating the spinner message even though there are no changes from the last message. This increases number of bytes transferred over the network for no good reason.

This PR improves this by deduplicating these messages.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
