### PR TITLE
Drop `pyopenssl` upper limit to version constraint

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -196,7 +196,7 @@ cloud_dependencies: Dict[str, List[str]] = {
         'google-cloud-storage',
         # see https://github.com/conda/conda/issues/13619
         # see https://github.com/googleapis/google-api-python-client/issues/2554
-        'pyopenssl >= 23.2.0, <24.3.0',
+        'pyopenssl >= 23.2.0',
     ],
     'ibm': [
         'ibm-cloud-sdk-core',


### PR DESCRIPTION
Fixes #8069 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
