### PR TITLE
Fix: Suppress FutureWarning from google.api_core about Python 3.10 support

### DIFF
--- a/sky/adaptors/gcp.py
+++ b/sky/adaptors/gcp.py
@@ -12,7 +12,8 @@ from sky.adaptors import common
 warnings.filterwarnings(
     'ignore',
     category=FutureWarning,
-    message=r'.*You are using a Python version.*which Google will stop supporting.*',
+    message=
+    r'.*You are using a Python version.*which Google will stop supporting.*',
 )
 
 _IMPORT_ERROR_MESSAGE = ('Failed to import dependencies for GCP. '


### PR DESCRIPTION
Fixes #7886

## Summary
Suppresses the FutureWarning from `google.api_core._python_version_support` that appears when GCP modules are imported. This warning is informational and does not affect functionality.

## Changes
- Added warning filter in `sky/adaptors/gcp.py` to suppress the FutureWarning about Python 3.10 support ending
- The filter specifically targets the warning message from `google.api_core._python_version_support`