### PR TITLE
chore: fix spelling issues

### DIFF
--- a/examples/github_actions/README.md
+++ b/examples/github_actions/README.md
@@ -39,7 +39,7 @@ In this example, create the following repository secrets:
 - ``SKYPILOT_API_URL``: URL to the SkyPilot API server, in format of ``http(s)://url-or-ip``.
 If using basic auth, the URL should also include the credentials in format of ``http(s)://username:password@url-or-ip``.
 - ``SKYPILOT_SERVICE_ACCOUNT_TOKEN``: Only required if using OAuth. Service account token for GitHub actions user generated above.
-- ``SLACK_BOT_TOKEN``: Optional, create a [Slack App](https://api.slack.com/apps) and get a slack "App-Level Token" with `connections:write` permssion to send a summary message. If not provided, a slack message is not sent after a job is queued.
+- ``SLACK_BOT_TOKEN``: Optional, create a [Slack App](https://api.slack.com/apps) and get a slack "App-Level Token" with `connections:write` permission to send a summary message. If not provided, a slack message is not sent after a job is queued.
 - ``SLACK_CHANNEL_ID``: Optional, Slack Channel ID to send a summary message. If not provided, a slack message is not sent after a job is queued.
 
 ## Repository Structure

--- a/examples/marimo/README.md
+++ b/examples/marimo/README.md
@@ -6,7 +6,7 @@ Run a personal [marimo](https://marimo.io/) server on a SkyPilot cluster.
 
 ## Launch with CLI
 
-Launch a marimo cluser with the command:
+Launch a marimo cluster with the command:
 
 ```bash
 sky launch -c marimo-example marimo.yaml

--- a/examples/training/torchtitan/README.md
+++ b/examples/training/torchtitan/README.md
@@ -2,7 +2,7 @@
 
 [TorchTitan](https://github.com/pytorch/torchtitan) is a PyTorch native platform for large-scale LLM training, featuring multi-dimensional parallelisms (FSDP2, Tensor/Pipeline/Context Parallel), distributed checkpointing, torch.compile, and Float8 support.
 
-This example demonstrates how to run [TorchTitan](https://github.com/pytorch/torchtitan) on your Kubernetes clusters, or any hypersclaers, neoclouds using SkyPilot, in addition to the instructions for runnning on [Slurm](https://github.com/pytorch/torchtitan?tab=readme-ov-file#multi-node-training).
+This example demonstrates how to run [TorchTitan](https://github.com/pytorch/torchtitan) on your Kubernetes clusters, or any hypersclaers, neoclouds using SkyPilot, in addition to the instructions for running on [Slurm](https://github.com/pytorch/torchtitan?tab=readme-ov-file#multi-node-training).
 
 ## Quick start
 Here is how to finetune Llama 3.1 on 2 nodes with 8 H100 (or 8 H200):

--- a/examples/training_network_storage_benchmarks/README.md
+++ b/examples/training_network_storage_benchmarks/README.md
@@ -8,7 +8,7 @@ Please edit the yamls as you like.
 
 To run disk tests, run `sky launch e2e_disk.yaml -c e2e_disk --env HF_TOKEN="YOUR TOKEN"`
 
-Requirements for disk benchmark, 2 s3 buckets (one for mount and one for mount cached) and 1 pvc (Check out [volumnes](https://docs.skypilot.co/en/stable/reference/volumes.html))
+Requirements for disk benchmark, 2 s3 buckets (one for mount and one for mount cached) and 1 pvc (Check out [volumes](https://docs.skypilot.co/en/stable/reference/volumes.html))
 
 Expected output, something like:
 


### PR DESCRIPTION
Corrected several spelling errors in docs:

- `permssion` → `permission`
- `cluser` → `cluster`  
- `runnning` → `running`
- `volumnes` → `volumes`


