### PR TITLE
[MISC] properly cleanup load map in LeastLoadPolicy

### DIFF
--- a/sky/serve/load_balancing_policies.py
+++ b/sky/serve/load_balancing_policies.py
@@ -121,7 +121,7 @@ class LeastLoadPolicy(LoadBalancingPolicy, name='least_load', default=True):
             return
         with self.lock:
             self.ready_replicas = ready_replicas
-            for r in self.ready_replicas:
+            for r in list(self.load_map.keys()):
                 if r not in ready_replicas:
                     del self.load_map[r]
             for replica in ready_replicas:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Tiny bug fix when cleaning up the `load_map` in `LeadLoadPolicy`. It iterated through `ready_replicas` and check if the replica is in `ready_replicas` which always be in there. I think it should check the keys (replica) of the load_map and if it were excluded in ready_replicas then should delete from the `load_map`


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
