### PR TITLE
[Consolidation] Fix env vars and skip the status refresh for controllers

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -3150,12 +3150,11 @@ def refresh_cluster_records() -> None:
     Raises:
         None
     """
-    exclude_managed_clusters = True
-    if env_options.Options.SHOW_DEBUG_INFO.get():
-        exclude_managed_clusters = False
+    # We force to exclude managed clusters to avoid multiple sources
+    # manipulating them. For example, SkyServe assumes the replica manager
+    # is the only source of truth for the cluster status.
     cluster_names = set(
-        global_user_state.get_cluster_names(
-            exclude_managed_clusters=exclude_managed_clusters,))
+        global_user_state.get_cluster_names(exclude_managed_clusters=True))
 
     # TODO(syang): we should try not to leak
     # request info in backend_utils.py.

--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -21,6 +21,7 @@ from sky.serve import autoscalers
 from sky.serve import replica_managers
 from sky.serve import serve_state
 from sky.serve import serve_utils
+from sky.skylet import constants
 from sky.utils import common_utils
 from sky.utils import context_utils
 from sky.utils import ux_utils
@@ -288,6 +289,7 @@ class SkyServeController:
 # specific time period.
 def run_controller(service_name: str, service_spec: serve.SkyServiceSpec,
                    version: int, controller_host: str, controller_port: int):
+    os.environ[constants.OVERRIDE_CONSOLIDATION_MODE] = 'true'
     # Hijack sys.stdout/stderr to be context aware.
     context_utils.hijack_sys_attrs()
     controller = SkyServeController(service_name, service_spec, version,

--- a/sky/server/daemons.py
+++ b/sky/server/daemons.py
@@ -120,14 +120,6 @@ def refresh_cluster_status_event():
     time.sleep(server_constants.CLUSTER_REFRESH_DAEMON_INTERVAL_SECONDS)
 
 
-# After #7332, we start a local API server for pool/serve controller.
-# We should skip the status refresh event on the pool/serve controller,
-# as they have their own logic to cleanup the cluster records. This refresh
-# will break existing workflows.
-def should_skip_refresh_cluster_status() -> bool:
-    return os.environ.get(constants.OVERRIDE_CONSOLIDATION_MODE) is not None
-
-
 def refresh_volume_status_event():
     """Periodically refresh the volume status."""
     # pylint: disable=import-outside-toplevel
@@ -274,7 +266,6 @@ INTERNAL_REQUEST_DAEMONS = [
         id='skypilot-status-refresh-daemon',
         name=request_names.RequestName.REQUEST_DAEMON_STATUS_REFRESH,
         event_fn=refresh_cluster_status_event,
-        should_skip=should_skip_refresh_cluster_status,
         default_log_level='DEBUG'),
     # Volume status refresh daemon to update the volume status periodically.
     InternalRequestDaemon(

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -569,7 +569,6 @@ def shared_controller_vars_to_fill(
         # with a remote API server.
         constants.USING_REMOTE_API_SERVER_ENV_VAR: str(
             common_utils.get_using_remote_api_server()),
-        constants.OVERRIDE_CONSOLIDATION_MODE: 'true',
         constants.IS_SKYPILOT_SERVE_CONTROLLER:
             ('true'
              if controller == Controllers.SKY_SERVE_CONTROLLER else 'false'),


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

In #7332, we set the override consolidation mode env var to true, which causes some problem. Originally this is for avoid both skyserve replica manager and status refresh deamon to conflict with each other. This PR fixes it by not refreshing any managed clusters.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
