### PR TITLE
[test] fix flaky test_stdout_stderr_restoration

### DIFF
--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -339,7 +339,7 @@ async def test_execute_with_isolated_env_and_config(isolated_database,
         os.environ.pop('TEST_VAR_A', None)
 
 
-FAKE_FD_START = 100
+FAKE_FD_START = 100000
 
 
 def _get_saved_fd_close_count(close_calls: List[int], created_fds: set) -> int:


### PR DESCRIPTION
In some cases, we were _actually_ closing an fd >100, which seems to sometimes be used by FileLock. Bump the fake fds values to a much higher number to avoid the conflict.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] Run the test 100 times
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
