### PR TITLE
remove remaining references to old k8s image

### DIFF
--- a/docs/source/reference/kubernetes/kubernetes-getting-started.rst
+++ b/docs/source/reference/kubernetes/kubernetes-getting-started.rst
@@ -193,8 +193,8 @@ Using custom images
 -------------------
 By default, we maintain and use two SkyPilot container images for use on Kubernetes clusters:
 
-1. ``us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot``: used for CPU-only clusters (`Dockerfile <https://github.com/skypilot-org/skypilot/blob/master/Dockerfile_k8s>`__).
-2. ``us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot-gpu``: used for GPU clusters (`Dockerfile <https://github.com/skypilot-org/skypilot/blob/master/Dockerfile_k8s_gpu>`__).
+1. ``us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot``: used for CPU-only clusters (`Dockerfile <https://github.com/skypilot-org/skypilot/blob/master/Dockerfile_k8s>`__).
+2. ``us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu``: used for GPU clusters (`Dockerfile <https://github.com/skypilot-org/skypilot/blob/master/Dockerfile_k8s_gpu>`__).
 
 These images are pre-installed with SkyPilot dependencies for fast startup.
 

--- a/docs/source/reference/kubernetes/kubernetes-troubleshooting.rst
+++ b/docs/source/reference/kubernetes/kubernetes-troubleshooting.rst
@@ -36,7 +36,7 @@ Step A1 - Can you create pods and services?
 
 As a sanity check, we will now try creating a simple pod running a HTTP server and a service to verify that your cluster and it's networking is functional.
 
-We will use the SkyPilot default image :code:`us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot:latest` to verify that the image can be pulled from the registry.
+We will use the SkyPilot default image :code:`us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:latest` to verify that the image can be pulled from the registry.
 
 .. code-block:: bash
 

--- a/sky/utils/kubernetes/create_cluster.sh
+++ b/sky/utils/kubernetes/create_cluster.sh
@@ -4,8 +4,8 @@
 set -e
 
 # Images
-IMAGE="us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot:latest"
-IMAGE_GPU="us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot-gpu:latest"
+IMAGE="us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:latest"
+IMAGE_GPU="us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:latest"
 
 # Arguments
 NAME=$1

--- a/tests/kubernetes/README.md
+++ b/tests/kubernetes/README.md
@@ -5,7 +5,7 @@ This directory contains useful scripts and notes for developing SkyPilot on Kube
 ## Building and pushing SkyPilot image
 
 We maintain a container image that has all basic SkyPilot dependencies installed.
-This image is hosted at `us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot:latest`.
+This image is hosted at `us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:latest`.
 
 To build this image locally and optionally push to the SkyPilot registry, run:
 ```bash

--- a/tests/kubernetes/cpu_test_pod.yaml
+++ b/tests/kubernetes/cpu_test_pod.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   containers:
   - name: skytest
-    image: us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot:latest
+    image: us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:latest
     # Run apt update and run a simple HTTP server
     command: ["/bin/bash", "-c", "--"]
     args: ["sudo apt update && python3 -m http.server 8080"]

--- a/tests/kubernetes/gpu_test_pod.yaml
+++ b/tests/kubernetes/gpu_test_pod.yaml
@@ -8,7 +8,7 @@ spec:
   restartPolicy: Never
   containers:
   - name: skygputest
-    image: us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot-gpu:latest
+    image: us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:latest
     command: ["nvidia-smi"]
     resources:
       limits:

--- a/tests/kubernetes/scripts/skypilot_ssh_k8s_deployment.yaml
+++ b/tests/kubernetes/scripts/skypilot_ssh_k8s_deployment.yaml
@@ -20,7 +20,7 @@ spec:
             secretName: ssh-key-secret
       containers:
       - name: skypilot
-        image: us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot:latest
+        image: us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:latest
         imagePullPolicy: Never
         env:
           - name: SECRET_THING


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
