### PR TITLE
[Doc] Add notes for volume config for multi-node clusters

### DIFF
--- a/docs/source/reference/volumes.rst
+++ b/docs/source/reference/volumes.rst
@@ -110,6 +110,10 @@ Quickstart
      run: |
        echo "Hello, World!" > /mnt/data/hello.txt
 
+.. note::
+
+  For multi-node clusters, volumes are mounted to all nodes. You must configure ``config.access_mode`` to ``ReadWriteMany`` and use a ``storage_class_name`` that supports the ``ReadWriteMany`` access mode. Otherwise, SkyPilot will fail to launch the cluster.
+
 .. _volumes-on-kubernetes-manage:
 
 Managing volumes
@@ -319,6 +323,10 @@ When you launch the cluster with ``sky launch``, the ephemeral volumes will be a
   Kubernetes PVCs:
   NAME                       TYPE     INFRA                      SIZE  USER  WORKSPACE  AGE   STATUS  LAST_USE             USED_BY                  IS_EPHEMERAL
   my-cluster-43dbb4ab-2f74bf k8s-pvc  Kubernetes/nebius-mk8s-vol 100Gi alice default    58m   IN_USE  2025-11-17 14:30:18  my-cluster-43dbb4ab-head True
+
+.. note::
+
+  For multi-node clusters, ephemeral volumes are mounted to all nodes. You must configure ``config.access_mode`` to ``ReadWriteMany`` and use a ``storage_class_name`` that supports the ``ReadWriteMany`` access mode. Otherwise, SkyPilot will fail to launch the cluster.
 
 When you terminate the cluster, the ephemeral volumes are automatically deleted:
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Add notes for volume config for multi-node clusters

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
