### PR TITLE
[GCP] Fix B200 spot instance support in catalog fetcher

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -1186,8 +1186,8 @@ class GCP(clouds.Cloud):
             # These series don't support pd-standard, use pd-balanced for LOW.
             _propagate_disk_type(
                 lowest=tier2name[resources_utils.DiskTier.MEDIUM])
-        if instance_type.startswith('a3-ultragpu') or series == 'n4':
-            # a3-ultragpu instances only support hyperdisk-balanced.
+        if instance_type.startswith('a3-ultragpu') or series in ('n4', 'a4'):
+            # a3-ultragpu, n4, and a4 instances only support hyperdisk-balanced.
             _propagate_disk_type(all='hyperdisk-balanced')
 
         # Series specific handling


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This fixes two issues preventing GCP B200 (a4-highgpu-8g) spot instances from being recognized:

1. A4 VM pricing missing: GCP doesn't provide separate CPU/RAM pricing for A4 instances in their SKUs API. The B200 GPU pricing includes the full VM cost. Added special handling to set A4 VM price to 0 so entries aren't dropped.

2. B200 spot pricing bug: Some B200 spot SKUs in GCP's API have usageType='OnDemand' even though the description says "Spot Preemptible". Added logic to match on description when usageType doesn't match for B200 spot queries.

Fixes #8102
<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
