### PR TITLE
feat: add scheduling constraints to SkyPilot API server helm chart

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -655,3 +655,15 @@ spec:
       - name: r2-config
         emptyDir: {}
       {{- end }}
+      {{- with .Values.apiService.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.apiService.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.apiService.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -178,6 +178,11 @@ apiService:
   # @schema type: [string, null]
   imagePullPolicy: Always
 
+  # Add scheduling constraints to the API server pod
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
 # Authentication configuration for the API server
 # Refer to https://docs.skypilot.co/en/latest/reference/auth.html for more details.
 # @schema type: [object, null]


### PR DESCRIPTION
Added nodeSelector, affinity, and tolerations to support scheduling on specific nodes.
