### PR TITLE
feat: add scheduling constraints to SkyPilot API server helm chart

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -655,3 +655,15 @@ spec:
       - name: r2-config
         emptyDir: {}
       {{- end }}
+      {{- with .Values.apiService.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.apiService.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.apiService.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -5,6 +5,9 @@
         "apiService": {
             "type": "object",
             "properties": {
+                "affinity": {
+                    "type": "object"
+                },
                 "annotations": {
                     "type": [
                         "object",
@@ -113,6 +116,9 @@
                         }
                     }
                 },
+                "nodeSelector": {
+                    "type": "object"
+                },
                 "preDeployHook": {
                     "type": "string"
                 },
@@ -142,6 +148,9 @@
                 },
                 "terminationGracePeriodSeconds": {
                     "type": "integer"
+                },
+                "tolerations": {
+                    "type": "array"
                 },
                 "upgradeStrategy": {
                     "type": "string"

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -178,6 +178,11 @@ apiService:
   # @schema type: [string, null]
   imagePullPolicy: Always
 
+  # Add scheduling constraints to the API server pod
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
 # Authentication configuration for the API server
 # Refer to https://docs.skypilot.co/en/latest/reference/auth.html for more details.
 # @schema type: [object, null]


### PR DESCRIPTION
This change adds nodeSelector, affinity, and tolerations to the Helm chart values, allowing the API server pod to be scheduled on specific nodes.

- [ ] Code formatting: install pre-commit (auto-check on commit) or bash format.sh
- [ ]  Any manual or new tests for this PR (please specify below)
- [ ]  All smoke tests: /smoke-test (CI) or pytest tests/test_smoke.py (local)
- [ ]  Relevant individual tests: /smoke-test -k test_name (CI) or pytest tests/test_smoke.py::test_name (local)
- [ ]  Backward compatibility: /quicktest-core (CI) or pytest tests/smoke_tests/test_backward_compat.py (local)