### PR TITLE
Fix buildkite test collect name

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -68,8 +68,19 @@ jobs:
       - name: Set branch name and commit message
         id: set_env
         run: |
-          echo "branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
-          echo "message=${{ github.event.pull_request.title }}" >> $GITHUB_OUTPUT
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
+            echo "message=${{ github.event.pull_request.title }}" >> $GITHUB_OUTPUT
+          else
+            echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            # For push events after merge, head_commit.message contains the merge commit message
+            # which includes the PR title. For merge_group events, use merge_group.head_commit.message
+            if [ "${{ github.event_name }}" == "merge_group" ]; then
+              echo "message=${{ github.event.merge_group.head_commit.message }}" >> $GITHUB_OUTPUT
+            else
+              echo "message=${{ github.event.head_commit.message }}" >> $GITHUB_OUTPUT
+            fi
+          fi
       - name: Run tests with pytest
         env:
           TEST_PATH: ${{ matrix.test-path }}
@@ -117,8 +128,19 @@ jobs:
       - name: Set branch name and commit message
         id: set_env
         run: |
-          echo "branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
-          echo "message=${{ github.event.pull_request.title }}" >> $GITHUB_OUTPUT
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
+            echo "message=${{ github.event.pull_request.title }}" >> $GITHUB_OUTPUT
+          else
+            echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            # For push events after merge, head_commit.message contains the merge commit message
+            # which includes the PR title. For merge_group events, use merge_group.head_commit.message
+            if [ "${{ github.event_name }}" == "merge_group" ]; then
+              echo "message=${{ github.event.merge_group.head_commit.message }}" >> $GITHUB_OUTPUT
+            else
+              echo "message=${{ github.event.head_commit.message }}" >> $GITHUB_OUTPUT
+            fi
+          fi
       - name: Run tests with pytest
         env:
           TEST_PATH: ${{ matrix.test-path }}
@@ -162,8 +184,19 @@ jobs:
       - name: Set branch name and commit message
         id: set_env
         run: |
-          echo "branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
-          echo "message=${{ github.event.pull_request.title }}" >> $GITHUB_OUTPUT
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
+            echo "message=${{ github.event.pull_request.title }}" >> $GITHUB_OUTPUT
+          else
+            echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            # For push events after merge, head_commit.message contains the merge commit message
+            # which includes the PR title. For merge_group events, use merge_group.head_commit.message
+            if [ "${{ github.event_name }}" == "merge_group" ]; then
+              echo "message=${{ github.event.merge_group.head_commit.message }}" >> $GITHUB_OUTPUT
+            else
+              echo "message=${{ github.event.head_commit.message }}" >> $GITHUB_OUTPUT
+            fi
+          fi
       - name: Run tests with pytest
         env:
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_ANALYTICS_TOKEN }}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Follw up on #8120

After PR get merged, a test will also be triggered from merge event in master branch

This build: https://github.com/skypilot-org/skypilot/actions/runs/19812878892 is triggered by merge event but we fail to extract necessary info from github CI env

<img width="1935" height="470" alt="image" src="https://github.com/user-attachments/assets/c319b00c-2150-4e97-9139-29b64dc8de3a" />


After this PR, we can get necessary info

Test result from personal repo:

<img width="2100" height="582" alt="image" src="https://github.com/user-attachments/assets/a097566f-9c6e-47fe-8826-94d29b16d628" />

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
