### PR TITLE
chore: fix spelling issues

### DIFF
--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -762,7 +762,7 @@ def update_job_status(job_ids: List[int],
     statuses = []
     for job_id in job_ids:
         # Per-job status lock is required because between the job status
-        # query and the job status update, the job status in the databse
+        # query and the job status update, the job status in the database
         # can be modified by the generated ray program.
         with filelock.FileLock(_get_lock_path(job_id)):
             status = None

--- a/sky/skylet/providers/ibm/node_provider.py
+++ b/sky/skylet/providers/ibm/node_provider.py
@@ -445,7 +445,7 @@ class IBMVPCNodeProvider(NodeProvider):
         """returns the worker's node private ip address"""
         node = self._get_cached_node(node_id)
 
-        # if a bug ocurred, or node data was fetched before primary_ip
+        # if a bug occurred, or node data was fetched before primary_ip
         # was assigned, refetch node data from cloud.
         try:
             primary_ip = node["network_interfaces"][0].get("primary_ip")["address"]

--- a/sky/skylet/providers/ibm/vpc_provider.py
+++ b/sky/skylet/providers/ibm/vpc_provider.py
@@ -346,7 +346,7 @@ class IBMVPCProvider:
                     return True
                 tries -= 1
                 time.sleep(sleep_interval)
-            logger.error("Failed to delete instance within the alloted time\n")
+            logger.error("Failed to delete instance within the allotted time\n")
             return False
 
         for subnet_id in self.get_vpc_subnets(vpc_data, region, field="id"):

--- a/sky/utils/asyncio_utils.py
+++ b/sky/utils/asyncio_utils.py
@@ -10,7 +10,7 @@ _background_tasks: Set[asyncio.Task] = set()
 def shield(func):
     """Shield the decorated async function from cancellation.
 
-    If the outter coroutine is cancelled, the inner decorated function
+    If the outer coroutine is cancelled, the inner decorated function
     will be protected from cancellation by asyncio.shield(). And we will
     maintain a reference to the the inner task to avoid it get GCed before
     it is done.

--- a/sky/utils/atomic.py
+++ b/sky/utils/atomic.py
@@ -1,4 +1,4 @@
-"""Atomic structures and utilties."""
+"""Atomic structures and utilities."""
 
 import threading
 

--- a/sky/utils/context.py
+++ b/sky/utils/context.py
@@ -158,7 +158,7 @@ class ContextualEnviron(MutableMapping[str, str]):
     aware.
 
     Behavior of spawning a subprocess:
-    - The contexual overrides will not be applied to the subprocess by
+    - The contextual overrides will not be applied to the subprocess by
       default.
     - When using env=os.environ to pass the environment variables to the
       subprocess explicitly. The subprocess will inherit the contextual


### PR DESCRIPTION
Several spelling errors in the code comments and error logs have been corrected:

- `databse` → `database`
- `ocurred` → `occurred`  
- `alloted ` → `allotted`
- `outter` → `outter `
- `utilties` → `utilities`
- `contexual` → `contextual`