### PR TITLE
[docker] fix docker on nebius

### DIFF
--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -29,10 +29,11 @@ SETUP_ENV_VARS_CMD = (
 # Docker daemon may not be ready when the machine is firstly started. The error
 # message starts with the following string. We should wait for a while and retry
 # the command.
-DOCKER_PERMISSION_DENIED_STR = ('permission denied while trying to connect to '
-                                'the Docker daemon socket')
+DOCKER_PERMISSION_DENIED_STR = ('permission denied while trying to connect to ')
 
 DOCKER_SOCKET_NOT_READY_STR = ('Is the docker daemon running?')
+DOCKER_SOCKET_NOT_READY_STR_2 = (
+    'check if the path is correct and if the daemon is running')
 
 _DOCKER_SOCKET_WAIT_TIMEOUT_SECONDS = 30
 
@@ -228,7 +229,8 @@ class DockerInitializer:
                 separate_stderr=separate_stderr,
                 log_path=self.log_path)
             if (DOCKER_PERMISSION_DENIED_STR in stdout + stderr or
-                    DOCKER_SOCKET_NOT_READY_STR in stdout + stderr):
+                    DOCKER_SOCKET_NOT_READY_STR in stdout + stderr or
+                    DOCKER_SOCKET_NOT_READY_STR_2 in stdout + stderr):
                 if wait_for_docker_daemon:
                     if time.time(
                     ) - start > _DOCKER_SOCKET_WAIT_TIMEOUT_SECONDS:


### PR DESCRIPTION
Upstream updated the error messages: moby/moby#50285 (Docker v29). It seems that Nebius has the new version first.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
