### PR TITLE
demonstrate use of secrets in marimo example

### DIFF
--- a/examples/marimo/marimo.yaml
+++ b/examples/marimo/marimo.yaml
@@ -13,7 +13,10 @@ resources:
 
 workdir: .
 
+secrets:
+  MARIMO_TOKEN_PASSWORD: secretpassword
+
 setup: pip install uv
 
 # Check the docs for more options: https://docs.marimo.io/cli/#marimo-edit
-run: uvx marimo edit --port 29324 --headless --host=0.0.0.0 --token-password='secretpassword'
+run: uvx marimo edit --port 29324 --headless --host=0.0.0.0 --token-password=$MARIMO_TOKEN_PASSWORD


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Update marimo notebook example (found [here](https://docs.skypilot.co/en/latest/examples/frameworks/marimo.html)) to demonstrate use of secrets to pass in sensitive fields.

The effect of using secrets is best demonstrated in the dashboard, where the provided value is redacted in displayed YAML:

Before:
<img width="865" height="397" alt="Screenshot 2025-12-02 at 11 25 06 AM" src="https://github.com/user-attachments/assets/022a8a72-5cb4-49fe-bda6-e7f472675074" />

After:
<img width="888" height="459" alt="Screenshot 2025-12-02 at 11 22 06 AM" src="https://github.com/user-attachments/assets/a6590145-6bd2-48eb-889b-abd07c0e5314" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
