### PR TITLE
Fix CI pipeline runs on master

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -71,7 +71,7 @@ jobs:
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             echo "branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
             {
-              echo "message=<<EOF"
+              echo "message<<EOF"
               echo "${{ github.event.pull_request.title }}"
               echo "EOF"
             } >> $GITHUB_OUTPUT
@@ -80,7 +80,7 @@ jobs:
             # For push events after merge, head_commit.message contains the merge commit message
             # which includes the PR title. For merge_group events, use merge_group.head_commit.message
             {
-              echo "message=<<EOF"
+              echo "message<<EOF"
               if [ "${{ github.event_name }}" == "merge_group" ]; then
                 echo "${{ github.event.merge_group.head_commit.message }}"
               else
@@ -203,7 +203,7 @@ jobs:
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             echo "branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
             {
-              echo "message=<<EOF"
+              echo "message<<EOF"
               echo "${{ github.event.pull_request.title }}"
               echo "EOF"
             } >> $GITHUB_OUTPUT
@@ -212,7 +212,7 @@ jobs:
             # For push events after merge, head_commit.message contains the merge commit message
             # which includes the PR title. For merge_group events, use merge_group.head_commit.message
             {
-              echo "message=<<EOF"
+              echo "message<<EOF"
               if [ "${{ github.event_name }}" == "merge_group" ]; then
                 echo "${{ github.event.merge_group.head_commit.message }}"
               else


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
CI pipeline on master has been failing due to failure in "Set branch name and commit message" step, notably:
<img width="738" height="607" alt="Screenshot 2025-12-02 at 1 21 18 PM" src="https://github.com/user-attachments/assets/f36f0355-bd7c-41c1-9646-4a6f96de792e" />

I believe using an EOF delimited multiline output format instead should get around this error.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
