### PR TITLE
Revert [Backend] Support running multiple skylets on a single machin…

### DIFF
--- a/sky/skylet/attempt_skylet.py
+++ b/sky/skylet/attempt_skylet.py
@@ -1,74 +1,12 @@
 """Restarts skylet if version does not match"""
 
 import os
-import signal
 import subprocess
-from typing import List
-
-import psutil
 
 from sky.skylet import constants
 from sky.skylet import runtime_utils
 
 VERSION_FILE = runtime_utils.get_runtime_dir_path(constants.SKYLET_VERSION_FILE)
-SKYLET_LOG_FILE = runtime_utils.get_runtime_dir_path(constants.SKYLET_LOG_FILE)
-PID_FILE = runtime_utils.get_runtime_dir_path(constants.SKYLET_PID_FILE)
-PORT_FILE = runtime_utils.get_runtime_dir_path(constants.SKYLET_PORT_FILE)
-
-
-def _is_running_skylet_process(pid: int) -> bool:
-    if pid <= 0:
-        return False
-    try:
-        process = psutil.Process(pid)
-        if not process.is_running():
-            return False
-        # Check if command line contains the skylet module identifier
-        cmdline = process.cmdline()
-        return any('sky.skylet.skylet' in arg for arg in cmdline)
-    except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess,
-            OSError) as e:
-        print(f'Error checking if skylet process {pid} is running: {e}')
-        return False
-
-
-def _find_running_skylet_pids() -> List[int]:
-    if os.path.exists(PID_FILE):
-        try:
-            with open(PID_FILE, 'r', encoding='utf-8') as pid_file:
-                pid = int(pid_file.read().strip())
-            if _is_running_skylet_process(pid):
-                return [pid]
-        except (OSError, ValueError, IOError) as e:
-            # Don't fallback to grep-based detection as the existence of the
-            # PID file implies that we are on the new version, and there is
-            # possibility of there being multiple skylet processes running,
-            # and we don't want to accidentally kill the wrong skylet(s).
-            print(f'Error reading PID file {PID_FILE}: {e}')
-        return []
-    else:
-        # Fall back to grep-based detection for backward compatibility.
-        pids = []
-        # We use -m to grep instead of {constants.SKY_PYTHON_CMD} -m to grep
-        # because need to handle the backward compatibility of the old skylet
-        # started before #3326, which does not use the full path to python.
-        proc = subprocess.run(
-            'ps aux | grep -v "grep" | grep "sky.skylet.skylet" | grep " -m"',
-            shell=True,
-            check=False,
-            capture_output=True,
-            text=True)
-        if proc.returncode == 0:
-            # Parse the output to extract PIDs (column 2)
-            for line in proc.stdout.strip().split('\n'):
-                if line:
-                    parts = line.split()
-                    if len(parts) >= 2:
-                        try:
-                            pids.append(int(parts[1]))
-                        except ValueError:
-                            continue
-        return pids
 
 
 def restart_skylet():
@@ -76,39 +14,32 @@ def restart_skylet():
     # TODO(zhwu): make the killing graceful, e.g., use a signal to tell
     # skylet to exit, instead of directly killing it.
 
-    # Find and kill running skylet processes
-    for pid in _find_running_skylet_pids():
-        try:
-            os.kill(pid, signal.SIGKILL)
-        except (OSError, ProcessLookupError):
-            # Process died between detection and kill
-            pass
-    # Clean up the PID file
-    try:
-        os.remove(PID_FILE)
-    except OSError:
-        pass  # Best effort cleanup
-
-    port = constants.SKYLET_GRPC_PORT
+    subprocess.run(
+        # We use -m to grep instead of {constants.SKY_PYTHON_CMD} -m to grep
+        # because need to handle the backward compatibility of the old skylet
+        # started before #3326, which does not use the full path to python.
+        'ps aux | grep "sky.skylet.skylet" | grep " -m "'
+        '| awk \'{print $2}\' | xargs kill >> ~/.sky/skylet.log 2>&1',
+        shell=True,
+        check=False)
     subprocess.run(
         # We have made sure that `attempt_skylet.py` is executed with the
         # skypilot runtime env activated, so that skylet can access the cloud
         # CLI tools.
-        f'nohup {constants.SKY_PYTHON_CMD} -m sky.skylet.skylet '
-        f'--port={port} '
-        f'>> {SKYLET_LOG_FILE} 2>&1 & echo $! > {PID_FILE}',
+        f'nohup {constants.SKY_PYTHON_CMD} -m sky.skylet.skylet'
+        ' >> ~/.sky/skylet.log 2>&1 &',
         shell=True,
         check=True)
-
-    with open(PORT_FILE, 'w', encoding='utf-8') as pf:
-        pf.write(str(port))
-
     with open(VERSION_FILE, 'w', encoding='utf-8') as v_f:
         v_f.write(constants.SKYLET_VERSION)
 
 
-# Check if our skylet is running
-running = bool(_find_running_skylet_pids())
+proc = subprocess.run(
+    'ps aux | grep -v "grep" | grep "sky.skylet.skylet" | grep " -m"',
+    shell=True,
+    check=False)
+
+running = (proc.returncode == 0)
 
 version_match = False
 found_version = None

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -116,15 +116,12 @@ TASK_ID_LIST_ENV_VAR = f'{SKYPILOT_ENV_VAR_PREFIX}TASK_IDS'
 # cluster yaml is updated.
 #
 # TODO(zongheng,zhanghao): make the upgrading of skylet automatic?
-SKYLET_VERSION = '27'
+SKYLET_VERSION = '26'
 # The version of the lib files that skylet/jobs use. Whenever there is an API
 # change for the job_lib or log_lib, we need to bump this version, so that the
 # user can be notified to update their SkyPilot version on the remote cluster.
 SKYLET_LIB_VERSION = 4
 SKYLET_VERSION_FILE = '.sky/skylet_version'
-SKYLET_LOG_FILE = '.sky/skylet.log'
-SKYLET_PID_FILE = '.sky/skylet_pid'
-SKYLET_PORT_FILE = '.sky/skylet_port'
 SKYLET_GRPC_PORT = 46590
 SKYLET_GRPC_TIMEOUT_SECONDS = 10
 

--- a/sky/skylet/skylet.py
+++ b/sky/skylet/skylet.py
@@ -1,6 +1,5 @@
 """skylet: a daemon running on the head node of a cluster."""
 
-import argparse
 import concurrent.futures
 import os
 import time
@@ -82,15 +81,7 @@ def run_event_loop():
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Start skylet daemon')
-    parser.add_argument('--port',
-                        type=int,
-                        default=constants.SKYLET_GRPC_PORT,
-                        help=f'gRPC port to listen on (default: '
-                        f'{constants.SKYLET_GRPC_PORT})')
-    args = parser.parse_args()
-
-    grpc_server = start_grpc_server(port=args.port)
+    grpc_server = start_grpc_server()
     try:
         run_event_loop()
     except KeyboardInterrupt:

--- a/tests/unit_tests/test_sky/skylet/test_attempt_skylet.py
+++ b/tests/unit_tests/test_sky/skylet/test_attempt_skylet.py
@@ -1,251 +1,29 @@
 """Unit tests for attempt_skylet module."""
 import importlib
-import signal
-import sys
+import os
 from unittest import mock
 
-import psutil
 import pytest
 
-from sky.skylet import constants
-
-MODULE_NAME = 'sky.skylet.attempt_skylet'
+from sky.skylet import attempt_skylet
 
 
-@pytest.fixture
-def skylet_env(tmp_path, monkeypatch):
-    """Shared fixture for skylet tests with isolated runtime directory."""
-    # Clear module BEFORE setting env to ensure fresh import picks up new env
-    sys.modules.pop(MODULE_NAME, None)
-    parent = sys.modules.get('sky.skylet')
-    if parent and hasattr(parent, 'attempt_skylet'):
-        delattr(parent, 'attempt_skylet')
+@pytest.mark.parametrize('use_custom_dir', [False, True])
+def test_version_file_runtime_dir(tmp_path, monkeypatch, use_custom_dir):
+    """Test VERSION_FILE respects SKY_RUNTIME_DIR overrides."""
+    monkeypatch.delenv('SKY_RUNTIME_DIR', raising=False)
+    if use_custom_dir:
+        monkeypatch.setenv('SKY_RUNTIME_DIR', str(tmp_path))
 
-    runtime_dir = tmp_path
-    monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY, str(runtime_dir))
+    # Mock subprocess and file operations to prevent actual execution
+    with mock.patch('subprocess.run'), \
+         mock.patch('builtins.open', mock.mock_open()), \
+         mock.patch('os.path.exists', return_value=True):
+        # RUNTIME_DIR is evaluated at import time; re-import for fresh values.
+        importlib.reload(attempt_skylet)
 
-    sky_dir = runtime_dir / '.sky'
-    sky_dir.mkdir(parents=True, exist_ok=True)
-
-    return {
-        'runtime_dir': runtime_dir,
-        'pid_file': sky_dir / 'skylet_pid',
-        'port_file': sky_dir / 'skylet_port',
-        'version_file': sky_dir / 'skylet_version',
-        'log_file': sky_dir / 'skylet.log',
-    }
-
-
-class TestRunningCheck:
-    """Test running check logic (PID file and grep fallback)."""
-
-    def test_pid_file_process_alive(self, skylet_env, monkeypatch):
-        """PID file exists + process alive -> running=True."""
-        pid = 12345
-        skylet_env['pid_file'].write_text(str(pid))
-
-        # Mock psutil.Process to simulate a running skylet process
-        mock_process = mock.Mock()
-        mock_process.is_running.return_value = True
-        mock_process.cmdline.return_value = [
-            'python', '-m', 'sky.skylet.skylet', '--port=46590'
-        ]
-        monkeypatch.setattr('psutil.Process', lambda p: mock_process)
-        monkeypatch.setattr('subprocess.run', mock.Mock())
-
-        from sky.skylet import attempt_skylet
-
-        assert attempt_skylet.running
-
-    def test_pid_file_process_dead(self, skylet_env, monkeypatch):
-        """PID file exists + process dead -> running=False."""
-        skylet_env['pid_file'].write_text('12345')
-
-        # Mock psutil.Process to simulate dead process
-        def mock_process_factory(pid):
-            raise psutil.NoSuchProcess(pid)
-
-        monkeypatch.setattr('psutil.Process', mock_process_factory)
-        monkeypatch.setattr('subprocess.run', mock.Mock())
-
-        from sky.skylet import attempt_skylet
-
-        assert not attempt_skylet.running
-
-    def test_no_pid_file_grep_fallback(self, skylet_env, monkeypatch):
-        """No PID file -> falls back to grep-based check."""
-        assert not skylet_env['pid_file'].exists()
-
-        # Mock subprocess.run with proper stdout for grep command output
-        # This simulates ps aux | grep ... output with PID 7680
-        mock_result = mock.Mock(
-            returncode=0,
-            stdout=
-            'sky         7680  0.0  0.0 1676360 153600 ?      Sl   09:30   0:16 /home/sky/skypilot-runtime/bin/python -m sky.skylet.skylet\n'
-        )
-        monkeypatch.setattr('subprocess.run', lambda *a, **kw: mock_result)
-
-        from sky.skylet import attempt_skylet
-
-        assert attempt_skylet.running
-
-
-class TestVersionMatch:
-    """Test version_match logic."""
-
-    def test_version_match_when_file_matches(self, skylet_env, monkeypatch):
-        """Version file with matching version -> version_match=True."""
-        skylet_env['pid_file'].write_text('12345')
-        # Write current version to version file so it matches.
-        skylet_env['version_file'].write_text(constants.SKYLET_VERSION)
-
-        # Mock psutil.Process to simulate a running skylet process
-        mock_process = mock.Mock()
-        mock_process.is_running.return_value = True
-        mock_process.cmdline.return_value = [
-            'python', '-m', 'sky.skylet.skylet', '--port=46590'
-        ]
-        monkeypatch.setattr('psutil.Process', lambda p: mock_process)
-        monkeypatch.setattr('subprocess.run', mock.Mock())
-
-        from sky.skylet import attempt_skylet
-
-        assert attempt_skylet.version_match
-
-    def test_version_mismatch_when_file_stale(self, skylet_env, monkeypatch):
-        """Version file with stale version -> version_match=False."""
-        skylet_env['pid_file'].write_text('12345')
-        skylet_env['version_file'].write_text('old_version')
-
-        # Mock psutil.Process to simulate a running skylet process
-        mock_process = mock.Mock()
-        mock_process.is_running.return_value = True
-        mock_process.cmdline.return_value = [
-            'python', '-m', 'sky.skylet.skylet', '--port=46590'
-        ]
-        monkeypatch.setattr('psutil.Process', lambda p: mock_process)
-        monkeypatch.setattr('subprocess.run', mock.Mock())
-
-        from sky.skylet import attempt_skylet
-
-        assert not attempt_skylet.version_match
-
-
-class TestRestartSkylet:
-    """Test restart_skylet() function."""
-
-    @pytest.fixture(autouse=True)
-    def setup(self, skylet_env, monkeypatch):
-        """Get restart_skylet function with correct runtime dir."""
-        self.env = skylet_env
-
-        from sky.skylet import attempt_skylet
-        self.restart_skylet = attempt_skylet.restart_skylet
-
-    def test_handles_dead_process_gracefully(self, monkeypatch):
-        """restart_skylet() doesn't crash if process already dead."""
-        self.env['pid_file'].write_text('99999')
-
-        # Mock psutil.Process to simulate dead process
-        def mock_process_factory(pid):
-            raise psutil.NoSuchProcess(pid)
-
-        monkeypatch.setattr('psutil.Process', mock_process_factory)
-
-        monkeypatch.setattr('os.kill', lambda p, s: None)
-        mock_run = mock.Mock(return_value=mock.Mock(returncode=0))
-        monkeypatch.setattr('subprocess.run', mock_run)
-
-        self.restart_skylet()
-        assert mock_run.called
-
-    def test_complete_flow_with_pid_file(self, monkeypatch):
-        """Complete flow: kill by PID, start new skylet, write all files."""
-        old_pid = 88888
-        self.env['pid_file'].write_text(str(old_pid))
-
-        # Mock psutil.Process to simulate a running skylet process
-        mock_process = mock.Mock()
-        mock_process.is_running.return_value = True
-        mock_process.cmdline.return_value = [
-            'python', '-m', 'sky.skylet.skylet', '--port=46590'
-        ]
-        monkeypatch.setattr('psutil.Process', lambda p: mock_process)
-
-        killed_pids = []
-        monkeypatch.setattr('os.kill', lambda p, s: killed_pids.append((p, s)))
-
-        subprocess_calls = []
-
-        def mock_run(cmd, **kwargs):
-            subprocess_calls.append(cmd)
-            return mock.Mock(returncode=0)
-
-        monkeypatch.setattr('subprocess.run', mock_run)
-
-        self.restart_skylet()
-
-        assert len(subprocess_calls) == 1
-
-        # Killed old process by PID
-        assert (old_pid, signal.SIGKILL) in killed_pids
-
-        # Started new skylet with hardcoded port
-        nohup_cmd = subprocess_calls[0]
-        assert f'--port={constants.SKYLET_GRPC_PORT}' in nohup_cmd
-        assert 'echo $!' in nohup_cmd
-        assert str(self.env['pid_file']) in nohup_cmd
-        assert str(self.env['log_file']) in nohup_cmd
-
-        # Wrote port and version files
-        assert self.env['port_file'].read_text() == str(
-            constants.SKYLET_GRPC_PORT)
-        assert self.env['version_file'].read_text() == constants.SKYLET_VERSION
-
-    def test_complete_flow_without_pid_file(self, monkeypatch):
-        """Complete flow: grep fallback kill, start new skylet, write all files."""
-        if self.env['pid_file'].exists():
-            self.env['pid_file'].unlink()
-
-        killed_pids = []
-        monkeypatch.setattr('os.kill', lambda p, s: killed_pids.append((p, s)))
-
-        subprocess_calls = []
-
-        def mock_run(cmd, **kwargs):
-            subprocess_calls.append(cmd)
-            # Mock subprocess.run with proper stdout for grep command output
-            # Simulates ps aux output with multiple skylet processes
-            if 'grep' in cmd:
-                mock_result = mock.Mock(
-                    returncode=0,
-                    stdout=
-                    'sky  7680  0.0  0.0 ... /python -m sky.skylet.skylet\nsky  7681  0.0  0.0 ... /python -m sky.skylet.skylet\n'
-                )
-            else:
-                mock_result = mock.Mock(returncode=0)
-            return mock_result
-
-        monkeypatch.setattr('subprocess.run', mock_run)
-
-        self.restart_skylet()
-
-        # 2 calls: grep detection + nohup start
-        assert len(subprocess_calls) == 2
-
-        # Used grep-based detection fallback
-        grep_cmd = subprocess_calls[0]
-        assert 'grep "sky.skylet.skylet"' in grep_cmd
-
-        # Started new skylet with hardcoded port
-        nohup_cmd = subprocess_calls[1]
-        assert f'--port={constants.SKYLET_GRPC_PORT}' in nohup_cmd
-
-        # Killed old processes found via grep
-        assert (7680, signal.SIGKILL) in killed_pids
-        assert (7681, signal.SIGKILL) in killed_pids
-
-        # Wrote files
-        assert self.env['port_file'].read_text() == str(
-            constants.SKYLET_GRPC_PORT)
-        assert self.env['version_file'].read_text() == constants.SKYLET_VERSION
+        if use_custom_dir:
+            expected_path = str(tmp_path / '.sky/skylet_version')
+        else:
+            expected_path = os.path.expanduser('~/.sky/skylet_version')
+        assert attempt_skylet.VERSION_FILE == expected_path


### PR DESCRIPTION
…e (#8156)"

This reverts commit 508d122ac97c2dc5de425ab737c6f9a59f438458.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
