### PR TITLE
[Test] Improve attempt_skylet tests to not need module reloads

### DIFF
--- a/tests/unit_tests/test_sky/skylet/test_attempt_skylet.py
+++ b/tests/unit_tests/test_sky/skylet/test_attempt_skylet.py
@@ -78,6 +78,34 @@ class TestRunningCheck:
         assert attempt_skylet._find_running_skylet_pids() == [7680]
 
 
+class TestVersionMatch:
+    """Test _check_version_match logic."""
+
+    def test_version_match_when_file_matches(self, skylet_env):
+        """Version file with matching version -> _check_version_match returns (True, version)."""
+        skylet_env['version_file'].write_text(constants.SKYLET_VERSION)
+
+        match, version = attempt_skylet._check_version_match()
+        assert match is True
+        assert version == constants.SKYLET_VERSION
+
+    def test_version_mismatch_when_file_stale(self, skylet_env):
+        """Version file with stale version -> _check_version_match returns (False, old_version)."""
+        skylet_env['version_file'].write_text('old_version')
+
+        match, version = attempt_skylet._check_version_match()
+        assert match is False
+        assert version == 'old_version'
+
+    def test_version_match_no_file(self, skylet_env):
+        """No version file -> _check_version_match returns (False, None)."""
+        assert not skylet_env['version_file'].exists()
+
+        match, version = attempt_skylet._check_version_match()
+        assert match is False
+        assert version is None
+
+
 class TestRestartSkylet:
     """Test restart_skylet() function."""
 


### PR DESCRIPTION
Follow up to #8156.

Monkeypatch the module level variables instead. Also extract the version matching logic to a function so that we don't need to hackily reload the module during the test, and instead can just call the function directly.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
