### PR TITLE
fix(serve): Clean up orphaned replica records during service shutdown

### DIFF
--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -140,6 +140,7 @@ def _cleanup(service_name: str, pool: bool) -> bool:
             except Exception as e:  # pylint: disable=broad-except
                 logger.warning(f'Failed to remove replica {info.replica_id} '
                                f'from database: {e}')
+                failed = True
             continue
 
         log_file_name = serve_utils.generate_replica_log_file_name(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
When a replica's cluster doesn't exist (failed launch, manually deleted, etc.), the `_cleanup()` function in `sky/serve/service.py` logs "Skipping" but never removes the replica record from the database. This causes stale replicas to appear when reusing a service name.

This PR fixes the issue by removing orphaned replica records from the database during normal `sky serve down`, matching the behavior of `--purge` in `_terminate_failed_services()`.

## Changes

- Added `serve_state.remove_replica()` call when cluster doesn't exist in `_cleanup()`


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
