### PR TITLE
[Docs] Bring GCP archive download instructions for macOS inline

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -373,7 +373,7 @@ GCP
           # This will generate ~/.config/gcloud/application_default_credentials.json.
           gcloud auth application-default login
 
-    .. tab-item:: Archive Download
+    .. tab-item:: Manual Install
         :sync: gcp-archive-download-tab
 
         For MacOS with Silicon Chips:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
For convenience, provide an inline instruction for GCP Archive download for MacOS.

<img width="831" height="438" alt="Screenshot 2025-12-03 at 12 33 25 PM" src="https://github.com/user-attachments/assets/0d4680ab-5bfa-4759-81ee-f066ae445fe1" />



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
