### PR TITLE
[Examples] Reintroduce CLI based approaches for select examples

### DIFF
--- a/examples/vector_database/README.md
+++ b/examples/vector_database/README.md
@@ -72,6 +72,35 @@ Processing files: 100%|██████████| 12/12 [00:05<00:00,  2.04
 
 To serve the constructed database, you expose an API endpoint that other applications (or your local client) can call to perform semantic search. Querying allows you to confirm that your database is working and retrieve semantic matches for a given text query. You can integrate this endpoint into larger applications (like an image search engine or recommendation system).
 
+### Option 1: Launch with CLI
+
+To serve the constructed database: 
+```
+sky launch -c vecdb_serve serve_vectordb.yaml
+```
+which runs the hosted vector database service. Alternatively, you can run 
+```
+sky serve up serve_vectordb.yaml -n vectordb
+```
+This deploys your vector database as a service on a cloud instance and allows you to interact with it via a public endpoint. Sky Serve facilitates automatic health checks and scaling of the service.
+
+To query the constructed database, 
+
+If you run through `sky launch`, use 
+```
+sky status --ip vecdb_serve
+```
+deployed cluster. 
+
+If you run through `sky serve`, you may run
+```
+sky serve status vectordb --endpoint
+```
+
+to get the endpoint address of the service. 
+
+### Option 2: Launch with SDK
+
 To serve the constructed database: 
 ```
 python3 serve_vectordb.py
@@ -80,8 +109,7 @@ which runs the hosted vector database service. Alternatively, you can run
 ```
 python3 serve_vectordb.py --serve
 ```
-This will deploy your vector database as a service on a cloud instance and allow you to interact with it via a public endpoint. Sky Serve facilitates automatic health checks and scaling of the service.
-
+This deploys your vector database as a service on a cloud instance and allows you to interact with it via a public endpoint. Sky Serve facilitates automatic health checks and scaling of the service.
 
 Use endpoint address of the service printed by the above script to query the constructed database. 
 

--- a/llm/localgpt/README.md
+++ b/llm/localgpt/README.md
@@ -19,10 +19,31 @@ Once you are done, we will use [SkyPilot YAML for localGPT](https://github.com/s
 
 
 ## Launching localGPT on your cloud with SkyPilot
-1. Use `launch_localgpt.py` to run localGPT on your cloud. SkyPilot will show the estimated cost and chosen cloud before provisioning. For reference, running on T4 instances on AWS would cost about $0.53 per hour. 
+1. Run localGPT on your cloud.
+
+---
+
+**Option 1: Run with CLI**
+
+Use `sky launch` to run localGPT on your cloud.
+
+```bash
+sky launch -c localgpt localgpt.yaml
+```
+
+Once you see `INFO:werkzeug:Press CTRL+C to quit`, you can safely Ctrl+C from the `sky launch` command.
+
+**Option 2: Run with SDK**
+
+Use `launch_localgpt.py` to run localGPT on your cloud.
+
 ```bash
 python3 launch_localgpt.py
 ```
+
+---
+
+SkyPilot will show the estimated cost and chosen cloud before provisioning. For reference, running on T4 instances on AWS would cost about $0.53 per hour. 
 
 2. Run `ssh -L 5111:localhost:5111 localgpt` in a new terminal window to forward the port 5111 to your local machine. Keep this terminal running.
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
https://github.com/skypilot-org/skypilot/pull/8003 revamped image vector search and localGPT examples to use SDK. In that PR, I _replaced_ the existing CLI approach with the SDK approach. This PR reintroduces the CLI approach so that both the CLI and SDK approaches are presented.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
