### PR TITLE
[actions] trigger the release-publish on testing-release/ branch

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -5,11 +5,12 @@ on:
     types: [closed]
     branches:
       - 'releases/**'
+      - 'testing-releases/**'
 
 jobs:
   extract-version:
     runs-on: ubuntu-latest
-    if: startsWith(github.head_ref, 'test_releases/')
+    if: startsWith(github.head_ref, 'test_releases/') && startsWith(github.base_ref, 'releases/')
     outputs:
       version: ${{ steps.extract_version.outputs.version }}
     steps:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This allows us to run debug tests using merges to the testing-release branch, e.g. #8184.

By default, if you do merge to this branch it won't do anything, but you can push an alternative workflow file to the testing-release/ branch to test stuff. The workflow trigger rules need to be in master, though.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
