### PR TITLE
[gh action] support publishing rc versions to pypi (#8188)

### DIFF
--- a/.github/workflows/publish-and-validate.yml
+++ b/.github/workflows/publish-and-validate.yml
@@ -44,6 +44,8 @@ jobs:
       - name: Validate published package
         run: |
           export SKYPILOT_DISABLE_USAGE_COLLECTION=1
+
+          # fastapi has some broken package info on test PyPI, so manually install it from real PyPI.
           pip install fastapi
 
           # Set up variables for package check
@@ -66,12 +68,13 @@ jobs:
             pip uninstall -y ${{ inputs.package_name }} || true
 
             # Install the package with no cache
+            # Use --pre so that pre-release versions (e.g. rcs) will be selected
             if [ "${{ inputs.repository_type }}" == "test-pypi" ]; then
               echo "Installing from Test PyPI..."
-              pip install --no-cache-dir --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple ${{ inputs.package_name }}
+              pip install --no-cache-dir --pre --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple ${{ inputs.package_name }}[server]
             else
               echo "Installing from PyPI..."
-              pip install --no-cache-dir ${{ inputs.package_name }}
+              pip install --no-cache-dir --pre ${{ inputs.package_name }}[server]
             fi
 
             # Check the version


### PR DESCRIPTION
* [gh action] support publishing rc versions to pypi

* install server dependencies

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
