### PR TITLE
[Pools] Fix Non-Existent Bucket Error on Scale Down

### DIFF
--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -1227,12 +1227,7 @@ class SkyPilotReplicaManager(ReplicaManager):
                 # Delete old version metadata.
                 serve_state.delete_version(self._service_name, version)
                 # Delete storage buckets of older versions.
-                if not self._is_pool:
-                    # For pools, we don't clean up the storage, because the
-                    # storage is shared between all replicas. We clean up the
-                    # storage in sky/service/service.pywhen the pool is
-                    # terminated so storage will not be leaked.
-                    service.cleanup_storage(yaml_content)
+                service.cleanup_storage(yaml_content)
             # newest version will be cleaned in serve down
             self.least_recent_version = current_least_recent_version
 

--- a/sky/serve/server/impl.py
+++ b/sky/serve/server/impl.py
@@ -517,7 +517,7 @@ def update(
                     f'{workers} is not supported. Ignoring the update.')
 
         # Load the existing task configuration from the service's YAML file
-        yaml_content = service_record['yaml_content']
+        yaml_content = service_record['pool_yaml']
 
         # Load the existing task configuration
         task = task_lib.Task.from_yaml_str(yaml_content)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Problem:
Before this PR if you attempted to change the number of workers with a pool yaml that had a workdir it would fail with `sky.exceptions.StorageBucketGetError: Attempted to use a non-existent bucket as a source`.

Why does this happen:
This is because the replicas will share the temporary bucket associated with a workdir. When we scale down the pool the `SkyPilotReplicaManager` triggers cleaning up the bucket, but the new version of the pool with the new number of workers will attempt to access the bucket and fail because the bucket no longer exists.

Fix:
This PR makes it so that the cleanup storage call only happens if the replica manager is not managing a pool. We will clean up the storage on pool termination so we don't need to worry about leaking buckets.

I added a new smoke test to catch this in the future.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
