### PR TITLE
[deps] pin urllib3 for k8s install due to dependency conflict

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -155,8 +155,7 @@ kubernetes_dependencies = [
     'kubernetes>=20.0.0,!=32.0.0',
     # Urllib 2.6.0 breaks kubernetes client because kubernetes client uses
     # deprecated in 2.0.0 and removed in 2.6.0 `getheaders()` call (instead of
-    # `headers` property). Tracked in
-    # https://github.com/kubernetes-client/python/issues/2477
+    # `headers` property). See #8216.
     'urllib3<2.6.0',
     'websockets',
     'python-dateutil',

--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -155,6 +155,9 @@ class TestBackwardCompatibility:
             # Fix https://github.com/skypilot-org/skypilot/issues/7287
             # for legacy skypilot versions.
             'uv pip install uvicorn==0.35.0 && '
+            # Fix https://github.com/skypilot-org/skypilot/issues/8216
+            # for legacy skypilot versions.
+            'uv pip install "urllib3<2.6.0" && '
             f'{pip_install_cmd}')
 
         # Install current version in current environment


### PR DESCRIPTION
Fixes #8216. See kubernetes-client/python#2477 and urllib3/urllib3#3731.

Newer versions of kubernetes pin urllib3<2.4.0, but if you already have urllib3 2.6.0 installed, installing `skypilot[kubernetes]` with uv will pick an older version of kubernetes (33.1.0) to avoid having to reinstall urllib3.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
