### PR TITLE
[SSH node pools] Ban heterogeneous nodes when setting up SSH node pool

### DIFF
--- a/sky/ssh_node_pools/deploy/deploy_ssh_node_pools.py
+++ b/sky/ssh_node_pools/deploy/deploy_ssh_node_pools.py
@@ -223,7 +223,7 @@ def start_agent_node(node,
     return node, True, False
 
 
-def check_gpu(node, user, ssh_key, use_ssh_config=False):
+def check_gpu(node, user, ssh_key, use_ssh_config=False, is_head=False):
     """Check if a node has a GPU."""
     cmd = 'command -v nvidia-smi &> /dev/null && nvidia-smi --query-gpu=gpu_name --format=csv,noheader'
     result = run_remote(node,
@@ -250,6 +250,10 @@ def check_gpu(node, user, ssh_key, use_ssh_config=False):
                 f'Node {node} has more than one GPU types '
                 f'({", ".join(sorted_gpu_names)}). '
                 'SkyPilot does not support a node with multiple GPU types.')
+        else:
+            progress_message(
+                f'GPU {list(gpu_names)[0]} detected on '
+                f'{"head" if is_head else "worker"} node ({node}).')
     return result is not None
 
 
@@ -821,8 +825,8 @@ def deploy_cluster(cluster_name,
     if check_gpu(head_node,
                  ssh_user,
                  ssh_key,
-                 use_ssh_config=head_use_ssh_config):
-        logger.info(f'{YELLOW}GPU detected on head node ({head_node}).{NC}')
+                 use_ssh_config=head_use_ssh_config,
+                 is_head=True):
         install_gpu = True
 
     # Fetch the head node's internal IP (this will be passed to worker nodes)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
SkyPilot k8s (and by extension, ssh node pools which sets up a k8s cluster) does not work with heterogenous nodes; i.e. nodes that have more than 1 GPU types.

The reason SkyPilot k8s does not support heterogenous node is as follows:
- SkyPilot relies on node labels to determine which GPU is on a node. The exact node label SkyPilot looks for can differ, as it is a mechanism with which SkyPilot seamlessly integrates with thirdparty solutions (e.g. NVIDIA GPU operator, GKE clusters, etc). We assume, and it is the case with enough of these "thirdparty labelers", that the label contains only 1 GPU type.
- SkyPilot relies on `nvidia.com/gpu`, `amd.com/gpu` or `google.com/tpu` resource keys to determine the number of GPUs there are available in each node. These keys, as resource keys, have scalar values. So there is a way to represent that there are 4 NVIDIA GPUs, but there is not way to represent that there are 2 L4s and 2 A100s in one node. The latter information is needed to correctly support heterogenous GPU nodes, but is not available for SkyPilot.

A user using SSH node pool with heterogenous GPU nodes ran into scheduling issues due to problems above. As explained above, implementing support for heterogenous GPU nodes is challenging, especially considering the implications of having to work around (as opposed to work with) the thirdparty label providers. Instead, I make sure the users of SSH node pools are not surprised by trying to deploy on heterogenous nodes by erroring out during node pool setup if any heterogenous GPU node is detected.

Tests:
- [x] Manual test: Test deploying SSH node pool on 2 GPU nodes (same type) still works.
- [x] Manual test: Test deploying SSH node pool on 1 GPU node still works.
- [x] Manual test: Test deploying SSH node pool on CPU node still works.
- [x] Manual test: Mock out the `nvidia-smi` command to return heterogenous GPU configuration: Test deploying SSH node pool fails. 
```
$ sky ssh up
Found 1 Node Pool: my-box
Checking SSH connection to head node (sky-a136-seungjinyang)...
✔ SSH connection established to head node sky-a136-seungjinyang.
Resolved head node sky-a136-seungjinyang to 44.202.75.96 from SSH config
✔ SkyPilot runtime successfully deployed on head node (sky-a136-seungjinyang).
Successfully deployed 0 cluster(s) (). Failed to deploy 1 cluster(s): 
  my-box: Node sky-a136-seungjinyang has more than one GPU types (NVIDIA A100, NVIDIA H100, NVIDIA L4). SkyPilot does not support a node with multiple GPU types.
RuntimeError: Failed to deploy SkyPilot on some Node Pools.
```
- [x] Smoke test: `/smoke-test -k test_pools`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
