### PR TITLE
[k8s] Disable ray memory monitor on k8s

### DIFF
--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -525,6 +525,10 @@ available_node_types:
                   resource: requests.memory
             # Disable Ray memory monitor to prevent Ray's memory manager 
             # from interfering with kubernetes resource manager.
+            # If ray memory monitor is enabled, the ray memory monitor kills
+            # the running job is the job uses more than 95% of allocated memory,
+            # even if the job is not misbehaving or using its full allocated memory.
+            # This behavior does not give a chance for k8s scheduler to evict the pod.
             - name: RAY_memory_monitor_refresh_ms
               value: "0"
             {% for key, value in k8s_env_vars.items() if k8s_env_vars is not none %}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
There are user reports of  `​ray.exceptions.OutOfMemoryError: Task was killed due to the node running low on memory` when running SkyPilot in Kubernetes.

This issue happens when a node is shared by multiple users and one user ends up using most of the VM's RAM.

The root cause of this issue is believe to be ray’s OOM protector (killing the process when there are 95% of memory used) preventing the k8s from kill the right pod correctly.

We should probably turn off ray’s memory manager when running on k8s to have k8s deal with the noisy neighbor issue.

Turning off ray's memory manager can be achieved by setting `RAY_memory_monitor_refresh_ms` environment variable to `0` [docs](https://docs.ray.io/en/latest/ray-core/scheduling/ray-oom-prevention.html#how-do-i-disable-the-memory-monitor)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
