### PR TITLE
[Slurm] Fix UV_CACHE_DIR permission issues with multiple users

### DIFF
--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -1415,11 +1415,11 @@ class SlurmCommandRunner(SSHCommandRunner):
         cmd = (
             f'export {constants.SKY_RUNTIME_DIR_ENV_VAR_KEY}='
             f'"{self.skypilot_runtime_dir}" && '
-            # Set the uv cache directory to /tmp/uv_cache to speed up
-            # package installation. Otherwise it defaults to ~/.cache/uv.
-            # This also means we can share the uv cache between multiple
-            # SkyPilot clusters.
-            f'export UV_CACHE_DIR=/tmp/uv_cache && '
+            # Set the uv cache directory to /tmp/uv_cache_$(id -u) to speed up
+            # package installation while avoiding permission conflicts when
+            # multiple users share the same host. Otherwise it defaults to
+            # ~/.cache/uv.
+            f'export UV_CACHE_DIR=/tmp/uv_cache_$(id -u) && '
             f'cd {self.sky_dir} && export HOME=$(pwd) && {cmd}')
         ssh_options = ('-o StrictHostKeyChecking=no '
                        '-o UserKnownHostsFile=/dev/null '


### PR DESCRIPTION
Previously, we always set `UV_CACHE_DIR=/tmp/uv_cache`. The problem is that on a given compute node, the directory will be created by the first user who happens to have a cluster launched on that node.

```bash
$ ls -ln /tmp/uv_cache/
total 32
-rw-rw-r--   1 1000 1000    43 Dec  3 22:16 CACHEDIR.TAG
drwxrwxr-x 227 1000 1000 12288 Dec  9 19:39 archive-v0
drwxrwxr-x   3 1000 1000  4096 Dec  3 22:16 interpreter-v4
drwxrwxr-x   2 1000 1000  4096 Dec  3 22:16 sdists-v9                                                      
drwxrwxr-x   3 1000 1000  4096 Dec  3 22:16 simple-v18
drwxrwxr-x   4 1000 1000  4096 Dec  3 22:16 wheels-v5
```

This is a problem if there's a uid 1001 for example that launches a cluster on that same compute node, and tries to reuse the same uv cache dir, they will get a permission denied error:

```
D 12-09 12:21:17 provisioner.py:770] error: failed to open file `/tmp/uv_cache/sdists-v9/.git`: Permission denied (os error 13)
D 12-09 12:21:17 provisioner.py:770] error: failed to open file `/tmp/uv_cache/sdists-v9/.git`: Permission denied (os error 13)
D 12-09 12:21:17 provisioner.py:770] error: failed to open file `/tmp/uv_cache/sdists-v9/.git`: Permission denied (os error 13)
D 12-09 12:21:17 provisioner.py:770] error: failed to open file `/tmp/uv_cache/sdists-v9/.git`: Permission denied (os error 13)
D 12-09 12:21:17 provisioner.py:770]
```

This PR fixes this by including the uid as part of the dir name:
```bash
$ ls -ln /tmp/uv_cache_1001/
total 24
-rw-rw-r--   1 1001 1001   43 Dec  9 20:27 CACHEDIR.TAG
drwxrwxr-x 103 1001 1001 4096 Dec  9 20:27 archive-v0
drwxrwxr-x   3 1001 1001 4096 Dec  9 20:27 interpreter-v4
drwxrwxr-x   2 1001 1001 4096 Dec  9 20:27 sdists-v9
drwxrwxr-x   3 1001 1001 4096 Dec  9 20:27 simple-v18
drwxrwxr-x   4 1001 1001 4096 Dec  9 20:27 wheels-v5
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
