### PR TITLE
[Slurm] show Slurm infra at cluster level (as opposed to partition level)

### DIFF
--- a/sky/clouds/slurm.py
+++ b/sky/clouds/slurm.py
@@ -568,16 +568,11 @@ class Slurm(clouds.Cloud):
 
     @classmethod
     def expand_infras(cls) -> List[str]:
-        """Returns a list of enabled Slurm cluster/partition combinations.
+        """Returns a list of enabled Slurm clusters.
 
-        Each is returned as 'Slurm/cluster-name/partition' to be displayed
-        as a separate option in the optimizer.
-
-        The default partition appears first,
-        and the rest are sorted alphabetically.
+        Each is returned as 'Slurm/cluster-name'.
         """
         infras = []
         for cluster in cls.existing_allowed_clusters(silent=True):
-            infras.append(
-                f'{cls.canonical_name()}/{cluster}')
+            infras.append(f'{cls.canonical_name()}/{cluster}')
         return infras


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Before:
<img width="942" height="37" alt="Screenshot 2025-12-09 at 2 00 51 PM" src="https://github.com/user-attachments/assets/02fa7d9e-8d9f-4580-a1c0-62add3de54e1" />

After:
<img width="796" height="41" alt="Screenshot 2025-12-09 at 2 00 59 PM" src="https://github.com/user-attachments/assets/1d061fb8-4f1d-4e55-9ed9-e5bf46806ca3" />

This PR changes the output of `sky status` such that each Slurm cluster is shown on `Enabled Infra` section as opposed to each partition.

Comparing Slurm output to Kubernetes output, a Kubernetes cluster maps to SkyPilot region and there is no Kubernetes equivalent to a zone. Kubernetes is displayed at cluster (region) level in `Enabled Infra` section.

A Slurm cluster maps to SkyPilot region, and Slurm partition maps to SkyPilot zone. By displaying Slurm at cluster level (as opposed to partition level), we keep the behavior between k8s and Slurm consistent (by displaying both at "region" level).

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
