### PR TITLE
[Slurm] Unify ssh proxycommand config for run and rsync in SlurmCommandRunner

### DIFF
--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -1351,6 +1351,9 @@ class SlurmCommandRunner(SSHCommandRunner):
         self._ssh_proxy_command = login_node_proxy_command
         # Update self.ip to target the compute node.
         self.ip = slurm_node
+        # Assume the compute node's SSH port is 22.
+        # TODO(kevin): Make this configurable if needed.
+        self.port = 22
 
     def rsync(
         self,


### PR DESCRIPTION
Minor cleanup. Previously, we were defining the SSH proxying logic in both SlurmCommandRunner.rysnc and SlurmCommandRunner.run. This PR unifies it to keep the logic centralized and unified between the two.



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
