### PR TITLE
Fix `test_nemorl` failure

### DIFF
--- a/tests/smoke_tests/test_examples.py
+++ b/tests/smoke_tests/test_examples.py
@@ -201,7 +201,7 @@ def test_nemorl(generic_cloud: str, accelerator: Dict[str, str]) -> None:
 
     infra = generic_cloud
     if generic_cloud == 'aws':
-        infra = 'aws/ap-northeast-1'
+        infra = 'aws'
 
     name = smoke_tests_utils.get_cluster_name()
     original_yaml_path = 'llm/nemorl/nemorl.sky.yaml'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The region lack of resources, causing smoke tests failure: https://buildkite.com/organizations/skypilot-1/pipelines/smoke-tests/builds/6407/jobs/019b06df-6da8-43db-9969-b521fd7fbdb3/log

Remove the specific region, let sky failover the region.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
