### PR TITLE
Fixed API server mem bench on k8s

### DIFF
--- a/tests/smoke_tests/test_api_server_benchmark.py
+++ b/tests/smoke_tests/test_api_server_benchmark.py
@@ -59,12 +59,16 @@ def test_api_server_memory(generic_cloud: str):
     stop_event = threading.Event()
     metrics_thread = threading.Thread(target=_collect_metrics)
     metrics_thread.start()
+    parallelism = 8
+    if generic_cloud == 'kubernetes':
+        # Kubernetes has limited resources, lower the concurrency
+        parallelism = 4
     test = smoke_tests_utils.Test(
         'test_api_server_memory',
         [
-            f'python tests/load_tests/workload_benchmark.py -t 8 -r 5 --detail -s workloads/basic.sh --cloud {generic_cloud}'
+            f'python tests/load_tests/workload_benchmark.py -t {parallelism} -r 5 --detail -s workloads/basic.sh --cloud {generic_cloud}'
         ],
-        teardown='sky down -y "load-test-*"; sky jobs cancel -a -y',
+        teardown='sky down -y "load-test-*"; sky jobs cancel -a -y || true',
         # Long timeout for benchmark to complete
         timeout=3600,
     )


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Kubernetes test env has limited resources to launch clusters, thus reduce the concurrency rate to avoid the script cannot allocate resources while `sky launch`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
