### PR TITLE
Release 0.11.0

### DIFF
--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -37,7 +37,7 @@ def _get_git_commit():
 
 
 __commit__ = _get_git_commit()
-__version__ = '0.11.0rc2'
+__version__ = '0.11.0'
 __root_dir__ = directory_utils.get_sky_dir()
 
 


### PR DESCRIPTION
## Promote RC to Stable Release 0.11.0

**Source:** `releases/0.11.0rc2` (RC version: 0.11.0rc2)  
**Target:** Stable release `0.11.0`

⚠️ **Smoke tests were SKIPPED** - This release is being promoted from a tested RC.

### Pre-release Testing
This version was previously tested as release candidate `0.11.0rc2` and deemed stable by early adopters.

### Changes in this PR
- Updated `sky/__init__.py`: `0.11.0rc2` → `0.11.0`
- Updated `charts/skypilot/values.yaml`: Docker image tag `0.11.0rc2` → `0.11.0`