### PR TITLE
[Azure] Explicitly mark CUSTOM_NETWORK_TIER is not supported

### DIFF
--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -98,7 +98,7 @@ class Azure(clouds.Cloud):
                 f'High availability controllers are not supported on {cls._REPR}.'
             ),
             clouds.CloudImplementationFeatures.CUSTOM_NETWORK_TIER:
-                (f'Custom network tier is not supported yet on {cls._REPR}.'),
+                (f'Custom network tier is not supported on {cls._REPR}.'),
             clouds.CloudImplementationFeatures.CUSTOM_MULTI_NETWORK: (
                 f'Customized multiple network interfaces are not supported on {cls._REPR}.'
             ),


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fix #8261

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
