### PR TITLE
Fix aiohttp version failure in buildkite

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -40,9 +40,6 @@ buildkite-test-collector
 # memory profiler
 memory_profiler==0.61.0
 
-# For testing SkyServe
-aiohttp==3.9.3
-
 # For mocking AWS
 moto==5.1.2
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

`pycares` published [5.0.0](https://pypi.org/project/pycares/) today
[Breaks our dependency](https://buildkite.com/skypilot-1/smoke-tests/builds/6441#_): 

```bash
2025-12-11 09:15:13 CST | Traceback (most recent call last):
-- | --
2025-12-11 09:15:13 CST | File "<string>", line 1, in <module>
2025-12-11 09:15:13 CST | File "/home/buildkite/sky-back-compat-base/lib/python3.10/site-packages/sky/__init__.py", line 85, in <module>
2025-12-11 09:15:13 CST | from sky import backends
2025-12-11 09:15:13 CST | File "/home/buildkite/sky-back-compat-base/lib/python3.10/site-packages/sky/backends/__init__.py", line 4, in <module>
2025-12-11 09:15:13 CST | from sky.backends.cloud_vm_ray_backend import CloudVmRayBackend
2025-12-11 09:15:13 CST | File "/home/buildkite/sky-back-compat-base/lib/python3.10/site-packages/sky/backends/cloud_vm_ray_backend.py", line 34, in <module>
2025-12-11 09:15:13 CST | from sky import jobs as managed_jobs
2025-12-11 09:15:13 CST | File "/home/buildkite/sky-back-compat-base/lib/python3.10/site-packages/sky/jobs/__init__.py", line 4, in <module>
2025-12-11 09:15:13 CST | from sky.jobs.client.sdk import cancel
2025-12-11 09:15:13 CST | File "/home/buildkite/sky-back-compat-base/lib/python3.10/site-packages/sky/jobs/client/sdk.py", line 11, in <module>
2025-12-11 09:15:13 CST | from sky.client import sdk
2025-12-11 09:15:13 CST | File "/home/buildkite/sky-back-compat-base/lib/python3.10/site-packages/sky/client/sdk.py", line 34, in <module>
2025-12-11 09:15:13 CST | from sky.jobs import scheduler
2025-12-11 09:15:13 CST | File "/home/buildkite/sky-back-compat-base/lib/python3.10/site-packages/sky/jobs/scheduler.py", line 63, in <module>
2025-12-11 09:15:13 CST | from sky.jobs import utils as managed_job_utils
2025-12-11 09:15:13 CST | File "/home/buildkite/sky-back-compat-base/lib/python3.10/site-packages/sky/jobs/utils.py", line 31, in <module>
2025-12-11 09:15:13 CST | from sky.backends import backend_utils
2025-12-11 09:15:13 CST | File "/home/buildkite/sky-back-compat-base/lib/python3.10/site-packages/sky/backends/backend_utils.py", line 23, in <module>
2025-12-11 09:15:13 CST | import aiohttp
2025-12-11 09:15:13 CST | File "/home/buildkite/sky-back-compat-base/lib/python3.10/site-packages/aiohttp/__init__.py", line 6, in <module>
2025-12-11 09:15:13 CST | from .client import (
2025-12-11 09:15:13 CST | File "/home/buildkite/sky-back-compat-base/lib/python3.10/site-packages/aiohttp/client.py", line 87, in <module>
2025-12-11 09:15:13 CST | from .connector import (
2025-12-11 09:15:13 CST | File "/home/buildkite/sky-back-compat-base/lib/python3.10/site-packages/aiohttp/connector.py", line 64, in <module>
2025-12-11 09:15:13 CST | from .resolver import DefaultResolver
2025-12-11 09:15:13 CST | File "/home/buildkite/sky-back-compat-base/lib/python3.10/site-packages/aiohttp/resolver.py", line 12, in <module>
2025-12-11 09:15:13 CST | import aiodns
2025-12-11 09:15:13 CST | File "/home/buildkite/sky-back-compat-base/lib/python3.10/site-packages/aiodns/__init__.py", line 60, in <module>
2025-12-11 09:15:13 CST | class DNSResolver:
2025-12-11 09:15:13 CST | File "/home/buildkite/sky-back-compat-base/lib/python3.10/site-packages/aiodns/__init__.py", line 162, in DNSResolver
2025-12-11 09:15:13 CST | ) -> asyncio.Future[list[pycares.ares_query_a_result]]: ...
2025-12-11 09:15:13 CST | AttributeError: module 'pycares' has no attribute 'ares_query_a_result'

```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
