### PR TITLE
[Slurm] Fix _get_ip_address in executor script

### DIFF
--- a/sky/skylet/executor/slurm.py
+++ b/sky/skylet/executor/slurm.py
@@ -19,12 +19,10 @@ from sky.skylet.log_lib import run_bash_command_with_log
 
 def _get_ip_address() -> str:
     """Get the IP address of the current node."""
-    ip_result = subprocess.run(['hostname', '-I'],
-                               capture_output=True,
-                               text=True,
-                               check=False)
-    return ip_result.stdout.strip().split(
-    )[0] if ip_result.returncode == 0 else 'unknown'
+    # Use socket.gethostbyname to be consistent with _get_job_node_ips(),
+    # which resolves hostnames the same way. Using `hostname -I` can return
+    # Docker bridge IPs (172.17.x.x) first, causing IP mismatch errors.
+    return socket.gethostbyname(socket.gethostname())
 
 
 def _get_job_node_ips() -> str:


### PR DESCRIPTION
Came across this regression while testing on Nebius Soperator. The Slurm executor fails on nodes that have Docker installed because `hostname -I` returns the Docker bridge IP (`172.17.0.1`) first, while `_get_job_node_ips()` uses DNS resolution which returns the actual node IP. This causes the node index lookup to fail with:

```
⚙︎ Launching on Slurm nebius (main).
└── Instance is up.
✓ Cluster launched: sky-97ff-kevin.  View logs: sky logs --provision sky-97ff-kevin
⚙︎ Syncing files.
⚙︎ Job submitted, ID: 1
├── Waiting for task resources on 1 node.
cpu-bind=MASK - worker-0, task  0  0 [30551]: mask 0x3 set
Traceback (most recent call last):
  File "/tmp/sky-97ff-kevin-7a2eebbf/skypilot-runtime/lib/python3.10/site-packages/sky/skylet/executor/slurm.py", line 103, in main
    node_idx = cluster_ips.index(ip_addr)
ValueError: '172.17.0.1' is not in list

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/tmp/sky-97ff-kevin-7a2eebbf/miniconda3/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/tmp/sky-97ff-kevin-7a2eebbf/miniconda3/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)                                                                      File "/tmp/sky-97ff-kevin-7a2eebbf/skypilot-runtime/lib/python3.10/site-packages/sky/skylet/executor/slurm.py", line 189, in <module>
    main()
  File "/tmp/sky-97ff-kevin-7a2eebbf/skypilot-runtime/lib/python3.10/site-packages/sky/skylet/executor/slurm.py", line 105, in main
    raise RuntimeError(f'IP address {ip_addr} not found in '
RuntimeError: IP address 172.17.0.1 not found in cluster IPs: ['10.135.238.238']
srun: error: worker-0: task 0: Exited with exit code 1
ERROR: Job 1's setup failed with return code 1 (pid=30517). See error logs above for more details.
✓ Job finished (status: FAILED_SETUP).
```

Diagnosed by running on the affected node:
```
$ srun --jobid=70 hostname -I
172.17.0.1 10.135.238.238

$ srun --jobid=70 python3 -c "import socket; print(socket.gethostbyname(socket.gethostname()))"
10.135.238.238
```

The fix changes `_get_ip_address()` to use `socket.gethostbyname(socket.gethostname())` for consistency with how `_get_job_node_ips()` resolves IPs.

---

I was curious what's the difference between the two, and this was my finding:

`hostname -I`:
- Iterates through all network interfaces via getifaddrs() syscall (source code: https://sources.debian.org/src/hostname/3.25/hostname.c#L289)
- Returns all non-loopback IP addresses assigned to any interface
- getifaddrs ([man page](https://man7.org/linux/man-pages/man3/getifaddrs.3.html)) does not promise any ordering, so we cannot rely on anything

`socket.gethostbyname(hostname)`:
- Calls gethostbyname() libc function ([man page](https://man7.org/linux/man-pages/man3/gethostbyname.3.html))
- Follows the resolution order in `/etc/nsswitch.conf` (typically: files dns)
- First checks `/etc/hosts` for a mapping
- Then queries DNS servers in `/etc/resolv.conf`
- Returns one IP address (the first A record)

For reference:
```bash
$ srun --jobid 70 cat /etc/hosts
cpu-bind=MASK - worker-0, task  0  0 [49313]: mask 0x3 set                                     
# Kubernetes-managed hosts file.                                                               
127.0.0.1       localhost                                                                      
::1     localhost ip6-localhost ip6-loopback                                                   
fe00::0 ip6-localnet                                                                           
fe00::0 ip6-mcastprefix                                                                        
fe00::1 ip6-allnodes                                                                           
fe00::2 ip6-allrouters                                                                         
10.135.238.238  worker-0....svc.cluster.local        worker-0
```

NOTE: `hostname -i` uses `gethostbyname` too I think, so that could've been the fix too, but it feels cleaner to call a python function than calling subprocess.run.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
