### PR TITLE
docs: Improve JuiceFS volume documentation with correct verification and provisioning examples

### DIFF
--- a/docs/source/reference/volumes.rst
+++ b/docs/source/reference/volumes.rst
@@ -232,7 +232,7 @@ This section demonstrates how to configure and use distributed filesystems as Sk
                 .. code-block:: yaml
 
                   # juicefs-volume.yaml
-                  name: juicefs-pvc
+                  name: juicefs-volume
                   type: k8s-pvc
                   infra: k8s
                   use_existing: true


### PR DESCRIPTION
## Summary

- Fix CSI driver verification step to check pods instead of StorageClass
- Add support for both dynamic (StorageClass) and static (PV) provisioning methods
- Provide complete examples for each provisioning approach