### PR TITLE
Fixed stall txn block write operation

### DIFF
--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -298,6 +298,11 @@ def drop_column_from_table_alembic(
             raise
 
 
+def fault_point():
+    """For test fault injection."""
+    pass
+
+
 class SQLiteConn(threading.local):
     """Thread-local connection to the sqlite3 database."""
 
@@ -376,6 +381,9 @@ class SQLiteConn(threading.local):
             # pylint: disable=protected-access
             with safe_cursor_on_connection(conn._conn) as cursor:
                 cursor.execute(sql, parameters)
+                # Note(dev): sqlite3.Connection cannot be patched, keep
+                # fault_point here to test the integrity of exec_fetch_all()
+                fault_point()
                 return cursor.fetchall()
 
         # pylint: disable=protected-access


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fix a potential case that may corrupt an sqlite connection:

- ConnectionA: open a read txn and get inetrrupted without calling fecthall()(which implicitly close the read txn)
, connectionA will hold a read snapshot in WAL mode
- ConnectionB: open a write txn and insert a request, which makes the snapshot of connectionA obsolete
- ConnectionA: insert a request, get SQLITE_BUSY_SNAPSHOT error, mapped to database is locked in python

By wrapping the operation with safe cursor, we ensures that the read txn is closed before executing next operation.

This is hard to unit test since `sqlite3.Connection` cannot be patched in python:

```
AttributeError: 'sqlite3.Connection' object attribute 'execute' is read-only
```

So a `fault_point` is added to complete a unit test. The test will fail if `safe_cursor_on_connection` is not used.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
