### PR TITLE
[Core] SkyPilot base image is missing infiniband dependencies

### DIFF
--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -9,10 +9,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 # We remove cuda lists to avoid conflicts with the cuda version installed by ray
 # Remove any conflicting InfiniBand packages (if present) to avoid version conflicts
 RUN rm -rf /etc/apt/sources.list.d/cuda* && \
-    apt update -y && \
+    apt-get update -y && \
     (apt-get purge -y ibverbs-utils libibverbs-dev libibverbs1 libmlx5-1 || true) && \
-    apt install git gcc rsync sudo patch openssh-server pciutils nano fuse unzip socat netcat-openbsd curl jq \
-        rdma-core libibverbs1 libmlx5-1 libibverbs-dev -y && \
+    apt-get install -y --no-install-recommends git gcc rsync sudo patch openssh-server pciutils nano fuse unzip socat netcat-openbsd curl jq \
+        rdma-core libibverbs1 libmlx5-1 libibverbs-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Setup SSH and generate hostkeys

--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -7,9 +7,12 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Install ssh and other local dependencies
 # We remove cuda lists to avoid conflicts with the cuda version installed by ray
+# Remove any conflicting InfiniBand packages (if present) to avoid version conflicts
 RUN rm -rf /etc/apt/sources.list.d/cuda* && \
     apt update -y && \
-    apt install git gcc rsync sudo patch openssh-server pciutils nano fuse unzip socat netcat-openbsd curl jq -y && \
+    (apt-get purge -y ibverbs-utils libibverbs-dev libibverbs1 libmlx5-1 || true) && \
+    apt install git gcc rsync sudo patch openssh-server pciutils nano fuse unzip socat netcat-openbsd curl jq \
+        rdma-core libibverbs1 libmlx5-1 libibverbs-dev -y && \
     rm -rf /var/lib/apt/lists/*
 
 # Setup SSH and generate hostkeys

--- a/docs/source/reference/kubernetes/kubernetes-getting-started.rst
+++ b/docs/source/reference/kubernetes/kubernetes-getting-started.rst
@@ -198,6 +198,8 @@ By default, we maintain and use two SkyPilot container images for use on Kuberne
 
 These images are pre-installed with SkyPilot dependencies for fast startup.
 
+The GPU image (``skypilot-gpu``) includes InfiniBand dependencies (``rdma-core``, ``libibverbs1``, ``libmlx5-1``, ``libibverbs-dev``) by default, enabling out-of-the-box support for InfiniBand/RDMA workloads. This eliminates the need to manually install these dependencies and avoids version conflicts. For examples of using InfiniBand with SkyPilot, see the `Nebius InfiniBand examples <https://github.com/skypilot-org/skypilot/blob/master/examples/nebius_infiniband/README.md>`__.
+
 To use your own image, add :code:`image_id: docker:<your image tag>` to the :code:`resources` section of your task YAML.
 
 .. code-block:: yaml


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixes #8274 

Adds InfiniBand dependencies `(rdma-core, libibverbs1, libmlx5-1, libibverbs-dev)` to the GPU Docker image `(Dockerfile_k8s_gpu)` to enable out-of-the-box support for `InfiniBand/RDMA` workloads. Also updates documentation to mention this feature.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR:
  - Verified Dockerfile builds successfully: `docker build -f Dockerfile_k8s_gpu -t test-gpu .`
  - Confirmed InfiniBand packages are installed in the image
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->

<!-- Describe the changes in this PR -->
Adds InfiniBand dependencies (rdma-core, libibverbs1, libmlx5-1, libibverbs-dev) to the GPU Docker image (Dockerfile_k8s_gpu) to enable out-of-the-box support for InfiniBand/RDMA workloads. Also updates documentation to mention this feature.