### PR TITLE
[Pools] Fix Fall Back to 1 Job Per Worker

### DIFF
--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -1004,7 +1004,7 @@ def get_next_cluster_name(
         # fallback to 1 job per replica. If we are truly resource bottlenecked
         # then we will see that there are jobs running on the replica and will
         # not schedule another.
-        elif len(idle_replicas) == 0:
+        if len(idle_replicas) == 0:
             logger.debug('Falling back to resource unaware scheduling')
             # Fall back to resource unaware scheduling if no task resources
             # are provided.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Our fallback to resource aware scheduling if all else fails was broken because we would skip the resource unaware block if we entered the resource aware block.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
