### PR TITLE
Release 0.11.0.post1

### DIFF
--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -37,7 +37,7 @@ def _get_git_commit():
 
 
 __commit__ = _get_git_commit()
-__version__ = '0.11.0'
+__version__ = '0.11.0.post1'
 __root_dir__ = directory_utils.get_sky_dir()
 
 


### PR DESCRIPTION
Release 0.11.0.post1

This is based on https://github.com/skypilot-org/skypilot/tree/staging/0.11.0.post1

It cherry picked: https://github.com/skypilot-org/skypilot/pull/8285 in to the 0.11.0 release

Buildkite Test Links:
- [Full Smoke Tests](https://buildkite.com/skypilot-1/full-smoke-tests-run/builds/96) -  ✅ Success (except for the known `test_minimal_with_git_workdir` due to new dependencies for the latest versions; and https://github.com/skypilot-org/skypilot/pull/8306 issue with ray template which is not critical; and `test_gcp_network_tier_with_gpu` due to availability issue)
- [Quicktest Core](https://buildkite.com/skypilot-1/quicktest-core/builds/2172) - ✅ Success
- [Quicktest Core (vs Previous Minor)](https://buildkite.com/skypilot-1/quicktest-core/builds/2171) - ✅ Success
- [Smoke Tests Remote Server Kubernetes](https://buildkite.com/skypilot-1/smoke-tests/builds/6542) - ✅ Success (except for the known `test_minimal_with_git_workdir` due to new dependencies for the latest versions)
- [Release Tests](https://buildkite.com/skypilot-1/release/builds/119) - ⏳ (not waiting for completion)

*Release Tests may take up to 24 hours to complete and might fail due to resource constraints.*