### PR TITLE
[Template] Add `--address` for list nodes to avoid warning for multiple ray cluster and fix a race in ray template

### DIFF
--- a/sky_templates/ray/start_cluster
+++ b/sky_templates/ray/start_cluster
@@ -82,10 +82,6 @@ RAY_ADDRESS=${LOCAL_RAY_ADDRESS}
 if [ "${SKYPILOT_NODE_RANK}" -ne 0 ]; then
     HEAD_IP=$(echo "${SKYPILOT_NODE_IPS}" | head -n1)
     RAY_ADDRESS="${HEAD_IP}:${RAY_HEAD_PORT}"
-    # DEBUG: Sleep 5 seconds to simulate network latency, and trigger the
-    # user-space Ray cluster check to succeed even if the Ray cluster is not
-    # started on the worker node.
-    sleep 5
 fi
 
 # Check if user-space Ray is already running. Use local address to check, as


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

1. Add `--address` head node `ray list nodes` command to avoid the following warning output:
```
(head, rank=0, pid=1096) 2025-12-14 05:32:44,856        WARNING services.py:403 -- Found multiple active Ray instances: {'10.112.1.21:6380', '10.112.1.21:6379'}. Connecting to latest cluster at 10.112.1.21:6379. You can override this by setting the `--address` flag or `RAY_ADDRESS` environment variable.
```

2. It also fixes an issue where the worker node's ray cluster may not be started, when the head node ray cluster already started, and the worker initial ray cluster check skips all the ray cluster start code path on the worker node.

Here is the changes to trigger the bug https://github.com/skypilot-org/skypilot/blob/2b0b42024c0809386196649853ad08ec312f4ac4/sky_templates/ray/start_cluster#L82-L85
```diff
if [ "${SKYPILOT_NODE_RANK}" -ne 0 ]; then
    HEAD_IP=$(echo "${SKYPILOT_NODE_IPS}" | head -n1)
    RAY_ADDRESS="${HEAD_IP}:${RAY_HEAD_PORT}"
+  sleep 5
fi
```

**Master** with the [debug sleep](https://github.com/skypilot-org/skypilot/pull/8306/commits/b4b31b21bee681a1d7be4e1e4144bbb504d24611) for simulating the different starting time of head and worker node of the ray cluster: (See the `(worker1, rank=1, pid=757, ip=10.112.2.8) Ray cluster is already running.`)
```
(head, rank=0, pid=1139)  + yarl==1.22.0
(head, rank=0, pid=1139)  + zipp==3.23.0
(worker1, rank=1, pid=757, ip=10.112.2.8) Ray 2.52.1 is installed.
(head, rank=0, pid=1139) Ray 2.52.1 is installed.
(head, rank=0, pid=1139) Starting Ray head node...
(head, rank=0, pid=1139) 2025-12-14 05:39:27,101        INFO usage_lib.py:447 -- Usage stats collection is disabled.
(head, rank=0, pid=1139) 2025-12-14 05:39:27,101        INFO scripts.py:919 -- Local node IP: 10.112.1.22
(worker1, rank=1, pid=757, ip=10.112.2.8) Ray cluster is already running.
(worker1, rank=1, pid=757, ip=10.112.2.8) No cluster status. It may take a few seconds for the Ray internal services to start up.
(head, rank=0, pid=1139) 2025-12-14 05:39:30,046        SUCC scripts.py:963 -- --------------------
(head, rank=0, pid=1139) 2025-12-14 05:39:30,047        SUCC scripts.py:964 -- Ray runtime started.
(head, rank=0, pid=1139) 2025-12-14 05:39:30,047        SUCC scripts.py:965 -- --------------------
(head, rank=0, pid=1139) 2025-12-14 05:39:30,047        INFO scripts.py:967 -- Next steps
(head, rank=0, pid=1139) 2025-12-14 05:39:30,047        INFO scripts.py:970 -- To add another node to this Ray cluster, run
(head, rank=0, pid=1139) 2025-12-14 05:39:30,047        INFO scripts.py:973 --   ray start --address='10.112.1.22:6379'
(head, rank=0, pid=1139) 2025-12-14 05:39:30,047        INFO scripts.py:982 -- To connect to this Ray cluster:
(head, rank=0, pid=1139) 2025-12-14 05:39:30,047        INFO scripts.py:984 -- import ray
(head, rank=0, pid=1139) 2025-12-14 05:39:30,047        INFO scripts.py:985 -- ray.init()
(head, rank=0, pid=1139) 2025-12-14 05:39:30,047        INFO scripts.py:997 -- To submit a Ray job using the Ray Jobs CLI:
(head, rank=0, pid=1139) 2025-12-14 05:39:30,048        INFO scripts.py:998 --   RAY_API_SERVER_ADDRESS='http://127.0.0.1:8265' ray job submit --working-dir . -- python my_script.py
(head, rank=0, pid=1139) 2025-12-14 05:39:30,048        INFO scripts.py:1007 -- See https://docs.ray.io/en/latest/cluster/running-applications/job-submission/index.html 
(head, rank=0, pid=1139) 2025-12-14 05:39:30,048        INFO scripts.py:1011 -- for more information on submitting Ray jobs to the Ray cluster.
(head, rank=0, pid=1139) 2025-12-14 05:39:30,048        INFO scripts.py:1016 -- To terminate the Ray runtime, run
(head, rank=0, pid=1139) 2025-12-14 05:39:30,048        INFO scripts.py:1017 --   ray stop
(head, rank=0, pid=1139) 2025-12-14 05:39:30,048        INFO scripts.py:1020 -- To view the status of the cluster, use
(head, rank=0, pid=1139) 2025-12-14 05:39:30,048        INFO scripts.py:1021 --   ray status
(head, rank=0, pid=1139) 2025-12-14 05:39:30,048        INFO scripts.py:1025 -- To monitor and debug Ray, view the dashboard at 
(head, rank=0, pid=1139) 2025-12-14 05:39:30,048        INFO scripts.py:1026 --   127.0.0.1:8265
(head, rank=0, pid=1139) 2025-12-14 05:39:30,048        INFO scripts.py:1033 -- If connection to the dashboard fails, check your firewall settings and network configuration.
(head, rank=0, pid=1139) Head node started successfully.
(head, rank=0, pid=1139) Waiting for all 2 nodes to join...
(head, rank=0, pid=1139) Waiting... (1 / 2 nodes ready)
(head, rank=0, pid=1139) Waiting... (1 / 2 nodes ready)
(head, rank=0, pid=1139) Waiting... (1 / 2 nodes ready)
```

**This PR**, with the debug sleep

The ray cluster sucessfully starts.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
