### PR TITLE
Release 0.11.1

### DIFF
--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -37,7 +37,7 @@ def _get_git_commit():
 
 
 __commit__ = _get_git_commit()
-__version__ = '0.11.0'
+__version__ = '0.11.1'
 __root_dir__ = directory_utils.get_sky_dir()
 
 


### PR DESCRIPTION
Release 0.11.1

Buildkite Test Links:
- [Full Smoke Tests](https://buildkite.com/skypilot-1/full-smoke-tests-run/builds/98) - ❌ Failed
  - test_minimal_with_git_workdir: https://github.com/skypilot-org/skypilot/pull/7760, doesn't really need to be cherrypicked
  - test_api_server_start_stop on azure: timeout, looks like azure is taking 30-60 seconds longer to provision the VM and this was already close to the timeout
  - test_gcp_network_tier_with_gpu: quota/availability
  - test_ray_train: #8306
- [Quicktest Core](https://buildkite.com/skypilot-1/quicktest-core/builds/2181) - ✅ Success
- [Quicktest Core (vs Previous Minor)](https://buildkite.com/skypilot-1/quicktest-core/builds/2180) - ✅ Success
- [Smoke Tests Remote Server Kubernetes](https://buildkite.com/skypilot-1/smoke-tests/builds/6552) - ✅ Success (except for the known test_minimal_with_git_workdir due to new dependencies for the latest versions)
- [Release Tests](https://buildkite.com/skypilot-1/release/builds/121) - ⏳ (not waiting for completion)

*Release Tests may take up to 24 hours to complete and might fail due to resource constraints.*