### PR TITLE
[Core] Up Migration Lock Timeout for Nebius

### DIFF
--- a/tests/smoke_tests/test_api_server.py
+++ b/tests/smoke_tests/test_api_server.py
@@ -246,8 +246,7 @@ def test_multi_tenant_managed_jobs(generic_cloud: str):
             ]),
             *controller_related_test_cmds,
         ],
-        # f'sky jobs cancel -y -n {name}-1; sky jobs cancel -y -n {name}-2; sky jobs cancel -y -n {name}-3',
-        teardown='sleep 10000',
+        f'sky jobs cancel -y -n {name}-1; sky jobs cancel -y -n {name}-2; sky jobs cancel -y -n {name}-3',
         env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
     )
     smoke_tests_utils.run_one_test(test)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR address and issue seen in Nebius where jobs would fail with `RuntimeError: Failed to initialize database due to a timeout when trying to acquire the lock at /home/ubuntu/.sky/locks/.state_db.lock. Please try again or manually remove the lock file if you believe it is stale.` The trouble is that migration takes longer than the current timeout even though the API server and jobs controller are still in a fine state. By upping the timeout we fix the issue.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
