### PR TITLE
[Dashboard] Fix Enabled Clouds During Kubernetes Refreshing

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -2064,10 +2064,7 @@ export function GPUs() {
   const workspaceEnabledClouds = React.useMemo(() => {
     // If Kubernetes data is still loading and workspaceInfrastructure is empty,
     // return null to indicate we should show all enabled clouds without filtering
-    if (
-      kubeLoading &&
-      Object.keys(workspaceInfrastructure).length === 0
-    ) {
+    if (kubeLoading && Object.keys(workspaceInfrastructure).length === 0) {
       return null;
     }
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We previously had an issue where if Kubernetes was loading the cloud section would show 0 clouds enabled before eventually showing the true number of clouds enabled. We add a check to make sure we are finished loading the enabled cloud data before showing the number of clouds enabled.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
