### PR TITLE
[Docs] Add Tip to Restart API Server if Credential Setup Fails

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -270,8 +270,8 @@ section :ref:`below <cloud-account-setup>`.
 
 .. tip::
 
-  If you are having trouble getting your credentials to setup it might be because your API server has already started and is 
-  failing to pick up the new credentials. You can try to restart the API server by running :code:`sky api stop` and then :code:`sky api start`.
+  If you are having trouble setting up credentials, it may be because the API server started before they were
+  configured. Try restarting the API server by running :code:`sky api stop` and then :code:`sky api start`.
 
 .. _cloud-account-setup:
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR adds another tip to the docs to suggest the user restart the API server if their credentials are not being picked up by the API server.

<img width="1646" height="304" alt="image" src="https://github.com/user-attachments/assets/55bc0edf-5556-46c8-9ae7-7c81aa25a0a3" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
