### PR TITLE
Fixed plugin load in metrics process

### DIFF
--- a/sky/server/plugins.py
+++ b/sky/server/plugins.py
@@ -164,6 +164,7 @@ def load_plugins(extension_context: ExtensionContext):
 
     for plugin_config in config.get('plugins', []):
         class_path = plugin_config['class']
+        logger.debug(f'Loading plugins: {class_path}')
         module_path, class_name = class_path.rsplit('.', 1)
         try:
             module = importlib.import_module(module_path)

--- a/tests/unit_tests/test_sky/server/test_plugins.py
+++ b/tests/unit_tests/test_sky/server/test_plugins.py
@@ -1,12 +1,15 @@
 """Unit tests for the SkyPilot API server plugins."""
 
+import importlib
 import sys
 import types
+from unittest import mock
 
 from fastapi import FastAPI
 import yaml
 
 from sky.server import plugins
+from sky.server import uvicorn as skyuvicorn
 
 
 def test_load_plugins_registers_and_installs(monkeypatch, tmp_path):
@@ -50,3 +53,61 @@ def test_load_plugins_registers_and_installs(monkeypatch, tmp_path):
     assert isinstance(plugin, DummyPlugin)
     assert plugin.value == 42
     assert installed['ctx'] is ctx
+
+
+def test_server_import_loads_plugins(monkeypatch):
+    load_mock = mock.MagicMock()
+    monkeypatch.setattr(plugins, 'load_plugins', load_mock)
+
+    server_module = importlib.import_module('sky.server.server')
+    load_mock.reset_mock()
+
+    importlib.reload(server_module)
+
+    load_mock.assert_called_once()
+    ctx = load_mock.call_args.args[0]
+    assert isinstance(ctx, plugins.ExtensionContext)
+    assert ctx.app is server_module.app
+
+
+def test_uvicorn_run_loads_plugins_for_multiple_workers(monkeypatch):
+    load_mock = mock.MagicMock()
+    monkeypatch.setattr(plugins, 'load_plugins', load_mock)
+
+    class DummyServer:
+
+        def __init__(self, config, max_db_connections=None):
+            del config, max_db_connections
+
+        def run(self, *args, **kwargs):
+            del args, kwargs
+
+    class DummyMultiprocess:
+
+        def __init__(self, config, target, sockets):
+            self.config = config
+            self.target = target
+            self.sockets = sockets
+            self.run_called = False
+
+        def run(self):
+            self.run_called = True
+
+    class DummyConfig:
+        reload = False
+        workers = 2
+        uds = None
+
+        def bind_socket(self):
+            return object()
+
+    monkeypatch.setattr(skyuvicorn, 'Server', DummyServer)
+    monkeypatch.setattr(skyuvicorn, 'SlowStartMultiprocess', DummyMultiprocess)
+
+    dummy_config = DummyConfig()
+    skyuvicorn.run(dummy_config)
+
+    load_mock.assert_called_once()
+    ctx = load_mock.call_args.args[0]
+    assert isinstance(ctx, plugins.ExtensionContext)
+    assert ctx.app is None


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixes an issue where the plugin is not loaded in the main process when `--deploy` is specified on a multi-core machine.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
