### PR TITLE
[Core] Update colorama version pin

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -144,9 +144,9 @@ aws_dependencies = [
     'awscli>=1.27.10',
     'botocore>=1.29.10',
     'boto3>=1.26.1',
-    # NOTE: colorama required by awscli. Current latest colorama is 0.4.6, so
-    # this is a no-op. However, we pin to the same as aws cli dependencies to
-    # avoid ray automatically installing a latest version in the future.
+    # NOTE: colorama is a dependency of awscli. We pin it to match the
+    # version constraint in awscli (<0.4.7) to prevent potential conflicts
+    # with other packages like ray, which might otherwise install a newer version.
     'colorama<0.4.7',
 ]
 


### PR DESCRIPTION
Closes https://github.com/skypilot-org/skypilot/issues/3701.

We should be able to safely update the colorama pin since [awscli now pins](https://github.com/aws/aws-cli/blame/master/setup.py#L31) colorama>=0.2.5,<0.4.7. Current latest colorma release is 0.4.6.