### PR TITLE
server: fix redirect URL in oauth2-proxy flow

### DIFF
--- a/sky/server/auth/oauth2_proxy.py
+++ b/sky/server/auth/oauth2_proxy.py
@@ -181,7 +181,7 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                 if request.url.query:
                     redirect_path += f'?{request.url.query}'
                 rd = urllib.parse.quote(redirect_path)
-                signin_url = (f'{request.base_url}oauth2/start?'
+                signin_url = (f'/oauth2/start?'
                               f'rd={rd}')
                 return fastapi.responses.RedirectResponse(url=signin_url)
             else:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

I encountered a problem running SkyPilot API server with oauth2-proxy behind a reverse proxy.

This redirect was sending a client to an internal URL (available behind the reverse proxy but not available from the client) thus breaking the flow.

I'm not sure if it was intentional. I can imagine if `root_path` should be taken into account somehow (e.g. if the server is deployed to be available with a prefix, like `http://example.com/my-skypilot/dashboard`) and I couldn't find a solid explanation in FastAPI / Starlette docs. In SkyPilot itself though there is a place where such a redirect is already used: https://github.com/skypilot-org/skypilot/blob/8572b319244bb19016629d752d91279dc1384a67/sky/server/server.py#L2144

With my fix it seems to work both behind a reverse proxy and directly.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
