### PR TITLE
[GKE] Avoid erroring out for unknown instance type when GKE autoscaler is used

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1057,7 +1057,7 @@ class GKEAutoscaler(Autoscaler):
             vcpus, mem = clouds.GCP.get_vcpus_mem_from_instance_type(
                 machine_type)
         except ValueError as e:
-            logger.error(
+            logger.warning(
                 f'Failed to get vcpu and memory from instance type '
                 f'{machine_type}. Skipping the fit check for node pool '
                 f'{node_pool_name}, assuming the node pool can create a node '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

A user encountered an issue when a GKE has a node pool with instance type that does not appear in the GCP catalog, with the `autoscaler: gke` set in config. The error only happens when scaling from 0 (to confirm?).

```
ValueError: No instance type c3d-highmem-16-lssd found.
```

We should add the following instance type: `c3d, c4, c4a, c4d, n4` to catalog as well

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] GKE cluster with a `c3d-highmem-16-lssd` node pool. Set the `autoscaler: gke`, and run `sky launch --cpus 10`, it outputs the optimizer table correctly.
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
