### PR TITLE
[Test]Fix `test_multi_echo` failure in non eks remote server tests

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -491,10 +491,9 @@ def test_multi_echo(generic_cloud: str):
     name = smoke_tests_utils.get_cluster_name()
     use_spot = True
     accelerator = 'T4'
-    if generic_cloud == 'kubernetes' or generic_cloud == 'slurm':
+    if generic_cloud in ('kubernetes', 'slurm'):
         # Slurm and Kubernetes do not support spot instances
         use_spot = False
-    if generic_cloud in ('kubernetes', 'slurm'):
         accelerator = smoke_tests_utils.get_available_gpus(infra=generic_cloud)
 
     # Determine timeout for 15 running jobs check: 2 min for remote server, single check for local


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Always set to no spot instance for k8s tests.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
