### PR TITLE
[Test] fix `helm_deploy` test failure

### DIFF
--- a/tests/kubernetes/scripts/helm_upgrade.sh
+++ b/tests/kubernetes/scripts/helm_upgrade.sh
@@ -153,7 +153,7 @@ get_previous_version() {
     # Convert current version format to match helm repo format
     # Convert 0.11.0rc1 -> 0.11.0-rc.1
     # Convert 1.0.0.dev20250913 -> 1.0.0-dev.20250913
-    local helm_format_ver=$(echo "$current_ver" | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+)rc([0-9]+)/\1-rc.\2/' | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+)\.dev([0-9]+)/\1-dev.\2/')
+    local helm_format_ver=$(echo "$current_ver" | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+)rc([0-9]+)/\1-rc.\2/;s/([0-9]+\.[0-9]+\.[0-9]+)\.dev([0-9]+)/\1-dev.\2/')
     echo "Looking for version: $helm_format_ver"
 
     # Check if current version is an RC version (before conversion)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

```bash
2025-12-17 06:05:54 UTC | ...Successfully got an update from the "skypilot" chart repository
-- | --
2025-12-17 06:05:54 UTC | Update Complete. ⎈Happy Helming!⎈
2025-12-17 06:05:54 UTC | Fetching available versions for package: skypilot
2025-12-17 06:05:54 UTC | Latest 10 versions:
2025-12-17 06:05:54 UTC | 0.10.2
2025-12-17 06:05:54 UTC | 0.10.3
2025-12-17 06:05:54 UTC | 0.10.3
2025-12-17 06:05:54 UTC | 0.10.4
2025-12-17 06:05:54 UTC | 0.10.5
2025-12-17 06:05:54 UTC | 0.10.5
2025-12-17 06:05:54 UTC | 0.11.0
2025-12-17 06:05:54 UTC | 0.11.0
2025-12-17 06:05:54 UTC | 0.11.1
2025-12-17 06:05:54 UTC | 0.11.1
2025-12-17 06:05:54 UTC | Looking for version: 0.11.2rc1
2025-12-17 06:05:54 UTC | Error: Could not find a previous version for 0.11.2rc1 (looking for 0.11.2rc1)
2025-12-17 06:05:54 UTC | available versions:
2025-12-17 06:05:54 UTC | 0.9.3
2025-12-17 06:05:54 UTC | 0.10.0
2025-12-17 06:05:54 UTC | 0.10.0
2025-12-17 06:05:54 UTC | 0.10.1
2025-12-17 06:05:54 UTC | 0.10.1
2025-12-17 06:05:54 UTC | 0.10.2
2025-12-17 06:05:54 UTC | 0.10.2
2025-12-17 06:05:54 UTC | 0.10.3
2025-12-17 06:05:54 UTC | 0.10.3
2025-12-17 06:05:54 UTC | 0.10.4
2025-12-17 06:05:54 UTC | 0.10.5
2025-12-17 06:05:54 UTC | 0.10.5
2025-12-17 06:05:54 UTC | 0.11.0
2025-12-17 06:05:54 UTC | 0.11.0
2025-12-17 06:05:54 UTC | 0.11.1
2025-12-17 06:05:54 UTC | 0.11.1
2025-12-17 06:05:54 UTC | Cleaning up...
2025-12-17 06:05:54 UTC | No API_ENDPOINT set, skipping Sky resource cleanup
2025-12-17 06:05:54 UTC | Deleting GKE cluster: skypilot-helm-test-cluster
```

Fail to get our latest version `pytest tests/smoke_tests/test_images.py::test_helm_deploy_gke --gcp --helm-version 0.11.2rc1 --helm-package skypilot` for the rc release, fix the issue

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
