### PR TITLE
[Consolidation] Fix File Mount Failure on RollingUpgrade

### DIFF
--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -107,7 +107,7 @@ def _upload_files_to_controller(dag: 'sky.Dag') -> Dict[str, str]:
     # If so, we should use cloud storage even in consolidation mode to persist
     # files across rolling updates and pod restarts.
     has_explicit_bucket = skypilot_config.get_nested(('jobs', 'bucket'),
-                                                      None) is not None
+                                                     None) is not None
     storage_clouds = (
         storage_lib.get_cached_enabled_storage_cloud_names_or_refresh())
     force_disable_cloud_bucket = skypilot_config.get_nested(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixes an issue we had with consolidation mode where a job’s file mounts would fail to work when performing a rolling update. 

The problem is that when running in jobs consolidation mode we would previously skip uploading jobs controller files to cloud storage (since it’s running local to the API server). However in the rolling update case this means that the local files are lost once the original API server goes down. 

We fix this by always using the user specified cloud storage for file mounts if it exists. I tested this by deploying an API server (with consolidation mode, rolling update, postgres and a cloud bucket for jobs) launching a job with a workdir that continually reads a file in the workdir, performing a rolling upgrade, verifying it stores the workdir in the cloud bucket, and then confirming that the job is able to continuously access the file mount stored in the cloud bucket after the upgrade.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
