### PR TITLE
Fix `test_launch_and_exec_async` failure in nightly

### DIFF
--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -1180,7 +1180,7 @@ def test_launch_and_exec_async(generic_cloud: str):
     test = smoke_tests_utils.Test(
         'launch_and_exec_async',
         [
-            f'sky launch -c --infra {generic_cloud} {name} -y --async',
+            f'sky launch -c {name} --infra {generic_cloud} -y --async',
             # Async exec.
             f'sky exec {name} echo --async',
             # Async exec and cancel immediately.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Nightly build fail: https://buildkite.com/skypilot-1/smoke-tests/builds/6638#_

```bash
sky.exceptions.ClusterNotUpError: Getting job status: skipped for cluster 't-launch-and-exec-57-a5' (status: INIT). It is only allowed for UP clusters. Wait for a launch to finish, or use this command to try to transition the cluster to UP: sky start t-launch-and-exec-57-a5
```

The issue is that the Buildkite environment's Sky API server might be slow, and the sync execution could run before the cluster reaches the `UP` state, which causes the tests to fail. Therefore, we wait for `UP` before performing the `sync exec`.

And we need to specific infra, otherwise buildkite env might use `slurm`, slurm currently can't pass this test.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
