### PR TITLE
hide clusters from dashboard when API server SKYPILOT_DEBUG is set

### DIFF
--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -55,6 +55,7 @@ export async function getClusters({ clusterNames = null } = {}) {
       include_credentials: false,
       include_handle: false,
       summary_response: clusterNames == null,
+      from_dashboard: true,
     });
 
     const clusterData = clusters.map((cluster) => {

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -149,6 +149,17 @@ class RequestBody(BasePayload):
 
     def __init__(self, **data):
         data['env_vars'] = data.get('env_vars', request_body_env_vars())
+        if data.get('from_dashboard', False):
+            # Limit the env vars to avoid leaking other API server env vars like
+            # SKYPILOT_DEBUG to the request.
+            data['env_vars'] = {
+                constants.USER_ID_ENV_VAR: data['env_vars']
+                                           [constants.USER_ID_ENV_VAR],
+                constants.USER_ENV_VAR: data['env_vars']
+                                        [constants.USER_ENV_VAR],
+                usage_constants.USAGE_RUN_ID_ENV_VAR: data['env_vars'][
+                    usage_constants.USAGE_RUN_ID_ENV_VAR],
+            }
         usage_lib_entrypoint = usage_lib.messages.usage.entrypoint
         if usage_lib_entrypoint is None:
             usage_lib_entrypoint = ''


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
