### PR TITLE
[Slurm] Fix GPU utilization calculation in sky show-gpus

### DIFF
--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -235,7 +235,7 @@ class SlurmClient:
             A list of GRES specs (e.g., 'gres/gpu:h100:4')
             for jobs on the node.
         """
-        cmd = f'squeue --me -h --nodelist {node_name} -o "%b"'
+        cmd = f'squeue -h --nodelist {node_name} -o "%b"'
         rc, stdout, stderr = self._run_slurm_cmd(cmd)
         subprocess_utils.handle_returncode(
             rc,


### PR DESCRIPTION
Previously, the Slurm command in `get_jobs_gres` uses `--me`, so it would only show jobs belonging to the user. This means if there are other jobs in the node, belonging to other users, it won't be taken into account in our logic when we do `sky show-gpus`. For example, here there's a job belonging to another user, using 2 GPUs:
```
$ squeue -o "%u %b"
USER TRES_PER_NODE
ubuntu gres/gpu:l40s:2
```

Before (shows 4/4 free, which is wrong):
```
Slurm GPUs
Slurm Cluster: hyperpod
GPU   REQUESTABLE_QTY_PER_NODE  UTILIZATION
L40S  1, 2, 4                   4 of 4 free
Slurm per node accelerator availability
CLUSTER   NODE             PARTITION                STATE  GPU   UTILIZATION
hyperpod  ip-10-3-0-193    dev*,cpus                idle         0 of 0 free
hyperpod  ip-10-3-215-227  dev*,cpus                idle         0 of 0 free
hyperpod  ip-10-3-225-4    dev*,gpus,ml.g5.2xlarge  mix    L40S  4 of 4 free
```

After (shows 2/4 free):
```
Slurm GPUs
Slurm Cluster: hyperpod
GPU   REQUESTABLE_QTY_PER_NODE  UTILIZATION
L40S  1, 2, 4                   2 of 4 free
Slurm per node accelerator availability
CLUSTER   NODE             PARTITION                STATE  GPU   UTILIZATION
hyperpod  ip-10-3-0-193    dev*,cpus                idle         0 of 0 free
hyperpod  ip-10-3-215-227  dev*,cpus                idle         0 of 0 free
hyperpod  ip-10-3-225-4    dev*,gpus,ml.g5.2xlarge  mix    L40S  2 of 4 free
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
