### PR TITLE
Do not take server env var for dashboard request

### DIFF
--- a/sky/dashboard/src/data/connectors/client.js
+++ b/sky/dashboard/src/data/connectors/client.js
@@ -19,7 +19,7 @@ export const apiClient = {
       if (body !== undefined) {
         body.env_vars = {
           ...(body.env_vars || {}),
-          'SKYPILOT_IS_FROM_DASHBOARD': 'true',
+          SKYPILOT_IS_FROM_DASHBOARD: 'true',
         };
       }
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Test: tested on local API server and remote API server, the request no longer use server env var

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
