### PR TITLE
[Test] Fix flaky slurm interactive ssh test

### DIFF
--- a/tests/unit_tests/test_sky/utils/test_command_runner.py
+++ b/tests/unit_tests/test_sky/utils/test_command_runner.py
@@ -234,6 +234,9 @@ class TestSSHCommandRunnerInteractiveAuth:
                 try:
                     if sock is not None:
                         sock.close()
+                except OSError:
+                    pass
+                try:
                     if pty_master_fd is not None:
                         os.close(pty_master_fd)
                 except OSError:


### PR DESCRIPTION
Follow up to #8317 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
