### PR TITLE
Fix Helm Unit Tests by Pinning Version

### DIFF
--- a/.github/workflows/helm-unittest.yaml
+++ b/.github/workflows/helm-unittest.yaml
@@ -22,11 +22,11 @@ jobs:
     - name: Set up Helm
       uses: azure/setup-helm@v4
       with:
-        version: '3.15.0'
+        version: '3.14.0'
 
     - name: Install helm unittest plugin
       run: |
-        helm plugin install https://github.com/helm-unittest/helm-unittest.git
+        helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 6f82a998e0b5461762ca959f87f5dd344af5e4eb
 
     - name: Update chart dependencies
       run: |


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

A recent update to helm unit tests https://github.com/helm-unittest/helm-unittest/commit/aa320e89debab12e54e0f5ec4df39bb8045f184e broke our github action since it used features only available in helm 4. With this PR we pin the version and the workflow is now passing https://github.com/skypilot-org/skypilot/actions/runs/20352368073.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
