### PR TITLE
[Dashboard] Reenable Jobs Table to Load Separately from Pools

### DIFF
--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -5,7 +5,6 @@ import ipaddress
 import os
 import pathlib
 import tempfile
-import time
 import typing
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib import parse as urlparse
@@ -884,22 +883,16 @@ def queue_v2(
             pass
 
     with metrics_lib.time_it('jobs.queue.generate_code', group='jobs'):
-        start = time.time()
         code = managed_job_utils.ManagedJobCodeGen.get_job_table(
             skip_finished, accessible_workspaces, job_ids, workspace_match,
             name_match, pool_match, page, limit, user_hashes, statuses, fields)
-        end = time.time()
-        logger.info(f'Generated code in {end - start} seconds')
     with metrics_lib.time_it('jobs.queue.run_on_head', group='jobs'):
-        start = time.time()
         returncode, job_table_payload, stderr = backend.run_on_head(
             handle,
             code,
             require_outputs=True,
             stream_logs=False,
             separate_stderr=True)
-        end = time.time()
-        logger.info(f'Ran code on head in {end - start} seconds')
 
     if returncode != 0:
         logger.error(job_table_payload + stderr)
@@ -916,7 +909,6 @@ def queue_v2(
     # Backward compatibility for old jobs controller without filtering
     # TODO(hailong): remove this after 0.12.0
     with metrics_lib.time_it('jobs.queue.filter_and_process', group='jobs'):
-        start = time.time()
         if not all_users:
 
             def user_hash_matches_or_missing(job: Dict[str, Any]) -> bool:
@@ -958,8 +950,6 @@ def queue_v2(
             enable_user_match=True,
             statuses=statuses,
         )
-        end = time.time()
-        logger.info(f'Filtered jobs in {end - start} seconds')
     return filtered_jobs, total, status_counts, total_no_filter
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

https://github.com/skypilot-org/skypilot/pull/8370 introduced some changes to the way we perform our preloading which broke our ability to load the jobs table in the jobs page and display it independent from the pools table. This led to a [smoke test failure](https://buildkite.com/skypilot-1/smoke-tests/builds/6771#019b4572-42f5-4a2c-8878-32eea5e3831f) in our postgres tests since the time to load the jobs was increased. This PR restores the ability to load them independently.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
