### PR TITLE
[UX] dashboard controller logs accessible earlier

### DIFF
--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -218,6 +218,7 @@ export async function getManagedJobs(options = {}) {
         links: job.links || {},
         pool: job.pool,
         pool_hash: job.pool_hash,
+        schedule_state: job.schedule_state,
         current_cluster_name: job.current_cluster_name,
         job_id_on_pool_cluster: job.job_id_on_pool_cluster,
         accelerators: job.accelerators, // Include accelerators field

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -524,7 +524,17 @@ function JobDetailsContent({
   const RECOVERING_STATUSES = ['RECOVERING'];
 
   const isPending = PENDING_STATUSES.includes(jobData.status);
-  const isPreStart = PRE_START_STATUSES.includes(jobData.status);
+  // Check if controller is running: either controller_pid is set, or schedule_state
+  // indicates the controller is alive (not INACTIVE or WAITING)
+  // After PR #5682, a job can be in PENDING state even though the controller is running
+  const isControllerRunning =
+    jobData.controller_pid != null ||
+    (jobData.schedule_state &&
+      jobData.schedule_state !== 'INACTIVE' &&
+      jobData.schedule_state !== 'WAITING');
+  // Controller is not started if job is in pre-start status AND controller is not running
+  const isPreStart =
+    PRE_START_STATUSES.includes(jobData.status) && !isControllerRunning;
   const isRecovering = RECOVERING_STATUSES.includes(jobData.status);
 
   const toggleYamlExpanded = () => {

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -528,10 +528,8 @@ function JobDetailsContent({
   // indicates the controller is alive (not INACTIVE or WAITING)
   // After PR #5682, a job can be in PENDING state even though the controller is running
   const isControllerRunning =
-    jobData.controller_pid != null ||
-    (jobData.schedule_state &&
-      jobData.schedule_state !== 'INACTIVE' &&
-      jobData.schedule_state !== 'WAITING');
+    jobData.schedule_state !== 'INACTIVE' &&
+    jobData.schedule_state !== 'WAITING';
   // Controller is not started if job is in pre-start status AND controller is not running
   const isPreStart =
     PRE_START_STATUSES.includes(jobData.status) && !isControllerRunning;
@@ -1071,6 +1069,7 @@ JobDetailsContent.propTypes = {
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     name: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     status: PropTypes.string,
+    schedule_state: PropTypes.string,
     user: PropTypes.string,
     user_hash: PropTypes.string,
     workspace: PropTypes.string,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Needs more testing, but should show the controller log in the dashboard, instead of the "Waiting for the job controller process to start, please refresh after a while" message.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
