### PR TITLE
[k8s] Fix rsync wait script

### DIFF
--- a/sky/utils/kubernetes/rsync_helper.sh
+++ b/sky/utils/kubernetes/rsync_helper.sh
@@ -61,4 +61,7 @@ fi
 # Timeout after MAX_WAIT_TIME_SECONDS seconds.
 MAX_WAIT_TIME_SECONDS=300
 MAX_WAIT_COUNT=$((MAX_WAIT_TIME_SECONDS * 2))
-eval "${kubectl_cmd_base% --} -i -- bash -c 'count=0; until which rsync >/dev/null 2>&1; do if [ \$count -ge $MAX_WAIT_COUNT ]; then echo \"Error when trying to rsync files to kubernetes cluster. Package installation may have failed.\" >&2; exit 1; fi; sleep 0.5; count=\$((count+1)); echo \"Waiting for rsync to be available... \$count seconds elapsed\"; done; exec \"\$@\"' -- \"\$@\""
+# Use --norc --noprofile to prevent bash from sourcing startup files that might
+# output to stdout and corrupt the rsync protocol. All debug output must go to
+# stderr (>&2) to keep stdout clean for rsync communication.
+eval "${kubectl_cmd_base% --} -i -- bash --norc --noprofile -c 'count=0; until which rsync >/dev/null 2>&1; do if [ \$count -ge $MAX_WAIT_COUNT ]; then echo \"Error when trying to rsync files to kubernetes cluster. Package installation may have failed.\" >&2; exit 1; fi; sleep 0.5; count=\$((count+1)); done; exec \"\$@\"' -- \"\$@\""


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The previous logic cause the following error:
`sky launch --infra k8s --image-id python:3.12-slim echo hi`
In provision log
```
Assuming resource is a pod: sky-ccbc-zhwu-fdeaebfa-head
--: line 1: [: 300*2: integer expression expected
--: line 1: [: 300*2: integer expression expected
--: line 1: [: 300*2: integer expression expected
--: line 1: [: 300*2: integer expression expected
--: line 1: [: 300*2: integer expression expected
sending incremental file list
```

Now (added a debug `sleep 30` in https://github.com/skypilot-org/skypilot/blob/0e38f5bcf87f173560f7f63185e1d134835e7f84/sky/templates/kubernetes-ray.yml.j2#L797-L798):
```
I 12-22 23:27:38.767 PID=21545 common.py:321] --------------------Start: internal_file_mounts --------------------
pod: sky-e258-zhwu-fdeaebfa-head
namespace_context: default+gke_sky-dev-465_us-central1-c_zhwu-demo
namespace: default
context: gke_sky-dev-465_us-central1-c_zhwu-demo
Assuming resource is a pod: sky-e258-zhwu-fdeaebfa-head
sending incremental file list
./
2dd479c8-9f98-4bd6-954b-f280e5dd278d
             88 100%    0.00kB/s    0:00:00 (xfr#1, to-chk=34/36)
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
