### PR TITLE
[UX] Add --user and --request filters to sky api status

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -6741,11 +6741,23 @@ INT_OR_NONE = IntOrNone()
     required=False,
     help=(f'Number of requests to show, default is {_NUM_REQUESTS_TO_SHOW},'
           f' set to "none" or "all" to show all requests.'))
+@click.option('--user',
+              '-u',
+              default=None,
+              required=False,
+              help='Filter requests by user name (similar to Slurm\'s squeue).')
+@click.option('--request',
+              '-r',
+              'request_name',
+              default=None,
+              required=False,
+              help='Filter requests by request name.')
 @flags.verbose_option('Show more details.')
 @usage_lib.entrypoint
 # pylint: disable=redefined-builtin
 def api_status(request_id_prefixes: Optional[List[str]], all_status: bool,
-               verbose: bool, limit: Optional[int]):
+               verbose: bool, limit: Optional[int], user: Optional[str],
+               request_name: Optional[str]):
     """List requests on SkyPilot API server."""
     if not request_id_prefixes:
         request_id_prefixes = None
@@ -6753,7 +6765,7 @@ def api_status(request_id_prefixes: Optional[List[str]], all_status: bool,
     if verbose:
         fields = _VERBOSE_REQUEST_FIELDS_TO_SHOW
     request_list = sdk.api_status(request_id_prefixes, all_status, limit,
-                                  fields)
+                                  fields, user, request_name)
     columns = ['ID', 'User', 'Name']
     if verbose:
         columns.append('Cluster')

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -2200,6 +2200,8 @@ def api_status(
     all_status: bool = False,
     limit: Optional[int] = None,
     fields: Optional[List[str]] = None,
+    user_filter: Optional[str] = None,
+    request_name_filter: Optional[str] = None,
 ) -> List[payloads.RequestPayload]:
     """Lists all requests.
 
@@ -2210,6 +2212,10 @@ def api_status(
             is ignored if request_ids is not None.
         limit: The number of requests to show. If None, show all requests.
         fields: The fields to get. If None, get all fields.
+        user_filter: Filter requests by user name (similar to Slurm's squeue -u).
+            If None, all users are included.
+        request_name_filter: Filter requests by request name (similar to Slurm's
+            squeue -n). If None, all request names are included.
 
     Returns:
         A list of request payloads.
@@ -2223,6 +2229,8 @@ def api_status(
         all_status=all_status,
         limit=limit,
         fields=fields,
+        user_filter=user_filter,
+        request_name_filter=request_name_filter,
     )
     response = server_common.make_authenticated_request(
         'GET',

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -590,6 +590,9 @@ class RequestStatusBody(pydantic.BaseModel):
     all_status: bool = False
     limit: Optional[int] = None
     fields: Optional[List[str]] = None
+    # Server-side filters similar to Slurm's squeue
+    user_filter: Optional[str] = None
+    request_name_filter: Optional[str] = None
 
 
 class ServeUpBody(RequestBody):

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1804,6 +1804,17 @@ async def api_status(
                 requests_lib.RequestStatus.PENDING,
                 requests_lib.RequestStatus.RUNNING,
             ]
+        # Convert user name to user hash for filtering
+        user_hash = None
+        if user_filter is not None:
+            users = await context_utils.to_thread(
+                global_user_state.get_user_by_name, user_filter)
+            if not users:
+                return []
+            # TODO(zhwu): User names are not guaranteed to be unique.
+            # For now, we just use the first one.
+            user_hash = users[0].id
+
         # Build include_request_names list if request_name_filter is provided
         include_request_names = None
         if request_name_filter is not None:
@@ -1814,7 +1825,7 @@ async def api_status(
                 limit=limit,
                 fields=fields,
                 sort=True,
-                user_id=user_filter,
+                user_id=user_hash,
                 include_request_names=include_request_names,
             ))
         return requests_lib.encode_requests(request_tasks)

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1791,6 +1791,10 @@ async def api_status(
         None, description='Number of requests to show.'),
     fields: Optional[List[str]] = fastapi.Query(
         None, description='Fields to get. If None, get all fields.'),
+    user_filter: Optional[str] = fastapi.Query(
+        None, description='Filter requests by user name.'),
+    request_name_filter: Optional[str] = fastapi.Query(
+        None, description='Filter requests by request name.'),
 ) -> List[payloads.RequestPayload]:
     """Gets the list of requests."""
     if request_ids is None:
@@ -1800,12 +1804,18 @@ async def api_status(
                 requests_lib.RequestStatus.PENDING,
                 requests_lib.RequestStatus.RUNNING,
             ]
+        # Build include_request_names list if request_name_filter is provided
+        include_request_names = None
+        if request_name_filter is not None:
+            include_request_names = [request_name_filter]
         request_tasks = await requests_lib.get_request_tasks_async(
             req_filter=requests_lib.RequestTaskFilter(
                 status=statuses,
                 limit=limit,
                 fields=fields,
                 sort=True,
+                user_id=user_filter,
+                include_request_names=include_request_names,
             ))
         return requests_lib.encode_requests(request_tasks)
     else:


### PR DESCRIPTION
## Summary

Add server-side filtering options to `sky api status` command, similar to Slurm's squeue:

- `--user` / `-u`: Filter requests by user name  
- `--request` / `-r`: Filter requests by request name

## Example Usage

```bash
# Filter by user
sky api status --user alice

# Filter by request name  
sky api status --request launch

# Combine filters
sky api status --user alice --request launch -a
```

## Changes

| File | Description |
|------|-------------|
| `sky/client/cli/command.py` | Add `--user` and `--request` CLI options |
| `sky/client/sdk.py` | Add `user_filter` and `request_name_filter` parameters |
| `sky/server/requests/payloads.py` | Add fields to `RequestStatusBody` |
| `sky/server/server.py` | Pass filters to `RequestTaskFilter` |

## Implementation Notes

- Filters are applied server-side using the existing `RequestTaskFilter` infrastructure which already supports `user_id` and `include_request_names` filtering
- This is more efficient than client-side filtering as it reduces data transfer
- Design follows Slurm's squeue pattern as suggested in the issue

## Test Plan

- Manual testing with `sky api status --user <name>`
- Manual testing with `sky api status --request <name>`

Fixes #8368

🤖 Generated with [Claude Code](https://claude.com/claude-code)