### PR TITLE
Support list of dicts syntax for accelerators in YAML

### DIFF
--- a/sky/resources.py
+++ b/sky/resources.py
@@ -2158,9 +2158,21 @@ class Resources:
             elif isinstance(accelerators, list) or isinstance(
                     accelerators, set):
                 accelerators_list = []
-                for accel_name in accelerators:
-                    parsed_accels = cls._parse_accelerators_from_str(accel_name)
-                    accelerators_list.extend(parsed_accels)
+                for accel_item in accelerators:
+                    if isinstance(accel_item, dict):
+                        # Handle dict items like {'T4': 1} in list
+                        accel_names = [
+                            f'{k}:{v}' if v is not None else f'{k}'
+                            for k, v in accel_item.items()
+                        ]
+                        for accel_name in accel_names:
+                            parsed_accels = cls._parse_accelerators_from_str(
+                                accel_name)
+                            accelerators_list.extend(parsed_accels)
+                    else:
+                        parsed_accels = cls._parse_accelerators_from_str(
+                            accel_item)
+                        accelerators_list.extend(parsed_accels)
             else:
                 assert False, ('Invalid accelerators type:'
                                f'{type(accelerators)}')

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -2159,20 +2159,18 @@ class Resources:
                     accelerators, set):
                 accelerators_list = []
                 for accel_item in accelerators:
+                    items_to_parse = []
                     if isinstance(accel_item, dict):
                         # Handle dict items like {'T4': 1} in list
-                        accel_names = [
+                        items_to_parse.extend(
                             f'{k}:{v}' if v is not None else f'{k}'
-                            for k, v in accel_item.items()
-                        ]
-                        for accel_name in accel_names:
-                            parsed_accels = cls._parse_accelerators_from_str(
-                                accel_name)
-                            accelerators_list.extend(parsed_accels)
+                            for k, v in accel_item.items())
                     else:
-                        parsed_accels = cls._parse_accelerators_from_str(
-                            accel_item)
-                        accelerators_list.extend(parsed_accels)
+                        items_to_parse.append(accel_item)
+
+                    for accel_name in items_to_parse:
+                        accelerators_list.extend(
+                            cls._parse_accelerators_from_str(accel_name))
             else:
                 assert False, ('Invalid accelerators type:'
                                f'{type(accelerators)}')

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -434,6 +434,18 @@ def get_resources_schema():
                     'items': {
                         'type': 'string',
                     }
+                }, {
+                    # Support list of dicts for ordered accelerator preferences
+                    # e.g., [{T4: 1}, {L4: 1}]
+                    'type': 'array',
+                    'items': {
+                        'type': 'object',
+                        'required': [],
+                        'maxProperties': 1,
+                        'additionalProperties': {
+                            'type': 'number'
+                        }
+                    }
                 }]
             },
             'any_of': {


### PR DESCRIPTION
## Purpose

Fixes #7098

This PR adds support for using a list of dicts syntax for specifying accelerators in YAML configuration files.

## Problem

Currently, specifying accelerators as a list of dicts fails with a schema validation error:

```yaml
resources:
  accelerators:
    - T4: 1
    - L4: 1
```

Error:
```
sky.utils.schemas.InvalidClusterNameError: Invalid config YAML...
```

While this equivalent dict syntax works:
```yaml
resources:
  accelerators:
    T4: 1
    L4: 1
```

## Solution

1. **Schema Update** (`sky/utils/schemas.py`): Added a new `anyOf` option allowing arrays of single-property objects (dicts) in the `accelerators` field.

2. **Parser Update** (`sky/resources.py`): Updated the list parsing logic in `from_yaml_config()` to detect and handle dict items, converting them to the standard `"ACC:COUNT"` format for parsing.

## Changes

| File | Change |
|------|--------|
| `sky/utils/schemas.py` | Added schema support for `[{T4: 1}, {L4: 1}]` syntax |
| `sky/resources.py` | Handle dict items when parsing accelerators list |

## Test Plan

- [ ] Verify YAML with list of dicts syntax is now accepted
- [ ] Verify existing dict syntax still works
- [ ] Verify existing list of strings syntax still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)