### PR TITLE
Fix IndexError when runners list is empty

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2142,7 +2142,8 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
             ip_list = (self.cached_external_ips
                        if force_cached else self.external_ips())
             if ip_list is None:
-                return []
+                raise exceptions.FetchClusterInfoError(
+                    exceptions.FetchClusterInfoError.Reason.HEAD)
             # Potentially refresh the external SSH ports, in case the existing
             # cluster before #2491 was launched without external SSH ports
             # cached.
@@ -2397,9 +2398,6 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
         # attempt to open the same port at the same time.
         for attempt in range(max_attempts):
             runners = self.get_command_runners()
-            if not runners:
-                raise exceptions.FetchClusterInfoError(
-                    exceptions.FetchClusterInfoError.Reason.HEAD)
             head_runner = runners[0]
             local_port = random.randint(10000, 65535)
             try:
@@ -3762,9 +3760,6 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                        local_file_path: str, remote_file_path: str) -> None:
         """Syncs file from remote to local."""
         runners = handle.get_command_runners()
-        if not runners:
-            raise exceptions.FetchClusterInfoError(
-                exceptions.FetchClusterInfoError.Reason.HEAD)
         head_runner = runners[0]
         head_runner.rsync(
             source=local_file_path,
@@ -3793,9 +3788,6 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         def _dump_code_to_file(codegen: str,
                                target_dir: str = SKY_REMOTE_APP_DIR) -> None:
             runners = handle.get_command_runners()
-            if not runners:
-                raise exceptions.FetchClusterInfoError(
-                    exceptions.FetchClusterInfoError.Reason.HEAD)
             head_runner = runners[0]
             with tempfile.NamedTemporaryFile('w', prefix='sky_app_') as fp:
                 fp.write(codegen)
@@ -5294,9 +5286,6 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         # This will try to fetch the head node IP if it is not cached.
 
         runners = handle.get_command_runners()
-        if not runners:
-            raise exceptions.FetchClusterInfoError(
-                exceptions.FetchClusterInfoError.Reason.HEAD)
         head_runner = runners[0]
         if under_remote_workdir:
             cmd = f'cd {SKY_REMOTE_WORKDIR} && {cmd}'

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2397,6 +2397,9 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
         # attempt to open the same port at the same time.
         for attempt in range(max_attempts):
             runners = self.get_command_runners()
+            if not runners:
+                raise exceptions.FetchClusterInfoError(
+                    exceptions.FetchClusterInfoError.Reason.HEAD)
             head_runner = runners[0]
             local_port = random.randint(10000, 65535)
             try:
@@ -3759,6 +3762,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                        local_file_path: str, remote_file_path: str) -> None:
         """Syncs file from remote to local."""
         runners = handle.get_command_runners()
+        if not runners:
+            raise exceptions.FetchClusterInfoError(
+                exceptions.FetchClusterInfoError.Reason.HEAD)
         head_runner = runners[0]
         head_runner.rsync(
             source=local_file_path,
@@ -3787,6 +3793,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         def _dump_code_to_file(codegen: str,
                                target_dir: str = SKY_REMOTE_APP_DIR) -> None:
             runners = handle.get_command_runners()
+            if not runners:
+                raise exceptions.FetchClusterInfoError(
+                    exceptions.FetchClusterInfoError.Reason.HEAD)
             head_runner = runners[0]
             with tempfile.NamedTemporaryFile('w', prefix='sky_app_') as fp:
                 fp.write(codegen)
@@ -5285,6 +5294,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         # This will try to fetch the head node IP if it is not cached.
 
         runners = handle.get_command_runners()
+        if not runners:
+            raise exceptions.FetchClusterInfoError(
+                exceptions.FetchClusterInfoError.Reason.HEAD)
         head_runner = runners[0]
         if under_remote_workdir:
             cmd = f'cd {SKY_REMOTE_WORKDIR} && {cmd}'


### PR DESCRIPTION
## Purpose

Fixes #8361

This PR fixes an `IndexError: list index out of range` that occurs when running `sky down` on clusters that are in INIT state or when the head node IP is unavailable.

## Problem

When a cluster's head node IP cannot be fetched (e.g., cluster in INIT state, failed provisioning), `get_command_runners()` returns an empty list. The code was directly accessing `runners[0]` without checking if the list was empty:

```python
runners = handle.get_command_runners()
head_runner = runners[0]  # IndexError if runners is empty!
```

This caused the following error instead of the expected `FetchClusterInfoError`:

```
IndexError: list index out of range
```

## Solution

Add a check for empty runners list before accessing `runners[0]`, raising `FetchClusterInfoError` with `Reason.HEAD` instead. This is the expected exception type (documented in the docstring) and is properly handled by callers like the teardown logic.

## Changes

Added empty list check in 4 locations in `sky/backends/cloud_vm_ray_backend.py`:

| Method | Line | Description |
|--------|------|-------------|
| `run_on_head()` | ~5288 | Main method for running commands on head node |
| `_open_and_update_skylet_tunnel()` | ~2400 | Opens SSH tunnel to Skylet |
| `_download_file()` | ~3765 | Downloads files from remote |
| `_dump_code_to_file()` | ~3796 | Uploads code to head node |

## Test Plan

- [ ] Run `sky down` on a cluster in INIT state
- [ ] Verify proper error handling instead of IndexError
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)