### PR TITLE
Fix --infra CLI override failing with Docker images

### DIFF
--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1928,6 +1928,16 @@ class Resources:
         # extract_docker_image() can properly match the region.
         image_id = override.pop('image_id', self.image_id)
         new_region = override.get('region', self.region)
+        if 'infra' in override and override['infra'] is not None:
+            try:
+                # This duplicates some logic from Resources.__init__, but is
+                # needed here to correctly handle the image_id update before
+                # calling __init__.
+                infra_info = infra_utils.InfraInfo.from_str(override['infra'])
+                new_region = infra_info.region
+            except ValueError:
+                # Let Resources.__init__ handle and raise the error.
+                pass
         if (image_id is not None and isinstance(image_id, dict) and
                 new_region is not None and new_region != self.region):
             if None in image_id and len(image_id) == 1:


### PR DESCRIPTION
## Purpose

Fixes #7175

This PR fixes the issue where using `--infra` CLI parameter to override region for Docker images fails, while the same configuration works when specified in YAML's `infra` field.

## Problem

When using `--infra` CLI override with Docker images:

**Working (YAML infra field):**
```yaml
resources:
  infra: aws/us-west-2
  image_id: docker:example.ecr.us-east-1.amazonaws.com/image:latest
```

**Failing (CLI --infra override):**
```bash
sky launch test.yaml --infra aws/us-west-2  # ❌ Fails
# Error: Image 'docker:...' not found in AWS region us-west-2
```

### Root Cause

1. YAML parsing creates `image_id` as `{None: 'docker:...'}`
2. CLI override changes `region` to `'us-west-2'`
3. `extract_docker_image()` fails because `image_key` (`None`) != `region` (`'us-west-2'`)

## Solution

Update `Resources.copy()` to update the `image_id` dictionary key when region is being overridden. If the `image_id` dict has `None` as its only key (meaning "any region"), we update it to the new region.

```python
# When region is overridden and image_id has None key
image_id = {new_region: image_id[None]}
```

## Changes

| File | Change |
|------|--------|
| `sky/resources.py` | Update `image_id` dict key in `copy()` when region changes |

## Test Plan

- [ ] `sky launch test.yaml --infra aws/us-west-2` with Docker image works
- [ ] YAML `infra` field with Docker image still works
- [ ] Multi-region image_id configurations still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)