### PR TITLE
Fix TypeError when deserializing built-in exceptions

### DIFF
--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -130,7 +130,16 @@ def deserialize_exception(serialized: Dict[str, Any]) -> Exception:
     except TypeError:
         # Built-in exceptions don't accept keyword arguments.
         # Construct with args only and set attributes manually.
-        e = exception_class(*serialized['args'])
+        try:
+            e = exception_class(*serialized['args'])
+        except Exception:  # pylint: disable=broad-except
+            # If construction with positional args also fails, the serialized
+            # data is likely incompatible. Fall back to a generic Exception
+            # to prevent crashing the deserialization process, which could
+            # mask the original error.
+            return Exception(
+                f'Failed to deserialize exception '
+                f'{exception_type}: {serialized["message"]}')
         for key, value in serialized['attributes'].items():
             try:
                 setattr(e, key, value)

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -120,7 +120,24 @@ def deserialize_exception(serialized: Dict[str, Any]) -> Exception:
     if exception_class is None:
         # Unknown exception type.
         return Exception(f'{exception_type}: {serialized["message"]}')
-    e = exception_class(*serialized['args'], **serialized['attributes'])
+
+    # Try to construct the exception with both args and attributes.
+    # Built-in exceptions (like RuntimeError, ValueError) don't accept
+    # keyword arguments, so we fall back to constructing with args only
+    # and then setting attributes manually.
+    try:
+        e = exception_class(*serialized['args'], **serialized['attributes'])
+    except TypeError:
+        # Built-in exceptions don't accept keyword arguments.
+        # Construct with args only and set attributes manually.
+        e = exception_class(*serialized['args'])
+        for key, value in serialized['attributes'].items():
+            try:
+                setattr(e, key, value)
+            except AttributeError:
+                # Some attributes may be read-only, skip them.
+                pass
+
     if serialized['stacktrace'] is not None:
         setattr(e, 'stacktrace', serialized['stacktrace'])
     return e

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -132,14 +132,16 @@ def deserialize_exception(serialized: Dict[str, Any]) -> Exception:
         # Construct with args only and set attributes manually.
         try:
             e = exception_class(*serialized['args'])
-        except Exception:  # pylint: disable=broad-except
+        except Exception as deserialize_err:  # pylint: disable=broad-except
             # If construction with positional args also fails, the serialized
             # data is likely incompatible. Fall back to a generic Exception
             # to prevent crashing the deserialization process, which could
             # mask the original error.
             return Exception(
-                f'Failed to deserialize exception '
-                f'{exception_type}: {serialized["message"]}')
+                f'Failed to deserialize exception {exception_type}: '
+                f'{serialized["message"]} (args={serialized["args"]}, '
+                f'attributes={serialized["attributes"]}, '
+                f'reason={deserialize_err})')
         for key, value in serialized['attributes'].items():
             try:
                 setattr(e, key, value)


### PR DESCRIPTION
## Purpose

Fixes #8201

This PR fixes a `TypeError` that occurs when deserializing built-in exceptions (like `RuntimeError`, `ValueError`) in the API server's error handling.

## Problem

When running concurrent cluster launches, some fail due to transient errors. When SkyPilot tries to report these failures, a secondary `TypeError` is raised that masks the original error:

```
TypeError: RuntimeError() takes no keyword arguments
```

This happens because `deserialize_exception()` tries to construct exceptions with keyword arguments:

```python
e = exception_class(*serialized['args'], **serialized['attributes'])
```

Python's built-in exceptions (like `RuntimeError`, `ValueError`, `OSError`) don't accept keyword arguments, only positional args.

## Solution

Catch `TypeError` during exception construction and fall back to:
1. Constructing with positional args only
2. Setting attributes manually via `setattr`

```python
try:
    e = exception_class(*args, **attributes)
except TypeError:
    e = exception_class(*args)
    for key, value in attributes.items():
        try:
            setattr(e, key, value)
        except AttributeError:
            pass  # Some attributes may be read-only
```

## Changes

| File | Change |
|------|--------|
| `sky/exceptions.py` | Handle built-in exceptions in `deserialize_exception()` |

## Test Plan

- [ ] Concurrent cluster launches show proper error messages
- [ ] SkyPilot custom exceptions still deserialize correctly
- [ ] Built-in exceptions (RuntimeError, ValueError, etc.) deserialize without TypeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)