### PR TITLE
Remove redundant ssh- prefix from Infra column for SSH Node Pools

### DIFF
--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -67,7 +67,7 @@ export async function getClusters({ clusterNames = null } = {}) {
       }
       // For SSH Node Pools, strip the 'ssh-' prefix from region display
       // to avoid redundant "SSH (ssh-poolname)" showing as "SSH (poolname)"
-      if (cluster.cloud === 'SSH' && region_or_zone.startsWith('ssh-')) {
+      if (cluster.cloud === 'SSH' && region_or_zone?.startsWith('ssh-')) {
         region_or_zone = region_or_zone.substring(4);
       }
       // Store the full value before truncation


### PR DESCRIPTION
## Summary

Fixes #7698

When displaying SSH Node Pool clusters in the dashboard, the Infra column was showing "SSH (ssh-poolname)" which is redundant. This fix strips the "ssh-" prefix from the region display.

## Before/After

| Before | After |
|--------|-------|
| `SSH (ssh-my-cluster)` | `SSH (my-cluster)` |
| `SSH (ssh-gpu-nodes)` | `SSH (gpu-nodes)` |

## Changes

Modified `sky/dashboard/src/data/connectors/clusters.jsx` to strip the `ssh-` prefix from `region_or_zone` when `cluster.cloud === 'SSH'`.

## Test Plan

- This is a display-only change in the dashboard
- The change only affects how SSH Node Pool regions are displayed in the Infra column