### PR TITLE
Show job names in sky jobs cancel confirmation message

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -5222,8 +5222,9 @@ def jobs_cancel(
                 }
                 # Format job IDs with names
                 job_strs = [
-                    f'{jid} ({jname})' if (jname := job_id_to_name.get(jid))
-                    else str(jid) for jid in job_ids
+                    f'{jid} ({jname})' if
+                    (jname := job_id_to_name.get(jid)) else str(jid)
+                    for jid in job_ids
                 ]
                 job_identity_str = f'managed job{plural}: {", ".join(job_strs)}'
             except Exception as e:  # pylint: disable=broad-except

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -5202,9 +5202,40 @@ def jobs_cancel(
 
     if not yes:
         plural = 's' if len(job_ids) > 1 else ''
-        job_identity_str = (f'managed job{plural} with ID{plural} {job_id_str}'
-                            if job_ids else f'{name!r}' if name is not None else
-                            f'managed jobs in pool {pool!r}')
+        job_identity_str = None
+        if job_ids:
+            # Query job names to show in confirmation message
+            try:
+                request_id, _ = cli_utils.get_managed_job_queue(
+                    refresh=False,
+                    job_ids=list(job_ids),
+                    fields=['job_id', 'job_name'])
+                job_records = sdk.stream_and_get(request_id)
+                # Handle both V1 (list) and V2 (tuple) response formats
+                if isinstance(job_records, tuple):
+                    job_records = job_records[0]
+                # Build a mapping of job_id to job_name
+                job_id_to_name = {
+                    r.job_id: r.job_name
+                    for r in job_records
+                    if r.job_id is not None
+                }
+                # Format job IDs with names
+                job_strs = []
+                for jid in job_ids:
+                    jname = job_id_to_name.get(jid)
+                    if jname:
+                        job_strs.append(f'{jid} ({jname})')
+                    else:
+                        job_strs.append(str(jid))
+                job_identity_str = f'managed job{plural}: {", ".join(job_strs)}'
+            except Exception:  # pylint: disable=broad-except
+                # If querying fails, fall back to just showing IDs
+                job_identity_str = (
+                    f'managed job{plural} with ID{plural} {job_id_str}')
+        if job_identity_str is None:
+            job_identity_str = (f'{name!r}' if name is not None else
+                                f'managed jobs in pool {pool!r}')
         if all_users:
             job_identity_str = 'all managed jobs FOR ALL USERS'
         elif all:

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -5221,16 +5221,14 @@ def jobs_cancel(
                     if r.job_id is not None
                 }
                 # Format job IDs with names
-                job_strs = []
-                for jid in job_ids:
-                    jname = job_id_to_name.get(jid)
-                    if jname:
-                        job_strs.append(f'{jid} ({jname})')
-                    else:
-                        job_strs.append(str(jid))
+                job_strs = [
+                    f'{jid} ({jname})' if (jname := job_id_to_name.get(jid))
+                    else str(jid) for jid in job_ids
+                ]
                 job_identity_str = f'managed job{plural}: {", ".join(job_strs)}'
-            except Exception:  # pylint: disable=broad-except
+            except Exception as e:  # pylint: disable=broad-except
                 # If querying fails, fall back to just showing IDs
+                logger.debug(f'Failed to query job names for confirmation: {e}')
                 job_identity_str = (
                     f'managed job{plural} with ID{plural} {job_id_str}')
         if job_identity_str is None:

--- a/tests/unit_tests/test_sky/test_cli_helpers.py
+++ b/tests/unit_tests/test_sky/test_cli_helpers.py
@@ -742,8 +742,11 @@ class TestJobsCancelConfirmation:
             with mock.patch.object(client_sdk,
                                    'stream_and_get',
                                    return_value=mock_result):
-                with mock.patch.object(click, 'confirm', side_effect=capture_confirm):
-                    with mock.patch.object(managed_jobs, 'cancel',
+                with mock.patch.object(click,
+                                       'confirm',
+                                       side_effect=capture_confirm):
+                    with mock.patch.object(managed_jobs,
+                                           'cancel',
                                            return_value='cancel-request-id'):
                         # Invoke jobs_cancel with job_ids
                         runner = click.testing.CliRunner()
@@ -793,8 +796,11 @@ class TestJobsCancelConfirmation:
             with mock.patch.object(client_sdk,
                                    'stream_and_get',
                                    return_value=mock_result):
-                with mock.patch.object(click, 'confirm', side_effect=capture_confirm):
-                    with mock.patch.object(managed_jobs, 'cancel',
+                with mock.patch.object(click,
+                                       'confirm',
+                                       side_effect=capture_confirm):
+                    with mock.patch.object(managed_jobs,
+                                           'cancel',
                                            return_value='cancel-request-id'):
                         try:
                             command.jobs_cancel.callback(
@@ -826,11 +832,14 @@ class TestJobsCancelConfirmation:
         with mock.patch.object(cli_utils,
                                'get_managed_job_queue',
                                side_effect=Exception('Query failed')):
-            with mock.patch.object(click, 'confirm', side_effect=capture_confirm):
+            with mock.patch.object(click,
+                                   'confirm',
+                                   side_effect=capture_confirm):
                 with mock.patch.object(client_sdk,
                                        'stream_and_get',
                                        return_value=None):
-                    with mock.patch.object(managed_jobs, 'cancel',
+                    with mock.patch.object(managed_jobs,
+                                           'cancel',
                                            return_value='cancel-request-id'):
                         try:
                             command.jobs_cancel.callback(

--- a/tests/unit_tests/test_sky/test_cli_helpers.py
+++ b/tests/unit_tests/test_sky/test_cli_helpers.py
@@ -705,3 +705,145 @@ def test_natural_order_group_list_commands_hides_aliases_and_hidden():
     group.add_command(other_cmd, name='other')
 
     assert group.list_commands(ctx=None) == ['volumes', 'other']
+
+
+class TestJobsCancelConfirmation:
+    """Tests for jobs cancel confirmation message with job names."""
+
+    def test_jobs_cancel_shows_job_names_in_confirmation(self):
+        """Test that jobs cancel confirmation shows job names."""
+        # Create mock managed job records
+        mock_job_1 = responses.ManagedJobRecord(
+            job_id=1,
+            job_name='my-training-job',
+            status=managed_jobs.ManagedJobStatus.RUNNING,
+        )
+        mock_job_2 = responses.ManagedJobRecord(
+            job_id=2,
+            job_name='my-inference-job',
+            status=managed_jobs.ManagedJobStatus.RUNNING,
+        )
+
+        managed_jobs_list = [mock_job_1, mock_job_2]
+        mock_result = (managed_jobs_list, 2, {}, 0)
+
+        request_id = 'test-request-id'
+        captured_confirm_message = None
+
+        def capture_confirm(message, **kwargs):
+            nonlocal captured_confirm_message
+            captured_confirm_message = message
+            # Don't abort, just return
+            return True
+
+        with mock.patch.object(cli_utils,
+                               'get_managed_job_queue',
+                               return_value=(request_id, None)):
+            with mock.patch.object(client_sdk,
+                                   'stream_and_get',
+                                   return_value=mock_result):
+                with mock.patch.object(click, 'confirm', side_effect=capture_confirm):
+                    with mock.patch.object(managed_jobs, 'cancel',
+                                           return_value='cancel-request-id'):
+                        # Invoke jobs_cancel with job_ids
+                        runner = click.testing.CliRunner()
+                        # We need to test the internal logic, so call the function directly
+                        # with mocked dependencies
+                        try:
+                            command.jobs_cancel.callback(
+                                job_ids=(1, 2),
+                                name=None,
+                                pool=None,
+                                all=False,
+                                all_users=False,
+                                yes=False,
+                            )
+                        except SystemExit:
+                            pass  # click.confirm may raise SystemExit
+
+        # Verify the confirmation message contains job names
+        assert captured_confirm_message is not None
+        assert '1 (my-training-job)' in captured_confirm_message
+        assert '2 (my-inference-job)' in captured_confirm_message
+        assert 'managed jobs:' in captured_confirm_message
+
+    def test_jobs_cancel_shows_only_id_when_job_has_no_name(self):
+        """Test that jobs without names show only the ID."""
+        # Create mock job without a name
+        mock_job = responses.ManagedJobRecord(
+            job_id=1,
+            job_name=None,
+            status=managed_jobs.ManagedJobStatus.RUNNING,
+        )
+
+        managed_jobs_list = [mock_job]
+        mock_result = (managed_jobs_list, 1, {}, 0)
+
+        request_id = 'test-request-id'
+        captured_confirm_message = None
+
+        def capture_confirm(message, **kwargs):
+            nonlocal captured_confirm_message
+            captured_confirm_message = message
+            return True
+
+        with mock.patch.object(cli_utils,
+                               'get_managed_job_queue',
+                               return_value=(request_id, None)):
+            with mock.patch.object(client_sdk,
+                                   'stream_and_get',
+                                   return_value=mock_result):
+                with mock.patch.object(click, 'confirm', side_effect=capture_confirm):
+                    with mock.patch.object(managed_jobs, 'cancel',
+                                           return_value='cancel-request-id'):
+                        try:
+                            command.jobs_cancel.callback(
+                                job_ids=(1,),
+                                name=None,
+                                pool=None,
+                                all=False,
+                                all_users=False,
+                                yes=False,
+                            )
+                        except SystemExit:
+                            pass
+
+        # Verify the confirmation message shows just the ID (no parentheses)
+        assert captured_confirm_message is not None
+        assert 'managed job: 1' in captured_confirm_message
+        assert '(' not in captured_confirm_message
+
+    def test_jobs_cancel_falls_back_on_query_failure(self):
+        """Test that jobs cancel falls back to IDs when query fails."""
+        request_id = 'test-request-id'
+        captured_confirm_message = None
+
+        def capture_confirm(message, **kwargs):
+            nonlocal captured_confirm_message
+            captured_confirm_message = message
+            return True
+
+        with mock.patch.object(cli_utils,
+                               'get_managed_job_queue',
+                               side_effect=Exception('Query failed')):
+            with mock.patch.object(click, 'confirm', side_effect=capture_confirm):
+                with mock.patch.object(client_sdk,
+                                       'stream_and_get',
+                                       return_value=None):
+                    with mock.patch.object(managed_jobs, 'cancel',
+                                           return_value='cancel-request-id'):
+                        try:
+                            command.jobs_cancel.callback(
+                                job_ids=(1, 2),
+                                name=None,
+                                pool=None,
+                                all=False,
+                                all_users=False,
+                                yes=False,
+                            )
+                        except SystemExit:
+                            pass
+
+        # Verify the confirmation message falls back to showing just IDs
+        assert captured_confirm_message is not None
+        assert 'managed jobs with IDs 1,2' in captured_confirm_message


### PR DESCRIPTION
## Summary

Fixes #8336

When cancelling managed jobs by ID, the confirmation message now includes the job names so users can verify they're cancelling the correct jobs.

## Before/After

| Before | After |
|--------|-------|
| `Cancelling managed jobs with IDs 13, 15. Proceed?` | `Cancelling managed jobs: 13 (my-training-job), 15 (data-proc). Proceed?` |

## Implementation

When job IDs are provided:
1. Query the jobs controller to fetch job names for the specified IDs
2. Format each job as `ID (name)` in the confirmation message
3. If the query fails (e.g., controller is down), fall back to showing just the IDs

## Test Plan

```bash
# Create a test job
sky jobs launch -n test-job -- echo hello

# Try to cancel it - confirmation should show the name
sky jobs cancel 1
# Expected: "Cancelling managed job: 1 (test-job). Proceed?"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)