### PR TITLE
Fix flaky `test_job_pipeline`

### DIFF
--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -314,7 +314,7 @@ _WAIT_UNTIL_PIPELINE_TASK_STATUS = (
     'fi; '
     's=$(sky jobs queue); echo "$s"; '
     'task_status=$(echo "$s" | grep -A 4 {job_name} | sed -n {task_line}p); '
-    'if echo "$task_status" | grep -q "{expected_status}"; then '
+    'if echo "$task_status" | grep -E -q "{expected_status}"; then '
     '  echo "Task {task_line} reached status {expected_status}."; break; '
     'fi; '
     'echo "Waiting for task {task_line} to be {expected_status}, current: $task_status"; '

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -196,6 +196,8 @@ def test_job_pipeline(generic_cloud: str):
                 # Wait for tasks to transition to CANCELLING/CANCELLED with retry logic
                 # to avoid flakiness. Use a reasonable timeout (60s) to allow for
                 # cancellation to propagate, especially on slower clouds like Kubernetes.
+                # Note: task_line corresponds to the line number in grep -A 4 output:
+                # line 1 = job header, line 2 = task 0, line 3 = task 1, line 4 = task 2, line 5 = task 3
                 smoke_tests_utils.get_cmd_wait_until_pipeline_task_status(
                     job_name=name,
                     task_line=2,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

When we are testing via remote server, the job pipeline might not transition as fast as expected. Use event-based waiting instead of time-based waiting.
 https://buildkite.com/skypilot-1/nightly-build-shared-gke-api-server/builds/82#019b5639-3ff7-499f-8609-1aac34bef4bb

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
