### PR TITLE
Show (SA) suffix for service account users in sky api status

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -6765,7 +6765,11 @@ def api_status(request_id_prefixes: Optional[List[str]], all_status: bool,
             if not verbose:
                 r_id = common_utils.truncate_long_string(r_id, 36)
             req_status = requests.RequestStatus(request.status)
-            row = [r_id, request.user_name, request.name]
+            # Append (SA) suffix for service account users
+            user_display = request.user_name
+            if request.user_id.lower().startswith('sa-'):
+                user_display = f'{request.user_name} (SA)'
+            row = [r_id, user_display, request.name]
             if verbose:
                 row.append(request.cluster_name)
             row.extend([


### PR DESCRIPTION
## Summary
- Display "(SA)" suffix next to usernames for service account users in `sky api status` output
- Service accounts are identified by their user_id starting with 'sa-'

## Before
```
sky api status -a
ID                                    User           Name                                 Created     Status
yyy-yyy skypilot-team  sky.core.status                    5 mins ago  SUCCEEDED
```

## After
```
sky api status -a
ID                                    User              Name                                 Created     Status
yyy-yyy skypilot-team (SA)  sky.core.status                    5 mins ago  SUCCEEDED
```

## Test plan
- [ ] Verify service account users show "(SA)" suffix
- [ ] Verify regular users don't show the suffix
- [ ] Test both verbose and non-verbose modes

Fixes #8369

🤖 Generated with [Claude Code](https://claude.com/claude-code)