### PR TITLE
Show error messages when API requests fail in dashboard

### DIFF
--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -1004,8 +1004,10 @@ export function ClusterTable({
                         <span className="font-medium">Error: </span>
                         {fetchError}
                       </div>
+                    ) : showHistory ? (
+                      'No clusters found'
                     ) : (
-                      showHistory ? 'No clusters found' : 'No active clusters'
+                      'No active clusters'
                     )}
                   </TableCell>
                 </TableRow>

--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -593,6 +593,7 @@ export function ClusterTable({
   const [isInitialLoad, setIsInitialLoad] = useState(true);
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
+  const [fetchError, setFetchError] = useState(null);
 
   const fetchOptionValuesFromClusters = (clusters) => {
     let optionValues = {
@@ -623,6 +624,7 @@ export function ClusterTable({
   const fetchData = React.useCallback(async () => {
     setLoading(true);
     setLocalLoading(true);
+    setFetchError(null);
 
     try {
       // Use cached data if available, which should have been preloaded by cache preloader
@@ -675,6 +677,7 @@ export function ClusterTable({
       }
     } catch (error) {
       console.error('Error fetching cluster data:', error);
+      setFetchError(error.message || 'Failed to fetch cluster data');
       setOptionValues(fetchOptionValuesFromClusters([]));
       setData([]);
     }
@@ -996,7 +999,14 @@ export function ClusterTable({
                     colSpan={9}
                     className="text-center py-6 text-gray-500"
                   >
-                    {showHistory ? 'No clusters found' : 'No active clusters'}
+                    {fetchError ? (
+                      <div className="text-red-500">
+                        <span className="font-medium">Error: </span>
+                        {fetchError}
+                      </div>
+                    ) : (
+                      showHistory ? 'No clusters found' : 'No active clusters'
+                    )}
                   </TableCell>
                 </TableRow>
               )}

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -367,6 +367,7 @@ export function ManagedJobsTable({
   const [isRestarting, setIsRestarting] = useState(false);
   const [activeTab, setActiveTab] = useState('all');
   const [showAllMode, setShowAllMode] = useState(true);
+  const [fetchError, setFetchError] = useState(null);
   const [confirmationModal, setConfirmationModal] = useState({
     isOpen: false,
     title: '',
@@ -425,6 +426,7 @@ export function ManagedJobsTable({
       requestSeqRef.current = version;
       setLocalLoading(true);
       setLoading(true); // Set parent loading state
+      setFetchError(null);
       try {
         // Build server-side filter params from UI filters
         const getFilterValue = (prop) => {
@@ -531,6 +533,7 @@ export function ManagedJobsTable({
         console.error('Error fetching data:', err);
         // Still set data to empty array on error to show proper UI
         if (version === requestSeqRef.current) {
+          setFetchError(err.message || 'Failed to fetch jobs data');
           setData([]);
           setControllerStopped(false);
           setIsInitialLoad(false);
@@ -1268,7 +1271,14 @@ export function ManagedJobsTable({
                         </div>
                       )}
                       {!controllerStopped && !controllerLaunching && (
-                        <p className="text-gray-500">No active jobs</p>
+                        fetchError ? (
+                          <div className="text-red-500">
+                            <span className="font-medium">Error: </span>
+                            {fetchError}
+                          </div>
+                        ) : (
+                          <p className="text-gray-500">No active jobs</p>
+                        )
                       )}
                       {/* Desktop controller stopped message stays in table */}
                       {!isMobile && controllerStopped && (
@@ -1748,7 +1758,14 @@ export function ClusterJobs({
                   colSpan={8}
                   className="text-center py-6 text-gray-500"
                 >
-                  No jobs found
+                  {fetchError ? (
+                    <div className="text-red-500">
+                      <span className="font-medium">Error: </span>
+                      {fetchError}
+                    </div>
+                  ) : (
+                    'No jobs found'
+                  )}
                 </TableCell>
               </TableRow>
             )}

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -1270,16 +1270,16 @@ export function ManagedJobsTable({
                           </div>
                         </div>
                       )}
-                      {!controllerStopped && !controllerLaunching && (
-                        fetchError ? (
+                      {!controllerStopped &&
+                        !controllerLaunching &&
+                        (fetchError ? (
                           <div className="text-red-500">
                             <span className="font-medium">Error: </span>
                             {fetchError}
                           </div>
                         ) : (
                           <p className="text-gray-500">No active jobs</p>
-                        )
-                      )}
+                        ))}
                       {/* Desktop controller stopped message stays in table */}
                       {!isMobile && controllerStopped && (
                         <div className="flex flex-col items-center space-y-3 px-4">

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -1513,6 +1513,7 @@ export function ClusterJobs({
   userFilter = null,
   nameFilter = null,
   workspace = 'default',
+  fetchError = null,
 }) {
   const [expandedRowId, setExpandedRowId] = useState(null);
   const [sortConfig, setSortConfig] = useState({

--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -332,6 +332,7 @@ export function useClusterDetails({ cluster, job = null }) {
   const [clusterJobData, setClusterJobData] = useState(null);
   const [loadingClusterData, setLoadingClusterData] = useState(true);
   const [loadingClusterJobData, setLoadingClusterJobData] = useState(true);
+  const [clusterJobError, setClusterJobError] = useState(null);
 
   // Separate loading states - cluster details vs cluster jobs
   const clusterDetailsLoading = loadingClusterData;
@@ -367,6 +368,7 @@ export function useClusterDetails({ cluster, job = null }) {
       if (cluster) {
         try {
           setLoadingClusterJobData(true);
+          setClusterJobError(null);
           // Use dashboard cache for cluster jobs
           const data = await dashboardCache.get(getClusterJobs, [
             {
@@ -377,6 +379,7 @@ export function useClusterDetails({ cluster, job = null }) {
           setClusterJobData(data);
         } catch (error) {
           console.error('Error fetching cluster job data:', error);
+          setClusterJobError(error.message || 'Failed to fetch cluster jobs');
         } finally {
           setLoadingClusterJobData(false);
         }
@@ -429,6 +432,7 @@ export function useClusterDetails({ cluster, job = null }) {
   return {
     clusterData,
     clusterJobData,
+    clusterJobError,
     loading: clusterDetailsLoading, // Only cluster details loading for initial page render
     clusterDetailsLoading,
     clusterJobsLoading,

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -77,6 +77,7 @@ function ClusterDetails() {
   const {
     clusterData,
     clusterJobData,
+    clusterJobError,
     loading,
     clusterDetailsLoading,
     clusterJobsLoading,
@@ -853,6 +854,7 @@ function ActiveTab({
             loading={clusterJobsLoading}
             refreshClusterJobsOnly={refreshClusterJobsOnly}
             workspace={clusterData.workspace}
+            fetchError={clusterJobError}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary

Fixes #8371

When API requests fail in the dashboard, users previously saw misleading messages like "No active clusters" or "No active jobs" even when the actual problem was an API error. This PR adds proper error handling to display the actual error message to users.

### Changes:
- **clusters.jsx**: Added `fetchError` state to track API errors and display them instead of "No active clusters" message
- **jobs.jsx**: Added `fetchError` state to track API errors and display them instead of "No active managed jobs" message

### Before:
When API fails, user sees "No active clusters" / "No active managed jobs" (misleading)

### After:
When API fails, user sees "Error: [actual error message]" (helpful for debugging)

## Test plan
- [ ] Test with API server running - verify normal cluster/job data displays correctly
- [ ] Test with API server down - verify error message is shown instead of "No active..." message
- [ ] Test error recovery - verify data loads correctly after API server comes back up

🤖 Generated with [Claude Code](https://claude.com/claude-code)