### PR TITLE
Fix duplicate config mismatch warning messages

### DIFF
--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -149,6 +149,10 @@ class ConfigContext:
 _active_workspace_context = threading.local()
 _global_config_context = ConfigContext()
 
+# Track config keys that have already been warned about to avoid duplicate
+# warnings when override_skypilot_config is called multiple times.
+_warned_config_keys: set = set()
+
 SKYPILOT_CONFIG_LOCK_PATH = '~/.sky/locks/.skypilot_config.lock'
 
 
@@ -730,9 +734,13 @@ def override_skypilot_config(
             disallowed_diff_keys.append('.'.join(key))
     # Only warn if there is a diff in disallowed override keys, as the client
     # use the same config file when connecting to a local server.
-    if disallowed_diff_keys:
+    # Filter out keys that have already been warned about to avoid duplicate
+    # warnings when this context manager is called multiple times.
+    new_diff_keys = [k for k in disallowed_diff_keys if k not in _warned_config_keys]
+    if new_diff_keys:
+        _warned_config_keys.update(new_diff_keys)
         logger.warning(
-            f'The following keys ({json.dumps(disallowed_diff_keys)}) have '
+            f'The following keys ({json.dumps(new_diff_keys)}) have '
             'different values in the client SkyPilot config with the server '
             'and will be ignored. Remove these keys to disable this warning. '
             'If you want to specify it, please modify it on server side or '


### PR DESCRIPTION
## Summary
Fix duplicate config mismatch warning messages that appear multiple times during a single command execution.

## Problem
When using commands like `sky show-gpus --infra k8s` or `sky exec`, the following warning appears twice:
```
The following keys (["allowed_clouds"]) have different values in the client SkyPilot config with the server and will be ignored...
```

## Solution
Add a module-level set `_warned_config_keys` to track which config keys have already been warned about. When `override_skypilot_config()` is called multiple times during a single command, only warn about new keys that haven't been warned about before.

Fixes #7874

## Test plan
- [x] Verified import works correctly
- [ ] Manual testing with mismatched config

🤖 Generated with [Claude Code](https://claude.com/claude-code)