### PR TITLE
Fix Docker network duplicate error when using --network=host

### DIFF
--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -149,10 +149,9 @@ def docker_start_cmds(
 
     # Check if network option is already specified in user_options to avoid
     # "network host is specified multiple times" error.
-    has_network_option = any(opt.startswith('--net=') or
-                              opt.startswith('--network=') or
-                              opt == '--net' or opt == '--network'
-                              for opt in user_options)
+    has_network_option = any(
+        opt.startswith('--net=') or opt.startswith('--network=') or
+        opt == '--net' or opt == '--network' for opt in user_options)
     user_options_str = ' '.join(user_options)
     docker_run = [
         docker_cmd,

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -147,6 +147,13 @@ def docker_start_cmds(
     env_flags = ' '.join(
         ['-e {name}={val}'.format(name=k, val=v) for k, v in env_vars.items()])
 
+    # Check if network option is already specified in user_options to avoid
+    # "network host is specified multiple times" error.
+    has_network_option = any(
+        opt.startswith('--net=') or opt.startswith('--network=') or
+        opt == '--net' or opt == '--network'
+        for opt in user_options
+    )
     user_options_str = ' '.join(user_options)
     docker_run = [
         docker_cmd,
@@ -158,14 +165,18 @@ def docker_start_cmds(
         '-it',
         env_flags,
         user_options_str,
-        '--net=host',
+    ]
+    # Only add --net=host if not already specified in user options
+    if not has_network_option:
+        docker_run.append('--net=host')
+    docker_run.extend([
         # SkyPilot: Add following options to enable fuse.
         '--cap-add=SYS_ADMIN',
         '--device=/dev/fuse',
         '--security-opt=apparmor:unconfined',
         '--entrypoint=/bin/bash',
         image,
-    ]
+    ])
     return ' '.join(docker_run)
 
 

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -149,11 +149,10 @@ def docker_start_cmds(
 
     # Check if network option is already specified in user_options to avoid
     # "network host is specified multiple times" error.
-    has_network_option = any(
-        opt.startswith('--net=') or opt.startswith('--network=') or
-        opt == '--net' or opt == '--network'
-        for opt in user_options
-    )
+    has_network_option = any(opt.startswith('--net=') or
+                              opt.startswith('--network=') or
+                              opt == '--net' or opt == '--network'
+                              for opt in user_options)
     user_options_str = ' '.join(user_options)
     docker_run = [
         docker_cmd,


### PR DESCRIPTION
## Summary
Fix the error "docker: network host is specified multiple times" that occurs when users specify `--network=host` in their docker run_options configuration.

## Problem
The `docker_start_cmds()` function always adds `--net=host` to the docker run command. If users specify `--network=host` in their configuration, Docker fails with:
```
docker: network "host" is specified multiple times.
See 'docker run --help'.
```

## Solution
Check if a network option (`--net=` or `--network=`) is already specified in user_options before adding `--net=host`.

Fixes #7139

## Test plan
- [x] Verified import works correctly
- [ ] Manual testing with `--network=host` in config

🤖 Generated with [Claude Code](https://claude.com/claude-code)