### PR TITLE
Fix show-gpus assertion error during k8s cluster scaling

### DIFF
--- a/sky/core.py
+++ b/sky/core.py
@@ -1346,9 +1346,9 @@ def realtime_kubernetes_gpu_availability(
         # information, to avoid assertion errors and show only reliable data.
         common_keys = set(counts.keys()) & set(capacity.keys()) & set(
             available.keys())
-        counts = {k: v for k, v in counts.items() if k in common_keys}
-        capacity = {k: v for k, v in capacity.items() if k in common_keys}
-        available = {k: v for k, v in available.items() if k in common_keys}
+        counts = {k: counts[k] for k in common_keys}
+        capacity = {k: capacity[k] for k in common_keys}
+        available = {k: available[k] for k in common_keys}
         realtime_gpu_availability_list: List[
             models.RealtimeGpuAvailability] = []
 


### PR DESCRIPTION
## Summary
Fix the `AssertionError: Keys of counts ([]), capacity ([]), and available (['L4']) must be the same` error that occurs during Kubernetes cluster GPU node pool scaling.

## Problem
When scaling a GKE cluster GPU node pool, `sky show-gpus --infra k8s` fails with:
```
AssertionError: Keys of counts ([]), capacity ([]), and available (['L4']) must be the same.
```

This happens because during scaling:
- Nodes exist but may have `NotReady` status
- GPUs are detected in capacity but filtering removes them from counts
- The three dictionaries end up with different keys

## Solution
Instead of asserting that all three dictionaries have identical keys, use the intersection of keys to show only GPUs with complete information. This makes the command work reliably during cluster scaling operations.

Fixes #7100

## Test plan
- [x] Verified import works correctly
- [ ] Manual testing during k8s cluster scaling

🤖 Generated with [Claude Code](https://claude.com/claude-code)