### PR TITLE
Add support for GCP G4 instances with RTX PRO 6000 GPUs

### DIFF
--- a/sky/catalog/gcp_catalog.py
+++ b/sky/catalog/gcp_catalog.py
@@ -128,6 +128,12 @@ _ACC_INSTANCE_TYPE_DICTS = {
     'B200': {
         8: ['a4-highgpu-8g'],
     },
+    'RTX-PRO-6000': {
+        1: ['g4-standard-48'],
+        2: ['g4-standard-96'],
+        4: ['g4-standard-192'],
+        8: ['g4-standard-384'],
+    },
 }
 # Enable GPU type inference from instance types
 _INSTANCE_TYPE_TO_ACC = {


### PR DESCRIPTION
## Summary
- Adds support for the new GCP G4 VM instances powered by NVIDIA RTX PRO 6000 Blackwell Server Edition GPUs
- G4 instances support 1, 2, 4, and 8 GPU configurations with g4-standard-{48,96,192,384} instance types
- The RTX PRO 6000 GPU has 96GB GDDR7 memory

## Changes
- Add g4 series to `SERIES_TO_DESCRIPTION` in `fetch_gcp.py`
- Add RTX-PRO-6000 GPU processing with valid GPU count validation
- Add RTX-PRO-6000 GPU memory info (96GB GDDR7)
- Add GPU price matching descriptions for RTX PRO 6000 SKUs
- Set G4 VM CPU/RAM price to 0 (pricing is bundled into GPU pricing, similar to A4 instances)
- Add RTX-PRO-6000 instance type mappings in `gcp_catalog.py`

## Test plan
- [ ] Run the GCP catalog fetcher to verify G4 instances and RTX-PRO-6000 GPUs are correctly recognized
- [ ] Verify `sky show-gpus --cloud gcp` includes RTX-PRO-6000
- [ ] Test launching a G4 instance when available in a region

Fixes #8428

🤖 Generated with [Claude Code](https://claude.com/claude-code)