### PR TITLE
feat: add default/global labels to all objects in the chart

### DIFF
--- a/charts/skypilot/templates/api-configmap.yaml
+++ b/charts/skypilot/templates/api-configmap.yaml
@@ -3,6 +3,12 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-config
   namespace: {{ .Release.Namespace }}
+  labels:
+    tier: skypilot
+    component: skypilot-api-cm
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 data:
   config.yaml: |-
     {{- if .Values.apiService.config }}

--- a/charts/skypilot/templates/api-dashboard-grafana-configmap.yaml
+++ b/charts/skypilot/templates/api-dashboard-grafana-configmap.yaml
@@ -7,6 +7,11 @@ metadata:
   labels:
     app: {{ .Release.Name }}-api
     grafana_dashboard: "true"
+    tier: skypilot
+    component: skypilot-api-grafana-dashboard-cm
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 data:
   api-server-overview.json: |
 {{ .Files.Get "manifests/api-server-overview.json" | indent 4 }}

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -3,6 +3,12 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}-api-server
   namespace: {{ .Release.Namespace }}
+  labels:
+    tier: skypilot
+    component: skypilot-api
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   # Note: replicas > 1 is not well tested.
   replicas: {{ .Values.apiService.replicas }}

--- a/charts/skypilot/templates/api-secrets.yaml
+++ b/charts/skypilot/templates/api-secrets.yaml
@@ -5,6 +5,12 @@ kind: Secret
 metadata:
   name: {{ .Release.Name }}-ssh-node-pools
   namespace: {{ .Release.Namespace }}
+  labels:
+    tier: skypilot
+    component: skypilot-api-secrets
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 stringData:
   ssh_node_pools.yaml: |
 {{ .Values.apiService.sshNodePools | indent 4 }} 

--- a/charts/skypilot/templates/api-service.yaml
+++ b/charts/skypilot/templates/api-service.yaml
@@ -3,6 +3,12 @@ kind: Service
 metadata:
   name: {{ .Release.Name }}-api-service
   namespace: {{ .Release.Namespace }}
+  labels:
+    tier: skypilot
+    component: skypilot-api-svc
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: ClusterIP  # Use clusterIP to allow ingress to authenticate
   ports:

--- a/charts/skypilot/templates/auth.yaml
+++ b/charts/skypilot/templates/auth.yaml
@@ -4,6 +4,12 @@ kind: Secret
 metadata:
   name: {{ .Release.Name }}-basic-auth
   namespace: {{ .Release.Namespace }}
+  labels:
+    tier: skypilot
+    component: skypilot-ingress-authcredentials-secret
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 type: Opaque
 stringData:
   auth: {{ .Values.ingress.authCredentials | quote }}

--- a/charts/skypilot/templates/datasource.yaml
+++ b/charts/skypilot/templates/datasource.yaml
@@ -7,6 +7,11 @@ metadata:
   labels:
     app: {{ .Release.Name }}-api
     grafana_datasource: "true"
+    tier: skypilot
+    component: skypilot-datasource-cm
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 data:
   prometheus.yaml: |-
     apiVersion: 1

--- a/charts/skypilot/templates/db-secrets.yaml
+++ b/charts/skypilot/templates/db-secrets.yaml
@@ -9,6 +9,12 @@ kind: Secret
 metadata:
   name: {{ .Release.Name }}-db-connection
   namespace: {{ .Release.Namespace }}
+  labels:
+    tier: skypilot
+    component: skypilot-dbconnection-secret
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 type: Opaque
 stringData:
   connection_string: {{ .Values.apiService.dbConnectionString }}

--- a/charts/skypilot/templates/dcgm-cluster-dashboard-grafana-configmap.yaml
+++ b/charts/skypilot/templates/dcgm-cluster-dashboard-grafana-configmap.yaml
@@ -7,6 +7,11 @@ metadata:
   labels:
     app: {{ .Release.Name }}-api
     grafana_dashboard: "true"
+    tier: skypilot
+    component: skypilot-dcgm-cluster-dashboard
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 data:
   dcgm-cluster-dashboard.json: |
 {{ .Files.Get "manifests/dcgm-cluster-dashboard.json" | indent 4 }}

--- a/charts/skypilot/templates/dcgm-cluster-filtering-dashboard-grafana-configmap.yaml
+++ b/charts/skypilot/templates/dcgm-cluster-filtering-dashboard-grafana-configmap.yaml
@@ -7,6 +7,11 @@ metadata:
   labels:
     app: {{ .Release.Name }}-api
     grafana_dashboard: "true"
+    tier: skypilot
+    component: skypilot-dcgm-cluster-filtering-dashboard
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 data:
   dcgm-skycluster-dashboard.json: |
 {{ .Files.Get "manifests/dcgm-cluster-filter-dashboard.json" | indent 4 }}

--- a/charts/skypilot/templates/dcgm-prometheus-scrape-service.yaml
+++ b/charts/skypilot/templates/dcgm-prometheus-scrape-service.yaml
@@ -6,6 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-dcgm-exporter
+    tier: skypilot
+    component: skypilot-dcgm-exporter
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9400"

--- a/charts/skypilot/templates/grafana-ingress.yaml
+++ b/charts/skypilot/templates/grafana-ingress.yaml
@@ -4,6 +4,12 @@ kind: Ingress
 metadata:
   name: {{ .Release.Name }}-grafana-authed
   namespace: {{ .Release.Namespace }}
+  labels:
+    tier: skypilot
+    component: skypilot-grafana-ingress
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     {{- if or .Values.auth.oauth.enabled (and .Values.ingress.enabled (index .Values.ingress "oauth2-proxy" "enabled")) }}
     # OAuth2 Proxy authentication for browser-based access

--- a/charts/skypilot/templates/ingress.yaml
+++ b/charts/skypilot/templates/ingress.yaml
@@ -9,6 +9,12 @@ kind: Ingress
 metadata:
   name: {{ .Release.Name }}-ingress
   namespace: {{ .Release.Namespace }}
+  labels:
+    tier: skypilot
+    component: skypilot-ingress
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     {{- if not $useNewIngressClass }}
     kubernetes.io/ingress.class: {{ .Values.ingress.ingressClassName }}

--- a/charts/skypilot/templates/initial-auth.yaml
+++ b/charts/skypilot/templates/initial-auth.yaml
@@ -4,6 +4,12 @@ kind: Secret
 metadata:
   name: {{ .Release.Name }}-initial-basic-auth
   namespace: {{ .Release.Namespace }}
+  labels:
+    tier: skypilot
+    component: skypilot-initial-basic-auth
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 type: Opaque
 stringData:
   auth: {{ .Values.apiService.initialBasicAuthCredentials | quote }}

--- a/charts/skypilot/templates/oauth2-proxy-deployment.yaml
+++ b/charts/skypilot/templates/oauth2-proxy-deployment.yaml
@@ -45,6 +45,10 @@ metadata:
   labels:
     app: {{ .Release.Name }}-oauth2-proxy
     skypilot.co/component: oauth2-proxy
+    tier: skypilot
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ .Release.Name }}-oauth2-proxy
   namespace: {{ .Release.Namespace }}
 spec:
@@ -57,6 +61,10 @@ spec:
       labels:
         app: {{ .Release.Name }}-oauth2-proxy
         skypilot.co/component: oauth2-proxy
+        tier: skypilot
+        {{- with .Values.global.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/skypilot/templates/oauth2-proxy-ingress.yaml
+++ b/charts/skypilot/templates/oauth2-proxy-ingress.yaml
@@ -11,6 +11,11 @@ metadata:
   labels:
     app: {{ .Release.Name }}-oauth2-proxy
     skypilot.co/component: oauth2-proxy
+    tier: skypilot
+    component: skypilot-oauth2-proxy-ingress
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     {{- if not $useNewIngressClass }}
     kubernetes.io/ingress.class: nginx

--- a/charts/skypilot/templates/oauth2-proxy-redis.yaml
+++ b/charts/skypilot/templates/oauth2-proxy-redis.yaml
@@ -12,6 +12,10 @@ metadata:
   labels:
     app: {{ .Release.Name }}-oauth2-proxy-redis
     skypilot.co/component: oauth2-proxy-redis
+    tier: skypilot
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: 1
   selector:
@@ -22,6 +26,10 @@ spec:
       labels:
         app: {{ .Release.Name }}-oauth2-proxy-redis
         skypilot.co/component: oauth2-proxy-redis
+        tier: skypilot
+        {{- with .Values.global.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
@@ -52,6 +60,10 @@ metadata:
   labels:
     app: {{ .Release.Name }}-oauth2-proxy-redis
     skypilot.co/component: oauth2-proxy-redis
+    tier: skypilot
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/skypilot/templates/oauth2-proxy-service.yaml
+++ b/charts/skypilot/templates/oauth2-proxy-service.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app: {{ .Release.Name }}-oauth2-proxy
     skypilot.co/component: oauth2-proxy
+    tier: skypilot
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ .Release.Name }}-oauth2-proxy
   namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/skypilot/templates/pvc.yaml
+++ b/charts/skypilot/templates/pvc.yaml
@@ -4,6 +4,12 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ .Release.Name }}-state
   namespace: {{ .Release.Namespace }}
+  labels:
+    tier: skypilot
+    component: skypilot-pvc
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.storage.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/skypilot/templates/rbac.yaml
+++ b/charts/skypilot/templates/rbac.yaml
@@ -5,6 +5,12 @@ kind: ServiceAccount
 metadata:
   name: {{ include "skypilot.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    tier: skypilot
+    component: skypilot
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- if .Values.rbac.serviceAccountAnnotations }}
   annotations:
     {{- toYaml .Values.rbac.serviceAccountAnnotations | nindent 4 }}
@@ -14,6 +20,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Release.Name }}-api-role
+  labels:
+    tier: skypilot
+    component: skypilot
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 rules:
 {{ toYaml .Values.rbac.clusterRules | indent 2 }}
 {{- if .Values.rbac.manageRbacPolicies }}
@@ -29,6 +41,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Release.Name }}-api-role-binding
+  labels:
+    tier: skypilot
+    component: skypilot
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "skypilot.serviceAccountName" . }}
@@ -48,6 +66,12 @@ kind: Role
 metadata:
   name: {{ .Release.Name }}-api-role
   namespace: {{ $namespace }}
+  labels:
+    tier: skypilot
+    component: skypilot
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 rules:
 {{ toYaml .Values.rbac.namespaceRules | indent 2 }}
 {{- if .Values.rbac.manageRbacPolicies }}
@@ -64,6 +88,12 @@ kind: RoleBinding
 metadata:
   name: {{ .Release.Name }}-api-role-binding
   namespace: {{ $namespace }}
+  labels:
+    tier: skypilot
+    component: skypilot
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "skypilot.serviceAccountName" . }}

--- a/charts/skypilot/templates/system-rbac.yaml
+++ b/charts/skypilot/templates/system-rbac.yaml
@@ -8,6 +8,12 @@ kind: Role
 metadata:
   name: {{ .Release.Name }}-system-role
   namespace: {{ $namespace }}
+  labels:
+    tier: skypilot
+    component: skypilot
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 rules:
   - apiGroups: [ "apps" ]
     resources: [ "daemonsets" ]
@@ -26,6 +32,12 @@ kind: RoleBinding
 metadata:
   name: {{ .Release.Name }}-system-role-binding
   namespace: {{ $namespace }}
+  labels:
+    tier: skypilot
+    component: skypilot
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "skypilot.serviceAccountName" . }}
@@ -41,6 +53,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Release.Name }}-system-cluster-role
+  labels:
+    tier: skypilot
+    component: skypilot
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 rules:
   - apiGroups: [ "" ]
     resources: [ "namespaces" ]
@@ -51,6 +69,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Release.Name }}-system-cluster-role-binding
+  labels:
+    tier: skypilot
+    component: skypilot
+    {{- with .Values.global.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "skypilot.serviceAccountName" . }}

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -355,6 +355,12 @@
                         "string",
                         "null"
                     ]
+                },
+                "labels": {
+                    "type": [
+                        "object",
+                        "null"
+                    ]
                 }
             }
         },

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -9,7 +9,9 @@ global:
   # Specify extra environment variables to set on all components in the chart.
   # @schema type: [array, null]; item: object
   extraEnvs: null
-
+  # Specify global labels to apply to all objects in the chart
+  # @schema type: [object, null]
+  labels: null
 
 apiService:
   # Docker image to use for the API server. The default value will be updated by the release pipeline to be consistent with the SkyPilot release or nightly build.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This change introduces globally setting up labels for all objects in the chart 


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
