### PR TITLE
[AWS] Improve doc and hint for launching clusters with multiple EFA interfaces

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -123,6 +123,7 @@ Below is the configuration syntax and some example values. See detailed explanat
       Owner: user-unique-name
     :ref:`vpc_name <config-yaml-aws-vpc-name>`: skypilot-vpc
     :ref:`use_internal_ips <config-yaml-aws-use-internal-ips>`: true
+    :ref:`use_ssm <config-yaml-aws-use-ssm>`: true
     :ref:`ssh_proxy_command <config-yaml-aws-ssh-proxy-command>`: ssh -W %h:%p user@host
     :ref:`security_group_name <config-yaml-aws-security-group-name>`: my-security-group
     :ref:`disk_encrypted <config-yaml-aws-disk-encrypted>`: false
@@ -681,7 +682,17 @@ Private subnets are defined as those satisfying both of these properties:
      (the ``map_public_ip_on_launch`` attribute is ``false``).
 
 This flag is typically set together with ``vpc_name`` above and
-``ssh_proxy_command`` below.
+``ssh_proxy_command`` or ``use_ssm`` below.
+
+Default: ``false``.
+
+.. _config-yaml-aws-use-ssm:
+
+``aws.use_ssm``
+~~~~~~~~~~~~~~~~
+
+Use SSM to communicate with SkyPilot nodes. This flag is typically set together with ``vpc_name`` and
+``use_internal_ips`` above. This is useful for launching clusters in private VPCs without public IPs, refer to :ref:`aws-ssm` for more details.
 
 Default: ``false``.
 

--- a/examples/aws_efa/README.md
+++ b/examples/aws_efa/README.md
@@ -69,7 +69,7 @@ This section is important for EFA integration:
   - `requests.vpc.amazonaws.com/efa: 4`: Requests 4 EFA devices for the Pod
 
 
-The `vpc.amazonaws.com/efa` resource type is exposed by the AWS EFA device plugin in Kubernetes. 
+The `vpc.amazonaws.com/efa` resource type is exposed by the AWS EFA device plugin in Kubernetes.
 To see how many EFA are available for each instance types that have EFA, see the [Network cards](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#network-cards) list in the Amazon EC2 User Guide.
 
 Check the following table for the GPU and EFA count mapping for AWS instance types:
@@ -192,6 +192,28 @@ sky launch -c efa efa_vm.yaml
 ```
 
 Check the [`efa_vm.yaml`](https://github.com/skypilot-org/skypilot/blob/master/examples/aws_efa/efa_vm.yaml) for the complete SkyPilot cluster yaml configurations.
+
+> **NOTE:** For VMs that support multiple EFA interfaces (e.g., `p4d.24xlarge` with 4 EFA interfaces), you must configure SkyPilot to use internal IPs to access all EFA interfaces.
+>
+> Add the following configuration to `~/.sky/config.yaml`:
+>
+> **Option 1: Using SSH proxy**
+> ```yaml
+> aws:
+>   use_internal_ips: true
+>   vpc_name: <vpc name>
+>   ssh_proxy_command: ssh -W %h:%p -i <ssh key path> -o StrictHostKeyChecking=no <user>@<jump server public ip>
+> ```
+>
+> **Option 2: Using AWS Systems Manager (SSM) Session Manager**
+> ```yaml
+> aws:
+>   use_internal_ips: true
+>   vpc_name: <vpc name>
+>   use_ssm: true
+> ```
+>
+> For more details, refer to the [configuration documentation](https://docs.skypilot.co/en/latest/reference/config.html#aws-use-internal-ips).
 
 ### Benchmark results
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
https://github.com/skypilot-org/skypilot/issues/8391
Improve doc and hint for launching clusters with multiple EFA interfaces

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
