### PR TITLE
[Dashboard] Show hint when no infra is enabled in the infra page

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -25,11 +25,11 @@ import {
 import {
   getWorkspaceInfrastructure,
   getCloudInfrastructure,
-  refreshCloudStatus,
   getContextJobs,
 } from '@/data/connectors/infra';
 import { getClusters } from '@/data/connectors/clusters';
 import { getManagedJobs } from '@/data/connectors/jobs';
+import { apiClient } from '@/data/connectors/client';
 import {
   getSSHNodePools,
   updateSSHNodePools,
@@ -1729,7 +1729,7 @@ export function GPUs() {
       try {
         if (forceRefresh) {
           try {
-            await refreshCloudStatus();
+            await apiClient.fetch('/check', {}, 'POST');
           } catch (error) {
             console.error('Error during sky check refresh:', error);
           }

--- a/sky/dashboard/src/data/connectors/infra.jsx
+++ b/sky/dashboard/src/data/connectors/infra.jsx
@@ -5,28 +5,6 @@ import { apiClient } from '@/data/connectors/client';
 import { getErrorMessageFromResponse } from '@/data/utils';
 import dashboardCache from '@/lib/cache';
 
-let ongoingCheckRefreshPromise = null;
-
-export async function refreshCloudStatus() {
-  if (ongoingCheckRefreshPromise) {
-    console.log('Sky check already in progress, reusing existing promise...');
-    return ongoingCheckRefreshPromise;
-  }
-
-  ongoingCheckRefreshPromise = (async () => {
-    try {
-      return await apiClient.fetch('/check', {}, 'POST');
-    } catch (checkError) {
-      console.error('Error running sky check:', checkError);
-      throw checkError;
-    } finally {
-      ongoingCheckRefreshPromise = null;
-    }
-  })();
-
-  return ongoingCheckRefreshPromise;
-}
-
 export async function getCloudInfrastructure(forceRefresh = false) {
   const { getClusters } = await import('@/data/connectors/clusters');
   const { getManagedJobs } = await import('@/data/connectors/jobs');


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

- Show a hint when no infra is enabled in the infra page
- Check the enabled cloud first before fetching data during manual refresh to ensure fresh data for enabled clouds

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
