### PR TITLE
[Coreweave] Add rack aware scheduling for NVL72 with `network_tier: best`

### DIFF
--- a/examples/coreweave_infiniband/README.md
+++ b/examples/coreweave_infiniband/README.md
@@ -4,6 +4,14 @@
 
 SkyPilot provides the `network_tier: best` configuration option that automatically enables InfiniBand support on CoreWeave Kubernetes clusters. This eliminates the need for manual configuration of `rdma/ib` resources, security contexts and environment variables.
 
+### GB300 NVL72 Rack-Aware Scheduling
+
+For CoreWeave GB300 NVL72 systems, SkyPilot automatically enables **rack-aware scheduling** when `network_tier: best` is set. This ensures that all nodes from the same multi-node job are scheduled onto the same rack with the same NVLink domain, which is required for optimal performance across the shared NVLink fabric.
+
+SkyPilot detects NVL72 clusters by checking for the `ds.coreweave.com/nvlink.domain` node label and automatically configures pod affinity rules to enforce same-rack scheduling. No additional configuration is needed.
+
+See [CoreWeave NVL72 documentation](https://docs.coreweave.com/docs/platform/instances/nvl72#manage-pod-affinity) for more details on NVLink domain placement.
+
 ### InfiniBand on CoreWeave managed Kubernetes clusters
 
 Simply add ``network_tier: best`` to your resources specification:

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -800,6 +800,12 @@ class Kubernetes(clouds.Cloud):
         deploy_vars['k8s_ipc_lock_capability'] = (
             network_type.requires_ipc_lock_capability())
 
+        # CoreWeave NVL72 (GB200/GB300) requires NVLink domain pod affinity
+        # to ensure all pods from the same job are scheduled on the same rack
+        # for optimal NVLink fabric performance.
+        deploy_vars['k8s_coreweave_nvlink_affinity'] = (
+            network_type.requires_nvlink_domain_affinity())
+
         return deploy_vars
 
     @staticmethod
@@ -1172,6 +1178,13 @@ class Kubernetes(clouds.Cloud):
                         if label_key.startswith('nebius.com/'):
                             return (KubernetesHighPerformanceNetworkType.NEBIUS,
                                     '')
+                        # Check for CoreWeave NVL72 (GB200/GB300) by
+                        # detecting the NVLink domain label.
+                        nvlink_label = (
+                            kubernetes_utils.COREWEAVE_NVLINK_DOMAIN_LABEL)
+                        if label_key == nvlink_label:
+                            return (KubernetesHighPerformanceNetworkType.
+                                    COREWEAVE_NVL72, '')
                         if label_key.startswith('ib.coreweave.cloud/'):
                             return (
                                 KubernetesHighPerformanceNetworkType.COREWEAVE,

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -46,6 +46,10 @@ provider:
     # Used to set up the necessary permissions and sidecars.
     fuse_device_required: {{k8s_fuse_device_required}}
 
+    # Boolean flag to indicate if this is a CoreWeave NVL72 cluster (GB200/GB300)
+    # requiring NVLink domain pod affinity for rack-aware scheduling.
+    coreweave_nvlink_affinity: {{k8s_coreweave_nvlink_affinity}}
+
     {% if ephemeral_volume_mounts %}
     ephemeral_volume_specs: {{ephemeral_volume_mounts | tojson}}
     {% endif %}
@@ -1168,7 +1172,7 @@ available_node_types:
               # https://cloud.google.com/kubernetes-engine/docs/concepts/tpus#how_tpus_work
               {{k8s_resource_key}}: {{accelerator_count}}
               {% endif %}
-              {% if k8s_network_type == 'coreweave' %}
+              {% if k8s_network_type in ['coreweave', 'coreweave_nvl72'] %}
               rdma/ib: 1
               {% endif %}
             {% if k8s_resource_key is not none %}
@@ -1177,7 +1181,7 @@ available_node_types:
               {% if k8s_resource_key is not none %}
               {{k8s_resource_key}}: {{accelerator_count}}
               {% endif %}
-              {% if k8s_network_type == 'coreweave' %}
+              {% if k8s_network_type in ['coreweave', 'coreweave_nvl72'] %}
               rdma/ib: 1
               {% endif %}
             {% endif %}


### PR DESCRIPTION
For GB200 and GB300, there is a rack concept for NVL72. The `network_tier: best` should be aware of that: https://docs.coreweave.com/docs/platform/instances/nvl72

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
