### PR TITLE
[Storage/Data] Add per-bucket config options for file_mounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ ARG NEXT_BASE_PATH=/dashboard
 # Install system packages
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y \
-        git gcc rsync sudo patch openssh-server \
+        git build-essential rsync sudo patch openssh-server \
         pciutils nano fuse socat netcat-openbsd curl tini autossh jq logrotate && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -5702,11 +5702,12 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             store = list(storage_obj.stores.values())[0]
             assert store is not None, storage_obj
             if storage_obj.mode == storage_lib.StorageMode.MOUNT:
-                mount_cmd = store.mount_command(dst)
+                mount_cmd = store.mount_command(dst, storage_obj.mount_config)
                 action_message = 'Mounting'
             else:
                 assert storage_obj.mode == storage_lib.StorageMode.MOUNT_CACHED
-                mount_cmd = store.mount_cached_command(dst)
+                mount_cmd = store.mount_cached_command(dst,
+                                                       storage_obj.mount_config)
                 action_message = 'Mounting cached mode'
             src_print = (storage_obj.source
                          if storage_obj.source else storage_obj.name)

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -523,14 +523,13 @@ def get_mount_cached_cmd(
 
     readonly_flag, _ = _get_readonly_flags(mount_config)
 
-    # Determine sequential_upload: per-bucket config overrides global config
-    # Global config default is False (parallel uploads)
+    # Determine sequential_upload: per-bucket config overrides global config.
     # '--transfers 1' guarantees the files written at the local mount point
     # to be uploaded to the backend storage in the order of creation.
-    sequential_upload = skypilot_config.get_nested(
-        ('data', 'mount_cached', 'sequential_upload'), False)
-    if mount_config is not None and mount_config.sequential_upload is not None:
-        sequential_upload = mount_config.sequential_upload
+    sequential_upload = getattr(mount_config, 'sequential_upload', None)
+    if sequential_upload is None:
+        sequential_upload = skypilot_config.get_nested(
+            ('data', 'mount_cached', 'sequential_upload'), False)
     transfers_flag = '--transfers 1 ' if sequential_upload else ''
 
     # when mounting multiple directories with vfs cache mode, it's handled by

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -23,7 +23,7 @@ def _get_readonly_flags(mount_config: Optional['storage.MountConfig']) -> tuple:
     with -o flag (e.g., -o allow_other,ro). The fuse_ro_flag is returned as
     ',ro' to be appended to existing -o options.
     """
-    readonly = mount_config.readonly if mount_config else False
+    readonly = getattr(mount_config, 'readonly', False)
     return ('--read-only ' if readonly else '', ',ro' if readonly else '')
 
 

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -548,14 +548,14 @@ def get_mount_cached_cmd(
         # interval allows for faster detection of new or updated files on the
         # remote, but increases the frequency of metadata lookups.
         f'--allow-other --vfs-cache-mode full --dir-cache-time 10s '
-        f'{readonly_flag}'
+        f'{readonly_flag}{transfers_flag}'
         # '--transfers 1' guarantees the files written at the local mount point
         # to be uploaded to the backend storage in the order of creation.
         # '--vfs-cache-poll-interval' specifies the frequency of how often
         # rclone checks the local mount point for stale objects in cache.
         # '--vfs-write-back' defines the time to write files on remote storage
         # after last use of the file in local mountpoint.
-        f'{transfers_flag}--vfs-cache-poll-interval 10s --vfs-write-back 1s '
+        '--vfs-cache-poll-interval 10s --vfs-write-back 1s '
         # Have rclone evict files if the cache size exceeds 10G.
         # This is to prevent cache from growing too large and
         # using up all the disk space. Note that files that opened

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -15,13 +15,10 @@ if typing.TYPE_CHECKING:
     from sky.data import storage
 
 
-def _get_readonly_flags(
-    mount_config: Optional['storage.MountConfig']
-) -> tuple:
+def _get_readonly_flags(mount_config: Optional['storage.MountConfig']) -> tuple:
     """Returns (rclone_flag, goofys_flag) for readonly mounting."""
     readonly = mount_config.readonly if mount_config else False
-    return ('--read-only ' if readonly else '',
-            '-o ro ' if readonly else '')
+    return ('--read-only ' if readonly else '', '-o ro ' if readonly else '')
 
 
 # Values used to construct mounting commands
@@ -105,10 +102,11 @@ def get_s3_mount_install_cmd() -> str:
 
 
 # pylint: disable=invalid-name
-def get_s3_mount_cmd(bucket_name: str,
-                     mount_path: str,
-                     _bucket_sub_path: Optional[str] = None,
-                     mount_config: Optional['storage.MountConfig'] = None) -> str:
+def get_s3_mount_cmd(
+        bucket_name: str,
+        mount_path: str,
+        _bucket_sub_path: Optional[str] = None,
+        mount_config: Optional['storage.MountConfig'] = None) -> str:
     """Returns a command to mount an S3 bucket (goofys by default, rclone for
     ARM64)"""
     if _bucket_sub_path is None:
@@ -137,12 +135,13 @@ def get_s3_mount_cmd(bucket_name: str,
     return mount_cmd
 
 
-def get_nebius_mount_cmd(nebius_profile_name: str,
-                         bucket_name: str,
-                         endpoint_url: str,
-                         mount_path: str,
-                         _bucket_sub_path: Optional[str] = None,
-                         mount_config: Optional['storage.MountConfig'] = None) -> str:
+def get_nebius_mount_cmd(
+        nebius_profile_name: str,
+        bucket_name: str,
+        endpoint_url: str,
+        mount_path: str,
+        _bucket_sub_path: Optional[str] = None,
+        mount_config: Optional['storage.MountConfig'] = None) -> str:
     """Returns a command to mount Nebius bucket (goofys by default, rclone for
     ARM64)."""
     if _bucket_sub_path is None:
@@ -174,13 +173,14 @@ def get_nebius_mount_cmd(nebius_profile_name: str,
     return mount_cmd
 
 
-def get_coreweave_mount_cmd(cw_credentials_path: str,
-                            coreweave_profile_name: str,
-                            bucket_name: str,
-                            endpoint_url: str,
-                            mount_path: str,
-                            _bucket_sub_path: Optional[str] = None,
-                            mount_config: Optional['storage.MountConfig'] = None) -> str:
+def get_coreweave_mount_cmd(
+        cw_credentials_path: str,
+        coreweave_profile_name: str,
+        bucket_name: str,
+        endpoint_url: str,
+        mount_path: str,
+        _bucket_sub_path: Optional[str] = None,
+        mount_config: Optional['storage.MountConfig'] = None) -> str:
     """Returns a command to mount CoreWeave bucket"""
     if _bucket_sub_path is None:
         _bucket_sub_path = ''
@@ -232,10 +232,11 @@ def get_gcs_mount_install_cmd() -> str:
 
 
 # pylint: disable=invalid-name
-def get_gcs_mount_cmd(bucket_name: str,
-                      mount_path: str,
-                      _bucket_sub_path: Optional[str] = None,
-                      mount_config: Optional['storage.MountConfig'] = None) -> str:
+def get_gcs_mount_cmd(
+        bucket_name: str,
+        mount_path: str,
+        _bucket_sub_path: Optional[str] = None,
+        mount_config: Optional['storage.MountConfig'] = None) -> str:
     """Returns a command to mount a GCS bucket using gcsfuse."""
     bucket_sub_path_arg = f'--only-dir {_bucket_sub_path} '\
         if _bucket_sub_path else ''
@@ -329,12 +330,13 @@ def get_az_mount_install_cmd() -> str:
 
 
 # pylint: disable=invalid-name
-def get_az_mount_cmd(container_name: str,
-                     storage_account_name: str,
-                     mount_path: str,
-                     storage_account_key: Optional[str] = None,
-                     _bucket_sub_path: Optional[str] = None,
-                     mount_config: Optional['storage.MountConfig'] = None) -> str:
+def get_az_mount_cmd(
+        container_name: str,
+        storage_account_name: str,
+        mount_path: str,
+        storage_account_key: Optional[str] = None,
+        _bucket_sub_path: Optional[str] = None,
+        mount_config: Optional['storage.MountConfig'] = None) -> str:
     """Returns a command to mount an AZ Container using blobfuse2.
 
     Args:
@@ -412,13 +414,14 @@ def get_az_mount_cmd(container_name: str,
 
 
 # pylint: disable=invalid-name
-def get_r2_mount_cmd(r2_credentials_path: str,
-                     r2_profile_name: str,
-                     endpoint_url: str,
-                     bucket_name: str,
-                     mount_path: str,
-                     _bucket_sub_path: Optional[str] = None,
-                     mount_config: Optional['storage.MountConfig'] = None) -> str:
+def get_r2_mount_cmd(
+        r2_credentials_path: str,
+        r2_profile_name: str,
+        endpoint_url: str,
+        bucket_name: str,
+        mount_path: str,
+        _bucket_sub_path: Optional[str] = None,
+        mount_config: Optional['storage.MountConfig'] = None) -> str:
     """Returns a command to mount R2 bucket (goofys by default, rclone for
     ARM64)."""
     if _bucket_sub_path is None:
@@ -452,12 +455,13 @@ def get_r2_mount_cmd(r2_credentials_path: str,
     return mount_cmd
 
 
-def get_cos_mount_cmd(rclone_config: str,
-                      rclone_profile_name: str,
-                      bucket_name: str,
-                      mount_path: str,
-                      _bucket_sub_path: Optional[str] = None,
-                      mount_config: Optional['storage.MountConfig'] = None) -> str:
+def get_cos_mount_cmd(
+        rclone_config: str,
+        rclone_profile_name: str,
+        bucket_name: str,
+        mount_path: str,
+        _bucket_sub_path: Optional[str] = None,
+        mount_config: Optional['storage.MountConfig'] = None) -> str:
     """Returns a command to mount an IBM COS bucket using rclone."""
     # stores bucket profile in rclone config file at the cluster's nodes.
     configure_rclone_profile = (f'{FUSE3_INSTALL_CMD} && '
@@ -557,14 +561,15 @@ def get_mount_cached_cmd(
     return mount_cmd
 
 
-def get_oci_mount_cmd(mount_path: str,
-                      store_name: str,
-                      region: str,
-                      namespace: str,
-                      compartment: str,
-                      config_file: str,
-                      config_profile: str,
-                      mount_config: Optional['storage.MountConfig'] = None) -> str:
+def get_oci_mount_cmd(
+        mount_path: str,
+        store_name: str,
+        region: str,
+        namespace: str,
+        compartment: str,
+        config_file: str,
+        config_profile: str,
+        mount_config: Optional['storage.MountConfig'] = None) -> str:
     """ OCI specific RClone mount command for oci object storage. """
     rclone_ro, _ = _get_readonly_flags(mount_config)
     # pylint: disable=line-too-long

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -524,6 +524,8 @@ def get_mount_cached_cmd(
 
     # Determine sequential_upload: per-bucket config overrides global config
     # Global config default is False (parallel uploads)
+    # '--transfers 1' guarantees the files written at the local mount point
+    # to be uploaded to the backend storage in the order of creation.
     sequential_upload = skypilot_config.get_nested(
         ('data', 'mount_cached', 'sequential_upload'), False)
     if mount_config is not None and mount_config.sequential_upload is not None:
@@ -549,8 +551,6 @@ def get_mount_cached_cmd(
         # remote, but increases the frequency of metadata lookups.
         f'--allow-other --vfs-cache-mode full --dir-cache-time 10s '
         f'{readonly_flag}{transfers_flag}'
-        # '--transfers 1' guarantees the files written at the local mount point
-        # to be uploaded to the backend storage in the order of creation.
         # '--vfs-cache-poll-interval' specifies the frequency of how often
         # rclone checks the local mount point for stale objects in cache.
         # '--vfs-write-back' defines the time to write files on remote storage

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -379,9 +379,10 @@ def get_az_mount_cmd(
         bucket_sub_path_arg = ''
     else:
         bucket_sub_path_arg = f'--subdirectory={_bucket_sub_path}/ '
+    _, fuse_ro = _get_readonly_flags(mount_config)
     mount_options = ['allow_other', 'default_permissions']
-    if mount_config and mount_config.readonly:
-        mount_options.append('ro')
+    if fuse_ro:
+        mount_options.append(fuse_ro.lstrip(','))
     # Format: -o flag1,flag2
     fusermount_options = '-o ' + ','.join(
         mount_options) if mount_options else ''

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1910,10 +1910,9 @@ class S3CompatibleStore(AbstractStore):
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cmd)
 
-    def mount_cached_command(
-            self,
-            mount_path: str,
-            mount_config: Optional[MountConfig] = None) -> str:
+    def mount_cached_command(self,
+                             mount_path: str,
+                             mount_config: Optional[MountConfig] = None) -> str:
         """Get cached mount command. Can be overridden by subclasses."""
         if self.config.mount_cached_cmd_factory is None:
             raise exceptions.NotSupportedError(
@@ -2633,10 +2632,9 @@ class GcsStore(AbstractStore):
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cmd, version_check_cmd)
 
-    def mount_cached_command(
-            self,
-            mount_path: str,
-            mount_config: Optional[MountConfig] = None) -> str:
+    def mount_cached_command(self,
+                             mount_path: str,
+                             mount_config: Optional[MountConfig] = None) -> str:
         install_cmd = mounting_utils.get_rclone_install_cmd()
         rclone_profile_name = (
             data_utils.Rclone.RcloneStores.GCS.get_profile_name(self.name))
@@ -3541,10 +3539,9 @@ class AzureBlobStore(AbstractStore):
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cmd)
 
-    def mount_cached_command(
-            self,
-            mount_path: str,
-            mount_config: Optional[MountConfig] = None) -> str:
+    def mount_cached_command(self,
+                             mount_path: str,
+                             mount_config: Optional[MountConfig] = None) -> str:
         install_cmd = mounting_utils.get_rclone_install_cmd()
         rclone_profile_name = (
             data_utils.Rclone.RcloneStores.AZURE.get_profile_name(self.name))
@@ -4634,10 +4631,9 @@ class S3Store(S3CompatibleStore):
             mount_cmd_factory=mounting_utils.get_s3_mount_cmd,
         )
 
-    def mount_cached_command(
-            self,
-            mount_path: str,
-            mount_config: Optional[MountConfig] = None) -> str:
+    def mount_cached_command(self,
+                             mount_path: str,
+                             mount_config: Optional[MountConfig] = None) -> str:
         install_cmd = mounting_utils.get_rclone_install_cmd()
         rclone_profile_name = (
             data_utils.Rclone.RcloneStores.S3.get_profile_name(self.name))
@@ -4688,7 +4684,9 @@ class R2Store(S3CompatibleStore):
         )
 
     @classmethod
-    def _get_r2_mount_cmd(cls, bucket_name: str, mount_path: str,
+    def _get_r2_mount_cmd(cls,
+                          bucket_name: str,
+                          mount_path: str,
                           bucket_sub_path: Optional[str],
                           mount_config: Optional[MountConfig] = None) -> str:
         """Factory method for R2 mount command."""
@@ -4699,10 +4697,9 @@ class R2Store(S3CompatibleStore):
                                                mount_path, bucket_sub_path,
                                                mount_config)
 
-    def mount_cached_command(
-            self,
-            mount_path: str,
-            mount_config: Optional[MountConfig] = None) -> str:
+    def mount_cached_command(self,
+                             mount_path: str,
+                             mount_config: Optional[MountConfig] = None) -> str:
         """R2-specific cached mount implementation using rclone."""
         install_cmd = mounting_utils.get_rclone_install_cmd()
         rclone_profile_name = (
@@ -4738,9 +4735,12 @@ class NebiusStore(S3CompatibleStore):
         )
 
     @classmethod
-    def _get_nebius_mount_cmd(cls, bucket_name: str, mount_path: str,
-                              bucket_sub_path: Optional[str],
-                              mount_config: Optional[MountConfig] = None) -> str:
+    def _get_nebius_mount_cmd(
+            cls,
+            bucket_name: str,
+            mount_path: str,
+            bucket_sub_path: Optional[str],
+            mount_config: Optional[MountConfig] = None) -> str:
         """Factory method for Nebius mount command."""
         # We need to get the endpoint URL, but since this is a static method,
         # we'll need to create a client to get it
@@ -4751,10 +4751,9 @@ class NebiusStore(S3CompatibleStore):
                                                    mount_path, bucket_sub_path,
                                                    mount_config)
 
-    def mount_cached_command(
-            self,
-            mount_path: str,
-            mount_config: Optional[MountConfig] = None) -> str:
+    def mount_cached_command(self,
+                             mount_path: str,
+                             mount_config: Optional[MountConfig] = None) -> str:
         """Nebius-specific cached mount implementation using rclone."""
         install_cmd = mounting_utils.get_rclone_install_cmd()
         rclone_profile_name = (
@@ -4831,9 +4830,12 @@ class CoreWeaveStore(S3CompatibleStore):
         #         f'{self.name}')
 
     @classmethod
-    def _get_coreweave_mount_cmd(cls, bucket_name: str, mount_path: str,
-                                 bucket_sub_path: Optional[str],
-                                 mount_config: Optional[MountConfig] = None) -> str:
+    def _get_coreweave_mount_cmd(
+            cls,
+            bucket_name: str,
+            mount_path: str,
+            bucket_sub_path: Optional[str],
+            mount_config: Optional[MountConfig] = None) -> str:
         """Factory method for CoreWeave mount command."""
         endpoint_url = coreweave.get_endpoint()
         return mounting_utils.get_coreweave_mount_cmd(
@@ -4841,10 +4843,9 @@ class CoreWeaveStore(S3CompatibleStore):
             coreweave.COREWEAVE_PROFILE_NAME, bucket_name, endpoint_url,
             mount_path, bucket_sub_path, mount_config)
 
-    def mount_cached_command(
-            self,
-            mount_path: str,
-            mount_config: Optional[MountConfig] = None) -> str:
+    def mount_cached_command(self,
+                             mount_path: str,
+                             mount_config: Optional[MountConfig] = None) -> str:
         """CoreWeave-specific cached mount implementation using rclone."""
         install_cmd = mounting_utils.get_rclone_install_cmd()
         rclone_profile_name = (

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -3530,12 +3530,9 @@ class AzureBlobStore(AbstractStore):
             str: a heredoc used to setup the AZ Container mount
         """
         install_cmd = mounting_utils.get_az_mount_install_cmd()
-        mount_cmd = mounting_utils.get_az_mount_cmd(self.container_name,
-                                                    self.storage_account_name,
-                                                    mount_path,
-                                                    self.storage_account_key,
-                                                    self._bucket_sub_path,
-                                                    mount_config)
+        mount_cmd = mounting_utils.get_az_mount_cmd(
+            self.container_name, self.storage_account_name, mount_path,
+            self.storage_account_key, self._bucket_sub_path, mount_config)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cmd)
 

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -568,6 +568,13 @@ def get_storage_schema():
                     'attach_mode': {
                         'type': 'string',
                     },
+                    # Mount configuration options for MOUNT/MOUNT_CACHED modes
+                    'readonly': {
+                        'type': 'boolean',
+                    },
+                    'sequential_upload': {
+                        'type': 'boolean',
+                    },
                 },
             },
             '_is_sky_managed': {

--- a/tests/unit_tests/test_sky/storage/test_mount_config.py
+++ b/tests/unit_tests/test_sky/storage/test_mount_config.py
@@ -151,12 +151,7 @@ class TestMountCachedCmd:
         """Test get_mount_cached_cmd sequential_upload with global config."""
         with mock.patch('sky.data.mounting_utils.skypilot_config.get_nested',
                         return_value=global_seq):
-            mount_config = storage.MountConfig(
-                sequential_upload=cfg_seq) if cfg_seq is not None else (
-                    storage.MountConfig() if cfg_seq is None else None)
-            # Handle the case where we want to test with None mount_config
-            if cfg_seq is None:
-                mount_config = storage.MountConfig()  # seq=None by default
+            mount_config = storage.MountConfig(sequential_upload=cfg_seq)
             cmd = self._get_cmd(mount_config)
             assert ('--transfers 1' in cmd) == expect_seq
 

--- a/tests/unit_tests/test_sky/storage/test_mount_config.py
+++ b/tests/unit_tests/test_sky/storage/test_mount_config.py
@@ -200,8 +200,10 @@ class TestMountCmd:
                                               mount_path='/mnt/data',
                                               _bucket_sub_path=None,
                                               mount_config=cfg)
-        has_flag = '--read-only' in cmd or '-o ro' in cmd
-        assert has_flag == expect_flag
+        # Check rclone uses --read-only flag
+        assert ('--read-only' in cmd) == expect_flag
+        # Check goofys uses comma-separated FUSE options: -o allow_other,ro
+        assert ('-o allow_other,ro' in cmd) == expect_flag
 
     @pytest.mark.parametrize('ro,expect_flag', [(False, False), (True, True)])
     def test_gcs_mount_cmd(self, ro, expect_flag):
@@ -211,4 +213,5 @@ class TestMountCmd:
                                                mount_path='/mnt/data',
                                                _bucket_sub_path=None,
                                                mount_config=cfg)
-        assert ('-o ro' in cmd) == expect_flag
+        # gcsfuse uses comma-separated FUSE options: -o allow_other,ro
+        assert ('-o allow_other,ro' in cmd) == expect_flag

--- a/tests/unit_tests/test_sky/storage/test_mount_config.py
+++ b/tests/unit_tests/test_sky/storage/test_mount_config.py
@@ -1,0 +1,294 @@
+"""Tests for MountConfig and Storage config field functionality."""
+import pytest
+
+from sky.data import storage
+from sky.data import mounting_utils
+
+
+class TestMountConfig:
+    """Tests for the MountConfig dataclass."""
+
+    def test_mount_config_defaults(self):
+        """Test MountConfig default values."""
+        config = storage.MountConfig()
+        assert config.readonly is False
+        # Default is True for backward compatibility
+        assert config.sequential_upload is True
+
+    def test_mount_config_custom_values(self):
+        """Test MountConfig with custom values."""
+        config = storage.MountConfig(readonly=True, sequential_upload=False)
+        assert config.readonly is True
+        assert config.sequential_upload is False
+
+    def test_mount_config_from_dict_none(self):
+        """Test MountConfig.from_dict with None input."""
+        config = storage.MountConfig.from_dict(None)
+        assert config.readonly is False
+        assert config.sequential_upload is True
+
+    def test_mount_config_from_dict_empty(self):
+        """Test MountConfig.from_dict with empty dict."""
+        config = storage.MountConfig.from_dict({})
+        assert config.readonly is False
+        assert config.sequential_upload is True
+
+    def test_mount_config_from_dict_readonly_only(self):
+        """Test MountConfig.from_dict with only readonly set."""
+        config = storage.MountConfig.from_dict({'readonly': True})
+        assert config.readonly is True
+        assert config.sequential_upload is True
+
+    def test_mount_config_from_dict_sequential_upload_false(self):
+        """Test MountConfig.from_dict with sequential_upload=False."""
+        config = storage.MountConfig.from_dict({'sequential_upload': False})
+        assert config.readonly is False
+        assert config.sequential_upload is False
+
+    def test_mount_config_from_dict_both_options(self):
+        """Test MountConfig.from_dict with both options set."""
+        config = storage.MountConfig.from_dict({
+            'readonly': True,
+            'sequential_upload': False
+        })
+        assert config.readonly is True
+        assert config.sequential_upload is False
+
+    def test_mount_config_from_dict_extra_fields_ignored(self):
+        """Test MountConfig.from_dict ignores unknown fields."""
+        config = storage.MountConfig.from_dict({
+            'readonly': True,
+            'unknown_field': 'value',
+            'another_field': 123
+        })
+        assert config.readonly is True
+        assert config.sequential_upload is True
+
+
+class TestStorageFromYamlConfig:
+    """Tests for Storage.from_yaml_config with mount config."""
+
+    def test_storage_from_yaml_no_config(self):
+        """Test Storage.from_yaml_config without config field."""
+        yaml_config = {
+            'name': 'test-bucket',
+            'mode': 'MOUNT_CACHED',
+        }
+        storage_obj = storage.Storage.from_yaml_config(yaml_config)
+        assert storage_obj.mount_config.readonly is False
+        assert storage_obj.mount_config.sequential_upload is True
+
+    def test_storage_from_yaml_with_empty_config(self):
+        """Test Storage.from_yaml_config with empty config field."""
+        yaml_config = {
+            'name': 'test-bucket',
+            'mode': 'MOUNT_CACHED',
+            'config': {},
+        }
+        storage_obj = storage.Storage.from_yaml_config(yaml_config)
+        assert storage_obj.mount_config.readonly is False
+        assert storage_obj.mount_config.sequential_upload is True
+
+    def test_storage_from_yaml_with_readonly_config(self):
+        """Test Storage.from_yaml_config with readonly config."""
+        yaml_config = {
+            'name': 'test-bucket',
+            'mode': 'MOUNT_CACHED',
+            'config': {
+                'readonly': True,
+            },
+        }
+        storage_obj = storage.Storage.from_yaml_config(yaml_config)
+        assert storage_obj.mount_config.readonly is True
+        assert storage_obj.mount_config.sequential_upload is True
+
+    def test_storage_from_yaml_with_sequential_upload_false(self):
+        """Test Storage.from_yaml_config with sequential_upload=False."""
+        yaml_config = {
+            'name': 'test-bucket',
+            'mode': 'MOUNT_CACHED',
+            'config': {
+                'sequential_upload': False,
+            },
+        }
+        storage_obj = storage.Storage.from_yaml_config(yaml_config)
+        assert storage_obj.mount_config.readonly is False
+        assert storage_obj.mount_config.sequential_upload is False
+
+    def test_storage_from_yaml_with_full_config(self):
+        """Test Storage.from_yaml_config with both config options."""
+        yaml_config = {
+            'name': 'test-bucket',
+            'mode': 'MOUNT_CACHED',
+            'config': {
+                'readonly': True,
+                'sequential_upload': False,
+            },
+        }
+        storage_obj = storage.Storage.from_yaml_config(yaml_config)
+        assert storage_obj.mount_config.readonly is True
+        assert storage_obj.mount_config.sequential_upload is False
+
+
+class TestStorageToYamlConfig:
+    """Tests for Storage.to_yaml_config with mount config."""
+
+    def test_storage_to_yaml_default_config(self):
+        """Test Storage.to_yaml_config with default mount config."""
+        storage_obj = storage.Storage(name='test-bucket')
+        yaml_config = storage_obj.to_yaml_config()
+        # Default config should not be included
+        assert 'config' not in yaml_config
+
+    def test_storage_to_yaml_with_readonly(self):
+        """Test Storage.to_yaml_config with readonly config."""
+        mount_config = storage.MountConfig(readonly=True)
+        storage_obj = storage.Storage(name='test-bucket',
+                                       mount_config=mount_config)
+        yaml_config = storage_obj.to_yaml_config()
+        assert 'config' in yaml_config
+        assert yaml_config['config']['readonly'] is True
+        # sequential_upload=True is default, so not serialized
+        assert 'sequential_upload' not in yaml_config['config']
+
+    def test_storage_to_yaml_with_sequential_upload_false(self):
+        """Test to_yaml_config with sequential_upload=False (non-default)."""
+        mount_config = storage.MountConfig(sequential_upload=False)
+        storage_obj = storage.Storage(name='test-bucket',
+                                       mount_config=mount_config)
+        yaml_config = storage_obj.to_yaml_config()
+        assert 'config' in yaml_config
+        # sequential_upload=False is non-default, so it should be serialized
+        assert yaml_config['config']['sequential_upload'] is False
+        assert 'readonly' not in yaml_config['config']
+
+    def test_storage_to_yaml_with_sequential_upload_true_not_serialized(self):
+        """Test to_yaml_config doesn't serialize default sequential_upload."""
+        mount_config = storage.MountConfig(sequential_upload=True)
+        storage_obj = storage.Storage(name='test-bucket',
+                                       mount_config=mount_config)
+        yaml_config = storage_obj.to_yaml_config()
+        # sequential_upload=True is default, so no config should be present
+        assert 'config' not in yaml_config
+
+    def test_storage_to_yaml_with_full_config(self):
+        """Test Storage.to_yaml_config with both non-default options."""
+        mount_config = storage.MountConfig(readonly=True,
+                                           sequential_upload=False)
+        storage_obj = storage.Storage(name='test-bucket',
+                                       mount_config=mount_config)
+        yaml_config = storage_obj.to_yaml_config()
+        assert 'config' in yaml_config
+        assert yaml_config['config']['readonly'] is True
+        assert yaml_config['config']['sequential_upload'] is False
+
+
+class TestMountCachedCmd:
+    """Tests for get_mount_cached_cmd with mount config."""
+
+    def test_mount_cached_cmd_default(self):
+        """Test get_mount_cached_cmd with default config."""
+        cmd = mounting_utils.get_mount_cached_cmd(
+            rclone_config='[test]\ntype = s3',
+            rclone_profile_name='test',
+            bucket_name='my-bucket',
+            mount_path='/mnt/data',
+            mount_config=None)
+        # Default should include --transfers 1 for sequential uploads
+        assert '--transfers 1' in cmd
+        assert '--read-only' not in cmd
+
+    def test_mount_cached_cmd_with_readonly(self):
+        """Test get_mount_cached_cmd with readonly config."""
+        mount_config = storage.MountConfig(readonly=True)
+        cmd = mounting_utils.get_mount_cached_cmd(
+            rclone_config='[test]\ntype = s3',
+            rclone_profile_name='test',
+            bucket_name='my-bucket',
+            mount_path='/mnt/data',
+            mount_config=mount_config)
+        assert '--read-only' in cmd
+        assert '--transfers 1' in cmd  # Default sequential
+
+    def test_mount_cached_cmd_with_sequential_upload_true(self):
+        """Test get_mount_cached_cmd with sequential_upload=True (default)."""
+        mount_config = storage.MountConfig(sequential_upload=True)
+        cmd = mounting_utils.get_mount_cached_cmd(
+            rclone_config='[test]\ntype = s3',
+            rclone_profile_name='test',
+            bucket_name='my-bucket',
+            mount_path='/mnt/data',
+            mount_config=mount_config)
+        assert '--transfers 1' in cmd
+        assert '--read-only' not in cmd
+
+    def test_mount_cached_cmd_with_sequential_upload_false(self):
+        """Test get_mount_cached_cmd with sequential_upload=False."""
+        mount_config = storage.MountConfig(sequential_upload=False)
+        cmd = mounting_utils.get_mount_cached_cmd(
+            rclone_config='[test]\ntype = s3',
+            rclone_profile_name='test',
+            bucket_name='my-bucket',
+            mount_path='/mnt/data',
+            mount_config=mount_config)
+        # Should NOT include --transfers 1 for parallel uploads
+        assert '--transfers 1' not in cmd
+        assert '--read-only' not in cmd
+
+    def test_mount_cached_cmd_with_both_options(self):
+        """Test get_mount_cached_cmd with readonly and parallel uploads."""
+        mount_config = storage.MountConfig(readonly=True,
+                                           sequential_upload=False)
+        cmd = mounting_utils.get_mount_cached_cmd(
+            rclone_config='[test]\ntype = s3',
+            rclone_profile_name='test',
+            bucket_name='my-bucket',
+            mount_path='/mnt/data',
+            mount_config=mount_config)
+        assert '--read-only' in cmd
+        # parallel uploads (sequential_upload=False)
+        assert '--transfers 1' not in cmd
+
+
+class TestMountCmd:
+    """Tests for mount commands (MOUNT mode) with mount config."""
+
+    def test_s3_mount_cmd_default(self):
+        """Test get_s3_mount_cmd with default config."""
+        cmd = mounting_utils.get_s3_mount_cmd(
+            bucket_name='my-bucket',
+            mount_path='/mnt/data',
+            _bucket_sub_path=None,
+            mount_config=None)
+        assert '--read-only' not in cmd
+        assert '-o ro' not in cmd
+
+    def test_s3_mount_cmd_readonly(self):
+        """Test get_s3_mount_cmd with readonly config."""
+        mount_config = storage.MountConfig(readonly=True)
+        cmd = mounting_utils.get_s3_mount_cmd(
+            bucket_name='my-bucket',
+            mount_path='/mnt/data',
+            _bucket_sub_path=None,
+            mount_config=mount_config)
+        # Should include readonly flag for both rclone (ARM) and goofys (x86)
+        assert '--read-only' in cmd or '-o ro' in cmd
+
+    def test_gcs_mount_cmd_default(self):
+        """Test get_gcs_mount_cmd with default config."""
+        cmd = mounting_utils.get_gcs_mount_cmd(
+            bucket_name='my-bucket',
+            mount_path='/mnt/data',
+            _bucket_sub_path=None,
+            mount_config=None)
+        assert '-o ro' not in cmd
+
+    def test_gcs_mount_cmd_readonly(self):
+        """Test get_gcs_mount_cmd with readonly config."""
+        mount_config = storage.MountConfig(readonly=True)
+        cmd = mounting_utils.get_gcs_mount_cmd(
+            bucket_name='my-bucket',
+            mount_path='/mnt/data',
+            _bucket_sub_path=None,
+            mount_config=mount_config)
+        assert '-o ro' in cmd

--- a/tests/unit_tests/test_sky/storage/test_mount_config.py
+++ b/tests/unit_tests/test_sky/storage/test_mount_config.py
@@ -12,283 +12,145 @@ class TestMountConfig:
         """Test MountConfig default values."""
         config = storage.MountConfig()
         assert config.readonly is False
-        # Default is True for backward compatibility
-        assert config.sequential_upload is True
+        assert config.sequential_upload is True  # default for backward compat
 
-    def test_mount_config_custom_values(self):
-        """Test MountConfig with custom values."""
-        config = storage.MountConfig(readonly=True, sequential_upload=False)
-        assert config.readonly is True
-        assert config.sequential_upload is False
-
-    def test_mount_config_from_dict_none(self):
-        """Test MountConfig.from_dict with None input."""
-        config = storage.MountConfig.from_dict(None)
-        assert config.readonly is False
-        assert config.sequential_upload is True
-
-    def test_mount_config_from_dict_empty(self):
-        """Test MountConfig.from_dict with empty dict."""
-        config = storage.MountConfig.from_dict({})
-        assert config.readonly is False
-        assert config.sequential_upload is True
-
-    def test_mount_config_from_dict_readonly_only(self):
-        """Test MountConfig.from_dict with only readonly set."""
-        config = storage.MountConfig.from_dict({'readonly': True})
-        assert config.readonly is True
-        assert config.sequential_upload is True
-
-    def test_mount_config_from_dict_sequential_upload_false(self):
-        """Test MountConfig.from_dict with sequential_upload=False."""
-        config = storage.MountConfig.from_dict({'sequential_upload': False})
-        assert config.readonly is False
-        assert config.sequential_upload is False
-
-    def test_mount_config_from_dict_both_options(self):
-        """Test MountConfig.from_dict with both options set."""
-        config = storage.MountConfig.from_dict({
-            'readonly': True,
-            'sequential_upload': False
-        })
-        assert config.readonly is True
-        assert config.sequential_upload is False
-
-    def test_mount_config_from_dict_extra_fields_ignored(self):
-        """Test MountConfig.from_dict ignores unknown fields."""
-        config = storage.MountConfig.from_dict({
-            'readonly': True,
-            'unknown_field': 'value',
-            'another_field': 123
-        })
-        assert config.readonly is True
-        assert config.sequential_upload is True
+    @pytest.mark.parametrize('input_dict,expected_readonly,expected_seq', [
+        (None, False, True),
+        ({}, False, True),
+        ({'readonly': True}, True, True),
+        ({'sequential_upload': False}, False, False),
+        ({'readonly': True, 'sequential_upload': False}, True, False),
+        ({'readonly': True, 'unknown_field': 'value'}, True, True),
+    ])
+    def test_mount_config_from_dict(self, input_dict, expected_readonly,
+                                    expected_seq):
+        """Test MountConfig.from_dict with various inputs."""
+        config = storage.MountConfig.from_dict(input_dict)
+        assert config.readonly is expected_readonly
+        assert config.sequential_upload is expected_seq
 
 
 class TestStorageFromYamlConfig:
     """Tests for Storage.from_yaml_config with mount config."""
 
-    def test_storage_from_yaml_no_config(self):
-        """Test Storage.from_yaml_config without config field."""
-        yaml_config = {
-            'name': 'test-bucket',
-            'mode': 'MOUNT_CACHED',
-        }
+    @pytest.mark.parametrize('config_field,expected_readonly,expected_seq', [
+        (None, False, True),
+        ({}, False, True),
+        ({'readonly': True}, True, True),
+        ({'sequential_upload': False}, False, False),
+        ({'readonly': True, 'sequential_upload': False}, True, False),
+    ])
+    def test_storage_from_yaml_config(self, config_field, expected_readonly,
+                                      expected_seq):
+        """Test Storage.from_yaml_config with various config fields."""
+        yaml_config = {'name': 'test-bucket', 'mode': 'MOUNT_CACHED'}
+        if config_field is not None:
+            yaml_config['config'] = config_field
         storage_obj = storage.Storage.from_yaml_config(yaml_config)
-        assert storage_obj.mount_config.readonly is False
-        assert storage_obj.mount_config.sequential_upload is True
-
-    def test_storage_from_yaml_with_empty_config(self):
-        """Test Storage.from_yaml_config with empty config field."""
-        yaml_config = {
-            'name': 'test-bucket',
-            'mode': 'MOUNT_CACHED',
-            'config': {},
-        }
-        storage_obj = storage.Storage.from_yaml_config(yaml_config)
-        assert storage_obj.mount_config.readonly is False
-        assert storage_obj.mount_config.sequential_upload is True
-
-    def test_storage_from_yaml_with_readonly_config(self):
-        """Test Storage.from_yaml_config with readonly config."""
-        yaml_config = {
-            'name': 'test-bucket',
-            'mode': 'MOUNT_CACHED',
-            'config': {
-                'readonly': True,
-            },
-        }
-        storage_obj = storage.Storage.from_yaml_config(yaml_config)
-        assert storage_obj.mount_config.readonly is True
-        assert storage_obj.mount_config.sequential_upload is True
-
-    def test_storage_from_yaml_with_sequential_upload_false(self):
-        """Test Storage.from_yaml_config with sequential_upload=False."""
-        yaml_config = {
-            'name': 'test-bucket',
-            'mode': 'MOUNT_CACHED',
-            'config': {
-                'sequential_upload': False,
-            },
-        }
-        storage_obj = storage.Storage.from_yaml_config(yaml_config)
-        assert storage_obj.mount_config.readonly is False
-        assert storage_obj.mount_config.sequential_upload is False
-
-    def test_storage_from_yaml_with_full_config(self):
-        """Test Storage.from_yaml_config with both config options."""
-        yaml_config = {
-            'name': 'test-bucket',
-            'mode': 'MOUNT_CACHED',
-            'config': {
-                'readonly': True,
-                'sequential_upload': False,
-            },
-        }
-        storage_obj = storage.Storage.from_yaml_config(yaml_config)
-        assert storage_obj.mount_config.readonly is True
-        assert storage_obj.mount_config.sequential_upload is False
+        assert storage_obj.mount_config.readonly is expected_readonly
+        assert storage_obj.mount_config.sequential_upload is expected_seq
 
 
 class TestStorageToYamlConfig:
     """Tests for Storage.to_yaml_config with mount config."""
 
-    def test_storage_to_yaml_default_config(self):
-        """Test Storage.to_yaml_config with default mount config."""
+    def test_default_config_not_serialized(self):
+        """Test default mount config is not included in yaml."""
         storage_obj = storage.Storage(name='test-bucket')
         yaml_config = storage_obj.to_yaml_config()
-        # Default config should not be included
         assert 'config' not in yaml_config
 
-    def test_storage_to_yaml_with_readonly(self):
-        """Test Storage.to_yaml_config with readonly config."""
-        mount_config = storage.MountConfig(readonly=True)
-        storage_obj = storage.Storage(name='test-bucket',
-                                       mount_config=mount_config)
-        yaml_config = storage_obj.to_yaml_config()
-        assert 'config' in yaml_config
-        assert yaml_config['config']['readonly'] is True
-        # sequential_upload=True is default, so not serialized
-        assert 'sequential_upload' not in yaml_config['config']
-
-    def test_storage_to_yaml_with_sequential_upload_false(self):
-        """Test to_yaml_config with sequential_upload=False (non-default)."""
-        mount_config = storage.MountConfig(sequential_upload=False)
-        storage_obj = storage.Storage(name='test-bucket',
-                                       mount_config=mount_config)
-        yaml_config = storage_obj.to_yaml_config()
-        assert 'config' in yaml_config
-        # sequential_upload=False is non-default, so it should be serialized
-        assert yaml_config['config']['sequential_upload'] is False
-        assert 'readonly' not in yaml_config['config']
-
-    def test_storage_to_yaml_with_sequential_upload_true_not_serialized(self):
-        """Test to_yaml_config doesn't serialize default sequential_upload."""
+    def test_sequential_upload_true_not_serialized(self):
+        """Test sequential_upload=True (default) is not serialized."""
         mount_config = storage.MountConfig(sequential_upload=True)
         storage_obj = storage.Storage(name='test-bucket',
                                        mount_config=mount_config)
         yaml_config = storage_obj.to_yaml_config()
-        # sequential_upload=True is default, so no config should be present
         assert 'config' not in yaml_config
 
-    def test_storage_to_yaml_with_full_config(self):
-        """Test Storage.to_yaml_config with both non-default options."""
-        mount_config = storage.MountConfig(readonly=True,
-                                           sequential_upload=False)
+    @pytest.mark.parametrize('readonly,seq_upload,expect_readonly,expect_seq', [
+        (True, True, True, None),  # readonly only, seq is default
+        (False, False, None, False),  # seq only, readonly is default
+        (True, False, True, False),  # both non-default
+    ])
+    def test_non_default_config_serialized(self, readonly, seq_upload,
+                                           expect_readonly, expect_seq):
+        """Test non-default mount config values are serialized."""
+        mount_config = storage.MountConfig(readonly=readonly,
+                                           sequential_upload=seq_upload)
         storage_obj = storage.Storage(name='test-bucket',
                                        mount_config=mount_config)
         yaml_config = storage_obj.to_yaml_config()
         assert 'config' in yaml_config
-        assert yaml_config['config']['readonly'] is True
-        assert yaml_config['config']['sequential_upload'] is False
+        if expect_readonly is not None:
+            assert yaml_config['config']['readonly'] is expect_readonly
+        else:
+            assert 'readonly' not in yaml_config['config']
+        if expect_seq is not None:
+            assert yaml_config['config']['sequential_upload'] is expect_seq
+        else:
+            assert 'sequential_upload' not in yaml_config['config']
 
 
 class TestMountCachedCmd:
     """Tests for get_mount_cached_cmd with mount config."""
 
-    def test_mount_cached_cmd_default(self):
-        """Test get_mount_cached_cmd with default config."""
-        cmd = mounting_utils.get_mount_cached_cmd(
-            rclone_config='[test]\ntype = s3',
-            rclone_profile_name='test',
-            bucket_name='my-bucket',
-            mount_path='/mnt/data',
-            mount_config=None)
-        # Default should include --transfers 1 for sequential uploads
-        assert '--transfers 1' in cmd
-        assert '--read-only' not in cmd
-
-    def test_mount_cached_cmd_with_readonly(self):
-        """Test get_mount_cached_cmd with readonly config."""
-        mount_config = storage.MountConfig(readonly=True)
-        cmd = mounting_utils.get_mount_cached_cmd(
+    def _get_cmd(self, mount_config=None):
+        return mounting_utils.get_mount_cached_cmd(
             rclone_config='[test]\ntype = s3',
             rclone_profile_name='test',
             bucket_name='my-bucket',
             mount_path='/mnt/data',
             mount_config=mount_config)
-        assert '--read-only' in cmd
-        assert '--transfers 1' in cmd  # Default sequential
 
-    def test_mount_cached_cmd_with_sequential_upload_true(self):
-        """Test get_mount_cached_cmd with sequential_upload=True (default)."""
-        mount_config = storage.MountConfig(sequential_upload=True)
-        cmd = mounting_utils.get_mount_cached_cmd(
-            rclone_config='[test]\ntype = s3',
-            rclone_profile_name='test',
-            bucket_name='my-bucket',
-            mount_path='/mnt/data',
-            mount_config=mount_config)
-        assert '--transfers 1' in cmd
-        assert '--read-only' not in cmd
-
-    def test_mount_cached_cmd_with_sequential_upload_false(self):
-        """Test get_mount_cached_cmd with sequential_upload=False."""
-        mount_config = storage.MountConfig(sequential_upload=False)
-        cmd = mounting_utils.get_mount_cached_cmd(
-            rclone_config='[test]\ntype = s3',
-            rclone_profile_name='test',
-            bucket_name='my-bucket',
-            mount_path='/mnt/data',
-            mount_config=mount_config)
-        # Should NOT include --transfers 1 for parallel uploads
-        assert '--transfers 1' not in cmd
-        assert '--read-only' not in cmd
-
-    def test_mount_cached_cmd_with_both_options(self):
-        """Test get_mount_cached_cmd with readonly and parallel uploads."""
-        mount_config = storage.MountConfig(readonly=True,
-                                           sequential_upload=False)
-        cmd = mounting_utils.get_mount_cached_cmd(
-            rclone_config='[test]\ntype = s3',
-            rclone_profile_name='test',
-            bucket_name='my-bucket',
-            mount_path='/mnt/data',
-            mount_config=mount_config)
-        assert '--read-only' in cmd
-        # parallel uploads (sequential_upload=False)
-        assert '--transfers 1' not in cmd
+    @pytest.mark.parametrize('readonly,seq_upload,expect_readonly,expect_seq', [
+        (None, None, False, True),  # None config
+        (False, True, False, True),  # Default config
+        (True, True, True, True),  # readonly only
+        (False, False, False, False),  # parallel only
+        (True, False, True, False),  # both
+    ])
+    def test_mount_cached_cmd(self, readonly, seq_upload, expect_readonly,
+                              expect_seq):
+        """Test get_mount_cached_cmd with various configs."""
+        if readonly is None:
+            mount_config = None
+        else:
+            mount_config = storage.MountConfig(readonly=readonly,
+                                               sequential_upload=seq_upload)
+        cmd = self._get_cmd(mount_config)
+        assert ('--read-only' in cmd) == expect_readonly
+        assert ('--transfers 1' in cmd) == expect_seq
 
 
 class TestMountCmd:
     """Tests for mount commands (MOUNT mode) with mount config."""
 
-    def test_s3_mount_cmd_default(self):
-        """Test get_s3_mount_cmd with default config."""
-        cmd = mounting_utils.get_s3_mount_cmd(
-            bucket_name='my-bucket',
-            mount_path='/mnt/data',
-            _bucket_sub_path=None,
-            mount_config=None)
-        assert '--read-only' not in cmd
-        assert '-o ro' not in cmd
-
-    def test_s3_mount_cmd_readonly(self):
+    @pytest.mark.parametrize('readonly,expect_flag', [
+        (False, False),
+        (True, True),
+    ])
+    def test_s3_mount_cmd(self, readonly, expect_flag):
         """Test get_s3_mount_cmd with readonly config."""
-        mount_config = storage.MountConfig(readonly=True)
+        mount_config = storage.MountConfig(readonly=readonly) if readonly else None
         cmd = mounting_utils.get_s3_mount_cmd(
             bucket_name='my-bucket',
             mount_path='/mnt/data',
             _bucket_sub_path=None,
             mount_config=mount_config)
-        # Should include readonly flag for both rclone (ARM) and goofys (x86)
-        assert '--read-only' in cmd or '-o ro' in cmd
+        has_flag = '--read-only' in cmd or '-o ro' in cmd
+        assert has_flag == expect_flag
 
-    def test_gcs_mount_cmd_default(self):
-        """Test get_gcs_mount_cmd with default config."""
-        cmd = mounting_utils.get_gcs_mount_cmd(
-            bucket_name='my-bucket',
-            mount_path='/mnt/data',
-            _bucket_sub_path=None,
-            mount_config=None)
-        assert '-o ro' not in cmd
-
-    def test_gcs_mount_cmd_readonly(self):
+    @pytest.mark.parametrize('readonly,expect_flag', [
+        (False, False),
+        (True, True),
+    ])
+    def test_gcs_mount_cmd(self, readonly, expect_flag):
         """Test get_gcs_mount_cmd with readonly config."""
-        mount_config = storage.MountConfig(readonly=True)
+        mount_config = storage.MountConfig(readonly=readonly) if readonly else None
         cmd = mounting_utils.get_gcs_mount_cmd(
             bucket_name='my-bucket',
             mount_path='/mnt/data',
             _bucket_sub_path=None,
             mount_config=mount_config)
-        assert '-o ro' in cmd
+        assert ('-o ro' in cmd) == expect_flag

--- a/tests/unit_tests/test_sky/storage/test_mount_config.py
+++ b/tests/unit_tests/test_sky/storage/test_mount_config.py
@@ -68,22 +68,21 @@ class TestStorageToYamlConfig:
         yaml_config = storage_obj.to_yaml_config()
         assert 'config' not in yaml_config
 
-    @pytest.mark.parametrize('readonly,seq_upload,expect_readonly,expect_seq', [
+    @pytest.mark.parametrize('ro,seq,expect_ro,expect_seq', [
         (True, True, True, None),  # readonly only, seq is default
         (False, False, None, False),  # seq only, readonly is default
         (True, False, True, False),  # both non-default
     ])
-    def test_non_default_config_serialized(self, readonly, seq_upload,
-                                           expect_readonly, expect_seq):
+    def test_non_default_config_serialized(self, ro, seq, expect_ro,
+                                           expect_seq):
         """Test non-default mount config values are serialized."""
-        mount_config = storage.MountConfig(readonly=readonly,
-                                           sequential_upload=seq_upload)
+        mount_config = storage.MountConfig(readonly=ro, sequential_upload=seq)
         storage_obj = storage.Storage(name='test-bucket',
                                        mount_config=mount_config)
         yaml_config = storage_obj.to_yaml_config()
         assert 'config' in yaml_config
-        if expect_readonly is not None:
-            assert yaml_config['config']['readonly'] is expect_readonly
+        if expect_ro is not None:
+            assert yaml_config['config']['readonly'] is expect_ro
         else:
             assert 'readonly' not in yaml_config['config']
         if expect_seq is not None:
@@ -103,54 +102,47 @@ class TestMountCachedCmd:
             mount_path='/mnt/data',
             mount_config=mount_config)
 
-    @pytest.mark.parametrize('readonly,seq_upload,expect_readonly,expect_seq', [
+    @pytest.mark.parametrize('ro,seq,expect_ro,expect_seq', [
         (None, None, False, True),  # None config
         (False, True, False, True),  # Default config
         (True, True, True, True),  # readonly only
         (False, False, False, False),  # parallel only
         (True, False, True, False),  # both
     ])
-    def test_mount_cached_cmd(self, readonly, seq_upload, expect_readonly,
-                              expect_seq):
+    def test_mount_cached_cmd(self, ro, seq, expect_ro, expect_seq):
         """Test get_mount_cached_cmd with various configs."""
-        if readonly is None:
+        if ro is None:
             mount_config = None
         else:
-            mount_config = storage.MountConfig(readonly=readonly,
-                                               sequential_upload=seq_upload)
+            mount_config = storage.MountConfig(readonly=ro,
+                                               sequential_upload=seq)
         cmd = self._get_cmd(mount_config)
-        assert ('--read-only' in cmd) == expect_readonly
+        assert ('--read-only' in cmd) == expect_ro
         assert ('--transfers 1' in cmd) == expect_seq
 
 
 class TestMountCmd:
     """Tests for mount commands (MOUNT mode) with mount config."""
 
-    @pytest.mark.parametrize('readonly,expect_flag', [
-        (False, False),
-        (True, True),
-    ])
-    def test_s3_mount_cmd(self, readonly, expect_flag):
+    @pytest.mark.parametrize('ro,expect_flag', [(False, False), (True, True)])
+    def test_s3_mount_cmd(self, ro, expect_flag):
         """Test get_s3_mount_cmd with readonly config."""
-        mount_config = storage.MountConfig(readonly=readonly) if readonly else None
+        cfg = storage.MountConfig(readonly=ro) if ro else None
         cmd = mounting_utils.get_s3_mount_cmd(
             bucket_name='my-bucket',
             mount_path='/mnt/data',
             _bucket_sub_path=None,
-            mount_config=mount_config)
+            mount_config=cfg)
         has_flag = '--read-only' in cmd or '-o ro' in cmd
         assert has_flag == expect_flag
 
-    @pytest.mark.parametrize('readonly,expect_flag', [
-        (False, False),
-        (True, True),
-    ])
-    def test_gcs_mount_cmd(self, readonly, expect_flag):
+    @pytest.mark.parametrize('ro,expect_flag', [(False, False), (True, True)])
+    def test_gcs_mount_cmd(self, ro, expect_flag):
         """Test get_gcs_mount_cmd with readonly config."""
-        mount_config = storage.MountConfig(readonly=readonly) if readonly else None
+        cfg = storage.MountConfig(readonly=ro) if ro else None
         cmd = mounting_utils.get_gcs_mount_cmd(
             bucket_name='my-bucket',
             mount_path='/mnt/data',
             _bucket_sub_path=None,
-            mount_config=mount_config)
+            mount_config=cfg)
         assert ('-o ro' in cmd) == expect_flag

--- a/tests/unit_tests/test_sky/storage/test_mount_config.py
+++ b/tests/unit_tests/test_sky/storage/test_mount_config.py
@@ -1,8 +1,8 @@
 """Tests for MountConfig and Storage config field functionality."""
 import pytest
 
-from sky.data import storage
 from sky.data import mounting_utils
+from sky.data import storage
 
 
 class TestMountConfig:

--- a/tests/unit_tests/test_sky/storage/test_mount_config.py
+++ b/tests/unit_tests/test_sky/storage/test_mount_config.py
@@ -17,10 +17,20 @@ class TestMountConfig:
     @pytest.mark.parametrize('input_dict,expected_readonly,expected_seq', [
         (None, False, True),
         ({}, False, True),
-        ({'readonly': True}, True, True),
-        ({'sequential_upload': False}, False, False),
-        ({'readonly': True, 'sequential_upload': False}, True, False),
-        ({'readonly': True, 'unknown_field': 'value'}, True, True),
+        ({
+            'readonly': True
+        }, True, True),
+        ({
+            'sequential_upload': False
+        }, False, False),
+        ({
+            'readonly': True,
+            'sequential_upload': False
+        }, True, False),
+        ({
+            'readonly': True,
+            'unknown_field': 'value'
+        }, True, True),
     ])
     def test_mount_config_from_dict(self, input_dict, expected_readonly,
                                     expected_seq):
@@ -36,9 +46,16 @@ class TestStorageFromYamlConfig:
     @pytest.mark.parametrize('config_field,expected_readonly,expected_seq', [
         (None, False, True),
         ({}, False, True),
-        ({'readonly': True}, True, True),
-        ({'sequential_upload': False}, False, False),
-        ({'readonly': True, 'sequential_upload': False}, True, False),
+        ({
+            'readonly': True
+        }, True, True),
+        ({
+            'sequential_upload': False
+        }, False, False),
+        ({
+            'readonly': True,
+            'sequential_upload': False
+        }, True, False),
     ])
     def test_storage_from_yaml_config(self, config_field, expected_readonly,
                                       expected_seq):
@@ -64,21 +81,23 @@ class TestStorageToYamlConfig:
         """Test sequential_upload=True (default) is not serialized."""
         mount_config = storage.MountConfig(sequential_upload=True)
         storage_obj = storage.Storage(name='test-bucket',
-                                       mount_config=mount_config)
+                                      mount_config=mount_config)
         yaml_config = storage_obj.to_yaml_config()
         assert 'config' not in yaml_config
 
-    @pytest.mark.parametrize('ro,seq,expect_ro,expect_seq', [
-        (True, True, True, None),  # readonly only, seq is default
-        (False, False, None, False),  # seq only, readonly is default
-        (True, False, True, False),  # both non-default
-    ])
+    @pytest.mark.parametrize(
+        'ro,seq,expect_ro,expect_seq',
+        [
+            (True, True, True, None),  # readonly only, seq is default
+            (False, False, None, False),  # seq only, readonly is default
+            (True, False, True, False),  # both non-default
+        ])
     def test_non_default_config_serialized(self, ro, seq, expect_ro,
                                            expect_seq):
         """Test non-default mount config values are serialized."""
         mount_config = storage.MountConfig(readonly=ro, sequential_upload=seq)
         storage_obj = storage.Storage(name='test-bucket',
-                                       mount_config=mount_config)
+                                      mount_config=mount_config)
         yaml_config = storage_obj.to_yaml_config()
         assert 'config' in yaml_config
         if expect_ro is not None:
@@ -102,13 +121,15 @@ class TestMountCachedCmd:
             mount_path='/mnt/data',
             mount_config=mount_config)
 
-    @pytest.mark.parametrize('ro,seq,expect_ro,expect_seq', [
-        (None, None, False, True),  # None config
-        (False, True, False, True),  # Default config
-        (True, True, True, True),  # readonly only
-        (False, False, False, False),  # parallel only
-        (True, False, True, False),  # both
-    ])
+    @pytest.mark.parametrize(
+        'ro,seq,expect_ro,expect_seq',
+        [
+            (None, None, False, True),  # None config
+            (False, True, False, True),  # Default config
+            (True, True, True, True),  # readonly only
+            (False, False, False, False),  # parallel only
+            (True, False, True, False),  # both
+        ])
     def test_mount_cached_cmd(self, ro, seq, expect_ro, expect_seq):
         """Test get_mount_cached_cmd with various configs."""
         if ro is None:
@@ -128,11 +149,10 @@ class TestMountCmd:
     def test_s3_mount_cmd(self, ro, expect_flag):
         """Test get_s3_mount_cmd with readonly config."""
         cfg = storage.MountConfig(readonly=ro) if ro else None
-        cmd = mounting_utils.get_s3_mount_cmd(
-            bucket_name='my-bucket',
-            mount_path='/mnt/data',
-            _bucket_sub_path=None,
-            mount_config=cfg)
+        cmd = mounting_utils.get_s3_mount_cmd(bucket_name='my-bucket',
+                                              mount_path='/mnt/data',
+                                              _bucket_sub_path=None,
+                                              mount_config=cfg)
         has_flag = '--read-only' in cmd or '-o ro' in cmd
         assert has_flag == expect_flag
 
@@ -140,9 +160,8 @@ class TestMountCmd:
     def test_gcs_mount_cmd(self, ro, expect_flag):
         """Test get_gcs_mount_cmd with readonly config."""
         cfg = storage.MountConfig(readonly=ro) if ro else None
-        cmd = mounting_utils.get_gcs_mount_cmd(
-            bucket_name='my-bucket',
-            mount_path='/mnt/data',
-            _bucket_sub_path=None,
-            mount_config=cfg)
+        cmd = mounting_utils.get_gcs_mount_cmd(bucket_name='my-bucket',
+                                               mount_path='/mnt/data',
+                                               _bucket_sub_path=None,
+                                               mount_config=cfg)
         assert ('-o ro' in cmd) == expect_flag


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR adds support for `readonly` and `sequential_upload` config options in file_mounts that can be set on a per-bucket basis:

```yaml
file_mounts:
  /mnt/path:
    name: my-bucket
    store: s3
    mode: MOUNT_CACHED
    config:
      readonly: true
      sequential_upload: true
```

Changes:
- Add `readonly` and `sequential_upload` fields to storage config schema
- Add `MountConfig` dataclass to hold mount configuration options
- Update `Storage` class to parse and store mount config from YAML
- Update all store mount_command/mount_cached_command methods to accept optional MountConfig parameter
- Update `get_mount_cached_cmd` in mounting_utils to use config options:
  - `readonly: true` adds `--read-only` flag to rclone mount
  - `sequential_upload: true` adds `--transfers 1` flag (default behavior)
  - `sequential_upload: false` uses parallel transfers (rclone default)
  
Fixes #8454

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
   - CI will verify formatting
- [x] Any manual or new tests for this PR (please specify below)
   - `TestMountConfig`: Tests for MountConfig dataclass and from_dict
   - `TestStorageFromYamlConfig`: Tests for Storage.from_yaml_config with config field
   - `TestStorageToYamlConfig`: Tests for Storage.to_yaml_config serialization
   - `TestMountCachedCmd`: Tests for get_mount_cached_cmd with mount config options
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
