### PR TITLE
[GPU Metrics] improve prometheus retention policy

### DIFF
--- a/charts/external-metrics/values.yaml
+++ b/charts/external-metrics/values.yaml
@@ -10,6 +10,10 @@ prometheus:
       enabled: true
       size: 50Gi
     retention: "1000d"
+    # The Prometheus documentations recommends setting the retention size to be 80-85% of the persistent volume size.
+    # ref: https://prometheus.io/docs/prometheus/latest/storage/#right-sizing-retention-size
+    # 43GB is roughly 80% of the 50Gi persistent volume size. We use Gi for the PV size and GB for the retention size
+    # because these are the units specified by the Prometheus chart schema for each respective field.
     retentionSize: "43GB"
   kube-state-metrics:
     enabled: true

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -568,6 +568,10 @@ prometheus:
       enabled: true
       size: 50Gi
     retention: "1000d"
+    # The Prometheus documentations recommends setting the retention size to be 80-85% of the persistent volume size.
+    # ref: https://prometheus.io/docs/prometheus/latest/storage/#right-sizing-retention-size
+    # 43GB is roughly 80% of the 50Gi persistent volume size. We use Gi for the PV size and GB for the retention size
+    # because these are the units set by the Prometheus chart schema for each respective field.
     retentionSize: "43GB"
   # Configure additional scrape configs using extraScrapeConfigs
   extraScrapeConfigs: |


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
We do not currently set an explicit retention policy for prometheus. This causes the backing persistent volume to run out of space after sometime (the exact amount of time depends on the volume of metrics being collected). This PR bumps up the default size of the backing PVC and also sets a size-based retention policy to fix this out of disk issue.


<!-- Describe the tests ran -->
I set these values in a live deployment that had hit the issue described above, and it resolved the issue.
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
