### PR TITLE
[GPU Metrics] add gpu temp panel to cluster gpu metrics

### DIFF
--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -356,6 +356,14 @@ function ActiveTab({
   isGrafanaAvailable,
   isHistoricalCluster = false,
 }) {
+  // Define panel data
+  const gpuPanels = [
+    { id: '1', title: 'GPU Utilization', keyPrefix: 'gpu-util' },
+    { id: '2', title: 'GPU Memory Utilization', keyPrefix: 'gpu-memory' },
+    { id: '3', title: 'GPU Temperature', keyPrefix: 'gpu-temp' },
+    { id: '4', title: 'GPU Power Usage', keyPrefix: 'gpu-power' },
+  ];
+
   const GPU_METRICS_EXPANDED_KEY = 'skypilot-gpu-metrics-expanded';
 
   const [isYamlExpanded, setIsYamlExpanded] = useState(false);
@@ -792,66 +800,25 @@ function ActiveTab({
                     </div>
                   </div>
 
-                  <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))' }}>
-                    {/* GPU Utilization */}
-                    <div className="bg-white rounded-md border border-gray-200 shadow-sm">
-                      <div className="p-2">
-                        <iframe
-                          src={buildGrafanaMetricsUrl('1')}
-                          width="100%"
-                          height="400"
-                          frameBorder="0"
-                          title="GPU Utilization"
-                          className="rounded"
-                          key={`gpu-util-${clusterData?.cluster}-${timeRange.from}-${timeRange.to}`}
-                        />
+                  <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(300px,1fr))]">
+                    {gpuPanels.map((panel) => (
+                      <div
+                        key={panel.id}
+                        className="bg-white rounded-md border border-gray-200 shadow-sm"
+                      >
+                        <div className="p-2">
+                          <iframe
+                            src={buildGrafanaMetricsUrl(panel.id)}
+                            width="100%"
+                            height="400"
+                            frameBorder="0"
+                            title={panel.title}
+                            className="rounded"
+                            key={`${panel.keyPrefix}-${clusterData?.cluster}-${timeRange.from}-${timeRange.to}`}
+                          />
+                        </div>
                       </div>
-                    </div>
-
-                    {/* GPU Memory Utilization */}
-                    <div className="bg-white rounded-md border border-gray-200 shadow-sm">
-                      <div className="p-2">
-                        <iframe
-                          src={buildGrafanaMetricsUrl('2')}
-                          width="100%"
-                          height="400"
-                          frameBorder="0"
-                          title="GPU Memory Utilization"
-                          className="rounded"
-                          key={`gpu-memory-${clusterData?.cluster}-${timeRange.from}-${timeRange.to}`}
-                        />
-                      </div>
-                    </div>
-
-                    {/* GPU Temperature */}
-                    <div className="bg-white rounded-md border border-gray-200 shadow-sm">
-                      <div className="p-2">
-                        <iframe
-                          src={buildGrafanaMetricsUrl('3')}
-                          width="100%"
-                          height="400"
-                          frameBorder="0"
-                          title="GPU Temperature"
-                          className="rounded"
-                          key={`gpu-temp-${clusterData?.cluster}-${timeRange.from}-${timeRange.to}`}
-                        />
-                      </div>
-                    </div>
-
-                    {/* GPU Power Usage */}
-                    <div className="bg-white rounded-md border border-gray-200 shadow-sm">
-                      <div className="p-2">
-                        <iframe
-                          src={buildGrafanaMetricsUrl('4')}
-                          width="100%"
-                          height="400"
-                          frameBorder="0"
-                          title="GPU Power Usage"
-                          className="rounded"
-                          key={`gpu-power-${clusterData?.cluster}-${timeRange.from}-${timeRange.to}`}
-                        />
-                      </div>
-                    </div>
+                    ))}
                   </div>
                 </div>
               )}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR adds a panel for GPU Temperature to the cluster details page and generally modularizes the frontend logic for GPU metrics panels. 
<img width="1512" height="982" alt="Screenshot 2026-01-02 at 4 36 03 PM" src="https://github.com/user-attachments/assets/cba34d50-9c3b-4890-bd1f-1d0c76789175" />


<!-- Describe the tests ran -->
Deployed on an API server that already had GPU metrics enabled, verified that GPU temperature panel is now included and all panels still show up after the refactor.
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
