### PR TITLE
Fix `test_helm_deploy_okta` failure in nightly

### DIFF
--- a/tests/kubernetes/scripts/helm_okta.sh
+++ b/tests/kubernetes/scripts/helm_okta.sh
@@ -536,4 +536,4 @@ fi
 python3 "$SCRIPT_DIR/okta_auto_login.py" sky-api --endpoint "$ENDPOINT" --username "$OKTA_TEST_USERNAME" --password "$OKTA_TEST_PASSWORD" || (echo "❌ Failed: sky api login" && exit 1)
 
 # run basic k8s ssh test
-pytest tests/smoke_tests/test_basic.py::test_kubernetes_ssh_proxy_connection --kubernetes || (echo "❌ Failed: basic k8s ssh test" && exit 1)
+pytest tests/smoke_tests/test_basic.py::test_kubernetes_slurm_ssh_proxy_connection --kubernetes || (echo "❌ Failed: basic k8s ssh test" && exit 1)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

https://buildkite.com/skypilot-1/smoke-tests/builds/7013#_

Regression in this PR: #8268

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
