### PR TITLE
[Tests] Fix CI failures with `'ABCMeta' object is not subscriptable`

### DIFF
--- a/.github/workflows/pytest-optimizer.yml
+++ b/.github/workflows/pytest-optimizer.yml
@@ -16,7 +16,7 @@ jobs:
   python-test-optimizer:
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.9"]
         test-path:
           - "tests/test_optimizer_dryruns.py -k \"partial\""
           - "tests/test_optimizer_dryruns.py -k \"not partial\""

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,7 +16,7 @@ jobs:
   python-test:
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.9"]
         test-path:
           # Group them based on running time to save CI time and resources
           - tests/unit_tests
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.13"]
+        python-version: ["3.9", "3.13"]
         test-path:
           - tests/test_jobs_and_serve.py tests/test_cli.py
         include:


### PR DESCRIPTION
Upgrade from Python 3.8 to 3.9 to fix compatibility issue with google-auth library. On Python 3.8, importing the kubernetes module fails with:

```
    TypeError: 'ABCMeta' object is not subscriptable
```

This is caused by type annotations like `Sequence[str]` in google/auth/_default.py that require Python 3.9+ without `from __future__ import annotations`.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
