### PR TITLE
[Slurm] Enable ssh multiplexing for SlurmClient with ProxyCommand

### DIFF
--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -122,8 +122,8 @@ class SlurmClient:
             for attempt in range(max_attempts):
                 local_port = random.randint(10000, 65535)
                 try:
-                    tunnel_proc = command_runner.open_ssh_tunnel(
-                        ssh_tunnel_runner, (local_port, 22))
+                    tunnel_proc = ssh_tunnel_runner.open_ssh_tunnel(
+                        (local_port, 22))
                     break
                 except exceptions.CommandError as e:
                     # Don't retry if the error is due to timeout or

--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -135,6 +135,7 @@ class SlurmClient:
                 for attempt in range(max_attempts):
                     local_port = random.randint(10000, 65535)
                     try:
+                        # TODO(kevin): Handle 2FA.
                         tunnel_proc = command_runner.open_ssh_tunnel(
                             ssh_tunnel_runner, (local_port, 22))
                         break

--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -187,6 +187,7 @@ class SlurmClient:
                 tunnel_proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 tunnel_proc.kill()
+                tunnel_proc.wait()
 
     def _run_slurm_cmd(self, cmd: str) -> Tuple[int, str, str]:
         return self._runner.run(cmd,

--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -135,8 +135,8 @@ class SlurmClient:
                 for attempt in range(max_attempts):
                     local_port = random.randint(10000, 65535)
                     try:
-                        tunnel_proc = ssh_tunnel_runner.open_ssh_tunnel(
-                            (local_port, 22))
+                        tunnel_proc = command_runner.open_ssh_tunnel(
+                            ssh_tunnel_runner, (local_port, 22))
                         break
                     except exceptions.CommandError as e:
                         # Don't retry if the error is due to timeout or

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -113,8 +113,6 @@ _LAUNCHED_RESERVED_WORKER_PATTERN = re.compile(
 # 10.133.0.5: ray.worker.default,
 _LAUNCHING_IP_PATTERN = re.compile(
     r'({}): ray[._]worker[._](?:default|reserved)'.format(IP_ADDR_REGEX))
-SSH_CONNECTION_ERROR_PATTERN = re.compile(
-    r'^ssh:.*(timed out|connection refused)$', re.IGNORECASE)
 _SSH_CONNECTION_TIMED_OUT_PATTERN = re.compile(r'^ssh:.*timed out$',
                                                re.IGNORECASE)
 K8S_PODS_NOT_FOUND_PATTERN = re.compile(r'.*(NotFound|pods .* not found).*',

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2400,7 +2400,7 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
             head_runner = runners[0]
             local_port = random.randint(10000, 65535)
             try:
-                ssh_tunnel_proc = backend_utils.open_ssh_tunnel(
+                ssh_tunnel_proc = command_runner.open_ssh_tunnel(
                     head_runner, (local_port, constants.SKYLET_GRPC_PORT))
             except exceptions.CommandError as e:
                 # Don't retry if the error is due to timeout,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2400,8 +2400,8 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
             head_runner = runners[0]
             local_port = random.randint(10000, 65535)
             try:
-                ssh_tunnel_proc = command_runner.open_ssh_tunnel(
-                    head_runner, (local_port, constants.SKYLET_GRPC_PORT))
+                ssh_tunnel_proc = head_runner.open_ssh_tunnel(
+                    (local_port, constants.SKYLET_GRPC_PORT))
             except exceptions.CommandError as e:
                 # Don't retry if the error is due to timeout,
                 # connection refused, Kubernetes pods not found,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2407,7 +2407,7 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
                 # connection refused, Kubernetes pods not found,
                 # or an in-progress termination.
                 if (e.detailed_reason is not None and
-                    (backend_utils.SSH_CONNECTION_ERROR_PATTERN.search(
+                    (command_runner.SSH_CONNECTION_ERROR_PATTERN.search(
                         e.detailed_reason) or
                      backend_utils.K8S_PODS_NOT_FOUND_PATTERN.search(
                          e.detailed_reason) or attempt == max_attempts - 1)):

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2400,8 +2400,8 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
             head_runner = runners[0]
             local_port = random.randint(10000, 65535)
             try:
-                ssh_tunnel_proc = head_runner.open_ssh_tunnel(
-                    (local_port, constants.SKYLET_GRPC_PORT))
+                ssh_tunnel_proc = command_runner.open_ssh_tunnel(
+                    head_runner, (local_port, constants.SKYLET_GRPC_PORT))
             except exceptions.CommandError as e:
                 # Don't retry if the error is due to timeout,
                 # connection refused, Kubernetes pods not found,

--- a/sky/clouds/slurm.py
+++ b/sky/clouds/slurm.py
@@ -7,7 +7,6 @@ from sky import catalog
 from sky import clouds
 from sky import sky_logging
 from sky import skypilot_config
-from sky.adaptors import slurm
 from sky.provision.slurm import utils as slurm_utils
 from sky.skylet import constants
 from sky.utils import annotations
@@ -505,7 +504,7 @@ class Slurm(clouds.Cloud):
             # Retrieve the config options for a given SlurmctldHost name alias.
             ssh_config_dict = ssh_config.lookup(cluster)
             try:
-                client = slurm.SlurmClient(
+                client = slurm_utils.get_slurm_client(
                     ssh_config_dict['hostname'],
                     int(ssh_config_dict.get('port', 22)),
                     ssh_config_dict['user'],

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -7,7 +7,6 @@ from typing import Any, cast, Dict, List, Optional, Tuple
 
 from sky import sky_logging
 from sky import skypilot_config
-from sky.adaptors import slurm
 from sky.provision import common
 from sky.provision import constants
 from sky.provision.slurm import utils as slurm_utils
@@ -75,7 +74,7 @@ def _create_virtual_instance(
     ssh_proxy_jump = ssh_config_dict.get('proxyjump', None)
     partition = slurm_utils.get_partition_from_config(provider_config)
 
-    client = slurm.SlurmClient(
+    client = slurm_utils.get_slurm_client(
         ssh_host,
         ssh_port,
         ssh_user,
@@ -313,7 +312,7 @@ def query_instances(
     ssh_proxy_command = ssh_config_dict.get('proxycommand', None)
     ssh_proxy_jump = ssh_config_dict.get('proxyjump', None)
 
-    client = slurm.SlurmClient(
+    client = slurm_utils.get_slurm_client(
         ssh_host,
         ssh_port,
         ssh_user,
@@ -411,7 +410,7 @@ def get_cluster_info(
     ssh_proxy_command = ssh_config_dict.get('proxycommand', None)
     ssh_proxy_jump = ssh_config_dict.get('proxyjump', None)
 
-    client = slurm.SlurmClient(
+    client = slurm_utils.get_slurm_client(
         ssh_host,
         ssh_port,
         ssh_user,
@@ -497,7 +496,7 @@ def terminate_instances(
     # TODO(kevin): Validate this assumption.
     if slurm_utils.is_inside_slurm_cluster():
         logger.debug('Running inside a Slurm cluster, using local execution')
-        client = slurm.SlurmClient(is_inside_slurm_cluster=True)
+        client = slurm_utils.get_slurm_client(is_inside_slurm_cluster=True)
     else:
         ssh_config_dict = provider_config['ssh']
         ssh_host = ssh_config_dict['hostname']
@@ -507,7 +506,7 @@ def terminate_instances(
         ssh_proxy_command = ssh_config_dict.get('proxycommand', None)
         ssh_proxy_jump = ssh_config_dict.get('proxyjump', None)
 
-        client = slurm.SlurmClient(
+        client = slurm_utils.get_slurm_client(
             ssh_host,
             ssh_port,
             ssh_user,

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -34,7 +34,7 @@ def get_slurm_ssh_config() -> SSHConfig:
     return slurm_config
 
 
-@annotations.lru_cache(scope='request', maxsize=10)
+@annotations.lru_cache(scope='request', maxsize=128)
 def get_slurm_client(
         ssh_host: Optional[str] = None,
         ssh_port: Optional[int] = None,

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -34,6 +34,32 @@ def get_slurm_ssh_config() -> SSHConfig:
     return slurm_config
 
 
+@annotations.lru_cache(scope='request', maxsize=10)
+def get_slurm_client(
+        ssh_host: Optional[str] = None,
+        ssh_port: Optional[int] = None,
+        ssh_user: Optional[str] = None,
+        ssh_key: Optional[str] = None,
+        *,
+        ssh_proxy_command: Optional[str] = None,
+        ssh_proxy_jump: Optional[str] = None,
+        is_inside_slurm_cluster: bool = False,  ## pylint: disable=redefined-outer-name
+) -> slurm.SlurmClient:
+    """Get or create a SlurmClient.
+
+    Within a single request, returns the same SlurmClient instance.
+    """
+    return slurm.SlurmClient(
+        ssh_host=ssh_host,
+        ssh_port=ssh_port,
+        ssh_user=ssh_user,
+        ssh_key=ssh_key,
+        ssh_proxy_command=ssh_proxy_command,
+        ssh_proxy_jump=ssh_proxy_jump,
+        is_inside_slurm_cluster=is_inside_slurm_cluster,
+    )
+
+
 class SlurmInstanceType:
     """Class to represent the "Instance Type" in a Slurm cluster.
 
@@ -203,7 +229,7 @@ def get_cluster_default_partition(cluster_name: str) -> Optional[str]:
             f'Failed to load SSH configuration from {DEFAULT_SLURM_PATH}: '
             f'{common_utils.format_exception(e)}') from e
 
-    client = slurm.SlurmClient(
+    client = get_slurm_client(
         ssh_config_dict['hostname'],
         int(ssh_config_dict.get('port', 22)),
         ssh_config_dict['user'],
@@ -296,7 +322,7 @@ def check_instance_fits(
                 f'could not be loaded: {common_utils.format_exception(e)}.')
     ssh_config_dict = ssh_config.lookup(cluster)
 
-    client = slurm.SlurmClient(
+    client = get_slurm_client(
         ssh_config_dict['hostname'],
         int(ssh_config_dict.get('port', 22)),
         ssh_config_dict['user'],
@@ -398,7 +424,7 @@ def get_gres_gpu_type(cluster: str, requested_gpu_type: str) -> str:
     try:
         ssh_config = get_slurm_ssh_config()
         ssh_config_dict = ssh_config.lookup(cluster)
-        client = slurm.SlurmClient(
+        client = get_slurm_client(
             ssh_config_dict['hostname'],
             int(ssh_config_dict.get('port', 22)),
             ssh_config_dict['user'],
@@ -449,7 +475,7 @@ def _get_slurm_node_info_list(
             f'configuration.')
     slurm_config_dict = slurm_config.lookup(slurm_cluster_name)
     logger.debug(f'Slurm config dict: {slurm_config_dict}')
-    slurm_client = slurm.SlurmClient(
+    slurm_client = get_slurm_client(
         slurm_config_dict['hostname'],
         int(slurm_config_dict.get('port', 22)),
         slurm_config_dict['user'],
@@ -597,7 +623,7 @@ def get_partitions(cluster_name: str) -> List[str]:
             os.path.expanduser(DEFAULT_SLURM_PATH))
         slurm_config_dict = slurm_config.lookup(cluster_name)
 
-        client = slurm.SlurmClient(
+        client = get_slurm_client(
             slurm_config_dict['hostname'],
             int(slurm_config_dict.get('port', 22)),
             slurm_config_dict['user'],

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -37,7 +37,7 @@ def get_slurm_ssh_config() -> SSHConfig:
 # maxsize=32 is mainly for status refresh daemon,
 # which fetches multiple clusters status concurrently.
 # For normal requests, each process likely only needs
-# to cache a single client object.
+# to cache a single client object per-request.
 @annotations.lru_cache(scope='request', maxsize=32)
 def get_slurm_client(
         ssh_host: Optional[str] = None,

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -34,7 +34,11 @@ def get_slurm_ssh_config() -> SSHConfig:
     return slurm_config
 
 
-@annotations.lru_cache(scope='request', maxsize=128)
+# maxsize=32 is mainly for status refresh daemon,
+# which fetches multiple clusters status concurrently.
+# For normal requests, each process likely only needs
+# to cache a single client object.
+@annotations.lru_cache(scope='request', maxsize=32)
 def get_slurm_client(
         ssh_host: Optional[str] = None,
         ssh_port: Optional[int] = None,

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -68,10 +68,6 @@ RSYNC_NO_OWNER_NO_GROUP_OPTION = '--no-owner --no-group'
 _HASH_MAX_LENGTH = 10
 _DEFAULT_CONNECT_TIMEOUT = 30
 
-# Messages used to detect successful port forward establishment
-_ACK_MESSAGE = 'ack'
-_FORWARDING_FROM_MESSAGE = 'Forwarding from'
-
 
 def _ssh_control_path(ssh_control_filename: Optional[str]) -> Optional[str]:
     """Returns a temporary path to be used as the ssh control path."""
@@ -547,18 +543,6 @@ class CommandRunner:
         """
         raise NotImplementedError
 
-    def open_ssh_tunnel(self, port_forward: Tuple[int,
-                                                  int]) -> subprocess.Popen:
-        """Opens an SSH tunnel for port forwarding.
-
-        Args:
-            port_forward: A tuple of (local_port, remote_port).
-
-        Returns:
-            The subprocess.Popen object of the tunnel process.
-        """
-        raise NotImplementedError
-
     @timeline.event
     def git_clone(
         self,
@@ -787,48 +771,6 @@ class SSHCommandRunner(CommandRunner):
                                      port_forward=port_forward,
                                      connect_timeout=connect_timeout)
 
-    def open_ssh_tunnel(self, port_forward: Tuple[int,
-                                                  int]) -> subprocess.Popen:
-        """Opens an SSH tunnel for port forwarding.
-
-        Args:
-            port_forward: A tuple of (local_port, remote_port).
-
-        Returns:
-            The subprocess.Popen object for the tunnel process.
-        """
-        local_port, remote_port = port_forward
-        # Disabling ControlMaster makes things easier to reason about
-        # with respect to resource management/ownership,
-        # as killing the process will close the tunnel too.
-        self.disable_control_master = False
-        self.port_forward_execute_remote_command = True
-
-        # The default connect_timeout of 1s is too short for
-        # connecting to clusters using a jump server.
-        # We use NON_INTERACTIVE mode to avoid allocating a pseudo-tty,
-        # which is counted towards non-idleness.
-        cmd: List[str] = self.port_forward_command(
-            [(local_port, remote_port)],
-            connect_timeout=5,
-            ssh_mode=SshMode.NON_INTERACTIVE)
-        # cat so the command doesn't exit until we kill it
-        cmd += [f'"echo {_ACK_MESSAGE} && cat"']
-        ack_fn: Callable[[str], bool] = lambda ack: ack == f'{_ACK_MESSAGE}\n'
-
-        try:
-            return _open_tunnel_subprocess(cmd, ack_fn)
-        except exceptions.CommandError as e:
-            # If the tunnel failed with exit code 255 and interactive auth is
-            # enabled, retry with interactive auth.
-            if not self.enable_interactive_auth or e.returncode != 255:
-                raise e
-            cmd, preexec_fn, cleanup = self._setup_interactive_auth(cmd)
-            try:
-                return _open_tunnel_subprocess(cmd, ack_fn, preexec_fn)
-            finally:
-                cleanup()
-
     def ssh_base_command(self, *, ssh_mode: SshMode,
                          port_forward: Optional[List[Tuple[int, int]]],
                          connect_timeout: Optional[int]) -> List[str]:
@@ -865,10 +807,12 @@ class SSHCommandRunner(CommandRunner):
                 f'{self.ssh_user}@{self.ip}'
             ]
 
-    def _setup_interactive_auth(
-        self, command: List[str]
-    ) -> Tuple[List[str], Callable[[], None], Callable[[], None]]:
-        """Set up PTY and socket for interactive auth.
+    def _retry_with_interactive_auth(
+            self, session_id: str, command: List[str], log_path: str,
+            require_outputs: bool, process_stream: bool, stream_logs: bool,
+            executable: str,
+            **kwargs) -> Union[int, Tuple[int, str, str], Tuple[int, int]]:
+        """Retries command with interactive auth.
 
         This handles SSH connections requiring keyboard-interactive
         authentication (e.g., 2FA) by using a PTY for auth prompts and
@@ -876,16 +820,10 @@ class SSHCommandRunner(CommandRunner):
         other SSH sessions can reuse without re-authenticating.
 
         The PTY is bridged to a websocket connection that allows the client
-        to handle interactive authentication.
+        to handle interactive authentication. Command output flows through
+        normal stdout/stderr pipes, which gets printed to log_path.
 
-        Args:
-            command: The SSH command to run.
-
-        Returns:
-            A tuple of (modified_command, preexec_fn, cleanup_fn) where:
-            - modified_command: Command with ControlPersist option added.
-            - preexec_fn: Function to call before exec in subprocess.
-            - cleanup_fn: Function to call to clean up PTY fds and sockets.
+        See ssh_options_list for when ControlMaster is not enabled.
         """
         extra_options = [
             # Override ControlPersist to reduce frequency of manual user
@@ -911,7 +849,6 @@ class SSHCommandRunner(CommandRunner):
         pty_m_fd, pty_s_fd = pty.openpty()
 
         # Create Unix socket to pass PTY master fd to websocket handler
-        session_id = str(uuid.uuid4())
         fd_socket_path = interactive_utils.get_pty_socket_path(session_id)
         if os.path.exists(fd_socket_path):
             os.unlink(fd_socket_path)
@@ -955,19 +892,32 @@ class SSHCommandRunner(CommandRunner):
             target=handle_unix_socket_connection, daemon=True)
         unix_sock_thread.start()
 
-        def setup_pty_session():
-            # Set PTY as controlling terminal so SSH can access /dev/tty
-            # for keyboard-interactive auth. Without this:
-            # "can't open /dev/tty: Device not configured"
-            fcntl.ioctl(pty_s_fd, termios.TIOCSCTTY, 0)
-            # Ignore SIGHUP so ControlMaster survives when PTY closes.
-            signal.signal(signal.SIGHUP, signal.SIG_IGN)
-            # Ignore SIGTERM so ControlMaster survives subprocess_daemon
-            # killing the process group.
-            if self._ssh_proxy_jump is not None:
-                signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        try:
 
-        def cleanup():
+            def setup_pty_session():
+                # Set PTY as controlling terminal so SSH can access /dev/tty
+                # for keyboard-interactive auth. Without this:
+                # "can't open /dev/tty: Device not configured"
+                fcntl.ioctl(pty_s_fd, termios.TIOCSCTTY, 0)
+                # Ignore SIGHUP so ControlMaster survives when PTY closes.
+                signal.signal(signal.SIGHUP, signal.SIG_IGN)
+                # Ignore SIGTERM so ControlMaster survives subprocess_daemon
+                # killing the process group.
+                if self._ssh_proxy_jump is not None:
+                    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+
+            return log_lib.run_with_log(' '.join(command),
+                                        log_path,
+                                        require_outputs=require_outputs,
+                                        stream_logs=stream_logs,
+                                        process_stream=process_stream,
+                                        shell=True,
+                                        executable=executable,
+                                        preexec_fn=setup_pty_session,
+                                        **kwargs)
+        except Exception as e:
+            raise RuntimeError(f'Exception in setup: {e}') from e
+        finally:
             # Clean up PTY fds and sockets.
             fd_server.close()
             if os.path.exists(fd_socket_path):
@@ -977,32 +927,6 @@ class SSHCommandRunner(CommandRunner):
             except OSError:
                 pass  # Already closed by background thread
             os.close(pty_s_fd)
-
-        return command, setup_pty_session, cleanup
-
-    def _retry_with_interactive_auth(
-            self, command: List[str], log_path: str, require_outputs: bool,
-            process_stream: bool, stream_logs: bool, executable: str,
-            **kwargs) -> Union[int, Tuple[int, str, str], Tuple[int, int]]:
-        """Retries command with interactive auth.
-
-        See _setup_interactive_auth for details on the interactive auth flow.
-        """
-        command, preexec_fn, cleanup = self._setup_interactive_auth(command)
-        try:
-            return log_lib.run_with_log(' '.join(command),
-                                        log_path,
-                                        require_outputs=require_outputs,
-                                        stream_logs=stream_logs,
-                                        process_stream=process_stream,
-                                        shell=True,
-                                        executable=executable,
-                                        preexec_fn=preexec_fn,
-                                        **kwargs)
-        except Exception as e:
-            raise RuntimeError(f'Exception in setup: {e}') from e
-        finally:
-            cleanup()
 
     def close_cached_connection(self) -> None:
         """Close the cached connection to the remote machine.
@@ -1132,7 +1056,8 @@ class SSHCommandRunner(CommandRunner):
         # the stdout/stderr does not contain the auth failure message,
         # which is why we don't check the output here, and just attempt
         # the interactive auth flow.
-        return self._retry_with_interactive_auth(command, log_path,
+        session_id = str(uuid.uuid4())
+        return self._retry_with_interactive_auth(session_id, command, log_path,
                                                  require_outputs,
                                                  process_stream, stream_logs,
                                                  executable, **kwargs)
@@ -1271,57 +1196,6 @@ class KubernetesCommandRunner(CommandRunner):
             f'{local_port_str}:{remote_port}',
         ]
         return kubectl_cmd
-
-    def open_ssh_tunnel(self, port_forward: Tuple[int,
-                                                  int]) -> subprocess.Popen:
-        """Opens a kubectl port-forward tunnel.
-
-        Args:
-            port_forward: A tuple of (local_port, remote_port).
-
-        Returns:
-            The subprocess.Popen object for the tunnel process.
-        """
-        local_port, remote_port = port_forward
-        cmd: List[str] = self.port_forward_command(
-            [(local_port, remote_port)],
-            connect_timeout=5,
-            ssh_mode=SshMode.NON_INTERACTIVE)
-
-        def ack_fn(ack: str) -> bool:
-            if _FORWARDING_FROM_MESSAGE in ack:
-                # On kind clusters, this error occurs if we make a request
-                # immediately after the port-forward is established on a
-                # new pod:
-                # "Unhandled Error" err="an error occurred forwarding
-                # ... -> 46590: failed to execute portforward in network
-                # namespace "/var/run/netns/cni-...": failed to connect to
-                # localhost:46590 inside namespace "...", IPv4: dial tcp4
-                # 127.0.0.1:46590: connect: connection refused
-                # So we need to poll the port on the pod to check if it is
-                # open. We did not observe this with real Kubernetes clusters.
-                timeout = 5
-                port_check_cmd = (
-                    # We install netcat in our ray-node container,
-                    # so we can use it here.
-                    # (See kubernetes-ray.yml.j2)
-                    f'end=$((SECONDS+{timeout})); '
-                    f'while ! nc -z -w 1 localhost {remote_port}; do '
-                    'if (( SECONDS >= end )); then exit 1; fi; '
-                    'sleep 0.1; '
-                    'done')
-                returncode, stdout, stderr = self.run(port_check_cmd,
-                                                      require_outputs=True,
-                                                      stream_logs=False)
-                subprocess_utils.handle_returncode(
-                    returncode,
-                    ' '.join(cmd),
-                    f'Failed to check remote port {remote_port}',
-                    stderr=stdout + '\n' + stderr)
-                return True
-            return False
-
-        return _open_tunnel_subprocess(cmd, ack_fn)
 
     @timeline.event
     @context_utils.cancellation_guard
@@ -1757,33 +1631,41 @@ class SlurmCommandRunner(SSHCommandRunner):
         return super().run(cmd, **kwargs)
 
 
-def _open_tunnel_subprocess(
-    cmd: List[str],
-    ack_fn: Callable[[str], bool],
-    preexec_fn: Optional[Callable[[], None]] = None,
-) -> subprocess.Popen:
-    """Spawns SSH tunnel subprocess and waits for ack message.
+_ACK_MESSAGE = 'ack'
+_FORWARDING_FROM_MESSAGE = 'Forwarding from'
 
-    Args:
-        cmd: The SSH command to run.
-        ack_fn: Function to check if the ack message is received.
-        preexec_fn: Optional function to call before exec in subprocess.
 
-    Returns:
-        The subprocess.Popen object. If the tunnel failed to establish,
-        the returncode will be set.
-    """
+def open_ssh_tunnel(head_runner: Union[SSHCommandRunner,
+                                       KubernetesCommandRunner],
+                    port_forward: Tuple[int, int]) -> subprocess.Popen:
+    local_port, remote_port = port_forward
+    if isinstance(head_runner, SSHCommandRunner):
+        # Disabling ControlMaster makes things easier to reason about
+        # with respect to resource management/ownership,
+        # as killing the process will close the tunnel too.
+        head_runner.disable_control_master = True
+        head_runner.port_forward_execute_remote_command = True
+
+    # The default connect_timeout of 1s is too short for
+    # connecting to clusters using a jump server.
+    # We use NON_INTERACTIVE mode to avoid allocating a pseudo-tty,
+    # which is counted towards non-idleness.
+    cmd: List[str] = head_runner.port_forward_command(
+        [(local_port, remote_port)],
+        connect_timeout=5,
+        ssh_mode=SshMode.NON_INTERACTIVE)
+    if isinstance(head_runner, SSHCommandRunner):
+        # cat so the command doesn't exit until we kill it
+        cmd += [f'"echo {_ACK_MESSAGE} && cat"']
     cmd_str = ' '.join(cmd)
     logger.debug(f'Running port forward command: {cmd_str}')
-    # pylint: disable=subprocess-popen-preexec-fn
     ssh_tunnel_proc = subprocess.Popen(cmd_str,
                                        shell=True,
                                        stdin=subprocess.PIPE,
                                        stdout=subprocess.PIPE,
                                        stderr=subprocess.PIPE,
                                        start_new_session=True,
-                                       text=True,
-                                       preexec_fn=preexec_fn)
+                                       text=True)
     # Wait until we receive an ack from the remote cluster or
     # the SSH connection times out.
     queue: queue_lib.Queue = queue_lib.Queue()
@@ -1800,18 +1682,50 @@ def _open_tunnel_subprocess(
             time.sleep(0.1)
             continue
         assert ack is not None
-        try:
-            if ack_fn(ack):
-                break
-        except Exception as e:  # pylint: disable=broad-except
-            try:
-                ssh_tunnel_proc.terminate()
-                ssh_tunnel_proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                ssh_tunnel_proc.kill()
-                ssh_tunnel_proc.wait()
-            finally:
-                raise e
+        if isinstance(head_runner,
+                      SSHCommandRunner) and ack == f'{_ACK_MESSAGE}\n':
+            break
+        elif isinstance(
+                head_runner,
+                KubernetesCommandRunner) and _FORWARDING_FROM_MESSAGE in ack:
+            # On kind clusters, this error occurs if we make a request
+            # immediately after the port-forward is established on a new pod:
+            # "Unhandled Error" err="an error occurred forwarding ... -> 46590:
+            # failed to execute portforward in network namespace
+            # "/var/run/netns/cni-...": failed to connect to localhost:46590
+            # inside namespace "...", IPv4: dial tcp4 127.0.0.1:46590:
+            # connect: connection refused
+            # So we need to poll the port on the pod to check if it is open.
+            # We did not observe this with real Kubernetes clusters.
+            timeout = 5
+            port_check_cmd = (
+                # We install netcat in our ray-node container,
+                # so we can use it here.
+                # (See kubernetes-ray.yml.j2)
+                f'end=$((SECONDS+{timeout})); '
+                f'while ! nc -z -w 1 localhost {remote_port}; do '
+                'if (( SECONDS >= end )); then exit 1; fi; '
+                'sleep 0.1; '
+                'done')
+            returncode, stdout, stderr = head_runner.run(port_check_cmd,
+                                                         require_outputs=True,
+                                                         stream_logs=False)
+            if returncode != 0:
+                try:
+                    ssh_tunnel_proc.terminate()
+                    ssh_tunnel_proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    ssh_tunnel_proc.kill()
+                    ssh_tunnel_proc.wait()
+                finally:
+                    error_msg = (f'Failed to check remote port {remote_port}')
+                    if stdout:
+                        error_msg += f'\n-- stdout --\n{stdout}\n'
+                    raise exceptions.CommandError(returncode=returncode,
+                                                  command=cmd_str,
+                                                  error_msg=error_msg,
+                                                  detailed_reason=stderr)
+            break
 
     if ssh_tunnel_proc.poll() is not None:
         stdout, stderr = ssh_tunnel_proc.communicate()

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -39,6 +39,10 @@ logger = sky_logging.init_logger(__name__)
 # Pattern to extract home directory from command output
 _HOME_DIR_PATTERN = re.compile(r'SKYPILOT_HOME_DIR: ([^\s\n]+)')
 
+# Pattern to detect SSH connection errors that should not be retried
+SSH_CONNECTION_ERROR_PATTERN = re.compile(
+    r'^ssh:.*(timed out|connection refused)$', re.IGNORECASE)
+
 # Rsync options
 # TODO(zhwu): This will print a per-file progress bar (with -P),
 # shooting a lot of messages to the output. --info=progress2 is used

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -5,10 +5,12 @@ import hashlib
 import os
 import pathlib
 import pty
+import queue as queue_lib
 import re
 import shlex
 import signal
 import socket
+import subprocess
 import sys
 import termios
 import threading
@@ -1623,3 +1625,111 @@ class SlurmCommandRunner(SSHCommandRunner):
             f'cd {self.sky_dir} && export HOME=$(pwd) && {cmd}')
 
         return super().run(cmd, **kwargs)
+
+
+_ACK_MESSAGE = 'ack'
+_FORWARDING_FROM_MESSAGE = 'Forwarding from'
+
+
+def open_ssh_tunnel(head_runner: Union[SSHCommandRunner,
+                                       KubernetesCommandRunner],
+                    port_forward: Tuple[int, int]) -> subprocess.Popen:
+    local_port, remote_port = port_forward
+    if isinstance(head_runner, SSHCommandRunner):
+        # Disabling ControlMaster makes things easier to reason about
+        # with respect to resource management/ownership,
+        # as killing the process will close the tunnel too.
+        head_runner.disable_control_master = True
+        head_runner.port_forward_execute_remote_command = True
+
+    # The default connect_timeout of 1s is too short for
+    # connecting to clusters using a jump server.
+    # We use NON_INTERACTIVE mode to avoid allocating a pseudo-tty,
+    # which is counted towards non-idleness.
+    cmd: List[str] = head_runner.port_forward_command(
+        [(local_port, remote_port)],
+        connect_timeout=5,
+        ssh_mode=SshMode.NON_INTERACTIVE)
+    if isinstance(head_runner, SSHCommandRunner):
+        # cat so the command doesn't exit until we kill it
+        cmd += [f'"echo {_ACK_MESSAGE} && cat"']
+    cmd_str = ' '.join(cmd)
+    logger.debug(f'Running port forward command: {cmd_str}')
+    ssh_tunnel_proc = subprocess.Popen(cmd_str,
+                                       shell=True,
+                                       stdin=subprocess.PIPE,
+                                       stdout=subprocess.PIPE,
+                                       stderr=subprocess.PIPE,
+                                       start_new_session=True,
+                                       text=True)
+    # Wait until we receive an ack from the remote cluster or
+    # the SSH connection times out.
+    queue: queue_lib.Queue = queue_lib.Queue()
+    stdout_thread = threading.Thread(
+        target=lambda queue, stdout: queue.put(stdout.readline()),
+        args=(queue, ssh_tunnel_proc.stdout),
+        daemon=True)
+    stdout_thread.start()
+    while ssh_tunnel_proc.poll() is None:
+        try:
+            ack = queue.get_nowait()
+        except queue_lib.Empty:
+            ack = None
+            time.sleep(0.1)
+            continue
+        assert ack is not None
+        if isinstance(head_runner,
+                      SSHCommandRunner) and ack == f'{_ACK_MESSAGE}\n':
+            break
+        elif isinstance(
+                head_runner,
+                KubernetesCommandRunner) and _FORWARDING_FROM_MESSAGE in ack:
+            # On kind clusters, this error occurs if we make a request
+            # immediately after the port-forward is established on a new pod:
+            # "Unhandled Error" err="an error occurred forwarding ... -> 46590:
+            # failed to execute portforward in network namespace
+            # "/var/run/netns/cni-...": failed to connect to localhost:46590
+            # inside namespace "...", IPv4: dial tcp4 127.0.0.1:46590:
+            # connect: connection refused
+            # So we need to poll the port on the pod to check if it is open.
+            # We did not observe this with real Kubernetes clusters.
+            timeout = 5
+            port_check_cmd = (
+                # We install netcat in our ray-node container,
+                # so we can use it here.
+                # (See kubernetes-ray.yml.j2)
+                f'end=$((SECONDS+{timeout})); '
+                f'while ! nc -z -w 1 localhost {remote_port}; do '
+                'if (( SECONDS >= end )); then exit 1; fi; '
+                'sleep 0.1; '
+                'done')
+            returncode, stdout, stderr = head_runner.run(port_check_cmd,
+                                                         require_outputs=True,
+                                                         stream_logs=False)
+            if returncode != 0:
+                try:
+                    ssh_tunnel_proc.terminate()
+                    ssh_tunnel_proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    ssh_tunnel_proc.kill()
+                    ssh_tunnel_proc.wait()
+                finally:
+                    error_msg = (f'Failed to check remote port {remote_port}')
+                    if stdout:
+                        error_msg += f'\n-- stdout --\n{stdout}\n'
+                    raise exceptions.CommandError(returncode=returncode,
+                                                  command=cmd_str,
+                                                  error_msg=error_msg,
+                                                  detailed_reason=stderr)
+            break
+
+    if ssh_tunnel_proc.poll() is not None:
+        stdout, stderr = ssh_tunnel_proc.communicate()
+        error_msg = 'Port forward failed'
+        if stdout:
+            error_msg += f'\n-- stdout --\n{stdout}\n'
+        raise exceptions.CommandError(returncode=ssh_tunnel_proc.returncode,
+                                      command=cmd_str,
+                                      error_msg=error_msg,
+                                      detailed_reason=stderr)
+    return ssh_tunnel_proc

--- a/sky/utils/command_runner.pyi
+++ b/sky/utils/command_runner.pyi
@@ -5,6 +5,7 @@ overloaded type hints for SSHCommandRunner.run(), as we need to
 determine the return type based on the value of require_outputs.
 """
 import enum
+import re
 import subprocess
 import typing
 from typing import Any, Callable, Iterable, List, Optional, Tuple, Union
@@ -17,6 +18,7 @@ from sky.utils import subprocess_utils as subprocess_utils
 
 GIT_EXCLUDE: str
 RSYNC_DISPLAY_OPTION: str
+SSH_CONNECTION_ERROR_PATTERN: re.Pattern[str]
 RSYNC_FILTER_GITIGNORE: str
 RSYNC_FILTER_SKYIGNORE: str
 RSYNC_EXCLUDE_OPTION: str

--- a/sky/utils/command_runner.pyi
+++ b/sky/utils/command_runner.pyi
@@ -117,6 +117,11 @@ class CommandRunner:
             ssh_mode: SshMode = SshMode.INTERACTIVE) -> List[str]:
         ...
 
+    def open_ssh_tunnel(
+            self,
+            port_forward: Tuple[int, int]) -> subprocess.Popen[str]:
+        ...
+
     @classmethod
     def make_runner_list(cls: typing.Type[CommandRunner],
                          node_list: Iterable[Tuple[Any, ...]],
@@ -234,6 +239,11 @@ class SSHCommandRunner(CommandRunner):
             ssh_mode: SshMode = SshMode.INTERACTIVE) -> List[str]:
         ...
 
+    def open_ssh_tunnel(
+            self,
+            port_forward: Tuple[int, int]) -> subprocess.Popen[str]:
+        ...
+
 
 class KubernetesCommandRunner(CommandRunner):
 
@@ -311,6 +321,11 @@ class KubernetesCommandRunner(CommandRunner):
             port_forward: List[Tuple[int, int]],
             connect_timeout: int = 1,
             ssh_mode: SshMode = SshMode.INTERACTIVE) -> List[str]:
+        ...
+
+    def open_ssh_tunnel(
+            self,
+            port_forward: Tuple[int, int]) -> subprocess.Popen[str]:
         ...
 
 
@@ -391,10 +406,3 @@ class LocalProcessCommandRunner(CommandRunner):
             skip_lines: int = ...,
             **kwargs) -> Union[Tuple[int, str, str], int]:
         ...
-
-
-def open_ssh_tunnel(
-    head_runner: Union[SSHCommandRunner, KubernetesCommandRunner],
-    port_forward: Tuple[int, int],
-) -> subprocess.Popen[str]:
-    ...

--- a/sky/utils/command_runner.pyi
+++ b/sky/utils/command_runner.pyi
@@ -117,11 +117,6 @@ class CommandRunner:
             ssh_mode: SshMode = SshMode.INTERACTIVE) -> List[str]:
         ...
 
-    def open_ssh_tunnel(
-            self,
-            port_forward: Tuple[int, int]) -> subprocess.Popen[str]:
-        ...
-
     @classmethod
     def make_runner_list(cls: typing.Type[CommandRunner],
                          node_list: Iterable[Tuple[Any, ...]],
@@ -239,11 +234,6 @@ class SSHCommandRunner(CommandRunner):
             ssh_mode: SshMode = SshMode.INTERACTIVE) -> List[str]:
         ...
 
-    def open_ssh_tunnel(
-            self,
-            port_forward: Tuple[int, int]) -> subprocess.Popen[str]:
-        ...
-
 
 class KubernetesCommandRunner(CommandRunner):
 
@@ -321,11 +311,6 @@ class KubernetesCommandRunner(CommandRunner):
             port_forward: List[Tuple[int, int]],
             connect_timeout: int = 1,
             ssh_mode: SshMode = SshMode.INTERACTIVE) -> List[str]:
-        ...
-
-    def open_ssh_tunnel(
-            self,
-            port_forward: Tuple[int, int]) -> subprocess.Popen[str]:
         ...
 
 
@@ -406,3 +391,10 @@ class LocalProcessCommandRunner(CommandRunner):
             skip_lines: int = ...,
             **kwargs) -> Union[Tuple[int, str, str], int]:
         ...
+
+
+def open_ssh_tunnel(
+    head_runner: Union[SSHCommandRunner, KubernetesCommandRunner],
+    port_forward: Tuple[int, int],
+) -> subprocess.Popen[str]:
+    ...

--- a/sky/utils/command_runner.pyi
+++ b/sky/utils/command_runner.pyi
@@ -5,6 +5,7 @@ overloaded type hints for SSHCommandRunner.run(), as we need to
 determine the return type based on the value of require_outputs.
 """
 import enum
+import subprocess
 import typing
 from typing import Any, Callable, Iterable, List, Optional, Tuple, Union
 
@@ -388,3 +389,10 @@ class LocalProcessCommandRunner(CommandRunner):
             skip_lines: int = ...,
             **kwargs) -> Union[Tuple[int, str, str], int]:
         ...
+
+
+def open_ssh_tunnel(
+    head_runner: Union[SSHCommandRunner, KubernetesCommandRunner],
+    port_forward: Tuple[int, int],
+) -> subprocess.Popen[str]:
+    ...

--- a/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
+++ b/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
@@ -339,8 +339,16 @@ class TestRequestScopedCache:
 
     def test_same_client_within_request(self, mock_ssh_tunnel):
         """Same params return same client instance within a request."""
-        client1 = slurm_utils.get_slurm_client('host', 22, 'user', None)
-        client2 = slurm_utils.get_slurm_client('host', 22, 'user', None)
+        client1 = slurm_utils.get_slurm_client('host',
+                                               22,
+                                               'user',
+                                               None,
+                                               ssh_proxy_command='proxy-cmd')
+        client2 = slurm_utils.get_slurm_client('host',
+                                               22,
+                                               'user',
+                                               None,
+                                               ssh_proxy_command='proxy-cmd')
 
         assert client1 is client2
         # Tunnel should only be created once
@@ -348,11 +356,19 @@ class TestRequestScopedCache:
 
     def test_new_client_after_cache_clear(self, mock_ssh_tunnel):
         """New client instance after clearing request cache."""
-        client1 = slurm_utils.get_slurm_client('host', 22, 'user', None)
+        client1 = slurm_utils.get_slurm_client('host',
+                                               22,
+                                               'user',
+                                               None,
+                                               ssh_proxy_command='proxy-cmd')
 
         annotations.clear_request_level_cache()
 
-        client2 = slurm_utils.get_slurm_client('host', 22, 'user', None)
+        client2 = slurm_utils.get_slurm_client('host',
+                                               22,
+                                               'user',
+                                               None,
+                                               ssh_proxy_command='proxy-cmd')
 
         assert client1 is not client2
         # Tunnel created twice (once per client)
@@ -360,7 +376,11 @@ class TestRequestScopedCache:
 
     def test_tunnel_cleanup_on_gc(self, mock_ssh_tunnel):
         """Tunnel process is terminated when client is garbage collected."""
-        client = slurm_utils.get_slurm_client('host', 22, 'user', None)
+        client = slurm_utils.get_slurm_client('host',
+                                              22,
+                                              'user',
+                                              None,
+                                              ssh_proxy_command='proxy-cmd')
         tunnel_proc = client._tunnel_proc
 
         annotations.clear_request_level_cache()

--- a/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
+++ b/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
@@ -17,10 +17,11 @@ def mock_ssh_tunnel():
     """Mock open_ssh_tunnel to avoid real SSH connections in tests."""
     mock_proc = mock.MagicMock(spec=subprocess.Popen)
     mock_proc.poll.return_value = None  # Tunnel is "running"
-    with mock.patch.object(command_runner,
+    with mock.patch.object(command_runner.SSHCommandRunner,
                            'open_ssh_tunnel',
-                           return_value=mock_proc):
-        yield mock_proc
+                           return_value=mock_proc) as mock_method:
+        mock_method.mock_proc = mock_proc
+        yield mock_method
 
 
 class TestGetPartitions:
@@ -344,7 +345,7 @@ class TestRequestScopedCache:
 
         assert client1 is client2
         # Tunnel should only be created once
-        assert command_runner.open_ssh_tunnel.call_count == 1
+        assert mock_ssh_tunnel.call_count == 1
 
     def test_new_client_after_cache_clear(self, mock_ssh_tunnel):
         """New client instance after clearing request cache."""
@@ -356,7 +357,7 @@ class TestRequestScopedCache:
 
         assert client1 is not client2
         # Tunnel created twice (once per client)
-        assert command_runner.open_ssh_tunnel.call_count == 2
+        assert mock_ssh_tunnel.call_count == 2
 
     def test_tunnel_cleanup_on_gc(self, mock_ssh_tunnel):
         """Tunnel process is terminated when client is garbage collected."""

--- a/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
+++ b/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
@@ -17,11 +17,10 @@ def mock_ssh_tunnel():
     """Mock open_ssh_tunnel to avoid real SSH connections in tests."""
     mock_proc = mock.MagicMock(spec=subprocess.Popen)
     mock_proc.poll.return_value = None  # Tunnel is "running"
-    with mock.patch.object(command_runner.SSHCommandRunner,
+    with mock.patch.object(command_runner,
                            'open_ssh_tunnel',
-                           return_value=mock_proc) as mock_method:
-        mock_method.mock_proc = mock_proc
-        yield mock_method
+                           return_value=mock_proc):
+        yield mock_proc
 
 
 class TestGetPartitions:
@@ -345,7 +344,7 @@ class TestRequestScopedCache:
 
         assert client1 is client2
         # Tunnel should only be created once
-        assert mock_ssh_tunnel.call_count == 1
+        assert command_runner.open_ssh_tunnel.call_count == 1
 
     def test_new_client_after_cache_clear(self, mock_ssh_tunnel):
         """New client instance after clearing request cache."""
@@ -357,7 +356,7 @@ class TestRequestScopedCache:
 
         assert client1 is not client2
         # Tunnel created twice (once per client)
-        assert mock_ssh_tunnel.call_count == 2
+        assert command_runner.open_ssh_tunnel.call_count == 2
 
     def test_tunnel_cleanup_on_gc(self, mock_ssh_tunnel):
         """Tunnel process is terminated when client is garbage collected."""

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -120,15 +120,15 @@ class TestTerminateInstances:
             ('STAGING_OUT', True, True),
         ])
     @patch('sky.provision.slurm.instance.slurm_utils.is_inside_slurm_cluster')
-    @patch('sky.provision.slurm.instance.slurm.SlurmClient')
+    @patch('sky.provision.slurm.instance.slurm_utils.get_slurm_client')
     def test_terminate_instances_handles_job_states(
-            self, mock_slurm_client_class, mock_is_inside_slurm_cluster,
+            self, mock_get_slurm_client, mock_is_inside_slurm_cluster,
             job_state, should_cancel, should_signal):
         """Test terminate_instances handles different job states correctly."""
         mock_is_inside_slurm_cluster.return_value = False
 
         mock_client = mock.MagicMock()
-        mock_slurm_client_class.return_value = mock_client
+        mock_get_slurm_client.return_value = mock_client
 
         cluster_name = 'test-cluster'
         provider_config = {
@@ -164,14 +164,14 @@ class TestTerminateInstances:
             mock_client.cancel_jobs_by_name.assert_not_called()
 
     @patch('sky.provision.slurm.instance.slurm_utils.is_inside_slurm_cluster')
-    @patch('sky.provision.slurm.instance.slurm.SlurmClient')
-    def test_terminate_instances_no_jobs_found(self, mock_slurm_client_class,
+    @patch('sky.provision.slurm.instance.slurm_utils.get_slurm_client')
+    def test_terminate_instances_no_jobs_found(self, mock_get_slurm_client,
                                                mock_is_inside_slurm_cluster):
         """Test terminate_instances when no jobs are found."""
         mock_is_inside_slurm_cluster.return_value = False
 
         mock_client = mock.MagicMock()
-        mock_slurm_client_class.return_value = mock_client
+        mock_get_slurm_client.return_value = mock_client
 
         cluster_name = 'test-cluster'
         provider_config = {


### PR DESCRIPTION
This is mainly to work around our current implementation of `SSHCommandRunner` which disables ControlMaster when `ProxyCommand` is used:

https://github.com/skypilot-org/skypilot/blob/a9a68117489c9ed565fd62178ed14dbb95d4439e/sky/utils/command_runner.py#L148-L154

Today, if you need `ProxyCommand`, i.e. AWS SSM, to connect to your Slurm cluster, you don't get SSH multiplexing, so you incur the AWS SSM connection initialization for every command we run against the Slurm cluster, which can take a long time.

With this PR, we create an SSH tunnel just once, when we initialize the `SlurmClient`, and we cache the `SlurmClient` per-request. Then we use this SSH tunnel to actually run all the SSH commands we need (and now we can use ControlMaster here because there's no `ProxyCommand` used anymore when connecting to the tunnel).

~Also did a small refactoring on top of #8317 to have the 2FA handling as well for port forward (not only run()).~ (will move to a separate PR)

For no `ProxyCommand`, ssh multiplexing is already done using ControlMaster, so this PR doesn't affect those cases.

## Benchmarks

Not including PR #8447.

Command: `sky launch --infra slurm -y --dryrun`.

### With AWS SSM ProxyCommand

Before: 1m21s
**After: 18s (78% faster)**

### Without AWS SSM ProxyCommand

Same, as we only use the SSH tunnel when ProxyCommand is used.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
