### PR TITLE
Fix `retry_until_up` flaky tests

### DIFF
--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -1853,30 +1853,6 @@ def test_cluster_setup_num_gpus():
         smoke_tests_utils.run_one_test(test)
 
 
-@pytest.mark.aws
-def test_launch_retry_until_up():
-    """Test that retry until up considers more resources after trying all zones."""
-    cluster_name = smoke_tests_utils.get_cluster_name()
-    timeout = 180
-    test = smoke_tests_utils.Test(
-        'launch-retry-until-up',
-        [
-            # Launch something we'll never get.
-            f's=$(timeout {timeout} sky launch -c {cluster_name} --gpus B200:8 --infra aws echo hi -y -d --retry-until-up --use-spot 2>&1 || true) && '
-            # Check that "Retry after" appears in the output
-            'echo "$s" | grep -q "Retry after" && '
-            # Find the first occurrence of "Retry after" and get its line number
-            'RETRY_LINE=$(echo "$s" | grep -n "Retry after" | head -1 | cut -d: -f1) && '
-            # Check that "Considered resources" appears after the first "Retry after"
-            # We do this by extracting all lines after RETRY_LINE and checking if "Considered resources" appears
-            'echo "$s" | tail -n +$((RETRY_LINE + 1)) | grep -q "Considered resources"'
-        ],
-        timeout=200,  # Slightly more than 180 to account for test overhead
-        teardown=f'sky down -y {cluster_name}',
-    )
-    smoke_tests_utils.run_one_test(test)
-
-
 def test_cancel_job_reliability(generic_cloud: str):
     """Test that sky cancel properly terminates running jobs."""
     name = smoke_tests_utils.get_cluster_name()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

```bash
D 01-06 16:59:51.285 PID=75468 optimizer.py:322] Defaulting the task's estimated time to 1 hour.
D 01-06 16:59:51.292 PID=75468 optimizer.py:367] resources: AWS(p6-b200.48xlarge[Spot], {'B200': 8}), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $32.2
D 01-06 16:59:51.299 PID=75468 optimizer.py:367] resources: AWS(p6-b200.48xlarge[Spot], {'B200': 8}), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $32.5
D 01-06 16:59:51.305 PID=75468 optimizer.py:367] resources: AWS(p6-b200.48xlarge[Spot], {'B200': 8}), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $32.6
D 01-06 16:59:51.312 PID=75468 optimizer.py:367] resources: AWS(p6-b200.48xlarge[Spot], {'B200': 8}), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $35.9
D 01-06 16:59:51.318 PID=75468 optimizer.py:367] resources: AWS(p6-b200.48xlarge[Spot], {'B200': 8}), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $37.2
D 01-06 16:59:51.324 PID=75468 optimizer.py:367] resources: AWS(p6-b200.48xlarge[Spot], {'B200': 8}), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $43.7
I 01-06 16:59:51.325 PID=75468 optimizer.py:920] Considered resources (1 node):
I 01-06 16:59:51.327 PID=75468 optimizer.py:988] --------------------------------------------------------------------------------------------
I 01-06 16:59:51.327 PID=75468 optimizer.py:988]  INFRA              INSTANCE                 vCPUs   Mem(GB)   GPUS     COST ($)   CHOSEN   
I 01-06 16:59:51.327 PID=75468 optimizer.py:988] --------------------------------------------------------------------------------------------
I 01-06 16:59:51.327 PID=75468 optimizer.py:988]  AWS (us-east-1d)   p6-b200.48xlarge[Spot]   192     2048      B200:8   32.19         ✔     
I 01-06 16:59:51.327 PID=75468 optimizer.py:988] --------------------------------------------------------------------------------------------
D 01-06 16:59:51.328 PID=75468 skypilot_config.py:424] No active workspace found, using default workspace: default
D 01-06 16:59:51.339 PID=75468 skypilot_config.py:424] No active workspace found, using default workspace: default
D 01-06 16:59:51.340 PID=75468 skypilot_config.py:424] No active workspace found, using default workspace: default
D 01-06 16:59:51.389 PID=75468 skypilot_config.py:424] No active workspace found, using default workspace: default
D 01-06 16:59:51.429 PID=75468 backend_utils.py:886] Using ssh_proxy_command: None
D 01-06 16:59:51.566 PID=75468 skypilot_config.py:424] No active workspace found, using default workspace: default
I 01-06 16:59:51.571 PID=75468 cloud_vm_ray_backend.py:1190] ⚙︎ Launching on AWS us-east-1 (us-east-1d).
D 01-06 16:59:51.571 PID=75468 provisioner.py:157] SkyPilot version: 1.0.0-dev0; commit: a9a68117489c9ed565fd62178ed14dbb95d4439e-dirty
D 01-06 16:59:51.571 PID=75468 provisioner.py:159] 
D 01-06 16:59:51.571 PID=75468 provisioner.py:159] 
D 01-06 16:59:51.571 PID=75468 provisioner.py:159] ==================== Provisioning ====================
D 01-06 16:59:51.571 PID=75468 provisioner.py:159] 
```

#8079 add the smoke tests we expect we will never get B200:8, but when it actually occurs, the smoke tests fail

Can't find a `never get` guarteen instance, remove the smoke tests to make sure nightly bulid pass.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
