### PR TITLE
[Pools] Fix `test_pools_num_jobs_basic` When Using Consolidation Mode

### DIFF
--- a/tests/smoke_tests/test_pools.py
+++ b/tests/smoke_tests/test_pools.py
@@ -1155,7 +1155,10 @@ def test_pools_num_jobs_basic(generic_cloud: str):
         with tempfile.NamedTemporaryFile(delete=True) as job_yaml:
             write_yaml(pool_yaml, pool_config)
             write_yaml(job_yaml, job_config)
-            job_ids = list(range(2, 2 + num_jobs))
+            if smoke_tests_utils.server_side_is_consolidation_mode():
+                job_ids = list(range(1, 1 + num_jobs))
+            else:
+                job_ids = list(range(2, 2 + num_jobs))
             test = smoke_tests_utils.Test(
                 'test_pools_num_jobs',
                 [


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixed an issue with our tests that was causing test_pools_num_jobs_basic to fail with consolidation mode. The issue is that we were checking the job status with the ID by assuming the ID but in consolidation mode the starting job ID is different, now we check the mode and set the IDs that we check accordingly.

This addresses issue #8434

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
