### PR TITLE
[GUI]Round k8s CPU and Memory info in dashboard

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -25,6 +25,7 @@ import {
 import {
   formatCpu,
   formatMemory,
+  formatMemoryValue,
   calculateAggregatedResource,
 } from '@/utils/resourceUtils';
 import { buildContextStatsKey } from '@/utils/infraUtils';
@@ -746,17 +747,18 @@ export function ContextDetails({
 
                       // Format memory display: "X of Y free" or just "Y" if free is unknown
                       // (GB is in column header, so don't include it in values)
+                      // Matches CLI format_float with precision=0: removes .0 for whole numbers
                       let memoryDisplay = '-';
                       if (
                         node.memory_gb !== null &&
                         node.memory_gb !== undefined
                       ) {
-                        const memoryTotal = node.memory_gb.toFixed(1);
+                        const memoryTotal = formatMemoryValue(node.memory_gb);
                         if (
                           node.memory_free_gb !== null &&
                           node.memory_free_gb !== undefined
                         ) {
-                          const memoryFree = node.memory_free_gb.toFixed(1);
+                          const memoryFree = formatMemoryValue(node.memory_free_gb);
                           memoryDisplay = `${memoryFree} of ${memoryTotal} free`;
                         } else {
                           memoryDisplay = memoryTotal;

--- a/sky/dashboard/src/data/connectors/infra.jsx
+++ b/sky/dashboard/src/data/connectors/infra.jsx
@@ -842,9 +842,7 @@ export async function getDetailedGpuInfo(filter) {
             : '-';
         const cpuCount =
           cpu_val !== null && !isNaN(cpu_val)
-            ? Number.isInteger(cpu_val)
-              ? cpu_val
-              : parseFloat(cpu_val).toFixed(1)
+            ? Math.round(parseFloat(cpu_val)).toString()
             : '-';
         const memory =
           mem_val !== null && !isNaN(mem_val)

--- a/sky/dashboard/src/utils/resourceUtils.js
+++ b/sky/dashboard/src/utils/resourceUtils.js
@@ -3,23 +3,50 @@
  */
 
 /**
+ * Format CPU value for display, matching CLI format_float with precision=0
+ * Rounds to 0 decimal places (removes .0 for whole numbers, rounds non-whole numbers to integers)
+ * @param {number|null|undefined} cpu - CPU count value
+ * @returns {string} - Formatted CPU string (e.g., "16" or "256" or "-")
+ */
+export function formatCpuValue(cpu) {
+  if (cpu === null || cpu === undefined) return '-';
+  // Round to 0 decimal places, matching CLI format_float with precision=0
+  // This removes .0 for whole numbers and rounds non-whole numbers to integers
+  return Math.round(cpu).toString();
+}
+
+/**
  * Format CPU count for display
  * @param {number|null|undefined} cpu - CPU count value
- * @returns {string} - Formatted CPU string (integer if whole, 1 decimal otherwise, or '-')
+ * @returns {string} - Formatted CPU string (e.g., "16" or "256" or "-")
  */
 export function formatCpu(cpu) {
   if (cpu === null || cpu === undefined) return '-';
-  return cpu === Math.floor(cpu) ? Math.floor(cpu).toString() : cpu.toFixed(1);
+  return formatCpuValue(cpu);
+}
+
+/**
+ * Format memory value (without unit) for display, matching CLI format_float with precision=0
+ * Rounds to 0 decimal places (removes .0 for whole numbers, rounds non-whole numbers to integers)
+ * @param {number|null|undefined} memory - Memory value in GB
+ * @returns {string} - Formatted memory string (e.g., "16" or "2000" or "-")
+ */
+export function formatMemoryValue(memory) {
+  if (memory === null || memory === undefined) return '-';
+  // Round to 0 decimal places, matching CLI format_float with precision=0
+  // This removes .0 for whole numbers and rounds non-whole numbers to integers
+  return Math.round(memory).toString();
 }
 
 /**
  * Format memory in GB for display
  * @param {number|null|undefined} memory - Memory value in GB
- * @returns {string} - Formatted memory string (e.g., "16.0 GB" or "-")
+ * @returns {string} - Formatted memory string (e.g., "16 GB" or "2000 GB" or "-")
  */
 export function formatMemory(memory) {
   if (memory === null || memory === undefined) return '-';
-  return `${memory.toFixed(1)} GB`;
+  const formatted = formatMemoryValue(memory);
+  return formatted === '-' ? '-' : `${formatted} GB`;
 }
 
 /**


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

# Before this PR

<img width="2289" height="687" alt="image" src="https://github.com/user-attachments/assets/56e76813-28ae-493f-ab13-76bac0bc449f" />

# After this PR

<img width="1566" height="795" alt="image" src="https://github.com/user-attachments/assets/6763af38-8f44-468e-8eff-32cda08dbdbb" />

Round to integer, remove the decimal precision. This is consistent with CLI but loses precision. By design, we thought the dashboard had more space to display more data, but since users have complained about it, we should reconsider consistency.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
