### PR TITLE
[Server] Fix BasicAuth rejecting Bearer tokens when both BasicAuth and service accounts are enabled (changed BearerToken for consistency)

### DIFF
--- a/tests/unit_tests/test_sky/server/test_bearer_token_middleware.py
+++ b/tests/unit_tests/test_sky/server/test_bearer_token_middleware.py
@@ -19,6 +19,15 @@ class TestBearerTokenMiddleware:
         return BearerTokenMiddleware(app=mock.Mock())
 
     @pytest.fixture
+    def base_mock_request(self):
+        """Create a basic mock request with auth_user initialized to None."""
+        request = mock.Mock(spec=fastapi.Request)
+        request.headers = {}
+        request.state = mock.Mock()
+        request.state.auth_user = None
+        return request
+
+    @pytest.fixture
     def mock_call_next(self):
         """Create a mock call_next function."""
 
@@ -29,44 +38,40 @@ class TestBearerTokenMiddleware:
 
     @pytest.mark.asyncio
     async def test_no_authorization_header_bypass(self, middleware,
+                                                  base_mock_request,
                                                   mock_call_next):
         """Test that requests without Authorization header bypass the middleware."""
-        request = mock.Mock(spec=fastapi.Request)
-        request.headers = {}  # No Authorization header
-        request.state = mock.Mock()
-        request.state.auth_user = None
-
-        response = await middleware.dispatch(request, mock_call_next)
+        # No Authorization header (default from fixture)
+        response = await middleware.dispatch(base_mock_request, mock_call_next)
 
         # Should call next middleware without processing
         assert response.status_code == 200
 
     @pytest.mark.asyncio
     async def test_non_bearer_authorization_bypass(self, middleware,
+                                                   base_mock_request,
                                                    mock_call_next):
         """Test that non-Bearer authorization headers bypass the middleware."""
-        request = mock.Mock(spec=fastapi.Request)
-        request.headers = {'authorization': 'Basic dXNlcjpwYXNz'}  # Basic auth
-        request.state = mock.Mock()
-        request.state.auth_user = None
+        base_mock_request.headers = {
+            'authorization': 'Basic dXNlcjpwYXNz'
+        }  # Basic auth
 
-        response = await middleware.dispatch(request, mock_call_next)
+        response = await middleware.dispatch(base_mock_request, mock_call_next)
 
         # Should call next middleware without processing
         assert response.status_code == 200
 
     @pytest.mark.asyncio
-    async def test_service_accounts_disabled(self, middleware, mock_call_next):
+    async def test_service_accounts_disabled(self, middleware,
+                                             base_mock_request, mock_call_next):
         """Test middleware when service accounts are disabled."""
-        request = mock.Mock(spec=fastapi.Request)
-        request.headers = {'authorization': 'Bearer sky_test_token'}
-        request.state = mock.Mock()
-        request.state.auth_user = None
+        base_mock_request.headers = {'authorization': 'Bearer sky_test_token'}
 
         with mock.patch.dict(
                 os.environ,
             {constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS: 'false'}):
-            response = await middleware.dispatch(request, mock_call_next)
+            response = await middleware.dispatch(base_mock_request,
+                                                 mock_call_next)
 
             # Should return 401 when service accounts are disabled and
             # a SkyPilot token is provided
@@ -76,31 +81,30 @@ class TestBearerTokenMiddleware:
 
     @pytest.mark.asyncio
     async def test_non_skypilot_bearer_token_bypass(self, middleware,
+                                                    base_mock_request,
                                                     mock_call_next):
         """Test that non-SkyPilot Bearer tokens bypass the middleware."""
-        request = mock.Mock(spec=fastapi.Request)
-        request.headers = {
+        base_mock_request.headers = {
             'authorization': 'Bearer oauth_token_123'
         }  # Not sky_ prefix
-        request.state = mock.Mock()
-        request.state.auth_user = None
 
         with mock.patch.dict(
                 os.environ,
             {constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS: 'true'}):
-            response = await middleware.dispatch(request, mock_call_next)
+            response = await middleware.dispatch(base_mock_request,
+                                                 mock_call_next)
 
             # Should call next middleware without processing
             assert response.status_code == 200
 
     @pytest.mark.asyncio
     async def test_invalid_service_account_token(self, middleware,
+                                                 base_mock_request,
                                                  mock_call_next):
         """Test middleware with invalid service account token."""
-        request = mock.Mock(spec=fastapi.Request)
-        request.headers = {'authorization': 'Bearer sky_invalid_token'}
-        request.state = mock.Mock()
-        request.state.auth_user = None
+        base_mock_request.headers = {
+            'authorization': 'Bearer sky_invalid_token'
+        }
 
         with mock.patch.dict(
                 os.environ,
@@ -109,7 +113,8 @@ class TestBearerTokenMiddleware:
 
             mock_token_service.verify_token.return_value = None
 
-            response = await middleware.dispatch(request, mock_call_next)
+            response = await middleware.dispatch(base_mock_request,
+                                                 mock_call_next)
 
             assert response.status_code == 401
             assert "Invalid or expired service account token" in response.body.decode(
@@ -117,12 +122,10 @@ class TestBearerTokenMiddleware:
 
     @pytest.mark.asyncio
     async def test_valid_service_account_token_success(self, middleware,
+                                                       base_mock_request,
                                                        mock_call_next):
         """Test middleware with valid service account token."""
-        request = mock.Mock(spec=fastapi.Request)
-        request.headers = {'authorization': 'Bearer sky_valid_token'}
-        request.state = mock.Mock()
-        request.state.auth_user = None
+        base_mock_request.headers = {'authorization': 'Bearer sky_valid_token'}
 
         mock_payload = {
             'sub': 'sa-123456',  # service account user ID
@@ -144,24 +147,25 @@ class TestBearerTokenMiddleware:
             mock_token_service.verify_token.return_value = mock_payload
             mock_get_user.return_value = mock_user_info
 
-            response = await middleware.dispatch(request, mock_call_next)
+            response = await middleware.dispatch(base_mock_request,
+                                                 mock_call_next)
 
             assert response.status_code == 200
             # Verify user was set in request state
-            assert request.state.auth_user.id == 'sa-123456'
-            assert request.state.auth_user.name == 'test-service-account'
+            assert base_mock_request.state.auth_user.id == 'sa-123456'
+            assert base_mock_request.state.auth_user.name == 'test-service-account'
             # Verify token last used was updated
             mock_update_last_used.assert_called_once_with('token_123')
             # Verify user info override was called
             mock_override_user_info.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_missing_user_id_in_token(self, middleware, mock_call_next):
+    async def test_missing_user_id_in_token(self, middleware, base_mock_request,
+                                            mock_call_next):
         """Test middleware when token payload is missing user_id."""
-        request = mock.Mock(spec=fastapi.Request)
-        request.headers = {'authorization': 'Bearer sky_invalid_payload_token'}
-        request.state = mock.Mock()
-        request.state.auth_user = None
+        base_mock_request.headers = {
+            'authorization': 'Bearer sky_invalid_payload_token'
+        }
 
         mock_payload = {
             # Missing 'sub' (user_id)
@@ -176,18 +180,19 @@ class TestBearerTokenMiddleware:
 
             mock_token_service.verify_token.return_value = mock_payload
 
-            response = await middleware.dispatch(request, mock_call_next)
+            response = await middleware.dispatch(base_mock_request,
+                                                 mock_call_next)
 
             assert response.status_code == 401
             assert "Invalid token payload" in response.body.decode()
 
     @pytest.mark.asyncio
-    async def test_missing_token_id_in_token(self, middleware, mock_call_next):
+    async def test_missing_token_id_in_token(self, middleware,
+                                             base_mock_request, mock_call_next):
         """Test middleware when token payload is missing token_id."""
-        request = mock.Mock(spec=fastapi.Request)
-        request.headers = {'authorization': 'Bearer sky_invalid_payload_token'}
-        request.state = mock.Mock()
-        request.state.auth_user = None
+        base_mock_request.headers = {
+            'authorization': 'Bearer sky_invalid_payload_token'
+        }
 
         mock_payload = {
             'sub': 'sa-123456',
@@ -202,18 +207,17 @@ class TestBearerTokenMiddleware:
 
             mock_token_service.verify_token.return_value = mock_payload
 
-            response = await middleware.dispatch(request, mock_call_next)
+            response = await middleware.dispatch(base_mock_request,
+                                                 mock_call_next)
 
             assert response.status_code == 401
             assert "Invalid token payload" in response.body.decode()
 
     @pytest.mark.asyncio
-    async def test_user_no_longer_exists(self, middleware, mock_call_next):
+    async def test_user_no_longer_exists(self, middleware, base_mock_request,
+                                         mock_call_next):
         """Test middleware when service account user no longer exists."""
-        request = mock.Mock(spec=fastapi.Request)
-        request.headers = {'authorization': 'Bearer sky_valid_token'}
-        request.state = mock.Mock()
-        request.state.auth_user = None
+        base_mock_request.headers = {'authorization': 'Bearer sky_valid_token'}
 
         mock_payload = {
             'sub': 'sa-deleted-user',
@@ -230,7 +234,8 @@ class TestBearerTokenMiddleware:
             mock_token_service.verify_token.return_value = mock_payload
             mock_get_user.return_value = None  # User no longer exists
 
-            response = await middleware.dispatch(request, mock_call_next)
+            response = await middleware.dispatch(base_mock_request,
+                                                 mock_call_next)
 
             assert response.status_code == 401
             assert "Service account user no longer exists" in response.body.decode(
@@ -238,12 +243,10 @@ class TestBearerTokenMiddleware:
 
     @pytest.mark.asyncio
     async def test_update_last_used_failure_not_fatal(self, middleware,
+                                                      base_mock_request,
                                                       mock_call_next):
         """Test that failure to update last used timestamp doesn't fail authentication."""
-        request = mock.Mock(spec=fastapi.Request)
-        request.headers = {'authorization': 'Bearer sky_valid_token'}
-        request.state = mock.Mock()
-        request.state.auth_user = None
+        base_mock_request.headers = {'authorization': 'Bearer sky_valid_token'}
 
         mock_payload = {
             'sub': 'sa-123456',
@@ -260,26 +263,27 @@ class TestBearerTokenMiddleware:
                 mock.patch('sky.users.token_service.token_service') as mock_token_service, \
                 mock.patch('sky.global_user_state.get_user') as mock_get_user, \
                 mock.patch('sky.global_user_state.update_service_account_token_last_used') as mock_update_last_used, \
-                mock.patch('sky.server.auth.authn.override_user_info_in_request_body') as mock_override_user_info:
+                mock.patch('sky.server.auth.authn.override_user_info_in_request_body'):
 
             mock_token_service.verify_token.return_value = mock_payload
             mock_get_user.return_value = mock_user_info
             mock_update_last_used.side_effect = Exception("Database error")
 
-            response = await middleware.dispatch(request, mock_call_next)
+            response = await middleware.dispatch(base_mock_request,
+                                                 mock_call_next)
 
             # Should still succeed despite update failure
             assert response.status_code == 200
-            assert request.state.auth_user.id == 'sa-123456'
+            assert base_mock_request.state.auth_user.id == 'sa-123456'
 
     @pytest.mark.asyncio
     async def test_token_verification_exception(self, middleware,
+                                                base_mock_request,
                                                 mock_call_next):
         """Test middleware when token verification raises an exception."""
-        request = mock.Mock(spec=fastapi.Request)
-        request.headers = {'authorization': 'Bearer sky_problematic_token'}
-        request.state = mock.Mock()
-        request.state.auth_user = None
+        base_mock_request.headers = {
+            'authorization': 'Bearer sky_problematic_token'
+        }
 
         with mock.patch.dict(
                 os.environ,
@@ -289,7 +293,8 @@ class TestBearerTokenMiddleware:
             mock_token_service.verify_token.side_effect = Exception(
                 "Token verification failed")
 
-            response = await middleware.dispatch(request, mock_call_next)
+            response = await middleware.dispatch(base_mock_request,
+                                                 mock_call_next)
 
             assert response.status_code == 401
             assert "Service account authentication failed" in response.body.decode(
@@ -297,14 +302,12 @@ class TestBearerTokenMiddleware:
 
     @pytest.mark.asyncio
     async def test_case_insensitive_bearer_check(self, middleware,
+                                                 base_mock_request,
                                                  mock_call_next):
         """Test that Bearer token check is case insensitive."""
-        request = mock.Mock(spec=fastapi.Request)
-        request.headers = {
+        base_mock_request.headers = {
             'authorization': 'bearer sky_test_token'
         }  # lowercase
-        request.state = mock.Mock()
-        request.state.auth_user = None
 
         mock_payload = {
             'sub': 'sa-123456',
@@ -326,13 +329,15 @@ class TestBearerTokenMiddleware:
             mock_token_service.verify_token.return_value = mock_payload
             mock_get_user.return_value = mock_user_info
 
-            response = await middleware.dispatch(request, mock_call_next)
+            response = await middleware.dispatch(base_mock_request,
+                                                 mock_call_next)
 
             assert response.status_code == 200
-            assert request.state.auth_user.id == 'sa-123456'
+            assert base_mock_request.state.auth_user.id == 'sa-123456'
 
     @pytest.mark.asyncio
     async def test_already_authenticated_user_bypass(self, middleware,
+                                                     base_mock_request,
                                                      mock_call_next):
         """Test that middleware bypasses when user is already authenticated.
 
@@ -340,15 +345,13 @@ class TestBearerTokenMiddleware:
         AuthProxy, BasicAuth) - when a previous middleware has authenticated
         the user, subsequent middlewares should pass through.
         """
-        request = mock.Mock(spec=fastapi.Request)
         # Request has a Bearer token header
-        request.headers = {'authorization': 'Bearer sky_some_token'}
-        request.state = mock.Mock()
+        base_mock_request.headers = {'authorization': 'Bearer sky_some_token'}
         # But user is already authenticated by a previous middleware
         mock_user = mock.Mock()
         mock_user.id = 'user-123'
         mock_user.name = 'basic-auth-user'
-        request.state.auth_user = mock_user
+        base_mock_request.state.auth_user = mock_user
 
         with mock.patch.dict(
                 os.environ,
@@ -356,12 +359,68 @@ class TestBearerTokenMiddleware:
                 mock.patch('sky.users.token_service.token_service') as mock_token_service:
 
             # Middleware should bypass without calling token_service
-            response = await middleware.dispatch(request, mock_call_next)
+            response = await middleware.dispatch(base_mock_request,
+                                                 mock_call_next)
 
             # Should pass through successfully
             assert response.status_code == 200
             # User should remain the same (not overwritten)
-            assert request.state.auth_user.id == 'user-123'
-            assert request.state.auth_user.name == 'basic-auth-user'
+            assert base_mock_request.state.auth_user.id == 'user-123'
+            assert base_mock_request.state.auth_user.name == 'basic-auth-user'
             # Token service should NOT be called
             mock_token_service.verify_token.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bearer_auth_then_basic_auth_middleware(
+            self, middleware, base_mock_request, mock_call_next):
+        """Test that BasicAuthMiddleware respects user authenticated by BearerTokenMiddleware.
+
+        This test simulates the middleware chain: BearerTokenMiddleware -> BasicAuthMiddleware.
+        When BearerTokenMiddleware successfully authenticates a service account,
+        BasicAuthMiddleware should pass through without attempting to re-authenticate.
+        """
+        base_mock_request.headers = {'authorization': 'Bearer sky_valid_token'}
+        # Mock request.url.path for BasicAuthMiddleware
+        base_mock_request.url = mock.Mock()
+        base_mock_request.url.path = '/api/some_endpoint'
+
+        mock_payload = {
+            'sub': 'sa-123456',
+            'name': 'test-service-account',
+            'token_id': 'token_123'
+        }
+
+        mock_user_info = mock.Mock()
+        mock_user_info.id = 'sa-123456'
+        mock_user_info.name = 'test-service-account'
+
+        # Mock BasicAuthMiddleware
+        from sky.server.server import BasicAuthMiddleware
+        basic_auth_middleware = BasicAuthMiddleware(app=mock.Mock())
+
+        # Create a call_next that simulates BasicAuthMiddleware being next in chain
+        async def bearer_then_basic_call_next(request):
+            # This simulates BasicAuthMiddleware being called after BearerTokenMiddleware
+            return await basic_auth_middleware.dispatch(request, mock_call_next)
+
+        with mock.patch.dict(
+                os.environ,
+            {constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS: 'true'}), \
+                mock.patch('sky.users.token_service.token_service') as mock_token_service, \
+                mock.patch('sky.global_user_state.get_user') as mock_get_user, \
+                mock.patch('sky.global_user_state.update_service_account_token_last_used'), \
+                mock.patch('sky.server.auth.authn.override_user_info_in_request_body'), \
+                mock.patch('sky.jobs.utils.is_consolidation_mode', return_value=False):
+
+            mock_token_service.verify_token.return_value = mock_payload
+            mock_get_user.return_value = mock_user_info
+
+            # First BearerTokenMiddleware authenticates
+            response = await middleware.dispatch(base_mock_request,
+                                                 bearer_then_basic_call_next)
+
+            # Should succeed through both middlewares
+            assert response.status_code == 200
+            # User should be the service account user from Bearer auth
+            assert base_mock_request.state.auth_user.id == 'sa-123456'
+            assert base_mock_request.state.auth_user.name == 'test-service-account'


### PR DESCRIPTION
## Bug Description
When both Basic Auth (`ENABLE_BASIC_AUTH=true`) and Service Account authentication (`ENABLE_SERVICE_ACCOUNTS=true`) are enabled on the API server, bearer token requests for service accounts are incorrectly rejected with a 401 "Invalid authentication method" error.

## How to Reproduce

**Setup:**
```bash
export ENABLE_BASIC_AUTH=true
export ENABLE_SERVICE_ACCOUNTS=true
# for basic auth "user" and "password"
export SKYPILOT_INITIAL_BASIC_AUTH="user:$apr1$sChzGibl$VdB36YoNQHN2l4spOrZzY1"                                              
export SKYPILOT_DEBUG=1
export SKYPILOT_DEV=1
sky api stop
sky api start

# First provision a service account bearer token from the dashboard

# Basic Auth works ✅
curl http://127.0.0.1:46580/api/status -u user:password
# Returns: 200 OK

# Bearer token fails ❌ (bug)
curl http://127.0.0.1:46580/api/status \
  -H "Authorization: Bearer sky_<token>"
# Returns: 401 Unauthorized: "Invalid authentication method" -> returned by BasicAuth middleware
```

Server logs when using bearer token shows that service account is authenticated, but request was still rejected:

```
D 12:34:05 token_service.py:67] Retrieved existing JWT secret from database
D 12:34:05 server.py:382] Authenticated service account: sa-3df97b1eada3cdad
I 12:34:05 httptools_impl.py:476] 127.0.0.1:54479 - "GET /api/status HTTP/1.1" 401
```

## Root Cause

The middleware execution order is:
BearerTokenMiddleware validates the Bearer token and sets request.state.auth_user ✅
BasicAuthMiddleware sees the same Authorization: Bearer ... header and rejects it ❌
BasicAuthMiddleware was rejecting ALL non-Basic auth headers instead of passing them through, even after successful authentication by previous middleware.

## Solution
Added early return in BasicAuthMiddleware (lines 230-232) to skip processing if request.state.auth_user is already set by a previous middleware. This follows the established pattern used by OAuth2ProxyMiddleware and AuthProxyMiddleware. 

For consistency with other auth middlewares (`OAuth2ProxyMiddleware`, `AuthProxyMiddleware`, and `BasicAuthMiddleware` (newly added), `BearerTokenMiddleware` now skips processing if a previous middleware has already authenticated the user.

This is defensive programming that prevents potential future issues if:
- Middleware execution order changes
- New auth methods are added
- Multiple auth methods are chained together

## Changes
**Code**:
- `sky/server/server.py`: 
  - Added early return in `BasicAuthMiddleware` (lines 230-232)
  - Added early return in `BearerTokenMiddleware` (lines 292-294)

**Tests**:
- `tests/unit_tests/test_sky/server/test_bearer_token_middleware.py`:
  - Added `test_already_authenticated_user_bypass` to verify bypass behavior
  - Fixed 12 existing tests to properly initialize `request.state.auth_user = None`
  - Removed unused `mock_request` fixture for consistency

## Tested

- [x] Code formatting: `bash format.sh` ✅
- [x] Unit tests: `pytest tests/unit_tests/test_sky/server/` ✅ (299/301 passed, 2 unrelated flaky tests - test_burstable_executor_pool_recovery and test_cancel_get_request_async failed due to timeout and file locks, unrelated to auth)
- [x] Specific test: `pytest tests/unit_tests/test_sky/server/test_bearer_token_middleware.py` ✅ (13/13 passed)
- [x] New test validates the bypass behavior when user is pre-authenticated

All authentication middleware now follows a consistent pattern for handling pre-authenticated users.
