### PR TITLE
[Server] Fix BasicAuth rejecting Bearer tokens when both BasicAuth and BearerToken methods enabled

### DIFF
--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -227,6 +227,10 @@ class BasicAuthMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             _try_set_basic_auth_user(request)
             return await call_next(request)
 
+        # If a previous middleware already authenticated the user, pass through
+        if request.state.auth_user is not None:
+            return await call_next(request)
+
         auth_header = request.headers.get('authorization')
         if not auth_header:
             return _basic_auth_401_response('Authentication required')


### PR DESCRIPTION
## Bug Description
When both Basic Auth (`ENABLE_BASIC_AUTH=true`) and Service Account authentication (`ENABLE_SERVICE_ACCOUNTS=true`) are enabled on the API server, bearer token requests for service accounts are incorrectly rejected with a 401 "Invalid authentication method" error.

## How to Reproduce

**Setup:**
```bash
export ENABLE_BASIC_AUTH=true
export ENABLE_SERVICE_ACCOUNTS=true
export ENABLE
# for basic auth "user" and "password"
export SKYPILOT_INITIAL_BASIC_AUTH="user:$apr1$sChzGibl$VdB36YoNQHN2l4spOrZzY1"                                              
export SKYPILOT_DEBUG=1
export SKYPILOT_DEV=1
sky api stop
sky api start

# First provision a service account bearer token from the dashboard

# Basic Auth works ✅
curl http://127.0.0.1:46580/api/status -u user:password
# Returns: 200 OK

# Bearer token fails ❌ (bug)
curl http://127.0.0.1:46580/api/status \
  -H "Authorization: Bearer sky_<token>"
# Returns: 401 Unauthorized: "Invalid authentication method" -> returned by BasicAuth middleware
```

Server logs when using bearer token shows that service account is authenticated, but request was still rejected:

```
D 12:34:05 token_service.py:67] Retrieved existing JWT secret from database
D 12:34:05 server.py:382] Authenticated service account: sa-3df97b1eada3cdad
I 12:34:05 httptools_impl.py:476] 127.0.0.1:54479 - "GET /api/status HTTP/1.1" 401
```

## Root Cause

The middleware execution order is:
BearerTokenMiddleware validates the Bearer token and sets request.state.auth_user ✅
BasicAuthMiddleware sees the same Authorization: Bearer ... header and rejects it ❌
BasicAuthMiddleware was rejecting ALL non-Basic auth headers instead of passing them through, even after successful authentication by previous middleware.

## Solution
Added early return in BasicAuthMiddleware (lines 230-232) to skip processing if request.state.auth_user is already set by a previous middleware. This follows the established pattern used by OAuth2ProxyMiddleware and AuthProxyMiddleware. 

For consistency and future-proofing, I have also added a similar check to BearerTokenMiddleware in case there might be a re-shuffling of auth middleware order. https://github.com/skypilot-org/skypilot/pull/8503

## Tested

Using the repro steps above, request with bearer token now returns a proper response.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh` ✅ (yapf, isort, black all pass; 1 pre-existing mypy error in unrelated setup.py)
- [x] Any manual or new tests for this PR (please specify below)
  - **Unit tests**: `pytest tests/unit_tests/test_sky/server/test_bearer_token_middleware.py` ✅ 12/12 passed
  - **Auth unit tests**: `pytest tests/unit_tests/test_sky/server/test_bearer_token_middleware.py tests/unit_tests/test_sky/server/test_common_auth.py tests/unit_units/test_sky/server/auth/test_oauth2_proxy.py` ✅ 37/37 passed
  - **All server unit tests**: `pytest tests/unit_tests/test_sky/server/` ✅ 299/300 passed (1 unrelated flaky filelock test)
  - **Manual verification**: Tested with both `ENABLE_BASIC_AUTH=true` and `ENABLE_SERVICE_ACCOUNTS=true` - both auth methods work correctly
- [ ] All smoke tests: Not applicable (middleware-only change, no cloud resources)
- [ ] Relevant individual tests: Not applicable
- [ ] Backward compatibility: Not applicable (pure bug fix, no API changes)

