### PR TITLE
[Dashboard]Change width for k8s memory display

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -244,7 +244,7 @@ export function InfrastructureSection({
                       <th className="p-3 text-left font-medium text-gray-600 w-1/6">
                         Memory
                       </th>
-                      <th className="p-3 text-left font-medium text-gray-600 w-1/5">
+                      <th className="p-3 text-left font-medium text-gray-600 w-1/6">
                         GPU Types
                       </th>
                       <th className="p-3 text-left font-medium text-gray-600 w-1/8">


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Memory column overflows, we should make it wider, and the GPU types column more narrow

<img width="1212" height="387" alt="image" src="https://github.com/user-attachments/assets/494435d3-fb8a-420b-b127-39cace9dec8a" />


# Before

<img width="1161" height="387" alt="image" src="https://github.com/user-attachments/assets/979b49af-2b0d-4dd9-a3ba-10da526d7e83" />

# After

<img width="1163" height="339" alt="image" src="https://github.com/user-attachments/assets/990cded0-e00d-4908-89d6-d7a62edec00e" />



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
