### PR TITLE
[K8s] Add support for parsing millibytes for memory

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -144,6 +144,7 @@ DEFAULT_NAMESPACE = 'default'
 DEFAULT_SERVICE_ACCOUNT_NAME = 'skypilot-service-account'
 
 MEMORY_SIZE_UNITS = {
+    'm': 0.001,
     'B': 1,
     'K': 2**10,
     'M': 2**20,
@@ -2366,7 +2367,7 @@ def parse_memory_resource(resource_qty_str: str,
     try:
         bytes_value = int(resource_str)
     except ValueError:
-        memory_size = re.sub(r'([KMGTPB]+)', r' \1', resource_str)
+        memory_size = re.sub(r'([KMGTPBm]+)', r' \1', resource_str)
         number, unit_index = [item.strip() for item in memory_size.split()]
         unit_index = unit_index[0]
         bytes_value = float(number) * MEMORY_SIZE_UNITS[unit_index]

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -1135,6 +1135,37 @@ def test_parse_cpu_or_gpu_resource_to_float():
     assert utils.parse_cpu_or_gpu_resource_to_float('') == 0.0  # Empty string
 
 
+def test_parse_memory_resource_with_millibytes():
+    """Test parse_memory_resource function with lowercase 'm' suffix.
+    
+    This test verifies that parse_memory_resource correctly handles memory
+    values with lowercase 'm' suffix like '100m' = 0.1 bytes.
+    Note: For memory, 'm' means milli (0.001 bytes), so 100m = 100 * 0.001 = 0.1 bytes.
+    """
+    # Test with lowercase 'm' suffix (millibytes)
+    # 100m = 100 * 0.001 bytes = 0.1 bytes
+    assert utils.parse_memory_resource('100m', unit='B') == 0.1
+
+    # 1000m = 1000 * 0.001 bytes = 1.0 bytes
+    assert utils.parse_memory_resource('1000m', unit='B') == 1.0
+
+    # 500m = 500 * 0.001 bytes = 0.5 bytes
+    assert utils.parse_memory_resource('500m', unit='B') == 0.5
+
+    # Test conversion to GB: 100m = 0.1 bytes = 0.1 / (2^30) GB
+    result = utils.parse_memory_resource('100m', unit='G')
+    expected = 0.1 / (2**30)
+    assert abs(result - expected) < 1e-15
+
+    # Test with standard memory units (should work)
+    assert utils.parse_memory_resource('1Gi', unit='G') == 1.0
+    assert utils.parse_memory_resource('512Mi', unit='G') == 0.5
+    assert utils.parse_memory_resource('1024Mi', unit='G') == 1.0
+
+    # Test with bytes (no unit)
+    assert utils.parse_memory_resource('1024', unit='K') == 1.0
+
+
 def test_coreweave_autoscaler():
     """Test that CoreweaveAutoscaler is properly configured."""
     from sky.provision.kubernetes.utils import AUTOSCALER_TYPE_TO_AUTOSCALER


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Currently if a k8s node has memory specified in millibytes (1000m -> 10B) our parsing will crash since we don't support this ending. This PR adds parsing and testing for this.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
