### PR TITLE
[Test] Skip remote server for label test

### DIFF
--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -2025,7 +2025,7 @@ def test_managed_job_labels_in_queue(generic_cloud: str):
 
         run: |
           echo "Hello from labeled job"
-          sleep 10
+          sleep 10000
         """)
 
     with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR skips the new managed job label test added in https://github.com/skypilot-org/skypilot/pull/8507 when using a remote server since we can't guarantee the remote server is updated and will respond with the job record. We also up the jobs sleep since labels for terminated jobs is currently not supported.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
