### PR TITLE
[Test] Fix `test_aws_manual_restart_recovery`

### DIFF
--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -532,6 +532,7 @@ def test_aws_manual_restart_recovery():
                     f'aws ec2 wait instance-running --region {region} '
                     f'--instance-ids $id'),
                 skip_remote_server_check=True),
+            "sleep 30",
             # Status refresh should time out, as the restarted
             # instance would get a new IP address.
             # We should see a warning message on how to recover


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

`test_aws_manual_restart_recovery` was flaky due to a timing issue, we add a sleep to enable it to pass reliably.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
