### PR TITLE
[Slurm] Fix rsync to be more robust

### DIFF
--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -1571,7 +1571,12 @@ exec {ssh_command} srun --unbuffered --quiet --overlap \
                         max_retry=max_retry,
                         get_remote_home_dir=lambda: self.sky_dir)
         finally:
-            os.unlink(rsh_script_path)
+            try:
+                os.unlink(rsh_script_path)
+            except OSError as e:
+                logger.warning('Failed to remove temporary rsh script '
+                               f'{rsh_script_path}: '
+                               f'{common_utils.exception_to_string(e)}')
 
     @timeline.event
     @context_utils.cancellation_guard


### PR DESCRIPTION
Regression from #8470 .

When rsync'ing to a SkyPilot cluster on Slurm with ProxyCommand (e.g., AWS SSM), the rsync command failed with shell quoting errors:
```
I 01-11 21:34:27.988 PID=40152 instance_setup.py:118] _internal_file_mounts: Retrying in 1.9 seconds, due to Command rsync -Pavz --filter='dir-merge,- .gitignore' -e 'bash --norc --noprofile -c '"'"'job_id=$(echo "$1"... failed with return code 255.
I 01-11 21:34:27.988 PID=40152 instance_setup.py:118] Failed to rsync up: /var/folders/y5/s2n482r93zv0rlrxdl9g9ndw0000gn/T/sky-tmptth1kbh8/tmpj5f8py0x -> ~/.sky/.runtime_files. Ensure that the network is stable, then retry.
I 01-11 21:34:27.988 PID=40152 instance_setup.py:118] usage: ssh [-46AaCfGgKkMNnqsTtVvXxYy] [-B bind_interface] [-b bind_address]
I 01-11 21:34:27.988 PID=40152 instance_setup.py:118]            [-c cipher_spec] [-D [bind_address:]port] [-E log_file]
I 01-11 21:34:27.988 PID=40152 instance_setup.py:118]            [-e escape_char] [-F configfile] [-I pkcs11] [-i identity_file]
I 01-11 21:34:27.988 PID=40152 instance_setup.py:118]            [-J destination] [-L address] [-l login_name] [-m mac_spec]
I 01-11 21:34:27.988 PID=40152 instance_setup.py:118]            [-O ctl_cmd] [-o option] [-P tag] [-p port] [-R address]
I 01-11 21:34:27.988 PID=40152 instance_setup.py:118]            [-S ctl_path] [-W host:port] [-w local_tun[:remote_tun]]
I 01-11 21:34:27.988 PID=40152 instance_setup.py:118]            destination [command [argument ...]]
I 01-11 21:34:27.988 PID=40152 instance_setup.py:118]        ssh [-Q query_option]
I 01-11 21:34:27.988 PID=40152 instance_setup.py:118] rsync(40445): error: unexpected end of file
I 01-11 21:34:27.988 PID=40152 instance_setup.py:118] rsync(40445): error: io_read_nonblocking
I 01-11 21:34:27.988 PID=40152 instance_setup.py:118] rsync(40445): error: io_read_buf
I 01-11 21:34:27.988 PID=40152 instance_setup.py:118] rsync(40445): error: io_read_int
I 01-11 21:34:27.988 PID=40152 instance_setup.py:118] rsync(40445): warning: child 40446 exited with status 255
I 01-11 21:34:27.988 PID=40152 instance_setup.py:118]
```
This is because the rsync rsh command was constructed using a bash -c '...' wrapper that embedded the SSH command directly. When ProxyCommand (which is `shlex.quote`ed) is used, embedding it inside another single-quoted string creates nested quoting that cannot be resolved.

```
bash --norc --noprofile -c 'job_id=$(echo "$1" | cut -d+ -f1); node_list=$(echo "$1" | cut -d+ -f2); shift; exec ssh -T -i \
/Users/kevin/.ssh/id_rsa -o Port=22 -o ProxyCommand='aws ssm start-session --target sagemaker-cluster:... --document-name \
AWS-StartSSHSession --parameters '"'"'portNumber=22'"'"' --region us-east-2' ubuntu@i-12345 \
srun --unbuffered --quiet --overlap --jobid="$job_id" --nodelist="$node_list" --nodes=1 --ntasks=1 "$@"' --
```

The fix writes the rsh script to a temp file instead of embedding it inline. This avoids all quoting issues because the script content is not embedded in another shell command string.

TODO: Out of scope of this PR, but use ProxyCommand in our smoke test to connect to our AWS Hyperpod Slurm test cluster, so that regressions like this can be discovered quicker.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
