### PR TITLE
deps: pin SQLAlchemy >= 2.0.0 and alembic >= 1.8.0

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -70,7 +70,7 @@ install_requires = [
     'aiofiles',
     'httpx',
     'setproctitle',
-    'sqlalchemy',
+    'sqlalchemy>=2.0.0',
     'psycopg2-binary',
     'aiosqlite',
     'asyncpg',
@@ -86,7 +86,7 @@ install_requires = [
     'gitpython',
     'paramiko',
     'types-paramiko',
-    'alembic',
+    'alembic>=1.8.0',
     'aiohttp',
     'anyio',
 ]


### PR DESCRIPTION
## Summary

Pin SQLAlchemy and alembic dependencies to versions that support SQLAlchemy 2.x.

## Problem

SkyPilot uses SQLAlchemy 2.x-only APIs throughout the codebase, such as:
- `sqlalchemy.Engine` type hint (only available in 2.x, 1.x uses `sqlalchemy.engine.Engine`)
- Other 2.x-specific patterns

When SkyPilot is installed alongside projects that pin to SQLAlchemy 1.4.x, users encounter confusing errors like:

```
AttributeError: module 'sqlalchemy' has no attribute 'Engine'. Did you mean: 'engine'?
```

## Solution

Explicitly pin version requirements to make them clear and fail fast during installation rather than at runtime:
- `sqlalchemy>=2.0.0` - required for 2.x-only APIs used in the codebase
- `alembic>=1.8.0` - version that added SQLAlchemy 2.0 support for database migrations

## Changes

```diff
- 'sqlalchemy',
+ 'sqlalchemy>=2.0.0',
```

```diff
- 'alembic',
+ 'alembic>=1.8.0',
```

## Testing

- [ ] Existing tests pass