### PR TITLE
[Dashboard] workspace page speed up

### DIFF
--- a/sky/dashboard/src/components/workspaces.jsx
+++ b/sky/dashboard/src/components/workspaces.jsx
@@ -557,7 +557,7 @@ export function Workspaces() {
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, []);
+  }, [handleRefresh]);
 
   // Sorting functionality
   const handleSort = (key) => {
@@ -667,7 +667,7 @@ export function Workspaces() {
     }
   };
 
-  const handleRefresh = async () => {
+  const handleRefresh = useCallback(async () => {
     // Invalidate cache to ensure fresh data is fetched
     dashboardCache.invalidate(getWorkspaces);
     dashboardCache.invalidateFunction(getEnabledClouds); // This function has arguments
@@ -686,7 +686,7 @@ export function Workspaces() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [fetchData]);
 
   const handleCancelDelete = () => {
     setDeleteState({
@@ -892,7 +892,7 @@ export function Workspaces() {
                     className="sortable whitespace-nowrap cursor-pointer hover:bg-gray-50"
                     onClick={() => handleSort('runningClusterCount')}
                   >
-                    Running Clusters{getSortDirection('runningClusterCount')}
+                    Running Clusters {getSortDirection('runningClusterCount')}
                   </TableHead>
                   <TableHead
                     className="sortable whitespace-nowrap cursor-pointer hover:bg-gray-50"


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

https://github.com/user-attachments/assets/e9679277-9f72-4849-bea8-bd5dc45c9b8c



  1. Cmd+R intercept - Added keyboard handler to trigger in-app refresh instead of browser reload
  2. Loading pattern - Added isInitialLoad state so table stays visible during refresh (only shows full-page spinner on first load)
  3. Cell spinners - Spinners replace count values during refresh (not shown next to them)
  4. Grey backgrounds - Added bg-gray-100 styling around cluster/job counts
  5. Running clusters only - Changed from "X running, Y total" to just show running count; renamed column to "Running Clusters"
  6. Sorting - Updated to sort by runningClusterCount instead of totalClusterCount


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
