### PR TITLE
[Storage] Add Tigris as S3-compatible object storage provider

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -1601,14 +1601,13 @@ If you already use the `Tigris Storage SDK <https://www.tigrisdata.com/docs/sdks
 
 When prompted for credentials (Option 1), enter your Tigris Access Key ID (starts with ``tid_``) and Secret Access Key (starts with ``tsec_``). See `Tigris documentation <https://www.tigrisdata.com/docs/iam/manage-access-key/>`_ to generate credentials. For the region, enter :code:`auto`.
 
-To use Tigris in your SkyPilot YAML, specify ``store: tigris``:
+To use Tigris in your SkyPilot YAML, use the ``tigris://`` URL scheme:
 
 .. code-block:: yaml
 
   file_mounts:
     /data:
-      source: s3://my-tigris-bucket
-      store: tigris
+      source: tigris://my-tigris-bucket
 
 .. note::
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -1572,11 +1572,16 @@ SkyPilot can download/upload data to Tigris buckets and mount them as local file
 
 Tigris uses S3-compatible APIs with the endpoint ``https://t3.storage.dev``. Tigris access keys start with ``tid_`` and secret keys start with ``tsec_``.
 
-**Option 1: Use a dedicated tigris profile (recommended)**
+**Option 1: Use an AWS profile (recommended)**
 
 .. code-block:: shell
 
+  # Default profile name is 'tigris'
   aws configure --profile tigris
+
+  # Or use a custom profile name
+  aws configure --profile my-tigris-profile
+  export TIGRIS_PROFILE=my-tigris-profile
 
 **Option 2: Use Tigris SDK environment variables**
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -1580,6 +1580,8 @@ Tigris uses S3-compatible APIs with the endpoint ``https://t3.storage.dev``. Tig
 
 **Option 2: Use Tigris SDK environment variables**
 
+If you already use the `Tigris Storage SDK <https://www.tigrisdata.com/docs/sdks/tigris/>`_, you can source your credentials from the environment variables used by the SDK:
+
 .. code-block:: shell
 
   export TIGRIS_STORAGE_ACCESS_KEY_ID=tid_...

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -1562,6 +1562,34 @@ Next, get your `Account ID <https://developers.cloudflare.com/fundamentals/get-s
 
   Support for R2 is in beta. Please report and issues on `Github <https://github.com/skypilot-org/skypilot/issues>`_ or reach out to us on `Slack <http://slack.skypilot.co/>`_.
 
+.. _tigris-installation:
+
+Tigris
+~~~~~~
+
+`Tigris <https://www.tigrisdata.com/>`__ is a globally distributed, S3-compatible object storage with zero egress fees.
+SkyPilot can download/upload data to Tigris buckets and mount them as local filesystem on clusters launched by SkyPilot. To set up Tigris support:
+
+Tigris uses the standard AWS credentials format. Run the following command to configure your Tigris credentials:
+
+.. code-block:: shell
+
+  # Configure your Tigris credentials using the 'tigris' profile
+  aws configure --profile tigris
+
+In the prompt, enter your Tigris Access Key ID and Secret Access Key (see `Tigris documentation <https://www.tigrisdata.com/docs/sdks/s3/aws-cli/>`_ to generate credentials). For the region, enter :code:`auto` and for the output format, enter :code:`json`.
+
+.. code-block:: text
+
+  AWS Access Key ID [None]: <your_tigris_access_key_id>
+  AWS Secret Access Key [None]: <your_tigris_secret_access_key>
+  Default region name [None]: auto
+  Default output format [None]: json
+
+.. note::
+
+  Support for Tigris is in beta. Please report any issues on `Github <https://github.com/skypilot-org/skypilot/issues>`_ or reach out to us on `Slack <http://slack.skypilot.co/>`_.
+
 
 Prime Intellect |community-badge|
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -1570,7 +1570,7 @@ Tigris
 `Tigris <https://www.tigrisdata.com/>`__ is a globally distributed, S3-compatible object storage with zero egress fees.
 SkyPilot can download/upload data to Tigris buckets and mount them as local filesystem on clusters launched by SkyPilot.
 
-Tigris uses standard AWS credentials format. You can configure credentials in one of three ways:
+Tigris uses S3-compatible APIs with the endpoint ``https://t3.storage.dev``. Tigris access keys start with ``tid_`` and secret keys start with ``tsec_``.
 
 **Option 1: Use a dedicated tigris profile (recommended)**
 
@@ -1582,14 +1582,19 @@ Tigris uses standard AWS credentials format. You can configure credentials in on
 
 .. code-block:: shell
 
-  export AWS_ACCESS_KEY_ID=<your_tigris_access_key_id>
-  export AWS_SECRET_ACCESS_KEY=<your_tigris_secret_access_key>
+  export AWS_ACCESS_KEY_ID=tid_...
+  export AWS_SECRET_ACCESS_KEY=tsec_...
 
-**Option 3: Use the default AWS credentials**
+When prompted for credentials, enter your Tigris Access Key ID (starts with ``tid_``) and Secret Access Key (starts with ``tsec_``). See `Tigris documentation <https://www.tigrisdata.com/docs/iam/manage-access-key/>`_ to generate credentials. For the region, enter :code:`auto`.
 
-If you have AWS credentials configured, SkyPilot will use them with Tigris's endpoint.
+To use Tigris in your SkyPilot YAML, specify ``store: tigris``:
 
-When prompted for credentials, enter your Tigris Access Key ID and Secret Access Key (see `Tigris documentation <https://www.tigrisdata.com/docs/sdks/s3/aws-cli/>`_ to generate credentials). For the region, enter :code:`auto`.
+.. code-block:: yaml
+
+  file_mounts:
+    /data:
+      source: s3://my-tigris-bucket
+      store: tigris
 
 .. note::
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -1568,23 +1568,28 @@ Tigris
 ~~~~~~
 
 `Tigris <https://www.tigrisdata.com/>`__ is a globally distributed, S3-compatible object storage with zero egress fees.
-SkyPilot can download/upload data to Tigris buckets and mount them as local filesystem on clusters launched by SkyPilot. To set up Tigris support:
+SkyPilot can download/upload data to Tigris buckets and mount them as local filesystem on clusters launched by SkyPilot.
 
-Tigris uses the standard AWS credentials format. Run the following command to configure your Tigris credentials:
+Tigris uses standard AWS credentials format. You can configure credentials in one of three ways:
+
+**Option 1: Use a dedicated tigris profile (recommended)**
 
 .. code-block:: shell
 
-  # Configure your Tigris credentials using the 'tigris' profile
   aws configure --profile tigris
 
-In the prompt, enter your Tigris Access Key ID and Secret Access Key (see `Tigris documentation <https://www.tigrisdata.com/docs/sdks/s3/aws-cli/>`_ to generate credentials). For the region, enter :code:`auto` and for the output format, enter :code:`json`.
+**Option 2: Use environment variables**
 
-.. code-block:: text
+.. code-block:: shell
 
-  AWS Access Key ID [None]: <your_tigris_access_key_id>
-  AWS Secret Access Key [None]: <your_tigris_secret_access_key>
-  Default region name [None]: auto
-  Default output format [None]: json
+  export AWS_ACCESS_KEY_ID=<your_tigris_access_key_id>
+  export AWS_SECRET_ACCESS_KEY=<your_tigris_secret_access_key>
+
+**Option 3: Use the default AWS credentials**
+
+If you have AWS credentials configured, SkyPilot will use them with Tigris's endpoint.
+
+When prompted for credentials, enter your Tigris Access Key ID and Secret Access Key (see `Tigris documentation <https://www.tigrisdata.com/docs/sdks/s3/aws-cli/>`_ to generate credentials). For the region, enter :code:`auto`.
 
 .. note::
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -1578,14 +1578,21 @@ Tigris uses S3-compatible APIs with the endpoint ``https://t3.storage.dev``. Tig
 
   aws configure --profile tigris
 
-**Option 2: Use environment variables**
+**Option 2: Use Tigris SDK environment variables**
+
+.. code-block:: shell
+
+  export TIGRIS_STORAGE_ACCESS_KEY_ID=tid_...
+  export TIGRIS_STORAGE_SECRET_ACCESS_KEY=tsec_...
+
+**Option 3: Use AWS environment variables**
 
 .. code-block:: shell
 
   export AWS_ACCESS_KEY_ID=tid_...
   export AWS_SECRET_ACCESS_KEY=tsec_...
 
-When prompted for credentials, enter your Tigris Access Key ID (starts with ``tid_``) and Secret Access Key (starts with ``tsec_``). See `Tigris documentation <https://www.tigrisdata.com/docs/iam/manage-access-key/>`_ to generate credentials. For the region, enter :code:`auto`.
+When prompted for credentials (Option 1), enter your Tigris Access Key ID (starts with ``tid_``) and Secret Access Key (starts with ``tsec_``). See `Tigris documentation <https://www.tigrisdata.com/docs/iam/manage-access-key/>`_ to generate credentials. For the region, enter :code:`auto`.
 
 To use Tigris in your SkyPilot YAML, specify ``store: tigris``:
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -1601,6 +1601,8 @@ If you already use the `Tigris Storage SDK <https://www.tigrisdata.com/docs/sdks
 
 When prompted for credentials (Option 1), enter your Tigris Access Key ID (starts with ``tid_``) and Secret Access Key (starts with ``tsec_``). See `Tigris documentation <https://www.tigrisdata.com/docs/iam/manage-access-key/>`_ to generate credentials. For the region, enter :code:`auto`.
 
+After configuring credentials, run ``sky check`` to verify. SkyPilot will automatically write the credentials to ``~/.tigris/credentials`` and propagate them to remote clusters, regardless of which configuration method you use.
+
 To use Tigris in your SkyPilot YAML, use the ``tigris://`` URL scheme:
 
 .. code-block:: yaml

--- a/docs/source/reference/storage.rst
+++ b/docs/source/reference/storage.rst
@@ -3,7 +3,7 @@
 Cloud Buckets
 ==============
 
-SkyPilot tasks can access data from buckets in cloud object storages such as AWS S3, Google Cloud Storage (GCS), Cloudflare R2, CoreWeave Object Storage, Tigris, OCI Object Storage or IBM COS.
+SkyPilot tasks can access data from buckets in cloud object storages such as AWS S3, Google Cloud Storage (GCS), Cloudflare R2, CoreWeave Object Storage, Tigris Object Storage, OCI Object Storage or IBM COS.
 
 Buckets are made available to each task at a local path on the remote VM, so
 the task can access bucket objects as if they were local files.
@@ -28,7 +28,7 @@ Object storages are specified using the :code:`file_mounts` field in a SkyPilot 
           # Mount an existing S3 bucket
           file_mounts:
             /my_data:
-              source: s3://my-bucket/  # or gs://, https://<azure_storage_account>.blob.core.windows.net/<container>, r2://, cw://, tigris://, cos://<region>/<bucket>, oci://<bucket_name>
+              source: s3://my-bucket/  # or gs://, https://<azure_storage_account>.blob.core.windows.net/<container>, r2://, cw://, cos://<region>/<bucket>, oci://<bucket_name>
               mode: MOUNT  # MOUNT or COPY or MOUNT_CACHED. Defaults to MOUNT. Optional.
 
         This will `mount <storage-mounting-modes_>`__ the contents of the bucket at ``s3://my-bucket/`` to the remote VM at ``/my_data``.
@@ -370,13 +370,15 @@ Storage YAML reference
             - https://<azure_storage_account>.blob.core.windows.net/<container_name>
             - r2://<bucket_name>
             - cw://<bucket_name>
-            - tigris://<bucket_name>
             - cos://<region_name>/<bucket_name>
             - oci://<bucket_name>@<region>
 
           If the source is local, data is uploaded to the cloud to an appropriate
           bucket (s3, gcs, azure, r2, coreweave, tigris, oci, or ibm). If source is bucket URI,
           the data is copied or mounted directly (see mode flag below).
+
+          Note: For Tigris, use s3:// URLs with ``store: tigris`` to route through
+          the Tigris endpoint.
 
         store: str; either of 's3', 'gcs', 'azure', 'r2', 'coreweave', 'tigris', 'ibm', 'oci'
           If you wish to force sky.Storage to be backed by a specific cloud object

--- a/docs/source/reference/storage.rst
+++ b/docs/source/reference/storage.rst
@@ -3,7 +3,7 @@
 Cloud Buckets
 ==============
 
-SkyPilot tasks can access data from buckets in cloud object storages such as AWS S3, Google Cloud Storage (GCS), Cloudflare R2, CoreWeave Object Storage, OCI Object Storage or IBM COS.
+SkyPilot tasks can access data from buckets in cloud object storages such as AWS S3, Google Cloud Storage (GCS), Cloudflare R2, CoreWeave Object Storage, Tigris, OCI Object Storage or IBM COS.
 
 Buckets are made available to each task at a local path on the remote VM, so
 the task can access bucket objects as if they were local files.
@@ -28,7 +28,7 @@ Object storages are specified using the :code:`file_mounts` field in a SkyPilot 
           # Mount an existing S3 bucket
           file_mounts:
             /my_data:
-              source: s3://my-bucket/  # or gs://, https://<azure_storage_account>.blob.core.windows.net/<container>, r2://, cw://, cos://<region>/<bucket>, oci://<bucket_name>
+              source: s3://my-bucket/  # or gs://, https://<azure_storage_account>.blob.core.windows.net/<container>, r2://, cw://, tigris://, cos://<region>/<bucket>, oci://<bucket_name>
               mode: MOUNT  # MOUNT or COPY or MOUNT_CACHED. Defaults to MOUNT. Optional.
 
         This will `mount <storage-mounting-modes_>`__ the contents of the bucket at ``s3://my-bucket/`` to the remote VM at ``/my_data``.
@@ -45,7 +45,7 @@ Object storages are specified using the :code:`file_mounts` field in a SkyPilot 
           file_mounts:
             /my_data:
               name: my-sky-bucket
-              store: gcs  # Optional: either of s3, gcs, azure, r2, coreweave, ibm, oci
+              store: gcs  # Optional: either of s3, gcs, azure, r2, coreweave, tigris, ibm, oci
 
         SkyPilot will create an empty GCS bucket called ``my-sky-bucket`` and mount it at ``/my_data``.
         This bucket can be used to write checkpoints, logs or other outputs directly to the cloud.
@@ -68,7 +68,7 @@ Object storages are specified using the :code:`file_mounts` field in a SkyPilot 
             /my_data:
               name: my-sky-bucket
               source: ~/dataset  # Optional: path to local data to upload to the bucket
-              store: s3  # Optional: either of s3, gcs, azure, r2, coreweave, ibm, oci
+              store: s3  # Optional: either of s3, gcs, azure, r2, coreweave, tigris, ibm, oci
               mode: MOUNT  # Optional: either MOUNT or COPY. Defaults to MOUNT.
 
         SkyPilot will create a S3 bucket called ``my-sky-bucket`` and upload the
@@ -370,14 +370,15 @@ Storage YAML reference
             - https://<azure_storage_account>.blob.core.windows.net/<container_name>
             - r2://<bucket_name>
             - cw://<bucket_name>
+            - tigris://<bucket_name>
             - cos://<region_name>/<bucket_name>
             - oci://<bucket_name>@<region>
 
           If the source is local, data is uploaded to the cloud to an appropriate
-          bucket (s3, gcs, azure, r2, coreweave, oci, or ibm). If source is bucket URI,
+          bucket (s3, gcs, azure, r2, coreweave, tigris, oci, or ibm). If source is bucket URI,
           the data is copied or mounted directly (see mode flag below).
 
-        store: str; either of 's3', 'gcs', 'azure', 'r2', 'coreweave','ibm', 'oci'
+        store: str; either of 's3', 'gcs', 'azure', 'r2', 'coreweave', 'tigris', 'ibm', 'oci'
           If you wish to force sky.Storage to be backed by a specific cloud object
           storage, you can specify it here. If not specified, SkyPilot chooses the
           appropriate object storage based on the source path and task's cloud provider.

--- a/sky/adaptors/tigris.py
+++ b/sky/adaptors/tigris.py
@@ -1,0 +1,174 @@
+"""Tigris cloud adaptor for object storage."""
+
+import os
+import threading
+from typing import Dict, Optional, Tuple
+
+from sky import exceptions
+from sky.adaptors import common
+from sky.clouds import cloud
+from sky.utils import annotations
+from sky.utils import ux_utils
+
+TIGRIS_PROFILE_NAME = 'tigris'
+ENDPOINT_URL = 'https://t3.storage.dev'
+NAME = 'Tigris'
+DEFAULT_REGION = 'auto'
+_INDENT_PREFIX = '    '
+
+_IMPORT_ERROR_MESSAGE = ('Failed to import dependencies for Tigris. '
+                         'Try pip install "skypilot[aws]"')
+
+boto3 = common.LazyImport('boto3', import_error_message=_IMPORT_ERROR_MESSAGE)
+botocore = common.LazyImport('botocore',
+                             import_error_message=_IMPORT_ERROR_MESSAGE)
+
+_LAZY_MODULES = (boto3, botocore)
+_session_creation_lock = threading.RLock()
+
+
+def get_tigris_credentials(boto3_session):
+    """Gets the Tigris credentials from the boto3 session object.
+
+    Args:
+        boto3_session: The boto3 session object.
+    Returns:
+        botocore.credentials.ReadOnlyCredentials object with the Tigris
+        credentials.
+    """
+    tigris_credentials = boto3_session.get_credentials()
+    if tigris_credentials is None:
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError('Tigris credentials not found. Run '
+                             '`sky check` to verify credentials are '
+                             'correctly set up.')
+    return tigris_credentials.get_frozen_credentials()
+
+
+@annotations.lru_cache(scope='global')
+def session():
+    """Create an AWS session for Tigris."""
+    # Creating the session object is not thread-safe for boto3,
+    # so we add a reentrant lock to synchronize the session creation.
+    # Reference: https://github.com/boto/boto3/issues/1592
+    # However, the session object itself is thread-safe, so we are
+    # able to use lru_cache() to cache the session object.
+    with _session_creation_lock:
+        session_ = boto3.session.Session(profile_name=TIGRIS_PROFILE_NAME)
+        return session_
+
+
+@annotations.lru_cache(scope='global')
+def resource(resource_name: str, **kwargs):
+    """Create a Tigris resource.
+
+    Args:
+        resource_name: Tigris resource name (e.g., 's3').
+        kwargs: Other options.
+    """
+    # Need to use the resource retrieved from the per-thread session
+    # to avoid thread-safety issues (Directly creating the client
+    # with boto3.resource() is not thread-safe).
+    # Reference: https://stackoverflow.com/a/59635814
+
+    session_ = session()
+    tigris_credentials = get_tigris_credentials(session_)
+
+    return session_.resource(
+        resource_name,
+        endpoint_url=ENDPOINT_URL,
+        aws_access_key_id=tigris_credentials.access_key,
+        aws_secret_access_key=tigris_credentials.secret_key,
+        region_name=DEFAULT_REGION,
+        **kwargs)
+
+
+@annotations.lru_cache(scope='global')
+def client(service_name: str):
+    """Create Tigris client of a certain service.
+
+    Args:
+        service_name: Tigris service name (e.g., 's3').
+    """
+    # Need to use the client retrieved from the per-thread session
+    # to avoid thread-safety issues (Directly creating the client
+    # with boto3.client() is not thread-safe).
+    # Reference: https://stackoverflow.com/a/59635814
+
+    session_ = session()
+    tigris_credentials = get_tigris_credentials(session_)
+
+    return session_.client(
+        service_name,
+        endpoint_url=ENDPOINT_URL,
+        aws_access_key_id=tigris_credentials.access_key,
+        aws_secret_access_key=tigris_credentials.secret_key,
+        region_name=DEFAULT_REGION,
+    )
+
+
+@common.load_lazy_modules(_LAZY_MODULES)
+def botocore_exceptions():
+    """AWS botocore exception."""
+    # pylint: disable=import-outside-toplevel
+    from botocore import exceptions as boto_exceptions
+    return boto_exceptions
+
+
+def check_credentials(
+        cloud_capability: cloud.CloudCapability) -> Tuple[bool, Optional[str]]:
+    if cloud_capability == cloud.CloudCapability.STORAGE:
+        return check_storage_credentials()
+    else:
+        raise exceptions.NotSupportedError(
+            f'{NAME} does not support {cloud_capability}.')
+
+
+def check_storage_credentials() -> Tuple[bool, Optional[str]]:
+    """Checks if the user has access credentials to Tigris Object Storage.
+
+    Returns:
+        A tuple of a boolean value and a hint message where the bool
+        is True when credentials needed for Tigris storage are set.
+        It is False when they are not set, which would hint with a
+        string on how to set them up.
+    """
+    hints = None
+    if not tigris_profile_in_aws_cred():
+        hints = (f'[{TIGRIS_PROFILE_NAME}] profile is not set in '
+                 '~/.aws/credentials.')
+        hints += ' Run the following commands:'
+        hints += f'\n{_INDENT_PREFIX}  $ pip install boto3'
+        hints += (f'\n{_INDENT_PREFIX}  $ aws configure --profile '
+                  f'{TIGRIS_PROFILE_NAME}')
+        hints += (f'\n{_INDENT_PREFIX}    # Enter your Tigris Access Key ID '
+                  'and Secret Access Key')
+        hints += (f'\n{_INDENT_PREFIX}    # For region, enter: auto')
+        hints += f'\n{_INDENT_PREFIX}For more info: '
+        hints += 'https://www.tigrisdata.com/docs/sdks/s3/aws-cli/'
+
+    return (False, hints) if hints else (True, hints)
+
+
+def tigris_profile_in_aws_cred() -> bool:
+    """Checks if Tigris profile is set in aws credentials"""
+    cred_path = os.path.expanduser('~/.aws/credentials')
+    tigris_profile_exists = False
+    if os.path.isfile(cred_path):
+        with open(cred_path, 'r', encoding='utf-8') as file:
+            for line in file:
+                if f'[{TIGRIS_PROFILE_NAME}]' in line:
+                    tigris_profile_exists = True
+                    break
+    return tigris_profile_exists
+
+
+def get_credential_file_mounts() -> Dict[str, str]:
+    """Returns credential file mounts for Tigris.
+
+    Returns:
+        Dict[str, str]: A dictionary mapping source paths to destination paths
+        for credential files.
+    """
+    # Tigris uses standard AWS credentials file
+    return {'~/.aws/credentials': '~/.aws/credentials'}

--- a/sky/adaptors/tigris.py
+++ b/sky/adaptors/tigris.py
@@ -152,7 +152,7 @@ def check_storage_credentials() -> Tuple[bool, Optional[str]]:
     2. Environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
     3. The default AWS credentials chain
 
-    Tigris keys have distinctive prefixes: tid_ for access key, tsec_ for secret.
+    Tigris keys have distinctive prefixes: tid_ (access key), tsec_ (secret).
 
     Returns:
         A tuple of a boolean value and a hint message where the bool
@@ -182,15 +182,17 @@ def check_storage_credentials() -> Tuple[bool, Optional[str]]:
         pass
 
     # No Tigris credentials found, provide hints
-    hints = ('Tigris credentials not found. Tigris keys start with tid_/tsec_.\n'
-             f'{_INDENT_PREFIX}You can configure them via:\n'
-             f'{_INDENT_PREFIX}Option 1: Create a [tigris] profile:\n'
-             f'{_INDENT_PREFIX}  $ aws configure --profile tigris\n'
-             f'{_INDENT_PREFIX}Option 2: Set environment variables:\n'
-             f'{_INDENT_PREFIX}  $ export AWS_ACCESS_KEY_ID=tid_...\n'
-             f'{_INDENT_PREFIX}  $ export AWS_SECRET_ACCESS_KEY=tsec_...\n'
-             f'{_INDENT_PREFIX}For more info: '
-             'https://www.tigrisdata.com/docs/sdks/s3/aws-cli/')
+    hints = (
+        'Tigris credentials not found. Tigris keys start with tid_/tsec_.\n'
+        f'{_INDENT_PREFIX}You can configure them via:\n'
+        f'{_INDENT_PREFIX}Option 1: Create a [tigris] profile:\n'
+        f'{_INDENT_PREFIX}  $ pip install "skypilot[tigris]"\n'
+        f'{_INDENT_PREFIX}  $ aws configure --profile tigris\n'
+        f'{_INDENT_PREFIX}Option 2: Set environment variables:\n'
+        f'{_INDENT_PREFIX}  $ export AWS_ACCESS_KEY_ID=tid_...\n'
+        f'{_INDENT_PREFIX}  $ export AWS_SECRET_ACCESS_KEY=tsec_...\n'
+        f'{_INDENT_PREFIX}For more info: '
+        'https://www.tigrisdata.com/docs/sdks/s3/aws-cli/')
 
     return (False, hints)
 
@@ -198,14 +200,13 @@ def check_storage_credentials() -> Tuple[bool, Optional[str]]:
 def tigris_profile_in_aws_cred() -> bool:
     """Checks if Tigris profile is set in aws credentials"""
     cred_path = os.path.expanduser('~/.aws/credentials')
-    tigris_profile_exists = False
-    if os.path.isfile(cred_path):
-        with open(cred_path, 'r', encoding='utf-8') as file:
-            for line in file:
-                if f'[{TIGRIS_PROFILE_NAME}]' in line:
-                    tigris_profile_exists = True
-                    break
-    return tigris_profile_exists
+    if not os.path.isfile(cred_path):
+        return False
+    with open(cred_path, 'r', encoding='utf-8') as file:
+        for line in file:
+            if line.strip() == f'[{TIGRIS_PROFILE_NAME}]':
+                return True
+    return False
 
 
 def get_credential_file_mounts() -> Dict[str, str]:

--- a/sky/adaptors/tigris.py
+++ b/sky/adaptors/tigris.py
@@ -115,8 +115,7 @@ def session():
     # able to use lru_cache() to cache the session object.
     with _session_creation_lock:
         with _load_tigris_credentials_env():
-            session_ = boto3.session.Session(
-                profile_name=TIGRIS_PROFILE_NAME)
+            session_ = boto3.session.Session(profile_name=TIGRIS_PROFILE_NAME)
         return session_
 
 

--- a/sky/adaptors/tigris.py
+++ b/sky/adaptors/tigris.py
@@ -1,5 +1,7 @@
 """Tigris cloud adaptor for object storage."""
 
+import configparser
+import contextlib
 import os
 import threading
 from typing import Dict, Optional, Tuple
@@ -19,12 +21,17 @@ NAME = 'Tigris'
 DEFAULT_REGION = 'auto'
 _INDENT_PREFIX = '    '
 
+# Dedicated credential file paths (separate from ~/.aws/credentials to avoid
+# conflicts). These files are uploaded to remote clusters via file mounts.
+TIGRIS_CREDENTIALS_PATH = '~/.tigris/credentials'
+TIGRIS_CONFIG_PATH = '~/.tigris/config'
+
 # Tigris SDK environment variables
 TIGRIS_ACCESS_KEY_ENV = 'TIGRIS_STORAGE_ACCESS_KEY_ID'
 TIGRIS_SECRET_KEY_ENV = 'TIGRIS_STORAGE_SECRET_ACCESS_KEY'
 
 _IMPORT_ERROR_MESSAGE = ('Failed to import dependencies for Tigris. '
-                         'Try pip install "skypilot[aws]"')
+                         'Try pip install "skypilot[tigris]"')
 
 boto3 = common.LazyImport('boto3', import_error_message=_IMPORT_ERROR_MESSAGE)
 botocore = common.LazyImport('botocore',
@@ -34,12 +41,31 @@ _LAZY_MODULES = (boto3, botocore)
 _session_creation_lock = threading.RLock()
 
 
-def get_tigris_profile() -> Optional[str]:
+@contextlib.contextmanager
+def _load_tigris_credentials_env():
+    """Context manager to temporarily change the AWS credentials file path."""
+    prev_credentials_path = os.environ.get('AWS_SHARED_CREDENTIALS_FILE')
+    prev_config_path = os.environ.get('AWS_CONFIG_FILE')
+    os.environ['AWS_SHARED_CREDENTIALS_FILE'] = TIGRIS_CREDENTIALS_PATH
+    os.environ['AWS_CONFIG_FILE'] = TIGRIS_CONFIG_PATH
+    try:
+        yield
+    finally:
+        if prev_credentials_path is None:
+            del os.environ['AWS_SHARED_CREDENTIALS_FILE']
+        else:
+            os.environ['AWS_SHARED_CREDENTIALS_FILE'] = prev_credentials_path
+        if prev_config_path is None:
+            del os.environ['AWS_CONFIG_FILE']
+        else:
+            os.environ['AWS_CONFIG_FILE'] = prev_config_path
+
+
+def get_tigris_profile() -> str:
     """Get the Tigris AWS profile name.
 
     Returns the profile name from TIGRIS_PROFILE env var if set,
     otherwise returns 'tigris' as the default profile name.
-    Returns None if credentials should come from env vars instead.
     """
     return os.environ.get(TIGRIS_PROFILE_ENV, TIGRIS_PROFILE_NAME)
 
@@ -57,45 +83,30 @@ def _get_tigris_sdk_env_credentials() -> Tuple[Optional[str], Optional[str]]:
 
 
 def get_tigris_credentials(boto3_session):
-    """Gets the Tigris credentials from the boto3 session or environment.
-
-    Checks for credentials in the following order:
-    1. Tigris SDK environment variables
-    2. boto3 session credentials (profile or AWS env vars)
+    """Gets the Tigris credentials from the boto3 session.
 
     Args:
         boto3_session: The boto3 session object.
     Returns:
-        A tuple of (access_key, secret_key) for Tigris.
+        botocore.credentials.ReadOnlyCredentials object with Tigris
+        credentials.
     """
-    # First check Tigris SDK environment variables
-    tigris_access, tigris_secret = _get_tigris_sdk_env_credentials()
-    if tigris_access and tigris_secret:
-        # Return a simple object with access_key and secret_key attributes
-        class TigrisCredentials:
-
-            def __init__(self, access_key, secret_key):
-                self.access_key = access_key
-                self.secret_key = secret_key
-
-        return TigrisCredentials(tigris_access, tigris_secret)
-
-    # Fall back to boto3 session credentials
-    tigris_credentials = boto3_session.get_credentials()
-    if tigris_credentials is None:
-        with ux_utils.print_exception_no_traceback():
-            raise ValueError('Tigris credentials not found. Run '
-                             '`sky check` to verify credentials are '
-                             'correctly set up.')
-    return tigris_credentials.get_frozen_credentials()
+    with _load_tigris_credentials_env():
+        tigris_credentials = boto3_session.get_credentials()
+        if tigris_credentials is None:
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError('Tigris credentials not found. Run '
+                                 '`sky check` to verify credentials are '
+                                 'correctly set up.')
+        return tigris_credentials.get_frozen_credentials()
 
 
 @annotations.lru_cache(scope='global')
 def session():
     """Create an AWS session for Tigris.
 
-    Uses the profile specified by TIGRIS_PROFILE env var, or 'tigris' by
-    default. Falls back to default credentials chain if profile not found.
+    Uses the dedicated Tigris credentials file at ~/.tigris/credentials
+    with the 'tigris' profile.
     """
     # Creating the session object is not thread-safe for boto3,
     # so we add a reentrant lock to synchronize the session creation.
@@ -103,12 +114,9 @@ def session():
     # However, the session object itself is thread-safe, so we are
     # able to use lru_cache() to cache the session object.
     with _session_creation_lock:
-        profile_name = get_tigris_profile()
-        if profile_name and _profile_exists(profile_name):
-            session_ = boto3.session.Session(profile_name=profile_name)
-        else:
-            # Fall back to default credentials chain (env vars, default profile)
-            session_ = boto3.session.Session()
+        with _load_tigris_credentials_env():
+            session_ = boto3.session.Session(
+                profile_name=TIGRIS_PROFILE_NAME)
         return session_
 
 
@@ -178,7 +186,7 @@ def check_credentials(
             f'{NAME} does not support {cloud_capability}.')
 
 
-def _profile_exists(profile_name: str) -> bool:
+def _profile_exists_in_aws_cred(profile_name: str) -> bool:
     """Check if an AWS profile exists in ~/.aws/credentials."""
     cred_path = os.path.expanduser('~/.aws/credentials')
     if not os.path.isfile(cred_path):
@@ -215,6 +223,43 @@ def _validate_credentials(access_key: str, secret_key: str) -> bool:
         return False
 
 
+def _write_tigris_credential_files(access_key: str, secret_key: str) -> None:
+    """Write Tigris credentials to dedicated credential files.
+
+    Writes credentials to ~/.tigris/credentials and config to
+    ~/.tigris/config so they can be uploaded to remote clusters
+    via file mounts, regardless of how credentials were originally
+    configured (AWS profile, Tigris SDK env vars, or AWS env vars).
+
+    Args:
+        access_key: The Tigris access key.
+        secret_key: The Tigris secret key.
+    """
+    cred_path = os.path.expanduser(TIGRIS_CREDENTIALS_PATH)
+    config_path = os.path.expanduser(TIGRIS_CONFIG_PATH)
+
+    os.makedirs(os.path.dirname(cred_path), exist_ok=True)
+
+    # Write credentials file
+    cred_config = configparser.RawConfigParser()
+    cred_config[TIGRIS_PROFILE_NAME] = {
+        'aws_access_key_id': access_key,
+        'aws_secret_access_key': secret_key,
+    }
+    with open(cred_path, 'w', encoding='utf-8') as f:
+        cred_config.write(f)
+    os.chmod(cred_path, 0o600)
+
+    # Write config file with endpoint URL.
+    # We write this directly instead of using configparser because
+    # configparser doesn't handle the nested s3 subsection cleanly.
+    with open(config_path, 'w', encoding='utf-8') as f:
+        f.write(f'[profile {TIGRIS_PROFILE_NAME}]\n')
+        f.write(f'endpoint_url = {ENDPOINT_URL}\n')
+        f.write('s3 =\n')
+        f.write('    addressing_style = virtual\n')
+
+
 def check_storage_credentials() -> Tuple[bool, Optional[str]]:
     """Checks if the user has access credentials to Tigris Object Storage.
 
@@ -222,7 +267,9 @@ def check_storage_credentials() -> Tuple[bool, Optional[str]]:
     1. AWS profile specified by TIGRIS_PROFILE env var (default: 'tigris')
     2. Tigris SDK env vars (TIGRIS_STORAGE_ACCESS_KEY_ID, etc.)
 
-    Credentials are validated by making an API call to Tigris.
+    When valid credentials are found, they are written to a dedicated
+    file (~/.tigris/credentials) so they can be propagated to remote
+    clusters.
 
     Returns:
         A tuple of a boolean value and a hint message where the bool
@@ -230,13 +277,18 @@ def check_storage_credentials() -> Tuple[bool, Optional[str]]:
         It is False when they are not set, which would hint with a
         string on how to set them up.
     """
+    # Fast path: if dedicated credential file already exists, skip
+    # the network validation call to avoid slowing down storage operations.
+    if tigris_profile_in_credential_file():
+        return (True, None)
+
     profile_name = get_tigris_profile()
     access_key = None
     secret_key = None
     credential_source = None
 
-    # Check for the configured profile
-    if profile_name and _profile_exists(profile_name):
+    # Check for the configured profile in ~/.aws/credentials
+    if profile_name and _profile_exists_in_aws_cred(profile_name):
         try:
             profile_session = boto3.session.Session(profile_name=profile_name)
             creds = profile_session.get_credentials()
@@ -256,9 +308,21 @@ def check_storage_credentials() -> Tuple[bool, Optional[str]]:
             secret_key = tigris_secret
             credential_source = 'Tigris SDK environment variables'
 
+    # Check for AWS environment variables as fallback
+    if access_key is None:
+        aws_access = os.environ.get('AWS_ACCESS_KEY_ID')
+        aws_secret = os.environ.get('AWS_SECRET_ACCESS_KEY')
+        if aws_access and aws_secret:
+            access_key = aws_access
+            secret_key = aws_secret
+            credential_source = 'AWS environment variables'
+
     # Validate credentials if found
     if access_key and secret_key:
         if _validate_credentials(access_key, secret_key):
+            # Write credentials to dedicated file so they can be
+            # uploaded to remote clusters via file mounts.
+            _write_tigris_credential_files(access_key, secret_key)
             return (True, None)
         else:
             # Credentials found but invalid
@@ -286,10 +350,16 @@ def check_storage_credentials() -> Tuple[bool, Optional[str]]:
     return (False, hints)
 
 
-def tigris_profile_in_aws_cred() -> bool:
-    """Checks if the configured Tigris profile exists in AWS credentials."""
-    profile_name = get_tigris_profile()
-    return profile_name is not None and _profile_exists(profile_name)
+def tigris_profile_in_credential_file() -> bool:
+    """Checks if Tigris profile is set in the dedicated credentials file."""
+    cred_path = os.path.expanduser(TIGRIS_CREDENTIALS_PATH)
+    if not os.path.isfile(cred_path):
+        return False
+    with open(cred_path, 'r', encoding='utf-8') as file:
+        for line in file:
+            if f'[{TIGRIS_PROFILE_NAME}]' in line:
+                return True
+    return False
 
 
 def get_credential_file_mounts() -> Dict[str, str]:
@@ -297,7 +367,9 @@ def get_credential_file_mounts() -> Dict[str, str]:
 
     Returns:
         Dict[str, str]: A dictionary mapping source paths to destination paths
-        for credential files.
+        for credential files that will be uploaded to remote clusters.
     """
-    # Tigris uses standard AWS credentials file
-    return {'~/.aws/credentials': '~/.aws/credentials'}
+    return {
+        TIGRIS_CREDENTIALS_PATH: TIGRIS_CREDENTIALS_PATH,
+        TIGRIS_CONFIG_PATH: TIGRIS_CONFIG_PATH,
+    }

--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -24,6 +24,7 @@ from sky.adaptors import gcp
 from sky.adaptors import ibm
 from sky.adaptors import nebius
 from sky.adaptors import oci
+from sky.adaptors import tigris
 from sky.skylet import constants
 from sky.skylet import log_lib
 from sky.utils import common_utils
@@ -1013,3 +1014,49 @@ def verify_coreweave_bucket(name: str, retry: int = 0) -> bool:
 
     # Should not reach here, but just in case
     return False
+
+
+def create_tigris_client() -> Client:
+    """Create Tigris S3 client."""
+    return tigris.client('s3')
+
+
+def split_tigris_path(tigris_path: str) -> Tuple[str, str]:
+    """Splits Tigris Path into Bucket name and Relative Path to Bucket
+
+    Args:
+      tigris_path: str; Tigris Path, e.g. tigris://imagenet/train/
+    """
+    path_parts = tigris_path.replace('tigris://', '').split('/')
+    bucket = path_parts.pop(0)
+    key = '/'.join(path_parts)
+    return bucket, key
+
+
+def verify_tigris_bucket(name: str) -> bool:
+    """Verify Tigris bucket exists and is accessible.
+
+    Args:
+      name: str; Name of Tigris Bucket (without tigris:// prefix)
+
+    Returns:
+      bool: True if bucket exists and is accessible, False otherwise.
+    """
+    tigris_client = create_tigris_client()
+    try:
+        tigris_client.head_bucket(Bucket=name)
+        return True
+    except tigris.botocore_exceptions().ClientError as e:
+        error_code = e.response['Error']['Code']
+        if error_code == '403':
+            logger.error(f'Access denied to bucket {name}')
+            return False
+        elif error_code == '404':
+            logger.debug(f'Bucket {name} does not exist')
+            return False
+        else:
+            logger.debug(f'Unexpected error checking Tigris bucket {name}: {e}')
+            return False
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Unexpected error checking Tigris bucket {name}: {e}')
+        return False

--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -1021,18 +1021,6 @@ def create_tigris_client() -> Client:
     return tigris.client('s3')
 
 
-def split_tigris_path(tigris_path: str) -> Tuple[str, str]:
-    """Splits Tigris Path into Bucket name and Relative Path to Bucket
-
-    Args:
-      tigris_path: str; Tigris Path, e.g. tigris://imagenet/train/
-    """
-    path_parts = tigris_path.replace('tigris://', '').split('/')
-    bucket = path_parts.pop(0)
-    key = '/'.join(path_parts)
-    return bucket, key
-
-
 def verify_tigris_bucket(name: str) -> bool:
     """Verify Tigris bucket exists and is accessible.
 

--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -54,6 +54,18 @@ def split_s3_path(s3_path: str) -> Tuple[str, str]:
     return bucket, key
 
 
+def split_tigris_path(tigris_path: str) -> Tuple[str, str]:
+    """Splits Tigris Path into Bucket name and Relative Path to Bucket
+
+    Args:
+      tigris_path: str; Tigris Path, e.g. tigris://imagenet/train/
+    """
+    path_parts = tigris_path.replace('tigris://', '').split('/')
+    bucket = path_parts.pop(0)
+    key = '/'.join(path_parts)
+    return bucket, key
+
+
 def split_gcs_path(gcs_path: str) -> Tuple[str, str]:
     """Splits GCS Path into Bucket name and Relative Path to Bucket
 

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -207,8 +207,13 @@ def get_tigris_mount_cmd(bucket_name: str,
                          _bucket_sub_path: Optional[str] = None) -> str:
     """Returns a command to mount Tigris bucket using s3fs/rclone.
 
-    Tigris credentials are read from ~/.aws/credentials with profile 'tigris'.
+    Tigris credentials are read from ~/.aws/credentials using the profile
+    specified by TIGRIS_PROFILE env var (default: 'tigris').
     """
+    # pylint: disable=import-outside-toplevel
+    from sky.adaptors import tigris
+    tigris_profile = tigris.get_tigris_profile()
+
     if _bucket_sub_path is None:
         _bucket_sub_path = ''
     else:
@@ -219,11 +224,11 @@ def get_tigris_mount_cmd(bucket_name: str,
     rclone_mount = (
         f'{FUSE3_INSTALL_CMD} && '
         f'{FUSERMOUNT3_SOFT_LINK_CMD} && '
-        f'AWS_PROFILE=tigris '
+        f'AWS_PROFILE={tigris_profile} '
         f'rclone mount :s3:{bucket_name}{_bucket_sub_path} {mount_path} '
         f'--s3-force-path-style=false '
         f'--s3-endpoint {endpoint_url} --daemon --allow-other')
-    goofys_mount = (f'AWS_PROFILE=tigris {_GOOFYS_WRAPPER} '
+    goofys_mount = (f'AWS_PROFILE={tigris_profile} {_GOOFYS_WRAPPER} '
                     '-o allow_other '
                     f'--stat-cache-ttl {_STAT_CACHE_TTL} '
                     f'--type-cache-ttl {_TYPE_CACHE_TTL} '

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -201,6 +201,45 @@ def get_coreweave_mount_cmd(cw_credentials_path: str,
     return mount_cmd
 
 
+def get_tigris_mount_cmd(bucket_name: str,
+                         mount_path: str,
+                         endpoint_url: str,
+                         _bucket_sub_path: Optional[str] = None) -> str:
+    """Returns a command to mount Tigris bucket using s3fs/rclone.
+
+    Tigris credentials are read from ~/.aws/credentials with profile 'tigris'.
+    """
+    if _bucket_sub_path is None:
+        _bucket_sub_path = ''
+    else:
+        _bucket_sub_path = f':{_bucket_sub_path}'
+
+    # Use rclone for ARM64 architectures since goofys doesn't support them
+    arch_check = 'ARCH=$(uname -m) && '
+    rclone_mount = (
+        f'{FUSE3_INSTALL_CMD} && '
+        f'{FUSERMOUNT3_SOFT_LINK_CMD} && '
+        f'AWS_PROFILE=tigris '
+        f'rclone mount :s3:{bucket_name}{_bucket_sub_path} {mount_path} '
+        f'--s3-force-path-style=false '
+        f'--s3-endpoint {endpoint_url} --daemon --allow-other')
+    goofys_mount = (f'AWS_PROFILE=tigris {_GOOFYS_WRAPPER} '
+                    '-o allow_other '
+                    f'--stat-cache-ttl {_STAT_CACHE_TTL} '
+                    f'--type-cache-ttl {_TYPE_CACHE_TTL} '
+                    f'--subdomain '
+                    f'--endpoint {endpoint_url} '
+                    f'{bucket_name}{_bucket_sub_path} {mount_path}')
+
+    mount_cmd = (f'{arch_check}'
+                 f'if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then '
+                 f'  {rclone_mount}; '
+                 f'else '
+                 f'  {goofys_mount}; '
+                 f'fi')
+    return mount_cmd
+
+
 def get_gcs_mount_install_cmd() -> str:
     """Returns a command to install GCS mount utility gcsfuse."""
     install_cmd = ('ARCH=$(uname -m) && '

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -201,19 +201,17 @@ def get_coreweave_mount_cmd(cw_credentials_path: str,
     return mount_cmd
 
 
-def get_tigris_mount_cmd(bucket_name: str,
-                         mount_path: str,
+def get_tigris_mount_cmd(tigris_credentials_path: str,
+                         tigris_profile_name: str,
+                         bucket_name: str,
                          endpoint_url: str,
+                         mount_path: str,
                          _bucket_sub_path: Optional[str] = None) -> str:
     """Returns a command to mount Tigris bucket using s3fs/rclone.
 
-    Tigris credentials are read from ~/.aws/credentials using the profile
-    specified by TIGRIS_PROFILE env var (default: 'tigris').
+    Tigris credentials are read from the dedicated credentials file
+    at ~/.tigris/credentials using the 'tigris' profile.
     """
-    # pylint: disable=import-outside-toplevel
-    from sky.adaptors import tigris
-    tigris_profile = tigris.get_tigris_profile()
-
     if _bucket_sub_path is None:
         _bucket_sub_path = ''
     else:
@@ -224,17 +222,20 @@ def get_tigris_mount_cmd(bucket_name: str,
     rclone_mount = (
         f'{FUSE3_INSTALL_CMD} && '
         f'{FUSERMOUNT3_SOFT_LINK_CMD} && '
-        f'AWS_PROFILE={tigris_profile} '
+        f'AWS_SHARED_CREDENTIALS_FILE={tigris_credentials_path} '
+        f'AWS_PROFILE={tigris_profile_name} '
         f'rclone mount :s3:{bucket_name}{_bucket_sub_path} {mount_path} '
         f'--s3-force-path-style=false '
         f'--s3-endpoint {endpoint_url} --daemon --allow-other')
-    goofys_mount = (f'AWS_PROFILE={tigris_profile} {_GOOFYS_WRAPPER} '
-                    '-o allow_other '
-                    f'--stat-cache-ttl {_STAT_CACHE_TTL} '
-                    f'--type-cache-ttl {_TYPE_CACHE_TTL} '
-                    f'--subdomain '
-                    f'--endpoint {endpoint_url} '
-                    f'{bucket_name}{_bucket_sub_path} {mount_path}')
+    goofys_mount = (
+        f'AWS_SHARED_CREDENTIALS_FILE={tigris_credentials_path} '
+        f'AWS_PROFILE={tigris_profile_name} {_GOOFYS_WRAPPER} '
+        '-o allow_other '
+        f'--stat-cache-ttl {_STAT_CACHE_TTL} '
+        f'--type-cache-ttl {_TYPE_CACHE_TTL} '
+        f'--subdomain '
+        f'--endpoint {endpoint_url} '
+        f'{bucket_name}{_bucket_sub_path} {mount_path}')
 
     mount_cmd = (f'{arch_check}'
                  f'if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then '

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -227,15 +227,14 @@ def get_tigris_mount_cmd(tigris_credentials_path: str,
         f'rclone mount :s3:{bucket_name}{_bucket_sub_path} {mount_path} '
         f'--s3-force-path-style=false '
         f'--s3-endpoint {endpoint_url} --daemon --allow-other')
-    goofys_mount = (
-        f'AWS_SHARED_CREDENTIALS_FILE={tigris_credentials_path} '
-        f'AWS_PROFILE={tigris_profile_name} {_GOOFYS_WRAPPER} '
-        '-o allow_other '
-        f'--stat-cache-ttl {_STAT_CACHE_TTL} '
-        f'--type-cache-ttl {_TYPE_CACHE_TTL} '
-        f'--subdomain '
-        f'--endpoint {endpoint_url} '
-        f'{bucket_name}{_bucket_sub_path} {mount_path}')
+    goofys_mount = (f'AWS_SHARED_CREDENTIALS_FILE={tigris_credentials_path} '
+                    f'AWS_PROFILE={tigris_profile_name} {_GOOFYS_WRAPPER} '
+                    '-o allow_other '
+                    f'--stat-cache-ttl {_STAT_CACHE_TTL} '
+                    f'--type-cache-ttl {_TYPE_CACHE_TTL} '
+                    f'--subdomain '
+                    f'--endpoint {endpoint_url} '
+                    f'{bucket_name}{_bucket_sub_path} {mount_path}')
 
     mount_cmd = (f'{arch_check}'
                  f'if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then '

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1798,8 +1798,8 @@ class S3CompatibleStore(AbstractStore):
     def _is_same_provider_source(self) -> bool:
         """Check if source is from the same provider."""
         url_prefix = self.config.url_prefix or 's3://'
-        return isinstance(self.source, str) and self.source.startswith(
-            url_prefix)
+        return isinstance(self.source,
+                          str) and self.source.startswith(url_prefix)
 
     def _needs_cross_provider_transfer(self) -> bool:
         """Check if source needs cross-provider transfer."""

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -908,7 +908,8 @@ class Storage(object):
                             f'{source} in the file_mounts section of your YAML')
                 is_local_source = True
             elif split_path.scheme in [
-                    's3', 'gs', 'https', 'r2', 'cos', 'oci', 'nebius', 'cw'
+                    's3', 'gs', 'https', 'r2', 'cos', 'oci', 'nebius', 'cw',
+                    'tigris'
             ]:
                 is_local_source = False
                 # Storage mounting does not support mounting specific files from
@@ -933,7 +934,7 @@ class Storage(object):
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.StorageSourceError(
                         f'Supported paths: local, s3://, gs://, https://, '
-                        f'r2://, cos://, oci://, nebius://, cw://. '
+                        f'r2://, cos://, oci://, nebius://, cw://, tigris://. '
                         f'Got: {source}')
         return source, is_local_source
 
@@ -958,6 +959,7 @@ class Storage(object):
                     'oci',
                     'nebius',
                     'cw',
+                    'tigris',
             ]:
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.StorageNameError(

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -141,6 +141,7 @@ class StoreType(enum.Enum):
     OCI = 'OCI'
     NEBIUS = 'NEBIUS'
     COREWEAVE = 'COREWEAVE'
+    TIGRIS = 'TIGRIS'
     VOLUME = 'VOLUME'
 
     @classmethod
@@ -168,7 +169,9 @@ class StoreType(enum.Enum):
         """Get S3-compatible store type by URL prefix."""
         for store_type, store_class in _S3_COMPATIBLE_STORES.items():
             config = store_class.get_config()
-            if source.startswith(config.url_prefix):
+            # Skip stores with no url_prefix (they use another store's scheme)
+            if config.url_prefix is not None and source.startswith(
+                    config.url_prefix):
                 return StoreType(store_type)
         return None
 
@@ -232,7 +235,8 @@ class StoreType(enum.Enum):
     def store_prefix(self) -> str:
         config = self._get_s3_compatible_config(self.value)
         if config:
-            return config.url_prefix
+            # For stores with no url_prefix (e.g., Tigris), use s3://
+            return config.url_prefix if config.url_prefix else 's3://'
 
         if self == StoreType.GCS:
             return 'gs://'
@@ -1442,7 +1446,9 @@ class S3CompatibleConfig:
     """Configuration for S3-compatible storage providers."""
     # Provider identification
     store_type: str  # Store type identifier (e.g., "S3", "R2", "MINIO")
-    url_prefix: str  # URL prefix (e.g., "s3://", "r2://", "minio://")
+    # URL prefix (e.g., "s3://", "r2://"). None for providers that share
+    # another provider's URL scheme (e.g., Tigris uses s3:// with store: tigris)
+    url_prefix: Optional[str]
 
     # Client creation
     client_factory: Callable[[Optional[str]], Any]
@@ -1611,7 +1617,8 @@ class S3CompatibleStore(AbstractStore):
         # Get prefixes from all registered S3-compatible stores
         for store_class in _S3_COMPATIBLE_STORES.values():
             config = store_class.get_config()
-            prefixes.add(config.url_prefix)
+            if config.url_prefix is not None:
+                prefixes.add(config.url_prefix)
 
         # Add hardcoded prefixes for non-S3-compatible stores
         prefixes.update({
@@ -1625,7 +1632,8 @@ class S3CompatibleStore(AbstractStore):
 
     def _validate(self):
         if self.source is not None and isinstance(self.source, str):
-            if self.source.startswith(self.config.url_prefix):
+            url_prefix = self.config.url_prefix or 's3://'
+            if self.source.startswith(url_prefix):
                 bucket_name, _ = self.config.split_path(self.source)
                 assert self.name == bucket_name, (
                     f'{self.config.store_type} Bucket is specified as path, '
@@ -1789,8 +1797,9 @@ class S3CompatibleStore(AbstractStore):
 
     def _is_same_provider_source(self) -> bool:
         """Check if source is from the same provider."""
+        url_prefix = self.config.url_prefix or 's3://'
         return isinstance(self.source, str) and self.source.startswith(
-            self.config.url_prefix)
+            url_prefix)
 
     def _needs_cross_provider_transfer(self) -> bool:
         """Check if source needs cross-provider transfer."""
@@ -1962,7 +1971,7 @@ class S3CompatibleStore(AbstractStore):
         else:
             source_message = source_path_list[0]
 
-        provider_prefix = self.config.url_prefix
+        provider_prefix = self.config.url_prefix or 's3://'
         log_path = sky_logging.generate_tmp_logging_file_path(
             _STORAGE_LOG_FILE_NAME)
         sync_path = (f'{source_message} -> '
@@ -2014,8 +2023,8 @@ class S3CompatibleStore(AbstractStore):
                         _BUCKET_FAIL_TO_CONNECT_MESSAGE.format(name=self.name) +
                         f' To debug, consider running `{command}`.') from e
 
-        if isinstance(self.source, str) and self.source.startswith(
-                self.config.url_prefix):
+        url_prefix = self.config.url_prefix or 's3://'
+        if isinstance(self.source, str) and self.source.startswith(url_prefix):
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.StorageBucketGetError(
                     'Attempted to use a non-existent bucket as a source: '

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -4773,6 +4773,9 @@ class CoreWeaveStore(S3CompatibleStore):
 class TigrisStore(S3CompatibleStore):
     """TigrisStore inherits from S3CompatibleStore and represents the backend
     for Tigris Object Storage buckets.
+
+    Tigris uses standard s3:// URLs. Users specify `store: tigris` in their
+    YAML to route requests through Tigris's endpoint instead of AWS S3.
     """
 
     @classmethod
@@ -4780,10 +4783,11 @@ class TigrisStore(S3CompatibleStore):
         """Return the configuration for Tigris Object Storage."""
         return S3CompatibleConfig(
             store_type='TIGRIS',
-            url_prefix='tigris://',
+            # Tigris uses s3:// URLs - routing is done via store: tigris
+            url_prefix=None,
             client_factory=lambda region: data_utils.create_tigris_client(),
             resource_factory=lambda name: tigris.resource('s3').Bucket(name),
-            split_path=data_utils.split_tigris_path,
+            split_path=data_utils.split_s3_path,
             verify_bucket=data_utils.verify_tigris_bucket,
             aws_profile=tigris.TIGRIS_PROFILE_NAME,
             get_endpoint_url=lambda: tigris.ENDPOINT_URL,

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -4001,11 +4001,11 @@ class IBMCosStore(AbstractStore):
           StorageBucketCreateError: If bucket creation fails.
         """
         try:
-            self.client.create_bucket(Bucket=bucket_name,
-                                      CreateBucketConfiguration={
-                                          'LocationConstraint':
-                                              f'{region}-smart'
-                                      })
+            self.client.create_bucket(
+                Bucket=bucket_name,
+                CreateBucketConfiguration={
+                    'LocationConstraint': f'{region}-smart'
+                })
             logger.info(f'  {colorama.Style.DIM}Created IBM COS bucket '
                         f'{bucket_name!r} in {region} '
                         'with storage class smart tier'

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -4801,8 +4801,8 @@ class TigrisStore(S3CompatibleStore):
             verify_bucket=data_utils.verify_tigris_bucket,
             aws_profile=tigris.TIGRIS_PROFILE_NAME,
             get_endpoint_url=lambda: tigris.ENDPOINT_URL,
-            credentials_file='~/.aws/credentials',
-            config_file=None,
+            credentials_file=tigris.TIGRIS_CREDENTIALS_PATH,
+            config_file=tigris.TIGRIS_CONFIG_PATH,
             cloud_name=tigris.NAME,
             default_region=tigris.DEFAULT_REGION,
             mount_cmd_factory=cls._get_tigris_mount_cmd,
@@ -4812,6 +4812,11 @@ class TigrisStore(S3CompatibleStore):
     def _get_tigris_mount_cmd(cls, bucket_name: str, mount_path: str,
                               bucket_sub_path: Optional[str]) -> str:
         """Factory method for Tigris mount command."""
-        return mounting_utils.get_tigris_mount_cmd(bucket_name, mount_path,
-                                                   tigris.ENDPOINT_URL,
-                                                   bucket_sub_path)
+        return mounting_utils.get_tigris_mount_cmd(
+            tigris.TIGRIS_CREDENTIALS_PATH,
+            tigris.TIGRIS_PROFILE_NAME,
+            bucket_name,
+            tigris.ENDPOINT_URL,
+            mount_path,
+            bucket_sub_path,
+        )

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -200,6 +200,7 @@ cloud_dependencies: Dict[str, List[str]] = {
     'lambda': [],  # No dependencies needed for lambda
     'cloudflare': aws_dependencies,
     'coreweave': aws_dependencies + kubernetes_dependencies,
+    'tigris': aws_dependencies,
     'scp': local_ray,
     'oci': ['oci'],
     'kubernetes': kubernetes_dependencies,


### PR DESCRIPTION
## Summary
- Add Tigris as an S3-compatible object storage provider to SkyPilot
- Tigris is a globally distributed object storage with zero egress fees (https://www.tigrisdata.com/)
- Credentials are stored in `~/.aws/credentials` with a `[tigris]` profile

## Changes
- New `sky/adaptors/tigris.py` adaptor for credential management
- `TigrisStore` class in storage.py using S3CompatibleStore base
- Helper functions in data_utils.py (split_tigris_path, create_tigris_client, verify_tigris_bucket)
- Mount command support in mounting_utils.py
- Credential checking in check.py
- Documentation in storage.rst and installation.rst

## Scope
Currently supports MOUNT mode only. COPY and MOUNT_CACHED modes will be added in follow-up PRs.

## Test plan
- [ ] Python syntax validation passes for all modified files
- [ ] Manual verification: configure Tigris credentials with `aws configure --profile tigris`
- [ ] Manual verification: `sky check` shows Tigris as enabled when credentials are configured
- [ ] Integration test: mount an existing Tigris bucket with `tigris://bucket-name` source

🤖 Generated with [Claude Code](https://claude.com/claude-code)