### PR TITLE
rsync: add --no-owner --no-group for both uploads and downloads

### DIFF
--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -56,7 +56,6 @@ RSYNC_FILTER_GITIGNORE = f'--filter=\'dir-merge,- {constants.GIT_IGNORE_FILE}\''
 # The git exclude file to support.
 GIT_EXCLUDE = '.git/info/exclude'
 RSYNC_EXCLUDE_OPTION = '--exclude-from={}'
-# Owner and group metadata is not needed for downloads.
 RSYNC_NO_OWNER_NO_GROUP_OPTION = '--no-owner --no-group'
 
 _HASH_MAX_LENGTH = 10


### PR DESCRIPTION
When using SkyPilot with RunPod (and likely other container-based providers), rsync file uploads fail with exit code 23 due to chown: Invalid argument errors. The files are actually transferred successfully, but rsync attempts to preserve ownership, which fails in containers that don't support changing file ownership.

SkyPilot treats exit code 23 as a failure and retries multiple times before eventually failing the entire provisioning process.

https://github.com/skypilot-org/skypilot/issues/8549
