### PR TITLE
Jobs recovery index

### DIFF
--- a/docs/source/docs/index.rst
+++ b/docs/source/docs/index.rst
@@ -300,6 +300,7 @@ Read the research:
    :maxdepth: 1
    :caption: Jobs
 
+   Jobs Index <../running-jobs/index>
    ../examples/managed-jobs
    Multi-Node Jobs <../running-jobs/distributed-jobs>
    Many Parallel Jobs <../running-jobs/many-jobs>

--- a/docs/source/running-jobs/index.rst
+++ b/docs/source/running-jobs/index.rst
@@ -1,0 +1,99 @@
+.. _jobs-index:
+
+Jobs
+====
+
+SkyPilot provides powerful job management capabilities for running AI workloads at scale.
+
+.. contents:: Contents
+   :local:
+   :backlinks: none
+
+Quick Links
+----------
+
+* :ref:`Recover by Exit Code <failure-recovery>` - Configure jobs to automatically recover on specific exit codes (e.g., NCCL timeouts, GPU driver issues)
+* :ref:`Checkpointing and Recovery <checkpointing>` - Learn how to recover jobs from preemptions and failures using checkpointing
+* :ref:`Managed Jobs <managed-jobs>` - Complete guide to managed jobs
+* :ref:`Multi-Node Jobs <dist-jobs>` - Running distributed jobs
+* :ref:`Many Parallel Jobs <many-jobs>` - Scaling to hundreds or thousands of jobs
+
+Recover by Exit Code
+--------------------
+
+SkyPilot allows you to configure jobs to automatically recover when they exit with specific exit codes. This is particularly useful for transient errors like NCCL timeouts or GPU driver issues.
+
+To configure recovery on specific exit codes, use the :code:`recover_on_exit_codes` field in your job's recovery configuration:
+
+.. code-block:: yaml
+
+  resources:
+    accelerators: A100:8
+    job_recovery:
+      max_restarts_on_errors: 3
+      # Always recover if the job exits with code 33 or 34
+      recover_on_exit_codes: [33, 34]
+
+For complete details, see the :ref:`Recovering on specific exit codes <failure-recovery>` section in the Managed Jobs guide.
+
+Checkpointing and Recovery
+--------------------------
+
+One of the most important features for production jobs is the ability to recover from failures and preemptions. SkyPilot provides comprehensive checkpointing and recovery capabilities:
+
+* :ref:`Checkpointing and recovery <checkpointing>` - Set up checkpointing to recover from spot instance preemptions
+* :ref:`Jobs restarts on user code failure <failure-recovery>` - Configure automatic restarts on failures
+
+For detailed information, see the :ref:`Checkpointing and recovery <checkpointing>` section in the Managed Jobs guide.
+
+Managed Jobs
+------------
+
+:ref:`Managed Jobs <managed-jobs>` are the recommended way to run production workloads. They provide:
+
+* Automatic recovery from spot instance preemptions
+* Automatic retry on failures
+* Automatic cleanup when done
+* Easy management of many jobs in parallel
+
+See the :ref:`Managed Jobs <managed-jobs>` guide for complete documentation.
+
+Multi-Node Jobs
+---------------
+
+:ref:`Multi-Node Jobs <dist-jobs>` allow you to run distributed workloads across multiple nodes, with support for:
+
+* Multi-node training (PyTorch DDP, DeepSpeed, etc.)
+* Multi-node inference
+* Custom distributed setups
+
+See :ref:`Multi-Node Jobs <dist-jobs>` for details.
+
+Many Parallel Jobs
+------------------
+
+:ref:`Many Parallel Jobs <many-jobs>` shows you how to:
+
+* Run hundreds or thousands of jobs in parallel
+* Manage hyperparameter sweeps
+* Process large datasets with batch jobs
+
+See :ref:`Many Parallel Jobs <many-jobs>` for examples and best practices.
+
+Additional Resources
+--------------------
+
+* :ref:`Environment Variables <env-vars>` - Environment variables available in jobs
+* :ref:`External Links <external-links>` - Add external links to jobs in the dashboard
+* :ref:`Model Training Guide <training-guide>` - Best practices for training models
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Jobs Documentation
+   :hidden:
+
+   ../examples/managed-jobs
+   distributed-jobs
+   many-jobs
+   environment-variables
+   external-links


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR improves the discoverability of job recovery documentation, especially for "Recover by Exit Code".

A new top-level `Jobs` index (`docs/source/running-jobs/index.rst`) has been created. This index:
*   Prominently features "Recover by Exit Code" with a code example in its "Quick Links" and a dedicated section.
*   Provides clear links to "Checkpointing and Recovery" and other job-related documentation.

The main documentation index (`docs/source/docs/index.rst`) has been updated to include this new `Jobs` index.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
    *   Verified RST syntax and built documentation locally (`make html`).
    *   Confirmed the new index and links render correctly.
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->

---
<a href="https://cursor.com/background-agent?bcId=bc-f9ee9600-72d6-4f13-8a3a-c3846f1c020e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f9ee9600-72d6-4f13-8a3a-c3846f1c020e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

