### PR TITLE
fix(serve): ha recovery multi controller

### DIFF
--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -266,132 +266,132 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
     os.makedirs(service_dir, exist_ok=True)
     controller_lock = filelock.FileLock(
         os.path.join(service_dir, 'controller.lock'))
-    controller_lock_held = False
     try:
         controller_lock.acquire(timeout=0)
     except filelock.Timeout:
         logger.warning('Controller already running for service '
                        f'{service_name!r}; skipping start.')
         return
-    controller_lock_held = True
-
-    if not is_recovery:
-        with filelock.FileLock(controller_utils.get_resources_lock_path()):
-            if not controller_utils.can_start_new_process(task.service.pool):
+    try:
+        if not is_recovery:
+            with filelock.FileLock(controller_utils.get_resources_lock_path()):
+                if not controller_utils.can_start_new_process(
+                        task.service.pool):
+                    cleanup_storage(yaml_content)
+                    with ux_utils.print_exception_no_traceback():
+                        raise RuntimeError(
+                            constants.MAX_NUMBER_OF_SERVICES_REACHED_ERROR)
+                success = serve_state.add_service(
+                    service_name,
+                    controller_job_id=job_id,
+                    policy=service_spec.autoscaling_policy_str(),
+                    requested_resources_str=backend_utils.
+                    get_task_resources_str(task),
+                    load_balancing_policy=service_spec.load_balancing_policy,
+                    status=serve_state.ServiceStatus.CONTROLLER_INIT,
+                    tls_encrypted=service_spec.tls_credential is not None,
+                    pool=service_spec.pool,
+                    controller_pid=os.getpid(),
+                    entrypoint=entrypoint)
+            # Directly throw an error here. See sky/serve/api.py::up
+            # for more details.
+            if not success:
                 cleanup_storage(yaml_content)
                 with ux_utils.print_exception_no_traceback():
-                    raise RuntimeError(
-                        constants.MAX_NUMBER_OF_SERVICES_REACHED_ERROR)
-            success = serve_state.add_service(
-                service_name,
-                controller_job_id=job_id,
-                policy=service_spec.autoscaling_policy_str(),
-                requested_resources_str=backend_utils.get_task_resources_str(
-                    task),
-                load_balancing_policy=service_spec.load_balancing_policy,
-                status=serve_state.ServiceStatus.CONTROLLER_INIT,
-                tls_encrypted=service_spec.tls_credential is not None,
-                pool=service_spec.pool,
-                controller_pid=os.getpid(),
-                entrypoint=entrypoint)
-        # Directly throw an error here. See sky/serve/api.py::up
-        # for more details.
-        if not success:
-            cleanup_storage(yaml_content)
-            with ux_utils.print_exception_no_traceback():
-                raise ValueError(f'Service {service_name} already exists.')
+                    raise ValueError(f'Service {service_name} already exists.')
 
-        # Create the service working directory.
-        os.makedirs(service_dir, exist_ok=True)
+            version = constants.INITIAL_VERSION
+            # Add initial version information to the service state.
+            serve_state.add_or_update_version(service_name, version,
+                                              service_spec, yaml_content)
+        else:
+            version = serve_state.get_latest_version(service_name)
+            if version is None:
+                raise ValueError(f'No version found for service {service_name}')
+            serve_state.update_service_controller_pid(service_name, os.getpid())
 
-        version = constants.INITIAL_VERSION
-        # Add initial version information to the service state.
-        serve_state.add_or_update_version(service_name, version, service_spec,
-                                          yaml_content)
-    else:
-        version = serve_state.get_latest_version(service_name)
-        if version is None:
-            raise ValueError(f'No version found for service {service_name}')
-        serve_state.update_service_controller_pid(service_name, os.getpid())
-
-    controller_process = None
-    load_balancer_process = None
-    try:
-        with filelock.FileLock(
-                os.path.expanduser(constants.PORT_SELECTION_FILE_LOCK_PATH)):
-            # Start the controller.
-            controller_port = (
-                common_utils.find_free_port(constants.CONTROLLER_PORT_START)
-                if not is_recovery else
-                serve_state.get_service_controller_port(service_name))
-
-            def _get_controller_host():
-                """Get the controller host address.
-                We expose the controller to the public network when running
-                inside a kubernetes cluster to allow external load balancers
-                (example, for high availability load balancers) to communicate
-                with the controller.
-                """
-                if 'KUBERNETES_SERVICE_HOST' in os.environ:
-                    return '0.0.0.0'
-                # Not using localhost to avoid using ipv6 address and causing
-                # the following error:
-                # ERROR:    [Errno 99] error while attempting to bind on address
-                # ('::1', 20001, 0, 0): cannot assign requested address
-                return '127.0.0.1'
-
-            controller_host = _get_controller_host()
-            controller_process = multiprocessing.Process(
-                target=controller.run_controller,
-                args=(service_name, service_spec, version, controller_host,
-                      controller_port))
-            controller_process.start()
-
-            if not is_recovery:
-                serve_state.set_service_controller_port(service_name,
-                                                        controller_port)
-
-            controller_addr = f'http://{controller_host}:{controller_port}'
-
-            # Start the load balancer.
-            load_balancer_port = (
-                common_utils.find_free_port(constants.LOAD_BALANCER_PORT_START)
-                if not is_recovery else
-                serve_state.get_service_load_balancer_port(service_name))
-            load_balancer_log_file = os.path.expanduser(
-                serve_utils.generate_remote_load_balancer_log_file_name(
-                    service_name))
-
-            # TODO(tian): Probably we could enable multiple ports specified in
-            # service spec and we could start multiple load balancers.
-            # After that, we will have a mapping from replica port to endpoint.
-            # NOTE(tian): We don't need the load balancer for pool.
-            # Skip the load balancer process for pool.
-            if not service_spec.pool:
-                load_balancer_process = multiprocessing.Process(
-                    target=ux_utils.RedirectOutputForProcess(
-                        load_balancer.run_load_balancer,
-                        load_balancer_log_file).run,
-                    args=(controller_addr, load_balancer_port,
-                          service_spec.load_balancing_policy,
-                          service_spec.tls_credential,
-                          service_spec.target_qps_per_replica))
-                load_balancer_process.start()
-
-            if not is_recovery:
-                serve_state.set_service_load_balancer_port(
-                    service_name, load_balancer_port)
-
-        while True:
-            _handle_signal(service_name)
-            time.sleep(1)
-    except exceptions.ServeUserTerminatedError:
-        serve_state.set_service_status_and_active_versions(
-            service_name, serve_state.ServiceStatus.SHUTTING_DOWN)
-    finally:
+        controller_process = None
+        load_balancer_process = None
         try:
-            # Kill load balancer process first since it will raise errors if
-            # failed to connect to the controller. Then the controller process.
+            with filelock.FileLock(
+                    os.path.expanduser(
+                        constants.PORT_SELECTION_FILE_LOCK_PATH)):
+                # Start the controller.
+                controller_port = (
+                    common_utils.find_free_port(constants.CONTROLLER_PORT_START)
+                    if not is_recovery else
+                    serve_state.get_service_controller_port(service_name))
+
+                def _get_controller_host():
+                    """Get the controller host address.
+                    We expose the controller to the public network when running
+                    inside a kubernetes cluster to allow external load balancers
+                    (example, for high availability load balancers) to
+                    communicate with the controller.
+                    """
+                    if 'KUBERNETES_SERVICE_HOST' in os.environ:
+                        return '0.0.0.0'
+                    # Not using localhost to avoid using ipv6 address and
+                    # causing the following error:
+                    # ERROR:    [Errno 99] error while attempting to bind on
+                    # address ('::1', 20001, 0, 0): cannot assign requested
+                    # address
+                    return '127.0.0.1'
+
+                controller_host = _get_controller_host()
+                controller_process = multiprocessing.Process(
+                    target=controller.run_controller,
+                    args=(service_name, service_spec, version, controller_host,
+                          controller_port))
+                controller_process.start()
+
+                if not is_recovery:
+                    serve_state.set_service_controller_port(
+                        service_name, controller_port)
+
+                controller_addr = f'http://{controller_host}:{controller_port}'
+
+                # Start the load balancer.
+                load_balancer_port = (
+                    common_utils.find_free_port(
+                        constants.LOAD_BALANCER_PORT_START)
+                    if not is_recovery else
+                    serve_state.get_service_load_balancer_port(service_name))
+                load_balancer_log_file = os.path.expanduser(
+                    serve_utils.generate_remote_load_balancer_log_file_name(
+                        service_name))
+
+                # TODO(tian): Probably we could enable multiple ports specified
+                # in service spec and we could start multiple load balancers.
+                # After that, we will have a mapping from replica port to
+                # endpoint.
+                # NOTE(tian): We don't need the load balancer for pool.
+                # Skip the load balancer process for pool.
+                if not service_spec.pool:
+                    load_balancer_process = multiprocessing.Process(
+                        target=ux_utils.RedirectOutputForProcess(
+                            load_balancer.run_load_balancer,
+                            load_balancer_log_file).run,
+                        args=(controller_addr, load_balancer_port,
+                              service_spec.load_balancing_policy,
+                              service_spec.tls_credential,
+                              service_spec.target_qps_per_replica))
+                    load_balancer_process.start()
+
+                if not is_recovery:
+                    serve_state.set_service_load_balancer_port(
+                        service_name, load_balancer_port)
+
+            while True:
+                _handle_signal(service_name)
+                time.sleep(1)
+        except exceptions.ServeUserTerminatedError:
+            serve_state.set_service_status_and_active_versions(
+                service_name, serve_state.ServiceStatus.SHUTTING_DOWN)
+        finally:
+            # Kill load balancer process first since it will raise errors
+            # if failed to connect to the controller. Then the controller
+            # process.
             process_to_kill = [
                 proc for proc in [load_balancer_process, controller_process]
                 if proc is not None
@@ -402,17 +402,17 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
             for process in process_to_kill:
                 process.join()
 
-            # Catch any exception here to avoid it kill the service monitoring
-            # process. In which case, the service will not only fail to clean
-            # up, but also cannot be terminated in the future as no process
-            # will handle the user signal anymore. Instead, we catch any error
-            # and set it to FAILED_CLEANUP instead.
+            # Catch any exception here to avoid it kill the service
+            # monitoring process. In which case, the service will not only
+            # fail to clean up, but also cannot be terminated in the future
+            # as no process will handle the user signal anymore. Instead,
+            # we catch any error and set it to FAILED_CLEANUP instead.
             try:
                 failed = _cleanup(service_name, service_spec.pool)
-            except Exception as e:  # pylint: disable=broad-except
-                logger.error(f'Failed to clean up service {service_name}: {e}')
+            except Exception:  # pylint: disable=broad-except
                 with ux_utils.enable_traceback():
-                    logger.error(f'  Traceback: {traceback.format_exc()}')
+                    logger.exception(
+                        f'Failed to clean up service {service_name}')
                 failed = True
 
             if failed:
@@ -422,13 +422,11 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
             else:
                 shutil.rmtree(service_dir)
                 serve_state.remove_service(service_name)
-                serve_state.delete_all_versions(service_name)
                 logger.info(f'Service {service_name} terminated successfully.')
 
             _cleanup_task_run_script(job_id)
-        finally:
-            if controller_lock_held:
-                controller_lock.release()
+    finally:
+        controller_lock.release()
 
 
 if __name__ == '__main__':

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -1106,7 +1106,7 @@ available_node_types:
                       continue
                     fi
                   fi
-                  service_name=$(grep -oE -- '--service-name[[:space:]]+[^[:space:]]+' "$file" | head -n1 | awk '{print $2}' || true)
+                  service_name=$(grep -oE -- '--service-name(=| +)[^[:space:]]+' "$file" | head -n1 | awk -F'[= ]' '{print $NF}' || true)
                   if [ -n "$service_name" ]; then
                     existing_job_id="${SERVICE_TO_JOB_ID[$service_name]}"
                     if [ -z "$existing_job_id" ] || [ "$JOB_ID" -gt "$existing_job_id" ]; then

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -1082,6 +1082,10 @@ available_node_types:
                 if [ "$ALL_IN_PROGRESS_JOBS" != "None" ]; then
                   read -ra ALL_IN_PROGRESS_JOBS_SEQ <<< "$ALL_IN_PROGRESS_JOBS"
                 fi
+                declare -A SERVICE_TO_JOB_ID
+                declare -A SERVICE_TO_SCRIPT
+                OTHER_SCRIPTS=()
+
                 for file in {{k8s_high_availability_deployment_run_script_dir}}/*; do
                   # This is the cluster job id on managed jobs controller, but it is guaranteed to be the same as the managed job id,
                   # so we directly use it here. See `CloudVmRayBackend._exec_code_on_head::_dump_code_to_file` for more details.
@@ -1092,10 +1096,31 @@ available_node_types:
                       continue
                     fi
                   fi
+                  service_name=$(grep -oE -- '--service-name[[:space:]]+[^[:space:]]+' "$file" | head -n1 | awk '{print $2}' || true)
+                  if [ -n "$service_name" ]; then
+                    existing_job_id="${SERVICE_TO_JOB_ID[$service_name]}"
+                    if [ -z "$existing_job_id" ] || [ "$JOB_ID" -gt "$existing_job_id" ]; then
+                      SERVICE_TO_JOB_ID[$service_name]=$JOB_ID
+                      SERVICE_TO_SCRIPT[$service_name]=$file
+                    fi
+                  else
+                    OTHER_SCRIPTS+=("$file")
+                  fi
+                done
+
+                for file in "${OTHER_SCRIPTS[@]}"; do
                   # ! Keep this aligned with `CloudVmRayBackend._execute()`
                   chmod +x $file
                   # TODO(tian): This logic may run a lot of things if the jobs controller previously had many jobs.
                   # We should do more tests and make sure it will scale well.
+                  /bin/bash --login -c "true && export OMP_NUM_THREADS=1 PYTHONWARNINGS='ignore' && $file > /tmp/task_run_$(basename $file).log 2>&1"
+                  echo "=== Controller task run for service / job (file: $file) completed for recovery at $(date) ===" >> $SKYPILOT_HA_RECOVERY_LOG
+                done
+
+                for service_name in "${!SERVICE_TO_SCRIPT[@]}"; do
+                  file="${SERVICE_TO_SCRIPT[$service_name]}"
+                  # ! Keep this aligned with `CloudVmRayBackend._execute()`
+                  chmod +x $file
                   /bin/bash --login -c "true && export OMP_NUM_THREADS=1 PYTHONWARNINGS='ignore' && $file > /tmp/task_run_$(basename $file).log 2>&1"
                   echo "=== Controller task run for service / job (file: $file) completed for recovery at $(date) ===" >> $SKYPILOT_HA_RECOVERY_LOG
                 done

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -523,7 +523,7 @@ available_node_types:
                 resourceFieldRef:
                   containerName: ray-node
                   resource: requests.memory
-            # Disable Ray memory monitor to prevent Ray's memory manager 
+            # Disable Ray memory monitor to prevent Ray's memory manager
             # from interfering with kubernetes resource manager.
             # If ray memory monitor is enabled, the ray memory monitor kills
             # the running job is the job uses more than 95% of allocated memory,
@@ -1082,6 +1082,16 @@ available_node_types:
                 if [ "$ALL_IN_PROGRESS_JOBS" != "None" ]; then
                   read -ra ALL_IN_PROGRESS_JOBS_SEQ <<< "$ALL_IN_PROGRESS_JOBS"
                 fi
+                run_task_script() {
+                  local script_file="$1"
+                  # ! Keep this aligned with `CloudVmRayBackend._execute()`
+                  chmod +x "$script_file"
+                  # TODO(tian): This logic may run a lot of things if the jobs controller previously had many jobs.
+                  # We should do more tests and make sure it will scale well.
+                  /bin/bash --login -c "true && export OMP_NUM_THREADS=1 PYTHONWARNINGS='ignore' && \"$script_file\" > /tmp/task_run_$(basename \"$script_file\").log 2>&1"
+                  echo "=== Controller task run for service / job (file: $script_file) completed for recovery at $(date) ===" >> $SKYPILOT_HA_RECOVERY_LOG
+                }
+
                 declare -A SERVICE_TO_JOB_ID
                 declare -A SERVICE_TO_SCRIPT
                 OTHER_SCRIPTS=()
@@ -1109,20 +1119,12 @@ available_node_types:
                 done
 
                 for file in "${OTHER_SCRIPTS[@]}"; do
-                  # ! Keep this aligned with `CloudVmRayBackend._execute()`
-                  chmod +x $file
-                  # TODO(tian): This logic may run a lot of things if the jobs controller previously had many jobs.
-                  # We should do more tests and make sure it will scale well.
-                  /bin/bash --login -c "true && export OMP_NUM_THREADS=1 PYTHONWARNINGS='ignore' && $file > /tmp/task_run_$(basename $file).log 2>&1"
-                  echo "=== Controller task run for service / job (file: $file) completed for recovery at $(date) ===" >> $SKYPILOT_HA_RECOVERY_LOG
+                  run_task_script "$file"
                 done
 
                 for service_name in "${!SERVICE_TO_SCRIPT[@]}"; do
                   file="${SERVICE_TO_SCRIPT[$service_name]}"
-                  # ! Keep this aligned with `CloudVmRayBackend._execute()`
-                  chmod +x $file
-                  /bin/bash --login -c "true && export OMP_NUM_THREADS=1 PYTHONWARNINGS='ignore' && $file > /tmp/task_run_$(basename $file).log 2>&1"
-                  echo "=== Controller task run for service / job (file: $file) completed for recovery at $(date) ===" >> $SKYPILOT_HA_RECOVERY_LOG
+                  run_task_script "$file"
                 done
                 rm {{k8s_high_availability_restarting_signal_file}}
 

--- a/tests/unit_tests/test_sky/serve/test_service.py
+++ b/tests/unit_tests/test_sky/serve/test_service.py
@@ -1,0 +1,569 @@
+import os
+
+import filelock
+
+from sky import exceptions
+from sky.serve import service as serve_service
+
+
+class _DummyServiceSpec:
+    pool = False
+    load_balancing_policy = 'round_robin'
+    tls_credential = None
+    target_qps_per_replica = None
+
+    @staticmethod
+    def autoscaling_policy_str():
+        return 'dummy'
+
+
+class _DummyTask:
+
+    def __init__(self, service, storage_mounts=None, file_mounts=None):
+        self.service = service
+        self.storage_mounts = storage_mounts or {}
+        self.file_mounts = file_mounts
+
+
+class _DummyProcess:
+    _pid_counter = 1234
+    instances = []
+
+    def __init__(self, *args, **kwargs):
+        if args:
+            self.target = args[0]
+            self.args = args[1] if len(args) > 1 else ()
+            self.kwargs = args[2] if len(args) > 2 else {}
+        else:
+            self.target = kwargs.get('target')
+            self.args = kwargs.get('args', ())
+            self.kwargs = kwargs.get('kwargs', {})
+        type(self)._pid_counter += 1
+        self.pid = type(self)._pid_counter
+        type(self).instances.append(self)
+
+    def start(self):
+        return None
+
+    def join(self):
+        return None
+
+
+def _patch_minimal_start(monkeypatch, tmp_path):
+
+    def _dummy_from_yaml_str(*_args, **_kwargs):
+        return _DummyTask(_DummyServiceSpec())
+
+    monkeypatch.setattr(serve_service.task_lib.Task, 'from_yaml_str',
+                        _dummy_from_yaml_str)
+    monkeypatch.setattr(serve_service.auth_utils, 'get_or_generate_keys',
+                        lambda: None)
+    monkeypatch.setattr(serve_service.serve_utils,
+                        'generate_remote_service_dir_name',
+                        lambda name: str(tmp_path / name))
+    monkeypatch.setattr(serve_service.serve_utils,
+                        'generate_remote_load_balancer_log_file_name',
+                        lambda name: str(tmp_path / f'{name}-lb.log'))
+    monkeypatch.setattr(serve_service.backend_utils, 'get_task_resources_str',
+                        lambda *_args, **_kwargs: 'resources')
+    monkeypatch.setattr(serve_service.subprocess_utils,
+                        'kill_children_processes', lambda *args, **kwargs: None)
+    monkeypatch.setattr(serve_service.multiprocessing, 'Process', _DummyProcess)
+    monkeypatch.setattr(serve_service, '_cleanup',
+                        lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(serve_service, '_cleanup_task_run_script',
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(serve_service.serve_state, 'get_service_from_name',
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(serve_service.serve_state, 'add_or_update_version',
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(serve_service.serve_state,
+                        'set_service_controller_port',
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(serve_service.serve_state,
+                        'set_service_load_balancer_port',
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(serve_service.serve_state,
+                        'set_service_status_and_active_versions',
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(serve_service.controller_utils, 'can_start_new_process',
+                        lambda *_args, **_kwargs: True)
+    _DummyProcess.instances = []
+
+
+def _write_dummy_yaml(tmp_path):
+    path = tmp_path / 'service.yaml'
+    path.write_text('service: dummy\n', encoding='utf-8')
+    return str(path)
+
+
+def test_start_skips_when_controller_lock_held(monkeypatch, tmp_path):
+    """Skip controller startup when another process holds the lock."""
+    _patch_minimal_start(monkeypatch, tmp_path)
+
+    class _LockWithTimeout:
+
+        def __init__(self, path, *args, **kwargs):
+            self.path = path
+            del args, kwargs
+
+        def acquire(self, timeout=None):
+            if self.path.endswith('controller.lock'):
+                raise filelock.Timeout(self.path)
+            return True
+
+        def release(self):
+            return None
+
+        def __enter__(self):
+            self.acquire()
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.release()
+            return False
+
+    monkeypatch.setattr(serve_service.filelock, 'FileLock', _LockWithTimeout)
+
+    add_service_called = {'value': False}
+
+    def _add_service(*_args, **_kwargs):
+        add_service_called['value'] = True
+        return True
+
+    monkeypatch.setattr(serve_service.serve_state, 'add_service', _add_service)
+
+    serve_service._start('svc', _write_dummy_yaml(tmp_path), 1, 'entrypoint')
+
+    assert not add_service_called['value']
+
+
+def test_start_releases_controller_lock_on_exit(monkeypatch, tmp_path):
+    """Release the controller lock when the service exits."""
+    _patch_minimal_start(monkeypatch, tmp_path)
+
+    locks = []
+
+    class _DummyLock:
+
+        def __init__(self, path, *args, **kwargs):
+            self.path = path
+            self.released = False
+            locks.append(self)
+            del args, kwargs
+
+        def acquire(self, timeout=None):
+            return True
+
+        def release(self):
+            self.released = True
+            return None
+
+        def __enter__(self):
+            self.acquire()
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.release()
+            return False
+
+    monkeypatch.setattr(serve_service.filelock, 'FileLock', _DummyLock)
+
+    def _raise_terminate(*_args, **_kwargs):
+        raise exceptions.ServeUserTerminatedError('test')
+
+    monkeypatch.setattr(serve_service, '_handle_signal', _raise_terminate)
+    monkeypatch.setattr(serve_service.serve_state, 'add_service',
+                        lambda *_args, **_kwargs: True)
+
+    serve_service._start('svc', _write_dummy_yaml(tmp_path), 2, 'entrypoint')
+
+    controller_lock = next(
+        lock for lock in locks if lock.path.endswith('controller.lock'))
+    assert controller_lock.released is True
+
+
+def test_start_acquires_controller_lock_before_registering_service(
+        monkeypatch, tmp_path):
+    """Acquire controller lock before writing service state."""
+    _patch_minimal_start(monkeypatch, tmp_path)
+
+    lock_state = {'acquired': False}
+
+    class _DummyLock:
+
+        def __init__(self, path, *args, **kwargs):
+            self.path = path
+            del args, kwargs
+
+        def acquire(self, timeout=None):
+            if self.path.endswith('controller.lock'):
+                lock_state['acquired'] = True
+            return True
+
+        def release(self):
+            return None
+
+        def __enter__(self):
+            self.acquire()
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.release()
+            return False
+
+    monkeypatch.setattr(serve_service.filelock, 'FileLock', _DummyLock)
+
+    def _raise_terminate(*_args, **_kwargs):
+        raise exceptions.ServeUserTerminatedError('test')
+
+    monkeypatch.setattr(serve_service, '_handle_signal', _raise_terminate)
+
+    def _add_service(*_args, **_kwargs):
+        assert lock_state['acquired'] is True
+        return True
+
+    monkeypatch.setattr(serve_service.serve_state, 'add_service', _add_service)
+
+    serve_service._start('svc', _write_dummy_yaml(tmp_path), 3, 'entrypoint')
+
+
+def test_handle_signal_raises_on_terminate(monkeypatch, tmp_path):
+    """Raise ServeUserTerminatedError when terminate signal is present."""
+    service_name = 'svc'
+    monkeypatch.setattr(serve_service.constants, 'SIGNAL_FILE_PATH',
+                        str(tmp_path / 'signal_{}'))
+    signal_path = serve_service.constants.SIGNAL_FILE_PATH.format(service_name)
+    os.makedirs(os.path.dirname(signal_path), exist_ok=True)
+    with open(signal_path, 'w', encoding='utf-8') as handle:
+        handle.write('terminate')
+
+    try:
+        serve_service._handle_signal(service_name)
+    except exceptions.ServeUserTerminatedError:
+        pass
+    else:
+        raise AssertionError('Expected ServeUserTerminatedError')
+
+    assert not os.path.exists(signal_path)
+
+
+def test_handle_signal_ignores_unknown(monkeypatch, tmp_path):
+    """Ignore unknown signals and delete the signal file."""
+    service_name = 'svc'
+    monkeypatch.setattr(serve_service.constants, 'SIGNAL_FILE_PATH',
+                        str(tmp_path / 'signal_{}'))
+    signal_path = serve_service.constants.SIGNAL_FILE_PATH.format(service_name)
+    os.makedirs(os.path.dirname(signal_path), exist_ok=True)
+    with open(signal_path, 'w', encoding='utf-8') as handle:
+        handle.write('unknown')
+
+    serve_service._handle_signal(service_name)
+
+    assert not os.path.exists(signal_path)
+
+
+def test_cleanup_storage_removes_local_mounts(monkeypatch, tmp_path):
+    """Clean up local mounts and return success when no errors occur."""
+    local_file = tmp_path / 'file.txt'
+    local_dir = tmp_path / 'dir'
+    local_file.write_text('data', encoding='utf-8')
+    local_dir.mkdir()
+
+    storage = {'s1': _DummyStorage()}
+    file_mounts = {
+        'file': str(local_file),
+        'dir': str(local_dir),
+    }
+
+    def _dummy_from_yaml_str(*_args, **_kwargs):
+        return _DummyTask(_DummyServiceSpec(),
+                          storage_mounts=storage,
+                          file_mounts=file_mounts)
+
+    class _DummyBackend:
+
+        def teardown_ephemeral_storage(self, *_args, **_kwargs):
+            return None
+
+    monkeypatch.setattr(serve_service.task_lib.Task, 'from_yaml_str',
+                        _dummy_from_yaml_str)
+    monkeypatch.setattr(serve_service.cloud_vm_ray_backend, 'CloudVmRayBackend',
+                        _DummyBackend)
+    monkeypatch.setattr(serve_service.data_utils, 'is_cloud_store_url',
+                        lambda *_args, **_kwargs: False)
+
+    assert serve_service.cleanup_storage('service: dummy') is True
+    assert storage['s1'].constructed is True
+    assert not local_file.exists()
+    assert not local_dir.exists()
+
+
+def test_cleanup_storage_returns_false_on_teardown_error(monkeypatch):
+    """Return False when storage teardown raises."""
+
+    def _dummy_from_yaml_str(*_args, **_kwargs):
+        return _DummyTask(_DummyServiceSpec())
+
+    class _DummyBackend:
+
+        def teardown_ephemeral_storage(self, *_args, **_kwargs):
+            raise RuntimeError('teardown error')
+
+    monkeypatch.setattr(serve_service.task_lib.Task, 'from_yaml_str',
+                        _dummy_from_yaml_str)
+    monkeypatch.setattr(serve_service.cloud_vm_ray_backend, 'CloudVmRayBackend',
+                        _DummyBackend)
+
+    assert serve_service.cleanup_storage('service: dummy') is False
+
+
+def test_cleanup_removes_missing_clusters(monkeypatch):
+    """Remove replicas whose clusters no longer exist."""
+    replicas = [
+        _DummyReplicaInfo(1, 'missing-1'),
+        _DummyReplicaInfo(2, 'missing-2'),
+    ]
+
+    monkeypatch.setattr(serve_service.serve_state, 'remove_ha_recovery_script',
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(serve_service.serve_state, 'get_replica_infos',
+                        lambda *_args, **_kwargs: replicas)
+    monkeypatch.setattr(serve_service.global_user_state,
+                        'get_cluster_names_start_with',
+                        lambda *_args, **_kwargs: [])
+    removed = []
+    monkeypatch.setattr(serve_service.serve_state, 'remove_replica',
+                        lambda *_args, **_kwargs: removed.append(_args[1]))
+    monkeypatch.setattr(serve_service.serve_state, 'get_service_versions',
+                        lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(serve_service.serve_state, 'delete_all_versions',
+                        lambda *_args, **_kwargs: None)
+
+    assert serve_service._cleanup('svc', pool=False) is False
+    assert sorted(removed) == [1, 2]
+
+
+def test_cleanup_terminates_replicas_success(monkeypatch):
+    """Remove replicas after successful terminate threads."""
+    replica = _DummyReplicaInfo(1, 'cluster-1')
+
+    def _dummy_safe_thread(target=None, args=()):
+        del target
+        return _DummyThread(args[0], format_exc=None)
+
+    monkeypatch.setattr(serve_service.serve_state, 'remove_ha_recovery_script',
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(serve_service.serve_state, 'get_replica_infos',
+                        lambda *_args, **_kwargs: [replica])
+    monkeypatch.setattr(serve_service.global_user_state,
+                        'get_cluster_names_start_with',
+                        lambda *_args, **_kwargs: ['cluster-1'])
+    monkeypatch.setattr(serve_service.serve_utils,
+                        'generate_replica_log_file_name',
+                        lambda *_args, **_kwargs: 'log')
+    monkeypatch.setattr(serve_service.thread_utils, 'SafeThread',
+                        _dummy_safe_thread)
+    monkeypatch.setattr(serve_service.controller_utils, 'can_terminate',
+                        lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(serve_service.time, 'sleep',
+                        lambda *_args, **_kwargs: None)
+    removed = []
+    monkeypatch.setattr(serve_service.serve_state, 'remove_replica',
+                        lambda *_args, **_kwargs: removed.append(_args[1]))
+    monkeypatch.setattr(serve_service.serve_state, 'add_or_update_replica',
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(serve_service.serve_state, 'get_service_versions',
+                        lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(serve_service.serve_state, 'delete_all_versions',
+                        lambda *_args, **_kwargs: None)
+
+    assert serve_service._cleanup('svc', pool=False) is False
+    assert removed == [1]
+
+
+def test_cleanup_marks_failed_on_thread_error(monkeypatch):
+    """Mark replica as failed cleanup when terminate thread errors."""
+    replica = _DummyReplicaInfo(1, 'cluster-1')
+
+    def _dummy_safe_thread(target=None, args=()):
+        del target
+        return _DummyThread(args[0], format_exc=RuntimeError('boom'))
+
+    monkeypatch.setattr(serve_service.serve_state, 'remove_ha_recovery_script',
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(serve_service.serve_state, 'get_replica_infos',
+                        lambda *_args, **_kwargs: [replica])
+    monkeypatch.setattr(serve_service.global_user_state,
+                        'get_cluster_names_start_with',
+                        lambda *_args, **_kwargs: ['cluster-1'])
+    monkeypatch.setattr(serve_service.serve_utils,
+                        'generate_replica_log_file_name',
+                        lambda *_args, **_kwargs: 'log')
+    monkeypatch.setattr(serve_service.thread_utils, 'SafeThread',
+                        _dummy_safe_thread)
+    monkeypatch.setattr(serve_service.controller_utils, 'can_terminate',
+                        lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(serve_service.time, 'sleep',
+                        lambda *_args, **_kwargs: None)
+    updates = []
+
+    def _add_or_update_replica(*_args, **_kwargs):
+        updates.append(_args[2].status_property.sky_down_status)
+
+    monkeypatch.setattr(serve_service.serve_state, 'add_or_update_replica',
+                        _add_or_update_replica)
+    monkeypatch.setattr(serve_service.serve_state, 'get_service_versions',
+                        lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(serve_service.serve_state, 'delete_all_versions',
+                        lambda *_args, **_kwargs: None)
+
+    assert serve_service._cleanup('svc', pool=False) is True
+    assert (serve_service.replica_managers.common_utils.ProcessStatus.FAILED
+            in updates)
+
+
+def test_start_recovery_uses_latest_version(monkeypatch, tmp_path):
+    """Use latest version and avoid service registration on recovery."""
+    _patch_minimal_start(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        serve_service.serve_state, 'get_service_from_name',
+        lambda *_args, **_kwargs: {'yaml_content': 'service: s'})
+    monkeypatch.setattr(serve_service.serve_state, 'get_latest_version',
+                        lambda *_args, **_kwargs: 5)
+    monkeypatch.setattr(serve_service.serve_state,
+                        'get_service_controller_port',
+                        lambda *_args, **_kwargs: 20001)
+    monkeypatch.setattr(serve_service.serve_state,
+                        'get_service_load_balancer_port',
+                        lambda *_args, **_kwargs: 20002)
+    monkeypatch.setattr(serve_service.serve_state,
+                        'update_service_controller_pid',
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(serve_service.serve_state, 'add_service',
+                        lambda *_args, **_kwargs: False)
+
+    def _raise_terminate(*_args, **_kwargs):
+        raise exceptions.ServeUserTerminatedError('test')
+
+    monkeypatch.setattr(serve_service, '_handle_signal', _raise_terminate)
+
+    serve_service._start('svc', _write_dummy_yaml(tmp_path), 4, 'entrypoint')
+
+    controller_proc = next(
+        proc for proc in _DummyProcess.instances
+        if proc.target == serve_service.controller.run_controller)
+    controller_args = controller_proc.args
+    assert controller_args[2] == 5
+
+
+def test_start_pool_mode_skips_load_balancer(monkeypatch, tmp_path):
+    """Skip load balancer process when running in pool mode."""
+    _patch_minimal_start(monkeypatch, tmp_path)
+
+    class _PoolServiceSpec(_DummyServiceSpec):
+        pool = True
+
+    def _dummy_from_yaml_str(*_args, **_kwargs):
+        return _DummyTask(_PoolServiceSpec())
+
+    monkeypatch.setattr(serve_service.task_lib.Task, 'from_yaml_str',
+                        _dummy_from_yaml_str)
+
+    def _raise_terminate(*_args, **_kwargs):
+        raise exceptions.ServeUserTerminatedError('test')
+
+    monkeypatch.setattr(serve_service, '_handle_signal', _raise_terminate)
+    monkeypatch.setattr(serve_service.serve_state, 'add_service',
+                        lambda *_args, **_kwargs: True)
+
+    serve_service._start('svc', _write_dummy_yaml(tmp_path), 5, 'entrypoint')
+
+    assert len(_DummyProcess.instances) == 1
+    assert (_DummyProcess.instances[0].target ==
+            serve_service.controller.run_controller)
+
+
+def test_start_adds_initial_version(monkeypatch, tmp_path):
+    """Record initial version metadata on first start."""
+    _patch_minimal_start(monkeypatch, tmp_path)
+    versions = []
+
+    def _add_or_update_version(*_args, **_kwargs):
+        versions.append(_args[1])
+
+    monkeypatch.setattr(serve_service.serve_state, 'add_or_update_version',
+                        _add_or_update_version)
+    monkeypatch.setattr(serve_service.serve_state, 'add_service',
+                        lambda *_args, **_kwargs: True)
+
+    def _raise_terminate(*_args, **_kwargs):
+        raise exceptions.ServeUserTerminatedError('test')
+
+    monkeypatch.setattr(serve_service, '_handle_signal', _raise_terminate)
+
+    serve_service._start('svc', _write_dummy_yaml(tmp_path), 6, 'entrypoint')
+
+    assert versions == [serve_service.constants.INITIAL_VERSION]
+
+
+def test_cleanup_task_run_script_removes_file(monkeypatch, tmp_path):
+    """Remove the task run script when it exists."""
+    monkeypatch.setattr(serve_service.skylet_constants,
+                        'PERSISTENT_RUN_SCRIPT_DIR', str(tmp_path))
+    script = tmp_path / 'sky_job_7'
+    script.write_text('echo', encoding='utf-8')
+
+    serve_service._cleanup_task_run_script(7)
+
+    assert not script.exists()
+
+
+def test_cleanup_task_run_script_missing_file(monkeypatch, tmp_path):
+    """Handle missing task run script without raising."""
+    monkeypatch.setattr(serve_service.skylet_constants,
+                        'PERSISTENT_RUN_SCRIPT_DIR', str(tmp_path))
+
+    serve_service._cleanup_task_run_script(8)
+
+
+class _DummyStorage:
+
+    def __init__(self):
+        self.constructed = False
+
+    def construct(self):
+        self.constructed = True
+
+
+class _DummyStatus:
+
+    def __init__(self):
+        self.sky_launch_status = None
+        self.sky_down_status = None
+
+
+class _DummyReplicaInfo:
+
+    def __init__(self, replica_id, cluster_name):
+        self.replica_id = replica_id
+        self.cluster_name = cluster_name
+        self.status_property = _DummyStatus()
+
+
+class _DummyThread:
+
+    def __init__(self, cluster_name, format_exc=None):
+        self.cluster_name = cluster_name
+        self.format_exc = format_exc
+        self._started = False
+
+    def is_alive(self):
+        return False
+
+    def start(self):
+        self._started = True
+        return None
+
+    def join(self):
+        return None

--- a/tests/unit_tests/test_sky/serve/test_service.py
+++ b/tests/unit_tests/test_sky/serve/test_service.py
@@ -49,6 +49,48 @@ class _DummyProcess:
         return None
 
 
+class _DummyStorage:
+
+    def __init__(self):
+        self.constructed = False
+
+    def construct(self):
+        self.constructed = True
+
+
+class _DummyStatus:
+
+    def __init__(self):
+        self.sky_launch_status = None
+        self.sky_down_status = None
+
+
+class _DummyReplicaInfo:
+
+    def __init__(self, replica_id, cluster_name):
+        self.replica_id = replica_id
+        self.cluster_name = cluster_name
+        self.status_property = _DummyStatus()
+
+
+class _DummyThread:
+
+    def __init__(self, cluster_name, format_exc=None):
+        self.cluster_name = cluster_name
+        self.format_exc = format_exc
+        self._started = False
+
+    def is_alive(self):
+        return False
+
+    def start(self):
+        self._started = True
+        return None
+
+    def join(self):
+        return None
+
+
 def _patch_minimal_start(monkeypatch, tmp_path):
 
     def _dummy_from_yaml_str(*_args, **_kwargs):
@@ -525,45 +567,3 @@ def test_cleanup_task_run_script_missing_file(monkeypatch, tmp_path):
                         'PERSISTENT_RUN_SCRIPT_DIR', str(tmp_path))
 
     serve_service._cleanup_task_run_script(8)
-
-
-class _DummyStorage:
-
-    def __init__(self):
-        self.constructed = False
-
-    def construct(self):
-        self.constructed = True
-
-
-class _DummyStatus:
-
-    def __init__(self):
-        self.sky_launch_status = None
-        self.sky_down_status = None
-
-
-class _DummyReplicaInfo:
-
-    def __init__(self, replica_id, cluster_name):
-        self.replica_id = replica_id
-        self.cluster_name = cluster_name
-        self.status_property = _DummyStatus()
-
-
-class _DummyThread:
-
-    def __init__(self, cluster_name, format_exc=None):
-        self.cluster_name = cluster_name
-        self.format_exc = format_exc
-        self._started = False
-
-    def is_alive(self):
-        return False
-
-    def start(self):
-        self._started = True
-        return None
-
-    def join(self):
-        return None

--- a/tests/unit_tests/test_sky/serve/test_service.py
+++ b/tests/unit_tests/test_sky/serve/test_service.py
@@ -360,8 +360,8 @@ def test_cleanup_storage_returns_false_on_teardown_error(monkeypatch):
     assert serve_service.cleanup_storage('service: dummy') is False
 
 
-def test_cleanup_removes_missing_clusters(monkeypatch):
-    """Remove replicas whose clusters no longer exist."""
+def test_cleanup_skips_missing_clusters(monkeypatch):
+    """Skip replicas whose clusters no longer exist."""
     replicas = [
         _DummyReplicaInfo(1, 'missing-1'),
         _DummyReplicaInfo(2, 'missing-2'),
@@ -383,7 +383,7 @@ def test_cleanup_removes_missing_clusters(monkeypatch):
                         lambda *_args, **_kwargs: None)
 
     assert serve_service._cleanup('svc', pool=False) is False
-    assert sorted(removed) == [1, 2]
+    assert sorted(removed) == []
 
 
 def test_cleanup_terminates_replicas_success(monkeypatch):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR (fixes #8564 ) prevents HA recovery from starting multiple serve controllers for the same service by introducing a per‑service controller lock and by de‑duplicating recovery scripts to run once per service. It also adds unit coverage around controller startup/locking to guard against regressions.

Details:
  - Acquire a per‑service lock before controller initialization so only one controller process runs per service.
  - Deduplicate recovery scripts in the HA path so a service is recovered exactly once.
  - Add targeted service tests covering the lock path and recovery startup behavior.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
