### PR TITLE
[Slurm] Disable controlmaster when ssh_proxy_jump is used

### DIFF
--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -256,11 +256,8 @@ def ssh_options_list(
     # ServerAliveInterval set, since the keepalive message may not be recognized
     # by the custom proxy command, such as AWS SSM Session Manager.
     #
-    # We also do not use ControlMaster when we use `kubectl port-forward`
-    # to access Kubernetes pods over SSH+Proxycommand. This is because the
-    # process running ProxyCommand is kept running as long as the ssh session
-    # is running and the ControlMaster keeps the session, which results in
-    # 'ControlPersist' number of seconds delay per ssh commands ran.
+    # Similarly for ssh_proxy_jump, where we've also observed flakiness that may
+    # occassionally cause ssh to error with exit code 255.
     if (ssh_control_name is not None and docker_ssh_proxy_command is None and
             ssh_proxy_command is None and ssh_proxy_jump is None and
             not disable_control_master):


### PR DESCRIPTION
We observed some flakiness when using ProxyJump which also has ControlMaster enabled (so two layers of ControlMaster, one for the outer SSH connection that is invoked by `SSHCommandRunner`, the other for the inner SSH to the proxy), especially when there's high volumes of data being transmitted. The problem seems to have went away after disabling the outer ControlMaster.

This PR disables ControlMaster when ProxyJump is used.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
