### PR TITLE
dedup gpu counts on sky show-gpus

### DIFF
--- a/sky/catalog/__init__.py
+++ b/sky/catalog/__init__.py
@@ -150,7 +150,7 @@ def list_accelerator_realtime(
     for gpu, items in qtys_map.items():
         for item in items:
             accelerator_counts[gpu].append(item.accelerator_count)
-        accelerator_counts[gpu] = sorted(accelerator_counts[gpu])
+        accelerator_counts[gpu] = sorted(set(accelerator_counts[gpu]))
     return (accelerator_counts, total_accelerators_capacity,
             total_accelerators_available)
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

before:
```
$ sky show-gpus                

Slurm GPUs
GPU     UTILIZATION          
AMPERE  23 of 25 free      
VOLTA   158 of 224 free  
Slurm Cluster: cluster1
GPU     REQUESTABLE_QTY_PER_NODE                                                                                                                                                                                                                                                                                                                                                                                                            UTILIZATION          
AMPERE  1, 1, 2, 2, 4, 4, 8, 8                                                                                                                                                                                                                                                                                                                                                                                                              235 of 256 free      
VOLTA   1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8  156 of 213 free
Slurm Cluster: cluster2
GPU    REQUESTABLE_QTY_PER_NODE                                                                                    UTILIZATION       
VOLTA  1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 8, 8, 8, 8, 8, 8, 8, 8, 8  25 of 102 free
```

after:
```
$ sky show-gpus                   

Slurm GPUs
GPU     UTILIZATION          
AMPERE  23 of 25 free      
VOLTA   159 of 224 free  
Slurm Cluster: cluster1
GPU     REQUESTABLE_QTY_PER_NODE  UTILIZATION          
AMPERE  1, 2, 4, 8                23 of 25 free      
VOLTA   1, 2, 4, 8                156 of 213 free  
Slurm Cluster: cluster2
GPU    REQUESTABLE_QTY_PER_NODE  UTILIZATION       
VOLTA  1, 2, 4, 8                23 of 102 free
...
```

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
