### PR TITLE
fix(serve): recover from missing yaml_content on restart

### DIFF
--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -788,6 +788,18 @@ def add_version_encoded(service_name: str) -> str:
     return message_utils.encode_payload(new_version)
 
 
+def backfill_version_yaml_content(service_name: str, version: int) -> None:
+    """Populate yaml_content and spec for a version from its task YAML file."""
+    task_yaml_path = generate_task_yaml_file_name(service_name, version)
+    with open(task_yaml_path, 'r', encoding='utf-8') as f:
+        yaml_content = f.read()
+    # pylint: disable=import-outside-toplevel
+    from sky.serve import service_spec
+    service = service_spec.SkyServiceSpec.from_yaml_str(yaml_content)
+    serve_state.add_or_update_version(service_name, version, service,
+                                      yaml_content)
+
+
 # TODO (kyuds): remove when serve codegen is removed
 def load_version_string(payload: str) -> str:
     return message_utils.decode_payload(payload)
@@ -1804,6 +1816,15 @@ class ServeCodeGen:
         code = [
             f'msg = serve_utils.add_version_encoded({service_name!r})',
             'print(msg, end="", flush=True)'
+        ]
+        return cls._build(code)
+
+    @classmethod
+    def backfill_version_yaml_content(cls, service_name: str,
+                                      version: int) -> str:
+        code = [
+            f'serve_utils.backfill_version_yaml_content({service_name!r}, '
+            f'{version})', 'print("ok", end="", flush=True)'
         ]
         return cls._build(code)
 

--- a/sky/serve/server/impl.py
+++ b/sky/serve/server/impl.py
@@ -650,7 +650,7 @@ def update(
                 stream_logs=True)
         except exceptions.CommandError as e:
             logger.warning('Failed to backfill serve version metadata for '
-                           f'{service_name} v{current_version}: {e.error_msg}')
+                           f'{service_name} v{current_version}: {e}')
 
         use_legacy = not handle.is_grpc_enabled_with_flag
 

--- a/sky/serve/server/impl.py
+++ b/sky/serve/server/impl.py
@@ -634,6 +634,24 @@ def update(
                                      {remote_task_yaml_path: service_file.name},
                                      storage_mounts=None)
 
+        try:
+            code = serve_utils.ServeCodeGen.backfill_version_yaml_content(
+                service_name, current_version)
+            returncode, _, stderr = backend.run_on_head(handle,
+                                                        code,
+                                                        require_outputs=True,
+                                                        stream_logs=False,
+                                                        separate_stderr=True)
+            subprocess_utils.handle_returncode(
+                returncode,
+                code,
+                f'Failed to backfill version {current_version} metadata',
+                stderr,
+                stream_logs=True)
+        except exceptions.CommandError as e:
+            logger.warning('Failed to backfill serve version metadata for '
+                           f'{service_name} v{current_version}: {e.error_msg}')
+
         use_legacy = not handle.is_grpc_enabled_with_flag
 
         if not use_legacy:

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -248,10 +248,10 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
     def _read_yaml_if_exists(yaml_path: Optional[str]) -> Optional[str]:
         if yaml_path is None:
             return None
-        expanded_path = os.path.expanduser(yaml_path)
-        if not os.path.exists(expanded_path):
+        try:
+            return _read_yaml_content(yaml_path)
+        except FileNotFoundError:
             return None
-        return _read_yaml_content(expanded_path)
 
     def _resolve_yaml_content(
             version: int,

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -9,7 +9,7 @@ import pathlib
 import shutil
 import time
 import traceback
-from typing import Dict
+from typing import Dict, Optional, Tuple
 
 import filelock
 
@@ -245,13 +245,55 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
         with open(os.path.expanduser(yaml_path), 'r', encoding='utf-8') as f:
             return f.read()
 
+    def _read_yaml_if_exists(yaml_path: Optional[str]) -> Optional[str]:
+        if yaml_path is None:
+            return None
+        expanded_path = os.path.expanduser(yaml_path)
+        if not os.path.exists(expanded_path):
+            return None
+        return _read_yaml_content(expanded_path)
+
+    def _resolve_yaml_content(
+            version: int,
+            allow_tmp_fallback: bool) -> Tuple[Optional[str], bool]:
+        yaml_content = serve_state.get_yaml_content(service_name, version)
+        if yaml_content is not None:
+            return yaml_content, False
+
+        task_yaml = serve_utils.generate_task_yaml_file_name(
+            service_name, version)
+        yaml_content = _read_yaml_if_exists(task_yaml)
+        if yaml_content is not None:
+            return yaml_content, True
+
+        if allow_tmp_fallback:
+            yaml_content = _read_yaml_if_exists(tmp_task_yaml)
+            if yaml_content is not None:
+                return yaml_content, True
+
+        return None, False
+
+    yaml_content = None
+    version = None
+    backfilled_from_file = False
     if is_recovery:
-        yaml_content = service['yaml_content']
-        # Backward compatibility for old service records that
-        # does not dump the yaml content to version database.
-        # TODO(tian): Remove this after 2 minor releases, i.e. 0.13.0.
-        if yaml_content is None:
-            yaml_content = _read_yaml_content(tmp_task_yaml)
+        versions = sorted(serve_state.get_service_versions(service_name),
+                          reverse=True)
+        if not versions:
+            raise ValueError(f'No version found for service {service_name}')
+        for idx, candidate in enumerate(versions):
+            yaml_content, backfilled_from_file = _resolve_yaml_content(
+                candidate, allow_tmp_fallback=(idx == 0))
+            if yaml_content is None:
+                logger.warning(
+                    f'Skipping version {candidate} for service {service_name}: '
+                    'yaml_content missing and task yaml unavailable.')
+                continue
+            version = candidate
+            break
+        if yaml_content is None or version is None:
+            raise ValueError(f'No valid yaml content found for service '
+                             f'{service_name}')
     else:
         yaml_content = _read_yaml_content(tmp_task_yaml)
 
@@ -298,9 +340,11 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
         serve_state.add_or_update_version(service_name, version, service_spec,
                                           yaml_content)
     else:
-        version = serve_state.get_latest_version(service_name)
-        if version is None:
-            raise ValueError(f'No version found for service {service_name}')
+        assert version is not None
+        existing_spec = serve_state.get_spec(service_name, version)
+        if backfilled_from_file or existing_spec is None:
+            serve_state.add_or_update_version(service_name, version,
+                                              service_spec, yaml_content)
         serve_state.update_service_controller_pid(service_name, os.getpid())
 
     controller_process = None

--- a/tests/unit_tests/test_sky/serve/test_service.py
+++ b/tests/unit_tests/test_sky/serve/test_service.py
@@ -1,0 +1,275 @@
+from sky import exceptions
+from sky.serve import serve_utils
+from sky.serve import service as serve_service
+from sky.serve import service_spec
+
+
+class _DummyServiceSpec:
+    pool = False
+    load_balancing_policy = 'round_robin'
+    tls_credential = None
+    target_qps_per_replica = None
+
+    @staticmethod
+    def autoscaling_policy_str():
+        return 'dummy'
+
+
+class _DummyTask:
+
+    def __init__(self, service):
+        self.service = service
+        self.storage_mounts = {}
+        self.file_mounts = {}
+
+
+class _DummyProcess:
+    _pid_counter = 1234
+    instances = []
+
+    def __init__(self, *args, **kwargs):
+        if args:
+            self.target = args[0]
+            self.args = args[1] if len(args) > 1 else ()
+            self.kwargs = args[2] if len(args) > 2 else {}
+        else:
+            self.target = kwargs.get('target')
+            self.args = kwargs.get('args', ())
+            self.kwargs = kwargs.get('kwargs', {})
+        type(self)._pid_counter += 1
+        self.pid = type(self)._pid_counter
+        type(self).instances.append(self)
+
+    def start(self):
+        return None
+
+    def join(self):
+        return None
+
+
+def _patch_minimal_start(monkeypatch, tmp_path):
+
+    def _dummy_from_yaml_str(*_args, **_kwargs):
+        return _DummyTask(_DummyServiceSpec())
+
+    monkeypatch.setattr(serve_service.task_lib.Task, 'from_yaml_str',
+                        _dummy_from_yaml_str)
+    monkeypatch.setattr(serve_service.auth_utils, 'get_or_generate_keys',
+                        lambda: None)
+    monkeypatch.setattr(serve_service.serve_utils,
+                        'generate_remote_service_dir_name',
+                        lambda name: str(tmp_path / name))
+    monkeypatch.setattr(serve_service.serve_utils,
+                        'generate_remote_load_balancer_log_file_name',
+                        lambda name: str(tmp_path / f'{name}-lb.log'))
+    monkeypatch.setattr(serve_service.backend_utils, 'get_task_resources_str',
+                        lambda *_args, **_kwargs: 'resources')
+    monkeypatch.setattr(serve_service.subprocess_utils,
+                        'kill_children_processes', lambda *args, **kwargs: None)
+    monkeypatch.setattr(serve_service.multiprocessing, 'Process', _DummyProcess)
+    monkeypatch.setattr(serve_service, '_cleanup',
+                        lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(serve_service, '_cleanup_task_run_script',
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(serve_service.shutil, 'rmtree',
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(serve_service.serve_state, 'remove_service',
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(serve_service.serve_state, 'delete_all_versions',
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(serve_service.serve_state,
+                        'set_service_controller_port',
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(serve_service.serve_state,
+                        'set_service_load_balancer_port',
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(serve_service.serve_state,
+                        'set_service_status_and_active_versions',
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(serve_service.serve_state,
+                        'get_service_controller_port',
+                        lambda *_args, **_kwargs: 20001)
+    monkeypatch.setattr(serve_service.serve_state,
+                        'get_service_load_balancer_port',
+                        lambda *_args, **_kwargs: 20002)
+    monkeypatch.setattr(serve_service.serve_state,
+                        'update_service_controller_pid',
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(serve_service.controller_utils, 'can_start_new_process',
+                        lambda *_args, **_kwargs: True)
+    _DummyProcess.instances = []
+
+
+def _write_dummy_yaml(tmp_path):
+    path = tmp_path / 'service.yaml'
+    path.write_text('service: dummy\n', encoding='utf-8')
+    return str(path)
+
+
+def test_start_recovery_uses_latest_version(monkeypatch, tmp_path):
+    """Use the latest version during recovery when yaml_content exists."""
+    _patch_minimal_start(monkeypatch, tmp_path)
+    monkeypatch.setattr(serve_service.serve_state, 'get_service_from_name',
+                        lambda *_args, **_kwargs: {'name': 'svc'})
+    monkeypatch.setattr(serve_service.serve_state, 'get_service_versions',
+                        lambda *_args, **_kwargs: [5])
+    monkeypatch.setattr(serve_service.serve_state, 'get_yaml_content',
+                        lambda *_args, **_kwargs: 'service: s')
+    monkeypatch.setattr(serve_service.serve_state, 'get_spec',
+                        lambda *_args, **_kwargs: _DummyServiceSpec())
+
+    def _raise_terminate(*_args, **_kwargs):
+        raise exceptions.ServeUserTerminatedError('test')
+
+    monkeypatch.setattr(serve_service, '_handle_signal', _raise_terminate)
+
+    serve_service._start('svc', _write_dummy_yaml(tmp_path), 4, 'entrypoint')
+
+    controller_proc = next(
+        proc for proc in _DummyProcess.instances
+        if proc.target == serve_service.controller.run_controller)
+    assert controller_proc.args[2] == 5
+
+
+def test_start_recovery_backfills_yaml_content(monkeypatch, tmp_path):
+    """Backfill yaml_content from task yaml when the DB is empty."""
+    _patch_minimal_start(monkeypatch, tmp_path)
+    service_name = 'svc'
+    service_dir = tmp_path / service_name
+    service_dir.mkdir(parents=True, exist_ok=True)
+    task_yaml = service_dir / 'task_v3.yaml'
+    task_yaml.write_text('service: dummy\n', encoding='utf-8')
+
+    monkeypatch.setattr(serve_service.serve_state, 'get_service_from_name',
+                        lambda *_args, **_kwargs: {'name': service_name})
+    monkeypatch.setattr(serve_service.serve_state, 'get_service_versions',
+                        lambda *_args, **_kwargs: [3])
+    monkeypatch.setattr(serve_service.serve_state, 'get_yaml_content',
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(serve_service.serve_state, 'get_spec',
+                        lambda *_args, **_kwargs: None)
+
+    backfilled = []
+
+    def _add_or_update_version(*_args, **_kwargs):
+        backfilled.append(_args[1])
+
+    monkeypatch.setattr(serve_service.serve_state, 'add_or_update_version',
+                        _add_or_update_version)
+
+    def _raise_terminate(*_args, **_kwargs):
+        raise exceptions.ServeUserTerminatedError('test')
+
+    monkeypatch.setattr(serve_service, '_handle_signal', _raise_terminate)
+
+    serve_service._start(service_name, _write_dummy_yaml(tmp_path), 7,
+                         'entrypoint')
+
+    assert backfilled == [3]
+    controller_proc = next(
+        proc for proc in _DummyProcess.instances
+        if proc.target == serve_service.controller.run_controller)
+    assert controller_proc.args[2] == 3
+
+
+def test_start_recovery_skips_missing_yaml(monkeypatch, tmp_path):
+    """Skip versions without yaml_content or task yaml during recovery."""
+    _patch_minimal_start(monkeypatch, tmp_path)
+    service_name = 'svc'
+    service_dir = tmp_path / service_name
+    service_dir.mkdir(parents=True, exist_ok=True)
+    task_yaml = service_dir / 'task_v2.yaml'
+    task_yaml.write_text('service: dummy\n', encoding='utf-8')
+
+    monkeypatch.setattr(serve_service.serve_state, 'get_service_from_name',
+                        lambda *_args, **_kwargs: {'name': service_name})
+    monkeypatch.setattr(serve_service.serve_state, 'get_service_versions',
+                        lambda *_args, **_kwargs: [3, 2])
+    monkeypatch.setattr(serve_service.serve_state, 'get_yaml_content',
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(serve_service.serve_state, 'get_spec',
+                        lambda *_args, **_kwargs: None)
+
+    backfilled = []
+
+    def _add_or_update_version(*_args, **_kwargs):
+        backfilled.append(_args[1])
+
+    monkeypatch.setattr(serve_service.serve_state, 'add_or_update_version',
+                        _add_or_update_version)
+
+    def _raise_terminate(*_args, **_kwargs):
+        raise exceptions.ServeUserTerminatedError('test')
+
+    monkeypatch.setattr(serve_service, '_handle_signal', _raise_terminate)
+
+    missing_yaml = str(tmp_path / 'missing.yaml')
+    serve_service._start(service_name, missing_yaml, 8, 'entrypoint')
+
+    assert backfilled == [2]
+    controller_proc = next(
+        proc for proc in _DummyProcess.instances
+        if proc.target == serve_service.controller.run_controller)
+    assert controller_proc.args[2] == 2
+
+
+def test_start_recovery_prefers_latest_non_null_yaml(monkeypatch, tmp_path):
+    """Choose the latest version that has non-null yaml_content."""
+    _patch_minimal_start(monkeypatch, tmp_path)
+    monkeypatch.setattr(serve_service.serve_state, 'get_service_from_name',
+                        lambda *_args, **_kwargs: {'name': 'svc'})
+    monkeypatch.setattr(serve_service.serve_state, 'get_service_versions',
+                        lambda *_args, **_kwargs: [4, 3])
+
+    def _get_yaml_content(_service_name, version):
+        return None if version == 4 else 'service: s'
+
+    monkeypatch.setattr(serve_service.serve_state, 'get_yaml_content',
+                        _get_yaml_content)
+    monkeypatch.setattr(serve_service.serve_state, 'get_spec',
+                        lambda *_args, **_kwargs: _DummyServiceSpec())
+
+    def _raise_terminate(*_args, **_kwargs):
+        raise exceptions.ServeUserTerminatedError('test')
+
+    monkeypatch.setattr(serve_service, '_handle_signal', _raise_terminate)
+
+    missing_yaml = str(tmp_path / 'missing.yaml')
+    serve_service._start('svc', missing_yaml, 9, 'entrypoint')
+
+    controller_proc = next(
+        proc for proc in _DummyProcess.instances
+        if proc.target == serve_service.controller.run_controller)
+    assert controller_proc.args[2] == 3
+
+
+def test_backfill_version_yaml_content(monkeypatch, tmp_path):
+    """Persist yaml_content and spec when backfilling a version."""
+    service_name = 'svc'
+    service_dir = tmp_path / service_name
+    service_dir.mkdir(parents=True, exist_ok=True)
+    task_yaml = service_dir / 'task_v2.yaml'
+    task_yaml.write_text('service: dummy\n', encoding='utf-8')
+
+    monkeypatch.setattr(serve_utils, 'generate_task_yaml_file_name',
+                        lambda *_args, **_kwargs: str(task_yaml))
+    monkeypatch.setattr(service_spec.SkyServiceSpec, 'from_yaml_str',
+                        lambda *_args, **_kwargs: 'spec')
+
+    captured = {}
+
+    def _add_or_update_version(_service_name, version, spec, yaml_content):
+        captured['service_name'] = _service_name
+        captured['version'] = version
+        captured['spec'] = spec
+        captured['yaml_content'] = yaml_content
+
+    monkeypatch.setattr(serve_utils.serve_state, 'add_or_update_version',
+                        _add_or_update_version)
+
+    serve_utils.backfill_version_yaml_content(service_name, 2)
+
+    assert captured['service_name'] == service_name
+    assert captured['version'] == 2
+    assert captured['spec'] == 'spec'
+    assert captured['yaml_content'] == 'service: dummy\n'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR makes controller recovery resilient when `version_specs.yaml_content` is missing by selecting the latest usable version (DB or task file) and backfilling the DB before the replica manager is created. It also adds a best‑effort backfill right after syncing `task_v*.yaml` on updates, so versions don’t get left with NULL YAML if the controller is unavailable.
  
fixes #8547 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
