### PR TITLE
[UX] Switch info to debug print

### DIFF
--- a/sky/utils/plugin_extensions/external_failure_source.py
+++ b/sky/utils/plugin_extensions/external_failure_source.py
@@ -119,7 +119,7 @@ class ExternalFailureSource:
         """
         cls._get_func = get_failures
         cls._clear_func = clear_failures
-        logger.info('Registered external failure source')
+        logger.debug('Registered external failure source')
 
     @classmethod
     def is_registered(cls) -> bool:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This info print statement might show up during calls to `sky job logs` causing confusion. This will now only happen in debug mode.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
