### PR TITLE
[Dashboard] Add external link to Grafana in GPU Metrics section

### DIFF
--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -772,9 +772,20 @@ function ActiveTab({
                         matchedClusterName ||
                         clusterData?.cluster_name_on_cloud ||
                         clusterData?.cluster;
+                      const dashboardPath =
+                        '/d/skypilot-dcgm-gpu/skypilot-dcgm-gpu-metrics';
+                      const queryParams = new URLSearchParams({
+                        orgId: '1',
+                        from: timeRange.from,
+                        to: timeRange.to,
+                        timezone: 'browser',
+                        'var-cluster': clusterParam,
+                        'var-node': '$__all',
+                        'var-gpu': '$__all',
+                      });
                       window.open(
                         buildGrafanaUrl(
-                          `/d/skypilot-dcgm-gpu/skypilot-dcgm-gpu-metrics?orgId=1&from=${encodeURIComponent(timeRange.from)}&to=${encodeURIComponent(timeRange.to)}&timezone=browser&var-cluster=${encodeURIComponent(clusterParam)}&var-node=$__all&var-gpu=$__all`
+                          `${dashboardPath}?${queryParams.toString()}`
                         ),
                         '_blank'
                       );


### PR DESCRIPTION

<img width="1024" height="1696" alt="Screenshot 2026-01-15 at 3 37 54 PM" src="https://github.com/user-attachments/assets/1f542bc6-bcac-412a-816d-d1da0ae203b5" />
<img width="1045" height="976" alt="Screenshot 2026-01-15 at 3 38 07 PM" src="https://github.com/user-attachments/assets/4d2e0f9f-44fc-4e47-abe1-1f5b7771f158" />


## Summary
- Add an external link button to the GPU Metrics header on the cluster detail page
- Clicking the button opens the full Grafana GPU metrics dashboard in a new tab
- The link includes the current time range and cluster name as query parameters for seamless navigation

## Test plan
- Deployed to test API server on Kubernetes with Grafana enabled
- Verified the external link icon appears in the GPU Metrics header
- Clicked the icon and confirmed it opens the correct Grafana dashboard with cluster and time range pre-selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)