### PR TITLE
[UX] Fix time in sky jobs queue CLI is incorrect

### DIFF
--- a/sky/dashboard/src/components/utils.jsx
+++ b/sky/dashboard/src/components/utils.jsx
@@ -24,41 +24,17 @@ export function relativeTime(date) {
   }
 
   const now = new Date();
-  const diff = now - date;
-
-  // Time constants for readability
-  const ONE_SECOND_MS = 1000;
-  const ONE_MINUTE_MS = 60 * ONE_SECOND_MS;
-  const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
-  const ONE_DAY_MS = 24 * ONE_HOUR_MS;
-  const ONE_WEEK_MS = 7 * ONE_DAY_MS;
-
-  let displayText;
-  // Use precise time calculation to avoid rounding issues with date-fns formatDistance
-  // (e.g., 50 minutes should show "50m ago" not "about 1 hour ago")
-  if (diff < ONE_WEEK_MS) {
-    if (diff < 5 * ONE_SECOND_MS) {
-      displayText = 'just now';
-    } else if (diff < ONE_MINUTE_MS) {
-      const seconds = Math.floor(diff / ONE_SECOND_MS);
-      displayText = `${seconds}s ago`;
-    } else if (diff < ONE_HOUR_MS) {
-      const minutes = Math.floor(diff / ONE_MINUTE_MS);
-      displayText = `${minutes}m ago`;
-    } else if (diff < ONE_DAY_MS) {
-      const hours = Math.floor(diff / ONE_HOUR_MS);
-      displayText = `${hours}h ago`;
-    } else {
-      const days = Math.floor(diff / ONE_DAY_MS);
-      displayText = `${days}d ago`;
-    }
+  const differenceInDays = (now - date) / (1000 * 3600 * 24);
+  if (Math.abs(differenceInDays) < 7) {
+    const originalTimeString = formatDistance(date, now, { addSuffix: true });
+    const shortenedTimeString = shortenTimeString(originalTimeString);
 
     return (
       <CustomTooltip
         content={formatDateTime(date)}
         className="capitalize text-sm text-muted-foreground"
       >
-        {displayText}
+        {shortenedTimeString}
       </CustomTooltip>
     );
   } else {
@@ -523,6 +499,7 @@ export function TimestampWithTooltip({ date }) {
   }
 
   const now = new Date();
+  const differenceInDays = (now - date) / (1000 * 3600 * 24);
 
   // Format the full timestamp in '2025-06-13, 03:53:33 PM PDT' format
   const dateStr =
@@ -540,37 +517,10 @@ export function TimestampWithTooltip({ date }) {
   });
   const fullLocalTimestamp = dateStr + ' ' + timeStr;
 
-  // Use precise time calculation to avoid rounding issues with date-fns formatDistance
-  // (e.g., 50 minutes should show "50m ago" not "about 1 hour ago")
-  const diff = now - date;
-
-  // Time constants for readability
-  const ONE_SECOND_MS = 1000;
-  const ONE_MINUTE_MS = 60 * ONE_SECOND_MS;
-  const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
-  const ONE_DAY_MS = 24 * ONE_HOUR_MS;
-  const ONE_WEEK_MS = 7 * ONE_DAY_MS;
-
   let displayText;
-  if (diff < 5 * ONE_SECOND_MS) {
-    displayText = 'just now';
-  } else if (diff < ONE_MINUTE_MS) {
-    const seconds = Math.floor(diff / ONE_SECOND_MS);
-    displayText = `${seconds}s ago`;
-  } else if (diff < ONE_HOUR_MS) {
-    const minutes = Math.floor(diff / ONE_MINUTE_MS);
-    displayText = `${minutes}m ago`;
-  } else if (diff < ONE_DAY_MS) {
-    const hours = Math.floor(diff / ONE_HOUR_MS);
-    displayText = `${hours}h ago`;
-  } else if (diff < ONE_WEEK_MS) {
-    const days = Math.floor(diff / ONE_DAY_MS);
-    displayText = `${days}d ago`;
-  } else {
-    // For times older than a week, use formatDistance for readability
-    const originalTimeString = formatDistance(date, now, { addSuffix: true });
-    displayText = shortenTimeString(originalTimeString);
-  }
+  // Always show relative time with shortened format
+  const originalTimeString = formatDistance(date, now, { addSuffix: true });
+  displayText = shortenTimeString(originalTimeString);
 
   return (
     <CustomTooltip

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1977,7 +1977,7 @@ def format_job_table(
             job_duration = log_utils.readable_time_duration(0,
                                                             job_duration,
                                                             absolute=True)
-            submitted = log_utils.readable_time_duration(submitted_at)
+            submitted = log_utils.readable_time_duration_ago(submitted_at)
             total_duration = log_utils.readable_time_duration(submitted_at,
                                                               end_at,
                                                               absolute=True)
@@ -2034,7 +2034,8 @@ def format_job_table(
             # dump_managed_job_queue().
             job_duration = log_utils.readable_time_duration(
                 0, task['job_duration'], absolute=True)
-            submitted = log_utils.readable_time_duration(task['submitted_at'])
+            submitted = log_utils.readable_time_duration_ago(
+                task['submitted_at'])
             user_values = get_user_column_values(task)
             task_workspace = '-' if len(job_tasks) > 1 else workspace
             pool = task.get('pool')

--- a/sky/utils/log_utils.py
+++ b/sky/utils/log_utils.py
@@ -263,6 +263,34 @@ def readable_time_duration(start: Optional[float],
     return diff
 
 
+def readable_time_duration_ago(start: Optional[float],
+                               end: Optional[float] = None,
+                               precision: int = 2) -> str:
+    """Human readable time duration with ' ago' suffix.
+
+    Calls readable_time_duration with absolute=True, limits to first N units,
+    and appends ' ago'.
+
+    Args:
+        start: Start timestamp.
+        end: End timestamp. If None, current time is used.
+        precision: Maximum number of time units to show (default 2).
+            E.g., precision=2: "1h 12m ago", precision=1: "1h ago"
+
+    Returns:
+        Human readable time with ' ago' suffix, e.g., "1h 12m ago".
+        Returns '-' for invalid inputs.
+    """
+    result = readable_time_duration(start, end, absolute=True)
+    if result == '-':
+        return result
+    # Limit to first N units (e.g., "1d 2h 30m" -> "1d 2h" with precision=2)
+    parts = result.split()
+    if len(parts) > precision:
+        result = ' '.join(parts[:precision])
+    return result + ' ago'
+
+
 def human_duration(start: int, end: Optional[int] = None) -> str:
     """Calculates the time elapsed between two timestamps and returns
        it as a human-readable string, similar to Kubernetes' duration format.

--- a/tests/unit_tests/test_sky/utils/test_cli_time_format.py
+++ b/tests/unit_tests/test_sky/utils/test_cli_time_format.py
@@ -1,0 +1,62 @@
+"""Tests for sky jobs queue SUBMITTED column time format."""
+
+from sky.utils import log_utils
+
+
+class TestReadableTimeDurationAgo:
+    """sky jobs queue: SUBMITTED uses readable_time_duration_ago().
+
+    Format: precise time with ' ago' suffix, limited to 2 units by default.
+    E.g., '1h 12m ago', '1d 2h ago'
+    """
+
+    NOW = 1758240750.0
+
+    def test_submitted_72_mins_ago(self):
+        """Test that 72 minutes shows as '1h 12m ago'."""
+        submitted_at = self.NOW - (72 * 60)
+        result = log_utils.readable_time_duration_ago(submitted_at,
+                                                      end=self.NOW)
+        assert result == '1h 12m ago', (
+            f'Expected \'1h 12m ago\' but got \'{result}\'')
+
+    def test_submitted_90_mins_ago(self):
+        """Test that 90 minutes shows as '1h 30m ago'."""
+        submitted_at = self.NOW - (90 * 60)
+        result = log_utils.readable_time_duration_ago(submitted_at,
+                                                      end=self.NOW)
+        assert result == '1h 30m ago', (
+            f'Expected \'1h 30m ago\' but got \'{result}\'')
+
+    def test_submitted_26_hours_ago(self):
+        """Test that 26 hours shows as '1d 2h ago'."""
+        submitted_at = self.NOW - (26 * 3600)
+        result = log_utils.readable_time_duration_ago(submitted_at,
+                                                      end=self.NOW)
+        assert result == '1d 2h ago', (
+            f'Expected \'1d 2h ago\' but got \'{result}\'')
+
+    def test_submitted_exact_hour(self):
+        """Test that exactly 1 hour shows as '1h ago'."""
+        submitted_at = self.NOW - 3600
+        result = log_utils.readable_time_duration_ago(submitted_at,
+                                                      end=self.NOW)
+        assert result == '1h ago', f'Expected \'1h ago\' but got \'{result}\''
+
+    def test_precision_1(self):
+        """Test that precision=1 shows only 1 unit."""
+        submitted_at = self.NOW - (26 * 3600 + 30 * 60)
+        result = log_utils.readable_time_duration_ago(submitted_at,
+                                                      end=self.NOW,
+                                                      precision=1)
+        assert result == '1d ago', f'Expected \'1d ago\' but got \'{result}\''
+
+    def test_invalid_returns_dash(self):
+        """Test that invalid submitted_at returns '-'."""
+        result = log_utils.readable_time_duration_ago(-1, end=self.NOW)
+        assert result == '-', f'Expected \'-\' but got \'{result}\''
+
+    def test_none_returns_dash(self):
+        """Test that None submitted_at returns '-'."""
+        result = log_utils.readable_time_duration_ago(None, end=self.NOW)
+        assert result == '-', f'Expected \'-\' but got \'{result}\''


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolve #8348

## Summary
Fix `sky jobs queue` SUBMITTED column to show precise time (e.g., "1h 58m ago" instead of "1 hr before").

## Changes

### User-Visible Change

| Command | Column | Before | After |
|---------|--------|--------|-------|
| `sky jobs queue` | SUBMITTED | "1 hr before" | "1h 58m ago" |

### Implementation
- Add `readable_time_duration_ago()` function in `sky/utils/log_utils.py`
  - Calls `readable_time_duration(absolute=True)` for precise time
  - Limits to first N units via `precision` param (default 2)
  - Appends " ago" suffix
- Use new function for SUBMITTED column in `sky/jobs/utils.py`

### Tests Added
- `tests/unit_tests/test_sky/utils/test_cli_time_format.py` - 7 tests

## Test plan
```bash
pytest tests/unit_tests/test_sky/utils/test_cli_time_format.py -v

# Manual verification
sky jobs queue  # SUBMITTED shows "1h 58m ago" instead of "1 hr before"
```

## Master

<img width="1479" height="726" alt="image" src="https://github.com/user-attachments/assets/82ed2be2-8085-4847-a371-abf2ef54ed8a" />

## Current branch

<img width="1563" height="687" alt="image" src="https://github.com/user-attachments/assets/606d9d4d-6391-44ed-acc1-07e3a2911c63" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
