### PR TITLE
Update Mistral docs link

### DIFF
--- a/docs/source/examples/models/index.rst
+++ b/docs/source/examples/models/index.rst
@@ -17,7 +17,7 @@ Models
    CodeLlama <codellama>
    Pixtral <pixtral>
    Mixtral <mixtral>
-   Mistral 7B <https://docs.mistral.ai/self-deployment/skypilot/>
+   Mistral 7B <https://docs.mistral.ai/deployment/self-deployment/skypilot/>
    Qwen 3 <qwen>
    Kimi K2 <kimi-k2>
    Kimi K2 Thinking <kimi-k2-thinking>


### PR DESCRIPTION
Updates the Mistral 7B documentation link in [index.rst](cci:7://file:///d:/friendly-project/skypilot/docs/source/examples/models/index.rst:0:0-0:0) to the current canonical path.
The previous URL path (`/self-deployment/...`) is outdated. The correct path is now `/deployment/self-deployment/skypilot/`. 