### PR TITLE
[Dashboard] Add glassy loading effect to infra page

### DIFF
--- a/sky/dashboard/src/app/globals.css
+++ b/sky/dashboard/src/app/globals.css
@@ -521,7 +521,12 @@
 .infra-skeleton-text {
   display: inline-block;
   height: 0.75rem;
-  background: linear-gradient(90deg, #e5e7eb 0%, #f3f4f6 50%, #e5e7eb 100%);
+  background: linear-gradient(
+    90deg,
+    hsl(var(--border)) 0%,
+    hsl(var(--secondary)) 50%,
+    hsl(var(--border)) 100%
+  );
   background-size: 200% 100%;
   animation: infra-shimmer 1.5s infinite;
   border-radius: 3px;


### PR DESCRIPTION
## Summary
- Add glassy/shimmer loading effect to infra page tables during refresh
- Replace `CircularProgress` spinners with skeleton badge placeholders
- Fix infinite spinner bug when GPU data fetch fails for a context

## Changes
- **CSS**: Added shimmer animation, skeleton text styles, row shimmer effect, and glass overlay with backdrop blur
- **SkeletonBadge component**: Replaces small `CircularProgress` spinners with animated skeleton placeholders
- **Glass overlay**: Tables show subtle glass overlay during refresh while preserving existing data
- **Row shimmer**: Individual rows shimmer during progressive Kubernetes context loading
- **Bug fix**: Added `.catch()` handler to GPU data fetch promises to prevent infinite top-right spinner

## Test plan
1. Navigate to Infra page
2. Verify initial load shows full panel spinners, then tables
3. Click Refresh button - should show glass overlay with skeleton badges
4. Verify progressive loading for Kubernetes contexts shows row shimmer
5. Verify spinner stops after all data loads (including error cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)