### PR TITLE
Fix buildkite test plugin test support

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -146,6 +146,7 @@ def _parse_args(args: Optional[str] = None):
     parser.add_argument('--grpc', action="store_true")
     parser.add_argument('--env-file')
     parser.add_argument('--plugin-yaml')
+    parser.add_argument('--submodule-base-branch')
     parser.add_argument('--dependency', nargs='?', const='', default='all')
 
     parsed_args, _ = parser.parse_known_args(args_list)
@@ -190,6 +191,11 @@ def _parse_args(args: Optional[str] = None):
         extra_args.append('--grpc')
     if parsed_args.env_file:
         extra_args.append(f'--env-file {parsed_args.env_file}')
+    if parsed_args.plugin_yaml:
+        extra_args.append(f'--plugin-yaml {parsed_args.plugin_yaml}')
+    if parsed_args.submodule_base_branch:
+        extra_args.append(
+            f'--submodule-base-branch {parsed_args.submodule_base_branch}')
     if parsed_args.dependency != 'all':
         space = ' ' if parsed_args.dependency else ''
         extra_args.append(f'--dependency{space}{parsed_args.dependency}')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -234,6 +234,13 @@ def pytest_addoption(parser):
               'has no effect when running locally)'),
     )
     parser.addoption(
+        '--submodule-base-branch',
+        type=str,
+        default=None,
+        help=('Base branch for submodule tests (configured in Buildkite '
+              'pipeline; has no effect when running locally)'),
+    )
+    parser.addoption(
         '--backend-test-cluster',
         type=str,
         default=None,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The `--plugin-yaml` and `--submodule-base-branch` options should be passed down to the test command so that Buildkite can recognize them.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
