### PR TITLE
[API] Add compression to dashboard log downloads

### DIFF
--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -209,7 +209,21 @@ def get_excluded_files(src_dir_path: str) -> List[str]:
 def zip_files_and_folders(items: List[str],
                           output_file: Union[str, pathlib.Path],
                           log_file: Optional[TextIO] = None,
-                          relative_to_items: bool = False):
+                          relative_to_items: bool = False,
+                          compression: int = zipfile.ZIP_DEFLATED,
+                          compresslevel: Optional[int] = None):
+    """Zip files and folders.
+
+    Args:
+        items: List of file/folder paths to include in the zip.
+        output_file: Path to the output zip file.
+        log_file: Optional file to log progress to.
+        relative_to_items: If True, paths in zip are relative to items.
+        compression: Compression method (default: ZIP_DEFLATED for good
+            compression with universal compatibility).
+        compresslevel: Compression level (1-9 for DEFLATED). None uses
+            the default (6).
+    """
 
     def _get_archive_name(file_path: str, item_path: str) -> str:
         """Get the archive name for a file based on the relative parameters."""
@@ -239,7 +253,10 @@ def zip_files_and_folders(items: List[str],
         warnings.filterwarnings('ignore',
                                 category=UserWarning,
                                 message='Duplicate name:')
-        with zipfile.ZipFile(output_file, 'w') as zipf:
+        with zipfile.ZipFile(output_file,
+                             'w',
+                             compression=compression,
+                             compresslevel=compresslevel) as zipf:
             for item in items:
                 item = os.path.expanduser(item)
                 if not os.path.isfile(item) and not os.path.isdir(item):

--- a/tests/unit_tests/test_zip_and_unzip.py
+++ b/tests/unit_tests/test_zip_and_unzip.py
@@ -115,3 +115,33 @@ def test_unzip_file(skyignore_dir, tmp_path):
         # Verify empty folders are preserved
         assert (unzipped_dir / 'empty-folder').is_dir()
         assert not any((unzipped_dir / 'empty-folder').iterdir())
+
+
+def test_zip_files_and_folders_compression():
+    """Test that compression is applied by default."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create a text file with repetitive content (highly compressible)
+        test_file = os.path.join(temp_dir, 'test.log')
+        with open(test_file, 'w', encoding='utf-8') as f:
+            f.write('INFO: This is a log line\n' * 10000)
+
+        uncompressed_size = os.path.getsize(test_file)
+
+        # Create zip file in the same temp directory for automatic cleanup
+        zip_path = os.path.join(temp_dir, 'test.zip')
+        storage_utils.zip_files_and_folders([test_file], zip_path)
+        compressed_size = os.path.getsize(zip_path)
+
+        # Compressed ZIP should be significantly smaller
+        # Log files with repetitive content should compress to <50% of
+        # original size
+        assert compressed_size < uncompressed_size * 0.5, (
+            f'Compression not effective: {compressed_size} >= '
+            f'{uncompressed_size * 0.5} (original: {uncompressed_size})')
+
+        # Verify the zip is valid and can be extracted
+        with zipfile.ZipFile(zip_path, 'r') as zipf:
+            assert len(zipf.namelist()) == 1
+            # Check compression method is DEFLATED
+            info = zipf.getinfo(zipf.namelist()[0])
+            assert info.compress_type == zipfile.ZIP_DEFLATED


### PR DESCRIPTION
## Summary

Resolve #8338

This PR enables ZIP compression for log file downloads from the SkyPilot API server dashboard, reducing file sizes by ~96% for typical log content.

## Problem

Large log downloads from the dashboard were slow because ZIP files were created **without compression**. The `zipfile.ZipFile` in Python defaults to `ZIP_STORED` (no compression), which meant log files were only packaged but not compressed.

## Solution

Added `ZIP_DEFLATED` compression to the `zip_files_and_folders()` function in `sky/data/storage_utils.py`.

## Changes

### `sky/data/storage_utils.py`

- Added `compression` parameter (default: `zipfile.ZIP_DEFLATED`)
- Added `compresslevel` parameter (default: `None`, which uses level 6)
- Updated `ZipFile` constructor to use these parameters

```python
def zip_files_and_folders(items: List[str],
                          output_file: Union[str, pathlib.Path],
                          log_file: Optional[TextIO] = None,
                          relative_to_items: bool = False,
                          compression: int = zipfile.ZIP_DEFLATED,
                          compresslevel: Optional[int] = None):
```

### `tests/unit_tests/test_zip_and_unzip.py`

- Added `test_zip_files_and_folders_compression()` to verify compression is applied

## Test Results

Tested with a 264MB log file:

| Branch | ZIP Size | Download Time | Method | Compression Ratio |
|--------|----------|---------------|--------|-------------------|
| master | 264.06 MB | 3.90s | Stored | 0% |
| feature | 9.58 MB | 1.23s | Defl:N | **96.4%** |

- **Size reduction: 96.4%** (264 MB → 9.58 MB)
- **Download time: ~3.2x faster** (3.90s → 1.23s)


## Benchmark: Compression CPU Overhead

Tested different file patterns to measure **ZIP creation time (CPU only)** on localhost:

| Scenario | Files | Size | STORED | DEFLATED | Compression | CPU Overhead | 10Mbps | 100Mbps | 1Gbps |
|----------|-------|------|--------|----------|-------------|--------------|--------|---------|-------|
| Many small text | 500 | 2.5MB | 0.03s | 0.05s | 76% | +0.02s | +3.9x | +2.4x | -0.9x |
| Few large text | 3 | 30.0MB | 0.07s | 0.44s | 87% | +0.37s | +6.6x | +3.2x | -0.7x |
| Mixed workload | 202 | 41.0MB | 0.10s | 0.58s | 86% | +0.49s | +6.5x | +3.3x | -0.7x |
| Binary/random | 5 | 50.0MB | 0.08s | 1.25s | 0% | +1.17s | -1.0x | -0.8x | -0.3x |
| Single large text | 1 | 50.0MB | 0.09s | 0.71s | 87% | +0.62s | +6.6x | +3.3x | -0.6x |

*Notes:*
- *STORED/DEFLATED columns: actual measured ZIP creation time (CPU only)*
- *10Mbps/100Mbps/1Gbps columns: estimated end-to-end speedup (DEFLATED vs STORED)*
- *+ = DEFLATED faster (speedup), - = DEFLATED slower (STORED wins)*

**Speedup calculation formula:**
```
total_time = zip_creation_time + (zip_size / bandwidth)
speedup = total_time_stored / total_time_deflated
```
*Example for 30MB text files at 100Mbps (12.5 MB/s):*
- *STORED: 0.07s + 30.0MB ÷ 12.5MB/s = 2.47s*
- *DEFLATED: 0.44s + 4.0MB ÷ 12.5MB/s = 0.76s*
- *Speedup: 2.47 ÷ 0.76 = 3.2x*

**Key findings:**
- **Text/log files**: 97-100% compression, minimal overhead → DEFLATED clearly wins
- **Binary/random data**: 0% compression, overhead wasted → STORED would be better
- For typical SkyPilot uploads (code, configs, logs): **Compression is highly beneficial**


<!-- Describe the changes in this PR -->

```bash
(sky) zpoint:~/codes/skypilot (dev/zeping/compress_web)$ 
(sky) zpoint:~/codes/skypilot (dev/zeping/compress_web)$ bash test_compression.sh 
==========================================
Log Download Compression Test
==========================================
Current branch: dev/zeping/compress_web


----------------------------------------
Testing branch: master
----------------------------------------
Reinstalling package...
Restarting API server...
Waiting for API server...
API server ready.
Creating test log file...
Created: /home/zpoint/.sky/api_server/clients/838c6a5f/sky_logs/test-compression/large.log (13.05 MB)
Downloading logs via API...

Results for master:
  ZIP size:           13.05 MB
  Download time:      .2732759 seconds
  Compression method: Stored
  Compression ratio:  0%
  Integrity:          OK

----------------------------------------
Testing branch: dev/zeping/compress_web
----------------------------------------
Reinstalling package...
Restarting API server...
Waiting for API server...
API server ready.
Creating test log file...
Created: /home/zpoint/.sky/api_server/clients/838c6a5f/sky_logs/test-compression/large.log (13.05 MB)
Downloading logs via API...

Results for dev/zeping/compress_web:
  ZIP size:           .47 MB
  Download time:      .1041691 seconds
  Compression method: Defl:N
  Compression ratio:  96.4%
  Integrity:          OK

==========================================
COMPARISON SUMMARY
==========================================

branch                   zip_size_mb  download_time_sec  compress_method  compression_ratio
master                   13.05        .2732759           Stored           0
dev/zeping/compress_web  .47          .1041691           Defl:N           96.4

Size reduction: 96.4%

Results saved to: /tmp/compression_test_results.txt

Cleaning up...
Restored to branch: dev/zeping/compress_web
(sky) zpoint:~/codes/skypilot (dev/zeping/compress_web)$ 
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
