### PR TITLE
[Catalog] Fix flaky github CI test failure `EmptyDataError`

### DIFF
--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -3,6 +3,7 @@ import ast
 import difflib
 import hashlib
 import os
+import tempfile
 import time
 import typing
 from typing import Callable, Dict, List, NamedTuple, Optional, Tuple, Union
@@ -243,9 +244,19 @@ def read_catalog(filename: str,
                             raise e
                 else:
                     # Download successful, save the catalog to a local file.
+                    # Use atomic write (write to temp file, then rename) to
+                    # avoid race conditions when multiple processes read/write
+                    # the catalog file concurrently during parallel test
+                    # execution.
                     os.makedirs(os.path.dirname(catalog_path), exist_ok=True)
-                    with open(catalog_path, 'w', encoding='utf-8') as f:
+                    with tempfile.NamedTemporaryFile(
+                            mode='w',
+                            dir=os.path.dirname(catalog_path),
+                            delete=False,
+                            encoding='utf-8') as f:
                         f.write(r.text)
+                        tmp_path = f.name
+                    os.rename(tmp_path, catalog_path)
                     with open(meta_path + '.md5', 'w', encoding='utf-8') as f:
                         f.write(hashlib.md5(r.text.encode()).hexdigest())
             logger.debug(f'Updated {cloud} catalog {filename}.')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

## Summary

Fix flaky catalog-related test failures by using atomic file writes (write to temp file, then rename) instead of direct writes when updating catalog CSV files.

---

## Problem

Flaky test failures in CI: tests randomly fail with `pandas.errors.EmptyDataError: No columns to parse from file` when reading catalog CSV files.

This can affect **any test that uses the cloud catalog** (e.g., `test_valid_image`, `test_aws_region`, or any test that validates resources, regions, zones, instance types, etc.), not just a specific test.

**Example failure**: https://github.com/skypilot-org/skypilot/actions/runs/21144328089/job/60806058808?pr=8605

## Root Cause (Assumption)

Since the test is flaky and cannot be reproduced 100%, the following is our hypothesis based on code analysis.

We believe there is a race condition in catalog file update when multiple pytest workers (16 parallel workers via `-n 16`) access the catalog simultaneously.

### The Race Condition

The issue occurs because `open(path, 'w')` **creates an empty file immediately** before writing content:

```
Worker A (writing catalog)                  Worker B (reading catalog)
────────────────────────────────────────────────────────────────────────
1. _need_update() → True (no file)
2. Acquires FileLock
3. Double-check → True
4. Downloads content... (takes time)
5. open(catalog_path, 'w')
   → FILE NOW EXISTS (0 bytes!)            1. _need_update() → False
6. f.write(r.text)...                         (file exists, mtime=now, not stale)
                                           2. Returns False via fast path (NO LOCK!)
                                           3. pd.read_csv() → EMPTY FILE → CRASH
```

### Why the Existing FileLock Doesn't Help

The `_update_catalog()` function has a fast path that bypasses the lock (line 202-204):

```python
def _update_catalog():
    # Fast path: Exit early to avoid lock contention.
    if not _need_update():
        return False  # ← Worker B exits here without acquiring lock

    with filelock.FileLock(...):
        # ... write file ...
```

The FileLock protects **writer-vs-writer** (prevents two processes from writing simultaneously), but NOT **reader-vs-writer**:

- Worker A holds the lock and creates an empty file with `open(path, 'w')`
- Worker B sees the file exists (0 bytes, but exists), thinks it's fresh (just created, not 7 hours old)
- Worker B takes the fast path, never acquires the lock, reads the empty file

## Fix

Use atomic write pattern: write to a temp file first, then atomically rename to the target path.

```python
# Before (non-atomic):
with open(catalog_path, 'w', encoding='utf-8') as f:
    f.write(r.text)

# After (atomic):
with tempfile.NamedTemporaryFile(mode='w',
                                 dir=os.path.dirname(catalog_path),
                                 delete=False,
                                 encoding='utf-8') as f:
    f.write(r.text)
    tmp_path = f.name
os.rename(tmp_path, catalog_path)  # Atomic on POSIX
```

### Why This Fixes the Race

`os.rename()` is atomic at the filesystem level on POSIX systems. The file pointer switch happens instantaneously. A reader will either see:

- **No file** (before rename) → goes through lock path → blocks until write completes
- **Complete file** (after rename) → reads successfully

There is no moment where the reader can see an empty or partial file, because Worker A writes to a temp file with a different name, then atomically swaps it.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
