### PR TITLE
Update outdated documentation links

### DIFF
--- a/docs/source/reference/kubernetes/kubernetes-troubleshooting.rst
+++ b/docs/source/reference/kubernetes/kubernetes-troubleshooting.rst
@@ -5,7 +5,7 @@ Kubernetes Troubleshooting
 
 If you're unable to run SkyPilot tasks on your Kubernetes cluster, this guide will help you debug common issues.
 
-If this guide does not help resolve your issue, please reach out to us on `Slack <https://slack.skypilot.co>`_ or `GitHub <http://www.github.com/skypilot-org/skypilot>`_.
+If this guide does not help resolve your issue, please reach out to us on `Slack <https://slack.skypilot.co>`_ or `GitHub <https://github.com/skypilot-org/skypilot>`_.
 
 .. _kubernetes-troubleshooting-basic:
 

--- a/examples/airflow/README.md
+++ b/examples/airflow/README.md
@@ -11,7 +11,7 @@ This example uses a remote SkyPilot API Server to manage shared state across inv
 </p>
 
 
-**💡 Tip:**  SkyPilot also supports defining and running pipelines without Airflow. Check out [Jobs Pipelines](https://skypilot.readthedocs.io/en/latest/examples/managed-jobs.html#job-pipelines) for more information.
+**💡 Tip:**  SkyPilot also supports defining and running pipelines without Airflow. Check out [Jobs Pipelines](https://docs.skypilot.co/en/latest/examples/managed-jobs.html#job-pipelines) for more information.
 
 ## Why use SkyPilot with Airflow?
 In AI workflows, **the transition from development to production is hard**.
@@ -28,7 +28,7 @@ production Airflow cluster. Behind the scenes, SkyPilot handles environment setu
 
 Here's how you can use SkyPilot to take your dev workflows to production in Airflow:
 1. **Define and test your workflow as SkyPilot tasks**.
-    - Use `sky launch` and [Sky VSCode integration](https://skypilot.readthedocs.io/en/latest/examples/interactive-development.html#dev-vscode) to run, debug and iterate on your code.
+    - Use `sky launch` and [Sky VSCode integration](https://docs.skypilot.co/en/latest/examples/interactive-development.html#dev-vscode) to run, debug and iterate on your code.
 2. **Orchestrate SkyPilot tasks in Airflow** by invoking `sky launch` on their YAMLs as a task in the Airflow DAG.
     - Airflow does the scheduling, logging, and monitoring, while SkyPilot handles the infra setup and task execution.
 
@@ -78,7 +78,7 @@ The train and eval step can be run in a similar way:
 sky launch -c train --env DATA_BUCKET_NAME=<bucket-name> --env DATA_BUCKET_STORE_TYPE=s3 train.yaml
 ```
 
-Hint: You can use `ssh` and VSCode to [interactively develop](https://skypilot.readthedocs.io/en/latest/examples/interactive-development.html) and debug the tasks.
+Hint: You can use `ssh` and VSCode to [interactively develop](https://docs.skypilot.co/en/latest/examples/interactive-development.html) and debug the tasks.
 
 Note: `eval` can be optionally run on the same cluster as `train` with `sky exec`.
 

--- a/examples/hyperpod-eks/README.md
+++ b/examples/hyperpod-eks/README.md
@@ -5,7 +5,7 @@ This example shows how to run SkyPilot on AWS SageMaker HyperPod with EKS.
 ## Prerequisites
 
 - An existing SageMaker HyperPod with EKS (or you can create one with AWS [doc](https://catalog.workshops.aws/sagemaker-hyperpod-eks/en-US/00-setup/own-account/01-workshop-infra-script))
-- SkyPilot installed: [installation doc](https://skypilot.readthedocs.io/en/latest/getting-started/installation.html)
+- SkyPilot installed: [installation doc](https://docs.skypilot.co/en/latest/getting-started/installation.html)
 ```bash
 pip install skypilot-nightly[kubernetes]
 ```

--- a/examples/redisvl-vector-search/README.md
+++ b/examples/redisvl-vector-search/README.md
@@ -1,6 +1,6 @@
 # RedisVL + SkyPilot: Vector Search at Scale
 
-Distributed vector search over [1M research papers](https://www.kaggle.com/datasets/nechbamohammed/research-papers-dataset) using [RedisVL](https://docs.redisvl.com/en/latest/) and [SkyPilot](https://skypilot.readthedocs.io/en/latest/).
+Distributed vector search over [1M research papers](https://www.kaggle.com/datasets/nechbamohammed/research-papers-dataset) using [RedisVL](https://docs.redisvl.com/en/latest/) and [SkyPilot](https://docs.skypilot.co/en/latest/).
 
 📖 [Read the full blog post](https://blog.skypilot.co/redisvl-skypilot/).
 

--- a/examples/streamlit/README.md
+++ b/examples/streamlit/README.md
@@ -76,5 +76,5 @@ resources:
 
 ## Learn more
 
-- [SkyPilot Documentation](https://skypilot.readthedocs.io/)
+- [SkyPilot Documentation](https://docs.skypilot.co/)
 - [Streamlit Documentation](https://docs.streamlit.io/)

--- a/sky/clouds/vast.py
+++ b/sky/clouds/vast.py
@@ -309,7 +309,7 @@ class Vast(clouds.Cloud):
                 '        $ pip install vastai\n'
                 '        $ mkdir -p ~/.config/vastai\n'
                 f'        $ echo [key] > {_CREDENTIAL_PATH}\n'
-                '    For more information, see https://skypilot.readthedocs.io/en/latest/getting-started/installation.html#vast'  # pylint: disable=line-too-long
+                '    For more information, see https://docs.skypilot.co/en/latest/getting-started/installation.html#vast'  # pylint: disable=line-too-long
             )
 
         return True, None

--- a/sky/dashboard/src/components/elements/sidebar.jsx
+++ b/sky/dashboard/src/components/elements/sidebar.jsx
@@ -567,7 +567,7 @@ export function TopBar() {
                   className="text-sm text-muted-foreground"
                 >
                   <a
-                    href="https://skypilot.readthedocs.io/en/latest/"
+                    href="https://docs.skypilot.co/en/latest/"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="inline-flex items-center align-middle border-b-2 border-transparent px-1 pt-1 space-x-1 text-gray-600 hover:text-blue-600 transition-colors duration-150 cursor-pointer"
@@ -845,7 +845,7 @@ export function TopBar() {
 
                 {/* External links in mobile */}
                 <a
-                  href="https://skypilot.readthedocs.io/en/latest/"
+                  href="https://docs.skypilot.co/en/latest/"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="flex items-center px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-100 hover:text-blue-600 rounded-md transition-colors"

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -4126,7 +4126,7 @@ class OciStore(AbstractStore):
                     'Storage \'store: oci\' specified, but ' \
                     'OCI access is disabled. To fix, enable '\
                     'OCI by running `sky check`. '\
-                    'More info: https://skypilot.readthedocs.io/en/latest/getting-started/installation.html.' # pylint: disable=line-too-long
+                    'More info: https://docs.skypilot.co/en/latest/getting-started/installation.html.' # pylint: disable=line-too-long
                     )
 
     @classmethod


### PR DESCRIPTION
Updates hardcoded documentation URLs from the legacy `skypilot.readthedocs.io` to the canonical `docs.skypilot.co` domain across dashboard components ([sidebar.jsx](cci:7://file:///d:/friendly-project/skypilot/sky/dashboard/src/components/elements/sidebar.jsx:0:0-0:0)), storage logic, and cloud implementations. 
