### PR TITLE
[k8s] Documentation - Fix Line Number for ClusterRoleBinding and remove Namespaces for Cluster Resources

### DIFF
--- a/docs/source/cloud-setup/cloud-permissions/kubernetes.rst
+++ b/docs/source/cloud-setup/cloud-permissions/kubernetes.rst
@@ -266,7 +266,6 @@ To create a service account that has all necessary permissions for SkyPilot (inc
     apiVersion: rbac.authorization.k8s.io/v1
     metadata:
       name: sky-sa-cluster-role  # Can be changed if needed
-      namespace: default  # Change to your namespace if using a different one.
       labels:
         parent: skypilot
     rules:
@@ -291,7 +290,6 @@ To create a service account that has all necessary permissions for SkyPilot (inc
     kind: ClusterRoleBinding
     metadata:
       name: sky-sa-cluster-role-binding  # Can be changed if needed
-      namespace: default  # Change to your namespace if using a different one.
       labels:
         parent: skypilot
     subjects:
@@ -300,7 +298,7 @@ To create a service account that has all necessary permissions for SkyPilot (inc
         namespace: default  # Change to your namespace if using a different one.
     roleRef:
       kind: ClusterRole
-      name: sky-sa-cluster-role  # Use the same name as the cluster role at line 43
+      name: sky-sa-cluster-role  # Use the same name as the cluster role at line 56
       apiGroup: rbac.authorization.k8s.io
     ---
     # Optional: If using object store mounting, create the skypilot-system namespace


### PR DESCRIPTION
Updating documentation with corrected line number for ClusterRoleBinding reference and removing namespaces for cluster-wide resources to avoid confusion.
Current Kubernetes setup documentation points to a line number 43 when creating a ClusterRoleBinding - this line number in the current [documentation](https://docs.skypilot.co/en/latest/cloud-setup/cloud-permissions/kubernetes.html#kubernetes) points to a wrong reference of a parent in the RoleBinding. Instead it should point to line 56 that has the name of a ClusterRole.
The change also removes namespace setup for both ClusterRole and ClusterRoleBinding as these resources are cluster-scope, not namespace scope. This will avoid confusion for any new users. The change does not move the fixed line-number reference.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
