### PR TITLE
[CLI] Fix usage of pandas>=3.0.0 in show-gpus

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -4521,7 +4521,6 @@ def show_gpus(
 
     outputs = _output()
     if show_all:
-        # print(''.join(outputs))
         click.echo_via_pager(outputs)
     else:
         for out in outputs:


### PR DESCRIPTION
Fixes `sky show-gpus --all` when using pandas>=3.0.0


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
