### PR TITLE
[CLI] Small refactor to avoid pandas 2.x issue

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -4476,12 +4476,8 @@ def show_gpus(
                                                    min_spot_price=('spot_price',
                                                                    'min'))
             df = df.merge(min_price_df, on='cloud')
-            # Sort within each cloud by price.
-            # using df.cloud.values is a hack to keep the 'cloud' column in the output for pandas>=3.0.0
-            df = df.groupby(df.cloud.values, group_keys=False).apply(
-                lambda x: x.sort_values(by=['price', 'spot_price']))
-            # Sort across groups (clouds).
-            df = df.sort_values(by=['min_price', 'min_spot_price'])
+            df = df.sort_values(
+                by=['min_price', 'min_spot_price', 'price', 'spot_price'])
             df = df.drop(columns=['min_price', 'min_spot_price'])
             sorted_dataclasses = [
                 catalog_common.InstanceTypeInfo(*row)


### PR DESCRIPTION
This Small PR refactor issue that is potentially cause by pandas 2.x when calling commands like `sky show-gpus H100` this usually would beans out on the cloud sorting. This fix address this and was tested on my end to verify that it works!. 

Before this change as of my latest skypilot install I would get the errors below

```bash

sky show-gpus H100:8
Traceback (most recent call last):
  File "/home/bstg/workspace/skydebug/.venv/bin/sky", line 7, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/sky/cli.py", line 9, in cli
    command.cli()
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/sky/utils/common_utils.py", line 615, in _record
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/sky/client/cli/command.py", line 839, in invoke
    return super().invoke(ctx)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/sky/catalog/config.py", line 51, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/sky/utils/common_utils.py", line 635, in _record
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/sky/client/cli/command.py", line 4128, in show_gpus
    for out in outputs:
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/sky/client/cli/command.py", line 4048, in _output
    sorted_dataclasses = [
                         ^
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/sky/client/cli/command.py", line 4049, in <listcomp>
    catalog_common.InstanceTypeInfo(*row)
TypeError: InstanceTypeInfo.__new__() missing 1 required positional argument: 'region'
```


```bash

(.venv) bstg@VAST-LAX-1Y5S:~/workspace/skydebug$ sky show-gpus H100:8
Traceback (most recent call last):
  File "/home/bstg/workspace/skydebug/.venv/bin/sky", line 7, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/sky/cli.py", line 9, in cli
    command.cli()
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/sky/utils/common_utils.py", line 615, in _record
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/sky/client/cli/command.py", line 839, in invoke
    return super().invoke(ctx)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/sky/catalog/config.py", line 51, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/sky/utils/common_utils.py", line 635, in _record
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/sky/client/cli/command.py", line 4132, in show_gpus
    for out in outputs:
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/sky/client/cli/command.py", line 4049, in _output
    df = df[['cloud', 'instance_type', 'accelerator_name',
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/pandas/core/frame.py", line 4384, in __getitem__
    indexer = self.columns._get_indexer_strict(key, "columns")[1]
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/pandas/core/indexes/base.py", line 6302, in _get_indexer_strict
    self._raise_if_missing(keyarr, indexer, axis_name)
  File "/home/bstg/workspace/skydebug/.venv/lib/python3.11/site-packages/pandas/core/indexes/base.py", line 6355, in _raise_if_missing
    raise KeyError(f"{not_found} not in index")
KeyError: "['cloud'] not in index"

```

Python 3.8 with pandas 2.2  would be broken
Python 3.12 with pandas 2.2 would be broken
Python 3.12 with pandas 1.5 would work

see working version below

<img width="1599" height="757" alt="image" src="https://github.com/user-attachments/assets/8bcf148c-1aa8-46ec-ab5e-eb71d8e9465a" />



/smoke-test
/quicktest-core
