### PR TITLE
Add greenlet to install_requires for sqlalchemy asyncio support

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -76,6 +76,8 @@ install_requires = [
     'psycopg2-binary',
     'aiosqlite',
     'asyncpg',
+    # Required by sqlalchemy.ext.asyncio which is used in sky/utils/db/db_utils.py
+    'greenlet',
     # TODO(hailong): These three dependencies should be removed after we make
     # the client-side actually not importing them.
     'casbin',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

## Summary

The `sqlalchemy.ext.asyncio` module is imported in `sky/utils/db/db_utils.py:16`, which requires the `greenlet` library. Without it, importing skypilot fails.

While `greenlet` is already in `server_dependencies`, it needs to be in `install_requires` since the asyncio import happens in core code that runs on import.

## Steps to reproduce

```bash
# Create a fresh virtual environment
uv venv /tmp/test-sky
source /tmp/test-sky/bin/activate

# Install skypilot 0.11+
uv pip install "skypilot>=0.11,<0.12"

# Try to import sky
python -c "import sky"
```

**Error:**
```
ImportError: The SQLAlchemy asyncio module requires that the Python 'greenlet'
library is installed. In order to ensure this dependency is available, use the
'sqlalchemy[asyncio]' install target: 'pip install sqlalchemy[asyncio]'
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->



Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Verified that `import sky` fails without greenlet pre-installed
  - Verified that `import sky` succeeds after this change
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
