### PR TITLE
[Test] Allow multiple `test_large_production_performance` to be run at the same time

### DIFF
--- a/tests/load_tests/db_scale_tests/test_large_production_performance.sh
+++ b/tests/load_tests/db_scale_tests/test_large_production_performance.sh
@@ -42,7 +42,8 @@ JOB_ID_FILE="/tmp/prod_test_job_id_$$"
 
 # Generate a unique suffix to allow multiple concurrent test runs
 # Use short UUID (first 8 chars) for uniqueness while keeping name manageable
-UNIQUE_SUFFIX=$(uuidgen 2>/dev/null | cut -c1-8 | tr '[:upper:]' '[:lower:]' || date +%s%N | sha256sum | cut -c1-8)
+# Fallbacks: uuidgen -> hash of timestamp -> plain timestamp
+UNIQUE_SUFFIX=$( (uuidgen 2>/dev/null || date +%s%N | (sha256sum 2>/dev/null || shasum -a 256) || date +%s) | cut -c1-8 | tr '[:upper:]' '[:lower:]' )
 
 # Cluster names with unique suffix to avoid conflicts
 ACTIVE_CLUSTER_NAME="scale-test-active-${UNIQUE_SUFFIX}"


### PR DESCRIPTION
Add a unique suffix to RDS instance IDs in the production performance test to allow multiple test runs to execute concurrently without resource naming conflicts.

Fixes #8526

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
