### PR TITLE
[Test] Fix test_cluster_labels_in_status to actually fail on assertion errors

### DIFF
--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -1040,25 +1040,13 @@ def test_cluster_labels_in_status(generic_cloud: str):
                 cluster_record = cluster
                 break
 
-        if cluster_record is None:
-            yield f'Cluster {name} not found in status'
-            return
-
-        if 'labels' not in cluster_record:
-            yield 'labels field missing from cluster record'
-            return
-
-        if cluster_record['labels'] is None:
-            yield 'labels field is None'
-            return
-
-        if cluster_record['labels'] != expected_labels:
-            yield (f"Expected labels {expected_labels}, "
-                   f"got {cluster_record['labels']}")
-            return
-
-        # Success - labels are correct
-        return
+        assert cluster_record is not None, f'Cluster {name} not found in status'
+        assert 'labels' in cluster_record, (
+            'labels field missing from cluster record')
+        assert cluster_record['labels'] is not None, 'labels field is None'
+        assert cluster_record['labels'] == expected_labels, (
+            f'Expected labels {expected_labels}, '
+            f'got {cluster_record["labels"]}')
 
     # Create YAML with labels
     yaml_content = textwrap.dedent("""\


### PR DESCRIPTION
The test was using yield+return pattern which only logged messages but didn't cause test failures. Changed to use assert statements that raise AssertionError when conditions aren't met, properly failing the test.

<!-- Describe the changes in this PR -->
Tested:
- [x] Before this PR, changing the labels in the test should cause it to fail but it does not
- [x] After this PR, the changing the labels in the test causes it to fail.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
