### PR TITLE
[Volume] Add unit tests for is_ephemeral PostgreSQL compatibility

### DIFF
--- a/tests/unit_tests/test_sky/volumes/test_global_user_state_volumes.py
+++ b/tests/unit_tests/test_sky/volumes/test_global_user_state_volumes.py
@@ -60,13 +60,31 @@ class TestVolumeIsEphemeralHandling:
         mock_db_module.insert.return_value = mock_insert
         return mock_insert
 
-    def test_add_volume_is_ephemeral_true_sqlite(
+    @pytest.mark.parametrize('dialect,db_module_path', [
+        ('sqlite', 'sky.global_user_state.sqlite'),
+        ('postgresql', 'sky.global_user_state.postgresql'),
+    ])
+    @pytest.mark.parametrize('is_ephemeral,expected_value', [
+        (True, 1),
+        (False, 0),
+    ])
+    def test_add_volume_is_ephemeral(
             self,
-            mock_engine,  # pylint: disable=unused-argument
+            mock_engine,
             mock_session,  # pylint: disable=unused-argument
-            mock_volume_config):
-        """Test add_volume with is_ephemeral=True on SQLite dialect."""
-        with mock.patch('sky.global_user_state.sqlite') as mock_sqlite:
+            mock_volume_config,
+            dialect,
+            db_module_path,
+            is_ephemeral,
+            expected_value):
+        """Test add_volume converts is_ephemeral boolean to integer.
+
+        This covers both SQLite and PostgreSQL dialects, verifying the fix
+        for issue #8178. Uses type() is int to ensure the value is actually
+        an int and not a bool (since bool is a subclass of int in Python).
+        """
+        mock_engine.dialect.name = dialect
+        with mock.patch(db_module_path) as mock_db_module:
             with mock.patch('time.time', return_value=1234567890):
                 with mock.patch(
                         'sky.global_user_state.common_utils.get_current_command',
@@ -80,195 +98,48 @@ class TestVolumeIsEphemeralHandling:
                                 return_value='default'):
                             mock_user.return_value = mock.Mock(id='user123')
                             mock_insert = self._setup_add_volume_mocks(
-                                mock_sqlite)
+                                mock_db_module)
 
                             global_user_state.add_volume(
                                 name='test-volume',
                                 config=mock_volume_config,
                                 status=status_lib.VolumeStatus.READY,
-                                is_ephemeral=True,
+                                is_ephemeral=is_ephemeral,
                             )
 
-                            # Verify insert was called with is_ephemeral=1
+                            # Verify insert was called with correct int value
                             mock_insert.values.assert_called_once()
                             call_kwargs = mock_insert.values.call_args[1]
-                            assert call_kwargs['is_ephemeral'] == 1
+                            assert call_kwargs['is_ephemeral'] == expected_value
+                            # Use type() is int because bool is subclass of int
+                            # pylint: disable=unidiomatic-typecheck
                             assert type(call_kwargs['is_ephemeral']) is int
 
-    def test_add_volume_is_ephemeral_false_sqlite(
-            self,
-            mock_engine,  # pylint: disable=unused-argument
-            mock_session,  # pylint: disable=unused-argument
-            mock_volume_config):
-        """Test add_volume with is_ephemeral=False on SQLite dialect."""
-        with mock.patch('sky.global_user_state.sqlite') as mock_sqlite:
-            with mock.patch('time.time', return_value=1234567890):
-                with mock.patch(
-                        'sky.global_user_state.common_utils.get_current_command',
-                        return_value='sky volumes apply'):
-                    with mock.patch(
-                            'sky.global_user_state.common_utils.get_current_user'
-                    ) as mock_user:
-                        with mock.patch(
-                                'sky.global_user_state.skypilot_config.'
-                                'get_active_workspace',
-                                return_value='default'):
-                            mock_user.return_value = mock.Mock(id='user123')
-                            mock_insert = self._setup_add_volume_mocks(
-                                mock_sqlite)
+    @pytest.mark.parametrize('dialect', ['sqlite', 'postgresql'])
+    @pytest.mark.parametrize('is_ephemeral,expected_value', [
+        (True, 1),
+        (False, 0),
+    ])
+    def test_get_volumes_filter_is_ephemeral(self, mock_engine, mock_session,
+                                             dialect, is_ephemeral,
+                                             expected_value):
+        """Test get_volumes filtering converts is_ephemeral to integer.
 
-                            global_user_state.add_volume(
-                                name='test-volume',
-                                config=mock_volume_config,
-                                status=status_lib.VolumeStatus.READY,
-                                is_ephemeral=False,
-                            )
-
-                            # Verify insert was called with is_ephemeral=0
-                            mock_insert.values.assert_called_once()
-                            call_kwargs = mock_insert.values.call_args[1]
-                            assert call_kwargs['is_ephemeral'] == 0
-                            assert type(call_kwargs['is_ephemeral']) is int
-
-    def test_add_volume_is_ephemeral_true_postgresql(
-            self,
-            mock_engine,
-            mock_session,  # pylint: disable=unused-argument
-            mock_volume_config):
-        """Test add_volume with is_ephemeral=True on PostgreSQL dialect.
-
-        This is the key test case for issue #8178 - verifies that
-        is_ephemeral is converted to integer (1) when inserting into
-        PostgreSQL.
+        This covers both SQLite and PostgreSQL dialects, verifying the fix
+        for issue #8178. Uses type() is int to ensure the value is actually
+        an int and not a bool (since bool is a subclass of int in Python).
         """
-        mock_engine.dialect.name = 'postgresql'
-
-        with mock.patch('sky.global_user_state.postgresql') as mock_pg:
-            with mock.patch('time.time', return_value=1234567890):
-                with mock.patch(
-                        'sky.global_user_state.common_utils.get_current_command',
-                        return_value='sky volumes apply'):
-                    with mock.patch(
-                            'sky.global_user_state.common_utils.get_current_user'
-                    ) as mock_user:
-                        with mock.patch(
-                                'sky.global_user_state.skypilot_config.'
-                                'get_active_workspace',
-                                return_value='default'):
-                            mock_user.return_value = mock.Mock(id='user123')
-                            mock_insert = self._setup_add_volume_mocks(mock_pg)
-
-                            global_user_state.add_volume(
-                                name='test-volume',
-                                config=mock_volume_config,
-                                status=status_lib.VolumeStatus.READY,
-                                is_ephemeral=True,
-                            )
-
-                            # Verify is_ephemeral=1 for PostgreSQL
-                            mock_insert.values.assert_called_once()
-                            call_kwargs = mock_insert.values.call_args[1]
-                            assert call_kwargs['is_ephemeral'] == 1
-                            assert type(call_kwargs['is_ephemeral']) is int
-
-    def test_add_volume_is_ephemeral_false_postgresql(
-            self,
-            mock_engine,
-            mock_session,  # pylint: disable=unused-argument
-            mock_volume_config):
-        """Test add_volume with is_ephemeral=False on PostgreSQL."""
-        mock_engine.dialect.name = 'postgresql'
-
-        with mock.patch('sky.global_user_state.postgresql') as mock_pg:
-            with mock.patch('time.time', return_value=1234567890):
-                with mock.patch(
-                        'sky.global_user_state.common_utils.get_current_command',
-                        return_value='sky volumes apply'):
-                    with mock.patch(
-                            'sky.global_user_state.common_utils.get_current_user'
-                    ) as mock_user:
-                        with mock.patch(
-                                'sky.global_user_state.skypilot_config.'
-                                'get_active_workspace',
-                                return_value='default'):
-                            mock_user.return_value = mock.Mock(id='user123')
-                            mock_insert = self._setup_add_volume_mocks(mock_pg)
-
-                            global_user_state.add_volume(
-                                name='test-volume',
-                                config=mock_volume_config,
-                                status=status_lib.VolumeStatus.READY,
-                                is_ephemeral=False,
-                            )
-
-                            # Verify is_ephemeral=0
-                            mock_insert.values.assert_called_once()
-                            call_kwargs = mock_insert.values.call_args[1]
-                            assert call_kwargs['is_ephemeral'] == 0
-                            assert type(call_kwargs['is_ephemeral']) is int
-
-    def test_get_volumes_filter_is_ephemeral_true_sqlite(
-            self,
-            mock_engine,  # pylint: disable=unused-argument
-            mock_session):
-        """Test get_volumes filtering by is_ephemeral=True on SQLite."""
+        mock_engine.dialect.name = dialect
         mock_session.query.return_value.filter_by.return_value.all.return_value = []
 
-        global_user_state.get_volumes(is_ephemeral=True)
+        global_user_state.get_volumes(is_ephemeral=is_ephemeral)
 
-        # Verify filter_by was called with is_ephemeral=1 (int, not bool)
+        # Verify filter_by was called with correct int value
         mock_session.query.return_value.filter_by.assert_called_once()
         call_kwargs = mock_session.query.return_value.filter_by.call_args[1]
-        assert call_kwargs['is_ephemeral'] == 1
-        # Use 'type() is int' because bool is a subclass of int
-        assert type(call_kwargs['is_ephemeral']) is int
-
-    def test_get_volumes_filter_is_ephemeral_false_sqlite(
-            self,
-            mock_engine,  # pylint: disable=unused-argument
-            mock_session):
-        """Test get_volumes filtering by is_ephemeral=False on SQLite."""
-        mock_session.query.return_value.filter_by.return_value.all.return_value = []
-
-        global_user_state.get_volumes(is_ephemeral=False)
-
-        # Verify filter_by was called with is_ephemeral=0 (int, not bool)
-        mock_session.query.return_value.filter_by.assert_called_once()
-        call_kwargs = mock_session.query.return_value.filter_by.call_args[1]
-        assert call_kwargs['is_ephemeral'] == 0
-        assert type(call_kwargs['is_ephemeral']) is int
-
-    def test_get_volumes_filter_is_ephemeral_true_postgresql(
-            self, mock_engine, mock_session):
-        """Test get_volumes filtering by is_ephemeral=True on PostgreSQL.
-
-        This is the key test case for issue #8178 - verifies that
-        is_ephemeral is converted to integer (1) when filtering on
-        PostgreSQL.
-        """
-        mock_engine.dialect.name = 'postgresql'
-        mock_session.query.return_value.filter_by.return_value.all.return_value = []
-
-        global_user_state.get_volumes(is_ephemeral=True)
-
-        # Verify filter_by was called with is_ephemeral=1 (int, not bool)
-        mock_session.query.return_value.filter_by.assert_called_once()
-        call_kwargs = mock_session.query.return_value.filter_by.call_args[1]
-        assert call_kwargs['is_ephemeral'] == 1
-        assert type(call_kwargs['is_ephemeral']) is int
-
-    def test_get_volumes_filter_is_ephemeral_false_postgresql(
-            self, mock_engine, mock_session):
-        """Test get_volumes filtering by is_ephemeral=False on PostgreSQL."""
-        mock_engine.dialect.name = 'postgresql'
-        mock_session.query.return_value.filter_by.return_value.all.return_value = []
-
-        global_user_state.get_volumes(is_ephemeral=False)
-
-        # Verify filter_by was called with is_ephemeral=0 (int, not bool)
-        mock_session.query.return_value.filter_by.assert_called_once()
-        call_kwargs = mock_session.query.return_value.filter_by.call_args[1]
-        assert call_kwargs['is_ephemeral'] == 0
+        assert call_kwargs['is_ephemeral'] == expected_value
+        # Use type() is int because bool is subclass of int
+        # pylint: disable=unidiomatic-typecheck
         assert type(call_kwargs['is_ephemeral']) is int
 
     def test_get_volumes_filter_none_returns_all(
@@ -284,27 +155,34 @@ class TestVolumeIsEphemeralHandling:
         mock_session.query.return_value.all.assert_called_once()
         mock_session.query.return_value.filter_by.assert_not_called()
 
-    def test_get_volumes_returns_bool_is_ephemeral_true(
+    @pytest.mark.parametrize('db_value,expected_bool,last_attached', [
+        (1, True, 1234567890),
+        (0, False, None),
+    ])
+    def test_get_volumes_returns_bool_is_ephemeral(
             self,
             mock_engine,  # pylint: disable=unused-argument
             mock_session,
-            mock_volume_config):
-        """Test get_volumes returns a boolean True for is_ephemeral=1.
+            mock_volume_config,
+            db_value,
+            expected_bool,
+            last_attached):
+        """Test get_volumes returns a boolean for is_ephemeral.
 
         Verifies that the integer value stored in the database is
         converted back to a Python boolean when returned.
         """
-        # Mock row with is_ephemeral=1 (as stored in database)
+        # Mock row with is_ephemeral as stored in database
         mock_row = mock.Mock()
         mock_row.name = 'test-volume'
         mock_row.launched_at = 1234567890
         mock_row.handle = pickle.dumps(mock_volume_config)
         mock_row.user_hash = 'user123'
         mock_row.workspace = 'default'
-        mock_row.last_attached_at = 1234567890
+        mock_row.last_attached_at = last_attached
         mock_row.last_use = 'sky volumes apply'
         mock_row.status = 'READY'
-        mock_row.is_ephemeral = 1  # Integer as stored in database
+        mock_row.is_ephemeral = db_value  # Integer as stored in database
         mock_row.error_message = None
         mock_row.usedby_pods = '[]'
         mock_row.usedby_clusters = '[]'
@@ -314,40 +192,7 @@ class TestVolumeIsEphemeralHandling:
         result = global_user_state.get_volumes()
 
         assert len(result) == 1
-        assert result[0]['is_ephemeral'] is True
-        assert isinstance(result[0]['is_ephemeral'], bool)
-
-    def test_get_volumes_returns_bool_is_ephemeral_false(
-            self,
-            mock_engine,  # pylint: disable=unused-argument
-            mock_session,
-            mock_volume_config):
-        """Test get_volumes returns a boolean False for is_ephemeral=0.
-
-        Verifies that the integer value stored in the database is
-        converted back to a Python boolean when returned.
-        """
-        # Mock row with is_ephemeral=0 (as stored in database)
-        mock_row = mock.Mock()
-        mock_row.name = 'test-volume'
-        mock_row.launched_at = 1234567890
-        mock_row.handle = pickle.dumps(mock_volume_config)
-        mock_row.user_hash = 'user123'
-        mock_row.workspace = 'default'
-        mock_row.last_attached_at = None
-        mock_row.last_use = 'sky volumes apply'
-        mock_row.status = 'READY'
-        mock_row.is_ephemeral = 0  # Integer as stored in database
-        mock_row.error_message = None
-        mock_row.usedby_pods = '[]'
-        mock_row.usedby_clusters = '[]'
-
-        mock_session.query.return_value.all.return_value = [mock_row]
-
-        result = global_user_state.get_volumes()
-
-        assert len(result) == 1
-        assert result[0]['is_ephemeral'] is False
+        assert result[0]['is_ephemeral'] is expected_bool
         assert isinstance(result[0]['is_ephemeral'], bool)
 
     def test_add_volume_unsupported_dialect(


### PR DESCRIPTION
## Summary
- Add unit tests to verify the `is_ephemeral` boolean/integer conversion in volume database operations
- Tests cover the fix from PR #8179 for issue #8178, ensuring that:
  - `add_volume()` converts `is_ephemeral` to `int(0/1)` when inserting
  - `get_volumes()` converts `is_ephemeral` to `int` when filtering
  - `get_volumes()` returns `is_ephemeral` as `bool` when retrieving
- Tests cover both SQLite and PostgreSQL dialects
- Uses `pytest.mark.parametrize` to reduce code duplication (addressing review feedback)

Closes #8193

## Test plan
- [x] Code formatting: `bash format.sh`
- [x] New unit tests for this PR:
  ```bash
  pytest tests/unit_tests/test_sky/volumes/test_global_user_state_volumes.py -v
  ```
  All 13 tests pass (4 add_volume + 4 filter + 2 return_bool + 3 other)

## Verification that tests catch the bug

Verified each test catches its corresponding bug by temporarily reverting fixes:

**1. `test_add_volume_is_ephemeral` (4 parameterized tests)**
Reverted `is_ephemeral=int(is_ephemeral)` to `is_ephemeral=is_ephemeral` in `add_volume()`:
```
FAILED test_add_volume_is_ephemeral[True-1-sqlite-...] - assert <class 'bool'> is int
FAILED test_add_volume_is_ephemeral[True-1-postgresql-...] - assert <class 'bool'> is int
FAILED test_add_volume_is_ephemeral[False-0-sqlite-...] - assert <class 'bool'> is int
FAILED test_add_volume_is_ephemeral[False-0-postgresql-...] - assert <class 'bool'> is int
```

**2. `test_get_volumes_filter_is_ephemeral` (4 parameterized tests)**
Reverted `filter_by(is_ephemeral=int(is_ephemeral))` to `filter_by(is_ephemeral=is_ephemeral)`:
```
FAILED test_get_volumes_filter_is_ephemeral[True-1-sqlite] - assert <class 'bool'> is int
FAILED test_get_volumes_filter_is_ephemeral[True-1-postgresql] - assert <class 'bool'> is int
FAILED test_get_volumes_filter_is_ephemeral[False-0-sqlite] - assert <class 'bool'> is int
FAILED test_get_volumes_filter_is_ephemeral[False-0-postgresql] - assert <class 'bool'> is int
```

**3. `test_get_volumes_returns_bool_is_ephemeral` (2 parameterized tests)**
Reverted `bool(row.is_ephemeral)` to `row.is_ephemeral`:
```
FAILED test_get_volumes_returns_bool_is_ephemeral[1-True-...] - assert 1 is True
FAILED test_get_volumes_returns_bool_is_ephemeral[0-False-...] - assert 0 is False
```

**Note:** Tests use `type(x) is int` instead of `isinstance(x, int)` because `bool` is a subclass of `int` in Python, so `isinstance(True, int)` returns `True`.

🤖 Generated with [Claude Code](https://claude.ai/code)