### PR TITLE
[RunPod] Add allowed_cuda_versions cloud config support

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -194,6 +194,11 @@ Below is the configuration syntax and some example values. See detailed explanat
     :ref:`tenant_id <config-yaml-nebius-tenant-id>`: tenant-1234567890
     :ref:`domain <config-yaml-nebius-domain>`: api.nebius.cloud:443
 
+  :ref:`runpod <config-yaml-runpod>`:
+    :ref:`allowed_cuda_versions <config-yaml-runpod-allowed-cuda-versions>`:
+      - '11.8'
+      - '12.0'
+
   :ref:`vast <config-yaml-vast>`:
     :ref:`datacenter_only <config-yaml-vast-datacenter-only>`: true
     :ref:`create_instance_kwargs <config-yaml-vast-create-instance-kwargs>`:
@@ -1738,6 +1743,41 @@ Example:
 
   nebius:
     domain: api.nebius.cloud:443
+
+.. _config-yaml-runpod:
+
+``runpod``
+~~~~~~~~~~
+
+Advanced RunPod configuration (optional).
+
+.. _config-yaml-runpod-allowed-cuda-versions:
+
+``runpod.allowed_cuda_versions``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Restrict RunPod instances to specific CUDA versions (optional).
+
+List of CUDA versions to allow when provisioning RunPod instances. When set,
+SkyPilot will only select RunPod instances that support the specified CUDA
+versions. This uses the RunPod API's ``allowedCudaVersions`` parameter.
+
+This is useful when you need to ensure compatibility with specific CUDA
+versions for your workloads.
+
+Available CUDA versions: ``12.9``, ``12.8``, ``12.7``, ``12.6``, ``12.5``, ``12.4``, ``12.3``, ``12.2``, ``12.1``, ``12.0``, ``11.8``
+
+Default: ``null`` (no CUDA version restrictions).
+
+Example:
+
+.. code-block:: yaml
+
+  runpod:
+    allowed_cuda_versions:
+      - '11.8'
+      - '12.0'
+      - '12.1'
 
 .. _config-yaml-vast:
 

--- a/sky/clouds/runpod.py
+++ b/sky/clouds/runpod.py
@@ -7,6 +7,7 @@ from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 from sky import catalog
 from sky import clouds
+from sky import skypilot_config
 from sky.utils import common_utils
 from sky.utils import registry
 from sky.utils import resources_utils
@@ -217,7 +218,7 @@ class RunPod(clouds.Cloud):
                                       if resources.docker_username_for_runpod
                                       is not None else 'root')
 
-        return {
+        deploy_vars = {
             'instance_type': instance_type,
             'custom_resources': custom_resources,
             'region': region.name,
@@ -227,6 +228,16 @@ class RunPod(clouds.Cloud):
             'bid_per_gpu': str(hourly_cost),
             'docker_username_for_runpod': docker_username_for_runpod,
         }
+
+        # Add allowed_cuda_versions from cloud config if specified
+        allowed_cuda_versions = skypilot_config.get_nested(
+            ('runpod', 'allowed_cuda_versions'),
+            None,
+            override_configs=resources.cluster_config_overrides)
+        if allowed_cuda_versions:
+            deploy_vars['allowed_cuda_versions'] = allowed_cuda_versions
+
+        return deploy_vars
 
     def _get_feasible_launchable_resources(
         self, resources: 'resources_lib.Resources'

--- a/sky/provision/runpod/instance.py
+++ b/sky/provision/runpod/instance.py
@@ -99,6 +99,8 @@ def run_instances(region: str, cluster_name: str, cluster_name_on_cloud: str,
     for _ in range(to_start_count):
         node_type = 'head' if head_instance_id is None else 'worker'
         try:
+            allowed_cuda_versions = config.node_config.get(
+                'AllowedCudaVersions')
             instance_id = utils.launch(
                 cluster_name=cluster_name_on_cloud,
                 node_type=node_type,
@@ -115,6 +117,7 @@ def run_instances(region: str, cluster_name: str, cluster_name_on_cloud: str,
                     'docker_login_config'),
                 network_volume_id=network_volume_id,
                 volume_mount_path=volume_mount_path,
+                allowed_cuda_versions=allowed_cuda_versions,
             )
         except Exception as e:  # pylint: disable=broad-except
             logger.warning(f'run_instances error: {e}\n'

--- a/sky/provision/runpod/utils.py
+++ b/sky/provision/runpod/utils.py
@@ -291,6 +291,7 @@ def launch(
     *,
     network_volume_id: Optional[str] = None,
     volume_mount_path: Optional[str] = None,
+    allowed_cuda_versions: Optional[List[str]] = None,
 ) -> str:
     """Launches an instance with the given parameters.
 
@@ -393,6 +394,7 @@ def launch(
     else:
         new_instance = runpod_commands.create_spot_pod(
             bid_per_gpu=bid_per_gpu,
+            allowed_cuda_versions=allowed_cuda_versions,
             **params,  # type: ignore[arg-type]
         )
 

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -482,6 +482,7 @@ OVERRIDEABLE_CONFIG_KEYS_IN_TASK: List[Tuple[str, ...]] = [
     ('gcp', 'placement_policy'),
     ('vast', 'datacenter_only'),
     ('vast', 'create_instance_kwargs'),
+    ('runpod', 'allowed_cuda_versions'),
     ('active_workspace',),
 ]
 # When overriding the SkyPilot configs on the API server with the client one,

--- a/sky/templates/runpod-ray.yml.j2
+++ b/sky/templates/runpod-ray.yml.j2
@@ -40,6 +40,9 @@ available_node_types:
         skypilot:ssh_public_key_content
       Preemptible: {{use_spot}}
       BidPerGPU: {{bid_per_gpu}}
+      {%- if allowed_cuda_versions is not none and allowed_cuda_versions %}
+      AllowedCudaVersions: {{allowed_cuda_versions}}
+      {%- endif %}
       {%- if volume_mounts and volume_mounts|length > 0 %}
       VolumeMounts:
       {%- for vm in volume_mounts %}

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1567,7 +1567,24 @@ def get_config_schema():
                     }
                 }
             },
-        }
+        },
+        'runpod': {
+            'type': 'object',
+            'required': [],
+            'additionalProperties': False,
+            'properties': {
+                'allowed_cuda_versions': {
+                    'type': 'array',
+                    'items': {
+                        'type': 'string',
+                        'case_sensitive_enum': [
+                            '12.9', '12.8', '12.7', '12.6', '12.5', '12.4',
+                            '12.3', '12.2', '12.1', '12.0', '11.8'
+                        ]
+                    },
+                },
+            }
+        },
     }
 
     admin_policy_schema = {


### PR DESCRIPTION
This enables restricting RunPod instances to specific CUDA versions by configuring allowed_cuda_versions in ~/.sky/config.yaml under the runpod section. This uses the RunPod API's allowedCudaVersions parameter.

Changes:
- Added runpod.allowed_cuda_versions to cloud config schema
- Updated RunPod cloud to read from config and pass to deployment
- Added to OVERRIDEABLE_CONFIG_KEYS_IN_TASK for task-level overrides
- Updated documentation with usage examples

Example configuration:
  runpod: allowed_cuda_versions: ['11.8', '12.0', '12.1']

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
