### PR TITLE
[Dashboard] Round CPU and memory values to integers on infra page

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -799,12 +799,12 @@ export function ContextDetails({
                         node.memory_gb !== null &&
                         node.memory_gb !== undefined
                       ) {
-                        const memoryTotal = node.memory_gb.toFixed(1);
+                        const memoryTotal = Math.round(node.memory_gb);
                         if (
                           node.memory_free_gb !== null &&
                           node.memory_free_gb !== undefined
                         ) {
-                          const memoryFree = node.memory_free_gb.toFixed(1);
+                          const memoryFree = Math.round(node.memory_free_gb);
                           memoryDisplay = `${memoryFree} of ${memoryTotal} free`;
                         } else {
                           memoryDisplay = memoryTotal;

--- a/sky/dashboard/src/utils/resourceUtils.js
+++ b/sky/dashboard/src/utils/resourceUtils.js
@@ -9,7 +9,7 @@
  */
 export function formatCpu(cpu) {
   if (cpu === null || cpu === undefined) return '-';
-  return cpu === Math.floor(cpu) ? Math.floor(cpu).toString() : cpu.toFixed(1);
+  return Math.round(cpu).toString();
 }
 
 /**
@@ -19,7 +19,7 @@ export function formatCpu(cpu) {
  */
 export function formatMemory(memory) {
   if (memory === null || memory === undefined) return '-';
-  return `${memory.toFixed(1)} GB`;
+  return `${Math.round(memory)} GB`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Rounds CPU and memory values to whole integers across the infra page (listing and detail views)
- Affects `formatCpu`, `formatMemory` in `resourceUtils.js` and per-node memory display in `infra.jsx`
- e.g., "5035.1 GB" → "5035 GB", "123.6 of 128 free" → "124 of 128 free"

## Test plan
- [x] `npm run build` passes
- [x] Verified listing page shows integer memory values ("5035 GB", "7049 GB")
- [x] Verified context detail nodes table shows integer CPU and memory ("124 of 128 free", "2001 of 2014 free")

🤖 Generated with [Claude Code](https://claude.com/claude-code)