### PR TITLE
[Dashboard] Replace node count asterisk with warning icon for unreachable contexts

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -404,7 +404,7 @@ export function InfrastructureSection({
                               </NonCapitalizedTooltip>
                               {contextErrors[context] && (
                                 <NonCapitalizedTooltip
-                                  content="Context unreachable"
+                                  content={`Context unreachable: ${contextErrors[context]}`}
                                   className="text-sm text-muted-foreground"
                                 >
                                   <AlertTriangleIcon className="w-4 h-4 text-yellow-500 flex-shrink-0" />


### PR DESCRIPTION
after:
<img width="1460" height="320" alt="Screenshot 2026-01-23 at 5 28 29 PM" src="https://github.com/user-attachments/assets/b07c1292-10ff-4074-9b84-d8205c991fe1" />
before:
<img width="1461" height="330" alt="Screenshot 2026-01-23 at 5 07 59 PM" src="https://github.com/user-attachments/assets/ae49b52d-eca2-4792-9ff9-9127cbd21c4c" />


## Summary
- Replaces the unclear "0*" notation in the Nodes column with a yellow warning icon (`AlertTriangleIcon`) next to the context name
- Warning icon has tooltip "Context unreachable" on hover
- Nodes column now always shows a plain number badge without asterisk or conditional styling

## Test plan
- [x] `npm run build` passes
- [x] Added fake unreachable context (`fake-unreachable` pointing to `https://nonexistent:6443`)
- [x] Verified yellow warning icon appears next to unreachable context name
- [x] Verified tooltip shows "Context unreachable" on hover
- [x] Verified Nodes column shows plain "0" (no asterisk)
- [x] Cleaned up test fixtures after verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)