### PR TITLE
[Dashboard] Fix service account expiry input not accepting 0

### DIFF
--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -2942,7 +2942,7 @@ function ServiceAccountTokensView({
                     placeholder="e.g., 30"
                     min="0"
                     max="365"
-                    value={newToken.expires_in_days || ''}
+                    value={newToken.expires_in_days ?? ''}
                     onChange={(e) =>
                       setNewToken({
                         ...newToken,


### PR DESCRIPTION
## Summary
- Fix the "Expiration (days)" input in the Create Service Account dialog not accepting `0` as a valid value

<img width="1640" height="998" alt="image" src="https://github.com/user-attachments/assets/4adf5402-997c-4ed9-a8fa-a0bee91de7a1" />

 
## Problem
When creating a service account token, users could not enter `0` for the expiration field. The UI states "Leave empty or enter 0 to never expire", but typing `0` would immediately clear the input.
 
## Root Cause
The input's `value` prop used JavaScript's `||` (OR) operator:
```jsx
value={newToken.expires_in_days || ''}
```

Since 0 is falsy in JavaScript, 0 || '' evaluates to '', causing the input to display empty instead of 0.

## Fix
Changed to the nullish coalescing operator ??:
```
value={newToken.expires_in_days ?? ''}
```
The ?? operator only returns the right-hand side for null or undefined, allowing 0 to be properly displayed and submitted.