### PR TITLE
[Helm] Fix global.imageRegistry to only apply to Docker Hub images

### DIFF
--- a/charts/skypilot/templates/_helpers.tpl
+++ b/charts/skypilot/templates/_helpers.tpl
@@ -35,6 +35,8 @@
 
 {{/*
 Resolve the image name, overriding the registry when global.imageRegistry is set.
+Only applies to Docker Hub images (those without an explicit registry prefix).
+Images from other registries (quay.io, gcr.io, etc.) are returned unchanged.
 Usage: {{ include "common.image" (dict "root" . "image" "repo/name:tag") }}
 */}}
 {{- define "common.image" -}}
@@ -43,13 +45,18 @@ Usage: {{ include "common.image" (dict "root" . "image" "repo/name:tag") }}
 {{- if $registry -}}
   {{- $imagePath := trimPrefix "/" $image -}}
   {{- $parts := splitList "/" $imagePath -}}
+  {{- $hasExplicitRegistry := false -}}
   {{- if gt (len $parts) 1 -}}
     {{- $first := index $parts 0 -}}
     {{- if or (contains "." $first) (contains ":" $first) (eq $first "localhost") -}}
-      {{- $imagePath = join "/" (slice $parts 1) -}}
+      {{- $hasExplicitRegistry = true -}}
     {{- end -}}
   {{- end -}}
-  {{- printf "%s/%s" (trimSuffix "/" $registry) $imagePath -}}
+  {{- if $hasExplicitRegistry -}}
+    {{- $image -}}
+  {{- else -}}
+    {{- printf "%s/%s" (trimSuffix "/" $registry) $imagePath -}}
+  {{- end -}}
 {{- else -}}
   {{- $image -}}
 {{- end -}}

--- a/charts/skypilot/tests/deployment_test.yaml
+++ b/charts/skypilot/tests/deployment_test.yaml
@@ -73,18 +73,19 @@ tests:
           value: registry.example.com/custom/berkeleyskypilot/skypilot-nightly:latest
 
 
-  - it: should replace original image registries when global registry override is set
+  - it: should NOT replace images that already have an explicit registry
     set:
       global.imageRegistry: registry.example.com/custom
       apiService.image: gcr.io/skypilot-dev/sky:dev
       apiService.logs.retention.enabled: true
     asserts:
+      # Images with explicit registry (gcr.io) should NOT be modified
       - equal:
           path: spec.template.spec.containers[0].image
-          value: registry.example.com/custom/skypilot-dev/sky:dev
+          value: gcr.io/skypilot-dev/sky:dev
       - equal:
           path: spec.template.spec.containers[1].image
-          value: registry.example.com/custom/skypilot-dev/sky:dev
+          value: gcr.io/skypilot-dev/sky:dev
 
   - it: should inject global extra envs into api containers and init containers
     set:

--- a/charts/skypilot/tests/oauth2_test.yaml
+++ b/charts/skypilot/tests/oauth2_test.yaml
@@ -324,6 +324,28 @@ tests:
         template: templates/oauth2-proxy-redis.yaml
         documentIndex: 0
 
+  - it: should NOT replace oauth2-proxy images that already have an explicit registry
+    set:
+      global.imageRegistry: harbor.example.com/docker-hub-proxy
+      auth.oauth.enabled: true
+      auth.oauth.oidc-issuer-url: "https://example.okta.com/oauth2/default"
+      auth.oauth.client-id: "test-client-id"
+      auth.oauth.client-secret: "test-client-secret"
+      # Use default images which have explicit registries (quay.io)
+      # These should NOT be replaced by global.imageRegistry
+    asserts:
+      # oauth2-proxy image from quay.io should NOT be modified
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0
+        template: templates/oauth2-proxy-deployment.yaml
+      # redis image (no explicit registry, Docker Hub) SHOULD be prefixed
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: harbor.example.com/docker-hub-proxy/redis:7-alpine
+        template: templates/oauth2-proxy-redis.yaml
+        documentIndex: 0
+
   - it: should not create oauth2-proxy ingress when using new auth config
     set:
       auth.oauth.enabled: true


### PR DESCRIPTION
## Summary
- Fix `global.imageRegistry` to only apply to Docker Hub images (those without an explicit registry prefix)
- Images from other registries (quay.io, gcr.io, localhost, etc.) are now preserved unchanged
- Add tests to verify the new behavior

Fixes #8680

## Test plan
- Updated existing helm unit test to verify images with explicit registries are NOT replaced
- Added new test case for oauth2-proxy that verifies:
  - `quay.io/oauth2-proxy/oauth2-proxy:v7.9.0` is unchanged when `global.imageRegistry` is set
  - `redis:7-alpine` (Docker Hub) is correctly prefixed with `global.imageRegistry`

Manual verification with `helm template`:
```bash
helm template skypilot charts/skypilot \
  --set global.imageRegistry=harbor.example.com/docker-hub-proxy \
  --set auth.oauth.enabled=true \
  | grep "image:"
```

Expected behavior:
- `berkeleyskypilot/skypilot` → `harbor.example.com/docker-hub-proxy/berkeleyskypilot/skypilot`
- `redis:7-alpine` → `harbor.example.com/docker-hub-proxy/redis:7-alpine`
- `quay.io/oauth2-proxy/oauth2-proxy:v7.9.0` → unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)