### PR TITLE
[Dashboard] Improve cluster detail and slurm context detail pages

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -753,19 +753,17 @@ export function ContextDetails({
                         Node
                       </th>
                       {!isSlurm && (
-                        <th className="p-3 text-left font-medium text-gray-600">
-                          IP Address
-                        </th>
-                      )}
-                      {!isSlurm && (
-                        <th className="p-3 text-left font-medium text-gray-600">
-                          vCPU
-                        </th>
-                      )}
-                      {!isSlurm && (
-                        <th className="p-3 text-left font-medium text-gray-600">
-                          Memory (GB)
-                        </th>
+                        <>
+                          <th className="p-3 text-left font-medium text-gray-600">
+                            IP Address
+                          </th>
+                          <th className="p-3 text-left font-medium text-gray-600">
+                            vCPU
+                          </th>
+                          <th className="p-3 text-left font-medium text-gray-600">
+                            Memory (GB)
+                          </th>
+                        </>
                       )}
                       <th className="p-3 text-left font-medium text-gray-600">
                         GPU
@@ -871,19 +869,17 @@ export function ContextDetails({
                             {node.node_name}
                           </td>
                           {!isSlurm && (
-                            <td className="p-3 whitespace-nowrap text-gray-700">
-                              {node.ip_address || '-'}
-                            </td>
-                          )}
-                          {!isSlurm && (
-                            <td className="p-3 whitespace-nowrap text-gray-700">
-                              {cpuDisplay}
-                            </td>
-                          )}
-                          {!isSlurm && (
-                            <td className="p-3 whitespace-nowrap text-gray-700">
-                              {memoryDisplay}
-                            </td>
+                            <>
+                              <td className="p-3 whitespace-nowrap text-gray-700">
+                                {node.ip_address || '-'}
+                              </td>
+                              <td className="p-3 whitespace-nowrap text-gray-700">
+                                {cpuDisplay}
+                              </td>
+                              <td className="p-3 whitespace-nowrap text-gray-700">
+                                {memoryDisplay}
+                              </td>
+                            </>
                           )}
                           <td className="p-3 whitespace-nowrap text-gray-700">
                             {node.gpu_name}

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -779,7 +779,7 @@ function ActiveTab({
         clusterData.full_infra.includes('Kubernetes') &&
         !clusterData.full_infra.includes('SSH') &&
         !clusterData.full_infra.includes('ssh') &&
-        !isGrafanaAvailable && (
+        isGrafanaAvailable && (
           <div className="mb-6">
             <div className="rounded-lg border bg-card text-card-foreground shadow-sm">
               <div


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Cluster detail - move jobs table above the GPU metrics
Slurm context detail - Change `Kubernetes` in the title to `Slurm`, hide ip address, cpu, and memory columns, hide GPU metrics


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
