### PR TITLE
[DO NOT MERGE][Kubernetes] Rename primary k8s container name to `skypilot-node`

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -1417,7 +1417,7 @@ Example:
                 medium: Memory
                 sizeLimit: 3Gi
 
-By default, SkyPilot automatically creates a single container named ``ray-node`` in the Pod. While you typically don't need to explicitly set the container name, if you do specify ``pod_config.spec.containers[0].name``, it must be set to ``ray-node``:
+By default, SkyPilot automatically creates a single container named ``skypilot-node`` in the Pod. Specify the container name to be ``skypilot-node`` to modify this automatically created container:
 
 .. code-block:: yaml
 
@@ -1425,8 +1425,12 @@ By default, SkyPilot automatically creates a single container named ``ray-node``
     pod_config:
       spec:
         containers:
-          - name: ray-node
+          - name: skypilot-node
             ...
+
+.. tip::
+
+  This container was previously named ``ray-node``. While using ``ray-node`` is also still supported, we encourage users to migrate to ``skypilot-node`` as it will be deprecated. SkyPilot will automatically rename ``ray-node`` to ``skypilot-node`` before launching.
 
 .. _config-yaml-kubernetes-kueue:
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -4023,7 +4023,7 @@ def open_ssh_tunnel(head_runner: Union[command_runner.SSHCommandRunner,
             # We did not observe this with real Kubernetes clusters.
             timeout = 5
             port_check_cmd = (
-                # We install netcat in our ray-node container,
+                # We install netcat in our skypilot-node container,
                 # so we can use it here.
                 # (See kubernetes-ray.yml.j2)
                 f'end=$((SECONDS+{timeout})); '

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2184,6 +2184,11 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
                     self.cluster_name)):
             self._update_cluster_info()
 
+        if (isinstance(self.launched_resources.cloud, clouds.Kubernetes) and
+                self.cached_cluster_info is not None and
+                self.cached_cluster_info.primary_container_name is None):
+            self._update_cluster_info()
+
         assert self.cached_cluster_info is not None, self
         runners = provision_lib.get_command_runners(
             self.cached_cluster_info.provider_name, self.cached_cluster_info,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2186,7 +2186,8 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
 
         if (isinstance(self.launched_resources.cloud, clouds.Kubernetes) and
                 self.cached_cluster_info is not None and
-                self.cached_cluster_info.primary_container_name is None):
+                any(infos[0].primary_container_name is None
+                    for infos in self.cached_cluster_info.instances.values())):
             self._update_cluster_info()
 
         assert self.cached_cluster_info is not None, self

--- a/sky/core.py
+++ b/sky/core.py
@@ -247,8 +247,13 @@ all_clusters, unmanaged_clusters, all_jobs, context
                 status_message += f's ({i + 1}/{len(jobs_controllers)})'
             spinner.update(f'{status_message}[/]')
             try:
+                primary_container = kubernetes_utils.get_pod_primary_container(
+                    pod)
+                primary_container_name = getattr(primary_container, 'name',
+                                                 None)
                 job_list = managed_jobs_core.queue_from_kubernetes_pod(
-                    pod.metadata.name)
+                    pod.metadata.name,
+                    primary_container_name=primary_container_name)
             except RuntimeError as e:
                 logger.warning('Failed to get managed jobs from controller '
                                f'{pod.metadata.name}: {str(e)}')

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -729,18 +729,18 @@ def queue_from_kubernetes_pod(
     provider_config = {'context': context}
     instances = {
         pod_name: [
-            provision_common.InstanceInfo(instance_id=pod_name,
-                                          internal_ip='',
-                                          external_ip='',
-                                          tags={})
+            provision_common.InstanceInfo(
+                instance_id=pod_name,
+                internal_ip='',
+                external_ip='',
+                tags={},
+                primary_container_name=primary_container_name)
         ]
     }  # Internal IP is not required for Kubernetes
-    cluster_info = provision_common.ClusterInfo(
-        provider_name='kubernetes',
-        head_instance_id=pod_name,
-        provider_config=provider_config,
-        instances=instances,
-        primary_container_name=primary_container_name)
+    cluster_info = provision_common.ClusterInfo(provider_name='kubernetes',
+                                                head_instance_id=pod_name,
+                                                provider_config=provider_config,
+                                                instances=instances)
     managed_jobs_runner = provision_lib.get_command_runners(
         'kubernetes', cluster_info)[0]
 

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -694,12 +694,14 @@ def launch(
 
 def queue_from_kubernetes_pod(
         pod_name: str,
+        primary_container_name: Optional[str] = None,
         context: Optional[str] = None,
         skip_finished: bool = False) -> List[Dict[str, Any]]:
     """Gets the jobs queue from a specific controller pod.
 
     Args:
         pod_name (str): The name of the controller pod to query for jobs.
+        primary_container_name (str): The name of the SkyPilot container.
         context (Optional[str]): The Kubernetes context to use. If None, the
             current context is used.
         skip_finished (bool): If True, does not return finished jobs.
@@ -733,10 +735,12 @@ def queue_from_kubernetes_pod(
                                           tags={})
         ]
     }  # Internal IP is not required for Kubernetes
-    cluster_info = provision_common.ClusterInfo(provider_name='kubernetes',
-                                                head_instance_id=pod_name,
-                                                provider_config=provider_config,
-                                                instances=instances)
+    cluster_info = provision_common.ClusterInfo(
+        provider_name='kubernetes',
+        head_instance_id=pod_name,
+        provider_config=provider_config,
+        instances=instances,
+        primary_container_name=primary_container_name)
     managed_jobs_runner = provision_lib.get_command_runners(
         'kubernetes', cluster_info)[0]
 

--- a/sky/provision/common.py
+++ b/sky/provision/common.py
@@ -121,6 +121,8 @@ class InstanceInfo:
     ssh_port: int = 22
     # The internal service address of the instance on Kubernetes.
     internal_svc: Optional[str] = None
+    # Primary (skypilot-node) container name on Kubernetes.
+    primary_container_name: Optional[str] = None
 
     def get_feasible_ip(self) -> str:
         """Get the most feasible IPs of the instance. This function returns
@@ -145,8 +147,6 @@ class ClusterInfo:
     # Override the ssh_user from the cluster config.
     ssh_user: Optional[str] = None
     custom_ray_options: Optional[Dict[str, Any]] = None
-
-    primary_container_name: Optional[str] = None
 
     @property
     def num_instances(self) -> int:

--- a/sky/provision/common.py
+++ b/sky/provision/common.py
@@ -146,6 +146,8 @@ class ClusterInfo:
     ssh_user: Optional[str] = None
     custom_ray_options: Optional[Dict[str, Any]] = None
 
+    primary_container_name: Optional[str] = None
+
     @property
     def num_instances(self) -> int:
         """Get the number of instances in the cluster."""

--- a/sky/provision/kubernetes/constants.py
+++ b/sky/provision/kubernetes/constants.py
@@ -72,7 +72,9 @@ TAG_POD_INITIALIZED = 'skypilot-initialized'
 TAG_SKYPILOT_DEPLOYMENT_NAME = 'skypilot-deployment-name'
 
 # Default name of the primary workload container in SkyPilot Ray pods.
-RAY_NODE_CONTAINER_NAME = 'ray-node'
+SKYPILOT_NODE_CONTAINER_NAME = 'skypilot-node'
+# TODO (kyuds): remove legacy container name and backwards compat code v0.13.0.
+LEGACY_NODE_CONTAINER_NAME = 'ray-node'
 
 # Pod phases that are not holding PVCs
 PVC_NOT_HOLD_POD_PHASES = ['Succeeded', 'Failed']

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -896,7 +896,7 @@ def pre_init(namespace: str, context: Optional[str], new_nodes: List) -> None:
         logger.info(f'{"-"*20}Start: Pre-init in pod {pod_name!r} {"-"*20}')
         runner = command_runner.KubernetesCommandRunner(
             ((namespace, context), pod_name),
-            container=k8s_constants.RAY_NODE_CONTAINER_NAME)
+            container=k8s_constants.SKYPILOT_NODE_CONTAINER_NAME)
 
         # Run the combined pre-init command
         rc, stdout, _ = runner.run(pre_init_cmd,
@@ -968,7 +968,7 @@ def _create_namespaced_pod_with_retries(namespace: str, pod_spec: dict,
             # Remove the AppArmor annotation
             annotations = pod_spec.get('metadata', {}).get('annotations', {})
             apparmor_key = ('container.apparmor.security.beta.kubernetes.io/'
-                            f'{k8s_constants.RAY_NODE_CONTAINER_NAME}')
+                            f'{k8s_constants.SKYPILOT_NODE_CONTAINER_NAME}')
             if apparmor_key in annotations:
                 del annotations[apparmor_key]
                 pod_spec['metadata']['annotations'] = annotations
@@ -1615,7 +1615,7 @@ def get_cluster_info(
     assert head_pod_name is not None
     runner = command_runner.KubernetesCommandRunner(
         ((namespace, context), head_pod_name),
-        container=k8s_constants.RAY_NODE_CONTAINER_NAME)
+        container=k8s_constants.SKYPILOT_NODE_CONTAINER_NAME)
     rc, stdout, stderr = runner.run(get_k8s_ssh_user_cmd,
                                     require_outputs=True,
                                     separate_stderr=True,
@@ -2120,7 +2120,7 @@ def get_command_runners(
         head_runner = command_runner.KubernetesCommandRunner(
             node_list[0],
             deployment=deployment,
-            container=k8s_constants.RAY_NODE_CONTAINER_NAME,
+            container=k8s_constants.SKYPILOT_NODE_CONTAINER_NAME,
             **credentials)
         runners.append(head_runner)
 
@@ -2130,7 +2130,7 @@ def get_command_runners(
     runners.extend(
         command_runner.KubernetesCommandRunner.make_runner_list(
             node_list,
-            container=k8s_constants.RAY_NODE_CONTAINER_NAME,
+            container=k8s_constants.SKYPILOT_NODE_CONTAINER_NAME,
             **credentials))
 
     return runners

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -2129,10 +2129,9 @@ def get_command_runners(
             **credentials)
         runners.append(head_runner)
 
-    node_list = [((namespace, context), pod_name)
-                 for pod_name in instances.keys()
-                 if pod_name != cluster_info.head_instance_id]
     for pod_name, instance_info in instances.items():
+        if pod_name == cluster_info.head_instance_id:
+            continue
         node_list = [((namespace, context), pod_name)]
         container = instance_info[0].primary_container_name
         runner = command_runner.KubernetesCommandRunner(node_list[0],

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1595,8 +1595,7 @@ def get_cluster_info(
             head_spec = pod.spec
             assert head_spec is not None, pod
             primary_container = kubernetes_utils.get_pod_primary_container(pod)
-            primary_container_name = getattr(primary_container_name, 'name',
-                                             None)
+            primary_container_name = getattr(primary_container, 'name', None)
             resources = getattr(primary_container, 'resources', None)
             requests = (getattr(resources, 'requests', None)
                         if resources else None)

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -3764,7 +3764,7 @@ class KubernetesSkyPilotClusterInfoPayload:
         )
 
 
-def get_pod_primary_container(
+def get_pod_primary_container(  # pylint: disable=dangerous-default-value
     pod: Any,
     *,
     primary_name_candidates: List[str] = [

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2893,15 +2893,16 @@ def combine_pod_config_fields(
         context_str = context[len('ssh-'):]
 
     def _modify_skypilot_container_name(pod_config):
+        skypilot_container = kubernetes_constants.SKYPILOT_NODE_CONTAINER_NAME
+
         containers = pod_config.get('spec', {}).get('containers', [])
         found_primary_container_names = 0
         for container in containers:
             name = container.get('name')
             if name == kubernetes_constants.LEGACY_NODE_CONTAINER_NAME:
-                container[
-                    'name'] = kubernetes_constants.SKYPILOT_NODE_CONTAINER_NAME
+                container['name'] = skypilot_container
                 found_primary_container_names += 1
-            elif name == kubernetes_constants.SKYPILOT_NODE_CONTAINER_NAME:
+            elif name == skypilot_container:
                 found_primary_container_names += 1
         if found_primary_container_names > 1:
             with ux_utils.print_exception_no_traceback():

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2904,9 +2904,11 @@ def combine_pod_config_fields(
             elif name == kubernetes_constants.SKYPILOT_NODE_CONTAINER_NAME:
                 found_primary_container_names += 1
         if found_primary_container_names > 1:
-            raise ValueError('Kubernetes `pod_config` should only modify the SkyPilot '
-                             'container using either the name `skypilot-node` or '
-                             '`ray-node`. Refer to https://docs.skypilot.co/en/latest/reference/config.html#kubernetes-pod-config for more details.')  # pylint: disable=line-too-long
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError('Kubernetes `pod_config` should only modify '
+                                 'the SkyPilot container using either '
+                                 '`skypilot-node` or `ray-node`. Refer to '
+                                 'https://docs.skypilot.co/en/latest/reference/config.html#kubernetes-pod-config for more details.')  # pylint: disable=line-too-long
 
     kubernetes_config = skypilot_config.get_effective_region_config(
         cloud=cloud_str,

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2882,6 +2882,7 @@ def combine_pod_config_fields(
                     - name: my-secret
         ```
     """
+
     merged_cluster_yaml_obj = copy.deepcopy(cluster_yaml_obj)
     # We don't use override_configs in `get_effective_region_config`, as merging
     # the pod config requires special handling.
@@ -2890,17 +2891,36 @@ def combine_pod_config_fields(
     if isinstance(cloud, clouds.SSH) and context is not None:
         assert context.startswith('ssh-'), 'SSH context must start with "ssh-"'
         context_str = context[len('ssh-'):]
+
+    def _modify_skypilot_container_name(pod_config):
+        containers = pod_config.get('spec', {}).get('containers', [])
+        found_primary_container_names = 0
+        for container in containers:
+            name = container.get('name')
+            if name == kubernetes_constants.LEGACY_NODE_CONTAINER_NAME:
+                container[
+                    'name'] = kubernetes_constants.SKYPILOT_NODE_CONTAINER_NAME
+                found_primary_container_names += 1
+            elif name == kubernetes_constants.SKYPILOT_NODE_CONTAINER_NAME:
+                found_primary_container_names += 1
+        if found_primary_container_names > 1:
+            raise ValueError('Kubernetes `pod_config` should only modify the SkyPilot '
+                             'container using either the name `skypilot-node` or '
+                             '`ray-node`. Refer to https://docs.skypilot.co/en/latest/reference/config.html#kubernetes-pod-config for more details.')  # pylint: disable=line-too-long
+
     kubernetes_config = skypilot_config.get_effective_region_config(
         cloud=cloud_str,
         region=context_str,
         keys=('pod_config',),
         default_value={})
+    _modify_skypilot_container_name(kubernetes_config)
     override_pod_config = config_utils.get_cloud_config_value_from_dict(
         dict_config=cluster_config_overrides,
         cloud=cloud_str,
         region=context_str,
         keys=('pod_config',),
         default_value={})
+    _modify_skypilot_container_name(override_pod_config)
     config_utils.merge_k8s_configs(kubernetes_config, override_pod_config)
 
     # Merge the kubernetes config into the YAML for both head and worker nodes.
@@ -3744,7 +3764,7 @@ class KubernetesSkyPilotClusterInfoPayload:
 def get_pod_primary_container(
     pod: Any,
     *,
-    primary_name: str = kubernetes_constants.RAY_NODE_CONTAINER_NAME,
+    primary_name_candidates: Optional[List[str]] = None,
 ):
     """Return the primary workload container for a SkyPilot pod.
 
@@ -3752,14 +3772,23 @@ def get_pod_primary_container(
     ordering of the `containers` list as authored, but mutating webhooks can
     inject additional containers. Callers should not rely on containers[0].
     """
+    if not primary_name_candidates:
+        # For backwards compatibility, SkyPilot pod can be named either
+        # skypilot-node or ray-node (legacy).
+        primary_name_candidates = [
+            kubernetes_constants.SKYPILOT_NODE_CONTAINER_NAME,
+            kubernetes_constants.LEGACY_NODE_CONTAINER_NAME
+        ]
+
     spec = getattr(pod, 'spec', None)
     containers = getattr(spec, 'containers', None) if spec is not None else None
     if not containers:
         pod_name = getattr(getattr(pod, 'metadata', None), 'name', '<unknown>')
         raise ValueError(f'Pod {pod_name!r} has no containers.')
-    for container in containers:
-        if getattr(container, 'name', None) == primary_name:
-            return container
+    for primary_name in primary_name_candidates:
+        for container in containers:
+            if getattr(container, 'name', None) == primary_name:
+                return container
     return containers[0]
 
 

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -505,7 +505,7 @@ available_node_types:
             path: /home/kubernetes/bin/gib
         {% endif %}
         containers:
-        - name: ray-node
+        - name: skypilot-node
           imagePullPolicy: Always
           image: {{image_id}}
           env:
@@ -516,12 +516,12 @@ available_node_types:
             - name: SKYPILOT_POD_CPU_CORE_LIMIT
               valueFrom:
                 resourceFieldRef:
-                  containerName: ray-node
+                  containerName: skypilot-node
                   resource: requests.cpu
             - name: SKYPILOT_POD_MEMORY_BYTES_LIMIT
               valueFrom:
                 resourceFieldRef:
-                  containerName: ray-node
+                  containerName: skypilot-node
                   resource: requests.memory
             # Disable Ray memory monitor to prevent Ray's memory manager
             # from interfering with kubernetes resource manager.

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -1308,7 +1308,7 @@ class KubernetesCommandRunner(CommandRunner):
                 `kubectl exec -c <container>`. This is recommended for
                 multi-container pods (e.g., when sidecars are injected) to
                 ensure commands target the primary workload container (such as
-                `ray-node`).
+                `skypilot-node`).
         """
         del kwargs
         super().__init__(node)

--- a/sky/utils/kubernetes/rsync_helper.sh
+++ b/sky/utils/kubernetes/rsync_helper.sh
@@ -31,7 +31,7 @@ echo "namespace: $namespace" >&2
 context=$(echo $namespace_context | grep '+' >/dev/null && echo $namespace_context | cut -d+ -f2- || echo "")
 echo "context: $context" >&2
 context_lower=$(echo "$context" | tr '[:upper:]' '[:lower:]')
-container="${SKYPILOT_K8S_EXEC_CONTAINER:-ray-node}"
+container="${SKYPILOT_K8S_EXEC_CONTAINER:-skypilot-node}"
 echo "container: $container" >&2
 
 # Check if the resource is a pod or a deployment (or other type)

--- a/tests/kubernetes/scripts/ray_k8s_sky.yaml
+++ b/tests/kubernetes/scripts/ray_k8s_sky.yaml
@@ -136,7 +136,7 @@ available_node_types:
           emptyDir:
             medium: Memory
         containers:
-        - name: ray-node
+        - name: skypilot-node
           imagePullPolicy: Never
           image: skypilot:latest
           command: ["/bin/bash", "-c", "--"]
@@ -199,7 +199,7 @@ available_node_types:
           emptyDir:
             medium: Memory
         containers:
-        - name: ray-node
+        - name: skypilot-node
           imagePullPolicy: Never
           image: skypilot:latest
           # Do not change this command - it keeps the pod alive until it is

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2829,8 +2829,8 @@ def test_kubernetes_pod_config_sidecar():
     This test verifies that SkyPilot correctly handles pods with multiple
     containers (sidecars) by:
     1. Launching a cluster with a sidecar container via pod_config
-    2. Verifying the pod has both ray-node and sidecar containers
-    3. Verifying sky exec commands run in the ray-node container
+    2. Verifying the pod has both skypilot-node and sidecar containers
+    3. Verifying sky exec commands run in the skypilot-node container
     4. Verifying the sidecar container is running
     """
     name = smoke_tests_utils.get_cluster_name()
@@ -2856,14 +2856,14 @@ def test_kubernetes_pod_config_sidecar():
                 # Launch SkyPilot cluster with sidecar
                 f'sky launch -y -c {name} --infra kubernetes '
                 f'{smoke_tests_utils.LOW_RESOURCE_ARG} {task_yaml_path}',
-                # Verify pod has 2 containers (ray-node and sidecar)
+                # Verify pod has 2 containers (skypilot-node and sidecar)
                 smoke_tests_utils.run_cloud_cmd_on_cluster(
                     name,
                     f'kubectl get pod -l skypilot-cluster-name={name_on_cloud} '
                     '-o jsonpath=\'{.items[0].spec.containers[*].name}\' | '
-                    'grep -E "ray-node.*sidecar|sidecar.*ray-node"'),
-                # Verify sky exec runs in ray-node container
-                f'sky exec {name} "echo CONTAINER_CHECK: ray-node is working"',
+                    'grep -E "skypilot-node.*sidecar|sidecar.*skypilot-node"'),
+                # Verify sky exec runs in skypilot-node container
+                f'sky exec {name} "echo CONTAINER_CHECK: skypilot-node is working"',
                 # Verify sidecar is running
                 smoke_tests_utils.run_cloud_cmd_on_cluster(
                     name,

--- a/tests/test_yamls/test_k8s_ephemeral_storage_eviction.yaml
+++ b/tests/test_yamls/test_k8s_ephemeral_storage_eviction.yaml
@@ -11,7 +11,7 @@ config:
     pod_config:
       spec:
         containers:
-          - name: ray-node
+          - name: skypilot-node
             resources:
               requests:
                 ephemeral-storage: "100Mi"

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -427,7 +427,7 @@ def test_pod_termination_reason_start_error(monkeypatch):
 
     # Container with StartError
     container_status = mock.MagicMock()
-    container_status.name = 'ray-node'
+    container_status.name = 'skypilot-node'
     container_status.state.terminated = mock.MagicMock()
     container_status.state.terminated.exit_code = 128
     container_status.state.terminated.reason = 'StartError'
@@ -464,7 +464,7 @@ def test_pod_termination_reason_kueue_preemption(monkeypatch):
     ready_condition = mock.MagicMock()
     ready_condition.type = 'Ready'
     ready_condition.reason = 'ContainersNotReady'
-    ready_condition.message = 'containers with unready status: [ray-node]'
+    ready_condition.message = 'containers with unready status: [skypilot-node]'
     ready_condition.last_transition_time = now
 
     # Taken from an actual Pod that got preempted by Kueue.
@@ -489,7 +489,7 @@ def test_pod_termination_reason_kueue_preemption(monkeypatch):
     expected = (
         'Preempted by Kueue: WorkloadEvictedDueToPodsReadyTimeout '
         '(Exceeded the PodsReady timeout default/test-pod).\n'
-        'Last known state: ContainersNotReady (containers with unready status: [ray-node]).'
+        'Last known state: ContainersNotReady (containers with unready status: [skypilot-node]).'
     )
     assert reason == expected
 
@@ -522,7 +522,7 @@ def test_pod_termination_reason_null_finished_at(monkeypatch):
 
     # Container with terminated state but null finished_at
     container_status = mock.MagicMock()
-    container_status.name = 'ray-node'
+    container_status.name = 'skypilot-node'
     container_status.state.terminated = mock.MagicMock()
     container_status.state.terminated.exit_code = 137
     container_status.state.terminated.reason = 'Unknown'

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes.py
@@ -1236,7 +1236,7 @@ class TestKubernetesSecurityContext(unittest.TestCase):
                         'kind': 'Pod',
                         'spec': {
                             'containers': [{
-                                'name': 'ray-node',
+                                'name': 'skypilot-node',
                                 'image': 'test-image',
                                 'securityContext': {
                                     'capabilities': {
@@ -1307,7 +1307,7 @@ class TestKubernetesSecurityContext(unittest.TestCase):
                         'kind': 'Pod',
                         'spec': {
                             'containers': [{
-                                'name': 'ray-node',
+                                'name': 'skypilot-node',
                                 'image': 'test-image'
                                 # No securityContext initially
                             }]
@@ -1382,7 +1382,7 @@ class TestKubernetesVolumeMerging(unittest.TestCase):
                                 }
                             }],
                             'containers': [{
-                                'name': 'ray-node',
+                                'name': 'skypilot-node',
                                 'image': 'test-image',
                                 'volumeMounts': [{
                                     'mountPath': '/dev/shm',

--- a/tests/unit_tests/test_sky/utils/test_command_runner.py
+++ b/tests/unit_tests/test_sky/utils/test_command_runner.py
@@ -317,13 +317,13 @@ def test_kubernetes_runner_adds_container_flag_to_kubectl_exec() -> None:
     with mock.patch.object(command_runner.log_lib,
                            'run_with_log',
                            side_effect=fake_run_with_log):
-        runner = command_runner.KubernetesCommandRunner((('ns', 'ctx'), 'pod'),
-                                                        container='ray-node')
+        runner = command_runner.KubernetesCommandRunner(
+            (('ns', 'ctx'), 'pod'), container='skypilot-node')
         runner.run('echo hello', require_outputs=True, stream_logs=False)
 
     assert 'kubectl exec' in captured['command']
     assert 'pod/pod' in captured['command']
-    assert '-c ray-node' in captured['command']
+    assert '-c skypilot-node' in captured['command']
 
 
 def test_kubernetes_runner_rsync_sets_exec_container_envvar() -> None:
@@ -367,7 +367,7 @@ def test_get_pod_primary_container_prefers_ray_node() -> None:
     sidecar = mock.MagicMock()
     sidecar.name = 'sidecar'
     primary = mock.MagicMock()
-    primary.name = 'ray-node'
+    primary.name = 'skypilot-node'
 
     pod = mock.MagicMock()
     pod.metadata.name = 'p'
@@ -380,9 +380,9 @@ def test_get_pod_primary_container_falls_back_to_first_container() -> None:
     from sky.provision.kubernetes import utils as kubernetes_utils
 
     c0 = mock.MagicMock()
-    c0.name = 'not-ray-node'
+    c0.name = 'not-skypilot-node'
     c1 = mock.MagicMock()
-    c1.name = 'also-not-ray-node'
+    c1.name = 'also-not-skypilot-node'
 
     pod = mock.MagicMock()
     pod.metadata.name = 'p'

--- a/tests/unit_tests/test_sky/utils/test_config_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_config_utils.py
@@ -647,7 +647,7 @@ def test_merge_k8s_configs_with_sidecar_containers():
     base_config = {
         'spec': {
             'containers': [{
-                'name': 'ray-node',
+                'name': 'skypilot-node',
                 'image': 'rayproject/ray:latest',
                 'command': ['/bin/bash', '-c', '--'],
                 'args': ['echo hello'],
@@ -682,8 +682,8 @@ def test_merge_k8s_configs_with_sidecar_containers():
     containers = base_config['spec']['containers']
     assert len(containers) == 2
 
-    # Verify ray-node container is preserved
-    ray_node = next(c for c in containers if c['name'] == 'ray-node')
+    # Verify skypilot-node container is preserved
+    ray_node = next(c for c in containers if c['name'] == 'skypilot-node')
     assert ray_node['image'] == 'rayproject/ray:latest'
     assert ray_node['command'] == ['/bin/bash', '-c', '--']
     assert ray_node['resources']['requests']['cpu'] == '2'
@@ -699,7 +699,7 @@ def test_merge_k8s_configs_with_sidecar_and_primary_container_override():
     base_config = {
         'spec': {
             'containers': [{
-                'name': 'ray-node',
+                'name': 'skypilot-node',
                 'image': 'rayproject/ray:latest',
                 'resources': {
                     'requests': {
@@ -714,7 +714,7 @@ def test_merge_k8s_configs_with_sidecar_and_primary_container_override():
         'spec': {
             'containers': [
                 {
-                    'name': 'ray-node',  # Override primary container
+                    'name': 'skypilot-node',  # Override primary container
                     'resources': {
                         'limits': {
                             'cpu': '4',
@@ -735,8 +735,8 @@ def test_merge_k8s_configs_with_sidecar_and_primary_container_override():
     containers = base_config['spec']['containers']
     assert len(containers) == 2
 
-    # Verify ray-node container is merged (not replaced)
-    ray_node = next(c for c in containers if c['name'] == 'ray-node')
+    # Verify skypilot-node container is merged (not replaced)
+    ray_node = next(c for c in containers if c['name'] == 'skypilot-node')
     assert ray_node['image'] == 'rayproject/ray:latest'  # Preserved
     assert ray_node['resources']['requests']['cpu'] == '2'  # Preserved
     assert ray_node['resources']['limits']['cpu'] == '4'  # Added from override


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Reimplementation of #8673.

Some caveats:
- Users cannot have `pod_config` that defines BOTH `skypilot-node` and `ray-node` in the same config file. We don't expect this to happen anyways, and this will only be the case prior to deprecation.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
