### PR TITLE
[Slurm] Fix auth section on cluster yaml and generated local private key

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1515,23 +1515,6 @@ def wait_until_ray_cluster_ready(
     return True, docker_user  # success
 
 
-def _get_ssh_control_name(config: Dict[str, Any]) -> str:
-    ssh_provider_module = config['provider']['module']
-    ssh_control_name = config.get('cluster_name',
-                                  command_runner.DEFAULT_SSH_CONTROL_NAME)
-    if 'slurm' in ssh_provider_module:
-        # For Slurm, multiple SkyPilot clusters may share the same underlying
-        # Slurm login node. By using a fixed ssh_control_name ('__default__'),
-        # we ensure that all connections to the same login node reuse the same
-        # SSH ControlMaster process, avoiding repeated SSH handshakes.
-        #
-        # The %C token in ControlPath (see ssh_options_list) ensures that
-        # connections to different login nodes use different sockets, avoiding
-        # collisions between different Slurm clusters.
-        ssh_control_name = command_runner.DEFAULT_SSH_CONTROL_NAME
-    return ssh_control_name
-
-
 def ssh_credential_from_yaml(
     cluster_yaml: Optional[str],
     docker_user: Optional[str] = None,
@@ -1552,7 +1535,7 @@ def ssh_credential_from_yaml(
     if ssh_user is None:
         ssh_user = auth_section['ssh_user'].strip()
     ssh_private_key_path = auth_section.get('ssh_private_key')
-    ssh_control_name = _get_ssh_control_name(config)
+    ssh_control_name = config.get('cluster_name', '__default__')
     ssh_proxy_command = auth_section.get('ssh_proxy_command')
 
     # Update the ssh_user placeholder in proxy command, if required
@@ -1606,7 +1589,7 @@ def ssh_credentials_from_handles(
         if ssh_user is None:
             ssh_user = auth_section['ssh_user'].strip()
         ssh_private_key_path = auth_section.get('ssh_private_key')
-        ssh_control_name = _get_ssh_control_name(config)
+        ssh_control_name = config.get('cluster_name', '__default__')
         ssh_proxy_command = auth_section.get('ssh_proxy_command')
 
         # Update the ssh_user placeholder in proxy command, if required

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -3,7 +3,7 @@
 import tempfile
 import textwrap
 import time
-from typing import Any, cast, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from sky import sky_logging
 from sky import skypilot_config
@@ -440,7 +440,6 @@ def get_cluster_info(
         return common.ClusterInfo(
             instances={},
             head_instance_id=None,
-            ssh_user=ssh_user,
             provider_name='slurm',
             provider_config=provider_config,
         )
@@ -471,7 +470,6 @@ def get_cluster_info(
     return common.ClusterInfo(
         instances=instances,
         head_instance_id=slurm_utils.instance_id(job_id, nodes[0]),
-        ssh_user=ssh_user,
         provider_name='slurm',
         provider_config=provider_config,
     )
@@ -585,6 +583,9 @@ def get_command_runners(
     **credentials: Dict[str, Any],
 ) -> List[command_runner.SlurmCommandRunner]:
     """Get a command runner for the given cluster."""
+    # For Slurm, we use the login node credentials from provider_config['ssh']
+    # instead of `credentials` which is for ssh'ing to the SkyPilot cluster.
+    del credentials
     assert cluster_info.provider_config is not None, cluster_info
 
     if cluster_info.head_instance_id is None:
@@ -602,26 +603,40 @@ def get_command_runners(
         instance_infos[0] for instance_infos in cluster_info.instances.values()
     ]
 
-    # Note: For Slurm, the external IP for all instances is the same,
-    # it is the login node's. The internal IP is the private IP of the node.
-    ssh_user = cast(str, credentials.pop('ssh_user'))
-    ssh_private_key = cast(str, credentials.pop('ssh_private_key'))
-    # ssh_proxy_jump is Slurm-specific, it does not exist in the auth section
-    # of the cluster yaml.
-    ssh_proxy_jump = cluster_info.provider_config.get('ssh', {}).get(
-        'proxyjump', None)
+    provider_config = cluster_info.provider_config
+
+    # Get login node SSH credentials.
+    login_node_ssh_config = provider_config['ssh']
+    login_node_ssh_user = login_node_ssh_config['user']
+    login_node_ssh_private_key = login_node_ssh_config['private_key']
+    login_node_ssh_proxy_command = login_node_ssh_config.get(
+        'proxycommand', None)
+    login_node_ssh_proxy_jump = login_node_ssh_config.get('proxyjump', None)
+    # For Slurm, multiple SkyPilot clusters may share the same underlying
+    # Slurm login node. By using a fixed ssh_control_name ('__default__'),
+    # we ensure that all connections to the same login node reuse the same
+    # SSH ControlMaster process, avoiding repeated SSH handshakes.
+    #
+    # The %C token in ControlPath (see ssh_options_list) ensures that
+    # connections to different login nodes use different sockets, avoiding
+    # collisions between different Slurm clusters.
+    ssh_control_name = command_runner.DEFAULT_SSH_CONTROL_NAME
+
     runners = [
+        # Note: For Slurm, the external IP for all instances is the same,
+        # it is the login node's. The internal IP is the private IP of the node.
         command_runner.SlurmCommandRunner(
             (instance_info.external_ip or '', instance_info.ssh_port),
-            ssh_user,
-            ssh_private_key,
+            login_node_ssh_user,
+            login_node_ssh_private_key,
             sky_dir=_sky_cluster_home_dir(cluster_name_on_cloud),
             skypilot_runtime_dir=_skypilot_runtime_dir(cluster_name_on_cloud),
             job_id=instance_info.tags['job_id'],
             slurm_node=instance_info.tags['node'],
-            ssh_proxy_jump=ssh_proxy_jump,
-            enable_interactive_auth=True,
-            **credentials) for instance_info in instances
+            ssh_proxy_jump=login_node_ssh_proxy_jump,
+            ssh_proxy_command=login_node_ssh_proxy_command,
+            ssh_control_name=ssh_control_name,
+            enable_interactive_auth=True) for instance_info in instances
     ]
 
     return runners

--- a/sky/templates/slurm-ray.yml.j2
+++ b/sky/templates/slurm-ray.yml.j2
@@ -26,15 +26,7 @@ provider:
 
 auth:
   ssh_user: {{ssh_user}}
-  # TODO(jwj,kevin): Modify this tmp workaround.
-  # Right now there's a chicken-and-egg problem:
-  # 1. ssh_credential_from_yaml reads from the auth.ssh_private_key: ~/.sky/clients/.../ssh/sky-key
-  # 2. This is SkyPilot's generated key, not the Slurm cluster's key
-  # 3. The internal_file_mounts stage tries to rsync using sky-key, but its public key isn't on the remote yet
-  # 4. The public key only gets added by setup_commands, which runs AFTER file_mounts
-  # ssh_private_key: {{ssh_private_key}}
-  ssh_private_key: {{slurm_private_key}}
-  ssh_proxy_command: {{slurm_proxy_command | tojson }}
+  ssh_private_key: {{ssh_private_key}}
 
 available_node_types:
   ray_head_default:


### PR DESCRIPTION
Routine cleanup. Technically not a problem for master, but needed for container support #8604, as the `~/.ssh/authorized_keys` differs between the login node and inside the container.

Previously, we had a TODO to fix a workaround where we did:
```yaml
# Slurm cluster yaml
provider:
  ssh:
    user: kevin
    private_key: ~/.ssh/id_rsa
auth:
  ssh_user: kevin
  private_key: ~/.ssh/id_rsa # Should be ~/.sky/clients/7a2eebbf/ssh/sky-key instead
```

For non containers, this isn't a problem because both the user's public key (i.e. `~/.ssh/id_rsa.pub`) and the SkyPilot cluster's public key is going to be in the user's `~/.ssh/authorized_keys`. So it works, but it's not 100% intended. In other words, before this PR:

```bash
# The generated local cluster key should be the same as sky-key, but it isn't
% diff <(cat ~/.sky/clients/7a2eebbf/ssh/sky-key) <(cat ~/.sky/generated/ssh-keys/sky-af35-kevin.key) > /dev/null
% echo $?
1
# Instead, it is the same as ~/.ssh/id_rsa (which is the private key for the Slurm login node of this cluster)
% diff <(cat ~/.ssh/id_rsa) <(cat ~/.sky/generated/ssh-keys/sky-af35-kevin.key)
% echo $?
0
```

After:
```bash
# Now, it is the same as sky-key
% diff <(cat ~/.sky/clients/7a2eebbf/ssh/sky-key) <(cat ~/.sky/generated/ssh-keys/ssh1.key)
% echo $?
0
```

For containers, the user inside the container will be `root`, and thus when we ssh, we will be reading `/root/.ssh/authorized_keys`, which will only have the public key of the generated `sky-key` and thus we will get an auth error.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
