### PR TITLE
add lighting ai to networkbest

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -1238,6 +1238,10 @@ class Kubernetes(clouds.Cloud):
                             return (
                                 KubernetesHighPerformanceNetworkType.TOGETHER,
                                 None)
+                        if label_key.startswith('lightning.ai/'):
+                            return (
+                                KubernetesHighPerformanceNetworkType.LIGHTNING_AI,
+                                None)
                         if label_key.startswith('k8s.io/cloud-provider-aws'):
                             network_type = (
                                 KubernetesHighPerformanceNetworkType.AWS_EFA)

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -82,6 +82,8 @@ class KubernetesHighPerformanceNetworkType(enum.Enum):
     - NEBIUS: Nebius clusters with InfiniBand support for high-throughput,
       low-latency networking
     - COREWEAVE: CoreWeave clusters with InfiniBand support.
+    - LIGHTNING_AI: Lightning AI clusters with InfiniBand support for
+      high-performance networking
     - NONE: Standard clusters without specialized networking optimizations
 
     The network configurations align with corresponding VM-based
@@ -97,6 +99,7 @@ class KubernetesHighPerformanceNetworkType(enum.Enum):
     NEBIUS = 'nebius'
     COREWEAVE = 'coreweave'
     TOGETHER = 'together'
+    LIGHTNING_AI = 'lightning_ai'
     AWS_EFA = 'aws_efa'
     NONE = 'none'
 
@@ -121,6 +124,13 @@ class KubernetesHighPerformanceNetworkType(enum.Enum):
                 'NCCL_SOCKET_IFNAME': 'eth0',
                 'NCCL_IB_HCA': 'ibp',
                 # Restrict UCX to TCP to avoid unneccsary errors. NCCL doesn't use UCX
+                'UCX_TLS': 'tcp',
+                'UCX_NET_DEVICES': 'eth0',
+            }
+        elif self == KubernetesHighPerformanceNetworkType.LIGHTNING_AI:
+            # Lightning AI cluster with InfiniBand - use InfiniBand optimizations
+            return {
+                'NCCL_IB_HCA': 'mlx5',
                 'UCX_TLS': 'tcp',
                 'UCX_NET_DEVICES': 'eth0',
             }


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
I believe this add the ability to do infiniband with lightning ai 


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
