### PR TITLE
[Core] Fix loopback detection for OAuth2/SSO with service account auth

### DIFF
--- a/sky/server/auth/loopback.py
+++ b/sky/server/auth/loopback.py
@@ -1,6 +1,7 @@
 """Shared loopback detection utilities for auth middlewares."""
 
 import ipaddress
+from typing import Optional
 
 import fastapi
 
@@ -8,10 +9,8 @@ from sky import sky_logging
 
 logger = sky_logging.init_logger(__name__)
 
-COMMON_PROXY_HEADERS = [
-    'X-Forwarded-For', 'Forwarded', 'X-Real-IP', 'X-Client-IP',
-    'X-Forwarded-Host', 'X-Forwarded-Proto'
-]
+# Headers that might indicate the original client IP when behind a proxy
+FORWARDED_IP_HEADERS = ['X-Forwarded-For', 'X-Real-IP', 'X-Client-IP']
 
 
 def _is_loopback_ip(ip_str: str) -> bool:
@@ -23,16 +22,60 @@ def _is_loopback_ip(ip_str: str) -> bool:
         return False
 
 
+def _get_forwarded_client_ip(request: fastapi.Request) -> Optional[str]:
+    """Extract the original client IP from forwarding headers.
+
+    Returns the first IP from X-Forwarded-For, X-Real-IP, or X-Client-IP.
+    For X-Forwarded-For, returns the leftmost (original client) IP.
+    """
+    # Check X-Forwarded-For first (most common)
+    xff = request.headers.get('X-Forwarded-For')
+    if xff:
+        # X-Forwarded-For can be a comma-separated list; first IP is the client
+        first_ip = xff.split(',')[0].strip()
+        if first_ip:
+            return first_ip
+
+    # Check other headers
+    for header in ['X-Real-IP', 'X-Client-IP']:
+        value = request.headers.get(header)
+        if value:
+            return value.strip()
+
+    return None
+
+
 def is_loopback_request(request: fastapi.Request) -> bool:
-    """Determine if a request is coming from localhost."""
+    """Determine if a request is coming from localhost.
+
+    Returns True if:
+    1. The direct client IP is loopback AND no forwarding headers indicate
+       a different original client, OR
+    2. The direct client IP is loopback AND the forwarded client IP is also
+       loopback (e.g., request went through a local proxy like OAuth2 proxy).
+    """
     if request.client is None:
         return False
 
     client_host = request.client.host
-    if client_host == 'localhost' or _is_loopback_ip(client_host):
-        # Additional checks: ensure no forwarding headers are present.
-        # If there are any, assume this traffic went through a proxy.
-        return not any(
-            request.headers.get(header) for header in COMMON_PROXY_HEADERS)
+    if not (client_host == 'localhost' or _is_loopback_ip(client_host)):
+        return False
 
+    # Direct connection is from loopback. Now check if there are forwarding
+    # headers that indicate the original client was NOT from loopback.
+    forwarded_ip = _get_forwarded_client_ip(request)
+    if forwarded_ip is None:
+        # No forwarding headers - this is a direct loopback connection
+        return True
+
+    # There are forwarding headers. Check if the original client was also
+    # from loopback. This handles cases like OAuth2 proxy running locally
+    # that adds X-Forwarded-For headers even for local requests.
+    if forwarded_ip == 'localhost' or _is_loopback_ip(forwarded_ip):
+        return True
+
+    # The forwarded IP indicates the original client was not from loopback,
+    # so this request went through a proxy from an external client.
+    logger.debug(f'Rejecting loopback bypass: direct client is {client_host} '
+                 f'but forwarded client is {forwarded_ip}')
     return False


### PR DESCRIPTION
## Summary
 
When OAuth2/SSO is enabled on the API server along with service account authentication, managed jobs fail to launch in consolidation mode with `ApiServerAuthenticationError`.
 
## Root Cause
 
The loopback detection in `sky/server/auth/loopback.py` was rejecting requests with ANY proxy headers, even if the original client was from loopback. This caused issues when:
 
1. Managed job controller makes a request to localhost:46580
2. OAuth2 proxy (or other infrastructure like service mesh) adds `X-Forwarded-*` headers
3. Server's loopback detection fails due to presence of any proxy headers
4. OAuth2 middleware tries to authenticate, fails, sets `anonymous_user=True`
5. Health endpoint returns `NEEDS_AUTH` status
6. Managed job fails with `ApiServerAuthenticationError`
 
## Solution
 
Improved the loopback detection logic to:
 
1. **Check the forwarded client IP** from `X-Forwarded-For`, `X-Real-IP`, `X-Client-IP` headers
2. **Allow loopback if the forwarded IP is also loopback** - handles cases like a local OAuth2 proxy adding headers for local requests
3. **Only reject if the forwarded IP indicates an external client** - e.g., if `X-Forwarded-For: 192.168.1.1`, then the original client was external
 
Headers like `X-Forwarded-Proto` and `X-Forwarded-Host` no longer affect the loopback decision since they don't contain client IP information.
 
Fixes #8703
 
## Test Plan
 
- Updated unit tests in `tests/unit_tests/test_sky/server/auth/test_loopback.py` to verify the new behavior
- All existing auth and server tests pass
- Manual testing: Deploy API server with OAuth2/SSO enabled, use service account auth, launch managed job in consolidation mode
 
## Changes
 
- `sky/server/auth/loopback.py` - Improved loopback detection logic
- `tests/unit_tests/test_sky/server/auth/test_loopback.py` - Updated tests for new behavior