### PR TITLE
[Kubernetes] Increase WebSocket open timeout for SSH proxy

### DIFF
--- a/sky/templates/websocket_proxy.py
+++ b/sky/templates/websocket_proxy.py
@@ -30,6 +30,10 @@ from sky.skylet import constants as skylet_constants
 BUFFER_SIZE = 2**16  # 64KB
 HEARTBEAT_INTERVAL_SECONDS = 10
 MAX_UNANSWERED_PINGS = 100
+# Timeout for opening the WebSocket connection. The default (10s) can be
+# insufficient when many concurrent SSH connections are established under load,
+# causing intermittent "timed out during opening handshake" errors.
+OPEN_TIMEOUT_SECONDS = 60
 
 
 async def main(url: str, timestamps_supported: bool, login_url: str) -> None:
@@ -37,7 +41,9 @@ async def main(url: str, timestamps_supported: bool, login_url: str) -> None:
     headers.update(server_common.get_cookie_header_for_url(url))
     headers.update(service_account_auth.get_service_account_headers())
     try:
-        async with connect(url, ping_interval=None,
+        async with connect(url,
+                           ping_interval=None,
+                           open_timeout=OPEN_TIMEOUT_SECONDS,
                            additional_headers=headers) as websocket:
             await run_websocket_proxy(websocket, timestamps_supported)
     except websockets.exceptions.InvalidStatus as e:


### PR DESCRIPTION
## Summary
- Increase WebSocket connection timeout from default 10s to 60s in `websocket_proxy.py`
- Fixes flaky `test_kubernetes_ssh_proxy_performance` smoke test failures in CI

## Root Cause
The test creates 20 parallel SSH connections, each spawning a `websocket_proxy.py` process that establishes a WebSocket connection to the API server. Under load (CI environment with multiple tests running, pytest workers, admin_policy server), some WebSocket handshakes exceed the default 10-second timeout, causing intermittent `asyncio.exceptions.TimeoutError: timed out during opening handshake` errors.

Evidence:
- Build #7683 failed after 5 retries, eventually passed on 7th retry
- Build #7692 (manual run of just this test) passed
- Manual runs outside pytest consistently pass

## Test plan
- Ran `test_kubernetes_ssh_proxy_performance` via pytest locally - passed with the fix
- Verified SSH proxy benchmark works correctly (2000/2000 commands successful)

🤖 Generated with [Claude Code](https://claude.com/claude-code)