### PR TITLE
[Vast] Fix SSH key injection with extra quotes in authorized_keys

### DIFF
--- a/sky/provision/vast/utils.py
+++ b/sky/provision/vast/utils.py
@@ -210,7 +210,7 @@ def launch(name: str,
             'chmod 700 ~/.ssh',
             # Add a newline first to ensure keys are on separate lines
             'echo "" >> ~/.ssh/authorized_keys',
-            (f'echo "{shlex.quote(ssh_public_key.strip())}" >> '
+            (f'echo {shlex.quote(ssh_public_key.strip())} >> '
              '~/.ssh/authorized_keys'),
             'chmod 600 ~/.ssh/authorized_keys',
         ])


### PR DESCRIPTION
The SSH public key was being double-quoted during injection into authorized_keys on vast.ai instances. The code used shlex.quote() which adds single quotes, then wrapped the result in double quotes in the echo command. This caused the key to be written with quotes around it, making SSH authentication fail.

Fixed by removing the extra double quotes and relying only on shlex.quote() for proper shell escaping.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
