### PR TITLE
Expose missing `MOUNT_CACHED` parameters in SkyPilot config

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -1985,6 +1985,10 @@ Data storage configuration (optional).
   data:
     mount_cached:
       sequential_upload: false
+      buffer_size: "16M"
+      vfs_read_ahead: "0"
+      vfs_cache_max_size: "10G"
+      transfers: 4
 
 .. _config-yaml-data-mount-cached:
 
@@ -2012,6 +2016,90 @@ The upload order is not guaranteed, but throughput is significantly higher.
   data:
     mount_cached:
       sequential_upload: true
+
+.. _config-yaml-data-mount-cached-buffer-size:
+
+``data.mount_cached.buffer_size``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Size of the in-memory buffer used for each open file (default: ``"16M"``).
+
+This corresponds to rclone's ``--buffer-size`` flag. Larger buffers can improve
+read performance, especially for sequential reads, but consume more memory per
+open file.
+
+.. code-block:: yaml
+
+  data:
+    mount_cached:
+      buffer_size: "64M"
+
+.. _config-yaml-data-mount-cached-vfs-read-ahead:
+
+``data.mount_cached.vfs_read_ahead``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Amount of data to pre-fetch during read operations (default: ``"0"``).
+
+This corresponds to rclone's ``--vfs-read-ahead`` flag. Setting this to a
+non-zero value (e.g., ``"128M"``) enables read-ahead, which can significantly
+improve performance for streaming or sequential reads by downloading data before
+it's requested.
+
+.. code-block:: yaml
+
+  data:
+    mount_cached:
+      vfs_read_ahead: "128M"
+
+.. _config-yaml-data-mount-cached-vfs-cache-max-size:
+
+``data.mount_cached.vfs_cache_max_size``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Maximum size of the local VFS cache (default: ``"10G"``).
+
+This corresponds to rclone's ``--vfs-cache-max-size`` flag. When the cache
+exceeds this size, rclone will evict files that are not currently in use.
+Increase this value if you have disk space available and want to cache more
+data locally.
+
+.. code-block:: yaml
+
+  data:
+    mount_cached:
+      vfs_cache_max_size: "50G"
+
+.. _config-yaml-data-mount-cached-transfers:
+
+``data.mount_cached.transfers``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Number of parallel file transfers (default: ``4``).
+
+This corresponds to rclone's ``--transfers`` flag. Higher values allow more
+files to be uploaded/downloaded in parallel, which can improve throughput.
+
+If this option is set, it takes precedence over ``sequential_upload``.
+For backward compatibility, ``sequential_upload: true`` is equivalent to
+``transfers: 1``.
+
+.. code-block:: yaml
+
+  data:
+    mount_cached:
+      transfers: 8
+
+**Example configuration for faster reads:**
+
+.. code-block:: yaml
+
+  data:
+    mount_cached:
+      buffer_size: "64M"       # Larger in-memory buffer per file
+      vfs_read_ahead: "128M"   # Pre-fetch data for streaming reads
+      vfs_cache_max_size: "50G"  # Larger local cache
+      transfers: 8             # More parallel transfers
 
 .. _config-yaml-daemons:
 

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1946,6 +1946,22 @@ def get_config_schema():
                     'sequential_upload': {
                         'type': 'boolean',
                     },
+                    'buffer_size': {
+                        'type': 'string',
+                        'pattern': constants.MEMORY_SIZE_PATTERN,
+                    },
+                    'vfs_read_ahead': {
+                        'type': 'string',
+                        'pattern': constants.MEMORY_SIZE_PATTERN,
+                    },
+                    'vfs_cache_max_size': {
+                        'type': 'string',
+                        'pattern': constants.MEMORY_SIZE_PATTERN,
+                    },
+                    'transfers': {
+                        'type': 'integer',
+                        'minimum': 1,
+                    },
                 },
             },
         },


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

## Description

`MOUNT_CACHED` can be a bit slow (I achieved less than 30MB/sec with the default configuration with an S3 bucket). This can bottleneck training scripts where we need to fetch checkpoints larger than 500GB.

I looked at the source code and seems like not all options for rclone are exposed. In particular, these are missing:
- `buffer_size`
- `vfs_read_ahead`
- `vfs_cache_max_size`
- `transfers`

This PR exposes the above missing parameters in the SkyPilot config.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
