### PR TITLE
[Slurm] Handle missing config file in slurm_node_info()

### DIFF
--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from paramiko.config import SSHConfig
 
+from sky import clouds
 from sky import exceptions
 from sky import sky_logging
 from sky.adaptors import slurm
@@ -491,13 +492,10 @@ def _get_slurm_node_info_list(
     # can raise FileNotFoundError if config file does not exist.
     slurm_config = get_slurm_ssh_config()
     if slurm_cluster_name is None:
-        slurm_cluster_names = get_all_slurm_cluster_names()
-        if slurm_cluster_names:
-            slurm_cluster_name = slurm_cluster_names[0]
-    if slurm_cluster_name is None:
-        raise ValueError(
-            f'No Slurm cluster name found in the {DEFAULT_SLURM_PATH} '
-            f'configuration.')
+        slurm_cluster_names = clouds.Slurm.existing_allowed_clusters()
+        if not slurm_cluster_names:
+            return []
+        slurm_cluster_name = slurm_cluster_names[0]
     slurm_config_dict = slurm_config.lookup(slurm_cluster_name)
     logger.debug(f'Slurm config dict: {slurm_config_dict}')
     slurm_client = slurm.SlurmClient(
@@ -590,8 +588,7 @@ def slurm_node_info(
     try:
         node_list = _get_slurm_node_info_list(
             slurm_cluster_name=slurm_cluster_name)
-    except (FileNotFoundError, ValueError, RuntimeError,
-            exceptions.NotSupportedError) as e:
+    except (FileNotFoundError, RuntimeError, exceptions.NotSupportedError) as e:
         logger.debug(f'Could not retrieve Slurm node info: {e}')
         return []
     return node_list


### PR DESCRIPTION
When the Slurm config file (~/.slurm/config) doesn't exist, the
slurm_node_info() function was raising FileNotFoundError instead of
gracefully returning an empty list. This caused the Infra page in
the dashboard to show an empty list with a 500 error.

Add FileNotFoundError to the list of caught exceptions, consistent
with how get_all_slurm_cluster_names() handles this case.