### PR TITLE
Fix External Link Support

### DIFF
--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -311,6 +311,8 @@ function JobDetails() {
                     refreshFlag={0}
                     poolsData={poolsData}
                     links={enhancedJobData?.links}
+                    logExtractedLinks={logExtractedLinks}
+                    onLinksExtracted={setLogExtractedLinks}
                   />
                 </div>
               </Card>
@@ -587,6 +589,7 @@ function JobDetails() {
                     selectedTaskIndex={isMultiTask ? selectedTaskIndex : null}
                     selectedNode={selectedNode}
                     onNodesExtracted={setLogNodes}
+                    onLinksExtracted={setLogExtractedLinks}
                   />
                 </div>
               </Card>


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The jobgroup PR accidentally removed our logic to update our set of extracted links for external links. This PR undoes that part of the change.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
