### PR TITLE
[AWS] Change g7e accelerator name in catalog to RTXPRO6000

### DIFF
--- a/sky/catalog/data_fetchers/fetch_aws.py
+++ b/sky/catalog/data_fetchers/fetch_aws.py
@@ -300,6 +300,9 @@ def _get_instance_types_df(region: str) -> Union[str, 'pd.DataFrame']:
                 acc_count = round(fraction, 3)
             elif row['InstanceType'] == 'p5.4xlarge':
                 acc_count = 1
+            elif row['InstanceType'].startswith('g7e'):
+                # Change name from "RTX PRO Server 6000" to "RTXPRO6000" for consistency
+                acc_name = 'RTXPRO6000'
             return pd.Series({
                 'AcceleratorName': acc_name,
                 'AcceleratorCount': acc_count,


### PR DESCRIPTION
Add a manual override for g7e instance types so that they are named `RTXPRO6000` instead of `RTX PRO Server 6000` in the skypilot catalog.

Tested (changing local CSVs to reflect new name):
<details>
<summary>
sky show-gpus RTXPRO6000
</summary>

```
[ValueError] Resources 'rtxpro6000' not found in Kubernetes clusters. If your cluster contains GPUs, make sure nvidia.com/gpu resource is available on the nodes and the node labels for identifying GPUs (e.g., skypilot.co/accelerator) are setup correctly. To show available accelerators on kubernetes,  run: sky show-gpus --cloud kubernetes 

[ValueError] Resources 'rtxpro6000' not found in SSH clusters. If your cluster contains GPUs, make sure nvidia.com/gpu resource is available on the nodes and the node labels for identifying GPUs (e.g., skypilot.co/accelerator) are setup correctly. To show available accelerators on ssh,  run: sky show-gpus --cloud ssh 

Cloud GPUs
GPU         QTY  CLOUD   INSTANCE_TYPE         DEVICE_MEM  vCPUs  HOST_MEM  HOURLY_PRICE  HOURLY_SPOT_PRICE  REGION     
RTXPRO6000  1.0  RunPod  1x_RTXPRO6000_SECURE  0GB         14     125GB     $ 1.840       $ 1.190            CA         
RTXPRO6000  2.0  RunPod  2x_RTXPRO6000_SECURE  0GB         28     250GB     $ 3.680       $ 2.380            CA         
RTXPRO6000  3.0  RunPod  3x_RTXPRO6000_SECURE  0GB         42     375GB     $ 5.520       $ 3.570            CA         
RTXPRO6000  4.0  RunPod  4x_RTXPRO6000_SECURE  0GB         56     500GB     $ 7.360       $ 4.760            CA         
RTXPRO6000  5.0  RunPod  5x_RTXPRO6000_SECURE  0GB         70     625GB     $ 9.200       $ 5.950            CA         
RTXPRO6000  6.0  RunPod  6x_RTXPRO6000_SECURE  0GB         84     750GB     $ 11.040      $ 7.140            CA         
RTXPRO6000  7.0  RunPod  7x_RTXPRO6000_SECURE  0GB         98     875GB     $ 12.880      $ 8.330            CA         
RTXPRO6000  8.0  RunPod  8x_RTXPRO6000_SECURE  0GB         112    1000GB    $ 14.720      $ 9.520            CA         
RTXPRO6000  9.0  RunPod  9x_RTXPRO6000_SECURE  0GB         126    1125GB    $ 16.560      $ 10.710           CA         
RTXPRO6000  1.0  AWS     g7e.2xlarge           96GB        8      64GB      $ 3.363       $ 1.326            us-east-2  
RTXPRO6000  1.0  AWS     g7e.4xlarge           96GB        16     128GB     $ 3.998       $ 1.623            us-east-2  
RTXPRO6000  1.0  AWS     g7e.8xlarge           96GB        32     256GB     $ 5.268       $ 2.046            us-east-2  
RTXPRO6000  2.0  AWS     g7e.12xlarge          96GB        48     512GB     $ 8.286       $ 3.224            us-east-2  
RTXPRO6000  4.0  AWS     g7e.24xlarge          96GB        96     1024GB    $ 16.572      $ 6.427            us-east-2  
RTXPRO6000  8.0  AWS     g7e.48xlarge          96GB        192    2048GB    $ 33.144      $ 13.481           us-east-2  

GPU            QTY  CLOUD   INSTANCE_TYPE            DEVICE_MEM  vCPUs  HOST_MEM  HOURLY_PRICE  HOURLY_SPOT_PRICE  REGION  
RTXPRO6000-WK  1.0  RunPod  1x_RTXPRO6000-WK_SECURE  0GB         12     186GB     $ 2.090       $ 1.180            CA      
RTXPRO6000-WK  2.0  RunPod  2x_RTXPRO6000-WK_SECURE  0GB         24     372GB     $ 4.180       $ 2.360            CA      
RTXPRO6000-WK  3.0  RunPod  3x_RTXPRO6000-WK_SECURE  0GB         36     558GB     $ 6.270       $ 3.540            CA      
RTXPRO6000-WK  4.0  RunPod  4x_RTXPRO6000-WK_SECURE  0GB         48     744GB     $ 8.360       $ 4.720            CA      

GPU           QTY  CLOUD  INSTANCE_TYPE                DEVICE_MEM  vCPUs  HOST_MEM  HOURLY_PRICE  HOURLY_SPOT_PRICE  REGION                    
RTXPRO6000WS  1.0  Vast   1x-RTX_PRO_6000_WS-32-65536  96GB        -      64GB      $ 0.930       $ 0.000            Switzerland, CH, EU       
RTXPRO6000WS  2.0  Vast   2x-RTX_PRO_6000_WS-32-65536  191GB       -      64GB      $ 2.000       $ 0.000            British Columbia, CA, NA  

GPU         QTY  CLOUD      INSTANCE_TYPE               DEVICE_MEM  vCPUs  HOST_MEM  HOURLY_PRICE  HOURLY_SPOT_PRICE  REGION            
RTXPro6000  1.0  Shadeform  massedcompute_RTXPro6000    0GB         16     192GB     $ 1.790       -                  beltsville-usa-1  
RTXPro6000  1.0  Shadeform  latitude_RTXPro6000-vm      0GB         16     128GB     $ 1.900       -                  ashburn-usa-7     
RTXPro6000  2.0  Shadeform  massedcompute_RTXPro6000x2  0GB         30     382GB     $ 3.580       -                  beltsville-usa-1  
RTXPro6000  4.0  Shadeform  massedcompute_RTXPro6000x4  0GB         60     768GB     $ 7.160       -                  beltsville-usa-1  
RTXPro6000  8.0  Shadeform  boostrun_RTXPro6000x8       0GB         128    1536GB    $ 9.680       -                  charlotte-usa-1   
RTXPro6000  8.0  Shadeform  latitude_RTXPro6000x8       0GB         192    1511GB    $ 12.800      -                  chicago-usa-4     
RTXPro6000  8.0  Shadeform  massedcompute_RTXPro6000x8  0GB         120    1536GB    $ 14.320      -                  beltsville-usa-1  
```
</details>

<details>
<summary>
sky launch --infra aws --gpus RTXPRO6000 -- echo hi
</summary>

```
ename-g7e-accelerator
Command to run: echo hi
Considered resources (1 node):
--------------------------------------------------------------------------------------
 INFRA             INSTANCE      vCPUs   Mem(GB)   GPUS           COST ($)   CHOSEN   
--------------------------------------------------------------------------------------
 AWS (us-east-1)   g7e.2xlarge   8       64        RTXPRO6000:1   3.36          ✔     
--------------------------------------------------------------------------------------
🔍 Multiple AWS instances satisfy RTXPRO6000:1. The cheapest (gpus=RTXPRO6000:1, g7e.2xlarge, ...) is considered among: g7e.2xlarge, g7e.8xlarge, g7e.4xlarge.
To list more details, run: sky show-gpus RTXPRO6000

Launching a new cluster 'sky-3b0e-kevinwang'. Proceed? [Y/n]: 
⚙︎ Launching on AWS us-east-1 (us-east-1b,us-east-1d).
└── Instance is up.
✓ Cluster launched: sky-3b0e-kevinwang.  View logs: sky logs --provision sky-3b0e-kevinwang
⚙︎ Syncing files.
⚙︎ Job submitted, ID: 1
├── Waiting for task resources on 1 node.
└── Job started. Streaming logs... (Ctrl-C to exit log streaming; job will not be killed)
(sky-cmd, pid=5141) hi
✓ Job finished (status: SUCCEEDED).

📋 Useful Commands
Job ID: 1
├── To cancel the job:          sky cancel sky-3b0e-kevinwang 1
├── To stream job logs:         sky logs sky-3b0e-kevinwang 1
└── To view job queue:          sky queue sky-3b0e-kevinwang
Cluster name: sky-3b0e-kevinwang
├── To log into the head VM:    ssh sky-3b0e-kevinwang
├── To submit a job:            sky exec sky-3b0e-kevinwang yaml_file
├── To stop the cluster:        sky stop sky-3b0e-kevinwang
└── To teardown the cluster:    sky down sky-3b0e-kevinwang
```

</details>

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
