### PR TITLE
[Test] Fix test_skyserve_llm by Hard Coding Transformers Library

### DIFF
--- a/tests/skyserve/llm/service.yaml
+++ b/tests/skyserve/llm/service.yaml
@@ -25,12 +25,17 @@ setup: |
   uv pip install vllm==0.10.0
   # Have to use triton==3.2.0 to avoid https://github.com/triton-lang/triton/issues/6698
   uv pip install triton==3.2.0
-  uv pip install transformers==4.57.3 to avoid https://github.com/verl-project/verl/issues/4337
+  # Pin transformers to avoid https://github.com/verl-project/verl/issues/4337
+  uv pip install transformers==4.57.3
   uv pip install openai
 
 run: |
   source .venv/bin/activate
   export PATH=$PATH:/sbin
+  # Use XFORMERS backend to avoid Triton compilation issues on T4/Turing GPUs
+  # See: https://github.com/vllm-project/vllm/issues/17639
+  export VLLM_ATTENTION_BACKEND=XFORMERS
+  export VLLM_USE_TRITON_FLASH_ATTN=0
   vllm serve $MODEL_NAME --trust-remote-code \
     --host 0.0.0.0 --port 8087 \
     --api-key $AUTH_TOKEN


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Running `test_skyserve_llm` has been failing with 
```
raise AttributeError(f"{self.__class__.__name__} has no attribute {key}")
--
(t-ss-llm-0ff7c67e-f7, pid=1178) AttributeError: Qwen2Tokenizer has no attribute all_special_tokens_extended. Did you mean: 'num_special_tokens_to_add'?
```
 this issue is captured in https://github.com/verl-project/verl/issues/4337.

We fix this by hardcoding the transformers version.

We also modify the backend to be compatible with T4 GPUs to prevent errors when our test infrastructure selects those.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
