### PR TITLE
[Test] Fail instead of skip when kubernetes cluster has no GPUs for GPU tests

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -542,7 +542,7 @@ def test_multi_echo(generic_cloud: str):
         use_spot = False
         accelerator = smoke_tests_utils.get_available_gpus(infra=generic_cloud)
         if not accelerator:
-            pytest.skip(f'No GPUs available for {generic_cloud}.')
+            pytest.fail(f'No GPUs available for {generic_cloud}.')
 
     # Determine timeout for 15 running jobs check: 2 min for remote server, single check for local
     is_remote = smoke_tests_utils.is_remote_server_test()
@@ -672,7 +672,7 @@ def test_huggingface(generic_cloud: str, accelerator: Dict[str, str]):
     if generic_cloud in ('kubernetes', 'slurm'):
         accelerator = smoke_tests_utils.get_available_gpus(infra=generic_cloud)
         if not accelerator:
-            pytest.skip(f'No GPUs available for {generic_cloud}.')
+            pytest.fail(f'No GPUs available for {generic_cloud}.')
     else:
         accelerator = accelerator.get(generic_cloud, 'T4')
     name = smoke_tests_utils.get_cluster_name()
@@ -1751,7 +1751,7 @@ def test_cancel_pytorch(generic_cloud: str, accelerator: Dict[str, str]):
     if generic_cloud in ('kubernetes', 'slurm'):
         accelerator = smoke_tests_utils.get_available_gpus(infra=generic_cloud)
         if not accelerator:
-            pytest.skip(f'No GPUs available for {generic_cloud}.')
+            pytest.fail(f'No GPUs available for {generic_cloud}.')
     else:
         accelerator = accelerator.get(generic_cloud, 'T4')
     name = smoke_tests_utils.get_cluster_name()

--- a/tests/smoke_tests/test_examples.py
+++ b/tests/smoke_tests/test_examples.py
@@ -24,7 +24,7 @@ def test_min_gpt(generic_cloud: str, train_file: str, accelerator: Dict[str,
     if generic_cloud in ('kubernetes', 'slurm'):
         accelerator = smoke_tests_utils.get_available_gpus(infra=generic_cloud)
         if not accelerator:
-            pytest.skip(f'No GPUs available for {generic_cloud}.')
+            pytest.fail(f'No GPUs available for {generic_cloud}.')
     else:
         accelerator = accelerator.get(generic_cloud, 'T4')
     name = smoke_tests_utils.get_cluster_name()
@@ -78,7 +78,7 @@ def test_ray_train(generic_cloud: str, accelerator: Dict[str, str]) -> None:
     if generic_cloud in ('kubernetes', 'slurm'):
         accelerator = smoke_tests_utils.get_available_gpus(infra=generic_cloud)
         if not accelerator:
-            pytest.skip(f'No GPUs available for {generic_cloud}.')
+            pytest.fail(f'No GPUs available for {generic_cloud}.')
     else:
         accelerator = accelerator.get(generic_cloud, 'T4')
     name = smoke_tests_utils.get_cluster_name()
@@ -201,7 +201,7 @@ def test_nemorl(generic_cloud: str, accelerator: Dict[str, str]) -> None:
     if generic_cloud in ('kubernetes', 'slurm'):
         accelerator = smoke_tests_utils.get_available_gpus(infra=generic_cloud)
         if not accelerator:
-            pytest.skip(f'No GPUs available for {generic_cloud}.')
+            pytest.fail(f'No GPUs available for {generic_cloud}.')
     else:
         accelerator = accelerator.get(generic_cloud, 'L4')
 

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -359,7 +359,7 @@ def test_skyserve_llm(generic_cloud: str, accelerator: Dict[str, str]):
     if generic_cloud == 'kubernetes':
         accelerator = smoke_tests_utils.get_available_gpus()
         if not accelerator:
-            pytest.skip('No GPUs available for kubernetes.')
+            pytest.fail('No GPUs available for kubernetes.')
     else:
         accelerator = accelerator.get(generic_cloud, 'T4')
 


### PR DESCRIPTION
Partly reverts #8736. Instead of skipping, we should fail loudly so we are aware if buildkite k8s fails to scale up GPUs.

This is still an overall improvement from before #8736, as previously it was failing with cryptic errors like the following:

```bash
ValueError: Invalid instance name: 2CPU--4GB--:1
ValueError: Invalid instance name: 2CPU--4GB--examples/huggingface_glue_imdb_app.yaml:1
NameError: name 'accelerator' is not defined
etc...
```

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
  - locally: `pytest -n0 tests/smoke_tests/test_cluster_job.py::test_huggingface --kubernetes -k accelerator0`
```
_________________________________________________________ test_huggingface[accelerator0] __________________________________________________________
tests/smoke_tests/test_cluster_job.py:675: in test_huggingface
    pytest.fail(f'No GPUs available for {generic_cloud}.')
E   Failed: No GPUs available for kubernetes.
```
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
