### PR TITLE
[Docs] Document that uv is pre-installed on all SkyPilot clusters

### DIFF
--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -1137,6 +1137,25 @@ OR
     conda activate myenv
     pip install torch torchvision
 
+.. tip::
+
+  `uv <https://docs.astral.sh/uv/>`_, the fast Python package installer, is **pre-installed on all SkyPilot clusters**.
+  You can use it in your ``setup`` commands for faster package installation:
+
+  .. code-block:: yaml
+
+    setup: |
+      uv pip install -r requirements.txt
+
+  Or create a virtual environment and install packages:
+
+  .. code-block:: yaml
+
+    setup: |
+      uv venv ~/myenv
+      source ~/myenv/bin/activate
+      uv pip install torch torchvision
+
 .. _yaml-spec-run:
 
 ``run``


### PR DESCRIPTION
Add a tip in the YAML spec documentation under the setup section
explaining that uv (the fast Python package installer) is pre-installed
on all SkyPilot clusters. This allows users to use uv pip install for
faster package installation in their setup commands.