### PR TITLE
[Config] Add env_file in yaml spec

### DIFF
--- a/docs/source/examples/docker-containers.rst
+++ b/docs/source/examples/docker-containers.rst
@@ -118,6 +118,27 @@ Private registries
 When using this mode, to access Docker images hosted on private registries,
 you can use :ref:`task environment variables <env-vars>`:
 
+.. tip::
+
+    Instead of specifying Docker credentials directly in the YAML, you can use ``env_file`` to load them from a ``.env`` file:
+
+    .. code-block:: yaml
+
+      resources:
+        image_id: docker:<user>/<your-docker-hub-repo>:<tag>
+
+      env_file: ~/.docker-credentials.env
+
+    Where ``~/.docker-credentials.env`` contains:
+
+    .. code-block:: bash
+
+      SKYPILOT_DOCKER_USERNAME=<user>
+      SKYPILOT_DOCKER_PASSWORD=<password>
+      SKYPILOT_DOCKER_SERVER=docker.io
+
+    This keeps sensitive credentials out of your task YAML files. See :ref:`env_file <yaml-spec-env-file>` for more details.
+
 .. tab-set::
 
     .. tab-item:: Docker Hub

--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -68,6 +68,7 @@ Below is the configuration syntax and some example values.  See details under ea
 
     :ref:`job_recovery <yaml-spec-resources-job-recovery>`: none
 
+  :ref:`env_file <yaml-spec-env-file>`: /path/to/.env
   :ref:`envs <yaml-spec-envs>`:
     MY_BUCKET: skypilot-temp-gcs-test
     MY_LOCAL_PATH: tmp-workdir
@@ -959,6 +960,57 @@ Available fields:
 - :code:`strategy`: The recovery strategy to use (:code:`FAILOVER` or :code:`EAGER_NEXT_REGION`)
 - :code:`max_restarts_on_errors`: Maximum number of times to restart the job on user code errors (non-zero exit codes)
 - :code:`recover_on_exit_codes`: Exit code(s) (0-255) that should always trigger recovery. Can be a single integer (e.g., :code:`33`) or a list (e.g., :code:`[33, 34]`). Restarts triggered by these exit codes do not count towards the :code:`max_restarts_on_errors` limit. Useful for specific transient errors like NCCL timeouts.
+
+.. _yaml-spec-env-file:
+
+``env_file``
+~~~~~~~~~~~~
+
+Path to environment file(s) to load (optional).
+
+Similar to Docker Compose's ``env_file`` option, this allows you to specify one or more files containing environment variables. Each file should contain lines in the format ``KEY=value``.
+
+The environment variables loaded from these files can be accessed in the ``file_mounts``, ``setup``, and ``run`` sections.
+
+**Precedence**: Variables defined in :ref:`envs <yaml-spec-envs>` take precedence over variables loaded from ``env_file``. If the same variable is defined in both, the value from ``envs`` will be used.
+
+When multiple files are specified, files listed later take precedence over files listed earlier.
+
+**Format**: Each line in the env file should be in the format ``KEY=value``. Lines starting with ``#`` are treated as comments. Empty lines are ignored.
+
+Example env file (``.env``):
+
+.. code-block:: bash
+
+  # Database configuration
+  DB_HOST=localhost
+  DB_PORT=5432
+
+  # API keys
+  API_KEY=my-api-key
+
+Example of using a single env file:
+
+.. code-block:: yaml
+
+  env_file: /path/to/.env
+
+Example of using multiple env files:
+
+.. code-block:: yaml
+
+  env_file:
+    - /path/to/.env
+    - /path/to/.env.local
+
+Example combining ``env_file`` with ``envs`` (envs takes precedence):
+
+.. code-block:: yaml
+
+  env_file: /path/to/.env  # Contains DB_HOST=localhost
+
+  envs:
+    DB_HOST: production-db.example.com  # This value will be used
 
 
 .. _yaml-spec-envs:

--- a/docs/source/running-jobs/environment-variables.rst
+++ b/docs/source/running-jobs/environment-variables.rst
@@ -31,6 +31,19 @@ You can specify environment variables and secrets to be made available to a task
       HF_TOKEN: null
       WANDB_API_KEY: null
 
+- ``env_file`` field in a :ref:`task YAML <yaml-spec>` to load environment variables from a `dotenv` file:
+
+  .. code-block:: yaml
+
+    # Load from a single .env file
+    env_file: /path/to/.env
+
+    # Or load from multiple files (later files take precedence)
+    env_file:
+      - /path/to/.env
+      - /path/to/.env.local
+
+  Variables defined in ``envs`` take precedence over ``env_file``. See :ref:`env_file <yaml-spec-env-file>` for more details.
 
 - ``--env`` and ``--secret`` flags in ``sky launch/exec`` :ref:`CLI <cli>` (takes precedence over the above)
 

--- a/sky/task.py
+++ b/sky/task.py
@@ -553,15 +553,19 @@ class Task:
         if (env_file_config := config.pop('env_file', None)):
             env_file_envs: Dict[str, Optional[str]] = {}
             # Validate env_file type.
-            if not isinstance(env_file_config, (str, list)):
+            if isinstance(env_file_config, str):
+                env_files: List[str] = [env_file_config]
+            elif isinstance(env_file_config, list):
+                if not all(isinstance(item, str) for item in env_file_config):
+                    with ux_utils.print_exception_no_traceback():
+                        raise ValueError('Invalid `env_file` list: '
+                                         'must contain only strings.')
+                env_files = env_file_config
+            else:
                 with ux_utils.print_exception_no_traceback():
                     raise ValueError(
-                        f'Invalid env_file type: {type(env_file_config)}. '
-                        'Must be str or list of str.')
-
-            # generalize for both str and list of str
-            env_files: List[str] = [env_file_config] if isinstance(
-                env_file_config, str) else env_file_config
+                        f'Invalid `env_file` type: {type(env_file_config)}. '
+                        'Must be a string or a list of strings.')
 
             for ef in env_files:
                 env_file_path = os.path.expanduser(ef)

--- a/sky/task.py
+++ b/sky/task.py
@@ -7,6 +7,7 @@ from typing import (Any, Callable, Dict, Iterable, List, Optional, Set, Tuple,
                     Union)
 
 import colorama
+from dotenv import dotenv_values
 from pydantic import SecretStr
 
 from sky import clouds
@@ -548,13 +549,41 @@ class Task:
     ) -> 'Task':
         user_specified_yaml = config.pop('_user_specified_yaml',
                                          yaml_utils.dump_yaml_str(config))
+        # Handle env_file from YAML.
+        if (env_file_config := config.pop('env_file', None)):
+            env_file_envs: Dict[str, Optional[str]] = {}
+            # Validate env_file type.
+            if not isinstance(env_file_config, (str, list)):
+                with ux_utils.print_exception_no_traceback():
+                    raise ValueError(
+                        f'Invalid env_file type: {type(env_file_config)}. '
+                        'Must be str or list of str.')
+
+            # generalize for both str and list of str
+            env_files: List[str] = [env_file_config] if isinstance(
+                env_file_config, str) else env_file_config
+
+            for ef in env_files:
+                env_file_path = os.path.expanduser(ef)
+                if not os.path.isfile(env_file_path):
+                    with ux_utils.print_exception_no_traceback():
+                        raise ValueError(f'env_file not found: {ef}')
+                ef_envs = dotenv_values(env_file_path)
+                env_file_envs.update(ef_envs)
+
+            # Merge env_file_envs with config['envs'], where envs takes
+            # precedence over env_file (similar to Docker Compose behavior).
+            if config.get('envs') is not None:
+                env_file_envs.update(config['envs'])
+            config['envs'] = env_file_envs
+
         # More robust handling for 'envs': explicitly convert keys and values to
         # str, since users may pass '123' as keys/values which will get parsed
         # as int causing validate_schema() to fail.
-        envs = config.get('envs')
-        if envs is not None and isinstance(envs, dict):
+        if (envs_config := config.get('envs')) is not None and isinstance(
+                envs_config, dict):
             new_envs: Dict[str, Optional[str]] = {}
-            for k, v in envs.items():
+            for k, v in envs_config.items():
                 if v is not None:
                     new_envs[str(k)] = str(v)
                 else:
@@ -564,10 +593,10 @@ class Task:
         # More robust handling for 'secrets': explicitly convert keys and values
         # to str, since users may pass '123' as keys/values which will get
         # parsed as int causing validate_schema() to fail.
-        secrets = config.get('secrets')
-        if secrets is not None and isinstance(secrets, dict):
+        if (secrets_config := config.get('secrets')) is not None and isinstance(
+                secrets_config, dict):
             new_secrets: Dict[str, Optional[str]] = {}
-            for k, v in secrets.items():
+            for k, v in secrets_config.items():
                 if v is not None:
                     new_secrets[str(k)] = str(v)
                 else:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -909,6 +909,16 @@ def get_task_schema():
             'run': {
                 'type': 'string',
             },
+            'env_file': {
+                'anyOf': [{
+                    'type': 'string',
+                }, {
+                    'type': 'array',
+                    'items': {
+                        'type': 'string',
+                    },
+                }],
+            },
             'envs': {
                 'type': 'object',
                 'required': [],

--- a/tests/unit_tests/test_sky/test_task.py
+++ b/tests/unit_tests/test_sky/test_task.py
@@ -246,7 +246,7 @@ def test_from_yaml_config_env_file_invalid_type():
             'invalid': 'type'
         },  # Should be str or list
     }
-    with pytest.raises(ValueError, match='Invalid env_file type'):
+    with pytest.raises(ValueError, match='Invalid `env_file` type'):
         task.Task.from_yaml_config(config)
 
 

--- a/tests/unit_tests/test_sky/test_task.py
+++ b/tests/unit_tests/test_sky/test_task.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from typing import Callable, Generator
 from unittest import mock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -12,6 +13,47 @@ from sky import resources as resources_lib
 from sky import task
 from sky.utils import git
 from sky.utils import registry
+
+# Type alias for the env file factory function
+EnvFileFactory = Callable[[dict[str, str]], str]
+
+
+@pytest.fixture
+def env_file_factory() -> Generator[EnvFileFactory, None, None]:
+    """Factory fixture for creating temporary .env files with automatic cleanup.
+
+    Usage:
+        def test_example(env_file_factory: EnvFileFactory):
+            env_file = env_file_factory({'API_KEY': 'value', 'DEBUG': 'true'})
+            # Use env_file path in test...
+            # No need to manually cleanup - fixture handles it
+    """
+    created_files: list[str] = []
+
+    def _create_env_file(env_vars: dict[str, str]) -> str:
+        """Create a temporary .env file with the given environment variables.
+
+        Args:
+            env_vars: Dictionary of environment variable names to values.
+
+        Returns:
+            Path to the created temporary .env file.
+        """
+        f = tempfile.NamedTemporaryFile(mode='w', suffix='.env', delete=False)
+        for key, value in env_vars.items():
+            f.write(f'{key}={value}\n')
+        f.close()
+        created_files.append(f.name)
+        return f.name
+
+    yield _create_env_file
+
+    # Cleanup all created files
+    for file_path in created_files:
+        try:
+            os.unlink(file_path)
+        except OSError:
+            pass
 
 
 def test_validate_workdir():
@@ -102,6 +144,125 @@ def test_to_yaml_config_without_envs():
     assert 'envs' not in yaml_config_redacted
     assert 'secrets' not in yaml_config_redacted
     assert yaml_config == yaml_config_redacted
+
+
+def test_from_yaml_config_with_only_env_file(env_file_factory: EnvFileFactory):
+    """Test from_yaml_config() loading envs from env_file only."""
+    env_file_path = env_file_factory({
+        'API_KEY': 'secret-from-file',
+        'DATABASE_URL': 'postgres://localhost/db',
+        'DEBUG': 'true',
+    })
+
+    config = {
+        'run': 'echo hello',
+        'env_file': env_file_path,
+    }
+    task_obj = task.Task.from_yaml_config(config)
+
+    # Envs should be loaded from the env_file
+    assert task_obj.envs == {
+        'API_KEY': 'secret-from-file',
+        'DATABASE_URL': 'postgres://localhost/db',
+        'DEBUG': 'true',
+    }
+
+
+def test_from_yaml_config_with_env_file_list(env_file_factory: EnvFileFactory):
+    """Test from_yaml_config() loading envs from multiple env_files."""
+    env_file1 = env_file_factory({
+        'VAR1': 'value1',
+        'SHARED': 'from-file1',
+    })
+    env_file2 = env_file_factory({
+        'VAR2': 'value2',
+        'SHARED': 'from-file2',  # Should override file1
+    })
+
+    config = {
+        'run': 'echo hello',
+        'env_file': [env_file1, env_file2],
+    }
+    task_obj = task.Task.from_yaml_config(config)
+
+    # Envs from later files should override earlier ones
+    assert task_obj.envs['VAR1'] == 'value1'
+    assert task_obj.envs['VAR2'] == 'value2'
+    assert task_obj.envs['SHARED'] == 'from-file2'
+
+
+def test_from_yaml_config_with_env_file_and_envs(
+        env_file_factory: EnvFileFactory):
+    """Test from_yaml_config() with both env_file and explicit envs."""
+    env_file_path = env_file_factory({
+        'FROM_FILE': 'file-value',
+        'SHARED': 'from-file',
+    })
+
+    config = {
+        'run': 'echo hello',
+        'env_file': env_file_path,
+        'envs': {
+            'FROM_YAML': 'yaml-value',
+            'SHARED': 'from-yaml',  # envs takes precedence over env_file
+        },
+    }
+    task_obj = task.Task.from_yaml_config(config)
+
+    # Both sources should be merged
+    assert task_obj.envs['FROM_FILE'] == 'file-value'
+    assert task_obj.envs['FROM_YAML'] == 'yaml-value'
+    # envs takes precedence over env_file (like Docker Compose)
+    assert task_obj.envs['SHARED'] == 'from-yaml'
+
+
+def test_from_yaml_config_with_cli_envs_overriding_env_file(
+        env_file_factory: EnvFileFactory):
+    """Test that CLI env_overrides take precedence over env_file."""
+    env_file_path = env_file_factory({
+        'API_KEY': 'from-file',
+        'OTHER_VAR': 'other-value',
+    })
+
+    config = {
+        'run': 'echo hello',
+        'env_file': env_file_path,
+    }
+    # CLI overrides should take precedence
+    env_overrides = [('API_KEY', 'from-cli')]
+    task_obj = task.Task.from_yaml_config(config, env_overrides=env_overrides)
+
+    # CLI override should win
+    assert task_obj.envs['API_KEY'] == 'from-cli'
+    # Other env_file values should still be present
+    assert task_obj.envs['OTHER_VAR'] == 'other-value'
+
+
+def test_from_yaml_config_env_file_invalid_type():
+    """Test that invalid env_file type raises ValueError."""
+    config = {
+        'run': 'echo hello',
+        'env_file': {
+            'invalid': 'type'
+        },  # Should be str or list
+    }
+    with pytest.raises(ValueError, match='Invalid env_file type'):
+        task.Task.from_yaml_config(config)
+
+
+@pytest.mark.parametrize('env_file_value', [
+    pytest.param('/nonexistent/path/.env', id='single_file'),
+    pytest.param(['/nonexistent/first.env', '/nonexistent/second.env'],
+                 id='list_of_files'),
+])
+def test_from_yaml_config_env_file_not_found(env_file_value):
+    """Test that missing env_file raises ValueError with clear message."""
+    config = {
+        'run': 'echo hello',
+        'env_file': env_file_value,
+    }
+    with pytest.raises(ValueError, match='env_file not found'):
+        task.Task.from_yaml_config(config)
 
 
 def test_to_yaml_config_with_envs_no_redaction():
@@ -681,6 +842,104 @@ def test_docker_login_config_no_mixed_envs_secrets():
             resources_lib.Resources(image_id='docker:ubuntu:latest'))
 
 
+def test_docker_login_config_from_env_file(env_file_factory: EnvFileFactory):
+    """Test Docker login credentials loaded entirely from env_file."""
+    env_file_path = env_file_factory({
+        'SKYPILOT_DOCKER_USERNAME': 'docker-user',
+        'SKYPILOT_DOCKER_PASSWORD': 'docker-password',
+        'SKYPILOT_DOCKER_SERVER': 'registry.example.com',
+    })
+
+    config = {
+        'run': 'echo hello',
+        'env_file': env_file_path,
+    }
+    # Should work - all Docker credentials are from env_file (merged into envs)
+    task_obj = task.Task.from_yaml_config(config)
+
+    # Verify credentials were loaded
+    assert task_obj.envs['SKYPILOT_DOCKER_USERNAME'] == 'docker-user'
+    assert task_obj.envs['SKYPILOT_DOCKER_PASSWORD'] == 'docker-password'
+    assert task_obj.envs['SKYPILOT_DOCKER_SERVER'] == 'registry.example.com'
+
+    # Verify set_resources passes validation (should not raise)
+    task_obj.set_resources(
+        resources_lib.Resources(image_id='docker:nginx:latest'))
+
+
+def test_docker_login_config_from_env_file_and_envs_works(
+        env_file_factory: EnvFileFactory):
+    """Test that partial Docker credentials from env_file and envs works."""
+    env_file_path = env_file_factory({
+        'SKYPILOT_DOCKER_PASSWORD': 'docker-password',
+    })
+    config = {
+        'run': 'echo hello',
+        'env_file': env_file_path,
+        'envs': {
+            'SKYPILOT_DOCKER_USERNAME': 'docker-user',
+            'SKYPILOT_DOCKER_SERVER': 'registry.example.com',
+        }
+    }
+    # Should work - all Docker credentials end up in envs
+    task.Task.from_yaml_config(config)
+
+
+def test_docker_login_config_env_file_with_envs_override(
+        env_file_factory: EnvFileFactory):
+    """Test Docker credentials from env_file can be overridden by envs."""
+    env_file_path = env_file_factory({
+        'SKYPILOT_DOCKER_USERNAME': 'file-user',
+        'SKYPILOT_DOCKER_PASSWORD': 'file-password',
+        'SKYPILOT_DOCKER_SERVER': 'file-registry.com',
+    })
+
+    config = {
+        'run': 'echo hello',
+        'env_file': env_file_path,
+        'envs': {
+            # Override password from envs (envs takes precedence)
+            'SKYPILOT_DOCKER_PASSWORD': 'envs-password',
+        },
+    }
+    # Should work - all Docker credentials end up in envs
+    task_obj = task.Task.from_yaml_config(config)
+
+    # env_file values should be present
+    assert task_obj.envs['SKYPILOT_DOCKER_USERNAME'] == 'file-user'
+    assert task_obj.envs['SKYPILOT_DOCKER_SERVER'] == 'file-registry.com'
+    # envs override should take precedence
+    assert task_obj.envs['SKYPILOT_DOCKER_PASSWORD'] == 'envs-password'
+
+    # Verify set_resources passes validation (should not raise)
+    task_obj.set_resources(
+        resources_lib.Resources(image_id='docker:nginx:latest'))
+
+
+def test_docker_login_config_env_file_mixed_with_secrets_fails(
+        env_file_factory: EnvFileFactory):
+    """Test that Docker credentials split between env_file and secrets fails."""
+    env_file_path = env_file_factory({
+        'SKYPILOT_DOCKER_USERNAME': 'file-user',
+        'SKYPILOT_DOCKER_SERVER': 'file-registry.com',
+    })
+
+    config = {
+        'run': 'echo hello',
+        'env_file': env_file_path,
+        'secrets': {
+            'SKYPILOT_DOCKER_PASSWORD': 'secret-password',
+        },
+    }
+    # Should fail because Docker credentials are split between envs and secrets
+    with pytest.raises(
+            ValueError,
+            match='Docker login variables must be specified together'):
+        task_obj = task.Task.from_yaml_config(config)
+        task_obj.set_resources(
+            resources_lib.Resources(image_id='docker:ubuntu:latest'))
+
+
 def make_mock_volume_config(name='vol1',
                             type='pvc',
                             cloud='aws',
@@ -977,6 +1236,57 @@ def test_resolve_volumes_with_envs_dict():
     }
     t = task.Task.from_yaml_config(config)
     assert t._volumes == {'/mnt': {'name': 'vol1_suffix'}}
+
+
+@pytest.mark.parametrize('env_vars,volumes_config,expected_volumes', [
+    pytest.param(
+        {'VOLUME_NAME': 'vol1'},
+        {'/mnt': '${VOLUME_NAME}'},
+        {'/mnt': 'vol1'},
+        id='single_env_var',
+    ),
+    pytest.param(
+        {
+            'VOLUME_NAME': 'vol1',
+            'VOLUME_SUFFIX': 'suffix'
+        },
+        {'/mnt': '${VOLUME_NAME}_${VOLUME_SUFFIX}'},
+        {'/mnt': 'vol1_suffix'},
+        id='multiple_env_vars',
+    ),
+    pytest.param(
+        {'VOLUME_NAME': 'vol1'},
+        {'/mnt': 'static_volume'},
+        {'/mnt': 'static_volume'},
+        id='no_substitution_needed',
+    ),
+    pytest.param(
+        {
+            'VOLUME_NAME': 'vol1',
+            'VOLUME_SUFFIX': 'suffix'
+        },
+        {'/mnt': {
+            'name': '${VOLUME_NAME}_${VOLUME_SUFFIX}'
+        }},
+        {'/mnt': {
+            'name': 'vol1_suffix'
+        }},
+        id='dict_volume_config',
+    ),
+])
+def test_resolve_volumes_with_env_file(env_file_factory: EnvFileFactory,
+                                       env_vars: dict[str, str],
+                                       volumes_config: dict,
+                                       expected_volumes: dict):
+    """Test that volume references can use env vars loaded from env_file."""
+    env_file_path = env_file_factory(env_vars)
+
+    config = {
+        'volumes': volumes_config,
+        'env_file': env_file_path,
+    }
+    t = task.Task.from_yaml_config(config)
+    assert t._volumes == expected_volumes
 
 
 def test_resources_to_config():


### PR DESCRIPTION
## Why

For security reasons, and for users who want to add version control to the SkyPilot YAML config, it might not be a good option to explicitly set environment variables directly in the YAML file.

Even though we have the `--env-file` flag for the Sky CLI, the YAML spec does not support it yet.

## What

- Add `env_file` to the YAML spec.
  - It provides the [same functionality as `env_file` in Docker Compose](https://docs.docker.com/compose/how-tos/environment-variables/set-environment-variables/#use-the-env_file-attribute) and can accept either a `str` or a `list[str]`.
- Update the corresponding user-facing docs about `env_file` usage.
- Add unit tests for `env_file` usage:
  - Basic `env_file` usage validation.
  - Using `envs` and `env_file` sections together.
  - Ensure Docker login can read from `env_file`.
  - Ensure volume paths that use environment variables are correctly resolved from `env_file`.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  Manual test with the following config with GCP infra and it works
  ```yaml
  name: skypilot
  
  resources:
    accelerators:
      - T4:1
    cpus: 16+
    memory: 32+
    ports: 8080
  
  env_file:
    - ../.env
  
  workdir: ../workdir

  setup: |
  # ...
  # other dependencies
  pip install whisperx==3.7.6

  # login to huggingface
  python -c "import huggingface_hub; huggingface_hub.login('${HF_TOKEN}')" # ---> passed by env_file
  ```
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
