### PR TITLE
[Core] Add SKYPILOT_USER env var for jobs

### DIFF
--- a/docs/source/running-jobs/environment-variables.rst
+++ b/docs/source/running-jobs/environment-variables.rst
@@ -188,8 +188,8 @@ Environment variables for ``setup``
          3.4.5.6
    * - ``SKYPILOT_SETUP_NUM_GPUS_PER_NODE``
      - Number of GPUs per node in the cluster.
-     
-       Note that GPUs may not be available at this stage. Do not assume 
+
+       Note that GPUs may not be available at this stage. Do not assume
        GPUs are available during setup.
      - 1
 
@@ -214,6 +214,9 @@ Environment variables for ``setup``
          )['cloud']
 
      - {"cluster_name": "my-cluster-name", "cloud": "GCP", "region": "us-central1", "zone": "us-central1-a"}
+   * - ``SKYPILOT_USER``
+     - The username of the user who launched the job.
+     - alice
    * - ``SKYPILOT_SERVE_REPLICA_ID``
      - The ID of a replica within the service (starting from 1). Available only for a :ref:`service <sky-serve>`'s replica task.
      - 1
@@ -270,6 +273,9 @@ Environment variables for ``run``
            os.environ['SKYPILOT_CLUSTER_INFO']
          )['cloud']
      - {"cluster_name": "my-cluster-name", "cloud": "GCP", "region": "us-central1", "zone": "us-central1-a"}
+   * - ``SKYPILOT_USER``
+     - The username of the user who launched the job.
+     - alice
    * - ``SKYPILOT_SERVE_REPLICA_ID``
      - The ID of a replica within the service (starting from 1). Available only for a :ref:`service <sky-serve>`'s replica task.
      - 1

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -6125,7 +6125,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 'cloud': str(handle.launched_resources.cloud),
                 'region': handle.launched_resources.region,
                 'zone': handle.launched_resources.zone,
-            })
+            }),
+            constants.USER_ENV_VAR: common_utils.get_current_user_name(),
         }
 
     def _get_task_env_vars(self, task: task_lib.Task, job_id: int,

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -89,13 +89,16 @@ def test_minimal(generic_cloud: str):
             f'sky logs {name} 5 --status',  # Ensure the job succeeded.
             f'sky exec {name} \'echo "$SKYPILOT_CLUSTER_INFO" | jq .cloud | grep -i {generic_cloud}\'',
             f'sky logs {name} 6 --status',  # Ensure the job succeeded.
+            # Check SKYPILOT_USER is set
+            f'sky exec {name} \'[[ ! -z "$SKYPILOT_USER" ]] && echo "SKYPILOT_USER=$SKYPILOT_USER"\'',
+            f'sky logs {name} 7 --status',  # Ensure the job succeeded.
             # Test '-c' for exec
             f'sky exec -c {name} echo',
-            f'sky logs {name} 7 --status',
-            f'sky exec echo -c {name}',
             f'sky logs {name} 8 --status',
+            f'sky exec echo -c {name}',
+            f'sky logs {name} 9 --status',
             f'sky exec -c {name} echo hi test',
-            f'sky logs {name} 9 | grep "hi test"',
+            f'sky logs {name} 10 | grep "hi test"',
             f'sky exec {name} && exit 1 || true',
             f'sky exec -c {name} && exit 1 || true',
             f's=$(sky cost-report --all) && echo $s && echo $s | grep {name} && echo $s | grep "Total Cost"',


### PR DESCRIPTION
Expose the username of the user who launched the job via the `SKYPILOT_USER` environment variable. This is available in both setup and run scripts. Resolves #8485 

## Changes
- Add `SKYPILOT_USER` to `_skypilot_predefined_env_vars()` in `sky/backends/cloud_vm_ray_backend.py`
- Document the new env var in `docs/source/running-jobs/environment-variables.rst` for both setup and run stages
- Add smoke test in `test_basic.py` to verify `SKYPILOT_USER` is set

Tested locally:
<details>
<summary>
 sky launch a job that prints the user
</summary>

skypilot yaml:
```yaml
# Test SKYPILOT_USER environment variable
# Usage: sky launch examples/test_skypilot_user.yaml

resources:
  cpus: 2

setup: |
  echo "=== Setup stage ==="
  echo "SKYPILOT_USER: $SKYPILOT_USER"
  if [[ -z "$SKYPILOT_USER" ]]; then
    echo "ERROR: SKYPILOT_USER is not set!"
    exit 1
  fi
  echo "Setup completed for user: $SKYPILOT_USER"

run: |
  echo "=== Run stage ==="
  echo "SKYPILOT_USER: $SKYPILOT_USER"
  if [[ -z "$SKYPILOT_USER" ]]; then
    echo "ERROR: SKYPILOT_USER is not set!"
    exit 1
  fi
  echo "Job running as user: $SKYPILOT_USER"
  echo ""
  echo "All SkyPilot env vars:"
  env | grep SKYPILOT_ | sort
```
logs:
```
$ sky launch examples/test_skypilot_user.yaml                                                                                                                                                                               skypilot/bjo HEAD
YAML to run: examples/test_skypilot_user.yaml
Considered resources (1 node):
----------------------------------------------------------------------------------------------
 INFRA                        INSTANCE           vCPUs   Mem(GB)   GPUS   COST ($)   CHOSEN   
----------------------------------------------------------------------------------------------
 Kubernetes (kind-skypilot)   -                  2       2         -      0.00          ✔     
 Nebius (eu-north1)           cpu-e2_2vcpu-8gb   2       8         -      0.05                
 AWS (us-east-1)              m6i.large          2       8         -      0.10                
----------------------------------------------------------------------------------------------
Launching a new cluster 'sky-cb37-kevinwang'. Proceed? [Y/n]: 
⚙︎ Launching on Kubernetes.
└── Pod is up.
✓ Cluster launched: sky-cb37-kevinwang.  View logs: sky logs --provision sky-cb37-kevinwang
⚙︎ Syncing files.
✓ Setup detached.
⚙︎ Job submitted, ID: 1
├── Waiting for task resources on 1 node.
└── Job started. Streaming logs... (Ctrl-C to exit log streaming; job will not be killed)
(setup pid=1378) === Setup stage ===
(setup pid=1378) SKYPILOT_USER: kevinwang
(setup pid=1378) Setup completed for user: kevinwang
(task, pid=1378) === Run stage ===
(task, pid=1378) SKYPILOT_USER: kevinwang
(task, pid=1378) Job running as user: kevinwang
(task, pid=1378) 
(task, pid=1378) All SkyPilot env vars:
(task, pid=1378) SKYPILOT_CLUSTER_INFO={"cluster_name": "sky-cb37-kevinwang", "cloud": "Kubernetes", "region": "kind-skypilot", "zone": null}
(task, pid=1378) SKYPILOT_INTERNAL_JOB_ID=1
(task, pid=1378) SKYPILOT_IN_CLUSTER_CONTEXT_NAME=kind-skypilot
(task, pid=1378) SKYPILOT_NODE_IPS=10.244.0.6
(task, pid=1378) SKYPILOT_NODE_RANK=0
(task, pid=1378) SKYPILOT_NUM_GPUS_PER_NODE=0
(task, pid=1378) SKYPILOT_NUM_NODES=1
(task, pid=1378) SKYPILOT_POD_CPU_CORE_LIMIT=2
(task, pid=1378) SKYPILOT_POD_MEMORY_BYTES_LIMIT=2000000000
(task, pid=1378) SKYPILOT_POD_NODE_TYPE=head
(task, pid=1378) SKYPILOT_TASK_ID=sky-2026-01-29-13-19-27-317429_sky-cb37-kevinwang_1
(task, pid=1378) SKYPILOT_USER=kevinwang
✓ Job finished (status: SUCCEEDED).
```
</details>

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

### Manual test

```bash
sky launch examples/test_skypilot_user.yaml
```

The test YAML verifies `SKYPILOT_USER` is set in both setup and run stages and prints all `SKYPILOT_*` env vars.