### PR TITLE
Force delete pods during cluster launch if pods from previous cluster are still deleting

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1027,9 +1027,10 @@ def _create_namespaced_pod_with_retries(namespace: str, pod_spec: dict,
                     namespace,
                     _request_timeout=config_lib.DELETION_TIMEOUT,
                     grace_period_seconds=0)
-            except Exception as delete_exception:
+            except kubernetes.api_exception() as delete_exception:
                 logger.warning(
-                    f'Failed to force delete pod {pod_name}, but proceeding to retry creation. Error: {delete_exception}')
+                    f'Failed to force delete pod {pod_name}, but proceeding '
+                    f'to retry creation. Error: {delete_exception}')
             try:
                 pod = kubernetes.core_api(context).create_namespaced_pod(
                     namespace, pod_spec)
@@ -1038,8 +1039,8 @@ def _create_namespaced_pod_with_retries(namespace: str, pod_spec: dict,
                     'after force deleting the pod from previous cluster.')
                 return pod
             except kubernetes.api_exception() as retry_exception:
-                logger.warning(
-                    f'Failed to create pod {pod_name} on retry: {retry_exception}')
+                logger.warning(f'Failed to create pod {pod_name} on retry: '
+                               f'{retry_exception}')
                 raise retry_exception
         else:
             # Re-raise the exception if it's a different error


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

**Problem statement:**

When `sky down` is called on a cluster, the pods of the cluster are force deleted. This means the pods usually terminate right there and then.

If the pods within a cluster were to be terminated for some other reason, though, there is no guarantee that the call to terminate the pods uses force deletion. In case the pods are deleted without specifying force deletion, the pods can stay in "Terminating" state for a long time.

One reason a pod can stay in `Terminating` state is if the pod was pulling an image when the pod gets issued a termination call. For ML images such as `nvcr.io/nvidia/nemo:24.05`, it may take a long time to pull the image. Therefore, if the pods get terminated while pulling a large image, the pods can be in `Terminating` state for a long time.

If, during this time, `sky launch` is issued with the same cluster name, the launch can fail with the following error message:
```
W 01-29 13:32:00.317 PID=92981 instance.py:1416] run_instances: Error occurred when creating pods:
W 01-29 13:32:00.317 PID=92981 instance.py:1416] kubernetes.client.exceptions.ApiException: (409)
W 01-29 13:32:00.317 PID=92981 instance.py:1416] Reason: Conflict
W 01-29 13:32:00.317 PID=92981 instance.py:1416] HTTP response headers: HTTPHeaderDict(...)
W 01-29 13:32:00.317 PID=92981 instance.py:1416] HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"object is being deleted: pods \"test-2dae7533-head\" already exists","reason":"AlreadyExists","details":{"name":"test-2dae7533-head","kind":"pods"},"code":409}
```

This can happen in any scenario where SkyPilot pods are deleted by something that is not SkyPilot API server without using force deletion. A known example of such scenario is kueue preemption.

In such cases, the error message 
```
"object is being deleted: pods \"test-2dae7533-head\" already exists"
```
Shows that the pod exists but is in `Terminating` state (as indicated by `object is being deleted` phrase). Therefore, it shouldn't hurt to try force deleting the pod to see if the pod will delete immediately before retrying pod creation one more time.

Tested (run the relevant ones):

- [x] Any manual tests for this PR (please specify below)

Created a scenario where a cluster is deleted but the pods of the cluster are still stuck in `Terminating` state. Ran `sky launch` and verified in that these provisioning logs print:
```
D 01-29 16:05:44.660 PID=19188 instance.py:1213] run_instances: calling create_namespaced_pod (count=2).
I 01-29 16:05:45.029 PID=19188 instance.py:1019] Pod test-2dae7533-head from previous cluster is still being deleted. Force deleting it and retrying pod creation.
I 01-29 16:05:45.597 PID=19188 instance.py:1038] Pod test-2dae7533-head created successfully after force deleting the pod from previous cluster.
D 01-29 16:05:45.599 PID=19188 instance.py:1413] run_instances: waiting for 10s for pods to schedule and run: ['test-2dae7533-head', 'test-2dae7533-worker1']
D 01-29 16:05:50.563 PID=19188 instance.py:1426] run_instances: waiting for pods to be running: ['test-2dae7533-head', 'test-2dae7533-worker1']
```
