### PR TITLE
[Slurm] Only setup ssh keys  and bashrc inside container when using containers

### DIFF
--- a/sky/templates/slurm-ray.yml.j2
+++ b/sky/templates/slurm-ray.yml.j2
@@ -1,4 +1,5 @@
 {% set user = ssh_user if image_id is none else 'root' %}
+{% set has_image = image_id is not none %}
 cluster_name: {{cluster_name_on_cloud}}
 
 # The maximum number of workers nodes to launch in addition to the head node.
@@ -77,11 +78,10 @@ setup_commands:
     {%- for initial_setup_command in initial_setup_commands %}
     {{ initial_setup_command }}
     {%- endfor %}
-{% if image_id is not none %}
-    # When using containers, setup commands run on both host AND container.
-    # SSH setup only needs to run on the container, if using containers.
-    if [ "$(id -u)" = "0" ]; then
-{% endif %}
+    # SSH setup: authorized_keys, host key, and bashrc for interactive sessions.
+    # - Non-container: always run (for the normal user)
+    # - Container: only run inside container (when root), not on the host
+    if [ {{ 'true' if not has_image else 'false' }} ] || [ "$(id -u)" = "0" ]; then
     # Generate host key for sshd -i if not exists
     mkdir -p ~{{user}}/.ssh && chmod 700 ~{{user}}/.ssh
     [ -f ~{{user}}/.ssh/{{slurm_sshd_host_key_filename}} ] || ssh-keygen -t ed25519 -f ~{{user}}/.ssh/{{slurm_sshd_host_key_filename}} -N "" -q
@@ -103,9 +103,7 @@ setup_commands:
     fi
     SKYPILOT_SSH_RC
     grep -q "source ~/.sky_ssh_rc" ~{{user}}/.bashrc 2>/dev/null || (echo "" >> ~{{user}}/.bashrc && echo "source ~/.sky_ssh_rc" >> ~{{user}}/.bashrc)
-{% if image_id is not none %}
     fi
-{% endif %}
     {{ setup_sky_dirs_commands }}
     {{ conda_installation_commands }}
     {{ uv_installation_commands }}


### PR DESCRIPTION
Previously, we were getting these errors when using containers on Slurm, which may look scary for users:

```bash
mkdir: cannot create directory ‘/root’: Permission denied
Saving key "/root/.ssh/skypilot_host_key" failed: Permission denied
/usr/bin/bash: line 8: /root/.ssh/authorized_keys: Permission denied
chmod: cannot access '/root/.ssh/authorized_keys': Permission denied
mkdir: cannot create directory ‘/root’: Permission denied
/usr/bin/bash: line 14: /root/.sky_ssh_rc: Permission denied
/usr/bin/bash: line 24: /root/.bashrc: Permission denied
```

This PR fixes this by not running these SSH setup steps on the host, and only in the container.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
