### PR TITLE
[CI] Fix critical OpenSSL vulnerability in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,7 @@ ARG NEXT_BASE_PATH=/dashboard
 
 # Install system packages
 RUN apt-get update -y && \
+    apt-get upgrade -y && \
     apt-get install --no-install-recommends -y \
         git gcc rsync sudo patch openssh-server \
         pciutils nano fuse socat netcat-openbsd curl tini autossh jq logrotate && \


### PR DESCRIPTION
Fix the failing "Scan Docker Image Vulnerabilities" CI workflow on master by adding `apt-get upgrade` to update system packages in Stage 3 of the Dockerfile.

**Root Cause:** The base image `python:3.10.18-slim` (Debian 13) ships with OpenSSL 3.5.1 which has CVE-2025-15467 (CRITICAL).

**Fix:** Add `apt-get upgrade -y` before installing packages to update OpenSSL to the fixed version (3.5.4-1~deb13u2).

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

**Test Plan:**
- The "Scan Docker Image Vulnerabilities" CI workflow will run automatically on this PR
- Once merged, the workflow should pass on master

Made with [Cursor](https://cursor.com)