### PR TITLE
[Usage] update USAGE_MESSAGE_REDACT_KEYS

### DIFF
--- a/sky/usage/constants.py
+++ b/sky/usage/constants.py
@@ -12,7 +12,7 @@ USAGE_POLICY_MESSAGE = (
     'Usage logging can be disabled by setting the '
     'environment variable SKYPILOT_DISABLE_USAGE_COLLECTION=1.')
 
-USAGE_MESSAGE_REDACT_KEYS = ['setup', 'run', 'envs']
+USAGE_MESSAGE_REDACT_KEYS = ['setup', 'run', 'envs', 'secrets']
 USAGE_MESSAGE_REDACT_TYPES = {str, dict}
 
 # Env var for the usage run id. This is used by the API server to associate


### PR DESCRIPTION
Fully redact `secrets` in telemetry to match the treatment of `envs`, `setup`, and `run`.

Before: Secret key **names** were visible, **values** were already redacted:
`{"secrets": {"OPENAI_API_KEY": "<redacted>", "DATABASE_PASSWORD": "<redacted>"}}`

After: Only line count shown
`{"secrets": "3 lines SECRETS redacted"}`

### Test plan

```
python -c "
from sky.usage import constants, usage_lib
yaml = {'secrets': {'API_KEY': 'secret123', 'TOKEN': 'abc'}}
cleaned = usage_lib._clean_yaml(yaml)
print(cleaned['secrets'])
assert 'API_KEY' not in cleaned['secrets']
"
# Output: 3 lines SECRETS redacted
```

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
