### PR TITLE
[Test] Fix flaky test_kubernetes_context_failover

### DIFF
--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -1451,7 +1451,7 @@ def test_kubernetes_context_failover(unreachable_context):
                 f'output=$(sky show-gpus --infra kubernetes/{context}) && echo "$output" && ! echo "$output" | grep H100',
                 # H100 should be displayed as long as it is available in one of the contexts
                 'output=$(sky show-gpus --infra kubernetes) && echo "$output" && echo "$output" | grep H100',
-                f'sky launch -y -c {name}-1 --cpus 1 echo hi',
+                f'sky launch -y -c {name}-1 --cpus 1 --infra kubernetes echo hi',
                 f'sky logs {name}-1 --status',
                 # It should be launched not on kind-skypilot
                 f'sky status -v {name}-1 | grep "{context}"',
@@ -1473,7 +1473,7 @@ def test_kubernetes_context_failover(unreachable_context):
                 f'kubectl config use-context {unreachable_context}',
                 f'sky launch -y -c {name}-4 --gpus H100 --cpus 1 --infra kubernetes/{unreachable_context} echo hi && exit 1 || true',
                 # Test failover from unreachable context
-                f'sky launch -y -c {name}-5 --cpus 1 echo hi',
+                f'sky launch -y -c {name}-5 --cpus 1 --infra kubernetes echo hi',
                 # switch back to kind-skypilot where GPU cluster is launched
                 f'kubectl config use-context kind-skypilot',
                 # test if sky status-kubernetes shows H100


### PR DESCRIPTION
## Summary
- Fix race condition in `test_kubernetes_context_failover` that caused intermittent failures
- Add explicit `sky check kubernetes` after API server restart in the `unreachable_context` fixture
- Add `--infra kubernetes` to launch commands to enforce Kubernetes-only resource selection

## Root Cause
Two issues were causing test failures:

### 1. Race condition with async sky check
When the `unreachable_context` fixture restarts the API server, it schedules a background `sky check` via `schedule_on_boot_check_async()`. This check runs **asynchronously** and tries to connect to all Kubernetes contexts, including the `_unreachable_context_` which causes connection timeouts (30+ seconds).

The test was running ~10 seconds after the server restart, **before** the background check completed, resulting in an empty enabled clouds cache and "Kubernetes is not enabled" errors.

### 2. Missing --infra kubernetes constraint
The launch commands at lines 1454 and 1476 did not specify `--infra kubernetes`. When other clouds like Slurm are enabled in the CI environment, the optimizer would choose Slurm over Kubernetes, causing the subsequent assertions (which expect specific Kubernetes contexts) to fail.

## Fix
1. Run `sky check kubernetes` synchronously after the API server restart, ensuring the cache is populated before the test runs.
2. Add `--infra kubernetes` to the two launch commands that test Kubernetes context failover, ensuring the optimizer only considers Kubernetes clusters.

## Test plan
The fix addresses the flakiness observed in [build 7903](https://buildkite.com/skypilot-1/smoke-tests/builds/7903#019c0fe8-4b95-43c3-ac48-2b231c380d06). The test should now be deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)