### PR TITLE
Add high_availability configuration option for jobs controller

### DIFF
--- a/docs/source/examples/managed-jobs.rst
+++ b/docs/source/examples/managed-jobs.rst
@@ -786,6 +786,7 @@ Consolidating the API server and the jobs controller has a few advantages:
 - Consistent cloud/Kubernetes credentials across the API server and jobs controller.
 - Persistent managed job state using the same database as the API server, e.g., PostgreSQL.
 - No extra VM/pod is needed for the jobs controller, saving cost.
+- High availability inherited from the API server: the controller auto-recovers when the API server restarts. During restarts, there may be brief periods of unreachability, but the SkyPilot client gracefully retries and running workloads are not affected.
 
 To enable the consolidated deployment, set :ref:`consolidation_mode <config-yaml-jobs-controller-consolidation-mode>` in the API server config.
 

--- a/docs/source/reference/api-server/examples/high-availability.rst
+++ b/docs/source/reference/api-server/examples/high-availability.rst
@@ -10,6 +10,9 @@ By default, the controller for both Managed Jobs and Sky Serve runs as a single 
 
 To enhance resilience and ensure controller plane continuity, we offer a high availability mode for the controller, which automatically recovers from failures.
 
+.. tip::
+  If you are using :ref:`consolidation mode <jobs-consolidation-mode>` (running the controller within the API server), the controller automatically inherits high availability from the API server. The ``high_availability`` field described on this page is for standalone controllers running on Kubernetes and has no effect when consolidation mode is enabled.
+
 High availability mode for the controller offers several key advantages:
 
 * **Automated Recovery:** The controller automatically restarts via Kubernetes Deployments if it encounters crashes or node failures.

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -41,6 +41,8 @@ Below is the configuration syntax and some example values. See detailed explanat
     :ref:`bucket <config-yaml-jobs-bucket>`: s3://my-bucket/
     :ref:`force_disable_cloud_bucket <config-yaml-jobs-force-disable-cloud-bucket>`: false
     controller:
+      :ref:`consolidation_mode <config-yaml-jobs-controller-consolidation-mode>`: false
+      :ref:`high_availability <config-yaml-jobs-controller-high-availability>`: false
       :ref:`resources <config-yaml-jobs-controller-resources>`:  # same spec as 'resources' in a task YAML
         infra: gcp/us-central1
         cpus: 4+  # number of vCPUs, max concurrent spot jobs = 2 * cpus
@@ -372,6 +374,8 @@ Example:
 
 Enable :ref:`consolidation mode <jobs-consolidation-mode>`, which will run the jobs controller within the remote API server, rather than in a separate sky cluster. Don't enable unless you are using a remotely-deployed API server.
 
+When consolidation mode is enabled, the controller automatically inherits high availability from the API server - it will auto-recover when the API server restarts. During restarts, there may be brief periods of unreachability, but the SkyPilot client gracefully retries during this period and running workloads are not affected.
+
 Default: ``false``.
 
 Example:
@@ -382,6 +386,30 @@ Example:
     controller:
       consolidation_mode: true
       # any specified resources will be ignored
+
+.. _config-yaml-jobs-controller-high-availability:
+
+``jobs.controller.high_availability``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Enable :ref:`high availability mode <high-availability-controller>` for the jobs controller when running as a standalone Kubernetes pod. When enabled, the controller runs as a Kubernetes Deployment with automatic restarts and persistent storage, ensuring resilience to pod crashes or node failures.
+
+This requires the controller to run on Kubernetes (set ``jobs.controller.resources.cloud: kubernetes``).
+
+.. note::
+  This field has no effect when :ref:`consolidation mode <config-yaml-jobs-controller-consolidation-mode>` is enabled. In consolidation mode, the controller automatically inherits high availability from the API server.
+
+Default: ``false``.
+
+Example:
+
+.. code-block:: yaml
+
+  jobs:
+    controller:
+      resources:
+        cloud: kubernetes  # Required for high availability mode
+      high_availability: true
 
 .. _config-yaml-jobs-controller-resources:
 


### PR DESCRIPTION
## Description

This PR adds documentation for the new `jobs.controller.high_availability` configuration option that enables high availability mode for the jobs controller.

When enabled, the controller runs as a Kubernetes Deployment with automatic restarts and persistent storage, ensuring resilience to pod crashes or node failures. This feature requires the controller to run on Kubernetes.

### Changes
- Added `high_availability` configuration option to the jobs controller section in the config reference documentation
- Added `consolidation_mode` to the configuration syntax example for completeness
- Included detailed explanation of the high availability feature, its requirements, and usage example

## Testing

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (documentation only)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

https://claude.ai/code/session_01Q8Nj1GhdupHTmy9c9goPqw