### PR TITLE
Skip dependency tests for plugin upload

### DIFF
--- a/tests/smoke_tests/test_plugin.py
+++ b/tests/smoke_tests/test_plugin.py
@@ -45,6 +45,7 @@ def test_plugin(generic_cloud: str):
 
 
 @pytest.mark.managed_jobs
+@pytest.mark.no_dependency
 @pytest.mark.no_remote_server  # Restart required so API picks up plugin upload config
 def test_plugin_upload_to_jobs_controller(generic_cloud: str):
     """Smoke test that plugin wheels are uploaded and installed on the jobs controller.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Similar to https://github.com/skypilot-org/skypilot/pull/7528, Skip test that require import kubernetes utils from client side


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
