### PR TITLE
[Test] Debug SSH proxy performance test

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -3150,3 +3150,6 @@ def test_cancel_logs_does_not_break_process_pool(generic_cloud: str):
         timeout=10 * 60,
     )
     smoke_tests_utils.run_one_test(test)
+
+
+# Debug trigger 1770069444


### PR DESCRIPTION
Debug the flaky test_kubernetes_ssh_proxy_performance test.

This PR is to trigger CI for debugging purposes.