### PR TITLE
[K8s] Fix debug command spell error in k8s retry wrapper

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -352,7 +352,7 @@ def _retry_on_error(max_retries=DEFAULT_MAX_RETRIES,
             # Format error message based on the type of exception
             resource_msg = f' when trying to get {resource_type} info' \
                 if resource_type else ''
-            debug_cmd = f' To debug, run: kubectl get {resource_type}s' \
+            debug_cmd = f' To debug, run: kubectl get {resource_type}' \
                 if resource_type else ''
             if context:
                 debug_cmd += f' --context {context}'


### PR DESCRIPTION
`resource_type` can end in an `s`, for example `runtimeclass` or `storageclass`. In this case, the debug command recommended leads to a typo. For example:

```
D 02-01 20:57:55.483 PID=3479 provisioner.py:184] sky.exceptions.KubeAPIUnreachableError: Timed out when trying to get runtimeclass info from Kubernetes cluster. Please check if the cluster is healthy and retry. To debug, run: kubectl get runtimeclasss --context kind-skypilot
```

Removing the `s`. Kubectl will still make a LIST call for the resource without the plural resource name. 

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)