### PR TITLE
build: avoid deleting build artifacts before argument parsing

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -60,7 +60,7 @@ if [ "$AUTO_BUILD" = true ]; then
         --ignore "**/llms.txt" \
         --port ${PORT:-8000}
 else
-    rm -rf build docs
+    rm -rf build
     
     # Set build environment (only if not already set by GitHub Actions)
     if [ -z "$SPHINX_BUILD_PRODUCTION" ]; then

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -39,8 +39,6 @@ if ! check_file_age "source/compute/show-gpus-h100-8.txt"; then
     sky show-gpus H100:8 > source/compute/show-gpus-h100-8.txt
 fi
 
-rm -rf build docs
-
 # Add command line argument parsing
 AUTO_BUILD=false
 while [[ "$#" -gt 0 ]]; do


### PR DESCRIPTION
Prevent unconditional removal of build/ and docs/ which breaks watch mode and causes duplicate cleanup