### PR TITLE
[Dashboard] Support plugin for user profile dropdown

### DIFF
--- a/sky/dashboard/src/components/elements/sidebar.jsx
+++ b/sky/dashboard/src/components/elements/sidebar.jsx
@@ -725,6 +725,7 @@ export function TopBar() {
                     </Link>
                     <PluginSlot
                       name="user-menu"
+                      wrapperClassName="contents"
                       context={{
                         closeDropdown: () => setIsDropdownOpen(false),
                       }}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Support plugin for user profile dropdown


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
