### PR TITLE
Use a short expiration to match typical Oauth2 access token lifetimes

### DIFF
--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -2832,9 +2832,14 @@ def api_login(endpoint: Optional[str] = None,
                 raise ValueError('Malformed token - bad key/value: '
                                  f'{name}: {value}')
 
-            # See CookieJar._cookie_from_cookie_tuple
-            # oauth2proxy default is Max-Age 604800
-            expires = int(time.time()) + 604800
+            # Use a short expiration (1 hour) to match typical OAuth2 access token
+            # lifetimes. Cookies will be refreshed from HTTP responses which have
+            # the correct expiration times from the OAuth2 proxy. This prevents
+            # issues where the OAuth2 proxy session expires before the hardcoded
+            # expiration time, causing frequent re-authentication.
+            # 1 hour matches common OAuth2 access token expiration times and ensures
+            # cookies are refreshed from responses before they become invalid.
+            expires = int(time.time()) + 3600  # 1 hour
             domain = str(parsed_url.hostname)
             domain_initial_dot = domain.startswith('.')
             secure = parsed_url.scheme == 'https'

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -2839,7 +2839,7 @@ def api_login(endpoint: Optional[str] = None,
             # expiration time, causing frequent re-authentication.
             # 1 hour matches common OAuth2 access token expiration times and ensures
             # cookies are refreshed from responses before they become invalid.
-            expires = int(time.time()) + 3600  # 1 hour
+            expires = int(time.time()) + (60 * 60)  # 1 hour
             domain = str(parsed_url.hostname)
             domain_initial_dot = domain.startswith('.')
             secure = parsed_url.scheme == 'https'


### PR DESCRIPTION
[Client] Fix frequent re-authentication with OAuth2 proxy

Reduce hardcoded cookie expiration from 7 days to 1 hour when
saving cookies from authentication tokens. This prevents frequent
re-authentication when OAuth2 proxy sessions expire before the
hardcoded expiration time.

The 1-hour expiration matches typical OAuth2 access token lifetimes
and ensures cookies are refreshed from HTTP responses with correct
expiration times. Cookies from responses will override the initial
1-hour expiration with the proper expiration from OAuth2 proxy
configuration.



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
