### PR TITLE
[Dashboard] Fix the alignment issue for the k8s table in the infra page

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -89,6 +89,7 @@ import {
 // Set the refresh interval to align with other pages
 const REFRESH_INTERVAL = REFRESH_INTERVALS.REFRESH_INTERVAL;
 const NAME_TRUNCATE_LENGTH = UI_CONFIG.NAME_TRUNCATE_LENGTH;
+const TABLE_MAX_ROWS_BEFORE_SCROLL = 5;
 
 // Shared GPU utilization bar to avoid duplicating percentage math and markup
 const GpuUtilizationBar = ({
@@ -267,7 +268,7 @@ export function InfrastructureSection({
               <div
                 className={`overflow-x-auto rounded-md border shadow-sm bg-card ${
                   isTableRefreshing ? 'infra-table-refreshing' : ''
-                } ${safeContexts.length > 5 ? 'max-h-[300px] overflow-y-auto' : ''}`}
+                } ${safeContexts.length > TABLE_MAX_ROWS_BEFORE_SCROLL ? 'max-h-[300px] overflow-y-auto' : ''}`}
               >
                 <table className="min-w-full text-sm">
                   <thead className="bg-gray-50 sticky top-0 z-10">
@@ -489,7 +490,7 @@ export function InfrastructureSection({
                 <div
                   className={`overflow-x-auto rounded-md border shadow-sm bg-card ${
                     isTableRefreshing ? 'infra-table-refreshing' : ''
-                  } ${gpus.length > 5 ? 'max-h-[300px] overflow-y-auto' : ''}`}
+                  } ${gpus.length > TABLE_MAX_ROWS_BEFORE_SCROLL ? 'max-h-[300px] overflow-y-auto' : ''}`}
                 >
                   <table className="min-w-full text-sm">
                     <thead className="bg-gray-50 sticky top-0 z-10">


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Before this PR, when there are more than 5 Kubernetes contexts or more than 5 kinds of GPUs, the table body and table header of the context table or the GPU table in the infra page will not align.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
