### PR TITLE
[Docs] Add uv to pytorch quickstart example

### DIFF
--- a/docs/source/getting-started/tutorial.rst
+++ b/docs/source/getting-started/tutorial.rst
@@ -100,7 +100,7 @@ This example uses SkyPilot to train a GPT-like model (inspired by Karpathy's `mi
               'git clone --depth 1 https://github.com/pytorch/examples || true',
               'cd examples',
               'git filter-branch --prune-empty --subdirectory-filter distributed/minGPT-ddp',
-              'pip install -r requirements.txt',
+              'uv pip install --system -r requirements.txt',
           ],
           run=[
               'cd examples/mingpt',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
