### PR TITLE
Change apisrv (debug) log directory

### DIFF
--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -1320,7 +1320,7 @@ To enable debug logging for all requests on server side, set
       --set-string 'apiService.extraEnvs[0].value=true'
 
 
-Debug level logs for each request are saved to ``~/.sky/logs/request_debug/<request_id>.log`` on the API server.
+Debug level logs for each request are saved to ``~/.sky/api_server/request_debug/<request_id>.log`` on the API server.
 Server-side debug logging does not affect output seen by the clients.
 
 Upgrade the API server

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -2410,7 +2410,7 @@ def api_start(
     logger.info(f'{ux_utils.INDENT_SYMBOL}SkyPilot API server and dashboard: '
                 f'{api_server_url}\n'
                 f'{ux_utils.INDENT_LAST_SYMBOL}'
-                f'View API server logs at: {constants.API_SERVER_LOGS}')
+                f'View API server logs at: {server_constants.API_SERVER_LOGS}')
 
 
 @usage_lib.entrypoint
@@ -2434,7 +2434,7 @@ def api_stop() -> None:
     # Acquire the api server creation lock to prevent multiple processes from
     # stopping and starting the API server at the same time.
     with filelock.FileLock(
-            os.path.expanduser(constants.API_SERVER_CREATION_LOCK_PATH)):
+            os.path.expanduser(server_constants.API_SERVER_CREATION_LOCK_PATH)):
         try:
             records = scheduler.get_controller_process_records()
             if records is not None:
@@ -2485,10 +2485,10 @@ def api_server_logs(follow: bool = True, tail: Optional[int] = None) -> None:
             tail_args.extend(['-n', '+1'])
         else:
             tail_args.extend(['-n', f'{tail}'])
-        log_path = os.path.expanduser(constants.API_SERVER_LOGS)
+        log_path = os.path.expanduser(server_constants.API_SERVER_LOGS)
         subprocess.run(['tail', *tail_args, f'{log_path}'], check=False)
     else:
-        stream_and_get(log_path=constants.API_SERVER_LOGS, tail=tail)
+        stream_and_get(log_path=server_constants.API_SERVER_LOGS, tail=tail)
 
 
 def _save_config_updates(endpoint: Optional[str] = None,

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -625,8 +625,9 @@ def _start_api_server(deploy: bool = False,
     assert server_url in AVAILABLE_LOCAL_API_SERVER_URLS, (
         f'server url {server_url} is not a local url')
 
-    with rich_utils.client_status('Starting SkyPilot API server, '
-                                  f'view logs at {constants.API_SERVER_LOGS}'):
+    with rich_utils.client_status(
+            'Starting SkyPilot API server, '
+            f'view logs at {server_constants.API_SERVER_LOGS}'):
         logger.info(f'{colorama.Style.DIM}Failed to connect to '
                     f'SkyPilot API server at {server_url}. '
                     'Starting a local server.'
@@ -674,7 +675,7 @@ def _start_api_server(deploy: bool = False,
                 os.environ[constants.ENV_VAR_ENABLE_BASIC_AUTH] = 'true'
             os.execvp(args[0], args)
 
-        log_path = os.path.expanduser(constants.API_SERVER_LOGS)
+        log_path = os.path.expanduser(server_constants.API_SERVER_LOGS)
         os.makedirs(os.path.dirname(log_path), exist_ok=True)
 
         # For spawn mode, copy the environ to avoid polluting the SDK process.
@@ -709,7 +710,7 @@ def _start_api_server(deploy: bool = False,
                 with ux_utils.print_exception_no_traceback():
                     raise RuntimeError(
                         'SkyPilot API server process exited unexpectedly.\n'
-                        f'View logs at: {constants.API_SERVER_LOGS}')
+                        f'View logs at: {server_constants.API_SERVER_LOGS}')
             try:
                 # Clear the cache to ensure fresh checks during startup
                 get_api_server_status.cache_clear()  # type: ignore
@@ -723,7 +724,7 @@ def _start_api_server(deploy: bool = False,
                             'Failed to start SkyPilot API server at '
                             f'{get_server_url(host)}'
                             '\nView logs at: '
-                            f'{constants.API_SERVER_LOGS}') from e
+                            f'{server_constants.API_SERVER_LOGS}') from e
                 time.sleep(0.5)
             else:
                 break
@@ -871,7 +872,8 @@ def check_server_healthy_or_start_fn(deploy: bool = False,
         # Lock to prevent multiple processes from starting the server at the
         # same time, causing issues with database initialization.
         with filelock.FileLock(
-                os.path.expanduser(constants.API_SERVER_CREATION_LOCK_PATH)):
+                os.path.expanduser(
+                    server_constants.API_SERVER_CREATION_LOCK_PATH)):
             # Check again if server is already running. Other processes may
             # have started the server while we were waiting for the lock.
             get_api_server_status.cache_clear()  # type: ignore[attr-defined]

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -37,8 +37,17 @@ MIN_AVAIL_MEM_GB = 2
 MIN_AVAIL_MEM_GB_CONSOLIDATION_MODE = 4
 # Default encoder/decoder handler name.
 DEFAULT_HANDLER_NAME = 'default'
+
+_API_SERVER_DIRECTORY = '~/.sky/api_server'
+# The log for SkyPilot API server.
+
+API_SERVER_LOGS = f'{_API_SERVER_DIRECTORY}/server.log'
+REQUEST_LOGS_PATH_PREFIX = f'{_API_SERVER_DIRECTORY}/request_logs'
+REQUEST_DEBUG_LOGS_PATH_PREFIX = f'{_API_SERVER_DIRECTORY}/request_debug'
+# The lock for creating the SkyPilot API server.
+API_SERVER_CREATION_LOCK_PATH = f'{_API_SERVER_DIRECTORY}/.creation.lock'
 # The path to the API request database.
-API_SERVER_REQUEST_DB_PATH = '~/.sky/api_server/requests.db'
+API_SERVER_REQUEST_DB_PATH = f'{_API_SERVER_DIRECTORY}/requests.db'
 
 # The interval (seconds) for the cluster status to be refreshed in the
 # background.

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -48,7 +48,7 @@ COL_USER_ID = 'user_id'
 COL_STATUS_MSG = 'status_msg'
 COL_SHOULD_RETRY = 'should_retry'
 COL_FINISHED_AT = 'finished_at'
-REQUEST_LOG_PATH_PREFIX = '~/.sky/api_server/request_logs'
+REQUEST_LOG_PATH_PREFIX = server_constants.REQUEST_LOGS_PATH_PREFIX
 
 DEFAULT_REQUESTS_RETENTION_HOURS = 24  # 1 day
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1969,9 +1969,9 @@ async def stream(
         del request_task
     else:
         assert log_path is not None, (request_id, log_path)
-        if log_path == constants.API_SERVER_LOGS:
+        if log_path == server_constants.API_SERVER_LOGS:
             resolved_log_path = pathlib.Path(
-                constants.API_SERVER_LOGS).expanduser()
+                server_constants.API_SERVER_LOGS).expanduser()
             if not resolved_log_path.exists():
                 raise fastapi.HTTPException(
                     status_code=404,

--- a/sky/sky_logging.py
+++ b/sky/sky_logging.py
@@ -9,6 +9,7 @@ import threading
 
 import colorama
 
+from sky.server import constants as server_constants
 from sky.skylet import constants
 from sky.utils import context
 from sky.utils import env_options
@@ -19,9 +20,6 @@ _FORMAT = ('%(levelname).1s %(asctime)s.%(msecs)03d PID=%(process)d '
            '%(filename)s:%(lineno)d] %(message)s')
 _DATE_FORMAT = '%m-%d %H:%M:%S'
 _SENSITIVE_LOGGER = ['sky.provisioner', 'sky.optimizer']
-
-_DEBUG_LOG_DIR = os.path.expanduser(
-    os.path.join(constants.SKY_LOGS_DIRECTORY, 'request_debug'))
 
 DEBUG = logging.DEBUG
 INFO = logging.INFO
@@ -274,8 +272,10 @@ def add_debug_log_handler(request_id: str):
         yield
         return
 
-    os.makedirs(_DEBUG_LOG_DIR, exist_ok=True)
-    log_path = os.path.join(_DEBUG_LOG_DIR, f'{request_id}.log')
+    debug_log_dir = os.path.expanduser(
+        server_constants.REQUEST_DEBUG_LOGS_PATH_PREFIX)
+    os.makedirs(debug_log_dir, exist_ok=True)
+    log_path = os.path.join(debug_log_dir, f'{request_id}.log')
     try:
         debug_log_handler = logging.FileHandler(log_path)
         debug_log_handler.setFormatter(FORMATTER)

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -438,10 +438,6 @@ FILE_MOUNTS_TMP_SUBPATH = 'job-{run_id}/tmp-files'
 # Serve: A default controller with 4 vCPU and 16 GB memory can run up to 16
 # services.
 CONTROLLER_PROCESS_CPU_DEMAND = 0.25
-# The log for SkyPilot API server.
-API_SERVER_LOGS = '~/.sky/api_server/server.log'
-# The lock for creating the SkyPilot API server.
-API_SERVER_CREATION_LOCK_PATH = '~/.sky/api_server/.creation.lock'
 
 # The name for the environment variable that stores the URL of the SkyPilot
 # API server.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Sky logs are traditionally stored at `~/sky_logs/...`. On API server side, we store the following logs in the directory:
- Managed jobs logs (at `~/sky_logs/managed_jobs`)
- Jobs controller logs (at `~/sky_logs/jobs_controller`)
- API server request logs (at `~/sky_logs/api_server`)

The top two managed jobs related logs are expected to be persistent across API server restarts. This goes back to the original rationale behind having a separate jobs controller - managed jobs related information are supposed to be persisted across API server restarts.

The API server request logs, on the other hand, are not meant to persist across API server restarts. This design choice obvious in `requests_lib.reset_db_and_logs()`, which deletes requests db and requests logs on API server restart.

we've observed users persisting `~/sky_logs` in a separate storage media (e.g. persistent NFS store). In this design, the API server request logs are also stored in NFS, which is not desired. Move the directory out of `~/sky_logs` into `~/.sky/api_server`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
