### PR TITLE
[Test] Fix Azure storage tests losing config when policy server overrides

### DIFF
--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -527,15 +527,7 @@ def override_sky_config(
         original_config = skypilot_config.parse_and_validate_config_file(
             env_dict[skypilot_config.ENV_VAR_GLOBAL_CONFIG])
     else:
-        # Read the default user config file if it exists, so that settings
-        # like azure.storage_account are preserved when overlaying overrides.
-        default_config_path = os.path.expanduser(
-            skypilot_config.get_user_config_path())
-        if os.path.exists(default_config_path):
-            original_config = skypilot_config.parse_and_validate_config_file(
-                default_config_path)
-        else:
-            original_config = skypilot_config.config_utils.Config()
+        original_config = skypilot_config.get_user_config()
     overlay_config = skypilot_config.overlay_skypilot_config(
         original_config, override_sky_config_dict)
     temp_config_file.write(yaml_utils.dump_yaml_str(dict(overlay_config)))


### PR DESCRIPTION
## Summary
- Fix 3 consistently failing Azure storage tests (`test_bucket_external_deletion`, `test_upload_to_existing_bucket`, `test_nonexistent_bucket`) caused by `--account-key None` being passed to Azure CLI commands
- Root cause: `override_sky_config()` used an empty config as the base when `SKYPILOT_GLOBAL_CONFIG` wasn't set, losing `azure.storage_account` from `~/.sky/config.yaml` when the session-scoped `setup_policy_server` fixture overlaid only `admin_policy`
- Fix: use `skypilot_config.get_user_config()` to read the default user config as the base, preserving existing settings

## Regression
Introduced by commit `4edf7ac63` in PR #6353 ("Enable restful admin policy in smoke test", Aug 12 2025, by @aylei).

Before that PR, `setup_policy_server` modified `~/.sky/config.yaml` **in-place** — it read the existing config, added `admin_policy`, wrote it back, and restored on cleanup. This preserved all settings like `azure.storage_account: buildkitestorage`.

PR #6353 switched to using `override_sky_config(config_dict={'admin_policy': url})`, which creates a **new temp config file**. But when `SKYPILOT_GLOBAL_CONFIG` is not yet set (as is the case at session start), `override_sky_config` used an empty `Config()` as the base instead of reading `~/.sky/config.yaml`. The resulting temp file only contained `admin_policy`, losing `azure.storage_account`.

Without `azure.storage_account` in config, the tests fall back to a hash-based default storage account name. `get_az_storage_account_key()` then fails to find the resource group for this account and returns `None`, causing `--account-key None` in all Azure CLI commands.

## Test plan
- Retrigger the 3 failing Azure storage tests on Buildkite:
  ```
  /smoke-test -k "test_bucket_external_deletion or test_upload_to_existing_bucket or test_nonexistent_bucket" --azure
  ```
- Verify all 3 tests pass with the fix
- Related failing build: https://buildkite.com/skypilot-1/smoke-tests/builds/7981

🤖 Generated with [Claude Code](https://claude.com/claude-code)