### PR TITLE
[AWS] Deduplicate stale local catalog entries

### DIFF
--- a/sky/catalog/aws_catalog.py
+++ b/sky/catalog/aws_catalog.py
@@ -185,6 +185,13 @@ def _fetch_and_apply_az_mapping(df: common.LazyDataFrame) -> 'pd.DataFrame':
     return df
 
 
+def _deduplicate_catalog(df: 'pd.DataFrame') -> 'pd.DataFrame':
+    """Drops duplicate rows per AZ, keeping the one with a valid SpotPrice."""
+    df = df.sort_values('SpotPrice', ascending=True, na_position='last')
+    return df.drop_duplicates(
+        subset=['InstanceType', 'Region', 'AvailabilityZone'], keep='first')
+
+
 def _get_df() -> 'pd.DataFrame':
     global _user_df
     with _apply_az_mapping_lock:
@@ -198,6 +205,7 @@ def _get_df() -> 'pd.DataFrame':
                     return _default_df
                 else:
                     raise
+            _user_df = _deduplicate_catalog(_user_df)
     return _user_df
 
 

--- a/sky/catalog/aws_catalog.py
+++ b/sky/catalog/aws_catalog.py
@@ -197,15 +197,15 @@ def _get_df() -> 'pd.DataFrame':
     with _apply_az_mapping_lock:
         if _user_df is None:
             try:
-                _user_df = _fetch_and_apply_az_mapping(_default_df)
+                df = _fetch_and_apply_az_mapping(_default_df)
             except (RuntimeError, ImportError) as e:
                 if config.get_use_default_catalog_if_failed():
                     logger.warning('Failed to fetch availability zone mapping. '
                                    f'{common_utils.format_exception(e)}')
-                    return _default_df
+                    df = _default_df
                 else:
                     raise
-            _user_df = _deduplicate_catalog(_user_df)
+            _user_df = _deduplicate_catalog(df)
     return _user_df
 
 

--- a/tests/unit_tests/test_catalog.py
+++ b/tests/unit_tests/test_catalog.py
@@ -8,6 +8,7 @@ import orjson
 import pandas as pd
 import pytest
 
+from sky.catalog import aws_catalog
 from sky.catalog import common as catalog_common
 from sky.utils import annotations
 
@@ -685,8 +686,6 @@ def test_get_hourly_cost_with_duplicate_catalog_entries():
     This is a regression test for GitHub issue #8638 where stale local
     catalogs had duplicate p4de.24xlarge rows with conflicting SpotPrice.
     """
-    from sky.catalog import aws_catalog
-
     df = pd.DataFrame([
         {
             'InstanceType': 'p4de.24xlarge',

--- a/tests/unit_tests/test_catalog.py
+++ b/tests/unit_tests/test_catalog.py
@@ -677,3 +677,41 @@ def test_slurm_get_hourly_cost_end_to_end(mock_nested):
     # Accelerator-only pricing: partition A100=5.00, cpu/memory ignored
     expected = 4 * 5.00
     assert cost == pytest.approx(expected)
+
+
+def test_get_hourly_cost_with_duplicate_catalog_entries():
+    """Test that duplicate catalog entries for the same AZ don't crash.
+
+    This is a regression test for GitHub issue #8638 where stale local
+    catalogs had duplicate p4de.24xlarge rows with conflicting SpotPrice.
+    """
+    from sky.catalog import aws_catalog
+
+    df = pd.DataFrame([
+        {
+            'InstanceType': 'p4de.24xlarge',
+            'SpotPrice': 12.29,
+            'Region': 'us-east-1',
+            'AvailabilityZone': 'us-east-1c',
+        },
+        {
+            'InstanceType': 'p4de.24xlarge',
+            'SpotPrice': np.nan,
+            'Region': 'us-east-1',
+            'AvailabilityZone': 'us-east-1c',
+        },
+    ])
+
+    saved = aws_catalog._user_df
+    try:
+        aws_catalog._user_df = None
+        with mock.patch.object(aws_catalog,
+                               '_fetch_and_apply_az_mapping',
+                               return_value=df):
+            cost = aws_catalog.get_hourly_cost('p4de.24xlarge',
+                                               use_spot=True,
+                                               region='us-east-1',
+                                               zone='us-east-1c')
+        assert cost == 12.29
+    finally:
+        aws_catalog._user_df = saved


### PR DESCRIPTION
## Summary

Stale local AWS catalogs can have duplicate rows for the same instance+zone, causing an `AssertionError` on spot price lookup. This PR deduplicates when loading the catalog.

Fixes #8638

## Test plan

Tested:

- [x] Code formatting: `bash format.sh --files sky/catalog/aws_catalog.py tests/unit_tests/test_catalog.py` — yapf, isort, mypy all pass
- [x] Any manual or new tests for this PR: added `test_get_hourly_cost_with_duplicate_catalog_entries` regression test
  - `pytest tests/unit_tests/test_catalog.py` — all 17 tests pass
- [ ] All smoke tests: `/smoke-test` (CI)
- [ ] Relevant individual tests: n/a (no cloud launch needed, change is catalog-load-time only)
- [ ] Backward compatibility: `/quicktest-core` (CI)

**Reproduction:** users can trigger the original bug by manually adding a duplicate `p4de.24xlarge` row with `SpotPrice: NaN` to their local catalog CSV at `~/.sky/catalogs/v8/aws/vms.csv`, then running `sky launch --gpus A100-80GB:8 --use-spot`.