### PR TITLE
[Nebius] Support k8s autoscaler from zero 

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -1381,8 +1381,12 @@ Can be one of:
 
 - ``gke``: Google Kubernetes Engine
 - ``karpenter``: Karpenter
+- ``nebius``: `Nebius Kubernetes cluster with autoscaling <https://docs.nebius.com/kubernetes/node-groups/autoscaling>`_ (Works only from 1 to many)
 - ``coreweave``: `CoreWeave autoscaler <https://docs.coreweave.com/docs/products/cks/nodes/autoscaling>`_
 - ``generic``: Generic autoscaler, assumes nodes are labelled with ``skypilot.co/accelerator``.
+
+If you want to use the autoscaler, set :ref:`provision_timeout <config-yaml-kubernetes-provision-timeout>` to at least 600.
+
 
 .. _config-yaml-kubernetes-pod-config:
 

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -683,7 +683,9 @@ class GFDLabelFormatter(GPULabelFormatter):
     def get_label_values(cls, accelerator: str) -> List[str]:
         # An accelerator can map to many Nvidia GFD labels
         # (e.g., A100-80GB-PCIE vs. A100-SXM4-80GB).
-        # TODO implement get_label_values for GFDLabelFormatter
+        # TODO: implement get_label_values for GFDLabelFormatter. We need a
+        #  mapping from SkyPilot accelerator names (e.g., l40s) to GFD labels
+        #  (e.g., NVIDIA-L40S)
         raise NotImplementedError
 
     @classmethod
@@ -765,13 +767,58 @@ class KarpenterLabelFormatter(SkyPilotLabelFormatter):
     LABEL_KEY = 'karpenter.k8s.aws/instance-gpu-name'
 
 
+class NebiusLabelFormatter(GPULabelFormatter):
+    """Nebius label formatter
+
+        Uses node.kubernetes.io/instance-type as the key, and the uppercase SkyPilot
+        accelerator str as the value.
+        """
+
+    LABEL_KEY = 'node.kubernetes.io/instance-type'
+    # From https://docs.nebius.com/compute/virtual-machines/types
+    NEBIUS_ACCELERATOR_TO_PLATFORM = {
+        'B200': ['gpu-b200-sxm'],
+        'H200': ['gpu-h200-sxm'],
+        'H100': ['gpu-h100-sxm'],
+        'L40S': ['gpu-l40s-a', 'gpu-l40s-d']
+    }
+
+    @classmethod
+    def get_label_key(cls, accelerator: Optional[str] = None) -> str:
+        return cls.LABEL_KEY
+
+    @classmethod
+    def get_label_keys(cls) -> List[str]:
+        return [cls.LABEL_KEY]
+
+    @classmethod
+    def get_label_values(cls, accelerator: str) -> List[str]:
+        return cls.NEBIUS_ACCELERATOR_TO_PLATFORM.get(accelerator, [])
+
+    @classmethod
+    def match_label_key(cls, label_key: str) -> bool:
+        return label_key == cls.LABEL_KEY
+
+    @classmethod
+    def get_accelerator_from_label_value(cls, value: str) -> str:
+        if value.startswith('gpu-'):
+            # All GPU platforms have format like 'gpu-h200-sxm'
+            # https://docs.nebius.com/compute/virtual-machines/types
+            return value.split('-')[1].upper()
+        elif value.startswith('cpu-'):
+            return ''
+        else:
+            raise ValueError(
+                f'Invalid accelerator name in Nebius cluster: {value}')
+
+
 # LABEL_FORMATTER_REGISTRY stores the label formats SkyPilot will try to
 # discover the accelerator type from. The order of the list is important, as
 # it will be used to determine the priority of the label formats when
 # auto-detecting the GPU label type.
 LABEL_FORMATTER_REGISTRY = [
     SkyPilotLabelFormatter, GKELabelFormatter, KarpenterLabelFormatter,
-    GFDLabelFormatter, CoreWeaveLabelFormatter
+    GFDLabelFormatter, CoreWeaveLabelFormatter, NebiusLabelFormatter
 ]
 
 
@@ -1213,6 +1260,14 @@ class CoreweaveAutoscaler(Autoscaler):
     can_query_backend: bool = False
 
 
+class NebiusAutoscaler(Autoscaler):
+    """Nebius autoscaler.
+    """
+
+    label_formatter: Any = NebiusLabelFormatter
+    can_query_backend: bool = False
+
+
 class GenericAutoscaler(Autoscaler):
     """Generic autoscaler
     """
@@ -1226,6 +1281,7 @@ AUTOSCALER_TYPE_TO_AUTOSCALER = {
     kubernetes_enums.KubernetesAutoscalerType.GKE: GKEAutoscaler,
     kubernetes_enums.KubernetesAutoscalerType.KARPENTER: KarpenterAutoscaler,
     kubernetes_enums.KubernetesAutoscalerType.COREWEAVE: CoreweaveAutoscaler,
+    kubernetes_enums.KubernetesAutoscalerType.NEBIUS: NebiusAutoscaler,
     kubernetes_enums.KubernetesAutoscalerType.GENERIC: GenericAutoscaler,
 }
 

--- a/sky/utils/kubernetes_enums.py
+++ b/sky/utils/kubernetes_enums.py
@@ -30,6 +30,7 @@ class KubernetesAutoscalerType(enum.Enum):
     GKE = 'gke'
     KARPENTER = 'karpenter'
     COREWEAVE = 'coreweave'
+    NEBIUS = 'nebius'
     GENERIC = 'generic'
 
     def emits_autoscale_event(self) -> bool:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
