### PR TITLE
[Test] Fix flaky test timeouts for helm_deploy_okta and tail_jobs_logs_blocks_ssh

### DIFF
--- a/tests/smoke_tests/test_api_server.py
+++ b/tests/smoke_tests/test_api_server.py
@@ -583,9 +583,9 @@ def test_tail_jobs_logs_blocks_ssh(generic_cloud: str):
         print("Attempting to ssh in.")
 
         # Now attempt to ssh in.
-        ssh_cmd = f'ssh -o ConnectTimeout=10 -o BatchMode=yes {name} "echo hi"'
+        ssh_cmd = f'ssh -o ConnectTimeout=30 -o BatchMode=yes {name} "echo hi"'
         ssh_ret = subprocess.Popen(ssh_cmd, shell=True)
-        if ssh_ret.wait(timeout=10) != 0:
+        if ssh_ret.wait(timeout=60) != 0:
             raise Exception("SSH failed.")
 
         print("SSH completed.")

--- a/tests/smoke_tests/test_images.py
+++ b/tests/smoke_tests/test_images.py
@@ -756,5 +756,6 @@ def test_helm_deploy_eks(request):
 def test_helm_deploy_okta():
     test = smoke_tests_utils.Test('helm_deploy_okta', [
         f'bash tests/kubernetes/scripts/helm_okta.sh',
-    ])
+    ],
+                                  timeout=30 * 60)
     smoke_tests_utils.run_one_test(test)


### PR DESCRIPTION
## Summary
- **test_helm_deploy_okta**: Increase timeout from 15min (default) to 30min. The `helm_okta.sh` script builds a Docker image, deploys Helm charts twice (legacy + new OAuth mode), performs Okta logins with Selenium, and runs a `sky launch` + SSH test. The Okta auth flow alone can take ~5min on timeout, leaving insufficient time for the final `sky launch` provisioning step.
- **test_tail_jobs_logs_blocks_ssh**: Increase SSH `ConnectTimeout` from 10s to 30s and `wait` timeout from 10s to 60s. On loaded kind cluster agents, the SSH proxy connection through Kubernetes can take longer than 10 seconds to establish.

## Related failing build
https://buildkite.com/skypilot-1/smoke-tests/builds/8065

## Test plan
- [x] Verify the timeout values are reasonable for CI environment
- [ ] Retrigger the failing tests on Buildkite:
  ```
  /smoke-test --kubernetes -k "test_helm_deploy_okta or test_tail_jobs_logs_blocks_ssh"
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)