### PR TITLE
fix: correct typos 'siganled' and 'recieved'

### DIFF
--- a/sky/server/uvicorn.py
+++ b/sky/server/uvicorn.py
@@ -106,7 +106,7 @@ class Server(uvicorn.Server):
         server will be forcefully shutdown.
         """
         if self.exiting and sig == signal.SIGINT:
-            # The server has been siganled to exit and recieved a SIGINT again,
+            # The server has been signaled to exit and received a SIGINT again,
             # do force shutdown.
             logger.info('Force shutdown.')
             self.should_exit = True


### PR DESCRIPTION
Fixed typos in sky/server/uvicorn.py comment:
- 'siganled' → 'signaled'
- 'recieved' → 'received'