### PR TITLE
[Storage] Add support for negation patterns `!` in .skyignore

### DIFF
--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -49,6 +49,11 @@ def get_excluded_files_from_skyignore(src_dir_path: str) -> List[str]:
                     is_negation = line.startswith('!')
                     if is_negation:
                         line = line[1:]  # Remove '!' prefix
+                    # Skip empty patterns (e.g., a line with just '!')
+                    # This aligns with gitignore behavior where empty patterns
+                    # match nothing.
+                    if not line:
+                        continue
 
                     # Make parsing consistent with rsync.
                     # Rsync uses '/' as current directory.

--- a/tests/unit_tests/test_sky/storage/test_storage_utils.py
+++ b/tests/unit_tests/test_sky/storage/test_storage_utils.py
@@ -174,6 +174,42 @@ def test_get_excluded_files_from_skyignore_with_negation():
         assert 'keep.txt' not in excluded_files
 
 
+def test_get_excluded_files_from_skyignore_empty_negation_pattern():
+    """Test that a line with just '!' is ignored (matches gitignore behavior).
+
+    A lone '!' should not accidentally re-include all files. This aligns with
+    gitignore semantics where empty patterns match nothing.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create test files
+        files = ['config.json', 'data.json', 'keep.txt']
+        for file_path in files:
+            full_path = os.path.join(temp_dir, file_path)
+            with open(full_path, 'w', encoding='utf-8') as f:
+                f.write('test content')
+
+        # Create .skyignore with a lone '!' which should be ignored
+        skyignore_content = textwrap.dedent("""\
+            # Exclude all json files
+            *.json
+            # A lone '!' should be ignored, not re-include everything
+            !
+            """)
+        skyignore_path = os.path.join(temp_dir, constants.SKY_IGNORE_FILE)
+        with open(skyignore_path, 'w', encoding='utf-8') as f:
+            f.write(skyignore_content)
+
+        # Test function
+        excluded_files = storage_utils.get_excluded_files_from_skyignore(
+            temp_dir)
+
+        # All json files should still be excluded (the lone '!' had no effect)
+        assert 'config.json' in excluded_files
+        assert 'data.json' in excluded_files
+        # Non-json files should not be affected
+        assert 'keep.txt' not in excluded_files
+
+
 def test_get_excluded_files_from_skyignore_negation_order_matters():
     """Test that negation only affects files excluded by earlier patterns."""
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
Fixes #8812
## Summary
- Add support for negation patterns (lines starting with `!`) in `.skyignore` files
- This follows rsync/gitignore semantics where negation patterns re-include previously excluded files
- Fixes issue where users couldn't selectively keep specific files when using broad exclusion patterns

## Example
```
# ignore all json
*.json

# but keep this one
!config.json
```

## Test plan
- [ ] Run unit tests: `pytest tests/unit_tests/test_sky/storage/test_storage_utils.py -k skyignore -v`
- [ ] Manual test with a workdir containing the example `.skyignore` pattern