### PR TITLE
[Slurm] Fix container init hang when srun fails

### DIFF
--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -374,6 +374,7 @@ echo "[container-init] Packages installed in $((SECONDS - INIT_START))s"
 
 # Cleanup function to remove cluster dirs on job termination.
 cleanup() {{
+    saved_exit=$?
     # The Skylet is daemonized, so it is not automatically terminated when
     # the Slurm job is terminated, we need to kill it manually.
     echo "Terminating Skylet..."
@@ -393,9 +394,13 @@ cleanup() {{
     # that created the sky directories.
     srun --nodes={num_nodes} rm -rf {skypilot_runtime_dir}
     rm -rf {sky_cluster_home_dir}
-    exit 0
+    exit $saved_exit
 }}
-trap cleanup TERM
+# Run cleanup on any exit, including container init failures.
+trap cleanup EXIT
+# On SIGTERM (job cancellation via scancel), exit 0 so cleanup treats
+# it as a graceful shutdown rather than propagating an error code.
+trap 'exit 0' TERM
 
 # Create sky home directory and subdirectories for the cluster.
 mkdir -p {sky_cluster_home_dir}/sky_logs {sky_cluster_home_dir}/sky_workdir {sky_cluster_home_dir}/.sky

--- a/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/containers.sh
+++ b/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/containers.sh
@@ -13,6 +13,7 @@
 
 # Cleanup function to remove cluster dirs on job termination.
 cleanup() {
+    saved_exit=$?
     # The Skylet is daemonized, so it is not automatically terminated when
     # the Slurm job is terminated, we need to kill it manually.
     echo "Terminating Skylet..."
@@ -32,9 +33,13 @@ cleanup() {
     # that created the sky directories.
     srun --nodes=1 rm -rf /tmp/test-cluster
     rm -rf /home/testuser/.sky_clusters/test-cluster
-    exit 0
+    exit $saved_exit
 }
-trap cleanup TERM
+# Run cleanup on any exit, including container init failures.
+trap cleanup EXIT
+# On SIGTERM (job cancellation via scancel), exit 0 so cleanup treats
+# it as a graceful shutdown rather than propagating an error code.
+trap 'exit 0' TERM
 
 # Create sky home directory and subdirectories for the cluster.
 mkdir -p /home/testuser/.sky_clusters/test-cluster/sky_logs /home/testuser/.sky_clusters/test-cluster/sky_workdir /home/testuser/.sky_clusters/test-cluster/.sky


### PR DESCRIPTION
When container initialization fails (e.g., OOM during image import), the sbatch polling loop hangs indefinitely waiting for marker files that will never be created. Fix by capturing the background srun PID and checking if it's still alive in the polling loop, exiting immediately with its error code if it died.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
