### PR TITLE
[Kubernetes] Exclude kubeconfig for non-controller clusters when allowed_contexts is set

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -777,18 +777,14 @@ def write_cluster_config(
             # interim, SSH Node Pools' get_credential_file_mounts can filter
             # contexts starting with ssh- and create a temp kubeconfig
             # to upload.
-            if allowed_contexts is None:
+            # When allowed_contexts is not set, or when it is set for a
+            # non-controller cluster, we exclude kubeconfig upload. Controller
+            # clusters need kubeconfig to manage other K8s clusters.
+            is_controller = controller_utils.Controllers.from_name(
+                cluster_name, expect_exact_match=False) is not None
+            if allowed_contexts is None or not is_controller:
                 excluded_clouds.add(clouds.Kubernetes())
                 excluded_clouds.add(clouds.SSH())
-            else:
-                # When allowed_contexts is configured, only upload kubeconfig
-                # for controller clusters (they need it to manage other K8s
-                # clusters). For regular clusters, exclude kubeconfig upload.
-                is_controller = controller_utils.Controllers.from_name(
-                    cluster_name, expect_exact_match=False) is not None
-                if not is_controller:
-                    excluded_clouds.add(clouds.Kubernetes())
-                    excluded_clouds.add(clouds.SSH())
         else:
             excluded_clouds.add(cloud)
 

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -1458,11 +1458,15 @@ def test_kubernetes_context_failover(unreachable_context):
                 f'sky logs {name}-1 --status',
                 # It should be launched not on kind-skypilot
                 f'sky status -v {name}-1 | grep "{context}"',
+                f'sky exec {name}-1 ls /home/sky/.kube',
+                f"sky logs {name}-1 2 | grep \"'/home/sky/.kube': No such file or directory\"",
                 # Test failure for launching H100 on other cluster
                 f'sky launch -y -c {name}-2 --gpus H100 --cpus 1 --infra kubernetes/{context} echo hi && exit 1 || true',
                 # Test failover
                 f'sky launch -y -c {name}-3 --gpus H100 --cpus 1 --infra kubernetes echo hi',
                 f'sky logs {name}-3 --status',
+                f'sky exec {name}-3 ls /home/sky/.kube',
+                f"sky logs {name}-3 2 | grep \"'/home/sky/.kube': No such file or directory\"",
                 # Test pods
                 f'kubectl get pods --context kind-skypilot | grep "{name}-3"',
                 # It should be launched on kind-skypilot
@@ -1477,6 +1481,8 @@ def test_kubernetes_context_failover(unreachable_context):
                 f'sky launch -y -c {name}-4 --gpus H100 --cpus 1 --infra kubernetes/{unreachable_context} echo hi && exit 1 || true',
                 # Test failover from unreachable context
                 f'sky launch -y -c {name}-5 --cpus 1 --infra kubernetes echo hi',
+                f'sky exec {name}-5 ls /home/sky/.kube',
+                f"sky logs {name}-5 2 | grep \"'/home/sky/.kube': No such file or directory\"",
                 # switch back to kind-skypilot where GPU cluster is launched
                 f'kubectl config use-context kind-skypilot',
                 # test if sky status-kubernetes shows H100


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fix https://github.com/skypilot-org/skypilot/issues/8781
Exclude kubeconfig upload for non-controller clusters when allowed_contexts is set


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - allowed_contexts is set
    - kubeconfig is uploaded to the job controller
    - kubeconfig is not uploaded to the clusters and managed job clusters
  - allowed_contexts is not set
    - kubeconfig is not uploaded to the job controller
    - kubeconfig is not uploaded to the clusters and managed job clusters 
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
