### PR TITLE
[Recipes] Provide Clear Upgrade Message for Outdated Clients

### DIFF
--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -912,6 +912,8 @@ def process_mounts_in_task_on_api_server(task: str, env_vars: Dict[str, str],
     """
     from sky.utils import dag_utils  # pylint: disable=import-outside-toplevel
 
+    versions.check_recipe_client_version(task)
+
     user_hash = env_vars.get(constants.USER_ID_ENV_VAR, 'unknown')
 
     # We should not use int(time.time()) as there can be multiple requests at

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -30,6 +30,9 @@ API_VERSION_HEADER = 'X-SkyPilot-API-Version'
 # The HTTP header name for the SkyPilot version of the sender.
 VERSION_HEADER = 'X-SkyPilot-Version'
 
+# Minimum client API version required to launch recipes.
+MIN_RECIPE_LAUNCH_API_VERSION = 33
+
 # Prefix for API request names.
 REQUEST_NAME_PREFIX = 'sky.'
 # The memory (GB) that SkyPilot tries to not use to prevent OOM.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

A user may attempt to launch a recipe with a client that does not support it. Supported versions will take the recipe name and fetch the corresponding yaml. For out of date clients that attempt to launch with `sky launch recipes:<recipe_name>` they will wrongfully interpret the recipe as a bash command. This PR changes the server to check for this case and display a clear message to the user to upgrade if they wish to launch a recipe.

<img width="1676" height="214" alt="image" src="https://github.com/user-attachments/assets/ba94b64e-bd27-41dd-b4a9-62ad1a13e880" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
