### PR TITLE
[Dashboard] Fix plugin support: ReactDOM exports, sub-route matching, and dev proxy

### DIFF
--- a/sky/dashboard/server.js
+++ b/sky/dashboard/server.js
@@ -24,6 +24,15 @@ app
       })
     );
 
+    // Proxy plugin static assets (JS bundles served by API server)
+    server.use(
+      '/plugins',
+      createProxyMiddleware({
+        target: `${process.env.SKYPILOT_API_SERVER_ENDPOINT || 'http://localhost:46580'}/plugins`,
+        changeOrigin: true,
+      })
+    );
+
     // Proxy Grafana requests
     server.use(
       '/grafana',

--- a/sky/dashboard/src/pages/_app.js
+++ b/sky/dashboard/src/pages/_app.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import * as ReactDOMAll from 'react-dom';
 import dynamic from 'next/dynamic';
 import PropTypes from 'prop-types';
 import '@/app/globals.css';
@@ -16,10 +17,12 @@ const Layout = dynamic(
   { ssr: false }
 );
 
-// Expose React and ReactDOM to window for plugins to use
+// Expose React and ReactDOM to window for plugins to use.
+// We merge react-dom/client (createRoot, hydrateRoot) with react-dom
+// (createPortal, flushSync, etc.) so plugins have access to all exports.
 if (typeof window !== 'undefined') {
   window.React = React;
-  window.ReactDOM = ReactDOM;
+  window.ReactDOM = { ...ReactDOMAll, ...ReactDOM };
 }
 
 function App({ Component, pageProps }) {

--- a/sky/dashboard/src/plugins/PluginProvider.jsx
+++ b/sky/dashboard/src/plugins/PluginProvider.jsx
@@ -742,7 +742,17 @@ export function usePluginRoute(pathname) {
     if (!pathname) {
       return null;
     }
-    return routes.find((route) => route.path === pathname) || null;
+    // Use prefix matching so plugin sub-routes (e.g. /plugins/my-plugin/details)
+    // are handled by the plugin that registered the base path (/plugins/my-plugin).
+    // Sort by path length descending so the most specific match wins.
+    return (
+      [...routes]
+        .sort((a, b) => b.path.length - a.path.length)
+        .find(
+          (route) =>
+            pathname === route.path || pathname.startsWith(route.path + '/')
+        ) || null
+    );
   }, [pathname, routes]);
 }
 


### PR DESCRIPTION
## Summary
- **ReactDOM exports**: Merge `react-dom` and `react-dom/client` exports on `window.ReactDOM` so plugins have access to both `createRoot` and `createPortal`/`flushSync`. Currently only `react-dom/client` is exposed, which breaks plugins using React portals (e.g. Radix UI dialogs, tooltips, popovers).
- **Plugin sub-route matching**: Change `usePluginRoute` from exact-match to prefix-match so plugin sub-routes (e.g. `/plugins/foo/details`) resolve to the plugin that registered `/plugins/foo`. Sorts by path length descending so the most specific match wins.
- **Dev proxy for `/plugins`**: Add a proxy rule in `server.js` so plugin JS bundles served by the API server (e.g. `/plugins/my-plugin.js`) are accessible through the Next.js dev server during local development.

## Test plan
- [ ] Verify plugins using `createPortal` (Radix UI dialogs/tooltips) render correctly
- [ ] Verify plugin sub-routes navigate correctly without a blank page
- [ ] Verify `npm run dev` proxies `/plugins/*` requests to the API server
- [ ] Verify existing dashboard pages are unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)