### PR TITLE
[Examples] Fix Ray train example for aarch64 GPUs

### DIFF
--- a/examples/distributed_ray_train/ray_train.yaml
+++ b/examples/distributed_ray_train/ray_train.yaml
@@ -19,7 +19,7 @@ setup: |
 
   uv pip install "ray[train]" "click<8.2.0"
   uv pip install tqdm
-  uv pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+  uv pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126
 
 run: |
   sudo chmod 777 -R /var/tmp


### PR DESCRIPTION
## Summary
- Update PyTorch wheel index from `cu118` to `cu126` in the distributed Ray train example
- `cu126` is the only index that provides CUDA-enabled aarch64 wheels (e.g. for GH200); `cu118`/`cu121`/`cu124` all only have CPU-only aarch64 builds
- Also works for x86_64 (cu126 has x86_64 CUDA wheels)

Previously, this example was failing on our Slurm SUNK test cluster (which only had aarch64 GPUs - GH200):
```bash
  (worker1, rank=0, pid=395293, ip=10.0.3.25) (TrainController pid=406127)     raise
  RuntimeError("Distributed package doesn't have NCCL " "built in")
  (worker1, rank=0, pid=395293, ip=10.0.3.25) (TrainController pid=406127) RuntimeError: Distributed
  package doesn't have NCCL built in
  (worker1, rank=0, pid=395293, ip=10.0.3.25) Traceback (most recent call last):
  (worker1, rank=0, pid=395293, ip=10.0.3.25)   File "/root/sky_workdir/train.py", line 154, in <module>
  (worker1, rank=0, pid=395293, ip=10.0.3.25)     train_fashion_mnist(num_workers=args.num_workers,
  use_gpu=True)
  (worker1, rank=0, pid=395293, ip=10.0.3.25)   File "/root/sky_workdir/train.py", line 146, in
  train_fashion_mnist
  (worker1, rank=0, pid=395293, ip=10.0.3.25)     result = trainer.fit()
  (worker1, rank=0, pid=395293, ip=10.0.3.25)   File
  "/root/sky_workdir/.venv/lib/python3.10/site-packages/ray/train/v2/api/data_parallel_trainer.py", line
  188, in fit
  (worker1, rank=0, pid=395293, ip=10.0.3.25)     raise result.error
  (worker1, rank=0, pid=395293, ip=10.0.3.25) ray.train.ControllerError: Training failed due to controller
  error:
  (worker1, rank=0, pid=395293, ip=10.0.3.25) ray::execute._setup_torch_process_group() (pid=86888,
  ip=10.0.0.49, actor_id=72dda28f587ed00e0cc5418501000000,
  repr=<ray.train.v2._internal.execution.worker_group.worker.RayTrainWorker object at 0xfc94e4768a60>)
  (worker1, rank=0, pid=395293, ip=10.0.3.25)   File "/root/sky_workdir/.venv/lib/python3.10/site-packages/
  ray/train/v2/_internal/execution/worker_group/worker.py", line 127, in execute
  (worker1, rank=0, pid=395293, ip=10.0.3.25)     return fn(*fn_args, **fn_kwargs)
  (worker1, rank=0, pid=395293, ip=10.0.3.25)   File
  "/root/sky_workdir/.venv/lib/python3.10/site-packages/ray/train/torch/config.py", line 122, in
  _setup_torch_process_group
  (worker1, rank=0, pid=395293, ip=10.0.3.25)     dist.init_process_group(
  (worker1, rank=0, pid=395293, ip=10.0.3.25)   File
  "/root/sky_workdir/.venv/lib/python3.10/site-packages/torch/distributed/distributed_c10d.py", line 907,
  in init_process_group
  (worker1, rank=0, pid=395293, ip=10.0.3.25)     default_pg = _new_process_group_helper(
  (worker1, rank=0, pid=395293, ip=10.0.3.25)   File
  "/root/sky_workdir/.venv/lib/python3.10/site-packages/torch/distributed/distributed_c10d.py", line 1013,
  in _new_process_group_helper
  (worker1, rank=0, pid=395293, ip=10.0.3.25)     raise RuntimeError("Distributed package doesn't have NCCL
   " "built in")
  (worker1, rank=0, pid=395293, ip=10.0.3.25) RuntimeError: Distributed package doesn't have NCCL built in
```

## Test plan
- Verified on 2-node GH200 Slurm cluster with `sky launch -c ray-train --infra slurm --image-id docker:rayproject/ray:nightly-py39-gpu --num-nodes 2 --gpus GH200:1 ray_train.yaml`
- Confirmed `torch==2.10.0+cu126`, `Is CUDA available: True`, `NCCL: True` via `python -m torch.utils.collect_env`

```
  # cu118: aarch64 wheels are CPU-only (no +cu118 tag)
  curl -s https://download.pytorch.org/whl/cu118/torch/ | grep aarch64 | grep "+cu118"
  # (no output — no CUDA aarch64 wheels)

  # cu118: aarch64 wheels exist but CPU-only
  curl -s https://download.pytorch.org/whl/cu118/torch/ | grep aarch64 | head -5
  # torch-2.0.1-cp39-cp39-manylinux2014_aarch64.whl  (no +cu118)

  # cu126: aarch64 wheels WITH CUDA
  curl -s https://download.pytorch.org/whl/cu126/torch/ | grep aarch64 | grep "+cu126"
  # torch-2.10.0+cu126-cp310-cp310-manylinux_2_28_aarch64.whl  ← CUDA enabled
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)