### PR TITLE
Fix sky api stop hang on zombie processes in containers

### DIFF
--- a/sky/utils/subprocess_utils.py
+++ b/sky/utils/subprocess_utils.py
@@ -215,8 +215,7 @@ GenericProcess = Union[multiprocessing.Process, psutil.Process,
                        subprocess.Popen]
 
 
-def _wait_non_child_process(proc: 'psutil.Process',
-                            grace_period: int) -> None:
+def _wait_non_child_process(proc: 'psutil.Process', grace_period: int) -> None:
     """Wait for a non-child process to exit by polling its status.
 
     psutil.Process.wait() internally polls kill(pid, 0) for non-children,


### PR DESCRIPTION
## Summary
- `sky api stop` hangs for 50+ seconds in containers without a proper init process (e.g. no tini/dumb-init)
- Root cause: `psutil.Process.wait()` polls `kill(pid, 0)` for non-child processes, which always succeeds for zombies, blocking for the full `grace_period` per process
- Fix: for non-child processes, poll `proc.status()` instead — this correctly detects zombies (exited but not reaped) vs running processes. Child processes still use the normal `wait()` path since `waitpid()` can reap them
- Also adds `alive()` guard to the `finally` block to skip unnecessary force-kill escalation when the process already exited

## Test plan
- [x] All 12 existing `test_subprocess_utils.py` tests pass
- [x] `sky api stop` completes in ~2.5s (down from 50+ seconds)
- [x] Verified with strace that the `kill(pid, 0)` polling loop no longer occurs
- [x] Confirmed `psutil.Process.wait()` bug with standalone [demo script](https://gist.github.com/) — `pidfd+poll` returns in 0.0ms for zombies but psutil still blocks the full timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)