### PR TITLE
Fix Grafana dashboard 414 URI Too Large on large clusters

### DIFF
--- a/charts/skypilot/manifests/dcgm-cluster-dashboard.json
+++ b/charts/skypilot/manifests/dcgm-cluster-dashboard.json
@@ -1394,6 +1394,7 @@
           "uid": "prometheus"
         },
         "definition": "query_result(label_replace(DCGM_FI_DEV_GPU_UTIL, \"host\", \"$1\", \"node\", \"(.*)\") or label_replace(amd_gpu_gfx_activity, \"host\", \"$1\", \"hostname\", \"(.*)\"))",
+        "allValue": ".*",
         "includeAll": true,
         "label": "Host",
         "multi": true,
@@ -1418,6 +1419,7 @@
           "uid": "prometheus"
         },
         "definition": "query_result(label_replace(DCGM_FI_DEV_GPU_UTIL{node=~\"$host\"}, \"gpu\", \"$1\", \"gpu\", \"(.*)\") or label_replace(amd_gpu_gfx_activity{hostname=~\"$host\"}, \"gpu\", \"$1\", \"gpu_id\", \"(.*)\"))",
+        "allValue": ".*",
         "includeAll": true,
         "label": "GPU ID",
         "multi": true,

--- a/charts/skypilot/manifests/dcgm-cluster-filter-dashboard.json
+++ b/charts/skypilot/manifests/dcgm-cluster-filter-dashboard.json
@@ -600,6 +600,7 @@
           "uid": "prometheus"
         },
         "definition": "label_values(kube_pod_labels, label_skypilot_cluster_name)",
+        "allValue": ".*",
         "includeAll": true,
         "name": "cluster",
         "options": [],
@@ -619,6 +620,7 @@
           "uid": "prometheus"
         },
         "definition": "query_result(label_replace(DCGM_FI_DEV_GPU_UTIL, \"node\", \"$1\", \"node\", \"(.*)\") or label_replace(amd_gpu_gfx_activity, \"node\", \"$1\", \"hostname\", \"(.*)\"))",
+        "allValue": ".*",
         "includeAll": true,
         "multi": true,
         "name": "node",
@@ -638,6 +640,7 @@
           "uid": "prometheus"
         },
         "definition": "query_result(label_replace(DCGM_FI_DEV_GPU_UTIL{node=~\"$node\"}, \"gpu\", \"$1\", \"gpu\", \"(.*)\") or label_replace(amd_gpu_gfx_activity{hostname=~\"$node\"}, \"gpu\", \"$1\", \"gpu_id\", \"(.*)\"))",
+        "allValue": ".*",
         "includeAll": true,
         "multi": true,
         "name": "gpu",


### PR DESCRIPTION
## Summary
- When "All" is selected for Host/GPU ID dropdowns on the DCGM Grafana dashboards, Grafana expands every individual value into the Prometheus query regex (e.g., `node=~"node1|node2|...|node200"`), causing **414 Request-URI Too Large** errors from nginx and **Prometheus parse errors** on clusters with many nodes/GPUs.
- Added `allValue: ".*"` to all multi-select template variables in both `dcgm-cluster-dashboard.json` and `dcgm-cluster-filter-dashboard.json`, so Grafana uses a compact `.*` wildcard regex when "All" is selected instead of enumerating all values.

## Test plan
- [ ] Deploy updated dashboards to a large cluster with many GPU nodes
- [ ] Verify DCGM Cluster Dashboard loads correctly with Host="All" and GPU ID="All"
- [ ] Verify DCGM GPU Metrics (filter) dashboard loads correctly with all variables set to "All"
- [ ] Confirm no 414 errors or parse errors appear in the dashboard panels
- [ ] Verify selecting specific hosts/GPUs still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)