### PR TITLE
[Core] Make decorators type annotation aware

### DIFF
--- a/sky/backends/backend.py
+++ b/sky/backends/backend.py
@@ -23,6 +23,26 @@ _ResourceHandleType = typing.TypeVar('_ResourceHandleType',
 # Examples: 'cluster.yaml'; 'ray://...', 'k8s://...'.
 class ResourceHandle:
 
+    launched_nodes: int
+    launched_resources: 'resources.Resources'
+    docker_user: Optional[str]
+
+    @property
+    def cluster_yaml(self) -> Optional[str]:
+        raise NotImplementedError
+
+    @property
+    def head_ip(self) -> Optional[str]:
+        raise NotImplementedError
+
+    @property
+    def head_ssh_port(self) -> Optional[int]:
+        raise NotImplementedError
+
+    @property
+    def ssh_user(self) -> Optional[str]:
+        raise NotImplementedError
+
     def get_cluster_name(self) -> str:
         raise NotImplementedError
 

--- a/sky/backends/backend.py
+++ b/sky/backends/backend.py
@@ -21,7 +21,7 @@ _ResourceHandleType = typing.TypeVar('_ResourceHandleType',
 
 # Backend-specific handle to the launched resources (e.g., a cluster).
 # Examples: 'cluster.yaml'; 'ray://...', 'k8s://...'.
-class ResourceHandle:
+class ResourceHandle:  # pylint: disable=missing-class-docstring
 
     launched_nodes: int
     launched_resources: 'resources.Resources'

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -654,7 +654,7 @@ def write_cluster_config(
     keep_launch_fields_in_existing_config: bool = True,
     volume_mounts: Optional[List['volume_utils.VolumeMount']] = None,
     cloud_specific_failover_overrides: Optional[Dict[str, Any]] = None,
-) -> Dict[str, Any]:
+) -> Dict[str, str]:
     """Fills in cluster configuration templates and writes them out.
 
     Returns:
@@ -1408,7 +1408,7 @@ def get_docker_user(ip: str, cluster_config_file: str) -> str:
     ssh_credentials = ssh_credential_from_yaml(cluster_config_file)
     runner = command_runner.SSHCommandRunner(node=(ip, 22), **ssh_credentials)
     container_name = constants.DEFAULT_DOCKER_CONTAINER_NAME
-    whoami_returncode, whoami_stdout, whoami_stderr = runner.run(
+    whoami_returncode, whoami_stdout, whoami_stderr = runner.run(  # pylint: disable=unpacking-non-sequence
         f'sudo docker exec {container_name} whoami',
         stream_logs=False,
         require_outputs=True)
@@ -1461,7 +1461,7 @@ def wait_until_ray_cluster_ready(
             ux_utils.spinner_message('Waiting for workers',
                                      log_path=log_path)) as worker_status:
         while True:
-            rc, output, stderr = runner.run(
+            rc, output, stderr = runner.run(  # pylint: disable=unpacking-non-sequence
                 instance_setup.RAY_STATUS_WITH_SKY_RAY_PORT_COMMAND,
                 log_path=log_path,
                 stream_logs=False,

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -17,7 +17,7 @@ import threading
 import time
 import typing
 from typing import (Any, Callable, Dict, Iterator, List, Optional, Sequence,
-                    Set, Tuple, TypeVar, Union)
+                    Set, Tuple, TYPE_CHECKING, TypeVar, Union)
 import uuid
 
 import aiohttp
@@ -654,7 +654,7 @@ def write_cluster_config(
     keep_launch_fields_in_existing_config: bool = True,
     volume_mounts: Optional[List['volume_utils.VolumeMount']] = None,
     cloud_specific_failover_overrides: Optional[Dict[str, Any]] = None,
-) -> Dict[str, str]:
+) -> Dict[str, Any]:
     """Fills in cluster configuration templates and writes them out.
 
     Returns:
@@ -3183,7 +3183,7 @@ def is_controller_accessible(
         # status of the controller.
         controller_status, handle = refresh_cluster_status_handle(
             cluster_name,
-            force_refresh_statuses=[status_lib.ClusterStatus.INIT],
+            force_refresh_statuses={status_lib.ClusterStatus.INIT},
             cluster_status_lock_timeout=0)
     except exceptions.ClusterStatusFetchingError as e:
         # We do not catch the exceptions related to the cluster owner identity
@@ -3223,6 +3223,9 @@ def is_controller_accessible(
                                                    handle.docker_user,
                                                    handle.ssh_user)
 
+        if TYPE_CHECKING:
+            assert handle.head_ip is not None
+            assert handle.head_ssh_port is not None
         runner = command_runner.SSHCommandRunner(node=(handle.head_ip,
                                                        handle.head_ssh_port),
                                                  **ssh_credentials)
@@ -3243,6 +3246,9 @@ def is_controller_accessible(
                                                handle=handle)
     assert handle is not None and handle.head_ip is not None, (
         handle, controller_status)
+    # TODO(jason810496): We should correct the return type to 'ResourceHandle' instead of 'CloudVmRayResourceHandle'.
+    if TYPE_CHECKING:
+        assert isinstance(handle, backends.CloudVmRayResourceHandle), handle
     return handle
 
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1054,20 +1054,23 @@ class RetryingVmProvisioner(object):
             for failover_overrides in to_provision.cloud.yield_cloud_specific_failover_overrides(
                     region=to_provision.region):
                 try:
-                    config_dict = backend_utils.write_cluster_config(
-                        to_provision,
-                        num_nodes,
-                        _get_cluster_config_template(to_provision.cloud),
-                        cluster_name,
-                        self._local_wheel_path,
-                        self._wheel_hash,
-                        region=region,
-                        zones=zones,
-                        dryrun=dryrun,
-                        keep_launch_fields_in_existing_config=cluster_exists,
-                        volume_mounts=volume_mounts,
-                        cloud_specific_failover_overrides=failover_overrides,
-                    )
+                    # cast from Dict[str, str] to Dict[str, Any] to silence mypy
+                    config_dict = typing.cast(
+                        Dict[str, Any],
+                        backend_utils.write_cluster_config(
+                            to_provision,
+                            num_nodes,
+                            _get_cluster_config_template(to_provision.cloud),
+                            cluster_name,
+                            self._local_wheel_path,
+                            self._wheel_hash,
+                            region=region,
+                            zones=zones,
+                            dryrun=dryrun,
+                            keep_launch_fields_in_existing_config=cluster_exists,
+                            volume_mounts=volume_mounts,
+                            cloud_specific_failover_overrides=failover_overrides,
+                        ))
                 except exceptions.ResourcesUnavailableError as e:
                     # Failed due to catalog issue, e.g. image not found, or
                     # GPUs are requested in a Kubernetes cluster but the cluster

--- a/sky/core.py
+++ b/sky/core.py
@@ -537,8 +537,11 @@ def _start(
     if handle is None:
         raise exceptions.ClusterDoesNotExist(
             f'Cluster {cluster_name!r} does not exist.')
+
     if not force and cluster_status == status_lib.ClusterStatus.UP:
         sky_logging.print(f'Cluster {cluster_name!r} is already up.')
+        if typing.TYPE_CHECKING:
+            assert isinstance(handle, backends.CloudVmRayResourceHandle)
         return handle
     assert force or cluster_status in (
         status_lib.ClusterStatus.INIT,

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -710,12 +710,12 @@ def launch(
             cluster_status, maybe_handle = (
                 backend_utils.refresh_cluster_status_handle(
                     cluster_name,
-                    force_refresh_statuses=[
+                    force_refresh_statuses={
                         # If the cluster is INIT, we want to try to grab the
                         # status lock, which should block until provisioning is
                         # finished.
                         status_lib.ClusterStatus.INIT,
-                    ],
+                    },
                     # Wait indefinitely to obtain the lock, so that we don't
                     # have multiple processes launching the same cluster at
                     # once.

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -530,7 +530,9 @@ def _execute_dag(
                 job_id = backend.execute(handle, task, dryrun=dryrun)
             finally:
                 # Enables post_execute() to be run after KeyboardInterrupt.
-                backend.post_execute(handle, down)
+                backend.post_execute(
+                    typing.cast(backends.CloudVmRayResourceHandle, handle),
+                    down)
 
         if Stage.DOWN in stages and not dryrun:
             if down and idle_minutes_to_autostop is None:

--- a/sky/provision/fluidstack/instance.py
+++ b/sky/provision/fluidstack/instance.py
@@ -36,14 +36,14 @@ def get_internal_ip(node_info: Dict[str, Any]) -> None:
                         require_outputs=True,
                         stream_logs=False)
 
-    if result[0] != 0:
+    if result[0] != 0:  # pylint: disable=unsubscriptable-object
         # Some DCs do not have internal IPs and can fail when getting
         # the IP. We set the `internal_ip` to the same as
         # external IP. It should be fine as the `ray cluster`
         # will also get and use that external IP in that case.
         logger.debug('Failed get obtain private IP from node')
     else:
-        node_info['internal_ip'] = result[1].strip()
+        node_info['internal_ip'] = result[1].strip()  # pylint: disable=unsubscriptable-object
 
 
 def _filter_instances(

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -899,9 +899,10 @@ def pre_init(namespace: str, context: Optional[str], new_nodes: List) -> None:
             container=k8s_constants.RAY_NODE_CONTAINER_NAME)
 
         # Run the combined pre-init command
-        rc, stdout, _ = runner.run(pre_init_cmd,
-                                   require_outputs=True,
-                                   stream_logs=False)
+        rc, stdout, _ = runner.run(  # pylint: disable=unpacking-non-sequence
+            pre_init_cmd,
+            require_outputs=True,
+            stream_logs=False)
         if rc == exceptions.INSUFFICIENT_PRIVILEGES_CODE:
             raise config_lib.KubernetesError(
                 'Insufficient system privileges detected. '
@@ -1706,10 +1707,11 @@ def get_cluster_info(
     runner = command_runner.KubernetesCommandRunner(
         ((namespace, context), head_pod_name),
         container=k8s_constants.RAY_NODE_CONTAINER_NAME)
-    rc, stdout, stderr = runner.run(get_k8s_ssh_user_cmd,
-                                    require_outputs=True,
-                                    separate_stderr=True,
-                                    stream_logs=False)
+    rc, stdout, stderr = runner.run(  # pylint: disable=unpacking-non-sequence
+        get_k8s_ssh_user_cmd,
+        require_outputs=True,
+        separate_stderr=True,
+        stream_logs=False)
     _raise_command_running_error('get ssh user', get_k8s_ssh_user_cmd,
                                  head_pod_name, rc, stdout + stderr)
 

--- a/sky/provision/seeweb/instance.py
+++ b/sky/provision/seeweb/instance.py
@@ -99,10 +99,11 @@ class SeewebNodeProvider:
             ssh_user=self._get_ssh_user(),
             ssh_private_key=self._get_private_key_path(),
         )
-        rc, stdout, stderr = runner.run(cmd,
-                                        stream_logs=stream_logs,
-                                        require_outputs=True,
-                                        connect_timeout=timeout)
+        rc, stdout, stderr = runner.run(  # pylint: disable=unpacking-non-sequence
+            cmd,
+            stream_logs=stream_logs,
+            require_outputs=True,
+            connect_timeout=timeout)
         # Convert to simple namespace for compatibility
         proc = subprocess.CompletedProcess(args=cmd,
                                            returncode=rc,

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -421,9 +421,10 @@ touch {sky_cluster_home_dir}/.hushlogin
     # pylint: enable=line-too-long
 
     cmd = f'mkdir -p {PROVISION_SCRIPTS_DIRECTORY}'
-    rc, stdout, stderr = login_node_runner.run(cmd,
-                                               require_outputs=True,
-                                               stream_logs=False)
+    rc, stdout, stderr = login_node_runner.run(  # pylint: disable=unpacking-non-sequence
+        cmd,
+        require_outputs=True,
+        stream_logs=False)
     subprocess_utils.handle_returncode(
         rc,
         cmd,
@@ -484,9 +485,10 @@ touch {sky_cluster_home_dir}/.hushlogin
             remaining_timeout,
         )
     except (TimeoutError, RuntimeError, exceptions.CommandError) as e:
-        _, stdout, _ = login_node_runner.run(f'cat {slurm_log} 2>/dev/null',
-                                             require_outputs=True,
-                                             stream_logs=False)
+        _, stdout, _ = login_node_runner.run(  # pylint: disable=unpacking-non-sequence
+            f'cat {slurm_log} 2>/dev/null',
+            require_outputs=True,
+            stream_logs=False)
         if stdout:
             logger.error(f'=== Slurm job logs ({slurm_log}) ===\n'
                          f'{stdout}'
@@ -860,9 +862,10 @@ def get_command_runners(
                                                  cluster_name_on_cloud)
     container_marker = (
         f'{sky_cluster_home_dir}/{slurm_utils.SLURM_CONTAINER_MARKER_FILE}')
-    rc, stdout, stderr = login_node_runner.run(f'test -f {container_marker}',
-                                               require_outputs=True,
-                                               stream_logs=False)
+    rc, stdout, stderr = login_node_runner.run(  # pylint: disable=unpacking-non-sequence
+        f'test -f {container_marker}',
+        require_outputs=True,
+        stream_logs=False)
     if rc not in (0, 1):
         subprocess_utils.handle_returncode(
             rc,

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -296,7 +296,9 @@ def ha_recovery_for_consolidation_mode(pool: bool):
                 f.write(f'{capnoun} {service_name}\'s recovery script does '
                         'not exist. Skipping recovery.\n')
                 continue
-            rc, out, err = runner.run(script, require_outputs=True)
+            rc, out, err = runner.run(  # pylint: disable=unpacking-non-sequence
+                script,
+                require_outputs=True)
             if rc:
                 f.write(f'Recovery script returned {rc}. '
                         f'Output: {out}\nError: {err}\n')

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -14,11 +14,13 @@ import tempfile
 import termios
 import threading
 import time
+import typing
 from typing import (Any, Callable, Dict, Iterable, List, Optional, Tuple, Type,
                     Union)
 import uuid
 
 import colorama
+from typing_extensions import Literal
 
 from sky import exceptions
 from sky import sky_logging
@@ -551,6 +553,40 @@ class CommandRunner:
                                            stderr=stdout + stderr,
                                            stream_logs=stream_logs)
 
+    @typing.overload
+    def run(self,
+            cmd: Union[str, List[str]],
+            *,
+            require_outputs: Literal[False] = ...,
+            log_path: str = ...,
+            process_stream: bool = ...,
+            stream_logs: bool = ...,
+            ssh_mode: SshMode = ...,
+            separate_stderr: bool = ...,
+            connect_timeout: Optional[int] = ...,
+            source_bashrc: bool = ...,
+            skip_num_lines: int = ...,
+            run_in_background: bool = ...,
+            **kwargs) -> int:
+        ...
+
+    @typing.overload
+    def run(self,
+            cmd: Union[str, List[str]],
+            *,
+            require_outputs: Literal[True],
+            log_path: str = ...,
+            process_stream: bool = ...,
+            stream_logs: bool = ...,
+            ssh_mode: SshMode = ...,
+            separate_stderr: bool = ...,
+            connect_timeout: Optional[int] = ...,
+            source_bashrc: bool = ...,
+            skip_num_lines: int = ...,
+            run_in_background: bool = ...,
+            **kwargs) -> Tuple[int, str, str]:
+        ...
+
     @timeline.event
     def run(
             self,
@@ -595,6 +631,20 @@ class CommandRunner:
         """
         raise NotImplementedError
 
+    @typing.overload
+    def run_driver(self,
+                   cmd: Union[str, List[str]],
+                   *,
+                   require_outputs: Literal[False] = ...,
+                   **kwargs) -> int:
+        ...
+
+    @typing.overload
+    def run_driver(self, cmd: Union[str, List[str]], *,
+                   require_outputs: Literal[True],
+                   **kwargs) -> Tuple[int, str, str]:
+        ...
+
     def run_driver(
         self,
         cmd: Union[str, List[str]],
@@ -617,6 +667,20 @@ class CommandRunner:
             A tuple of (returncode, stdout, stderr).
         """
         return self.run(cmd, **kwargs)
+
+    @typing.overload
+    def run_setup(self,
+                  cmd: Union[str, List[str]],
+                  *,
+                  require_outputs: Literal[False] = ...,
+                  **kwargs) -> int:
+        ...
+
+    @typing.overload
+    def run_setup(self, cmd: Union[str, List[str]], *,
+                  require_outputs: Literal[True],
+                  **kwargs) -> Tuple[int, str, str]:
+        ...
 
     def run_setup(
         self,
@@ -1199,6 +1263,42 @@ class SSHCommandRunner(CommandRunner):
                                      process_stream=False,
                                      shell=True)
 
+    @typing.overload
+    def run(self,
+            cmd: Union[str, List[str]],
+            *,
+            require_outputs: Literal[False] = ...,
+            port_forward: Optional[List[Tuple[int, int]]] = ...,
+            log_path: str = ...,
+            process_stream: bool = ...,
+            stream_logs: bool = ...,
+            ssh_mode: SshMode = ...,
+            separate_stderr: bool = ...,
+            connect_timeout: Optional[int] = ...,
+            source_bashrc: bool = ...,
+            skip_num_lines: int = ...,
+            run_in_background: bool = ...,
+            **kwargs) -> int:
+        ...
+
+    @typing.overload
+    def run(self,
+            cmd: Union[str, List[str]],
+            *,
+            require_outputs: Literal[True],
+            port_forward: Optional[List[Tuple[int, int]]] = ...,
+            log_path: str = ...,
+            process_stream: bool = ...,
+            stream_logs: bool = ...,
+            ssh_mode: SshMode = ...,
+            separate_stderr: bool = ...,
+            connect_timeout: Optional[int] = ...,
+            source_bashrc: bool = ...,
+            skip_num_lines: int = ...,
+            run_in_background: bool = ...,
+            **kwargs) -> Tuple[int, str, str]:
+        ...
+
     @timeline.event
     @context_utils.cancellation_guard
     def run(
@@ -1495,6 +1595,42 @@ class KubernetesCommandRunner(CommandRunner):
         ]
         return kubectl_cmd
 
+    @typing.overload
+    def run(self,
+            cmd: Union[str, List[str]],
+            *,
+            port_forward: Optional[List[int]] = ...,
+            require_outputs: Literal[False] = ...,
+            log_path: str = ...,
+            process_stream: bool = ...,
+            stream_logs: bool = ...,
+            ssh_mode: SshMode = ...,
+            separate_stderr: bool = ...,
+            connect_timeout: Optional[int] = ...,
+            source_bashrc: bool = ...,
+            skip_num_lines: int = ...,
+            run_in_background: bool = ...,
+            **kwargs) -> int:
+        ...
+
+    @typing.overload
+    def run(self,
+            cmd: Union[str, List[str]],
+            *,
+            port_forward: Optional[List[int]] = ...,
+            require_outputs: Literal[True],
+            log_path: str = ...,
+            process_stream: bool = ...,
+            stream_logs: bool = ...,
+            ssh_mode: SshMode = ...,
+            separate_stderr: bool = ...,
+            connect_timeout: Optional[int] = ...,
+            source_bashrc: bool = ...,
+            skip_num_lines: int = ...,
+            run_in_background: bool = ...,
+            **kwargs) -> Tuple[int, str, str]:
+        ...
+
     @timeline.event
     @context_utils.cancellation_guard
     def run(
@@ -1680,6 +1816,42 @@ class LocalProcessCommandRunner(CommandRunner):
 
     def __init__(self):
         super().__init__('local')
+
+    @typing.overload
+    def run(self,
+            cmd: Union[str, List[str]],
+            *,
+            require_outputs: Literal[False] = ...,
+            port_forward: Optional[List[Tuple[int, int]]] = ...,
+            log_path: str = ...,
+            process_stream: bool = ...,
+            stream_logs: bool = ...,
+            ssh_mode: SshMode = ...,
+            separate_stderr: bool = ...,
+            connect_timeout: Optional[int] = ...,
+            source_bashrc: bool = ...,
+            skip_num_lines: int = ...,
+            run_in_background: bool = ...,
+            **kwargs) -> int:
+        ...
+
+    @typing.overload
+    def run(self,
+            cmd: Union[str, List[str]],
+            *,
+            require_outputs: Literal[True],
+            port_forward: Optional[List[Tuple[int, int]]] = ...,
+            log_path: str = ...,
+            process_stream: bool = ...,
+            stream_logs: bool = ...,
+            ssh_mode: SshMode = ...,
+            separate_stderr: bool = ...,
+            connect_timeout: Optional[int] = ...,
+            source_bashrc: bool = ...,
+            skip_num_lines: int = ...,
+            run_in_background: bool = ...,
+            **kwargs) -> Tuple[int, str, str]:
+        ...
 
     @timeline.event
     @context_utils.cancellation_guard
@@ -1959,6 +2131,19 @@ exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
                              stream_logs=stream_logs,
                              max_retry=max_retry)
 
+    @typing.overload
+    def run(self,
+            cmd: Union[str, List[str]],
+            *,
+            require_outputs: Literal[False] = ...,
+            **kwargs) -> int:
+        ...
+
+    @typing.overload
+    def run(self, cmd: Union[str, List[str]], *, require_outputs: Literal[True],
+            **kwargs) -> Tuple[int, str, str]:
+        ...
+
     @timeline.event
     @context_utils.cancellation_guard
     def run(
@@ -1969,6 +2154,20 @@ exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
         in_container = self.container_args is not None
         return self._run_via_srun(cmd, in_container=in_container, **kwargs)
 
+    @typing.overload
+    def run_driver(self,
+                   cmd: Union[str, List[str]],
+                   *,
+                   require_outputs: Literal[False] = ...,
+                   **kwargs) -> int:
+        ...
+
+    @typing.overload
+    def run_driver(self, cmd: Union[str, List[str]], *,
+                   require_outputs: Literal[True],
+                   **kwargs) -> Tuple[int, str, str]:
+        ...
+
     def run_driver(
         self,
         cmd: Union[str, List[str]],
@@ -1976,6 +2175,20 @@ exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
     ) -> Union[int, Tuple[int, str, str]]:
         # Host only: driver uses srun internally to launch work in containers.
         return self._run_via_srun(cmd, in_container=False, **kwargs)
+
+    @typing.overload
+    def run_setup(self,
+                  cmd: Union[str, List[str]],
+                  *,
+                  require_outputs: Literal[False] = ...,
+                  **kwargs) -> int:
+        ...
+
+    @typing.overload
+    def run_setup(self, cmd: Union[str, List[str]], *,
+                  require_outputs: Literal[True],
+                  **kwargs) -> Tuple[int, str, str]:
+        ...
 
     def run_setup(
         self,

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -2198,7 +2198,7 @@ exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
         # Both host and container: ensure environment is consistent.
         result = self._run_via_srun(cmd, in_container=False, **kwargs)
         if self.container_args:
-            returncode = result if isinstance(result, int) else result[0]
+            returncode = result if isinstance(result, int) else result[0]  # pylint: disable=unsubscriptable-object
             if returncode != 0:
                 return result
             result = self._run_via_srun(cmd, in_container=True, **kwargs)

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -620,8 +620,22 @@ def user_and_hostname_hash() -> str:
     return f'{getpass.getuser()}-{hostname_hash}'
 
 
-def make_decorator(cls, name_or_fn: Union[str, Callable],
-                   **ctx_kwargs) -> Callable:
+F = typing.TypeVar('F', bound=Callable)
+
+
+@typing.overload
+def make_decorator(cls: Any, name_or_fn: str,
+                   **ctx_kwargs: Any) -> Callable[[F], F]:
+    ...
+
+
+@typing.overload
+def make_decorator(cls: Any, name_or_fn: F, **ctx_kwargs: Any) -> F:
+    ...
+
+
+def make_decorator(cls: Any, name_or_fn: Union[str, Callable],
+                   **ctx_kwargs: Any) -> Any:
     """Make the cls a decorator.
 
     class cls:

--- a/sky/utils/timeline.py
+++ b/sky/utils/timeline.py
@@ -9,9 +9,12 @@ import os
 import threading
 import time
 import traceback
-from typing import Callable, Optional, Union
+import typing
+from typing import Any, Callable, Optional, Union
 
 from sky.utils import common_utils
+
+F = typing.TypeVar('F', bound=Callable)
 
 _events = []
 
@@ -82,7 +85,18 @@ class Event:
         self.end()
 
 
-def event(name_or_fn: Union[str, Callable], message: Optional[str] = None):
+@typing.overload
+def event(name_or_fn: str, message: Optional[str] = None) -> Callable[[F], F]:
+    ...
+
+
+@typing.overload
+def event(name_or_fn: F, message: Optional[str] = None) -> F:
+    ...
+
+
+def event(name_or_fn: Union[str, Callable],
+          message: Optional[str] = None) -> Any:
     return common_utils.make_decorator(Event, name_or_fn, message=message)
 
 


### PR DESCRIPTION
## Why

While tracing through the codebase, I noticed that VSCode shows `refresh_cluster_status_handle` as returning `Any, Any` instead of the actual type. The root cause is that some common decorators are not type-annotation-aware.

## What

- Make the following common decorators type-annotation-aware.
- Correct the type annotations in downstream references
- Add the missing attributes to the `ResourceHandle` base interface.

## Verfication

Before:
<img width="819" height="235" alt="Screenshot 2026-02-13 at 11 19 24 PM" src="https://github.com/user-attachments/assets/d3b61da8-4fd4-4061-8aa9-ad99e4a5d491" />

After:
<img width="832" height="216" alt="Screenshot 2026-02-13 at 11 19 10 PM" src="https://github.com/user-attachments/assets/18f8692a-af90-4db2-8f03-d3285b65b636" />



Tested (run the relevant ones):

- [x] Code formatting: install pre-commit 
- [x] Any manual or new tests for this PR: pass GitHub CI
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)
