### PR TITLE
[Core] Enhance local_up to respect PATH env in current shell

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -7139,7 +7139,10 @@ def local_up(gpus: bool, name: Optional[str], port_start: Optional[int],
 @usage_lib.entrypoint
 def local_down(name: Optional[str], async_call: bool):
     """Deletes a local cluster."""
-    request_id = sdk.local_down(name)
+    # get current PATH environment variable from CLI side
+    # and pass it to server side
+    path = os.environ.get('PATH')
+    request_id = sdk.local_down(name, path)
     _async_call_or_wait(request_id, async_call, request_name='sky.local.down')
 
 

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -7122,7 +7122,10 @@ def local():
 def local_up(gpus: bool, name: Optional[str], port_start: Optional[int],
              async_call: bool):
     """Creates a local cluster."""
-    request_id = sdk.local_up(gpus, name, port_start)
+    # get current PATH environment variable from CLI side
+    # and pass it to server side
+    path = os.environ.get('PATH')
+    request_id = sdk.local_up(gpus, name, port_start, path)
     _async_call_or_wait(request_id, async_call, request_name='local up')
 
 

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1889,7 +1889,8 @@ def local_up(gpus: bool,
 @usage_lib.entrypoint
 @server_common.check_server_healthy_or_start
 @annotations.client_api
-def local_down(name: Optional[str]) -> server_common.RequestId[None]:
+def local_down(name: Optional[str],
+               path: Optional[str] = None) -> server_common.RequestId[None]:
     """Tears down the Kubernetes cluster started by local_up."""
     # We do not allow local up when the API server is running remotely since it
     # will modify the kubeconfig.
@@ -1899,7 +1900,7 @@ def local_down(name: Optional[str]) -> server_common.RequestId[None]:
             raise ValueError('`sky local down` is only supported when running '
                              'SkyPilot locally.')
 
-    body = payloads.LocalDownBody(name=name)
+    body = payloads.LocalDownBody(name=name, path=path)
     response = server_common.make_authenticated_request(
         'POST', '/local_down', json=json.loads(body.model_dump_json()))
     return server_common.get_request_id(response)

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1862,7 +1862,8 @@ def storage_delete(name: str) -> server_common.RequestId[None]:
 @annotations.client_api
 def local_up(gpus: bool,
              name: Optional[str] = None,
-             port_start: Optional[int] = None) -> server_common.RequestId[None]:
+             port_start: Optional[int] = None,
+             path: Optional[str] = None) -> server_common.RequestId[None]:
     """Launches a Kubernetes cluster on local machines.
 
     Returns:
@@ -1876,7 +1877,10 @@ def local_up(gpus: bool,
             raise ValueError('`sky local up` is only supported when '
                              'running SkyPilot locally.')
 
-    body = payloads.LocalUpBody(gpus=gpus, name=name, port_start=port_start)
+    body = payloads.LocalUpBody(gpus=gpus,
+                                name=name,
+                                port_start=port_start,
+                                path=path)
     response = server_common.make_authenticated_request(
         'POST', '/local_up', json=json.loads(body.model_dump_json()))
     return server_common.get_request_id(response)

--- a/sky/core.py
+++ b/sky/core.py
@@ -1699,8 +1699,7 @@ def local_up(gpus: bool,
     kubernetes_deploy_utils.deploy_local_cluster(name, port_start, gpus, path)
 
 
-def local_down(name: Optional[str] = None,
-               path: Optional[str] = None) -> None:
+def local_down(name: Optional[str] = None, path: Optional[str] = None) -> None:
     """Tears down the Kubernetes cluster started by local_up."""
     kubernetes_deploy_utils.teardown_local_cluster(name, path)
 

--- a/sky/core.py
+++ b/sky/core.py
@@ -1699,9 +1699,10 @@ def local_up(gpus: bool,
     kubernetes_deploy_utils.deploy_local_cluster(name, port_start, gpus, path)
 
 
-def local_down(name: Optional[str] = None) -> None:
+def local_down(name: Optional[str] = None,
+               path: Optional[str] = None) -> None:
     """Tears down the Kubernetes cluster started by local_up."""
-    kubernetes_deploy_utils.teardown_local_cluster(name)
+    kubernetes_deploy_utils.teardown_local_cluster(name, path)
 
 
 def get_all_contexts() -> List[str]:

--- a/sky/core.py
+++ b/sky/core.py
@@ -1693,9 +1693,10 @@ def realtime_slurm_gpu_availability(
 @usage_lib.entrypoint
 def local_up(gpus: bool,
              name: Optional[str] = None,
-             port_start: Optional[int] = None) -> None:
+             port_start: Optional[int] = None,
+             path: Optional[str] = None) -> None:
     """Creates a local cluster."""
-    kubernetes_deploy_utils.deploy_local_cluster(name, port_start, gpus)
+    kubernetes_deploy_utils.deploy_local_cluster(name, port_start, gpus, path)
 
 
 def local_down(name: Optional[str] = None) -> None:

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -731,6 +731,7 @@ class LocalUpBody(RequestBody):
 class LocalDownBody(RequestBody):
     """The request body for the local down endpoint."""
     name: Optional[str] = None
+    path: Optional[str] = None
 
 
 class SSHUpBody(RequestBody):

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -725,6 +725,7 @@ class LocalUpBody(RequestBody):
     gpus: bool = True
     name: Optional[str] = None
     port_start: Optional[int] = None
+    path: Optional[str] = None
 
 
 class LocalDownBody(RequestBody):

--- a/sky/utils/kubernetes/kubernetes_deploy_utils.py
+++ b/sky/utils/kubernetes/kubernetes_deploy_utils.py
@@ -79,14 +79,12 @@ def _merge_given_path_with_shell_path(given_path: Optional[str] = None) -> dict:
                                 text=True,
                                 timeout=10,
                                 check=True)
-        if result.returncode == 0:
-            login_path = result.stdout.strip()
-            merged_set = set(merged)
-            extra_login = [
-                p for p in login_path.split(os.pathsep)
-                if p and p not in merged_set
-            ]
-            merged.extend(extra_login)
+        login_path = result.stdout.strip()
+        merged_set = set(merged)
+        extra_login = [
+            p for p in login_path.split(os.pathsep) if p and p not in merged_set
+        ]
+        merged.extend(extra_login)
 
     env['PATH'] = os.pathsep.join(merged)
     return env

--- a/sky/utils/kubernetes/kubernetes_deploy_utils.py
+++ b/sky/utils/kubernetes/kubernetes_deploy_utils.py
@@ -1,4 +1,5 @@
 """Utility functions for deploying local Kubernetes kind clusters."""
+from contextlib import suppress
 import os
 import random
 import shlex
@@ -27,6 +28,68 @@ DEFAULT_LOCAL_CLUSTER_NAME = 'skypilot'
 LOCAL_CLUSTER_PORT_RANGE = 100
 LOCAL_CLUSTER_INTERNAL_PORT_START = 30000
 LOCAL_CLUSTER_INTERNAL_PORT_END = 30099
+
+
+def _merge_given_path_with_shell_path(given_path: Optional[str] = None) -> dict:
+    """Get env dict with PATH merged from a given PATH and login shell.
+
+    Builds a process environment whose PATH is the union of three
+    sources (highest priority first):
+    1. ``given_path`` - caller-supplied PATH value (e.g. from a custom
+       shell wrapper that sets its own PATH programmatically).
+    2. The current process ``os.environ['PATH']``.
+    3. Additional entries discovered from the user's login shell
+       profile (e.g. ``~/.bashrc``, ``~/.zshrc``) so that tools like
+       ``kind``, ``kubectl``, ``docker`` and ``helm`` installed in
+       non-standard locations can be found.
+
+    Args:
+        given_path: Optional PATH string supplied by the caller.
+            When provided its entries are prepended so they take the
+            highest priority.
+
+    Returns:
+        A copy of ``os.environ`` with the merged PATH.
+    """
+    env = os.environ.copy()
+    current_path = env.get('PATH', '')
+
+    # Start with the given_path entries (highest priority), then
+    # append entries from the current process PATH that are not
+    # already present.
+    if given_path:
+        given_parts = given_path.split(os.pathsep)
+        given_set = set(given_parts)
+        extra_current = [
+            p for p in current_path.split(os.pathsep)
+            if p and p not in given_set
+        ]
+        merged = given_parts + extra_current
+    else:
+        merged = current_path.split(os.pathsep)
+
+    # Now append any login-shell-only entries so that profile-
+    # configured paths are also available.
+    with suppress(Exception):
+        # If anything goes wrong (e.g. shell not found, timeout),
+        # fall back to what we already have.
+        user_shell = env.get('SHELL', '/bin/bash')
+        result = subprocess.run([user_shell, '-l', '-c', 'echo "$PATH"'],
+                                capture_output=True,
+                                text=True,
+                                timeout=10,
+                                check=True)
+        if result.returncode == 0:
+            login_path = result.stdout.strip()
+            merged_set = set(merged)
+            extra_login = [
+                p for p in login_path.split(os.pathsep)
+                if p and p not in merged_set
+            ]
+            merged.extend(extra_login)
+
+    env['PATH'] = os.pathsep.join(merged)
+    return env
 
 
 def generate_kind_config(port_start: int,
@@ -112,7 +175,7 @@ def _get_port_range(name: str, port_start: Optional[int]) -> Tuple[int, int]:
 
 
 def deploy_local_cluster(name: Optional[str], port_start: Optional[int],
-                         gpus: bool):
+                         gpus: bool, path: Optional[str]):
     name = name or DEFAULT_LOCAL_CLUSTER_NAME
     port_start, port_end = _get_port_range(name, port_start)
     context_name = f'kind-{name}'
@@ -153,6 +216,11 @@ def deploy_local_cluster(name: Optional[str], port_start: Optional[int],
             run_command += ' --gpus'
         run_command = shlex.split(run_command)
 
+        # Build an env that includes PATH entries from the caller,
+        # current process, and the user's login shell profile so that
+        # tools like kind, kubectl, docker and helm can be found.
+        env = _merge_given_path_with_shell_path(path)
+
         # Setup logging paths
         run_timestamp = sky_logging.get_run_timestamp()
         log_path = os.path.join(constants.SKY_LOGS_DIRECTORY, run_timestamp,
@@ -170,7 +238,8 @@ def deploy_local_cluster(name: Optional[str], port_start: Optional[int],
                 stream_logs=False,
                 line_processor=log_utils.SkyLocalUpLineProcessor(
                     log_path=log_path, is_local=True),
-                cwd=cwd)
+                cwd=cwd,
+                env=env)
 
     # Kind always writes to stderr even if it succeeds.
     # If the failure happens after the cluster is created, we need
@@ -262,7 +331,8 @@ def deploy_local_cluster(name: Optional[str], port_start: Optional[int],
                     f'{gpu_hint}')))
 
 
-def teardown_local_cluster(name: Optional[str] = None):
+def teardown_local_cluster(name: Optional[str] = None,
+                           path: Optional[str] = None):
     name = name or DEFAULT_LOCAL_CLUSTER_NAME
     cluster_removed = False
 
@@ -272,6 +342,11 @@ def teardown_local_cluster(name: Optional[str] = None):
     cwd = os.path.dirname(os.path.abspath(down_script_path))
     run_command = f'{down_script_path} {name}'
     run_command = shlex.split(run_command)
+
+    # Build an env that includes PATH entries from the caller,
+    # current process, and the user's login shell profile so that
+    # tools like kind, kubectl, docker and helm can be found.
+    env = _merge_given_path_with_shell_path(path)
 
     # Setup logging paths
     run_timestamp = sky_logging.get_run_timestamp()
@@ -287,7 +362,8 @@ def teardown_local_cluster(name: Optional[str] = None):
                                                           log_path=log_path,
                                                           require_outputs=True,
                                                           stream_logs=False,
-                                                          cwd=cwd)
+                                                          cwd=cwd,
+                                                          env=env)
         stderr = stderr.replace('No kind clusters found.\n', '')
 
         if returncode == 0:

--- a/tests/unit_tests/test_sky/utils/kubernetes/test_kubernetes_deploy_utils.py
+++ b/tests/unit_tests/test_sky/utils/kubernetes/test_kubernetes_deploy_utils.py
@@ -25,8 +25,9 @@ class TestMergeGivenPathWithShellPath:
     @mock.patch('subprocess.run')
     def test_no_given_path_uses_current_env(self, mock_run):
         """When given_path is None the current PATH should be kept."""
-        mock_run.return_value = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout='/usr/bin\n')
+        mock_run.return_value = subprocess.CompletedProcess(args=[],
+                                                            returncode=0,
+                                                            stdout='/usr/bin\n')
         env = kubernetes_deploy_utils._merge_given_path_with_shell_path(None)
         assert '/usr/bin' in env['PATH'].split(os.pathsep)
         assert '/usr/local/bin' in env['PATH'].split(os.pathsep)
@@ -36,8 +37,9 @@ class TestMergeGivenPathWithShellPath:
     @mock.patch('subprocess.run')
     def test_given_path_prepended(self, mock_run):
         """given_path entries must appear before current PATH entries."""
-        mock_run.return_value = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout='/usr/bin\n')
+        mock_run.return_value = subprocess.CompletedProcess(args=[],
+                                                            returncode=0,
+                                                            stdout='/usr/bin\n')
         given = '/my/custom/bin:/another/bin'
         env = kubernetes_deploy_utils._merge_given_path_with_shell_path(given)
         parts = env['PATH'].split(os.pathsep)
@@ -50,8 +52,9 @@ class TestMergeGivenPathWithShellPath:
     def test_given_path_deduplicates_current(self, mock_run):
         """Entries already in given_path should not be duplicated from
         the current PATH."""
-        mock_run.return_value = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout='/usr/bin\n')
+        mock_run.return_value = subprocess.CompletedProcess(args=[],
+                                                            returncode=0,
+                                                            stdout='/usr/bin\n')
         given = '/usr/bin:/my/bin'
         env = kubernetes_deploy_utils._merge_given_path_with_shell_path(given)
         parts = env['PATH'].split(os.pathsep)
@@ -60,32 +63,29 @@ class TestMergeGivenPathWithShellPath:
         # /usr/local/bin from current env should be added
         assert '/usr/local/bin' in parts
 
-    @mock.patch.dict(os.environ, {'PATH': '/usr/bin'},
-                     clear=False)
+    @mock.patch.dict(os.environ, {'PATH': '/usr/bin'}, clear=False)
     @mock.patch('subprocess.run')
     def test_login_shell_entries_appended(self, mock_run):
         """New entries from the login shell PATH should be appended."""
         mock_run.return_value = subprocess.CompletedProcess(
-            args=[], returncode=0,
-            stdout='/usr/bin:/home/user/.local/bin\n')
+            args=[], returncode=0, stdout='/usr/bin:/home/user/.local/bin\n')
         env = kubernetes_deploy_utils._merge_given_path_with_shell_path(None)
         parts = env['PATH'].split(os.pathsep)
         assert '/home/user/.local/bin' in parts
 
-    @mock.patch.dict(os.environ, {'PATH': '/usr/bin'},
-                     clear=False)
+    @mock.patch.dict(os.environ, {'PATH': '/usr/bin'}, clear=False)
     @mock.patch('subprocess.run')
     def test_login_shell_entries_not_duplicated(self, mock_run):
         """Entries already present should not be added again from the login
         shell."""
-        mock_run.return_value = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout='/usr/bin\n')
+        mock_run.return_value = subprocess.CompletedProcess(args=[],
+                                                            returncode=0,
+                                                            stdout='/usr/bin\n')
         env = kubernetes_deploy_utils._merge_given_path_with_shell_path(None)
         parts = env['PATH'].split(os.pathsep)
         assert parts.count('/usr/bin') == 1
 
-    @mock.patch.dict(os.environ, {'PATH': '/usr/bin'},
-                     clear=False)
+    @mock.patch.dict(os.environ, {'PATH': '/usr/bin'}, clear=False)
     @mock.patch('subprocess.run',
                 side_effect=subprocess.TimeoutExpired(cmd='bash', timeout=10))
     def test_login_shell_timeout_falls_back(self, mock_run):
@@ -94,8 +94,7 @@ class TestMergeGivenPathWithShellPath:
         env = kubernetes_deploy_utils._merge_given_path_with_shell_path(None)
         assert '/usr/bin' in env['PATH'].split(os.pathsep)
 
-    @mock.patch.dict(os.environ, {'PATH': '/usr/bin'},
-                     clear=False)
+    @mock.patch.dict(os.environ, {'PATH': '/usr/bin'}, clear=False)
     @mock.patch('subprocess.run', side_effect=FileNotFoundError('no shell'))
     def test_login_shell_not_found_falls_back(self, mock_run):
         """If the login shell executable is not found the error should be
@@ -103,8 +102,7 @@ class TestMergeGivenPathWithShellPath:
         env = kubernetes_deploy_utils._merge_given_path_with_shell_path(None)
         assert '/usr/bin' in env['PATH'].split(os.pathsep)
 
-    @mock.patch.dict(os.environ, {'PATH': '/usr/bin'},
-                     clear=False)
+    @mock.patch.dict(os.environ, {'PATH': '/usr/bin'}, clear=False)
     @mock.patch('subprocess.run',
                 side_effect=subprocess.CalledProcessError(1, 'bash'))
     def test_login_shell_nonzero_exit_falls_back(self, mock_run):
@@ -112,24 +110,28 @@ class TestMergeGivenPathWithShellPath:
         env = kubernetes_deploy_utils._merge_given_path_with_shell_path(None)
         assert '/usr/bin' in env['PATH'].split(os.pathsep)
 
-    @mock.patch.dict(os.environ, {'PATH': '/a:/b', 'SHELL': '/bin/zsh'},
+    @mock.patch.dict(os.environ, {
+        'PATH': '/a:/b',
+        'SHELL': '/bin/zsh'
+    },
                      clear=False)
     @mock.patch('subprocess.run')
     def test_uses_shell_env_variable(self, mock_run):
         """The function should use the SHELL env var for the login shell."""
-        mock_run.return_value = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout='/a\n')
+        mock_run.return_value = subprocess.CompletedProcess(args=[],
+                                                            returncode=0,
+                                                            stdout='/a\n')
         kubernetes_deploy_utils._merge_given_path_with_shell_path(None)
         call_args = mock_run.call_args
         assert call_args[0][0][0] == '/bin/zsh'
 
-    @mock.patch.dict(os.environ, {'PATH': '/a:/b'},
-                     clear=False)
+    @mock.patch.dict(os.environ, {'PATH': '/a:/b'}, clear=False)
     @mock.patch('subprocess.run')
     def test_defaults_to_bash_when_no_shell_env(self, mock_run):
         """If SHELL is not set, /bin/bash should be the default."""
-        mock_run.return_value = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout='/a\n')
+        mock_run.return_value = subprocess.CompletedProcess(args=[],
+                                                            returncode=0,
+                                                            stdout='/a\n')
         env_without_shell = os.environ.copy()
         env_without_shell.pop('SHELL', None)
         with mock.patch.dict(os.environ, env_without_shell, clear=True):
@@ -137,8 +139,7 @@ class TestMergeGivenPathWithShellPath:
         call_args = mock_run.call_args
         assert call_args[0][0][0] == '/bin/bash'
 
-    @mock.patch.dict(os.environ, {'PATH': ''},
-                     clear=False)
+    @mock.patch.dict(os.environ, {'PATH': ''}, clear=False)
     @mock.patch('subprocess.run')
     def test_empty_current_path(self, mock_run):
         """An empty current PATH should still produce a valid env dict."""
@@ -147,15 +148,13 @@ class TestMergeGivenPathWithShellPath:
         env = kubernetes_deploy_utils._merge_given_path_with_shell_path(None)
         assert '/login/bin' in env['PATH'].split(os.pathsep)
 
-    @mock.patch.dict(os.environ, {'PATH': '/usr/bin'},
-                     clear=False)
+    @mock.patch.dict(os.environ, {'PATH': '/usr/bin'}, clear=False)
     @mock.patch('subprocess.run')
     def test_given_path_with_login_shell(self, mock_run):
         """given_path, current PATH, and login shell entries should all
         be merged with correct priority order."""
         mock_run.return_value = subprocess.CompletedProcess(
-            args=[], returncode=0,
-            stdout='/usr/bin:/login/only\n')
+            args=[], returncode=0, stdout='/usr/bin:/login/only\n')
         given = '/given/bin'
         env = kubernetes_deploy_utils._merge_given_path_with_shell_path(given)
         parts = env['PATH'].split(os.pathsep)
@@ -163,24 +162,28 @@ class TestMergeGivenPathWithShellPath:
         assert parts.index('/given/bin') < parts.index('/usr/bin')
         assert '/login/only' in parts
 
-    @mock.patch.dict(os.environ, {'PATH': '/usr/bin', 'HOME': '/home/test'},
+    @mock.patch.dict(os.environ, {
+        'PATH': '/usr/bin',
+        'HOME': '/home/test'
+    },
                      clear=False)
     @mock.patch('subprocess.run')
     def test_returns_full_env_copy(self, mock_run):
         """The returned dict should contain all env vars, not just PATH."""
-        mock_run.return_value = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout='/usr/bin\n')
+        mock_run.return_value = subprocess.CompletedProcess(args=[],
+                                                            returncode=0,
+                                                            stdout='/usr/bin\n')
         env = kubernetes_deploy_utils._merge_given_path_with_shell_path(None)
         assert env.get('HOME') == '/home/test'
 
-    @mock.patch.dict(os.environ, {'PATH': '/usr/bin'},
-                     clear=False)
+    @mock.patch.dict(os.environ, {'PATH': '/usr/bin'}, clear=False)
     @mock.patch('subprocess.run')
     def test_empty_given_path_string(self, mock_run):
         """An empty string given_path should be treated as falsy (no
         given_path)."""
-        mock_run.return_value = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout='/usr/bin\n')
+        mock_run.return_value = subprocess.CompletedProcess(args=[],
+                                                            returncode=0,
+                                                            stdout='/usr/bin\n')
         env = kubernetes_deploy_utils._merge_given_path_with_shell_path('')
         # '' is falsy, so should behave like None
         assert '/usr/bin' in env['PATH'].split(os.pathsep)
@@ -216,8 +219,7 @@ class TestGenerateKindConfig:
         assert 'nvidia-container-devices' in config
 
     def test_no_gpu_support(self):
-        config = kubernetes_deploy_utils.generate_kind_config(30000,
-                                                              gpus=False)
+        config = kubernetes_deploy_utils.generate_kind_config(30000, gpus=False)
         assert 'nvidia-container-devices' not in config
 
     def test_multi_node(self):
@@ -276,8 +278,7 @@ class TestGetPortRange:
     def test_non_default_cluster_random_port(self):
         """When port_start is None for a non-default cluster, a random
         port in the 301xx-399xx range should be chosen."""
-        start, end = kubernetes_deploy_utils._get_port_range(
-            'my-cluster', None)
+        start, end = kubernetes_deploy_utils._get_port_range('my-cluster', None)
         assert start % 100 == 0
         assert 30100 <= start <= 39900
         assert end == start + kubernetes_deploy_utils.LOCAL_CLUSTER_PORT_RANGE - 1
@@ -296,12 +297,12 @@ class TestLocalUpBody:
 
     def test_path_field_set(self):
         from sky.server.requests import payloads
-        body = payloads.LocalUpBody(gpus=True,
-                                    path='/usr/bin:/custom/bin')
+        body = payloads.LocalUpBody(gpus=True, path='/usr/bin:/custom/bin')
         assert body.path == '/usr/bin:/custom/bin'
 
     def test_path_field_serialization(self):
         import json
+
         from sky.server.requests import payloads
         body = payloads.LocalUpBody(gpus=True,
                                     name='test',

--- a/tests/unit_tests/test_sky/utils/kubernetes/test_kubernetes_deploy_utils.py
+++ b/tests/unit_tests/test_sky/utils/kubernetes/test_kubernetes_deploy_utils.py
@@ -1,0 +1,320 @@
+"""Tests for sky.utils.kubernetes.kubernetes_deploy_utils.
+
+Covers the new PATH-merging logic introduced in
+'[Core] Enhance local_up to respect PATH environment variable in current
+shell', as well as the existing generate_kind_config and _get_port_range
+utilities.
+"""
+import os
+import subprocess
+from unittest import mock
+
+import pytest
+
+from sky.utils.kubernetes import kubernetes_deploy_utils
+
+
+# ---------------------------------------------------------------------------
+# Tests for _merge_given_path_with_shell_path
+# ---------------------------------------------------------------------------
+class TestMergeGivenPathWithShellPath:
+    """Tests for _merge_given_path_with_shell_path."""
+
+    @mock.patch.dict(os.environ, {'PATH': '/usr/bin:/usr/local/bin'},
+                     clear=False)
+    @mock.patch('subprocess.run')
+    def test_no_given_path_uses_current_env(self, mock_run):
+        """When given_path is None the current PATH should be kept."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout='/usr/bin\n')
+        env = kubernetes_deploy_utils._merge_given_path_with_shell_path(None)
+        assert '/usr/bin' in env['PATH'].split(os.pathsep)
+        assert '/usr/local/bin' in env['PATH'].split(os.pathsep)
+
+    @mock.patch.dict(os.environ, {'PATH': '/usr/bin:/usr/local/bin'},
+                     clear=False)
+    @mock.patch('subprocess.run')
+    def test_given_path_prepended(self, mock_run):
+        """given_path entries must appear before current PATH entries."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout='/usr/bin\n')
+        given = '/my/custom/bin:/another/bin'
+        env = kubernetes_deploy_utils._merge_given_path_with_shell_path(given)
+        parts = env['PATH'].split(os.pathsep)
+        assert parts[0] == '/my/custom/bin'
+        assert parts[1] == '/another/bin'
+
+    @mock.patch.dict(os.environ, {'PATH': '/usr/bin:/usr/local/bin'},
+                     clear=False)
+    @mock.patch('subprocess.run')
+    def test_given_path_deduplicates_current(self, mock_run):
+        """Entries already in given_path should not be duplicated from
+        the current PATH."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout='/usr/bin\n')
+        given = '/usr/bin:/my/bin'
+        env = kubernetes_deploy_utils._merge_given_path_with_shell_path(given)
+        parts = env['PATH'].split(os.pathsep)
+        # /usr/bin should appear only once (from given_path)
+        assert parts.count('/usr/bin') == 1
+        # /usr/local/bin from current env should be added
+        assert '/usr/local/bin' in parts
+
+    @mock.patch.dict(os.environ, {'PATH': '/usr/bin'},
+                     clear=False)
+    @mock.patch('subprocess.run')
+    def test_login_shell_entries_appended(self, mock_run):
+        """New entries from the login shell PATH should be appended."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0,
+            stdout='/usr/bin:/home/user/.local/bin\n')
+        env = kubernetes_deploy_utils._merge_given_path_with_shell_path(None)
+        parts = env['PATH'].split(os.pathsep)
+        assert '/home/user/.local/bin' in parts
+
+    @mock.patch.dict(os.environ, {'PATH': '/usr/bin'},
+                     clear=False)
+    @mock.patch('subprocess.run')
+    def test_login_shell_entries_not_duplicated(self, mock_run):
+        """Entries already present should not be added again from the login
+        shell."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout='/usr/bin\n')
+        env = kubernetes_deploy_utils._merge_given_path_with_shell_path(None)
+        parts = env['PATH'].split(os.pathsep)
+        assert parts.count('/usr/bin') == 1
+
+    @mock.patch.dict(os.environ, {'PATH': '/usr/bin'},
+                     clear=False)
+    @mock.patch('subprocess.run',
+                side_effect=subprocess.TimeoutExpired(cmd='bash', timeout=10))
+    def test_login_shell_timeout_falls_back(self, mock_run):
+        """A timeout when querying the login shell should be silently
+        ignored and the PATH should still contain current entries."""
+        env = kubernetes_deploy_utils._merge_given_path_with_shell_path(None)
+        assert '/usr/bin' in env['PATH'].split(os.pathsep)
+
+    @mock.patch.dict(os.environ, {'PATH': '/usr/bin'},
+                     clear=False)
+    @mock.patch('subprocess.run', side_effect=FileNotFoundError('no shell'))
+    def test_login_shell_not_found_falls_back(self, mock_run):
+        """If the login shell executable is not found the error should be
+        suppressed and the PATH should still be usable."""
+        env = kubernetes_deploy_utils._merge_given_path_with_shell_path(None)
+        assert '/usr/bin' in env['PATH'].split(os.pathsep)
+
+    @mock.patch.dict(os.environ, {'PATH': '/usr/bin'},
+                     clear=False)
+    @mock.patch('subprocess.run',
+                side_effect=subprocess.CalledProcessError(1, 'bash'))
+    def test_login_shell_nonzero_exit_falls_back(self, mock_run):
+        """A non-zero exit from the login shell should be suppressed."""
+        env = kubernetes_deploy_utils._merge_given_path_with_shell_path(None)
+        assert '/usr/bin' in env['PATH'].split(os.pathsep)
+
+    @mock.patch.dict(os.environ, {'PATH': '/a:/b', 'SHELL': '/bin/zsh'},
+                     clear=False)
+    @mock.patch('subprocess.run')
+    def test_uses_shell_env_variable(self, mock_run):
+        """The function should use the SHELL env var for the login shell."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout='/a\n')
+        kubernetes_deploy_utils._merge_given_path_with_shell_path(None)
+        call_args = mock_run.call_args
+        assert call_args[0][0][0] == '/bin/zsh'
+
+    @mock.patch.dict(os.environ, {'PATH': '/a:/b'},
+                     clear=False)
+    @mock.patch('subprocess.run')
+    def test_defaults_to_bash_when_no_shell_env(self, mock_run):
+        """If SHELL is not set, /bin/bash should be the default."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout='/a\n')
+        env_without_shell = os.environ.copy()
+        env_without_shell.pop('SHELL', None)
+        with mock.patch.dict(os.environ, env_without_shell, clear=True):
+            kubernetes_deploy_utils._merge_given_path_with_shell_path(None)
+        call_args = mock_run.call_args
+        assert call_args[0][0][0] == '/bin/bash'
+
+    @mock.patch.dict(os.environ, {'PATH': ''},
+                     clear=False)
+    @mock.patch('subprocess.run')
+    def test_empty_current_path(self, mock_run):
+        """An empty current PATH should still produce a valid env dict."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout='/login/bin\n')
+        env = kubernetes_deploy_utils._merge_given_path_with_shell_path(None)
+        assert '/login/bin' in env['PATH'].split(os.pathsep)
+
+    @mock.patch.dict(os.environ, {'PATH': '/usr/bin'},
+                     clear=False)
+    @mock.patch('subprocess.run')
+    def test_given_path_with_login_shell(self, mock_run):
+        """given_path, current PATH, and login shell entries should all
+        be merged with correct priority order."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0,
+            stdout='/usr/bin:/login/only\n')
+        given = '/given/bin'
+        env = kubernetes_deploy_utils._merge_given_path_with_shell_path(given)
+        parts = env['PATH'].split(os.pathsep)
+        # Priority: given > current > login
+        assert parts.index('/given/bin') < parts.index('/usr/bin')
+        assert '/login/only' in parts
+
+    @mock.patch.dict(os.environ, {'PATH': '/usr/bin', 'HOME': '/home/test'},
+                     clear=False)
+    @mock.patch('subprocess.run')
+    def test_returns_full_env_copy(self, mock_run):
+        """The returned dict should contain all env vars, not just PATH."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout='/usr/bin\n')
+        env = kubernetes_deploy_utils._merge_given_path_with_shell_path(None)
+        assert env.get('HOME') == '/home/test'
+
+    @mock.patch.dict(os.environ, {'PATH': '/usr/bin'},
+                     clear=False)
+    @mock.patch('subprocess.run')
+    def test_empty_given_path_string(self, mock_run):
+        """An empty string given_path should be treated as falsy (no
+        given_path)."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout='/usr/bin\n')
+        env = kubernetes_deploy_utils._merge_given_path_with_shell_path('')
+        # '' is falsy, so should behave like None
+        assert '/usr/bin' in env['PATH'].split(os.pathsep)
+
+
+# ---------------------------------------------------------------------------
+# Tests for generate_kind_config
+# ---------------------------------------------------------------------------
+class TestGenerateKindConfig:
+    """Tests for generate_kind_config."""
+
+    def test_basic_config_structure(self):
+        config = kubernetes_deploy_utils.generate_kind_config(30000)
+        assert 'kind: Cluster' in config
+        assert 'apiVersion: kind.x-k8s.io/v1alpha4' in config
+        assert 'role: control-plane' in config
+
+    def test_port_mappings_count(self):
+        config = kubernetes_deploy_utils.generate_kind_config(30000)
+        # Should have LOCAL_CLUSTER_PORT_RANGE port mappings
+        assert config.count('containerPort:') == \
+            kubernetes_deploy_utils.LOCAL_CLUSTER_PORT_RANGE
+
+    def test_port_mapping_values(self):
+        port_start = 40000
+        config = kubernetes_deploy_utils.generate_kind_config(port_start)
+        assert f'containerPort: {kubernetes_deploy_utils.LOCAL_CLUSTER_INTERNAL_PORT_START}' in config
+        assert f'hostPort: {port_start}' in config
+
+    def test_gpu_support(self):
+        config = kubernetes_deploy_utils.generate_kind_config(30000, gpus=True)
+        assert '/dev/null' in config
+        assert 'nvidia-container-devices' in config
+
+    def test_no_gpu_support(self):
+        config = kubernetes_deploy_utils.generate_kind_config(30000,
+                                                              gpus=False)
+        assert 'nvidia-container-devices' not in config
+
+    def test_multi_node(self):
+        config = kubernetes_deploy_utils.generate_kind_config(30000,
+                                                              num_nodes=3)
+        # Should have 2 worker nodes (num_nodes - 1)
+        assert config.count('role: worker') == 2
+
+    def test_single_node_no_workers(self):
+        config = kubernetes_deploy_utils.generate_kind_config(30000,
+                                                              num_nodes=1)
+        assert 'role: worker' not in config
+
+    def test_service_node_port_range(self):
+        config = kubernetes_deploy_utils.generate_kind_config(30000)
+        expected_range = (
+            f'{kubernetes_deploy_utils.LOCAL_CLUSTER_INTERNAL_PORT_START}-'
+            f'{kubernetes_deploy_utils.LOCAL_CLUSTER_INTERNAL_PORT_END}')
+        assert expected_range in config
+
+
+# ---------------------------------------------------------------------------
+# Tests for _get_port_range
+# ---------------------------------------------------------------------------
+class TestGetPortRange:
+    """Tests for _get_port_range."""
+
+    def test_default_cluster_default_port(self):
+        start, end = kubernetes_deploy_utils._get_port_range('skypilot', None)
+        assert start == kubernetes_deploy_utils.LOCAL_CLUSTER_INTERNAL_PORT_START
+        assert end == start + kubernetes_deploy_utils.LOCAL_CLUSTER_PORT_RANGE - 1
+
+    def test_default_cluster_correct_port(self):
+        start, end = kubernetes_deploy_utils._get_port_range('skypilot', 30000)
+        assert start == 30000
+        assert end == 30099
+
+    def test_default_cluster_wrong_port_raises(self):
+        with pytest.raises(ValueError, match='30000 to 30099'):
+            kubernetes_deploy_utils._get_port_range('skypilot', 40000)
+
+    def test_non_default_cluster_with_reserved_port_raises(self):
+        with pytest.raises(ValueError, match='reserved'):
+            kubernetes_deploy_utils._get_port_range('my-cluster', 30000)
+
+    def test_non_default_cluster_non_multiple_of_100_raises(self):
+        with pytest.raises(ValueError, match='multiple of 100'):
+            kubernetes_deploy_utils._get_port_range('my-cluster', 30050)
+
+    def test_non_default_cluster_valid_port(self):
+        start, end = kubernetes_deploy_utils._get_port_range(
+            'my-cluster', 40000)
+        assert start == 40000
+        assert end == 40099
+
+    def test_non_default_cluster_random_port(self):
+        """When port_start is None for a non-default cluster, a random
+        port in the 301xx-399xx range should be chosen."""
+        start, end = kubernetes_deploy_utils._get_port_range(
+            'my-cluster', None)
+        assert start % 100 == 0
+        assert 30100 <= start <= 39900
+        assert end == start + kubernetes_deploy_utils.LOCAL_CLUSTER_PORT_RANGE - 1
+
+
+# ---------------------------------------------------------------------------
+# Tests for LocalUpBody / LocalDownBody payloads
+# ---------------------------------------------------------------------------
+class TestLocalUpBody:
+    """Tests for LocalUpBody with the new path field."""
+
+    def test_path_field_defaults_to_none(self):
+        from sky.server.requests import payloads
+        body = payloads.LocalUpBody(gpus=True)
+        assert body.path is None
+
+    def test_path_field_set(self):
+        from sky.server.requests import payloads
+        body = payloads.LocalUpBody(gpus=True,
+                                    path='/usr/bin:/custom/bin')
+        assert body.path == '/usr/bin:/custom/bin'
+
+    def test_path_field_serialization(self):
+        import json
+        from sky.server.requests import payloads
+        body = payloads.LocalUpBody(gpus=True,
+                                    name='test',
+                                    port_start=40000,
+                                    path='/my/path')
+        data = json.loads(body.model_dump_json())
+        assert data['path'] == '/my/path'
+        assert data['gpus'] is True
+        assert data['name'] == 'test'
+        assert data['port_start'] == 40000
+
+    def test_local_down_body_has_no_path(self):
+        from sky.server.requests import payloads
+        body = payloads.LocalDownBody(name='test')
+        assert not hasattr(body, 'path') or \
+            'path' not in body.model_fields

--- a/tests/unit_tests/test_sky/utils/kubernetes/test_kubernetes_deploy_utils.py
+++ b/tests/unit_tests/test_sky/utils/kubernetes/test_kubernetes_deploy_utils.py
@@ -313,8 +313,9 @@ class TestLocalUpBody:
         assert data['name'] == 'test'
         assert data['port_start'] == 40000
 
-    def test_local_down_body_has_no_path(self):
+    def test_local_down_body_has_path(self):
         from sky.server.requests import payloads
-        body = payloads.LocalDownBody(name='test')
-        assert not hasattr(body, 'path') or \
-            'path' not in body.model_fields
+        body = payloads.LocalDownBody(name='test', path='/usr/bin')
+        assert hasattr(body, 'path') and \
+            'path' in body.model_fields
+        assert body.path == '/usr/bin'


### PR DESCRIPTION
## Why

While testing the `sky local up` command, I found that it doesn’t respect the `PATH` environment variable in the current shell due to the client–server separation.

In the demo before the fix, the `kind` executable is located in `/Users/jason/Desktop/airflow/.venv/bin`. Even if I set `PATH` before running `sky local up`, it still couldn’t find `kind` because `sky api` started before `PATH` was set.

<img width="1183" height="654" alt="before-fix" src="https://github.com/user-attachments/assets/6688812e-b09a-4cfb-954d-e5c0427bd6f9" />

## How

The CLI (client side) should pass `PATH` from the current shell to the server side. Additionally, the server side should respect the `PATH` environment variable in the shell context before running `sky api start`, as well as the user’s login shell, to resolve common executables.


## What

- `sky local up` will respect the `PATH` of the current shell context and pass it through to the server side.
- The `PATH` resolution priority will be: 1) the client-side shell context, 2) the shell context of `sky api`, and 3) the user’s login shell.
- Add corresponding unit tests.

## Verification

**Scenario 1**: Set `PATH` before `sky api start`
<img width="945" height="512" alt="set-path-before-api-start" src="https://github.com/user-attachments/assets/844d7b7d-43ce-4867-8568-74c7be2ee62f" />


**Scenario 2**: Pass `PATH` from CLI client side
<img width="776" height="483" alt="pass-path-from-cli-client-side" src="https://github.com/user-attachments/assets/dd1122bb-f419-4da7-b685-385e7fcc9c5b" />



Tested (run the relevant ones):

- [x] Code formatting: install pre-commit
- [x] Manual test
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

