### PR TITLE
[Nebius] K8s autoscaler fix typo

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -793,7 +793,7 @@ class NebiusLabelFormatter(GPULabelFormatter):
 
     @classmethod
     def get_accelerator_from_label_value(cls, value: str) -> str:
-        return value.lower()
+        return value.upper()
 
     @classmethod
     def validate_label_value(cls, value: str) -> Tuple[bool, str]:


### PR DESCRIPTION

Make `get_accelerator_from_label_value` return lowercase values