### PR TITLE
[Dashboard] Fix recipe boxes width regression

### DIFF
--- a/sky/dashboard/src/components/recipe-hub.jsx
+++ b/sky/dashboard/src/components/recipe-hub.jsx
@@ -112,7 +112,7 @@ function RecipeCard({ recipe, onPin }) {
   const slug = generateRecipeSlug(recipe.name);
 
   return (
-    <div className="relative">
+    <div className="relative max-w-[300px]">
       <Link href={`/recipes/${slug}`} className="block">
         <Card className="h-full hover:bg-gray-50 transition-colors cursor-pointer group">
           <CardContent className="p-3">
@@ -225,7 +225,13 @@ function TemplateRow({
         <h2 className="text-base text-gray-700">{title}</h2>
         <span className="text-sm text-gray-500">({recipes.length})</span>
       </div>
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+      <div
+        className="grid gap-4"
+        style={{
+          gridTemplateColumns:
+            'repeat(auto-fill, minmax(min(300px, 100%), 1fr))',
+        }}
+      >
         {recipes.map((recipe) => (
           <RecipeCard key={recipe.name} recipe={recipe} onPin={onPin} />
         ))}


### PR DESCRIPTION
## Summary
- Recipe cards in the Pinned/My Recipes sections were expanding too wide on large screens because the responsive grid had no max card width constraint
- Replace the fixed breakpoint grid (`grid-cols-1 sm:grid-cols-2 ... xl:grid-cols-5`) with `repeat(auto-fill, minmax(300px, 1fr))`, so cards maintain a reasonable ~300px width on all screen sizes including ultra-wide monitors
<img width="2812" height="580" alt="image" src="https://github.com/user-attachments/assets/ade71e34-3924-40cb-855a-3fc7e84519b1" />