### PR TITLE
[Api Server] Fix Version Setting

### DIFF
--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -822,6 +822,13 @@ def check_server_healthy(
         with ux_utils.print_exception_no_traceback():
             raise exceptions.ApiServerConnectionError(endpoint)
 
+    # Ensure the remote API version is set in the current thread's context.
+    # get_api_server_status() may return a cached result (TTLCache), in which
+    # case request_without_retry() was never called in this thread and the
+    # context variable would still be None.
+    if api_server_info.version is not None:
+        versions.set_remote_version(api_server_info.version)
+
     # If the user ran pip upgrade, but the server wasn't restarted, warn them.
     # We check this using the info from /api/health, rather than in the
     # executor, because the executor could be started after the main server


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

From Claude:
```
The fundamental bug: check_server_healthy_or_start relies on get_api_server_status() 
which has the api_version in its return value (ApiServerInfo.api_version), but never extracts 
it to call set_remote_api_version(). The version only gets set as a side effect of request_without_retry, 
which doesn't run on cache hits. And validate() reads the version before making its own HTTP request.

This isn't nightly-specific — it affects all builds when running through the managed jobs controller, 
because asyncio.to_thread always creates a fresh context and the TTLCache almost always hits (Thread A's 
api_start populates it, Thread B's launch reads it <5 seconds later).
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
