### PR TITLE
Update supported infrastructure list in READMEA

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ pip install "skypilot-nightly[kubernetes,aws,gcp,azure,oci,nebius,lambda,runpod,
   <img src="docs/source/_static/intro.gif" alt="SkyPilot">
 </p>
 
-Current supported infra: Kubernetes, Slurm, AWS, GCP, Azure, OCI, CoreWeave, Nebius, Lambda Cloud, RunPod, Fluidstack,
+Current supported infra: Kubernetes, Slurm, AWS, GCP, Azure, OCI, Crusoe, CoreWeave, Nebius, Lambda Cloud, RunPod, Fluidstack,
 Cudo, Digital Ocean, Paperspace, Cloudflare, Samsung, IBM, Vast.ai, VMware vSphere, Seeweb, Prime Intellect, Shadeform.
 <p align="center">
   <picture>


### PR DESCRIPTION
Adding Crusoe as a supported infrastructure thanks to the partnership : https://www.crusoe.ai/resources/blog/crusoe-skypilot-ai-workloads

<!-- Describe the changes in this PR -->
Update Crusoe as supported infra to the list per the partnership and adding the logo
<img width="396" height="127" alt="CrusoeLogo" src="https://github.com/user-attachments/assets/f656b7f8-16f8-4f39-be02-aef7e169c0d4" />

https://www.crusoe.ai/resources/blog/crusoe-skypilot-ai-workloads