### PR TITLE
[Recipes] Fix Vertical and Horizontal Size, Use consistent Gaps between recipes.

### DIFF
--- a/sky/dashboard/src/components/recipe-hub.jsx
+++ b/sky/dashboard/src/components/recipe-hub.jsx
@@ -158,7 +158,9 @@ function RecipeCard({ recipe, onPin }) {
               </div>
 
               {/* Last updated info - always render line for consistent height */}
-              <div className={`text-sm text-gray-500 truncate ${!(recipe.is_editable && recipe.user_name !== 'local') ? 'invisible' : ''}`}>
+              <div
+                className={`text-sm text-gray-500 truncate ${!(recipe.is_editable && recipe.user_name !== 'local') ? 'invisible' : ''}`}
+              >
                 Updated by{' '}
                 <UserName name={recipe.updated_by_name || recipe.user_name} />{' '}
                 <TimestampWithTooltip
@@ -221,9 +223,7 @@ function TemplateRow({
         <h2 className="text-base text-gray-700">{title}</h2>
         <span className="text-sm text-gray-500">({recipes.length})</span>
       </div>
-      <div
-        className="flex flex-wrap gap-3"
-      >
+      <div className="flex flex-wrap gap-3">
         {recipes.map((recipe) => (
           <RecipeCard key={recipe.name} recipe={recipe} onPin={onPin} />
         ))}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Before this PR recipes would have different vertical sizes (due to different fields) which makes the UX not as good, now we fix the vertical size using empty fields if necessary. We also fix the gaps between recipes introduced by the width change.

Before 
<img width="1372" height="992" alt="image" src="https://github.com/user-attachments/assets/25850ccb-6126-4705-af72-1d81657a452e" />


The below image shows the functionality working as intended
<img width="1398" height="1186" alt="image" src="https://github.com/user-attachments/assets/0ebef76f-79c3-4566-bc2f-1f0967591f73" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
