### PR TITLE
[Docs] Remove Early Access badge from Slurm docs

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -3,9 +3,6 @@
 .. |community-badge| image:: https://img.shields.io/badge/Community%20Maintained-EAFAFF?style=flat
    :alt: Community Maintained
 
-.. |early-access-badge| image:: https://img.shields.io/badge/Early%20Access-F66A0A?style=flat
-   :alt: Early Access
-
 Installation
 ============
 
@@ -370,12 +367,12 @@ See :ref:`SkyPilot on Kubernetes <kubernetes-overview>` for more.
 
 .. _slurm-installation:
 
-Slurm |early-access-badge|
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Slurm
+~~~~~
 
 .. note::
 
-    **Early Access:** Slurm support is under active development. If you're interested in trying it out,
+    Slurm support is under active development. We'd love to hear from you —
     please `fill out this form <https://forms.gle/rfdWQcd9oQgp41Hm8>`_.
 
 SkyPilot can run workloads on Slurm clusters. The only requirement is SSH access to a Slurm login node.

--- a/docs/source/reference/slurm/index.rst
+++ b/docs/source/reference/slurm/index.rst
@@ -5,7 +5,7 @@ Using Slurm
 
 .. note::
 
-    **Early Access:** Slurm support is under active development. If you're interested in trying it out,
+    Slurm support is under active development. We'd love to hear from you —
     please `fill out this form <https://forms.gle/rfdWQcd9oQgp41Hm8>`_.
 
 SkyPilot tasks can be run on your Slurm clusters.
@@ -27,12 +27,12 @@ Why use SkyPilot on Slurm?
                 :text-align: center
 
                 Access multiple Slurm clusters through one interface - no need to juggle different login nodes or sbatch scripts.
-            
+
             .. grid-item-card::  🌍 Unified interface for all infra
                 :text-align: center
 
                 The same SkyPilot YAML works on Slurm, Kubernetes, and cloud VMs - switch between them seamlessly.
-            
+
             .. grid-item-card::  🚀 Easy job submission
                 :text-align: center
 
@@ -89,4 +89,3 @@ Table of contents
    :hidden:
 
    Getting Started <slurm-getting-started>
-

--- a/docs/source/reference/slurm/slurm-getting-started.rst
+++ b/docs/source/reference/slurm/slurm-getting-started.rst
@@ -5,7 +5,7 @@ Getting Started on Slurm
 
 .. note::
 
-    **Early Access:** Slurm support is under active development. If you're interested in trying it out,
+    Slurm support is under active development. We'd love to hear from you —
     please `fill out this form <https://forms.gle/rfdWQcd9oQgp41Hm8>`_.
 
 Quickstart


### PR DESCRIPTION
## Summary
- Remove the "Early Access" badge and label from Slurm documentation pages
- Reword note boxes to remove "Early Access" framing while keeping the Google Forms link for interested users to fill in

Preview:
- https://docs.skypilot.co/en/slurm-early-access/getting-started/installation.html#slurm
- https://docs.skypilot.co/en/slurm-early-access/reference/slurm/index.html
- https://docs.skypilot.co/en/slurm-early-access/reference/slurm/slurm-getting-started.html