### PR TITLE
[Kubernetes] Allow configuring custom fusermount-server image

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -642,11 +642,11 @@ class Kubernetes(clouds.Cloud):
 
         fuse_device_required = bool(resources.requires_fuse)
 
-        # Get fuse_device_manager config for custom fusermount-server image
-        fuse_device_manager_image = skypilot_config.get_effective_region_config(
+        # Get fuse_mounting config for custom fusermount-server image
+        fuse_mounting_image = skypilot_config.get_effective_region_config(
             cloud='kubernetes',
             region=context,
-            keys=('fuse_device_manager', 'image'),
+            keys=('fuse_mounting', 'image'),
             default_value=None)
 
         # Configure spot labels, if requested and supported
@@ -780,7 +780,7 @@ class Kubernetes(clouds.Cloud):
             'k8s_service_account_name': k8s_service_account_name,
             'k8s_automount_sa_token': 'true',
             'k8s_fuse_device_required': fuse_device_required,
-            'k8s_fuse_device_manager_image': fuse_device_manager_image,
+            'k8s_fuse_mounting_image': fuse_mounting_image,
             'k8s_kueue_local_queue_name': k8s_kueue_local_queue_name,
             # Namespace to run the fusermount-server daemonset in
             'k8s_skypilot_system_namespace': _SKYPILOT_SYSTEM_NAMESPACE,

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -642,6 +642,13 @@ class Kubernetes(clouds.Cloud):
 
         fuse_device_required = bool(resources.requires_fuse)
 
+        # Get fuse_device_manager config for custom fusermount-server image
+        fuse_device_manager_image = skypilot_config.get_effective_region_config(
+            cloud='kubernetes',
+            region=context,
+            keys=('fuse_device_manager', 'image'),
+            default_value=None)
+
         # Configure spot labels, if requested and supported
         spot_label_key, spot_label_value = None, None
         if resources.use_spot:
@@ -773,6 +780,7 @@ class Kubernetes(clouds.Cloud):
             'k8s_service_account_name': k8s_service_account_name,
             'k8s_automount_sa_token': 'true',
             'k8s_fuse_device_required': fuse_device_required,
+            'k8s_fuse_device_manager_image': fuse_device_manager_image,
             'k8s_kueue_local_queue_name': k8s_kueue_local_queue_name,
             # Namespace to run the fusermount-server daemonset in
             'k8s_skypilot_system_namespace': _SKYPILOT_SYSTEM_NAMESPACE,

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -642,11 +642,11 @@ class Kubernetes(clouds.Cloud):
 
         fuse_device_required = bool(resources.requires_fuse)
 
-        # Get fuse_mounting config for custom fusermount-server image
-        fuse_mounting_image = skypilot_config.get_effective_region_config(
+        # Get fusermount_server config for custom fusermount-server image
+        fusermount_server_image = skypilot_config.get_effective_region_config(
             cloud='kubernetes',
             region=context,
-            keys=('fuse_mounting', 'image'),
+            keys=('fusermount_server', 'image'),
             default_value=None)
 
         # Configure spot labels, if requested and supported
@@ -780,7 +780,7 @@ class Kubernetes(clouds.Cloud):
             'k8s_service_account_name': k8s_service_account_name,
             'k8s_automount_sa_token': 'true',
             'k8s_fuse_device_required': fuse_device_required,
-            'k8s_fuse_mounting_image': fuse_mounting_image,
+            'k8s_fusermount_server_image': fusermount_server_image,
             'k8s_kueue_local_queue_name': k8s_kueue_local_queue_name,
             # Namespace to run the fusermount-server daemonset in
             'k8s_skypilot_system_namespace': _SKYPILOT_SYSTEM_NAMESPACE,

--- a/sky/provision/kubernetes/config.py
+++ b/sky/provision/kubernetes/config.py
@@ -542,13 +542,21 @@ def _configure_fuse_mounting(provider_config: Dict[str, Any]) -> None:
     root_dir = os.path.dirname(os.path.dirname(__file__))
 
     # Load and create the DaemonSet
-    # TODO(aylei): support customize and upgrade the fusermount-server image
     logger.info('_configure_fuse_mounting: Creating daemonset.')
     daemonset_path = os.path.join(
         root_dir, 'kubernetes/manifests/fusermount-server-daemonset.yaml')
     with open(daemonset_path, 'r', encoding='utf-8') as file:
         daemonset = yaml_utils.safe_load(file)
     kubernetes_utils.merge_custom_metadata(daemonset['metadata'])
+
+    # Override fusermount-server image if configured
+    fuse_device_manager_config = provider_config.get('fuse_device_manager', {})
+    custom_image = fuse_device_manager_config.get('image')
+    if custom_image:
+        daemonset['spec']['template']['spec']['containers'][0][
+            'image'] = custom_image
+        logger.info('_configure_fuse_mounting: Using custom fusermount-server '
+                    f'image: {custom_image}')
     try:
         kubernetes.apps_api(context).create_namespaced_daemon_set(
             fuse_proxy_namespace, daemonset)

--- a/sky/provision/kubernetes/config.py
+++ b/sky/provision/kubernetes/config.py
@@ -550,8 +550,8 @@ def _configure_fuse_mounting(provider_config: Dict[str, Any]) -> None:
     kubernetes_utils.merge_custom_metadata(daemonset['metadata'])
 
     # Override fusermount-server image if configured
-    fuse_device_manager_config = provider_config.get('fuse_device_manager', {})
-    custom_image = fuse_device_manager_config.get('image')
+    fuse_mounting_config = provider_config.get('fuse_mounting', {})
+    custom_image = fuse_mounting_config.get('image')
     if custom_image:
         daemonset['spec']['template']['spec']['containers'][0][
             'image'] = custom_image

--- a/sky/provision/kubernetes/config.py
+++ b/sky/provision/kubernetes/config.py
@@ -550,8 +550,8 @@ def _configure_fuse_mounting(provider_config: Dict[str, Any]) -> None:
     kubernetes_utils.merge_custom_metadata(daemonset['metadata'])
 
     # Override fusermount-server image if configured
-    fuse_mounting_config = provider_config.get('fuse_mounting', {})
-    custom_image = fuse_mounting_config.get('image')
+    fusermount_server_config = provider_config.get('fusermount_server', {})
+    custom_image = fusermount_server_config.get('image')
     if custom_image:
         daemonset['spec']['template']['spec']['containers'][0][
             'image'] = custom_image

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -46,11 +46,11 @@ provider:
     # Used to set up the necessary permissions and sidecars.
     fuse_device_required: {{k8s_fuse_device_required}}
 
-    # Configuration for the fusermount-server daemonset (FUSE device manager).
+    # Configuration for FUSE mounting (fusermount-server daemonset).
     # Allows customizing the image for air-gapped or rate-limited environments.
-    fuse_device_manager:
-      {% if k8s_fuse_device_manager_image %}
-      image: {{k8s_fuse_device_manager_image}}
+    fuse_mounting:
+      {% if k8s_fuse_mounting_image %}
+      image: {{k8s_fuse_mounting_image}}
       {% endif %}
 
     {% if ephemeral_volume_mounts %}

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -46,11 +46,11 @@ provider:
     # Used to set up the necessary permissions and sidecars.
     fuse_device_required: {{k8s_fuse_device_required}}
 
-    # Configuration for FUSE mounting (fusermount-server daemonset).
+    # Configuration for fusermount-server daemonset.
     # Allows customizing the image for air-gapped or rate-limited environments.
-    fuse_mounting:
-      {% if k8s_fuse_mounting_image %}
-      image: {{k8s_fuse_mounting_image}}
+    fusermount_server:
+      {% if k8s_fusermount_server_image %}
+      image: {{k8s_fusermount_server_image}}
       {% endif %}
 
     {% if ephemeral_volume_mounts %}

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -46,12 +46,12 @@ provider:
     # Used to set up the necessary permissions and sidecars.
     fuse_device_required: {{k8s_fuse_device_required}}
 
+    {% if k8s_fusermount_server_image %}
     # Configuration for fusermount-server daemonset.
     # Allows customizing the image for air-gapped or rate-limited environments.
     fusermount_server:
-      {% if k8s_fusermount_server_image %}
       image: {{k8s_fusermount_server_image}}
-      {% endif %}
+    {% endif %}
 
     {% if ephemeral_volume_mounts %}
     ephemeral_volume_specs: {{ephemeral_volume_mounts | tojson}}

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -46,6 +46,13 @@ provider:
     # Used to set up the necessary permissions and sidecars.
     fuse_device_required: {{k8s_fuse_device_required}}
 
+    # Configuration for the fusermount-server daemonset (FUSE device manager).
+    # Allows customizing the image for air-gapped or rate-limited environments.
+    fuse_device_manager:
+      {% if k8s_fuse_device_manager_image %}
+      image: {{k8s_fuse_device_manager_image}}
+      {% endif %}
+
     {% if ephemeral_volume_mounts %}
     ephemeral_volume_specs: {{ephemeral_volume_mounts | tojson}}
     {% endif %}

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1288,7 +1288,7 @@ _CONTEXT_CONFIG_SCHEMA_KUBERNETES = {
             'minimum': 1,
         }],
     },
-    'fuse_device_manager': {
+    'fuse_mounting': {
         'type': 'object',
         'required': [],
         'additionalProperties': False,

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1288,6 +1288,16 @@ _CONTEXT_CONFIG_SCHEMA_KUBERNETES = {
             'minimum': 1,
         }],
     },
+    'fuse_device_manager': {
+        'type': 'object',
+        'required': [],
+        'additionalProperties': False,
+        'properties': {
+            'image': {
+                'type': 'string',
+            },
+        },
+    },
 }
 
 

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1288,7 +1288,7 @@ _CONTEXT_CONFIG_SCHEMA_KUBERNETES = {
             'minimum': 1,
         }],
     },
-    'fuse_mounting': {
+    'fusermount_server': {
         'type': 'object',
         'required': [],
         'additionalProperties': False,


### PR DESCRIPTION
## Summary
- Adds a `fusermount_server.image` config option for Kubernetes to allow overriding the default `berkeleyskypilot/fusermount-server` DaemonSet image
- Useful for air-gapped or rate-limited environments where pulling from Docker Hub is not feasible

Fixes #8872

### Example config

```yaml
kubernetes:
  fusermount_server:
    image: my-private-registry.example.com/fusermount-server:0.2.1
```

Or per-context:

```yaml
kubernetes:
  allowed_contexts:
    - my-cluster:
        fusermount_server:
          image: my-registry.internal/fusermount-server:0.2.1
```

## Test plan

### Unit tests
Added schema validation tests in `tests/unit_tests/test_sky/utils/test_schemas.py::TestKubernetesSchema`:
- `test_fusermount_server_valid` — accepts valid `fusermount_server: {image: "..."}` config
- `test_fusermount_server_empty` — accepts empty `fusermount_server: {}`
- `test_fusermount_server_rejects_extra_fields` — rejects unknown fields
- `test_fusermount_server_image_must_be_string` — rejects non-string image values
- `test_fusermount_server_in_context_configs` — works inside per-context config

### Manual test (verified on Kind cluster)
1. Set `~/.sky/config.yaml` with `fusermount_server.image: berkeleyskypilot/fusermount-server:0.2.1`
2. Launched a task with S3 MOUNT storage on Kubernetes → DaemonSet created with image `:0.2.1`
3. Changed config to `fusermount_server.image: berkeleyskypilot/fusermount-server:0.1`
4. Deleted existing DaemonSet, re-launched → DaemonSet created with image `:0.1`
5. Verified with `kubectl get ds fusermount-server -n skypilot-system -o jsonpath='{.spec.template.spec.containers[0].image}'`
6. Without config set, default image `berkeleyskypilot/fusermount-server:0.2.1` from the manifest is used (unchanged behavior)