### PR TITLE
[Slurm] Fix get_job_nodes to handle compact hostlist notation

### DIFF
--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -450,9 +450,12 @@ class SlurmClient:
         """
 
         cmd = (
-            f'squeue -h --jobs {job_id} -o "%N" | tr \',\' \'\\n\' | '
-            f'while read node; do '
+            # Use scontrol show hostnames to expand both compact Slurm
+            # hostlist notation (e.g. ml-16-node-[001-002]) and
+            # comma-separated nodes into individual node names.
             # TODO(kevin): Use json output for more robust parsing.
+            f'nodelist=$(squeue -h --jobs {job_id} -o "%N"); '
+            f'scontrol show hostnames $nodelist | while read -r node; do '
             f'node_addr=$(scontrol show node=$node | grep NodeAddr= | '
             f'awk -F= \'{{print $2}}\' | awk \'{{print $1}}\'); '
             f'echo "$node $node_addr"; '


### PR DESCRIPTION
Slurm opportunistically compacts node names into bracket-range notation (e.g. `ml-16-node-[001-002]`) when nodes share a common prefix with contiguous numeric suffixes. The previous shell command used `tr ',' '\n'` which only splits comma-separated names and does not expand bracket ranges, causing all nodes in the range to be treated as a single instance ID.

Fix by using `scontrol show hostnames` to expand the nodelist inline — the Slurm-native approach — while keeping the same single SSH call.

`scontrol show hostnames` handles both comma-separated and compressed hostlist notation, which is exactly what we need:
```
$ scontrol show hostnames ml-16-node-[001-002,004],ml-17-node-[001-003]
ml-16-node-001
ml-16-node-002
ml-16-node-004
ml-17-node-001
ml-17-node-002
ml-17-node-003
```

Verified with a 2-node CPU job on a cluster where this occured: both nodes now show up as separate instances with individual IPs.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
