### PR TITLE
Avoid duplicate "Transitioned to INIT" events

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2279,6 +2279,7 @@ def _update_cluster_status(
           the node number larger than expected.
     """
     handle = record['handle']
+    status = record['status']
     if handle.cluster_yaml is None:
         # Remove cluster from db since this cluster does not have a config file
         # or any other ongoing requests
@@ -2719,13 +2720,15 @@ def _update_cluster_status(
         if status_reason:
             log_message += f' ({status_reason})'
         log_message += '. Transitioned to INIT.'
-        global_user_state.add_cluster_event(
-            cluster_name,
-            status_lib.ClusterStatus.INIT,
-            log_message,
-            global_user_state.ClusterEventType.STATUS_CHANGE,
-            nop_if_duplicate=True,
-            duplicate_regex=init_reason_regex)
+        # Do not add event if the cluster is already in INIT status.
+        if status != status_lib.ClusterStatus.INIT:
+            global_user_state.add_cluster_event(
+                cluster_name,
+                status_lib.ClusterStatus.INIT,
+                log_message,
+                global_user_state.ClusterEventType.STATUS_CHANGE,
+                nop_if_duplicate=True,
+                duplicate_regex=init_reason_regex)
         global_user_state.add_or_update_cluster(
             cluster_name,
             handle,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
If a cluster is in abnormal status, "Transitioned to INIT" event is emitted every time the status refresh daemon runs. This PR only emits the event when the cluster is not already in INIT state, because if it is already in INIT state, it's not really a transition.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
