### PR TITLE
nit: define variables so they are in scope

### DIFF
--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -955,6 +955,7 @@ def set_failed(
         spot_table.c.status: failure_type.value,
         spot_table.c.failure_reason: failure_reason,
     }
+    updated = False
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         # Get previous status
         previous_status = session.execute(
@@ -1011,6 +1012,7 @@ def set_pending_cancelled(job_id: int):
     add_job_event(job_id, None, ManagedJobStatus.CANCELLED,
                   'Job has been cancelled')
     assert _SQLALCHEMY_ENGINE is not None
+    count = 0
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         # Subquery to get the spot_job_ids that match the joined condition
         subquery = session.query(spot_table.c.job_id).join(
@@ -2575,6 +2577,7 @@ async def set_failed_async(
         spot_table.c.status: failure_type.value,
         spot_table.c.failure_reason: failure_reason,
     }
+    updated = False
     async with sql_async.AsyncSession(_SQLALCHEMY_ENGINE_ASYNC) as session:
         # Get previous status
         result = await session.execute(
@@ -2694,6 +2697,7 @@ async def set_cancelled_async(job_id: int, callback_func: AsyncCallbackType):
     await add_job_event_async(job_id, None, ManagedJobStatus.CANCELLED,
                               'Job has been cancelled')
     assert _SQLALCHEMY_ENGINE_ASYNC is not None
+    updated = False
     async with sql_async.AsyncSession(_SQLALCHEMY_ENGINE_ASYNC) as session:
         result = await session.execute(
             sqlalchemy.update(spot_table).where(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
These variables were only being defined within the `with` block but were being used after the block ends - introduce the variables before beginning the block for more defensive coding

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
