### PR TITLE
[Dashboard] Add Launch button to recipe detail page for SSO users

### DIFF
--- a/docs/source/examples/managed-jobs.rst
+++ b/docs/source/examples/managed-jobs.rst
@@ -819,3 +819,24 @@ To enable the consolidated deployment, set :ref:`consolidation_mode <config-yaml
       bucket: s3://xxx
 
 The jobs controller will use a bit of overhead - it reserves an extra 2GB of memory for itself, which may reduce the amount of requests your API server can handle. To counteract, you can increase the amount of CPU and memory allocated to the API server: See :ref:`sky-api-server-resources-tuning`.
+
+.. _jobs-consolidation-mode-resource-calculation:
+
+Resource calculation in consolidation mode
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In consolidation mode, the maximum number of concurrent job controllers is determined by the available memory on the API server pod after reserving resources for the API server workers:
+
+1. **Total usable memory** is computed as the system memory minus a 2GB reservation for the controller overhead (doubled when pool services share the controller).
+2. **API server worker memory** is subtracted: the memory used by the API server's long and short request workers (based on their guaranteed and burstable parallelism settings).
+3. **Per-controller memory** is approximately 400MB (for the job worker process).
+4. **Max controllers** = ``available_memory / per_controller_memory``, capped at 64.
+
+For example, on a pod with 16GB RAM, after reserving ~4GB for controller overhead and ~6GB for API server workers, roughly 6GB remains. With 400MB per controller, this allows approximately 15 concurrent job controllers.
+
+In **non-consolidation mode** (dedicated controller VM), the calculation also accounts for the memory of the local API server workers that run on the controller. Each controller needs memory for both its own process and 8 concurrent launches, so fewer controllers fit within the same memory.
+
+To increase the number of concurrent jobs, either:
+
+- Increase the API server pod memory (consolidation mode).
+- Use a controller VM with more memory by configuring ``jobs.controller.resources`` in ``~/.sky/config.yaml`` (non-consolidation mode).

--- a/docs/source/serving/sky-serve.rst
+++ b/docs/source/serving/sky-serve.rst
@@ -547,3 +547,49 @@ The :code:`resources` field has the same spec as a normal SkyPilot job; see `her
   These settings will not take effect if you have an existing controller (either
   stopped or live).  For them to take effect, tear down the existing controller
   first, which requires all services to be terminated.
+
+.. _sky-serve-max-services-calculation:
+
+How the maximum number of services is calculated
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The maximum number of concurrent services is determined by the available memory on the controller. Each service monitoring process requires approximately 512MB of memory.
+
+**Non-consolidation mode** (dedicated controller VM):
+
+1. **Total usable memory** = system memory - 2GB (reserved for controller overhead).
+2. Each service additionally needs memory for its local API server workers (4 concurrent launches per service).
+3. **Max services** = ``usable_memory / (512MB + worker_memory_per_service)``.
+
+**Consolidation mode** (controller running on the API server pod):
+
+When consolidation mode is enabled (``serve.controller.consolidation_mode: true``), the controller shares the API server pod. The calculation changes:
+
+1. **Total usable memory** = pod memory - 2GB controller overhead - API server worker memory.
+2. Since the API server manages request scheduling, no additional worker memory is needed per service.
+3. **Max services** = ``usable_memory / 512MB``.
+
+The following table shows the approximate minimum memory required for different numbers of concurrent services (non-consolidation mode):
+
+.. list-table::
+   :header-rows: 1
+
+   * - Max Services
+     - Min Memory Required (GB)
+   * - 2
+     - 10
+   * - 3
+     - 14
+   * - 4
+     - 17
+   * - 6
+     - 25
+   * - 8
+     - 32
+   * - 16
+     - 62
+
+If you encounter the "Max number of services reached" error, you can increase the limit by:
+
+- **Consolidation mode**: Increasing the API server pod memory.
+- **Non-consolidation mode**: Configuring a controller VM with more memory via ``serve.controller.resources`` above.

--- a/sky/dashboard/src/components/recipe-detail.jsx
+++ b/sky/dashboard/src/components/recipe-detail.jsx
@@ -11,6 +11,7 @@ import {
   CopyIcon,
   PinIcon,
   PinOffIcon,
+  PlayIcon,
   Trash2Icon,
   EditIcon,
   ShareIcon,
@@ -46,6 +47,7 @@ import {
   updateRecipe,
   deleteRecipe,
   togglePinRecipe,
+  launchRecipe,
 } from '@/data/connectors/recipes';
 import {
   getRecipeTypeInfo,
@@ -237,6 +239,65 @@ function DeleteModal({ isOpen, onClose, template, onDelete }) {
   );
 }
 
+// Launch Confirmation Modal
+function LaunchModal({ isOpen, onClose, template, onLaunch }) {
+  const [isLaunching, setIsLaunching] = useState(false);
+
+  const handleLaunch = async () => {
+    setIsLaunching(true);
+    try {
+      await onLaunch();
+      onClose();
+    } catch (error) {
+      showToast(`Launch failed: ${error.message}`, 'error');
+    } finally {
+      setIsLaunching(false);
+    }
+  };
+
+  if (!template) return null;
+
+  const typeInfo = getRecipeTypeInfo(template.recipe_type);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-xl text-gray-900">
+            Launch Recipe
+          </DialogTitle>
+          <DialogDescription>
+            Are you sure you want to launch &quot;{template.name}&quot; ({typeInfo.fullLabel})?
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter className="mt-4">
+          <Button variant="outline" onClick={onClose} disabled={isLaunching}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleLaunch}
+            disabled={isLaunching}
+            className="bg-sky-600 hover:bg-sky-700 text-white"
+          >
+            {isLaunching ? (
+              <>
+                <CircularProgress size={16} className="mr-2" />
+                Launching...
+              </>
+            ) : (
+              <>
+                <PlayIcon className="w-4 h-4 mr-2" />
+                Launch
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 // Main YamlDetail Component
 export function RecipeDetail() {
   const router = useRouter();
@@ -251,9 +312,25 @@ export function RecipeDetail() {
   const [commandCopied, setCommandCopied] = useState(false);
   const [yamlCopied, setYamlCopied] = useState(false);
 
+  // Auth state
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
   // Modal states
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [isLaunchModalOpen, setIsLaunchModalOpen] = useState(false);
+
+  // Fetch auth state to determine if launch button should be shown
+  useEffect(() => {
+    fetch(`${window.location.origin}/internal/dashboard/users/role`)
+      .then((res) => res.json())
+      .then((data) => {
+        setIsAuthenticated(!!data.id && data.id !== 'local');
+      })
+      .catch(() => {
+        setIsAuthenticated(false);
+      });
+  }, []);
 
   const fetchTemplate = useCallback(async () => {
     // Wait for router to be ready before accessing query params
@@ -320,6 +397,18 @@ export function RecipeDetail() {
       }
     } catch (error) {
       showToast(`Recipe pin operation failed: ${error.message}`, 'error');
+    }
+  };
+
+  const handleLaunch = async () => {
+    try {
+      await launchRecipe(template.name);
+      showToast(
+        `Recipe "${template.name}" launch submitted successfully!`,
+        'success'
+      );
+    } catch (error) {
+      throw error;
     }
   };
 
@@ -456,6 +545,16 @@ export function RecipeDetail() {
         </div>
 
         <div className="flex items-center gap-4">
+          {isAuthenticated && (
+            <Button
+              onClick={() => setIsLaunchModalOpen(true)}
+              className="bg-sky-600 hover:bg-sky-700 text-white"
+              size="sm"
+            >
+              <PlayIcon className="w-4 h-4 mr-1.5" />
+              Launch
+            </Button>
+          )}
           <button
             onClick={handleShare}
             className="text-sky-blue hover:text-sky-blue-bright flex items-center"
@@ -660,6 +759,12 @@ export function RecipeDetail() {
         onClose={() => setIsDeleteModalOpen(false)}
         template={template}
         onDelete={handleDelete}
+      />
+      <LaunchModal
+        isOpen={isLaunchModalOpen}
+        onClose={() => setIsLaunchModalOpen(false)}
+        template={template}
+        onLaunch={handleLaunch}
       />
     </div>
   );

--- a/sky/dashboard/src/data/connectors/recipes.js
+++ b/sky/dashboard/src/data/connectors/recipes.js
@@ -140,3 +140,21 @@ export async function togglePinRecipe(recipeName, pinned) {
     throw error;
   }
 }
+
+/**
+ * Launch a recipe by name.
+ * This is a fire-and-forget operation that submits the recipe for execution.
+ *
+ * @param {string} recipeName - The recipe's unique name
+ * @returns {Promise<string>} Request ID for tracking the launch
+ */
+export async function launchRecipe(recipeName) {
+  const response = await apiClient.fetchImmediate('/recipes/launch', {
+    recipe_name: recipeName,
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Launch failed: ${text}`);
+  }
+  return response.headers.get('X-Skypilot-Request-ID');
+}

--- a/sky/recipes/core.py
+++ b/sky/recipes/core.py
@@ -291,3 +291,79 @@ def toggle_pin(recipe_name: str, pinned: bool) -> Optional[Dict[str, Any]]:
     if recipe is None:
         return None
     return recipe.to_dict()
+
+
+def launch_recipe(
+    recipe_name: str,
+) -> Optional[str]:
+    """Launch a recipe by name.
+
+    Fetches the recipe from the database and dispatches to the appropriate
+    launch handler based on recipe_type.
+
+    Args:
+        recipe_name: The recipe's unique name.
+
+    Returns:
+        A status message string on success.
+
+    Raises:
+        ValueError: If recipe not found or YAML is invalid.
+    """
+    # pylint: disable=import-outside-toplevel
+    from sky import execution
+    from sky.jobs.server import core as jobs_server_core
+    from sky.utils import dag_utils
+    from sky.volumes.server import core as volumes_server_core
+    from sky.volumes import volume as volume_lib
+
+    recipe = recipes_db.get_recipe(recipe_name)
+    if recipe is None:
+        raise ValueError(f'Recipe not found: {recipe_name}')
+
+    content = recipe.content
+    recipe_type = recipe.recipe_type
+
+    if recipe_type == RecipeType.CLUSTER:
+        dag = dag_utils.load_chain_dag_from_yaml_str(content)
+        execution.launch(dag, cluster_name=recipe_name)
+        return f'Cluster recipe {recipe_name!r} launched successfully.'
+
+    if recipe_type == RecipeType.JOB:
+        dag = dag_utils.load_chain_dag_from_yaml_str(content)
+        jobs_server_core.launch(task=dag)
+        return f'Job recipe {recipe_name!r} launched successfully.'
+
+    if recipe_type == RecipeType.VOLUME:
+        config = yaml.safe_load(content)
+        volume = volume_lib.Volume.from_yaml_config(config)
+        volumes_server_core.volume_apply(
+            name=volume.name,
+            volume_type=volume.type,
+            cloud=volume.cloud,
+            region=volume.region,
+            zone=volume.zone,
+            size=volume.size,
+            config=volume.config or {},
+            labels=volume.labels,
+            use_existing=volume.use_existing,
+        )
+        return f'Volume recipe {recipe_name!r} applied successfully.'
+
+    if recipe_type == RecipeType.POOL:
+        config = yaml.safe_load(content)
+        pool_config = config.pop('pool', {})
+        pool_name = pool_config.get('name', recipe_name)
+        workers = pool_config.get('workers')
+        # Rebuild YAML without pool section for the task
+        task_yaml = yaml.dump(config) if config else ''
+        dag = dag_utils.load_chain_dag_from_yaml_str(task_yaml)
+        task = dag.tasks[0]
+        jobs_server_core.pool_apply(
+            task=task,
+            pool_name=pool_name,
+            workers=workers,
+        )
+        return f'Pool recipe {recipe_name!r} applied successfully.'
+
+    raise ValueError(f'Unsupported recipe type: {recipe_type}')

--- a/sky/recipes/server.py
+++ b/sky/recipes/server.py
@@ -122,3 +122,19 @@ async def pin_recipe(
         func=core.toggle_pin,
         schedule_type=api_requests.ScheduleType.SHORT,
     )
+
+
+@router.post('/launch')
+async def launch_recipe(
+    request: fastapi.Request,
+    launch_body: payloads.RecipeLaunchBody,
+) -> None:
+    """Launch a recipe by name."""
+    await executor.schedule_request_async(
+        request_id=request.state.request_id,
+        request_name=request_names.RequestName.RECIPE_LAUNCH,
+        request_body=launch_body,
+        func=core.launch_recipe,
+        schedule_type=api_requests.ScheduleType.LONG,
+        auth_user=request.state.auth_user,
+    )

--- a/sky/serve/constants.py
+++ b/sky/serve/constants.py
@@ -114,5 +114,6 @@ TERMINATE_REPLICA_VERSION_MISMATCH_ERROR = (
 # Dummy run command for pool.
 POOL_DUMMY_RUN_COMMAND = 'echo "setup done"'
 
-# Error message for max number of services reached.
-MAX_NUMBER_OF_SERVICES_REACHED_ERROR = 'Max number of services reached.'
+# Error message prefix for max number of services reached.
+# This is used as a marker to detect the error in controller logs.
+MAX_NUMBER_OF_SERVICES_REACHED_ERROR = 'Max number of services reached'

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -1249,9 +1249,16 @@ def wait_service_registration(service_name: str, job_id: int,
                 if (constants.MAX_NUMBER_OF_SERVICES_REACHED_ERROR
                         in log_content):
                     with ux_utils.print_exception_no_traceback():
-                        raise RuntimeError('Max number of services reached. '
-                                           'To spin up more services, please '
-                                           'tear down some existing services.')
+                        raise RuntimeError(
+                            'Max number of services reached. '
+                            'To spin up more services, please '
+                            'tear down some existing services. '
+                            'Check `sky serve status` for current '
+                            'service count, and see https://docs.'
+                            'skypilot.co/en/latest/serving/'
+                            'sky-serve.html#customizing-skyserve-'
+                            'controller-resources for how to '
+                            'increase the limit.')
         elapsed = time.time() - start_time
         if elapsed > constants.SERVICE_REGISTER_TIMEOUT_SECONDS:
             # Print the controller log to help user debug.

--- a/sky/serve/server/impl.py
+++ b/sky/serve/server/impl.py
@@ -380,9 +380,12 @@ def up(
                 backend.cancel_jobs(controller_handle, [controller_job_id])
                 with ux_utils.print_exception_no_traceback():
                     raise RuntimeError(
-                        'Max number of services reached. '
-                        'To spin up more services, please '
-                        'tear down some existing services.') from None
+                        'Max number of services reached due to vCPU '
+                        'constraint on the controller. To spin up more '
+                        'services, please tear down some existing services '
+                        'or increase the controller resources by '
+                        'configuring `serve.controller.resources` in '
+                        '~/.sky/config.yaml.') from None
             else:
                 # Possible cases:
                 # (1) name conflict;

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -276,7 +276,8 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
                 cleanup_storage(yaml_content)
                 with ux_utils.print_exception_no_traceback():
                     raise RuntimeError(
-                        constants.MAX_NUMBER_OF_SERVICES_REACHED_ERROR)
+                        controller_utils.get_max_services_error_message(
+                            task.service.pool))
             success = serve_state.add_service(
                 service_name,
                 controller_job_id=job_id,

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -997,3 +997,8 @@ class RecipePinBody(RequestBody):
     """The request body for toggling pin status."""
     recipe_name: str
     pinned: bool
+
+
+class RecipeLaunchBody(RequestBody):
+    """The request body for launching a recipe."""
+    recipe_name: str

--- a/sky/server/requests/request_names.py
+++ b/sky/server/requests/request_names.py
@@ -85,6 +85,7 @@ class RequestName(str, enum.Enum):
     RECIPE_UPDATE = 'recipes.update'
     RECIPE_DELETE = 'recipes.delete'
     RECIPE_PIN = 'recipes.pin'
+    RECIPE_LAUNCH = 'recipes.launch'
     # Internal request daemons
     REQUEST_DAEMON_STATUS_REFRESH = 'status-refresh'
     REQUEST_DAEMON_VOLUME_REFRESH = 'volume-refresh'

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -1428,6 +1428,34 @@ def can_start_new_process(pool: bool) -> bool:
     return serve_state.get_num_services() < _get_number_of_services(pool)
 
 
+def get_max_services_error_message(pool: bool) -> str:
+    """Returns a detailed error message when max services is reached."""
+    current = serve_state.get_num_services()
+    maximum = _get_number_of_services(pool)
+    consolidation = _is_consolidation_mode(pool)
+    controller_type = 'jobs' if pool else 'serve'
+
+    msg = (f'Max number of services reached: {current}/{maximum} '
+           f'services are running.')
+    msg += ' To spin up more services, please tear down some existing ones.'
+
+    if consolidation:
+        msg += (f'\n\nThe {controller_type} controller is running in '
+                'consolidation mode, sharing memory with the API server. '
+                'The max number of concurrent services is calculated based '
+                'on the available memory after reserving resources for the '
+                'API server workers. To increase the limit, allocate more '
+                'memory to the API server pod.')
+    else:
+        msg += (f'\n\nThe max number of concurrent services is calculated '
+                f'based on the controller VM memory. To increase the limit, '
+                f'use a controller with more memory by configuring '
+                f'`{controller_type}.controller.resources` in '
+                f'~/.sky/config.yaml.')
+
+    return msg
+
+
 def can_terminate(pool: bool) -> bool:
     # TODO(tian): probe API server to see if there is any pending terminate
     # requests.


### PR DESCRIPTION
## Summary
- Adds a **Launch** button to the recipe detail page in the dashboard, visible only when the user is authenticated via SSO
- New `POST /recipes/launch` server endpoint that resolves a recipe by name and dispatches to the correct handler (cluster launch, jobs launch, volume apply, pool apply)
- Frontend uses fire-and-forget API call with confirmation modal and toast notifications

## Test plan
- [ ] Deploy API server with SSO enabled (`auth.oauth.enabled: true` in Helm values)
- [ ] Navigate to a recipe detail page — verify the **Launch** button appears
- [ ] Click Launch on a cluster recipe — verify confirmation modal appears, then cluster shows up in Clusters page
- [ ] Click Launch on a job recipe — verify job appears in Jobs page
- [ ] Test without SSO (local API server) — verify Launch button is **hidden**
- [ ] Run `pytest tests/unit_tests/` for regression checks