### PR TITLE
[Slurm] Detect FUSE availability and error early on MOUNT/MOUNT_CACHED

### DIFF
--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -649,6 +649,40 @@ class SlurmClient:
         rc, _, _ = self._run_slurm_cmd(cmd)
         return rc == 0
 
+    def check_fuse_enabled(self) -> bool:
+        """Check if FUSE is available on the cluster.
+
+        FUSE is required for mounting object stores (e.g., via goofys or
+        rclone). We check for /dev/fuse which is the device node that FUSE
+        requires.
+
+        We first try to check on a compute node via srun, since that is
+        where mounts actually happen. If srun cannot allocate resources
+        (cluster is full, etc.), we fall back to checking the login node.
+
+        Returns:
+            True if FUSE is available, False otherwise.
+        """
+        # Try checking on a compute node first. We use a wrapper that
+        # prints a marker so we can distinguish "command ran and /dev/fuse
+        # is missing" from "srun itself failed to allocate".
+        srun_cmd = ('srun --immediate=10 --time=00:00:30 '
+                    'bash -c \'test -e /dev/fuse '
+                    '&& echo FUSE_OK || echo FUSE_MISSING\'')
+        rc, stdout, _ = self._run_slurm_cmd(srun_cmd)
+        stdout = stdout.strip()
+        if rc == 0 and 'FUSE_OK' in stdout:
+            return True
+        if rc == 0 and 'FUSE_MISSING' in stdout:
+            return False
+
+        # srun failed (no resources, misconfigured, etc.).
+        # Fall back to checking the login node.
+        logger.debug('srun FUSE check failed, falling back to login node')
+        cmd = 'test -e /dev/fuse'
+        rc, _, _ = self._run_slurm_cmd(cmd)
+        return rc == 0
+
     def check_homedir_shared_fs(self) -> Optional[str]:
         """Check the filesystem type of the home directory.
 

--- a/sky/clouds/slurm.py
+++ b/sky/clouds/slurm.py
@@ -57,6 +57,16 @@ class Slurm(clouds.Cloud):
             'the Pyxis plugin is not installed. Please ask your cluster '
             'administrator to install Pyxis '
             '(https://github.com/NVIDIA/pyxis).',
+        clouds.CloudImplementationFeatures.STORAGE_MOUNTING:
+            'Storage mounting is not supported on this Slurm cluster '
+            'because FUSE is not enabled (/dev/fuse not found). '
+            'Please ask your cluster administrator to enable FUSE.',
+    }
+    # Features that are checked dynamically per cluster (e.g., via SSH).
+    # Used for early exit in _unsupported_features_for_resources().
+    _DYNAMICALLY_CHECKED_FEATURES = {
+        clouds.CloudImplementationFeatures.DOCKER_IMAGE,
+        clouds.CloudImplementationFeatures.STORAGE_MOUNTING,
     }
     _MAX_CLUSTER_NAME_LEN_LIMIT = 120
     _regions: List[clouds.Region] = []
@@ -95,12 +105,11 @@ class Slurm(clouds.Cloud):
         region: Optional[str] = None,
     ) -> Dict[clouds.CloudImplementationFeatures, str]:
         unsupported = cls._CLOUD_UNSUPPORTED_FEATURES.copy()
-        # Docker image support requires the Pyxis SPANK plugin.
-        # When region is None, we check all clusters and mark Docker as
-        # supported if ANY cluster has Pyxis. This is intentionally
+        # When region is None, we check all clusters and mark a feature as
+        # supported if ANY cluster supports it. This is intentionally
         # permissive -- per-cluster filtering happens in
         # regions_with_offering(), which calls check_features_are_supported()
-        # with a specific region to filter out non-Pyxis clusters.
+        # with a specific region to filter out unsupported clusters.
         cluster = region if region is not None else resources.region
         if cluster is None:
             clusters = cls.existing_allowed_clusters()
@@ -108,13 +117,22 @@ class Slurm(clouds.Cloud):
             clusters = [cluster]
         for c in clusters:
             try:
+                # Docker image support requires the Pyxis SPANK plugin.
                 if slurm_utils.check_pyxis_enabled(c):
                     unsupported.pop(
                         clouds.CloudImplementationFeatures.DOCKER_IMAGE, None)
-                    break
+                # Storage mounting requires FUSE (/dev/fuse).
+                if slurm_utils.check_fuse_enabled(c):
+                    unsupported.pop(
+                        clouds.CloudImplementationFeatures.STORAGE_MOUNTING,
+                        None)
             except Exception as e:  # pylint: disable=broad-except
-                logger.debug(f'Failed to check Pyxis on cluster {c}: '
+                logger.debug(f'Failed to check cluster features on {c}: '
                              f'{common_utils.format_exception(e)}')
+            # Stop early if all dynamically checked features are resolved.
+            if not any(f in unsupported
+                       for f in cls._DYNAMICALLY_CHECKED_FEATURES):
+                break
         return unsupported
 
     @classmethod

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -5,7 +5,7 @@ import os
 import re
 import shlex
 import time
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from paramiko.config import SSHConfig
 
@@ -35,6 +35,8 @@ _SLURM_NODES_INFO_CACHE_TTL = 30 * 60
 _SLURM_PROCTRACK_TYPE_CACHE_TTL = 24 * 60 * 60
 # Pyxis plugin availability is unlikely to change frequently.
 _SLURM_PYXIS_CHECK_CACHE_TTL = 24 * 60 * 60
+# FUSE availability is unlikely to change frequently.
+_SLURM_FUSE_CHECK_CACHE_TTL = 24 * 60 * 60
 
 
 def get_gpu_type_and_count(gres_str: str) -> Tuple[Optional[str], int]:
@@ -152,17 +154,26 @@ def get_proctrack_type(cluster: str) -> Optional[str]:
     return proctrack_type
 
 
-def check_pyxis_enabled(cluster: str) -> bool:
-    """Check if the Pyxis SPANK plugin is installed on a Slurm cluster.
+def _check_cluster_feature(
+    cluster: str,
+    feature_name: str,
+    check_fn: Callable[[slurm.SlurmClient], bool],
+    cache_ttl: int,
+) -> bool:
+    """Check if a feature is available on a Slurm cluster, with caching.
 
-    Pyxis is required for Docker container support on Slurm. This function
-    caches the result per cluster since the plugin availability is unlikely
-    to change frequently.
+    Args:
+        cluster: Name of the Slurm cluster.
+        feature_name: Short name for the feature (used in cache key and logs).
+        check_fn: A callable that takes a SlurmClient and returns True if
+            the feature is available.
+        cache_ttl: Time-to-live for the cache entry in seconds.
     """
-    cache_key = f'slurm:pyxis_enabled:{cluster}'
+    cache_key = f'slurm:{feature_name}_enabled:{cluster}'
     cached = kv_cache.get_cache_entry(cache_key)
     if cached is not None:
-        logger.debug(f'Slurm pyxis check found in cache ({cache_key})')
+        logger.debug(f'Slurm {feature_name} check found in cache '
+                     f'({cache_key})')
         return cached == 'true'
 
     ssh_config = get_slurm_ssh_config()
@@ -176,17 +187,41 @@ def check_pyxis_enabled(cluster: str) -> bool:
         ssh_proxy_jump=ssh_config_dict.get('proxyjump', None),
         identities_only=get_identities_only(ssh_config_dict),
     )
-    enabled = client.check_pyxis_enabled()
+    enabled = check_fn(client)
 
     try:
-        kv_cache.add_or_update_cache_entry(
-            cache_key, 'true' if enabled else 'false',
-            time.time() + _SLURM_PYXIS_CHECK_CACHE_TTL)
+        kv_cache.add_or_update_cache_entry(cache_key,
+                                           'true' if enabled else 'false',
+                                           time.time() + cache_ttl)
     except Exception as e:  # pylint: disable=broad-except
-        logger.debug(f'Failed to cache slurm pyxis check for {cluster}: '
-                     f'{common_utils.format_exception(e)}')
+        logger.debug(f'Failed to cache slurm {feature_name} check for '
+                     f'{cluster}: {common_utils.format_exception(e)}')
 
     return enabled
+
+
+def check_pyxis_enabled(cluster: str) -> bool:
+    """Check if the Pyxis SPANK plugin is installed on a Slurm cluster.
+
+    Pyxis is required for Docker container support on Slurm. This function
+    caches the result per cluster since the plugin availability is unlikely
+    to change frequently.
+    """
+    return _check_cluster_feature(cluster, 'pyxis',
+                                  lambda c: c.check_pyxis_enabled(),
+                                  _SLURM_PYXIS_CHECK_CACHE_TTL)
+
+
+def check_fuse_enabled(cluster: str) -> bool:
+    """Check if FUSE is available on a Slurm cluster.
+
+    FUSE is required for storage mounting (MOUNT/MOUNT_CACHED modes) via
+    tools like goofys and rclone. This function caches the result per
+    cluster since FUSE availability is unlikely to change frequently.
+    """
+    return _check_cluster_feature(cluster, 'fuse',
+                                  lambda c: c.check_fuse_enabled(),
+                                  _SLURM_FUSE_CHECK_CACHE_TTL)
 
 
 class SlurmInstanceType:


### PR DESCRIPTION
Add early detection of FUSE (/dev/fuse) on Slurm clusters so that users get a clear error message when using storage mount modes (MOUNT or MOUNT_CACHED) on clusters without FUSE support, instead of failing during mount setup.

The detection mirrors the existing pyxis/container pattern:
- SlurmClient.check_fuse_enabled() probes a compute node via srun --immediate, falling back to the login node if allocation fails
- Cached wrapper in slurm/utils.py with 24h TTL via kv_cache
- STORAGE_MOUNTING added to unsupported features, conditionally removed when FUSE is detected (per-cluster filtering in regions_with_offering)

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
