### PR TITLE
[Core] Fix uv >=0.10.5 stripping execute permissions on XFS filesystems

### DIFF
--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -104,7 +104,9 @@ SKY_UV_INSTALL_DIR = '"$HOME/.local/bin"'
 # set UV_SYSTEM_PYTHON to false in case the
 # user provided docker image set it to true.
 # unset PYTHONPATH in case the user provided docker image set it.
-SKY_UV_CMD = ('UV_SYSTEM_PYTHON=false '
+# UV_LINK_MODE=copy avoids a uv >=0.10.5 bug where clone/reflink mode
+# strips execute permissions on XFS filesystems, breaking Ray binaries.
+SKY_UV_CMD = ('UV_LINK_MODE=copy UV_SYSTEM_PYTHON=false '
               f'{SKY_UNSET_PYTHONPATH_AND_SET_CWD} {SKY_UV_INSTALL_DIR}/uv')
 # This won't reinstall uv if it's already installed, so it's safe to re-run.
 SKY_UV_INSTALL_CMD = (f'{SKY_UV_CMD} -V >/dev/null 2>&1 || '

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -922,7 +922,7 @@ available_node_types:
 
                 # set UV_SYSTEM_PYTHON to false in case the user provided docker image set it to true.
                 # unset PYTHONPATH and set CWD to $HOME to avoid user image interfering with SkyPilot runtime.
-                VIRTUAL_ENV=~/skypilot-runtime UV_SYSTEM_PYTHON=false {{sky_unset_pythonpath_and_set_cwd}} ~/.local/bin/uv pip install skypilot[kubernetes,remote]
+                VIRTUAL_ENV=~/skypilot-runtime UV_LINK_MODE=copy UV_SYSTEM_PYTHON=false {{sky_unset_pythonpath_and_set_cwd}} ~/.local/bin/uv pip install skypilot[kubernetes,remote]
                 # Wait for `patch` package to be installed before applying ray patches
                 until dpkg -l | grep -q "^ii  patch "; do
                   sleep 0.1
@@ -930,7 +930,7 @@ available_node_types:
                 done
                 # Apply Ray patches for progress bar fix
                 # ~/.sky/python_path is seeded by conda_installation_commands
-                VIRTUAL_ENV=~/skypilot-runtime UV_SYSTEM_PYTHON=false {{sky_unset_pythonpath_and_set_cwd}} ~/.local/bin/uv pip list | grep "ray " | grep 2.9.3 2>&1 > /dev/null && {
+                VIRTUAL_ENV=~/skypilot-runtime UV_LINK_MODE=copy UV_SYSTEM_PYTHON=false {{sky_unset_pythonpath_and_set_cwd}} ~/.local/bin/uv pip list | grep "ray " | grep 2.9.3 2>&1 > /dev/null && {
                   {{sky_unset_pythonpath_and_set_cwd}} $(cat ~/.sky/python_path) -c "from sky.skylet.ray_patches import patch; patch()" || exit 1;
                 }
                 touch /tmp/ray_skypilot_installation_complete


### PR DESCRIPTION
## Summary

- uv 0.10.5 introduced a regression where its reflink/clone link mode strips execute permissions from wheel data files on XFS filesystems, causing Ray's `gcs_server` and `raylet` binaries to be installed as `664` instead of `775`, breaking `ray start` with `PermissionError` on Amazon Linux 2023
- Set `UV_LINK_MODE=copy` in all uv invocations (`SKY_UV_CMD` and Kubernetes templates) to bypass the broken reflink code path

## Root Cause

uv 0.10.5 PRs [#18117](https://github.com/astral-sh/uv/pull/18117) ("Attempt to use reflinks by default on Linux") and [#18104](https://github.com/astral-sh/uv/pull/18104) ("Fallback to hardlinks after reflink failure") introduced clone/reflink as the default link mode on Linux. On XFS filesystems (used by Amazon Linux 2023), this strips execute permissions from installed files. Ubuntu (ext4, no reflink support) is unaffected because uv falls back to copy mode.

**Evidence — same commit, different uv versions:**
- Build [#8390](https://buildkite.com/skypilot-1/smoke-tests/builds/8390) — **passed** (ran 00:36 UTC, got uv 0.10.4)
- Build [#8401](https://buildkite.com/skypilot-1/smoke-tests/builds/8401) — **failed** (ran 08:56 UTC, got uv 0.10.5, published 00:55 UTC)
- A/B test on AL2023 VM confirmed: uv 0.10.4 → `775` permissions, uv 0.10.5 → `664` permissions

## Changes

| File | Change |
|------|--------|
| `sky/skylet/constants.py` | Add `UV_LINK_MODE=copy` to `SKY_UV_CMD` (propagates to all downstream uv commands) |
| `sky/templates/kubernetes-ray.yml.j2` | Add `UV_LINK_MODE=copy` to 2 hardcoded uv invocations that bypass `SKY_UV_CMD` |

## Test plan

- [x] `bash format.sh` — all checks pass (yapf, isort, mypy, pylint)
- [x] `pytest tests/unit_tests/test_controller_utils.py` — 34/34 passed
- [x] Pre-commit hooks pass
- [x] `sky launch` on AL2023 AMI (`ami-0a5a5b7e2278263e5`, us-east-2) with uv 0.10.5 → `gcs_server` and `raylet` permissions are `775`
- [x] `/smoke-test -k test_aws_storage_mounts_cached`: https://buildkite.com/skypilot-1/smoke-tests/builds/8406#019c8f7e-b307-4f1b-a4a7-09912ed3489b

🤖 Generated with [Claude Code](https://claude.com/claude-code)