### PR TITLE
[Nebius] Fix docker permission denied by adding sudo to docker commands

### DIFF
--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -206,7 +206,11 @@ class DockerInitializer:
         self.initialized = False
         # podman is not fully tested yet.
         use_podman = docker_config.get('use_podman', False)
-        self.docker_cmd = 'podman' if use_podman else 'docker'
+        self.docker_cmd_name = 'podman' if use_podman else 'docker'
+        # Use sudo to avoid 'permission denied' errors when the SSH user
+        # is not in the docker group (e.g., on Nebius). The provisioned VM
+        # always has passwordless sudo. See #8764.
+        self.docker_cmd = f'sudo {self.docker_cmd_name}'
         self.log_path = log_path
 
     def _run(
@@ -491,15 +495,16 @@ class DockerInitializer:
         # before checking if docker is installed to avoid permission issues.
         docker_cmd = ('id -nG $USER | grep -qw docker || '
                       'sudo usermod -aG docker $USER > /dev/null 2>&1;'
-                      f'command -v {self.docker_cmd} || echo {no_exist!r}')
+                      f'command -v {self.docker_cmd_name} || echo {no_exist!r}')
         cleaned_output = self._run(docker_cmd)
         timeout = 60 * 10  # 10 minute timeout
         start = time.time()
         while no_exist in cleaned_output or 'docker' not in cleaned_output:
             if time.time() - start > timeout:
                 logger.error(
-                    f'{self.docker_cmd.capitalize()} not installed. Please use '
-                    f'an image with {self.docker_cmd.capitalize()} installed.')
+                    f'{self.docker_cmd_name.capitalize()} not installed. '
+                    f'Please use an image with '
+                    f'{self.docker_cmd_name.capitalize()} installed.')
                 return
             time.sleep(5)
             cleaned_output = self._run(docker_cmd)

--- a/tests/smoke_tests/test_images.py
+++ b/tests/smoke_tests/test_images.py
@@ -712,6 +712,37 @@ def test_docker_nonroot_user(generic_cloud: str):
     smoke_tests_utils.run_one_test(test)
 
 
+@pytest.mark.nebius
+def test_nebius_docker_image(generic_cloud: str):
+    """Test that docker images work on Nebius without permission denied errors.
+
+    Nebius GPU VMs use the ubuntu24.04-cuda12 image which has Docker
+    pre-installed, but the SSH user (ubuntu) is NOT in the docker group.
+    With the sudo fix, docker commands should succeed without triggering
+    the 'permission denied' retry path. (GH #8764)
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    test = smoke_tests_utils.Test(
+        'nebius_docker_image',
+        [
+            f'sky launch -y -c {name} --infra nebius '
+            f'--image-id docker:ubuntu:22.04 '
+            f'--gpus L40S:1 '
+            f'"echo hello from docker && whoami"',
+            f'sky logs {name} 1 --status',
+            # Verify provision log does NOT contain permission denied errors.
+            # With the sudo fix, docker commands run as root and never hit
+            # the permission denied + retry path.
+            f's=$(sky logs --provision {name}) && '
+            f'echo "$s" | grep -q "initialize_docker" && '
+            f'! echo "$s" | grep -q "permission denied"',
+        ],
+        f'sky down -y {name}',
+        timeout=20 * 60,
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
 @pytest.mark.gcp
 def test_helm_deploy_gke(request):
     if not request.config.getoption('--helm-package'):


### PR DESCRIPTION
## Summary

Fixes #8764.

Add `sudo` to host-level docker commands in `DockerInitializer` to eliminate "permission denied" errors on Nebius GPU VMs.

### Background & Investigation

On Nebius GPU VMs (`ubuntu24.04-cuda12`), Docker is pre-installed but the SSH user (`ubuntu`) is **not** in the docker group. The existing code in `_check_docker_installed()` runs `sudo usermod -aG docker $USER` to add the user, but this requires a new SSH session to take effect.

PR #8151 (Dec 2025) fixed the error string matching so the retry mechanism in `_run()` properly detects "permission denied" errors, calls `close_cached_connection()` to refresh the SSH session, and retries. **This means launches already succeed on the current codebase** — but every Nebius GPU docker launch still hits the error + retry path, adding ~5 seconds of latency:

```
+ docker inspect -f {{.State.Running}} sky_container || true
permission denied while trying to connect to the docker API at unix:///var/run/docker.sock
Failed to connect to docker daemon. It might be initializing, retrying in 5 seconds...
error: no such object: sky_container    ← retry succeeds
+ docker pull ubuntu:22.04              ← subsequent commands work
```

The original issue reporter (#8764) was on a version **before** #8151 where the error string didn't match (`'the Docker daemon socket'` vs `'the docker API at unix:///...'`), so the retry never fired and the launch failed entirely.

### What this PR does

By prefixing docker commands with `sudo`, we eliminate the permission error entirely — no error, no retry, no 5-second delay. This is safe because SkyPilot-provisioned VMs always have passwordless sudo configured.

### Changes

- **`sky/provision/docker_utils.py`**: Added `docker_cmd_name` to store the bare command (`docker`/`podman`) for use in `command -v` checks and error messages. Changed `docker_cmd` to `sudo docker` for all host-level docker operations.
- **`tests/smoke_tests/test_images.py`**: Updated `test_nebius_docker_image` smoke test to launch a Nebius GPU VM with a docker image and verify the provision log contains **no** "permission denied" errors.

## Test plan

### Manual verification (performed)

**On master (before fix):**
```
$ sky launch -y -c test --infra nebius --image-id docker:ubuntu:22.04 --gpus L40S:1 "echo hello"
$ sky logs --provision test | grep "permission denied"
permission denied while trying to connect to the docker API at unix:///var/run/docker.sock
```
→ "permission denied" present, retry fires, launch still succeeds after ~5s delay

**On this PR (after fix):**
```
$ sky launch -y -c test --infra nebius --image-id docker:ubuntu:22.04 --gpus L40S:1 "echo hello"
$ sky logs --provision test | grep "permission denied"
(no output)
```
→ No "permission denied", no retry needed, clean launch

### Smoke test

- `test_nebius_docker_image`: Launches Nebius GPU VM with `docker:ubuntu:22.04`, verifies job succeeds and provision log has zero "permission denied" errors
  - **Fails on master** (permission denied appears in provision log)
  - **Passes on this PR** (sudo eliminates the error)