### PR TITLE
Release 0.11.2rc3

### DIFF
--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -37,7 +37,7 @@ def _get_git_commit():
 
 
 __commit__ = _get_git_commit()
-__version__ = '1.0.0-dev0'
+__version__ = '0.11.2rc3'
 __root_dir__ = directory_utils.get_sky_dir()
 
 


### PR DESCRIPTION
Release 0.11.2rc3

This release is based upon the 0.11.2rc2 release https://github.com/skypilot-org/skypilot/pull/8846 and adds one cherry-picked PR to fix an issue with a uv regression https://github.com/skypilot-org/skypilot/pull/8904.

⚠️ **Smoke tests were SKIPPED** - Please ensure manual testing was performed.