### PR TITLE
[Core] Make Jobs Logs Tailing Cancellation Quiet

### DIFF
--- a/sky/server/requests/threads.py
+++ b/sky/server/requests/threads.py
@@ -1,5 +1,6 @@
 """Request execution threads management."""
 
+import asyncio
 import concurrent.futures
 import sys
 import threading
@@ -55,9 +56,12 @@ class OnDemandThreadExecutor(concurrent.futures.Executor):
         try:
             result = fn(*args, **kwargs)
             fut.set_result(result)
-        except BaseException as e:  # pylint: disable=broad-except
+        except (Exception, asyncio.exceptions.CancelledError) as e:  # pylint: disable=broad-except
             logger.debug(f'Executor [{self.name}] error executing {fn}: {e}')
-            fut.set_exception(e)
+            if not fut.cancelled():
+                # Only set the exception if the future is not cancelled to avoid
+                # setting the exception twice leading to another exception.
+                fut.set_exception(e)
         finally:
             self.running.decrement()
             self._cleanup_thread(threading.current_thread())


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixes an issue where cancelling jobs logs tailing would result in an asyncio exception being raised with traceback in the API server logs.

When a client stops logs tailing `task.cancel()` is called which leads to us setting the request's context's cancelled event to true, eventually resulting in raising `asyncio.CancelledError`.

The `_task_wrapper` in the `OnDemandThreadExecutor` class is supposed to catch such exceptions and set the result of the future with the exception, and tries to do so with `except Exception as e`. This does not happen however because `asyncio.CancelledError` inherits from `BaseException` rather than `Exception`. This also means that the future does not get resolved.

So we modify the `_task_wrapper` to also catch `asyncio.CancelledError` directly instead. I tested this manually to verify that we no longer see the cancellation stack trace when cancelling jobs logs tailing.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
