### PR TITLE
[Slurm] Fix gpus list crash when filtering by GPU name

### DIFF
--- a/sky/catalog/slurm_catalog.py
+++ b/sky/catalog/slurm_catalog.py
@@ -145,9 +145,11 @@ def list_accelerators_realtime(
 
         # Apply name filter to the determined GPU type
         regex_flags = 0 if case_sensitive else re.IGNORECASE
-        if name_filter and not re.match(
-                name_filter, gpu_type, flags=regex_flags):
-            continue
+        if name_filter:
+            if gpu_type is None:
+                continue
+            if not re.match(name_filter, gpu_type, flags=regex_flags):
+                continue
 
         # Apply quantity filter (total GPUs on node must meet this)
         if quantity_filter and node_total_gpus < quantity_filter:


### PR DESCRIPTION
## Summary
- Fix `sky gpus list --infra slurm <GPU_NAME>` crashing with:
  ```
  Error: Could not query Slurm cluster for info: TypeError: expected string or bytes-like object, got 'NoneType'
  ```
- Nodes without GPUs have `gpu_type=None`; `re.match()` was called on `None` when a name filter was provided
- Added a `gpu_type is None` guard to skip these nodes during name filtering

## Test plan
```bash
# Previously crashed, now works:
sky gpus list --infra slurm L40S

# No regression:
sky gpus list --infra slurm

# Unit tests pass:
pytest tests/unit_tests/ -k slurm  # 128 passed
```