### PR TITLE
[Docs] Add pool section to YAML spec reference

### DIFF
--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -1452,3 +1452,125 @@ Port to run your service on each replica.
 
   resources:
     ports: 8080
+
+.. _pool-yaml-spec:
+
+Job Pools
+=========
+
+To define a YAML for use with :ref:`job pools <job-pool>`, use previously mentioned fields to describe each worker, then add a pool section to configure the pool's scaling behavior.
+
+Syntax
+
+.. parsed-literal::
+
+  pool:
+    :ref:`workers <yaml-spec-pool-workers>`: 3
+
+  pool:
+    :ref:`min_workers <yaml-spec-pool-min-workers>`: 1
+    :ref:`max_workers <yaml-spec-pool-max-workers>`: 10
+    :ref:`queue_length_threshold <yaml-spec-pool-queue-length-threshold>`: 5
+    :ref:`upscale_delay_seconds <yaml-spec-pool-upscale-delay-seconds>`: 300
+    :ref:`downscale_delay_seconds <yaml-spec-pool-downscale-delay-seconds>`: 1200
+
+
+Fields
+----------
+
+.. _yaml-spec-pool-workers:
+
+``pool.workers``
+~~~~~~~~~~~~~~~~
+
+Number of workers in the pool.
+
+If ``min_workers`` and ``max_workers`` are not specified, the pool maintains a fixed number of workers with no autoscaling. If autoscaling is enabled (``min_workers``/``max_workers`` are set), this serves as the initial number of workers.
+
+.. code-block:: yaml
+
+  pool:
+    workers: 3
+
+
+.. _yaml-spec-pool-min-workers:
+
+``pool.min_workers``
+~~~~~~~~~~~~~~~~~~~~
+
+Minimum number of workers when autoscaling is enabled (required with ``max_workers``).
+
+The pool never scales below this count. Setting to ``0`` enables **scale-to-zero**: the pool terminates all workers when idle, and provisions workers automatically when new jobs are submitted.
+
+.. code-block:: yaml
+
+  pool:
+    min_workers: 1
+    max_workers: 10
+
+
+.. _yaml-spec-pool-max-workers:
+
+``pool.max_workers``
+~~~~~~~~~~~~~~~~~~~~
+
+Maximum number of workers when autoscaling is enabled (required with ``min_workers``).
+
+The pool never scales above this count. Must be greater than or equal to ``min_workers``.
+
+.. code-block:: yaml
+
+  pool:
+    min_workers: 1
+    max_workers: 10
+
+
+.. _yaml-spec-pool-queue-length-threshold:
+
+``pool.queue_length_threshold``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Number of pending jobs that triggers upscaling (default: 1).
+
+When the number of pending jobs exceeds this threshold, the pool scales up. Requires ``max_workers`` to be set.
+
+.. code-block:: yaml
+
+  pool:
+    min_workers: 1
+    max_workers: 10
+    queue_length_threshold: 5
+
+
+.. _yaml-spec-pool-upscale-delay-seconds:
+
+``pool.upscale_delay_seconds``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Delay in seconds between upscaling decisions (default: 300).
+
+Controls how frequently the pool evaluates whether to add workers.
+
+.. code-block:: yaml
+
+  pool:
+    min_workers: 1
+    max_workers: 10
+    upscale_delay_seconds: 60
+
+
+.. _yaml-spec-pool-downscale-delay-seconds:
+
+``pool.downscale_delay_seconds``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Delay in seconds between downscaling decisions (default: 1200).
+
+Controls how frequently the pool evaluates whether to remove workers.
+
+.. code-block:: yaml
+
+  pool:
+    min_workers: 1
+    max_workers: 10
+    downscale_delay_seconds: 600


### PR DESCRIPTION
## Summary
- Adds a "Job Pools" section to `docs/source/reference/yaml-spec.rst` documenting the `pool` top-level field and all its sub-fields
- Covers `workers`, `min_workers`, `max_workers`, `queue_length_threshold`, `upscale_delay_seconds`, and `downscale_delay_seconds`
- Follows the same format as the existing SkyServe Service section

Addresses @Michaelvll's comment on #8873 to add pool autoscaling fields to the task YAML spec.

## Test plan
- Verify the RST renders correctly in the built docs