### PR TITLE
load plugins on each remote cluster

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -44,6 +44,8 @@ from sky.provision import common as provision_common
 from sky.provision import instance_setup
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.serve import serve_utils
+from sky.server import plugin_utils
+from sky.server import plugins
 from sky.server.requests import requests as requests_lib
 from sky.skylet import autostop_lib
 from sky.skylet import constants
@@ -807,6 +809,19 @@ def write_cluster_config(
             assert k not in credentials, f'{k} already in credentials'
             credentials[k] = v
 
+    # Upload plugin wheels and config to regular clusters so that
+    # notifications (and other plugins) work on-cluster.
+    cluster_plugin_mounts, cluster_plugin_install_cmds = (
+        plugin_utils.get_cluster_plugin_mounts_and_commands())
+    for k, v in cluster_plugin_mounts.items():
+        credentials[k] = v
+    # Upload remote_plugins.yaml as ~/.sky/plugins.yaml on the cluster so
+    # that plugins.load_plugins() can discover and load the plugins.
+    cluster_plugins_config = plugin_utils.get_cluster_plugins_config_path()
+    if cluster_plugins_config is not None:
+        credentials[plugins.REMOTE_PLUGINS_CONFIG_PATH] = (
+            cluster_plugins_config)
+
     private_key_path, _ = auth_utils.get_or_generate_keys()
     auth_config = {'ssh_private_key': private_key_path}
     region_name = resources_vars.get('region')
@@ -1075,6 +1090,25 @@ def write_cluster_config(
     common_utils.fill_template(cluster_config_template,
                                variables,
                                output_path=tmp_yaml_path)
+
+    # Inject plugin wheel installation commands into setup_commands.
+    # This must happen after fill_template renders the YAML and after
+    # the runtime setup (conda, uv, skypilot) so that uv pip is
+    # available.  We append to the last setup_commands entry.
+    if cluster_plugin_install_cmds:
+        yaml_config = yaml_utils.read_yaml(tmp_yaml_path)
+        setup_cmds = yaml_config.get('setup_commands', [])
+        if setup_cmds:
+            # Strip trailing whitespace/newlines from the last command
+            # to avoid "bash: syntax error near unexpected token `&&'"
+            # when the YAML multi-line string ends with a newline.
+            setup_cmds[-1] = (f'{setup_cmds[-1].rstrip()} && '
+                              f'{cluster_plugin_install_cmds}')
+        else:
+            setup_cmds = [cluster_plugin_install_cmds]
+        yaml_config['setup_commands'] = setup_cmds
+        yaml_utils.dump_yaml(tmp_yaml_path, yaml_config)
+
     config_dict['cluster_name'] = cluster_name
     config_dict['ray'] = yaml_path
 

--- a/sky/backends/task_codegen.py
+++ b/sky/backends/task_codegen.py
@@ -66,6 +66,13 @@ class TaskCodeGen:
             from sky.skylet import job_lib
             from sky.utils import log_utils
             from sky.utils import subprocess_utils
+
+            # Load cluster plugins (e.g., notifications) if configured.
+            try:
+                from sky.server import plugins as _sky_plugins
+                _sky_plugins.load_plugins(_sky_plugins.ExtensionContext())
+            except Exception:
+                pass
             """))
 
     def _add_logging_functions(self) -> None:

--- a/sky/server/plugin_utils.py
+++ b/sky/server/plugin_utils.py
@@ -83,6 +83,34 @@ def get_plugin_mounts_and_commands() -> Tuple[Dict[str, str], str]:
     return file_mounts, ' && '.join(commands)
 
 
+def get_cluster_plugin_mounts_and_commands() -> Tuple[Dict[str, str], str]:
+    """Get file mounts and installation commands for cluster plugin wheels.
+
+    Regular (non-controller) clusters use the same wheel source and remote
+    plugin config as controllers.  This thin wrapper makes the intent
+    explicit at the call-site.
+
+    Returns:
+        A tuple of:
+        - Dictionary mapping remote paths to local paths for plugin wheels
+        - Shell commands to install all plugin wheels
+    """
+    return get_plugin_mounts_and_commands()
+
+
+def get_cluster_plugins_config_path() -> Optional[str]:
+    """Return the path to remote_plugins.yaml for uploading to clusters.
+
+    On the cluster the file will be installed as ``~/.sky/plugins.yaml`` so
+    that ``plugins.load_plugins()`` can discover and load the plugins.
+
+    Returns:
+        Path to the remote_plugins.yaml file if it exists and contains
+        plugins, or None if no remote plugins are configured.
+    """
+    return get_filtered_plugins_config_path()
+
+
 def get_filtered_plugins_config_path() -> Optional[str]:
     """Return the path to remote_plugins.yaml if it exists.
 

--- a/sky/skylet/skylet.py
+++ b/sky/skylet/skylet.py
@@ -94,6 +94,13 @@ def main():
                         f'{constants.SKYLET_GRPC_PORT})')
     args = parser.parse_args()
 
+    # Load cluster plugins (e.g., notifications) if configured.
+    try:
+        from sky.server import plugins  # pylint: disable=import-outside-toplevel  # isort: skip
+        plugins.load_plugins(plugins.ExtensionContext())
+    except Exception:  # pylint: disable=broad-except
+        logger.debug('Failed to load cluster plugins', exc_info=True)
+
     grpc_server = start_grpc_server(port=args.port)
     try:
         run_event_loop()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
