### PR TITLE
[Slurm] Add fallback mirror for dropbear SSH tarball download

### DIFF
--- a/sky/templates/slurm-ray.yml.j2
+++ b/sky/templates/slurm-ray.yml.j2
@@ -125,6 +125,7 @@ setup_commands:
     # lightweight SSH server popular in embedded and resource-constrained
     # environments. It's actively maintained (https://github.com/mkj/dropbear/releases)
     # and doesn't have the same issue with OpenSSH.
+    # Mirror: https://dropbear.nl/mirror/releases/ (fallback if primary is down)
     #
     # This section runs on both host and container; only install when root (container).
     # TODO(kevin): Host the binary somewhere, so we don't have to build it every time.
@@ -162,7 +163,9 @@ setup_commands:
       if ! /usr/local/bin/dropbear -V 2>&1 | grep -q "$DROPBEAR_VERSION"; then
         cd /tmp
         apt_install_with_retries build-essential $PACKAGES
-        curl -sL https://matt.ucc.asn.au/dropbear/releases/dropbear-$DROPBEAR_VERSION.tar.bz2 | tar xj
+        curl -sfL https://matt.ucc.asn.au/dropbear/releases/dropbear-$DROPBEAR_VERSION.tar.bz2 -o /tmp/dropbear.tar.bz2 || \
+          curl -sfL https://dropbear.nl/mirror/releases/dropbear-$DROPBEAR_VERSION.tar.bz2 -o /tmp/dropbear.tar.bz2
+        tar xjf /tmp/dropbear.tar.bz2 && rm -f /tmp/dropbear.tar.bz2
         cd dropbear-$DROPBEAR_VERSION
         ./configure --disable-zlib --disable-syslog --disable-wtmp --disable-lastlog >/dev/null
         BUILD_START=$SECONDS


### PR DESCRIPTION
## Summary

- The primary dropbear download URL (`matt.ucc.asn.au`) is currently down, causing Slurm container launches to fail with `bzip2: (stdin) is not a bzip2 file`
- Added `-f` flag to `curl` so HTTP errors are properly detected (instead of silently downloading the error page)
- Added fallback to the official mirror at `https://dropbear.nl/mirror/releases/` (from the [GitHub releases page](https://github.com/mkj/dropbear/releases))
- Changed from piping directly to tar to downloading to a file first, so failures are caught before extraction

## Test plan

- Confirmed `matt.ucc.asn.au` returns HTTP error (`curl -sf` exit code 22)
- Confirmed `dropbear.nl` mirror works (`curl -sf` exit code 0)
- Launched containers on `slurm/aws-hyperpod` with `docker:ubuntu` — succeeded with the fallback