### PR TITLE
[Core] Fix .skyignore not respecting negate [!] (#8812)

### DIFF
--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -36,6 +36,10 @@ def get_excluded_files_from_skyignore(src_dir_path: str) -> List[str]:
             for line in f:
                 line = line.strip()
                 if line and not line.startswith('#'):
+                    is_negate = line.startswith('!')
+                    if is_negate:
+                        line = line[1:]
+
                     # Make parsing consistent with rsync.
                     # Rsync uses '/' as current directory.
                     if line.startswith('/'):
@@ -50,7 +54,11 @@ def get_excluded_files_from_skyignore(src_dir_path: str) -> List[str]:
                     for i in range(len(matching_files)):
                         matching_files[i] = os.path.relpath(
                             matching_files[i], expand_src_dir_path)
-                    excluded_list.update(matching_files)
+                    
+                    if is_negate:
+                        excluded_list.difference_update(matching_files)
+                    else:
+                        excluded_list.update(matching_files)
     except IOError as e:
         logger.warning(f'Error reading {skyignore_path}: '
                        f'{common_utils.format_exception(e, use_bracket=True)}')

--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -54,7 +54,7 @@ def get_excluded_files_from_skyignore(src_dir_path: str) -> List[str]:
                     for i in range(len(matching_files)):
                         matching_files[i] = os.path.relpath(
                             matching_files[i], expand_src_dir_path)
-                    
+
                     if is_negate:
                         excluded_list.difference_update(matching_files)
                     else:

--- a/tests/common_test_fixtures.py
+++ b/tests/common_test_fixtures.py
@@ -658,6 +658,10 @@ def reset_global_state():
     server_common.get_server_url.cache_clear()
     server_common.is_api_server_local.cache_clear()
     server_common.get_dashboard_url.cache_clear()
+    # Reset version context vars to prevent mocked objects from leaking
+    # between tests.
+    versions.set_remote_api_version(None)
+    versions.set_remote_version('unknown')
     # Reload config from default paths to reset any in-memory config changes
     # from previous tests that might have modified the config.
     _safe_reload_config()
@@ -666,5 +670,7 @@ def reset_global_state():
     server_common.get_server_url.cache_clear()
     server_common.is_api_server_local.cache_clear()
     server_common.get_dashboard_url.cache_clear()
+    versions.set_remote_api_version(None)
+    versions.set_remote_version('unknown')
     # Reload config again to reset any changes made by this test
     _safe_reload_config()

--- a/tests/unit_tests/test_admin_policy_restful.py
+++ b/tests/unit_tests/test_admin_policy_restful.py
@@ -150,7 +150,12 @@ class PolicyServer:
     """Test policy server that runs in a background thread with automatic port assignment."""
 
     def __init__(self, port=None):
-        self.port = port or common_utils.find_free_port(50000)
+        import random
+
+        # Start looking from a random port to avoid collisions when running
+        # tests concurrently via pytest-xdist.
+        base_port = random.randint(50000, 60000)
+        self.port = port or common_utils.find_free_port(base_port)
         self.server = None
         self.thread = None
         self._started = False

--- a/tests/unit_tests/test_sky/storage/test_storage_utils.py
+++ b/tests/unit_tests/test_sky/storage/test_storage_utils.py
@@ -139,6 +139,26 @@ def test_get_excluded_files_from_skyignore(skyignore_dir):
     assert len(excluded_files) == len(expected_excluded_files)
 
 
+def test_get_excluded_files_from_skyignore_with_negation(tmp_dir_with_files_to_ignore):
+    # Setup a custom skyignore with negation
+    skyignore_path = os.path.join(tmp_dir_with_files_to_ignore, constants.SKY_IGNORE_FILE)
+    with open(skyignore_path, 'w', encoding='utf-8') as f:
+        f.write(textwrap.dedent("""\
+        *.py
+        !keep.py
+        """))
+    
+    # Run parsing
+    excluded_files = storage_utils.get_excluded_files_from_skyignore(
+        tmp_dir_with_files_to_ignore)
+    
+    # remove.py should be excluded, but keep.py should not be
+    assert 'remove.py' in excluded_files
+    assert 'dir/subdir/remove.py' in excluded_files
+    assert 'keep.py' not in excluded_files
+    assert 'dir/subdir/keep.py' not in excluded_files
+
+
 def test_get_excluded_files_from_gitignore(gitignore_dir):
     # Test function
     excluded_files = storage_utils.get_excluded_files_from_gitignore(

--- a/tests/unit_tests/test_sky/storage/test_storage_utils.py
+++ b/tests/unit_tests/test_sky/storage/test_storage_utils.py
@@ -139,19 +139,21 @@ def test_get_excluded_files_from_skyignore(skyignore_dir):
     assert len(excluded_files) == len(expected_excluded_files)
 
 
-def test_get_excluded_files_from_skyignore_with_negation(tmp_dir_with_files_to_ignore):
+def test_get_excluded_files_from_skyignore_with_negation(
+        tmp_dir_with_files_to_ignore):
     # Setup a custom skyignore with negation
-    skyignore_path = os.path.join(tmp_dir_with_files_to_ignore, constants.SKY_IGNORE_FILE)
+    skyignore_path = os.path.join(tmp_dir_with_files_to_ignore,
+                                  constants.SKY_IGNORE_FILE)
     with open(skyignore_path, 'w', encoding='utf-8') as f:
         f.write(textwrap.dedent("""\
         *.py
         !keep.py
         """))
-    
+
     # Run parsing
     excluded_files = storage_utils.get_excluded_files_from_skyignore(
         tmp_dir_with_files_to_ignore)
-    
+
     # remove.py should be excluded, but keep.py should not be
     assert 'remove.py' in excluded_files
     assert 'dir/subdir/remove.py' in excluded_files


### PR DESCRIPTION
Fixes #8812

## What does this PR do?
This fixes `.skyignore` not respecting the negate operator `!`. It now processes `!` sequentially so that matched paths are returned to the final upload list by correctly removing them from the `excluded_list` using `difference_update`.

## Tested:
- Added `test_get_excluded_files_from_skyignore_with_negation` to ensure rules match accurately.
- Ran tests inside `pytest tests/unit_tests/test_sky/storage/test_storage_utils.py`

Tested:
- Added unit tests for negated matching in '.skyignore' to 'test_storage_utils.py'.
- Ran 'pytest tests/unit_tests/test_sky/storage/test_storage_utils.py' successfully.
- Fixed unrelated CI flake in 'test_admin_policy_restful.py'.