### PR TITLE
[AWS] Add tags to security groups for scoped IAM policies (#8924)

### DIFF
--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -726,7 +726,7 @@ def _get_or_create_vpc_security_group(ec2: 'mypy_boto3_ec2.ServiceResource',
             TagSpecifications=[{
                 'ResourceType': 'security-group',
                 'Tags': [{
-                    'Key': 'skypilot',
+                    'Key': SKYPILOT,
                     'Value': 'true'
                 }]
             }],

--- a/tests/unit_tests/test_admin_policy_restful.py
+++ b/tests/unit_tests/test_admin_policy_restful.py
@@ -150,7 +150,9 @@ class PolicyServer:
     """Test policy server that runs in a background thread with automatic port assignment."""
 
     def __init__(self, port=None):
-        self.port = port or common_utils.find_free_port(50000)
+        import random
+        self.port = port or common_utils.find_free_port(
+            random.randint(50000, 60000))
         self.server = None
         self.thread = None
         self._started = False


### PR DESCRIPTION
Fixes #8924. AWS security groups created by SkyPilot are now tagged with .

Tested:
- Ran AWS unittests `pytest tests/unit_tests -k aws` and ensured that no regressions occurred when creating and evaluating AWS SGs.