### PR TITLE
[Slurm] Remove provision timeout from job initialization phase

### DIFF
--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -134,26 +134,16 @@ def _wait_for_job_ready(
     job_id: str,
     ready_signal: str,
     slurm_log: str,
-    timeout: Optional[float] = None,
 ) -> None:
     """Wait for Slurm job initialization to complete.
 
     Polls while the job is running. Fails if:
     1. The job exits/fails (state not in PENDING/RUNNING/CONFIGURING)
     2. The ready signal file never appears
-    3. The timeout is exceeded (if specified)
     """
     poll_interval_seconds = 1
-    start_time = time.time()
 
     while True:
-        if timeout is not None:
-            elapsed = time.time() - start_time
-            if elapsed >= timeout:
-                raise TimeoutError(f'Slurm job {job_id} initialization timed '
-                                   'out. See sbatch logs for details: '
-                                   f'{slurm_log}')
-
         rc, _, _ = login_node_runner.run(f'test -f {ready_signal}',
                                          require_outputs=True,
                                          stream_logs=False)
@@ -559,7 +549,7 @@ touch {sky_cluster_home_dir}/.hushlogin
             ready_signal,
             slurm_log,
         )
-    except (TimeoutError, RuntimeError, exceptions.CommandError) as e:
+    except (RuntimeError, exceptions.CommandError) as e:
         _, stdout, _ = login_node_runner.run(f'cat {slurm_log} 2>/dev/null',
                                              require_outputs=True,
                                              stream_logs=False)


### PR DESCRIPTION
## Summary
- Remove the provision timeout from the job initialization phase (`_wait_for_job_ready`). Once nodes are allocated, the provision has effectively succeeded — container image pulls and package installation can take many minutes for large images and should not be subject to the provision timeout.
- The provision timeout now only applies to `_wait_for_job_nodes` (waiting for the Slurm scheduler to allocate nodes), which is the intended use case.

## Test plan
- Unit tests: `pytest tests/unit_tests/test_sky/clouds/test_slurm.py` (71 passed)
- Manual test on aws-hyperpod: verified that large container image pulls (`nvidia/cuda:12.4.0-runtime-ubuntu22.04`) no longer cause spurious timeouts during the image pull phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)