### PR TITLE
populate current cluster name for managed jobs

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -501,6 +501,10 @@ class JobController:
                 raise asyncio.CancelledError()
         assert cluster_name is not None, (cluster_name, job_id_on_pool_cluster)
 
+        if self._pool is None:
+            await managed_job_state.set_current_cluster_name_async(
+                self._job_id, cluster_name)
+
         if not is_resume:
             await managed_job_state.set_started_async(
                 job_id=self._job_id,
@@ -1264,6 +1268,8 @@ class JobController:
 
             # Only set STARTED state if not resuming (already started before)
             if not is_resuming:
+                await managed_job_state.set_current_cluster_name_async(
+                    self._job_id, cluster_name)
                 callback_func = managed_job_utils.event_callback_func(
                     job_id=self._job_id, task_id=task_id, task=task)
                 await managed_job_state.set_started_async(

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -1870,6 +1870,20 @@ def set_current_cluster_name(job_id: int, current_cluster_name: str) -> None:
         session.commit()
 
 
+@_init_db_async
+async def set_current_cluster_name_async(job_id: int,
+                                         current_cluster_name: str) -> None:
+    """Set the current cluster name for a job."""
+    assert _SQLALCHEMY_ENGINE_ASYNC is not None
+    async with sql_async.AsyncSession(_SQLALCHEMY_ENGINE_ASYNC) as session:
+        await session.execute(
+            sqlalchemy.update(job_info_table).where(
+                job_info_table.c.spot_job_id == job_id).values(
+                    {job_info_table.c.current_cluster_name:
+                     current_cluster_name}))
+        await session.commit()
+
+
 @_init_db
 def set_job_infra(job_id: int,
                   cloud: Optional[str] = None,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
