### PR TITLE
[Examples] Reduce resnet_app batch size for T4 compatibility

### DIFF
--- a/examples/resnet_app.yaml
+++ b/examples/resnet_app.yaml
@@ -4,6 +4,7 @@ resources:
   infra: aws
   accelerators:
     T4: 1
+  memory: 32+
 
 inputs: {
   gs://cloud-tpu-test-dataset/fake_imagenet: 70,
@@ -53,7 +54,7 @@ run: |
 
   export XLA_FLAGS='--xla_gpu_cuda_data_dir=/usr/local/cuda/'
   python -u models/official/resnet/resnet_main.py --use_tpu=False \
-      --mode=train --train_batch_size=256 --train_steps=250 \
+      --mode=train --train_batch_size=64 --train_steps=250 \
       --iterations_per_loop=125 \
       --data_dir=gs://cloud-tpu-test-datasets/fake_imagenet \
       --model_dir=resnet-model-dir \


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

When resnet_app.yaml was updated to use T4 instead of V100, two issues cause the training to OOM:
1. The default T4 instance (g4dn.xlarge) only has 16GB system RAM. The TF 2.4 conda environment plus the training process use ~13GB RAM, causing Ray to OOM kill the worker. Adding memory: 32+ selects g4dn.2xlarge (32GB RAM).
2. train_batch_size=256 is too large for T4's 16GB VRAM. Reducing to 64 fits comfortably.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
