### PR TITLE
fix type error in create table utilities

### DIFF
--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -126,7 +126,7 @@ def add_column_to_table(
 
 def add_all_tables_to_db_sqlalchemy(
     metadata: sqlalchemy.MetaData,
-    engine: sqlalchemy.Engine,
+    engine: Union[sqlalchemy.Engine, sqlalchemy.engine.Connection],
 ):
     """Add tables to the database."""
     for table in metadata.tables.values():
@@ -142,7 +142,7 @@ def add_all_tables_to_db_sqlalchemy(
 
 def add_table_to_db_sqlalchemy(
     metadata: sqlalchemy.MetaData,
-    engine: sqlalchemy.Engine,
+    engine: Union[sqlalchemy.Engine, sqlalchemy.engine.Connection],
     table_name: str,
 ):
     """Add a specific table to the database."""


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
`table.create` can take either qlalchemy.Engine or sqlalchemy.engine.Connection, so change the function signatures to reflect that fact.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
