### PR TITLE
[Test] Fix PVC permission denied in k8s pod_config test

### DIFF
--- a/tests/test_yamls/test_k8s_pod_config_pvc.yaml.j2
+++ b/tests/test_yamls/test_k8s_pod_config_pvc.yaml.j2
@@ -2,6 +2,9 @@ config:
   kubernetes:
     pod_config:
       spec:
+        securityContext:
+          fsGroup: 1000
+          fsGroupChangePolicy: OnRootMismatch
         volumes:
         - name: test-volume
           persistentVolumeClaim:


### PR DESCRIPTION
## Summary
- Add `securityContext` with `fsGroup: 1000` and `fsGroupChangePolicy: OnRootMismatch` to the PVC test pod config template so the container can write to the mounted volume.
- The test `test_kubernetes_pod_config_pvc` was previously passing due to a bug where failed jobs were reported as SUCCEEDED, which was fixed in #8930. Now that exit codes are correctly propagated, the underlying permission issue is exposed.

## Test plan
- The nightly `shared-gke-api-server` builds 199-202 all fail on this test with `bash: /mnt/test-data/hello.txt: Permission denied`. Build 198 (before #8930) also had the same permission error but the job was incorrectly reported as SUCCEEDED so the test passed.
- After this fix, the PVC mount gets `fsGroup: 1000` which matches what SkyPilot's Kubernetes template already does for native `volume_mounts`, allowing the container to write to the PVC.