### PR TITLE
Update README.md: use --secret in the sky launch command

### DIFF
--- a/examples/openclaw/README.md
+++ b/examples/openclaw/README.md
@@ -16,7 +16,7 @@ This gives you an isolated sandbox environment separate from your local machine,
 1. Launch the gateway:
 
 ```bash
-sky launch -c openclaw openclaw.yaml --env ANTHROPIC_API_KEY
+sky launch -c openclaw openclaw.yaml --secret ANTHROPIC_API_KEY
 ```
 
 2. Open an SSH tunnel and access WebChat:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Change README.md:

$ sky launch -c openclaw openclaw.yaml --secret ANTHROPIC_API_KEY

<!-- Describe the tests ran -->

$ sky launch -c openclaw openclaw.yaml --env ANTHROPIC_API_KEY
YAML to run: openclaw.yaml
ValueError: Secret variable 'ANTHROPIC_API_KEY' is None. Please set a value for it in task YAML or with --secret flag. To set it to be empty, use an empty string (ANTHROPIC_API_KEY: "" in task YAML or --secret ANTHROPIC_API_KEY="" in CLI).

$ sky launch -c openclaw openclaw.yaml --secret ANTHROPIC_API_KEY

works as intended

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
