### PR TITLE
[Examples] AWS EFA on HyperPod Slurm

### DIFF
--- a/examples/aws_efa/README.md
+++ b/examples/aws_efa/README.md
@@ -69,7 +69,7 @@ Check the following table for the GPU and EFA count mapping for AWS instance typ
 
 ### Running NCCL test with EFA using SkyPilot
 
-Check the [`nccl_efa.yaml`](https://github.com/skypilot-org/skypilot/blob/master/examples/aws_efa/nccl_efa.yaml) for the complete SkyPilot cluster yaml configurations.
+See [`nccl_efa.yaml`](https://github.com/skypilot-org/skypilot/blob/master/examples/aws_efa/nccl_efa.yaml) for the complete SkyPilot YAML configurations.
 
 The image [public.ecr.aws/hpc-cloud/nccl-tests:latest](https://github.com/aws-samples/awsome-distributed-training/blob/main/micro-benchmarks/nccl-tests/nccl-tests.Dockerfile) provides the environment setup for [NCCL](https://developer.nvidia.com/nccl) (NVIDIA Collective Communications Library) and EFA (Elastic Fabric Adapter).
 
@@ -135,6 +135,62 @@ The `Speed-up` column is calculated by `busbw EFA (GB/s) / busbw Non-EFA (GB/s)`
 | ≥ 32 MB       | The fabric really kicks in: ≥ 8 x at 32 MB, climbing to ~18 x for 1–2 GB messages. Non-EFA tops out around 4 GB/s, while EFA pushes ≈ 77 GB/s. |
 
 EFA provides much higher throughput than the traditional TCP transport. Enabling EFA could enhance the performance of inter-instance communication significantly, which could speedup distributed AI training and inference.
+
+## Using EFA on HyperPod Slurm
+
+EFA is available by default on HyperPod Slurm clusters with EFA-enabled instances (p4d, p5, etc.). No `network_tier` setting is needed — the compute nodes have direct access to the EFA devices.
+
+### Running NCCL test with EFA on Slurm
+
+See [`efa_slurm.yaml`](https://github.com/skypilot-org/skypilot/blob/master/examples/aws_efa/efa_slurm.yaml) for the complete SkyPilot YAML configuration.
+
+To run the NCCL test with EFA support:
+
+```bash
+sky launch -c efa --infra slurm efa_slurm.yaml
+```
+
+### Benchmark results
+
+We compare the performance with and without EFA using NCCL test reports on the same HyperPod Slurm cluster (2x p4d.24xlarge, i.e. 2xA100:8).
+
+The non-EFA baseline was measured by removing the `aws-ofi-nccl` plugin from `LD_LIBRARY_PATH`, forcing NCCL to use its built-in Socket transport over the standard ENA interface (`ens33`).
+
+The `Speed-up` column is calculated by `busbw EFA (GB/s) / busbw Non-EFA (GB/s)`.
+
+| Message Size | busbw EFA (GB/s) | busbw Non-EFA (GB/s) | Speed-up |
+|--------------|-------------|-------------|---------------|
+| 8 B          | 0           | 0           | -             |
+| 16 B         | 0           | 0           | -             |
+| 32 B         | 0           | 0           | -             |
+| 64 B         | 0           | 0           | -             |
+| 128 B        | 0           | 0           | -             |
+| 256 B        | 0           | 0           | -             |
+| 512 B        | 0.00        | 0.01        | -             |
+| 1 KB         | 0.01        | 0.01        | 1 x           |
+| 2 KB         | 0.02        | 0.02        | 1 x           |
+| 4 KB         | 0.04        | 0.04        | 1 x           |
+| 8 KB         | 0.07        | 0.05        | 1.4 x         |
+| 16 KB        | 0.13        | 0.04        | 3.3 x         |
+| 32 KB        | 0.21        | 0.13        | 1.6 x         |
+| 64 KB        | 0.42        | 0.24        | 1.8 x         |
+| 128 KB       | 0.81        | 0.38        | 2.1 x         |
+| 256 KB       | 1.53        | 0.59        | 2.6 x         |
+| 512 KB       | 2.27        | 0.92        | 2.5 x         |
+| 1 MB         | 3.36        | 1.69        | 2.0 x         |
+| 2 MB         | 4.97        | 2.35        | 2.1 x         |
+| 4 MB         | 7.74        | 3.81        | 2.0 x         |
+| 8 MB         | 10.30       | 5.31        | 1.9 x         |
+| 16 MB        | 17.99       | 6.43        | 2.8 x         |
+| 32 MB        | 29.99       | 7.19        | 4.2 x         |
+| 64 MB        | 43.29       | 7.63        | 5.7 x         |
+| 128 MB       | 54.27       | 7.85        | 6.9 x         |
+| 256 MB       | 65.02       | 7.90        | 8.2 x         |
+| 512 MB       | 71.27       | 7.98        | 8.9 x         |
+| 1 GB         | 75.01       | 8.02        | 9.4 x         |
+| 2 GB         | 77.12       | 8.04        | 9.6 x         |
+
+EFA results match the HyperPod/EKS numbers above. Without EFA, NCCL Socket transport over ENA tops out at ~8 GB/s — making EFA **~9.6x faster** for large messages on p4d.24xlarge.
 
 ## Using EFA on AWS VM
 

--- a/examples/aws_efa/efa_slurm.yaml
+++ b/examples/aws_efa/efa_slurm.yaml
@@ -1,0 +1,39 @@
+# This example is used to test the NCCL performance
+# with EFA on AWS HyperPod Slurm clusters.
+name: nccl-efa-slurm
+
+resources:
+  accelerators: A100:8
+
+num_nodes: 2
+
+run: |
+  if [ "${SKYPILOT_NODE_RANK}" == "0" ]; then
+    echo "Head node"
+
+    # Total number of processes, NP should be the total number of GPUs in the cluster
+    NP=$(($SKYPILOT_NUM_GPUS_PER_NODE * $SKYPILOT_NUM_NODES))
+
+    export NCCL_DEBUG=INFO
+
+    # --mpi=pmix: use PMIx for MPI process management
+    srun --overlap --mpi=pmix \
+      -N $SKYPILOT_NUM_NODES \
+      --ntasks=$NP \
+      --ntasks-per-node=$SKYPILOT_NUM_GPUS_PER_NODE \
+      --gpus-per-node=$SKYPILOT_NUM_GPUS_PER_NODE \
+      --cpu-bind=none \
+      --export=ALL \
+      # NOTE: The test binary path may vary by cluster. Check
+      # /usr/local/cuda/efa/ for available versions.
+      /usr/local/cuda/efa/test-cuda-12.9/all_reduce_perf \
+      -b 8 \
+      -e 2G \
+      -f 2 \
+      -g 1 \
+      -c 5 \
+      -w 5 \
+      -n 100
+  else
+    echo "Worker nodes"
+  fi


### PR DESCRIPTION
  Summary

  - Add HyperPod Slurm section to examples/aws_efa/README.md with EFA benchmark results on 2x `p4d.24xlarge`
   (2x A100:8)
  - Add examples/aws_efa/efa_slurm.yaml example for running NCCL all_reduce_perf with EFA on Slurm

  Test plan

  - Ran sky launch -c efa --infra slurm/aws-hyperpod efa_slurm.yaml on HyperPod Slurm cluster (2x
  `p4d.24xlarge`)
  - Verified 77 GB/s peak busbw with EFA

Preview: https://docs.skypilot.co/en/slurm-efa-docs/examples/performance/aws_efa.html#using-efa-on-hyperpod-slurm

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
