### PR TITLE
Fix add or update cluster none check

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -815,8 +815,8 @@ def add_or_update_cluster(cluster_name: str,
             conditional_values.update({
                 'workspace': active_workspace,
             })
-        if is_launch and (cluster_row is None or
-                          cluster_row.status != status_lib.ClusterStatus.UP.value):
+        if is_launch and (cluster_row is None or cluster_row.status !=
+                          status_lib.ClusterStatus.UP.value):
             conditional_values.update({
                 'last_creation_yaml': yaml_utils.dump_yaml_str(task_config)
                                       if task_config else None,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

- **Fix AttributeError in `add_or_update_cluster` when `cluster_row` is None.** In `sky/global_user_state.py`, the condition that decides whether to update `last_creation_yaml` and related fields used `(is_launch and not cluster_row or cluster_row.status != ...)`. Because of operator precedence, when `cluster_row` was None the expression still evaluated `cluster_row.status`, causing `'NoneType' object has no attribute 'status'`. The fix is to guard the attribute access: `if is_launch and (cluster_row is None or cluster_row.status != status_lib.ClusterStatus.UP.value):` so `.status` is only read when `cluster_row` is not None. This can occur during job recovery/launch when the cluster is not yet in the DB.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

No new unit tests added; change is a one-line guard in `add_or_update_cluster`. Verified logic: when `cluster_row` is None we now only check `cluster_row is None` and do not access `.status`.

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
