### PR TITLE
[Kubernetes] Add retry for optional packages installation

### DIFF
--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -682,10 +682,17 @@ available_node_types:
                   local delay=1
                   local i
                   for i in $(seq 1 $tries); do
-                    DEBIAN_FRONTEND=noninteractive $(prefix_cmd) apt-get update >> "$log" 2>&1 && { set -e; return 0; }
-                    echo "apt-get update attempt $i/$tries failed; retrying in ${delay}s" >> "$log"
-                    sleep $delay
-                    delay=$((delay * 2))
+                    # apt-get update returns 0 even when sources fail to fetch,
+                    # so we also check output for failure indicators.
+                    local output
+                    output=$(DEBIAN_FRONTEND=noninteractive $(prefix_cmd) apt-get update 2>&1)
+                    local rc=$?
+                    echo "$output" >> "$log"
+                    if [ $rc -eq 0 ] && ! echo "$output" | grep -iq "Failed to fetch"; then
+                      set -e; return 0
+                    fi
+                    echo "apt-get update attempt $i/$tries failed" >> "$log"
+                    [ $i -lt $tries ] && { echo "retrying in ${delay}s" >> "$log"; sleep $delay; delay=$((delay * 2)); }
                   done
                   set -e
                   return 1
@@ -703,8 +710,7 @@ available_node_types:
                     echo "apt-get install failed for: $packages (attempt $i/$tries). Running -f install and retrying..." >> "$log"
                     DEBIAN_FRONTEND=noninteractive $(prefix_cmd) apt-get -f install -y >> "$log" 2>&1 || true
                     DEBIAN_FRONTEND=noninteractive $(prefix_cmd) apt-get clean >> "$log" 2>&1 || true
-                    sleep $delay
-                    delay=$((delay * 2))
+                    [ $i -lt $tries ] && { echo "retrying in ${delay}s" >> "$log"; sleep $delay; delay=$((delay * 2)); }
                   done
                   set -e
                   return 1
@@ -719,78 +725,22 @@ available_node_types:
                   if [ -f /etc/apt/sources.list ] && [ ! -f "$backup_dir/sources.list" ]; then
                     $(prefix_cmd) cp -a /etc/apt/sources.list "$backup_dir/sources.list" || true
                   fi
+                  if [ -f /etc/apt/sources.list.d/ubuntu.sources ] && [ ! -f "$backup_dir/ubuntu.sources" ]; then
+                    $(prefix_cmd) cp -a /etc/apt/sources.list.d/ubuntu.sources "$backup_dir/ubuntu.sources" || true
+                  fi
                 }
                 restore_source() {
                   if [ -f "$backup_dir/sources.list" ]; then
                     $(prefix_cmd) cp -a "$backup_dir/sources.list" /etc/apt/sources.list || true
+                  fi
+                  if [ -f "$backup_dir/ubuntu.sources" ]; then
+                    $(prefix_cmd) cp -a "$backup_dir/ubuntu.sources" /etc/apt/sources.list.d/ubuntu.sources || true
                   fi
                 }
                 update_apt_sources() {
                   local host=$1
                   local apt_file=$2
                   $(prefix_cmd) sed -i -E "s|https?://[a-zA-Z0-9.-]+\.ubuntu\.com/ubuntu|http://$host/ubuntu|g" $apt_file
-                }
-                # Helper: install packages across mirrors with retries
-                apt_install_with_mirrors() {
-                  local required=$1; shift
-                  local packages="$@"
-                  [ -z "$packages" ] && return 0
-                  set +e
-                  # Install packages with default sources first
-                  local log=/tmp/apt-update.log
-                  echo "$(date +%Y-%m-%d\ %H:%M:%S) Installing packages: $packages" >> "$log"
-                  restore_source
-                  apt_update_install_with_retries $packages >> "$log" 2>&1 && { set -e; return 0; }
-                  echo "Install failed with default sources: $packages" >> "$log"
-                  # Detect distro (ubuntu/debian)
-                  local APT_OS="unknown"
-                  if [ -f /etc/os-release ]; then
-                    . /etc/os-release
-                    case "$ID" in
-                      debian) APT_OS="debian" ;;
-                      ubuntu) APT_OS="ubuntu" ;;
-                      *)
-                        if [ -n "$ID_LIKE" ]; then
-                          case " $ID $ID_LIKE " in
-                            *ubuntu*) APT_OS="ubuntu" ;;
-                            *debian*) APT_OS="debian" ;;
-                          esac
-                        fi
-                        ;;
-                    esac
-                  fi
-                  # Build mirror candidates
-                  # deb.debian.org is a CDN endpoint, if one backend goes down,
-                  # the CDN automatically fails over to another mirror,
-                  # so we only retry for ubuntu here.
-                  if [ "$APT_OS" = "ubuntu" ]; then
-                    # Backup current sources once
-                    backup_source
-                    # Selected from https://launchpad.net/ubuntu/+archivemirrors
-                    # and results from apt-select
-                    local MIRROR_CANDIDATES="mirrors.wikimedia.org mirror.umd.edu"
-                    for host in $MIRROR_CANDIDATES; do
-                      echo "Trying APT mirror ($APT_OS): $host" >> "$log"
-                      if [ -f /etc/apt/sources.list ]; then
-                        update_apt_sources $host /etc/apt/sources.list
-                      else
-                        echo "Error: /etc/apt/sources.list not found" >> "$log"
-                        break
-                      fi
-                      apt_update_install_with_retries $packages >> "$log" 2>&1 && { set -e; return 0; }
-                      echo "Install failed with mirror ($APT_OS): $host" >> "$log"
-                      # Restore to default sources
-                      restore_source
-                    done
-                  fi
-                  set -e
-                  if [ "$required" = "1" ]; then
-                    echo "Error: required package install failed across all mirrors: $packages" >> "$log"
-                    return 1
-                  else
-                    echo "Optional package install failed across all mirrors: $packages; skipping." >> "$log"
-                    return 0
-                  fi
                 }
                 # Install both fuse2 and fuse3 for compatibility for all possible fuse adapters in advance,
                 # so that both fusemount and fusermount3 can be masked before enabling SSH access.
@@ -816,20 +766,91 @@ available_node_types:
                     fi
                   fi
                 done;
-                if [ ! -z "$INSTALL_FIRST" ]; then
-                  echo "Installing core packages: $INSTALL_FIRST";
-                  apt_install_with_mirrors 1 $INSTALL_FIRST || { echo "Error: core package installation failed." >> /tmp/apt-update.log; exit 1; }
-                fi;
-                # SSH and other packages are not necessary, so we disable set -e
-                set +e
 
-                if [ ! -z "$MISSING_PACKAGES" ]; then
-                  # Install missing packages individually to avoid failure installation breaks the whole install process,
-                  # e.g. fuse3 is not available on some distributions.
-                  echo "Installing missing packages individually: $MISSING_PACKAGES";
-                  for pkg in $MISSING_PACKAGES; do
-                    DEBIAN_FRONTEND=noninteractive $(prefix_cmd) apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" $pkg || echo "Optional package $pkg installation failed, skip.";
-                  done
+                # Detect distro for mirror fallback
+                APT_OS="unknown"
+                if [ -f /etc/os-release ]; then
+                  . /etc/os-release
+                  case "$ID" in
+                    debian) APT_OS="debian" ;;
+                    ubuntu) APT_OS="ubuntu" ;;
+                    *)
+                      if [ -n "$ID_LIKE" ]; then
+                        case " $ID $ID_LIKE " in
+                          *ubuntu*) APT_OS="ubuntu" ;;
+                          *debian*) APT_OS="debian" ;;
+                        esac
+                      fi
+                      ;;
+                  esac
+                fi
+
+                # Build candidate list: default (empty string) first, then mirrors for ubuntu.
+                # deb.debian.org is a CDN endpoint, if one backend goes down,
+                # the CDN automatically fails over to another mirror,
+                # so we only add mirror candidates for ubuntu here.
+                # Selected from https://launchpad.net/ubuntu/+archivemirrors
+                # and results from apt-select
+                MIRROR_CANDIDATES=""
+                if [ "$APT_OS" = "ubuntu" ]; then
+                  MIRROR_CANDIDATES="mirrors.wikimedia.org mirror.umd.edu"
+                fi
+
+                INSTALL_SUCCESS=false
+                backup_source
+                for candidate in "" $MIRROR_CANDIDATES; do
+                  restore_source
+                  if [ -n "$candidate" ]; then
+                    echo "Trying APT mirror ($APT_OS): $candidate" >> /tmp/apt-update.log
+                    found_sources=false
+                    if [ -f /etc/apt/sources.list ]; then
+                      update_apt_sources $candidate /etc/apt/sources.list
+                      found_sources=true
+                    fi
+                    if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+                      update_apt_sources $candidate /etc/apt/sources.list.d/ubuntu.sources
+                      found_sources=true
+                    fi
+                    if [ "$found_sources" = "false" ]; then
+                      echo "Error: no apt sources file found" >> /tmp/apt-update.log
+                      break
+                    fi
+                  fi
+
+                  # Try INSTALL_FIRST (required core packages)
+                  if [ ! -z "$INSTALL_FIRST" ]; then
+                    echo "Installing core packages: $INSTALL_FIRST" >> /tmp/apt-update.log;
+                    apt_update_install_with_retries $INSTALL_FIRST >> /tmp/apt-update.log 2>&1 || {
+                      echo "Install failed with ${candidate:-default sources}: $INSTALL_FIRST" >> /tmp/apt-update.log
+                      continue
+                    }
+                  else
+                    # No core packages to install, but we still need to update the
+                    # package index for MISSING_PACKAGES.
+                    apt_update_with_retries >> /tmp/apt-update.log 2>&1 || {
+                      echo "apt-get update failed with ${candidate:-default sources}" >> /tmp/apt-update.log
+                      continue
+                    }
+                  fi
+
+                  # INSTALL_FIRST succeeded (or was empty) with this source.
+                  # Install MISSING_PACKAGES individually (optional, some may not exist on certain distros).
+                  set +e
+                  if [ ! -z "$MISSING_PACKAGES" ]; then
+                    echo "Installing missing packages individually: $MISSING_PACKAGES" >> /tmp/apt-update.log;
+                    for pkg in $MISSING_PACKAGES; do
+                      apt_install_with_retries $pkg >> /tmp/apt-update.log 2>&1 || echo "Optional package $pkg installation failed, skip." >> /tmp/apt-update.log;
+                    done
+                  fi
+
+                  INSTALL_SUCCESS=true
+                  break
+                done
+                restore_source
+
+                if [ "$INSTALL_SUCCESS" = "false" ] && [ ! -z "$INSTALL_FIRST" ]; then
+                  echo "Error: core package installation failed across all sources." >> /tmp/apt-update.log
+                  exit 1
                 fi;
 
                 {% if k8s_fuse_device_required %}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Before this PR
- If the required packages had all been installed in the base image or the Ubuntu source was good during required package installation, while is down during the optional package installation, the optional package installation would not be retried.
- The mirror failover does not work with Ubuntu 24.04


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
The following cases are verified with `image_id: docker:ubuntu:20.04/22.04/24.04`:
- Default mirror works
- Default mirror fails, fail over to `mirrors.wikimedia.org`
- Default mirror and `mirrors.wikimedia.org` fail, fail over to `mirror.umd.edu`
- All the three mirrors fail, keep the same behavior with the master, here we do not abort the launching process because 1) It should be very low probability for the three mirrors to be down at the same time 2) The package installation was intended to be executed in a background process to speed up the launching process
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
