### PR TITLE
[Kubernetes] Fail fast during cluster provisioning on k8s

### DIFF
--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -986,6 +986,7 @@ available_node_types:
                   fi;
                 fi;
                 export -p > ~/container_env_var.sh && $(prefix_cmd) mv ~/container_env_var.sh /etc/profile.d/container_env_var.sh
+                touch /tmp/env_setup_complete
                 ) > /tmp/${STEPS[2]}.log 2>&1
                 if [ "$?" -ne "0" ]; then
                   {
@@ -1042,6 +1043,21 @@ available_node_types:
                   sleep 0.1
                 done
               }
+
+              # Wait for all three background setup steps to complete by
+              # polling their completion/failure markers. If any step fails,
+              # exit the container so the pod enters a failed state instead
+              # of hanging indefinitely.
+              STEP_COMPLETE_FILES=(/tmp/apt_ssh_setup_complete /tmp/ray_skypilot_installation_complete /tmp/env_setup_complete)
+              for i in "${!STEPS[@]}"; do
+                until [ -f "${STEP_COMPLETE_FILES[$i]}" ] || [ -f "/tmp/${STEPS[$i]}.failed" ]; do
+                  sleep 1
+                done
+                if [ -f "/tmp/${STEPS[$i]}.failed" ]; then
+                  echo "Error: setup step '${STEPS[$i]}' failed. Pod will exit."
+                  exit 1
+                fi
+              done
 
               {% if high_availability %}
               mkdir -p {{k8s_high_availability_deployment_run_script_dir}}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Before this PR, the cluster would hang with an init status if the installation of the required packages failed.
This PR makes it fail fast in this case.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Cluster launching succeeds in the normal case
  - Cluster launching fails if the installation of the required packages fails
  - Launching on the existing cluster succeeds
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
