### PR TITLE
Add extension slots in user page

### DIFF
--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -695,14 +695,17 @@ export function Users() {
   };
 
   // Show loading while fetching health check
-  const handleTabChange = useCallback((tab) => {
-    setActiveMainTab(tab);
-    if (tab === 'users') {
-      router.push('/users', undefined, { shallow: true });
-    } else {
-      router.push(`/users?tab=${tab}`, undefined, { shallow: true });
-    }
-  }, [router]);
+  const handleTabChange = useCallback(
+    (tab) => {
+      setActiveMainTab(tab);
+      if (tab === 'users') {
+        router.push('/users', undefined, { shallow: true });
+      } else {
+        router.push(`/users?tab=${tab}`, undefined, { shallow: true });
+      }
+    },
+    [router]
+  );
 
   if (healthCheckLoading) {
     return (
@@ -740,7 +743,11 @@ export function Users() {
               Service Accounts
             </button>
           )}
-          <PluginSlot name="users.tabs" context={{ activeTab: activeMainTab, onTabChange: handleTabChange }} wrapperClassName="contents" />
+          <PluginSlot
+            name="users.tabs"
+            context={{ activeTab: activeMainTab, onTabChange: handleTabChange }}
+            wrapperClassName="contents"
+          />
         </div>
 
         <div className="flex items-center">
@@ -847,7 +854,11 @@ export function Users() {
             )}
           </div>
         ) : (
-          <PluginSlot name="users.tab-filter" context={{ activeTab: activeMainTab }} wrapperClassName="contents" />
+          <PluginSlot
+            name="users.tab-filter"
+            context={{ activeTab: activeMainTab }}
+            wrapperClassName="contents"
+          />
         )}
 
         {/* Deduplicate Users Toggle - only show on users tab when NOT using SSO/OAuth2 */}
@@ -881,9 +892,7 @@ export function Users() {
         )}
 
         {/* Plugin actions slot for users tab */}
-        {activeMainTab === 'users' && (
-          <PluginSlot name="users.actions" />
-        )}
+        {activeMainTab === 'users' && <PluginSlot name="users.actions" />}
 
         {/* Create Service Account Button for Service Accounts Tab */}
         {activeMainTab === 'service-accounts' && serviceAccountTokenEnabled && (
@@ -966,9 +975,11 @@ export function Users() {
           />
         )
       ) : (
-        <PluginSlot name="users.tab-content" context={{ activeTab: activeMainTab }} />
+        <PluginSlot
+          name="users.tab-content"
+          context={{ activeTab: activeMainTab }}
+        />
       )}
-
 
       {/* Create User Dialog */}
       <Dialog


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Add extension slots in user page for plugin

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
