### PR TITLE
[Dashboard] Add soft delete for cluster history (#8933)

### DIFF
--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -36,6 +36,7 @@ import {
   getClusters,
   getClusterHistory,
   useClusterData,
+  DELETED_CLUSTERS_STORAGE_KEY,
 } from '@/data/connectors/clusters';
 import { getWorkspaces } from '@/data/connectors/workspaces';
 import { sortData } from '@/data/utils';
@@ -59,7 +60,11 @@ import {
 } from '@/components/ui/select';
 import dashboardCache from '@/lib/cache';
 import cachePreloader from '@/lib/cache-preloader';
-import { ChevronDownIcon, ChevronRightIcon } from 'lucide-react';
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  Trash2Icon,
+} from 'lucide-react';
 import yaml from 'js-yaml';
 import { UserDisplay } from '@/components/elements/UserDisplay';
 import { evaluateCondition } from '@/components/shared/FilterSystem';
@@ -600,6 +605,34 @@ export function ClusterTable({
     direction: 'ascending',
   });
 
+  // Soft delete: mark history rows as deleted (persisted in localStorage)
+  const loadDeletedFromHistory = () => {
+    if (typeof window === 'undefined') return new Set();
+    try {
+      const stored = localStorage.getItem(DELETED_CLUSTERS_STORAGE_KEY);
+      return stored ? new Set(JSON.parse(stored)) : new Set();
+    } catch {
+      return new Set();
+    }
+  };
+  const [deletedFromHistory, setDeletedFromHistory] = useState(
+    loadDeletedFromHistory
+  );
+  const removeFromHistory = (clusterHash) => {
+    const next = new Set(deletedFromHistory);
+    next.add(clusterHash);
+    setDeletedFromHistory(next);
+    try {
+      localStorage.setItem(
+        DELETED_CLUSTERS_STORAGE_KEY,
+        JSON.stringify(Array.from(next))
+      );
+    } catch (e) {
+      console.warn('Failed to persist deleted clusters:', e);
+    }
+    refresh();
+  };
+
   // Use the cluster data hook (supports plugin override for server-side pagination)
   const {
     data: hookData,
@@ -621,6 +654,7 @@ export function ClusterTable({
     refreshInterval: preloadingComplete ? refreshInterval : null,
     sortConfig,
     filters,
+    deletedFromHistory,
   });
 
   // Track loading state for parent component
@@ -1057,13 +1091,23 @@ export function ClusterTable({
       ),
       renderCell: (item) => (
         <TableCell className="text-left md:sticky md:right-0 md:bg-white">
-          {!item.isHistorical && (
+          {!item.isHistorical ? (
             <Status2Actions
               cluster={item.cluster}
               status={item.status}
               onOpenSSHModal={onOpenSSHModal}
               onOpenVSCodeModal={onOpenVSCodeModal}
             />
+          ) : (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 px-2 text-gray-500 hover:text-red-600"
+              onClick={() => removeFromHistory(item.cluster_hash)}
+              title="Remove from history"
+            >
+              <Trash2Icon className="h-4 w-4" />
+            </Button>
           )}
         </TableCell>
       ),

--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -496,6 +496,9 @@ export function useClusterDetails({ cluster, job = null }) {
  * @param {number} options.refreshInterval - Auto-refresh interval in ms
  * @returns {Object} Cluster data with pagination state and actions
  */
+export const DELETED_CLUSTERS_STORAGE_KEY =
+  'skypilot-dashboard-deleted-clusters';
+
 export function useClusterData(options = {}) {
   const {
     showHistory = false,
@@ -503,6 +506,7 @@ export function useClusterData(options = {}) {
     refreshInterval = null,
     sortConfig = { key: null, direction: 'ascending' },
     filters = [],
+    deletedFromHistory = new Set(),
   } = options;
 
   // Convert sortConfig to API format
@@ -616,7 +620,10 @@ export function useClusterData(options = {}) {
 
       allClusters = [...markedActive];
       markedHistory.forEach((hist) => {
-        if (!activeClusters.some((a) => a.cluster_hash === hist.cluster_hash)) {
+        if (
+          !activeClusters.some((a) => a.cluster_hash === hist.cluster_hash) &&
+          !deletedFromHistory.has(hist.cluster_hash)
+        ) {
           allClusters.push(hist);
         }
       });
@@ -639,7 +646,7 @@ export function useClusterData(options = {}) {
     setHasNext(page < clientTotalPages);
     setHasPrev(page > 1);
     setIsServerPagination(false);
-  }, [showHistory, historyDays, page, limit]);
+  }, [showHistory, historyDays, page, limit, deletedFromHistory]);
 
   /**
    * Main fetch function - chooses server or client path


### PR DESCRIPTION
Fixes #8933

## Summary
Add soft delete for cluster/job history in the Dashboard. Users can mark a row as deleted from the history view - the row is hidden from the table but not actually removed from the backend (client-side only).

## Changes
- \sky/dashboard/src/data/connectors/clusters.jsx\: Add deletedFromHistory param to useClusterData, filter out deleted clusters when building history list
- \sky/dashboard/src/components/clusters.jsx\: Add state for deleted cluster hashes (persisted in localStorage), add Remove from history button (trash icon) for historical clusters

## Note
Jobs history support can be added in a follow-up if the jobs page has a similar history view.

Made with [Cursor](https://cursor.com)