### PR TITLE
[Test] Fix flaky test_admin_policy_restful parallel execution

### DIFF
--- a/tests/unit_tests/test_admin_policy_restful.py
+++ b/tests/unit_tests/test_admin_policy_restful.py
@@ -419,10 +419,12 @@ def test_restful_policy_with_user(monkeypatch):
                 config_path = f.name
 
             try:
-                dag, config = _load_task_and_apply_policy(task,
-                                                          config_path,
-                                                          monkeypatch,
-                                                          at_client_side=False)
+                dag, config = _load_task_and_apply_policy(
+                    task,
+                    config_path,
+                    monkeypatch,
+                    at_client_side=False,
+                )
 
                 # Verify the policy was called with proper request structure
                 assert len(ImageIdInspectorPolicy.received_requests) == 1

--- a/tests/unit_tests/test_admin_policy_restful.py
+++ b/tests/unit_tests/test_admin_policy_restful.py
@@ -43,9 +43,10 @@ def _load_task_and_apply_policy(
     config_path: str,
     monkeypatch,
     idle_minutes_to_autostop: Optional[int] = None,
+    at_client_side: bool = True,
 ) -> Tuple[sky.Dag, config_utils.Config]:
     """Apply admin policy using real SkyPilot patterns.
-    
+
     This function is copied from tests/unit_tests/test_admin_policy.py
     to avoid import path complexity while reusing the same proven pattern.
     """
@@ -60,7 +61,8 @@ def _load_task_and_apply_policy(
             idle_minutes_to_autostop=idle_minutes_to_autostop,
             down=False,
             dryrun=False,
-        ))
+        ),
+        at_client_side=at_client_side)
 
 
 # Global registry to track active servers for cleanup
@@ -417,8 +419,10 @@ def test_restful_policy_with_user(monkeypatch):
                 config_path = f.name
 
             try:
-                dag, config = _load_task_and_apply_policy(
-                    task, config_path, monkeypatch)
+                dag, config = _load_task_and_apply_policy(task,
+                                                          config_path,
+                                                          monkeypatch,
+                                                          at_client_side=False)
 
                 # Verify the policy was called with proper request structure
                 assert len(ImageIdInspectorPolicy.received_requests) == 1

--- a/tests/unit_tests/test_admin_policy_restful.py
+++ b/tests/unit_tests/test_admin_policy_restful.py
@@ -47,8 +47,8 @@ def _load_task_and_apply_policy(
 ) -> Tuple[sky.Dag, config_utils.Config]:
     """Apply admin policy using real SkyPilot patterns.
 
-    This function is copied from tests/unit_tests/test_admin_policy.py
-    to avoid import path complexity while reusing the same proven pattern.
+    This function is based on the one in tests/unit_tests/test_admin_policy.py
+    and has been modified for the specific needs of these tests.
     """
     # Use monkeypatch instead of directly modifying os.environ
     monkeypatch.setenv(skypilot_config.ENV_VAR_SKYPILOT_CONFIG, config_path)


### PR DESCRIPTION
## Summary

Fix flaky `test_admin_policy_restful` tests that fail intermittently when running in parallel with pytest-xdist.

`_load_task_and_apply_policy()` calls `admin_policy_utils.apply()` without `at_client_side=True`, taking the server-side path which reads `client_api_version`/`client_version` from `contextvars`. When running in parallel, leaked mocks from other tests can contaminate these contextvars, causing `pydantic ValidationError` on `_UserRequestBody` (expects `int`/`str`, gets `Mock` objects).

Fix: default `at_client_side=True` in `_load_task_and_apply_policy()` since these are client-side tests. The one test that needs the server-side path (`test_restful_policy_with_user`) explicitly passes `at_client_side=False`.

Related: #7636

## Test plan

- [x] `pytest tests/unit_tests/test_admin_policy_restful.py -v` — 9/9 passed
- [x] `pytest tests/unit_tests/test_admin_policy_restful.py tests/unit_tests/test_sky/server/test_common.py -v` — 24/24 passed (verifies no regression when running alongside the tests that leak mocks)
- [x] Previously flaky tests now pass reliably: `test_task_without_skypilot_config`, `test_minimal_task`, `test_complex_task_serialization`

🤖 Generated with [Claude Code](https://claude.com/claude-code)