### PR TITLE
Stream process nodes when detect GPU resource key

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -3956,7 +3956,8 @@ def _gpu_resource_key_helper(context: Optional[str]) -> str:
             for capacity in ijson.items(response,
                                         'items.item.status.capacity',
                                         buf_size=IJSON_BUFFER_SIZE):
-                capacity_keys.update(supported_gpu_keys.intersection(capacity.keys()))
+                capacity_keys.update(
+                    supported_gpu_keys.intersection(capacity.keys()))
                 if len(capacity_keys) == len(supported_gpu_keys):
                     break
             for gpu_key in SUPPORTED_GPU_RESOURCE_KEYS.values():


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Optimize the memory usage using streaming.

Profile script (mock 5000 Node object) https://gist.github.com/aylei/e45956b2f2478bf97b1cd170920f5be5

Benchmark result: **About 200MB peak memory reduction on 5000 Node case.**

```bash
$ python profile_gpu_key_helper.py --mode old
Platform: darwin
Python:   3.10.13 | packaged by conda-forge | (main, Dec 23 2023, 15:35:25) [Clang 16.0.6 ]
Nodes:    5000
Requests: 30
Mode:     old

Generating mock JSON data...
API response size: 16.7 MB
Baseline RSS (after data generation): 181.8 MB

========================================================================
OLD _gpu_resource_key_helper (full V1Node deserialization)
========================================================================
RSS after warmup: 177.6 MB
Iter   pre(MB)   post(MB)  spike(MB)   after_gc     growth
   0     177.6      328.1     +150.5      327.1     +149.5
   5     425.3      403.3      -22.0      403.3     +225.6
  10     364.0      391.1      +27.1      391.1     +213.5
  15     357.0      394.7      +37.7      394.8     +217.1
  20     384.7      376.5       -8.2      376.5     +198.9
  25     362.9      331.6      -31.3      330.8     +153.1
  29     343.7      376.9      +33.2      375.9     +198.3

  result: gpu_key=nvidia.com/gpu
  Per-call peak spike (max): +150.5 MB
  Absolute peak RSS:         438.1 MB
  Cumulative growth:         +198.3 MB (over 30 requests)
$ python profile_gpu_key_helper.py --mode new
Platform: darwin
Python:   3.10.13 | packaged by conda-forge | (main, Dec 23 2023, 15:35:25) [Clang 16.0.6 ]
Nodes:    5000
Requests: 30
Mode:     new

Generating mock JSON data...
API response size: 16.7 MB
Baseline RSS (after data generation): 180.6 MB

========================================================================
NEW _gpu_resource_key_helper (ijson streaming)
========================================================================
RSS after warmup: 180.7 MB
Iter   pre(MB)   post(MB)  spike(MB)   after_gc     growth
   0     180.7      180.9       +0.2      180.9       +0.2
   5     181.0      181.0       +0.0      181.0       +0.3
  10     181.0      181.0       +0.0      181.0       +0.3
  15     181.0      181.0       +0.0      181.0       +0.3
  20     181.5      181.8       +0.3      181.8       +1.1
  25     181.8      181.8       +0.0      181.8       +1.1
  29     182.0      182.0       +0.0      182.0       +1.3

  result: gpu_key=nvidia.com/gpu
  Per-call peak spike (max): +0.4 MB
  Absolute peak RSS:         182.0 MB
  Cumulative growth:         +1.3 MB (over 30 requests)
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
