### PR TITLE
fix: fix bid_per_gpu for runpod spot pods

### DIFF
--- a/sky/clouds/runpod.py
+++ b/sky/clouds/runpod.py
@@ -216,7 +216,7 @@ class RunPod(clouds.Cloud):
         hourly_cost = self.instance_type_to_hourly_cost(
             instance_type=instance_type, use_spot=use_spot)
 
-        gpu_count = list(acc_dict.values())[0] if acc_dict else 1
+        gpu_count = list(acc_dict.values())[0] if acc_dict is not None else 1
 
         # default to root
         docker_username_for_runpod = (resources.docker_username_for_runpod


### PR DESCRIPTION
# Description

hi i work at runpod and noticed users are overbidding on pods. diagnosed issue and realized skypilot is sending the total hourly cost across all gpus instead of price per gpu. updated

- bid_per_gpu was set to the total instance hourly cost instead of the per-GPU cost
- The RunPod API expects bidPerGpu as a per-GPU price, with gpuCount passed separately
- This caused multi-GPU spot instances to overbid (e.g., a 4x GPU instance at $4/hr total would bid $4/GPU instead of
  $1/GPU)

# Fix
- Divide hourly_cost by the GPU count from acc_dict (already computed in the method) to get the correct per-GPU bid.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
