### PR TITLE
[Core] Fix WebSocket SSH proxy timeout under concurrent connections

### DIFF
--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2213,27 +2213,27 @@ async def _get_cluster_and_validate(
     cloud_type: Type[clouds.Cloud],
 ) -> 'backends.CloudVmRayResourceHandle':
     """Fetch cluster status and validate it's UP and correct cloud type."""
-    # Use a lightweight database lookup instead of the full core.status() call.
-    # core.status() calls backend_utils.get_clusters() which does workspace
-    # lookups, resource string formatting, and other overhead unnecessary for
-    # simple cluster validation. With many concurrent WebSocket connections
-    # (e.g., 20 parallel SSH sessions), the overhead of core.status() can cause
-    # WebSocket handshake timeouts.
-    # TODO(aylei): this will be called with server user, which has permission to
-    # all workspaces, this will break workspace isolation. It is ok for now, as
-    # users with limited access will not get the ssh config for the clusters in
-    # non-accessible workspaces.
+    # Run core.status in another thread to avoid blocking the event loop.
+    # Use summary_response=True to skip expensive DB columns (owner, metadata,
+    # last_creation_yaml) and cluster event queries that are unnecessary for
+    # simple cluster validation. This keeps per-call overhead low enough to
+    # handle 20+ concurrent WebSocket SSH connections without timeout.
+    # TODO(aylei): core.status() will be called with server user, which has
+    # permission to all workspaces, this will break workspace isolation.
+    # It is ok for now, as users with limited access will not get the ssh config
+    # for the clusters in non-accessible workspaces.
     with ThreadPoolExecutor(max_workers=1) as thread_pool_executor:
-        cluster_record = await context_utils.to_thread_with_executor(
+        cluster_records = await context_utils.to_thread_with_executor(
             thread_pool_executor,
-            global_user_state.get_cluster_from_name,
+            core.status,
             cluster_name,
-            include_user_info=False,
+            all_users=True,
             summary_response=True)
 
-    if cluster_record is None:
+    if not cluster_records:
         raise fastapi.HTTPException(status_code=404,
                                     detail=f'Cluster {cluster_name} not found')
+    cluster_record = cluster_records[0]
 
     if cluster_record['status'] not in (status_lib.ClusterStatus.INIT,
                                         status_lib.ClusterStatus.UP,


### PR DESCRIPTION
## Summary

Use `core.status(summary_response=True)` instead of `core.status()` (default `summary_response=False`) in `_get_cluster_and_validate()` for WebSocket SSH proxy validation. This keeps the proper `core.status()` API surface while cutting per-call overhead by 49%.

**Why**: `test_kubernetes_ssh_proxy_performance` is flaky on nightly CI — failed 5 times before passing on retry 6 in [build 8676](https://buildkite.com/skypilot-1/smoke-tests/builds/8676). Connections hit `TimeoutError: timed out during opening handshake` (60s WebSocket timeout) because the server-side validation via `core.status(summary_response=False)` adds unnecessary overhead per connection.

## Breakdown of `core.status()` internal steps

Profiled on Buildkite CI (build 8747, 4-CPU EC2 kind agent, 20 iterations each).

`core.status()` executes these 5 steps sequentially. The table shows the cost of each step under all 3 approaches:

| Step | What it does | Approach 1: `get_cluster_from_name()` | Approach 2: `core.status(summary=False)` | Approach 3: `core.status(summary=True)` |
|------|-------------|------|------|------|
| 1. `workspaces_core.get_workspaces()` | Workspace permission lookup | **skipped** | 0.04 ms | 0.04 ms |
| 2. `global_user_state.get_clusters()` | DB query for cluster records | **0.58 ms** (via `get_cluster_from_name()`) | **1.56 ms** | **0.66 ms** |
| 3. `_update_records_with_handle_info()` | Resource string formatting | **skipped** | 0.26 ms | 0.26 ms |
| 4. `_update_records_with_resources()` | Cloud/region/CPU extraction | **skipped** | 0.23 ms | 0.23 ms |
| 5. `StatusResponse.model_validate()` | Pydantic validation (30+ fields) | **skipped** | 0.00 ms | 0.00 ms |
| **Total** | | **0.58 ms** | **1.79 ms** | **0.91 ms** |

**Step 2 is the bottleneck.** With `summary=False`, `get_clusters()` fetches 7 extra DB columns (`last_creation_yaml`, `owner`, `metadata`, etc.), runs a `_get_last_or_terminal_cluster_event_multiple()` window function query, and does JSON deserialization — none needed for SSH proxy validation. `summary=True` skips all of this.

## 3-way end-to-end comparison

| Approach | Implementation | Per-call (ms) | 20x accumulated (ms) | vs Approach 2 | API design |
|----------|---------------|-------------|---------------------|--------|------------|
| **Approach 1**: commit [`f4e37f4`](https://github.com/skypilot-org/skypilot/commit/f4e37f46e), previously in this PR but replaced by Approach 3 to address [Michaelvll's review](https://github.com/skypilot-org/skypilot/pull/9001#issuecomment-4007831931) | `get_cluster_from_name()` — skip `core.status()`, call DB directly | 0.58 | 11.6 | -68% (fastest) | Breaks abstraction — bypasses workspace checks, handle formatting, Pydantic validation |
| **Approach 2**: current master | `core.status(summary=False)` — default | 1.79 | 35.7 | baseline | Proper API but slow — caused 12/20 timeout under contention |
| **Approach 3**: current PR | `core.status(summary=True)` | 0.91 | 18.1 | **-49%** | Proper API, fair trade-off |

The 0.33ms gap between Approach 3 and Approach 1 comes from steps 1/3/4/5 (workspace + handle info + resource extraction + Pydantic) — a fair trade-off for keeping the proper `core.status()` API surface, adding only 6.6ms total for 20 connections.

## 3-way SSH proxy benchmark

20 parallel SSH connections, 100 commands each (2000 total):

| Approach | Build | Result | Success | Mean latency | Median latency | Std Dev | Test duration |
|----------|-------|--------|---------|-------------|---------------|---------|---------------|
| **Approach 1**: `get_cluster_from_name()` — skip `core.status()`, call DB directly | [8709](https://buildkite.com/skypilot-1/smoke-tests/builds/8709) | **PASS** | 2000/2000 (100%) | 0.0056s | 0.0024s | 0.0153s | 87.51s |
| **Approach 2**: `core.status(summary=False)` — current master | [8709 manual](https://buildkite.com/skypilot-1/smoke-tests/builds/8709) | **FAIL/TIMEOUT** | 8/20 connected, 12 timed out | N/A | N/A | N/A | >180s (killed) |
| **Approach 3**: `core.status(summary=True)` — current PR | [8749](https://buildkite.com/skypilot-1/smoke-tests/builds/8749) | **PASS** | 2000/2000 (100%) | 0.0051s | 0.0023s | 0.0141s | 69.23s |

Note: Approach 2 was tested by manually reverting the fix on the same build 8709 agent and rerunning. Under GIL serialization with 20 concurrent WebSocket connections on a single uvicorn worker, the overhead compounds with contention, causing 12 of 20 connections to exceed the 60s WebSocket handshake timeout.

## What changed
- `_get_cluster_and_validate()` now calls `core.status(cluster_name, all_users=True, summary_response=True)` instead of the default `summary_response=False`
- No new API parameters, no new files — uses existing `summary_response=True` parameter

## Test plan
- [x] Per-step profiling on Buildkite agent (build 8747): `summary_response=True` cuts per-call from 1.79ms to 0.91ms
- [x] SSH proxy benchmark Approach 1: [build 8709](https://buildkite.com/skypilot-1/smoke-tests/builds/8709) — PASS, 100% success, mean 0.0056s
- [x] SSH proxy benchmark Approach 2: manual revert on build 8709 agent — FAIL, 12/20 timeout
- [x] SSH proxy benchmark Approach 3: [build 8749](https://buildkite.com/skypilot-1/smoke-tests/builds/8749) — PASS, 100% success, mean 0.0051s
- [x] Formatting passes: yapf, isort, mypy, pylint all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)