### PR TITLE
[Core] Fix bash operator precedence in cloud deps install chain

### DIFF
--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -302,8 +302,10 @@ def _get_cloud_dependencies_installation_commands(
     python_packages.add('flask')
 
     step_prefix = prefix_str.replace('<step>', str(len(commands) + 1))
-    commands.append(f'echo -en "\\r{step_prefix}uv{empty_str}" &&'
-                    f'{constants.SKY_UV_INSTALL_CMD} >/dev/null 2>&1')
+    # Wrap in braces to isolate the || in SKY_UV_INSTALL_CMD from
+    # the outer && chain, preventing operator precedence issues.
+    commands.append(f'echo -en "\\r{step_prefix}uv{empty_str}" && '
+                    f'{{ {constants.SKY_UV_INSTALL_CMD} >/dev/null 2>&1; }}')
 
     enabled_compute_clouds = set(
         sky_check.get_cached_enabled_clouds_or_refresh(
@@ -352,14 +354,15 @@ def _get_cloud_dependencies_installation_commands(
                     '(gcloud components install gke-gcloud-auth-plugin --quiet &>/dev/null))')  # pylint: disable=line-too-long
         elif isinstance(cloud, clouds.Nebius):
             step_prefix = prefix_str.replace('<step>', str(len(commands) + 1))
+            # Wrap in braces to isolate the || from the outer && chain.
             commands.append(
                 f'echo -en "\\r{step_prefix}Nebius{empty_str}" && '
-                'curl -sSL https://storage.eu-north1.nebius.cloud/cli/install.sh '  # pylint: disable=line-too-long
+                '{ curl -sSL https://storage.eu-north1.nebius.cloud/cli/install.sh '  # pylint: disable=line-too-long
                 '| sudo NEBIUS_INSTALL_FOLDER=/usr/local/bin bash &> /dev/null && '
                 'nebius profile create --profile sky '
                 '--endpoint api.nebius.cloud '
                 '--service-account-file $HOME/.nebius/credentials.json '
-                '&> /dev/null || echo "Unable to create Nebius profile."')
+                '&> /dev/null || echo "Unable to create Nebius profile."; }')
         elif (isinstance(cloud, clouds.Kubernetes) and
               not k8s_dependencies_installed):
             step_prefix = prefix_str.replace('<step>', str(len(commands) + 1))
@@ -400,9 +403,11 @@ def _get_cloud_dependencies_installation_commands(
                 cloud_python_dependencies = []
         elif isinstance(cloud, clouds.Vast):
             step_prefix = prefix_str.replace('<step>', str(len(commands) + 1))
-            commands.append(f'echo -en "\\r{step_prefix}Vast{empty_str}" && '
-                            'pip list | grep vastai_sdk > /dev/null 2>&1 || '
-                            'pip install "vastai_sdk>=0.1.12" > /dev/null 2>&1')
+            # Wrap in braces to isolate the || from the outer && chain.
+            commands.append(
+                f'echo -en "\\r{step_prefix}Vast{empty_str}" && '
+                '{ pip list | grep vastai_sdk > /dev/null 2>&1 || '
+                'pip install "vastai_sdk>=0.1.12" > /dev/null 2>&1; }')
 
         python_packages.update(cloud_python_dependencies)
 


### PR DESCRIPTION
## Summary
- Wrap commands containing `||` in `{ ...; }` group commands within `_get_cloud_dependencies_installation_commands()` to isolate them from the outer `&&` chain
- Fixes flaky `test_docker_storage_mounts[docker:nvidia/cuda:11.8.0-devel-ubuntu18.04]` that constantly fails on Buildkite CI (e.g., [build #8633](https://buildkite.com/skypilot-1/smoke-tests/builds/8633) — failed 7 retries)

## Root Cause
In bash, `&&` and `||` have **equal precedence** (left-to-right associativity). The cloud deps installation commands are joined with `&&`, but several individual commands contain `||` for fallback logic (e.g., `uv -V || curl ... | sh`).

This means `echo step1 && uv -V || curl install && echo step2 && ...` evaluates as `((echo step1 && uv -V) || curl install) && echo step2 && ...`. If both `uv -V` fails AND the curl fallback fails, the `||` result is falsy and the entire `&&` chain breaks — all subsequent steps are skipped.

The CI logs confirm this: only `[1/7] uv` was ever printed, steps 2-7 were skipped, then `bash: gsutil: command not found` and `bash: az: command not found` because GCP SDK and Azure CLI were never installed.

### Why it's flaky (passes on retry)
`enabled_clouds` is a Python `set()`, which has **non-deterministic iteration order**. Different runs produce different orderings of cloud dependency commands in the `&&` chain. The operator precedence bug only triggers when a command whose `||` fallback also fails lands in a position that breaks the chain. Lucky orderings pass; unlucky ones fail — explaining why the same test can fail 7 times then pass on retry.

**Three commands had this issue:**
1. **uv install**: `SKY_UV_INSTALL_CMD` contains `uv -V || curl ... | sh`
2. **Nebius install**: `curl ... | sudo bash && nebius profile create ... || echo "Unable to create Nebius profile."`
3. **Vast SDK install**: `pip list | grep vastai_sdk || pip install "vastai_sdk>=0.1.12"`

## Fix
Wrap each of these commands in `{ ...; }` group commands (consistent with `GOOGLE_SDK_INSTALLATION_COMMAND` in `gcp.py`) so the `||` is scoped locally and doesn't interact with the outer `&&` chain, without the overhead of spawning a subshell:
```bash
# Before (broken):
echo [1/7] && uv -V || curl install && echo [2/7] && ...
# After (fixed):
echo [1/7] && { uv -V || curl install; } && echo [2/7] && ...
```

## Test plan

### Verification performed
- **Buildkite log analysis**: Confirmed the failure pattern across [build #8633](https://buildkite.com/skypilot-1/smoke-tests/builds/8633) (7 retries all failed) — only step `[1/7] uv` printed, steps 2-7 skipped, `gsutil`/`az` not found
- **SSH into Buildkite VM**: Launched fresh `nvidia/cuda:11.8.0-devel-ubuntu18.04` pod, tested individual commands and full chain
- **Bash operator precedence audit**: Verified all `||` operators in the `&&` chain are now either:
  - Wrapped in `{ ...; }` group commands (uv, Nebius, Vast)
  - Already wrapped in `(...)` subshells (gke-gcloud-auth-plugin, kubectl)
  - Inside `sudo bash -c "..."` strings (K8s apt install — scoped to the inner bash)
  - Inside `if` conditionals (K8s ARCH check — scoped to the if block)
- **Unit tests**: All 34 `test_controller_utils` tests pass; 508/515 broader unit tests pass (7 failures are pre-existing/environment-related)
- **Formatting**: `format.sh` passes (yapf, isort, mypy, pylint 10.00/10)

### Smoke test
- [ ] `/smoke-test --kubernetes` to verify `test_docker_storage_mounts` passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)