### PR TITLE
[Dashboard] Remove `see all users` button in the user profile

### DIFF
--- a/sky/dashboard/src/components/elements/sidebar.jsx
+++ b/sky/dashboard/src/components/elements/sidebar.jsx
@@ -726,21 +726,15 @@ export function TopBar() {
                         </>
                       );
                     })()}
-                    <div className="border-t border-gray-200 mx-1 my-1"></div>
-                    <Link
-                      href="/users"
-                      className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 hover:text-blue-600"
-                      onClick={() => setIsDropdownOpen(false)}
-                      prefetch={false}
-                    >
-                      See all users
-                    </Link>
                     <PluginSlot
                       name="user-menu"
                       wrapperClassName="contents"
                       context={{
                         closeDropdown: () => setIsDropdownOpen(false),
                       }}
+                      prefix={
+                        <div className="border-t border-gray-200 mx-1 my-1"></div>
+                      }
                     />
                   </div>
                 )}

--- a/sky/dashboard/src/plugins/PluginSlot.jsx
+++ b/sky/dashboard/src/plugins/PluginSlot.jsx
@@ -16,6 +16,7 @@ export function PluginSlot({
   context = {},
   fallback = null,
   wrapperClassName = '',
+  prefix = null,
 }) {
   const components = usePluginComponents(name);
 
@@ -25,6 +26,7 @@ export function PluginSlot({
 
   return (
     <div className={wrapperClassName || undefined}>
+      {prefix}
       {components.map((config) => {
         const Component = config.component;
         return <Component key={config.id} {...context} />;


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Remove `see all users` button in the user profile


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
