### PR TITLE
[Dashboard] Truncate workspace list in infra Kubernetes table to 3 + …

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -374,11 +374,9 @@ export function InfrastructureSection({
                           ? ` (workspaces: ${workspaces.join(', ')})`
                           : '';
                       const workspaceDisplay =
-                        workspaces.length > 1
-                          ? workspaces.length > MAX_INLINE_WORKSPACES
-                            ? ` (workspaces: ${workspaces.slice(0, MAX_INLINE_WORKSPACES).join(', ')} +${workspaces.length - MAX_INLINE_WORKSPACES} more)`
-                            : ` (workspaces: ${workspaces.join(', ')})`
-                          : '';
+                        workspaces.length > MAX_INLINE_WORKSPACES
+                          ? ` (workspaces: ${workspaces.slice(0, MAX_INLINE_WORKSPACES).join(', ')} +${workspaces.length - MAX_INLINE_WORKSPACES} more)`
+                          : workspaceDisplayFull;
 
                       return (
                         <tr


### PR DESCRIPTION
## [Dashboard] Truncate long workspace list in Infra Kubernetes/SSH context table          
                                                                                             
  When a Kubernetes or SSH context is shared across many workspaces, the                     
  `(workspaces: ...)` label in the Infra table expanded into an unreadable                   
  multi-line wall of text listing every workspace name.                                      
                                                                                           
  **Changes:**                                                                               
  - Inline display now shows at most 3 workspace names followed by `+N more`
    (e.g. `workspaces: LLMONB, MASTSV25, QUANTUMCOE +47 more`)
  - Hovering the row still shows the full workspace list in the tooltip

  ## Tested

  - [x] Code formatting: `bash format.sh`
  - [x] Manual: Verified visually on the Infra page with a cluster shared across
    many workspaces — truncated label renders correctly and tooltip shows full list