### PR TITLE
[Test] Fix K8s container status eviction test consistently failing

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2239,7 +2239,11 @@ def test_kubernetes_container_status_unknown_status_refresh():
     test = smoke_tests_utils.Test(
         'kubernetes_container_status_unknown_status_refresh',
         [
-            f'sky launch -y -c {name} --infra kubernetes --num-nodes 8 --detach-run tests/test_yamls/test_k8s_ephemeral_storage_eviction.yaml',
+            # First, launch the cluster with an idle task so provisioning
+            # completes fully (ray, skylet started) before pods get evicted.
+            f'sky launch -y -c {name} --infra kubernetes --num-nodes 8 -- "echo cluster ready"',
+            # Now trigger eviction via exec --detach-run on the running cluster.
+            f'sky exec {name} --detach-run tests/test_yamls/test_k8s_ephemeral_storage_eviction.yaml',
             # Poll sky status --refresh, fail fast if error found.
             # Before the fix this logged: "Failed to query ... [TypeError]..."
             (f'for i in $(seq 1 20); do '


### PR DESCRIPTION
## Summary

- Fixes `test_kubernetes_container_status_unknown_status_refresh` which was consistently failing in CI
- The test was launching a cluster with a task that immediately fills ephemeral storage, causing pod eviction before provisioning (ray/skylet startup) could complete
- Split the single `sky launch` into two steps: first launch the cluster with an idle command, then trigger the eviction task via `sky exec --detach-run`

## Root Cause

The original test ran `sky launch --detach-run` with the eviction YAML directly. The pods' 200Mi ephemeral storage limit would be exceeded before ray and skylet could start on the head node, causing failures like:
- `RuntimeError: Failed to start skylet on the head node - cannot exec into a container in a completed pod; current phase is Failed`
- `return code 137` (SIGKILL from eviction)

## Test Plan

- Ran the test locally with `--kubernetes` flag:
  - **Before fix**: fails consistently (`sky launch` fails before reaching the status refresh step)
  - **After fix**: passes — cluster provisions fully, eviction is triggered via exec, and `sky status --refresh` handles evicted pods without errors