### PR TITLE
[Test] Fix flaky docker storage mount test on older images

### DIFF
--- a/tests/smoke_tests/test_region_and_zone.py
+++ b/tests/smoke_tests/test_region_and_zone.py
@@ -274,8 +274,8 @@ def test_docker_storage_mounts(generic_cloud: str, image_id: str):
     # Guard the azure check with `command -v az` so that it is skipped
     # (rather than failing with exit code 127) when azure-cli failed to
     # install — e.g. on older Docker images like Ubuntu 18.04.
-    azure_blob_command = (f'command -v az > /dev/null 2>&1 && '
-                          f'{azure_blob_command_raw}')
+    azure_blob_command = (f'{{ command -v az > /dev/null 2>&1 && '
+                          f'{azure_blob_command_raw}; }}')
     # TODO(zpoint): this is a temporary fix. We should make it more robust.
     # If azure is used, the azure blob storage checking assumes the bucket is
     # created in the centralus region when getting the storage account. We


### PR DESCRIPTION
## Summary

Fixes intermittent failure in `test_docker_storage_mounts[docker:nvidia/cuda:11.8.0-devel-ubuntu18.04]` caused by `azure-cli` install failing on Ubuntu 18.04 and breaking the `&&` chain in `_get_cloud_dependencies_installation_commands`, which prevents ALL subsequent CLI installs (including `awscli`, `boto3`).

**Test-only fix (no production code changes):**

- **Prefer GCP storage**: `gsutil` is installed as a standalone SDK early in the dependency chain, so it remains available even when later steps fail. Moved `clouds.GCP()` to first in `allowed_cloud_storages`.
- **Guard azure blob check**: Wrap the `az` CLI check with `command -v az` so it's cleanly skipped (rather than failing with exit code 127) when `azure-cli` isn't installed.

## Test plan

- [ ] Run `test_docker_storage_mounts` locally to verify the fix
- [ ] Verify CI passes on Buildkite