### PR TITLE
[Auth] Allow logout through OAuth2ProxyMiddleware without auth

### DIFF
--- a/sky/server/auth/oauth2_proxy.py
+++ b/sky/server/auth/oauth2_proxy.py
@@ -165,6 +165,13 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                     request.state.anonymous_user = True
                     return await call_next(request)
 
+                # Allow unauthenticated access to the logout endpoint.
+                # Logout must be reachable even with expired or invalid
+                # sessions so the frontend can cleanly clear state.
+                if request.url.path == '/api/v1/auth/logout':
+                    request.state.anonymous_user = True
+                    return await call_next(request)
+
                 # TODO(aylei): in unified authentication, the redirection
                 # or rejection should be done after all the authentication
                 # methods are performed.


### PR DESCRIPTION
## Summary
- Allow `/api/v1/auth/logout` through `OAuth2ProxyMiddleware` without requiring authentication, matching the existing pattern for `/api/health` and `/api/v1/auth/token`

## Root Cause
When oauth2-proxy is enabled, the `OAuth2ProxyMiddleware` runs before downstream auth middlewares. It checks authentication via the oauth2-proxy `/oauth2/auth` endpoint, and if the user has no valid session, it redirects to `/oauth2/start`. This blocks the logout endpoint for users with expired or invalid sessions -- the frontend gets a redirect instead of a clean 200 response.

The logout handler is already designed to be idempotent and safe for unauthenticated callers. It just needs to be reachable.

## Test plan
- [ ] Deploy to a cluster with oauth2-proxy enabled
- [ ] `curl -X POST https://<host>/api/v1/auth/logout` without a session cookie returns `200 {"status": "ok"}` (previously returned 307 redirect)
- [ ] `curl -X POST https://<host>/api/v1/auth/logout` with a valid session cookie still returns 200 and clears the session
- [ ] Normal login/logout flow via the dashboard still works