### PR TITLE
[API server] Add GC for request debug log

### DIFF
--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -1443,7 +1443,7 @@ To enable debug logging for all requests on server side, set
       --set-string 'apiService.extraEnvs[0].value=true'
 
 
-Debug level logs for each request are saved to ``~/sky_logs/request_debug/<request_id>.log`` on the API server.
+Debug level logs for each request are saved to ``~/.sky/api_server/request_debug_logs/<request_id>.log`` on the API server.
 Server-side debug logging does not affect output seen by the clients.
 
 Upgrade the API server

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -1209,6 +1209,7 @@ async def clean_finished_requests_with_retention(retention_seconds: int,
             requests older than the retention period will be deleted
             regardless of the batch size.
     """
+    debug_log_dir = pathlib.Path(sky_logging.DEBUG_LOG_DIR)
     total_deleted = 0
     while True:
         reqs = await get_request_tasks_async(
@@ -1234,6 +1235,12 @@ async def clean_finished_requests_with_retention(retention_seconds: int,
             futs.append(
                 asyncio.create_task(
                     anyio.Path(legacy_log_path).unlink(missing_ok=True)))
+            # Delete debug log if it exists
+            debug_log_path = (debug_log_dir /
+                              req.request_id).with_suffix('.log')
+            futs.append(
+                asyncio.create_task(
+                    anyio.Path(debug_log_path).unlink(missing_ok=True)))
         await asyncio.gather(*futs)
 
         await _delete_requests([req.request_id for req in reqs])

--- a/sky/sky_logging.py
+++ b/sky/sky_logging.py
@@ -20,8 +20,7 @@ _FORMAT = ('%(levelname).1s %(asctime)s.%(msecs)03d PID=%(process)d '
 _DATE_FORMAT = '%m-%d %H:%M:%S'
 _SENSITIVE_LOGGER = ['sky.provisioner', 'sky.optimizer']
 
-_DEBUG_LOG_DIR = os.path.expanduser(
-    os.path.join(constants.SKY_LOGS_DIRECTORY, 'request_debug'))
+DEBUG_LOG_DIR = os.path.expanduser('~/.sky/api_server/request_debug_logs')
 
 DEBUG = logging.DEBUG
 INFO = logging.INFO
@@ -274,8 +273,8 @@ def add_debug_log_handler(request_id: str):
         yield
         return
 
-    os.makedirs(_DEBUG_LOG_DIR, exist_ok=True)
-    log_path = os.path.join(_DEBUG_LOG_DIR, f'{request_id}.log')
+    os.makedirs(DEBUG_LOG_DIR, exist_ok=True)
+    log_path = os.path.join(DEBUG_LOG_DIR, f'{request_id}.log')
     try:
         debug_log_handler = logging.FileHandler(log_path)
         debug_log_handler.setFormatter(FORMATTER)

--- a/tests/unit_tests/test_logging.py
+++ b/tests/unit_tests/test_logging.py
@@ -11,11 +11,8 @@ def test_add_debug_log_handler_writes_log(tmp_path: Path, monkeypatch):
     # Enable feature
     monkeypatch.setenv(constants.ENV_VAR_ENABLE_REQUEST_DEBUG_LOGGING, 'true')
     # Redirect debug log directory to a temp path
-    debug_dir = tmp_path / 'request_debug'
-    monkeypatch.setattr(sky_logging, '_DEBUG_LOG_DIR', str(debug_dir))
-    # Also redirect general SKY_LOGS_DIRECTORY to tmp
-    monkeypatch.setattr(constants, 'SKY_LOGS_DIRECTORY',
-                        str(tmp_path / 'sky_logs'))
+    debug_dir = tmp_path / '.sky' / 'api_server' / 'request_debug_logs'
+    monkeypatch.setattr(sky_logging, 'DEBUG_LOG_DIR', str(debug_dir))
 
     request_id = 'req-test-123'
     log_path = debug_dir / f'{request_id}.log'
@@ -38,11 +35,8 @@ def test_add_debug_log_handler_noop_when_disabled(tmp_path: Path, monkeypatch):
     # Ensure disabled
     monkeypatch.delenv(constants.ENV_VAR_ENABLE_REQUEST_DEBUG_LOGGING,
                        raising=False)
-    debug_dir = tmp_path / 'request_debug'
-    monkeypatch.setattr(sky_logging, '_DEBUG_LOG_DIR', str(debug_dir))
-    # Also redirect general SKY_LOGS_DIRECTORY to tmp
-    monkeypatch.setattr(constants, 'SKY_LOGS_DIRECTORY',
-                        str(tmp_path / 'sky_logs'))
+    debug_dir = tmp_path / '.sky' / 'api_server' / 'request_debug_logs'
+    monkeypatch.setattr(sky_logging, 'DEBUG_LOG_DIR', str(debug_dir))
 
     request_id = 'req-disabled-123'
     log_path = debug_dir / f'{request_id}.log'

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -184,9 +184,9 @@ async def test_clean_finished_requests_with_retention(isolated_database):
     # Verify old running request was NOT deleted
     assert requests.get_request('old-running-1') is not None
 
-    # Verify log file unlink was called for both current and legacy paths
-    # (2 calls per deleted request: current path + legacy path)
-    assert mock_unlink.call_count == 2
+    # Verify log file unlink was called for current, legacy, and debug paths
+    # (3 calls per deleted request: current path + legacy path + debug log)
+    assert mock_unlink.call_count == 3
 
     # Verify logging
     mock_logger.info.assert_called_once()
@@ -278,8 +278,8 @@ async def test_clean_finished_requests_with_retention_batch_size_functionality(
     assert call_counts[2] == 5  # Third batch (remaining)
 
     # Verify log file unlink was called for each deleted request
-    # (2 calls per request: current path + legacy path)
-    assert mock_unlink.call_count == 50
+    # (3 calls per request: current path + legacy path + debug log)
+    assert mock_unlink.call_count == 75
 
     # Verify logging shows correct total
     mock_logger.info.assert_called_once()
@@ -665,14 +665,13 @@ async def test_clean_finished_requests_cleans_both_paths(
                 await requests.clean_finished_requests_with_retention(
                     retention_seconds)
 
-    # Verify that unlink was called for both current and legacy paths
-    assert len(unlinked_paths) == 2
+    # Verify that unlink was called for current, legacy, and debug log paths
+    assert len(unlinked_paths) == 3
 
-    # One path should be under the current log path prefix (from isolated_database)
-    # One path should be under the legacy log path prefix
+    # All paths should contain the request ID
     current_path_count = sum(
         1 for p in unlinked_paths if 'legacy-test-req-1.log' in p)
-    assert current_path_count == 2  # Both paths should have the request ID
+    assert current_path_count == 3  # All paths should have the request ID
 
     # Verify the request was deleted
     assert requests.get_request('legacy-test-req-1') is None


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR introduce GC for request debug logs, with the same retention duration as the requests. It is debated that we may need another retention duration for debug logs since debug log still can be helpful even if the request get GCed. But I will leave it as a future decision for simplicity, and GC the debug log with the request should be reasonable in most cases.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
