### PR TITLE
Enable service accounts in remote test Docker image

### DIFF
--- a/tests/smoke_tests/docker/Dockerfile_test
+++ b/tests/smoke_tests/docker/Dockerfile_test
@@ -48,6 +48,9 @@ RUN echo "Building for user: $USERNAME"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Feature Flags
+ENV ENABLE_SERVICE_ACCOUNTS=true
+
 # Install dependencies
 RUN apt update -y && \
     apt install -y \


### PR DESCRIPTION
## Summary

- Add `ENABLE_SERVICE_ACCOUNTS=true` to `tests/smoke_tests/docker/Dockerfile_test`

This mirrors the change we made to add the same flag to the Buildkite test Docker image. With service accounts enabled in the remote test environment, we can run `test_managed_jobs_api_access` smoke tests end-to-end https://github.com/skypilot-org/skypilot/pull/8900.

## Test plan
- [ ] Rebuild the remote test Docker image with this change
- [ ] Run `test_managed_jobs_api_access` smoke test against a remote API server

🤖 Generated with [Claude Code](https://claude.com/claude-code)