### PR TITLE
Use jemalloc to reduce API server memory fragmentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,8 @@ RUN apt-get update -y && \
     apt-get upgrade -y && \
     apt-get install --no-install-recommends -y \
         git gcc rsync sudo patch openssh-server \
-        pciutils nano fuse socat netcat-openbsd curl tini autossh jq logrotate && \
+        pciutils nano fuse socat netcat-openbsd curl tini autossh jq logrotate \
+        libjemalloc2 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install the session manager plugin for AWS CLI.

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -168,6 +168,10 @@ spec:
             resourceFieldRef:
               containerName: skypilot-api
               resource: requests.memory
+        # Use jemalloc to avoid glibc malloc arena fragmentation that causes
+        # RSS growth in multi-threaded workloads (status refresh daemon, etc.)
+        - name: LD_PRELOAD
+          value: "libjemalloc.so.2"
         # Use tini as the init process
         command: ["tini", "--"]
         # Start API server in foreground (if supported) to:


### PR DESCRIPTION
## Summary
- Install `libjemalloc2` in the Docker image and set `LD_PRELOAD=libjemalloc.so.2` on the API server container
- Eliminates glibc malloc arena fragmentation that causes monotonic RSS growth in multi-threaded workloads (status refresh daemon, kubectl exec, DB queries, etc.)

## Test setup
  - ~500 clusters (`--infra k8s`) on a shared PostgreSQL-backed API server
  - `refresh_cluster_records()` (same as status refresh daemon) running in a loop with 128 parallel threads
  - RSS sampled every 30s via a background thread
  - Run for 8-10 hours
  - Environment: Python 3.10, Debian slim (python:3.10.19-slim), 16 vCPUs
  - Script: https://gist.github.com/kevinmingtarja/37a262f41d8f84e9617285cab54d620c

## Results
  - glibc: RSS climbs monotonically from 303 → 382 MB (+79 MB), never returns memory
  - jemalloc: RSS oscillates 254–338 MB, actively returns memory between refreshes
  - jemalloc average steady-state ~60 MB lower than glibc plateau

<img width="4000" height="1600" alt="memory_comparison" src="https://github.com/user-attachments/assets/087cb054-f71c-4b43-bb8b-44d330e7c2d3" />


## Test plan
- [x] Verified `libjemalloc.so.2` is in the dynamic linker search path (works on both amd64 and arm64)
- [x] Tested with 100 iterations of full daemon refresh (228 clusters): RSS +0.8 MB
- [x] Tested concurrent tail_logs (100 threads × 50 iters): malloc Used +0.4 MB
- [x] Build Docker image and deploy to staging
- [x] Monitor RSS over 24h to confirm long-term stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)