### PR TITLE
[CI] Fix helm deploy EKS test for K8s 1.34+

### DIFF
--- a/tests/kubernetes/scripts/create_cluster.sh
+++ b/tests/kubernetes/scripts/create_cluster.sh
@@ -97,7 +97,7 @@ managedNodeGroups:
   - name: ng-default
     instanceType: ${INSTANCE_TYPE}
     desiredCapacity: ${NODE_COUNT}
-    amiFamily: AmazonLinux2
+    amiFamily: AmazonLinux2023
 addons:
   - name: aws-ebs-csi-driver
 EOF


### PR DESCRIPTION
## Summary
- Migrate EKS node group AMI family from `AmazonLinux2` to `AmazonLinux2023` in `tests/kubernetes/scripts/create_cluster.sh`
- AWS dropped AL2 support starting with Kubernetes 1.33. Since the eksctl config doesn't pin a K8s version, it defaults to 1.34+, causing: `Error: AmazonLinux2 is not supported for Kubernetes version 1.34`

## Test plan
- [x] Verify no other `AmazonLinux2` references remain in the skypilot repo (grep confirms this was the only one)
- [x] Re-run `test_helm_deploy_eks` smoke test to confirm the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)