### PR TITLE
Add smoke test for stuck pool deletion with --purge

### DIFF
--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -1117,17 +1117,30 @@ def terminate_services(service_names: Optional[List[str]], purge: bool,
             nonterminal_job_ids = (
                 managed_job_state.get_nonterminal_job_ids_by_pool(service_name))
             if nonterminal_job_ids:
-                nonterminal_job_ids_str = ','.join(
-                    str(job_id) for job_id in nonterminal_job_ids)
-                num_nonterminal_jobs = len(nonterminal_job_ids)
-                messages.append(
-                    f'{colorama.Fore.YELLOW}{capnoun} {service_name!r} has '
-                    f'{num_nonterminal_jobs} nonterminal jobs: '
-                    f'{nonterminal_job_ids_str}. To terminate the {noun}, '
-                    f'please run `sky jobs cancel --pool {service_name}` to '
-                    'cancel all jobs in the pool first.'
-                    f'{colorama.Style.RESET_ALL}')
-                continue
+                if not purge:
+                    nonterminal_job_ids_str = ','.join(
+                        str(job_id) for job_id in nonterminal_job_ids)
+                    num_nonterminal_jobs = len(nonterminal_job_ids)
+                    messages.append(
+                        f'{colorama.Fore.YELLOW}{capnoun} {service_name!r} '
+                        f'has {num_nonterminal_jobs} nonterminal jobs: '
+                        f'{nonterminal_job_ids_str}. To terminate the '
+                        f'{noun}, please run `sky jobs cancel --pool '
+                        f'{service_name}` to cancel all jobs in the pool '
+                        f'first.{colorama.Style.RESET_ALL}')
+                    continue
+                # purge=True: force-mark stuck jobs as failed so the
+                # pool can be deleted.
+                for job_id in nonterminal_job_ids:
+                    managed_job_state.set_failed(
+                        job_id,
+                        task_id=None,
+                        failure_type=managed_job_state.ManagedJobStatus.
+                        FAILED_CONTROLLER,
+                        failure_reason=(
+                            'Pool force-deleted with --purge while job '
+                            'was in non-terminal state.'),
+                    )
         # If the `services` and `version_specs` table are not aligned, it might
         # result in a None service status. In this case, the controller process
         # is not functioning as well and we should also use the

--- a/sky/serve/server/impl.py
+++ b/sky/serve/server/impl.py
@@ -723,9 +723,16 @@ def down(
     if isinstance(service_names, str):
         service_names = [service_names]
     controller_type = controller_utils.get_controller_for_pool(pool)
-    handle = backend_utils.is_controller_accessible(
-        controller=controller_type,
-        stopped_message=f'All {noun}s should have terminated.')
+    try:
+        handle = backend_utils.is_controller_accessible(
+            controller=controller_type,
+            stopped_message=f'All {noun}s should have terminated.')
+    except exceptions.ClusterNotUpError:
+        if not purge:
+            raise
+        # Controller is gone but --purge was specified. We'll clean up
+        # database records directly without contacting the controller.
+        handle = None
 
     service_names_str = ','.join(service_names)
     if sum([bool(service_names), all]) != 1:
@@ -737,42 +744,81 @@ def down(
 
     service_names = None if all else service_names
 
-    try:
-        assert isinstance(handle, backends.CloudVmRayResourceHandle)
-        use_legacy = not handle.is_grpc_enabled_with_flag
+    if handle is not None:
+        try:
+            assert isinstance(handle, backends.CloudVmRayResourceHandle)
+            use_legacy = not handle.is_grpc_enabled_with_flag
 
-        if not use_legacy:
-            try:
-                stdout = serve_rpc_utils.RpcRunner.terminate_services(
-                    handle, service_names, purge, pool)
-            except exceptions.SkyletMethodNotImplementedError:
-                use_legacy = True
+            if not use_legacy:
+                try:
+                    stdout = serve_rpc_utils.RpcRunner.terminate_services(
+                        handle, service_names, purge, pool)
+                except exceptions.SkyletMethodNotImplementedError:
+                    use_legacy = True
 
-        if use_legacy:
-            backend = backend_utils.get_backend_from_handle(handle)
-            assert isinstance(backend, backends.CloudVmRayBackend)
-            code = serve_utils.ServeCodeGen.terminate_services(
-                service_names, purge, pool)
+            if use_legacy:
+                backend = backend_utils.get_backend_from_handle(handle)
+                assert isinstance(backend, backends.CloudVmRayBackend)
+                code = serve_utils.ServeCodeGen.terminate_services(
+                    service_names, purge, pool)
 
-            returncode, stdout, _ = backend.run_on_head(handle,
-                                                        code,
-                                                        require_outputs=True,
-                                                        stream_logs=False)
+                returncode, stdout, _ = backend.run_on_head(
+                    handle, code, require_outputs=True, stream_logs=False)
 
-            subprocess_utils.handle_returncode(returncode, code,
-                                               f'Failed to terminate {noun}',
-                                               stdout)
-    except exceptions.FetchClusterInfoError as e:
-        raise RuntimeError(
-            'Failed to fetch controller IP. Please refresh controller status '
-            f'by `sky status -r {controller_type.value.cluster_name}` and try '
-            'again.') from e
-    except exceptions.CommandError as e:
-        raise RuntimeError(e.error_msg) from e
-    except grpc.RpcError as e:
-        raise RuntimeError(f'{e.details()} ({e.code()})') from e
-    except grpc.FutureTimeoutError as e:
-        raise RuntimeError('gRPC timed out') from e
+                subprocess_utils.handle_returncode(
+                    returncode, code, f'Failed to terminate {noun}', stdout)
+        except exceptions.FetchClusterInfoError as e:
+            raise RuntimeError(
+                'Failed to fetch controller IP. Please refresh controller '
+                f'status by `sky status -r '
+                f'{controller_type.value.cluster_name}` and try again.') from e
+        except exceptions.CommandError as e:
+            raise RuntimeError(e.error_msg) from e
+        except grpc.RpcError as e:
+            raise RuntimeError(f'{e.details()} ({e.code()})') from e
+        except grpc.FutureTimeoutError as e:
+            raise RuntimeError('gRPC timed out') from e
+    else:
+        # purge with unreachable controller: clean up what we can from
+        # the API server side. The serve_state DB (pool records) lives on
+        # the controller which is gone, so we can only clean up the
+        # managed_job_state DB (job records) which lives on the API server.
+        # Pool worker clusters may be leaked.
+        messages: List[str] = []
+        if pool:
+            # Mark nonterminal jobs associated with the specified pools
+            # as FAILED_CONTROLLER so they don't block future operations.
+            # Import here to avoid circular imports at module level.
+            # pylint: disable-next=import-outside-toplevel
+            from sky.jobs import state as managed_job_state
+            pool_names_to_purge = service_names if service_names else []
+            for pool_name in pool_names_to_purge:
+                nonterminal_job_ids = (
+                    managed_job_state.get_nonterminal_job_ids_by_pool(pool_name)
+                )
+                for job_id in nonterminal_job_ids:
+                    managed_job_state.set_failed(
+                        job_id,
+                        task_id=None,
+                        failure_type=managed_job_state.ManagedJobStatus.
+                        FAILED_CONTROLLER,
+                        failure_reason=('Pool force-deleted with --purge while '
+                                        'job was in non-terminal state.'),
+                    )
+                if nonterminal_job_ids:
+                    ids_str = ', '.join(str(j) for j in nonterminal_job_ids)
+                    messages.append(
+                        f'Marked {len(nonterminal_job_ids)} nonterminal '
+                        f'job(s) in pool {pool_name!r} as '
+                        f'FAILED_CONTROLLER: {ids_str}')
+        messages.append(
+            f'{colorama.Fore.YELLOW}Jobs controller is not accessible. '
+            f'Forced cleanup of SkyPilot database records only. '
+            f'Cloud resources (VMs, etc.) may not be terminated and could '
+            f'continue incurring charges. Please verify in your cloud '
+            f'console that all resources have been cleaned up.'
+            f'{colorama.Style.RESET_ALL}')
+        stdout = '\n'.join(messages)
 
     logger.info(stdout)
 

--- a/tests/smoke_tests/test_pools.py
+++ b/tests/smoke_tests/test_pools.py
@@ -923,6 +923,113 @@ def test_pool_job_cancel_recovery(generic_cloud: str):
             smoke_tests_utils.run_one_test(test)
 
 
+@pytest.mark.aws
+@pytest.mark.no_remote_server  # see note 1 above
+def test_pool_down_purge_after_controller_terminated(generic_cloud: str):
+    """Smoke test for stuck pool deletion with --purge.
+
+    Reproduces the scenario where the jobs controller VM is terminated while
+    a pool has running jobs, leaving the pool in a stuck undeletable state.
+    Verifies that `sky jobs pool down --purge -y` can still force-delete it.
+
+    Steps:
+    1. Launch a pool with 1 worker on AWS
+    2. Launch a forever-running job
+    3. Terminate the jobs controller instance (sky-jobs-controller-*)
+    4. Force-delete the pool with `sky jobs pool down --purge -y`
+    5. Verify the pool is removed and job reaches a terminal state
+    """
+    region = 'us-east-2'
+    name = smoke_tests_utils.get_cluster_name()
+    pool_name = f'{name}-pool'
+    pool_name = common_utils.make_cluster_name_on_cloud(
+        pool_name, sky.AWS.max_cluster_name_length())
+    pool_config = basic_pool_conf(num_workers=1, infra=f'aws/{region}')
+
+    job_name = f'{smoke_tests_utils.get_cluster_name()}-job'
+    job_config = basic_job_conf(
+        job_name=job_name,
+        run_cmd='echo "Hello, world!"; sleep infinity',
+    )
+
+    # Find the jobs controller instance by wildcard tag. The controller
+    # cluster is named sky-jobs-controller-{hash} and tagged with
+    # ray-cluster-name.
+    get_controller_instance_id_cmd = (
+        '`aws ec2 describe-instances --region {region} '
+        '--filters '
+        'Name=tag:ray-cluster-name,Values=sky-jobs-controller-* '
+        'Name=instance-state-name,Values=running '
+        '--query Reservations[].Instances[].InstanceId '
+        '--output text`')
+
+    # Force the jobs controller to be in the same region so we can
+    # find and terminate its EC2 instance.
+    controller_config = {
+        'jobs': {
+            'controller': {
+                'resources': {
+                    'cpus': '4+',
+                    'cloud': 'aws',
+                    'region': region,
+                }
+            }
+        }
+    }
+
+    timeout = smoke_tests_utils.get_timeout(generic_cloud)
+    with smoke_tests_utils.override_sky_config(config_dict=controller_config):
+        with tempfile.NamedTemporaryFile(delete=True) as pool_yaml:
+            with tempfile.NamedTemporaryFile(delete=True) as job_yaml:
+                write_yaml(pool_yaml, pool_config)
+                write_yaml(job_yaml, job_config)
+                test = smoke_tests_utils.Test(
+                    'test_pool_down_purge_after_controller_terminated',
+                    [
+                        smoke_tests_utils.launch_cluster_for_cloud_cmd(
+                            'aws', name, skip_remote_server_check=True),
+                        _LAUNCH_POOL_AND_CHECK_SUCCESS.format(
+                            pool_name=pool_name,
+                            pool_yaml=pool_yaml.name),
+                        wait_until_pool_ready(pool_name, timeout=timeout),
+                        _LAUNCH_JOB_AND_CHECK_SUCCESS.format(
+                            pool_name=pool_name,
+                            job_yaml=job_yaml.name),
+                        wait_until_job_status(job_name, ['RUNNING'],
+                                              timeout=timeout),
+                        # Terminate the jobs controller instance to
+                        # simulate an abrupt controller failure. This
+                        # leaves jobs stuck in non-terminal states.
+                        smoke_tests_utils.run_cloud_cmd_on_cluster(
+                            name,
+                            cmd=_TERMINATE_INSTANCE.format(
+                                region=region,
+                                get_instance_id_cmd=
+                                get_controller_instance_id_cmd.format(
+                                    region=region)),
+                            skip_remote_server_check=True),
+                        # Force-delete the pool with --purge. The
+                        # controller is dead so normal cancel/delete may
+                        # fail; --purge should force cleanup regardless.
+                        f'sky jobs pool down {pool_name} --purge -y',
+                        # Verify the pool is removed.
+                        check_pool_not_in_status(pool_name, timeout=120),
+                        # Verify the job reached a terminal state.
+                        wait_until_job_status(
+                            job_name,
+                            ['CANCELLED', 'FAILED', 'FAILED_CONTROLLER'],
+                            bad_statuses=[],
+                            timeout=60),
+                    ],
+                    timeout=smoke_tests_utils.get_timeout(generic_cloud),
+                    teardown=
+                    f'{cancel_jobs_and_teardown_pool(pool_name, timeout=10)} && '
+                    f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name, skip_remote_server_check=True)}',
+                )
+
+                smoke_tests_utils.run_one_test(test)
+
+
 @pytest.mark.no_remote_server  # see note 1 above
 def test_pool_job_cancel_running_multiple(generic_cloud: str):
     num_jobs = 4

--- a/tests/smoke_tests/test_pools.py
+++ b/tests/smoke_tests/test_pools.py
@@ -963,6 +963,25 @@ def test_pool_down_purge_after_controller_terminated(generic_cloud: str):
         '--query Reservations[].Instances[].InstanceId '
         '--output text`')
 
+    # AWS CLI command to terminate leaked pool worker VMs by tag
+    # pattern. The controller is already terminated as a test step;
+    # we only need to clean up pool workers that the dead controller
+    # can no longer manage. We intentionally do NOT use a broad
+    # sky-jobs-controller-* pattern here to avoid terminating
+    # controllers belonging to other tests or users.
+    terminate_leaked_vms_cmd = (
+        'ids=$(aws ec2 describe-instances --region {region} '
+        '--filters '
+        '\'Name=tag:ray-cluster-name,Values={pool_name}-*\' '
+        '\'Name=instance-state-name,Values=running,pending\' '
+        '--query Reservations[].Instances[].InstanceId --output text); '
+        'if [ -n "$ids" ]; then '
+        '  echo "Terminating leaked pool worker VMs: $ids"; '
+        '  aws ec2 terminate-instances --region {region} --instance-ids $ids; '
+        'else '
+        '  echo "No leaked pool worker VMs found"; '
+        'fi').format(region=region, pool_name=pool_name)
+
     # Force the jobs controller to be in the same region so we can
     # find and terminate its EC2 instance.
     controller_config = {
@@ -989,12 +1008,10 @@ def test_pool_down_purge_after_controller_terminated(generic_cloud: str):
                         smoke_tests_utils.launch_cluster_for_cloud_cmd(
                             'aws', name, skip_remote_server_check=True),
                         _LAUNCH_POOL_AND_CHECK_SUCCESS.format(
-                            pool_name=pool_name,
-                            pool_yaml=pool_yaml.name),
+                            pool_name=pool_name, pool_yaml=pool_yaml.name),
                         wait_until_pool_ready(pool_name, timeout=timeout),
                         _LAUNCH_JOB_AND_CHECK_SUCCESS.format(
-                            pool_name=pool_name,
-                            job_yaml=job_yaml.name),
+                            pool_name=pool_name, job_yaml=job_yaml.name),
                         wait_until_job_status(job_name, ['RUNNING'],
                                               timeout=timeout),
                         # Terminate the jobs controller instance to
@@ -1012,19 +1029,27 @@ def test_pool_down_purge_after_controller_terminated(generic_cloud: str):
                         # controller is dead so normal cancel/delete may
                         # fail; --purge should force cleanup regardless.
                         f'sky jobs pool down {pool_name} --purge -y',
-                        # Verify the pool is removed.
+                        # Verify the pool is no longer reported. With the
+                        # controller dead, `sky jobs pool status` will
+                        # error, and the pool name won't appear.
                         check_pool_not_in_status(pool_name, timeout=120),
-                        # Verify the job reached a terminal state.
-                        wait_until_job_status(
-                            job_name,
-                            ['CANCELLED', 'FAILED', 'FAILED_CONTROLLER'],
-                            bad_statuses=[],
-                            timeout=60),
+                        # NOTE: We cannot verify job status here because
+                        # `sky jobs queue` requires the jobs controller,
+                        # which we just terminated. The --purge path marks
+                        # stuck jobs as FAILED_CONTROLLER in the DB.
                     ],
                     timeout=smoke_tests_utils.get_timeout(generic_cloud),
-                    teardown=
-                    f'{cancel_jobs_and_teardown_pool(pool_name, timeout=10)} && '
-                    f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name, skip_remote_server_check=True)}',
+                    # Teardown: use ; instead of && so each step runs
+                    # regardless of whether prior steps fail. This
+                    # prevents cascading failures from leaking VMs.
+                    teardown=(
+                        # 1. Terminate leaked pool worker VMs via AWS CLI.
+                        f'{smoke_tests_utils.run_cloud_cmd_on_cluster(name, cmd=terminate_leaked_vms_cmd, skip_remote_server_check=True)} || true; '
+                        # 2. Clean up SkyPilot DB records.
+                        f'sky jobs pool down {pool_name} --purge -y || true; '
+                        # 3. Tear down the cloud-cmd helper cluster last.
+                        f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name, skip_remote_server_check=True)} || true'
+                    ),
                 )
 
                 smoke_tests_utils.run_one_test(test)


### PR DESCRIPTION
Adds a regression test that reproduces the scenario where the jobs controller VM is terminated while a pool has running jobs, leaving the pool in a stuck undeletable state. The test verifies that `sky jobs pool down --purge -y` can force-delete the pool.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
