### PR TITLE
[Dashboard] Add PluginSlot for version display on settings page

### DIFF
--- a/sky/dashboard/src/components/config.js
+++ b/sky/dashboard/src/components/config.js
@@ -14,6 +14,7 @@ import {
 } from '@/components/elements/version-display';
 import { apiClient } from '@/data/connectors/client';
 import { checkGrafanaAvailability, getGrafanaUrl } from '@/utils/grafana';
+import { PluginSlot } from '@/plugins/PluginSlot';
 
 export function Config() {
   const [editableConfig, setEditableConfig] = useState('');
@@ -197,7 +198,10 @@ export function Config() {
             </button>
           )}
           <NewVersionAvailable />
-          <VersionDisplay />
+          <PluginSlot
+            name="settings.version-display"
+            fallback={<VersionDisplay />}
+          />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Wrap `VersionDisplay` in a `PluginSlot` on the settings page, allowing plugins to customize the version display
- No behavior change — the `PluginSlot` renders the existing `VersionDisplay` as fallback when no plugin registers into the slot

## Test plan
- [x] Open Settings > API Server page — verify "Version: X.Y.Z" displays as before
- [x] Hover the version text — verify the tooltip shows commit and plugin info as before
- [x] With a plugin registering into `settings.version-display`, verify the plugin component replaces the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
