### PR TITLE
[Tests] Increase test_api_server_start_stop timeout to 1200s to prevent flakiness

### DIFF
--- a/tests/smoke_tests/test_api_server.py
+++ b/tests/smoke_tests/test_api_server.py
@@ -494,8 +494,7 @@ def test_api_server_start_stop(generic_cloud: str):
             f'sky launch -n {name} --cloud {generic_cloud} tests/test_yamls/apiserver-start-stop.yaml -y {smoke_tests_utils.LOW_RESOURCE_ARG}'
         ],
         f'sky down -y {name} || true',
-        timeout=smoke_tests_utils.get_timeout(generic_cloud,
-                                              override_timeout=1200),
+        timeout=1200,
     )
     smoke_tests_utils.run_one_test(test)
 


### PR DESCRIPTION
## Summary
- Increase the timeout for `test_api_server_start_stop` from the default 900s to 1200s to reduce flaky timeout failures

## Test plan
- [ ] Existing CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)