### PR TITLE
[Tests] Increase test_plugin_upload job status timeout to 400s

### DIFF
--- a/tests/smoke_tests/test_plugin.py
+++ b/tests/smoke_tests/test_plugin.py
@@ -103,7 +103,7 @@ def test_plugin_upload_to_jobs_controller(generic_cloud: str):
                 # It is possible this timeout is not enough
                 # (since the jobs controller needs to be created from scratch).
                 # Increase this as needed.
-                timeout=200,
+                timeout=400,
             ),
             # Controller setup includes "uv pip install" (or "pip install") for plugin wheels
             (


### PR DESCRIPTION
## Summary
- Increase the managed job SUCCEEDED status wait timeout in `test_plugin_upload` from 200s to 400s
- The comment in the code already notes this timeout may be insufficient when the jobs controller is created from scratch

## Test plan
- [ ] Existing CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)