### PR TITLE
Fix ssh-key double-quoting for vast.

### DIFF
--- a/sky/provision/vast/utils.py
+++ b/sky/provision/vast/utils.py
@@ -210,7 +210,7 @@ def launch(name: str,
             'chmod 700 ~/.ssh',
             # Add a newline first to ensure keys are on separate lines
             'echo "" >> ~/.ssh/authorized_keys',
-            (f'echo "{shlex.quote(ssh_public_key.strip())}" >> '
+            (f'echo {shlex.quote(ssh_public_key.strip())} >> '
              '~/.ssh/authorized_keys'),
             'chmod 600 ~/.ssh/authorized_keys',
         ])


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

When starting Vast instances, `onstart.sh` incorrectly double-quotes `ssh_public_key`. This leads to the key being rejected by sshd despite it being present in `~/.ssh/authorized_keys.`

Here's what currently gets written to `onstart.sh` (note the double quotes after the echo):

```bash
  touch ~/.no_auto_tmux;echo "key" > ~/.vast_api_key;mkdir -p ~/.ssh;chmod 700 ~/.ssh;echo "" >>
  ~/.ssh/authorized_keys;echo "'ssh-rsa AAAA...'" >> ~/.ssh/authorized_keys;chmod 600
  ~/.ssh/authorized_keys
```

Vs what this PR writes:

```bash
  touch ~/.no_auto_tmux;echo "key" > ~/.vast_api_key;mkdir -p ~/.ssh;chmod 700 ~/.ssh;echo "" >>
  ~/.ssh/authorized_keys;echo 'ssh-rsa AAAA...' >> ~/.ssh/authorized_keys;chmod 600
  ~/.ssh/authorized_keys
```


<!-- Describe the tests ran -->

I reproduced the current behavior, modified my local skypilot files with this fix, ran again, and verified ssh connects properly with the fix (and does not connect without it.) 

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
