### PR TITLE
[Tests] Fix test_huggingface on Nebius: use L40S instead of H100

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -704,7 +704,7 @@ def test_multi_echo(generic_cloud: str):
 @pytest.mark.no_hyperbolic  # Hyperbolic has low availability of T4 GPUs
 @pytest.mark.no_seeweb  # Seeweb does not support T4 GPUs
 @pytest.mark.resource_heavy
-@pytest.mark.parametrize('accelerator', [{'do': 'H100', 'nebius': 'H100'}])
+@pytest.mark.parametrize('accelerator', [{'do': 'H100', 'nebius': 'L40S'}])
 def test_huggingface(generic_cloud: str, accelerator: Dict[str, str]):
     if generic_cloud in ('kubernetes', 'slurm'):
         accelerator = smoke_tests_utils.get_available_gpus(infra=generic_cloud)


### PR DESCRIPTION
## Summary
- `test_huggingface` on Nebius was parameterized to use H100, but `huggingface_glue_imdb_app.yaml` installs `torch==1.12.1+cu113` which doesn't support H100 (sm_90, added in PyTorch 2.0+)
- Changed Nebius accelerator from H100 to L40S, consistent with other Nebius test parametrizations (`test_min_gpt`, `test_ray_train`, `test_skyserve`)

## Test plan
- [ ] Verify `test_huggingface --nebius` passes with L40S in the next full smoke test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)