### PR TITLE
[Tests] Fix test_cancel_pytorch on Nebius: use L40S instead of H100

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1921,7 +1921,7 @@ def test_cancel_azure():
 @pytest.mark.no_hyperbolic  # Hyperbolic does not support num_nodes > 1 yet
 @pytest.mark.no_seeweb  # Seeweb does not support num_nodes > 1 yet
 @pytest.mark.resource_heavy
-@pytest.mark.parametrize('accelerator', [{'do': 'H100', 'nebius': 'H100'}])
+@pytest.mark.parametrize('accelerator', [{'do': 'H100', 'nebius': 'L40S'}])
 def test_cancel_pytorch(generic_cloud: str, accelerator: Dict[str, str]):
     if generic_cloud in ('kubernetes', 'slurm'):
         accelerator = smoke_tests_utils.get_available_gpus(infra=generic_cloud)


### PR DESCRIPTION
## Summary
- `test_cancel_pytorch` on Nebius was parameterized to use H100, but `resnet_distributed_torch.yaml` installs `torch==1.12.1+cu113` which doesn't support H100 (sm_90, added in PyTorch 2.0+)
- Changed Nebius accelerator from H100 to L40S, consistent with other Nebius test parametrizations (`test_min_gpt`, `test_ray_train`, `test_skyserve`)

## Test plan
- [ ] Verify `test_cancel_pytorch --nebius` passes with L40S in the next full smoke test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)