### PR TITLE
[Tests] Fix flaky multiprocess race condition test timeout

### DIFF
--- a/tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend.py
+++ b/tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend.py
@@ -309,6 +309,7 @@ class TestCloudVmRayBackendGetGrpcChannel:
 
     INITIAL_TUNNEL_PORT = 10000
     INITIAL_TUNNEL_PID = 12345
+    PROCESS_JOIN_TIMEOUT_SECONDS = 30
 
     def _simulate_process_get_grpc_channel(self, queue, tunnel_creation_count,
                                            tunnel_port, tunnel_pid,
@@ -389,7 +390,7 @@ class TestCloudVmRayBackendGetGrpcChannel:
             p.start()
 
         for p in processes:
-            p.join(timeout=15)
+            p.join(timeout=self.PROCESS_JOIN_TIMEOUT_SECONDS)
             if p.is_alive():
                 p.terminate()
                 p.join()
@@ -420,7 +421,7 @@ class TestCloudVmRayBackendGetGrpcChannel:
             p.start()
 
         for p in processes:
-            p.join(timeout=15)
+            p.join(timeout=self.PROCESS_JOIN_TIMEOUT_SECONDS)
             if p.is_alive():
                 p.terminate()
                 p.join()


### PR DESCRIPTION
## Summary
- Increase process join timeout from 15s to 30s in `test_get_grpc_channel_multiprocess_race_condition`
- Extract timeout as `PROCESS_JOIN_TIMEOUT_SECONDS` class constant

## Root cause

Benchmarked on a 2-core GitHub Actions runner (AMD EPYC 7763, same as CI):

| Scenario | Time |
|---|---|
| `-n 0` (no parallel pytest workers) | ~17.5s |
| `-n 4` (4 parallel pytest workers) | ~29.5s |

The test spawns 5 multiprocessing workers, each doing `time.sleep(2)`. On a 2-core runner, process spawn + scheduling overhead takes ~13.5s on top of the 2×2s sleep rounds. With `-n 4`, pytest-xdist worker processes compete for the same 2 CPUs, adding ~12s and pushing total time to ~29.5s — right at the edge of the 2×15s timeout budget. When the full test suite runs concurrently and further starves CPU, one or more processes exceed the 15s join timeout and get terminated, losing their queue result.

## Test plan
- Ran the test locally with `-n 4` — all passed
- The test logic is unchanged; only the join timeout is increased

🤖 Generated with [Claude Code](https://claude.com/claude-code)