### PR TITLE
No server heartbeat on controllers

### DIFF
--- a/sky/server/daemons.py
+++ b/sky/server/daemons.py
@@ -302,15 +302,12 @@ def should_skip_pool_status_refresh():
 
 
 def should_skip_server_heartbeat():
-    """Skip server heartbeat when not running on the API server or
-    is running as a controller."""
+    """Skip server heartbeat when running as a controller."""
     if os.environ.get(constants.OVERRIDE_CONSOLIDATION_MODE) is not None:
         # We are running as a controller.
         return True
-    if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is None:
-        # We are not running on the API server.
-        return True
     return False
+
 
 def server_heartbeat_event():
     """Periodically send server-side plugin metrics to Loki."""


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Currently, server heartbeat also runs on jobs / serve controller. This change makes server heartbeat only run on API Server.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
