### PR TITLE
[Dashboard] Fix GCP instance links to use cloud cluster name

### DIFF
--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -583,7 +583,9 @@ class StrategyExecutor:
                                         instance_links_utils.
                                         generate_instance_links(
                                             cluster_info, self.cluster_name,
-                                            handle.cluster_name_on_cloud))
+                                            getattr(handle,
+                                                    'cluster_name_on_cloud',
+                                                    None)))
                                     if instance_links:
                                         # Store instance links directly in
                                         # database

--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -579,10 +579,11 @@ class StrategyExecutor:
                                         handle, 'cached_cluster_info') and
                                         handle.cached_cluster_info is not None):
                                     cluster_info = handle.cached_cluster_info
-                                    instance_links = (instance_links_utils.
-                                                      generate_instance_links(
-                                                          cluster_info,
-                                                          self.cluster_name))
+                                    instance_links = (
+                                        instance_links_utils.
+                                        generate_instance_links(
+                                            cluster_info, self.cluster_name,
+                                            handle.cluster_name_on_cloud))
                                     if instance_links:
                                         # Store instance links directly in
                                         # database

--- a/sky/utils/instance_links.py
+++ b/sky/utils/instance_links.py
@@ -1,5 +1,5 @@
 """Utility functions for generating instance links for cloud providers."""
-from typing import Dict
+from typing import Dict, Optional
 
 from sky import sky_logging
 from sky.provision import common
@@ -75,6 +75,7 @@ def _build_gcp_instances_url(project_id: str, tag_key: str,
 def generate_instance_links(
     cluster_info: common.ClusterInfo,
     cluster_name: str,
+    cluster_name_on_cloud: Optional[str] = None,
 ) -> Dict[str, str]:
     """Generate instance links for a cluster based on the cloud provider.
 
@@ -84,6 +85,8 @@ def generate_instance_links(
     Args:
         cluster_info: ClusterInfo object containing instance information.
         cluster_name: Cluster name for tag-based filtering.
+        cluster_name_on_cloud: Optional cloud-side cluster name/tag value.
+            If provided, this is used for cloud console filtering.
 
     Returns:
         Dictionary mapping link labels to URLs. Empty dict if links cannot be
@@ -99,6 +102,7 @@ def generate_instance_links(
 
     # Tag used by SkyPilot to identify cluster instances
     tag_key = provision_constants.TAG_RAY_CLUSTER_NAME
+    cluster_tag_value = cluster_name_on_cloud or cluster_name
 
     if provider_name == 'aws':
         region = provider_config.get('region')
@@ -109,7 +113,7 @@ def generate_instance_links(
         links['AWS Instances'] = AWS_INSTANCES_URL.format(
             region=region,
             tag_key=tag_key,
-            cluster_name=cluster_name,
+            cluster_name=cluster_tag_value,
         )
 
     elif provider_name == 'gcp':
@@ -121,7 +125,7 @@ def generate_instance_links(
         links['GCP Instances'] = _build_gcp_instances_url(
             project_id=project_id,
             tag_key=tag_key,
-            cluster_name=cluster_name,
+            cluster_name=cluster_tag_value,
         )
 
     elif provider_name == 'azure':

--- a/tests/unit_tests/test_instance_links.py
+++ b/tests/unit_tests/test_instance_links.py
@@ -1,0 +1,53 @@
+"""Tests for cloud instance link generation."""
+
+from sky.provision import common
+from sky.utils import instance_links
+
+
+def _cluster_info(provider_name: str,
+                  provider_config: dict) -> common.ClusterInfo:
+    return common.ClusterInfo(
+        instances={},
+        head_instance_id=None,
+        provider_name=provider_name,
+        provider_config=provider_config,
+    )
+
+
+def test_generate_gcp_link_uses_cluster_name_on_cloud_override():
+    cluster_info = _cluster_info('gcp', {'project_id': 'my-project'})
+
+    links = instance_links.generate_instance_links(
+        cluster_info=cluster_info,
+        cluster_name='local-cluster-name',
+        cluster_name_on_cloud='cloud-cluster-tag',
+    )
+
+    gcp_link = links['GCP Instances']
+    assert 'project=my-project' in gcp_link
+    assert '_3Acloud-cluster-tag_5C_22' in gcp_link
+    assert '_3Alocal-cluster-name_5C_22' not in gcp_link
+
+
+def test_generate_aws_link_uses_cluster_name_on_cloud_override():
+    cluster_info = _cluster_info('aws', {'region': 'us-east-1'})
+
+    links = instance_links.generate_instance_links(
+        cluster_info=cluster_info,
+        cluster_name='local-cluster-name',
+        cluster_name_on_cloud='cloud-cluster-tag',
+    )
+
+    assert links['AWS Instances'].endswith(
+        '#Instances:tag:ray-cluster-name=cloud-cluster-tag')
+
+
+def test_generate_link_falls_back_to_cluster_name_without_override():
+    cluster_info = _cluster_info('gcp', {'project_id': 'my-project'})
+
+    links = instance_links.generate_instance_links(
+        cluster_info=cluster_info,
+        cluster_name='local-cluster-name',
+    )
+
+    assert '_3Alocal-cluster-name_5C_22' in links['GCP Instances']


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #9047

- Pass `cluster_name_on_cloud` when generating managed-job instance links.
- Update instance link generator to accept `cluster_name_on_cloud` and use it for AWS/GCP tag filtering.
- Add unit tests covering override + fallback behavior.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

Manual/new tests:
- `HOME=/tmp/skypilot-home SKYPILOT_DISABLE_USAGE_COLLECTION=1 pytest tests/unit_tests/test_instance_links.py -q`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
