### PR TITLE
[Jobs] Remove stale managed jobs dashboard setup

### DIFF
--- a/sky/jobs/constants.py
+++ b/sky/jobs/constants.py
@@ -2,8 +2,6 @@
 import os
 from typing import Any, Dict, Union
 
-from sky.skylet import constants as skylet_constants
-
 # Environment variable for JobGroup name, injected into all jobs in a JobGroup
 SKYPILOT_JOBGROUP_NAME_ENV_VAR = 'SKYPILOT_JOBGROUP_NAME'
 
@@ -59,25 +57,3 @@ JOBS_CLUSTER_NAME_PREFIX_LENGTH = 25
 # WARNING: If you update this due to a codegen change, make sure to make the
 # corresponding change in the ManagedJobsService AND bump the SKYLET_VERSION.
 MANAGED_JOBS_VERSION = 16  # new fields for job graceful cancel
-
-# The command for setting up the jobs dashboard on the controller. It firstly
-# checks if the systemd services are available, and if not (e.g., Kubernetes
-# containers may not have systemd), it starts the dashboard manually.
-DASHBOARD_SETUP_CMD = (
-    'if command -v systemctl &>/dev/null && systemctl --user show &>/dev/null; '
-    'then '
-    '  systemctl --user daemon-reload; '
-    '  systemctl --user enable --now skypilot-dashboard; '
-    'else '
-    '  echo "Systemd services not found. Starting SkyPilot dashboard '
-    'manually."; '
-    # Kill any old dashboard processes;
-    '  ps aux | grep -v nohup | grep -v grep | '
-    '  grep -- \'-m sky.jobs.dashboard.dashboard\' | awk \'{print $2}\' | '
-    '  xargs kill > /dev/null 2>&1 || true;'
-    # Launch the dashboard in the background if not already running
-    '  (ps aux | grep -v nohup | grep -v grep | '
-    '  grep -q -- \'-m sky.jobs.dashboard.dashboard\') || '
-    f'(nohup {skylet_constants.SKY_PYTHON_CMD} -m sky.jobs.dashboard.dashboard '
-    '>> ~/.sky/job-dashboard.log 2>&1 &); '
-    'fi')

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -298,9 +298,6 @@ def _get_cloud_dependencies_installation_commands(
     # installed, so we don't check that.
     python_packages: Set[str] = set()
 
-    # add flask to the controller dependencies for dashboard
-    python_packages.add('flask')
-
     step_prefix = prefix_str.replace('<step>', str(len(commands) + 1))
     # Wrap in braces to isolate the || in SKY_UV_INSTALL_CMD from
     # the outer && chain, preventing operator precedence issues.

--- a/tests/unit_tests/test_controller_utils.py
+++ b/tests/unit_tests/test_controller_utils.py
@@ -260,8 +260,6 @@ def test_get_cloud_dependencies_installation_commands_empty_clouds(
     assert len(commands) >= 3
     # Check that uv installation is included
     assert any('uv' in cmd for cmd in commands)
-    # Check that flask is included for dashboard
-    assert any('flask' in cmd for cmd in commands)
     # Should end with "done" message
     assert 'done.' in commands[-1]
 
@@ -539,11 +537,10 @@ def test_get_cloud_dependencies_installation_commands_command_structure(
     assert 'uv' in commands[0]
     assert constants.SKY_UV_INSTALL_CMD in commands[0]
 
-    # Python packages command should include flask
+    # Python packages command should use uv pip
     python_cmd = next(
         (cmd for cmd in commands if 'cloud python packages' in cmd), None)
     assert python_cmd is not None
-    assert 'flask' in python_cmd
     assert constants.SKY_UV_PIP_CMD in python_cmd
 
     # Last command should be the "done" message


### PR DESCRIPTION
## Review Note
* Checked the changes manually. No obvious issue.

## Description

This PR removes the dashboard setup command and Flask dependency from the controller initialization process. The changes include:

1. **Removed `DASHBOARD_SETUP_CMD`** from `sky/jobs/constants.py` - This constant contained the logic for setting up the SkyPilot dashboard on the controller, including systemd service management and fallback manual startup.

2. **Removed Flask dependency** from controller Python packages in `sky/utils/controller_utils.py` - Flask was previously added as a required dependency for the dashboard functionality.

3. **Updated tests** in `tests/unit_tests/test_controller_utils.py` to remove assertions checking for Flask in the controller setup commands.

4. **Removed unused import** of `skylet_constants` from `sky/jobs/constants.py` that was only used by the removed `DASHBOARD_SETUP_CMD`.

These changes simplify the controller initialization by removing dashboard-related setup logic, likely as part of a broader refactoring of how the dashboard is managed or deployed.

## Tests

- Existing unit tests updated to reflect removal of Flask dependency checks
- No new tests needed as this is a removal of functionality

https://claude.ai/code/session_011UsRWK2SDjwUMPUdLtcAh8