### PR TITLE
[Kubernetes] Fix flaky test_docker_storage_mounts by adding sudo shim for custom Docker images

### DIFF
--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -34,6 +34,7 @@ from sky.setup_files import dependencies
 from sky.skylet import constants
 from sky.skylet import log_lib
 from sky.utils import annotations
+from sky.utils import command_runner
 from sky.utils import common
 from sky.utils import common_utils
 from sky.utils import config_utils
@@ -306,7 +307,8 @@ def _get_cloud_dependencies_installation_commands(
     # Wrap in braces to isolate the || in SKY_UV_INSTALL_CMD from
     # the outer && chain, preventing operator precedence issues.
     commands.append(f'echo -en "\\r{step_prefix}uv{empty_str}" && '
-                    f'{{ {constants.SKY_UV_INSTALL_CMD} >/dev/null 2>&1; }}')
+                    f'{{ {constants.SKY_UV_INSTALL_CMD} >/dev/null 2>&1; }} && '
+                    f'{command_runner.ALIAS_SUDO_TO_EMPTY_FOR_ROOT_CMD}')
 
     enabled_compute_clouds = set(
         sky_check.get_cached_enabled_clouds_or_refresh(


### PR DESCRIPTION
## Summary

Fix flaky `test_docker_storage_mounts` on Kubernetes by reusing the existing `ALIAS_SUDO_TO_EMPTY_FOR_ROOT_CMD` sudo shim in the cloud dependency installation commands.

Custom Docker images like `nvidia/cuda:11.8.0-devel-ubuntu18.04` and `ubuntu:18.04` run as root but don't have the `sudo` binary. The Kubernetes cloud dependency step in `controller_utils.py` uses `sudo` 4 times, which fails with exit code 127 when `sudo` is not installed.

## Root Cause Analysis

### Why it's flaky (not always failing)

The `enabled_clouds` variable in `controller_utils.py:319` is a Python `set()`. Since set iteration order is non-deterministic, the cloud dependency installation steps execute in **random order** each run.

The test checks Azure Blob Storage (`az storage blob list`). Whether it passes depends on whether the `azure-cli` installation step runs **before or after** the Kubernetes step (which breaks the `&&` chain due to missing `sudo`):

| | PASS — [Build #8978](https://buildkite.com/skypilot/skypilot/builds/8978#0196a37d-6aa5-4c34-95f5-5ba7b1a1f4e3) | FAIL — [Build #8987](https://buildkite.com/skypilot/skypilot/builds/8987#0196cbc1-19b3-4a09-9bf8-20a77b0e94e9) |
|---|---|---|
| **Step order** | `(8/11) azure` → ... → `(10/11) kubernetes` | `(8/11) kubernetes` → ... → `(10/11) azure` |
| **azure-cli** | Installed before chain breaks | Never reached, not installed |
| **kubernetes step** | `sudo` fails (exit 127), breaks `&&` chain | `sudo` fails (exit 127), breaks `&&` chain |
| **Storage check** | Runs (uses `;` not `&&`), `az` works | Runs (uses `;` not `&&`), `az` not found |
| **Result** | PASS | FAIL |

The root cause of the non-deterministic ordering is `enabled_clouds` being a Python `set()`, which has random iteration order across runs.

## Fix

### Why the sudo shim fixes this

The existing `ALIAS_SUDO_TO_EMPTY_FOR_ROOT_CMD` defines a shell **function** `sudo() { "$@"; }` when running as root. This function acts as a passthrough — it just executes its arguments directly without privilege escalation (which is unnecessary since we're already root).

**Before the fix:** There was no sudo shim in the controller setup. The Kubernetes step calls `sudo` 4 times (`sudo bash -c ...`, `sudo install ...`, `sudo tee ...`, `sudo chmod ...`). On images without the `sudo` binary, these all fail with exit 127, breaking the `&&` chain and preventing all subsequent cloud steps from running.

**After the fix:** The shim is defined once (at line 311 in `controller_utils.py`) as part of the setup script, **before** any cloud-specific steps run. Since all commands in the setup script share the same shell session, the `sudo` function definition persists for all subsequent commands. Now when the Kubernetes step calls `sudo bash -c ...`, it invokes the shim function (which just runs `bash -c ...` directly), and the step succeeds. The `&&` chain no longer breaks, so all cloud steps run regardless of order.

The constant was already used in 5 other places (`mounting_utils.py`, `job_group_networking.py`, `cloud_vm_ray_backend.py`, `docker_utils.py`) for the same purpose. This PR simply adds the missing usage in `controller_utils.py`.

**Change: 1 file, 3 insertions, 1 deletion** — only `controller_utils.py` is modified.

## Test plan

- `/smoke-test --kubernetes -k test_docker_storage_mounts`
- Existing unit tests pass