### PR TITLE
[CI] Fix RTD /build-docs slug to lowercase branch names

### DIFF
--- a/.github/workflows/readthedocs-manual-pr-build.yml
+++ b/.github/workflows/readthedocs-manual-pr-build.yml
@@ -81,7 +81,7 @@ jobs:
           # See: https://docs.readthedocs.com/platform/latest/versions.html
           # So we need to match that behavior when calling the API
           # Then URL-encode the sanitized branch name for the API call
-          SANITIZED_BRANCH=$(echo -n "${BRANCH_NAME}" | sed 's/\//-/g')
+          SANITIZED_BRANCH=$(echo -n "${BRANCH_NAME}" | sed 's/\//-/g' | tr '[:upper:]' '[:lower:]')
           VERSION_SLUG=$(echo -n "${SANITIZED_BRANCH}" | jq -sRr @uri)
 
           echo "Triggering ReadTheDocs build for project: ${READTHEDOCS_PROJECT}, branch: ${BRANCH_NAME}"
@@ -195,7 +195,7 @@ jobs:
             // See: https://docs.readthedocs.com/platform/latest/versions.html
             // So we need to match that behavior for the documentation URL
             // Then URL-encode the sanitized branch name for the documentation URL
-            const sanitizedBranch = branch.replace(/\//g, '-');
+            const sanitizedBranch = branch.replace(/\//g, '-').toLowerCase();
             const encodedBranch = encodeURIComponent(sanitizedBranch);
 
             // Add label to track that a preview was built
@@ -251,7 +251,7 @@ jobs:
           # See: https://docs.readthedocs.com/platform/latest/versions.html
           # So we need to match that behavior when calling the API
           # Then URL-encode the sanitized branch name for the API call
-          SANITIZED_BRANCH=$(echo -n "${BRANCH_NAME}" | sed 's/\//-/g')
+          SANITIZED_BRANCH=$(echo -n "${BRANCH_NAME}" | sed 's/\//-/g' | tr '[:upper:]' '[:lower:]')
           VERSION_SLUG=$(echo -n "${SANITIZED_BRANCH}" | jq -sRr @uri)
 
           echo "Deactivating ReadTheDocs preview for branch: ${BRANCH_NAME}"


### PR DESCRIPTION
## Summary
- Fix ReadTheDocs version slug sanitization to lowercase the entire slug
- RTD lowercases slugs internally, but our workflow only replaced `/` with `-` without lowercasing, causing 404s for branches with uppercase characters

**Root cause**: Branch `claude/add-copy-markdown-button-zHp4b` produced slug `claude-add-copy-markdown-button-zHp4b` (preserving case), but RTD expected `claude-add-copy-markdown-button-zhp4b` (all lowercase).

**Fix**: Add `| tr '[:upper:]' '[:lower:]'` to bash sanitization (2 sites) and `.toLowerCase()` to JS sanitization (1 site).

## Test plan
- [ ] Comment `/build-docs` on a PR with uppercase characters in the branch name
- [ ] Verify the build triggers successfully and the docs URL in the comment is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)