### PR TITLE
Fix upload mem usage smoke test

### DIFF
--- a/tests/smoke_tests/metrics_utils.py
+++ b/tests/smoke_tests/metrics_utils.py
@@ -38,6 +38,54 @@ TimeSeries = List[Tuple[float, float]]
 Failures = List[str]
 
 
+def wait_for_stable_metrics(url: str,
+                            metric_name: str,
+                            stability_seconds: int = 15,
+                            poll_interval: int = 5,
+                            timeout: int = 120) -> None:
+    """Wait until the set of metric keys stabilizes.
+
+    Polls the metrics endpoint until no new process keys appear for
+    ``stability_seconds``, ensuring all server processes are reporting
+    before baseline collection begins.
+    """
+    last_keys: set = set()
+    last_change_time = time.time()
+    start_time = time.time()
+
+    while time.time() - last_change_time < stability_seconds:
+        if time.time() - start_time > timeout:
+            print(
+                f'  Warning: metrics did not stabilize within {timeout}s, '
+                f'proceeding with {len(last_keys)} keys',
+                file=sys.stderr,
+                flush=True)
+            break
+
+        try:
+            response = requests.get(url, timeout=10)
+            response.raise_for_status()
+            current_metrics = parse_metrics(metric_name, response.text)
+            current_keys = set(current_metrics.keys())
+
+            if current_keys != last_keys:
+                print(f'  Process set changed, now {len(current_keys)} keys',
+                      file=sys.stderr,
+                      flush=True)
+                last_keys = current_keys
+                last_change_time = time.time()
+        except Exception as e:  # pylint: disable=broad-except
+            print(f'  Error checking metrics stability: {e}',
+                  file=sys.stderr,
+                  flush=True)
+
+        time.sleep(poll_interval)
+
+    print(f'  Metrics stabilized with {len(last_keys)} keys',
+          file=sys.stderr,
+          flush=True)
+
+
 def collect_metrics(url: str,
                     metric_name: str,
                     duration_seconds: Optional[int] = None,

--- a/tests/smoke_tests/test_api_server.py
+++ b/tests/smoke_tests/test_api_server.py
@@ -426,6 +426,12 @@ def test_big_file_upload_memory_usage(generic_cloud: str):
         metrics_server_url = smoke_tests_utils.get_metrics_server_url()
         metrics_url = f'{metrics_server_url}/metrics'
 
+        print('Waiting for all processes to report metrics...',
+              file=sys.stderr,
+              flush=True)
+        metrics_utils.wait_for_stable_metrics(metrics_url,
+                                              'sky_apiserver_process_peak_rss')
+
         print("Collecting baseline RSS measurements...",
               file=sys.stderr,
               flush=True)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Failed test on master:

```
KEY                 BASELINE     ACTUAL   INCREASE       %
1140:worker:short   145.7 MB   146.0 MB    +0.2 MB   +0.2%
1148:worker:short   146.7 MB   146.9 MB    +0.2 MB   +0.2%
1143:server         149.7 MB   157.2 MB    +7.5 MB   +5.0%
1146:worker:short   147.2 MB   147.2 MB    +0.0 MB   +0.0%
9598:worker:long      0.0 MB   244.9 MB  +244.9 MB   +inf%
1150:worker:short   236.8 MB   259.6 MB   +22.9 MB   +9.7%
3447:server           0.0 MB   154.2 MB  +154.2 MB   +inf%
1145:server         151.5 MB   171.0 MB   +19.5 MB  +12.9%
1152:worker:short   146.5 MB   146.5 MB    +0.0 MB   +0.0%
1086:server         151.9 MB   156.2 MB    +4.2 MB   +2.8%
TOTAL              1276.0 MB  1729.7 MB  +453.7 MB  +35.6%
```

`3447:server` appeared after the baseline collection, which is not desired, since the baseline can be affected by our startup code, this PR added a conditional wait to start the profiling until the metric series are stable (all processes are started)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
