### PR TITLE
[Test] Remove overly tight timeout from recipe tests

### DIFF
--- a/tests/smoke_tests/test_recipes.py
+++ b/tests/smoke_tests/test_recipes.py
@@ -237,8 +237,6 @@ def test_recipe_duplicate_name():
         [
             _test_duplicate_recipe_name,
         ],
-        None,
-        timeout=30,
     )
     smoke_tests_utils.run_one_test(test)
 
@@ -293,8 +291,6 @@ def test_recipe_delete_authorization():
         [
             _test_recipe_delete_authorization,
         ],
-        None,
-        timeout=30,
     )
     smoke_tests_utils.run_one_test(test)
 


### PR DESCRIPTION
## Summary
- `test_recipe_duplicate_name` and `test_recipe_delete_authorization` used `timeout=30s`, the tightest of any test
- The auto-inserted `sky status -u` health check shares this timeout
- On a fresh API server, the on-boot `sky check` occupies the SHORT worker pool for 30+ seconds while verifying cloud credentials, blocking all other SHORT requests (status, managed_jobs, enabled_clouds, etc.)
- These are the only tests that fail because every other test uses the default 15-minute timeout or a cloud-specific timeout well above 30s
- Drop the explicit timeout so they use the default, consistent with other non-provisioning tests

## Test plan
- `test_recipe_duplicate_name` and `test_recipe_delete_authorization` on kubernetes should pass
- No impact on other tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)