### PR TITLE
[Test] Skip HA kill tests when consolidation mode is active

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -300,6 +300,13 @@ def pytest_configure(config):
             'markers', f'{cloud_keyword}: mark test as {cloud} specific')
 
     # Validate incompatible option combinations
+    # TODO(cooperc): --remote-server now auto-enables consolidation mode
+    # (deploy-mode Docker servers). The --jobs-consolidation flag is redundant
+    # for remote servers. To test --remote-server without consolidation, we
+    # need a --no-jobs-consolidation flag that writes consolidation_mode: false
+    # into the Docker container's ~/.sky/config.yaml before the API server
+    # starts (the entrypoint runs `sky api start --deploy`). This would also
+    # let us lift this block and allow --remote-server --jobs-consolidation.
     if config.getoption('--remote-server'):
         if config.getoption('--jobs-consolidation'):
             raise ValueError(

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -1663,6 +1663,9 @@ def test_managed_jobs_ha_kill_running(generic_cloud: str):
         pytest.skip(
             'Skipping HA test in non-docker remote api server environment as '
             'controller might be managed by different user/test agents')
+    if smoke_tests_utils.server_side_is_consolidation_mode():
+        pytest.skip('Skipping HA kill test in consolidation mode: no separate '
+                    'controller pod to kill')
 
     name = smoke_tests_utils.get_cluster_name()
     test = _get_ha_kill_test(
@@ -1682,6 +1685,9 @@ def test_managed_jobs_ha_kill_starting(generic_cloud: str):
         pytest.skip(
             'Skipping HA test in non-docker remote api server environment as '
             'controller might be managed by different user/test agents')
+    if smoke_tests_utils.server_side_is_consolidation_mode():
+        pytest.skip('Skipping HA kill test in consolidation mode: no separate '
+                    'controller pod to kill')
     name = smoke_tests_utils.get_cluster_name()
     test = _get_ha_kill_test(
         name,


### PR DESCRIPTION
## Summary
- HA kill tests (`test_managed_jobs_ha_kill_running/starting`) kill the jobs controller pod to test recovery. In consolidation mode there is no separate controller pod, so these tests fail.
- After #9090 (auto-enable consolidation for deploy-mode servers), these tests fail in two nightly configurations: `--jobs-consolidation` and `--remote-server` (Docker deploy-mode auto-enables)
- Fix: skip when `server_side_is_consolidation_mode()` returns True

## Test plan
- `--managed-jobs` (no consolidation): HA tests still run (no regression)
- `--jobs-consolidation --managed-jobs`: HA tests skip (fix)
- `--managed-jobs --remote-server`: HA tests skip (fix)
- `--managed-jobs --postgres`: HA tests still run (no regression)
- `--jobs-consolidation --managed-jobs --postgres`: HA tests skip (fix)

TODO: Add `--no-jobs-consolidation` flag to allow testing remote servers without consolidation, and lift the `--remote-server --jobs-consolidation` incompatibility block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)