### PR TITLE
[Test] Bump nebius timeout for test_managed_jobs_retry_logs

### DIFF
--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -1005,7 +1005,7 @@ def test_managed_jobs_cancellation_gcp():
 def test_managed_jobs_retry_logs(generic_cloud: str):
     """Test managed job retry logs are properly displayed when a task fails."""
     timeout = 7 * 60  # 7 mins
-    if generic_cloud == 'azure':
+    if generic_cloud in ('azure', 'nebius'):
         timeout *= 2
     name = smoke_tests_utils.get_cluster_name()
     yaml_path = 'tests/test_yamls/test_managed_jobs_retry.yaml'


### PR DESCRIPTION
## Summary
- Double the timeout for `test_managed_jobs_retry_logs` on nebius from 7 min to 14 min, matching the existing azure treatment.
- Nebius consistently times out at the 420s default (failed 6 consecutive attempts in release build #109).

## Test plan
- Verify the test passes on nebius with the increased timeout in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)