### PR TITLE
Add api_access support for regular clusters

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -5121,6 +5121,24 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         cluster_name_on_cloud = handle.cluster_name_on_cloud
         cloud = handle.launched_resources.cloud
 
+        # Clean up API access token for this cluster, if any.
+        # Done on both stop and terminate since a stopped cluster no longer
+        # needs API access; a fresh token is created on restart.
+        try:
+            token_id = global_user_state.get_cluster_api_access_token_id(
+                handle.cluster_name)
+            if token_id is not None:
+                global_user_state.delete_service_account_token(token_id)
+                global_user_state.delete_cluster_api_access_token_id(
+                    handle.cluster_name)
+                logger.info('Revoked API access token for cluster '
+                            f'{handle.cluster_name}')
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(
+                f'Failed to revoke API access token for cluster '
+                f'{handle.cluster_name}: '
+                f'{common_utils.format_exception(e, use_bracket=True)}')
+
         if terminate and handle.launched_resources.is_image_managed is True:
             # Delete the image when terminating a "cloned" cluster, i.e.,
             # whose image is created by SkyPilot (--clone-disk-from)

--- a/sky/client/common.py
+++ b/sky/client/common.py
@@ -504,3 +504,39 @@ def upload_mounts_to_api_server(
         if use_v2:
             return dag, blob_id
     return dag, None
+
+
+def maybe_inject_api_access_endpoint(dag: 'sky.Dag') -> 'sky.Dag':
+    """Inject API server endpoint for tasks with api_access enabled.
+
+    Done client-side because get_server_url() returns the externally
+    reachable endpoint here, whereas the server sees 127.0.0.1.
+    """
+    any_api_access = any(t.api_access for t in dag.tasks)
+    if not any_api_access:
+        return dag
+
+    remote_api_version = versions.get_remote_api_version()
+    if (remote_api_version is not None and
+            remote_api_version < server_constants.MIN_API_ACCESS_API_VERSION):
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError('api_access: true requires a newer API server. '
+                             'Please upgrade the server to use this feature.')
+
+    endpoint = server_common.get_server_url()
+    if server_common.is_api_server_local(endpoint):
+        # Warn instead of raising an error to allow local testing and CI
+        # environments where the server may be accessible via Docker
+        # networking or port forwarding despite appearing local.
+        logger.warning('api_access: true is set but the API server '
+                       f'appears to be local ({endpoint}). The task '
+                       'may not be able to reach the API server from '
+                       'remote VMs.')
+
+    for task_ in dag.tasks:
+        if task_.api_access:
+            task_.update_envs({
+                constants.SKY_API_SERVER_URL_ENV_VAR: endpoint,
+            })
+
+    return dag

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -794,6 +794,7 @@ def _launch(
         click.secho('Running on cluster: ', fg='cyan', nl=False)
         click.secho(cluster_name)
 
+    dag = client_common.maybe_inject_api_access_endpoint(dag)
     dag, file_mounts_blob_id = client_common.upload_mounts_to_api_server(dag)
 
     dag_str = dag_utils.dump_dag_to_yaml_str(dag)
@@ -887,6 +888,7 @@ def exec(  # pylint: disable=redefined-builtin
     """
     dag = dag_utils.convert_entrypoint_to_dag(task)
     validate(dag, workdir_only=True)
+    dag = client_common.maybe_inject_api_access_endpoint(dag)
     dag, file_mounts_blob_id = client_common.upload_mounts_to_api_server(
         dag, workdir_only=True)
     dag_str = dag_utils.dump_dag_to_yaml_str(dag)

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -4,6 +4,7 @@ See `Stage` for a Task's life cycle.
 """
 import enum
 import logging
+import os
 import time
 import typing
 from typing import Callable, List, Optional, Tuple, Union
@@ -38,6 +39,69 @@ if typing.TYPE_CHECKING:
     from sky import resources as resources_lib
 
 logger = sky_logging.init_logger(__name__)
+
+
+def _inject_cluster_api_access_token(task: 'task_lib.Task',
+                                     cluster_name: str) -> None:
+    """Create and inject an API access token for a cluster task.
+
+    Creates a service account token and injects it as a secret env var
+    into the task. Revokes any existing token for this cluster first
+    (since we cannot retrieve the plaintext from the stored hash).
+    """
+    # Lazy imports to avoid circular dependencies.
+    # pylint: disable=import-outside-toplevel
+    from pydantic import SecretStr as _SecretStr
+
+    from sky.skylet import constants as skylet_constants
+    from sky.users.token_service import token_service
+
+    # pylint: enable=import-outside-toplevel
+
+    sa_enabled = os.environ.get(
+        skylet_constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS, 'false').lower()
+    if sa_enabled != 'true':
+        with ux_utils.print_exception_no_traceback():
+            env_var = skylet_constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS
+            raise ValueError('api_access: true requires service accounts to be '
+                             f'enabled on the API server. Set {env_var}=true '
+                             'environment variable on the server.')
+
+    user_id = os.environ.get(skylet_constants.USER_ID_ENV_VAR)
+    if user_id is None:
+        with ux_utils.print_exception_no_traceback():
+            raise RuntimeError('Cannot determine user identity for '
+                               'api_access credential injection.')
+
+    # Revoke any existing token for this cluster since we cannot
+    # retrieve the plaintext from the stored hash.
+    existing_token_id = global_user_state.get_cluster_api_access_token_id(
+        cluster_name)
+    if existing_token_id is not None:
+        global_user_state.delete_service_account_token(existing_token_id)
+        global_user_state.delete_cluster_api_access_token_id(cluster_name)
+
+    token_name = f'cluster-{cluster_name}'
+    token_data = token_service.create_token(creator_user_id=user_id,
+                                            service_account_user_id=user_id,
+                                            token_name=token_name,
+                                            expires_in_days=30)
+
+    global_user_state.add_service_account_token(
+        token_id=token_data['token_id'],
+        token_name=token_name,
+        token_hash=token_data['token_hash'],
+        creator_user_hash=user_id,
+        service_account_user_id=user_id,
+        expires_at=token_data['expires_at'])
+
+    global_user_state.set_cluster_api_access_token_id(cluster_name,
+                                                      token_data['token_id'])
+
+    task._secrets[  # pylint: disable=protected-access
+        skylet_constants.SERVICE_ACCOUNT_TOKEN_ENV_VAR] = _SecretStr(
+            token_data['token'])
+    logger.info(f'Injected API access token for cluster {cluster_name}')
 
 
 class Stage(enum.Enum):
@@ -522,6 +586,9 @@ def _execute_dag(
                                      down,
                                      hook=hook,
                                      hook_timeout=hook_timeout)
+
+        if task.api_access and not dryrun:
+            _inject_cluster_api_access_token(task, handle.get_cluster_name())
 
         job_id = None
         if Stage.EXEC in stages:

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -264,6 +264,15 @@ service_account_token_table = sqlalchemy.Table(
                       sqlalchemy.Text),  # Service account's own user ID
 )
 
+# Separate table for API access token IDs associated with clusters.
+# Maps cluster_name -> token_id for cleanup when the cluster is terminated.
+cluster_api_access_token_table = sqlalchemy.Table(
+    'cluster_api_access_tokens',
+    Base.metadata,
+    sqlalchemy.Column('cluster_name', sqlalchemy.Text, primary_key=True),
+    sqlalchemy.Column('token_id', sqlalchemy.Text, nullable=False),
+)
+
 cluster_yaml_table = sqlalchemy.Table(
     'cluster_yaml',
     Base.metadata,
@@ -2661,6 +2670,39 @@ def delete_service_account_token(token_id: str) -> bool:
             token_id=token_id).delete()
         session.commit()
     return result > 0
+
+
+def set_cluster_api_access_token_id(cluster_name: str, token_id: str) -> None:
+    """Store the API access token ID for a cluster."""
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        session.execute(
+            sqlalchemy.insert(cluster_api_access_token_table).values(
+                cluster_name=cluster_name, token_id=token_id))
+        session.commit()
+
+
+def get_cluster_api_access_token_id(cluster_name: str) -> Optional[str]:
+    """Get the API access token ID for a cluster, if any."""
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        result = session.execute(
+            sqlalchemy.select(cluster_api_access_token_table.c.token_id).where(
+                cluster_api_access_token_table.c.cluster_name ==
+                cluster_name)).fetchone()
+        if result is None:
+            return None
+        return result[0]
+
+
+def delete_cluster_api_access_token_id(cluster_name: str) -> None:
+    """Remove the API access token record for a cluster."""
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        session.execute(
+            sqlalchemy.delete(cluster_api_access_token_table).where(
+                cluster_api_access_token_table.c.cluster_name == cluster_name))
+        session.commit()
 
 
 @metrics_lib.time_me

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -13,7 +13,6 @@ from sky.client import sdk
 from sky.schemas.api import responses
 from sky.serve.client import impl
 from sky.server import common as server_common
-from sky.server import constants as server_constants
 from sky.server import rest
 from sky.server import versions
 from sky.server.requests import payloads
@@ -121,34 +120,7 @@ def launch(
                               abort=True,
                               show_default=True)
 
-        # Inject the client's API server endpoint for tasks with
-        # api_access. Done client-side because get_server_url()
-        # returns the externally reachable endpoint here, whereas
-        # the server sees 127.0.0.1.
-        any_api_access = any(t.api_access for t in dag.tasks)
-        if any_api_access:
-            remote_api_version = versions.get_remote_api_version()
-            if (remote_api_version is not None and remote_api_version <
-                    server_constants.MIN_API_ACCESS_API_VERSION):
-                raise click.UsageError(
-                    'api_access: true requires a newer API server. '
-                    'Please upgrade the server to use this '
-                    'feature.')
-            endpoint = server_common.get_server_url()
-            if server_common.is_api_server_local(endpoint):
-                # Warn instead of raising an error to allow local
-                # testing and CI environments where the server may
-                # be accessible via Docker networking or port
-                # forwarding despite appearing local.
-                logger.warning('api_access: true is set but the API server '
-                               f'appears to be local ({endpoint}). The '
-                               'managed job may not be able to reach the '
-                               'API server from remote clusters.')
-            for task_ in dag.tasks:
-                if task_.api_access:
-                    task_.update_envs({
-                        constants.SKY_API_SERVER_URL_ENV_VAR: endpoint,
-                    })
+        dag = client_common.maybe_inject_api_access_endpoint(dag)
 
         dag, file_mounts_blob_id = (
             client_common.upload_mounts_to_api_server(dag))

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -13,6 +13,7 @@ from sky.client import sdk
 from sky.schemas.api import responses
 from sky.serve.client import impl
 from sky.server import common as server_common
+from sky.server import constants as server_constants
 from sky.server import rest
 from sky.server import versions
 from sky.server.requests import payloads
@@ -126,31 +127,27 @@ def launch(
         # the server sees 127.0.0.1.
         any_api_access = any(t.api_access for t in dag.tasks)
         if any_api_access:
-            from sky.server import constants as server_constants
             remote_api_version = versions.get_remote_api_version()
-            if (remote_api_version is not None and remote_api_version
-                    < server_constants.MIN_API_ACCESS_API_VERSION):
+            if (remote_api_version is not None and remote_api_version <
+                    server_constants.MIN_API_ACCESS_API_VERSION):
                 raise click.UsageError(
                     'api_access: true requires a newer API server. '
                     'Please upgrade the server to use this '
                     'feature.')
-            logger = sky_logging.init_logger(__name__)
             endpoint = server_common.get_server_url()
             if server_common.is_api_server_local(endpoint):
                 # Warn instead of raising an error to allow local
                 # testing and CI environments where the server may
                 # be accessible via Docker networking or port
                 # forwarding despite appearing local.
-                logger.warning(
-                    'api_access: true is set but the API server '
-                    f'appears to be local ({endpoint}). The '
-                    'managed job may not be able to reach the '
-                    'API server from remote clusters.')
+                logger.warning('api_access: true is set but the API server '
+                               f'appears to be local ({endpoint}). The '
+                               'managed job may not be able to reach the '
+                               'API server from remote clusters.')
             for task_ in dag.tasks:
                 if task_.api_access:
                     task_.update_envs({
-                        constants.SKY_API_SERVER_URL_ENV_VAR:
-                            endpoint,
+                        constants.SKY_API_SERVER_URL_ENV_VAR: endpoint,
                     })
 
         dag, file_mounts_blob_id = (

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -120,6 +120,39 @@ def launch(
                               abort=True,
                               show_default=True)
 
+        # Inject the client's API server endpoint for tasks with
+        # api_access. Done client-side because get_server_url()
+        # returns the externally reachable endpoint here, whereas
+        # the server sees 127.0.0.1.
+        any_api_access = any(t.api_access for t in dag.tasks)
+        if any_api_access:
+            from sky.server import constants as server_constants
+            remote_api_version = versions.get_remote_api_version()
+            if (remote_api_version is not None and remote_api_version
+                    < server_constants.MIN_API_ACCESS_API_VERSION):
+                raise click.UsageError(
+                    'api_access: true requires a newer API server. '
+                    'Please upgrade the server to use this '
+                    'feature.')
+            logger = sky_logging.init_logger(__name__)
+            endpoint = server_common.get_server_url()
+            if server_common.is_api_server_local(endpoint):
+                # Warn instead of raising an error to allow local
+                # testing and CI environments where the server may
+                # be accessible via Docker networking or port
+                # forwarding despite appearing local.
+                logger.warning(
+                    'api_access: true is set but the API server '
+                    f'appears to be local ({endpoint}). The '
+                    'managed job may not be able to reach the '
+                    'API server from remote clusters.')
+            for task_ in dag.tasks:
+                if task_.api_access:
+                    task_.update_envs({
+                        constants.SKY_API_SERVER_URL_ENV_VAR:
+                            endpoint,
+                    })
+
         dag, file_mounts_blob_id = (
             client_common.upload_mounts_to_api_server(dag))
         dag_str = dag_utils.dump_dag_to_yaml_str(dag)

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1804,6 +1804,16 @@ class ControllerManager:
             except Exception as e:  # pylint: disable=broad-except
                 error = e
 
+        # Clean up API access token if one was created for this job.
+        try:
+            token_id = managed_job_state.get_api_access_token_id(job_id)
+            if token_id is not None:
+                global_user_state.delete_service_account_token(token_id)
+                logger.info(f'Revoked API access token for job {job_id}')
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(
+                f'Failed to revoke API access token for job {job_id}: {e}')
+
         if error is not None:
             # we only raise the last error that occurred, but its fine to lose
             # some data here.

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1805,11 +1805,14 @@ class ControllerManager:
                 error = e
 
         # Clean up API access token if one was created for this job.
-        try:
+        def _cleanup_api_access_token(job_id: int):
             token_id = managed_job_state.get_api_access_token_id(job_id)
             if token_id is not None:
                 global_user_state.delete_service_account_token(token_id)
                 logger.info(f'Revoked API access token for job {job_id}')
+
+        try:
+            await asyncio.to_thread(_cleanup_api_access_token, job_id)
         except Exception as e:  # pylint: disable=broad-except
             logger.warning(
                 f'Failed to revoke API access token for job {job_id}: {e}')

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -37,7 +37,6 @@ from sky.schemas.api import responses
 from sky.serve import serve_state
 from sky.serve import serve_utils
 from sky.serve.server import impl
-from sky.server import common as server_common
 from sky.server.requests import request_names
 from sky.skylet import constants as skylet_constants
 from sky.usage import usage_lib

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -9,6 +9,7 @@ from urllib import parse as urlparse
 import uuid
 
 import colorama
+from pydantic import SecretStr as _SecretStr
 
 from sky import backends
 from sky import core
@@ -36,6 +37,7 @@ from sky.schemas.api import responses
 from sky.serve import serve_state
 from sky.serve import serve_utils
 from sky.serve.server import impl
+from sky.server import common as server_common
 from sky.server.requests import request_names
 from sky.skylet import constants as skylet_constants
 from sky.usage import usage_lib
@@ -745,54 +747,52 @@ def launch(
             task_.update_envs({'SKYPILOT_NUM_JOBS': str(num_jobs)})
 
         # Inject API server credentials for tasks with api_access enabled.
-        for task_ in dag.tasks:
-            if task_.api_access:
-                sa_enabled = os.environ.get(
-                    skylet_constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS,
-                    'false').lower()
-                if sa_enabled != 'true':
-                    with ux_utils.print_exception_no_traceback():
-                        env_var = (
-                            skylet_constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS)
-                        raise ValueError('api_access: true requires service '
-                                         'accounts to be enabled on the API '
-                                         f'server. Set {env_var}=true '
-                                         'environment variable on the server.')
+        # Create a single token for the entire DAG and reuse it across all
+        # tasks that need API access, rather than creating one per task.
+        any_api_access = any(task_.api_access for task_ in dag.tasks)
+        if any_api_access:
+            sa_enabled = os.environ.get(
+                skylet_constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS,
+                'false').lower()
+            if sa_enabled != 'true':
+                with ux_utils.print_exception_no_traceback():
+                    env_var = (skylet_constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS)
+                    raise ValueError('api_access: true requires service '
+                                     'accounts to be enabled on the API '
+                                     f'server. Set {env_var}=true '
+                                     'environment variable on the server.')
 
-                # pylint: disable=import-outside-toplevel
-                from pydantic import SecretStr as _SecretStr
+            endpoint = server_common.get_server_url()
+            if server_common.is_api_server_local(endpoint):
+                with ux_utils.print_exception_no_traceback():
+                    raise ValueError('api_access: true requires a remote API '
+                                     'server. A local API server '
+                                     f'({endpoint}) is not reachable from '
+                                     'managed jobs running on remote clusters.')
+            user_id = os.environ.get(skylet_constants.USER_ID_ENV_VAR)
+            if user_id is None:
+                with ux_utils.print_exception_no_traceback():
+                    raise RuntimeError('Cannot determine user identity for '
+                                       'api_access credential injection.')
+            token, token_id = _create_job_api_token(
+                creator_user_id=user_id,
+                job_name=dag.name,
+                dag_uuid=dag_uuid,
+            )
 
-                from sky.server import common as server_common
+            for task_ in dag.tasks:
+                if task_.api_access:
+                    task_.update_envs({
+                        skylet_constants.SKY_API_SERVER_URL_ENV_VAR: endpoint,
+                    })
+                    task_._secrets[  # pylint: disable=protected-access
+                        skylet_constants.
+                        SERVICE_ACCOUNT_TOKEN_ENV_VAR] = _SecretStr(token)
 
-                api_endpoint = server_common.get_server_url()
-                if server_common.is_api_server_local(api_endpoint):
-                    with ux_utils.print_exception_no_traceback():
-                        raise ValueError(
-                            'api_access: true requires a remote API '
-                            'server. A local API server '
-                            f'({api_endpoint}) is not reachable from '
-                            'managed jobs running on remote clusters.')
-                user_id = os.environ.get(skylet_constants.USER_ID_ENV_VAR)
-                if user_id is None:
-                    with ux_utils.print_exception_no_traceback():
-                        raise RuntimeError('Cannot determine user identity for '
-                                           'api_access credential injection.')
-                token, token_id = _create_job_api_token(
-                    creator_user_id=user_id,
-                    job_name=dag.name,
-                    dag_uuid=dag_uuid,
-                )
-                task_.update_envs({
-                    skylet_constants.SKY_API_SERVER_URL_ENV_VAR: api_endpoint,
-                })
-                task_._secrets[  # pylint: disable=protected-access
-                    skylet_constants.
-                    SERVICE_ACCOUNT_TOKEN_ENV_VAR] = _SecretStr(token)
-
-                # Store the token ID so it can be cleaned up when the
-                # job completes.
-                for job_id in job_ids:
-                    managed_job_state.set_api_access_token_id(job_id, token_id)
+            # Store the token ID so it can be cleaned up when the
+            # job completes.
+            for job_id in job_ids:
+                managed_job_state.set_api_access_token_id(job_id, token_id)
 
         dag_utils.dump_dag_to_yaml(dag, f.name)
 

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -460,6 +460,39 @@ def _submit_remotely(controller: controller_utils.Controllers,
     return job_ids
 
 
+def _create_job_api_token(creator_user_id: str, job_name: Optional[str],
+                          dag_uuid: str) -> Tuple[str, str]:
+    """Create a service account token for a managed job with api_access.
+
+    Issues a token as the original user so nested jobs have the same
+    identity and permissions as the launching user.
+
+    Returns:
+        A tuple of (token_string, token_id).
+    """
+    # Lazy imports to avoid circular dependencies and keep import time low.
+    # pylint: disable=import-outside-toplevel
+    from sky.users.token_service import token_service
+
+    token_name = f'managed-job-{job_name or "unnamed"}-{dag_uuid[:8]}'
+
+    token_data = token_service.create_token(
+        creator_user_id=creator_user_id,
+        service_account_user_id=creator_user_id,
+        token_name=token_name,
+        expires_in_days=7)
+
+    global_user_state.add_service_account_token(
+        token_id=token_data['token_id'],
+        token_name=token_name,
+        token_hash=token_data['token_hash'],
+        creator_user_hash=creator_user_id,
+        service_account_user_id=creator_user_id,
+        expires_at=token_data['expires_at'])
+
+    return token_data['token'], token_data['token_id']
+
+
 @timeline.event
 @usage_lib.entrypoint
 def launch(
@@ -710,6 +743,56 @@ def launch(
         # Set the num_jobs env variable for each task.
         for task_ in dag.tasks:
             task_.update_envs({'SKYPILOT_NUM_JOBS': str(num_jobs)})
+
+        # Inject API server credentials for tasks with api_access enabled.
+        for task_ in dag.tasks:
+            if task_.api_access:
+                sa_enabled = os.environ.get(
+                    skylet_constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS,
+                    'false').lower()
+                if sa_enabled != 'true':
+                    with ux_utils.print_exception_no_traceback():
+                        env_var = (
+                            skylet_constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS)
+                        raise ValueError('api_access: true requires service '
+                                         'accounts to be enabled on the API '
+                                         f'server. Set {env_var}=true '
+                                         'environment variable on the server.')
+
+                # pylint: disable=import-outside-toplevel
+                from pydantic import SecretStr as _SecretStr
+
+                from sky.server import common as server_common
+
+                api_endpoint = server_common.get_server_url()
+                if server_common.is_api_server_local(api_endpoint):
+                    with ux_utils.print_exception_no_traceback():
+                        raise ValueError(
+                            'api_access: true requires a remote API '
+                            'server. A local API server '
+                            f'({api_endpoint}) is not reachable from '
+                            'managed jobs running on remote clusters.')
+                user_id = os.environ.get(skylet_constants.USER_ID_ENV_VAR)
+                if user_id is None:
+                    with ux_utils.print_exception_no_traceback():
+                        raise RuntimeError('Cannot determine user identity for '
+                                           'api_access credential injection.')
+                token, token_id = _create_job_api_token(
+                    creator_user_id=user_id,
+                    job_name=dag.name,
+                    dag_uuid=dag_uuid,
+                )
+                task_.update_envs({
+                    skylet_constants.SKY_API_SERVER_URL_ENV_VAR: api_endpoint,
+                })
+                task_._secrets[  # pylint: disable=protected-access
+                    skylet_constants.
+                    SERVICE_ACCOUNT_TOKEN_ENV_VAR] = _SecretStr(token)
+
+                # Store the token ID so it can be cleaned up when the
+                # job completes.
+                for job_id in job_ids:
+                    managed_job_state.set_api_access_token_id(job_id, token_id)
 
         dag_utils.dump_dag_to_yaml(dag, f.name)
 

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -749,6 +749,9 @@ def launch(
         # Inject API server credentials for tasks with api_access enabled.
         # Create a single token for the entire DAG and reuse it across all
         # tasks that need API access, rather than creating one per task.
+        # Note: the API server endpoint env var is injected client-side
+        # (sky/jobs/client/sdk.py) where get_server_url() returns the
+        # externally reachable endpoint.
         any_api_access = any(task_.api_access for task_ in dag.tasks)
         if any_api_access:
             sa_enabled = os.environ.get(
@@ -762,13 +765,6 @@ def launch(
                                      f'server. Set {env_var}=true '
                                      'environment variable on the server.')
 
-            endpoint = server_common.get_server_url()
-            if server_common.is_api_server_local(endpoint):
-                with ux_utils.print_exception_no_traceback():
-                    raise ValueError('api_access: true requires a remote API '
-                                     'server. A local API server '
-                                     f'({endpoint}) is not reachable from '
-                                     'managed jobs running on remote clusters.')
             user_id = os.environ.get(skylet_constants.USER_ID_ENV_VAR)
             if user_id is None:
                 with ux_utils.print_exception_no_traceback():
@@ -782,9 +778,6 @@ def launch(
 
             for task_ in dag.tasks:
                 if task_.api_access:
-                    task_.update_envs({
-                        skylet_constants.SKY_API_SERVER_URL_ENV_VAR: endpoint,
-                    })
                     task_._secrets[  # pylint: disable=protected-access
                         skylet_constants.
                         SERVICE_ACCOUNT_TOKEN_ENV_VAR] = _SecretStr(token)

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -161,11 +161,15 @@ job_info_table = sqlalchemy.Table(
     sqlalchemy.Column('zone', sqlalchemy.Text, server_default=None),
     # Node names for dashboard display (comma-separated)
     sqlalchemy.Column('node_names', sqlalchemy.Text, server_default=None),
-    # Token ID for the API access token created for this job (if any).
-    # Used to clean up the token when the job completes.
-    sqlalchemy.Column('api_access_token_id',
-                      sqlalchemy.Text,
-                      server_default=None),
+)
+
+# Separate table for API access token IDs associated with managed jobs.
+# Maps job_id -> token_id for cleanup when the job completes.
+api_access_token_table = sqlalchemy.Table(
+    'api_access_tokens',
+    Base.metadata,
+    sqlalchemy.Column('job_id', sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column('token_id', sqlalchemy.Text, nullable=False),
 )
 
 # TODO(cooperc): drop the table in a migration
@@ -1880,9 +1884,8 @@ def set_api_access_token_id(job_id: int, token_id: str) -> None:
     engine = _db_manager.get_engine()
     with orm.Session(engine) as session:
         session.execute(
-            sqlalchemy.update(job_info_table).where(
-                job_info_table.c.spot_job_id == job_id).values(
-                    api_access_token_id=token_id))
+            sqlalchemy.insert(api_access_token_table).values(job_id=job_id,
+                                                             token_id=token_id))
         session.commit()
 
 
@@ -1891,8 +1894,8 @@ def get_api_access_token_id(job_id: int) -> Optional[str]:
     engine = _db_manager.get_engine()
     with orm.Session(engine) as session:
         result = session.execute(
-            sqlalchemy.select(job_info_table.c.api_access_token_id).where(
-                job_info_table.c.spot_job_id == job_id)).fetchone()
+            sqlalchemy.select(api_access_token_table.c.token_id).where(
+                api_access_token_table.c.job_id == job_id)).fetchone()
         if result is None:
             return None
         return result[0]

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -1898,7 +1898,6 @@ def get_api_access_token_id(job_id: int) -> Optional[str]:
         return result[0]
 
 
-
 async def scheduler_set_launching_async(job_id: int):
     engine = await _db_manager.get_async_engine()
     async with sql_async.AsyncSession(engine) as session:

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -161,6 +161,11 @@ job_info_table = sqlalchemy.Table(
     sqlalchemy.Column('zone', sqlalchemy.Text, server_default=None),
     # Node names for dashboard display (comma-separated)
     sqlalchemy.Column('node_names', sqlalchemy.Text, server_default=None),
+    # Token ID for the API access token created for this job (if any).
+    # Used to clean up the token when the job completes.
+    sqlalchemy.Column('api_access_token_id',
+                      sqlalchemy.Text,
+                      server_default=None),
 )
 
 # TODO(cooperc): drop the table in a migration
@@ -1868,6 +1873,30 @@ async def get_pool_submit_info_async(
         if info is None:
             return None, None
         return info[0], info[1]
+
+
+def set_api_access_token_id(job_id: int, token_id: str) -> None:
+    """Store the API access token ID for a managed job."""
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        session.execute(
+            sqlalchemy.update(job_info_table).where(
+                job_info_table.c.spot_job_id == job_id).values(
+                    api_access_token_id=token_id))
+        session.commit()
+
+
+def get_api_access_token_id(job_id: int) -> Optional[str]:
+    """Get the API access token ID for a managed job."""
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        result = session.execute(
+            sqlalchemy.select(job_info_table.c.api_access_token_id).where(
+                job_info_table.c.spot_job_id == job_id)).fetchone()
+        if result is None:
+            return None
+        return result[0]
+
 
 
 async def scheduler_set_launching_async(job_id: int):

--- a/sky/schemas/db/global_user_state/016_cluster_api_access_tokens.py
+++ b/sky/schemas/db/global_user_state/016_cluster_api_access_tokens.py
@@ -1,0 +1,36 @@
+"""Add cluster_api_access_tokens table.
+
+This migration creates a separate cluster_api_access_tokens table to store
+the token ID of the API access token created for a cluster with api_access
+enabled, so the token can be cleaned up when the cluster is terminated.
+
+Revision ID: 016
+Revises: 015
+Create Date: 2026-03-16
+
+"""
+# pylint: disable=invalid-name
+from typing import Sequence, Union
+
+from alembic import op
+
+from sky.global_user_state import Base
+from sky.utils.db import db_utils
+
+# revision identifiers, used by Alembic.
+revision: str = '016'
+down_revision: Union[str, Sequence[str], None] = '015'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    """Create cluster_api_access_tokens table."""
+    with op.get_context().autocommit_block():
+        db_utils.add_table_to_db_sqlalchemy(Base.metadata, op.get_bind(),
+                                            'cluster_api_access_tokens')
+
+
+def downgrade():
+    """Drop cluster_api_access_tokens table."""
+    op.drop_table('cluster_api_access_tokens')

--- a/sky/schemas/db/spot_jobs/016_add_api_access_token_id.py
+++ b/sky/schemas/db/spot_jobs/016_add_api_access_token_id.py
@@ -1,8 +1,8 @@
-"""Add api_access_token_id column to job_info table.
+"""Add api_access_tokens table.
 
-This migration adds api_access_token_id column to store the token ID of the
-API access token created for a managed job with api_access enabled, so the
-token can be cleaned up when the job completes.
+This migration creates a separate api_access_tokens table to store the token
+ID of the API access token created for a managed job with api_access enabled,
+so the token can be cleaned up when the job completes.
 
 Revision ID: 016
 Revises: 015
@@ -15,8 +15,6 @@ from typing import Sequence, Union
 from alembic import op
 import sqlalchemy as sa
 
-from sky.utils.db import db_utils
-
 # revision identifiers, used by Alembic.
 revision: str = '016'
 down_revision: Union[str, Sequence[str], None] = '015'
@@ -25,14 +23,14 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade():
-    """Add api_access_token_id column to job_info table."""
-    with op.get_context().autocommit_block():
-        db_utils.add_column_to_table_alembic('job_info',
-                                             'api_access_token_id',
-                                             sa.Text(),
-                                             server_default=None)
+    """Create api_access_tokens table."""
+    op.create_table(
+        'api_access_tokens',
+        sa.Column('job_id', sa.Integer, primary_key=True),
+        sa.Column('token_id', sa.Text, nullable=False),
+    )
 
 
 def downgrade():
-    """No downgrade logic."""
-    pass
+    """Drop api_access_tokens table."""
+    op.drop_table('api_access_tokens')

--- a/sky/schemas/db/spot_jobs/016_add_api_access_token_id.py
+++ b/sky/schemas/db/spot_jobs/016_add_api_access_token_id.py
@@ -1,0 +1,38 @@
+"""Add api_access_token_id column to job_info table.
+
+This migration adds api_access_token_id column to store the token ID of the
+API access token created for a managed job with api_access enabled, so the
+token can be cleaned up when the job completes.
+
+Revision ID: 016
+Revises: 015
+Create Date: 2026-02-23
+
+"""
+# pylint: disable=invalid-name
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from sky.utils.db import db_utils
+
+# revision identifiers, used by Alembic.
+revision: str = '016'
+down_revision: Union[str, Sequence[str], None] = '015'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    """Add api_access_token_id column to job_info table."""
+    with op.get_context().autocommit_block():
+        db_utils.add_column_to_table_alembic('job_info',
+                                             'api_access_token_id',
+                                             sa.Text(),
+                                             server_default=None)
+
+
+def downgrade():
+    """No downgrade logic."""
+    pass

--- a/sky/schemas/db/spot_jobs/016_add_api_access_token_id.py
+++ b/sky/schemas/db/spot_jobs/016_add_api_access_token_id.py
@@ -13,7 +13,9 @@ Create Date: 2026-02-23
 from typing import Sequence, Union
 
 from alembic import op
-import sqlalchemy as sa
+
+from sky.jobs.state import Base
+from sky.utils.db import db_utils
 
 # revision identifiers, used by Alembic.
 revision: str = '016'
@@ -24,11 +26,9 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade():
     """Create api_access_tokens table."""
-    op.create_table(
-        'api_access_tokens',
-        sa.Column('job_id', sa.Integer, primary_key=True),
-        sa.Column('token_id', sa.Text, nullable=False),
-    )
+    with op.get_context().autocommit_block():
+        db_utils.add_table_to_db_sqlalchemy(Base.metadata, op.get_bind(),
+                                            'api_access_tokens')
 
 
 def downgrade():

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -10,7 +10,7 @@ from sky.skylet import constants
 # based on version info is needed.
 # For more details and code guidelines, refer to:
 # https://docs.skypilot.co/en/latest/developers/CONTRIBUTING.html#backward-compatibility-guidelines
-API_VERSION = 41  # file mounts upload v2
+API_VERSION = 42  # api_access support for managed jobs
 
 # The minimum peer API version that the code should still work with.
 # Notes (dev):
@@ -35,6 +35,9 @@ MIN_RECIPE_LAUNCH_API_VERSION = 33
 
 # Minimum API version that supports upload API v2.
 UPLOAD_API_V2_VERSION = 41
+
+# Minimum server API version required for api_access in managed jobs.
+MIN_API_ACCESS_API_VERSION = 42
 
 # Prefix for API request names.
 REQUEST_NAME_PREFIX = 'sky.'

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -38,6 +38,7 @@ from sky import exceptions
 from sky import global_user_state
 from sky import models
 from sky import sky_logging
+from sky.adaptors import kubernetes as kubernetes_adaptor
 from sky import skypilot_config
 from sky.metrics import utils as metrics_utils
 from sky.server import common as server_common
@@ -357,6 +358,15 @@ def override_request_env_and_config(
         # Remove the db connection uri from client supplied env vars, as the
         # client should not set the db string on server side.
         request_body.env_vars.pop(constants.ENV_VAR_DB_CONNECTION_URI, None)
+        # Remove the in-cluster context name from client supplied env vars.
+        # When a client runs inside a Kubernetes pod (e.g., a managed job with
+        # api_access), its env has SKYPILOT_IN_CLUSTER_CONTEXT_NAME set by the
+        # pod template. If this leaks into the server's os.environ, it causes
+        # the server to attempt in-cluster auth (load_incluster_config) instead
+        # of using its own kubeconfig, which fails when the server is not
+        # running in a Kubernetes pod.
+        request_body.env_vars.pop(
+            kubernetes_adaptor.IN_CLUSTER_CONTEXT_NAME_ENV_VAR, None)
         os.environ.update(request_body.env_vars)
         # Note: may be overridden by AuthProxyMiddleware.
         # TODO(zhwu): we need to make the entire request a context available to

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -38,8 +38,8 @@ from sky import exceptions
 from sky import global_user_state
 from sky import models
 from sky import sky_logging
-from sky.adaptors import kubernetes as kubernetes_adaptor
 from sky import skypilot_config
+from sky.adaptors import kubernetes as kubernetes_adaptor
 from sky.metrics import utils as metrics_utils
 from sky.server import common as server_common
 from sky.server import config as server_config

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -32,6 +32,7 @@ from sky import serve
 from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import common as adaptors_common
+from sky.adaptors import kubernetes as kubernetes_adaptor
 from sky.server import common
 from sky.skylet import autostop_lib
 from sky.skylet import constants
@@ -102,6 +103,10 @@ def request_body_env_vars() -> dict:
     # Any new environment variables that are server-specific should
     # use SKYPILOT_SERVER_ENV_VAR_PREFIX.
     env_vars.pop(constants.ENV_VAR_DB_CONNECTION_URI, None)
+    # Remove the in-cluster context name - this is only meaningful for the
+    # local Kubernetes environment and should not be forwarded to the server,
+    # which has its own cluster context configuration.
+    env_vars.pop(kubernetes_adaptor.IN_CLUSTER_CONTEXT_NAME_ENV_VAR, None)
     return env_vars
 
 

--- a/sky/task.py
+++ b/sky/task.py
@@ -262,6 +262,7 @@ class Task:
         event_callback: Optional[str] = None,
         blocked_resources: Optional[Iterable['resources_lib.Resources']] = None,
         # Internal use only.
+        api_access: bool = False,
         _file_mounts_mapping: Optional[Dict[str, str]] = None,
         _volume_mounts: Optional[List[volume_lib.VolumeMount]] = None,
         _metadata: Optional[Dict[str, Any]] = None,
@@ -345,6 +346,9 @@ class Task:
           event_callback: A bash script that will be executed when the task
             changes state.
           blocked_resources: A set of resources that this task cannot run on.
+          api_access: If True, auto-inject API server credentials (endpoint
+            and service account token) into the job's environment so that the
+            job can call ``sky`` SDK / CLI to launch nested jobs.
           _file_mounts_mapping: (Internal use only) A dictionary of file mounts
             mapping.
           _volume_mounts: (Internal use only) A list of volume mounts.
@@ -362,6 +366,7 @@ class Task:
         if secrets is not None:
             self._secrets = {k: SecretStr(v) for k, v in secrets.items()}
         self._volumes = volumes or {}
+        self._api_access = api_access
 
         # concatenate commands if given as list
         def _concat(commands: Optional[Union[str, List[str]]]) -> Optional[str]:
@@ -645,6 +650,7 @@ class Task:
             secrets=config.pop('secrets', None),
             volumes=config.pop('volumes', None),
             event_callback=config.pop('event_callback', None),
+            api_access=config.pop('api_access', False),
             _file_mounts_mapping=config.pop('file_mounts_mapping', None),
             _metadata=config.pop('_metadata', None),
             _user_specified_yaml=user_specified_yaml,
@@ -964,6 +970,10 @@ class Task:
     @property
     def secrets(self) -> Dict[str, SecretStr]:
         return self._secrets
+
+    @property
+    def api_access(self) -> bool:
+        return self._api_access
 
     @property
     def volumes(self) -> Dict[str, Union[str, Dict[str, Any]]]:
@@ -1790,6 +1800,7 @@ class Task:
                 volume_mount.to_yaml_config()
                 for volume_mount in self.volume_mounts
             ]
+        add_if_not_none('api_access', self._api_access or None)
         # we manually check if its empty to not clog up the generated yaml
         add_if_not_none('_metadata', self._metadata if self._metadata else None)
         add_if_not_none('_user_specified_yaml', self._user_specified_yaml)

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -34,7 +34,7 @@ GLOBAL_USER_STATE_VERSION = '015'  # add node_names column
 GLOBAL_USER_STATE_LOCK_PATH = f'~/.sky/locks/.{GLOBAL_USER_STATE_DB_NAME}.lock'
 
 SPOT_JOBS_DB_NAME = 'spot_jobs_db'
-SPOT_JOBS_VERSION = '015'  # add node_names column
+SPOT_JOBS_VERSION = '016'  # add api_access_token_id column
 SPOT_JOBS_LOCK_PATH = f'~/.sky/locks/.{SPOT_JOBS_DB_NAME}.lock'
 
 SERVE_DB_NAME = 'serve_db'

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -30,7 +30,7 @@ DB_INIT_LOCK_TIMEOUT_SECONDS = 10
 _alembic_thread_lock = threading.Lock()
 
 GLOBAL_USER_STATE_DB_NAME = 'state_db'
-GLOBAL_USER_STATE_VERSION = '015'  # add node_names column
+GLOBAL_USER_STATE_VERSION = '016'  # add cluster_api_access_tokens table
 GLOBAL_USER_STATE_LOCK_PATH = f'~/.sky/locks/.{GLOBAL_USER_STATE_DB_NAME}.lock'
 
 SPOT_JOBS_DB_NAME = 'spot_jobs_db'

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1027,6 +1027,9 @@ def get_task_schema():
                 'type': 'array',
                 'items': get_volume_mount_schema(),
             },
+            'api_access': {
+                'type': 'boolean',
+            },
             '_metadata': {
                 'type': 'object',
             },

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -3376,3 +3376,32 @@ def test_cancel_logs_does_not_break_process_pool(generic_cloud: str):
         timeout=10 * 60,
     )
     smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.kubernetes
+@pytest.mark.remote_server
+def test_cluster_api_access(generic_cloud: str):
+    """Test cluster launch with api_access: nested job launch from a cluster.
+
+    This test only works with kubernetes and remote server enabled. It is the
+    only test configuration that gives us an API server that is accessible from
+    within the entity running the job since the kind cluster can access the
+    remote server container via the docker bridge network. If this assumption
+    changes then this test will not work.
+    """
+    if not smoke_tests_utils.is_remote_server_test():
+        pytest.skip('Requires a remote API server (--remote-server)')
+    name = smoke_tests_utils.get_cluster_name()
+    test = smoke_tests_utils.Test(
+        'cluster-api-access',
+        [
+            f'sky launch -c {name} --infra {generic_cloud} '
+            f'{smoke_tests_utils.LOW_RESOURCE_ARG} '
+            f'tests/test_yamls/test_api_access.yaml -y',
+            # Verify the job succeeded by checking exit code
+            f'sky logs {name} 1 --status',
+        ],
+        f'sky down -y {name}; sky jobs cancel -y -n nested-job',
+        timeout=30 * 60,
+    )
+    smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -2921,8 +2921,6 @@ def test_managed_jobs_api_access(generic_cloud: str):
                 job_name=name,
                 job_status=[sky.ManagedJobStatus.SUCCEEDED],
                 timeout=600),
-            f's=$(sky jobs logs -n {name} --no-follow); echo "$s"; '
-            f'echo "$s" | grep "NESTED_JOB_SUCCESS"',
         ],
         f'sky jobs cancel -y -n {name}; sky jobs cancel -y -n nested-job',
         env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -2899,6 +2899,7 @@ def test_managed_jobs_consolidation_mode_file_mount_cleanup(generic_cloud: str):
         smoke_tests_utils.run_one_test(test)
 
 
+@pytest.mark.kubernetes
 @pytest.mark.remote_server
 @pytest.mark.managed_jobs
 def test_managed_jobs_api_access(generic_cloud: str):

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -2897,3 +2897,35 @@ def test_managed_jobs_consolidation_mode_file_mount_cleanup(generic_cloud: str):
             timeout=10 * 60,
         )
         smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.remote_server
+@pytest.mark.managed_jobs
+def test_managed_jobs_api_access(generic_cloud: str):
+    """Test managed jobs with api_access: nested job launch from a job.
+
+    Requires a remote API server because the worker VM must be able to
+    reach the API server endpoint over the network.
+    """
+    if not smoke_tests_utils.is_remote_server_test():
+        pytest.skip('Requires a remote API server (--remote-server)')
+    name = smoke_tests_utils.get_cluster_name()
+    test = smoke_tests_utils.Test(
+        'managed-jobs-api-access',
+        [
+            f'sky jobs launch -n {name} --infra {generic_cloud} '
+            f'{smoke_tests_utils.LOW_RESOURCE_ARG} '
+            f'tests/test_yamls/test_api_access.yaml -y -d',
+            smoke_tests_utils.
+            get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                job_name=name,
+                job_status=[sky.ManagedJobStatus.SUCCEEDED],
+                timeout=600),
+            f's=$(sky jobs logs -n {name} --no-follow); echo "$s"; '
+            f'echo "$s" | grep "NESTED_JOB_SUCCESS"',
+        ],
+        f'sky jobs cancel -y -n {name}; sky jobs cancel -y -n nested-job',
+        env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
+        timeout=30 * 60,
+    )
+    smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -2905,8 +2905,11 @@ def test_managed_jobs_consolidation_mode_file_mount_cleanup(generic_cloud: str):
 def test_managed_jobs_api_access(generic_cloud: str):
     """Test managed jobs with api_access: nested job launch from a job.
 
-    Requires a remote API server because the worker VM must be able to
-    reach the API server endpoint over the network.
+    This test only works with kubernetes and remote server enabled. It is the
+    only test configuration that gives us an API server that is accessible from
+    within the entity running the job since the kind cluster can access the
+    remote server container via the docker bridge network. If this assumption
+    changes then this test will not work.
     """
     if not smoke_tests_utils.is_remote_server_test():
         pytest.skip('Requires a remote API server (--remote-server)')

--- a/tests/test_yamls/test_api_access.yaml
+++ b/tests/test_yamls/test_api_access.yaml
@@ -1,0 +1,34 @@
+resources:
+  cpus: 2+
+  memory: 4+
+
+api_access: true
+
+setup: |
+  pip install "skypilot-nightly[remote]" > /dev/null 2>&1
+  # Login to the API server using the injected credentials
+  sky api login -e "$SKYPILOT_API_SERVER_ENDPOINT" --token "$SKYPILOT_SERVICE_ACCOUNT_TOKEN"
+
+run: |
+  # Verify API access env vars are set
+  echo "API endpoint: $SKYPILOT_API_SERVER_ENDPOINT"
+  test -n "$SKYPILOT_API_SERVER_ENDPOINT" || (echo "FAIL: no endpoint" && exit 1)
+  test -n "$SKYPILOT_SERVICE_ACCOUNT_TOKEN" || (echo "FAIL: no token" && exit 1)
+
+  # Verify we can authenticate to the API server
+  sky api info
+
+  # Launch a nested job and wait for it
+  sky jobs launch --cpus 2+ --memory 4+ -n nested-job -y -d "echo nested-job-success"
+
+  # Wait for nested job to complete
+  for i in $(seq 1 60); do
+    status=$(sky jobs queue | grep nested-job | awk '{print $NF}')
+    if [ "$status" = "SUCCEEDED" ]; then
+      echo "NESTED_JOB_SUCCESS"
+      exit 0
+    fi
+    sleep 10
+  done
+  echo "FAIL: nested job did not succeed"
+  exit 1

--- a/tests/test_yamls/test_api_access.yaml
+++ b/tests/test_yamls/test_api_access.yaml
@@ -6,8 +6,6 @@ api_access: true
 
 setup: |
   pip install "skypilot-nightly[remote]" > /dev/null 2>&1
-  # Login to the API server using the injected credentials
-  sky api login -e "$SKYPILOT_API_SERVER_ENDPOINT" --token "$SKYPILOT_SERVICE_ACCOUNT_TOKEN"
 
 run: |
   # Verify API access env vars are set
@@ -23,7 +21,9 @@ run: |
 
   # Wait for nested job to complete
   for i in $(seq 1 60); do
-    status=$(sky jobs queue | grep nested-job | awk '{print $NF}')
+    # Strip ANSI codes and debug lines before parsing status
+    status=$(sky jobs queue 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' | grep nested-job | grep -oE 'SUCCEEDED|FAILED[A-Z_]*|RUNNING|STARTING|CANCELLED' | head -1)
+    echo "Poll $i: status=$status"
     if [ "$status" = "SUCCEEDED" ]; then
       echo "NESTED_JOB_SUCCESS"
       exit 0

--- a/tests/unit_tests/test_sky/test_task.py
+++ b/tests/unit_tests/test_sky/test_task.py
@@ -1236,6 +1236,29 @@ secrets:
         assert value.get_secret_value() == expected_secrets[key]
 
 
+def test_api_access_from_yaml_config():
+    """Test that api_access is parsed from YAML and serialized correctly."""
+    # Test default (False)
+    config = {'run': 'echo hello'}
+    task_obj = task.Task.from_yaml_config(config)
+    assert task_obj.api_access is False
+
+    # Test explicit True
+    config_with_access = {'run': 'echo hello', 'api_access': True}
+    task_obj = task.Task.from_yaml_config(config_with_access)
+    assert task_obj.api_access is True
+
+    # Test serialization round-trip
+    yaml_config = task_obj.to_yaml_config()
+    assert yaml_config.get('api_access') is True
+
+    # Test that False is not serialized (to keep YAML clean)
+    config_no_access = {'run': 'echo hello', 'api_access': False}
+    task_obj = task.Task.from_yaml_config(config_no_access)
+    yaml_config = task_obj.to_yaml_config()
+    assert 'api_access' not in yaml_config
+
+
 def test_secrets_not_plaintext_from_yaml():
     """Test that from_yaml stores secrets as SecretStr objects, not plain strings."""
     yaml_content = """

--- a/tests/unit_tests/test_sky/users/test_token_service.py
+++ b/tests/unit_tests/test_sky/users/test_token_service.py
@@ -223,6 +223,37 @@ class TestTokenService:
         assert isinstance(token_service.token_service,
                           token_service.TokenService)
 
+    def test_token_preserves_user_identity_for_nested_jobs(self):
+        """Test that a token created for a managed job preserves user identity.
+
+        When api_access: true is set, _create_job_api_token creates a token
+        where both creator_user_id and service_account_user_id are the same
+        user. This ensures nested jobs launched via the token authenticate as
+        the original user.
+        """
+        with mock.patch('sky.users.token_service.global_user_state'
+                       ) as mock_global_state:
+            mock_global_state.get_system_config.return_value = 'test_secret_key'
+
+            service = token_service.TokenService()
+
+            # Mirror _create_job_api_token: both IDs are the same user
+            user_hash = 'user_abc123'
+            token_data = service.create_token(
+                creator_user_id=user_hash,
+                service_account_user_id=user_hash,
+                token_name='managed-job-test-12345678',
+                expires_in_days=7)
+
+            # Verify the token carries the original user's identity
+            payload = service.verify_token(token_data['token'])
+            assert payload is not None
+            assert payload['sub'] == user_hash, (
+                'Token subject should be the original user so nested jobs '
+                'authenticate with the same identity')
+            assert payload['token_id'] == token_data['token_id']
+            assert payload['type'] == 'service_account'
+
     def test_jwt_payload_format(self):
         """Test that JWT payload uses correct format."""
         with mock.patch('sky.users.token_service.global_user_state'


### PR DESCRIPTION
## Summary
- Extend `api_access: true` to `sky launch` / `sky exec` clusters (not just managed jobs)
- Refactor endpoint injection into shared `client_common.maybe_inject_api_access_endpoint()` used by both cluster and managed job code paths
- Add DB table + migration for tracking per-cluster API access tokens
- Token cleanup on `sky down` / `sky stop` / autodown / autostop

## Test plan
- [ ] `bash format.sh` passes
- [ ] `sky launch --cloud k8s -c test-api-access tests/test_yamls/test_api_access.yaml` — verifies nested job launch from cluster
- [ ] Smoke test: `test_cluster_api_access` in `tests/smoke_tests/test_cluster_job.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)