### PR TITLE
[Serve] Adds new user configurable options

### DIFF
--- a/agent/skills/skypilot/references/yaml-spec.md
+++ b/agent/skills/skypilot/references/yaml-spec.md
@@ -1279,6 +1279,11 @@ service:
     post_data: {'model_name': 'model'}
     initial_delay_seconds: 1200
     timeout_seconds: 15
+    endpoint_probe_interval_seconds: 10
+    consecutive_failure_threshold_timeout: 180
+
+  load_balancer:
+    stream_timeout_seconds: 120
 
   readiness_probe: /v1/models
 
@@ -1323,6 +1328,11 @@ service:
     post_data: '{"model_name": "my_model"}'
     initial_delay_seconds: 600
     timeout_seconds: 10
+    endpoint_probe_interval_seconds: 10
+    consecutive_failure_threshold_timeout: 180
+
+  load_balancer:
+    stream_timeout_seconds: 120
 
 ```
 
@@ -1387,6 +1397,66 @@ Note, having a too high timeout will delay the detection of a real failure of yo
   service:
     readiness_probe:
       timeout_seconds: 10
+
+```
+
+
+### ``service.readiness_probe.endpoint_probe_interval_seconds``
+
+Time between readiness probe attempts (default: 10).
+
+SkyServe probes each replica endpoint at this interval to update readiness and
+detect unhealthy replicas.
+
+```yaml
+  service:
+    readiness_probe:
+      endpoint_probe_interval_seconds: 5
+
+```
+
+
+### ``service.readiness_probe.consecutive_failure_threshold_timeout``
+
+Maximum consecutive probe failure window before tearing down a ready replica.
+
+If omitted, SkyServe keeps the existing defaults: `10` seconds for pools and
+`180` seconds for regular services.
+
+```yaml
+  service:
+    readiness_probe:
+      consecutive_failure_threshold_timeout: 30
+
+```
+
+
+### ``service.load_balancer``
+
+Load balancer configuration (optional).
+
+Controls request proxy behavior for the SkyServe load balancer.
+
+```yaml
+  service:
+    load_balancer:
+      stream_timeout_seconds: 300
+
+```
+
+
+### ``service.load_balancer.stream_timeout_seconds``
+
+Maximum time the load balancer waits for a proxied response stream (default:
+120).
+
+This controls the timeout for requests forwarded by the SkyServe load balancer
+to a ready replica.
+
+```yaml
+  service:
+    load_balancer:
+      stream_timeout_seconds: 300
 
 ```
 

--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -1348,6 +1348,11 @@ Syntax
       :ref:`post_data <yaml-spec-service-readiness-probe-post-data>`: {'model_name': 'model'}
       :ref:`initial_delay_seconds <yaml-spec-service-readiness-probe-initial-delay-seconds>`: 1200
       :ref:`timeout_seconds <yaml-spec-service-readiness-probe-timeout-seconds>`: 15
+      :ref:`endpoint_probe_interval_seconds <yaml-spec-service-readiness-probe-endpoint-probe-interval-seconds>`: 10
+      :ref:`consecutive_failure_threshold_timeout <yaml-spec-service-readiness-probe-consecutive-failure-threshold-timeout>`: 180
+
+    :ref:`load_balancer <yaml-spec-service-load-balancer>`:
+      :ref:`stream_timeout_seconds <yaml-spec-service-load-balancer-stream-timeout-seconds>`: 120
 
     :ref:`readiness_probe <yaml-spec-service-readiness-probe>`: /v1/models
 
@@ -1395,6 +1400,11 @@ OR
       post_data: '{"model_name": "my_model"}'
       initial_delay_seconds: 600
       timeout_seconds: 10
+      endpoint_probe_interval_seconds: 10
+      consecutive_failure_threshold_timeout: 180
+
+    load_balancer:
+      stream_timeout_seconds: 120
 
 
 .. _yaml-spec-service-readiness-probe-path:
@@ -1467,6 +1477,74 @@ Note, having a too high timeout will delay the detection of a real failure of yo
     service:
       readiness_probe:
         timeout_seconds: 10
+
+
+.. _yaml-spec-service-readiness-probe-endpoint-probe-interval-seconds:
+
+``service.readiness_probe.endpoint_probe_interval_seconds``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Time between readiness probe attempts (default: 10).
+
+SkyServe probes each replica endpoint at this interval to update readiness and
+detect unhealthy replicas.
+
+.. code-block:: yaml
+
+    service:
+      readiness_probe:
+        endpoint_probe_interval_seconds: 5
+
+
+.. _yaml-spec-service-readiness-probe-consecutive-failure-threshold-timeout:
+
+``service.readiness_probe.consecutive_failure_threshold_timeout``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Maximum consecutive probe failure window before tearing down a ready replica.
+
+If omitted, SkyServe keeps the existing defaults: ``10`` seconds for pools and
+``180`` seconds for regular services.
+
+.. code-block:: yaml
+
+    service:
+      readiness_probe:
+        consecutive_failure_threshold_timeout: 30
+
+
+.. _yaml-spec-service-load-balancer:
+
+``service.load_balancer``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Load balancer configuration (optional).
+
+Controls request proxy behavior for the SkyServe load balancer.
+
+.. code-block:: yaml
+
+    service:
+      load_balancer:
+        stream_timeout_seconds: 300
+
+
+.. _yaml-spec-service-load-balancer-stream-timeout-seconds:
+
+``service.load_balancer.stream_timeout_seconds``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Maximum time the load balancer waits for a proxied response stream (default:
+120).
+
+This controls the timeout for requests forwarded by the SkyServe load balancer
+to a ready replica.
+
+.. code-block:: yaml
+
+    service:
+      load_balancer:
+        stream_timeout_seconds: 300
 
 
 .. _yaml-spec-service-replica-policy:

--- a/sky/serve/__init__.py
+++ b/sky/serve/__init__.py
@@ -8,7 +8,6 @@ from sky.serve.client.sdk import tail_logs
 from sky.serve.client.sdk import terminate_replica
 from sky.serve.client.sdk import up
 from sky.serve.client.sdk import update
-from sky.serve.constants import ENDPOINT_PROBE_INTERVAL_SECONDS
 from sky.serve.constants import INITIAL_VERSION
 from sky.serve.constants import LB_CONTROLLER_SYNC_INTERVAL_SECONDS
 from sky.serve.constants import SKYSERVE_METADATA_DIR
@@ -29,7 +28,6 @@ os.makedirs(os.path.expanduser(SKYSERVE_METADATA_DIR), exist_ok=True)
 
 __all__ = [
     'down',
-    'ENDPOINT_PROBE_INTERVAL_SECONDS',
     'format_service_table',
     'generate_replica_cluster_name',
     'generate_service_name',

--- a/sky/serve/constants.py
+++ b/sky/serve/constants.py
@@ -46,8 +46,7 @@ LB_MAX_RETRY = 3
 # Large LLMs like Llama2-70b is able to process the request within ~30 seconds.
 # We set the timeout to 120s to be safe. For reference, FastChat uses 100s:
 # https://github.com/lm-sys/FastChat/blob/f2e6ca964af7ad0585cadcf16ab98e57297e2133/fastchat/constants.py#L39 # pylint: disable=line-too-long
-# TODO(tian): Expose this option to users in yaml file.
-LB_STREAM_TIMEOUT = 120
+DEFAULT_LB_STREAM_TIMEOUT = 120
 
 # Default interval in seconds to probe replica endpoint.
 DEFAULT_ENDPOINT_PROBE_INTERVAL_SECONDS = 10

--- a/sky/serve/constants.py
+++ b/sky/serve/constants.py
@@ -49,8 +49,10 @@ LB_MAX_RETRY = 3
 # TODO(tian): Expose this option to users in yaml file.
 LB_STREAM_TIMEOUT = 120
 
-# Interval in seconds to probe replica endpoint.
-ENDPOINT_PROBE_INTERVAL_SECONDS = 10
+# Default interval in seconds to probe replica endpoint.
+DEFAULT_ENDPOINT_PROBE_INTERVAL_SECONDS = 10
+# Backward compatibility alias.
+ENDPOINT_PROBE_INTERVAL_SECONDS = DEFAULT_ENDPOINT_PROBE_INTERVAL_SECONDS
 
 # The default timeout in seconds for a readiness probe request. We set the
 # timeout to 15s since using actual generation in LLM services as readiness

--- a/sky/serve/load_balancer.py
+++ b/sky/serve/load_balancer.py
@@ -36,7 +36,7 @@ class SkyServeLoadBalancer:
         load_balancing_policy_name: Optional[str] = None,
         tls_credential: Optional[serve_utils.TLSCredential] = None,
         target_qps_per_replica: Optional[Union[float, Dict[str, float]]] = None,
-        stream_timeout_seconds: int = constants.LB_STREAM_TIMEOUT,
+        stream_timeout_seconds: int = constants.DEFAULT_LB_STREAM_TIMEOUT,
     ) -> None:
         """Initialize the load balancer.
 
@@ -295,9 +295,9 @@ def run_load_balancer(
     load_balancing_policy_name: Optional[str] = None,
     tls_credential: Optional[serve_utils.TLSCredential] = None,
     target_qps_per_replica: Optional[Union[float, Dict[str, float]]] = None,
-    stream_timeout_seconds: int = constants.LB_STREAM_TIMEOUT,
+    stream_timeout_seconds: int = constants.DEFAULT_LB_STREAM_TIMEOUT,
 ) -> None:
-    """ Run the load balancer.
+    """Run the load balancer.
 
     Args:
         controller_addr: The address of the controller.

--- a/sky/serve/load_balancer.py
+++ b/sky/serve/load_balancer.py
@@ -35,7 +35,8 @@ class SkyServeLoadBalancer:
         load_balancer_port: int,
         load_balancing_policy_name: Optional[str] = None,
         tls_credential: Optional[serve_utils.TLSCredential] = None,
-        target_qps_per_replica: Optional[Union[float, Dict[str, float]]] = None
+        target_qps_per_replica: Optional[Union[float, Dict[str, float]]] = None,
+        stream_timeout_seconds: int = constants.LB_STREAM_TIMEOUT,
     ) -> None:
         """Initialize the load balancer.
 
@@ -49,6 +50,7 @@ class SkyServeLoadBalancer:
             target_qps_per_replica: Target QPS per replica for instance-aware
                 load balancing. Can be a float or dict mapping GPU types to QPS.
                 Defaults to None.
+            stream_timeout_seconds: Timeout in seconds for proxied responses.
         """
         self._app = fastapi.FastAPI()
         self._controller_url: str = controller_url
@@ -71,6 +73,7 @@ class SkyServeLoadBalancer:
             serve_utils.RequestTimestamp())
         self._tls_credential: Optional[serve_utils.TLSCredential] = (
             tls_credential)
+        self._stream_timeout_seconds: int = stream_timeout_seconds
         # TODO(tian): httpx.Client has a resource limit of 100 max connections
         # for each client. We should wait for feedback on the best max
         # connections.
@@ -187,7 +190,7 @@ class SkyServeLoadBalancer:
                 worker_url,
                 headers=request.headers.raw,
                 content=await request.body(),
-                timeout=constants.LB_STREAM_TIMEOUT)
+                timeout=self._stream_timeout_seconds)
             proxy_response = await client.send(proxy_request, stream=True)
 
             async def background_func():
@@ -291,7 +294,8 @@ def run_load_balancer(
     load_balancer_port: int,
     load_balancing_policy_name: Optional[str] = None,
     tls_credential: Optional[serve_utils.TLSCredential] = None,
-    target_qps_per_replica: Optional[Union[float, Dict[str, float]]] = None
+    target_qps_per_replica: Optional[Union[float, Dict[str, float]]] = None,
+    stream_timeout_seconds: int = constants.LB_STREAM_TIMEOUT,
 ) -> None:
     """ Run the load balancer.
 
@@ -305,13 +309,15 @@ def run_load_balancer(
         target_qps_per_replica: Target QPS per replica for instance-aware
             load balancing. Can be a float or dict mapping GPU types to QPS.
             Defaults to None.
+        stream_timeout_seconds: Timeout in seconds for proxied responses.
     """
     load_balancer = SkyServeLoadBalancer(
         controller_url=controller_addr,
         load_balancer_port=load_balancer_port,
         load_balancing_policy_name=load_balancing_policy_name,
         tls_credential=tls_credential,
-        target_qps_per_replica=target_qps_per_replica)
+        target_qps_per_replica=target_qps_per_replica,
+        stream_timeout_seconds=stream_timeout_seconds)
     load_balancer.run()
 
 

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -702,14 +702,6 @@ class ReplicaManager:
         # Oldest version among the currently provisioned and launched replicas
         self.least_recent_version: int = version
 
-    def _consecutive_failure_threshold_timeout(self) -> int:
-        """The timeout for the consecutive failure threshold in seconds.
-
-        We reduce the timeout for pool to 10 seconds to make the pool more
-        responsive to the failure.
-        """
-        return 10 if self._is_pool else 180
-
     def scale_up(self,
                  resources_override: Optional[Dict[str, Any]] = None) -> None:
         """Scale up the service by 1 replica with resources_override.

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -692,6 +692,8 @@ class ReplicaManager:
             header_keys = list(spec.readiness_headers.keys())
         logger.info(f'Readiness probe path: {spec.readiness_path}\n'
                     f'Initial delay seconds: {spec.initial_delay_seconds}\n'
+                    'Endpoint probe interval seconds: '
+                    f'{spec.endpoint_probe_interval_seconds}\n'
                     f'Post data: {spec.post_data}\n'
                     f'Readiness header keys: {header_keys}')
 
@@ -706,7 +708,6 @@ class ReplicaManager:
         We reduce the timeout for pool to 10 seconds to make the pool more
         responsive to the failure.
         """
-        # TODO(tian): Maybe let user determine this threshold
         return 10 if self._is_pool else 180
 
     def scale_up(self,
@@ -1453,7 +1454,7 @@ class SkyPilotReplicaManager(ReplicaManager):
                 with ux_utils.enable_traceback():
                     logger.error(f'  Traceback: {traceback.format_exc()}')
             # TODO(MaoZiming): Probe cloud for early preemption warning.
-            time.sleep(serve_constants.ENDPOINT_PROBE_INTERVAL_SECONDS)
+            time.sleep(self._get_endpoint_probe_interval_seconds())
 
     def get_active_replica_urls(self) -> List[str]:
         """Get the urls of all active replicas."""
@@ -1562,3 +1563,20 @@ class SkyPilotReplicaManager(ReplicaManager):
 
     def _get_readiness_timeout_seconds(self, version: int) -> int:
         return self._get_version_spec(version).readiness_timeout_seconds
+
+    def _get_endpoint_probe_interval_seconds(self) -> int:
+        return self._get_version_spec(
+            self.latest_version).endpoint_probe_interval_seconds
+
+    def _consecutive_failure_threshold_timeout(self) -> int:
+        """The timeout for the consecutive failure threshold in seconds.
+
+        If not set by the user, we utilize 180 seconds as the default.
+        If it is a pool, we reduce the timeout to 10 seconds to make the
+        pool more responsive to the failure.
+        """
+        spec_timeout = self._get_version_spec(
+            self.latest_version).consecutive_failure_threshold_timeout
+        if spec_timeout is not None:
+            return spec_timeout
+        return 10 if self._is_pool else 180

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -509,7 +509,8 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
                     args=(controller_addr, load_balancer_port,
                           service_spec.load_balancing_policy,
                           service_spec.tls_credential,
-                          service_spec.target_qps_per_replica))
+                          service_spec.target_qps_per_replica,
+                          service_spec.lb_stream_timeout_seconds))
                 load_balancer_process.start()
 
             if not is_recovery:

--- a/sky/serve/service_spec.py
+++ b/sky/serve/service_spec.py
@@ -216,9 +216,8 @@ class SkyServiceSpec:
             lb_stream_timeout_seconds = load_balancer_section.get(
                 'stream_timeout_seconds', None)
         if lb_stream_timeout_seconds is None:
-            lb_stream_timeout_seconds = constants.LB_STREAM_TIMEOUT
-        service_config['lb_stream_timeout_seconds'] = (
-            lb_stream_timeout_seconds)
+            lb_stream_timeout_seconds = constants.DEFAULT_LB_STREAM_TIMEOUT
+        service_config['lb_stream_timeout_seconds'] = lb_stream_timeout_seconds
         if isinstance(post_data, str):
             try:
                 post_data = json.loads(post_data)

--- a/sky/serve/service_spec.py
+++ b/sky/serve/service_spec.py
@@ -26,6 +26,8 @@ class SkyServiceSpec:
         readiness_path: str,
         initial_delay_seconds: int,
         readiness_timeout_seconds: int,
+        endpoint_probe_interval_seconds: int,
+        lb_stream_timeout_seconds: int,
         min_replicas: int,
         max_replicas: Optional[int] = None,
         num_overprovision: Optional[int] = None,
@@ -42,6 +44,7 @@ class SkyServiceSpec:
         load_balancing_policy: Optional[str] = None,
         pool: Optional[bool] = None,
         queue_length_threshold: Optional[int] = None,
+        consecutive_failure_threshold_timeout: Optional[int] = None,
     ) -> None:
         if pool:
             # For pools, max_replicas should never be specified directly by the
@@ -128,6 +131,9 @@ class SkyServiceSpec:
         self._readiness_path: str = readiness_path
         self._initial_delay_seconds: int = initial_delay_seconds
         self._readiness_timeout_seconds: int = readiness_timeout_seconds
+        self._endpoint_probe_interval_seconds: int = (
+            endpoint_probe_interval_seconds)
+        self._lb_stream_timeout_seconds: int = lb_stream_timeout_seconds
         self._min_replicas: int = min_replicas
         self._max_replicas: Optional[int] = max_replicas
         self._num_overprovision: Optional[int] = num_overprovision
@@ -148,6 +154,8 @@ class SkyServiceSpec:
         self._load_balancing_policy: Optional[str] = load_balancing_policy
         self._pool: Optional[bool] = pool
         self._queue_length_threshold: Optional[int] = queue_length_threshold
+        self._consecutive_failure_threshold_timeout: Optional[int] = (
+            consecutive_failure_threshold_timeout)
 
         self._use_ondemand_fallback: bool = (
             self.dynamic_ondemand_fallback is not None and
@@ -173,6 +181,8 @@ class SkyServiceSpec:
             initial_delay_seconds = None
             post_data = None
             readiness_timeout_seconds = None
+            endpoint_probe_interval_seconds = None
+            consecutive_failure_threshold_timeout = None
             readiness_headers = None
         else:
             service_config['readiness_path'] = readiness_section['path']
@@ -181,6 +191,10 @@ class SkyServiceSpec:
             post_data = readiness_section.get('post_data', None)
             readiness_timeout_seconds = readiness_section.get(
                 'timeout_seconds', None)
+            endpoint_probe_interval_seconds = readiness_section.get(
+                'endpoint_probe_interval_seconds', None)
+            consecutive_failure_threshold_timeout = readiness_section.get(
+                'consecutive_failure_threshold_timeout', None)
             readiness_headers = readiness_section.get('headers', None)
         if initial_delay_seconds is None:
             initial_delay_seconds = constants.DEFAULT_INITIAL_DELAY_SECONDS
@@ -189,6 +203,22 @@ class SkyServiceSpec:
             readiness_timeout_seconds = (
                 constants.DEFAULT_READINESS_PROBE_TIMEOUT_SECONDS)
         service_config['readiness_timeout_seconds'] = readiness_timeout_seconds
+        if endpoint_probe_interval_seconds is None:
+            endpoint_probe_interval_seconds = (
+                constants.DEFAULT_ENDPOINT_PROBE_INTERVAL_SECONDS)
+        service_config['endpoint_probe_interval_seconds'] = (
+            endpoint_probe_interval_seconds)
+        service_config['consecutive_failure_threshold_timeout'] = (
+            consecutive_failure_threshold_timeout)
+        load_balancer_section = config.get('load_balancer', None)
+        lb_stream_timeout_seconds = None
+        if load_balancer_section is not None:
+            lb_stream_timeout_seconds = load_balancer_section.get(
+                'stream_timeout_seconds', None)
+        if lb_stream_timeout_seconds is None:
+            lb_stream_timeout_seconds = constants.LB_STREAM_TIMEOUT
+        service_config['lb_stream_timeout_seconds'] = (
+            lb_stream_timeout_seconds)
         if isinstance(post_data, str):
             try:
                 post_data = json.loads(post_data)
@@ -422,6 +452,13 @@ class SkyServiceSpec:
         add_if_not_none('readiness_probe', 'post_data', self.post_data)
         add_if_not_none('readiness_probe', 'timeout_seconds',
                         self.readiness_timeout_seconds)
+        add_if_not_none('readiness_probe', 'endpoint_probe_interval_seconds',
+                        self.endpoint_probe_interval_seconds)
+        add_if_not_none('readiness_probe',
+                        'consecutive_failure_threshold_timeout',
+                        self.consecutive_failure_threshold_timeout)
+        add_if_not_none('load_balancer', 'stream_timeout_seconds',
+                        self.lb_stream_timeout_seconds)
         add_if_not_none('readiness_probe', 'headers', self._readiness_headers)
         add_if_not_none('replica_policy', 'min_replicas', self.min_replicas)
         add_if_not_none('replica_policy', 'max_replicas', self.max_replicas)
@@ -547,6 +584,14 @@ class SkyServiceSpec:
         return self._readiness_timeout_seconds
 
     @property
+    def endpoint_probe_interval_seconds(self) -> int:
+        return self._endpoint_probe_interval_seconds
+
+    @property
+    def lb_stream_timeout_seconds(self) -> int:
+        return self._lb_stream_timeout_seconds
+
+    @property
     def min_replicas(self) -> int:
         return self._min_replicas
 
@@ -625,6 +670,10 @@ class SkyServiceSpec:
     def queue_length_threshold(self) -> Optional[int]:
         return self._queue_length_threshold
 
+    @property
+    def consecutive_failure_threshold_timeout(self) -> Optional[int]:
+        return self._consecutive_failure_threshold_timeout
+
     def copy(self, **override) -> 'SkyServiceSpec':
         return SkyServiceSpec(
             readiness_path=override.pop('readiness_path', self._readiness_path),
@@ -632,6 +681,11 @@ class SkyServiceSpec:
                                                self._initial_delay_seconds),
             readiness_timeout_seconds=override.pop(
                 'readiness_timeout_seconds', self._readiness_timeout_seconds),
+            endpoint_probe_interval_seconds=override.pop(
+                'endpoint_probe_interval_seconds',
+                self._endpoint_probe_interval_seconds),
+            lb_stream_timeout_seconds=override.pop(
+                'lb_stream_timeout_seconds', self._lb_stream_timeout_seconds),
             min_replicas=override.pop('min_replicas', self._min_replicas),
             max_replicas=override.pop('max_replicas', self._max_replicas),
             num_overprovision=override.pop('num_overprovision',
@@ -658,4 +712,7 @@ class SkyServiceSpec:
             pool=override.pop('pool', self._pool),
             queue_length_threshold=override.pop('queue_length_threshold',
                                                 self._queue_length_threshold),
+            consecutive_failure_threshold_timeout=override.pop(
+                'consecutive_failure_threshold_timeout',
+                self._consecutive_failure_threshold_timeout),
         )

--- a/sky/serve/service_spec.py
+++ b/sky/serve/service_spec.py
@@ -462,13 +462,20 @@ class SkyServiceSpec:
         add_if_not_none('readiness_probe', 'post_data', self.post_data)
         add_if_not_none('readiness_probe', 'timeout_seconds',
                         self.readiness_timeout_seconds)
-        add_if_not_none('readiness_probe', 'endpoint_probe_interval_seconds',
-                        self.endpoint_probe_interval_seconds)
+        # Omit default-valued newer fields to preserve compatibility with
+        # older controllers that do not recognize them during serve update.
+        if (self.endpoint_probe_interval_seconds !=
+                constants.DEFAULT_ENDPOINT_PROBE_INTERVAL_SECONDS):
+            add_if_not_none('readiness_probe',
+                            'endpoint_probe_interval_seconds',
+                            self.endpoint_probe_interval_seconds)
         add_if_not_none('readiness_probe',
                         'consecutive_failure_threshold_timeout',
                         self.consecutive_failure_threshold_timeout)
-        add_if_not_none('load_balancer', 'stream_timeout_seconds',
-                        self.lb_stream_timeout_seconds)
+        if (self.lb_stream_timeout_seconds !=
+                constants.DEFAULT_LB_STREAM_TIMEOUT):
+            add_if_not_none('load_balancer', 'stream_timeout_seconds',
+                            self.lb_stream_timeout_seconds)
         add_if_not_none('readiness_probe', 'headers', self._readiness_headers)
         add_if_not_none('replica_policy', 'min_replicas', self.min_replicas)
         add_if_not_none('replica_policy', 'max_replicas', self.max_replicas)

--- a/sky/serve/service_spec.py
+++ b/sky/serve/service_spec.py
@@ -163,6 +163,17 @@ class SkyServiceSpec:
                 self.base_ondemand_fallback_replicas is not None and
                 self.base_ondemand_fallback_replicas > 0)
 
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        """Set state from pickled state, for backward compatibility."""
+        # These fields were added after earlier releases had already persisted
+        # SkyServiceSpec objects in the serve DB.
+        state.setdefault('_endpoint_probe_interval_seconds',
+                         constants.DEFAULT_ENDPOINT_PROBE_INTERVAL_SECONDS)
+        state.setdefault('_lb_stream_timeout_seconds',
+                         constants.DEFAULT_LB_STREAM_TIMEOUT)
+        state.setdefault('_consecutive_failure_threshold_timeout', None)
+        self.__dict__.update(state)
+
     @staticmethod
     def from_yaml_config(config: Dict[str, Any]) -> 'SkyServiceSpec':
         common_utils.validate_schema(config, schemas.get_service_schema(),

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -862,6 +862,12 @@ def get_service_schema():
                         'timeout_seconds': {
                             'type': 'number',
                         },
+                        'endpoint_probe_interval_seconds': {
+                            'type': 'number',
+                        },
+                        'consecutive_failure_threshold_timeout': {
+                            'type': 'number',
+                        },
                         'post_data': {
                             'anyOf': [{
                                 'type': 'string',
@@ -877,6 +883,16 @@ def get_service_schema():
                         },
                     }
                 }]
+            },
+            'load_balancer': {
+                'type': 'object',
+                'required': [],
+                'additionalProperties': False,
+                'properties': {
+                    'stream_timeout_seconds': {
+                        'type': 'number',
+                    },
+                },
             },
             'pool': {
                 'type': 'object',

--- a/tests/unit_tests/test_sky/test_replica_managers.py
+++ b/tests/unit_tests/test_sky/test_replica_managers.py
@@ -1,0 +1,59 @@
+"""Tests for replica manager probe configuration behavior."""
+from typing import Optional
+from unittest import mock
+
+from sky.serve import replica_managers
+from sky.serve import service_spec
+
+
+class TestSkypilotReplicaManager:
+
+    @staticmethod
+    def _make_spec(
+        pool: bool,
+        consecutive_failure_threshold_timeout: Optional[int] = None
+    ) -> service_spec.SkyServiceSpec:
+        config = {'readiness_probe': {'path': '/health',}}
+        if consecutive_failure_threshold_timeout:
+            config['readiness_probe'][
+                'consecutive_failure_threshold_timeout'] = (
+                    consecutive_failure_threshold_timeout)
+        if pool:
+            config['pool'] = {
+                'min_workers': 1,
+                'max_workers': 5,
+            }
+        else:
+            config['replicas'] = 1
+        return service_spec.SkyServiceSpec.from_yaml_config(config)
+
+    @staticmethod
+    def _build_mock_skypilot_replica_manager(spec):
+        mock_replica_manager = mock.MagicMock(
+            spec=replica_managers.SkyPilotReplicaManager)
+        mock_replica_manager._get_version_spec.return_value = spec
+        mock_replica_manager._is_pool = spec.pool
+        mock_replica_manager.latest_version = 1
+        mock_replica_manager._consecutive_failure_threshold_timeout.side_effect = (
+            lambda: replica_managers.SkyPilotReplicaManager.
+            _consecutive_failure_threshold_timeout(mock_replica_manager))
+        return mock_replica_manager
+
+    def test_consecutive_failure_threshold_timeout_uses_non_pool_default(self):
+        spec = self._make_spec(pool=False)
+        manager = self._build_mock_skypilot_replica_manager(spec)
+
+        assert manager._consecutive_failure_threshold_timeout() == 180
+
+    def test_consecutive_failure_threshold_timeout_uses_pool_default(self):
+        spec = self._make_spec(pool=True)
+        manager = self._build_mock_skypilot_replica_manager(spec)
+
+        assert manager._consecutive_failure_threshold_timeout() == 10
+
+    def test_consecutive_failure_threshold_timeout_uses_config_override(self):
+        spec = self._make_spec(pool=True,
+                               consecutive_failure_threshold_timeout=25)
+        manager = self._build_mock_skypilot_replica_manager(spec)
+
+        assert manager._consecutive_failure_threshold_timeout() == 25

--- a/tests/unit_tests/test_sky/test_service_spec.py
+++ b/tests/unit_tests/test_sky/test_service_spec.py
@@ -1,6 +1,7 @@
 """Tests for SkyServiceSpec, specifically pool configuration validation."""
 import pytest
 
+from sky.serve import constants as serve_constants
 from sky.serve import service_spec
 
 
@@ -164,3 +165,46 @@ class TestPoolConfiguration:
 
         assert spec.min_replicas == 3
         assert spec.max_replicas == 3
+
+
+class TestReadinessProbeConfiguration:
+    """Test readiness probe configuration parsing."""
+
+    def test_readiness_probe_uses_default_endpoint_probe_interval(self):
+        spec = service_spec.SkyServiceSpec.from_yaml_config({
+            'readiness_probe': '/',
+        })
+
+        assert (spec.endpoint_probe_interval_seconds ==
+                serve_constants.DEFAULT_ENDPOINT_PROBE_INTERVAL_SECONDS)
+        assert spec.consecutive_failure_threshold_timeout is None
+
+    def test_readiness_probe_accepts_probe_overrides(self):
+        spec = service_spec.SkyServiceSpec.from_yaml_config({
+            'readiness_probe': {
+                'path': '/health',
+                'endpoint_probe_interval_seconds': 7,
+                'consecutive_failure_threshold_timeout': 45,
+            },
+        })
+
+        assert spec.endpoint_probe_interval_seconds == 7
+        assert spec.consecutive_failure_threshold_timeout == 45
+
+
+class TestLoadBalancerConfiguration:
+
+    def test_default_load_balancer_settings(self):
+        spec = service_spec.SkyServiceSpec.from_yaml_config({})
+        assert (
+            spec.lb_stream_timeout_seconds == serve_constants.LB_STREAM_TIMEOUT)
+
+    def test_load_balancer_stream_timeout_seconds_override(self):
+
+        spec = service_spec.SkyServiceSpec.from_yaml_config({
+            'load_balancer': {
+                'stream_timeout_seconds': 240,
+            },
+        })
+
+        assert spec.lb_stream_timeout_seconds == 240

--- a/tests/unit_tests/test_sky/test_service_spec.py
+++ b/tests/unit_tests/test_sky/test_service_spec.py
@@ -196,8 +196,8 @@ class TestLoadBalancerConfiguration:
 
     def test_default_load_balancer_settings(self):
         spec = service_spec.SkyServiceSpec.from_yaml_config({})
-        assert (
-            spec.lb_stream_timeout_seconds == serve_constants.LB_STREAM_TIMEOUT)
+        assert (spec.lb_stream_timeout_seconds ==
+                serve_constants.DEFAULT_LB_STREAM_TIMEOUT)
 
     def test_load_balancer_stream_timeout_seconds_override(self):
 

--- a/tests/unit_tests/test_sky/test_service_spec.py
+++ b/tests/unit_tests/test_sky/test_service_spec.py
@@ -220,6 +220,22 @@ class TestLoadBalancerConfiguration:
         assert (spec.lb_stream_timeout_seconds ==
                 serve_constants.DEFAULT_LB_STREAM_TIMEOUT)
 
+    def test_to_yaml_config_omits_default_new_fields_for_compatibility(self):
+        spec = service_spec.SkyServiceSpec.from_yaml_config({
+            'readiness_probe': {
+                'path': '/health',
+            },
+            'replicas': 1,
+        })
+
+        config = spec.to_yaml_config()
+
+        assert 'load_balancer' not in config
+        assert 'endpoint_probe_interval_seconds' not in config[
+            'readiness_probe']
+        assert 'consecutive_failure_threshold_timeout' not in config[
+            'readiness_probe']
+
     def test_load_balancer_stream_timeout_seconds_override(self):
 
         spec = service_spec.SkyServiceSpec.from_yaml_config({
@@ -229,3 +245,24 @@ class TestLoadBalancerConfiguration:
         })
 
         assert spec.lb_stream_timeout_seconds == 240
+
+    def test_to_yaml_config_keeps_non_default_new_fields(self):
+        spec = service_spec.SkyServiceSpec.from_yaml_config({
+            'readiness_probe': {
+                'path': '/health',
+                'endpoint_probe_interval_seconds': 7,
+                'consecutive_failure_threshold_timeout': 45,
+            },
+            'load_balancer': {
+                'stream_timeout_seconds': 240,
+            },
+            'replicas': 1,
+        })
+
+        config = spec.to_yaml_config()
+
+        assert (
+            config['readiness_probe']['endpoint_probe_interval_seconds'] == 7)
+        assert (config['readiness_probe']
+                ['consecutive_failure_threshold_timeout'] == 45)
+        assert config['load_balancer']['stream_timeout_seconds'] == 240

--- a/tests/unit_tests/test_sky/test_service_spec.py
+++ b/tests/unit_tests/test_sky/test_service_spec.py
@@ -1,4 +1,6 @@
 """Tests for SkyServiceSpec, specifically pool configuration validation."""
+import pickle
+
 import pytest
 
 from sky.serve import constants as serve_constants
@@ -190,6 +192,25 @@ class TestReadinessProbeConfiguration:
 
         assert spec.endpoint_probe_interval_seconds == 7
         assert spec.consecutive_failure_threshold_timeout == 45
+
+    def test_unpickle_old_spec_backfills_new_probe_fields(self):
+        spec = service_spec.SkyServiceSpec.from_yaml_config({
+            'readiness_probe': {
+                'path': '/health',
+            },
+            'replicas': 1,
+        })
+        del spec._endpoint_probe_interval_seconds
+        del spec._lb_stream_timeout_seconds
+        del spec._consecutive_failure_threshold_timeout
+
+        restored = pickle.loads(pickle.dumps(spec))
+
+        assert (restored.endpoint_probe_interval_seconds ==
+                serve_constants.DEFAULT_ENDPOINT_PROBE_INTERVAL_SECONDS)
+        assert (restored.lb_stream_timeout_seconds ==
+                serve_constants.DEFAULT_LB_STREAM_TIMEOUT)
+        assert restored.consecutive_failure_threshold_timeout is None
 
 
 class TestLoadBalancerConfiguration:

--- a/tests/unit_tests/test_sky/utils/test_schemas.py
+++ b/tests/unit_tests/test_sky/utils/test_schemas.py
@@ -837,6 +837,34 @@ class TestAWSConfigSchema(unittest.TestCase):
         config = {'subnet_names': []}
         jsonschema.validate(instance=config, schema=self.aws_schema)
 
+        
+class TestServiceSchema(unittest.TestCase):
+    """Tests for the service schema in schemas.py."""
+
+    def setUp(self):
+        self.service_schema = schemas.get_service_schema()
+
+    def test_valid_load_balancer_config(self):
+        config = {
+            'readiness_probe': '/',
+            'load_balancer': {
+                'stream_timeout_seconds': 240,
+            },
+        }
+
+        jsonschema.validate(instance=config, schema=self.service_schema)
+
+    def test_rejects_lb_stream_timeout_under_readiness_probe(self):
+        config = {
+            'readiness_probe': {
+                'path': '/health',
+                'lb_stream_timeout_seconds': 240,
+            },
+        }
+
+        with self.assertRaises(jsonschema.exceptions.ValidationError):
+            jsonschema.validate(instance=config, schema=self.service_schema)
+
 
 class TestRegisterKubernetesProperty(unittest.TestCase):
     """Tests for register_kubernetes_property and schema validation."""

--- a/tests/unit_tests/test_sky/utils/test_schemas.py
+++ b/tests/unit_tests/test_sky/utils/test_schemas.py
@@ -837,7 +837,7 @@ class TestAWSConfigSchema(unittest.TestCase):
         config = {'subnet_names': []}
         jsonschema.validate(instance=config, schema=self.aws_schema)
 
-        
+
 class TestServiceSchema(unittest.TestCase):
     """Tests for the service schema in schemas.py."""
 


### PR DESCRIPTION
Adding 3 configurable options for Serve.
* LB_STREAM_TIMEOUT
* ENDPOINT_PROBE_INTERVAL_SECONDS
* consecutive_failure_threshold_timeout

Added test for:

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->
Tested (run the relevant ones):
* pytest tests/unit_tests/test_sky/utils/test_schemas.py   
* pytest tests/unit_tests/test_sky/test_replica_managers.py
* pytest tests/unit_tests/test_sky/test_service_spec.py

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
    * tests/unit_tests/test_sky/test_replica_managers (NEW)
    * tests/unit_tests/test_sky/test_service_spec (partial NEW)
    * pytest tests/unit_tests/test_sky/utils/test_schemas.py (partial NEW)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
