### PR TITLE
Improve Vast Launch Reliability

### DIFF
--- a/sky/clouds/vast.py
+++ b/sky/clouds/vast.py
@@ -219,6 +219,13 @@ class Vast(clouds.Cloud):
             default_value={},
             override_configs=resources.cluster_config_overrides,
         )
+        launch_timeout = skypilot_config.get_effective_region_config(
+            cloud='vast',
+            region=region.name,
+            keys=('launch_timeout',),
+            default_value=None,
+            override_configs=resources.cluster_config_overrides,
+        )
 
         return {
             'instance_type': resources.instance_type,
@@ -227,6 +234,7 @@ class Vast(clouds.Cloud):
             'image_id': image_id,
             'secure_only': secure_only,
             'create_instance_kwargs': create_instance_kwargs or {},
+            'launch_timeout': launch_timeout,
         }
 
     def _get_feasible_launchable_resources(

--- a/sky/clouds/vast.py
+++ b/sky/clouds/vast.py
@@ -16,8 +16,6 @@ if typing.TYPE_CHECKING:
     from sky.utils import volume as volume_lib
 
 _CREDENTIAL_PATH = '~/.config/vastai/vast_api_key'
-_DEFAULT_LAUNCH_TIMEOUT = 600
-_DEFAULT_POST_LAUNCH_DELAY = 1
 
 
 @registry.CLOUD_REGISTRY.register
@@ -225,14 +223,14 @@ class Vast(clouds.Cloud):
             cloud='vast',
             region=region.name,
             keys=('launch_timeout',),
-            default_value=_DEFAULT_LAUNCH_TIMEOUT,
+            default_value=600,  # 10 minutes
             override_configs=resources.cluster_config_overrides,
         )
         post_launch_delay = skypilot_config.get_effective_region_config(
             cloud='vast',
             region=region.name,
             keys=('post_launch_delay',),
-            default_value=_DEFAULT_POST_LAUNCH_DELAY,
+            default_value=1,  # seconds
             override_configs=resources.cluster_config_overrides,
         )
 

--- a/sky/clouds/vast.py
+++ b/sky/clouds/vast.py
@@ -16,6 +16,8 @@ if typing.TYPE_CHECKING:
     from sky.utils import volume as volume_lib
 
 _CREDENTIAL_PATH = '~/.config/vastai/vast_api_key'
+_DEFAULT_LAUNCH_TIMEOUT = 600
+_DEFAULT_POST_LAUNCH_DELAY = 1
 
 
 @registry.CLOUD_REGISTRY.register
@@ -223,7 +225,14 @@ class Vast(clouds.Cloud):
             cloud='vast',
             region=region.name,
             keys=('launch_timeout',),
-            default_value=None,
+            default_value=_DEFAULT_LAUNCH_TIMEOUT,
+            override_configs=resources.cluster_config_overrides,
+        )
+        post_launch_delay = skypilot_config.get_effective_region_config(
+            cloud='vast',
+            region=region.name,
+            keys=('post_launch_delay',),
+            default_value=_DEFAULT_POST_LAUNCH_DELAY,
             override_configs=resources.cluster_config_overrides,
         )
 
@@ -235,6 +244,7 @@ class Vast(clouds.Cloud):
             'secure_only': secure_only,
             'create_instance_kwargs': create_instance_kwargs or {},
             'launch_timeout': launch_timeout,
+            'post_launch_delay': post_launch_delay,
         }
 
     def _get_feasible_launchable_resources(

--- a/sky/provision/vast/instance.py
+++ b/sky/provision/vast/instance.py
@@ -12,6 +12,9 @@ from sky.utils import status_lib
 from sky.utils import ux_utils
 
 POLL_INTERVAL = 10
+# Default launch timeout in seconds.  Can be overridden via the
+# ``vast.launch_timeout`` config key.
+_DEFAULT_LAUNCH_TIMEOUT = 600
 
 logger = sky_logging.init_logger(__name__)
 # a much more convenient method
@@ -148,7 +151,13 @@ def run_instances(region: str, cluster_name: str, cluster_name_on_cloud: str,
             if head_instance_id is None:
                 head_instance_id = instance_id
 
-    # Wait for instances to be ready.
+    # Wait for instances to be ready.  If any instance fails to become
+    # ready within the timeout, raise so the provisioner's except handler
+    # terminates the cluster and retries on a fresh set of offers.
+    launch_timeout = config.provider_config.get('launch_timeout')
+    if launch_timeout is None:
+        launch_timeout = _DEFAULT_LAUNCH_TIMEOUT
+    deadline = time.time() + launch_timeout
     while True:
         instances = _filter_instances(cluster_name_on_cloud, ['RUNNING'])
         ready_instance_cnt = 0
@@ -159,6 +168,11 @@ def run_instances(region: str, cluster_name: str, cluster_name_on_cloud: str,
                     f'({ready_instance_cnt}/{config.count}).')
         if ready_instance_cnt == config.count:
             break
+
+        if time.time() >= deadline:
+            raise RuntimeError(f'Timed out after {launch_timeout}s waiting for '
+                               f'{config.count} instance(s) to be ready '
+                               f'(only {ready_instance_cnt} ready).')
 
         time.sleep(POLL_INTERVAL)
 

--- a/sky/provision/vast/instance.py
+++ b/sky/provision/vast/instance.py
@@ -12,9 +12,6 @@ from sky.utils import status_lib
 from sky.utils import ux_utils
 
 POLL_INTERVAL = 10
-# Default launch timeout in seconds.  Can be overridden via the
-# ``vast.launch_timeout`` config key.
-_DEFAULT_LAUNCH_TIMEOUT = 600
 
 logger = sky_logging.init_logger(__name__)
 # a much more convenient method
@@ -126,6 +123,7 @@ def run_instances(region: str, cluster_name: str, cluster_name_on_cloud: str,
                                           created_instance_ids=[])
 
         secure_only = config.provider_config.get('secure_only', False)
+        post_launch_delay = config.provider_config['post_launch_delay']
         for _ in range(to_start_count):
             node_type = 'head' if head_instance_id is None else 'worker'
             try:
@@ -142,6 +140,7 @@ def run_instances(region: str, cluster_name: str, cluster_name_on_cloud: str,
                     login=login_args,
                     create_instance_kwargs=create_instance_kwargs,
                     ssh_public_key=ssh_public_key,
+                    post_launch_delay=post_launch_delay,
                 )
             except Exception as e:  # pylint: disable=broad-except
                 logger.warning(f'run_instances error: {e}')
@@ -154,9 +153,7 @@ def run_instances(region: str, cluster_name: str, cluster_name_on_cloud: str,
     # Wait for instances to be ready.  If any instance fails to become
     # ready within the timeout, raise so the provisioner's except handler
     # terminates the cluster and retries on a fresh set of offers.
-    launch_timeout = config.provider_config.get('launch_timeout')
-    if launch_timeout is None:
-        launch_timeout = _DEFAULT_LAUNCH_TIMEOUT
+    launch_timeout = config.provider_config['launch_timeout']
     deadline = time.time() + launch_timeout
     while True:
         instances = _filter_instances(cluster_name_on_cloud, ['RUNNING'])

--- a/sky/provision/vast/instance.py
+++ b/sky/provision/vast/instance.py
@@ -123,7 +123,7 @@ def run_instances(region: str, cluster_name: str, cluster_name_on_cloud: str,
                                           created_instance_ids=[])
 
         secure_only = config.provider_config.get('secure_only', False)
-        post_launch_delay = config.provider_config['post_launch_delay']
+        post_launch_delay = config.provider_config.get('post_launch_delay', 1)
         for _ in range(to_start_count):
             node_type = 'head' if head_instance_id is None else 'worker'
             try:
@@ -153,7 +153,7 @@ def run_instances(region: str, cluster_name: str, cluster_name_on_cloud: str,
     # Wait for instances to be ready.  If any instance fails to become
     # ready within the timeout, raise so the provisioner's except handler
     # terminates the cluster and retries on a fresh set of offers.
-    launch_timeout = config.provider_config['launch_timeout']
+    launch_timeout = config.provider_config.get('launch_timeout', 600)
     deadline = time.time() + launch_timeout
     while True:
         instances = _filter_instances(cluster_name_on_cloud, ['RUNNING'])

--- a/sky/provision/vast/utils.py
+++ b/sky/provision/vast/utils.py
@@ -7,12 +7,19 @@
 """Vast library wrapper for SkyPilot."""
 from pathlib import Path
 import shlex
+import time
 from typing import Any, Dict, List, Optional
 
 from sky import sky_logging
 from sky.adaptors import vast
+from sky.utils import locks
 
 logger = sky_logging.init_logger(__name__)
+
+# Cross-process lock for the search+buy critical section.  Prevents
+# concurrent pool worker processes from purchasing the same Vast offer
+# before it is removed from the search results.
+_launch_lock = locks.get_lock('vast-launch')
 
 
 def list_instances() -> Dict[str, Dict[str, Any]]:
@@ -125,22 +132,12 @@ def launch(name: str,
         query.append('hosting_type>=1')
     query_str = ' '.join(query)
 
-    instance_list = vast.vast().search_offers(query=query_str)
-
-    if isinstance(instance_list, int) or len(instance_list) == 0:
-        raise RuntimeError('Failed to create instances, could not find an '
-                           'offer that satisfies the requirements '
-                           f'"{query_str}".')
-
-    instance_touse = instance_list[0]
-
     # Start with user-provided kwargs as the base
     launch_params: Dict[str, Any] = dict(create_instance_kwargs or {})
     # Remove None values to avoid overriding defaults
     launch_params = {k: v for k, v in launch_params.items() if v is not None}
 
     # Required skypilot parameters
-    launch_params['id'] = instance_touse['id']
     launch_params['direct'] = True
     launch_params['ssh'] = True
     # Use user's label if provided, otherwise use skypilot name
@@ -177,8 +174,6 @@ def launch(name: str,
     if 'price' in launch_params:
         # Normalize to bid_price for SDK compatibility
         launch_params['bid_price'] = launch_params.pop('price')
-    if 'bid_price' not in launch_params and preemptible:
-        launch_params['bid_price'] = instance_touse.get('min_bid')
 
     # Handle onstart_cmd - read from file if onstart path provided
     user_onstart_cmd = launch_params.pop('onstart_cmd', None)
@@ -231,7 +226,25 @@ def launch(name: str,
         env_parts.append(user_env)
     launch_params['env'] = ' '.join(env_parts).strip()
 
-    new_instance_contract = vast.vast().create_instance(**launch_params)
+    # Lock the search+buy critical section so concurrent workers cannot
+    # purchase the same offer before it disappears from search results.
+    with _launch_lock:
+        instance_list = vast.vast().search_offers(query=query_str)
+
+        if isinstance(instance_list, int) or len(instance_list) == 0:
+            raise RuntimeError('Failed to create instances, could not find an '
+                               'offer that satisfies the requirements '
+                               f'"{query_str}".')
+
+        instance_touse = instance_list[0]
+        launch_params['id'] = instance_touse['id']
+        if 'bid_price' not in launch_params and preemptible:
+            launch_params['bid_price'] = instance_touse.get('min_bid')
+
+        new_instance_contract = vast.vast().create_instance(**launch_params)
+        # Give the Vast API time to remove the purchased offer from
+        # search results before the next worker searches.
+        time.sleep(1)
 
     new_instance = vast.vast().show_instance(
         id=new_instance_contract['new_contract'])

--- a/sky/provision/vast/utils.py
+++ b/sky/provision/vast/utils.py
@@ -53,7 +53,8 @@ def launch(name: str,
            private_docker_registry: Optional[bool] = None,
            login: Optional[str] = None,
            create_instance_kwargs: Optional[Dict[str, Any]] = None,
-           ssh_public_key: Optional[str] = None) -> str:
+           ssh_public_key: Optional[str] = None,
+           post_launch_delay: float = 1) -> str:
     """Launches an instance with the given parameters.
 
     Converts the instance_type to the Vast GPU name, finds the specs for the
@@ -244,7 +245,7 @@ def launch(name: str,
         new_instance_contract = vast.vast().create_instance(**launch_params)
         # Give the Vast API time to remove the purchased offer from
         # search results before the next worker searches.
-        time.sleep(1)
+        time.sleep(post_launch_delay)
 
     new_instance = vast.vast().show_instance(
         id=new_instance_contract['new_contract'])

--- a/sky/templates/vast-ray.yml.j2
+++ b/sky/templates/vast-ray.yml.j2
@@ -11,6 +11,8 @@ provider:
   region: "{{region}}"
   disable_launch_config_check: true
   secure_only: {{secure_only}}
+  launch_timeout: {{launch_timeout}}
+  post_launch_delay: {{post_launch_delay}}
   {%- if create_instance_kwargs %}
   create_instance_kwargs: {{create_instance_kwargs | tojson}}
   {%- endif %}

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1717,6 +1717,9 @@ def get_config_schema():
                 'launch_timeout': {
                     'type': 'number',
                 },
+                'post_launch_delay': {
+                    'type': 'number',
+                },
             }
         },
         'nebius': {

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1714,6 +1714,9 @@ def get_config_schema():
                 'create_instance_kwargs': {
                     'type': 'object',
                 },
+                'launch_timeout': {
+                    'type': 'number',
+                },
             }
         },
         'nebius': {


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Vast has a number of issues that make launching instances unreliable. This PR attempts to address them:

### Search/buy race condition

When launching clusters, SkyPilot submits multiple `launch` jobs to a process pool. However, `vast.vast().search_offers()` returns the same `offer_id`s to most/all workers. Since all workers use the same criteria, `instance_to_use = instance_list[0]` is very often the same `offer_id`.

When vast receives two (or more) requests to purchase the same `offer_id`, it accepts both and attempts to launch both. It should really raise an error, but doesn't. All but one of the conflicting instances will then either fail to fully start or raise an error when the remote node's Docker daemon attempts to bind the same port multiple times - however, this error never propagates back to SkyPilot.

For example, launching a pool of 2 workers almost always leads to 1 worker failing and the other succeeding, both having attempted to rent the same offer_id.

To resolve this, I've added a lock (and configurable repeat delay) to the critical search-and-buy part of the launch code. This gives vast enough time to register the purchase, update its search results, and return a new `offer_id` for the next launch attempt using the same criteria.

### Add a launch timeout

Even with the above changes, some instances still fail to launch. To deal with this, I've added a timeout (configurable, default 10 minutes) when launching a cluster. If a cluster has not come online and started talking over SSH in this window, it is terminated and a new cluster launched to take its place.

<!-- Describe the tests ran -->

## Testing

On the current `main` release of SkyPilot, I repeatedly tried increasing pool workers from 0 to 32 and back to 0. Each time, **30-50% of these clusters would fail** to launch with either docker port conflicts or just "not running".

After adding the lock and timeout, repeating this process would have only 1-3 out of 32 clusters failing to launch. After waiting for the launch timeout, these instances would be deleted, new instances spun up, and finally 32 clusters would be running successfully.


<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

There don't seem to be any Vast.ai-specific smoke tests. As described above, I tested this PR manually.

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
