### PR TITLE
[Jobs] Add typing overloads for sdk.jobs.queue

### DIFF
--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -290,7 +290,7 @@ def queue(
     ...
 
 
-@usage_lib.entrypoint  # type: ignore[misc]
+@usage_lib.entrypoint
 @server_common.check_server_healthy_or_start
 def queue(
     refresh: bool,
@@ -298,8 +298,9 @@ def queue(
     all_users: bool = False,
     job_ids: Optional[List[int]] = None,
     version: int = 1,
-) -> server_common.RequestId[Union[List[responses.ManagedJobRecord], Tuple[
-        List[responses.ManagedJobRecord], int, Dict[str, int], int]]]:
+) -> Union[server_common.RequestId[List[responses.ManagedJobRecord]],
+           server_common.RequestId[Tuple[List[responses.ManagedJobRecord], int,
+                                         Dict[str, int], int]]]:
     """Gets statuses of managed jobs.
 
     Deprecated. Please use queue_v2 instead for better performance.

--- a/sky/jobs/client/sdk_async.py
+++ b/sky/jobs/client/sdk_async.py
@@ -79,6 +79,8 @@ async def queue(
 ) -> Union[List[responses.ManagedJobRecord], Tuple[
         List[responses.ManagedJobRecord], int, Dict[str, int], int]]:
     """Async version of queue() that gets statuses of managed jobs."""
+    # mypy cannot resolve overloaded functions passed as callable arguments
+    # to asyncio.to_thread.
     request_id = await asyncio.to_thread(
         sdk.queue,  # type: ignore[arg-type]
         refresh,


### PR DESCRIPTION
## Summary
- Add `@overload` signatures for `sdk.jobs.queue()` so that the return type is precise based on the `version` parameter:
  - `version=1` (or omitted) → `RequestId[List[ManagedJobRecord]]`
  - `version=2` → `RequestId[Tuple[List[ManagedJobRecord], int, Dict[str, int], int]]`
- Add `type: ignore` comments for known mypy limitations with overloaded functions passed as arguments (`asyncio.to_thread`) and invariant generics (`RequestId`).

## Test plan
- [x] `bash format.sh --files sky/jobs/client/sdk.py sky/jobs/client/sdk_async.py` passes with no new errors
- [x] mypy reports no new errors on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)