### PR TITLE
Add link to dashboard when calling `sky jobs launch`

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -1308,9 +1308,20 @@ def launch(
             returncode = sdk.tail_logs(handle.get_cluster_name(),
                                        job_id,
                                        follow=True)
+        cluster_dashboard_url = None
+        if not server_common.is_api_server_local():
+            query = urllib.parse.urlencode({
+                'property': 'cluster',
+                'operator': ':',
+                'value': handle.get_cluster_name(),
+            })
+            cluster_dashboard_url = server_common.get_dashboard_url(
+                server_common.get_server_url(),
+                starting_page=f'clusters?{query}')
         click.secho(
             ux_utils.command_hint_messages(ux_utils.CommandHintType.CLUSTER_JOB,
-                                           job_id, handle.get_cluster_name()))
+                                           job_id, handle.get_cluster_name(),
+                                           cluster_dashboard_url))
         sys.exit(returncode)
 
 
@@ -5582,47 +5593,61 @@ def jobs_launch(
     job_ids = [job_id_handle[0]] if isinstance(job_id_handle[0],
                                                int) else job_id_handle[0]
 
-    if not detach_run:
-        if len(job_ids) == 1:
-            job_id = job_ids[0]
+    if len(job_ids) == 1:
+        job_id = job_ids[0]
+        if not detach_run:
             returncode = managed_jobs.tail_logs(name=None,
                                                 job_id=job_id,
                                                 follow=True,
                                                 controller=False)
             sys.exit(returncode)
         else:
-            # TODO(tian): This can be very long. Considering have a "group id"
-            # and query all job ids with the same group id.
-            # Sort job ids to ensure consistent ordering.
-            job_ids_str = ','.join(map(str, sorted(job_ids)))
-            dashboard_hint = ''
-            if not server_common.is_api_server_local() and pool is not None:
+            job_dashboard_url = None
+            if not server_common.is_api_server_local():
                 query = urllib.parse.urlencode({
-                    'property': 'pool',
-                    'operator': ':',
-                    'value': pool,
+                    'property': 'id',
+                    'operator': '=',
+                    'value': job_id,
                 })
-                dashboard_url = server_common.get_dashboard_url(
+                job_dashboard_url = server_common.get_dashboard_url(
                     server_common.get_server_url(),
                     starting_page=f'jobs?{query}')
-                dashboard_hint = (
-                    f'\n{ux_utils.INDENT_SYMBOL}Show all jobs in the pool:'
-                    f'\t\t{ux_utils.BOLD}{dashboard_url}'
-                    f'{ux_utils.RESET_BOLD}')
             click.secho(
-                f'Jobs submitted with IDs: {colorama.Fore.CYAN}'
-                f'{job_ids_str}{colorama.Style.RESET_ALL}.'
-                f'\n📋 Useful Commands'
-                f'{dashboard_hint}'
-                f'\n{ux_utils.INDENT_SYMBOL}To stream job logs:\t\t\t'
-                f'{ux_utils.BOLD}sky jobs logs <job-id>'
-                f'{ux_utils.RESET_BOLD}'
-                f'\n{ux_utils.INDENT_SYMBOL}To stream controller logs:\t\t'
-                f'{ux_utils.BOLD}sky jobs logs --controller <job-id>'
-                f'{ux_utils.RESET_BOLD}'
-                f'\n{ux_utils.INDENT_LAST_SYMBOL}To cancel all jobs on the '
-                f'pool:\t{ux_utils.BOLD}sky jobs cancel --pool {pool}'
+                ux_utils.command_hint_messages(
+                    ux_utils.CommandHintType.MANAGED_JOB,
+                    job_id=str(job_id),
+                    dashboard_url=job_dashboard_url))
+    else:
+        # TODO(tian): This can be very long. Considering have a "group id"
+        # and query all job ids with the same group id.
+        # Sort job ids to ensure consistent ordering.
+        job_ids_str = ','.join(map(str, sorted(job_ids)))
+        dashboard_hint = ''
+        if not server_common.is_api_server_local():
+            query = urllib.parse.urlencode({
+                'property': 'pool',
+                'operator': ':',
+                'value': pool,
+            })
+            dashboard_url = server_common.get_dashboard_url(
+                server_common.get_server_url(), starting_page=f'jobs?{query}')
+            dashboard_hint = (
+                f'\n{ux_utils.INDENT_SYMBOL}Show all jobs in the pool:'
+                f'\t\t{ux_utils.BOLD}{dashboard_url}'
                 f'{ux_utils.RESET_BOLD}')
+        click.secho(f'Jobs submitted with IDs: {colorama.Fore.CYAN}'
+                    f'{job_ids_str}{colorama.Style.RESET_ALL}.'
+                    f'\n📋 Useful Commands'
+                    f'{dashboard_hint}'
+                    f'\n{ux_utils.INDENT_SYMBOL}To stream job logs:\t\t\t'
+                    f'{ux_utils.BOLD}sky jobs logs <job-id>'
+                    f'{ux_utils.RESET_BOLD}'
+                    f'\n{ux_utils.INDENT_SYMBOL}To stream controller logs:\t\t'
+                    f'{ux_utils.BOLD}sky jobs logs --controller <job-id>'
+                    f'{ux_utils.RESET_BOLD}'
+                    f'\n{ux_utils.INDENT_LAST_SYMBOL}To cancel all jobs on the '
+                    f'pool:\t{ux_utils.BOLD}sky jobs cancel --pool {pool}'
+                    f'{ux_utils.RESET_BOLD}')
 
 
 @jobs.command('queue', cls=_DocumentedCodeCommand)

--- a/sky/dashboard/package-lock.json
+++ b/sky/dashboard/package-lock.json
@@ -131,7 +131,6 @@
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -2026,7 +2025,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.39.11.tgz",
       "integrity": "sha512-bWdeR8gWM87l4DB/kYSF9A+dVackzDb/V56Tq7QVrQ7rn86W0rgZFtlL3g3pem6AeGcb9NQNoy3ao4WpW4h5tQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -2132,7 +2130,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2176,7 +2173,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz",
       "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -3499,7 +3495,6 @@
       "resolved": "https://registry.npmjs.org/@nextui-org/system/-/system-2.4.6.tgz",
       "integrity": "sha512-6ujAriBZMfQ16n6M6Ad9g32KJUa1CzqIVaHN/tymadr/3m8hrr7xDw6z50pVjpCRq2PaaA1hT8Hx7EFU3f2z3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@internationalized/date": "3.6.0",
         "@nextui-org/react-utils": "2.1.3",
@@ -3544,6 +3539,7 @@
       "resolved": "https://registry.npmjs.org/@nextui-org/theme/-/theme-2.4.5.tgz",
       "integrity": "sha512-c7Y17n+hBGiFedxMKfg7Qyv93iY5MteamLXV4Po4c1VF1qZJI6I+IKULFh3FxPWzAoz96r6NdYT7OLFjrAJdWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nextui-org/shared-utils": "2.1.2",
         "clsx": "^1.2.1",
@@ -3563,6 +3559,7 @@
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
       "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4928,7 +4925,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5218,7 +5216,6 @@
       "integrity": "sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.35.0",
         "@typescript-eslint/types": "8.35.0",
@@ -5812,7 +5809,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6504,7 +6500,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -6726,7 +6721,6 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
       "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -6919,6 +6913,7 @@
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
       "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1",
         "color-string": "^1.9.0"
@@ -6950,6 +6945,7 @@
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
       "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -6959,7 +6955,8 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
       "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -7446,7 +7443,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -7813,7 +7811,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8012,7 +8009,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8707,6 +8703,7 @@
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "bin": {
         "flat": "cli.js"
       }
@@ -10245,7 +10242,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -11538,6 +11534,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -11743,6 +11740,7 @@
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.19.0.tgz",
       "integrity": "sha512-m96uqq8VbwxFLU0mtmlsIVe8NGGSdpBvBSHbnnOJQxniPaabvVdGgxSamhuDwBsRhwX7xPxdICgVJlOpzn/5bw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "motion-utils": "^12.19.0"
       }
@@ -11751,7 +11749,8 @@
       "version": "12.19.0",
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.19.0.tgz",
       "integrity": "sha512-BuFTHINYmV07pdWs6lj6aI63vr2N4dg0vR+td0rtrdpWOhBzIkEklZyLcvKBoEtwSqx8Jg06vUB5RS0xDiUybw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -12440,7 +12439,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -12609,6 +12607,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -12624,6 +12623,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -12636,7 +12636,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
@@ -12815,7 +12816,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -12848,7 +12848,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -13705,6 +13704,7 @@
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }
@@ -13713,7 +13713,8 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -14216,6 +14217,7 @@
       "resolved": "https://registry.npmjs.org/tailwind-variants/-/tailwind-variants-0.1.20.tgz",
       "integrity": "sha512-AMh7x313t/V+eTySKB0Dal08RHY7ggYK0MSn/ad8wKWOrDUIzyiWNayRUm2PIJ4VRkvRnfNuyRuKbLV3EN+ewQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tailwind-merge": "^1.14.0"
       },
@@ -14232,6 +14234,7 @@
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-1.14.0.tgz",
       "integrity": "sha512-3mFKyCo/MBcgyOTlrY8T7odzZFx+w+qKSMAmdFzRvqBfLlSigU6TZnlFHK0lkMwj9Bj8OYU+9yW9lmGuS0QEnQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"
@@ -14242,7 +14245,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -14387,7 +14389,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -148,6 +148,10 @@ export function getAggregatedStatus(tasks) {
 // Define filter options for the filter dropdown
 const PROPERTY_OPTIONS = [
   {
+    label: 'ID',
+    value: 'id',
+  },
+  {
     label: 'Name',
     value: 'name',
   },
@@ -330,6 +334,7 @@ export function ManagedJobs() {
   const updateFiltersByURLParams = React.useCallback(() => {
     const propertyMap = new Map();
     propertyMap.set('', '');
+    propertyMap.set('id', 'ID');
     propertyMap.set('status', 'Status');
     propertyMap.set('name', 'Name');
     propertyMap.set('user', 'User');
@@ -542,8 +547,10 @@ export function ManagedJobsTable({
         };
 
         // Build params for jobsCacheManager
+        const jobIdFilter = getFilterValue('id');
         const params = {
           allUsers: true,
+          jobIdMatch: jobIdFilter,
           nameMatch: getFilterValue('name'),
           userMatch: getFilterValue('user'),
           workspaceMatch: getFilterValue('workspace'),

--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -112,6 +112,7 @@ export async function getManagedJobs(options = {}) {
       allUsers = true,
       skipFinished = false,
       allFields = false,
+      jobIdMatch,
       nameMatch,
       userMatch,
       workspaceMatch,
@@ -135,7 +136,10 @@ export async function getManagedJobs(options = {}) {
     if (page !== undefined) body.page = page;
     if (limit !== undefined) body.limit = limit;
     if (statuses !== undefined && statuses.length > 0) body.statuses = statuses;
-    if (jobIDs !== undefined && jobIDs.length > 0) body.job_ids = jobIDs;
+    // Support both jobIdMatch (from filter UI) and jobIDs (direct usage)
+    const resolvedJobIDs = jobIdMatch ? [jobIdMatch] : jobIDs;
+    if (resolvedJobIDs !== undefined && resolvedJobIDs.length > 0)
+      body.job_ids = resolvedJobIDs;
     if (!allFields) {
       if (fields && fields.length > 0) {
         body.fields = fields;

--- a/sky/dashboard/src/lib/jobs-cache-manager.js
+++ b/sky/dashboard/src/lib/jobs-cache-manager.js
@@ -43,6 +43,7 @@ class JobsCacheManager {
       sortBy = 'submitted_at',
       sortOrder = 'desc',
       allUsers = true,
+      jobIdMatch,
       nameMatch,
       userMatch,
       workspaceMatch,
@@ -57,6 +58,7 @@ class JobsCacheManager {
       sortBy,
       sortOrder,
       allUsers,
+      jobIdMatch: jobIdMatch || null,
       nameMatch: nameMatch || null,
       userMatch: userMatch || null,
       workspaceMatch: workspaceMatch || null,
@@ -74,6 +76,7 @@ class JobsCacheManager {
   _generateFilterKey(options) {
     const {
       allUsers = true,
+      jobIdMatch,
       nameMatch,
       userMatch,
       workspaceMatch,
@@ -83,6 +86,7 @@ class JobsCacheManager {
 
     const keyObj = {
       allUsers,
+      jobIdMatch: jobIdMatch || null,
       nameMatch: nameMatch || null,
       userMatch: userMatch || null,
       workspaceMatch: workspaceMatch || null,
@@ -364,6 +368,9 @@ class JobsCacheManager {
   _convertFiltersToPluginFormat(filterOptions) {
     const filters = [];
 
+    if (filterOptions.jobIdMatch) {
+      filters.push({ property: 'id', value: filterOptions.jobIdMatch });
+    }
     if (filterOptions.nameMatch) {
       filters.push({ property: 'name', value: filterOptions.nameMatch });
     }
@@ -585,6 +592,7 @@ class JobsCacheManager {
         const keyObj = JSON.parse(key);
         const keyFilterObj = {
           allUsers: keyObj.allUsers,
+          jobIdMatch: keyObj.jobIdMatch,
           nameMatch: keyObj.nameMatch,
           userMatch: keyObj.userMatch,
           workspaceMatch: keyObj.workspaceMatch,

--- a/sky/utils/ux_utils.py
+++ b/sky/utils/ux_utils.py
@@ -248,8 +248,13 @@ class CommandHintType(enum.Enum):
 
 def command_hint_messages(hint_type: CommandHintType,
                           job_id: Optional[str] = None,
-                          cluster_name: Optional[str] = None) -> str:
+                          cluster_name: Optional[str] = None,
+                          dashboard_url: Optional[str] = None) -> str:
     """Gets the command hint messages for the given job id."""
+    dashboard_hint = ''
+    if dashboard_url is not None:
+        dashboard_hint = (f'\n{INDENT_SYMBOL}View on dashboard:'
+                          f'\t\t{BOLD}{dashboard_url}{RESET_BOLD}')
     if hint_type == CommandHintType.CLUSTER_JOB:
         job_hint_str = (f'\nJob ID: {job_id}'
                         f'\n{INDENT_SYMBOL}To cancel the job:\t\t'
@@ -259,6 +264,7 @@ def command_hint_messages(hint_type: CommandHintType,
                         f'\n{INDENT_LAST_SYMBOL}To view job queue:\t\t'
                         f'{BOLD}sky queue {cluster_name}{RESET_BOLD}')
         cluster_hint_str = (f'\nCluster name: {cluster_name}'
+                            f'{dashboard_hint}'
                             f'\n{INDENT_SYMBOL}To log into the head VM:\t'
                             f'{BOLD}ssh {cluster_name}'
                             f'{RESET_BOLD}'
@@ -279,13 +285,14 @@ def command_hint_messages(hint_type: CommandHintType,
     elif hint_type == CommandHintType.MANAGED_JOB:
         return (f'\n📋 Useful Commands'
                 f'\nManaged Job ID: {job_id}'
+                f'{dashboard_hint}'
                 f'\n{INDENT_SYMBOL}To cancel the job:\t\t'
                 f'{BOLD}sky jobs cancel {job_id}{RESET_BOLD}'
                 f'\n{INDENT_SYMBOL}To stream job logs:\t\t'
                 f'{BOLD}sky jobs logs {job_id}{RESET_BOLD}'
-                f'\n{INDENT_SYMBOL}To stream controller logs:\t\t'
+                f'\n{INDENT_SYMBOL}To stream controller logs:\t'
                 f'{BOLD}sky jobs logs --controller {job_id}{RESET_BOLD}'
-                f'\n{INDENT_LAST_SYMBOL}To view all managed jobs:\t\t'
+                f'\n{INDENT_LAST_SYMBOL}To view all managed jobs:\t'
                 f'{BOLD}sky jobs queue{RESET_BOLD}')
     else:
         raise ValueError(f'Invalid hint type: {hint_type}')


### PR DESCRIPTION
There's a note from @cblmemo in command.py that for large jobs, just printing a list of job ids is rather impractical. This is a simple workaround - it shows a link to the dashboard filtered to just the jobs launched.

This is rather more ergonomic than the other useful commands the ci currently shares.

If you approve this, I can add to `sky launch` too, and update tests.




<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

Testing:
I ran against my skypilot api:
```
Submitting 2 jobs to pool adam-dev (sweep: 2 items)
YAML to run: /tmp/timaeus-sky-zcfdmt3i.yaml
Submitting to pool 'adam-dev' with 2 jobs.
Managed job 'sky-9294-root' will be launched on (estimated):
Use resources from pool 'adam-dev': 1x[RTX4090:1].
Launching 2 managed jobs 'sky-9294-root'. Proceed? [Y/n]: 
Launching 2 managed jobs 34-35 'sky-9294-root'...
Jobs submitted with IDs: 34,35.
📋 Useful Commands
├── To view on dashboard:               http://<redacted>/dashboard/jobs?property=name&operator=%3A&value=sky-9294-root
├── To stream job logs:                 sky jobs logs <job-id>
├── To stream controller logs:          sky jobs logs --controller <job-id>
└── To cancel all jobs on the pool:     sky jobs cancel --pool adam-dev
```

I tried to run the smoke tests, but I couldn't get the running locally.

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
