### PR TITLE
[Test] Bump Timeout to fix Flaky `test_gcp_network_tier_with_gpu`

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2632,6 +2632,7 @@ def test_gcp_network_tier_with_gpu():
             smoke_tests_utils.launch_cluster_for_cloud_cmd('gcp', name),
             f'sky launch -y -c {name} --cloud gcp '
             f'--gpus H100:8 --network-tier best '
+            f'--region asia-southeast1 '
             f'echo "Testing network tier best with GPU"',
             # Check if LD_LIBRARY_PATH contains the required NCCL and TCPX paths for GPU workloads
             f'sky exec {name} {shlex.quote(cmd)} && sky logs {name} --status'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixes two issues that we've had with `test_gcp_network_tier_with_gpu` making it flaky. The core issue is that this test resolves to `a3-highgpu-8g` which has availability issues so we timeout before successfully launching.

We improve this in two ways
- First we explicitly set the region to `asia-southeast1`. All of our recent test successes have been on this region, without this fix we spend a bunch of time trying to launch on us-central1 and us-west neither of which have capacity.
- Second we bump the timeout to allow more time to go through rounds of provisioning -> failed -> provisioning.


## Reviewer Note
This is an organic hand-crafted PR written by a human. 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
