### PR TITLE
[Dashboard] Fix routing for catch-all pages opened in new tabs

### DIFF
--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2985,8 +2985,11 @@ async def serve_dashboard(full_path: str):
 
     # Try serving a pre-rendered HTML page for the path.
     # e.g. /clusters -> clusters.html, /jobs -> jobs.html
+    safe_full_path = full_path.lstrip('/')
+    if '..' in safe_full_path.split('/'):
+        raise fastapi.HTTPException(status_code=400, detail='Invalid path')
     html_path = os.path.join(server_constants.DASHBOARD_DIR,
-                             f'{full_path}.html')
+                             f'{safe_full_path}.html')
     if os.path.isfile(html_path):
         return fastapi.responses.FileResponse(html_path)
 


### PR DESCRIPTION
## Summary
- When a dashboard page handled by the `[...path]` catch-all route was opened directly in a new browser tab, the server served `index.html` which lacks the JS chunks for the catch-all page, causing Next.js to redirect to the literal URL `/dashboard/[...path]`.
- Fix by adding two new resolution steps in `serve_dashboard`: try `{path}.html` for pre-rendered pages, and serve `[...path].html` as a catch-all before falling back to `index.html`.

## Test plan
- Start the API server locally (`sky api stop && sky api start`)
- Navigate to a plugin page (e.g. Quota) via the sidebar — verify it loads correctly
- Verify known pages like `/dashboard/clusters` and `/dashboard/jobs` still work when opened directly in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)