### PR TITLE
[Dashboard] Fix root page showing infinite spinner

### DIFF
--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -3013,7 +3013,7 @@ async def serve_dashboard(full_path: str):
     # e.g. /quota, /cron
     catchall_path = os.path.join(server_constants.DASHBOARD_DIR,
                                  '[...path].html')
-    if os.path.isfile(catchall_path):
+    if safe_full_path and os.path.isfile(catchall_path):
         return fastapi.responses.FileResponse(catchall_path)
 
     # Serve index.html as a last resort.


### PR DESCRIPTION
## Summary
- The catch-all `[...path].html` fallback added in #9137 is served even when `full_path` is empty (root dashboard URL `/dashboard/`), causing the root page to render the plugin catch-all component which shows a "Preparing plugin route..." spinner forever
- Guard the catch-all fallback so it only triggers when there are actual path segments, letting the root URL fall through to `index.html`

## Testing
1. Start the API server (`sky api stop && sky api start`)
2. Navigate to `http://localhost:46580/dashboard/` — should load the home page instead of showing a spinner
3. Navigate to a plugin catch-all route like `/dashboard/quota` — should still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)