### PR TITLE
Autoresearch one-liner

### DIFF
--- a/examples/autoresearch/setup.sh
+++ b/examples/autoresearch/setup.sh
@@ -46,7 +46,7 @@ echo "=== Credential check ==="
 # then inspect the text. (sky check exits non-zero when some clouds are absent,
 # which would otherwise trip set -e / pipefail on the pipe.)
 SKY_CHECK=$(sky check 2>&1 || true)
-if echo "$SKY_CHECK" | grep -q "enabled"; then
+if echo "$SKY_CHECK" | grep -q ": enabled"; then
     echo "Cloud credentials OK."
 else
     echo ""


### PR DESCRIPTION
A bootstrap script that installs uv and SkyPilot if missing, clones https://github.com/karpathy/autoresearch , downloads the SkyPilot experiment.yaml and instructions.md into it, and prints a ready-to-run prompt for launching parallel experiments via an AI agent.

Once merged:
```
curl -sL https://raw.githubusercontent.com/skypilot-org/skypilot/master/examples/autoresearch/setup.sh | bash
```