### PR TITLE
[k8s] Fix GPU labeler crash: preserve method metadata in RetryableClientWrapper

### DIFF
--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -281,6 +281,7 @@ class RetryableClientWrapper:
         if not callable(attr):
             return attr
 
+        @functools.wraps(attr)
         def with_refresh(*args, **kwargs):
             if self._should_refresh():
                 with self._refresh_lock:


### PR DESCRIPTION
## Summary

Fix `AttributeError: 'dict' object has no attribute 'metadata'` crash in the GPU labeler by adding `@functools.wraps(attr)` to `RetryableClientWrapper.__getattr__`.

**One-line root cause fix** instead of defensive dict-handling in every watch consumer.

## Root Cause

Introduced by **4943694ed** (#8976, March 10) — "Kubernetes teleport ssl retry".

That PR replaced `ClientWrapper` with `RetryableClientWrapper`. The `__getattr__` method wraps API methods in `with_refresh` closures that **lose the original method's `__doc__`**:

```python
# OLD: ClientWrapper — returns the actual bound method (with docstring)
class ClientWrapper:
    def __getattr__(self, name):
        return getattr(self._client, name)

# NEW: RetryableClientWrapper — returns a closure (no docstring)
class RetryableClientWrapper:
    def __getattr__(self, name):
        def with_refresh(*args, **kwargs):  # ← no __doc__
            ...
        return with_refresh
```

The kubernetes `Watch.stream()` determines the return type for event deserialization by parsing the function's docstring (`:return: V1JobList` → `V1Job`). Without a docstring, `get_return_type()` returns `""`, `unmarshal_event()` skips deserialization, and `event['object']` remains a raw dict.

This affects **all** watch consumers through SkyPilot's kubernetes adaptor, not just the GPU labeler.

## Fix

```python
@functools.wraps(attr)  # preserves __doc__, __name__, etc.
def with_refresh(*args, **kwargs):
    ...
```

`functools.wraps` copies the original bound method's metadata onto the closure, restoring pre-#8976 behavior.

## Test plan

- [x] Verified on a fresh EKS Buildkite cluster: `python -m sky.utils.kubernetes.gpu_labeler` crashes with `AttributeError` before fix
- [x] After fix: `Watch.get_return_type()` correctly returns `V1Job`, events are deserialized as API objects, GPU labeler completes without error
- [x] Verified: `kubernetes.batch_api().list_namespaced_job.__doc__` is non-empty after fix (was empty before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)