### PR TITLE
fix: replace bare except: with except Exception: in docs and examples

### DIFF
--- a/docs/verify_llms_links.py
+++ b/docs/verify_llms_links.py
@@ -33,7 +33,7 @@ def main():
     if base_url.startswith("http://127.0.0.1"):
         try:
             requests.get(base_url, timeout=1)
-        except:
+        except Exception:
             print(f"WARNING: No server at {base_url}")
 
     failures = []

--- a/examples/redisvl-vector-search/app.py
+++ b/examples/redisvl-vector-search/app.py
@@ -85,7 +85,7 @@ async def health():
     try:
         redis_client.ping()
         return {"status": "healthy", "papers": index.info().get("num_docs", 0)}
-    except:
+    except Exception:
         return {"status": "unhealthy"}
 
 


### PR DESCRIPTION
## Summary

Replaces bare `except:` clauses with `except Exception:` in two utility files.

Bare `except:` inadvertently catches `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit` — signals that should propagate up the call stack. In both cases the intent is to handle runtime errors gracefully, so `except Exception:` is the correct scope.

**Files changed:**

`docs/verify_llms_links.py` (line 36):
```python
# Before
try:
    response = requests.get(url, ...)
except:
    print(f"WARNING: No server at {base_url}")

# After
try:
    response = requests.get(url, ...)
except Exception:
    print(f"WARNING: No server at {base_url}")
```

`examples/redisvl-vector-search/app.py` (line 88):
```python
# Before
try:
    ...
except:
    return {"status": "unhealthy"}

# After
try:
    ...
except Exception:
    return {"status": "unhealthy"}
```

## Testing
No behavior change for normal exception flows. Resolves PEP 8 E722 bare-except lint warnings in both files.