### PR TITLE
Enforce commit SHA for github action

### DIFF
--- a/.github/workflows/action-pin-check.yaml
+++ b/.github/workflows/action-pin-check.yaml
@@ -1,0 +1,60 @@
+name: action-pin-check
+
+on:
+  pull_request:
+    branches:
+      - master
+      - 'releases/**'
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+jobs:
+  check-action-pins:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Check third-party actions are pinned to full-length commit SHAs
+        run: |
+          # Find all workflow and action YAML files
+          FILES=$(find .github/workflows .github/actions -type f \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null)
+
+          EXIT_CODE=0
+          for file in $FILES; do
+            # Extract 'uses:' lines, skip local actions (./) and reusable workflow calls (.github/)
+            while IFS= read -r line; do
+              # Get the action reference (everything after 'uses:')
+              ref=$(echo "$line" | sed "s/.*uses:[[:space:]]*//" | tr -d "'" | tr -d '"')
+
+              # Skip local actions and reusable workflows
+              if echo "$ref" | grep -qE '^\./'; then
+                continue
+              fi
+
+              # Skip Docker references (docker://)
+              if echo "$ref" | grep -qE '^docker://'; then
+                continue
+              fi
+
+              # Extract the version part (after @), stripping inline comments and whitespace
+              version=$(echo "$ref" | sed 's/.*@//' | sed 's/[[:space:]]*#.*//' | tr -d '[:space:]')
+
+              # Check if version is a full-length (40 char) hex SHA
+              if ! echo "$version" | grep -qE '^[0-9a-fA-F]{40}$'; then
+                echo "::error file=${file}::Action '${ref}' is not pinned to a full-length commit SHA. See https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions"
+                EXIT_CODE=1
+              fi
+            done < <(grep -n '^\s*-\?\s*uses:' "$file" | grep -v '^\s*#')
+          done
+
+          if [ "$EXIT_CODE" -ne 0 ]; then
+            echo ""
+            echo "All third-party GitHub Actions must be pinned to a full-length commit SHA."
+            echo "Example: uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4"
+            echo ""
+            echo "You can find the full SHA for a release tag by running:"
+            echo "  git ls-remote https://github.com/OWNER/REPO refs/tags/TAG"
+            exit 1
+          fi
+
+          echo "All third-party actions are pinned to full-length commit SHAs."

--- a/.github/workflows/buildkite-trigger-wait.yml
+++ b/.github/workflows/buildkite-trigger-wait.yml
@@ -74,7 +74,7 @@ jobs:
       # Trigger Buildkite smoke tests
       - name: Trigger Buildkite Smoke Tests
         id: trigger_buildkite
-        uses: buildkite/trigger-pipeline-action@v2.3.0
+        uses: buildkite/trigger-pipeline-action@3b5d98081fffc1a90e7eaa739f05e6106585a11a # v2.3.0
         with:
           buildkite_api_access_token: ${{ secrets.BUILDKITE_TOKEN }}
           pipeline: skypilot-1/${{ inputs.pipeline }}

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -17,7 +17,7 @@ jobs:
   dashboard:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - name: Install dependencies and check
       run: |
         npm --prefix sky/dashboard install

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,9 +20,9 @@ jobs:
       matrix:
         python-version: ["3.9"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f # v4
       with:
         version: "latest"
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/image-vulnerability.yml
+++ b/.github/workflows/image-vulnerability.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build Docker image
         run: |

--- a/.github/workflows/test-doc-build.yml
+++ b/.github/workflows/test-doc-build.yml
@@ -20,9 +20,9 @@ jobs:
       matrix:
         python-version: ["3.10"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f # v4
       with:
         version: "latest"
         python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Enforce we always reference 3rd party actions via full commit SHA

Expected to pass after https://github.com/skypilot-org/skypilot/pull/9160 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
