### PR TITLE
[Core] Add workspace name limitation

### DIFF
--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -430,6 +430,11 @@ class InvalidRecipeNameError(Exception):
     pass
 
 
+class InvalidWorkspaceNameError(Exception):
+    """Raised when the workspace name is invalid."""
+    pass
+
+
 class RecipeAlreadyExistsError(Exception):
     """Raised when attempting to create a recipe with an existing name."""
     pass

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -409,6 +409,11 @@ CLUSTER_NAME_VALID_REGEX = '[a-zA-Z]([-_.a-zA-Z0-9]*[a-zA-Z0-9])?'
 RECIPE_NAME_VALID_REGEX = r'[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?'
 RECIPE_NAME_MAX_LENGTH = 40
 
+# Workspace names: lowercase letters, numbers, dashes, and underscores.
+# Must start with a lowercase letter, end with a lowercase letter or digit.
+WORKSPACE_NAME_VALID_REGEX = r'[a-z]([-_a-z0-9]*[a-z0-9])?'
+WORKSPACE_NAME_MAX_LENGTH = 63
+
 # Used for translate local file mounts to cloud storage. Please refer to
 # sky/execution.py::_maybe_translate_local_file_mounts_and_sync_up for
 # more details.

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -221,6 +221,36 @@ def check_recipe_name_is_valid(recipe_name: Optional[str]) -> None:
                 'only contains letters, numbers, and dashes).')
 
 
+def check_workspace_name_is_valid(workspace_name: Optional[str]) -> None:
+    """Errors out on invalid workspace names.
+
+    Workspace names must:
+    - Start with a lowercase letter
+    - Contain only lowercase letters, numbers, dashes, and underscores
+    - End with a lowercase letter or number
+    - Be at most constants.WORKSPACE_NAME_MAX_LENGTH characters
+
+    Raises:
+        exceptions.InvalidWorkspaceNameError: If the workspace name is invalid.
+    """
+    if workspace_name is None:
+        return
+    if len(workspace_name) > constants.WORKSPACE_NAME_MAX_LENGTH:
+        with ux_utils.print_exception_no_traceback():
+            raise exceptions.InvalidWorkspaceNameError(
+                f'Workspace name "{workspace_name}" is too long; '
+                f'maximum length is {constants.WORKSPACE_NAME_MAX_LENGTH} '
+                f'characters, got {len(workspace_name)}')
+    valid_regex = constants.WORKSPACE_NAME_VALID_REGEX
+    if re.fullmatch(valid_regex, workspace_name) is None:
+        with ux_utils.print_exception_no_traceback():
+            raise exceptions.InvalidWorkspaceNameError(
+                f'Workspace name "{workspace_name}" is invalid; '
+                'ensure it starts with a lowercase letter, ends with '
+                'a lowercase letter or number, and contains only '
+                'lowercase letters, numbers, dashes, and underscores.')
+
+
 def make_cluster_name_on_cloud(display_name: str,
                                max_length: Optional[int] = 15,
                                add_user_hash: bool = True) -> str:

--- a/sky/workspaces/core.py
+++ b/sky/workspaces/core.py
@@ -432,6 +432,7 @@ def create_workspace(workspace_name: str, config: Dict[str,
     # Validate the workspace name
     if not workspace_name or not isinstance(workspace_name, str):
         raise ValueError('Workspace name must be a non-empty string.')
+    common_utils.check_workspace_name_is_valid(workspace_name)
 
     _validate_workspace_config(workspace_name, config)
 
@@ -567,6 +568,9 @@ def update_config(config: Dict[str, Any]) -> Dict[str, Any]:
     # Check each workspace that is being modified
     for workspace_name, new_workspace_config in new_workspaces.items():
         if workspace_name not in current_workspaces:
+            # Validate names for newly added workspaces only (not existing
+            # ones, for backward compatibility with pre-validation names).
+            common_utils.check_workspace_name_is_valid(workspace_name)
             users = workspaces_utils.get_workspace_users(new_workspace_config)
             workspaces_to_check_policy['add'][workspace_name] = users
             continue

--- a/tests/unit_tests/test_sky/utils/test_common_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_common_utils.py
@@ -507,6 +507,60 @@ class TestRedactSecretsValues:
         assert result == expected
 
 
+class TestCheckWorkspaceNameIsValid:
+
+    @pytest.mark.parametrize('name', [
+        'a',
+        'dev',
+        'my-workspace',
+        'my_workspace',
+        'team-alpha-2',
+        'a1',
+        'default',
+        'a' * 63,
+        'abc-def_ghi-123',
+    ])
+    def test_valid_names(self, name):
+        """Valid workspace names should pass validation."""
+        common_utils.check_workspace_name_is_valid(name)
+
+    @pytest.mark.parametrize('name', [
+        '',
+        '1workspace',
+        '-workspace',
+        '_workspace',
+        'MyWorkspace',
+        'my.workspace',
+        'workspace-',
+        'workspace_',
+        'a' * 64,
+        'ALLCAPS',
+        'has space',
+        'has@symbol',
+        '123',
+    ])
+    def test_invalid_names(self, name):
+        """Invalid workspace names should raise InvalidWorkspaceNameError."""
+        with pytest.raises(exceptions.InvalidWorkspaceNameError):
+            common_utils.check_workspace_name_is_valid(name)
+
+    def test_none_name(self):
+        """None workspace name should pass (no-op)."""
+        common_utils.check_workspace_name_is_valid(None)
+
+    def test_too_long_error_message(self):
+        """Error message for too-long names should mention the length limit."""
+        with pytest.raises(exceptions.InvalidWorkspaceNameError,
+                           match='too long'):
+            common_utils.check_workspace_name_is_valid('a' * 64)
+
+    def test_invalid_chars_error_message(self):
+        """Error message for invalid chars should mention allowed characters."""
+        with pytest.raises(exceptions.InvalidWorkspaceNameError,
+                           match='lowercase'):
+            common_utils.check_workspace_name_is_valid('MyWorkspace')
+
+
 @pytest.mark.asyncio
 async def test_set_request_context_coroutine_is_context_safe():
     original_user = common_utils.get_current_user()

--- a/tests/unit_tests/test_sky/workspaces/test_workspace_management.py
+++ b/tests/unit_tests/test_sky/workspaces/test_workspace_management.py
@@ -5,7 +5,9 @@ import tempfile
 import unittest
 from unittest import mock
 
+from sky import exceptions
 from sky.skylet import constants
+from sky.utils import common_utils
 from sky.workspaces import core
 
 
@@ -42,15 +44,13 @@ class TestWorkspaceManagement(unittest.TestCase):
         import shutil
         shutil.rmtree(self.temp_dir)
 
-    @mock.patch('sky.skypilot_config.get_user_config_path')
+    @mock.patch('sky.skypilot_config.get_skypilot_config_lock_path')
     @mock.patch('sky.skypilot_config.to_dict')
-    @mock.patch('sky.utils.yaml_utils.dump_yaml')
-    @mock.patch('sky.skypilot_config.reload_config')
-    def test_internal_update_workspaces_config(self, mock_reload_config,
-                                               mock_dump_yaml, mock_to_dict,
-                                               mock_get_path):
+    @mock.patch('sky.skypilot_config.update_api_server_config_no_lock')
+    def test_internal_update_workspaces_config(self, mock_update_no_lock,
+                                               mock_to_dict, mock_lock_path):
         """Test the internal helper for updating workspaces configuration."""
-        mock_get_path.return_value = self.config_path
+        mock_lock_path.return_value = self.config_path + '.lock'
         mock_to_dict.return_value = self.sample_config.copy()
 
         new_workspaces = {
@@ -70,10 +70,13 @@ class TestWorkspaceManagement(unittest.TestCase):
         result = core._update_workspaces_config(modifier_fn)
 
         # Verify the function called the right methods
-        mock_dump_yaml.assert_called_once()
         mock_to_dict.assert_called_once()
-        mock_get_path.assert_called_once()
-        mock_reload_config.assert_called_once()
+        mock_lock_path.assert_called_once()
+        mock_update_no_lock.assert_called_once()
+
+        # Verify the written config has the updated workspaces
+        written_config = mock_update_no_lock.call_args[0][0]
+        self.assertEqual(written_config['workspaces'], new_workspaces)
 
         # Verify the result
         self.assertEqual(result, new_workspaces)
@@ -645,6 +648,183 @@ class TestWorkspaceManagement(unittest.TestCase):
 
         # Should not call resource checker since no users were removed
         mock_check_resources.assert_not_called()
+
+
+class TestWorkspaceNameBackwardCompatibility(unittest.TestCase):
+    """Tests that existing workspaces with non-conforming names still work."""
+
+    @mock.patch('sky.skypilot_config.get_nested')
+    @mock.patch(
+        'sky.utils.resource_checker.check_no_active_resources_for_workspaces')
+    @mock.patch('sky.utils.schemas.get_config_schema')
+    @mock.patch('sky.utils.common_utils.validate_schema')
+    @mock.patch('sky.check.check')
+    @mock.patch('sky.workspaces.core._update_workspaces_config')
+    def test_update_existing_workspace_with_nonconforming_name(
+            self, mock_update_config, mock_sky_check, mock_validate_schema,
+            mock_get_schema, mock_check_resources, mock_get_nested):
+        """Updating an existing workspace with a non-conforming name should
+        succeed because we only validate names on creation."""
+        mock_get_nested.return_value = {
+            'default': {},
+            'My_Old.Workspace': {
+                'gcp': {
+                    'project_id': 'old-project'
+                }
+            },
+        }
+        mock_check_resources.return_value = None
+        mock_get_schema.return_value = {
+            'properties': {
+                'workspaces': {
+                    'additionalProperties': {}
+                }
+            }
+        }
+        mock_validate_schema.return_value = None
+        mock_update_config.return_value = {}
+
+        new_config = {'gcp': {'project_id': 'new-project'}}
+        # Should NOT raise InvalidWorkspaceNameError
+        core.update_workspace('My_Old.Workspace', new_config)
+        mock_update_config.assert_called_once()
+
+    @mock.patch('sky.skypilot_config.get_skypilot_config_lock_path')
+    @mock.patch('sky.skypilot_config.update_api_server_config_no_lock')
+    @mock.patch('sky.skypilot_config.to_dict')
+    @mock.patch('sky.utils.schemas.get_config_schema')
+    @mock.patch('sky.utils.common_utils.validate_schema')
+    @mock.patch('sky.check.check')
+    @mock.patch(
+        'sky.utils.resource_checker.check_no_active_resources_for_workspaces')
+    @mock.patch('sky.users.permission.permission_service')
+    @mock.patch(
+        'sky.workspaces.core._validate_workspace_config_changes_with_lock')
+    def test_update_config_existing_nonconforming_workspaces_unchanged(
+            self, mock_validate_changes, mock_permission, mock_check_resources,
+            mock_sky_check, mock_validate_schema, mock_get_schema, mock_to_dict,
+            mock_update_no_lock, mock_lock_path):
+        """update_config with existing non-conforming workspace names that are
+        unchanged should succeed."""
+        existing_config = {
+            'workspaces': {
+                'default': {},
+                'Legacy.WS': {
+                    'gcp': {
+                        'project_id': 'old'
+                    }
+                },
+            }
+        }
+        mock_to_dict.return_value = existing_config.copy()
+        mock_get_schema.return_value = {
+            'properties': {
+                'workspaces': {
+                    'additionalProperties': {}
+                }
+            }
+        }
+        mock_validate_schema.return_value = None
+        mock_check_resources.return_value = None
+        mock_lock_path.return_value = '/tmp/test-lock'
+
+        # Modify the non-conforming workspace's config so it goes through
+        # the workspace change validation path (not the early return).
+        modified_config = {
+            'workspaces': {
+                'default': {},
+                'Legacy.WS': {
+                    'gcp': {
+                        'project_id': 'new-project'
+                    }
+                },
+            }
+        }
+        # Should NOT raise InvalidWorkspaceNameError for existing workspace
+        core.update_config(modified_config)
+
+    @mock.patch('sky.skypilot_config.get_skypilot_config_lock_path')
+    @mock.patch('sky.skypilot_config.update_api_server_config_no_lock')
+    @mock.patch('sky.skypilot_config.to_dict')
+    @mock.patch('sky.utils.schemas.get_config_schema')
+    @mock.patch('sky.utils.common_utils.validate_schema')
+    @mock.patch('sky.check.check')
+    @mock.patch(
+        'sky.utils.resource_checker.check_no_active_resources_for_workspaces')
+    @mock.patch('sky.users.permission.permission_service')
+    @mock.patch('sky.workspaces.utils.get_workspace_users')
+    def test_update_config_adds_new_conforming_workspace(
+            self, mock_get_users, mock_permission, mock_check_resources,
+            mock_sky_check, mock_validate_schema, mock_get_schema, mock_to_dict,
+            mock_update_no_lock, mock_lock_path):
+        """update_config adding a new workspace with a valid name should
+        succeed."""
+        existing_config = {'workspaces': {'default': {},}}
+        mock_to_dict.return_value = existing_config.copy()
+        mock_get_schema.return_value = {
+            'properties': {
+                'workspaces': {
+                    'additionalProperties': {}
+                }
+            }
+        }
+        mock_validate_schema.return_value = None
+        mock_check_resources.return_value = None
+        mock_lock_path.return_value = '/tmp/test-lock'
+        mock_get_users.return_value = []
+
+        new_config = {
+            'workspaces': {
+                'default': {},
+                'my-new-ws': {
+                    'gcp': {
+                        'project_id': 'test'
+                    }
+                },
+            }
+        }
+        # Should NOT raise any exception
+        core.update_config(new_config)
+
+    @mock.patch('sky.skypilot_config.get_skypilot_config_lock_path')
+    @mock.patch('sky.skypilot_config.update_api_server_config_no_lock')
+    @mock.patch('sky.skypilot_config.to_dict')
+    @mock.patch('sky.utils.schemas.get_config_schema')
+    @mock.patch('sky.utils.common_utils.validate_schema')
+    @mock.patch('sky.check.check')
+    @mock.patch(
+        'sky.utils.resource_checker.check_no_active_resources_for_workspaces')
+    @mock.patch('sky.users.permission.permission_service')
+    def test_update_config_rejects_new_nonconforming_workspace(
+            self, mock_permission, mock_check_resources, mock_sky_check,
+            mock_validate_schema, mock_get_schema, mock_to_dict,
+            mock_update_no_lock, mock_lock_path):
+        """update_config adding a new workspace with a non-conforming name
+        should fail."""
+        existing_config = {'workspaces': {'default': {},}}
+        mock_to_dict.return_value = existing_config.copy()
+        mock_get_schema.return_value = {
+            'properties': {
+                'workspaces': {
+                    'additionalProperties': {}
+                }
+            }
+        }
+        mock_validate_schema.return_value = None
+        mock_lock_path.return_value = '/tmp/test-lock'
+
+        new_config = {
+            'workspaces': {
+                'default': {},
+                'Bad.Name': {
+                    'gcp': {
+                        'project_id': 'test'
+                    }
+                },
+            }
+        }
+        with self.assertRaises(exceptions.InvalidWorkspaceNameError):
+            core.update_config(new_config)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

- Pattern: `[a-z]([-_a-z0-9]*[a-z0-9])?` — lowercase letters, digits, hyphens, underscores. Must start with letter, end with letter/digit.
  - No uppercase: YAML keys are case-sensitive, `Dev` vs `dev` would be confusing
  - No dots: dots are uncommon in workspace names and could confuse with domain names
- Max length: 63
- Backward compat: Only validate on creation/addition, not existing workspaces


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Before upgrade
    - Create workspaces with names conforming and not conforming to the new pattern
    - Launch clusters with the above workspaces
  - After upgrade
    - `sky exec` on the above clusters works
    - `sky launch` with the above workspaces works
    - Creating new workspaces with non-confirming names fails
    - Creating new workspaces with confirming names succeeds
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
