### PR TITLE
fix: replace bare except with except Exception in two scripts

### DIFF
--- a/docs/verify_llms_links.py
+++ b/docs/verify_llms_links.py
@@ -33,7 +33,7 @@ def main():
     if base_url.startswith("http://127.0.0.1"):
         try:
             requests.get(base_url, timeout=1)
-        except:
+        except Exception:
             print(f"WARNING: No server at {base_url}")
 
     failures = []

--- a/llm/vicuna-llama-2/scripts/train.py
+++ b/llm/vicuna-llama-2/scripts/train.py
@@ -297,7 +297,7 @@ def cleanup_incomplete_checkpoints(output_dir):
                 subprocess.run(
                     ['gsutil', '-m', 'rsync', '-r', checkpoint, tmp_dir],
                     check=True)
-            except:
+            except Exception:
                 print('Failed to optimize checkpoint loading. Skip.')
             break
 


### PR DESCRIPTION
## Summary

Replace bare `except:` clauses with `except Exception:` in two scripts.

Bare `except:` catches **all** exceptions including `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit` which is almost never intentional. Neither of these blocks re-raises the original exception, so `except Exception:` is the correct replacement.

**Files changed:**

### `docs/verify_llms_links.py` (line 36)
```python
# Before
except:
    print(f"WARNING: No server at {base_url}")

# After
except Exception:
    print(f"WARNING: No server at {base_url}")
```

### `llm/vicuna-llama-2/scripts/train.py` (line 300)
```python
# Before
except:
    print('Failed to optimize checkpoint loading. Skip.')

# After
except Exception:
    print('Failed to optimize checkpoint loading. Skip.')
```

## Testing
No behavior change for normal exception paths — correctness fix only. Allows `KeyboardInterrupt` / `SystemExit` to propagate normally instead of being silently swallowed.