### PR TITLE
[Test] Switch image_id dict tests from us-east-2 to us-west-2

### DIFF
--- a/examples/per_region_images.yaml
+++ b/examples/per_region_images.yaml
@@ -2,8 +2,8 @@ resources:
   infra: aws
   accelerators: T4:1
   image_id:
-    us-west-2: skypilot:gpu-ubuntu-1804
-    us-east-2: skypilot:gpu-ubuntu-2004
+    us-east-1: skypilot:gpu-ubuntu-1804
+    us-west-2: skypilot:gpu-ubuntu-2004
 
 
 setup: |

--- a/tests/smoke_tests/test_images.py
+++ b/tests/smoke_tests/test_images.py
@@ -141,12 +141,12 @@ def test_aws_image_id_dict_region():
         [
             # YAML has
             #   image_id:
-            #       us-west-2: skypilot:gpu-ubuntu-1804
-            #       us-east-2: skypilot:gpu-ubuntu-2004
+            #       us-east-1: skypilot:gpu-ubuntu-1804
+            #       us-west-2: skypilot:gpu-ubuntu-2004
             # Use region to filter image_id dict.
-            f'sky launch -y -c {name} {smoke_tests_utils.LOW_RESOURCE_ARG} --infra aws/us-east-1 examples/per_region_images.yaml && exit 1 || true',
+            f'sky launch -y -c {name} {smoke_tests_utils.LOW_RESOURCE_ARG} --infra aws/us-east-2 examples/per_region_images.yaml && exit 1 || true',
             f'sky status | grep {name} && exit 1 || true',  # Ensure the cluster is not created.
-            f'sky launch -y -c {name} {smoke_tests_utils.LOW_RESOURCE_ARG} --infra aws/us-east-2 examples/per_region_images.yaml',
+            f'sky launch -y -c {name} {smoke_tests_utils.LOW_RESOURCE_ARG} --infra aws/us-west-2 examples/per_region_images.yaml',
             # Should success because the image id match for the region.
             f'sky launch -c {name} --image-id skypilot:gpu-ubuntu-2004 examples/minimal.yaml',
             f'sky exec {name} --image-id skypilot:gpu-ubuntu-2004 examples/minimal.yaml',
@@ -154,11 +154,11 @@ def test_aws_image_id_dict_region():
             f'sky logs {name} 1 --status',
             f'sky logs {name} 2 --status',
             f'sky logs {name} 3 --status',
-            f'sky status -v | grep {name} | grep us-east-2',  # Ensure the region is correct.
+            f'sky status -v | grep {name} | grep us-west-2',  # Ensure the region is correct.
             # Ensure exec works.
-            f'sky exec {name} --infra aws/us-east-2 examples/per_region_images.yaml',
+            f'sky exec {name} --infra aws/us-west-2 examples/per_region_images.yaml',
             f'sky exec {name} examples/per_region_images.yaml',
-            f'sky exec {name} --infra aws/us-east-2 "ls ~"',
+            f'sky exec {name} --infra aws/us-west-2 "ls ~"',
             f'sky exec {name} "ls ~"',
             f'sky logs {name} 4 --status',
             f'sky logs {name} 5 --status',
@@ -211,12 +211,12 @@ def test_aws_image_id_dict_zone():
         [
             # YAML has
             #   image_id:
-            #       us-west-2: skypilot:gpu-ubuntu-1804
-            #       us-east-2: skypilot:gpu-ubuntu-2004
+            #       us-east-1: skypilot:gpu-ubuntu-1804
+            #       us-west-2: skypilot:gpu-ubuntu-2004
             # Use zone to filter image_id dict.
-            f'sky launch -y -c {name} --infra aws/*/us-east-1b {smoke_tests_utils.LOW_RESOURCE_ARG} examples/per_region_images.yaml && exit 1 || true',
+            f'sky launch -y -c {name} --infra aws/*/us-east-2b {smoke_tests_utils.LOW_RESOURCE_ARG} examples/per_region_images.yaml && exit 1 || true',
             f'sky status | grep {name} && exit 1 || true',  # Ensure the cluster is not created.
-            f'sky launch -y -c {name} --infra aws/*/us-east-2a {smoke_tests_utils.LOW_RESOURCE_ARG} examples/per_region_images.yaml',
+            f'sky launch -y -c {name} --infra aws/*/us-west-2a {smoke_tests_utils.LOW_RESOURCE_ARG} examples/per_region_images.yaml',
             # Should success because the image id match for the zone.
             f'sky launch -y -c {name} {smoke_tests_utils.LOW_RESOURCE_ARG} --image-id skypilot:gpu-ubuntu-2004 examples/minimal.yaml',
             f'sky exec {name} --image-id skypilot:gpu-ubuntu-2004 examples/minimal.yaml',
@@ -225,11 +225,11 @@ def test_aws_image_id_dict_zone():
             f'sky logs {name} 1 --status',
             f'sky logs {name} 2 --status',
             f'sky logs {name} 3 --status',
-            f'sky status -v | grep {name} | grep us-east-2a',  # Ensure the zone is correct.
+            f'sky status -v | grep {name} | grep us-west-2a',  # Ensure the zone is correct.
             # Ensure exec works.
-            f'sky exec {name} --infra aws/*/us-east-2a examples/per_region_images.yaml',
+            f'sky exec {name} --infra aws/*/us-west-2a examples/per_region_images.yaml',
             f'sky exec {name} examples/per_region_images.yaml',
-            f'sky exec {name} --infra aws/us-east-2 "ls ~"',
+            f'sky exec {name} --infra aws/us-west-2 "ls ~"',
             f'sky exec {name} "ls ~"',
             f'sky logs {name} 4 --status',
             f'sky logs {name} 5 --status',


### PR DESCRIPTION
## Summary
- Switch `test_aws_image_id_dict_region` and `test_aws_image_id_dict_zone` from launching GPU instances in `us-east-2` to `us-west-2`
- Root cause: Buildkite EKS infra (8x `g4dn.2xlarge`) permanently consumes 64 of 128 G-family vCPUs in `us-east-2`, causing `VcpuLimitExceeded` when parallel smoke tests try to launch additional `g4dn` instances there
- Updated `examples/per_region_images.yaml` region mapping from `{us-west-2, us-east-2}` to `{us-east-1, us-west-2}`

## Test plan
- [ ] `/smoke-test --generic-cloud --args test_aws_image_id_dict_region`
- [ ] `/smoke-test --generic-cloud --args test_aws_image_id_dict_zone`
- [ ] `/smoke-test --generic-cloud --args test_aws_image_id_dict`
- [ ] `/smoke-test --generic-cloud --args test_image_no_conda`

🤖 Generated with [Claude Code](https://claude.com/claude-code)