### PR TITLE
fix(dashboard): use cluster_name_on_cloud for instance link filters

### DIFF
--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -582,7 +582,7 @@ class StrategyExecutor:
                                     instance_links = (instance_links_utils.
                                                       generate_instance_links(
                                                           cluster_info,
-                                                          self.cluster_name))
+                                                          handle.cluster_name_on_cloud))
                                     if instance_links:
                                         # Store instance links directly in
                                         # database


### PR DESCRIPTION
## Summary

Instance links in the managed jobs dashboard point to wrong VM names in the cloud console.

## Root Cause

`generate_instance_links()` receives `self.cluster_name` (generated with `add_user_hash=False`), but cloud instances are tagged with `cluster_name_on_cloud` (which includes the user hash suffix). The URL filter therefore matches nothing.

For example:
- `self.cluster_name` = `sky-job-abc`
- `handle.cluster_name_on_cloud` = `sky-job-abc-user123`
- GCP/AWS instances are tagged with `ray-cluster-name: sky-job-abc-user123`
- The generated console URL filters for `ray-cluster-name: sky-job-abc` → no results

## Fix

Use `handle.cluster_name_on_cloud` instead of `self.cluster_name` when calling `generate_instance_links()` in `sky/jobs/recovery_strategy.py`.

Fixes #9047