### PR TITLE
Expose filters to queue v2 and cli

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -5675,18 +5675,65 @@ def jobs_launch(
               is_flag=True,
               required=False,
               help='Show only pending/running jobs\' information.')
+@click.option('--name',
+              '-n',
+              default=None,
+              type=str,
+              required=False,
+              help='Filter jobs by name (substring match).')
+@click.option('--pool',
+              default=None,
+              type=str,
+              required=False,
+              help='Filter jobs by pool name (substring match).')
+@click.option('--user',
+              '-u',
+              default=None,
+              type=str,
+              required=False,
+              help='Filter jobs by user (substring match).')
+@click.option('--workspace',
+              '-w',
+              default=None,
+              type=str,
+              required=False,
+              help='Filter jobs by workspace (substring match).')
+@click.option('--status',
+              default=None,
+              type=str,
+              multiple=True,
+              required=False,
+              help='Filter jobs by status (can be specified multiple times).')
+@click.option('--sort-by',
+              default=None,
+              type=str,
+              required=False,
+              help='Field to sort by (e.g., job_id, name, submitted_at).')
+@click.option('--sort-order',
+              default=None,
+              type=click.Choice(['asc', 'desc']),
+              required=False,
+              help='Sort direction.')
 @flags.all_users_option('Show jobs from all users.')
 @flags.all_option('Show all jobs.')
 @flags.output_format_option()
 @usage_lib.entrypoint
 # pylint: disable=redefined-builtin
-def jobs_queue(verbose: bool,
-               refresh: bool,
-               skip_finished: bool,
-               all_users: bool,
-               all: bool,
-               limit: int,
-               output_format: str = 'table'):
+def jobs_queue(
+        verbose: bool,
+        refresh: bool,
+        skip_finished: bool,
+        all_users: bool,
+        all: bool,
+        limit: int,
+        name: Optional[str],
+        pool: Optional[str],  # pylint: disable=redefined-outer-name
+        user: Optional[str],
+        workspace: Optional[str],
+        status: Tuple[str, ...],  # pylint: disable=redefined-outer-name
+        sort_by: Optional[str],
+        sort_order: Optional[str],
+        output_format: str = 'table'):
     """Show statuses of managed jobs.
 
     Each managed jobs can have one of the following statuses:
@@ -5757,12 +5804,23 @@ def jobs_queue(verbose: bool,
                 fields = fields + _USER_HASH_FIELD
         # Call both cli_utils.get_managed_job_queue and managed_jobs.pool_status
         # in parallel
+        statuses = list(status) if status else None
+
         def get_managed_jobs_queue():
-            return cli_utils.get_managed_job_queue(refresh=refresh,
-                                                   skip_finished=skip_finished,
-                                                   all_users=all_users,
-                                                   limit=max_num_jobs_to_show,
-                                                   fields=fields)
+            return cli_utils.get_managed_job_queue(
+                refresh=refresh,
+                skip_finished=skip_finished,
+                all_users=all_users,
+                limit=max_num_jobs_to_show,
+                fields=fields,
+                sort_by=sort_by,
+                sort_order=sort_order,
+                name_match=name,
+                pool_match=pool,
+                user_match=user,
+                workspace_match=workspace,
+                statuses=statuses,
+            )
 
         def get_pool_status():
             try:

--- a/sky/client/cli/utils.py
+++ b/sky/client/cli/utils.py
@@ -36,6 +36,15 @@ def get_managed_job_queue(
     job_ids: Optional[List[int]] = None,
     limit: Optional[int] = None,
     fields: Optional[List[str]] = None,
+    sort_by: Optional[str] = None,
+    sort_order: Optional[str] = None,
+    *,
+    name_match: Optional[str] = None,
+    pool_match: Optional[str] = None,
+    user_match: Optional[str] = None,
+    workspace_match: Optional[str] = None,
+    statuses: Optional[List[str]] = None,
+    page: Optional[int] = None,
 ) -> Tuple[server_common.RequestId[Union[List[responses.ManagedJobRecord],
                                          Tuple[List[responses.ManagedJobRecord],
                                                int, Dict[str, int], int]]],
@@ -51,6 +60,14 @@ def get_managed_job_queue(
         job_ids: IDs of the managed jobs to show.
         limit: Number of jobs to show.
         fields: Fields to get for the managed jobs.
+        sort_by: Field to sort by (e.g., 'job_id', 'name', 'submitted_at').
+        sort_order: Sort direction ('asc' or 'desc').
+        name_match: Filter jobs by name (substring match).
+        pool_match: Filter jobs by pool name (substring match).
+        user_match: Filter jobs by user (substring match).
+        workspace_match: Filter jobs by workspace (substring match).
+        statuses: Filter jobs by statuses.
+        page: Page number for pagination.
 
     Returns:
         - the request ID of the queue request
@@ -61,15 +78,46 @@ def get_managed_job_queue(
           does not exist.
         RuntimeError: if failed to get the managed jobs with ssh.
     """
+    # These args are only supported by queue_v2. Collect them so we can
+    # raise if we have to fall back to the v1 endpoint.
+    v2_only_kwargs = dict(
+        sort_by=sort_by,
+        sort_order=sort_order,
+        name_match=name_match,
+        pool_match=pool_match,
+        user_match=user_match,
+        workspace_match=workspace_match,
+        statuses=statuses,
+        page=page,
+    )
     try:
         return typing.cast(
             server_common.RequestId[
                 Union[List[responses.ManagedJobRecord],
                       Tuple[List[responses.ManagedJobRecord], int,
                             Dict[str, int], int]]],
-            managed_jobs.queue_v2(refresh, skip_finished, all_users, job_ids,
-                                  limit, fields)), QueueResultVersion.V2
-    except exceptions.APINotSupportedError:
+            managed_jobs.queue_v2(refresh,
+                                  skip_finished,
+                                  all_users,
+                                  job_ids,
+                                  limit,
+                                  fields,
+                                  sort_by,
+                                  sort_order,
+                                  name_match=name_match,
+                                  pool_match=pool_match,
+                                  user_match=user_match,
+                                  workspace_match=workspace_match,
+                                  statuses=statuses,
+                                  page=page)), QueueResultVersion.V2
+    except exceptions.APINotSupportedError as e:
+        used_v2_args = [k for k, v in v2_only_kwargs.items() if v is not None]
+        if used_v2_args:
+            raise exceptions.APINotSupportedError(
+                f'The following filter/sort options require queue_v2 which '
+                f'is not supported by the API server: '
+                f'{", ".join(used_v2_args)}. '
+                f'Please upgrade the API server.') from e
         return typing.cast(
             server_common.RequestId[
                 Union[List[responses.ManagedJobRecord],

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -169,6 +169,12 @@ def queue_v2(
     skip_finished: bool = False,
     all_users: bool = False,
     job_ids: Optional[List[int]] = None,
+    name_match: Optional[str] = None,
+    pool_match: Optional[str] = None,
+    user_match: Optional[str] = None,
+    workspace_match: Optional[str] = None,
+    statuses: Optional[List[str]] = None,
+    page: Optional[int] = None,
     limit: Optional[int] = None,
     fields: Optional[List[str]] = None,
     sort_by: Optional[str] = None,
@@ -184,6 +190,12 @@ def queue_v2(
         skip_finished: Whether to skip finished jobs.
         all_users: Whether to show all users' jobs.
         job_ids: IDs of the managed jobs to show.
+        name_match: Filter jobs by name (substring match).
+        pool_match: Filter jobs by pool name (substring match).
+        user_match: Filter jobs by user (substring match).
+        workspace_match: Filter jobs by workspace (substring match).
+        statuses: Filter jobs by statuses.
+        page: Page number for pagination.
         limit: Number of jobs to show.
         fields: Fields to get for the managed jobs.
         sort_by: Field to sort by (e.g., 'job_id', 'name', 'submitted_at').
@@ -236,6 +248,12 @@ def queue_v2(
         skip_finished=skip_finished,
         all_users=all_users,
         job_ids=job_ids,
+        name_match=name_match,
+        pool_match=pool_match,
+        user_match=user_match,
+        workspace_match=workspace_match,
+        statuses=statuses,
+        page=page,
         limit=limit,
         fields=fields,
         sort_by=sort_by,

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -169,16 +169,17 @@ def queue_v2(
     skip_finished: bool = False,
     all_users: bool = False,
     job_ids: Optional[List[int]] = None,
+    limit: Optional[int] = None,
+    fields: Optional[List[str]] = None,
+    sort_by: Optional[str] = None,
+    sort_order: Optional[str] = None,
+    *,
     name_match: Optional[str] = None,
     pool_match: Optional[str] = None,
     user_match: Optional[str] = None,
     workspace_match: Optional[str] = None,
     statuses: Optional[List[str]] = None,
     page: Optional[int] = None,
-    limit: Optional[int] = None,
-    fields: Optional[List[str]] = None,
-    sort_by: Optional[str] = None,
-    sort_order: Optional[str] = None,
 ) -> server_common.RequestId[Tuple[List[responses.ManagedJobRecord], int, Dict[
         str, int], int]]:
     """Gets statuses of managed jobs.

--- a/sky/jobs/client/sdk_async.py
+++ b/sky/jobs/client/sdk_async.py
@@ -54,12 +54,34 @@ async def queue_v2(
     job_ids: Optional[List[int]] = None,
     limit: Optional[int] = None,
     fields: Optional[List[str]] = None,
+    sort_by: Optional[str] = None,
+    sort_order: Optional[str] = None,
+    *,
+    name_match: Optional[str] = None,
+    pool_match: Optional[str] = None,
+    user_match: Optional[str] = None,
+    workspace_match: Optional[str] = None,
+    statuses: Optional[List[str]] = None,
+    page: Optional[int] = None,
     stream_logs: Optional[
         sdk_async.StreamConfig] = sdk_async.DEFAULT_STREAM_CONFIG
 ) -> Tuple[List[responses.ManagedJobRecord], int, Dict[str, int], int]:
     """Async version of queue_v2() that gets statuses of managed jobs."""
-    request_id = await asyncio.to_thread(sdk.queue_v2, refresh, skip_finished,
-                                         all_users, job_ids, limit, fields)
+    request_id = await asyncio.to_thread(sdk.queue_v2,
+                                         refresh,
+                                         skip_finished,
+                                         all_users,
+                                         job_ids,
+                                         limit,
+                                         fields,
+                                         sort_by,
+                                         sort_order,
+                                         name_match=name_match,
+                                         pool_match=pool_match,
+                                         user_match=user_match,
+                                         workspace_match=workspace_match,
+                                         statuses=statuses,
+                                         page=page)
     if stream_logs is not None:
         return await sdk_async._stream_and_get(request_id, stream_logs)  # pylint: disable=protected-access
     else:

--- a/tests/unit_tests/test_sky/jobs/test_server_queue.py
+++ b/tests/unit_tests/test_sky/jobs/test_server_queue.py
@@ -534,6 +534,63 @@ class TestQueue:
         assert [j['job_id'] for j in filtered] == [1]
         assert total_no_filter == 2
 
+    def test_queue_name_match(self, monkeypatch):
+        jobs = [
+            _make_job(1, job_name='train-gpt'),
+            _make_job(2, job_name='eval-gpt'),
+            _make_job(3, job_name='train-bert'),
+            _make_job(4, job_name='serve-llama'),
+        ]
+        self._patch_backend_and_utils(monkeypatch, jobs)
+
+        # Match jobs containing 'train'
+        filtered, total, status_counts, total_no_filter = jobs_core.queue_v2(
+            refresh=False,
+            skip_finished=False,
+            all_users=True,
+            job_ids=None,
+            user_match=None,
+            workspace_match=None,
+            name_match='train',
+            pool_match=None,
+            page=None,
+            limit=None)
+        assert total == 2
+        assert [j['job_id'] for j in filtered] == [1, 3]
+        assert total_no_filter == 4
+
+        # Match jobs containing 'gpt'
+        filtered, total, status_counts, total_no_filter = jobs_core.queue_v2(
+            refresh=False,
+            skip_finished=False,
+            all_users=True,
+            job_ids=None,
+            user_match=None,
+            workspace_match=None,
+            name_match='gpt',
+            pool_match=None,
+            page=None,
+            limit=None)
+        assert total == 2
+        assert [j['job_id'] for j in filtered] == [1, 2]
+        assert total_no_filter == 4
+
+        # No match
+        filtered, total, status_counts, total_no_filter = jobs_core.queue_v2(
+            refresh=False,
+            skip_finished=False,
+            all_users=True,
+            job_ids=None,
+            user_match=None,
+            workspace_match=None,
+            name_match='nonexistent',
+            pool_match=None,
+            page=None,
+            limit=None)
+        assert total == 0
+        assert len(filtered) == 0
+        assert total_no_filter == 4
+
     def test_queue_skip_finished_includes_all_tasks_of_active_jobs(
             self, monkeypatch):
 


### PR DESCRIPTION
This adds additional filtering options to python sdk `queue_v2`, and to cli `sky jobs queue`.

All the options are already supported externally, this just exposes them publicly.

I am anticipating this will be useful for managing busy queues.

# Example:

```
$ sky jobs queue --name root
Fetching managed job statuses...
Managed jobs
In progress tasks: 1 PENDING
ID  TASK  NAME           REQUESTED      SUBMITTED  TOT. DURATION  JOB DURATION  #RECOVERIES  STATUS   POOL      
1   -     sky-a37a-root  1x[RTX4090:1]  1 min ago  1m 3s          -             0            PENDING  adam-dev  
$ sky jobs queue --name adsf
Fetching managed job statuses...
Managed jobs
No in-progress managed jobs.
```

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)


Note:
1) I did not expose `page` to the CLI as this felt silly. Arguably sort order doesn't belong either
2) that all the filters are done via substring match. In python, they are called `name_filter`. I opted not to complicate the CLI with `--name-filter`, and use `--name` instead. Could be changed.
3) I made the new arguments in `queue_v2` keyword only. I think this is appropriate for methods that need to preserve compatibility and have many arguments. 