### PR TITLE
[UX] print out url when job launch failed

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -1310,14 +1310,9 @@ def launch(
                                        follow=True)
         cluster_dashboard_url = None
         if not server_common.is_api_server_local():
-            query = urllib.parse.urlencode({
-                'property': 'cluster',
-                'operator': ':',
-                'value': handle.get_cluster_name(),
-            })
             cluster_dashboard_url = server_common.get_dashboard_url(
                 server_common.get_server_url(),
-                starting_page=f'clusters?{query}')
+                starting_page=f'clusters/{handle.get_cluster_name()}')
         click.secho(
             ux_utils.command_hint_messages(ux_utils.CommandHintType.CLUSTER_JOB,
                                            job_id, handle.get_cluster_name(),
@@ -5603,19 +5598,12 @@ def jobs_launch(
                                                 controller=False)
         job_dashboard_url = None
         if not server_common.is_api_server_local():
-            query = urllib.parse.urlencode({
-                'property': 'id',
-                'operator': '=',
-                'value': job_id,
-            })
             job_dashboard_url = server_common.get_dashboard_url(
-                server_common.get_server_url(),
-                starting_page=f'jobs?{query}')
+                server_common.get_server_url(), starting_page=f'jobs/{job_id}')
         click.secho(
-            ux_utils.command_hint_messages(
-                ux_utils.CommandHintType.MANAGED_JOB,
-                job_id=str(job_id),
-                dashboard_url=job_dashboard_url))
+            ux_utils.command_hint_messages(ux_utils.CommandHintType.MANAGED_JOB,
+                                           job_id=str(job_id),
+                                           dashboard_url=job_dashboard_url))
         if returncode is not None:
             sys.exit(returncode)
     else:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

<img width="641" height="227" alt="image" src="https://github.com/user-attachments/assets/562e1a0b-339e-4cba-877a-dc8d9b65de3c" />
<img width="761" height="363" alt="image" src="https://github.com/user-attachments/assets/3dbcdcb0-50b6-435a-9b44-f8651adb3e90" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
