### PR TITLE
[Dashboard] Improve performance for the cluster detail and job pages

### DIFF
--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -381,28 +381,46 @@ export function useClusterDetails({ cluster, job = null }) {
   const clusterJobsLoading = loadingClusterJobData;
 
   const fetchClusterData = useCallback(async () => {
-    if (cluster) {
-      try {
-        setLoadingClusterData(true);
-        // Use dashboard cache for cluster data
-        const data = await dashboardCache.get(getClusters, [
-          { clusterNames: [cluster] },
-        ]);
-        if (data.length > 0) {
-          setClusterData(data[0]); // Assuming getClusters returns an array
-          return data[0]; // Return the data for use in fetchClusterJobData
-        } else {
-          console.error('No cluster data found for cluster:', cluster);
-          return null;
+    if (!cluster) return null;
+    try {
+      setLoadingClusterData(true);
+
+      // Try all-clusters cache first (populated by the cluster list page)
+      const cachedAll = dashboardCache.getCached(getClusters);
+      if (cachedAll) {
+        const found = cachedAll.find((c) => c.cluster === cluster);
+        if (found) {
+          setClusterData(found);
+          return found;
         }
-      } catch (error) {
-        console.error('Error fetching cluster data:', error);
-        return null;
-      } finally {
-        setLoadingClusterData(false);
       }
+
+      // Try per-cluster cache (populated by a prior visit to this detail page)
+      const cachedSingle = dashboardCache.getCached(getClusters, [
+        { clusterNames: [cluster] },
+      ]);
+      if (cachedSingle && cachedSingle.length > 0) {
+        setClusterData(cachedSingle[0]);
+        return cachedSingle[0];
+      }
+
+      // Fallback: fetch from API (direct URL navigation, first visit)
+      const data = await dashboardCache.get(getClusters, [
+        { clusterNames: [cluster] },
+      ]);
+      if (data.length > 0) {
+        setClusterData(data[0]);
+        return data[0];
+      } else {
+        console.error('No cluster data found for cluster:', cluster);
+        return null;
+      }
+    } catch (error) {
+      console.error('Error fetching cluster data:', error);
+      return null;
+    } finally {
+      setLoadingClusterData(false);
     }
-    return null;
   }, [cluster]);
 
   const fetchClusterJobData = useCallback(
@@ -410,13 +428,22 @@ export function useClusterDetails({ cluster, job = null }) {
       if (cluster) {
         try {
           setLoadingClusterJobData(true);
-          // Use dashboard cache for cluster jobs
-          const data = await dashboardCache.get(getClusterJobs, [
+          const cacheArgs = [
             {
               clusterName: cluster,
               workspace: workspace || 'default',
             },
-          ]);
+          ];
+
+          // Try synchronous cache first to avoid background refresh
+          const cached = dashboardCache.getCached(getClusterJobs, cacheArgs);
+          if (cached) {
+            setClusterJobData(cached);
+            return;
+          }
+
+          // Fallback: fetch from API (direct navigation or cache miss)
+          const data = await dashboardCache.get(getClusterJobs, cacheArgs);
           setClusterJobData(data);
         } catch (error) {
           console.error('Error fetching cluster job data:', error);
@@ -429,7 +456,9 @@ export function useClusterDetails({ cluster, job = null }) {
   );
 
   const refreshData = useCallback(async () => {
-    // Invalidate cache for fresh data
+    // Invalidate both all-clusters cache (used by list page lookup) and
+    // per-cluster cache (used by direct URL fallback) for fresh data
+    dashboardCache.invalidate(getClusters);
     dashboardCache.invalidate(getClusters, [{ clusterNames: [cluster] }]);
 
     const clusterInfo = await fetchClusterData();

--- a/sky/dashboard/src/lib/cache.js
+++ b/sky/dashboard/src/lib/cache.js
@@ -191,6 +191,25 @@ class DashboardCache {
   }
 
   /**
+   * Synchronously return cached data without triggering a fetch.
+   * Returns null on cache miss or stale data.
+   * @param {Function} fetchFunction - The function used to generate the cache key
+   * @param {Array} [args=[]] - Arguments used to generate the cache key
+   * @param {Object} [options={}] - Options
+   * @param {number} [options.ttl] - Time to live in milliseconds (default: DEFAULT_CACHE_TTL)
+   * @returns {*|null} - The cached data or null
+   */
+  getCached(fetchFunction, args = [], options = {}) {
+    const ttl = options.ttl || DEFAULT_CACHE_TTL;
+    const key = this._generateKey(fetchFunction, args);
+    const cachedItem = this.cache.get(key);
+    if (cachedItem && Date.now() - cachedItem.lastUpdated < ttl) {
+      return cachedItem.data;
+    }
+    return null;
+  }
+
+  /**
    * Get cache statistics for debugging
    */
   getStats() {


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The cluster detail page re-fetches `/status` on every visit due to a cache key mismatch with the list page (different args → different cache key → cache miss). This also delays the `/queue` fetch, which depends on it sequentially.
This PR added `getCached()` to `DashboardCache` for synchronous cache lookup without background refetch. `fetchClusterData` and `fetchClusterJobData` now check existing cache entries first, only falling back to API calls on cache miss (e.g., direct URL navigation).

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
