### PR TITLE
[Kubernetes] Run rsync helper with bash

### DIFF
--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -1674,13 +1674,12 @@ class KubernetesCommandRunner(CommandRunner):
             target,
             node_destination=f'{self.pod_name}@{encoded_namespace_context}',
             up=up,
-            rsh_option=helper_path,
+            rsh_option=f'bash {helper_path}',
             log_path=log_path,
             stream_logs=stream_logs,
             max_retry=max_retry,
-            prefix_command=(f'chmod +x {helper_path} && ' + (
-                '' if self.container is None else
-                f'SKYPILOT_K8S_EXEC_CONTAINER={shlex.quote(self.container)} ')),
+            prefix_command=('' if self.container is None else
+                            f'SKYPILOT_K8S_EXEC_CONTAINER={shlex.quote(self.container)} '),
             # rsync with `kubectl` as the rsh command will cause ~/xx parsed as
             # /~/xx, so we need to replace ~ with the remote home directory. We
             # only need to do this when ~ is at the beginning of the path.

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -1658,9 +1658,8 @@ class KubernetesCommandRunner(CommandRunner):
         """
 
         # Build command.
-        helper_path = shlex.quote(
-            os.path.join(os.path.abspath(os.path.dirname(__file__)),
-                         'kubernetes', 'rsync_helper.sh'))
+        helper_path = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                                   'kubernetes', 'rsync_helper.sh')
         namespace_context = f'{self.namespace}+{self.context}'
         # Avoid rsync interpreting :, /, and + in namespace_context as the
         # default delimiter for options and arguments.
@@ -1677,7 +1676,7 @@ class KubernetesCommandRunner(CommandRunner):
             target,
             node_destination=f'{self.pod_name}@{encoded_namespace_context}',
             up=up,
-            rsh_option=f'bash {helper_path}',
+            rsh_option=f'bash {shlex.quote(helper_path)}',
             log_path=log_path,
             stream_logs=stream_logs,
             max_retry=max_retry,

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -1669,6 +1669,9 @@ class KubernetesCommandRunner(CommandRunner):
         encoded_namespace_context = (namespace_context.replace(
             '@', '%40').replace(':', '%3A').replace('/',
                                                     '%2F').replace('+', '%2B'))
+        container_env = ('' if self.container is None else
+                         f'SKYPILOT_K8S_EXEC_CONTAINER='
+                         f'{shlex.quote(self.container)} ')
         self._rsync(
             source,
             target,
@@ -1678,8 +1681,7 @@ class KubernetesCommandRunner(CommandRunner):
             log_path=log_path,
             stream_logs=stream_logs,
             max_retry=max_retry,
-            prefix_command=('' if self.container is None else
-                            f'SKYPILOT_K8S_EXEC_CONTAINER={shlex.quote(self.container)} '),
+            prefix_command=container_env,
             # rsync with `kubectl` as the rsh command will cause ~/xx parsed as
             # /~/xx, so we need to replace ~ with the remote home directory. We
             # only need to do this when ~ is at the beginning of the path.

--- a/tests/unit_tests/test_sky/utils/test_command_runner.py
+++ b/tests/unit_tests/test_sky/utils/test_command_runner.py
@@ -2,6 +2,7 @@
 
 from contextlib import suppress
 import os
+import shlex
 import select
 import socket
 import tempfile
@@ -374,6 +375,9 @@ def test_kubernetes_runner_adds_container_flag_to_kubectl_exec() -> None:
 
 def test_kubernetes_runner_rsync_sets_exec_container_envvar() -> None:
     captured = {}
+    helper_path = os.path.join(os.path.abspath(os.path.dirname(
+        command_runner.__file__)), 'kubernetes', 'rsync_helper.sh')
+    expected_rsh = shlex.quote(f'bash {shlex.quote(helper_path)}')
 
     def fake_run_with_log(command: str, *args, **kwargs):
         captured['command'] = command
@@ -387,8 +391,7 @@ def test_kubernetes_runner_rsync_sets_exec_container_envvar() -> None:
         runner.rsync('/tmp/src', '/tmp/dst', up=True, stream_logs=False)
 
     assert 'SKYPILOT_K8S_EXEC_CONTAINER=sidecar0' in captured['command']
-    assert 'bash ' in captured['command']
-    assert 'rsync_helper.sh' in captured['command']
+    assert f'-e {expected_rsh}' in captured['command']
     assert 'chmod +x' not in captured['command']
     assert 'rsync' in captured['command']
 
@@ -396,6 +399,9 @@ def test_kubernetes_runner_rsync_sets_exec_container_envvar() -> None:
 def test_kubernetes_runner_rsync_does_not_set_exec_container_envvar_by_default(
 ) -> None:
     captured = {}
+    helper_path = os.path.join(os.path.abspath(os.path.dirname(
+        command_runner.__file__)), 'kubernetes', 'rsync_helper.sh')
+    expected_rsh = shlex.quote(f'bash {shlex.quote(helper_path)}')
 
     def fake_run_with_log(command: str, *args, **kwargs):
         captured['command'] = command
@@ -408,8 +414,7 @@ def test_kubernetes_runner_rsync_does_not_set_exec_container_envvar_by_default(
         runner.rsync('/tmp/src', '/tmp/dst', up=True, stream_logs=False)
 
     assert 'SKYPILOT_K8S_EXEC_CONTAINER=' not in captured['command']
-    assert 'bash ' in captured['command']
-    assert 'rsync_helper.sh' in captured['command']
+    assert f'-e {expected_rsh}' in captured['command']
     assert 'chmod +x' not in captured['command']
 
 

--- a/tests/unit_tests/test_sky/utils/test_command_runner.py
+++ b/tests/unit_tests/test_sky/utils/test_command_runner.py
@@ -387,6 +387,9 @@ def test_kubernetes_runner_rsync_sets_exec_container_envvar() -> None:
         runner.rsync('/tmp/src', '/tmp/dst', up=True, stream_logs=False)
 
     assert 'SKYPILOT_K8S_EXEC_CONTAINER=sidecar0' in captured['command']
+    assert 'bash ' in captured['command']
+    assert 'rsync_helper.sh' in captured['command']
+    assert 'chmod +x' not in captured['command']
     assert 'rsync' in captured['command']
 
 
@@ -405,6 +408,9 @@ def test_kubernetes_runner_rsync_does_not_set_exec_container_envvar_by_default(
         runner.rsync('/tmp/src', '/tmp/dst', up=True, stream_logs=False)
 
     assert 'SKYPILOT_K8S_EXEC_CONTAINER=' not in captured['command']
+    assert 'bash ' in captured['command']
+    assert 'rsync_helper.sh' in captured['command']
+    assert 'chmod +x' not in captured['command']
 
 
 def test_get_pod_primary_container_prefers_ray_node() -> None:


### PR DESCRIPTION
## Summary
- run the Kubernetes rsync helper via `bash` instead of trying to `chmod +x` it first
- avoid failures when SkyPilot is installed in a read-only package location while still keeping the helper runnable when the exec bit is missing
- extend the Kubernetes command runner unit assertions to cover the new helper invocation path

## Testing
- `pytest -c /dev/null --noconftest tests/unit_tests/test_sky/utils/test_command_runner.py -q -k kubernetes_runner_rsync`