### PR TITLE
Fix sky jobs log --controller retry

### DIFF
--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -459,12 +459,12 @@ def tail_logs(name: Optional[str] = None,
         timeout=(5, None))
     request_id: server_common.RequestId[int] = server_common.get_request_id(
         response)
-    # Log request is idempotent when tail is 0, thus can resume previous
-    # streaming point on retry.
+    # Log request is idempotent when tail is None or 0 (both stream from
+    # the beginning), thus can resume previous streaming point on retry.
     return sdk.stream_response(request_id=request_id,
                                response=response,
                                output_stream=output_stream,
-                               resumable=(tail == 0),
+                               resumable=(tail is None or tail == 0),
                                get_result=follow)
 
 

--- a/tests/smoke_tests/test_cli.py
+++ b/tests/smoke_tests/test_cli.py
@@ -161,6 +161,7 @@ def test_cli_auto_retry(generic_cloud: str):
     if parsed.username and parsed.password:
         api_proxy_url = f'http://{parsed.username}:{parsed.password}@127.0.0.1:{port}'
     run_command = 'for i in {1..120}; do echo "output $i" && sleep 1; done'
+    job_run_command = 'for i in {1..60}; do echo "job output $i" && sleep 1; done'
     test = smoke_tests_utils.Test(
         'cli_auto_retry',
         [
@@ -168,11 +169,17 @@ def test_cli_auto_retry(generic_cloud: str):
             f'python tests/chaos/chaos_proxy.py --port {port} --interval 30 & echo $! > /tmp/{name}-chaos.pid',
             # Both launch streaming and logs streaming should survive the chaos.
             f'SKYPILOT_API_SERVER_ENDPOINT={api_proxy_url} sky launch -y -c {name} {smoke_tests_utils.LOW_RESOURCE_ARG} --infra {generic_cloud} \'{run_command}\'',
+            # Test managed job controller logs streaming through the chaos
+            # proxy. Launch a job that runs long enough (~60s) to survive at
+            # least one connection drop (30s interval), then verify
+            # sky jobs logs --controller in follow mode completes successfully.
+            f'SKYPILOT_API_SERVER_ENDPOINT={api_proxy_url} sky jobs launch -n {name} --infra {generic_cloud} {smoke_tests_utils.LOW_RESOURCE_ARG} -y -d \'{job_run_command}\'',
+            f'SKYPILOT_API_SERVER_ENDPOINT={api_proxy_url} sky jobs logs --controller -n {name}',
             f'kill $(cat /tmp/{name}-chaos.pid)',
         ],
         timeout=smoke_tests_utils.get_timeout(generic_cloud),
-        teardown=f'sky down -y {name}; kill $(cat /tmp/{name}-chaos.pid) || true'
-    )
+        teardown=(f'sky down -y {name}; sky jobs cancel -y -n {name};'
+                  f' kill $(cat /tmp/{name}-chaos.pid) || true'))
     smoke_tests_utils.run_one_test(test)
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

`sky jobs logs --controller` pass `tail=None` which will be assumed not resumed before, this PR fix this behavior.

See the smoke test case update for validation.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
