### PR TITLE
[Dashboard] Show all users and workspaces from cache in the job filter

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -817,25 +817,32 @@ export function ManagedJobsTable({
       });
     }
 
-    // Use cached users/workspaces data (preloaded by cache-preloader) for
-    // complete filter values, instead of deriving from current page only.
-    // Fall back to current page data if cache is not yet available.
-    const cachedUsers = dashboardCache.getCached(getUsers, []);
-    const allUsers = cachedUsers
-      ? [...new Set(cachedUsers.map((u) => u.username).filter(Boolean))].sort()
-      : Array.from(users).sort();
-
-    const cachedWorkspaces = dashboardCache.getCached(getWorkspaces, []);
-    const allWorkspaces = cachedWorkspaces
-      ? Object.keys(cachedWorkspaces).sort()
-      : Array.from(workspaces).sort();
-
     setValueList({
       name: Array.from(names).sort(),
-      user: allUsers,
-      workspace: allWorkspaces,
+      user: Array.from(users).sort(),
+      workspace: Array.from(workspaces).sort(),
       pool: Array.from(pools).sort(),
       labels: Array.from(labels).sort(),
+    });
+
+    // Fetch full users/workspaces from cache (preloaded by cache-preloader).
+    // dashboardCache.get() returns cached data if fresh, or re-fetches if
+    // expired. Updates only user/workspace to avoid blocking other fields.
+    Promise.all([
+      dashboardCache.get(getUsers, []),
+      dashboardCache.get(getWorkspaces, []),
+    ]).then(([usersData, workspacesData]) => {
+      setValueList((prev) => ({
+        ...prev,
+        user: usersData
+          ? [
+              ...new Set(usersData.map((u) => u.username).filter(Boolean)),
+            ].sort()
+          : prev.user,
+        workspace: workspacesData
+          ? Object.keys(workspacesData).sort()
+          : prev.workspace,
+      }));
     });
   }, [data, poolsData, setValueList]);
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Show all users and workspaces from cache in the job filter


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Full user and workspace lists are shown when first entering the managed jobs page and staying in the page for longer than the cache TTL
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
