### PR TITLE
[Dashboard] Fix cluster detail page missing data from summary cache

### DIFF
--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -381,17 +381,9 @@ export function useClusterDetails({ cluster, job = null }) {
     try {
       setLoadingClusterData(true);
 
-      // Try all-clusters cache first (populated by the cluster list page)
-      const cachedAll = dashboardCache.getCached(getClusters);
-      if (cachedAll) {
-        const found = cachedAll.find((c) => c.cluster === cluster);
-        if (found) {
-          setClusterData(found);
-          return found;
-        }
-      }
-
-      // Try per-cluster cache (populated by a prior visit to this detail page)
+      // Try per-cluster cache first (has full detail data including
+      // cluster_name_on_cloud, last_creation_command, last_creation_yaml,
+      // etc. that are omitted from summary responses)
       const cachedSingle = dashboardCache.getCached(getClusters, [
         { clusterNames: [cluster] },
       ]);
@@ -400,7 +392,21 @@ export function useClusterDetails({ cluster, job = null }) {
         return cachedSingle[0];
       }
 
-      // Fallback: fetch from API (direct URL navigation, first visit)
+      // Show summary data immediately from all-clusters cache while we
+      // fetch full detail below. The all-clusters cache uses
+      // summary_response=true which omits fields like
+      // cluster_name_on_cloud, last_creation_command, and
+      // last_creation_yaml, so we must not return early here.
+      const cachedAll = dashboardCache.getCached(getClusters);
+      if (cachedAll) {
+        const found = cachedAll.find((c) => c.cluster === cluster);
+        if (found) {
+          setClusterData(found);
+        }
+      }
+
+      // Fetch full detail data (summary_response=false when clusterNames
+      // is specified)
       const data = await dashboardCache.get(getClusters, [
         { clusterNames: [cluster] },
       ]);


### PR DESCRIPTION
## Summary
- Fix cluster detail page showing incomplete data when navigating from the cluster list
- The `useClusterDetails` hook was using cached summary data (which omits `cluster_name_on_cloud`, `last_creation_command`, `last_creation_yaml`, `last_event`) instead of fetching full detail data
- Reorder cache lookups: check per-cluster cache first, use all-clusters cache only for immediate display, always fetch full detail

## Details
The cache preloader populates the `getClusters` cache with `summary_response=true`, which omits important fields from the backend response. When navigating to a cluster detail page, `useClusterDetails` found this summary data and returned it immediately without fetching full details.

This caused three visible issues:
1. Missing Entrypoint command and SkyPilot YAML sections
2. Missing Infra Nodes panel (needs `cluster_name_on_cloud` to derive pod names)
3. Missing Last Event information

## Test plan
- Navigate to cluster list page, then click on a cluster to view details
- Verify the Entrypoint section shows the creation command
- Verify the "Show SkyPilot YAML" collapsible section appears
- Verify the Infra Nodes panel shows pod/node information
- Verify Last Event shows the actual event text
- Verify refreshing the detail page still works correctly
- Verify direct URL navigation to a cluster detail page works

🤖 Generated with [Claude Code](https://claude.com/claude-code)