### PR TITLE
[Dashboard] Fix plugin state ref race condition on navigation mount

### DIFF
--- a/sky/dashboard/src/plugins/PluginProvider.jsx
+++ b/sky/dashboard/src/plugins/PluginProvider.jsx
@@ -783,17 +783,26 @@ export function PluginProvider({ children }) {
     }
   }, []);
 
-  // Expose state reference for getDataEnhancements to access outside React context
+  // Expose state reference for plugins to access outside React context.
+  // Use a stable ref updated during render (not in useEffect) so that child
+  // components' effects always read the latest state — even on the same commit
+  // that first mounts them.  The previous approach (useEffect with [state] dep)
+  // deleted and recreated __pluginStateRef on every state change; because React
+  // runs all cleanups before all new effects (children-first), a child mounting
+  // on the same render would read undefined during its effect.
+  const pluginStateRef = useRef(state);
+  pluginStateRef.current = state;
+
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      window.__pluginStateRef = { current: state };
+      window.__pluginStateRef = pluginStateRef;
       return () => {
-        if (window.__pluginStateRef) {
+        if (window.__pluginStateRef === pluginStateRef) {
           delete window.__pluginStateRef;
         }
       };
     }
-  }, [state]);
+  }, []);
 
   // Persist nav links to localStorage after plugins have fully loaded
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Fix a race condition where `window.__pluginStateRef` was `undefined` when plugin navigation components first mounted, causing cached nav links to not render until the next 1-second polling interval.

## Details

`__pluginStateRef` was managed via `useEffect([state])`, which deleted and recreated the window property on every state change. React runs all effect cleanups before all new effects (children-first ordering):

1. **Cleanup phase**: PluginProvider's cleanup ran → deleted `window.__pluginStateRef`
2. **New effects phase**: Child plugin's effect ran first (child before parent) → read `window.__pluginStateRef` → `undefined` → empty nav links
3. Then PluginProvider's new effect ran → set `window.__pluginStateRef` again

The fix uses a stable `useRef` whose `.current` is updated during render (synchronously, before any effects), and `window.__pluginStateRef` is only assigned on mount / cleaned up on unmount — never deleted between state changes.

## Test plan
- Load the dashboard with a plugin that registers nav links (e.g., a plugin registering `registerTopNavLink`)
- On first load, nav links appear correctly in the navigation
- Refresh the page — cached nav links should appear immediately when the navigation component mounts, with no flash of empty navigation
- Verify nav links update correctly when plugins finish loading (cached entries replaced by fresh registrations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)