### PR TITLE
[storage] Upgrade goofys to 0.24.0-ec7d1b84

### DIFF
--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -88,7 +88,7 @@ def get_s3_mount_install_cmd() -> str:
         f'  {get_rclone_install_cmd()}; '
         'else '
         '  sudo wget -nc https://github.com/aylei/goofys/'
-        'releases/download/0.24.0-aylei-upstream/goofys '
+        'releases/download/0.24.0-ec7d1b84/goofys-linux-amd64 '
         '-O /usr/local/bin/goofys && '
         'sudo chmod 755 /usr/local/bin/goofys; '
         'fi')


### PR DESCRIPTION
Upgrades goofys to [0.24.0-ec7d1b84](https://github.com/aylei/goofys/releases/tag/0.24.0-ec7d1b84)


Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)