### PR TITLE
[Docs] Remove March 2026 meetup announcement banner

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -128,7 +128,7 @@ html_theme_options = {
         'icon': 'fab fa-github',
     }],
     'use_edit_page_button': True,
-    'announcement': '<div style="padding: 24px; text-align: center; font-size: 0.8rem; line-height: 1;">👋 Join us for the <b>SkyPilot AI Infra Meetup</b> in San Francisco on March 25! <a href="https://luma.com/h52qyhmt?utm_source=skydocs">Register here</a></div>',
+    'announcement': '',  # Put announcements such as meetups here.
     'secondary_sidebar_items': [
         'page-toc',
         'edit-this-page',


### PR DESCRIPTION
## Summary
- Remove the expired March 25 meetup announcement banner from the docs site

## Test plan
- Verify the docs site no longer shows the meetup banner at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)