### PR TITLE
Fix race condition in release workflow causing untagged releases

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -111,6 +111,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          ref: ${{ github.base_ref }}
           fetch-depth: 0
           token: ${{ secrets.GH_PAT_FOR_RELEASE }}
 
@@ -121,6 +122,23 @@ jobs:
           git config --global user.email "action@github.com"
           git tag -a "v${VERSION}" -m "Release v${VERSION}"
           git push origin "v${VERSION}"
+
+      - name: Wait for tag to be available via GitHub API
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_RELEASE }}
+        run: |
+          VERSION="${{ needs.extract-version.outputs.version }}"
+          echo "Waiting for tag v${VERSION} to be visible via GitHub API..."
+          for i in $(seq 1 30); do
+            if gh api "repos/${{ github.repository }}/git/refs/tags/v${VERSION}" &>/dev/null; then
+              echo "✅ Tag v${VERSION} is visible via GitHub API (attempt $i)"
+              exit 0
+            fi
+            echo "⏳ Tag v${VERSION} not yet visible, retrying in 2s... (attempt $i/30)"
+            sleep 2
+          done
+          echo "❌ Tag v${VERSION} not visible after 60 seconds"
+          exit 1
 
       - name: Find previous release from git tags
         id: find_previous_release
@@ -179,10 +197,21 @@ jobs:
           EOF
 
           echo "Creating release from $PREVIOUS_TAG to v$VERSION"
+          TAG_COMMIT=$(git rev-parse "v${VERSION}^{commit}")
+          echo "Tag v${VERSION} points to commit ${TAG_COMMIT}"
           gh release create "v$VERSION" \
+            --target "$TAG_COMMIT" \
             --title "Release v$VERSION" \
             --notes-file final_release_notes.md \
             --draft
+
+          # Verify the release was created with the correct tag
+          RELEASE_TAG=$(gh release view "v$VERSION" --json tagName -q .tagName 2>/dev/null || echo "")
+          if [ "$RELEASE_TAG" != "v$VERSION" ]; then
+            echo "❌ Release verification failed: expected tag 'v$VERSION', got '${RELEASE_TAG}'"
+            exit 1
+          fi
+          echo "✅ Release created and verified with tag v$VERSION"
 
   cleanup-branches:
     needs: extract-version


### PR DESCRIPTION
## Summary

Fixes the issue causing the v0.12.0 release to show `untagged-ba5e4d688ad5317df6db` instead of the correct `v0.12.0` tag.

### Root cause

The `create-release` job in `release-publish.yml` had three compounding issues:

1. **No `ref` on checkout**: The checkout step didn't specify a `ref`, so for a `pull_request: closed` event it defaulted to checking out `refs/pull/{number}/merge`. While this happened to resolve to the right commit for v0.12.0, it's fragile and non-deterministic — we should be explicitly checking out the `releases/X.Y.Z` branch (the PR base).

2. **Race condition between `git push` and `gh release create`**: The job pushed the `v0.12.0` tag via `git push` and then immediately (3 seconds later) called `gh release create "v0.12.0"`. The GitHub Releases API hadn't indexed the just-pushed tag yet. When `gh release create` couldn't find the tag, it attempted to auto-create it, but since the tag already existed in Git (just not yet in the API), GitHub generated an `untagged-f1e766dd66c13b8450bc` placeholder. The workflow created a broken **draft** release.

3. **No `--target` on `gh release create`**: Without an explicit `--target`, when the tag lookup failed, `gh` defaulted to the repository's default branch (`master`) HEAD — which had moved 44 commits past the actual release commit.

### Changes

- **Checkout the release branch explicitly** (`ref: ${{ github.base_ref }}`) instead of the ambiguous PR merge ref
- **Poll the GitHub API** (up to 60s) for the tag to be visible before creating the release
- **Pass `--target <commit-sha>`** to `gh release create` so the release is explicitly pinned to the tagged commit
- **Verify after creation** that the release has the correct tag — fails the workflow loudly if it gets an `untagged-*` instead of silently producing a broken release

## Test plan
- [ ] Next release cycle should produce a correctly-tagged release
- [ ] If the race condition occurs, the polling step retries for up to 60s before failing
- [ ] If the release still gets an `untagged-*` tag somehow, the verification step fails the workflow loudly instead of silently producing a broken release

🤖 Generated with [Claude Code](https://claude.com/claude-code)