### PR TITLE
simplify debug dump log message

### DIFF
--- a/sky/core.py
+++ b/sky/core.py
@@ -1779,5 +1779,5 @@ def create_debug_dump(request_ids: Optional[List[str]] = None,
         recent_minutes=recent_minutes,
         client_info=client_info)
     logger.info('Debug dump created')
-    logger.debug(f'API server path: {debug_dump_path}')
+    logger.debug(f'Debug dump path on API server: {debug_dump_path}')
     return str(debug_dump_path)


### PR DESCRIPTION
Updated logging to simplify info message and add debug detail.

Without this the user will see the server-side path which is confusing.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
