### PR TITLE
[Test] Fix test_debug_dump_no_args timeout in remote-server mode

### DIFF
--- a/tests/smoke_tests/test_cli.py
+++ b/tests/smoke_tests/test_cli.py
@@ -427,7 +427,7 @@ def test_debug_dump_no_args(generic_cloud: str):
             ' grep -qi "at least one of" /tmp/test_debug_dump_noargs.txt',
         ],
         teardown='rm -f /tmp/test_debug_dump_noargs.txt',
-        timeout=30,
+        timeout=2 * 60,
     )
     smoke_tests_utils.run_one_test(test)
 


### PR DESCRIPTION
## Summary
- Increase `test_debug_dump_no_args` timeout from 30s to 120s (matching `test_debug_dump_nonexistent_resources`)

## Root Cause Analysis

The test fails 100% of the time in `--remote-server --kubernetes` nightly builds (7/7 retries): https://buildkite.com/skypilot-1/smoke-tests/builds/9448

**Investigation (SSH debug on Buildkite agent):**

1. The test framework auto-prepends `sky status -u` before the actual test command
2. In `--remote-server` mode, the nested Docker container starts the API server with `sky api start --deploy`
3. In deploy mode, `burstable_parallelism=0` (by design, to prevent OOM in production)
4. On boot, the API server schedules `sky.check` as a SHORT request to discover cloud credentials (~38s for all clouds)
5. The on-boot `sky.check` + 3 daemon requests (status-refresh, volume-refresh, managed-job-refresh) saturate the SHORT worker pool
6. `sky status -u` gets queued but cannot be scheduled until `sky.check` finishes

**Why the blocking is intentional:**

`sky.check` on boot validates cloud credentials. Until it completes, the server doesn't know which clouds are available. Other commands depend on this credential discovery, so blocking the SHORT pool during boot is correct behavior — it prevents serving requests with incomplete cloud state.

**Why this wasn't a problem before:**

`test_debug_dump_no_args` was newly introduced in #8868. The 30s timeout was set without accounting for the deploy-mode boot sequence in `--remote-server` CI. The on-boot blocking has always existed.

## Test plan
- The fix increases timeout from 30s to 120s, matching the other debug-dump test (`test_debug_dump_nonexistent_resources`)
- Verified on Buildkite agent via SSH: `sky status -u` completes in ~38s in deploy mode, well within 120s

🤖 Generated with [Claude Code](https://claude.com/claude-code)