### PR TITLE
Create skypilot-system namespace for custom service accounts

### DIFF
--- a/sky/provision/kubernetes/config.py
+++ b/sky/provision/kubernetes/config.py
@@ -95,13 +95,13 @@ def bootstrap_instances(
     # account being used. This is needed because the namespace may not exist on
     # newly added clusters. When a custom service account is used, RBAC for the
     # namespace is assumed to be managed by the cluster admin.
+    # This is a lightweight call: a single GET to check if the namespace exists,
+    # returning immediately if it does (common case).
     if (requested_service_account !=
             kubernetes_utils.DEFAULT_SERVICE_ACCOUNT_NAME):
         skypilot_system_namespace = config.provider_config.get(
             'skypilot_system_namespace')
         if skypilot_system_namespace is not None:
-            context = kubernetes_utils.get_context_from_config(
-                config.provider_config)
             kubernetes_utils.create_namespace(skypilot_system_namespace,
                                               context)
 

--- a/sky/provision/kubernetes/config.py
+++ b/sky/provision/kubernetes/config.py
@@ -90,6 +90,21 @@ def bootstrap_instances(
     elif requested_service_account != 'default':
         logger.info(f'Using service account {requested_service_account!r}, '
                     'skipping role and role binding setup.')
+
+    # Always create the skypilot-system namespace regardless of the service
+    # account being used. This is needed because the namespace may not exist on
+    # newly added clusters. When a custom service account is used, RBAC for the
+    # namespace is assumed to be managed by the cluster admin.
+    if (requested_service_account !=
+            kubernetes_utils.DEFAULT_SERVICE_ACCOUNT_NAME):
+        skypilot_system_namespace = config.provider_config.get(
+            'skypilot_system_namespace')
+        if skypilot_system_namespace is not None:
+            context = kubernetes_utils.get_context_from_config(
+                config.provider_config)
+            kubernetes_utils.create_namespace(skypilot_system_namespace,
+                                              context)
+
     if config.provider_config.get('fuse_device_required', False):
         _configure_fuse_mounting(config.provider_config)
     return config

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -1221,6 +1221,9 @@ class TestBootstrapCustomServiceAccount:
         create_ns_mock = mock.MagicMock()
         monkeypatch.setattr('sky.provision.kubernetes.utils.create_namespace',
                             create_ns_mock)
+        monkeypatch.setattr(
+            'sky.provision.kubernetes.utils.get_context_from_config',
+            lambda cfg: 'test-context')
 
         # Mock _configure_services to do nothing
         monkeypatch.setattr(
@@ -1257,7 +1260,8 @@ class TestBootstrapCustomServiceAccount:
                                        provision_config)
 
         # Verify that create_namespace was called with skypilot-system
-        create_ns_mock.assert_called_once_with('skypilot-system', None)
+        create_ns_mock.assert_called_once_with('skypilot-system',
+                                               'test-context')
 
     def test_default_sa_does_not_double_create_namespace(self, monkeypatch):
         """When the default service account is used, the namespace creation
@@ -1269,6 +1273,9 @@ class TestBootstrapCustomServiceAccount:
         create_ns_mock = mock.MagicMock()
         monkeypatch.setattr('sky.provision.kubernetes.utils.create_namespace',
                             create_ns_mock)
+        monkeypatch.setattr(
+            'sky.provision.kubernetes.utils.get_context_from_config',
+            lambda cfg: 'test-context')
 
         # Mock all the configure functions
         monkeypatch.setattr(

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -1206,3 +1206,124 @@ class TestRbac409ConflictHandling:
         config_lib._configure_autoscaler_cluster_role_binding(
             'default', None, provider_config)
         auth_api_mock.patch_cluster_role_binding.assert_called_once()
+
+
+class TestBootstrapCustomServiceAccount:
+    """Tests that bootstrap_instances creates skypilot-system namespace
+    even when a custom (non-default) service account is used."""
+
+    def test_custom_sa_creates_system_namespace(self, monkeypatch):
+        """When a custom service account is used, the skypilot-system
+        namespace should still be created."""
+        from sky.provision import common
+        from sky.provision.kubernetes import utils as kubernetes_utils
+
+        create_ns_mock = mock.MagicMock()
+        monkeypatch.setattr('sky.provision.kubernetes.utils.create_namespace',
+                            create_ns_mock)
+
+        # Mock _configure_services to do nothing
+        monkeypatch.setattr(
+            'sky.provision.kubernetes.config._configure_services',
+            lambda *args, **kwargs: None)
+        # Mock _configure_fuse_mounting to do nothing
+        monkeypatch.setattr(
+            'sky.provision.kubernetes.config._configure_fuse_mounting',
+            lambda *args, **kwargs: None)
+
+        provider_config = {
+            'namespace': 'my-namespace',
+            'skypilot_system_namespace': 'skypilot-system',
+            'fuse_device_required': False,
+        }
+        node_config = {
+            'spec': {
+                'serviceAccountName': 'sky-api-sa',
+            },
+        }
+
+        provision_config = common.ProvisionConfig(
+            provider_config=provider_config,
+            authentication_config={},
+            docker_config={},
+            node_config=node_config,
+            count=1,
+            tags={},
+            resume_stopped_nodes=False,
+            ports_to_open_on_launch=None,
+        )
+
+        config_lib.bootstrap_instances('kubernetes', 'test-cluster',
+                                       provision_config)
+
+        # Verify that create_namespace was called with skypilot-system
+        create_ns_mock.assert_called_once_with('skypilot-system', None)
+
+    def test_default_sa_does_not_double_create_namespace(self, monkeypatch):
+        """When the default service account is used, the namespace creation
+        should only happen via _configure_skypilot_system_namespace (not the
+        new fallback path)."""
+        from sky.provision import common
+        from sky.provision.kubernetes import utils as kubernetes_utils
+
+        create_ns_mock = mock.MagicMock()
+        monkeypatch.setattr('sky.provision.kubernetes.utils.create_namespace',
+                            create_ns_mock)
+
+        # Mock all the configure functions
+        monkeypatch.setattr(
+            'sky.provision.kubernetes.config._configure_services',
+            lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            'sky.provision.kubernetes.config.'
+            '_configure_autoscaler_service_account',
+            lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            'sky.provision.kubernetes.config._configure_autoscaler_role',
+            lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            'sky.provision.kubernetes.config.'
+            '_configure_autoscaler_role_binding', lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            'sky.provision.kubernetes.config.'
+            '_configure_autoscaler_cluster_role', lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            'sky.provision.kubernetes.config.'
+            '_configure_autoscaler_cluster_role_binding',
+            lambda *args, **kwargs: None)
+        configure_system_ns_mock = mock.MagicMock()
+        monkeypatch.setattr(
+            'sky.provision.kubernetes.config.'
+            '_configure_skypilot_system_namespace', configure_system_ns_mock)
+
+        provider_config = {
+            'namespace': 'my-namespace',
+            'skypilot_system_namespace': 'skypilot-system',
+            'fuse_device_required': False,
+            'port_mode': 'loadbalancer',
+        }
+        node_config = {
+            'spec': {
+                'serviceAccountName':
+                    kubernetes_utils.DEFAULT_SERVICE_ACCOUNT_NAME,
+            },
+        }
+
+        provision_config = common.ProvisionConfig(
+            provider_config=provider_config,
+            authentication_config={},
+            docker_config={},
+            node_config=node_config,
+            count=1,
+            tags={},
+            resume_stopped_nodes=False,
+            ports_to_open_on_launch=None,
+        )
+
+        config_lib.bootstrap_instances('kubernetes', 'test-cluster',
+                                       provision_config)
+
+        # _configure_skypilot_system_namespace should be called (existing path)
+        configure_system_ns_mock.assert_called_once()
+        # create_namespace should NOT be called directly (no double creation)
+        create_ns_mock.assert_not_called()


### PR DESCRIPTION
## Description

When a custom (non-default) service account is used in Kubernetes provisioning, the `skypilot-system` namespace may not be created, causing failures for components that depend on it. This PR ensures the namespace is always created regardless of which service account is configured.

The fix adds a lightweight fallback path that creates the `skypilot-system` namespace when a custom service account is detected. This is a simple GET request that returns immediately if the namespace already exists (the common case).

When the default service account is used, the existing `_configure_skypilot_system_namespace` path handles namespace creation, avoiding any duplication.

## Changes

- **sky/provision/kubernetes/config.py**: Added namespace creation logic in `bootstrap_instances()` that triggers when a custom service account is used
- **tests/unit_tests/kubernetes/test_provision.py**: Added two test cases:
  - `test_custom_sa_creates_system_namespace`: Verifies namespace is created with custom service accounts
  - `test_default_sa_does_not_double_create_namespace`: Ensures no duplicate creation with default service account

## Testing

Added unit tests that verify:
1. The `skypilot-system` namespace is created when using a custom service account
2. The existing namespace creation path is used (no duplication) when using the default service account

https://claude.ai/code/session_01CbCeHA4tk7qmpwuWbw8r3r