### PR TITLE
[Doc] Fix llms.txt using localhost URLs on ReadTheDocs

### DIFF
--- a/docs/source/extension/dynamic_llms_txt.py
+++ b/docs/source/extension/dynamic_llms_txt.py
@@ -14,6 +14,12 @@ def get_base_url():
     if os.getenv('SPHINX_BUILD_PRODUCTION') == 'true':
         return "https://docs.skypilot.co/en/latest"
 
+    # ReadTheDocs sets READTHEDOCS and READTHEDOCS_CANONICAL_URL.
+    # See: https://docs.readthedocs.io/en/stable/reference/environment-variables.html
+    canonical_url = os.getenv('READTHEDOCS_CANONICAL_URL')
+    if canonical_url:
+        return canonical_url.rstrip('/')
+
     port = os.getenv('SPHINX_PORT', os.getenv('PORT', '8000'))
     return f"http://127.0.0.1:{port}"
 


### PR DESCRIPTION
## Summary
- The `llms.txt` file at https://docs.skypilot.co/en/latest/llms.txt has all links pointing to `http://127.0.0.1:8000/...` instead of `https://docs.skypilot.co/...`
- The `dynamic_llms_txt` Sphinx extension only checked the custom `SPHINX_BUILD_PRODUCTION` env var. ReadTheDocs doesn't set that, so builds fell through to the localhost fallback.
- Fix: detect RTD builds via `READTHEDOCS_CANONICAL_URL`, which RTD sets automatically and also handles versioned URLs (e.g. `/en/v0.10.0/`) correctly.

## Test plan
- Verify locally: `READTHEDOCS_CANONICAL_URL=https://docs.skypilot.co/en/latest/ python -c "import os; exec(open('docs/source/extension/dynamic_llms_txt.py').read()); print(get_base_url())"` prints the correct production URL.
- After merge, verify https://docs.skypilot.co/en/latest/llms.txt has correct links on next RTD build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)