### PR TITLE
fix: replace args/command lists instead of extending in k8s config merge

### DIFF
--- a/sky/utils/config_utils.py
+++ b/sky/utils/config_utils.py
@@ -11,9 +11,12 @@ _REGION_CONFIG_CLOUDS = ['nebius', 'oci']
 # Kubernetes API use list to represent dictionary fields with patch strategy
 # merge and each item is indexed by the patch merge key. The following map
 # maps the field name to the patch merge key.
-# pylint: disable=line-too-long
-# Ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podspec-v1-core
-# NOTE: field imagePullSecrets are not included deliberately for backward compatibility
+# - If the value is a string, items are merged by that key (e.g., 'name')
+# - If the value is None, the list is replaced atomically (e.g., args, command)
+# Ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/
+#      #podspec-v1-core
+# NOTE: field imagePullSecrets are not included deliberately for backward
+# compatibility
 _PATCH_MERGE_KEYS = {
     'containers': 'name',
     'initContainers': 'name',
@@ -26,6 +29,9 @@ _PATCH_MERGE_KEYS = {
     'topologySpreadConstraints': 'topologyKey',
     'ports': 'containerPort',
     'volumeDevices': 'devicePath',
+    # Atomic list fields - replaced entirely, not merged item-by-item
+    'args': None,
+    'command': None,
 }
 
 
@@ -240,26 +246,32 @@ def merge_k8s_configs(
             # by the patch merge key.
             elif key in _PATCH_MERGE_KEYS:
                 patch_merge_key = _PATCH_MERGE_KEYS[key]
-                for override_item in value:
-                    override_item_name = override_item.get(patch_merge_key)
-                    if override_item_name is not None:
-                        # Item has a name - use patch merge by name
-                        existing_base_item = next(
-                            (v for v in base_config[key]
-                             if v.get(patch_merge_key) == override_item_name),
-                            None)
-                        if existing_base_item is not None:
-                            merge_k8s_configs(existing_base_item, override_item)
+                if patch_merge_key is None:
+                    # Atomic list field (e.g., args, command) - replace entirely
+                    base_config[key] = value
+                else:
+                    for override_item in value:
+                        override_item_name = override_item.get(patch_merge_key)
+                        if override_item_name is not None:
+                            # Item has a name - use patch merge by name
+                            existing_base_item = next(
+                                (v for v in base_config[key]
+                                 if v.get(patch_merge_key) == override_item_name
+                                ), None)
+                            if existing_base_item is not None:
+                                merge_k8s_configs(existing_base_item,
+                                                  override_item)
+                            else:
+                                base_config[key].append(override_item)
+                        elif key == 'containers' and base_config[key]:
+                            # Backward compatibility for containers: if no name
+                            # is specified, merge into the first container
+                            merge_k8s_configs(base_config[key][0],
+                                              override_item,
+                                              next_allowed_override_keys,
+                                              next_disallowed_override_keys)
                         else:
                             base_config[key].append(override_item)
-                    elif key == 'containers' and base_config[key]:
-                        # Backward compatibility for containers: if no name is
-                        # specified, merge into the first container (index 0)
-                        merge_k8s_configs(base_config[key][0], override_item,
-                                          next_allowed_override_keys,
-                                          next_disallowed_override_keys)
-                    else:
-                        base_config[key].append(override_item)
             else:
                 base_config[key].extend(value)
         else:

--- a/tests/unit_tests/test_sky/utils/test_config_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_config_utils.py
@@ -744,3 +744,149 @@ def test_merge_k8s_configs_with_sidecar_and_primary_container_override():
     # Verify sidecar is added
     sidecar = next(c for c in containers if c['name'] == 'sidecar')
     assert sidecar['image'] == 'busybox:latest'
+
+
+def test_merge_k8s_configs_args_replaced_not_extended():
+    """Test that container args are replaced, not extended, when merging.
+
+    This is a regression test for a bug where merging two containers with
+    the same name would extend (concatenate) the args list instead of
+    replacing it. For example, args: ["echo", "hello"] would become
+    args: ["echo", "hello", "echo", "hello"] after merge.
+    """
+    base_config = {
+        'spec': {
+            'initContainers': [{
+                'name': 'my-init',
+                'image': 'busybox:latest',
+                'args': ['echo', 'hello']
+            }]
+        }
+    }
+    override_config = {
+        'spec': {
+            'initContainers': [{
+                'name': 'my-init',
+                'image': 'busybox:latest',
+                'args': ['echo', 'hello']
+            }]
+        }
+    }
+
+    config_utils.merge_k8s_configs(base_config, override_config)
+
+    # Args should be replaced, not extended
+    init_container = base_config['spec']['initContainers'][0]
+    assert init_container['args'] == [
+        'echo', 'hello'
+    ], (f"Expected args to be replaced, not extended. Got: {init_container['args']}"
+       )
+
+
+def test_merge_k8s_configs_command_replaced_not_extended():
+    """Test that container command is replaced, not extended, when merging.
+
+    Similar to test_merge_k8s_configs_args_replaced_not_extended but for
+    the command field.
+    """
+    base_config = {
+        'spec': {
+            'containers': [{
+                'name': 'main',
+                'image': 'nginx:latest',
+                'command': ['/bin/sh', '-c']
+            }]
+        }
+    }
+    override_config = {
+        'spec': {
+            'containers': [{
+                'name': 'main',
+                'image': 'nginx:latest',
+                'command': ['/bin/sh', '-c']
+            }]
+        }
+    }
+
+    config_utils.merge_k8s_configs(base_config, override_config)
+
+    # Command should be replaced, not extended
+    container = base_config['spec']['containers'][0]
+    assert container['command'] == [
+        '/bin/sh', '-c'
+    ], (f"Expected command to be replaced, not extended. Got: {container['command']}"
+       )
+
+
+def test_merge_k8s_configs_args_override_replaces():
+    """Test that args from override completely replace base args."""
+    base_config = {
+        'spec': {
+            'containers': [{
+                'name': 'main',
+                'args': ['--old-flag', '--old-value']
+            }]
+        }
+    }
+    override_config = {
+        'spec': {
+            'containers': [{
+                'name': 'main',
+                'args': ['--new-flag', '--new-value']
+            }]
+        }
+    }
+
+    config_utils.merge_k8s_configs(base_config, override_config)
+
+    container = base_config['spec']['containers'][0]
+    assert container['args'] == [
+        '--new-flag', '--new-value'
+    ], (f"Expected args to be replaced with override. Got: {container['args']}")
+
+
+def test_merge_k8s_configs_env_still_merged_by_name():
+    """Test that env vars are still merged by name (existing behavior preserved)."""
+    base_config = {
+        'spec': {
+            'containers': [{
+                'name': 'main',
+                'env': [{
+                    'name': 'FOO',
+                    'value': '1'
+                }, {
+                    'name': 'BAR',
+                    'value': '2'
+                }]
+            }]
+        }
+    }
+    override_config = {
+        'spec': {
+            'containers': [{
+                'name': 'main',
+                'env': [{
+                    'name': 'FOO',
+                    'value': 'updated'
+                }, {
+                    'name': 'BAZ',
+                    'value': '3'
+                }]
+            }]
+        }
+    }
+
+    config_utils.merge_k8s_configs(base_config, override_config)
+
+    container = base_config['spec']['containers'][0]
+    env_names = [e['name'] for e in container['env']]
+
+    # All three env vars should exist (merged by name)
+    assert len(container['env']) == 3
+    assert 'FOO' in env_names
+    assert 'BAR' in env_names
+    assert 'BAZ' in env_names
+
+    # FOO should be updated
+    foo = next(e for e in container['env'] if e['name'] == 'FOO')
+    assert foo['value'] == 'updated'


### PR DESCRIPTION
## Summary

When merging two Kubernetes containers with the same name in `merge_k8s_configs()`, the `args` and `command` fields were being **extended** (concatenated) instead of **replaced**. This caused duplication when admin policies added `initContainers` with `args`/`command`, as the policy is applied multiple times during managed jobs workflow.

**Example of the bug:**
- Policy adds: `args: ["echo", "hello"]`
- After config merge: `args: ["echo", "hello", "echo", "hello"]`

## Root Cause

In `sky/utils/config_utils.py`, the `_PATCH_MERGE_KEYS` map determines which list fields should be merged by a unique key (e.g., `initContainers` merged by `name`). However, `args` and `command` are not in this map, so when two containers with the same name are merged, their `args`/`command` lists fall through to the `else` branch:

```python
else:
    base_config[key].extend(value)  # Bug: extends instead of replaces
```

## The Fix

Extended `_PATCH_MERGE_KEYS` to support `None` as a merge key value, indicating the list should be **replaced atomically** instead of merged by key:

```python
_PATCH_MERGE_KEYS = {
    'containers': 'name',
    'initContainers': 'name',
    # ... existing entries ...
    # Atomic list fields - replaced entirely, not merged item-by-item
    'args': None,
    'command': None,
}
```

This approach keeps all merge strategies in a single config map rather than adding a separate set.

## When This Bug Occurs

1. **Managed Jobs (`sky jobs launch`)**: Policy applied twice (client + server)
2. **Cluster reuse**: Stored cluster config merged with new config
3. **Resources.copy()**: Internal copying with `_cluster_config_overrides`

## Test Plan

- [x] Added unit tests for `args` replacement behavior
- [x] Added unit tests for `command` replacement behavior  
- [x] Added unit tests verifying `env` still merges by name (existing behavior preserved)
- [x] Verified fix with E2E managed jobs workflow

## Impact

Any admin policy that adds init containers or sidecars with `args`/`command` will no longer see corrupted container specs after config merging.