### PR TITLE
[Jobs] Fix duplicate reason in managed job recovery events

### DIFF
--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -2312,17 +2312,16 @@ async def set_recovering_async(
     cluster_event_reason: Optional[str] = None,
 ):
     """Set the task to recovering state, and update the job duration."""
-    # Build code and reason from external failures for the event log
+    # Build code and reason from external failures for the event log.
+    # Prefer external_failures over cluster_event_reason to avoid
+    # duplicating the same message when a plugin writes the same reason
+    # to both cluster events and cluster failures.
     code = None
-    reason_parts = []
-    if cluster_event_reason:
-        reason_parts.append(cluster_event_reason)
     if external_failures:
         code = '; '.join(f.code for f in external_failures)
-        external_failure_reason = '; '.join(f.reason for f in external_failures)
-        reason_parts.append(external_failure_reason)
-    if reason_parts:
-        reason = ': '.join(reason_parts)
+        reason = '; '.join(f.reason for f in external_failures)
+    elif cluster_event_reason:
+        reason = cluster_event_reason
     else:
         assert code is None, 'Code should be None if there are no reasons.'
         reason = 'Cluster preempted or failed, recovering'


### PR DESCRIPTION
## Summary
- Fix duplicate message in managed job recovery events where the same error reason appeared twice joined by `: `
- When a plugin writes the same reason to both cluster events and the external failure source, `set_recovering_async` was concatenating both copies, producing messages like `"<reason>: <reason>"`
- Changed to prefer `external_failures` over `cluster_event_reason` since they can contain the same information from the same source

## Test plan
- [ ] Verify managed job recovery events show a single reason instead of a duplicated message
- [ ] Verify events with only `cluster_event_reason` (no external failures) still display correctly
- [ ] Verify events with only external failures (no cluster event reason) still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)