### PR TITLE
[AWS] Add timeout and catch ReadTimeoutError in AZ fetch to prevent sky check hang

### DIFF
--- a/sky/adaptors/aws.py
+++ b/sky/adaptors/aws.py
@@ -32,7 +32,7 @@ import logging
 import threading
 import time
 import typing
-from typing import Callable, Literal, Optional, TypeVar
+from typing import Any, Callable, Dict, Literal, Optional, TypeVar
 
 from sky import skypilot_config
 from sky.adaptors import common
@@ -225,6 +225,20 @@ def client(service_name: str, **kwargs):
     _assert_kwargs_builtin_type(kwargs)
 
     check_credentials = kwargs.pop('check_credentials', True)
+    connect_timeout: Optional[int] = kwargs.pop('connect_timeout', None)
+    read_timeout: Optional[int] = kwargs.pop('read_timeout', None)
+    total_max_attempts: Optional[int] = kwargs.pop('total_max_attempts', None)
+
+    config_kwargs: Dict[str, Any] = {}
+    if connect_timeout is not None:
+        config_kwargs['connect_timeout'] = connect_timeout
+    if read_timeout is not None:
+        config_kwargs['read_timeout'] = read_timeout
+    if total_max_attempts is not None:
+        config_kwargs['retries'] = {'total_max_attempts': total_max_attempts}
+    if config_kwargs:
+        kwargs['config'] = botocore_config().Config(**config_kwargs)
+
     profile = get_workspace_profile()
 
     # Need to use the client retrieved from the per-thread session to avoid

--- a/sky/catalog/data_fetchers/fetch_aws.py
+++ b/sky/catalog/data_fetchers/fetch_aws.py
@@ -146,14 +146,12 @@ def _get_instance_type_offerings(region: str) -> 'pd.DataFrame':
 def _get_availability_zones(region: str) -> 'pd.DataFrame':
     # Use a shorter timeout than the default 60s connect / 60s read to avoid
     # blocking sky check when a region endpoint is unreachable or unresponsive.
-    # With max_attempts=3, worst case is ~45s per region, but since regions are
-    # checked in parallel this only affects total wall time by ~45s.
+    # total_max_attempts=3 means 3 total attempts. Worst case ~30s per region.
     client = aws.client('ec2',
                         region_name=region,
-                        config=aws.botocore_config().Config(
-                            connect_timeout=10,
-                            read_timeout=15,
-                            retries={'max_attempts': 3}))
+                        connect_timeout=10,
+                        read_timeout=10,
+                        total_max_attempts=3)
     zones = []
     try:
         response = client.describe_availability_zones()


### PR DESCRIPTION
## Summary
- Add explicit timeouts (`connect_timeout=10s`, `read_timeout=15s`, `max_attempts=3`) to the EC2 client used for AZ fetching, reducing worst-case hang from ~300s to ~45s per unreachable region
- Catch `ReadTimeoutError` alongside `ConnectionError` in `_get_availability_zones()` — the #9240 fix only caught `ConnectionError` but `ReadTimeoutError` is a separate exception hierarchy in botocore

## Context
When an AWS region endpoint (e.g. `me-south-1`) is reachable but unresponsive from certain VPCs, `describe_availability_zones()` hangs for up to 300s (60s default boto3 timeout × 5 legacy retries). Since `sky check` runs all region checks in parallel via ThreadPool but blocks on `list(p.imap(...))`, one stuck region blocks the entire check.

This caused all nightly managed job tests to fail: the jobs controller's `sky check` on startup hung during AWS credential verification, leaving managed jobs stuck in STARTING until test timeouts fired.

Extends the fix in #9240 which caught `ConnectionError` (fast TCP failures) but missed `ReadTimeoutError` (TCP connects but response never arrives).

Fixes #9239 (additional failure mode)

## Test plan
- On a jobs controller where `me-south-1` is unreachable: `sky check aws` should complete in <60s instead of hanging indefinitely
- Normal regions (responding in 0.1-1s) are unaffected by the timeout values
- Verify `ReadTimeoutError` is properly caught and the region is gracefully skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)