### PR TITLE
[Test] Add connection establishment timing to SSH proxy benchmark

### DIFF
--- a/tests/load_tests/test_ssh_proxy.py
+++ b/tests/load_tests/test_ssh_proxy.py
@@ -3,6 +3,8 @@
 
 import argparse
 import concurrent.futures
+from dataclasses import dataclass
+from dataclasses import field
 import logging
 import statistics
 import subprocess
@@ -28,8 +30,12 @@ class SSHClient:
         self.cluster = cluster
         self.process = None
 
-    def connect(self) -> bool:
-        """Establish persistent SSH connection."""
+    def connect(self) -> float:
+        """Establish persistent SSH connection.
+
+        Returns the connection latency in seconds, or -1.0 on failure.
+        """
+        start_time = time.time()
         try:
             # Start SSH with persistent connection
             self.process = subprocess.Popen(
@@ -44,19 +50,21 @@ class SSHClient:
             # Test the connection with a simple command
             test_result = self._execute_command('echo "CONNECTION_TEST_OK"')
             if test_result[1] and 'CONNECTION_TEST_OK' in test_result[2]:
-                logger.info(f'SSH connection established to {self.cluster}')
-                return True
+                latency = time.time() - start_time
+                logger.info(f'SSH connection established to {self.cluster} '
+                            f'in {latency:.4f}s')
+                return latency
             else:
                 logger.error(f'SSH connection test failed to {self.cluster}, '
                              f'output: {test_result[2]}')
                 self.disconnect()
-                return False
+                return -1.0
 
         except Exception as e:
             logger.error(f'Failed to establish SSH connection to '
                          f'{self.cluster}: {e}')
             self.disconnect()
-            return False
+            return -1.0
 
     def _execute_command(self,
                          command: str,
@@ -147,19 +155,28 @@ def generate_echo_command(size_bytes: int) -> str:
     return f'echo "{text}"'
 
 
+@dataclass
+class WorkerResult:
+    """Results from a single worker thread."""
+    connection_latency: float  # -1.0 means failure
+    command_results: List[Tuple[float, bool]] = field(default_factory=list)
+
+
 def worker_thread(cluster: str, size_bytes: int, num: int,
-                  thread_id: int) -> List[Tuple[float, bool]]:
+                  thread_id: int) -> WorkerResult:
     """Worker function that maintains persistent SSH connection."""
-    results = []
     ssh_client = SSHClient(cluster)
 
     logger.info(f"Thread {thread_id}: Establishing SSH connection")
 
-    # Establish persistent connection
-    if not ssh_client.connect():
+    # Establish persistent connection and measure latency
+    conn_latency = ssh_client.connect()
+    if conn_latency < 0:
         logger.error(f"Thread {thread_id}: Failed to connect to {cluster}")
-        # Return failed results for all commands
-        return [(0.0, False) for _ in range(num)]
+        return WorkerResult(connection_latency=-1.0,
+                            command_results=[(0.0, False) for _ in range(num)])
+
+    result = WorkerResult(connection_latency=conn_latency)
 
     logger.info(
         f"Thread {thread_id}: Starting {num} commands on persistent connection")
@@ -173,7 +190,7 @@ def worker_thread(cluster: str, size_bytes: int, num: int,
                 logger.error(
                     f"Thread {thread_id} disconnected at command {i+1}: {e}")
                 break
-            results.append((latency, success))
+            result.command_results.append((latency, success))
             if not success:
                 logger.error(
                     f"Thread {thread_id}, command {i+1}: Command failed")
@@ -185,40 +202,65 @@ def worker_thread(cluster: str, size_bytes: int, num: int,
         ssh_client.disconnect()
         logger.info(f"Thread {thread_id}: SSH connection closed")
 
-    return results
+    return result
 
 
-def print_statistics(all_results: List[Tuple[float, bool]], parallelism: int):
+def _print_latency_stats(name: str, latencies: List[float]):
+    """Print min/max/mean/median/stddev for a list of latencies."""
+    if not latencies:
+        print(f"  No data for {name}.")
+        return
+    print(f"  Minimum: {min(latencies):.4f}s")
+    print(f"  Maximum: {max(latencies):.4f}s")
+    print(f"  Mean: {statistics.mean(latencies):.4f}s")
+    print(f"  Median: {statistics.median(latencies):.4f}s")
+    if len(latencies) > 1:
+        print(f"  Std Dev: {statistics.stdev(latencies):.4f}s")
+
+
+def print_statistics(worker_results: List[WorkerResult], parallelism: int):
     """Calculate and print benchmark statistics."""
-    successes = [result[1] for result in all_results]
+    # Connection latencies (exclude failures)
+    conn_latencies = [
+        r.connection_latency
+        for r in worker_results
+        if r.connection_latency >= 0
+    ]
+    conn_failures = sum(1 for r in worker_results if r.connection_latency < 0)
 
-    latencies = [lat for lat, success in all_results if success]
+    # Command latencies
+    all_cmd_results = []
+    for r in worker_results:
+        all_cmd_results.extend(r.command_results)
 
-    total_commands = len(all_results)
-    successful_commands = sum(successes)
+    cmd_latencies = [lat for lat, success in all_cmd_results if success]
+    total_commands = len(all_cmd_results)
+    successful_commands = sum(1 for _, success in all_cmd_results if success)
     failed_commands = total_commands - successful_commands
-    success_rate = (successful_commands / total_commands) * 100
 
     print("\n" + "=" * 60)
     print("BENCHMARK RESULTS")
     print("=" * 60)
-    print(f"Total commands executed: {total_commands}")
-    print(f"Successful commands: {successful_commands}")
-    print(f"Failed commands: {failed_commands}")
-    print(f"Success rate: {success_rate:.2f}%")
     print(f"Parallelism: {parallelism}")
     print()
 
-    if latencies:
-        print("LATENCY STATISTICS (successful commands only):")
-        print(f"  Minimum: {min(latencies):.4f}s")
-        print(f"  Maximum: {max(latencies):.4f}s")
-        print(f"  Mean: {statistics.mean(latencies):.4f}s")
-        print(f"  Median: {statistics.median(latencies):.4f}s")
-        if len(latencies) > 1:
-            print(f"  Std Dev: {statistics.stdev(latencies):.4f}s")
-    else:
-        print("No successful commands to calculate latency statistics.")
+    # Connection stats
+    print("CONNECTION ESTABLISHMENT:")
+    print(f"  Successful connections: {len(conn_latencies)}/{parallelism}")
+    if conn_failures:
+        print(f"  Failed connections: {conn_failures}")
+    _print_latency_stats("connection", conn_latencies)
+    print()
+
+    # Command stats
+    print("COMMAND EXECUTION:")
+    print(f"  Total commands: {total_commands}")
+    print(f"  Successful: {successful_commands}")
+    print(f"  Failed: {failed_commands}")
+    if total_commands > 0:
+        print(f"  Success rate: "
+              f"{(successful_commands / total_commands) * 100:.2f}%")
+    _print_latency_stats("command", cmd_latencies)
 
     print("=" * 60)
 
@@ -290,7 +332,8 @@ Examples:
     # Test basic SSH connectivity first
     print("Testing SSH connectivity...")
     test_client = SSHClient(args.cluster)
-    if not test_client.connect():
+    test_conn_latency = test_client.connect()
+    if test_conn_latency < 0:
         print(f"Error: Cannot establish SSH connection to {args.cluster}. "
               f"Please check:")
         print("  1. Cluster name is correct")
@@ -305,15 +348,15 @@ Examples:
         print(f"Error: Test command failed on {args.cluster}")
         sys.exit(1)
 
-    print(f"SSH connectivity test passed (echo latency: "
-          f"{test_latency:.4f}s)")
+    print(f"SSH connectivity test passed (connection: "
+          f"{test_conn_latency:.4f}s, echo: {test_latency:.4f}s)")
     print()
 
     # Run concurrent benchmark
     print("Starting concurrent benchmark with persistent connections...")
     start_time = time.time()
 
-    all_results = []
+    worker_results = []
     with concurrent.futures.ThreadPoolExecutor(
             max_workers=args.parallelism) as executor:
         # Submit all worker threads
@@ -324,8 +367,7 @@ Examples:
             futures.append(future)
         for future in concurrent.futures.as_completed(futures):
             try:
-                thread_results = future.result()
-                all_results.extend(thread_results)
+                worker_results.append(future.result())
             except Exception as exc:
                 logger.error(f'Thread generated an exception: {exc}')
 
@@ -335,7 +377,7 @@ Examples:
     print(f"\nBenchmark completed in {total_duration:.2f} seconds")
 
     # Print detailed statistics
-    print_statistics(all_results, args.parallelism)
+    print_statistics(worker_results, args.parallelism)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Add connection establishment latency measurement to the SSH proxy benchmark script
- Report connection stats (min/max/mean/median/stddev) separately from command execution stats
- No changes to test pass/fail criteria — purely additional instrumentation

## Test plan
- Ran `python tests/load_tests/test_ssh_proxy.py -c <cluster> -p 5 -n 5 --size 1` against a SkyPilot cluster
- Verified connection establishment timing is reported correctly
- Verified command execution stats remain unchanged in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)