### PR TITLE
Security: Hardcoded default K3s token enables unauthorized cluster joining

### DIFF
--- a/sky/ssh_node_pools/constants.py
+++ b/sky/ssh_node_pools/constants.py
@@ -8,5 +8,6 @@ NODE_POOLS_INFO_DIR = os.path.expanduser('~/.sky/ssh_node_pools_info')
 NODE_POOLS_KEY_DIR = os.path.expanduser('~/.sky/ssh_keys')
 DEFAULT_SSH_NODE_POOLS_PATH = os.path.expanduser('~/.sky/ssh_node_pools.yaml')
 
-# TODO (kyuds): make this configurable?
-K3S_TOKEN = 'mytoken'  # Any string can be used as the token
+K3S_TOKEN = os.environ.get('SKYPILOT_K3S_TOKEN')
+if not K3S_TOKEN:
+    raise ValueError('SKYPILOT_K3S_TOKEN must be set for SSH node pools.')


### PR DESCRIPTION
## Problem

A static token (`mytoken`) is embedded as the default K3s join secret. If this value is used in real deployments, any party that can reach the control plane and knows this predictable token may join rogue nodes or impersonate legitimate ones.

**Severity**: `high`
**File**: `sky/ssh_node_pools/constants.py`

## Solution

Remove the hardcoded token and require a per-cluster cryptographically random secret loaded from secure configuration (env var/secret manager). Rotate existing tokens and fail fast if no token is explicitly provided.

## Changes

- `sky/ssh_node_pools/constants.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
