### PR TITLE
Fix #9193: CloudError cannot be pickled

### DIFF
--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -138,6 +138,10 @@ class CloudError(Exception):
         return (f'{self.cloud_provider} error ({self.error_type}): '
                 f'{super().__str__()}')
 
+    def __reduce__(self):
+        return (self.__class__, (super().__str__(), self.cloud_provider,
+                                 self.error_type))
+
 
 class InvalidSkyPilotConfigError(ValueError):
     """Raised when the SkyPilot config is invalid."""

--- a/tests/unit_tests/test_exceptions.py
+++ b/tests/unit_tests/test_exceptions.py
@@ -1,5 +1,7 @@
 """Test exception serialization and deserialization."""
 
+import pickle
+
 from sky import exceptions
 from sky.utils import status_lib
 
@@ -113,6 +115,17 @@ def test_aws_az_fetching_error():
     assert deserialized.region == 'us-east-1'
     assert deserialized.reason == exceptions.AWSAzFetchingError.Reason.AUTH_FAILURE
     assert deserialized.stacktrace == 'test_stacktrace'
+
+
+def test_cloud_error_pickling():
+    """Test that CloudError can be pickled and unpickled correctly."""
+    e = exceptions.CloudError('some error message', 'aws', 'some message type')
+    pickled = pickle.dumps(e)
+    unpickled = pickle.loads(pickled)
+    assert isinstance(unpickled, exceptions.CloudError)
+    assert unpickled.cloud_provider == 'aws'
+    assert unpickled.error_type == 'some message type'
+    assert str(unpickled) == 'aws error (some message type): some error message'
 
 
 def test_wrap_unsafe_exceptions():


### PR DESCRIPTION
Closes #9193

`CloudError` in `sky/exceptions.py` stores extra constructor arguments (`cloud_provider`, `error_type`) beyond the base `Exception` message string. Python's default pickling for exceptions only preserves `args` (i.e., the positional args passed to `Exception.__init__`), so unpickling a `CloudError` attempts to call `CloudError.__init__(message)` — missing the two required positional arguments — and raises `TypeError`.

The fix adds a `__reduce__` method to `CloudError` that returns the class and the full set of constructor arguments needed to reconstruct the instance: `(str(self.args[0]), self.cloud_provider, self.error_type)`. This is the standard pattern for making custom exceptions with extra fields picklable.

**Changed files:**
- `sky/exceptions.py`: Added `__reduce__` to `CloudError` (after line 138) returning `(self.__class__, (super().__str__(), self.cloud_provider, self.error_type))`.
- `tests/unit_tests/test_exceptions.py`: Added `test_cloud_error_pickling` which round-trips a `CloudError` through `pickle.dumps`/`pickle.loads` and asserts the `cloud_provider`, `error_type`, and full `str()` representation are preserved.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

New unit test `test_cloud_error_pickling` in `tests/unit_tests/test_exceptions.py` verifies that a `CloudError('some error message', 'aws', 'some message type')` survives a `pickle` round-trip with all fields intact.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*