### PR TITLE
Remove hint to "bootstrap skypilot"

### DIFF
--- a/agent/INSTALL.md
+++ b/agent/INSTALL.md
@@ -43,7 +43,7 @@ You should see a symlink pointing to the skypilot skills directory.
 
 ## Reload
 
-You may need to restart the agent to reload the skypilot skill if it is not available after installation. Hint user to ask "Bootstrap skypilot" after the skill is loaded.
+You may need to restart the agent to reload the skypilot skill if it is not available after installation. Hint user to ask "Check my available infra" after the skill is loaded.
 
 ## Updating
 


### PR DESCRIPTION
This PR removes the "bootstrap skypilot" hint from the install.md and replaces it with "Check my available infra"

Signed-off-by: Avril Aysha <68642378+avriiil@users.noreply.github.com>

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
