### PR TITLE
[Core] Fix CloudError pickle support

### DIFF
--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -135,8 +135,9 @@ class CloudError(Exception):
         self.error_type = error_type
 
     def __reduce__(self):
-        return (self.__class__, (self.args[0], self.cloud_provider,
-                                 self.error_type))
+        message = self.args[0] if self.args else ''
+        return (self.__class__, (message, self.cloud_provider,
+                                 self.error_type), self.__dict__)
 
     def __str__(self):
         return (f'{self.cloud_provider} error ({self.error_type}): '

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -134,6 +134,10 @@ class CloudError(Exception):
         self.cloud_provider = cloud_provider
         self.error_type = error_type
 
+    def __reduce__(self):
+        return (self.__class__, (self.args[0], self.cloud_provider,
+                                 self.error_type))
+
     def __str__(self):
         return (f'{self.cloud_provider} error ({self.error_type}): '
                 f'{super().__str__()}')


### PR DESCRIPTION
## Summary
- Add `__reduce__` method to `CloudError` so it can be properly pickled/unpickled across process boundaries
- Fixes #9193: `CloudError` has required positional arguments (`cloud_provider`, `error_type`) in `__init__`, causing `TypeError` when unpickling via `multiprocessing`

## Test plan
- Verify `CloudError` can be pickled and unpickled:
```python
import pickle
from sky.exceptions import CloudError

e = CloudError("some error message", "aws", "some message type")
data = pickle.dumps(e)
e2 = pickle.loads(data)
assert str(e) == str(e2)
assert e2.cloud_provider == "aws"
assert e2.error_type == "some message type"
```
- Verify the multiprocessing example from the issue works:
```python
from concurrent.futures import ProcessPoolExecutor
from sky.exceptions import CloudError

def raise_cloud_error():
    raise CloudError("some error message", "aws", "some message type")

with ProcessPoolExecutor(max_workers=1) as pool:
    future = pool.submit(raise_cloud_error)
    try:
        future.result()
    except CloudError as e:
        print(f"Got CloudError: {e}")
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)