### PR TITLE
[CLI] Fix ValueError: False backend is not supported

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -1226,7 +1226,7 @@ def launch(
     secret = _merge_cli_and_file_vars([env_file, secret_file], secret)
     controller_utils.check_cluster_name_not_controller(
         cluster, operation_str='Launching tasks on it')
-    if backend_name is None:
+    if not backend_name:
         backend_name = backends.CloudVmRayBackend.NAME
 
     cloud, region, zone = _handle_infra_cloud_region_zone_options(


### PR DESCRIPTION
## Summary
- Fixes #9094: `ValueError: False backend is not supported` when launching a cluster
- The `--docker` click option declares `default=False`, so when the flag is not passed, `backend_name` is the boolean `False` rather than `None`. The existing check `if backend_name is None` missed this, causing `False` to fall through to the error branch.
- Changed `if backend_name is None` to `if not backend_name` to correctly handle both `None` and `False` as "no backend specified" and default to `CloudVmRayBackend`.

## Test plan
- [x] `sky launch` without `--docker` flag no longer raises `ValueError: False backend is not supported`
- [x] `sky launch --docker` still selects the LocalDockerBackend (deprecated path)
- [x] Verified no other commands have the same pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)