### PR TITLE
[Dashboard] Show controller logs for PENDING jobs when controller is running

### DIFF
--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -295,6 +295,7 @@ export async function getManagedJobs(options = {}) {
         links: job.links || {},
         pool: job.pool,
         pool_hash: job.pool_hash,
+        schedule_state: job.schedule_state,
         current_cluster_name: job.current_cluster_name,
         cluster_name_on_cloud: job.cluster_name_on_cloud,
         job_id_on_pool_cluster: job.job_id_on_pool_cluster,

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -899,7 +899,16 @@ function JobDetailsContent({
   const RECOVERING_STATUSES = ['RECOVERING'];
 
   const isPending = PENDING_STATUSES.includes(jobData.status);
-  const isPreStart = PRE_START_STATUSES.includes(jobData.status);
+  // After priority-based scheduling (#5682), a job can be PENDING while its
+  // controller is already running. Show controller logs when schedule_state
+  // indicates the controller has been claimed (anything other than
+  // INACTIVE/WAITING/null).
+  const isControllerRunning =
+    jobData.schedule_state != null &&
+    jobData.schedule_state !== 'INACTIVE' &&
+    jobData.schedule_state !== 'WAITING';
+  const isPreStart =
+    PRE_START_STATUSES.includes(jobData.status) && !isControllerRunning;
   const isRecovering = RECOVERING_STATUSES.includes(jobData.status);
 
   // Compute job group status based on primary tasks
@@ -1552,6 +1561,7 @@ JobDetailsContent.propTypes = {
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     name: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     status: PropTypes.string,
+    schedule_state: PropTypes.string,
     user: PropTypes.string,
     user_hash: PropTypes.string,
     workspace: PropTypes.string,


### PR DESCRIPTION
## Summary

After priority-based scheduling (#5682), a managed job can be in `PENDING` state while its controller is already running. The dashboard previously showed a "Waiting for the job controller process to start" message for all PENDING/SUBMITTED jobs, even when the controller was active.

This PR uses `schedule_state` to determine if the controller has been claimed by the scheduler. If `schedule_state` is anything other than `INACTIVE`, `WAITING`, or `null`, the controller is running and we show its logs instead of the waiting message.

Based on #8393 by @lucamanolache with an added null guard for `schedule_state` (handles legacy jobs or transient states where the field hasn't been set yet).

Closes #5895

### Practical impact

The window where this matters is the time between the scheduler starting the controller process (`schedule_state` → `LAUNCHING`) and the controller calling `set_starting_async()` (status → `STARTING`). In testing this was ~13 seconds — during which the controller is doing startup work (loading env vars, parsing the DAG, initializing the strategy executor) and producing useful log output that the old code hid behind the "Waiting..." message. On systems with heavy load or slow controller startup (large DAGs, slow filesystem), this window could be wider.

The other schedule states where the controller is running (`ALIVE`, `ALIVE_BACKOFF`, `ALIVE_WAITING`) only occur when the job status is already `STARTING`/`RUNNING`/`RECOVERING`, so they don't affect this code path.

## Test plan

- [x] Dashboard lint and format pass
- [x] Verified on dashboard: PENDING job with `schedule_state=WAITING` correctly shows "Waiting for the job controller process to start" message
- [x] Verified via fetch interception: PENDING job with `schedule_state=LAUNCHING` on the jobs list page renders as PENDING (API layer correctly passes `schedule_state` through)
- [x] In-browser unit tests: all 11 test cases pass covering PENDING/SUBMITTED × LAUNCHING/ALIVE/WAITING/INACTIVE/null/undefined, plus STARTING and RUNNING baselines
- [x] Baseline comparison: confirmed original code has no `schedule_state` logic and always shows "Waiting..." for all PENDING/SUBMITTED jobs regardless of controller state

🤖 Generated with [Claude Code](https://claude.com/claude-code)