### PR TITLE
[Core] Check workspace permission for enabled_clouds and check

### DIFF
--- a/sky/check.py
+++ b/sky/check.py
@@ -390,6 +390,12 @@ def check(
     clouds: Optional[Iterable[str]] = None,
     workspace: Optional[str] = None,
 ) -> Dict[str, Dict[str, List[str]]]:
+    if workspace is not None:
+        # Import here to avoid circular import:
+        # pylint: disable=import-outside-toplevel
+        from sky.workspaces import core as workspaces_core
+        workspaces_core.check_workspace_permission(
+            common_utils.get_current_user(), workspace)
     capabilities_result = check_capabilities(quiet, verbose, clouds,
                                              sky_cloud.ALL_CAPABILITIES,
                                              workspace)

--- a/sky/core.py
+++ b/sky/core.py
@@ -1451,6 +1451,9 @@ def enabled_clouds(workspace: Optional[str] = None,
                    expand: bool = False) -> List[str]:
     if workspace is None:
         workspace = skypilot_config.get_active_workspace()
+    else:
+        workspaces_core.check_workspace_permission(
+            common_utils.get_current_user(), workspace)
     cached_clouds = global_user_state.get_cached_enabled_clouds(
         sky_cloud.CloudCapability.COMPUTE, workspace=workspace)
     with skypilot_config.local_active_workspace_ctx(workspace):

--- a/sky/workspaces/core.py
+++ b/sky/workspaces/core.py
@@ -638,6 +638,24 @@ def update_config(config: Dict[str, Any]) -> Dict[str, Any]:
     return config
 
 
+def check_workspace_permission(user: models.User, workspace: str) -> None:
+    """Checks that a user has permission to access the given workspace.
+
+    Args:
+        user: The user making the request.
+        workspace: The workspace name to check.
+
+    Raises:
+        PermissionDeniedError: If the user does not have permission to access
+            the workspace.
+    """
+    if not permission.permission_service.check_workspace_permission(
+            user.id, workspace):
+        raise exceptions.PermissionDeniedError(
+            f'User {user.name} ({user.id}) does not have '
+            f'permission to access workspace {workspace!r}')
+
+
 def reject_request_for_unauthorized_workspace(user: models.User) -> None:
     """Rejects a request that has no permission to access active workspace.
 
@@ -648,12 +666,7 @@ def reject_request_for_unauthorized_workspace(user: models.User) -> None:
         PermissionDeniedError: If the user does not have permission to access
             the active workspace.
     """
-    active_workspace = skypilot_config.get_active_workspace()
-    if not permission.permission_service.check_workspace_permission(
-            user.id, active_workspace):
-        raise exceptions.PermissionDeniedError(
-            f'User {user.name} ({user.id}) does not have '
-            f'permission to access workspace {active_workspace!r}')
+    check_workspace_permission(user, skypilot_config.get_active_workspace())
 
 
 def is_workspace_private(workspace_config: Dict[str, Any]) -> bool:

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -1,6 +1,10 @@
 from unittest import mock
 
+import pytest
+
 from sky import core
+from sky import exceptions
+from sky import models
 from sky.backends.cloud_vm_ray_backend import CloudVmRayResourceHandle
 from sky.utils import common
 from sky.utils import common_utils
@@ -80,3 +84,32 @@ def test_status_best_effort(mock_get_clusters) -> None:
     log_message = mock_logger.warning.call_args[0][0]
     assert ('Failed to validate status responses for cluster malformed-cluster'
             in log_message)
+
+
+class TestEnabledCloudsWorkspacePermission:
+    """Tests for workspace permission check in core.enabled_clouds."""
+
+    @mock.patch('sky.core.global_user_state.get_cached_enabled_clouds',
+                return_value=[])
+    @mock.patch('sky.core.workspaces_core.check_workspace_permission')
+    def test_rejects_unauthorized_workspace(self, mock_check, _):
+        mock_check.side_effect = exceptions.PermissionDeniedError('no access')
+        mock_user = models.User(id='user-1', name='User1')
+        with mock.patch('sky.core.common_utils.get_current_user',
+                        return_value=mock_user):
+            with pytest.raises(exceptions.PermissionDeniedError,
+                               match='no access'):
+                core.enabled_clouds(workspace='restricted')
+        mock_check.assert_called_once_with(mock_user, 'restricted')
+
+    @mock.patch('sky.core.global_user_state.get_cached_enabled_clouds',
+                return_value=[])
+    @mock.patch('sky.core.workspaces_core.check_workspace_permission')
+    def test_skips_check_when_workspace_is_none(self, mock_check, _):
+        """When workspace is None, falls back to active workspace
+        and does not call check_workspace_permission."""
+        with mock.patch('sky.core.skypilot_config.get_active_workspace',
+                        return_value='default'), \
+             mock.patch('sky.core.skypilot_config.local_active_workspace_ctx'):
+            core.enabled_clouds(workspace=None)
+        mock_check.assert_not_called()

--- a/tests/unit_tests/test_sky/test_check.py
+++ b/tests/unit_tests/test_sky/test_check.py
@@ -6,6 +6,8 @@ from click import testing as cli_testing
 import pytest
 
 from sky import clouds as sky_clouds
+from sky import exceptions
+from sky import models
 import sky.check as sky_check
 from sky.client.cli import command
 from sky.clouds import cloud as sky_cloud
@@ -585,3 +587,25 @@ class TestCheckJsonOutput:
 
         assert result.exit_code == 0
         assert f'Using SkyPilot API server: {server_url}' in result.stdout
+
+
+class TestCheckWorkspacePermission:
+    """Tests for workspace permission check in sky.check.check."""
+
+    @mock.patch('sky.check.check_capabilities', return_value={})
+    @mock.patch('sky.workspaces.core.check_workspace_permission')
+    def test_rejects_unauthorized_workspace(self, mock_check, _):
+        mock_check.side_effect = exceptions.PermissionDeniedError('no access')
+        mock_user = models.User(id='user-1', name='User1')
+        with mock.patch('sky.check.common_utils.get_current_user',
+                        return_value=mock_user):
+            with pytest.raises(exceptions.PermissionDeniedError,
+                               match='no access'):
+                sky_check.check(workspace='restricted')
+        mock_check.assert_called_once_with(mock_user, 'restricted')
+
+    @mock.patch('sky.check.check_capabilities', return_value={})
+    @mock.patch('sky.workspaces.core.check_workspace_permission')
+    def test_skips_check_when_workspace_is_none(self, mock_check, _):
+        sky_check.check(workspace=None)
+        mock_check.assert_not_called()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The `/enabled_clouds` and `/check` handlers may retrieve the info for a specific workspace, however, we currently only check the permission to the active_workspace instead of the workspace in the request body/parameters.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- check
  - cli
    - no workspace specified - only accessible workspaces are checked
    - accessible workspace specified - succeed with the workspace
    - non-accessible workspace specified - `sky.exceptions.PermissionDeniedError: User test2 (ad023482) does not have permission to access workspace 'pri2'`
  - curl
    - no workspace specified - only accessible workspaces are checked
    - accessible workspace specified - succeed with the workspace
    - non-accessible workspace specified - "type":"PermissionDeniedError","message":"User test2 (ad023482) does not have permission to access workspace 'pri2'"
- enabled_clouds
  - cli
    - active workspace accessible - `sky status` succeeds
    - active workspace non-accessible - `sky status` fails with `sky.exceptions.PermissionDeniedError: User test2 (ad023482) does not have permission to access workspace 'pri2'`
  - curl
    - no workspace specified - return with the result for the default active workspace
    - accessible workspace specified - return with the result for the workspace
    - non-accessible workspace specified - "type":"PermissionDeniedError","message":"User test2 (ad023482) does not have permission to access workspace 'pri2'"
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
