### PR TITLE
[Serve] Fix scale-down sort key returning list instead of index

### DIFF
--- a/sky/serve/autoscalers.py
+++ b/sky/serve/autoscalers.py
@@ -880,7 +880,7 @@ class InstanceAwareRequestRateAutoscaler(RequestRateAutoscaler):
         sorted_replicas = sorted(
             replica_infos,
             key=lambda info: (
-                info.status.scale_down_decision_order(),
+                serve_state.ReplicaStatus.scale_down_decision_order().index(info.status),
                 replica_qps_map.get(info.replica_id, float('inf')),
                 info.version,
                 -info.replica_id,


### PR DESCRIPTION
## Summary

In `InstanceAwareRequestRateAutoscaler._select_replicas_to_scale_down_by_qps`, the sort key at line 883 calls `info.status.scale_down_decision_order()` on an enum instance. Since `scale_down_decision_order` is a `@classmethod`, calling it on any instance returns the full `List[ReplicaStatus]` — identical for every replica. This makes the first element of every sort tuple the same list, so status-based priority ordering is silently a no-op. Replicas are sorted only by QPS/version/id.

**Root cause:** The correct pattern (used at line 99 in `_select_nonterminal_replicas_to_scale_down`) calls `.index(info.status)` on the list to get an integer position. Line 883 forgot the `.index()` call.

**Impact:** When scaling down, READY replicas (actively serving traffic) may be terminated before PENDING/PROVISIONING ones, causing unnecessary service disruption.

**Fix:** Use `serve_state.ReplicaStatus.scale_down_decision_order().index(info.status)` to match the existing correct pattern.

## Test plan

- [ ] Verify that with mixed-status replicas, PENDING/PROVISIONING replicas are selected for scale-down before READY ones
- [ ] Existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)