### PR TITLE
[Core] Fall back to SSH when skylet gRPC is unreachable

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -4220,6 +4220,11 @@ def _handle_grpc_error(e: 'grpc.RpcError', current_backoff: float) -> None:
         with ux_utils.print_exception_no_traceback():
             raise exceptions.SkyletInternalError(e.details())
     elif e.code() == grpc.StatusCode.UNAVAILABLE:
+        details = e.details() or ''
+        if 'Connection refused' in details:
+            # Skylet is not running — retrying won't help.
+            raise RuntimeError(
+                f'Skylet is not running (connection refused): {details}') from e
         time.sleep(current_backoff)
     elif e.code() == grpc.StatusCode.UNIMPLEMENTED or e.code(
     ) == grpc.StatusCode.UNKNOWN:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -4170,13 +4170,6 @@ def open_ssh_tunnel(head_runner: Union[command_runner.SSHCommandRunner,
 
 T = TypeVar('T')
 
-# Exception types that indicate gRPC failed and the caller should fall
-# back to the legacy SSH code path.
-SKYLET_GRPC_FALLBACK_ERRORS = (
-    exceptions.SkyletMethodNotImplementedError,
-    exceptions.SkyletUnavailableError,
-)
-
 
 def invoke_skylet_with_retries(func: Callable[..., T]) -> T:
     """Generic helper for making Skylet gRPC requests.

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -4170,6 +4170,13 @@ def open_ssh_tunnel(head_runner: Union[command_runner.SSHCommandRunner,
 
 T = TypeVar('T')
 
+# Exception types that indicate gRPC failed and the caller should fall
+# back to the legacy SSH code path.
+SKYLET_GRPC_FALLBACK_ERRORS = (
+    exceptions.SkyletMethodNotImplementedError,
+    exceptions.SkyletUnavailableError,
+)
+
 
 def invoke_skylet_with_retries(func: Callable[..., T]) -> T:
     """Generic helper for making Skylet gRPC requests.
@@ -4189,7 +4196,7 @@ def invoke_skylet_with_retries(func: Callable[..., T]) -> T:
             last_exception = e
             _handle_grpc_error(e, backoff.current_backoff())
 
-    raise RuntimeError(
+    raise exceptions.SkyletUnavailableError(
         f'Failed to invoke Skylet after {max_attempts} attempts: {last_exception}'
     ) from last_exception
 
@@ -4210,7 +4217,7 @@ def invoke_skylet_streaming_with_retries(
             last_exception = e
             _handle_grpc_error(e, backoff.current_backoff())
 
-    raise RuntimeError(
+    raise exceptions.SkyletUnavailableError(
         f'Failed to stream Skylet response after {max_attempts} attempts'
     ) from last_exception
 
@@ -4223,7 +4230,7 @@ def _handle_grpc_error(e: 'grpc.RpcError', current_backoff: float) -> None:
         details = e.details() or ''
         if 'Connection refused' in details:
             # Skylet is not running — retrying won't help.
-            raise RuntimeError(
+            raise exceptions.SkyletUnavailableError(
                 f'Skylet is not running (connection refused): {details}') from e
         time.sleep(current_backoff)
     elif e.code() == grpc.StatusCode.UNIMPLEMENTED or e.code(

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3414,7 +3414,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                         backend_utils.invoke_skylet_with_retries(
                             lambda: SkyletClient(handle.get_grpc_channel()
                                                 ).update_status(request))
-                    except exceptions.SkyletMethodNotImplementedError:
+                    except (exceptions.SkyletMethodNotImplementedError,
+                            RuntimeError) as e:
+                        logger.debug(f'gRPC failed, falling back to SSH: {e}')
                         use_legacy = True
 
                 if use_legacy:
@@ -3438,7 +3440,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     backend_utils.invoke_skylet_with_retries(
                         lambda: SkyletClient(handle.get_grpc_channel(
                         )).fail_all_in_progress_jobs(fail_request))
-                except exceptions.SkyletMethodNotImplementedError:
+                except (exceptions.SkyletMethodNotImplementedError,
+                        RuntimeError) as e:
+                    logger.debug(f'gRPC failed, falling back to SSH: {e}')
                     use_legacy = True
 
             if use_legacy:
@@ -3934,7 +3938,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
                 backend_utils.invoke_skylet_with_retries(lambda: SkyletClient(
                     handle.get_grpc_channel()).queue_job(queue_job_request))
-            except exceptions.SkyletMethodNotImplementedError:
+            except (exceptions.SkyletMethodNotImplementedError,
+                    RuntimeError) as e:
+                logger.debug(f'gRPC failed, falling back to SSH: {e}')
                 use_legacy = True
 
         if use_legacy:
@@ -4007,7 +4013,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 job_id = response.job_id
                 log_dir = response.log_dir
                 return job_id, log_dir
-            except exceptions.SkyletMethodNotImplementedError:
+            except (exceptions.SkyletMethodNotImplementedError,
+                    RuntimeError) as e:
+                logger.debug(f'gRPC failed, falling back to SSH: {e}')
                 use_legacy = True
 
         if use_legacy:
@@ -4095,7 +4103,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     lambda: SkyletClient(handle.get_grpc_channel()
                                         ).set_job_info_without_job_id(request))
                 return list(response.job_ids)
-            except exceptions.SkyletMethodNotImplementedError:
+            except (exceptions.SkyletMethodNotImplementedError,
+                    RuntimeError) as e:
+                logger.debug(f'gRPC failed, falling back to SSH: {e}')
                 use_legacy = True
 
         if use_legacy:
@@ -4327,8 +4337,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     for job_id, proto_status in response.job_statuses.items()
                 }
                 return statuses
-            except exceptions.SkyletMethodNotImplementedError:
-                pass
+            except (exceptions.SkyletMethodNotImplementedError,
+                    RuntimeError) as e:
+                logger.debug(f'gRPC failed, falling back to SSH: {e}')
 
         code = job_lib.JobLibCodeGen.get_job_status(job_ids)
         returncode, stdout, stderr = self.run_on_head(handle,
@@ -4361,7 +4372,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     lambda: SkyletClient(handle.get_grpc_channel()).cancel_jobs(
                         request))
                 cancelled_ids = response.cancelled_job_ids
-            except exceptions.SkyletMethodNotImplementedError:
+            except (exceptions.SkyletMethodNotImplementedError,
+                    RuntimeError) as e:
+                logger.debug(f'gRPC failed, falling back to SSH: {e}')
                 use_legacy = True
 
         if use_legacy:
@@ -4416,7 +4429,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 for job_id, log_dir in job_log_dirs.items():
                     # Convert to string for backwards compatibility
                     job_to_dir[str(job_id)] = log_dir
-            except exceptions.SkyletMethodNotImplementedError:
+            except (exceptions.SkyletMethodNotImplementedError,
+                    RuntimeError) as e:
+                logger.debug(f'gRPC failed, falling back to SSH: {e}')
                 use_legacy = True
 
         if use_legacy:
@@ -4538,8 +4553,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                         print(resp.log_line, end='', flush=True)
                     last_exit_code = resp.exit_code
                 return last_exit_code
-            except exceptions.SkyletMethodNotImplementedError:
-                pass
+            except (exceptions.SkyletMethodNotImplementedError,
+                    RuntimeError) as e:
+                logger.debug(f'gRPC failed, falling back to SSH: {e}')
             except grpc.RpcError as e:
                 if e.code() == grpc.StatusCode.CANCELLED:
                     return last_exit_code
@@ -4692,7 +4708,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                         lambda: SkyletClient(handle.get_grpc_channel(
                         )).get_all_managed_job_ids_by_name(request))
                     job_ids = list(response.job_ids)
-                except exceptions.SkyletMethodNotImplementedError:
+                except (exceptions.SkyletMethodNotImplementedError,
+                        RuntimeError) as e:
+                    logger.debug(f'gRPC failed, falling back to SSH: {e}')
                     use_legacy = True
 
             if use_legacy:
@@ -4750,7 +4768,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     run_timestamps = {}
                     for jid, log_dir in job_log_dirs.items():
                         run_timestamps[int(jid)] = log_dir
-                except exceptions.SkyletMethodNotImplementedError:
+                except (exceptions.SkyletMethodNotImplementedError,
+                        RuntimeError) as e:
+                    logger.debug(f'gRPC failed, falling back to SSH: {e}')
                     use_legacy = True
 
             if use_legacy:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3414,7 +3414,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                         backend_utils.invoke_skylet_with_retries(
                             lambda: SkyletClient(handle.get_grpc_channel()
                                                 ).update_status(request))
-                    except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
+                    except exceptions.SKYLET_GRPC_FALLBACK_ERRORS as e:
                         logger.debug(f'gRPC failed, falling back to SSH: {e}')
                         use_legacy = True
 
@@ -3439,7 +3439,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     backend_utils.invoke_skylet_with_retries(
                         lambda: SkyletClient(handle.get_grpc_channel(
                         )).fail_all_in_progress_jobs(fail_request))
-                except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
+                except exceptions.SKYLET_GRPC_FALLBACK_ERRORS as e:
                     logger.debug(f'gRPC failed, falling back to SSH: {e}')
                     use_legacy = True
 
@@ -3936,7 +3936,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
                 backend_utils.invoke_skylet_with_retries(lambda: SkyletClient(
                     handle.get_grpc_channel()).queue_job(queue_job_request))
-            except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
+            except exceptions.SKYLET_GRPC_FALLBACK_ERRORS as e:
                 logger.debug(f'gRPC failed, falling back to SSH: {e}')
                 use_legacy = True
 
@@ -4010,7 +4010,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 job_id = response.job_id
                 log_dir = response.log_dir
                 return job_id, log_dir
-            except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
+            except exceptions.SKYLET_GRPC_FALLBACK_ERRORS as e:
                 logger.debug(f'gRPC failed, falling back to SSH: {e}')
                 use_legacy = True
 
@@ -4099,7 +4099,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     lambda: SkyletClient(handle.get_grpc_channel()
                                         ).set_job_info_without_job_id(request))
                 return list(response.job_ids)
-            except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
+            except exceptions.SKYLET_GRPC_FALLBACK_ERRORS as e:
                 logger.debug(f'gRPC failed, falling back to SSH: {e}')
                 use_legacy = True
 
@@ -4332,7 +4332,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     for job_id, proto_status in response.job_statuses.items()
                 }
                 return statuses
-            except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
+            except exceptions.SKYLET_GRPC_FALLBACK_ERRORS as e:
                 logger.debug(f'gRPC failed, falling back to SSH: {e}')
 
         code = job_lib.JobLibCodeGen.get_job_status(job_ids)
@@ -4366,7 +4366,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     lambda: SkyletClient(handle.get_grpc_channel()).cancel_jobs(
                         request))
                 cancelled_ids = response.cancelled_job_ids
-            except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
+            except exceptions.SKYLET_GRPC_FALLBACK_ERRORS as e:
                 logger.debug(f'gRPC failed, falling back to SSH: {e}')
                 use_legacy = True
 
@@ -4422,7 +4422,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 for job_id, log_dir in job_log_dirs.items():
                     # Convert to string for backwards compatibility
                     job_to_dir[str(job_id)] = log_dir
-            except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
+            except exceptions.SKYLET_GRPC_FALLBACK_ERRORS as e:
                 logger.debug(f'gRPC failed, falling back to SSH: {e}')
                 use_legacy = True
 
@@ -4545,7 +4545,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                         print(resp.log_line, end='', flush=True)
                     last_exit_code = resp.exit_code
                 return last_exit_code
-            except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
+            except exceptions.SKYLET_GRPC_FALLBACK_ERRORS as e:
                 logger.debug(f'gRPC failed, falling back to SSH: {e}')
             except grpc.RpcError as e:
                 if e.code() == grpc.StatusCode.CANCELLED:
@@ -4699,7 +4699,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                         lambda: SkyletClient(handle.get_grpc_channel(
                         )).get_all_managed_job_ids_by_name(request))
                     job_ids = list(response.job_ids)
-                except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
+                except exceptions.SKYLET_GRPC_FALLBACK_ERRORS as e:
                     logger.debug(f'gRPC failed, falling back to SSH: {e}')
                     use_legacy = True
 
@@ -4758,7 +4758,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     run_timestamps = {}
                     for jid, log_dir in job_log_dirs.items():
                         run_timestamps[int(jid)] = log_dir
-                except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
+                except exceptions.SKYLET_GRPC_FALLBACK_ERRORS as e:
                     logger.debug(f'gRPC failed, falling back to SSH: {e}')
                     use_legacy = True
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3414,8 +3414,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                         backend_utils.invoke_skylet_with_retries(
                             lambda: SkyletClient(handle.get_grpc_channel()
                                                 ).update_status(request))
-                    except (exceptions.SkyletMethodNotImplementedError,
-                            RuntimeError) as e:
+                    except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
                         logger.debug(f'gRPC failed, falling back to SSH: {e}')
                         use_legacy = True
 
@@ -3440,8 +3439,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     backend_utils.invoke_skylet_with_retries(
                         lambda: SkyletClient(handle.get_grpc_channel(
                         )).fail_all_in_progress_jobs(fail_request))
-                except (exceptions.SkyletMethodNotImplementedError,
-                        RuntimeError) as e:
+                except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
                     logger.debug(f'gRPC failed, falling back to SSH: {e}')
                     use_legacy = True
 
@@ -3938,8 +3936,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
                 backend_utils.invoke_skylet_with_retries(lambda: SkyletClient(
                     handle.get_grpc_channel()).queue_job(queue_job_request))
-            except (exceptions.SkyletMethodNotImplementedError,
-                    RuntimeError) as e:
+            except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
                 logger.debug(f'gRPC failed, falling back to SSH: {e}')
                 use_legacy = True
 
@@ -4013,8 +4010,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 job_id = response.job_id
                 log_dir = response.log_dir
                 return job_id, log_dir
-            except (exceptions.SkyletMethodNotImplementedError,
-                    RuntimeError) as e:
+            except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
                 logger.debug(f'gRPC failed, falling back to SSH: {e}')
                 use_legacy = True
 
@@ -4103,8 +4099,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     lambda: SkyletClient(handle.get_grpc_channel()
                                         ).set_job_info_without_job_id(request))
                 return list(response.job_ids)
-            except (exceptions.SkyletMethodNotImplementedError,
-                    RuntimeError) as e:
+            except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
                 logger.debug(f'gRPC failed, falling back to SSH: {e}')
                 use_legacy = True
 
@@ -4337,8 +4332,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     for job_id, proto_status in response.job_statuses.items()
                 }
                 return statuses
-            except (exceptions.SkyletMethodNotImplementedError,
-                    RuntimeError) as e:
+            except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
                 logger.debug(f'gRPC failed, falling back to SSH: {e}')
 
         code = job_lib.JobLibCodeGen.get_job_status(job_ids)
@@ -4372,8 +4366,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     lambda: SkyletClient(handle.get_grpc_channel()).cancel_jobs(
                         request))
                 cancelled_ids = response.cancelled_job_ids
-            except (exceptions.SkyletMethodNotImplementedError,
-                    RuntimeError) as e:
+            except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
                 logger.debug(f'gRPC failed, falling back to SSH: {e}')
                 use_legacy = True
 
@@ -4429,8 +4422,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 for job_id, log_dir in job_log_dirs.items():
                     # Convert to string for backwards compatibility
                     job_to_dir[str(job_id)] = log_dir
-            except (exceptions.SkyletMethodNotImplementedError,
-                    RuntimeError) as e:
+            except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
                 logger.debug(f'gRPC failed, falling back to SSH: {e}')
                 use_legacy = True
 
@@ -4553,8 +4545,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                         print(resp.log_line, end='', flush=True)
                     last_exit_code = resp.exit_code
                 return last_exit_code
-            except (exceptions.SkyletMethodNotImplementedError,
-                    RuntimeError) as e:
+            except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
                 logger.debug(f'gRPC failed, falling back to SSH: {e}')
             except grpc.RpcError as e:
                 if e.code() == grpc.StatusCode.CANCELLED:
@@ -4708,8 +4699,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                         lambda: SkyletClient(handle.get_grpc_channel(
                         )).get_all_managed_job_ids_by_name(request))
                     job_ids = list(response.job_ids)
-                except (exceptions.SkyletMethodNotImplementedError,
-                        RuntimeError) as e:
+                except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
                     logger.debug(f'gRPC failed, falling back to SSH: {e}')
                     use_legacy = True
 
@@ -4768,8 +4758,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     run_timestamps = {}
                     for jid, log_dir in job_log_dirs.items():
                         run_timestamps[int(jid)] = log_dir
-                except (exceptions.SkyletMethodNotImplementedError,
-                        RuntimeError) as e:
+                except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
                     logger.debug(f'gRPC failed, falling back to SSH: {e}')
                     use_legacy = True
 

--- a/sky/core.py
+++ b/sky/core.py
@@ -1071,7 +1071,7 @@ def _get_job_queue(handle: backends.CloudVmRayResourceHandle,
                 job_dict['username'] = user.name if user is not None else None
                 jobs.append(job_dict)
             return jobs
-        except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
+        except exceptions.SKYLET_GRPC_FALLBACK_ERRORS as e:
             logger.debug(f'gRPC failed, falling back to SSH: {e}')
 
     code = job_lib.JobLibCodeGen.get_job_queue(user_hash, all_jobs)

--- a/sky/core.py
+++ b/sky/core.py
@@ -1071,8 +1071,8 @@ def _get_job_queue(handle: backends.CloudVmRayResourceHandle,
                 job_dict['username'] = user.name if user is not None else None
                 jobs.append(job_dict)
             return jobs
-        except exceptions.SkyletMethodNotImplementedError:
-            pass
+        except (exceptions.SkyletMethodNotImplementedError, RuntimeError) as e:
+            logger.debug(f'gRPC failed, falling back to SSH: {e}')
 
     code = job_lib.JobLibCodeGen.get_job_queue(user_hash, all_jobs)
     returncode, jobs_payload, stderr = backend.run_on_head(handle,

--- a/sky/core.py
+++ b/sky/core.py
@@ -1071,7 +1071,7 @@ def _get_job_queue(handle: backends.CloudVmRayResourceHandle,
                 job_dict['username'] = user.name if user is not None else None
                 jobs.append(job_dict)
             return jobs
-        except (exceptions.SkyletMethodNotImplementedError, RuntimeError) as e:
+        except backend_utils.SKYLET_GRPC_FALLBACK_ERRORS as e:
             logger.debug(f'gRPC failed, falling back to SSH: {e}')
 
     code = job_lib.JobLibCodeGen.get_job_queue(user_hash, all_jobs)

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -711,6 +711,14 @@ class SkyletUnavailableError(Exception):
     pass
 
 
+# Exception types that indicate gRPC failed and the caller should fall
+# back to the legacy SSH code path.
+SKYLET_GRPC_FALLBACK_ERRORS = (
+    SkyletMethodNotImplementedError,
+    SkyletUnavailableError,
+)
+
+
 class ClientError(Exception):
     """Raised when a there is a client error occurs.
 

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -706,6 +706,11 @@ class SkyletMethodNotImplementedError(Exception):
     pass
 
 
+class SkyletUnavailableError(Exception):
+    """Raised when the Skylet gRPC server is unreachable."""
+    pass
+
+
 class ClientError(Exception):
     """Raised when a there is a client error occurs.
 


### PR DESCRIPTION
## Summary
- Add `SkyletUnavailableError` exception for when the skylet gRPC server is unreachable (connection refused, exhausted retries). Distinct from `SkyletMethodNotImplementedError` (skylet too old).
- Add `SKYLET_GRPC_FALLBACK_ERRORS` tuple constant in `exceptions.py` so all 12+ call sites catch one name instead of listing both exception types.
- All gRPC call sites now catch `SKYLET_GRPC_FALLBACK_ERRORS` and transparently fall back to the SSH code path with a debug log, instead of surfacing the error to the user.
- Connection refused skips retries — raises `SkyletUnavailableError` immediately since retrying a dead process won't help (~7.7s saved).

## Test plan
- [x] Kill skylet on a cluster: `ssh <cluster> 'kill -9 $(pgrep -f skylet)'`
- [x] `sky queue <cluster>` — should fall back to SSH and return results (debug log only)
- [x] `sky exec <cluster> echo hi` — should fall back to SSH
- [x] Wait for skylet to auto-restart, verify gRPC path works again
- [x] Verify no behavior change when skylet is healthy (gRPC path still used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)