### PR TITLE
Fix oauth pod scheduling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 docs/build/
 docs/_build/
 build/
+dist/
 sky_logs/
 sky/clouds/service_catalog/data_fetchers/*.csv
 .vscode/

--- a/charts/skypilot/templates/_helpers.tpl
+++ b/charts/skypilot/templates/_helpers.tpl
@@ -55,6 +55,26 @@ Usage: {{ include "common.image" (dict "root" . "image" "repo/name:tag") }}
 {{- end -}}
 {{- end -}}
 
+{{/*
+Pod scheduling aligned with apiService (nodeSelector, affinity, tolerations).
+Applied to oauth2-proxy and bundled redis so they schedule like the API server
+when umbrella charts set apiService.nodeSelector / tolerations / affinity.
+*/}}
+{{- define "skypilot.apiPodScheduling" -}}
+{{- with .Values.apiService.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.apiService.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.apiService.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+{{- end }}
+{{- end -}}
+
 
 {{/*
 Check for apiService.config during upgrade and display warning

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -804,15 +804,4 @@ spec:
       - name: r2-config
         emptyDir: {}
       {{- end }}
-      {{- with .Values.apiService.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.apiService.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.apiService.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "skypilot.apiPodScheduling" . }}

--- a/charts/skypilot/templates/oauth2-proxy-deployment.yaml
+++ b/charts/skypilot/templates/oauth2-proxy-deployment.yaml
@@ -63,6 +63,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "skypilot.apiPodScheduling" . }}
       containers:
       - name: oauth2-proxy
         image: {{ include "common.image" (dict "root" . "image" (default "quay.io/oauth2-proxy/oauth2-proxy:v7.9.0" (index $oauth2 "image"))) }}

--- a/charts/skypilot/templates/oauth2-proxy-redis.yaml
+++ b/charts/skypilot/templates/oauth2-proxy-redis.yaml
@@ -28,6 +28,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "skypilot.apiPodScheduling" . }}
       containers:
       - name: redis
         image: {{ include "common.image" (dict "root" . "image" (default "redis:7-alpine" (index $oauth2 "redis-image"))) }}

--- a/charts/skypilot/tests/fixtures/oauth2-scheduling-values.yaml
+++ b/charts/skypilot/tests/fixtures/oauth2-scheduling-values.yaml
@@ -1,0 +1,19 @@
+auth:
+  oauth:
+    enabled: true
+    oidc-issuer-url: "https://example.okta.com/oauth2/default"
+    client-id: "test-client-id"
+    client-secret: "test-client-secret"
+apiService:
+  nodeSelector:
+    pool: system
+  tolerations:
+    - key: components.gke.io/gke-managed-components
+      operator: Exists
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app: skypilot-api
+          topologyKey: kubernetes.io/hostname

--- a/charts/skypilot/tests/oauth2_test.yaml
+++ b/charts/skypilot/tests/oauth2_test.yaml
@@ -488,3 +488,55 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "redis-url and redis-secret are mutually exclusive when OAuth2 proxy is enabled"
+
+  - it: should inherit apiService nodeSelector tolerations and affinity on oauth2-proxy
+    values:
+      - fixtures/oauth2-scheduling-values.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.pool
+          value: system
+        template: templates/oauth2-proxy-deployment.yaml
+      - equal:
+          path: spec.template.spec.tolerations[0].key
+          value: components.gke.io/gke-managed-components
+        template: templates/oauth2-proxy-deployment.yaml
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey
+          value: kubernetes.io/hostname
+        template: templates/oauth2-proxy-deployment.yaml
+      - equal:
+          path: spec.template.spec.nodeSelector.pool
+          value: system
+        template: templates/oauth2-proxy-redis.yaml
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.tolerations[0].key
+          value: components.gke.io/gke-managed-components
+        template: templates/oauth2-proxy-redis.yaml
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey
+          value: kubernetes.io/hostname
+        template: templates/oauth2-proxy-redis.yaml
+        documentIndex: 0
+
+  - it: should inherit apiService scheduling for legacy ingress oauth2-proxy
+    set:
+      auth.oauth.enabled: false
+      ingress.enabled: true
+      ingress.oauth2-proxy.enabled: true
+      ingress.oauth2-proxy.oidc-issuer-url: "https://example.okta.com/oauth2/default"
+      ingress.oauth2-proxy.client-id: "test-client-id"
+      ingress.oauth2-proxy.client-secret: "test-client-secret"
+      apiService.nodeSelector.role: control-plane
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.role
+          value: control-plane
+        template: templates/oauth2-proxy-deployment.yaml
+      - equal:
+          path: spec.template.spec.nodeSelector.role
+          value: control-plane
+        template: templates/oauth2-proxy-redis.yaml
+        documentIndex: 0

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -197,7 +197,10 @@ apiService:
   # @schema type: [string, null]
   imagePullPolicy: Always
 
-  # Add scheduling constraints to the API server pod
+  # Add scheduling constraints to the API server pod. The same values are applied to
+  # oauth2-proxy and the bundled oauth2-proxy-redis Deployment when OAuth is enabled,
+  # so auth stays on the same node pool as the API. See
+  # https://docs.skypilot.co/en/latest/reference/api-server/helm-values-spec.html
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
Ensure oauth proxy & redis pods use the same scheduling as the API server to prevent landing on other pools.

<!-- Describe the tests ran -->
Manually validated by creating a .tgz and deploying into my own k8s cluster to verify the assigned node was correct.

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
