### PR TITLE
[Core] Handle None/string inputs in deserialize_exception gracefully

### DIFF
--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -112,6 +112,12 @@ def serialize_exception(e: BaseException) -> Dict[str, Any]:
 
 def deserialize_exception(serialized: Dict[str, Any]) -> Exception:
     """Deserialize the exception."""
+    if serialized is None:
+        return RuntimeError('Unknown server error (no detail in response)')
+    if isinstance(serialized, str):
+        return RuntimeError(serialized)
+    if not isinstance(serialized, dict) or 'type' not in serialized:
+        return RuntimeError(f'Server error: {serialized}')
     exception_type = serialized['type']
     if hasattr(builtins, exception_type):
         exception_class = getattr(builtins, exception_type)

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -120,9 +120,7 @@ def deserialize_exception(serialized: Any) -> Exception:
         return RuntimeError('Unknown server error (no detail in response)')
     if isinstance(serialized, str):
         return RuntimeError(serialized)
-    required_keys = {'type', 'message', 'args', 'attributes', 'stacktrace'}
-    if not isinstance(serialized,
-                      dict) or not required_keys.issubset(serialized):
+    if not isinstance(serialized, dict) or 'type' not in serialized:
         return RuntimeError(f'Server error: {serialized}')
     exception_type = serialized['type']
     if hasattr(builtins, exception_type):
@@ -131,10 +129,13 @@ def deserialize_exception(serialized: Any) -> Exception:
         exception_class = globals().get(exception_type, None)
     if exception_class is None:
         # Unknown exception type.
-        return Exception(f'{exception_type}: {serialized["message"]}')
-    e = exception_class(*serialized['args'], **serialized['attributes'])
-    if serialized['stacktrace'] is not None:
-        setattr(e, 'stacktrace', serialized['stacktrace'])
+        return Exception(
+            f'{exception_type}: {serialized.get("message", serialized)}')
+    e = exception_class(*serialized.get('args', ()),
+                        **serialized.get('attributes', {}))
+    stacktrace = serialized.get('stacktrace')
+    if stacktrace is not None:
+        setattr(e, 'stacktrace', stacktrace)
     return e
 
 

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -110,13 +110,19 @@ def serialize_exception(e: BaseException) -> Dict[str, Any]:
     return data
 
 
-def deserialize_exception(serialized: Dict[str, Any]) -> Exception:
-    """Deserialize the exception."""
+def deserialize_exception(serialized: Any) -> Exception:
+    """Deserialize the exception.
+
+    Handles non-standard inputs gracefully (None, str, partial dicts) to
+    avoid crashing when the server returns unexpected error responses.
+    """
     if serialized is None:
         return RuntimeError('Unknown server error (no detail in response)')
     if isinstance(serialized, str):
         return RuntimeError(serialized)
-    if not isinstance(serialized, dict) or 'type' not in serialized:
+    required_keys = {'type', 'message', 'args', 'attributes', 'stacktrace'}
+    if not isinstance(serialized,
+                      dict) or not required_keys.issubset(serialized):
         return RuntimeError(f'Server error: {serialized}')
     exception_type = serialized['type']
     if hasattr(builtins, exception_type):

--- a/tests/unit_tests/test_exceptions.py
+++ b/tests/unit_tests/test_exceptions.py
@@ -143,22 +143,35 @@ def test_deserialize_non_dict_input():
 
 
 def test_deserialize_partial_dict():
-    """Test that dicts missing required keys return RuntimeError."""
-    # Dict with only 'type'
+    """Test that dicts with 'type' but missing other keys still work."""
+    # Dict with only 'type' - should construct with no args
     e = exceptions.deserialize_exception({'type': 'ValueError'})
-    assert isinstance(e, RuntimeError)
-    assert 'Server error' in str(e)
+    assert isinstance(e, ValueError)
 
     # Dict with 'type' and 'message' but missing others
     e = exceptions.deserialize_exception({
         'type': 'ValueError',
         'message': 'test'
     })
-    assert isinstance(e, RuntimeError)
+    assert isinstance(e, ValueError)
 
-    # Empty dict
+    # Empty dict - no 'type' key, falls through to RuntimeError
     e = exceptions.deserialize_exception({})
     assert isinstance(e, RuntimeError)
+
+    # Unknown type with message uses message in fallback
+    e = exceptions.deserialize_exception({
+        'type': 'NonExistent',
+        'message': 'details'
+    })
+    assert isinstance(e, Exception)
+    assert 'NonExistent' in str(e)
+    assert 'details' in str(e)
+
+    # Unknown type without message still works
+    e = exceptions.deserialize_exception({'type': 'NonExistent'})
+    assert isinstance(e, Exception)
+    assert 'NonExistent' in str(e)
 
 
 def test_wrap_unsafe_exceptions():

--- a/tests/unit_tests/test_exceptions.py
+++ b/tests/unit_tests/test_exceptions.py
@@ -115,6 +115,52 @@ def test_aws_az_fetching_error():
     assert deserialized.stacktrace == 'test_stacktrace'
 
 
+def test_deserialize_none_input():
+    """Test that None input returns RuntimeError instead of crashing."""
+    e = exceptions.deserialize_exception(None)
+    assert isinstance(e, RuntimeError)
+    assert 'Unknown server error' in str(e)
+
+
+def test_deserialize_string_input():
+    """Test that string input is wrapped in RuntimeError."""
+    e = exceptions.deserialize_exception('Something went wrong')
+    assert isinstance(e, RuntimeError)
+    assert str(e) == 'Something went wrong'
+
+    # Empty string
+    e = exceptions.deserialize_exception('')
+    assert isinstance(e, RuntimeError)
+    assert str(e) == ''
+
+
+def test_deserialize_non_dict_input():
+    """Test that non-dict inputs (list, int, bool) return RuntimeError."""
+    for bad_input in [42, True, [{'loc': ['body'], 'msg': 'invalid'}]]:
+        e = exceptions.deserialize_exception(bad_input)
+        assert isinstance(e, RuntimeError)
+        assert 'Server error' in str(e)
+
+
+def test_deserialize_partial_dict():
+    """Test that dicts missing required keys return RuntimeError."""
+    # Dict with only 'type'
+    e = exceptions.deserialize_exception({'type': 'ValueError'})
+    assert isinstance(e, RuntimeError)
+    assert 'Server error' in str(e)
+
+    # Dict with 'type' and 'message' but missing others
+    e = exceptions.deserialize_exception({
+        'type': 'ValueError',
+        'message': 'test'
+    })
+    assert isinstance(e, RuntimeError)
+
+    # Empty dict
+    e = exceptions.deserialize_exception({})
+    assert isinstance(e, RuntimeError)
+
+
 def test_wrap_unsafe_exceptions():
     """Test that non-safe exceptions are wrapped properly."""
 


### PR DESCRIPTION
## Summary
- `deserialize_exception` crashes with `TypeError: 'NoneType' object is not subscriptable` when the server returns a non-standard error response (e.g. version mismatch with no serialized exception in the `detail` field).
- Handle `None`, string, and non-dict inputs by returning a `RuntimeError` with the raw content instead of crashing.

## Root cause
When a server returns a 400 response without the expected serialized exception format in `detail`, the client calls `deserialize_exception(None)` which immediately crashes at `serialized['type']`.

## Fix
Add input validation at the top of `deserialize_exception`:
- `None` → `RuntimeError('Unknown server error')`
- `str` → `RuntimeError(the_string)`  
- non-dict or missing `type` key → `RuntimeError(str(input))`

## Test plan
- Verified that `deserialize_exception(None)` returns `RuntimeError` instead of crashing
- Verified that `deserialize_exception("some message")` returns `RuntimeError("some message")`
- Verified that normal dict input still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)