### PR TITLE
[Dashboard] Reorder cluster detail page and fix chevron sizes

### DIFF
--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -652,6 +652,23 @@ function ActiveTab({
         </div>
       </div>
 
+      {/* GPU Metrics Section - Show for all Kubernetes clusters (in-cluster and external), but not SSH node pools */}
+      {clusterData &&
+        clusterData.full_infra &&
+        clusterData.full_infra.includes('Kubernetes') &&
+        !clusterData.full_infra.includes('SSH') &&
+        !clusterData.full_infra.includes('ssh') &&
+        isGrafanaAvailable && (
+          <div className="mb-6">
+            <GPUMetricsSection
+              clusterNameOnCloud={clusterData?.cluster_name_on_cloud}
+              displayName={clusterData?.cluster}
+              refreshTrigger={gpuMetricsRefreshTrigger}
+              storageKey="skypilot-gpu-metrics-expanded"
+            />
+          </div>
+        )}
+
       {/* Plugin Slot: Cluster Infra Nodes */}
       <PluginSlot
         name="clusters.detail.nodes"
@@ -680,6 +697,15 @@ function ActiveTab({
         </div>
       )}
 
+      {/* Plugin Slot: Cluster Detail Events */}
+      <PluginSlot
+        name="clusters.detail.events"
+        context={{
+          clusterHash: clusterData.cluster_hash,
+        }}
+        wrapperClassName="mb-8"
+      />
+
       {/* Provision Logs - Only show for active clusters */}
       {!isHistoricalCluster && (
         <div className="mb-8">
@@ -689,32 +715,6 @@ function ActiveTab({
           />
         </div>
       )}
-
-      {/* GPU Metrics Section - Show for all Kubernetes clusters (in-cluster and external), but not SSH node pools */}
-      {clusterData &&
-        clusterData.full_infra &&
-        clusterData.full_infra.includes('Kubernetes') &&
-        !clusterData.full_infra.includes('SSH') &&
-        !clusterData.full_infra.includes('ssh') &&
-        isGrafanaAvailable && (
-          <div className="mb-6">
-            <GPUMetricsSection
-              clusterNameOnCloud={clusterData?.cluster_name_on_cloud}
-              displayName={clusterData?.cluster}
-              refreshTrigger={gpuMetricsRefreshTrigger}
-              storageKey="skypilot-gpu-metrics-expanded"
-            />
-          </div>
-        )}
-
-      {/* Plugin Slot: Cluster Detail Events */}
-      <PluginSlot
-        name="clusters.detail.events"
-        context={{
-          clusterHash: clusterData.cluster_hash,
-        }}
-        wrapperClassName="mb-8"
-      />
     </div>
   );
 }
@@ -771,12 +771,12 @@ function ProvisionLogs({ clusterName, numNodes }) {
         <div className="flex items-center">
           <button
             onClick={() => setIsExpanded(!isExpanded)}
-            className="flex items-center text-left focus:outline-none text-gray-700 hover:text-gray-900 transition-colors duration-200"
+            className="flex items-center text-left focus:outline-none hover:text-gray-700 transition-colors duration-200"
           >
             {isExpanded ? (
-              <ChevronDownIcon className="w-4 h-4 mr-1" />
+              <ChevronDownIcon className="w-5 h-5 mr-2" />
             ) : (
-              <ChevronRightIcon className="w-4 h-4 mr-1" />
+              <ChevronRightIcon className="w-5 h-5 mr-2" />
             )}
             <h2 className="text-lg font-semibold">Provision Logs</h2>
           </button>

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -655,9 +655,8 @@ function ActiveTab({
       {/* GPU Metrics Section - Show for all Kubernetes clusters (in-cluster and external), but not SSH node pools */}
       {clusterData &&
         clusterData.full_infra &&
-        clusterData.full_infra.includes('Kubernetes') &&
-        !clusterData.full_infra.includes('SSH') &&
-        !clusterData.full_infra.includes('ssh') &&
+        clusterData.full_infra.toLowerCase().includes('kubernetes') &&
+        !clusterData.full_infra.toLowerCase().includes('ssh') &&
         isGrafanaAvailable && (
           <div className="mb-6">
             <GPUMetricsSection


### PR DESCRIPTION
## Summary
- Reorder cluster detail page sections so GPU Metrics appears first (after the header panel), matching the visual priority of the job detail page. New order: GPU Metrics → Infra Nodes → Cluster Jobs → Events → Provision Logs
- Fix Provision Logs collapsible chevron from `w-4 h-4 mr-1` to `w-5 h-5 mr-2` to match `GPUMetricsSection` styling, making all collapsible section headers on the cluster detail page visually consistent

## Test plan
- [ ] Open a cluster detail page for an active Kubernetes cluster
- [ ] Verify section order: GPU Metrics → Infra Nodes → Cluster Jobs → Events → Provision Logs
- [ ] Verify Provision Logs chevron size matches the GPU Metrics chevron
- [ ] Verify Show SkyPilot YAML chevron (smaller text context) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)