### PR TITLE
fix(controller): disable remote API server access for jobs and serve controllers

### DIFF
--- a/sky/templates/jobs-controller.yaml.j2
+++ b/sky/templates/jobs-controller.yaml.j2
@@ -23,6 +23,10 @@ file_mounts:
   {%- endif %}
   {%- endif %}
 
+# The remote jobs controller needs to be able to communicate to the local API server it starts.
+# It should not use the remote API server.
+api_server_access: false
+
 # NOTE(dev): This needs to be a subset of sky/templates/sky-serve-controller.yaml.j2.
 # It is because we use the --fast flag to submit jobs and no --fast flag to launch pools.
 # So when we launch a new pool, it will install the required dependencies.

--- a/sky/templates/sky-serve-controller.yaml.j2
+++ b/sky/templates/sky-serve-controller.yaml.j2
@@ -2,6 +2,10 @@
 
 name: {{service_name}}
 
+# The serve controller needs to be able to communicate to the local API server it starts.
+# It should not use the remote API server.
+api_server_access: false
+
 setup: |
   {{ sky_activate_python_env }}
   # Disable the pip version check to avoid the warning message, which makes the


### PR DESCRIPTION
## Changes

The jobs controller and serve controller each start their own local SkyPilot API server when running. This PR sets `api_server_access: false` in both controller templates so they communicate with that local server instead of inheriting any remote API server endpoint from the user environment.

## Problem

If a user has a remote `api_server.endpoint` configured in their `~/.sky/config.yaml`, the controller tasks inherit that setting and forward requests to the remote server instead of the local one they just started. This causes failures because the remote server has no knowledge of the controller's local state.

## Fix

Add `api_server_access: false` to:
- `sky/templates/jobs-controller.yaml.j2`
- `sky/templates/sky-serve-controller.yaml.j2`

This ensures controllers always talk to their own local API server.

## Testing

- [ ] Tested jobs controller with remote API endpoint configured
- [ ] Tested serve controller with remote API endpoint configured