### PR TITLE
[Serve] Fix instance-aware autoscaler counting terminal replicas in upscale formula

### DIFF
--- a/sky/serve/autoscalers.py
+++ b/sky/serve/autoscalers.py
@@ -673,7 +673,8 @@ class InstanceAwareRequestRateAutoscaler(RequestRateAutoscaler):
                 # for upscaling, max_target_qps is the standard qps
                 max_target_qps = max(target_qps_dict.values())
                 over_request_num = num_requests_per_second - total_qps
-                current_num_replicas = len(replica_infos)
+                current_num_replicas = sum(
+                    1 for info in replica_infos if not info.is_terminal)
                 raw_target_num = current_num_replicas + math.ceil(
                     over_request_num / max_target_qps)
                 target_num_replicas = self._clip_target_num_replicas(


### PR DESCRIPTION
## Bug

In `InstanceAwareRequestRateAutoscaler._set_target_num_replicas_with_instance_aware_logic()`, the upscale formula at line 676 uses:

```python
current_num_replicas = len(replica_infos)
```

This counts **all** replicas including terminal ones (SHUTTING_DOWN, FAILED, etc.). Meanwhile, `_calculate_total_qps_from_replicas()` correctly skips terminal replicas — only counting READY, STARTING, and PROVISIONING.

The mismatch inflates `current_num_replicas` relative to `total_qps`, causing over-scaling:

```
raw_target_num = current_num_replicas + ceil(over_request_num / max_target_qps)
```

If 3 of 5 replicas are terminal (2 live), `total_qps` reflects 2 replicas of capacity, `over_request_num` is correctly large, but `current_num_replicas = 5` sets the base too high. The caller at line 618 then computes `target - len(latest_nonterminal_replicas)` = too many scale-ups.

## Fix

Filter to non-terminal replicas, consistent with how `_generate_scaling_decisions()` (line 618) uses `latest_nonterminal_replicas`.

## Test plan

Verified the logic by tracing the scaling formula with terminal replicas present. The fix aligns `current_num_replicas` with the capacity reflected by `total_qps`.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>