### PR TITLE
[Test] Fix closure bug in optimizer random DAG test

### DIFF
--- a/tests/test_optimizer_random_dag.py
+++ b/tests/test_optimizer_random_dag.py
@@ -39,7 +39,11 @@ def generate_random_dag(
         for i in range(num_tasks):
             op = sky.Task(name=f'task{i}')
             task_runtime = random.random() * max_task_runtime
-            op.set_time_estimator(lambda _: task_runtime)
+
+            def make_estimator(runtime):
+                return lambda _: runtime
+
+            op.set_time_estimator(make_estimator(task_runtime))
             op.num_nodes = random.randint(2, max_num_nodes)
             if i in single_node_task_ids:
                 op.num_nodes = 1


### PR DESCRIPTION
## Summary
- Fix Python late-binding closure bug in `tests/test_optimizer_random_dag.py` that causes flaky CI failures when the remote catalog is updated.
- `lambda _: task_runtime` captures the loop variable by reference, so all 5 tasks share the last iteration's runtime instead of each having their own.
- This causes the ILP optimizer's cost (computed on region-resolved Resources from `_fill_in_launchable_resources`) to diverge from brute-force verification cost (computed on the original region-less Resources), exceeding the $2 tolerance when specific instance/region price spreads are large enough.

### Why `lambda _: task_runtime` is wrong

```python
>>> funcs = []
>>> for x in [10, 20, 30]:
...     funcs.append(lambda: x)      # all 3 lambdas point to the SAME `x`
>>> [f() for f in funcs]
[30, 30, 30]                          # all return 30 (current value of x)

>>> funcs = []
>>> for x in [10, 20, 30]:
...     funcs.append((lambda v: lambda: v)(x))  # each lambda gets its own `v`
>>> [f() for f in funcs]
[10, 20, 30]                          # each returns its own value
```

`lambda: x` doesn't snapshot `x=10` at creation time. It holds a reference to the **variable** `x`. When called later, it reads whatever `x` is *now* — which is `30` after the loop.

## Root cause details
The catalog at `skypilot-org/skypilot-catalog` commit `4e78685a` (Apr 9, 08:53 UTC) introduced a GCP H200 instance configuration where the `asia-south1` region price differs from the default by ~$0.40/node. With 6 nodes and the closure bug making all tasks use the same runtime, this single-task error alone reaches $2.38 > $2 tolerance.

With the fix, each task has its own unique runtime, producing diverse cost patterns that keep the per-catalog accumulated error well within tolerance.

## Test plan
- Reproduced on Linux x86_64 Python 3.9 Docker container (matching CI) with pinned failing catalog commit `4e78685a`:
  - Buggy code + failing catalog → **FAIL** (`assert 2.37974884723576 < 2`)
  - Buggy code + passing catalog (`924989b6`) → **PASS**
  - Fixed code + failing catalog → **PASS**


🤖 Generated with [Claude Code](https://claude.com/claude-code)