### PR TITLE
[Docs] Document _cluster_config_overrides in Python SDK docs

### DIFF
--- a/docs/source/reference/config-sources.rst
+++ b/docs/source/reference/config-sources.rst
@@ -131,6 +131,59 @@ Example:
     nvidia_gpus:
       disable_ecc: ...
 
+.. _config-client-python-sdk:
+
+Python SDK
+~~~~~~~~~~
+
+When using the Python SDK, you can pass configuration overrides via the
+``_cluster_config_overrides`` parameter on :class:`sky.Resources`. The dict
+structure is identical to the YAML ``config`` field.
+
+Example:
+
+.. code-block:: python
+
+  import sky
+
+  task = sky.Task(run='nvidia-smi')
+  task.set_resources(
+      sky.Resources(
+          infra='k8s',
+          accelerators='H100:8',
+          _cluster_config_overrides={
+              'kubernetes': {
+                  'provision_timeout': 600,
+                  'pod_config': {
+                      'metadata': {
+                          'annotations': {
+                              'my-annotation': 'my-value',
+                          },
+                      },
+                  },
+              },
+          },
+      ))
+  sky.launch(task)
+
+This is equivalent to the following task YAML:
+
+.. code-block:: yaml
+
+  resources:
+    infra: k8s
+    accelerators: H100:8
+
+  config:
+    kubernetes:
+      provision_timeout: 600
+      pod_config:
+        metadata:
+          annotations:
+            my-annotation: my-value
+
+  run: nvidia-smi
+
 .. _config-client-cli-flag:
 
 CLI flag

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -292,6 +292,14 @@ class Resources:
             setup for FUSE mounting. This flag also safeguards against using
             FUSE mounting on existing clusters that do not support it. If None,
             defaults to False.
+          _cluster_config_overrides: an optional dict of cluster configuration
+            overrides. This is the Python SDK equivalent of the ``config`` field
+            in a :ref:`task YAML <yaml-spec-config>`. The dict structure mirrors
+            the :ref:`SkyPilot configuration syntax <config-yaml>` and supports
+            the same fields allowed in the task YAML ``config`` field (e.g.
+            ``kubernetes.pod_config``, ``kubernetes.provision_timeout``,
+            ``docker.run_options``, etc.). See
+            :ref:`config-sources-and-overrides` for full details.
 
         Raises:
             ValueError: if some attributes are invalid.


### PR DESCRIPTION
## Summary

- Add documentation for the `_cluster_config_overrides` parameter on `sky.Resources`, which is the Python SDK equivalent of the YAML `config` field
- Add a "Python SDK" section to `config-sources.rst` with a full example and YAML equivalence
- Add `_cluster_config_overrides` to the `Resources.__init__` docstring with cross-references to the config docs

This was previously undocumented, making it hard for SDK users to discover how to set per-task config overrides (e.g. Kubernetes `pod_config`, `provision_timeout`).

## Test plan
- No testing needed — this is a documentation-only change
- Verified the RST renders correctly by inspecting the diff