### PR TITLE
[Test] Pre-install azcopy in Dockerfile_test

### DIFF
--- a/tests/smoke_tests/docker/Dockerfile_test
+++ b/tests/smoke_tests/docker/Dockerfile_test
@@ -91,6 +91,13 @@ RUN ARCH=$(case "${TARGETARCH:-$(uname -m)}" in \
     sudo dpkg -i session-manager-plugin.deb && \
     rm session-manager-plugin.deb
 
+# Pre-install azcopy (Azure CLI's runtime download is unreliable)
+RUN curl -sL "https://aka.ms/downloadazcopy-v10-linux" -o /tmp/azcopy.tar.gz && \
+    tar xzf /tmp/azcopy.tar.gz -C /tmp && \
+    cp /tmp/azcopy_linux_amd64_*/azcopy /usr/local/bin/azcopy && \
+    chmod +x /usr/local/bin/azcopy && \
+    rm -rf /tmp/azcopy*
+
 # Add a custom user with sudo privileges
 RUN useradd -m ${USERNAME} && \
     echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers


### PR DESCRIPTION
## Summary
- Pre-install `azcopy` in `tests/smoke_tests/docker/Dockerfile_test` to match what the main buildkite Dockerfile already does
- Azure CLI's runtime download of azcopy is unreliable — both the primary CDN and GitHub fallback URLs fail, causing `az storage blob sync` to exit with rc=1

## Root Cause
`Dockerfile_test` (used by `--remote-server` smoke tests) installs `azure-cli` via pip but never pre-installs `azcopy`. When `az storage blob sync` runs inside the nested test container, it tries to download azcopy on-the-fly and fails:

```
WARNING: Azcopy not found, installing at /home/buildkite/.azure/bin/azcopy
WARNING: There is an error downloading from the url: https://azcopyvnext-awgzd8g7aagqhzhe.b02.azurefd.net/...
ERROR: Invalid downloading url https://release-assets.githubusercontent.com/...
```

This breaks all 5 Azure storage tests in `nightly-build-pypi --remote-server --kubernetes` ([build 9697](https://buildkite.com/skypilot-1/smoke-tests/builds/9697)), while the same tests pass in `nightly-build-pypi --kubernetes` ([build 9692](https://buildkite.com/skypilot-1/smoke-tests/builds/9692)) because the main buildkite container already has azcopy pre-installed.

## Test plan
- Verified root cause by SSHing into Buildkite VM, starting a debug container, patching `data_utils.py` to capture stderr, and reproducing the exact failure
- The fix matches the existing working solution in the main buildkite Dockerfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)