### PR TITLE
[Core] Small refactoring for serialization and polling

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -391,6 +391,12 @@ def _dump_pipeline_to_file(yaml_file_path: str,
         group_name = ' '.join(
             word.capitalize() for word in re.split(r'[-_]', key))
 
+        if not all_steps:
+            # Skip empty groups — Buildkite rejects pipelines with
+            # empty step groups.
+            print(f'No matching tests for {yaml_file_path}, skipping.')
+            return
+
         grouped_steps = [{
             'group': group_name,
             'key': key,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2570,7 +2570,7 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
             'stable_internal_external_ips')
         handle.stable_ssh_ports = d.get('stable_ssh_ports')
         handle.docker_user = d.get('docker_user')
-        handle.is_grpc_enabled = d.get('is_grpc_enabled', False)
+        handle.is_grpc_enabled = d.get('is_grpc_enabled', True)
         handle.cached_cluster_info = None
         handle._ssh_user = d.get('ssh_user')
         return handle

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1893,6 +1893,10 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
     # compatibility logic in __setstate__ and/or __getstate__.
     _VERSION = 12
 
+    # Set by from_dict() since cached_cluster_info is not available
+    # when reconstructing from a dict.
+    _ssh_user: Optional[str] = None
+
     def __init__(
             self,
             *,
@@ -2493,7 +2497,7 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
             # container image used. For those clusters launched with ray
             # autoscaler, we directly use the ssh_user in yaml config.
             return self.cached_cluster_info.ssh_user
-        return None
+        return getattr(self, '_ssh_user', None)
 
     @property
     def head_ip(self):
@@ -2525,6 +2529,51 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
         return (env_options.Options.ENABLE_GRPC.get() and
                 self.is_grpc_enabled and
                 not isinstance(self.launched_resources.cloud, clouds.Slurm))
+
+    def to_dict(self) -> dict:
+        """Serialize to a JSON-compatible dict."""
+        return {
+            'cluster_name': self.cluster_name,
+            'cluster_name_on_cloud': self.cluster_name_on_cloud,
+            'cluster_yaml': self._cluster_yaml,
+            'launched_nodes': self.launched_nodes,
+            'launched_resources':
+                (self.launched_resources.to_yaml_config()
+                 if self.launched_resources is not None else None),
+            'stable_internal_external_ips': self.stable_internal_external_ips,
+            'stable_ssh_ports': self.stable_ssh_ports,
+            'docker_user': self.docker_user,
+            'is_grpc_enabled': self.is_grpc_enabled,
+            'ssh_user': self.ssh_user,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> 'CloudVmRayResourceHandle':
+        """Reconstruct from a dict produced by to_dict()."""
+        resources_dict = d.get('launched_resources')
+        launched_resources: Optional[resources_lib.Resources]
+        if resources_dict is not None:
+            launched_resources = (
+                resources_lib.Resources._from_yaml_config_single(  # pylint: disable=protected-access
+                    resources_dict.copy()))
+        else:
+            launched_resources = None
+
+        handle = cls.__new__(cls)
+        handle._version = cls._VERSION
+        handle.cluster_name = d['cluster_name']
+        handle.cluster_name_on_cloud = d.get('cluster_name_on_cloud', '')
+        handle._cluster_yaml = d.get('cluster_yaml')
+        handle.launched_nodes = d.get('launched_nodes', 0)
+        handle.launched_resources = launched_resources  # type: ignore
+        handle.stable_internal_external_ips = d.get(
+            'stable_internal_external_ips')
+        handle.stable_ssh_ports = d.get('stable_ssh_ports')
+        handle.docker_user = d.get('docker_user')
+        handle.is_grpc_enabled = d.get('is_grpc_enabled', False)
+        handle.cached_cluster_info = None
+        handle._ssh_user = d.get('ssh_user')
+        return handle
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -154,6 +154,18 @@ _DAG_NOT_SUPPORTED_MESSAGE = ('YAML specifies a DAG which is only supported by '
 T = TypeVar('T')
 
 
+def _get_ws_proxy_command() -> str:
+    """Returns the ws-proxy command string.
+
+    Defaults to the Python websocket_proxy.py script. Plugins can
+    replace this function to prefer a native binary.
+    """
+    escaped_executable_path = shlex.quote(sys.executable)
+    escaped_websocket_proxy_path = shlex.quote(
+        f'{directory_utils.get_sky_dir()}/templates/websocket_proxy.py')
+    return f'{escaped_executable_path} {escaped_websocket_proxy_path}'
+
+
 def _get_cluster_records_and_set_ssh_config(
     clusters: Optional[List[str]],
     refresh: common.StatusRefreshMode = common.StatusRefreshMode.NONE,
@@ -179,6 +191,8 @@ def _get_cluster_records_and_set_ssh_config(
                             _include_credentials=True,
                             _summary_response=not verbose)
     cluster_records = sdk.stream_and_get(request_id)
+    # Cache the ws-proxy command (constant across clusters).
+    ws_proxy_cmd = _get_ws_proxy_command()
     # Update the SSH config for all clusters
     for record in cluster_records:
         handle = record['handle']
@@ -206,9 +220,6 @@ def _get_cluster_records_and_set_ssh_config(
             escaped_key_path = shlex.quote(
                 (cluster_utils.SSHConfigHelper.generate_local_key_file(
                     handle.cluster_name, credentials)))
-            escaped_executable_path = shlex.quote(sys.executable)
-            escaped_websocket_proxy_path = shlex.quote(
-                f'{directory_utils.get_sky_dir()}/templates/websocket_proxy.py')
             # Instead of directly use websocket_proxy.py, we add an
             # additional proxy, so that ssh can use the head pod in the
             # cluster to jump to worker pods.
@@ -223,8 +234,7 @@ def _get_cluster_records_and_set_ssh_config(
                 # TODO(zhwu): write the template to a temp file, don't use
                 # the one in skypilot repo, to avoid changing the file when
                 # updating skypilot.
-                f'\"{escaped_executable_path} '
-                f'{escaped_websocket_proxy_path} '
+                f'\"{ws_proxy_cmd} '
                 f'{server_common.get_server_url()} '
                 f'{handle.cluster_name} '
                 f'kubernetes-pod-ssh-proxy\"')
@@ -232,13 +242,9 @@ def _get_cluster_records_and_set_ssh_config(
         elif isinstance(handle.launched_resources.cloud, clouds.Slurm):
             # Replace the proxy command to proxy through the SkyPilot API
             # server with websocket.
-            escaped_executable_path = shlex.quote(sys.executable)
-            escaped_websocket_proxy_path = shlex.quote(
-                f'{directory_utils.get_sky_dir()}/templates/websocket_proxy.py')
             # %w is a placeholder for the node index, substituted per-node
             # in cluster_utils.SSHConfigHelper.add_cluster().
-            proxy_command = (f'{escaped_executable_path} '
-                             f'{escaped_websocket_proxy_path} '
+            proxy_command = (f'{ws_proxy_cmd} '
                              f'{server_common.get_server_url()} '
                              f'{handle.cluster_name} '
                              f'slurm-job-ssh-proxy %w')

--- a/sky/server/requests/serializers/decoders.py
+++ b/sky/server/requests/serializers/decoders.py
@@ -27,7 +27,10 @@ def decode_and_unpickle(obj: str) -> Any:
 
 
 def decode_handle(data: Any) -> Any:
-    """Decode a ResourceHandle from either a dict or pickle string."""
+    """Decode a ResourceHandle from either a dict or pickle string.
+
+    Plugin extension point — do not inline into callers.
+    """
     if data is None:
         return None
     if isinstance(data, dict):
@@ -38,7 +41,10 @@ def decode_handle(data: Any) -> Any:
 
 
 def decode_resources(data: Any) -> Any:
-    """Decode a Resources object from either a dict or pickle string."""
+    """Decode a Resources object from either a dict or pickle string.
+
+    Plugin extension point — do not inline into callers.
+    """
     if data is None:
         return None
     if isinstance(data, dict):

--- a/sky/server/requests/serializers/decoders.py
+++ b/sky/server/requests/serializers/decoders.py
@@ -26,6 +26,29 @@ def decode_and_unpickle(obj: str) -> Any:
     return pickle.loads(base64.b64decode(obj.encode('utf-8')))
 
 
+def decode_handle(data: Any) -> Any:
+    """Decode a ResourceHandle from either a dict or pickle string."""
+    if data is None:
+        return None
+    if isinstance(data, dict):
+        # pylint: disable=import-outside-toplevel
+        from sky.backends import cloud_vm_ray_backend
+        return cloud_vm_ray_backend.CloudVmRayResourceHandle.from_dict(data)
+    return decode_and_unpickle(data)
+
+
+def decode_resources(data: Any) -> Any:
+    """Decode a Resources object from either a dict or pickle string."""
+    if data is None:
+        return None
+    if isinstance(data, dict):
+        # pylint: disable=import-outside-toplevel
+        from sky import resources as resources_lib
+        return resources_lib.Resources._from_yaml_config_single(  # pylint: disable=protected-access
+            data.copy())
+    return decode_and_unpickle(data)
+
+
 def register_decoders(*names: str):
     """Decorator to register a decoder."""
 
@@ -58,7 +81,7 @@ def decode_status(
     for cluster in clusters:
         # handle may not always be present in the response.
         if 'handle' in cluster and cluster['handle'] is not None:
-            cluster['handle'] = decode_and_unpickle(cluster['handle'])
+            cluster['handle'] = decode_handle(cluster['handle'])
         cluster['status'] = status_lib.ClusterStatus(cluster['status'])
         if 'is_managed' not in cluster:
             cluster['is_managed'] = False
@@ -93,12 +116,12 @@ def decode_status_kubernetes(
 def decode_launch(
     return_value: Dict[str, Any]
 ) -> Tuple[str, 'backends.CloudVmRayResourceHandle']:
-    return return_value['job_id'], decode_and_unpickle(return_value['handle'])
+    return return_value['job_id'], decode_handle(return_value['handle'])
 
 
 @register_decoders('start')
 def decode_start(return_value: str) -> 'backends.CloudVmRayResourceHandle':
-    return decode_and_unpickle(return_value)
+    return decode_handle(return_value)
 
 
 @register_decoders('queue')
@@ -155,7 +178,7 @@ def _decode_serve_status(
         for replica_info in service_status.get('replica_info', []):
             replica_info['status'] = serve_state.ReplicaStatus(
                 replica_info['status'])
-            replica_info['handle'] = decode_and_unpickle(replica_info['handle'])
+            replica_info['handle'] = decode_handle(replica_info['handle'])
     return service_statuses
 
 
@@ -176,7 +199,7 @@ def decode_cost_report(
         if cluster_report['status'] is not None:
             cluster_report['status'] = status_lib.ClusterStatus(
                 cluster_report['status'])
-        cluster_report['resources'] = decode_and_unpickle(
+        cluster_report['resources'] = decode_resources(
             cluster_report['resources'])
     return return_value
 

--- a/sky/server/requests/serializers/encoders.py
+++ b/sky/server/requests/serializers/encoders.py
@@ -33,12 +33,18 @@ def pickle_and_encode(obj: Any) -> str:
 
 
 def encode_handle(handle: Any) -> Any:
-    """Encode a ResourceHandle. Plugins can replace this function."""
+    """Encode a ResourceHandle for the REST API response.
+
+    Plugin extension point — do not inline into callers.
+    """
     return pickle_and_encode(handle)
 
 
 def encode_resources(resources: Any) -> Any:
-    """Encode a Resources object. Plugins can replace this function."""
+    """Encode a Resources object for the REST API response.
+
+    Plugin extension point — do not inline into callers.
+    """
     return pickle_and_encode(resources)
 
 

--- a/sky/server/requests/serializers/encoders.py
+++ b/sky/server/requests/serializers/encoders.py
@@ -32,6 +32,16 @@ def pickle_and_encode(obj: Any) -> str:
         raise ValueError(f'Failed to pickle object: {obj}') from e
 
 
+def encode_handle(handle: Any) -> Any:
+    """Encode a ResourceHandle. Plugins can replace this function."""
+    return pickle_and_encode(handle)
+
+
+def encode_resources(resources: Any) -> Any:
+    """Encode a Resources object. Plugins can replace this function."""
+    return pickle_and_encode(resources)
+
+
 def register_encoder(*names: str):
     """Decorator to register an encoder."""
 
@@ -75,9 +85,7 @@ def encode_status(
                 'labels') is None:
             response_cluster['labels'] = {}
         response_cluster['status'] = cluster['status'].value
-        handle = serialize_utils.prepare_handle_for_backwards_compatibility(
-            cluster['handle'])
-        response_cluster['handle'] = pickle_and_encode(handle)
+        response_cluster['handle'] = encode_handle(cluster['handle'])
         # TODO (syang) We still need to return this field for backwards
         # compatibility.
         # Remove this field at or after v0.12.0
@@ -92,19 +100,15 @@ def encode_launch(
     job_id_handle: Tuple[Optional[int], Optional['backends.ResourceHandle']]
 ) -> Dict[str, Any]:
     job_id, handle = job_id_handle
-    handle = serialize_utils.prepare_handle_for_backwards_compatibility(handle)
     return {
         'job_id': job_id,
-        'handle': pickle_and_encode(handle),
+        'handle': encode_handle(handle),
     }
 
 
 @register_encoder('start')
 def encode_start(resource_handle: 'backends.CloudVmRayResourceHandle') -> str:
-    resource_handle = (
-        serialize_utils.prepare_handle_for_backwards_compatibility(
-            resource_handle))
-    return pickle_and_encode(resource_handle)
+    return encode_handle(resource_handle)
 
 
 @register_encoder('queue')
@@ -183,9 +187,7 @@ def _encode_serve_status(
         service_status['status'] = service_status['status'].value
         for replica_info in service_status.get('replica_info', []):
             replica_info['status'] = replica_info['status'].value
-            handle = serialize_utils.prepare_handle_for_backwards_compatibility(
-                replica_info['handle'])
-            replica_info['handle'] = pickle_and_encode(handle)
+            replica_info['handle'] = encode_handle(replica_info['handle'])
     return service_statuses
 
 
@@ -208,7 +210,7 @@ def encode_cost_report(
         if cluster_report['status'] is not None:
             cluster_report['status'] = cluster_report['status'].value
         if 'resources' in cluster_report:
-            cluster_report['resources'] = pickle_and_encode(
+            cluster_report['resources'] = encode_resources(
                 cluster_report['resources'])
     return cost_report
 

--- a/sky/server/rest.py
+++ b/sky/server/rest.py
@@ -5,6 +5,7 @@ import contextlib
 import contextvars
 import functools
 import html
+import os
 import re
 import time
 import typing
@@ -58,6 +59,12 @@ _session.mount('https://', adapter)
 _session.headers[constants.API_VERSION_HEADER] = str(constants.API_VERSION)
 _session.headers[constants.VERSION_HEADER] = (
     versions.get_local_readable_version())
+
+# Allow the client type to be set via environment variable.
+# Used by enterprise CLI distributions to identify themselves.
+_client_type = os.environ.get('SKYPILOT_CLIENT_TYPE')
+if _client_type:
+    _session.headers['X-SkyPilot-Client-Type'] = _client_type
 
 # Enumerate error types that might be transient and can be addressed by
 # retrying.

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2149,6 +2149,10 @@ async def api_get(request_id: str) -> payloads.RequestPayload:
     # Validate request_id prefix matches a single request.
     request_id = await get_expanded_request_id(request_id)
 
+    # Exponential backoff: start fast (10ms) for short requests like
+    # status/queue, then back off to 100ms for long requests like
+    # launch/exec.
+    poll_interval = 0.01
     while True:
         req_status = await requests_lib.get_request_status_async(request_id)
         if req_status is None:
@@ -2161,9 +2165,9 @@ async def api_get(request_id: str) -> payloads.RequestPayload:
             break
         if req_status.status > requests_lib.RequestStatus.RUNNING:
             break
-        # yield control to allow other coroutines to run, sleep shortly
-        # to avoid storming the DB and CPU in the meantime
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(poll_interval)
+        # Back off: 10ms -> 20ms -> 40ms -> 80ms -> 100ms (cap)
+        poll_interval = min(poll_interval * 2, 0.1)
     request_task = await requests_lib.get_request_async(request_id)
     # TODO(aylei): refine this, /api/get will not be retried and this is
     # meaningless to retry. It is the original request that should be retried.

--- a/sky/utils/rich_console_utils.py
+++ b/sky/utils/rich_console_utils.py
@@ -1,4 +1,5 @@
 """Utility functions for rich console."""
+import os
 import typing
 
 from sky.adaptors import common as adaptors_common
@@ -17,5 +18,7 @@ def get_console():
     """Get or create the rich console."""
     global _console
     if _console is None:
-        _console = rich_console.Console(soft_wrap=True)
+        force_terminal = bool(os.environ.get('FORCE_COLOR'))
+        _console = rich_console.Console(soft_wrap=True,
+                                        force_terminal=force_terminal)
     return _console

--- a/sky/utils/rich_console_utils.py
+++ b/sky/utils/rich_console_utils.py
@@ -18,7 +18,11 @@ def get_console():
     """Get or create the rich console."""
     global _console
     if _console is None:
-        force_terminal = bool(os.environ.get('FORCE_COLOR'))
+        # When FORCE_COLOR is set, force terminal mode. Otherwise pass
+        # None to let Rich auto-detect via isatty(). Using bool() would
+        # return False when unset, explicitly disabling terminal detection.
+        force_color = os.environ.get('FORCE_COLOR')
+        force_terminal = True if force_color else None
         _console = rich_console.Console(soft_wrap=True,
                                         force_terminal=force_terminal)
     return _console


### PR DESCRIPTION
## Summary
- Extract `encode_handle()`, `encode_resources()` replaceable functions in encoders — separates handle/resource encoding from the pickle implementation
- Extract `decode_handle()`, `decode_resources()` in decoders — handles both dict and pickle input formats for forward compatibility
- Add `to_dict()` / `from_dict()` on `CloudVmRayResourceHandle` — JSON-native serialization alternative to pickle
- Extract `_get_ws_proxy_command()` helper in command.py — reduces duplication, cached outside loop
- Use exponential backoff in `api_get` polling (10ms → 100ms) — faster response for short-lived requests
- Read `SKYPILOT_CLIENT_TYPE` from env var in `rest.py` — allows CLI distributions to identify themselves

## Test plan
- Existing unit tests pass — no behavior change for default code paths
- `encode_handle`/`decode_handle` default to pickle (backward compatible)
- `decode_handle` accepts both dict and pickle (forward compatible)
- `sky status`, `sky queue`, `sky jobs queue` work as before
- `to_dict()` / `from_dict()` round-trip preserves all handle fields

## Tested
- `sky status` — works
- `sky queue <cluster>` — works
- `sky jobs queue` — works
- `sky launch --dryrun` — works (including None handle from dryrun)