### PR TITLE
[Core] Fix TypeError crash when catalog has NaN regions

### DIFF
--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -310,7 +310,7 @@ def validate_region_zone_impl(
 
     def _get_all_supported_regions_str() -> str:
         all_regions: List[str] = sorted(
-            df['Region'].str.lower().unique().tolist())
+            df['Region'].dropna().str.lower().unique().tolist())
         return (f'\nList of supported {cloud_name} regions: '
                 f'{", ".join(all_regions)!r}')
 
@@ -323,7 +323,8 @@ def validate_region_zone_impl(
             with ux_utils.print_exception_no_traceback():
                 error_msg = (f'Invalid region {region!r}')
                 candidate_strs = _get_candidate_str(
-                    region.lower(), df['Region'].str.lower().unique())
+                    region.lower(),
+                    df['Region'].dropna().str.lower().unique())
                 if not candidate_strs:
                     if cloud_name in ('azure', 'gcp'):
                         faq_msg = (
@@ -349,7 +350,8 @@ def validate_region_zone_impl(
             with ux_utils.print_exception_no_traceback():
                 error_msg = (f'Invalid zone {zone!r}{region_str}')
                 error_msg += _get_candidate_str(
-                    zone, maybe_region_df['AvailabilityZone'].unique())
+                    zone,
+                    maybe_region_df['AvailabilityZone'].dropna().unique())
                 raise ValueError(error_msg)
         region_df = filter_df['Region'].unique()
         assert len(region_df) == 1, 'Zone should be unique across regions.'


### PR DESCRIPTION
## Summary

- Fix `TypeError: object of type 'float' has no len()` crash in `validate_region_zone_impl` when a cloud catalog contains entries with empty (NaN) regions or zones.
- Add `.dropna()` before passing `Region`/`AvailabilityZone` columns to `difflib.get_close_matches()` and `str.join()`, which require string elements.

## Event Log

| Time (UTC) | Event |
|---|---|
| **Apr 10, 19:42** | Last passing `pytest-optimizer` CI run ([run 24260926445](https://github.com/skypilot-org/skypilot/actions/runs/24260926445)) |
| **Apr 10, 19:57** | Seeweb catalog bot update ([`06fb704d`](https://github.com/skypilot-org/skypilot-catalog/commit/06fb704d8451ff51f8e22d242a16988cf27741b5)) blanks the `Region` field for 14 instance types (RTX6000, A30, H200 4x/8x, A100 1x/2x/4x, L4 2x/4x/8x, L40S 8x, H100 2x/4x, eCS5HM, RTX PRO 6000 4x/8x) — changing them from `it-fr2` to empty |
| **Apr 10, 20:22** | First failing CI run ([run 24262493461](https://github.com/skypilot-org/skypilot/actions/runs/24262493461)) — CI runner pulls updated catalog with NaN regions |
| **Apr 10, 20:22–23:15** | Every `pytest-optimizer` run that includes Part 2 fails with the same error. [Run 24264778991](https://github.com/skypilot-org/skypilot/actions/runs/24264778991) reached 9 retry attempts, all failing on `test_infer_cloud_from_region_or_zone` |
| **Apr 10, 22:22** | Second catalog bot update ([`7627c0d4`](https://github.com/skypilot-org/skypilot-catalog/commit/7627c0d4496b91f0bee8f4f22107f169e5a748a2)) restores region for only 2 of 14 rows (A100 1x/2x) — 12 NaN regions remain, failure persists |

## Root Cause

`validate_region_zone_impl` in `sky/catalog/common.py` passes `df['Region'].str.lower().unique()` to `difflib.get_close_matches()`. When the Seeweb catalog contains rows with empty Region fields, pandas represents them as `NaN` (a float). `difflib.get_close_matches()` calls `len()` on each candidate, which crashes on the float NaN:

```
difflib.py:658: in real_quick_ratio
    la, lb = len(self.a), len(self.b)
E   TypeError: object of type 'float' has no len()
```

The same issue exists for the `AvailabilityZone` column on line 353.

## Test plan

- `pytest tests/test_optimizer_dryruns.py::test_infer_cloud_from_region_or_zone` — currently fails, should pass with this fix
- Existing optimizer dryrun tests cover region/zone validation paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)