### PR TITLE
[Core] Fix CI: handle NaN regions in catalog validation

### DIFF
--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -310,7 +310,7 @@ def validate_region_zone_impl(
 
     def _get_all_supported_regions_str() -> str:
         all_regions: List[str] = sorted(
-            df['Region'].str.lower().unique().tolist())
+            df['Region'].dropna().str.lower().unique().tolist())
         return (f'\nList of supported {cloud_name} regions: '
                 f'{", ".join(all_regions)!r}')
 
@@ -323,7 +323,7 @@ def validate_region_zone_impl(
             with ux_utils.print_exception_no_traceback():
                 error_msg = (f'Invalid region {region!r}')
                 candidate_strs = _get_candidate_str(
-                    region.lower(), df['Region'].str.lower().unique())
+                    region.lower(), df['Region'].dropna().str.lower().unique())
                 if not candidate_strs:
                     if cloud_name in ('azure', 'gcp'):
                         faq_msg = (

--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -350,8 +350,7 @@ def validate_region_zone_impl(
             with ux_utils.print_exception_no_traceback():
                 error_msg = (f'Invalid zone {zone!r}{region_str}')
                 error_msg += _get_candidate_str(
-                    zone, maybe_region_df['AvailabilityZone'].dropna().unique().
-                    tolist())
+                    zone, maybe_region_df['AvailabilityZone'].unique().tolist())
                 raise ValueError(error_msg)
         region_df = filter_df['Region'].unique()
         assert len(region_df) == 1, 'Zone should be unique across regions.'

--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -323,7 +323,8 @@ def validate_region_zone_impl(
             with ux_utils.print_exception_no_traceback():
                 error_msg = (f'Invalid region {region!r}')
                 candidate_strs = _get_candidate_str(
-                    region.lower(), df['Region'].dropna().str.lower().unique())
+                    region.lower(),
+                    df['Region'].dropna().str.lower().unique().tolist())
                 if not candidate_strs:
                     if cloud_name in ('azure', 'gcp'):
                         faq_msg = (
@@ -349,7 +350,8 @@ def validate_region_zone_impl(
             with ux_utils.print_exception_no_traceback():
                 error_msg = (f'Invalid zone {zone!r}{region_str}')
                 error_msg += _get_candidate_str(
-                    zone, maybe_region_df['AvailabilityZone'].unique())
+                    zone, maybe_region_df['AvailabilityZone'].dropna().unique().
+                    tolist())
                 raise ValueError(error_msg)
         region_df = filter_df['Region'].unique()
         assert len(region_df) == 1, 'Zone should be unique across regions.'


### PR DESCRIPTION
## Summary
- Add `dropna().tolist()` before passing `df['Region']` to string operations in `validate_region_zone_impl`
- Fixes `TypeError: object of type 'float' has no len()` crash in CI test `test_infer_cloud_from_region_or_zone`

## Root Cause
Seeweb catalog recently added 14 GPU instance types (ECS*GPU*) without region values. Pandas reads empty CSV fields as `NaN` (float). When a user specifies an invalid region, `validate_region_zone_impl` builds a "did you mean?" message by passing all region values (including `NaN`) to `difflib.get_close_matches`, which calls `len()` on `NaN` and crashes.

The optimizer and launch paths already handle this (`get_region_zones` drops NaN at line 804), so NaN-region instances are never scheduled. The crash is only in the error message path.

Note: `AvailabilityZone` is intentionally left unchanged — no catalog currently has NaN zones, and silently dropping them could mask real data bugs.

## Test plan
- This fixes the existing failing CI test `test_infer_cloud_from_region_or_zone`
- The Seeweb catalog fetcher should also be updated in the skypilot-catalog repo to stop emitting rows without regions

🤖 Generated with [Claude Code](https://claude.com/claude-code)