### PR TITLE
[Core] Fix AssertionError in owner-identity check for pre-#1808 non-k8s clusters

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2092,6 +2092,13 @@ def _check_owner_identity_with_record(cluster_name: str,
         except exceptions.CloudUserIdentityError:
             _raise_identity_error()
 
+    if owner_identity is None:
+        # Non-Kubernetes cluster created by a pre-#1808 SkyPilot: adopt
+        # the current active identity (matches pre-#9190 behavior).
+        global_user_state.set_owner_identity_for_cluster(
+            cluster_name, user_identities[0])
+        return
+
     assert isinstance(owner_identity, list)
     # It is OK if the owner identity is shorter, which will happen when
     # the cluster is launched before #1808. In that case, we only check


### PR DESCRIPTION
## Bug

Any cluster operation that runs `_check_owner_identity_with_record` on a non-Kubernetes cluster whose stored `owner` is `NULL` now crashes with a bare `AssertionError` from `sky/backends/backend_utils.py:2095`, instead of silently patching the owner identity.

This happens for clusters created by a pre-#1808 SkyPilot version on AWS/GCP/Azure/etc. (the row's `owner` column in the cluster DB is `None`), and any later `sky status`, `sky launch`, `sky down`, etc. that hits this code path.

## Root cause

#9190 ([k8s] Set proper owner context identity) restructured this function. The old code was:

\`\`\`python
if owner_identity is None:
    # Adopt the current active identity for any cloud.
    global_user_state.set_owner_identity_for_cluster(
        cluster_name, user_identities[0])
else:
    assert isinstance(owner_identity, list)
    ...
\`\`\`

The new code handles `None` **only for Kubernetes**, and then unconditionally asserts:

\`\`\`python
if owner_identity is None and is_k8s_cloud:
    # patch from k8s context ...
    return

assert isinstance(owner_identity, list)   # <-- trips for non-k8s + None
\`\`\`

So a pre-#1808 non-k8s cluster falls through the `if` (its cloud isn't Kubernetes), hits the `assert`, and dies. The previous, cloud-agnostic `None` fallback was dropped inadvertently — the stated purpose of #9190 was to tighten the k8s path, not to make non-k8s stricter.

## Fix

Restore the pre-#9190 behavior for the non-k8s `None` case: adopt the current active identity and return. The Kubernetes-specific patching still runs first and returns early when it succeeds; the subsequent `assert isinstance(owner_identity, list)` is reached only in the normal happy path.

\`\`\`diff
         except exceptions.CloudUserIdentityError:
             _raise_identity_error()
 
+    if owner_identity is None:
+        # Non-Kubernetes cluster created by a pre-#1808 SkyPilot: adopt
+        # the current active identity (matches pre-#9190 behavior).
+        global_user_state.set_owner_identity_for_cluster(
+            cluster_name, user_identities[0])
+        return
+
     assert isinstance(owner_identity, list)
\`\`\`

## Test plan

- Unit: construct a fake cluster record with `owner=None` on a non-k8s cloud; call `_check_owner_identity_with_record`; verify it no longer raises and `global_user_state.set_owner_identity_for_cluster` is called with `user_identities[0]`.
- Smoke: a pre-#1808-style AWS cluster (owner NULL) can now be listed / stopped / taken down without tripping `AssertionError`.