### PR TITLE
fix: use identity checks for None comparisons (PEP 8 E711)

### DIFF
--- a/sky/backends/task_codegen.py
+++ b/sky/backends/task_codegen.py
@@ -520,7 +520,7 @@ class RayCodeGen(TaskCodeGen):
                 for i in range(len(setup_returncodes)):
                     returncode = setup_returncodes[i]
                     pid = setup_pids[i]
-                    if pid == None:
+                    if pid is None:
                         pid = os.getpid()
                     if returncode != 0 and returncode != CANCELLED_RETURN_CODE:
                         success = False
@@ -653,7 +653,7 @@ class RayCodeGen(TaskCodeGen):
             rank = job_ip_rank_map[ip]
 
             if len(cluster_ips_to_node_id) == 1: # Single-node task on single-node cluter
-                name_str = '{task_name},' if {task_name!r} != None else 'task,'
+                name_str = '{task_name},' if {task_name!r} is not None else 'task,'
                 log_path = os.path.expanduser(os.path.join({log_dir!r}, 'run.log'))
             else: # Single-node or multi-node task on multi-node cluster
                 idx_in_cluster = cluster_ips_to_node_id[ip]

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -2806,7 +2806,7 @@ class ManagedJobCodeGen:
             if managed_job_version >= 8:
                 from sky.serve import serve_state
                 pool_hash = None
-                if {pool!r} != None:
+                if {pool!r} is not None:
                     pool_hash = serve_state.get_service_hash({pool!r})
                 set_job_info_kwargs['pool'] = {pool!r}
                 set_job_info_kwargs['pool_hash'] = pool_hash


### PR DESCRIPTION
## Summary

Replace `== None` and `!= None` comparisons with `is None` and `is not None` identity checks per PEP 8 (E711).

Python's `is` operator checks identity, which is the recommended way to compare with singletons like `None`. Using `==` can produce unexpected results if a class defines a custom `__eq__` method.

**Files changed:**

- `sky/backends/task_codegen.py` (lines 523, 656)
- `sky/jobs/utils.py` (line 2809)

**Change:**
```python
# Before
if pid == None:
if {task_name!r} != None
if {pool!r} != None:

# After
if pid is None:
if {task_name!r} is not None
if {pool!r} is not None:
```

## Testing
No behavior change — this is a PEP 8 style fix. Identity checks with `is`/`is not` are functionally equivalent to `==`/`!=` for `None` comparisons in standard usage.