### PR TITLE
[Serve] Fix blue-green scale-down including terminal replicas

### DIFF
--- a/sky/serve/autoscalers.py
+++ b/sky/serve/autoscalers.py
@@ -297,6 +297,7 @@ class Autoscaler:
             info.replica_id
             for info in replica_infos
             if info.version < latest_version_with_min_replicas
+            and not info.is_terminal
         ]
 
     def generate_scaling_decisions(


### PR DESCRIPTION
## Summary

In `_select_outdated_replicas_to_scale_down`, the rolling update path (line 252) correctly filters old replicas with `not info.is_terminal`, but the blue-green path (lines 296–300) omits this guard. This causes the autoscaler to issue redundant `SCALE_DOWN` decisions for replicas already in terminal states (SHUTTING_DOWN, FAILED, PREEMPTED, etc.) on every autoscaler cycle.

**Fix:** Add `and not info.is_terminal` to the blue-green list comprehension, matching the rolling update path's behavior.

## Test plan

- [x] Verified rolling path at line 252 uses `not info.is_terminal`
- [x] Verified blue-green path at line 296-300 was missing the guard
- [ ] `pytest tests/unit_tests/test_autoscaler.py` should continue to pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)