### PR TITLE
fix: replace bare except with except Exception (PEP 8 E722)

### DIFF
--- a/docs/verify_llms_links.py
+++ b/docs/verify_llms_links.py
@@ -33,7 +33,7 @@ def main():
     if base_url.startswith("http://127.0.0.1"):
         try:
             requests.get(base_url, timeout=1)
-        except:
+        except Exception:
             print(f"WARNING: No server at {base_url}")
 
     failures = []

--- a/examples/redisvl-vector-search/app.py
+++ b/examples/redisvl-vector-search/app.py
@@ -85,7 +85,7 @@ async def health():
     try:
         redis_client.ping()
         return {"status": "healthy", "papers": index.info().get("num_docs", 0)}
-    except:
+    except Exception:
         return {"status": "unhealthy"}
 
 

--- a/examples/redisvl-vector-search/streamlit_app.py
+++ b/examples/redisvl-vector-search/streamlit_app.py
@@ -36,7 +36,7 @@ with st.sidebar:
                 st.error("System offline")
         else:
             st.error("API error")
-    except:
+    except Exception:
         st.error("Connection failed")
 
 


### PR DESCRIPTION
## Summary

Replace bare `except:` clauses with `except Exception:` in three files:
- `docs/verify_llms_links.py`
- `examples/redisvl-vector-search/app.py`
- `examples/redisvl-vector-search/streamlit_app.py`

Bare `except:` catches all exceptions including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, which can mask critical errors and make debugging harder. Using `except Exception:` is the PEP 8 recommended practice (E722) and preserves the ability to interrupt the program.

**Change:**
```python
# Before
except:
    ...

# After
except Exception:
    ...
```

## Testing
No behavior change for normal exception handling — this is a correctness/style fix that only affects the handling of `BaseException` subclasses like `KeyboardInterrupt`.