### PR TITLE
Refinements for graceful upgrade

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -242,7 +242,11 @@ spec:
 
           {{- if .Values.apiService.serveServerLog }}
           mkdir -p /root/.sky/api_server
-          exec sky api start {{ include "skypilot.apiArgs" . }} --foreground  2>&1 | tee -a /root/.sky/api_server/server.log
+          # Use a FIFO instead of a pipe so that exec replaces the shell,
+          # allowing tini to send SIGTERM directly to the API server process
+          mkfifo /tmp/skylog
+          tee -a /root/.sky/api_server/server.log < /tmp/skylog &
+          exec sky api start {{ include "skypilot.apiArgs" . }} --foreground > /tmp/skylog 2>&1
           {{- else }}
           exec sky api start {{ include "skypilot.apiArgs" . }} --foreground
           {{- end }}

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -244,7 +244,7 @@ spec:
           mkdir -p /root/.sky/api_server
           # Use a FIFO instead of a pipe so that exec replaces the shell,
           # allowing tini to send SIGTERM directly to the API server process
-          mkfifo /tmp/skylog
+          rm -f /tmp/skylog && mkfifo /tmp/skylog
           tee -a /root/.sky/api_server/server.log < /tmp/skylog &
           exec sky api start {{ include "skypilot.apiArgs" . }} --foreground > /tmp/skylog 2>&1
           {{- else }}

--- a/sky/server/blob/blob_storage.py
+++ b/sky/server/blob/blob_storage.py
@@ -103,16 +103,7 @@ class BlobStorage(abc.ABC):
         return os.path.expanduser(constants.FILE_MOUNTS_LOCAL_TMP_BASE_PATH)
 
     def download_tmp_dir(self, user_hash: str) -> str:
-        """Return a staging directory for log downloads for a user.
-
-        The returned path is set as `local_dir` for log sync-down
-        requests, so the server stores downloaded logs there and returns
-        paths under it to the client.
-
-        In multi-replica mode this must be on shared storage so that
-        any replica can serve the ``/download`` request after another
-        replica synced the logs from the cluster.
-        """
+        """Return a staging directory for log downloads for a user."""
         raise NotImplementedError
 
     def download_tmp_base_dir(self) -> Optional[str]:
@@ -122,6 +113,11 @@ class BlobStorage(abc.ABC):
         (no separate cleanup needed).
         """
         return None
+
+    @abc.abstractmethod
+    def reset_on_startup(self) -> None:
+        """Called on server startup to clean up ephemeral client state."""
+        raise NotImplementedError
 
     def get_staging_dir(self, user_id: str, blob_id: str) -> pathlib.Path:
         """Return the staging directory path for an in-progress upload."""

--- a/sky/server/blob/local_blob_storage.py
+++ b/sky/server/blob/local_blob_storage.py
@@ -11,9 +11,12 @@ from typing import List, Tuple
 import anyio
 import filelock
 
+from sky import sky_logging
 from sky.server import common as server_common
 from sky.server.blob import blob_storage as bs
 from sky.server.requests import executor
+
+logger = sky_logging.init_logger(__name__)
 
 
 class LocalFilesystemBlobStorage(bs.BlobStorage):
@@ -107,3 +110,10 @@ class LocalFilesystemBlobStorage(bs.BlobStorage):
             if entry.is_dir() and (entry / 'file_mounts' / 'blobs').is_dir():
                 users.append(entry.name)
         return users
+
+    def reset_on_startup(self) -> None:
+        """Called on server startup to clean up ephemeral client state."""
+        logger.debug('clearing local API server client directory at '
+                     f'{server_common.API_SERVER_CLIENT_DIR.expanduser()}')
+        shutil.rmtree(server_common.API_SERVER_CLIENT_DIR.expanduser(),
+                      ignore_errors=True)

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -30,6 +30,7 @@ from sky.metrics import utils as metrics_lib
 from sky.server import common as server_common
 from sky.server import constants as server_constants
 from sky.server import daemons
+from sky.server.blob import blob_storage as bs
 from sky.server.requests import payloads
 from sky.server.requests import storage as request_storage
 from sky.server.requests.serializers import decoders
@@ -540,10 +541,7 @@ def reset_db_and_logs():
                  f'{LEGACY_REQUEST_LOG_PATH_PREFIX}')
     shutil.rmtree(pathlib.Path(LEGACY_REQUEST_LOG_PATH_PREFIX).expanduser(),
                   ignore_errors=True)
-    logger.debug('clearing local API server client directory at '
-                 f'{server_common.API_SERVER_CLIENT_DIR.expanduser()}')
-    shutil.rmtree(server_common.API_SERVER_CLIENT_DIR.expanduser(),
-                  ignore_errors=True)
+    bs.get_blob_storage().reset_on_startup()
     request_storage.get_request_backend().reset_on_startup()
 
 

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -1411,6 +1411,19 @@ class SqliteRequestBackend(request_storage.RequestBackend):
                 (RequestStatus.PENDING.value, RequestStatus.RUNNING.value))
             return {row[0] for row in cursor.fetchall()}
 
+    def get_shutdown_active_requests(self) -> List[Tuple[str, str]]:
+        """Get (request_id, name) pairs to wait for during graceful shutdown."""
+
+        tasks = self.query_requests(
+            RequestTaskFilter(
+                status=[
+                    RequestStatus.PENDING,
+                    RequestStatus.RUNNING,
+                ],
+                fields=['request_id', 'name'],
+            ))
+        return [(t.request_id, t.name) for t in tasks]
+
     # --- Lifecycle ---
 
     def reset_on_startup(self) -> None:

--- a/sky/server/requests/storage.py
+++ b/sky/server/requests/storage.py
@@ -155,12 +155,7 @@ class RequestBackend(abc.ABC):
         raise NotImplementedError
 
     def reset_on_startup(self) -> None:
-        """Called on server startup for backend-specific initialization.
-
-        The default SQLite implementation re-creates the database and checks
-        the SQLite version. Alternative backends may run migrations, mark
-        stale requests as failed, etc.
-        """
+        """Called on server startup for backend-specific initialization."""
 
 
 _storage_backend: Optional[RequestBackend] = None

--- a/sky/server/requests/storage.py
+++ b/sky/server/requests/storage.py
@@ -1,9 +1,11 @@
 """Abstract interface for request persistence."""
+
 from __future__ import annotations
 
 import abc
 import contextlib
-from typing import AsyncGenerator, Generator, List, Optional, Set, TYPE_CHECKING
+from typing import (AsyncGenerator, Generator, List, Optional, Set, Tuple,
+                    TYPE_CHECKING)
 
 if TYPE_CHECKING:
     from sky.server.requests.requests import Request
@@ -147,6 +149,11 @@ class RequestBackend(abc.ABC):
         """Get blob IDs referenced by active (PENDING/RUNNING) requests."""
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def get_shutdown_active_requests(self) -> List[Tuple[str, str]]:
+        """Get (request_id, name) pairs to wait for during graceful shutdown."""
+        raise NotImplementedError
+
     def reset_on_startup(self) -> None:
         """Called on server startup for backend-specific initialization.
 
@@ -165,6 +172,7 @@ def get_request_backend() -> RequestBackend:
     if _storage_backend is None:
         # pylint: disable=import-outside-toplevel
         from sky.server.requests.requests import SqliteRequestBackend
+
         _storage_backend = SqliteRequestBackend()
     return _storage_backend
 

--- a/sky/server/uvicorn.py
+++ b/sky/server/uvicorn.py
@@ -150,7 +150,7 @@ class Server(uvicorn.Server):
 
     def _wait_requests(self) -> None:
         """Wait until all on-going requests are finished or cancelled."""
-        start_time = time.time()
+        start_time = time.time() - _GRACE_WAIT_SECONDS
         while True:
             requests = (request_storage.get_request_backend().
                         get_shutdown_active_requests())

--- a/sky/server/uvicorn.py
+++ b/sky/server/uvicorn.py
@@ -3,6 +3,7 @@
 This module is a wrapper around uvicorn to customize the behavior of the
 server.
 """
+
 import asyncio
 import logging
 import os
@@ -22,6 +23,7 @@ from sky.server import daemons
 from sky.server import metrics as metrics_lib
 from sky.server import state
 from sky.server.requests import requests as requests_lib
+from sky.server.requests import storage as request_storage
 from sky.skylet import constants
 from sky.utils import context_utils
 from sky.utils import env_options
@@ -31,6 +33,8 @@ from sky.utils.db import db_utils
 
 logger = sky_logging.init_logger(__name__)
 
+# A short wait for the endpoints update propagated to the ingress/LB
+_GRACE_WAIT_SECONDS = 5
 # File lock path for coordinating graceful shutdown across processes
 _GRACEFUL_SHUTDOWN_LOCK_PATH = '/tmp/skypilot_graceful_shutdown.lock'
 
@@ -122,6 +126,7 @@ class Server(uvicorn.Server):
     def _graceful_shutdown(self, sig: int, frame: Union[FrameType,
                                                         None]) -> None:
         """Perform graceful shutdown."""
+        time.sleep(_GRACE_WAIT_SECONDS)
         # Block new requests so that we can wait until all on-going requests
         # are finished. Note that /api/$verb operations are still allowed in
         # this stage to ensure the client can still operate the on-going
@@ -147,15 +152,8 @@ class Server(uvicorn.Server):
         """Wait until all on-going requests are finished or cancelled."""
         start_time = time.time()
         while True:
-            statuses = [
-                requests_lib.RequestStatus.PENDING,
-                requests_lib.RequestStatus.RUNNING,
-            ]
-            requests = [(request_task.request_id, request_task.name)
-                        for request_task in requests_lib.get_request_tasks(
-                            req_filter=requests_lib.RequestTaskFilter(
-                                status=statuses, fields=['request_id', 'name']))
-                       ]
+            requests = (request_storage.get_request_backend().
+                        get_shutdown_active_requests())
             if not requests:
                 break
             logger.info(f'{len(requests)} on-going requests '
@@ -215,9 +213,11 @@ class Server(uvicorn.Server):
             event_loop.set_debug(True)
             event_loop.slow_callback_duration = lag_threshold
         stop_monitor = threading.Event()
-        monitor = threading.Thread(target=metrics_lib.process_monitor,
-                                   args=('server', stop_monitor),
-                                   daemon=True)
+        monitor = threading.Thread(
+            target=metrics_lib.process_monitor,
+            args=('server', stop_monitor),
+            daemon=True,
+        )
         monitor.start()
         try:
             with self.capture_signals():


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fix a regression introduced in https://github.com/skypilot-org/skypilot/pull/7226, which prevents the `exec` replace the shell and breaks signal propagation from `tini`

Process tree on master:
```
  tini (PID 1)
   └─ sh -c "exec sky api start ... | tee ..."   # a shell for pipe
       ├─ sky api start ...  
       └─ tee ...    
```

`sh` does not propagate `SIGTERM` properly

After ths fix:

```
# graceful upgrade works on SIGTERM
  tini (PID 1)
   └─ sky api start ...
```

Also, this PR introduce a short delay to block the requests on graceful shutdown, to avoid race between endpoints update.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
