### PR TITLE
[Vast] Fix KeyError in query_instances for unmapped statuses

### DIFF
--- a/sky/provision/vast/instance.py
+++ b/sky/provision/vast/instance.py
@@ -278,7 +278,7 @@ def query_instances(
     statuses: Dict[str, Tuple[Optional['status_lib.ClusterStatus'],
                               Optional[str]]] = {}
     for inst_id, inst in instances.items():
-        status = status_map[inst['status']]
+        status = status_map.get(inst['status'])
         if non_terminated_only and status is None:
             continue
         statuses[inst_id] = (status, None)


### PR DESCRIPTION
## Bug

In `query_instances()`, `status_map[inst['status']]` crashes with `KeyError` when an instance has a status not present in the map. The `UNKNOWN` status is explicitly set as a fallback in `utils.list_instances()` (line 30) when `actual_status` is not a string, but `UNKNOWN` is not in `status_map`.

## Root cause

Direct dict indexing (`status_map[key]`) instead of `.get()`. The existing `non_terminated_only` guard on line 282 (`if ... status is None: continue`) was designed to handle unmapped statuses, but can never trigger because `status_map[key]` raises `KeyError` before `status` can be `None`.

## Fix

Changed `status_map[inst['status']]` to `status_map.get(inst['status'])`, matching the pattern used by FluidStack and Lambda Cloud provisioners.

🤖 Generated with [Claude Code](https://claude.ai/code)