### PR TITLE
[Log] Fix unexpected CancelledError log

### DIFF
--- a/sky/server/requests/threads.py
+++ b/sky/server/requests/threads.py
@@ -56,7 +56,7 @@ class OnDemandThreadExecutor(concurrent.futures.Executor):
         try:
             result = fn(*args, **kwargs)
             fut.set_result(result)
-        except asyncio.exceptions.CancelledError:
+        except asyncio.CancelledError:
             # Cancellation is an expected terminal state, not an error.
             # Put the future into CANCELLED state instead of FINISHED with a
             # CancelledError exception, so that the asyncio-side future (via
@@ -71,7 +71,11 @@ class OnDemandThreadExecutor(concurrent.futures.Executor):
                 # set_running_or_notify_cancel(), so the future stays PENDING
                 # here. If a future refactor changes that, fall back to
                 # set_exception to preserve the cancellation signal.
-                if not fut.cancel():
+                # Also guard with fut.done() in case of a race where the future
+                # transitioned to a terminal state between our cancelled() check
+                # and cancel() call — set_exception on a done future raises
+                # InvalidStateError.
+                if not fut.cancel() and not fut.done():
                     fut.set_exception(asyncio.CancelledError())
         except Exception as e:  # pylint: disable=broad-except
             logger.debug(f'Executor [{self.name}] error executing {fn}: {e}')

--- a/sky/server/requests/threads.py
+++ b/sky/server/requests/threads.py
@@ -56,7 +56,24 @@ class OnDemandThreadExecutor(concurrent.futures.Executor):
         try:
             result = fn(*args, **kwargs)
             fut.set_result(result)
-        except (Exception, asyncio.exceptions.CancelledError) as e:  # pylint: disable=broad-except
+        except asyncio.exceptions.CancelledError:
+            # Cancellation is an expected terminal state, not an error.
+            # Put the future into CANCELLED state instead of FINISHED with a
+            # CancelledError exception, so that the asyncio-side future (via
+            # asyncio.wrap_future / loop.run_in_executor) is also cancelled
+            # and does not trigger the "Future exception was never retrieved"
+            # warning when the awaiter was itself cancelled and never consumes
+            # the exception.
+            logger.debug(f'Executor [{self.name}] cancelled {fn}')
+            if not fut.cancelled():
+                # fut.cancel() succeeds only when the future is in PENDING
+                # state. OnDemandThreadExecutor does not call
+                # set_running_or_notify_cancel(), so the future stays PENDING
+                # here. If a future refactor changes that, fall back to
+                # set_exception to preserve the cancellation signal.
+                if not fut.cancel():
+                    fut.set_exception(asyncio.CancelledError())
+        except Exception as e:  # pylint: disable=broad-except
             logger.debug(f'Executor [{self.name}] error executing {fn}: {e}')
             if not fut.cancelled():
                 # Only set the exception if the future is not cancelled to avoid


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fix the `ERROR:asyncio:Future exception was never retrieved future: <Future finished exception=CancelledError()>` warning emitted when a streaming request (e.g. `sky logs --follow`) is cancelled by the client.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Manually reproduce this issue and verify that the fix works:
```
SKY_URL='http://xx:yy@3.2.19.6'
CLUSTER=e56
JOB_ID=1
curl -sN -X POST "${SKY_URL}/logs" \
    -H 'Content-Type: application/json' \
    -d "{\"cluster_name\":\"${CLUSTER}\",\"job_id\":${JOB_ID},\"follow\":true,\"tail\":0}" \
    > /tmp/curl.out 2>&1 &
CURL_PID=$!

sleep 6
kill -9 $CURL_PID
```
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
