### PR TITLE
[Test] Fix test_api_server_memory on kubernetes

### DIFF
--- a/tests/load_tests/workloads/basic.sh
+++ b/tests/load_tests/workloads/basic.sh
@@ -12,7 +12,12 @@
 # Each phase manages its own resources and cleanup.
 # Emits ##BENCH_START / ##BENCH_END markers for per-operation timing.
 
-set -uo pipefail
+# Abort a phase on the first unexpected failure.  Ops that are allowed to
+# fail (e.g. sky_jobs_logs, sky_jobs_cancel) use explicit `|| true` below.
+# Without `-e`, a broken cluster-side setup silently runs every phase and
+# puts the managed-jobs controller into an unbounded recovery loop, which
+# can exhaust API-server memory in long-running benchmarks.
+set -euo pipefail
 
 UNIQUE_ID=${BENCHMARK_UNIQUE_ID:-"test-$(date +%s)-$$"}
 CLOUD=${BENCHMARK_CLOUD:-"kubernetes"}

--- a/tests/smoke_tests/docker/entrypoint.sh
+++ b/tests/smoke_tests/docker/entrypoint.sh
@@ -60,6 +60,14 @@ regenerate_user_hash() {
 # if TEMP_FILE_FOR_TEST exists, skip the following steps
 if [ -f "$HOME/TEMP_FILE_FOR_TEST" ]; then
     echo "TEMP_FILE_FOR_TEST exists, skipping the following steps"
+    # Match the CWD used on first-run below so Python resolves `sky` to the
+    # editable install at /skypilot (buildkite-owned) rather than the
+    # root-owned copy left by the Dockerfile at ~/sky_workdir/skypilot.
+    # Without this, `docker restart` (e.g. from test_api_server_memory)
+    # leaves CWD at the Dockerfile's WORKDIR, and sys.path[0]='' picks up
+    # the root-owned tree, making every k8s rsync's `chmod +x
+    # rsync_helper.sh` fail with "Operation not permitted".
+    cd /skypilot
     start_sky_api_server
     exit 0
 fi


### PR DESCRIPTION
## Summary

Two independent bugs stacked to break `test_api_server_memory on kubernetes` in the nightly (first failing build: [9760](https://buildkite.com/skypilot-1/smoke-tests/builds/9760); last green: [9750](https://buildkite.com/skypilot-1/smoke-tests/builds/9750)). The test has been retrying and timing out for every `--remote-server --kubernetes` nightly since #9295 merged.

### Bug A — latent: wrong `sky` path after `docker restart`

`test_api_server_memory` calls `docker restart` on the remote-API-server container (to apply `--cpus 4 --memory 16g`). On restart, `entrypoint.sh`'s `TEMP_FILE_FOR_TEST` fast path calls `start_sky_api_server` **without** doing `cd /skypilot` (which the first-start path does at line 96). CWD falls back to the Dockerfile's `WORKDIR /home/\${USERNAME}/sky_workdir/skypilot`.

That directory contains a copy of the source tree that the Dockerfile `COPY`'d as root (`Dockerfile_test:140`), so every file is `root:root`. Python's `sys.path[0]=''` resolves `import sky` to that tree before the editable finder (pointing at `/skypilot`) is consulted.

Once `sky` loads from the root-owned tree, [`sky/utils/command_runner.py:1681`](https://github.com/skypilot-org/skypilot/blob/master/sky/utils/command_runner.py#L1681) builds a `chmod +x /home/buildkite/sky_workdir/skypilot/sky/utils/kubernetes/rsync_helper.sh` for every k8s rsync. The buildkite user (uid 1000) cannot `chmod` a root-owned file — result: `Operation not permitted`, every `sky launch / exec / start / logs` against kubernetes fails.

Verified live on the running 5th-retry VM:

| Probe | Result |
|---|---|
| API server PID 51 CWD | `/home/buildkite/sky_workdir/skypilot` |
| `cd /home/buildkite/sky_workdir/skypilot && python -c "import sky; print(sky.__file__)"` | `/home/buildkite/sky_workdir/skypilot/sky/__init__.py` |
| `cd / && python -c "import sky; print(sky.__file__)"` | `/skypilot/sky/__init__.py` |
| `stat /home/buildkite/sky_workdir/skypilot/sky/utils/kubernetes/rsync_helper.sh` | `Uid: (0/root)` mode `0775` |
| Per-thread BENCH markers | `sky_launch rc=1`, `sky_exec rc=1`, `ssh rc=255`, `sky_logs rc=1`, `sky_start rc=1` |

### Bug B — regression from #9295: failures no longer abort

[#9295](https://github.com/skypilot-org/skypilot/pull/9295) rewrote `tests/load_tests/workloads/basic.sh`. Two changes combined to turn Bug A from "fast-fail" into "memory storm":

1. `set -euo pipefail` → `set -uo pipefail` — dropped `-e`.
2. Every op wrapped in `bench_run` which does `"\$@" || rc=\$?` — swallows the failure locally, then `return \$rc`.

Before #9295: the chmod error on the very first `sky launch` aborted `basic.sh` immediately; the benchmark logged a failed run (but `workload_benchmark.py` doesn't run with `--check`, so the outer test assertion `peak_memory <= 14 GB` passed against an idle API server). Test green.

After #9295: every op in `phase_cluster` fails silently, `phase_jobs` still runs, `sky jobs launch` submits successfully but the managed-jobs controller cannot rsync to the worker pod and loops on recovery forever. I watched worker pods in `test-namespace` (`bench-job-bench-*-head`) cycle — killed every ~2.5 min and rescheduled with the same name. Four threads × infinite recovery ⇒ API server exceeds 14 GB peak RSS or the pytest 3600s timeout fires. Test red.

## Fix

- **`tests/smoke_tests/docker/entrypoint.sh`** — add `cd /skypilot` to the `TEMP_FILE_FOR_TEST` fast path so the restarted API server has the same CWD as on first start.
- **`tests/load_tests/workloads/basic.sh`** — restore `set -e`. Ops that are intentionally best-effort (`sky_jobs_logs`, `sky_jobs_cancel`) already have explicit `|| true`, so they still don't abort the phase.

Either fix alone would restore green, but both are needed:
- Bug A fix alone: test turns green AND actually exercises k8s. Bug B still means a future latent failure can silently no-op the benchmark.
- Bug B fix alone: test turns green but the benchmark effectively does nothing on k8s (still hits chmod on first op and aborts).

## Test plan

- [ ] `/smoke-test --kubernetes --remote-server -k test_api_server_memory` on this PR should pass without retries.
- [ ] After merge, next nightly `nightly-build-pypi --remote-server --kubernetes` should pass `test_api_server_memory` on the first attempt (not after 4+ retries).
- [ ] Manual: ssh into the test container on the buildkite VM, `docker restart sky-remote-test-*`, then inside the container `cd / && python -c "import sky; print(sky.__file__)"` — should print `/skypilot/sky/__init__.py` (after this fix), regardless of PWD.

## Out of scope (noted while investigating, not fixed here)

- `tests/smoke_tests/test_api_server_benchmark.py:71` teardown glob is stale after #9295's rename: `sky down -y "load-test-*"` should be `"bench-cl-*"`. Per-phase `trap RETURN` cleanup mostly handles this, but the teardown is still dead code.
- `Dockerfile_test:140` `COPY . /home/\${USERNAME}/sky_workdir/skypilot/` leaves the whole tree root-owned. Changing `WORKDIR` to `/skypilot` (line 142) or chowning after COPY would make Bug A impossible to hit again. Worth doing in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)