### PR TITLE
[Telemetry] Add CPU/Memory panels to cluster and job details and rename gpu metrics section to telemetry

### DIFF
--- a/charts/skypilot/manifests/dcgm-cluster-filter-dashboard.json
+++ b/charts/skypilot/manifests/dcgm-cluster-filter-dashboard.json
@@ -636,9 +636,8 @@
               }
             ]
           },
-          "unit": "percent",
-          "min": 0,
-          "max": 100
+          "unit": "short",
+          "min": 0
         },
         "overrides": []
       },
@@ -674,15 +673,15 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(1 - avg by (node) (\n  rate(node_cpu_seconds_total{mode=\"idle\"}[2m])\n  * on(node) group_left() (\n    group by (node) (\n      kube_pod_labels{label_skypilot_cluster_name=~\"$cluster\"}\n    )\n  )\n)) * 100",
+          "expr": "sum by (pod, namespace) (\n  rate(container_cpu_usage_seconds_total{container!=\"\", container!=\"POD\"}[5m])\n)\n* on(pod, namespace) group_left(label_skypilot_cluster_name)\ngroup by (pod, namespace, label_skypilot_cluster_name) (\n  kube_pod_labels{label_skypilot_cluster_name=~\"$cluster\"}\n)",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{node}}",
+          "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "CPU Utilization",
+      "title": "CPU Usage",
       "type": "timeseries"
     },
     {
@@ -741,9 +740,8 @@
               }
             ]
           },
-          "unit": "percent",
-          "min": 0,
-          "max": 100
+          "unit": "bytes",
+          "min": 0
         },
         "overrides": []
       },
@@ -779,15 +777,15 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(1 - (\n  (node_memory_MemAvailable_bytes\n    * on(node) group_left() (\n      group by (node) (\n        kube_pod_labels{label_skypilot_cluster_name=~\"$cluster\"}\n      )\n    )\n  )\n  / on(node)\n  (node_memory_MemTotal_bytes\n    * on(node) group_left() (\n      group by (node) (\n        kube_pod_labels{label_skypilot_cluster_name=~\"$cluster\"}\n      )\n    )\n  )\n)) * 100",
+          "expr": "sum by (pod, namespace) (\n  container_memory_working_set_bytes{container!=\"\", container!=\"POD\"}\n)\n* on(pod, namespace) group_left(label_skypilot_cluster_name)\ngroup by (pod, namespace, label_skypilot_cluster_name) (\n  kube_pod_labels{label_skypilot_cluster_name=~\"$cluster\"}\n)",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{node}}",
+          "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Memory Utilization",
+      "title": "Memory Usage",
       "type": "timeseries"
     }
   ],

--- a/charts/skypilot/manifests/dcgm-cluster-filter-dashboard.json
+++ b/charts/skypilot/manifests/dcgm-cluster-filter-dashboard.json
@@ -636,8 +636,9 @@
               }
             ]
           },
-          "unit": "short",
-          "min": 0
+          "unit": "percent",
+          "min": 0,
+          "max": 100
         },
         "overrides": []
       },
@@ -673,15 +674,15 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (pod) (\n  rate(container_cpu_usage_seconds_total{container!=\"\", container!=\"POD\"}[2m])\n)\n* on(pod, namespace) group_left(label_skypilot_cluster_name)\ngroup by (pod, namespace, label_skypilot_cluster_name) (\n  kube_pod_labels{label_skypilot_cluster_name=~\"$cluster\"}\n)",
+          "expr": "(1 - avg by (node) (\n  rate(node_cpu_seconds_total{mode=\"idle\"}[2m])\n  * on(node) group_left() (\n    group by (node) (\n      kube_pod_labels{label_skypilot_cluster_name=~\"$cluster\"}\n    )\n  )\n)) * 100",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{pod}}",
+          "legendFormat": "{{node}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "CPU Usage",
+      "title": "CPU Utilization",
       "type": "timeseries"
     },
     {
@@ -740,8 +741,9 @@
               }
             ]
           },
-          "unit": "bytes",
-          "min": 0
+          "unit": "percent",
+          "min": 0,
+          "max": 100
         },
         "overrides": []
       },
@@ -777,15 +779,15 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (pod) (\n  container_memory_working_set_bytes{container!=\"\", container!=\"POD\"}\n)\n* on(pod, namespace) group_left(label_skypilot_cluster_name)\ngroup by (pod, namespace, label_skypilot_cluster_name) (\n  kube_pod_labels{label_skypilot_cluster_name=~\"$cluster\"}\n)",
+          "expr": "(1 - (\n  (node_memory_MemAvailable_bytes\n    * on(node) group_left() (\n      group by (node) (\n        kube_pod_labels{label_skypilot_cluster_name=~\"$cluster\"}\n      )\n    )\n  )\n  / on(node)\n  (node_memory_MemTotal_bytes\n    * on(node) group_left() (\n      group by (node) (\n        kube_pod_labels{label_skypilot_cluster_name=~\"$cluster\"}\n      )\n    )\n  )\n)) * 100",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{pod}}",
+          "legendFormat": "{{node}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Memory Usage",
+      "title": "Memory Utilization",
       "type": "timeseries"
     }
   ],

--- a/charts/skypilot/manifests/dcgm-cluster-filter-dashboard.json
+++ b/charts/skypilot/manifests/dcgm-cluster-filter-dashboard.json
@@ -681,7 +681,7 @@
           "refId": "A"
         }
       ],
-      "title": "CPU Usage",
+      "title": "CPU Usage (cores)",
       "type": "timeseries"
     },
     {

--- a/charts/skypilot/manifests/dcgm-cluster-filter-dashboard.json
+++ b/charts/skypilot/manifests/dcgm-cluster-filter-dashboard.json
@@ -579,6 +579,214 @@
       ],
       "title": "XID Errors",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod) (\n  rate(container_cpu_usage_seconds_total{container!=\"\", container!=\"POD\"}[2m])\n)\n* on(pod, namespace) group_left(label_skypilot_cluster_name)\ngroup by (pod, namespace, label_skypilot_cluster_name) (\n  kube_pod_labels{label_skypilot_cluster_name=~\"$cluster\"}\n)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod) (\n  container_memory_working_set_bytes{container!=\"\", container!=\"POD\"}\n)\n* on(pod, namespace) group_left(label_skypilot_cluster_name)\ngroup by (pod, namespace, label_skypilot_cluster_name) (\n  kube_pod_labels{label_skypilot_cluster_name=~\"$cluster\"}\n)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Usage",
+      "type": "timeseries"
     }
   ],
   "preload": false,

--- a/sky/dashboard/src/components/TelemetrySection.jsx
+++ b/sky/dashboard/src/components/TelemetrySection.jsx
@@ -8,10 +8,13 @@ import { CustomTooltip as Tooltip } from '@/components/utils';
 import { getGrafanaUrl, buildGrafanaUrl } from '@/utils/grafana';
 
 // Grafana configuration constants
-const GRAFANA_DASHBOARD_SLUG = 'skypilot-dcgm-gpu/skypilot-dcgm-gpu-metrics';
+const GRAFANA_GPU_DASHBOARD_SLUG =
+  'skypilot-dcgm-gpu/skypilot-dcgm-gpu-metrics';
+const GRAFANA_CLUSTER_DASHBOARD_SLUG =
+  'skypilot-dcgm-cluster-dashboard/skypilot-dcgm-kubernetes-cluster-dashboard';
 const GRAFANA_ORG_ID = '1';
 
-// Time range presets for GPU metrics
+// Time range presets
 const TIME_RANGE_PRESETS = [
   { label: '15m', value: '15m' },
   { label: '1h', value: '1h' },
@@ -20,35 +23,75 @@ const TIME_RANGE_PRESETS = [
   { label: '7d', value: '7d' },
 ];
 
-// GPU panels configuration
-const GPU_PANELS = [
-  { id: '1', title: 'GPU Utilization', keyPrefix: 'gpu-util' },
-  { id: '2', title: 'GPU Memory Utilization', keyPrefix: 'gpu-memory' },
-  { id: '3', title: 'GPU Temperature', keyPrefix: 'gpu-temp' },
-  { id: '4', title: 'GPU Power Usage', keyPrefix: 'gpu-power' },
+// Telemetry panels configuration. Each panel specifies which Grafana
+// dashboard it lives in so we can mix GPU panels (skypilot-dcgm-gpu) with
+// host-level CPU/Memory panels (skypilot-dcgm-cluster-dashboard) in one
+// section.
+const TELEMETRY_PANELS = [
+  {
+    id: '1',
+    title: 'GPU Utilization',
+    keyPrefix: 'gpu-util',
+    dashboardSlug: GRAFANA_GPU_DASHBOARD_SLUG,
+  },
+  {
+    id: '2',
+    title: 'GPU Memory Utilization',
+    keyPrefix: 'gpu-memory',
+    dashboardSlug: GRAFANA_GPU_DASHBOARD_SLUG,
+  },
+  {
+    id: '3',
+    title: 'GPU Temperature',
+    keyPrefix: 'gpu-temp',
+    dashboardSlug: GRAFANA_GPU_DASHBOARD_SLUG,
+  },
+  {
+    id: '4',
+    title: 'GPU Power Usage',
+    keyPrefix: 'gpu-power',
+    dashboardSlug: GRAFANA_GPU_DASHBOARD_SLUG,
+  },
+  {
+    id: '22',
+    title: 'CPU Utilization',
+    keyPrefix: 'cpu-util',
+    dashboardSlug: GRAFANA_CLUSTER_DASHBOARD_SLUG,
+  },
+  {
+    id: '21',
+    title: 'Memory Utilization',
+    keyPrefix: 'mem-util',
+    dashboardSlug: GRAFANA_CLUSTER_DASHBOARD_SLUG,
+  },
 ];
 
 /**
- * Build Grafana panel URL with filters
+ * Build Grafana panel URL with filters. Both target dashboards accept
+ * var-cluster, var-gpu, and either var-node or var-host; setting all of
+ * them is harmless because Grafana ignores unknown template variables.
  */
-const buildGrafanaMetricsUrl = (panelId, clusterNameOnCloud, timeRange) => {
+const buildGrafanaPanelUrl = (panel, clusterNameOnCloud, timeRange) => {
   const grafanaUrl = getGrafanaUrl();
   const params = new URLSearchParams({
     orgId: GRAFANA_ORG_ID,
     from: timeRange.from,
     to: timeRange.to,
     timezone: 'browser',
+    'var-datasource': 'prometheus',
     'var-cluster': clusterNameOnCloud,
     'var-node': '$__all',
+    'var-host': '$__all',
     'var-gpu': '$__all',
     theme: 'light',
-    panelId: panelId,
+    panelId: panel.id,
   });
-  return `${grafanaUrl}/d-solo/${GRAFANA_DASHBOARD_SLUG}?${params.toString()}&__feature.dashboardSceneSolo`;
+  return `${grafanaUrl}/d-solo/${panel.dashboardSlug}?${params.toString()}&__feature.dashboardSceneSolo`;
 };
 
 /**
- * Reusable GPU Metrics Section component
+ * Reusable Telemetry section that embeds Grafana panels for GPU metrics
+ * (utilization, memory, temperature, power) and host-level CPU/Memory.
  *
  * @param {Object} props
  * @param {string} props.clusterNameOnCloud - The cluster name for filtering metrics
@@ -58,13 +101,13 @@ const buildGrafanaMetricsUrl = (panelId, clusterNameOnCloud, timeRange) => {
  * @param {React.ReactNode} props.headerExtra - Optional extra content for header (e.g., task selector)
  * @param {string} props.noMetricsMessage - Custom message when no metrics available
  */
-export function GPUMetricsSection({
+export function TelemetrySection({
   clusterNameOnCloud,
   displayName,
   refreshTrigger = 0,
-  storageKey = 'skypilot-gpu-metrics-expanded',
+  storageKey = 'skypilot-telemetry-expanded',
   headerExtra = null,
-  noMetricsMessage = 'No GPU metrics available.',
+  noMetricsMessage = 'No telemetry available.',
 }) {
   const [timeRange, setTimeRange] = useState({ from: 'now-1h', to: 'now' });
   const [isExpanded, setIsExpanded] = useState(() => {
@@ -90,18 +133,23 @@ export function GPUMetricsSection({
     }
   };
 
+  // Open the cluster dashboard (which contains both GPU and host-level
+  // panels) so the user lands on the most comprehensive view.
   const openInGrafana = () => {
     const queryParams = new URLSearchParams({
       orgId: GRAFANA_ORG_ID,
       from: timeRange.from,
       to: timeRange.to,
       timezone: 'browser',
+      'var-datasource': 'prometheus',
       'var-cluster': clusterNameOnCloud,
-      'var-node': '$__all',
+      'var-host': '$__all',
       'var-gpu': '$__all',
     });
     window.open(
-      buildGrafanaUrl(`/d/${GRAFANA_DASHBOARD_SLUG}?${queryParams.toString()}`),
+      buildGrafanaUrl(
+        `/d/${GRAFANA_CLUSTER_DASHBOARD_SLUG}?${queryParams.toString()}`
+      ),
       '_blank'
     );
   };
@@ -122,7 +170,7 @@ export function GPUMetricsSection({
               ) : (
                 <ChevronRightIcon className="w-5 h-5 mr-2" />
               )}
-              <h3 className="text-lg font-semibold">GPU Metrics</h3>
+              <h3 className="text-lg font-semibold">Telemetry</h3>
             </button>
             {headerExtra}
           </div>
@@ -174,15 +222,15 @@ export function GPUMetricsSection({
 
             {clusterNameOnCloud ? (
               <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(300px,1fr))]">
-                {GPU_PANELS.map((panel) => (
+                {TELEMETRY_PANELS.map((panel) => (
                   <div
                     key={panel.id}
                     className="bg-white rounded-md border border-gray-200 shadow-sm"
                   >
                     <div className="p-2">
                       <iframe
-                        src={buildGrafanaMetricsUrl(
-                          panel.id,
+                        src={buildGrafanaPanelUrl(
+                          panel,
                           clusterNameOnCloud,
                           timeRange
                         )}
@@ -209,4 +257,4 @@ export function GPUMetricsSection({
   );
 }
 
-export default GPUMetricsSection;
+export default TelemetrySection;

--- a/sky/dashboard/src/components/TelemetrySection.jsx
+++ b/sky/dashboard/src/components/TelemetrySection.jsx
@@ -38,13 +38,8 @@ const TELEMETRY_PANELS = [
   },
   { id: '3', title: 'GPU Temperature', keyPrefix: 'gpu-temp', family: 'gpu' },
   { id: '4', title: 'GPU Power Usage', keyPrefix: 'gpu-power', family: 'gpu' },
-  { id: '6', title: 'CPU Utilization', keyPrefix: 'cpu-util', family: 'host' },
-  {
-    id: '7',
-    title: 'Memory Utilization',
-    keyPrefix: 'mem-util',
-    family: 'host',
-  },
+  { id: '6', title: 'CPU Usage', keyPrefix: 'cpu-usage', family: 'host' },
+  { id: '7', title: 'Memory Usage', keyPrefix: 'mem-usage', family: 'host' },
 ];
 
 /**

--- a/sky/dashboard/src/components/TelemetrySection.jsx
+++ b/sky/dashboard/src/components/TelemetrySection.jsx
@@ -7,26 +7,12 @@ import {
 import { CustomTooltip as Tooltip } from '@/components/utils';
 import { getGrafanaUrl, buildGrafanaUrl } from '@/utils/grafana';
 
-/**
- * Extract the Kubernetes context name from a SkyPilot infra string.
- *
- * SkyPilot's full_infra is formatted like "Kubernetes (coreweave-dev)" — the
- * value inside the parentheses is the K8s context name used as the
- * `cluster` label by node_exporter scrapes. Returns null if the string isn't
- * a Kubernetes infra or can't be parsed.
- */
-export function extractKubernetesContext(fullInfra) {
-  if (!fullInfra || typeof fullInfra !== 'string') return null;
-  if (!fullInfra.toLowerCase().includes('kubernetes')) return null;
-  const m = fullInfra.match(/\(([^)]+)\)/);
-  return m ? m[1].trim() : null;
-}
 
-// Grafana configuration constants
-const GRAFANA_GPU_DASHBOARD_SLUG =
-  'skypilot-dcgm-gpu/skypilot-dcgm-gpu-metrics';
-const GRAFANA_CLUSTER_DASHBOARD_SLUG =
-  'skypilot-dcgm-cluster-dashboard/skypilot-dcgm-kubernetes-cluster-dashboard';
+// All Telemetry panels — GPU (DCGM) and per-pod CPU/Memory (cAdvisor) — live
+// in the same SkyPilot cluster-filter dashboard so a single var-cluster
+// (the SkyPilot cluster_name_on_cloud) filters all of them via the standard
+// kube_pod_labels join.
+const GRAFANA_DASHBOARD_SLUG = 'skypilot-dcgm-gpu/skypilot-dcgm-gpu-metrics';
 const GRAFANA_ORG_ID = '1';
 
 // Time range presets
@@ -38,92 +24,45 @@ const TIME_RANGE_PRESETS = [
   { label: '7d', value: '7d' },
 ];
 
-// Telemetry panels configuration. Each panel specifies which Grafana
-// dashboard it lives in so we can mix GPU panels (skypilot-dcgm-gpu) with
-// host-level CPU/Memory panels (skypilot-dcgm-cluster-dashboard) in one
-// section. The `family` field lets consumers hide GPU panels when the
-// underlying cluster/job is CPU-only.
+// Telemetry panels — all live in the same skypilot-dcgm-gpu dashboard,
+// pre-scoped to a single SkyPilot cluster via var-cluster. The `family`
+// field lets consumers hide GPU panels when the underlying cluster/job
+// is CPU-only.
 const TELEMETRY_PANELS = [
-  {
-    id: '1',
-    title: 'GPU Utilization',
-    keyPrefix: 'gpu-util',
-    dashboardSlug: GRAFANA_GPU_DASHBOARD_SLUG,
-    family: 'gpu',
-  },
+  { id: '1', title: 'GPU Utilization', keyPrefix: 'gpu-util', family: 'gpu' },
   {
     id: '2',
     title: 'GPU Memory Utilization',
     keyPrefix: 'gpu-memory',
-    dashboardSlug: GRAFANA_GPU_DASHBOARD_SLUG,
     family: 'gpu',
   },
-  {
-    id: '3',
-    title: 'GPU Temperature',
-    keyPrefix: 'gpu-temp',
-    dashboardSlug: GRAFANA_GPU_DASHBOARD_SLUG,
-    family: 'gpu',
-  },
-  {
-    id: '4',
-    title: 'GPU Power Usage',
-    keyPrefix: 'gpu-power',
-    dashboardSlug: GRAFANA_GPU_DASHBOARD_SLUG,
-    family: 'gpu',
-  },
-  {
-    id: '22',
-    title: 'CPU Utilization',
-    keyPrefix: 'cpu-util',
-    dashboardSlug: GRAFANA_CLUSTER_DASHBOARD_SLUG,
-    family: 'host',
-  },
-  {
-    id: '21',
-    title: 'Memory Utilization',
-    keyPrefix: 'mem-util',
-    dashboardSlug: GRAFANA_CLUSTER_DASHBOARD_SLUG,
-    family: 'host',
-  },
+  { id: '3', title: 'GPU Temperature', keyPrefix: 'gpu-temp', family: 'gpu' },
+  { id: '4', title: 'GPU Power Usage', keyPrefix: 'gpu-power', family: 'gpu' },
+  { id: '6', title: 'CPU Usage', keyPrefix: 'cpu-usage', family: 'host' },
+  { id: '7', title: 'Memory Usage', keyPrefix: 'mem-usage', family: 'host' },
 ];
 
 /**
- * Build Grafana panel URL with filters.
- *
- * GPU panels filter by `var-cluster` set to SkyPilot's `cluster_name_on_cloud`
- * because DCGM is configured to label metrics with that name. Host CPU/Memory
- * panels (from node_exporter) need `var-cluster` set to the Kubernetes context
- * name instead — node_exporter is host-level and has no notion of Sky clusters,
- * so it falls back to the K8s cluster label. When the K8s context isn't known
- * we reuse the SkyPilot cluster name (legacy behavior); the dashboard will
- * render "no data" rather than misleading numbers.
+ * Build Grafana panel URL with filters. All panels live in the same
+ * SkyPilot cluster-filter dashboard and share var-cluster, so the same
+ * `cluster_name_on_cloud` filter scopes both GPU (DCGM) and per-pod
+ * CPU/Memory (cAdvisor) panels via the kube_pod_labels join in each
+ * panel's PromQL.
  */
-const buildGrafanaPanelUrl = (
-  panel,
-  clusterNameOnCloud,
-  kubernetesContext,
-  timeRange
-) => {
+const buildGrafanaPanelUrl = (panel, clusterNameOnCloud, timeRange) => {
   const grafanaUrl = getGrafanaUrl();
-  const clusterFilter =
-    panel.family === 'host' && kubernetesContext
-      ? kubernetesContext
-      : clusterNameOnCloud;
   const params = new URLSearchParams({
     orgId: GRAFANA_ORG_ID,
     from: timeRange.from,
     to: timeRange.to,
     timezone: 'browser',
-    'var-datasource': 'prometheus',
-    'var-cluster': clusterFilter,
+    'var-cluster': clusterNameOnCloud,
     'var-node': '$__all',
-    'var-host': '$__all',
     'var-gpu': '$__all',
     theme: 'light',
     panelId: panel.id,
   });
-  return `${grafanaUrl}/d-solo/${panel.dashboardSlug}?${params.toString()}&__feature.dashboardSceneSolo`;
+  return `${grafanaUrl}/d-solo/${GRAFANA_DASHBOARD_SLUG}?${params.toString()}&__feature.dashboardSceneSolo`;
 };
 
 /**
@@ -131,8 +70,7 @@ const buildGrafanaPanelUrl = (
  * (utilization, memory, temperature, power) and host-level CPU/Memory.
  *
  * @param {Object} props
- * @param {string} props.clusterNameOnCloud - The Sky cluster name (used as DCGM `cluster` label for GPU panels)
- * @param {string} props.kubernetesContext - The K8s context name (used as `cluster` label for node_exporter host panels)
+ * @param {string} props.clusterNameOnCloud - The SkyPilot cluster name (drives var-cluster on every panel)
  * @param {string} props.displayName - The name to show in the "Showing:" text
  * @param {number} props.refreshTrigger - Increment to trigger iframe refresh
  * @param {string} props.storageKey - LocalStorage key for expanded state
@@ -142,7 +80,6 @@ const buildGrafanaPanelUrl = (
  */
 export function TelemetrySection({
   clusterNameOnCloud,
-  kubernetesContext = null,
   displayName,
   refreshTrigger = 0,
   storageKey = 'skypilot-telemetry-expanded',
@@ -177,23 +114,18 @@ export function TelemetrySection({
     }
   };
 
-  // Open the cluster dashboard (which contains both GPU and host-level
-  // panels) so the user lands on the most comprehensive view.
   const openInGrafana = () => {
     const queryParams = new URLSearchParams({
       orgId: GRAFANA_ORG_ID,
       from: timeRange.from,
       to: timeRange.to,
       timezone: 'browser',
-      'var-datasource': 'prometheus',
       'var-cluster': clusterNameOnCloud,
-      'var-host': '$__all',
+      'var-node': '$__all',
       'var-gpu': '$__all',
     });
     window.open(
-      buildGrafanaUrl(
-        `/d/${GRAFANA_CLUSTER_DASHBOARD_SLUG}?${queryParams.toString()}`
-      ),
+      buildGrafanaUrl(`/d/${GRAFANA_DASHBOARD_SLUG}?${queryParams.toString()}`),
       '_blank'
     );
   };
@@ -265,7 +197,7 @@ export function TelemetrySection({
             </div>
 
             {clusterNameOnCloud ? (
-              <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(300px,1fr))]">
+              <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
                 {visiblePanels.map((panel) => (
                   <div
                     key={panel.id}
@@ -276,7 +208,6 @@ export function TelemetrySection({
                         src={buildGrafanaPanelUrl(
                           panel,
                           clusterNameOnCloud,
-                          kubernetesContext,
                           timeRange
                         )}
                         width="100%"

--- a/sky/dashboard/src/components/TelemetrySection.jsx
+++ b/sky/dashboard/src/components/TelemetrySection.jsx
@@ -7,6 +7,21 @@ import {
 import { CustomTooltip as Tooltip } from '@/components/utils';
 import { getGrafanaUrl, buildGrafanaUrl } from '@/utils/grafana';
 
+/**
+ * Extract the Kubernetes context name from a SkyPilot infra string.
+ *
+ * SkyPilot's full_infra is formatted like "Kubernetes (coreweave-dev)" — the
+ * value inside the parentheses is the K8s context name used as the
+ * `cluster` label by node_exporter scrapes. Returns null if the string isn't
+ * a Kubernetes infra or can't be parsed.
+ */
+export function extractKubernetesContext(fullInfra) {
+  if (!fullInfra || typeof fullInfra !== 'string') return null;
+  if (!fullInfra.toLowerCase().includes('kubernetes')) return null;
+  const m = fullInfra.match(/\(([^)]+)\)/);
+  return m ? m[1].trim() : null;
+}
+
 // Grafana configuration constants
 const GRAFANA_GPU_DASHBOARD_SLUG =
   'skypilot-dcgm-gpu/skypilot-dcgm-gpu-metrics';
@@ -74,19 +89,34 @@ const TELEMETRY_PANELS = [
 ];
 
 /**
- * Build Grafana panel URL with filters. Both target dashboards accept
- * var-cluster, var-gpu, and either var-node or var-host; setting all of
- * them is harmless because Grafana ignores unknown template variables.
+ * Build Grafana panel URL with filters.
+ *
+ * GPU panels filter by `var-cluster` set to SkyPilot's `cluster_name_on_cloud`
+ * because DCGM is configured to label metrics with that name. Host CPU/Memory
+ * panels (from node_exporter) need `var-cluster` set to the Kubernetes context
+ * name instead — node_exporter is host-level and has no notion of Sky clusters,
+ * so it falls back to the K8s cluster label. When the K8s context isn't known
+ * we reuse the SkyPilot cluster name (legacy behavior); the dashboard will
+ * render "no data" rather than misleading numbers.
  */
-const buildGrafanaPanelUrl = (panel, clusterNameOnCloud, timeRange) => {
+const buildGrafanaPanelUrl = (
+  panel,
+  clusterNameOnCloud,
+  kubernetesContext,
+  timeRange
+) => {
   const grafanaUrl = getGrafanaUrl();
+  const clusterFilter =
+    panel.family === 'host' && kubernetesContext
+      ? kubernetesContext
+      : clusterNameOnCloud;
   const params = new URLSearchParams({
     orgId: GRAFANA_ORG_ID,
     from: timeRange.from,
     to: timeRange.to,
     timezone: 'browser',
     'var-datasource': 'prometheus',
-    'var-cluster': clusterNameOnCloud,
+    'var-cluster': clusterFilter,
     'var-node': '$__all',
     'var-host': '$__all',
     'var-gpu': '$__all',
@@ -101,7 +131,8 @@ const buildGrafanaPanelUrl = (panel, clusterNameOnCloud, timeRange) => {
  * (utilization, memory, temperature, power) and host-level CPU/Memory.
  *
  * @param {Object} props
- * @param {string} props.clusterNameOnCloud - The cluster name for filtering metrics
+ * @param {string} props.clusterNameOnCloud - The Sky cluster name (used as DCGM `cluster` label for GPU panels)
+ * @param {string} props.kubernetesContext - The K8s context name (used as `cluster` label for node_exporter host panels)
  * @param {string} props.displayName - The name to show in the "Showing:" text
  * @param {number} props.refreshTrigger - Increment to trigger iframe refresh
  * @param {string} props.storageKey - LocalStorage key for expanded state
@@ -111,6 +142,7 @@ const buildGrafanaPanelUrl = (panel, clusterNameOnCloud, timeRange) => {
  */
 export function TelemetrySection({
   clusterNameOnCloud,
+  kubernetesContext = null,
   displayName,
   refreshTrigger = 0,
   storageKey = 'skypilot-telemetry-expanded',
@@ -244,6 +276,7 @@ export function TelemetrySection({
                         src={buildGrafanaPanelUrl(
                           panel,
                           clusterNameOnCloud,
+                          kubernetesContext,
                           timeRange
                         )}
                         width="100%"

--- a/sky/dashboard/src/components/TelemetrySection.jsx
+++ b/sky/dashboard/src/components/TelemetrySection.jsx
@@ -26,43 +26,50 @@ const TIME_RANGE_PRESETS = [
 // Telemetry panels configuration. Each panel specifies which Grafana
 // dashboard it lives in so we can mix GPU panels (skypilot-dcgm-gpu) with
 // host-level CPU/Memory panels (skypilot-dcgm-cluster-dashboard) in one
-// section.
+// section. The `family` field lets consumers hide GPU panels when the
+// underlying cluster/job is CPU-only.
 const TELEMETRY_PANELS = [
   {
     id: '1',
     title: 'GPU Utilization',
     keyPrefix: 'gpu-util',
     dashboardSlug: GRAFANA_GPU_DASHBOARD_SLUG,
+    family: 'gpu',
   },
   {
     id: '2',
     title: 'GPU Memory Utilization',
     keyPrefix: 'gpu-memory',
     dashboardSlug: GRAFANA_GPU_DASHBOARD_SLUG,
+    family: 'gpu',
   },
   {
     id: '3',
     title: 'GPU Temperature',
     keyPrefix: 'gpu-temp',
     dashboardSlug: GRAFANA_GPU_DASHBOARD_SLUG,
+    family: 'gpu',
   },
   {
     id: '4',
     title: 'GPU Power Usage',
     keyPrefix: 'gpu-power',
     dashboardSlug: GRAFANA_GPU_DASHBOARD_SLUG,
+    family: 'gpu',
   },
   {
     id: '22',
     title: 'CPU Utilization',
     keyPrefix: 'cpu-util',
     dashboardSlug: GRAFANA_CLUSTER_DASHBOARD_SLUG,
+    family: 'host',
   },
   {
     id: '21',
     title: 'Memory Utilization',
     keyPrefix: 'mem-util',
     dashboardSlug: GRAFANA_CLUSTER_DASHBOARD_SLUG,
+    family: 'host',
   },
 ];
 
@@ -100,6 +107,7 @@ const buildGrafanaPanelUrl = (panel, clusterNameOnCloud, timeRange) => {
  * @param {string} props.storageKey - LocalStorage key for expanded state
  * @param {React.ReactNode} props.headerExtra - Optional extra content for header (e.g., task selector)
  * @param {string} props.noMetricsMessage - Custom message when no metrics available
+ * @param {boolean} props.hasGpu - When false, hide GPU panels and only show CPU/Memory.
  */
 export function TelemetrySection({
   clusterNameOnCloud,
@@ -108,7 +116,11 @@ export function TelemetrySection({
   storageKey = 'skypilot-telemetry-expanded',
   headerExtra = null,
   noMetricsMessage = 'No telemetry available.',
+  hasGpu = true,
 }) {
+  const visiblePanels = hasGpu
+    ? TELEMETRY_PANELS
+    : TELEMETRY_PANELS.filter((p) => p.family !== 'gpu');
   const [timeRange, setTimeRange] = useState({ from: 'now-1h', to: 'now' });
   const [isExpanded, setIsExpanded] = useState(() => {
     if (typeof window !== 'undefined') {
@@ -222,7 +234,7 @@ export function TelemetrySection({
 
             {clusterNameOnCloud ? (
               <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(300px,1fr))]">
-                {TELEMETRY_PANELS.map((panel) => (
+                {visiblePanels.map((panel) => (
                   <div
                     key={panel.id}
                     className="bg-white rounded-md border border-gray-200 shadow-sm"

--- a/sky/dashboard/src/components/TelemetrySection.jsx
+++ b/sky/dashboard/src/components/TelemetrySection.jsx
@@ -38,8 +38,13 @@ const TELEMETRY_PANELS = [
   },
   { id: '3', title: 'GPU Temperature', keyPrefix: 'gpu-temp', family: 'gpu' },
   { id: '4', title: 'GPU Power Usage', keyPrefix: 'gpu-power', family: 'gpu' },
-  { id: '6', title: 'CPU Usage', keyPrefix: 'cpu-usage', family: 'host' },
-  { id: '7', title: 'Memory Usage', keyPrefix: 'mem-usage', family: 'host' },
+  { id: '6', title: 'CPU Utilization', keyPrefix: 'cpu-util', family: 'host' },
+  {
+    id: '7',
+    title: 'Memory Utilization',
+    keyPrefix: 'mem-util',
+    family: 'host',
+  },
 ];
 
 /**

--- a/sky/dashboard/src/components/TelemetrySection.jsx
+++ b/sky/dashboard/src/components/TelemetrySection.jsx
@@ -37,7 +37,12 @@ const TELEMETRY_PANELS = [
   },
   { id: '3', title: 'GPU Temperature', keyPrefix: 'gpu-temp', family: 'gpu' },
   { id: '4', title: 'GPU Power Usage', keyPrefix: 'gpu-power', family: 'gpu' },
-  { id: '6', title: 'CPU Usage', keyPrefix: 'cpu-usage', family: 'host' },
+  {
+    id: '6',
+    title: 'CPU Usage (cores)',
+    keyPrefix: 'cpu-usage',
+    family: 'host',
+  },
   { id: '7', title: 'Memory Usage', keyPrefix: 'mem-usage', family: 'host' },
 ];
 

--- a/sky/dashboard/src/components/TelemetrySection.jsx
+++ b/sky/dashboard/src/components/TelemetrySection.jsx
@@ -7,7 +7,6 @@ import {
 import { CustomTooltip as Tooltip } from '@/components/utils';
 import { getGrafanaUrl, buildGrafanaUrl } from '@/utils/grafana';
 
-
 // All Telemetry panels — GPU (DCGM) and per-pod CPU/Memory (cAdvisor) — live
 // in the same SkyPilot cluster-filter dashboard so a single var-cluster
 // (the SkyPilot cluster_name_on_cloud) filters all of them via the standard

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -38,7 +38,10 @@ import { formatYaml } from '@/lib/yamlUtils';
 import { UserDisplay } from '@/components/elements/UserDisplay';
 import { YamlHighlighter } from '@/components/YamlHighlighter';
 import { PluginSlot } from '@/plugins/PluginSlot';
-import { TelemetrySection } from '@/components/TelemetrySection';
+import {
+  TelemetrySection,
+  extractKubernetesContext,
+} from '@/components/TelemetrySection';
 import { resourcesHaveGpu } from '@/utils/gpuUtils';
 import { useLogStreamer } from '@/hooks/useLogStreamer';
 import {
@@ -662,6 +665,9 @@ function ActiveTab({
           <div className="mb-6">
             <TelemetrySection
               clusterNameOnCloud={clusterData?.cluster_name_on_cloud}
+              kubernetesContext={extractKubernetesContext(
+                clusterData?.full_infra || clusterData?.infra
+              )}
               displayName={clusterData?.cluster}
               refreshTrigger={gpuMetricsRefreshTrigger}
               storageKey="skypilot-clusters-telemetry-expanded"

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -39,7 +39,7 @@ import { UserDisplay } from '@/components/elements/UserDisplay';
 import { YamlHighlighter } from '@/components/YamlHighlighter';
 import { PluginSlot } from '@/plugins/PluginSlot';
 import { TelemetrySection } from '@/components/TelemetrySection';
-import { resourcesHaveGpu } from '@/utils/gpuUtils';
+import { hasAccelerator } from '@/utils/gpuUtils';
 import { useLogStreamer } from '@/hooks/useLogStreamer';
 import {
   Select,
@@ -665,9 +665,7 @@ function ActiveTab({
               displayName={clusterData?.cluster}
               refreshTrigger={telemetryRefreshTrigger}
               storageKey="skypilot-clusters-telemetry-expanded"
-              hasGpu={resourcesHaveGpu(
-                clusterData?.resources_str_full || clusterData?.resources_str
-              )}
+              hasGpu={hasAccelerator(clusterData?.gpus)}
             />
           </div>
         )}

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -38,7 +38,7 @@ import { formatYaml } from '@/lib/yamlUtils';
 import { UserDisplay } from '@/components/elements/UserDisplay';
 import { YamlHighlighter } from '@/components/YamlHighlighter';
 import { PluginSlot } from '@/plugins/PluginSlot';
-import { GPUMetricsSection } from '@/components/GPUMetricsSection';
+import { TelemetrySection } from '@/components/TelemetrySection';
 import { useLogStreamer } from '@/hooks/useLogStreamer';
 import {
   Select,
@@ -652,18 +652,18 @@ function ActiveTab({
         </div>
       </div>
 
-      {/* GPU Metrics Section - Show for all Kubernetes clusters (in-cluster and external), but not SSH node pools */}
+      {/* Telemetry Section (GPU + CPU/Memory) - Show for all Kubernetes clusters (in-cluster and external), but not SSH node pools */}
       {clusterData &&
         clusterData.full_infra &&
         clusterData.full_infra.toLowerCase().includes('kubernetes') &&
         !clusterData.full_infra.toLowerCase().includes('ssh') &&
         isGrafanaAvailable && (
           <div className="mb-6">
-            <GPUMetricsSection
+            <TelemetrySection
               clusterNameOnCloud={clusterData?.cluster_name_on_cloud}
               displayName={clusterData?.cluster}
               refreshTrigger={gpuMetricsRefreshTrigger}
-              storageKey="skypilot-gpu-metrics-expanded"
+              storageKey="skypilot-clusters-telemetry-expanded"
             />
           </div>
         )}

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -38,10 +38,7 @@ import { formatYaml } from '@/lib/yamlUtils';
 import { UserDisplay } from '@/components/elements/UserDisplay';
 import { YamlHighlighter } from '@/components/YamlHighlighter';
 import { PluginSlot } from '@/plugins/PluginSlot';
-import {
-  TelemetrySection,
-  extractKubernetesContext,
-} from '@/components/TelemetrySection';
+import { TelemetrySection } from '@/components/TelemetrySection';
 import { resourcesHaveGpu } from '@/utils/gpuUtils';
 import { useLogStreamer } from '@/hooks/useLogStreamer';
 import {
@@ -665,9 +662,6 @@ function ActiveTab({
           <div className="mb-6">
             <TelemetrySection
               clusterNameOnCloud={clusterData?.cluster_name_on_cloud}
-              kubernetesContext={extractKubernetesContext(
-                clusterData?.full_infra || clusterData?.infra
-              )}
               displayName={clusterData?.cluster}
               refreshTrigger={gpuMetricsRefreshTrigger}
               storageKey="skypilot-clusters-telemetry-expanded"

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -81,9 +81,9 @@ function ClusterDetails() {
   const [historyData, setHistoryData] = useState(null);
   const [isHistoricalCluster, setIsHistoricalCluster] = useState(false);
   const [historyLoading, setHistoryLoading] = useState(false);
-  // Counter incremented on refresh to force GPU metrics iframes to reload.
+  // Counter incremented on refresh to force telemetry iframes to reload.
   // When this value changes, the iframe key changes, causing React to remount the iframe.
-  const [gpuMetricsRefreshTrigger, setGpuMetricsRefreshTrigger] = useState(0);
+  const [telemetryRefreshTrigger, setTelemetryRefreshTrigger] = useState(0);
   const isMobile = useMobile();
   const {
     clusterData,
@@ -95,7 +95,7 @@ function ClusterDetails() {
     refreshClusterJobsOnly,
   } = useClusterDetails({ cluster });
 
-  // GPU metrics state
+  // Telemetry state
   const [isGrafanaAvailable, setIsGrafanaAvailable] = useState(false);
 
   // Check Grafana availability on mount
@@ -147,8 +147,8 @@ function ClusterDetails() {
   const handleManualRefresh = async () => {
     setIsRefreshing(true);
     await refreshData();
-    // Increment GPU metrics refresh trigger to force iframe reload
-    setGpuMetricsRefreshTrigger((prev) => prev + 1);
+    // Increment telemetry refresh trigger to force iframe reload
+    setTelemetryRefreshTrigger((prev) => prev + 1);
     setIsRefreshing(false);
   };
 
@@ -239,7 +239,7 @@ function ClusterDetails() {
             isVSCodeModalOpen={isVSCodeModalOpen}
             setIsVSCodeModalOpen={setIsVSCodeModalOpen}
             isGrafanaAvailable={isGrafanaAvailable}
-            gpuMetricsRefreshTrigger={gpuMetricsRefreshTrigger}
+            telemetryRefreshTrigger={telemetryRefreshTrigger}
             isHistoricalCluster={false}
           />
         ) : isHistoricalCluster && historyData ? (
@@ -251,7 +251,7 @@ function ClusterDetails() {
             isVSCodeModalOpen={false}
             setIsVSCodeModalOpen={() => {}}
             isGrafanaAvailable={false}
-            gpuMetricsRefreshTrigger={0}
+            telemetryRefreshTrigger={0}
             isHistoricalCluster={true}
           />
         ) : (
@@ -288,7 +288,7 @@ function ActiveTab({
   isVSCodeModalOpen,
   setIsVSCodeModalOpen,
   isGrafanaAvailable,
-  gpuMetricsRefreshTrigger,
+  telemetryRefreshTrigger,
   isHistoricalCluster = false,
 }) {
   const [isYamlExpanded, setIsYamlExpanded] = useState(false);
@@ -663,7 +663,7 @@ function ActiveTab({
             <TelemetrySection
               clusterNameOnCloud={clusterData?.cluster_name_on_cloud}
               displayName={clusterData?.cluster}
-              refreshTrigger={gpuMetricsRefreshTrigger}
+              refreshTrigger={telemetryRefreshTrigger}
               storageKey="skypilot-clusters-telemetry-expanded"
               hasGpu={resourcesHaveGpu(
                 clusterData?.resources_str_full || clusterData?.resources_str

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -39,6 +39,7 @@ import { UserDisplay } from '@/components/elements/UserDisplay';
 import { YamlHighlighter } from '@/components/YamlHighlighter';
 import { PluginSlot } from '@/plugins/PluginSlot';
 import { TelemetrySection } from '@/components/TelemetrySection';
+import { resourcesHaveGpu } from '@/utils/gpuUtils';
 import { useLogStreamer } from '@/hooks/useLogStreamer';
 import {
   Select,
@@ -664,6 +665,9 @@ function ActiveTab({
               displayName={clusterData?.cluster}
               refreshTrigger={gpuMetricsRefreshTrigger}
               storageKey="skypilot-clusters-telemetry-expanded"
+              hasGpu={resourcesHaveGpu(
+                clusterData?.resources_str_full || clusterData?.resources_str
+              )}
             />
           </div>
         )}

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -60,7 +60,7 @@ import { YamlHighlighter } from '@/components/YamlHighlighter';
 import dashboardCache from '@/lib/cache';
 import { PluginSlot } from '@/plugins/PluginSlot';
 import { checkGrafanaAvailability } from '@/utils/grafana';
-import { GPUMetricsSection } from '@/components/GPUMetricsSection';
+import { TelemetrySection } from '@/components/TelemetrySection';
 import { useLogStreamer } from '@/hooks/useLogStreamer';
 import PropTypes from 'prop-types';
 
@@ -85,11 +85,11 @@ function JobDetails() {
   const [logExtractedLinks, setLogExtractedLinks] = useState({});
   const isMobile = useMobile();
 
-  // GPU metrics state
+  // Telemetry state
   const [isGrafanaAvailable, setIsGrafanaAvailable] = useState(false);
-  // GPU metrics task selection for job groups
+  // Telemetry task selection for job groups
   const [gpuMetricsTaskIndex, setGpuMetricsTaskIndex] = useState(0);
-  const GPU_METRICS_EXPANDED_KEY = 'skypilot-jobs-gpu-metrics-expanded';
+  const TELEMETRY_EXPANDED_KEY = 'skypilot-jobs-telemetry-expanded';
 
   // Update isInitialLoad when data is first loaded
   React.useEffect(() => {
@@ -519,9 +519,9 @@ function JobDetails() {
               </div>
             )}
 
-            {/* GPU Metrics Section - Show for Kubernetes managed jobs with cluster_name_on_cloud */}
+            {/* Telemetry Section (GPU + CPU/Memory) - Show for Kubernetes managed jobs with cluster_name_on_cloud */}
             {isGrafanaAvailable && hasAnyTaskWithGpuMetrics && (
-              <GPUMetricsSection
+              <TelemetrySection
                 clusterNameOnCloud={gpuMetricsClusterName}
                 displayName={
                   isMultiTask
@@ -530,13 +530,13 @@ function JobDetails() {
                       gpuMetricsTask?.name ||
                       detailJobData.name
                 }
-                storageKey={GPU_METRICS_EXPANDED_KEY}
+                storageKey={TELEMETRY_EXPANDED_KEY}
                 noMetricsMessage={
                   gpuMetricsTask?.pool
-                    ? 'GPU metrics are not available for pool jobs.'
+                    ? 'Telemetry is not available for pool jobs.'
                     : !gpuMetricsTask?.full_infra?.includes('Kubernetes')
-                      ? 'GPU metrics are only available for Kubernetes tasks.'
-                      : 'No GPU metrics available for this task.'
+                      ? 'Telemetry is only available for Kubernetes tasks.'
+                      : 'No telemetry available for this task.'
                 }
                 headerExtra={
                   isMultiTask && (

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -86,10 +86,10 @@ function JobDetails() {
   const [logExtractedLinks, setLogExtractedLinks] = useState({});
   const isMobile = useMobile();
 
-  // Telemetry state
+    // Telemetry state
   const [isGrafanaAvailable, setIsGrafanaAvailable] = useState(false);
   // Telemetry task selection for job groups
-  const [gpuMetricsTaskIndex, setGpuMetricsTaskIndex] = useState(0);
+  const [telemetryTaskIndex, setTelemetryTaskIndex] = useState(0);
   const TELEMETRY_EXPANDED_KEY = 'skypilot-jobs-telemetry-expanded';
 
   // Update isInitialLoad when data is first loaded
@@ -197,8 +197,8 @@ function JobDetails() {
       setRefreshLogsFlag((prev) => prev + 1);
       // Trigger controller logs refresh
       setRefreshControllerLogsFlag((prev) => prev + 1);
-      // Trigger GPU metrics refresh
-      setGpuMetricsRefreshTrigger((prev) => prev + 1);
+      // Trigger telemetry refresh
+      setTelemetryRefreshTrigger((prev) => prev + 1);
     } catch (error) {
       console.error('Error refreshing data:', error);
     } finally {
@@ -215,16 +215,16 @@ function JobDetails() {
     setRefreshControllerLogsFlag((prev) => prev + 1);
   };
 
-  // Get all tasks for this job (supports multi-task jobs) - computed early for GPU metrics
-  const allTasksForGpuMetrics = useMemo(() => {
+  // Get all tasks for this job (supports multi-task jobs) - computed early for telemetry
+  const allTasksForTelemetry = useMemo(() => {
     return (
       jobData?.jobs?.filter((item) => String(item.id) === String(jobId)) || []
     );
   }, [jobData, jobId]);
 
-  // Determine which tasks have GPU metrics (Kubernetes, not pool, has cluster_name_on_cloud)
-  const tasksWithGpuMetrics = useMemo(() => {
-    return allTasksForGpuMetrics.map((task, index) => ({
+  // Determine which tasks have telemetry (Kubernetes, not pool, has cluster_name_on_cloud)
+  const tasksWithTelemetry = useMemo(() => {
+    return allTasksForTelemetry.map((task, index) => ({
       index,
       task,
       hasMetrics:
@@ -232,20 +232,20 @@ function JobDetails() {
         !task.pool &&
         task.cluster_name_on_cloud,
     }));
-  }, [allTasksForGpuMetrics]);
+  }, [allTasksForTelemetry]);
 
-  const hasAnyTaskWithGpuMetrics = tasksWithGpuMetrics.some(
+  const hasAnyTaskWithTelemetry = tasksWithTelemetry.some(
     (t) => t.hasMetrics
   );
 
-  // Get the currently selected task for GPU metrics
-  const gpuMetricsTask =
-    allTasksForGpuMetrics[gpuMetricsTaskIndex] || allTasksForGpuMetrics[0];
+  // Get the currently selected task for telemetry
+  const telemetryTask =
+    allTasksForTelemetry[telemetryTaskIndex] || allTasksForTelemetry[0];
 
-  // Get cluster name for GPU metrics from selected task
-  const gpuMetricsClusterName =
-    gpuMetricsTask?.cluster_name_on_cloud ||
-    allTasksForGpuMetrics[0]?.cluster_name_on_cloud;
+  // Get cluster name for telemetry from selected task
+  const telemetryClusterName =
+    telemetryTask?.cluster_name_on_cloud ||
+    allTasksForTelemetry[0]?.cluster_name_on_cloud;
 
   if (!router.isReady) {
     return <div>Loading...</div>;
@@ -521,25 +521,25 @@ function JobDetails() {
             )}
 
             {/* Telemetry Section (GPU + CPU/Memory) - Show for Kubernetes managed jobs with cluster_name_on_cloud */}
-            {isGrafanaAvailable && hasAnyTaskWithGpuMetrics && (
+            {isGrafanaAvailable && hasAnyTaskWithTelemetry && (
               <TelemetrySection
-                clusterNameOnCloud={gpuMetricsClusterName}
+                clusterNameOnCloud={telemetryClusterName}
                 displayName={
                   isMultiTask
-                    ? `${gpuMetricsTask?.task || gpuMetricsTask?.name || detailJobData.name} (Task ${gpuMetricsTaskIndex})`
-                    : gpuMetricsTask?.task ||
-                      gpuMetricsTask?.name ||
+                    ? `${telemetryTask?.task || telemetryTask?.name || detailJobData.name} (Task ${telemetryTaskIndex})`
+                    : telemetryTask?.task ||
+                      telemetryTask?.name ||
                       detailJobData.name
                 }
                 storageKey={TELEMETRY_EXPANDED_KEY}
                 hasGpu={resourcesHaveGpu(
-                  gpuMetricsTask?.requested_resources ||
-                    gpuMetricsTask?.resources_str
+                  telemetryTask?.requested_resources ||
+                    telemetryTask?.resources_str
                 )}
                 noMetricsMessage={
-                  gpuMetricsTask?.pool
+                  telemetryTask?.pool
                     ? 'Telemetry is not available for pool jobs.'
-                    : !gpuMetricsTask?.full_infra?.includes('Kubernetes')
+                    : !telemetryTask?.full_infra?.includes('Kubernetes')
                       ? 'Telemetry is only available for Kubernetes tasks.'
                       : 'No telemetry available for this task.'
                 }
@@ -547,9 +547,9 @@ function JobDetails() {
                   isMultiTask && (
                     <Select
                       onValueChange={(value) =>
-                        setGpuMetricsTaskIndex(parseInt(value, 10))
+                        setTelemetryTaskIndex(parseInt(value, 10))
                       }
-                      value={String(gpuMetricsTaskIndex)}
+                      value={String(telemetryTaskIndex)}
                     >
                       <SelectTrigger
                         onClick={(e) => e.stopPropagation()}
@@ -559,7 +559,7 @@ function JobDetails() {
                         <SelectValue placeholder="Select Task" />
                       </SelectTrigger>
                       <SelectContent>
-                        {tasksWithGpuMetrics.map(
+                        {tasksWithTelemetry.map(
                           ({ index, task, hasMetrics }) => (
                             <SelectItem
                               key={index}

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -60,7 +60,10 @@ import { YamlHighlighter } from '@/components/YamlHighlighter';
 import dashboardCache from '@/lib/cache';
 import { PluginSlot } from '@/plugins/PluginSlot';
 import { checkGrafanaAvailability } from '@/utils/grafana';
-import { TelemetrySection } from '@/components/TelemetrySection';
+import {
+  TelemetrySection,
+  extractKubernetesContext,
+} from '@/components/TelemetrySection';
 import { resourcesHaveGpu } from '@/utils/gpuUtils';
 import { useLogStreamer } from '@/hooks/useLogStreamer';
 import PropTypes from 'prop-types';
@@ -524,6 +527,9 @@ function JobDetails() {
             {isGrafanaAvailable && hasAnyTaskWithGpuMetrics && (
               <TelemetrySection
                 clusterNameOnCloud={gpuMetricsClusterName}
+                kubernetesContext={extractKubernetesContext(
+                  gpuMetricsTask?.full_infra
+                )}
                 displayName={
                   isMultiTask
                     ? `${gpuMetricsTask?.task || gpuMetricsTask?.name || detailJobData.name} (Task ${gpuMetricsTaskIndex})`

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -228,7 +228,7 @@ function JobDetails() {
       index,
       task,
       hasMetrics:
-        task.full_infra?.includes('Kubernetes') &&
+        task.full_infra?.toLowerCase().includes('kubernetes') &&
         !task.pool &&
         task.cluster_name_on_cloud,
     }));

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -61,7 +61,7 @@ import dashboardCache from '@/lib/cache';
 import { PluginSlot } from '@/plugins/PluginSlot';
 import { checkGrafanaAvailability } from '@/utils/grafana';
 import { TelemetrySection } from '@/components/TelemetrySection';
-import { resourcesHaveGpu } from '@/utils/gpuUtils';
+import { hasAccelerator } from '@/utils/gpuUtils';
 import { useLogStreamer } from '@/hooks/useLogStreamer';
 import PropTypes from 'prop-types';
 
@@ -530,10 +530,7 @@ function JobDetails() {
                       detailJobData.name
                 }
                 storageKey={TELEMETRY_EXPANDED_KEY}
-                hasGpu={resourcesHaveGpu(
-                  telemetryTask?.requested_resources ||
-                    telemetryTask?.resources_str
-                )}
+                hasGpu={hasAccelerator(telemetryTask?.accelerators)}
                 noMetricsMessage={
                   telemetryTask?.pool
                     ? 'Telemetry is not available for pool jobs.'

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -61,6 +61,7 @@ import dashboardCache from '@/lib/cache';
 import { PluginSlot } from '@/plugins/PluginSlot';
 import { checkGrafanaAvailability } from '@/utils/grafana';
 import { TelemetrySection } from '@/components/TelemetrySection';
+import { resourcesHaveGpu } from '@/utils/gpuUtils';
 import { useLogStreamer } from '@/hooks/useLogStreamer';
 import PropTypes from 'prop-types';
 
@@ -531,6 +532,10 @@ function JobDetails() {
                       detailJobData.name
                 }
                 storageKey={TELEMETRY_EXPANDED_KEY}
+                hasGpu={resourcesHaveGpu(
+                  gpuMetricsTask?.requested_resources ||
+                    gpuMetricsTask?.resources_str
+                )}
                 noMetricsMessage={
                   gpuMetricsTask?.pool
                     ? 'Telemetry is not available for pool jobs.'

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -86,7 +86,7 @@ function JobDetails() {
   const [logExtractedLinks, setLogExtractedLinks] = useState({});
   const isMobile = useMobile();
 
-    // Telemetry state
+  // Telemetry state
   const [isGrafanaAvailable, setIsGrafanaAvailable] = useState(false);
   // Telemetry task selection for job groups
   const [telemetryTaskIndex, setTelemetryTaskIndex] = useState(0);
@@ -234,9 +234,7 @@ function JobDetails() {
     }));
   }, [allTasksForTelemetry]);
 
-  const hasAnyTaskWithTelemetry = tasksWithTelemetry.some(
-    (t) => t.hasMetrics
-  );
+  const hasAnyTaskWithTelemetry = tasksWithTelemetry.some((t) => t.hasMetrics);
 
   // Get the currently selected task for telemetry
   const telemetryTask =

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -60,10 +60,7 @@ import { YamlHighlighter } from '@/components/YamlHighlighter';
 import dashboardCache from '@/lib/cache';
 import { PluginSlot } from '@/plugins/PluginSlot';
 import { checkGrafanaAvailability } from '@/utils/grafana';
-import {
-  TelemetrySection,
-  extractKubernetesContext,
-} from '@/components/TelemetrySection';
+import { TelemetrySection } from '@/components/TelemetrySection';
 import { resourcesHaveGpu } from '@/utils/gpuUtils';
 import { useLogStreamer } from '@/hooks/useLogStreamer';
 import PropTypes from 'prop-types';
@@ -527,9 +524,6 @@ function JobDetails() {
             {isGrafanaAvailable && hasAnyTaskWithGpuMetrics && (
               <TelemetrySection
                 clusterNameOnCloud={gpuMetricsClusterName}
-                kubernetesContext={extractKubernetesContext(
-                  gpuMetricsTask?.full_infra
-                )}
                 displayName={
                   isMultiTask
                     ? `${gpuMetricsTask?.task || gpuMetricsTask?.name || detailJobData.name} (Task ${gpuMetricsTaskIndex})`

--- a/sky/dashboard/src/pages/jobs/[job]/[task].js
+++ b/sky/dashboard/src/pages/jobs/[job]/[task].js
@@ -30,6 +30,7 @@ import dashboardCache from '@/lib/cache';
 import { useLogStreamer } from '@/hooks/useLogStreamer';
 import { checkGrafanaAvailability } from '@/utils/grafana';
 import { TelemetrySection } from '@/components/TelemetrySection';
+import { resourcesHaveGpu } from '@/utils/gpuUtils';
 
 function TaskDetails() {
   const router = useRouter();
@@ -193,6 +194,9 @@ function TaskDetails() {
                   displayName={taskData.task || `Task ${taskIndex}`}
                   refreshTrigger={gpuMetricsRefreshTrigger}
                   storageKey="skypilot-task-telemetry-expanded"
+                  hasGpu={resourcesHaveGpu(
+                    taskData.requested_resources || taskData.resources_str
+                  )}
                 />
               )}
 

--- a/sky/dashboard/src/pages/jobs/[job]/[task].js
+++ b/sky/dashboard/src/pages/jobs/[job]/[task].js
@@ -29,7 +29,7 @@ import { UserDisplay } from '@/components/elements/UserDisplay';
 import dashboardCache from '@/lib/cache';
 import { useLogStreamer } from '@/hooks/useLogStreamer';
 import { checkGrafanaAvailability } from '@/utils/grafana';
-import { GPUMetricsSection } from '@/components/GPUMetricsSection';
+import { TelemetrySection } from '@/components/TelemetrySection';
 
 function TaskDetails() {
   const router = useRouter();
@@ -183,16 +183,16 @@ function TaskDetails() {
               </Card>
             </div>
 
-            {/* GPU Metrics Section - Show for Kubernetes tasks with cluster_name_on_cloud */}
+            {/* Telemetry Section (GPU + CPU/Memory) - Show for Kubernetes tasks with cluster_name_on_cloud */}
             {isGrafanaAvailable &&
               taskData.full_infra?.includes('Kubernetes') &&
               !taskData.pool &&
               taskData.cluster_name_on_cloud && (
-                <GPUMetricsSection
+                <TelemetrySection
                   clusterNameOnCloud={taskData.cluster_name_on_cloud}
                   displayName={taskData.task || `Task ${taskIndex}`}
                   refreshTrigger={gpuMetricsRefreshTrigger}
-                  storageKey="skypilot-task-gpu-metrics-expanded"
+                  storageKey="skypilot-task-telemetry-expanded"
                 />
               )}
 

--- a/sky/dashboard/src/pages/jobs/[job]/[task].js
+++ b/sky/dashboard/src/pages/jobs/[job]/[task].js
@@ -47,7 +47,7 @@ function TaskDetails() {
 
   // GPU metrics state
   const [isGrafanaAvailable, setIsGrafanaAvailable] = useState(false);
-  const [gpuMetricsRefreshTrigger, setGpuMetricsRefreshTrigger] = useState(0);
+  const [telemetryRefreshTrigger, setTelemetryRefreshTrigger] = useState(0);
 
   // Update isInitialLoad when data is first loaded
   React.useEffect(() => {
@@ -85,7 +85,7 @@ function TaskDetails() {
     try {
       setRefreshTrigger((prev) => prev + 1);
       setRefreshLogsFlag((prev) => prev + 1);
-      setGpuMetricsRefreshTrigger((prev) => prev + 1);
+      setTelemetryRefreshTrigger((prev) => prev + 1);
     } catch (error) {
       console.error('Error refreshing data:', error);
     } finally {
@@ -192,7 +192,7 @@ function TaskDetails() {
                 <TelemetrySection
                   clusterNameOnCloud={taskData.cluster_name_on_cloud}
                   displayName={taskData.task || `Task ${taskIndex}`}
-                  refreshTrigger={gpuMetricsRefreshTrigger}
+                  refreshTrigger={telemetryRefreshTrigger}
                   storageKey="skypilot-task-telemetry-expanded"
                   hasGpu={resourcesHaveGpu(
                     taskData.requested_resources || taskData.resources_str

--- a/sky/dashboard/src/pages/jobs/[job]/[task].js
+++ b/sky/dashboard/src/pages/jobs/[job]/[task].js
@@ -29,10 +29,7 @@ import { UserDisplay } from '@/components/elements/UserDisplay';
 import dashboardCache from '@/lib/cache';
 import { useLogStreamer } from '@/hooks/useLogStreamer';
 import { checkGrafanaAvailability } from '@/utils/grafana';
-import {
-  TelemetrySection,
-  extractKubernetesContext,
-} from '@/components/TelemetrySection';
+import { TelemetrySection } from '@/components/TelemetrySection';
 import { resourcesHaveGpu } from '@/utils/gpuUtils';
 
 function TaskDetails() {
@@ -194,9 +191,6 @@ function TaskDetails() {
               taskData.cluster_name_on_cloud && (
                 <TelemetrySection
                   clusterNameOnCloud={taskData.cluster_name_on_cloud}
-                  kubernetesContext={extractKubernetesContext(
-                    taskData.full_infra
-                  )}
                   displayName={taskData.task || `Task ${taskIndex}`}
                   refreshTrigger={gpuMetricsRefreshTrigger}
                   storageKey="skypilot-task-telemetry-expanded"

--- a/sky/dashboard/src/pages/jobs/[job]/[task].js
+++ b/sky/dashboard/src/pages/jobs/[job]/[task].js
@@ -30,7 +30,7 @@ import dashboardCache from '@/lib/cache';
 import { useLogStreamer } from '@/hooks/useLogStreamer';
 import { checkGrafanaAvailability } from '@/utils/grafana';
 import { TelemetrySection } from '@/components/TelemetrySection';
-import { resourcesHaveGpu } from '@/utils/gpuUtils';
+import { hasAccelerator } from '@/utils/gpuUtils';
 
 function TaskDetails() {
   const router = useRouter();
@@ -194,9 +194,7 @@ function TaskDetails() {
                   displayName={taskData.task || `Task ${taskIndex}`}
                   refreshTrigger={telemetryRefreshTrigger}
                   storageKey="skypilot-task-telemetry-expanded"
-                  hasGpu={resourcesHaveGpu(
-                    taskData.requested_resources || taskData.resources_str
-                  )}
+                  hasGpu={hasAccelerator(taskData.accelerators)}
                 />
               )}
 

--- a/sky/dashboard/src/pages/jobs/[job]/[task].js
+++ b/sky/dashboard/src/pages/jobs/[job]/[task].js
@@ -29,7 +29,10 @@ import { UserDisplay } from '@/components/elements/UserDisplay';
 import dashboardCache from '@/lib/cache';
 import { useLogStreamer } from '@/hooks/useLogStreamer';
 import { checkGrafanaAvailability } from '@/utils/grafana';
-import { TelemetrySection } from '@/components/TelemetrySection';
+import {
+  TelemetrySection,
+  extractKubernetesContext,
+} from '@/components/TelemetrySection';
 import { resourcesHaveGpu } from '@/utils/gpuUtils';
 
 function TaskDetails() {
@@ -191,6 +194,9 @@ function TaskDetails() {
               taskData.cluster_name_on_cloud && (
                 <TelemetrySection
                   clusterNameOnCloud={taskData.cluster_name_on_cloud}
+                  kubernetesContext={extractKubernetesContext(
+                    taskData.full_infra
+                  )}
                   displayName={taskData.task || `Task ${taskIndex}`}
                   refreshTrigger={gpuMetricsRefreshTrigger}
                   storageKey="skypilot-task-telemetry-expanded"

--- a/sky/dashboard/src/pages/jobs/[job]/[task].js
+++ b/sky/dashboard/src/pages/jobs/[job]/[task].js
@@ -186,7 +186,7 @@ function TaskDetails() {
 
             {/* Telemetry Section (GPU + CPU/Memory) - Show for Kubernetes tasks with cluster_name_on_cloud */}
             {isGrafanaAvailable &&
-              taskData.full_infra?.includes('Kubernetes') &&
+              taskData.full_infra?.toLowerCase().includes('kubernetes') &&
               !taskData.pool &&
               taskData.cluster_name_on_cloud && (
                 <TelemetrySection

--- a/sky/dashboard/src/utils/gpuUtils.js
+++ b/sky/dashboard/src/utils/gpuUtils.js
@@ -80,3 +80,30 @@ export function canonicalizeGpuName(rawName) {
       .trim() || 'Unknown'
   );
 }
+
+/**
+ * Heuristic: does a resources / requested-resources string mention any GPU?
+ *
+ * Returns true if the string contains any canonical GPU model name as a word
+ * (e.g. "1x(cpus=4, mem=16GB, A100:1)" → true, "1x(cpus=4, mem=16GB)" → false).
+ *
+ * Used to decide whether to render GPU telemetry panels for a cluster or job;
+ * CPU-only resources should suppress GPU panels to avoid empty charts.
+ *
+ * @param {string} resourcesStr - A SkyPilot resources string
+ * @returns {boolean} True if any GPU model name is detected.
+ */
+export function resourcesHaveGpu(resourcesStr) {
+  if (!resourcesStr) return false;
+  for (const canonical of CANONICAL_GPU_NAMES) {
+    const re = new RegExp(
+      `\\b${canonical.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`,
+      'i'
+    );
+    if (re.test(resourcesStr)) return true;
+  }
+  // Generic fallbacks for accelerators not in CANONICAL_GPU_NAMES.
+  if (/\bgpu\b/i.test(resourcesStr)) return true;
+  if (/\bnvidia[\s-]/i.test(resourcesStr)) return true;
+  return false;
+}

--- a/sky/dashboard/src/utils/gpuUtils.js
+++ b/sky/dashboard/src/utils/gpuUtils.js
@@ -82,28 +82,36 @@ export function canonicalizeGpuName(rawName) {
 }
 
 /**
- * Heuristic: does a resources / requested-resources string mention any GPU?
+ * Check whether a cluster or managed-job task has any accelerator requested.
  *
- * Returns true if the string contains any canonical GPU model name as a word
- * (e.g. "1x(cpus=4, mem=16GB, A100:1)" → true, "1x(cpus=4, mem=16GB)" → false).
+ * Accepts the structured `accelerators` field SkyPilot exposes on both
+ * clusters and managed jobs. The value can be:
+ *   - An object: {"A100": 4}, {"H100-80GB": 8}, or {} for none
+ *   - A Python-repr string: "{'A100': 4}" or "None" or ""
+ *   - null / undefined
  *
- * Used to decide whether to render GPU telemetry panels for a cluster or job;
- * CPU-only resources should suppress GPU panels to avoid empty charts.
+ * Used to decide whether to render GPU telemetry panels; CPU-only resources
+ * should suppress GPU panels to avoid empty charts.
  *
- * @param {string} resourcesStr - A SkyPilot resources string
- * @returns {boolean} True if any GPU model name is detected.
+ * @param {Object|string|null} accelerators - The accelerators field
+ * @returns {boolean} True if any accelerator is requested.
  */
-export function resourcesHaveGpu(resourcesStr) {
-  if (!resourcesStr) return false;
-  for (const canonical of CANONICAL_GPU_NAMES) {
-    const re = new RegExp(
-      `\\b${canonical.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`,
-      'i'
-    );
-    if (re.test(resourcesStr)) return true;
+export function hasAccelerator(accelerators) {
+  if (accelerators == null) return false;
+  let parsed = accelerators;
+  // Handle Python-repr strings like "{'A100': 4}" or "None".
+  if (typeof accelerators === 'string') {
+    const trimmed = accelerators.trim();
+    if (!trimmed || trimmed === 'None' || trimmed === 'null') return false;
+    try {
+      parsed = JSON.parse(trimmed.replace(/'/g, '"').replace(/None/g, 'null'));
+    } catch {
+      return false;
+    }
   }
-  // Generic fallbacks for accelerators not in CANONICAL_GPU_NAMES.
-  if (/\bgpu\b/i.test(resourcesStr)) return true;
-  if (/\bnvidia[\s-]/i.test(resourcesStr)) return true;
+  if (typeof parsed === 'object' && parsed !== null) {
+    // Any entry with a non-zero count means an accelerator is requested.
+    return Object.values(parsed).some((v) => Number(v) > 0);
+  }
   return false;
 }

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -494,12 +494,16 @@ async def get_metrics_for_context(context: str) -> str:
     Raises:
         Exception: If metrics collection fails for any reason
     """
-    # Query both DCGM metrics and kube_pod_labels metrics
-    # This ensures the dashboard can perform joins to filter by skypilot cluster
+    # Query DCGM, host CPU/memory, kube_pod_labels, and cAdvisor container
+    # metrics. The container_* metrics enable per-pod CPU/Memory in the
+    # Telemetry section by joining on (pod, namespace) with kube_pod_labels —
+    # same join shape the GPU panels use to filter by SkyPilot cluster name.
     match_patterns = [
         '{__name__=~"node_memory_MemAvailable_bytes|node_memory_MemTotal_bytes|DCGM_.*"}',  # pylint: disable=line-too-long
         'kube_pod_labels',
-        'node_cpu_seconds_total{mode="idle"}'
+        'node_cpu_seconds_total{mode="idle"}',
+        'container_cpu_usage_seconds_total{container!="",container!="POD"}',
+        'container_memory_working_set_bytes{container!="",container!="POD"}',
     ]
 
     # TODO(rohan): don't hardcode the namespace and service name


### PR DESCRIPTION
## Summary

Adds CPU and Memory utilization to the Grafana telemetry section on cluster and managed-job detail pages, scoped to the SkyPilot cluster's pods. The bundled DCGM dashboard already had cluster-wide host CPU/Memory panels, but they weren't surfaced in the dashboard UI and weren't filterable to a single Sky cluster. This PR makes per-pod CPU/Memory available end-to-end so users can debug OOMs and CPU-bound workloads without leaving the page.

- Renames `GPUMetricsSection` → `TelemetrySection` since the section now covers more than GPU metrics. Heading reads "Telemetry".
- Federates two extra metric families from each Kubernetes cluster's Prometheus in `sky/metrics/utils.py` so the SkyPilot Prometheus has them: `container_cpu_usage_seconds_total` and `container_memory_working_set_bytes` (cAdvisor).
- Adds two panels (`CPU Usage`, `Memory Usage` — IDs 6 and 7) to the existing `skypilot-dcgm-gpu` cluster-filter dashboard. Queries join cAdvisor metrics with `kube_pod_labels{label_skypilot_cluster_name=~"$cluster"}` on `(pod, namespace)` — the same join shape the GPU panels in this dashboard already use, so a single `var-cluster=cluster_name_on_cloud` filters every panel.
- Hides GPU panels in the section when the cluster/job is CPU-only (detected from the resources string via a new `resourcesHaveGpu` helper). Avoids showing four empty GPU charts on CPU-only workloads.
- Caps the panel grid at 4 columns (`grid-cols-1/2/3/4` responsive) to keep charts readable on wide screens.
- Uses a `[5m]` rate window for CPU to absorb gaps in the 30 s federate scrape interval (`[2m]` was intermittently empty).

## Screenshots

Verified in local Tilt.

**Managed job detail page** (CPU-only job — GPU panels correctly hidden, per-pod CPU ≈ 1.28 cores / Memory ≈ 700 MB rendered):

![Managed job Telemetry](https://raw.githubusercontent.com/skypilot-org/skypilot/rohan/screenshots-9324/9324-job-telemetry.png)

**Cluster detail page** (CPU-only cluster — same):

![Cluster Telemetry](https://raw.githubusercontent.com/skypilot-org/skypilot/rohan/screenshots-9324/9324-cluster-telemetry.png)

## Test plan

```bash
sky launch --infra k8s/coreweave-dev "sleep infinity" --cpus 2 --memory 2 -y -c telemetry-cpu-test --detach-run
sky jobs launch --infra k8s/coreweave-dev "sleep infinity" --name telemetry-test --cpus 2 --memory 2 -y
```

- [x] Cluster detail page (`/dashboard/clusters/telemetry-cpu-test`): Telemetry renders per-pod CPU and Memory with real data; GPU panels hidden because the resources string contains no GPU.
- [x] Managed job detail page (`/dashboard/jobs/1`): same — per-pod CPU/Mem panels render with real data, GPU panels hidden for the CPU-only job.
- [x] PromQL `sum by (pod, namespace) (rate(container_cpu_usage_seconds_total{container!="",container!="POD"}[5m])) * on(pod, namespace) group_left(label_skypilot_cluster_name) group by (pod, namespace, label_skypilot_cluster_name) (kube_pod_labels{label_skypilot_cluster_name=~"<cluster>"})` returns the expected per-pod values.
- [x] `npm run build` in `sky/dashboard` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)