### PR TITLE
instance update after _get_instance_info

### DIFF
--- a/sky/provision/primeintellect/instance.py
+++ b/sky/provision/primeintellect/instance.py
@@ -377,7 +377,8 @@ def get_cluster_info(
                   f'(attempt {retry_count + 1}/{max_retries})')
             time.sleep(SSH_CONN_RETRY_INTERVAL_SECONDS)
             retry_count += 1
-            running_instances[instance_id] = _get_instance_info(instance_id)
+            instance = _get_instance_info(instance_id)
+            running_instances[instance_id] = instance
 
         if instance.get('sshConnection') is not None:
             print('SSH connection is ready!')

--- a/sky/provision/primeintellect/instance.py
+++ b/sky/provision/primeintellect/instance.py
@@ -378,7 +378,6 @@ def get_cluster_info(
             time.sleep(SSH_CONN_RETRY_INTERVAL_SECONDS)
             retry_count += 1
             instance = _get_instance_info(instance_id)
-            running_instances[instance_id] = instance
 
         if instance.get('sshConnection') is not None:
             print('SSH connection is ready!')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
bug in primeintellect provision function, which prevent ssh connections.

is `provision.py` Line 380 updates `running_instances[instance_id] `but the loop variable instance still points to the original dict. The while condition on line 372 and the check on line 382 both read from the stale instance


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
