### PR TITLE
Honor cluster override config in k8s service rendering

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3431,6 +3431,11 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             f'Opening ports {handle.launched_resources.ports} for {cloud}')
         config = global_user_state.get_cluster_yaml_dict(handle.cluster_yaml)
         provider_config = config['provider']
+        cluster_config_overrides = (
+            handle.launched_resources.cluster_config_overrides)
+        if cluster_config_overrides:
+            provider_config['cluster_config_overrides'] = (
+                cluster_config_overrides)
         provision_lib.open_ports(repr(cloud), handle.cluster_name_on_cloud,
                                  handle.launched_resources.ports,
                                  provider_config)

--- a/sky/provision/kubernetes/network.py
+++ b/sky/provision/kubernetes/network.py
@@ -63,10 +63,9 @@ def _open_ports_using_loadbalancer(
     )
 
     # Update metadata from config
-    kubernetes_utils.merge_custom_metadata(
-        content['service_spec']['metadata'],
-        context=context,
-        cluster_config_overrides=overrides)
+    kubernetes_utils.merge_custom_metadata(content['service_spec']['metadata'],
+                                           context=context,
+                                           cluster_config_overrides=overrides)
 
     network_utils.create_or_replace_namespaced_service(
         namespace=kubernetes_utils.get_namespace_from_config(provider_config),
@@ -135,10 +134,9 @@ def _open_ports_using_ingress(
             service_spec=service_spec,
         )
 
-    kubernetes_utils.merge_custom_metadata(
-        content['ingress_spec']['metadata'],
-        context=context,
-        cluster_config_overrides=overrides)
+    kubernetes_utils.merge_custom_metadata(content['ingress_spec']['metadata'],
+                                           context=context,
+                                           cluster_config_overrides=overrides)
     # Create or update the single ingress for all services
     network_utils.create_or_replace_namespaced_ingress(
         namespace=namespace,

--- a/sky/provision/kubernetes/network.py
+++ b/sky/provision/kubernetes/network.py
@@ -50,6 +50,7 @@ def _open_ports_using_loadbalancer(
         cluster_name_on_cloud=cluster_name_on_cloud)
     context = kubernetes_utils.get_context_from_config(provider_config)
     namespace = kubernetes_utils.get_namespace_from_config(provider_config)
+    overrides = provider_config.get('cluster_config_overrides')
 
     content = network_utils.fill_loadbalancer_template(
         namespace=namespace,
@@ -58,10 +59,14 @@ def _open_ports_using_loadbalancer(
         ports=ports,
         selector_key=provision_constants.TAG_SKYPILOT_CLUSTER_NAME,
         selector_value=cluster_name_on_cloud,
+        cluster_config_overrides=overrides,
     )
 
     # Update metadata from config
-    kubernetes_utils.merge_custom_metadata(content['service_spec']['metadata'])
+    kubernetes_utils.merge_custom_metadata(
+        content['service_spec']['metadata'],
+        context=context,
+        cluster_config_overrides=overrides)
 
     network_utils.create_or_replace_namespaced_service(
         namespace=kubernetes_utils.get_namespace_from_config(provider_config),
@@ -77,6 +82,7 @@ def _open_ports_using_ingress(
 ) -> None:
     context = kubernetes_utils.get_context_from_config(provider_config)
     namespace = kubernetes_utils.get_namespace_from_config(provider_config)
+    overrides = provider_config.get('cluster_config_overrides')
     # Check if an ingress controller exists
     if not network_utils.ingress_controller_exists(context):
         raise Exception(
@@ -112,12 +118,16 @@ def _open_ports_using_ingress(
         ingress_name=f'{cluster_name_on_cloud}-skypilot-ingress',
         selector_key=provision_constants.TAG_SKYPILOT_CLUSTER_NAME,
         selector_value=cluster_name_on_cloud,
+        cluster_config_overrides=overrides,
     )
 
     # Create or update services based on the generated specs
     for service_name, service_spec in content['services_spec'].items():
         # Update metadata from config
-        kubernetes_utils.merge_custom_metadata(service_spec['metadata'])
+        kubernetes_utils.merge_custom_metadata(
+            service_spec['metadata'],
+            context=context,
+            cluster_config_overrides=overrides)
         network_utils.create_or_replace_namespaced_service(
             namespace=namespace,
             context=context,
@@ -125,7 +135,10 @@ def _open_ports_using_ingress(
             service_spec=service_spec,
         )
 
-    kubernetes_utils.merge_custom_metadata(content['ingress_spec']['metadata'])
+    kubernetes_utils.merge_custom_metadata(
+        content['ingress_spec']['metadata'],
+        context=context,
+        cluster_config_overrides=overrides)
     # Create or update the single ingress for all services
     network_utils.create_or_replace_namespaced_ingress(
         namespace=namespace,

--- a/sky/provision/kubernetes/network_utils.py
+++ b/sky/provision/kubernetes/network_utils.py
@@ -2,7 +2,7 @@
 import os
 import time
 import typing
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from sky import exceptions
 from sky import sky_logging
@@ -55,9 +55,14 @@ def get_port_mode(
     return port_mode
 
 
-def fill_loadbalancer_template(namespace: str, context: Optional[str],
-                               service_name: str, ports: List[int],
-                               selector_key: str, selector_value: str) -> Dict:
+def fill_loadbalancer_template(
+        namespace: str,
+        context: Optional[str],
+        service_name: str,
+        ports: List[int],
+        selector_key: str,
+        selector_value: str,
+        cluster_config_overrides: Optional[Dict[str, Any]] = None) -> Dict:
     template_path = os.path.join(directory_utils.get_sky_dir(), 'templates',
                                  _LOADBALANCER_TEMPLATE_NAME)
     if not os.path.exists(template_path):
@@ -72,12 +77,14 @@ def fill_loadbalancer_template(namespace: str, context: Optional[str],
         cloud=cloud_str,
         region=context,
         keys=('custom_metadata', 'annotations'),
-        default_value={})
+        default_value={},
+        override_configs=cluster_config_overrides)
     labels = skypilot_config.get_effective_region_config(
         cloud=cloud_str,
         region=context,
         keys=('custom_metadata', 'labels'),
-        default_value={})
+        default_value={},
+        override_configs=cluster_config_overrides)
     j2_template = jinja2.Template(template)
     cont = j2_template.render(
         namespace=namespace,
@@ -92,10 +99,14 @@ def fill_loadbalancer_template(namespace: str, context: Optional[str],
     return content
 
 
-def fill_ingress_template(namespace: str, context: Optional[str],
-                          service_details: List[Tuple[str, int,
-                                                      str]], ingress_name: str,
-                          selector_key: str, selector_value: str) -> Dict:
+def fill_ingress_template(
+        namespace: str,
+        context: Optional[str],
+        service_details: List[Tuple[str, int, str]],
+        ingress_name: str,
+        selector_key: str,
+        selector_value: str,
+        cluster_config_overrides: Optional[Dict[str, Any]] = None) -> Dict:
     template_path = os.path.join(directory_utils.get_sky_dir(), 'templates',
                                  _INGRESS_TEMPLATE_NAME)
     if not os.path.exists(template_path):
@@ -109,12 +120,14 @@ def fill_ingress_template(namespace: str, context: Optional[str],
         cloud=cloud_str,
         region=context,
         keys=('custom_metadata', 'annotations'),
-        default_value={})
+        default_value={},
+        override_configs=cluster_config_overrides)
     labels = skypilot_config.get_effective_region_config(
         cloud=cloud_str,
         region=context,
         keys=('custom_metadata', 'labels'),
-        default_value={})
+        default_value={},
+        override_configs=cluster_config_overrides)
     j2_template = jinja2.Template(template)
     cont = j2_template.render(
         namespace=namespace,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
