### PR TITLE
[ManagedJob] Disable plugin loading logs in managed job code gen

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -2766,8 +2766,12 @@ class ManagedJobCodeGen:
 
         # Plugins are only loaded for managed jobs version 13 and above.
         if managed_job_version >= 13:
+            from sky import sky_logging as _sky_logging
             from sky.server import plugins
-            plugins.load_plugins(plugins.ExtensionContext())
+            # Suppress logging during plugin loading to prevent installation
+            # logs from leaking into codegen output.
+            with _sky_logging.silent():
+                plugins.load_plugins(plugins.ExtensionContext())
         """)
 
     @classmethod


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Disable plugin loading logs in managed job code gen

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - `sky jobs queue/logs/cancel` do not show plugin loading logs
  - If an error occurs during plugin loading, the error will be returned successfully
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
