### PR TITLE
[GCP] Support selecting specific VPC subnets

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -1134,14 +1134,14 @@ By default, only VPCs from the current project are used.
 .. code-block:: yaml
 
   gcp:
-    vpc-name: my-vpc
+    vpc_name: my-vpc
 
 To use a shared VPC from another GCP project, specify the name as ``<project ID>/<vpc name>``. For example:
 
 .. code-block:: yaml
 
   gcp:
-    vpc-name: my-project-123456/default
+    vpc_name: my-project-123456/default
 
 .. _config-yaml-gcp-subnet-names:
 
@@ -1155,6 +1155,14 @@ string or list of strings. This can be used together with ``vpc_name`` to pick
 one specific subnet inside a custom VPC. If ``vpc_name`` is not set, SkyPilot
 will infer the VPC from the matching subnet. The matched subnets must belong to
 the same VPC.
+
+For shared VPCs, ``vpc_name`` must be set to ``<project ID>/<vpc name>`` when
+using ``subnet_names``. The subnet-only inference path only searches the
+current project and will not find subnets in a shared VPC host project.
+
+When ``subnet_names`` is set, SkyPilot uses the selected VPC/subnet as-is.
+Make sure the chosen VPC already has the
+:ref:`necessary firewall rules <gcp-minimum-firewall-rules>`.
 
 Because each GCP VM interface uses a single subnet, SkyPilot uses the first
 matching subnet in the order provided.

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -183,6 +183,8 @@ Below is the configuration syntax and some example values. See detailed explanat
       Owner: user-unique-name
       my-label: my-value
     :ref:`vpc_name <config-yaml-gcp-vpc-name>`: skypilot-vpc
+    :ref:`subnet_names <config-yaml-gcp-subnet-names>`:
+      - skypilot-subnet
     :ref:`use_internal_ips <config-yaml-gcp-use-internal-ips>`: true
     :ref:`force_enable_external_ips <config-yaml-gcp-force-enable-external-ips>`: true
     :ref:`ssh_proxy_command <config-yaml-gcp-ssh-proxy-command>`: ssh -W %h:%p user@host
@@ -1140,6 +1142,33 @@ To use a shared VPC from another GCP project, specify the name as ``<project ID>
 
   gcp:
     vpc-name: my-project-123456/default
+
+.. _config-yaml-gcp-subnet-names:
+
+``gcp.subnet_names``
+~~~~~~~~~~~~~~~~~~~~
+
+Subnet(s) to use within the selected GCP VPC (optional).
+
+If set, SkyPilot will only consider subnets whose names match the provided
+string or list of strings. This can be used together with ``vpc_name`` to pick
+one specific subnet inside a custom VPC. If ``vpc_name`` is not set, SkyPilot
+will infer the VPC from the matching subnet. The matched subnets must belong to
+the same VPC.
+
+Because each GCP VM interface uses a single subnet, SkyPilot uses the first
+matching subnet in the order provided.
+
+Default: ``null`` (automatically select a subnet from the VPC).
+
+Example:
+
+.. code-block:: yaml
+
+  gcp:
+    vpc_name: my-vpc
+    subnet_names:
+      - train-subnet-a
 
 .. _config-yaml-gcp-use-internal-ips:
 

--- a/sky/clouds/utils/gcp_utils.py
+++ b/sky/clouds/utils/gcp_utils.py
@@ -177,9 +177,13 @@ def _list_reservations_for_instance_type(
 
 def get_minimal_compute_permissions() -> List[str]:
     permissions = copy.copy(constants.VM_MINIMAL_PERMISSIONS)
-    if skypilot_config.get_effective_region_config(
-            cloud='gcp', region=None, keys=('vpc_name',),
-            default_value=None) is None:
+    custom_vpc_name = skypilot_config.get_effective_region_config(
+        cloud='gcp', region=None, keys=('vpc_name',), default_value=None)
+    custom_subnet_names = skypilot_config.get_effective_region_config(
+        cloud='gcp', region=None, keys=('subnet_names',), default_value=None)
+    has_custom_network = (custom_vpc_name is not None or
+                          custom_subnet_names is not None)
+    if not has_custom_network:
         # If custom VPC is not specified, permissions to modify network are
         # required to ensure SkyPilot to be able to setup the network, and
         # allow opening ports (e.g., via `resources.ports`).

--- a/sky/clouds/utils/gcp_utils.py
+++ b/sky/clouds/utils/gcp_utils.py
@@ -181,8 +181,7 @@ def get_minimal_compute_permissions() -> List[str]:
         cloud='gcp', region=None, keys=('vpc_name',), default_value=None)
     custom_subnet_names = skypilot_config.get_effective_region_config(
         cloud='gcp', region=None, keys=('subnet_names',), default_value=None)
-    has_custom_network = (custom_vpc_name is not None or
-                          custom_subnet_names is not None)
+    has_custom_network = bool(custom_vpc_name) or bool(custom_subnet_names)
     if not has_custom_network:
         # If custom VPC is not specified, permissions to modify network are
         # required to ensure SkyPilot to be able to setup the network, and

--- a/sky/provision/gcp/config.py
+++ b/sky/provision/gcp/config.py
@@ -587,6 +587,20 @@ def _network_interface_to_vpc_name(network_interface: Dict[str, str]) -> str:
     return network_interface['network'].split('/')[-1]
 
 
+def _get_subnets_with_names(
+    subnets: List['google.cloud.compute_v1.types.compute.Subnetwork'],
+    subnet_names: List[str],
+) -> List['google.cloud.compute_v1.types.compute.Subnetwork']:
+    """Returns matching subnets in user-specified order."""
+    ordered_names = list(dict.fromkeys(subnet_names))
+    subnets_by_name = {subnet['name']: subnet for subnet in subnets}
+    return [
+        subnets_by_name[name]
+        for name in ordered_names
+        if name in subnets_by_name
+    ]
+
+
 def get_usable_vpc_and_subnet(
     cluster_name: str,
     region: str,
@@ -595,10 +609,11 @@ def get_usable_vpc_and_subnet(
 ) -> Tuple[str, 'google.cloud.compute_v1.types.compute.Subnetwork']:
     """Return a usable VPC and the subnet in it.
 
-    If config.provider_config['vpc_name'] is set, return the VPC with the name
-    (errors out if not found). When this field is set, no firewall rules
-    checking or overrides will take place; it is the user's responsibility to
-    properly set up the VPC.
+    If config.provider_config['vpc_name'] or
+    config.provider_config['subnet_names'] is set, use the user-specified
+    network configuration (errors out if not found). When these fields are
+    set, no firewall rules checking or overrides will take place; it is the
+    user's responsibility to properly set up the VPC.
 
     If not found, create a new one with sufficient firewall rules.
 
@@ -622,6 +637,9 @@ def get_usable_vpc_and_subnet(
     # for every launch just for this rare case.
 
     specific_vpc_to_use = config.provider_config.get('vpc_name', None)
+    subnet_names = config.provider_config.get('subnet_names', None)
+    if isinstance(subnet_names, str):
+        subnet_names = [subnet_names]
     if specific_vpc_to_use is not None:
         if '/' in specific_vpc_to_use:
             # VPC can also be specified in the format PROJECT_ID/VPC_NAME.
@@ -654,6 +672,18 @@ def get_usable_vpc_and_subnet(
                                 region,
                                 compute,
                                 network=specific_vpc_to_use)
+        if subnet_names:
+            subnets = _get_subnets_with_names(subnets, subnet_names)
+            if not subnets:
+                _skypilot_log_error_and_exit_for_failover(
+                    'SUBNET_NOT_FOUND_FOR_VPC',
+                    f'No subnet with name(s) {subnet_names!r} found in '
+                    f'region {region} for specified VPC '
+                    f'{specific_vpc_to_use!r}.')
+            logger.info('Using user-specified subnet %r in VPC %r.',
+                        subnets[0]['name'], specific_vpc_to_use)
+            return specific_vpc_to_use, subnets[0]
+
         if not subnets:
             _skypilot_log_error_and_exit_for_failover(
                 'SUBNET_NOT_FOUND_FOR_VPC',
@@ -662,6 +692,29 @@ def get_usable_vpc_and_subnet(
                 f'Check the subnets of VPC {specific_vpc_to_use!r} at '
                 'https://console.cloud.google.com/networking/networks')
         return specific_vpc_to_use, subnets[0]
+
+    if subnet_names:
+        subnets = _get_subnets_with_names(
+            _list_subnets(project_id, region, compute), subnet_names)
+        if not subnets:
+            _skypilot_log_error_and_exit_for_failover(
+                'SUBNET_NOT_FOUND',
+                f'No subnet with name(s) {subnet_names!r} found in region '
+                f'{region}. To fix: specify a correct subnet name, or set '
+                'gcp.vpc_name to narrow the search.')
+        vpc_names = {
+            _network_interface_to_vpc_name(subnet) for subnet in subnets
+        }
+        if len(vpc_names) > 1:
+            _skypilot_log_error_and_exit_for_failover(
+                'SUBNETS_SPAN_MULTIPLE_VPCS',
+                f'Subnet(s) {subnet_names!r} found in region {region} belong '
+                f'to multiple VPCs {sorted(vpc_names)!r}. To fix: specify '
+                'subnet_names from a single VPC, or also set gcp.vpc_name.')
+        vpc_name = next(iter(vpc_names))
+        logger.info('Using user-specified subnet %r in VPC %r.',
+                    subnets[0]['name'], vpc_name)
+        return vpc_name, subnets[0]
 
     subnets_all = _list_subnets(project_id, region, compute)
 

--- a/sky/provision/gcp/config.py
+++ b/sky/provision/gcp/config.py
@@ -680,8 +680,8 @@ def get_usable_vpc_and_subnet(
                     f'No subnet with name(s) {subnet_names!r} found in '
                     f'region {region} for specified VPC '
                     f'{specific_vpc_to_use!r}.')
-            logger.info('Using user-specified subnet %r in VPC %r.',
-                        subnets[0]['name'], specific_vpc_to_use)
+            logger.info(f'Using user-specified subnet {subnets[0]["name"]!r} '
+                        f'in VPC {specific_vpc_to_use!r}.')
             return specific_vpc_to_use, subnets[0]
 
         if not subnets:
@@ -712,8 +712,8 @@ def get_usable_vpc_and_subnet(
                 f'to multiple VPCs {sorted(vpc_names)!r}. To fix: specify '
                 'subnet_names from a single VPC, or also set gcp.vpc_name.')
         vpc_name = next(iter(vpc_names))
-        logger.info('Using user-specified subnet %r in VPC %r.',
-                    subnets[0]['name'], vpc_name)
+        logger.info(f'Using user-specified subnet {subnets[0]["name"]!r} '
+                    f'in VPC {vpc_name!r}.')
         return vpc_name, subnets[0]
 
     subnets_all = _list_subnets(project_id, region, compute)

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -500,6 +500,8 @@ OVERRIDEABLE_CONFIG_KEYS_IN_TASK: List[Tuple[str, ...]] = [
     ('kubernetes', 'enable_docker'),
     ('azure', 'remote_identity'),
     ('azure', 'vpc_name'),
+    ('gcp', 'vpc_name'),
+    ('gcp', 'subnet_names'),
     ('gcp', 'managed_instance_group'),
     ('gcp', 'enable_gvnic'),
     ('gcp', 'enable_gpu_direct'),

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -43,6 +43,10 @@ provider:
   # NOTE: This is a new field added by SkyPilot to force use a specific VPC.
   vpc_name: {{vpc_name}}
 {% endif %}
+{% if subnet_names is not none %}
+  # NOTE: This is a new field added by SkyPilot to force use specific subnets.
+  subnet_names: {{subnet_names | tojson}}
+{% endif %}
   # The firewall rule name for customized firewall rules. Only enabled
   # if we have ports requirement.
 {% if firewall_rule is not none %}

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1759,6 +1759,18 @@ def get_config_schema():
                         }
                     ],
                 },
+                'subnet_names': {
+                    'oneOf': [{
+                        'type': 'string',
+                    }, {
+                        'type': 'null',
+                    }, {
+                        'type': 'array',
+                        'items': {
+                            'type': 'string'
+                        }
+                    }],
+                },
                 **_CAPABILITIES_SCHEMA,
                 **_LABELS_SCHEMA,
                 **_NETWORK_CONFIG_SCHEMA,

--- a/tests/unit_tests/test_gcp.py
+++ b/tests/unit_tests/test_gcp.py
@@ -1,10 +1,22 @@
+import pathlib
+from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
 
+from sky import logs
+from sky import resources
 from sky import skypilot_config
+from sky.backends import backend_utils
+from sky.clouds import Region
+from sky.clouds import Zone
 from sky.clouds.gcp import GCP
 from sky.clouds.utils import gcp_utils
+from sky.provision import common
+from sky.provision.gcp import config as gcp_config
+from sky.provision.gcp import constants as gcp_constants
+from sky.utils import common_utils
+from sky.utils import config_utils
 
 
 @pytest.mark.parametrize((
@@ -164,3 +176,169 @@ def test_gcp_get_user_identities_workspace_cache_bypass():
         # Verify workspace cloud was queried for each call
         assert mock_get_workspace_cloud.call_count == 3
         mock_get_workspace_cloud.assert_any_call('gcp')
+
+
+def _make_subnet(name: str, vpc_name: str):
+    return {
+        'name': name,
+        'network': f'projects/test-project/global/networks/{vpc_name}',
+        'selfLink': f'https://example.com/{name}',
+    }
+
+
+def test_gcp_get_usable_vpc_and_subnet_uses_specified_subnet(monkeypatch):
+    provider_config = {
+        'project_id': 'test-project',
+        'vpc_name': 'train-vpc',
+        'subnet_names': ['train-subnet-b', 'train-subnet-a'],
+    }
+    provision_config = common.ProvisionConfig(
+        provider_config=provider_config,
+        authentication_config={},
+        docker_config={},
+        node_config={},
+        count=1,
+        tags={},
+        resume_stopped_nodes=False,
+        ports_to_open_on_launch=None,
+    )
+    monkeypatch.setattr(gcp_config, '_list_vpcnets', lambda *args, **kwargs: [{
+        'name': 'train-vpc'
+    }])
+    monkeypatch.setattr(
+        gcp_config, '_list_subnets', lambda *args, **kwargs: [
+            _make_subnet('train-subnet-a', 'train-vpc'),
+            _make_subnet('train-subnet-b', 'train-vpc'),
+        ])
+
+    vpc_name, subnet = gcp_config.get_usable_vpc_and_subnet(
+        'cluster', 'us-central1', provision_config, MagicMock())
+
+    assert vpc_name == 'train-vpc'
+    assert subnet['name'] == 'train-subnet-b'
+
+
+def test_gcp_get_usable_vpc_and_subnet_infers_vpc_from_subnet(monkeypatch):
+    provider_config = {
+        'project_id': 'test-project',
+        'subnet_names': 'train-subnet',
+    }
+    provision_config = common.ProvisionConfig(
+        provider_config=provider_config,
+        authentication_config={},
+        docker_config={},
+        node_config={},
+        count=1,
+        tags={},
+        resume_stopped_nodes=False,
+        ports_to_open_on_launch=None,
+    )
+    monkeypatch.setattr(
+        gcp_config, '_list_subnets', lambda *args, **kwargs: [
+            _make_subnet('train-subnet', 'train-vpc'),
+        ])
+
+    vpc_name, subnet = gcp_config.get_usable_vpc_and_subnet(
+        'cluster', 'us-central1', provision_config, MagicMock())
+
+    assert vpc_name == 'train-vpc'
+    assert subnet['name'] == 'train-subnet'
+
+
+def test_gcp_get_usable_vpc_and_subnet_rejects_multiple_vpcs(monkeypatch):
+    provider_config = {
+        'project_id': 'test-project',
+        'subnet_names': ['train-subnet-a', 'train-subnet-b'],
+    }
+    provision_config = common.ProvisionConfig(
+        provider_config=provider_config,
+        authentication_config={},
+        docker_config={},
+        node_config={},
+        count=1,
+        tags={},
+        resume_stopped_nodes=False,
+        ports_to_open_on_launch=None,
+    )
+    monkeypatch.setattr(
+        gcp_config, '_list_subnets', lambda *args, **kwargs: [
+            _make_subnet('train-subnet-a', 'train-vpc-a'),
+            _make_subnet('train-subnet-b', 'train-vpc-b'),
+        ])
+
+    with pytest.raises(RuntimeError) as exc_info:
+        gcp_config.get_usable_vpc_and_subnet('cluster', 'us-central1',
+                                             provision_config, MagicMock())
+
+    assert 'multiple VPCs' in str(exc_info.value)
+
+
+def test_gcp_minimal_compute_permissions_skip_firewall_for_custom_subnet():
+
+    def get_effective_region_config_side_effect(cloud,
+                                                region,
+                                                keys,
+                                                default_value=None,
+                                                **kwargs):
+        del cloud, region, kwargs
+        if keys == ('subnet_names',):
+            return ['train-subnet']
+        return default_value
+
+    with patch.object(skypilot_config,
+                      'get_effective_region_config',
+                      side_effect=get_effective_region_config_side_effect):
+        permissions = gcp_utils.get_minimal_compute_permissions()
+
+    for permission in gcp_constants.FIREWALL_PERMISSIONS:
+        assert permission not in permissions
+
+
+def test_gcp_network_config_override_in_cluster_config(monkeypatch):
+    """Test that GCP network overrides are passed through to the template."""
+    monkeypatch.setattr(common_utils, 'make_cluster_name_on_cloud',
+                        lambda *args, **kwargs: args[0])
+    monkeypatch.setattr(backend_utils, '_get_yaml_path_from_cluster_name',
+                        lambda *args, **kwargs: '/tmp/fake-gcp-yaml-path')
+    monkeypatch.setattr(resources.Resources, 'make_deploy_variables',
+                        lambda *args, **kwargs: {'region': 'us-central1'})
+    monkeypatch.setattr(logs, 'get_logging_agent', lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        backend_utils.auth_utils, 'get_or_generate_keys',
+        lambda *args, **kwargs:
+        ('/tmp/fake-private-key', '/tmp/fake-public-key'))
+
+    config_dict = config_utils.Config.from_dict({})
+    monkeypatch.setattr(skypilot_config, '_get_loaded_config',
+                        lambda *args, **kwargs: config_dict)
+
+    override_configs = {
+        'gcp': {
+            'vpc_name': 'override-vpc',
+            'subnet_names': ['override-subnet'],
+        },
+    }
+
+    def fill_template_side_effect(*args, **kwargs):
+        del kwargs
+        template_vars = args[1]
+        assert template_vars['vpc_name'] == 'override-vpc'
+        assert template_vars['subnet_names'] == ['override-subnet']
+        raise RuntimeError('fake-error')
+
+    monkeypatch.setattr(common_utils, 'fill_template',
+                        fill_template_side_effect)
+
+    with pytest.raises(RuntimeError):
+        backend_utils.write_cluster_config(
+            to_provision=resources.Resources(
+                cloud=GCP(),
+                instance_type='n1-standard-4',
+                _cluster_config_overrides=override_configs),
+            num_nodes=1,
+            cluster_config_template='gcp-ray.yml.j2',
+            cluster_name='fake-gcp-cluster',
+            local_wheel_path=pathlib.Path('fake-wheel-path'),
+            wheel_hash='fake-wheel-hash',
+            region=Region(name='us-central1'),
+            zones=[Zone(name='us-central1-a')])

--- a/tests/unit_tests/test_gcp.py
+++ b/tests/unit_tests/test_gcp.py
@@ -294,6 +294,27 @@ def test_gcp_minimal_compute_permissions_skip_firewall_for_custom_subnet():
         assert permission not in permissions
 
 
+def test_gcp_minimal_compute_permissions_include_firewall_for_empty_subnets():
+
+    def get_effective_region_config_side_effect(cloud,
+                                                region,
+                                                keys,
+                                                default_value=None,
+                                                **kwargs):
+        del cloud, region, kwargs
+        if keys == ('subnet_names',):
+            return []
+        return default_value
+
+    with patch.object(skypilot_config,
+                      'get_effective_region_config',
+                      side_effect=get_effective_region_config_side_effect):
+        permissions = gcp_utils.get_minimal_compute_permissions()
+
+    for permission in gcp_constants.FIREWALL_PERMISSIONS:
+        assert permission in permissions
+
+
 def test_gcp_network_config_override_in_cluster_config(monkeypatch):
     """Test that GCP network overrides are passed through to the template."""
     monkeypatch.setattr(common_utils, 'make_cluster_name_on_cloud',

--- a/tests/unit_tests/test_gcp.py
+++ b/tests/unit_tests/test_gcp.py
@@ -178,21 +178,16 @@ def test_gcp_get_user_identities_workspace_cache_bypass():
         mock_get_workspace_cloud.assert_any_call('gcp')
 
 
-def _make_subnet(name: str, vpc_name: str):
+def _make_subnet(name: str, vpc_name: str, project_id: str = 'test-project'):
     return {
         'name': name,
-        'network': f'projects/test-project/global/networks/{vpc_name}',
+        'network': f'projects/{project_id}/global/networks/{vpc_name}',
         'selfLink': f'https://example.com/{name}',
     }
 
 
-def test_gcp_get_usable_vpc_and_subnet_uses_specified_subnet(monkeypatch):
-    provider_config = {
-        'project_id': 'test-project',
-        'vpc_name': 'train-vpc',
-        'subnet_names': ['train-subnet-b', 'train-subnet-a'],
-    }
-    provision_config = common.ProvisionConfig(
+def _make_provision_config(provider_config):
+    return common.ProvisionConfig(
         provider_config=provider_config,
         authentication_config={},
         docker_config={},
@@ -202,6 +197,15 @@ def test_gcp_get_usable_vpc_and_subnet_uses_specified_subnet(monkeypatch):
         resume_stopped_nodes=False,
         ports_to_open_on_launch=None,
     )
+
+
+def test_gcp_get_usable_vpc_and_subnet_uses_specified_subnet(monkeypatch):
+    provider_config = {
+        'project_id': 'test-project',
+        'vpc_name': 'train-vpc',
+        'subnet_names': ['train-subnet-b', 'train-subnet-a'],
+    }
+    provision_config = _make_provision_config(provider_config)
     monkeypatch.setattr(gcp_config, '_list_vpcnets', lambda *args, **kwargs: [{
         'name': 'train-vpc'
     }])
@@ -223,16 +227,7 @@ def test_gcp_get_usable_vpc_and_subnet_infers_vpc_from_subnet(monkeypatch):
         'project_id': 'test-project',
         'subnet_names': 'train-subnet',
     }
-    provision_config = common.ProvisionConfig(
-        provider_config=provider_config,
-        authentication_config={},
-        docker_config={},
-        node_config={},
-        count=1,
-        tags={},
-        resume_stopped_nodes=False,
-        ports_to_open_on_launch=None,
-    )
+    provision_config = _make_provision_config(provider_config)
     monkeypatch.setattr(
         gcp_config, '_list_subnets', lambda *args, **kwargs: [
             _make_subnet('train-subnet', 'train-vpc'),
@@ -250,16 +245,7 @@ def test_gcp_get_usable_vpc_and_subnet_rejects_multiple_vpcs(monkeypatch):
         'project_id': 'test-project',
         'subnet_names': ['train-subnet-a', 'train-subnet-b'],
     }
-    provision_config = common.ProvisionConfig(
-        provider_config=provider_config,
-        authentication_config={},
-        docker_config={},
-        node_config={},
-        count=1,
-        tags={},
-        resume_stopped_nodes=False,
-        ports_to_open_on_launch=None,
-    )
+    provision_config = _make_provision_config(provider_config)
     monkeypatch.setattr(
         gcp_config, '_list_subnets', lambda *args, **kwargs: [
             _make_subnet('train-subnet-a', 'train-vpc-a'),
@@ -271,6 +257,90 @@ def test_gcp_get_usable_vpc_and_subnet_rejects_multiple_vpcs(monkeypatch):
                                              provision_config, MagicMock())
 
     assert 'multiple VPCs' in str(exc_info.value)
+
+
+def test_gcp_get_usable_vpc_and_subnet_partial_name_match(monkeypatch):
+    provider_config = {
+        'project_id': 'test-project',
+        'vpc_name': 'train-vpc',
+        'subnet_names': ['missing-subnet', 'train-subnet-b'],
+    }
+    provision_config = _make_provision_config(provider_config)
+    monkeypatch.setattr(gcp_config, '_list_vpcnets', lambda *args, **kwargs: [{
+        'name': 'train-vpc'
+    }])
+    monkeypatch.setattr(
+        gcp_config, '_list_subnets', lambda *args, **kwargs: [
+            _make_subnet('train-subnet-a', 'train-vpc'),
+            _make_subnet('train-subnet-b', 'train-vpc'),
+        ])
+
+    vpc_name, subnet = gcp_config.get_usable_vpc_and_subnet(
+        'cluster', 'us-central1', provision_config, MagicMock())
+
+    assert vpc_name == 'train-vpc'
+    assert subnet['name'] == 'train-subnet-b'
+
+
+def test_gcp_get_usable_vpc_and_subnet_empty_subnet_names(monkeypatch):
+    provider_config = {
+        'project_id': 'test-project',
+        'vpc_name': 'train-vpc',
+        'subnet_names': [],
+    }
+    provision_config = _make_provision_config(provider_config)
+    monkeypatch.setattr(gcp_config, '_list_vpcnets', lambda *args, **kwargs: [{
+        'name': 'train-vpc'
+    }])
+    monkeypatch.setattr(
+        gcp_config, '_list_subnets', lambda *args, **kwargs: [
+            _make_subnet('train-subnet-a', 'train-vpc'),
+            _make_subnet('train-subnet-b', 'train-vpc'),
+        ])
+
+    vpc_name, subnet = gcp_config.get_usable_vpc_and_subnet(
+        'cluster', 'us-central1', provision_config, MagicMock())
+
+    assert vpc_name == 'train-vpc'
+    assert subnet['name'] == 'train-subnet-a'
+
+
+def test_gcp_get_usable_vpc_and_subnet_shared_vpc_with_subnet_names(
+        monkeypatch):
+    provider_config = {
+        'project_id': 'service-project',
+        'vpc_name': 'host-project/train-vpc',
+        'subnet_names': ['train-subnet-b'],
+    }
+    provision_config = _make_provision_config(provider_config)
+    seen_projects = []
+
+    def list_vpcnets(project_id, *args, **kwargs):
+        seen_projects.append(project_id)
+        return [{'name': 'train-vpc'}]
+
+    def list_subnets(project_id, *args, **kwargs):
+        seen_projects.append(project_id)
+        return [
+            _make_subnet('train-subnet-a',
+                         'train-vpc',
+                         project_id='host-project'),
+            _make_subnet('train-subnet-b',
+                         'train-vpc',
+                         project_id='host-project'),
+        ]
+
+    monkeypatch.setattr(gcp_config, '_list_vpcnets', list_vpcnets)
+    monkeypatch.setattr(gcp_config, '_list_subnets', list_subnets)
+
+    vpc_name, subnet = gcp_config.get_usable_vpc_and_subnet(
+        'cluster', 'us-central1', provision_config, MagicMock())
+
+    assert seen_projects == ['host-project', 'host-project']
+    assert vpc_name == 'train-vpc'
+    assert subnet['name'] == 'train-subnet-b'
+    assert subnet['network'] == (
+        'projects/host-project/global/networks/train-vpc')
 
 
 def test_gcp_minimal_compute_permissions_skip_firewall_for_custom_subnet():

--- a/tests/unit_tests/test_sky/utils/test_schemas.py
+++ b/tests/unit_tests/test_sky/utils/test_schemas.py
@@ -640,6 +640,49 @@ class TestSSHSchema(unittest.TestCase):
             self.assertEqual(default_identity, 'LOCAL_CREDENTIALS')
 
 
+class TestGCPSchema(unittest.TestCase):
+    """Tests for the GCP config schema."""
+
+    def setUp(self):
+        self.config_schema = schemas.get_config_schema()
+        self.gcp_schema = self.config_schema['properties']['gcp']
+
+    def test_gcp_subnet_names_single_string(self):
+        """Test that GCP accepts a single string for subnet_names."""
+        config = {'subnet_names': 'train-subnet'}
+        jsonschema.validate(instance=config, schema=self.gcp_schema)
+
+    def test_gcp_subnet_names_list(self):
+        """Test that GCP accepts a list of subnet_names."""
+        config = {'subnet_names': ['train-subnet-a', 'train-subnet-b']}
+        jsonschema.validate(instance=config, schema=self.gcp_schema)
+
+    def test_gcp_subnet_names_null(self):
+        """Test that GCP accepts null for subnet_names."""
+        config = {'subnet_names': None}
+        jsonschema.validate(instance=config, schema=self.gcp_schema)
+
+    def test_gcp_subnet_names_with_vpc_name(self):
+        """Test that GCP accepts both subnet_names and vpc_name together."""
+        config = {
+            'vpc_name': 'my-vpc',
+            'subnet_names': ['train-subnet-a'],
+        }
+        jsonschema.validate(instance=config, schema=self.gcp_schema)
+
+    def test_gcp_subnet_names_rejects_integer(self):
+        """Test that GCP rejects non-string subnet_names."""
+        config = {'subnet_names': 123}
+        with self.assertRaises(jsonschema.exceptions.ValidationError):
+            jsonschema.validate(instance=config, schema=self.gcp_schema)
+
+    def test_gcp_subnet_names_rejects_list_of_integers(self):
+        """Test that GCP rejects list of non-string subnet_names."""
+        config = {'subnet_names': [123, 456]}
+        with self.assertRaises(jsonschema.exceptions.ValidationError):
+            jsonschema.validate(instance=config, schema=self.gcp_schema)
+
+
 class TestAzureSchema(unittest.TestCase):
     """Tests for the Azure config schema."""
 


### PR DESCRIPTION
### Description
- Adding `gcp.subnet_names` support for selecting specific subnets on GCP
- Adding schema validation, docs, and unit coverage for the new config surface
- Allowing task/job-level overrides for `gcp.vpc_name` and `gcp.subnet_names`

Closes #9318 

### Tests
- `pytest tests/unit_tests/test_gcp.py -o addopts='' -q`
- `pytest tests/unit_tests/test_sky/utils/test_schemas.py -o addopts='' -q`

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
    - Manual: launched a GCP cluster with gcp.vpc_name=test-network and gcp.subnet_names=[test-subnet], and verified the instance was created in the expected subnet
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
  - Couldn't run this properly
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
