### PR TITLE
[Test] Increase RUNNING timeout for managed job cancel log tests

### DIFF
--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -120,8 +120,7 @@ def test_managed_jobs_cancelled_job_logs(generic_cloud: str):
             get_cmd_wait_until_managed_job_status_contains_matching_job_name(
                 job_name=name,
                 job_status=[sky.ManagedJobStatus.RUNNING],
-                timeout=360
-                if generic_cloud in ['azure', 'kubernetes', 'nebius'] else 120),
+                timeout=360),
             # Give time for log output to be flushed to disk on cluster.
             'sleep 10',
             f'sky jobs cancel -y -n {name}',
@@ -170,8 +169,7 @@ def test_pipeline_cancelled_logs(generic_cloud: str):
                 get_cmd_wait_until_managed_job_status_contains_matching_job_name(
                     job_name=name,
                     job_status=[sky.ManagedJobStatus.RUNNING],
-                    timeout=360 if generic_cloud
-                    in ['azure', 'kubernetes', 'nebius'] else 120),
+                    timeout=360),
                 # Give time for log output to be flushed to disk on cluster.
                 'sleep 10',
                 f'sky jobs cancel -y -n {name}',


### PR DESCRIPTION
## Summary
- **Test:** `test_pipeline_cancelled_logs` and `test_managed_jobs_cancelled_job_logs` on `gcp`
- **Classification:** TIMEOUT
- **Confidence:** HIGH

## Root Cause
GCP provisioning for the managed jobs controller VM takes longer than 120 seconds in CI, causing these tests to timeout before the managed job reaches RUNNING status. The timeout of 120s was only applied to GCP and other clouds not in the Azure/Kubernetes/Nebius list, while those three clouds already had a 360s timeout.

## Fix
Unify the RUNNING status wait timeout to 360 seconds for all clouds in both `test_pipeline_cancelled_logs` and `test_managed_jobs_cancelled_job_logs`. This matches the timeout already used for Azure, Kubernetes, and Nebius, and provides sufficient headroom for GCP controller provisioning + job launch.

## Buildkite Failure
https://buildkite.com/skypilot-1/full-smoke-tests-run/builds/114#019d8d10-f2f9-4f2f-81b1-6bacafb8bce9

---
> **Note:** This fix was auto-generated. Confidence level: HIGH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)