### PR TITLE
[Test] Increase managed job RUNNING timeout for GCP to 360s

### DIFF
--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -76,8 +76,8 @@ def test_managed_jobs_basic(generic_cloud: str):
             get_cmd_wait_until_managed_job_status_contains_matching_job_name(
                 job_name=f'{name}-2',
                 job_status=[sky.ManagedJobStatus.RUNNING],
-                timeout=360
-                if generic_cloud in ['azure', 'kubernetes', 'nebius'] else 120),
+                timeout=360 if generic_cloud
+                in ['azure', 'gcp', 'kubernetes', 'nebius'] else 120),
             f'sky jobs cancel -y -n {name}-1',
             smoke_tests_utils.
             get_cmd_wait_until_managed_job_status_contains_matching_job_name(
@@ -120,8 +120,8 @@ def test_managed_jobs_cancelled_job_logs(generic_cloud: str):
             get_cmd_wait_until_managed_job_status_contains_matching_job_name(
                 job_name=name,
                 job_status=[sky.ManagedJobStatus.RUNNING],
-                timeout=360
-                if generic_cloud in ['azure', 'kubernetes', 'nebius'] else 120),
+                timeout=360 if generic_cloud
+                in ['azure', 'gcp', 'kubernetes', 'nebius'] else 120),
             # Give time for log output to be flushed to disk on cluster.
             'sleep 10',
             f'sky jobs cancel -y -n {name}',
@@ -171,7 +171,7 @@ def test_pipeline_cancelled_logs(generic_cloud: str):
                     job_name=name,
                     job_status=[sky.ManagedJobStatus.RUNNING],
                     timeout=360 if generic_cloud
-                    in ['azure', 'kubernetes', 'nebius'] else 120),
+                    in ['azure', 'gcp', 'kubernetes', 'nebius'] else 120),
                 # Give time for log output to be flushed to disk on cluster.
                 'sleep 10',
                 f'sky jobs cancel -y -n {name}',


### PR DESCRIPTION
## Summary
- **Test:** `test_managed_jobs_cancelled_job_logs` on `gcp`
- **Classification:** TIMEOUT
- **Confidence:** HIGH

## Root Cause
GCP VM provisioning for managed job worker nodes consistently takes >120 seconds, causing `test_managed_jobs_cancelled_job_logs` to time out waiting for the job to reach RUNNING status. The test had a 120-second timeout for GCP, while Azure, Kubernetes, and Nebius already had 360-second timeouts for the same reason. The failure was consistent across 6 Buildkite attempts.

## Fix
Add `'gcp'` to the list of clouds that receive a 360-second timeout when waiting for managed job RUNNING status. This affects three tests:
- `test_managed_jobs_basic` (line 80)
- `test_managed_jobs_cancelled_job_logs` (line 124)
- `test_pipeline_cancelled_logs` (line 174)

## Buildkite Failure
https://buildkite.com/skypilot-1/full-smoke-tests-run/builds/114#019d8d10-f0b0-448f-ab68-111c74ff6149

---
> **Note:** This fix was auto-generated. Confidence level: HIGH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)