### PR TITLE
[Core] Increase DB init lock timeout from 10s to 60s

### DIFF
--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -17,7 +17,7 @@ from sky.skylet import constants
 
 logger = sky_logging.init_logger(__name__)
 
-DB_INIT_LOCK_TIMEOUT_SECONDS = 10
+DB_INIT_LOCK_TIMEOUT_SECONDS = 60
 
 # Serialize all Alembic migrations within a process. Alembic's
 # EnvironmentContext stores the active migration context in a module-level


### PR DESCRIPTION
## Summary
- **Test:** `test_managed_job_node_names_multi_node` on `nebius`
- **Classification:** DB_LOCK
- **Confidence:** HIGH

## Root Cause
The `DB_INIT_LOCK_TIMEOUT_SECONDS` constant in `migration_utils.py` is set to 10 seconds, which is too short when multiple processes on a shared jobs controller VM compete to acquire the file lock for database initialization. When concurrent managed job launches trigger simultaneous Alembic migrations (e.g., multiple tests sharing the same controller), the second process times out waiting for the lock and raises a `RuntimeError`. This has caused 6 consecutive failures of the same test across multiple retry attempts (alternating between DB_LOCK timeout and job execution timeout).

## Fix
Increases `DB_INIT_LOCK_TIMEOUT_SECONDS` from 10 to 60 seconds. This gives ample time for any in-progress Alembic migration to complete before a competing process gives up. The file lock (`fcntl.flock`) is kernel-level and automatically released on process death, so there is no risk of indefinite blocking from stale locks. The only downside of a longer timeout is that a process waits longer before failing in the rare case where the lock is truly stuck, which is a better outcome than failing prematurely.

## Buildkite Failure
https://buildkite.com/skypilot-1/full-smoke-tests-run/builds/114#019d8d0c-5537-4a3a-a157-f7079f812448

---
> **Note:** This fix was auto-generated. Confidence level: HIGH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)