### PR TITLE
[Test] Bump managed job node_names test timeout

### DIFF
--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -2760,7 +2760,7 @@ def test_managed_job_node_names_single_node(generic_cloud: str):
                 # Wait for job to be running and node_names to be populated
                 # Use longer timeout to account for controller startup
                 job = smoke_tests_utils.wait_for_managed_job_status_sdk(
-                    name, [sky.ManagedJobStatus.SUCCEEDED], timeout=300)
+                    name, [sky.ManagedJobStatus.SUCCEEDED], timeout=400)
                 # Give time for node_names to be populated after launch
                 time.sleep(10)
                 # Re-fetch to get updated node_names
@@ -2792,7 +2792,7 @@ def test_managed_job_node_names_multi_node(generic_cloud: str):
                 # Wait for job to be running
                 # Use longer timeout to account for controller startup
                 job = smoke_tests_utils.wait_for_managed_job_status_sdk(
-                    name, [sky.ManagedJobStatus.SUCCEEDED], timeout=300)
+                    name, [sky.ManagedJobStatus.SUCCEEDED], timeout=400)
                 # Give time for node_names to be populated after launch
                 time.sleep(10)
                 # Re-fetch to get updated node_names


### PR DESCRIPTION
## Summary
- Bump `wait_for_managed_job_status_sdk` timeout from 300s to 400s in `test_managed_job_node_names_single_node` and `test_managed_job_node_names_multi_node`
- GCP/Nebius provisioning for managed jobs (especially multi-node) consistently takes longer than 300s when accounting for controller startup, causing flaky CI timeouts

## Test plan
- Trigger smoke test on this PR for `test_managed_job_node_names_multi_node --nebius`

🤖 Generated with [Claude Code](https://claude.com/claude-code)