### PR TITLE
[GPU Metrics] reload config and add /debug-gpu-metrics endpoint

### DIFF
--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -196,6 +196,57 @@ def metrics() -> fastapi.Response:
 # scrape target as down.
 _PER_CONTEXT_TIMEOUT_SECONDS = 8
 
+_CREDENTIAL_MANAGER_KUBECONFIG_PATH = (
+    '/var/skypilot/credentials/kubeconfig/kubeconfig')
+
+
+@metrics_app.get('/debug-gpu-metrics')
+async def gpu_metrics_debug() -> dict:
+    """Debug endpoint for diagnosing GPU metrics collection issues."""
+    kubeconfig_env = os.environ.get('KUBECONFIG', 'NOT_SET')
+    default_path = os.path.expanduser('~/.kube/config')
+
+    # Check what contexts are visible before and after cache clear
+    pre_clear_contexts = core.get_all_contexts()
+    annotations.clear_request_level_cache()
+    post_clear_contexts = core.get_all_contexts()
+
+    # Check kubeconfig file existence
+    kubeconfig_paths = kubeconfig_env.split(':') if kubeconfig_env != 'NOT_SET' else [default_path]
+    path_info = {}
+    for p in kubeconfig_paths:
+        expanded = os.path.expanduser(p)
+        path_info[p] = {
+            'exists': os.path.exists(expanded),
+            'size': os.path.getsize(expanded) if os.path.exists(expanded) else 0,
+        }
+
+    # Check credential manager kubeconfig separately
+    cred_mgr_exists = os.path.exists(_CREDENTIAL_MANAGER_KUBECONFIG_PATH)
+    cred_mgr_contexts = []
+    if cred_mgr_exists:
+        try:
+            from kubernetes import config as k8s_config
+            ctxs, _ = k8s_config.list_kube_config_contexts(
+                config_file=_CREDENTIAL_MANAGER_KUBECONFIG_PATH)
+            cred_mgr_contexts = [c['name'] for c in ctxs]
+        except Exception as e:  # pylint: disable=broad-except
+            cred_mgr_contexts = [f'error: {e}']
+
+    return {
+        'pid': os.getpid(),
+        'thread': threading.current_thread().name,
+        'KUBECONFIG': kubeconfig_env,
+        'kubeconfig_paths': path_info,
+        'credential_manager_kubeconfig': {
+            'path': _CREDENTIAL_MANAGER_KUBECONFIG_PATH,
+            'exists': cred_mgr_exists,
+            'contexts': cred_mgr_contexts,
+        },
+        'contexts_before_cache_clear': pre_clear_contexts,
+        'contexts_after_cache_clear': post_clear_contexts,
+    }
+
 
 @metrics_app.get('/gpu-metrics')
 async def gpu_metrics() -> fastapi.Response:

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -217,10 +217,11 @@ async def gpu_metrics_debug() -> dict:
     path_info = {}
     for p in kubeconfig_paths:
         expanded = os.path.expanduser(p)
-        path_info[p] = {
-            'exists': os.path.exists(expanded),
-            'size': os.path.getsize(expanded) if os.path.exists(expanded) else 0,
-        }
+        try:
+            st = os.stat(expanded)
+            path_info[p] = {'exists': True, 'size': st.st_size}
+        except OSError:
+            path_info[p] = {'exists': False, 'size': 0}
 
     # Check credential manager kubeconfig separately
     cred_mgr_exists = os.path.exists(_CREDENTIAL_MANAGER_KUBECONFIG_PATH)

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -19,6 +19,7 @@ import uvicorn
 from sky import core
 from sky import global_user_state
 from sky import sky_logging
+from sky import skypilot_config
 from sky.metrics import utils as metrics_utils
 from sky.utils import annotations
 
@@ -252,9 +253,12 @@ async def gpu_metrics_debug() -> dict:
 async def gpu_metrics() -> fastapi.Response:
     """Gets the GPU metrics from multiple external k8s clusters"""
     # The metrics server runs as a daemon thread, not as a normal request
-    # handler, so request-scoped caches (e.g. kubernetes API clients,
-    # context names) are never cleared automatically. Clear them on each
-    # scrape so that newly uploaded kubeconfigs are discovered.
+    # handler, so:
+    # 1. The global config context (allowed_contexts, etc.) is a snapshot
+    #    from startup. Reload it from the DB to pick up config changes.
+    # 2. Request-scoped caches (kubernetes API clients, context names) are
+    #    never cleared automatically. Clear them to pick up new kubeconfigs.
+    skypilot_config.reload_config()
     annotations.clear_request_level_cache()
     contexts = core.get_all_contexts()
     all_metrics: List[str] = []

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -213,7 +213,7 @@ async def gpu_metrics_debug() -> dict:
     post_clear_contexts = core.get_all_contexts()
 
     # Check kubeconfig file existence
-    kubeconfig_paths = kubeconfig_env.split(':') if kubeconfig_env != 'NOT_SET' else [default_path]
+    kubeconfig_paths = kubeconfig_env.split(os.pathsep) if kubeconfig_env != 'NOT_SET' else [default_path]
     path_info = {}
     for p in kubeconfig_paths:
         expanded = os.path.expanduser(p)

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -20,6 +20,7 @@ from sky import core
 from sky import global_user_state
 from sky import sky_logging
 from sky import skypilot_config
+from sky.adaptors import kubernetes as kubernetes_adaptor
 from sky.metrics import utils as metrics_utils
 from sky.utils import annotations
 
@@ -213,7 +214,10 @@ async def gpu_metrics_debug() -> dict:
     post_clear_contexts = core.get_all_contexts()
 
     # Check kubeconfig file existence
-    kubeconfig_paths = kubeconfig_env.split(os.pathsep) if kubeconfig_env != 'NOT_SET' else [default_path]
+    if kubeconfig_env != 'NOT_SET':
+        kubeconfig_paths = kubeconfig_env.split(os.pathsep)
+    else:
+        kubeconfig_paths = [default_path]
     path_info = {}
     for p in kubeconfig_paths:
         expanded = os.path.expanduser(p)
@@ -228,9 +232,9 @@ async def gpu_metrics_debug() -> dict:
     cred_mgr_contexts = []
     if cred_mgr_exists:
         try:
-            from kubernetes import config as k8s_config
-            ctxs, _ = k8s_config.list_kube_config_contexts(
-                config_file=_CREDENTIAL_MANAGER_KUBECONFIG_PATH)
+            ctxs, _ = (
+                kubernetes_adaptor.kubernetes.config.list_kube_config_contexts(
+                    config_file=_CREDENTIAL_MANAGER_KUBECONFIG_PATH))
             cred_mgr_contexts = [c['name'] for c in ctxs]
         except Exception as e:  # pylint: disable=broad-except
             cred_mgr_contexts = [f'error: {e}']


### PR DESCRIPTION
## Summary
- Reload the server config to avoid stale values
- Add `/debug-gpu-metrics` diagnostic endpoint to the metrics server
- Reports KUBECONFIG env var, kubeconfig file paths/existence, credential manager kubeconfig contexts, and discovered contexts before/after cache clear
- Helps diagnose cases where the metrics server daemon thread doesn't discover newly uploaded kubeconfig contexts (e.g. KUBECONFIG not set in the main process where the metrics thread runs)

## Test plan
- [ ] Verified import succeeds
- [ ] Deploy and hit `/debug-gpu-metrics` to confirm it surfaces KUBECONFIG state

🤖 Generated with [Claude Code](https://claude.com/claude-code)