### PR TITLE
[Volume] Add volume mount check

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -942,13 +942,12 @@ def write_cluster_config(
                 vol.volume_config.cloud = repr(cloud)
                 vol.volume_config.region = region.name
                 vol.volume_config.name = volume_name
-                conflict_checker.check(
-                    volume_utils.VolumeInfo(
-                        name=volume_name,
-                        path=vol.path,
-                        volume_type=volume_utils.VolumeType.PVC.value),
-                    source='task YAML volumes (ephemeral)',
-                    volume_desc=f'ephemeral volume {volume_name!r}')
+                conflict_checker.check(volume_utils.VolumeInfo(
+                    name=volume_name,
+                    path=vol.path,
+                    volume_type=volume_utils.VolumeType.PVC.value),
+                                       source='task YAML volumes (ephemeral)',
+                                       volume_desc='ephemeral volume')
                 ephemeral_volume_mount_vars.append(vol.to_yaml_config())
             else:
                 volume_info = volume_utils.VolumeInfo(

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -932,6 +932,8 @@ def write_cluster_config(
 
     volume_mount_vars = []
     ephemeral_volume_mount_vars = []
+    conflict_checker = volume_utils.VolumeMountConflictChecker()
+
     if volume_mounts is not None:
         for vol in volume_mounts:
             if vol.is_ephemeral:
@@ -940,6 +942,13 @@ def write_cluster_config(
                 vol.volume_config.cloud = repr(cloud)
                 vol.volume_config.region = region.name
                 vol.volume_config.name = volume_name
+                conflict_checker.check(
+                    volume_utils.VolumeInfo(
+                        name=volume_name,
+                        path=vol.path,
+                        volume_type=volume_utils.VolumeType.PVC.value),
+                    source='task YAML volumes (ephemeral)',
+                    volume_desc=f'ephemeral volume {volume_name!r}')
                 ephemeral_volume_mount_vars.append(vol.to_yaml_config())
             else:
                 volume_info = volume_utils.VolumeInfo(
@@ -951,6 +960,10 @@ def write_cluster_config(
                     volume_type=vol.volume_config.type,
                     host_path=vol.volume_config.config.get('host_path'),
                 )
+                conflict_checker.check(
+                    volume_info,
+                    source='task YAML volumes',
+                    volume_desc=f'volume {vol.volume_name!r}')
                 volume_mount_vars.append(volume_info)
 
     # Resolve auto_mounts from config and add them to volume_mount_vars so
@@ -1002,16 +1015,20 @@ def write_cluster_config(
                         sub_path = None
                     else:
                         continue
-                    volume_mount_vars.append(
-                        volume_utils.VolumeInfo(
-                            name=k8s_volume_name,
-                            path=mount_path,
-                            volume_name_on_cloud=(volume_config.name_on_cloud),
-                            volume_id_on_cloud=(volume_config.id_on_cloud),
-                            sub_path=sub_path if sub_path else None,
-                            volume_type=volume_config.type,
-                            host_path=volume_config.config.get('host_path'),
-                        ))
+                    vol_info = volume_utils.VolumeInfo(
+                        name=k8s_volume_name,
+                        path=mount_path,
+                        volume_name_on_cloud=volume_config.name_on_cloud,
+                        volume_id_on_cloud=volume_config.id_on_cloud,
+                        sub_path=sub_path if sub_path else None,
+                        volume_type=volume_config.type,
+                        host_path=volume_config.config.get('host_path'),
+                    )
+                    conflict_checker.check(
+                        vol_info,
+                        source='auto_mounts config',
+                        volume_desc=f'auto-mount volume {volume_name!r}')
+                    volume_mount_vars.append(vol_info)
 
     runcmd = skypilot_config.get_effective_region_config(
         cloud=str(to_provision.cloud).lower(),

--- a/sky/utils/volume.py
+++ b/sky/utils/volume.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import enum
 import re
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from sky import exceptions
 from sky import global_user_state
@@ -201,3 +201,119 @@ class VolumeMount:
                 f'\n\tis_ephemeral={self.is_ephemeral},'
                 f'\n\tsub_path={self.sub_path},'
                 f'\n\tvolume_config={self.volume_config})')
+
+
+class VolumeMountConflictChecker:
+    """Detects conflicts between volume mounts from different sources.
+
+    Three checks are performed as each volume mount is registered:
+    1. Mount path uniqueness — no two mounts can share the same path.
+    2. Volume name consistency — if two mounts share a volume name,
+       they must reference the same underlying volume (same PVC claim
+       or host directory).  Otherwise the template's name-based dedup
+       silently drops one volume definition.
+    3. Same PVC from different volume entries — different volume names
+       pointing to the same PVC is almost certainly a misconfiguration.
+       Refer to https://github.com/kubernetes/kubernetes/issues/127004.
+    """
+
+    def __init__(self):
+        # mount_path -> (source, volume_desc)
+        self._seen_mount_paths: Dict[str, Tuple[str, str]] = {}
+        # volume_name -> (source, volume_desc, vol_source_id)
+        self._seen_volume_names: Dict[str, Tuple[str, str, Optional[str]]] = {}
+        # volume_name_on_cloud -> (volume_name, source, volume_desc)
+        self._seen_pvcs: Dict[str, Tuple[str, str, str]] = {}
+
+    @staticmethod
+    def _get_vol_source_identity(
+            volume_type: Optional[str],
+            vol_name_on_cloud: Optional[str] = None,
+            vol_host_path: Optional[str] = None) -> Optional[str]:
+        """Return a type-aware volume source identity string.
+
+        Each volume type defines its own identity key. Returns None if
+        the type is unknown or the identity cannot be determined (e.g.,
+        ephemeral volumes before provisioning).
+        """
+        if volume_type == VolumeType.PVC.value:
+            return f'pvc:{vol_name_on_cloud}'
+        if volume_type == VolumeType.HOSTPATH.value:
+            return f'hostpath:{vol_host_path}'
+        return None
+
+    def check(self, vol: VolumeInfo, source: str, volume_desc: str) -> None:
+        """Check for volume mount conflicts and register the entry.
+
+        Args:
+            vol: Volume info to check.
+            source: Where the volume came from (e.g. 'task YAML volumes',
+                'auto_mounts config').
+            volume_desc: Human-readable description for error messages.
+
+        Raises ValueError on conflict with a message identifying both
+        conflicting volumes and their sources.
+        """
+        # Check 1: Mount path uniqueness
+        if vol.path in self._seen_mount_paths:
+            prev_source, prev_desc = self._seen_mount_paths[vol.path]
+            raise ValueError(
+                f'Volume mount path conflict: {vol.path!r} is '
+                f'mounted by {volume_desc} (from {source}) and also '
+                f'by {prev_desc} (from {prev_source}). '
+                f'Please remove the duplicate from your task YAML '
+                f'volumes config or auto_mounts config.')
+        self._seen_mount_paths[vol.path] = (source, volume_desc)
+
+        if not vol.name:
+            return
+
+        # Check 2: Volume name consistency.
+        # Volume definitions are deduplicated by name but volume mounts
+        # are not. If two entries share the same name but reference
+        # different volume sources, one volume definition is silently
+        # dropped.
+        vol_source_id = self._get_vol_source_identity(vol.volume_type,
+                                                      vol.volume_name_on_cloud,
+                                                      vol.host_path)
+        if vol.name in self._seen_volume_names:
+            prev_src, prev_desc, prev_vol_source_id = (
+                self._seen_volume_names[vol.name])
+            # If identity is None (unknown type or ephemeral), we
+            # cannot confirm they are the same volume, so treat same
+            # name as a conflict.
+            if (vol_source_id is None or prev_vol_source_id is None or
+                    vol_source_id != prev_vol_source_id):
+                raise ValueError(
+                    f'Volume name conflict: volume name '
+                    f'{vol.name!r} is used by {volume_desc} '
+                    f'(from {source}) and by {prev_desc} '
+                    f'(from {prev_src}), but they reference different '
+                    f'volumes. This would cause one volume definition '
+                    f'to be silently ignored. Please remove the '
+                    f'duplicate from your task YAML volumes config or '
+                    f'auto_mounts config.')
+            # Same name, same volume source: OK (e.g. auto_mount with
+            # multiple mount_paths).
+            return
+        self._seen_volume_names[vol.name] = (source, volume_desc, vol_source_id)
+
+        # Check 3: Same PVC from different volume entries.
+        if (vol.volume_type == VolumeType.PVC.value and
+                vol.volume_name_on_cloud):
+            if vol.volume_name_on_cloud in self._seen_pvcs:
+                prev_vol_name, prev_src, prev_desc = (
+                    self._seen_pvcs[vol.volume_name_on_cloud])
+                if prev_vol_name != vol.name:
+                    raise ValueError(
+                        f'Volume PVC conflict: PVC '
+                        f'{vol.volume_name_on_cloud!r} is referenced '
+                        f'by {volume_desc} (from {source}) and also '
+                        f'by {prev_desc} (from {prev_src}). If you '
+                        f'need to mount different sub-paths of the '
+                        f'same PVC, use a single volume entry with '
+                        f'sub_path. Otherwise, please remove the '
+                        f'duplicate from your task YAML volumes '
+                        f'config or auto_mounts config.')
+            self._seen_pvcs[vol.volume_name_on_cloud] = (vol.name, source,
+                                                         volume_desc)

--- a/sky/utils/volume.py
+++ b/sky/utils/volume.py
@@ -236,9 +236,9 @@ class VolumeMountConflictChecker:
         the type is unknown or the identity cannot be determined (e.g.,
         ephemeral volumes before provisioning).
         """
-        if volume_type == VolumeType.PVC.value:
+        if volume_type == VolumeType.PVC.value and vol_name_on_cloud:
             return f'pvc:{vol_name_on_cloud}'
-        if volume_type == VolumeType.HOSTPATH.value:
+        if volume_type == VolumeType.HOSTPATH.value and vol_host_path:
             return f'hostpath:{vol_host_path}'
         return None
 

--- a/sky/utils/volume.py
+++ b/sky/utils/volume.py
@@ -289,10 +289,8 @@ class VolumeMountConflictChecker:
                     f'{vol.name!r} is used by {volume_desc} '
                     f'(from {source}) and by {prev_desc} '
                     f'(from {prev_src}), but they reference different '
-                    f'volumes. This would cause one volume definition '
-                    f'to be silently ignored. Please remove the '
-                    f'duplicate from your task YAML volumes config or '
-                    f'auto_mounts config.')
+                    f'volumes. Please remove the duplicate from your task '
+                    f'YAML volumes config or auto_mounts config.')
             # Same name, same volume source: OK (e.g. auto_mount with
             # multiple mount_paths).
             return
@@ -312,7 +310,7 @@ class VolumeMountConflictChecker:
                         f'by {prev_desc} (from {prev_src}). If you '
                         f'need to mount different sub-paths of the '
                         f'same PVC, use a single volume entry with '
-                        f'sub_path. Otherwise, please remove the '
+                        f'sub_path. Please remove the '
                         f'duplicate from your task YAML volumes '
                         f'config or auto_mounts config.')
             self._seen_pvcs[vol.volume_name_on_cloud] = (vol.name, source,

--- a/tests/unit_tests/test_sky/utils/test_volume_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_volume_utils.py
@@ -596,6 +596,15 @@ class TestVolumeMountConflictChecker:
             checker.check(_pvc('vol-x', '/mnt/b', 'different-pvc'),
                           'task YAML volumes', 'volume vol-x')
 
+    def test_name_conflict_ephemeral_vs_ephemeral(self):
+        """Two ephemeral volumes with hash-colliding names."""
+        checker = volume.VolumeMountConflictChecker()
+        checker.check(_ephemeral('cluster-abc123', '/mnt/a'),
+                      'task YAML volumes (ephemeral)', 'ephemeral vol 1')
+        with pytest.raises(ValueError, match='Volume name conflict'):
+            checker.check(_ephemeral('cluster-abc123', '/mnt/b'),
+                          'task YAML volumes (ephemeral)', 'ephemeral vol 2')
+
     def test_name_same_pvc_ok(self):
         """Auto-mount multiple mount_paths: same name, same PVC."""
         checker = volume.VolumeMountConflictChecker()
@@ -677,4 +686,22 @@ class TestVolumeMountConflictChecker:
     def test_vol_source_identity_empty(self):
         identity = volume.VolumeMountConflictChecker._get_vol_source_identity(
             '')
+        assert identity is None
+
+    def test_vol_source_identity_pvc_none_cloud_name(self):
+        """PVC type but vol_name_on_cloud is None should return None."""
+        identity = volume.VolumeMountConflictChecker._get_vol_source_identity(
+            PVC_TYPE, vol_name_on_cloud=None)
+        assert identity is None
+
+    def test_vol_source_identity_hostpath_none_path(self):
+        """hostPath type but vol_host_path is None should return None."""
+        identity = volume.VolumeMountConflictChecker._get_vol_source_identity(
+            HOSTPATH_TYPE, vol_host_path=None)
+        assert identity is None
+
+    def test_vol_source_identity_runpod_returns_none(self):
+        """RunPod network volume returns None (not supported yet)."""
+        identity = volume.VolumeMountConflictChecker._get_vol_source_identity(
+            'runpod-network-volume')
         assert identity is None

--- a/tests/unit_tests/test_sky/utils/test_volume_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_volume_utils.py
@@ -524,3 +524,157 @@ class TestVolumeMount:
         assert volume_mount.volume_name == 'test-volume'
         assert volume_mount.volume_config == mock_volume_config
         assert volume_mount.is_ephemeral is False
+
+
+PVC_TYPE = 'k8s-pvc'
+HOSTPATH_TYPE = 'k8s-hostpath'
+
+
+def _pvc(name, path, pvc_name):
+    return volume.VolumeInfo(name=name,
+                             path=path,
+                             volume_name_on_cloud=pvc_name,
+                             volume_type=PVC_TYPE)
+
+
+def _hostpath(name, path, host_path):
+    return volume.VolumeInfo(name=name,
+                             path=path,
+                             host_path=host_path,
+                             volume_type=HOSTPATH_TYPE)
+
+
+def _ephemeral(name, path):
+    return volume.VolumeInfo(name=name, path=path, volume_type=PVC_TYPE)
+
+
+class TestVolumeMountConflictChecker:
+    """Tests for VolumeMountConflictChecker."""
+
+    # -- Check 1: Mount path uniqueness --
+
+    def test_mount_path_conflict_persistent_vs_automount(self):
+        checker = volume.VolumeMountConflictChecker()
+        checker.check(_pvc('my-vol', '/mnt/data', 'my-pvc'),
+                      'task YAML volumes', 'volume my-vol')
+        with pytest.raises(ValueError, match='mount path conflict'):
+            checker.check(_pvc('auto-mount-shared', '/mnt/data', 'shared-pvc'),
+                          'auto_mounts config', 'auto-mount volume shared')
+
+    def test_mount_path_conflict_ephemeral_vs_persistent(self):
+        checker = volume.VolumeMountConflictChecker()
+        checker.check(_ephemeral('eph-123', '/mnt/data'),
+                      'task YAML volumes (ephemeral)', 'ephemeral volume')
+        with pytest.raises(ValueError, match='mount path conflict'):
+            checker.check(_pvc('my-vol', '/mnt/data', 'my-pvc'),
+                          'task YAML volumes', 'volume my-vol')
+
+    def test_mount_path_conflict_ephemeral_vs_automount(self):
+        checker = volume.VolumeMountConflictChecker()
+        checker.check(_ephemeral('eph-123', '/mnt/data'),
+                      'task YAML volumes (ephemeral)', 'ephemeral volume')
+        with pytest.raises(ValueError, match='mount path conflict'):
+            checker.check(_pvc('auto-mount-shared', '/mnt/data', 'shared-pvc'),
+                          'auto_mounts config', 'auto-mount volume shared')
+
+    # -- Check 2: Volume name consistency --
+
+    def test_name_conflict_different_pvc(self):
+        checker = volume.VolumeMountConflictChecker()
+        checker.check(_pvc('shared-name', '/mnt/a', 'pvc-a'),
+                      'task YAML volumes', 'volume vol-a')
+        with pytest.raises(ValueError, match='Volume name conflict'):
+            checker.check(_pvc('shared-name', '/mnt/b', 'pvc-b'),
+                          'auto_mounts config', 'auto-mount volume vol-b')
+
+    def test_name_conflict_ephemeral_vs_persistent(self):
+        """Ephemeral and persistent share a name but different PVCs."""
+        checker = volume.VolumeMountConflictChecker()
+        checker.check(_ephemeral('vol-x', '/mnt/a'),
+                      'task YAML volumes (ephemeral)', 'ephemeral vol')
+        with pytest.raises(ValueError, match='Volume name conflict'):
+            checker.check(_pvc('vol-x', '/mnt/b', 'different-pvc'),
+                          'task YAML volumes', 'volume vol-x')
+
+    def test_name_same_pvc_ok(self):
+        """Auto-mount multiple mount_paths: same name, same PVC."""
+        checker = volume.VolumeMountConflictChecker()
+        checker.check(_pvc('auto-mount-shared', '/mnt/a', 'shared-pvc'),
+                      'auto_mounts config', 'auto-mount volume shared')
+        checker.check(_pvc('auto-mount-shared', '/mnt/b', 'shared-pvc'),
+                      'auto_mounts config', 'auto-mount volume shared')
+
+    def test_name_same_hostpath_ok(self):
+        """Same hostPath volume at different mount paths."""
+        checker = volume.VolumeMountConflictChecker()
+        checker.check(_hostpath('auto-mount-hv', '/mnt/a', '/data/shared'),
+                      'auto_mounts config', 'auto-mount volume hv')
+        checker.check(_hostpath('auto-mount-hv', '/mnt/b', '/data/shared'),
+                      'auto_mounts config', 'auto-mount volume hv')
+
+    # -- Check 3: Same PVC from different volume entries --
+
+    def test_pvc_conflict_different_names(self):
+        checker = volume.VolumeMountConflictChecker()
+        checker.check(_pvc('vol-a', '/mnt/a', 'shared-pvc'),
+                      'task YAML volumes', 'volume vol-a')
+        with pytest.raises(ValueError, match='PVC conflict'):
+            checker.check(_pvc('auto-mount-vol-b', '/mnt/b', 'shared-pvc'),
+                          'auto_mounts config', 'auto-mount volume vol-b')
+
+    def test_pvc_conflict_two_automounts(self):
+        """Two different auto_mount entries referencing the same PVC."""
+        checker = volume.VolumeMountConflictChecker()
+        checker.check(_pvc('auto-mount-vol-a', '/mnt/a', 'shared-pvc'),
+                      'auto_mounts config', 'auto-mount volume vol-a')
+        with pytest.raises(ValueError, match='PVC conflict'):
+            checker.check(_pvc('auto-mount-vol-b', '/mnt/b', 'shared-pvc'),
+                          'auto_mounts config', 'auto-mount volume vol-b')
+
+    # -- No conflict scenarios --
+
+    def test_no_conflict_different_volumes_different_paths(self):
+        checker = volume.VolumeMountConflictChecker()
+        checker.check(_pvc('vol-a', '/mnt/a', 'pvc-a'), 'task YAML volumes',
+                      'volume vol-a')
+        checker.check(_pvc('auto-mount-vol-b', '/mnt/b', 'pvc-b'),
+                      'auto_mounts config', 'auto-mount volume vol-b')
+
+    def test_no_conflict_automount_multiple_paths(self):
+        """One auto_mount volume at three different mount paths."""
+        checker = volume.VolumeMountConflictChecker()
+        for path in ['/mnt/a', '/mnt/b', '/mnt/c']:
+            checker.check(_pvc('auto-mount-shared', path, 'shared-pvc'),
+                          'auto_mounts config', 'auto-mount volume shared')
+
+    def test_no_conflict_mixed_types(self):
+        """PVC, hostPath, and ephemeral at different paths."""
+        checker = volume.VolumeMountConflictChecker()
+        checker.check(_pvc('pvc-vol', '/mnt/pvc', 'my-pvc'),
+                      'task YAML volumes', 'volume pvc-vol')
+        checker.check(_hostpath('auto-mount-hv', '/mnt/host', '/data/host'),
+                      'auto_mounts config', 'auto-mount volume hv')
+        checker.check(_ephemeral('cluster-eph1', '/mnt/eph'),
+                      'task YAML volumes (ephemeral)', 'ephemeral vol')
+
+    # -- _get_vol_source_identity --
+
+    def test_vol_source_identity_pvc(self):
+        identity = volume.VolumeMountConflictChecker._get_vol_source_identity(
+            PVC_TYPE, vol_name_on_cloud='my-pvc')
+        assert identity == 'pvc:my-pvc'
+
+    def test_vol_source_identity_hostpath(self):
+        identity = volume.VolumeMountConflictChecker._get_vol_source_identity(
+            HOSTPATH_TYPE, vol_host_path='/data/dir')
+        assert identity == 'hostpath:/data/dir'
+
+    def test_vol_source_identity_unknown(self):
+        identity = volume.VolumeMountConflictChecker._get_vol_source_identity(
+            None)
+        assert identity is None
+
+    def test_vol_source_identity_empty(self):
+        identity = volume.VolumeMountConflictChecker._get_vol_source_identity(
+            '')
+        assert identity is None


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Three Conflict Checks

Check 1: Mount path uniqueness
No two volume mounts (persistent, ephemeral, or auto-mount) can use the same `mountPath`. Duplicate `mountPath` causes K8s pod scheduling failure (PENDING).

Check 2: Volume name consistency
The Jinja2 template deduplicates volume **definitions** by `name` but renders all **volumeMounts** without dedup. If two entries share the same K8s `name` but reference different underlying volume source, one volume definition is silently dropped and both mounts point to the wrong volume source.

- Same K8s name + same volume source → OK (e.g., auto_mount with multiple `mount_paths`)
- Same K8s name + different volume source → **Error**

Check 3: Same PVC from different volume entries
Different K8s volume names pointing to the same PVC (`volume_name_on_cloud`). Even though K8s technically allows this, it's almost certainly a user misconfiguration (same PVC via both task YAML and auto_mounts). Only applies to PVC-type volumes with non-empty `volume_name_on_cloud`.

To avoid false positives for auto_mount's multiple `mount_paths` (same K8s name, same PVC, different paths): only error if the K8s volume names differ.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Normal case
  - Mount path conflict
    - Persistent volume vs auto mount
    - Ephemeral volume vs auto mount
    - auto mount vs auto mount
  - Volume name conflict
    - Persistent volume vs auto mount
  - PVC conflict
    - Persistent volume vs auto mount
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
