### PR TITLE
[Test] Wire --serve-consolidation flag through CI pipeline

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -143,6 +143,7 @@ def _parse_args(args: Optional[str] = None):
     parser.add_argument('--helm-version')
     parser.add_argument('--helm-package')
     parser.add_argument('--jobs-consolidation', action="store_true")
+    parser.add_argument('--serve-consolidation', action="store_true")
     parser.add_argument('--grpc', action="store_true")
     parser.add_argument('--env-file')
     parser.add_argument('--plugin-yaml')
@@ -187,6 +188,8 @@ def _parse_args(args: Optional[str] = None):
         extra_args.append(f'--helm-package {parsed_args.helm_package}')
     if parsed_args.jobs_consolidation:
         extra_args.append('--jobs-consolidation')
+    if parsed_args.serve_consolidation:
+        extra_args.append('--serve-consolidation')
     if parsed_args.grpc:
         extra_args.append('--grpc')
     if parsed_args.env_file:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -239,6 +239,14 @@ def pytest_addoption(parser):
               'ensure the tests will not be skipped but no actual effect)'),
     )
     parser.addoption(
+        '--serve-consolidation',
+        action='store_true',
+        default=False,
+        help=('If set, the tests will be run in serve consolidation mode '
+              '(The config change is made in buildkite so this is a flag to '
+              'ensure the tests will not be skipped but no actual effect)'),
+    )
+    parser.addoption(
         '--grpc',
         action='store_true',
         default=False,


### PR DESCRIPTION
## Summary
- The `--serve-consolidation` flag was handled in the Buildkite pre-command but never actually reached test steps because `generate_pipeline.py` did not register it as a known argument
- `parse_known_args` silently dropped the flag, making it a no-op when triggered via PR comment (`/smoke-tests --serve-consolidation --kubernetes`)
- Register `--serve-consolidation` in `generate_pipeline.py` and `conftest.py` so it passes through to `BUILDKITE_COMMAND` end-to-end

## Test plan
- [ ] Trigger `/smoke-tests --serve-consolidation --kubernetes` on this PR
- [ ] Confirm the flag appears in individual test step `BUILDKITE_COMMAND`
- [ ] Confirm pre-command logs "serve consolidation config applied via API"

🤖 Generated with [Claude Code](https://claude.com/claude-code)