### PR TITLE
Add put_async for queue backend

### DIFF
--- a/sky/jobs/server/server.py
+++ b/sky/jobs/server/server.py
@@ -139,7 +139,7 @@ async def logs(
         # Cancel the coroutine after the request is done or client disconnects
         background_tasks.add_task(task.cancel)
     else:
-        executor.schedule_prepared_request(request_task)
+        await executor.schedule_prepared_request(request_task)
         # When runs in long executor process, we should kill the request on
         # disconnect to cancel the running routine.
         kill_request_on_disconnect = True

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -823,15 +823,15 @@ async def schedule_request_async(
                                                schedule_type,
                                                is_skypilot_system,
                                                auth_user=auth_user)
-    schedule_prepared_request(request_task, ignore_return_value, precondition,
-                              retryable)
+    await schedule_prepared_request(request_task, ignore_return_value,
+                                    precondition, retryable)
 
 
-def schedule_prepared_request(request_task: api_requests.Request,
-                              ignore_return_value: bool = False,
-                              precondition: Optional[
-                                  preconditions.Precondition] = None,
-                              retryable: bool = False) -> None:
+async def schedule_prepared_request(request_task: api_requests.Request,
+                                    ignore_return_value: bool = False,
+                                    precondition: Optional[
+                                        preconditions.Precondition] = None,
+                                    retryable: bool = False) -> None:
     """Enqueue a request to the request queue
 
     Args:
@@ -845,16 +845,16 @@ def schedule_prepared_request(request_task: api_requests.Request,
         retryable: Whether the request should be retried if it fails.
     """
 
-    def enqueue():
+    async def enqueue():
         input_tuple = (request_task.request_id, ignore_return_value, retryable)
         logger.info(f'Queuing request: {request_task.request_id}')
-        _get_queue(request_task.schedule_type).put(input_tuple)
+        await _get_queue(request_task.schedule_type).put_async(input_tuple)
 
     if precondition is not None:
         # Wait async to avoid blocking caller.
         precondition.wait_async(on_condition_met=enqueue)
     else:
-        enqueue()
+        await enqueue()
 
 
 def start(

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -128,6 +128,14 @@ class RequestQueue:
         """
         self._backend.put(request)
 
+    async def put_async(self, request: Tuple[str, bool, bool]) -> None:
+        """Put a request to the queue, async.
+
+        Args:
+            request: A tuple of request_id, ignore_return_value, and retryable.
+        """
+        await self._backend.put_async(request)
+
     def get(self) -> Optional[Tuple[str, bool, bool]]:
         """Get a request from the queue.
 

--- a/sky/server/requests/preconditions.py
+++ b/sky/server/requests/preconditions.py
@@ -8,8 +8,9 @@ Preconditions are introduced so that:
 """
 import abc
 import asyncio
+import inspect
 import time
-from typing import Callable, Optional, Tuple
+from typing import Any, Awaitable, Callable, Optional, Tuple, Union
 
 from sky import exceptions
 from sky import global_user_state
@@ -49,14 +50,22 @@ class Precondition(abc.ABC):
         return self._wait().__await__()
 
     def wait_async(
-            self,
-            on_condition_met: Optional[Callable[[], None]] = None) -> None:
-        """Wait precondition asynchronously and execute the callback on met."""
+        self,
+        on_condition_met: Optional[Callable[[], Union[None,
+                                                      Awaitable[Any]]]] = None
+    ) -> None:
+        """Wait precondition asynchronously and execute the callback on met.
+
+        The callback may be either a sync function or a coroutine function;
+        coroutines are awaited on the same event loop used for waiting.
+        """
 
         async def wait_with_callback():
             met = await self
             if met and on_condition_met is not None:
-                on_condition_met()
+                result = on_condition_met()
+                if inspect.isawaitable(result):
+                    await result
 
         event_loop.run(wait_with_callback())
 

--- a/sky/server/requests/queues/base.py
+++ b/sky/server/requests/queues/base.py
@@ -22,6 +22,12 @@ class QueueBackend(abc.ABC):
         """Put a (request_id, ignore_return_value, retryable) tuple."""
         raise NotImplementedError
 
+    async def put_async(self, item: Tuple[str, bool, bool]) -> None:
+        """Async version of put."""
+        # By default we assume put is not blocking and can be
+        # called directly in event loop
+        self.put(item)
+
     @abc.abstractmethod
     def get(self) -> Optional[Tuple[str, bool, bool]]:
         """Non-blocking get. Returns None if queue is empty."""

--- a/tests/common_test_fixtures.py
+++ b/tests/common_test_fixtures.py
@@ -392,6 +392,9 @@ def mock_queue(monkeypatch):
             request_id, ignore_return_value, _ = item
             self.queue_map[request_id] = ignore_return_value
 
+        async def put_async(self, item):
+            self.put(item)
+
         def get(self, request_id):
             # Retrieve ignore_return_value for a given request_id
             return self.queue_map.get(request_id)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR introduce `put_async` interface to avoid put blocking the uvicorn's event loop

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
