### PR TITLE
Support disable session affinity on ingress

### DIFF
--- a/charts/skypilot/templates/ingress.yaml
+++ b/charts/skypilot/templates/ingress.yaml
@@ -15,14 +15,21 @@ metadata:
     {{- if not $useNewIngressClass }}
     kubernetes.io/ingress.class: {{ .Values.ingress.ingressClassName }}
     {{- end }}
-    {{- if and (eq .Values.apiService.upgradeStrategy "RollingUpdate") .Values.ingress.sessionAffinity }}
-    # Enable session affinity and retry on 502 for RollingUpdate strategy
+    {{- if eq .Values.apiService.upgradeStrategy "RollingUpdate" }}
+    # Retry on 502 during RollingUpdate so requests hitting a terminating pod are
+    # transparently re-dispatched to a ready pod (zero-downtime upgrades).
+    nginx.ingress.kubernetes.io/proxy-next-upstream: "http_502 non_idempotent"
+    nginx.ingress.kubernetes.io/proxy-next-upstream-tries: "3"
+    {{- if .Values.ingress.sessionAffinity }}
+    # Cookie-based session affinity keeps a client pinned to the same pod across
+    # requests during a rolling upgrade. Disable via ingress.sessionAffinity=false
+    # when stickiness is managed externally (e.g., upstream load balancer) or the
+    # ingress controller does not support it.
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: "SKYPILOT_ROUTEID"
     nginx.ingress.kubernetes.io/affinity-mode: "persistent"
     nginx.ingress.kubernetes.io/session-cookie-change-on-failure: "true"
-    nginx.ingress.kubernetes.io/proxy-next-upstream: "http_502 non_idempotent"
-    nginx.ingress.kubernetes.io/proxy-next-upstream-tries: "3"
+    {{- end }}
     {{- end }}
     {{/* If oauth authentication is enabled on the API server, disable the oauth2-proxy at ingress to avoid conflicts */}}
     {{- if and (index .Values.ingress "oauth2-proxy" "enabled") (not .Values.auth.oauth.enabled) }}

--- a/charts/skypilot/templates/ingress.yaml
+++ b/charts/skypilot/templates/ingress.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- if not $useNewIngressClass }}
     kubernetes.io/ingress.class: {{ .Values.ingress.ingressClassName }}
     {{- end }}
-    {{- if eq .Values.apiService.upgradeStrategy "RollingUpdate" }}
+    {{- if and (eq .Values.apiService.upgradeStrategy "RollingUpdate") .Values.ingress.sessionAffinity }}
     # Enable session affinity and retry on 502 for RollingUpdate strategy
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: "SKYPILOT_ROUTEID"

--- a/charts/skypilot/tests/ingress_test.yaml
+++ b/charts/skypilot/tests/ingress_test.yaml
@@ -303,7 +303,7 @@ tests:
       - notExists:
           path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-next-upstream-tries"]
 
-  - it: should not add session affinity annotations when sessionAffinity is disabled under RollingUpdate
+  - it: should not add session affinity annotations but keep retry annotations when sessionAffinity is disabled under RollingUpdate
     set:
       ingress.enabled: true
       ingress.sessionAffinity: false
@@ -319,7 +319,11 @@ tests:
           path: metadata.annotations["nginx.ingress.kubernetes.io/affinity-mode"]
       - notExists:
           path: metadata.annotations["nginx.ingress.kubernetes.io/session-cookie-change-on-failure"]
-      - notExists:
+      # proxy-next-upstream retry annotations must remain so zero-downtime
+      # upgrades still work when session affinity is disabled.
+      - equal:
           path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-next-upstream"]
-      - notExists:
+          value: "http_502 non_idempotent"
+      - equal:
           path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-next-upstream-tries"]
+          value: "3"

--- a/charts/skypilot/tests/ingress_test.yaml
+++ b/charts/skypilot/tests/ingress_test.yaml
@@ -257,7 +257,7 @@ tests:
           value: "RELEASE-NAME-api-service"
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.port.number
-          value: 80 
+          value: 80
 
   # Test cases for upgradeStrategy-related annotations
   - it: should add session affinity annotations for RollingUpdate strategy
@@ -298,6 +298,27 @@ tests:
           path: metadata.annotations["nginx.ingress.kubernetes.io/affinity"]
       - notExists:
           path: metadata.annotations["nginx.ingress.kubernetes.io/session-cookie-name"]
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-next-upstream"]
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-next-upstream-tries"]
+
+  - it: should not add session affinity annotations when sessionAffinity is disabled under RollingUpdate
+    set:
+      ingress.enabled: true
+      ingress.sessionAffinity: false
+      apiService.upgradeStrategy: RollingUpdate
+      apiService.dbConnectionSecretName: test-db-secret
+      storage.enabled: false
+    asserts:
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/affinity"]
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/session-cookie-name"]
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/affinity-mode"]
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/session-cookie-change-on-failure"]
       - notExists:
           path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-next-upstream"]
       - notExists:

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -493,6 +493,9 @@
                 "path": {
                     "type": "string"
                 },
+                "sessionAffinity": {
+                    "type": "boolean"
+                },
                 "tls": {
                     "type": "object",
                     "properties": {

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -365,6 +365,12 @@ ingress:
   # Custom annotations for the ingress
   # @schema type: [object, null]
   annotations: null
+  # Enable cookie-based session affinity (sticky sessions) on the ingress. Only takes effect
+  # when apiService.upgradeStrategy is RollingUpdate, where it ensures consistent routing to
+  # the same pod during rolling upgrades. Set to false to disable it, e.g., when using an
+  # ingress controller that does not support sticky sessions, or when stickiness is managed
+  # externally (e.g., at an upstream load balancer).
+  sessionAffinity: true
 
   # TODO(aylei): deprecate skypilot managed proxy auth to reduce our maintenance burden, replace with examples instead.
   # OAuth2 Proxy configuration for authentication


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Support `ingress.sessionAffinity` value to control whether we should enable session affinity on the ingress.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
