### PR TITLE
[Azure] Fix open_ports crash when NSG has no user-defined inbound rules

### DIFF
--- a/sky/provision/azure/instance.py
+++ b/sky/provision/azure/instance.py
@@ -1036,10 +1036,13 @@ def open_ports(
 
                 # Azure NSG rules have a priority field that determines the
                 # order in which they are applied. The priority must be unique
-                # across all inbound rules in one NSG.
-                priority = max(rule.priority
-                               for rule in nsg.security_rules
-                               if rule.direction == 'Inbound') + 1
+                # across all inbound rules in one NSG. If the NSG has no
+                # user-defined inbound rules yet, start priorities at 100
+                # (the minimum allowed for custom rules).
+                priority = max((rule.priority
+                                for rule in nsg.security_rules
+                                if rule.direction == 'Inbound'),
+                               default=99) + 1
                 nsg.security_rules.append(
                     azure.create_security_rule(
                         name=f'sky-ports-{cluster_name_on_cloud}-{priority}',


### PR DESCRIPTION
## Bug

\`sky.provision.azure.instance.open_ports\` can raise \`ValueError: max() arg is an empty sequence\` and surface as

> Failed to open ports ['...'] in NSG ...

whenever the target NSG has no user-defined inbound rules yet (common on freshly-provisioned clusters).

## Root cause

The next rule's priority is computed in-line as:

\`\`\`python
priority = max(rule.priority
               for rule in nsg.security_rules
               if rule.direction == 'Inbound') + 1
\`\`\`

On an Azure NSG, \`nsg.security_rules\` only exposes **user-defined** rules (default rules such as \`AllowVnetInBound\` / \`AllowAzureLoadBalancerInBound\` / \`DenyAllInBound\` live on \`nsg.default_security_rules\`). For a newly created NSG, \`nsg.security_rules\` is an empty list, so the generator is empty and \`max(...)\` raises \`ValueError\`. The surrounding \`try\` block catches only \`azure.exceptions().HttpResponseError\`, so the \`ValueError\` propagates and aborts \`open_ports\`.

## Fix

Provide a \`default=\` to \`max()\` so an empty generator yields a sentinel priority instead of crashing:

\`\`\`diff
-                priority = max(rule.priority
-                               for rule in nsg.security_rules
-                               if rule.direction == 'Inbound') + 1
+                priority = max((rule.priority
+                                for rule in nsg.security_rules
+                                if rule.direction == 'Inbound'),
+                               default=99) + 1
\`\`\`

\`default=99\` makes the first custom inbound rule's priority \`100\`, which is the minimum priority allowed for user-defined NSG rules (Azure reserves the \`100\`–\`4096\` range for custom rules and \`65000\`+ for defaults). Subsequent rules continue to increment as before.