### PR TITLE
[Dashboard] Fix filter bar expanding to full width on page navigation

### DIFF
--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -465,7 +465,7 @@ export function Clusters() {
             Sky Clusters
           </Link>
         </div>
-        <div className="w-full sm:w-auto max-w-[520px]">
+        <div className="w-full sm:w-auto max-w-lg">
           <FilterDropdown
             propertyList={PROPERTY_OPTIONS}
             valueList={optionValues}

--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -465,7 +465,7 @@ export function Clusters() {
             Sky Clusters
           </Link>
         </div>
-        <div className="w-full sm:w-auto">
+        <div className="w-full sm:w-auto max-w-[520px]">
           <FilterDropdown
             propertyList={PROPERTY_OPTIONS}
             valueList={optionValues}

--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -1564,7 +1564,7 @@ const FilterDropdown = ({
           </SelectContent>
         </Select>
       </div>
-      <div className="relative flex-1">
+      <div className="relative flex-1 sm:flex-none">
         <input
           type="text"
           ref={inputRef}

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -366,7 +366,7 @@ export function ManagedJobs() {
             Managed Jobs
           </Link>
         </div>
-        <div className="w-full sm:w-auto">
+        <div className="w-full sm:w-auto max-w-[520px]">
           <FilterDropdown
             propertyList={PROPERTY_OPTIONS}
             valueList={valueList}

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -366,7 +366,7 @@ export function ManagedJobs() {
             Managed Jobs
           </Link>
         </div>
-        <div className="w-full sm:w-auto max-w-[520px]">
+        <div className="w-full sm:w-auto max-w-lg">
           <FilterDropdown
             propertyList={PROPERTY_OPTIONS}
             valueList={valueList}


### PR DESCRIPTION
## Changes

The filter bar on the Clusters and Jobs pages would intermittently expand
to full row width after navigating away and back to those pages.

**Root cause:** The filter wrapper div (`w-full sm:w-auto`) had no upper
bound on its width. In a flex-wrap container, browsers inconsistently
resolve the flex base size for `width: auto` items between initial render
and subsequent renders — sometimes picking min-content (~480px), sometimes
max-content (unrestricted). Without a hard `max-width` constraint, the
browser could choose the wider value on re-render, causing the filter bar
to expand to fill the row.

The previous fix in 9fba426 added `sm:flex-none` to the inner input
wrapper, which bounds the inner element's flex growth, but not the outer
wrapper's intrinsic size — so the outer div could still expand.

**Fix:** Add `max-w-[520px]` to the outer wrapper div on both pages. This
matches the existing pattern already used in `users.jsx` (`max-w-md`),
which does not exhibit the same bug.

## Test plan

- Navigate to the Clusters page — filter bar renders at normal width
- Navigate away (e.g. to another page) and back to Clusters — filter bar stays at the same width
- Same verification for the Jobs page