### PR TITLE
[Storage] Fix git dubious ownership error during workdir sync

### DIFF
--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -76,7 +76,12 @@ def get_excluded_files_from_gitignore(src_dir_path: str) -> List[str]:
     # list the submodules and run `ls-files` within the root and each submodule.
     # Print the submodule paths relative to expand_src_dir_path, separated by
     # null chars.
-    submodules_cmd = (f'git -C {shlex.quote(expand_src_dir_path)} '
+    # Use safe.directory=* to avoid "dubious ownership" errors when the
+    # workdir is on a shared filesystem (e.g. EFS) where the UID on disk
+    # may differ from the running process.  See:
+    # https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/577
+    submodules_cmd = (f'git -c safe.directory="*" '
+                      f'-C {shlex.quote(expand_src_dir_path)} '
                       'submodule foreach -q "printf \\$displaypath\\\\\\0"')
 
     try:
@@ -140,7 +145,8 @@ def get_excluded_files_from_gitignore(src_dir_path: str) -> List[str]:
         #              entry rather than listing every single file
         # Since we are using --others instead of --cached, this will not show
         # files that are tracked but also present in .gitignore.
-        filter_cmd = (f'git -C {shlex.quote(repo_path)} ls-files -z '
+        filter_cmd = (f'git -c safe.directory="*" '
+                      f'-C {shlex.quote(repo_path)} ls-files -z '
                       '--others --ignore --exclude-standard --directory')
         output = subprocess.run(filter_cmd,
                                 shell=True,


### PR DESCRIPTION
## Summary
- When the API server processes a workdir containing a `.git` directory, `get_excluded_files_from_gitignore()` runs git commands to resolve `.gitignore` exclusions. If the workdir files are owned by a different UID than the running process, git 2.35.2+ refuses with `fatal: detected dubious ownership in repository` (exit 128).
- We encountered this on AWS EFS, where the EFS CSI driver's dynamic provisioning remaps file ownership to UID 50000 regardless of which process wrote the files ([aws-efs-csi-driver#577](https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/577)). The API server runs as root (UID 0), so git sees a mismatch and refuses to operate.
<img width="1591" height="195" alt="Screenshot 2026-04-15 at 2 03 29 PM" src="https://github.com/user-attachments/assets/aca4e72c-c645-4a70-b4fa-8015feea4f7b" />

- This could also be worked around by setting `uid`/`gid` parameters on the EFS StorageClass to match the API server's UID, but this fix is more general — it handles any shared filesystem where ownership may be remapped, without requiring deployment-specific configuration.
- Fix: pass `-c safe.directory="*"` to both `git submodule foreach` and `git ls-files` calls so `.gitignore` exclusion works correctly regardless of file ownership.

## Test plan
- Reproduced on a Kubernetes deployment with EFS-backed shared storage. Verified that `git -c safe.directory="*" -C <path> submodule foreach ...` succeeds where the same command without the flag fails with exit 128.
- `test_ignore_exclusions[.gitignore]` should pass on shared-filesystem deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)