### PR TITLE
[Automount] Use volume name directly, disable subpath config for now

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1002,17 +1002,12 @@ def write_cluster_config(
                         f'auto_mounts. Skipping.')
                     continue
                 for path in mount_paths:
-                    # Disable sub_path usage, which turns out to be confusing,
-                    # for now. See #9353.
                     if path.startswith('/'):
                         mount_path = path
-                        # sub_path = path.lstrip('/')
                     elif path.startswith('~/'):
                         mount_path = f'{home_dir}/{path[2:]}'
-                        # sub_path = path[2:]
                     elif path == '~':
                         mount_path = home_dir
-                        # sub_path = None
                     else:
                         logger.warning(f'Malformed automount path {path}')
                         continue
@@ -1021,7 +1016,6 @@ def write_cluster_config(
                         path=mount_path,
                         volume_name_on_cloud=volume_config.name_on_cloud,
                         volume_id_on_cloud=volume_config.id_on_cloud,
-                        # sub_path=sub_path if sub_path else None,
                         volume_type=volume_config.type,
                         host_path=volume_config.config.get('host_path'),
                     )

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -989,7 +989,6 @@ def write_cluster_config(
                         f'ReadWriteMany PVC volumes are supported for '
                         f'auto_mounts. Skipping.')
                     continue
-                k8s_volume_name = f'auto-mount-{volume_name}'
                 for path in mount_paths:
                     if path.startswith('/'):
                         mount_path = path
@@ -1004,7 +1003,7 @@ def write_cluster_config(
                         continue
                     volume_mount_vars.append(
                         volume_utils.VolumeInfo(
-                            name=k8s_volume_name,
+                            name=volume_name,
                             path=mount_path,
                             volume_name_on_cloud=(volume_config.name_on_cloud),
                             volume_id_on_cloud=(volume_config.id_on_cloud),

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1002,23 +1002,26 @@ def write_cluster_config(
                         f'auto_mounts. Skipping.')
                     continue
                 for path in mount_paths:
+                    # Disable sub_path usage, which turns out to be confusing,
+                    # for now. See #9353.
                     if path.startswith('/'):
                         mount_path = path
-                        sub_path = path.lstrip('/')
+                        # sub_path = path.lstrip('/')
                     elif path.startswith('~/'):
                         mount_path = f'{home_dir}/{path[2:]}'
-                        sub_path = path[2:]
+                        # sub_path = path[2:]
                     elif path == '~':
                         mount_path = home_dir
-                        sub_path = None
+                        # sub_path = None
                     else:
+                        logger.warning(f'Malformed automount path {path}')
                         continue
                     vol_info = volume_utils.VolumeInfo(
                         name=volume_name,
                         path=mount_path,
                         volume_name_on_cloud=volume_config.name_on_cloud,
                         volume_id_on_cloud=volume_config.id_on_cloud,
-                        sub_path=sub_path if sub_path else None,
+                        # sub_path=sub_path if sub_path else None,
                         volume_type=volume_config.type,
                         host_path=volume_config.config.get('host_path'),
                     )


### PR DESCRIPTION
This PR has two effective changes:
1. #9343 adds a check for when two k8s pod volumes have the same underlying PVC. We can hit this case when a sky volume is mounted in the task yaml and also in an automount. This can cause the pod to hang in a pending state - kubernetes/kubernetes#127004. Fix this by just using the same k8s pod volume name for both the automount volume and the task yaml volume. They will get deduplicated by the yaml template.
2. Remove the volume subpath for automount. This is useful for the shared cache use case, but most use-cases we see are more like "the team has a shared data volume that they want mounted everywhere" and in this case the subpath behavior is counter-intuitive. We will follow up and figure out how to support that case better.