### PR TITLE
[Test] Sync local user_hash with SA identity for smoke tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -907,27 +907,33 @@ def prepare_env_file(request):
     # local ~/.sky/user_hash with the server-side SA identity.  We back up
     # the original file so that it can be restored after the session.
     user_hash_file = common_utils.USER_HASH_FILE
-    user_hash_backup = user_hash_file + '.bak'
+    # Use a PID-stamped backup name to avoid clashing with parallel workers.
+    user_hash_backup = f'{user_hash_file}.bak.{os.getpid()}'
+    user_hash_existed = os.path.exists(user_hash_file)
     config = skypilot_config.parse_and_validate_config_file(local_file_path)
     sa_token = config.get_nested(('api_server', 'service_account_token'),
                                  default_value=None)
     if sa_token:
         endpoint = config.get_nested(('api_server', 'endpoint'),
                                      default_value=None)
-        # Back up the existing user_hash file
-        if os.path.exists(user_hash_file):
-            shutil.move(user_hash_file, user_hash_backup)
-            logger.info(f'Backed up {user_hash_file} -> {user_hash_backup}')
-        try:
-            from sky.client import sdk  # pylint: disable=import-outside-toplevel
-            sdk.api_login(endpoint, service_account_token=sa_token)
-            logger.info(
-                'SA token detected; ran api_login to sync user_hash '
-                f'(now: {common_utils.get_user_hash()})')
-        except Exception as e:  # pylint: disable=broad-except
-            logger.warning(f'api_login with SA token failed: {e}. '
-                           'Tests computing name_on_cloud may use the '
-                           'wrong user hash.')
+        if endpoint is None:
+            logger.warning('SA token detected but no endpoint found in config. '
+                           'Skipping api_login to avoid interactive prompt.')
+        else:
+            # Back up the existing user_hash file
+            if user_hash_existed:
+                shutil.move(user_hash_file, user_hash_backup)
+                logger.info(f'Backed up {user_hash_file} -> {user_hash_backup}')
+            try:
+                import sky.client.sdk as sdk  # pylint: disable=import-outside-toplevel
+                sdk.api_login(endpoint, service_account_token=sa_token)
+                logger.info(
+                    'SA token detected; ran api_login to sync user_hash '
+                    f'(now: {common_utils.get_user_hash()})')
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning(f'api_login with SA token failed: {e}. '
+                               'Tests computing name_on_cloud may use the '
+                               'wrong user hash.')
 
     yield local_file_path
 
@@ -936,3 +942,7 @@ def prepare_env_file(request):
     if os.path.exists(user_hash_backup):
         shutil.move(user_hash_backup, user_hash_file)
         logger.info(f'Restored {user_hash_backup} -> {user_hash_file}')
+    elif not user_hash_existed and os.path.exists(user_hash_file):
+        # api_login created the file; remove it to avoid polluting the env.
+        os.remove(user_hash_file)
+        logger.info(f'Removed {user_hash_file} (created during test session)')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from smoke_tests.docker import docker_utils
 
 from sky import cloud_stores
 from sky import sky_logging
+from sky import skypilot_config
 from sky.utils import annotations
 from sky.utils import common_utils
 from sky.utils import context_utils
@@ -879,6 +880,14 @@ def prepare_env_file(request):
     If the env-file option is a local directory or file, use it directly.
     Otherwise, treat it as a cloud storage URL (e.g., s3://bucket/path) and
     download from storage.
+
+    When the env file contains a service account token, we call
+    ``sdk.api_login`` so that ``~/.sky/user_hash`` is set to the server-side
+    SA identity.  This is necessary because test helpers compute the on-cloud
+    cluster name client-side via ``get_user_hash()``, which must match the
+    user-id the server embeds in pod/service labels.  The original user_hash
+    file is restored after the session so subsequent tests on the same agent
+    are not affected.
     """
     env_file_path = request.config.getoption('--env-file')
     if env_file_path is None:
@@ -893,4 +902,37 @@ def prepare_env_file(request):
     os.environ['PYTEST_SKYPILOT_CONFIG_FILE_OVERRIDE'] = local_file_path
     if has_api_server:
         os.environ['PYTEST_SKYPILOT_REMOTE_SERVER_TEST'] = '1'
+
+    # When a service account token is present, run api_login to sync the
+    # local ~/.sky/user_hash with the server-side SA identity.  We back up
+    # the original file so that it can be restored after the session.
+    user_hash_file = common_utils.USER_HASH_FILE
+    user_hash_backup = user_hash_file + '.bak'
+    config = skypilot_config.parse_and_validate_config_file(local_file_path)
+    sa_token = config.get_nested(('api_server', 'service_account_token'),
+                                 default_value=None)
+    if sa_token:
+        endpoint = config.get_nested(('api_server', 'endpoint'),
+                                     default_value=None)
+        # Back up the existing user_hash file
+        if os.path.exists(user_hash_file):
+            shutil.move(user_hash_file, user_hash_backup)
+            logger.info(f'Backed up {user_hash_file} -> {user_hash_backup}')
+        try:
+            from sky.client import sdk  # pylint: disable=import-outside-toplevel
+            sdk.api_login(endpoint, service_account_token=sa_token)
+            logger.info(
+                'SA token detected; ran api_login to sync user_hash '
+                f'(now: {common_utils.get_user_hash()})')
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'api_login with SA token failed: {e}. '
+                           'Tests computing name_on_cloud may use the '
+                           'wrong user hash.')
+
     yield local_file_path
+
+    # Restore the original user_hash file so subsequent tests on this
+    # agent are not affected.
+    if os.path.exists(user_hash_backup):
+        shutil.move(user_hash_backup, user_hash_file)
+        logger.info(f'Restored {user_hash_backup} -> {user_hash_file}')


### PR DESCRIPTION
When smoke tests run with `--env-file` containing a service_account_token, the server uses the SA identity for on-cloud cluster names, but test helpers compute name_on_cloud client-side using the local user_hash. This mismatch causes kubectl label queries to return empty results, failing tests like `test_kubernetes_service_cleanup_on_down`, `test_kubernetes_pod_config_sidecar`, `test_kubernetes_sigterm_keepalive`, etc.

Fix: call sdk.api_login() in the prepare_env_file session fixture so ~/.sky/user_hash is set to the server-side SA identity. The original file is backed up and restored after the session to avoid polluting subsequent tests on the same Buildkite agent.

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
