### PR TITLE
[Kubernetes] Surface pod/node diagnostics in cluster health events

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -3438,23 +3438,27 @@ def _summarize_pod_reasons(
     # 1. Node-level summary
     if node_issues:
         # Group by issue type (e.g., all NotReady together)
+        # Track affected pod count per issue type, not globally.
         by_issue: Dict[str, List[str]] = {}
-        total_affected = 0
+        affected_by_issue: Dict[str, int] = {}
         for node_name, info in node_issues.items():
             by_issue.setdefault(info['issue'], []).append(node_name)
-            total_affected += len(info['pods'])
+            affected_by_issue[info['issue']] = (
+                affected_by_issue.get(info['issue'], 0) + len(info['pods']))
 
         for issue, nodes in by_issue.items():
             names = sorted(nodes)
+            affected = affected_by_issue[issue]
             if len(names) == 1:
                 part = f'node {names[0]} is {issue}'
             else:
                 shown = names[:_MAX_NAMES_IN_SUMMARY]
                 name_list = ', '.join(shown)
                 if len(names) > _MAX_NAMES_IN_SUMMARY:
-                    name_list += f' + {len(names) - _MAX_NAMES_IN_SUMMARY} more'
+                    name_list += (
+                        f' + {len(names) - _MAX_NAMES_IN_SUMMARY} more')
                 part = f'{len(names)} nodes are {issue} ({name_list})'
-            part += f', affecting {total_affected}/{total_nodes} pods'
+            part += f', affecting {affected}/{total_nodes} pods'
             parts.append(part)
 
     # 2. Pod-level summary

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2721,7 +2721,7 @@ def _update_cluster_status(
         # to provide better diagnostics (e.g., "node X is NotReady").
         node_health: Optional[Dict[str, 'NodeHealthInfo']] = None
         if (ray_cluster_unhealthy and
-                repr(launched_resources.cloud) == 'Kubernetes'):
+                isinstance(launched_resources.cloud, clouds.Kubernetes)):
             unhealthy_pods = [
                 pod_name for pod_name, (_, reason) in node_statuses.items()
                 if reason is not None
@@ -3467,7 +3467,7 @@ def _summarize_pod_reasons(
             parts.append(part)
 
     # Collect pod names that are already explained by node issues
-    node_explained_pods: set = set()
+    node_explained_pods = set()
     if node_health:
         for info in node_health.values():
             node_explained_pods.update(info.pods)

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -84,6 +84,7 @@ if typing.TYPE_CHECKING:
     from sky import task as task_lib
     from sky.backends import cloud_vm_ray_backend
     from sky.backends import local_docker_backend
+    from sky.provision.kubernetes.instance import NodeHealthInfo
 else:
     yaml = adaptors_common.LazyImport('yaml')
     requests = adaptors_common.LazyImport('requests')
@@ -2718,7 +2719,7 @@ def _update_cluster_status(
 
         # For Kubernetes clusters with unhealthy pods, check node health
         # to provide better diagnostics (e.g., "node X is NotReady").
-        node_health: Optional[Dict[str, Dict[str, Any]]] = None
+        node_health: Optional[Dict[str, 'NodeHealthInfo']] = None
         if (ray_cluster_unhealthy and
                 repr(launched_resources.cloud) == 'Kubernetes'):
             unhealthy_pods = [
@@ -3419,7 +3420,7 @@ _MAX_NAMES_IN_SUMMARY = 3
 def _summarize_pod_reasons(
     node_statuses: Dict[str, Tuple[status_lib.ClusterStatus, Optional[str]]],
     total_pods: int,
-    node_health: Optional[Dict[str, Dict[str, Any]]] = None,
+    node_health: Optional[Dict[str, 'NodeHealthInfo']] = None,
 ) -> str:
     """Summarize per-pod reasons into a concise grouped message.
 
@@ -3433,7 +3434,7 @@ def _summarize_pod_reasons(
         total_pods: Total number of pods in the SkyPilot cluster.
         node_health: Optional structured node health data from
             get_node_health_for_cluster(). Maps node_name ->
-            {'issue': str, 'pods': [pod_name, ...]}.
+            NodeHealthInfo.
 
     Returns:
         A summarized string, or '' if no reasons found.
@@ -3446,10 +3447,9 @@ def _summarize_pod_reasons(
         by_issue: Dict[str, List[str]] = {}
         affected_by_issue: Dict[str, int] = {}
         for node_name, info in node_health.items():
-            issue = info['issue']
-            by_issue.setdefault(issue, []).append(node_name)
-            affected_by_issue[issue] = (affected_by_issue.get(issue, 0) +
-                                        len(info['pods']))
+            by_issue.setdefault(info.issue, []).append(node_name)
+            affected_by_issue[info.issue] = (
+                affected_by_issue.get(info.issue, 0) + len(info.pods))
 
         for issue, nodes in by_issue.items():
             names = sorted(nodes)
@@ -3467,10 +3467,10 @@ def _summarize_pod_reasons(
             parts.append(part)
 
     # Collect pod names that are already explained by node issues
-    node_explained_pods = set()
+    node_explained_pods: set = set()
     if node_health:
         for info in node_health.values():
-            node_explained_pods.update(info['pods'])
+            node_explained_pods.update(info.pods)
 
     # 2. Pod-level summary (pods not already explained by node issues)
     pod_issues: Dict[str, List[str]] = {}

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2712,13 +2712,20 @@ def _update_cluster_status(
         # earlier. So if all_nodes_up is True and we are here, it means the ray
         # cluster must have been unhealthy.
         ray_cluster_unhealthy = all_nodes_up
-        status_reason = ', '.join(
-            [status[1] for status in node_statuses if status[1] is not None])
+        status_reason = _summarize_pod_reasons(node_statuses,
+                                               handle.launched_nodes)
 
         if some_nodes_terminated:
             init_reason = 'one or more nodes terminated'
         elif ray_cluster_unhealthy:
-            init_reason = f'ray cluster is unhealthy ({ray_status_details})'
+            if status_reason:
+                # K8s diagnostics explain the issue — lead with that
+                # instead of the generic "ray cluster is unhealthy" message.
+                init_reason = status_reason
+                status_reason = ''  # already incorporated
+            else:
+                init_reason = (
+                    f'ray cluster is unhealthy ({ray_status_details})')
         elif some_nodes_not_stopped:
             init_reason = 'some but not all nodes are stopped'
         logger.debug('The cluster is abnormal. Setting to INIT status. '

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -3387,7 +3387,9 @@ def _get_glob_clusters(
 
 
 _MAX_NAMES_IN_SUMMARY = 3
-_NODE_ISSUE_PATTERN = re.compile(r'; node (\S+) is (.+)$')
+# Separator used by query_instances to append node info to pod reasons.
+# Format: '{pod}: {pod_reason}; node {name} is {issue}'
+_NODE_ISSUE_SEPARATOR = '; node '
 
 
 def _summarize_pod_reasons(
@@ -3407,8 +3409,10 @@ def _summarize_pod_reasons(
     Returns:
         A summarized string, or '' if no reasons found.
     """
-    # Separate node-level and pod-level issues
+    # Separate node-level and pod-level issues.
     # Reason format: '{pod}: {pod_reason}; node {name} is {issue}'
+    # We split on _NODE_ISSUE_SEPARATOR to extract node info rather than
+    # using regex, since the format is fully controlled by query_instances.
     node_issues: Dict[str, Dict[str, Any]] = {}  # node -> {issue, pods}
     pod_issues: Dict[str, List[str]] = {}  # reason -> [pod_names]
 
@@ -3420,10 +3424,11 @@ def _summarize_pod_reasons(
         pod_name = reason.split(':')[0].strip()
 
         # Check for node-level issue suffix
-        node_match = _NODE_ISSUE_PATTERN.search(reason)
-        if node_match:
-            node_name = node_match.group(1)
-            node_issue = node_match.group(2)
+        if _NODE_ISSUE_SEPARATOR in reason:
+            # Split: 'pod: reason; node X is Y' -> 'node X is Y'
+            node_part = reason.rsplit(_NODE_ISSUE_SEPARATOR, 1)[1]
+            # Split: 'X is Y' -> node_name='X', node_issue='Y'
+            node_name, node_issue = node_part.split(' is ', 1)
             if node_name not in node_issues:
                 node_issues[node_name] = {'issue': node_issue, 'pods': []}
             node_issues[node_name]['pods'].append(pod_name)
@@ -3458,7 +3463,7 @@ def _summarize_pod_reasons(
                     name_list += (
                         f' + {len(names) - _MAX_NAMES_IN_SUMMARY} more')
                 part = f'{len(names)} nodes are {issue} ({name_list})'
-            part += f', affecting {affected}/{total_nodes} pods'
+            part += f', affecting {affected} out of {total_nodes} pods'
             parts.append(part)
 
     # 2. Pod-level summary

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -3418,7 +3418,7 @@ _MAX_NAMES_IN_SUMMARY = 3
 
 def _summarize_pod_reasons(
     node_statuses: Dict[str, Tuple[status_lib.ClusterStatus, Optional[str]]],
-    total_nodes: int,
+    total_pods: int,
     node_health: Optional[Dict[str, Dict[str, Any]]] = None,
 ) -> str:
     """Summarize per-pod reasons into a concise grouped message.
@@ -3430,7 +3430,7 @@ def _summarize_pod_reasons(
     Args:
         node_statuses: Dict mapping instance/pod name to (status, reason)
             as returned by _query_cluster_status_via_cloud_api.
-        total_nodes: Total number of nodes in the cluster.
+        total_pods: Total number of pods in the SkyPilot cluster.
         node_health: Optional structured node health data from
             get_node_health_for_cluster(). Maps node_name ->
             {'issue': str, 'pods': [pod_name, ...]}.
@@ -3463,7 +3463,7 @@ def _summarize_pod_reasons(
                     name_list += (
                         f' + {len(names) - _MAX_NAMES_IN_SUMMARY} more')
                 part = f'{len(names)} nodes are {issue} ({name_list})'
-            part += f', affecting {affected} out of {total_nodes} pods'
+            part += f', affecting {affected} out of {total_pods} pods'
             parts.append(part)
 
     # Collect pod names that are already explained by node issues

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2726,14 +2726,12 @@ def _update_cluster_status(
             if unhealthy_pods:
                 try:
                     # pylint: disable=import-outside-toplevel
-                    import importlib
-                    k8s_mod = importlib.import_module(
-                        'sky.provision.kubernetes.instance')
+                    from sky.provision.kubernetes import instance as k8s_instance  # isort: skip  # noqa: E501
                     ray_config = global_user_state.get_cluster_yaml_dict(
                         handle.cluster_yaml)
-                    node_health = (k8s_mod.get_node_health_for_cluster(
+                    node_health = k8s_instance.get_node_health_for_cluster(
                         handle.cluster_name_on_cloud, ray_config['provider'],
-                        unhealthy_pods))
+                        unhealthy_pods)
                 except Exception as e:  # pylint: disable=broad-except
                     logger.debug('Failed to get node health for '
                                  f'{cluster_name!r}: {e}')

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -42,6 +42,7 @@ from sky.adaptors import common as adaptors_common
 from sky.jobs import utils as managed_job_utils
 from sky.provision import common as provision_common
 from sky.provision import instance_setup
+from sky.provision.kubernetes import instance as k8s_instance
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.serve import serve_utils
 from sky.server.requests import requests as requests_lib
@@ -2728,8 +2729,6 @@ def _update_cluster_status(
             ]
             if unhealthy_pods:
                 try:
-                    # pylint: disable=import-outside-toplevel
-                    from sky.provision.kubernetes import instance as k8s_instance  # isort: skip  # noqa: E501
                     ray_config = global_user_state.get_cluster_yaml_dict(
                         handle.cluster_yaml)
                     node_health = k8s_instance.get_node_health_for_cluster(

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -3379,6 +3379,92 @@ def _get_glob_clusters(
     return list(set(glob_clusters))
 
 
+_MAX_NAMES_IN_SUMMARY = 3
+_NODE_ISSUE_PATTERN = re.compile(r'; node (\S+) is (.+)$')
+
+
+def _summarize_pod_reasons(
+    node_statuses: List[Tuple[status_lib.ClusterStatus, Optional[str]]],
+    total_nodes: int,
+) -> str:
+    """Summarize per-pod reasons into a concise grouped message.
+
+    Groups issues by root cause:
+    1. Node-level issues (deduplicated by node name, counted by pods affected)
+    2. Pod-level issues (grouped by reason)
+
+    Args:
+        node_statuses: List of (status, reason) tuples from query_instances.
+        total_nodes: Total number of nodes in the cluster (for "N/M pods").
+
+    Returns:
+        A summarized string, or '' if no reasons found.
+    """
+    # Separate node-level and pod-level issues
+    # Reason format: '{pod}: {pod_reason}; node {name} is {issue}'
+    node_issues: Dict[str, Dict[str, Any]] = {}  # node -> {issue, pods}
+    pod_issues: Dict[str, List[str]] = {}  # reason -> [pod_names]
+
+    for _, reason in node_statuses:
+        if reason is None:
+            continue
+
+        # Extract pod name (everything before the first ':')
+        pod_name = reason.split(':')[0].strip()
+
+        # Check for node-level issue suffix
+        node_match = _NODE_ISSUE_PATTERN.search(reason)
+        if node_match:
+            node_name = node_match.group(1)
+            node_issue = node_match.group(2)
+            if node_name not in node_issues:
+                node_issues[node_name] = {'issue': node_issue, 'pods': []}
+            node_issues[node_name]['pods'].append(pod_name)
+        else:
+            # Pod-level issue — extract the reason part after pod name
+            pod_reason = (reason.split(':', 1)[1].strip()
+                          if ':' in reason else reason)
+            pod_issues.setdefault(pod_reason, []).append(pod_name)
+
+    parts = []
+
+    # 1. Node-level summary
+    if node_issues:
+        # Group by issue type (e.g., all NotReady together)
+        by_issue: Dict[str, List[str]] = {}
+        total_affected = 0
+        for node_name, info in node_issues.items():
+            by_issue.setdefault(info['issue'], []).append(node_name)
+            total_affected += len(info['pods'])
+
+        for issue, nodes in by_issue.items():
+            names = sorted(nodes)
+            if len(names) == 1:
+                part = f'node {names[0]} is {issue}'
+            else:
+                shown = names[:_MAX_NAMES_IN_SUMMARY]
+                name_list = ', '.join(shown)
+                if len(names) > _MAX_NAMES_IN_SUMMARY:
+                    name_list += f' + {len(names) - _MAX_NAMES_IN_SUMMARY} more'
+                part = f'{len(names)} nodes are {issue} ({name_list})'
+            part += f', affecting {total_affected}/{total_nodes} pods'
+            parts.append(part)
+
+    # 2. Pod-level summary
+    for reason, pods in pod_issues.items():
+        names = sorted(pods)
+        if len(names) == 1:
+            parts.append(f'{names[0]} is not ready ({reason})')
+        else:
+            shown = names[:_MAX_NAMES_IN_SUMMARY]
+            name_list = ', '.join(shown)
+            if len(names) > _MAX_NAMES_IN_SUMMARY:
+                name_list += f' + {len(names) - _MAX_NAMES_IN_SUMMARY} more'
+            parts.append(f'{len(names)} pods not ready ({name_list}): {reason}')
+
+    return '; '.join(parts)
+
+
 def _refresh_cluster(
         cluster_name: str,
         force_refresh_statuses: Optional[Set[status_lib.ClusterStatus]],

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2144,9 +2144,11 @@ def tag_filter_for_cluster(cluster_name: str) -> Dict[str, str]:
 def _query_cluster_status_via_cloud_api(
     handle: 'cloud_vm_ray_backend.CloudVmRayResourceHandle',
     retry_if_missing: bool,
-) -> List[Tuple[status_lib.ClusterStatus, Optional[str]]]:
-    """Returns the status of the cluster as a list of tuples corresponding
-    to the node status and an optional reason string for said status.
+) -> Dict[str, Tuple[status_lib.ClusterStatus, Optional[str]]]:
+    """Returns a dict mapping instance/pod name to (status, reason).
+
+    For the new provisioner API, keys are instance IDs (e.g., pod names
+    on Kubernetes). For the legacy query_status API, keys are str(index).
 
     Raises:
         exceptions.ClusterStatusFetchingError: the cluster status cannot be
@@ -2178,7 +2180,6 @@ def _query_cluster_status_via_cloud_api(
             logger.debug(f'Querying {cloud_name} cluster '
                          f'{cluster_name_in_hint} '
                          f'status:\n{pprint.pformat(node_status_dict)}')
-            node_statuses = list(node_status_dict.values())
         except Exception as e:  # pylint: disable=broad-except
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.ClusterStatusFetchingError(
@@ -2193,11 +2194,13 @@ def _query_cluster_status_via_cloud_api(
         # TODO (kyuds): refactor cloud.query_status api to include reason.
         # Currently not refactoring as this API is actually supposed to be
         # deprecated soon.
-        node_statuses = cloud.query_status(
+        statuses = cloud.query_status(
             cluster_name_on_cloud,
             tag_filter_for_cluster(cluster_name_on_cloud), region, zone)
-        node_statuses = [(status, None) for status in node_statuses]
-    return node_statuses
+        node_status_dict = {
+            str(i): (status, None) for i, status in enumerate(statuses)
+        }
+    return node_status_dict
 
 
 def _query_cluster_info_via_cloud_api(
@@ -2407,7 +2410,7 @@ def _update_cluster_status(
         handle, retry_if_missing=retry_if_missing)
 
     all_nodes_up = (all(status[0] == status_lib.ClusterStatus.UP
-                        for status in node_statuses) and
+                        for status in node_statuses.values()) and
                     len(node_statuses) == handle.launched_nodes)
 
     external_cluster_failures = ExternalFailureSource.get(
@@ -2704,7 +2707,7 @@ def _update_cluster_status(
     #      autostopping/autodowning.
     some_nodes_terminated = 0 < len(node_statuses) < handle.launched_nodes
     some_nodes_not_stopped = any(status[0] != status_lib.ClusterStatus.STOPPED
-                                 for status in node_statuses)
+                                 for status in node_statuses.values())
     is_abnormal = (some_nodes_terminated or some_nodes_not_stopped)
 
     if is_abnormal and not external_cluster_failures:
@@ -2719,9 +2722,8 @@ def _update_cluster_status(
         if (ray_cluster_unhealthy and
                 repr(launched_resources.cloud) == 'Kubernetes'):
             unhealthy_pods = [
-                status[1].split(':')[0].strip()
-                for status in node_statuses
-                if status[1] is not None
+                pod_name for pod_name, (_, reason) in node_statuses.items()
+                if reason is not None
             ]
             if unhealthy_pods:
                 try:
@@ -3415,7 +3417,7 @@ _MAX_NAMES_IN_SUMMARY = 3
 
 
 def _summarize_pod_reasons(
-    node_statuses: List[Tuple[status_lib.ClusterStatus, Optional[str]]],
+    node_statuses: Dict[str, Tuple[status_lib.ClusterStatus, Optional[str]]],
     total_nodes: int,
     node_health: Optional[Dict[str, Dict[str, Any]]] = None,
 ) -> str:
@@ -3423,11 +3425,11 @@ def _summarize_pod_reasons(
 
     Groups issues by root cause:
     1. Node-level issues (from node_health dict, deduplicated by node)
-    2. Pod-level issues (from reason strings, grouped by reason)
+    2. Pod-level issues (grouped by reason, pod names from dict keys)
 
     Args:
-        node_statuses: List of (status, reason) tuples from query_instances.
-            Reason format: '{pod_name}: {pod_reason}'.
+        node_statuses: Dict mapping instance/pod name to (status, reason)
+            as returned by _query_cluster_status_via_cloud_api.
         total_nodes: Total number of nodes in the cluster.
         node_health: Optional structured node health data from
             get_node_health_for_cluster(). Maps node_name ->
@@ -3438,7 +3440,7 @@ def _summarize_pod_reasons(
     """
     parts = []
 
-    # 1. Node-level summary (from structured data — no string parsing)
+    # 1. Node-level summary (from structured data)
     if node_health:
         # Group by issue type (e.g., all NotReady together)
         by_issue: Dict[str, List[str]] = {}
@@ -3472,15 +3474,12 @@ def _summarize_pod_reasons(
 
     # 2. Pod-level summary (pods not already explained by node issues)
     pod_issues: Dict[str, List[str]] = {}
-    for _, reason in node_statuses:
+    for pod_name, (_, reason) in node_statuses.items():
         if reason is None:
             continue
-        pod_name = reason.split(':')[0].strip()
         if pod_name in node_explained_pods:
             continue
-        pod_reason = (reason.split(':', 1)[1].strip()
-                      if ':' in reason else reason)
-        pod_issues.setdefault(pod_reason, []).append(pod_name)
+        pod_issues.setdefault(reason, []).append(pod_name)
 
     for reason, pods in pod_issues.items():
         names = sorted(pods)

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2712,8 +2712,35 @@ def _update_cluster_status(
         # earlier. So if all_nodes_up is True and we are here, it means the ray
         # cluster must have been unhealthy.
         ray_cluster_unhealthy = all_nodes_up
+
+        # For Kubernetes clusters with unhealthy pods, check node health
+        # to provide better diagnostics (e.g., "node X is NotReady").
+        node_health: Optional[Dict[str, Dict[str, Any]]] = None
+        if (ray_cluster_unhealthy and
+                repr(launched_resources.cloud) == 'Kubernetes'):
+            unhealthy_pods = [
+                status[1].split(':')[0].strip()
+                for status in node_statuses
+                if status[1] is not None
+            ]
+            if unhealthy_pods:
+                try:
+                    # pylint: disable=import-outside-toplevel
+                    import importlib
+                    k8s_mod = importlib.import_module(
+                        'sky.provision.kubernetes.instance')
+                    ray_config = global_user_state.get_cluster_yaml_dict(
+                        handle.cluster_yaml)
+                    node_health = (k8s_mod.get_node_health_for_cluster(
+                        handle.cluster_name_on_cloud, ray_config['provider'],
+                        unhealthy_pods))
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.debug('Failed to get node health for '
+                                 f'{cluster_name!r}: {e}')
+
         status_reason = _summarize_pod_reasons(node_statuses,
-                                               handle.launched_nodes)
+                                               handle.launched_nodes,
+                                               node_health)
 
         if some_nodes_terminated:
             init_reason = 'one or more nodes terminated'
@@ -3387,69 +3414,42 @@ def _get_glob_clusters(
 
 
 _MAX_NAMES_IN_SUMMARY = 3
-# Separator used by query_instances to append node info to pod reasons.
-# Format: '{pod}: {pod_reason}; node {name} is {issue}'
-_NODE_ISSUE_SEPARATOR = '; node '
 
 
 def _summarize_pod_reasons(
     node_statuses: List[Tuple[status_lib.ClusterStatus, Optional[str]]],
     total_nodes: int,
+    node_health: Optional[Dict[str, Dict[str, Any]]] = None,
 ) -> str:
     """Summarize per-pod reasons into a concise grouped message.
 
     Groups issues by root cause:
-    1. Node-level issues (deduplicated by node name, counted by pods affected)
-    2. Pod-level issues (grouped by reason)
+    1. Node-level issues (from node_health dict, deduplicated by node)
+    2. Pod-level issues (from reason strings, grouped by reason)
 
     Args:
         node_statuses: List of (status, reason) tuples from query_instances.
-        total_nodes: Total number of nodes in the cluster (for "N/M pods").
+            Reason format: '{pod_name}: {pod_reason}'.
+        total_nodes: Total number of nodes in the cluster.
+        node_health: Optional structured node health data from
+            get_node_health_for_cluster(). Maps node_name ->
+            {'issue': str, 'pods': [pod_name, ...]}.
 
     Returns:
         A summarized string, or '' if no reasons found.
     """
-    # Separate node-level and pod-level issues.
-    # Reason format: '{pod}: {pod_reason}; node {name} is {issue}'
-    # We split on _NODE_ISSUE_SEPARATOR to extract node info rather than
-    # using regex, since the format is fully controlled by query_instances.
-    node_issues: Dict[str, Dict[str, Any]] = {}  # node -> {issue, pods}
-    pod_issues: Dict[str, List[str]] = {}  # reason -> [pod_names]
-
-    for _, reason in node_statuses:
-        if reason is None:
-            continue
-
-        # Extract pod name (everything before the first ':')
-        pod_name = reason.split(':')[0].strip()
-
-        # Check for node-level issue suffix
-        if _NODE_ISSUE_SEPARATOR in reason:
-            # Split: 'pod: reason; node X is Y' -> 'node X is Y'
-            node_part = reason.rsplit(_NODE_ISSUE_SEPARATOR, 1)[1]
-            # Split: 'X is Y' -> node_name='X', node_issue='Y'
-            node_name, node_issue = node_part.split(' is ', 1)
-            if node_name not in node_issues:
-                node_issues[node_name] = {'issue': node_issue, 'pods': []}
-            node_issues[node_name]['pods'].append(pod_name)
-        else:
-            # Pod-level issue — extract the reason part after pod name
-            pod_reason = (reason.split(':', 1)[1].strip()
-                          if ':' in reason else reason)
-            pod_issues.setdefault(pod_reason, []).append(pod_name)
-
     parts = []
 
-    # 1. Node-level summary
-    if node_issues:
+    # 1. Node-level summary (from structured data — no string parsing)
+    if node_health:
         # Group by issue type (e.g., all NotReady together)
-        # Track affected pod count per issue type, not globally.
         by_issue: Dict[str, List[str]] = {}
         affected_by_issue: Dict[str, int] = {}
-        for node_name, info in node_issues.items():
-            by_issue.setdefault(info['issue'], []).append(node_name)
-            affected_by_issue[info['issue']] = (
-                affected_by_issue.get(info['issue'], 0) + len(info['pods']))
+        for node_name, info in node_health.items():
+            issue = info['issue']
+            by_issue.setdefault(issue, []).append(node_name)
+            affected_by_issue[issue] = (affected_by_issue.get(issue, 0) +
+                                        len(info['pods']))
 
         for issue, nodes in by_issue.items():
             names = sorted(nodes)
@@ -3466,7 +3466,24 @@ def _summarize_pod_reasons(
             part += f', affecting {affected} out of {total_nodes} pods'
             parts.append(part)
 
-    # 2. Pod-level summary
+    # Collect pod names that are already explained by node issues
+    node_explained_pods = set()
+    if node_health:
+        for info in node_health.values():
+            node_explained_pods.update(info['pods'])
+
+    # 2. Pod-level summary (pods not already explained by node issues)
+    pod_issues: Dict[str, List[str]] = {}
+    for _, reason in node_statuses:
+        if reason is None:
+            continue
+        pod_name = reason.split(':')[0].strip()
+        if pod_name in node_explained_pods:
+            continue
+        pod_reason = (reason.split(':', 1)[1].strip()
+                      if ':' in reason else reason)
+        pod_issues.setdefault(pod_reason, []).append(pod_name)
+
     for reason, pods in pod_issues.items():
         names = sorted(pods)
         if len(names) == 1:

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -2288,6 +2288,7 @@ def query_instances(
     # Check if the pods are running or pending
     cluster_status: Dict[str, Tuple[Optional['status_lib.ClusterStatus'],
                                     Optional[str]]] = {}
+    pod_node_map: Dict[str, Optional[str]] = {}  # pod_name -> node_name
     for pod in pods:
         phase = pod.status.phase
         is_terminating = pod.metadata.deletion_timestamp is not None
@@ -2296,12 +2297,15 @@ def query_instances(
         if phase in ('Failed', 'Unknown') or is_terminating:
             reason = _get_pod_termination_reason(pod, cluster_name)
             logger.debug(f'Pod Status ({phase}) Reason(s): {reason}')
+        elif phase == 'Running':
+            reason = _get_pod_health_issues(pod)
         if non_terminated_only and pod_status is None:
             logger.debug(f'Pod {pod.metadata.name} is terminated, but '
                          'query_instances is called with '
                          f'non_terminated_only=True. Phase: {phase}')
             continue
         pod_name = pod.metadata.name
+        pod_node_map[pod_name] = getattr(pod.spec, 'node_name', None)
         reason = f'{pod_name}: {reason}' if reason is not None else None
         cluster_status[pod_name] = (pod_status, reason)
 
@@ -2327,6 +2331,26 @@ def query_instances(
                       if reason is not None else None)
             if not non_terminated_only:
                 cluster_status[target_pod_name] = (None, reason)
+
+    # Check node health for Running pods that have issues.
+    # This is conditional — only triggered when a pod reports a problem,
+    # so healthy clusters pay zero overhead.
+    unhealthy_pod_nodes = {
+        pod_name: pod_node_map.get(pod_name)
+        for pod_name, (pod_status, pod_reason) in cluster_status.items()
+        if (pod_reason is not None and pod_status == status_lib.ClusterStatus.UP
+           )
+    }
+    if unhealthy_pod_nodes:
+        unique_nodes = {n for n in unhealthy_pod_nodes.values() if n}
+        if unique_nodes:
+            node_issues = _check_nodes_health(context, unique_nodes)
+            for pod_name, node_name in unhealthy_pod_nodes.items():
+                if node_name and node_name in node_issues:
+                    existing_reason = cluster_status[pod_name][1]
+                    cluster_status[pod_name] = (
+                        cluster_status[pod_name][0], f'{existing_reason}; '
+                        f'node {node_name} is {node_issues[node_name]}')
 
     return cluster_status
 

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -23,6 +23,7 @@ from sky.utils import command_runner
 from sky.utils import common_utils
 from sky.utils import config_utils
 from sky.utils import kubernetes_enums
+from sky.utils import plugin_extensions
 from sky.utils import rich_utils
 from sky.utils import status_lib
 from sky.utils import subprocess_utils
@@ -1836,6 +1837,58 @@ def _get_pod_health_issues(pod: Any) -> Optional[str]:
         parts.append('; '.join(container_issues))
 
     return '; '.join(parts)
+
+
+def _check_nodes_health(
+    context: Optional[str],
+    node_names: set,
+) -> Dict[str, str]:
+    """Check health of specific Kubernetes nodes.
+
+    Tries the NodeInfoSource plugin first (fast, cached), then falls back
+    to direct Kubernetes API calls.
+
+    Args:
+        context: Kubernetes context name.
+        node_names: Set of node names to check.
+
+    Returns:
+        Dict mapping node_name -> issue description for unhealthy nodes.
+        Healthy nodes are omitted.
+    """
+    if not node_names:
+        return {}
+
+    issues: Dict[str, str] = {}
+
+    # Try NodeInfoSource plugin first (node-info-service sidecar).
+    # get() safely returns None when no provider is registered.
+    node_info = plugin_extensions.NodeInfoSource.get(
+        context) if context is not None else None
+    if node_info is not None:
+        for name in node_names:
+            info = node_info.node_info_dict.get(name)
+            if info is None:
+                continue
+            if not info.is_ready:
+                issues[name] = 'NotReady'
+            elif info.is_cordoned:
+                issues[name] = 'cordoned'
+        return issues
+
+    # Fallback: direct Kubernetes API
+    for name in sorted(node_names):
+        try:
+            node = kubernetes.core_api(context).read_node(
+                name, _request_timeout=kubernetes.API_TIMEOUT)
+            for condition in (node.status.conditions or []):
+                if condition.type == 'Ready' and condition.status != 'True':
+                    issues[name] = 'NotReady'
+                    break
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Failed to read node {name}: {e}')
+
+    return issues
 
 
 def _get_pod_termination_reason(pod: Any, cluster_name: str) -> str:

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1831,7 +1831,7 @@ def _get_pod_health_issues(pod: Any) -> Optional[str]:
             container_issues.append(waiting.reason)
         elif terminated and terminated.exit_code != 0:
             container_issues.append(f'{terminated.reason or "terminated"}'
-                                    f'(exit code {terminated.exit_code})')
+                                    f' (exit code {terminated.exit_code})')
 
     if container_issues:
         parts.append('; '.join(container_issues))
@@ -1881,9 +1881,13 @@ def _check_nodes_health(
         try:
             node = kubernetes.core_api(context).read_node(
                 name, _request_timeout=kubernetes.API_TIMEOUT)
+            # Check NotReady first (more severe than cordoned)
             for condition in (node.status.conditions or []):
                 if condition.type == 'Ready' and condition.status != 'True':
                     return (name, 'NotReady')
+            # Check if node is cordoned (unschedulable)
+            if getattr(node.spec, 'unschedulable', False):
+                return (name, 'cordoned')
         except Exception as e:  # pylint: disable=broad-except
             logger.debug(f'Failed to read node {name}: {e}')
         return None

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -5,7 +5,7 @@ import json
 import re
 import sys
 import time
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 from sky import exceptions
 from sky import global_user_state
@@ -1793,6 +1793,14 @@ def get_cluster_info(
         provider_config=provider_config)
 
 
+class NodeHealthInfo:
+    """Health info for a single Kubernetes node."""
+
+    def __init__(self, issue: str, pods: List[str]):
+        self.issue = issue
+        self.pods = pods
+
+
 def _get_pod_health_issues(pod: Any) -> Optional[str]:
     """Check a Running pod for health issues.
 
@@ -1841,7 +1849,7 @@ def _get_pod_health_issues(pod: Any) -> Optional[str]:
 
 def _check_nodes_health(
     context: Optional[str],
-    node_names: set,
+    node_names: Set[str],
 ) -> Dict[str, str]:
     """Check health of specific Kubernetes nodes.
 
@@ -1909,7 +1917,7 @@ def get_node_health_for_cluster(
     cluster_name_on_cloud: str,
     provider_config: Dict[str, Any],
     unhealthy_pod_names: List[str],
-) -> Dict[str, Dict[str, Any]]:
+) -> Dict[str, NodeHealthInfo]:
     """Check node health for specific unhealthy pods in a cluster.
 
     Fetches pods to determine which nodes they run on, then checks
@@ -1921,8 +1929,7 @@ def get_node_health_for_cluster(
         unhealthy_pod_names: Pod names that have health issues.
 
     Returns:
-        Dict mapping node_name -> {'issue': str, 'pods': [pod_name, ...]}.
-        Only unhealthy nodes are included.
+        Dict mapping node_name -> NodeHealthInfo for unhealthy nodes.
     """
     namespace = kubernetes_utils.get_namespace_from_config(provider_config)
     context = kubernetes_utils.get_context_from_config(provider_config)
@@ -1950,16 +1957,14 @@ def get_node_health_for_cluster(
     if not node_issues:
         return {}
 
-    # Build structured result: node -> {issue, pods}
-    result: Dict[str, Dict[str, Any]] = {}
+    # Build structured result: node -> NodeHealthInfo
+    result: Dict[str, NodeHealthInfo] = {}
     for pod_name, node_name in pod_node_map.items():
         if node_name and node_name in node_issues:
             if node_name not in result:
-                result[node_name] = {
-                    'issue': node_issues[node_name],
-                    'pods': []
-                }
-            result[node_name]['pods'].append(pod_name)
+                result[node_name] = NodeHealthInfo(issue=node_issues[node_name],
+                                                   pods=[])
+            result[node_name].pods.append(pod_name)
 
     return result
 

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1810,7 +1810,8 @@ def _get_pod_health_issues(pod: Any) -> Optional[str]:
 
     Returns None if the pod appears healthy, or a descriptive reason string.
     """
-    conditions = getattr(pod.status, 'conditions', None)
+    pod_status = getattr(pod, 'status', None)
+    conditions = getattr(pod_status, 'conditions', None)
     if not conditions:
         return None
 
@@ -1828,7 +1829,7 @@ def _get_pod_health_issues(pod: Any) -> Optional[str]:
     parts = [f'pod not ready ({ready_reason})']
 
     # Check container statuses for more specific info
-    container_statuses = getattr(pod.status, 'container_statuses', None) or []
+    container_statuses = getattr(pod_status, 'container_statuses', None) or []
     container_issues = []
     for cs in container_statuses:
         if cs.ready:
@@ -1894,11 +1895,13 @@ def _check_nodes_health(
             node = kubernetes.core_api(context).read_node(
                 name, _request_timeout=kubernetes.API_TIMEOUT)
             # Check NotReady first (more severe than cordoned)
-            for condition in (node.status.conditions or []):
+            node_status = getattr(node, 'status', None)
+            for condition in (getattr(node_status, 'conditions', None) or []):
                 if condition.type == 'Ready' and condition.status != 'True':
                     return (name, 'NotReady')
             # Check if node is cordoned (unschedulable)
-            if getattr(node.spec, 'unschedulable', False):
+            node_spec = getattr(node, 'spec', None)
+            if getattr(node_spec, 'unschedulable', False):
                 return (name, 'cordoned')
         except Exception as e:  # pylint: disable=broad-except
             logger.debug(f'Failed to read node {name}: {e}')

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1863,6 +1863,10 @@ def _check_nodes_health(
 
     # Try NodeInfoSource plugin first (node-info-service sidecar).
     # get() safely returns None when no provider is registered.
+    # Note: if a node is in node_names but not in the cache, it's silently
+    # skipped (we don't fall back to the k8s API for missing entries). This
+    # is acceptable since this is diagnostic-only and doesn't affect the
+    # cluster status transition.
     node_info = plugin_extensions.NodeInfoSource.get(
         context) if context is not None else None
     if node_info is not None:

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1792,6 +1792,52 @@ def get_cluster_info(
         provider_config=provider_config)
 
 
+def _get_pod_health_issues(pod: Any) -> Optional[str]:
+    """Check a Running pod for health issues.
+
+    Examines pod conditions and container statuses to detect problems
+    that would explain why the pod is Running but not functioning
+    (e.g., Ready=False, CrashLoopBackOff).
+
+    Returns None if the pod appears healthy, or a descriptive reason string.
+    """
+    conditions = getattr(pod.status, 'conditions', None)
+    if not conditions:
+        return None
+
+    ready_condition = None
+    for condition in conditions:
+        if condition.type == 'Ready':
+            ready_condition = condition
+            break
+
+    if ready_condition is None or ready_condition.status == 'True':
+        return None
+
+    # Pod is not ready — build a reason string
+    ready_reason = ready_condition.reason or 'Unknown'
+    parts = [f'pod not ready ({ready_reason})']
+
+    # Check container statuses for more specific info
+    container_statuses = getattr(pod.status, 'container_statuses', None) or []
+    container_issues = []
+    for cs in container_statuses:
+        if cs.ready:
+            continue
+        waiting = getattr(cs.state, 'waiting', None)
+        terminated = getattr(cs.state, 'terminated', None)
+        if waiting and waiting.reason:
+            container_issues.append(waiting.reason)
+        elif terminated and terminated.exit_code != 0:
+            container_issues.append(f'{terminated.reason or "terminated"}'
+                                    f'(exit code {terminated.exit_code})')
+
+    if container_issues:
+        parts.append('; '.join(container_issues))
+
+    return '; '.join(parts)
+
+
 def _get_pod_termination_reason(pod: Any, cluster_name: str) -> str:
     """Get pod termination reason and write to cluster events.
 

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -2373,7 +2373,6 @@ def query_instances(
                          f'non_terminated_only=True. Phase: {phase}')
             continue
         pod_name = pod.metadata.name
-        reason = f'{pod_name}: {reason}' if reason is not None else None
         cluster_status[pod_name] = (pod_status, reason)
 
     # Find the list of pod names that should be there
@@ -2394,8 +2393,6 @@ def query_instances(
             reason = _get_pod_missing_reason(context, namespace, cluster_name,
                                              target_pod_name, first_pod)
             first_pod = False
-            reason = (f'{target_pod_name}: {reason}'
-                      if reason is not None else None)
             if not non_terminated_only:
                 cluster_status[target_pod_name] = (None, reason)
 

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1901,6 +1901,65 @@ def _check_nodes_health(
     return issues
 
 
+def get_node_health_for_cluster(
+    cluster_name_on_cloud: str,
+    provider_config: Dict[str, Any],
+    unhealthy_pod_names: List[str],
+) -> Dict[str, Dict[str, Any]]:
+    """Check node health for specific unhealthy pods in a cluster.
+
+    Fetches pods to determine which nodes they run on, then checks
+    those nodes' health via NodeInfoSource or the Kubernetes API.
+
+    Args:
+        cluster_name_on_cloud: The cluster name as known to the cloud.
+        provider_config: The provider config from the cluster YAML.
+        unhealthy_pod_names: Pod names that have health issues.
+
+    Returns:
+        Dict mapping node_name -> {'issue': str, 'pods': [pod_name, ...]}.
+        Only unhealthy nodes are included.
+    """
+    namespace = kubernetes_utils.get_namespace_from_config(provider_config)
+    context = kubernetes_utils.get_context_from_config(provider_config)
+    is_ssh = context.startswith('ssh-') if context else False
+    identity = 'SSH Node Pool' if is_ssh else 'Kubernetes cluster'
+    label_selector = (f'{constants.TAG_SKYPILOT_CLUSTER_NAME}='
+                      f'{cluster_name_on_cloud}')
+
+    pods = list_namespaced_pod(context, namespace, cluster_name_on_cloud,
+                               is_ssh, identity, label_selector)
+
+    # Build pod -> node mapping for unhealthy pods
+    unhealthy_set = set(unhealthy_pod_names)
+    pod_node_map: Dict[str, Optional[str]] = {}
+    for pod in pods:
+        name = pod.metadata.name
+        if name in unhealthy_set:
+            pod_node_map[name] = getattr(pod.spec, 'node_name', None)
+
+    unique_nodes = {n for n in pod_node_map.values() if n}
+    if not unique_nodes:
+        return {}
+
+    node_issues = _check_nodes_health(context, unique_nodes)
+    if not node_issues:
+        return {}
+
+    # Build structured result: node -> {issue, pods}
+    result: Dict[str, Dict[str, Any]] = {}
+    for pod_name, node_name in pod_node_map.items():
+        if node_name and node_name in node_issues:
+            if node_name not in result:
+                result[node_name] = {
+                    'issue': node_issues[node_name],
+                    'pods': []
+                }
+            result[node_name]['pods'].append(pod_name)
+
+    return result
+
+
 def _get_pod_termination_reason(pod: Any, cluster_name: str) -> str:
     """Get pod termination reason and write to cluster events.
 
@@ -2298,7 +2357,6 @@ def query_instances(
     # Check if the pods are running or pending
     cluster_status: Dict[str, Tuple[Optional['status_lib.ClusterStatus'],
                                     Optional[str]]] = {}
-    pod_node_map: Dict[str, Optional[str]] = {}  # pod_name -> node_name
     for pod in pods:
         phase = pod.status.phase
         is_terminating = pod.metadata.deletion_timestamp is not None
@@ -2315,7 +2373,6 @@ def query_instances(
                          f'non_terminated_only=True. Phase: {phase}')
             continue
         pod_name = pod.metadata.name
-        pod_node_map[pod_name] = getattr(pod.spec, 'node_name', None)
         reason = f'{pod_name}: {reason}' if reason is not None else None
         cluster_status[pod_name] = (pod_status, reason)
 
@@ -2341,26 +2398,6 @@ def query_instances(
                       if reason is not None else None)
             if not non_terminated_only:
                 cluster_status[target_pod_name] = (None, reason)
-
-    # Check node health for Running pods that have issues.
-    # This is conditional — only triggered when a pod reports a problem,
-    # so healthy clusters pay zero overhead.
-    unhealthy_pod_nodes = {
-        pod_name: pod_node_map.get(pod_name)
-        for pod_name, (pod_status, pod_reason) in cluster_status.items()
-        if (pod_reason is not None and pod_status == status_lib.ClusterStatus.UP
-           )
-    }
-    if unhealthy_pod_nodes:
-        unique_nodes = {n for n in unhealthy_pod_nodes.values() if n}
-        if unique_nodes:
-            node_issues = _check_nodes_health(context, unique_nodes)
-            for pod_name, node_name in unhealthy_pod_nodes.items():
-                if node_name and node_name in node_issues:
-                    existing_reason = cluster_status[pod_name][1]
-                    cluster_status[pod_name] = (
-                        cluster_status[pod_name][0], f'{existing_reason}; '
-                        f'node {node_name} is {node_issues[node_name]}')
 
     return cluster_status
 

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1876,17 +1876,23 @@ def _check_nodes_health(
                 issues[name] = 'cordoned'
         return issues
 
-    # Fallback: direct Kubernetes API
-    for name in sorted(node_names):
+    # Fallback: direct Kubernetes API (parallelized)
+    def _check_single_node(name: str) -> Optional[Tuple[str, str]]:
         try:
             node = kubernetes.core_api(context).read_node(
                 name, _request_timeout=kubernetes.API_TIMEOUT)
             for condition in (node.status.conditions or []):
                 if condition.type == 'Ready' and condition.status != 'True':
-                    issues[name] = 'NotReady'
-                    break
+                    return (name, 'NotReady')
         except Exception as e:  # pylint: disable=broad-except
             logger.debug(f'Failed to read node {name}: {e}')
+        return None
+
+    results = subprocess_utils.run_in_parallel(_check_single_node,
+                                               sorted(node_names))
+    for result in results:
+        if result is not None:
+            issues[result[0]] = result[1]
 
     return issues
 

--- a/tests/unit_tests/test_backend_utils_summarize.py
+++ b/tests/unit_tests/test_backend_utils_summarize.py
@@ -27,7 +27,7 @@ class TestSummarizePodReasons:
         result = _summarize_pod_reasons(statuses, 2)
         assert 'gke-node-1' in result
         assert 'NotReady' in result
-        assert '1/2 pods' in result
+        assert '1 out of 2 pods' in result
 
     def test_multiple_pods_same_node(self):
         statuses = [
@@ -36,7 +36,7 @@ class TestSummarizePodReasons:
         ]
         result = _summarize_pod_reasons(statuses, 4)
         assert 'gke-node-1' in result
-        assert '2/4 pods' in result
+        assert '2 out of 4 pods' in result
 
     def test_multiple_nodes_down(self):
         statuses = [
@@ -101,8 +101,8 @@ class TestSummarizePodReasons:
             (UP, 'w-2: pod not ready; node node-2 is cordoned'),
         ]
         result = _summarize_pod_reasons(statuses, 6)
-        assert '2/6 pods' in result  # NotReady affects 2 pods
-        assert '1/6 pods' in result  # cordoned affects 1 pod
+        assert '2 out of 6 pods' in result  # NotReady affects 2 pods
+        assert '1 out of 6 pods' in result  # cordoned affects 1 pod
 
 
 class TestStatusReasonIntegration:

--- a/tests/unit_tests/test_backend_utils_summarize.py
+++ b/tests/unit_tests/test_backend_utils_summarize.py
@@ -91,3 +91,36 @@ class TestSummarizePodReasons:
         result = _summarize_pod_reasons(statuses, 2)
         assert 'node-1' in result
         assert 'cordoned' in result
+
+
+class TestStatusReasonIntegration:
+    """Verify that _summarize_pod_reasons output is used correctly
+    when building the init_reason for ray_cluster_unhealthy."""
+
+    def test_status_reason_replaces_ray_message(self):
+        statuses = [
+            (UP, 'w-0: pod not ready; node node-1 is NotReady'),
+            (UP, None),
+        ]
+        summary = _summarize_pod_reasons(statuses, 2)
+        ray_cluster_unhealthy = True
+        ray_status_details = '1/2 ready'
+        if ray_cluster_unhealthy:
+            if summary:
+                init_reason = summary
+            else:
+                init_reason = f'ray cluster is unhealthy ({ray_status_details})'
+        assert 'ray' not in init_reason
+        assert 'node-1' in init_reason
+
+    def test_empty_summary_falls_back_to_ray(self):
+        statuses = [(UP, None), (UP, None)]
+        summary = _summarize_pod_reasons(statuses, 2)
+        ray_cluster_unhealthy = True
+        ray_status_details = '1/2 ready'
+        if ray_cluster_unhealthy:
+            if summary:
+                init_reason = summary
+            else:
+                init_reason = f'ray cluster is unhealthy ({ray_status_details})'
+        assert 'ray cluster is unhealthy' in init_reason

--- a/tests/unit_tests/test_backend_utils_summarize.py
+++ b/tests/unit_tests/test_backend_utils_summarize.py
@@ -1,0 +1,93 @@
+"""Tests for _summarize_pod_reasons in backend_utils."""
+from sky.backends.backend_utils import _summarize_pod_reasons
+from sky.utils import status_lib
+
+UP = status_lib.ClusterStatus.UP
+
+# _summarize_pod_reasons takes:
+#   node_statuses: List[Tuple[ClusterStatus, Optional[str]]]
+#   total_nodes: int
+# The reason strings follow the format from query_instances:
+#   '{pod_name}: {reason}; node {node_name} is {issue}'
+
+
+class TestSummarizePodReasons:
+
+    def test_no_reasons_returns_empty(self):
+        statuses = [(UP, None), (UP, None)]
+        assert _summarize_pod_reasons(statuses, 2) == ''
+
+    def test_single_node_issue(self):
+        statuses = [
+            (UP, None),
+            (UP, 'worker-0: pod not ready (ContainersNotReady); '
+             'node gke-node-1 is NotReady'),
+        ]
+        result = _summarize_pod_reasons(statuses, 2)
+        assert 'gke-node-1' in result
+        assert 'NotReady' in result
+        assert '1/2 pods' in result
+
+    def test_multiple_pods_same_node(self):
+        statuses = [
+            (UP, 'worker-0: pod not ready; node gke-node-1 is NotReady'),
+            (UP, 'worker-1: pod not ready; node gke-node-1 is NotReady'),
+        ]
+        result = _summarize_pod_reasons(statuses, 4)
+        assert 'gke-node-1' in result
+        assert '2/4 pods' in result
+
+    def test_multiple_nodes_down(self):
+        statuses = [
+            (UP, 'w-0: pod not ready; node node-1 is NotReady'),
+            (UP, 'w-1: pod not ready; node node-2 is NotReady'),
+            (UP, 'w-2: pod not ready; node node-3 is NotReady'),
+        ]
+        result = _summarize_pod_reasons(statuses, 6)
+        assert '3 nodes are NotReady' in result
+
+    def test_node_names_capped_at_3(self):
+        statuses = [(UP, f'w-{i}: pod not ready; node node-{i} is NotReady')
+                    for i in range(5)]
+        result = _summarize_pod_reasons(statuses, 10)
+        assert '5 nodes are NotReady' in result
+        assert '+ 2 more' in result
+
+    def test_pod_only_issue_single(self):
+        statuses = [
+            (UP, None),
+            (UP, 'worker-0: pod not ready (CrashLoopBackOff)'),
+        ]
+        result = _summarize_pod_reasons(statuses, 2)
+        assert 'worker-0' in result
+        assert 'CrashLoopBackOff' in result
+
+    def test_pod_only_issue_multiple_same_reason(self):
+        statuses = [
+            (UP, 'w-0: pod not ready (CrashLoopBackOff)'),
+            (UP, 'w-1: pod not ready (CrashLoopBackOff)'),
+            (UP, 'w-2: pod not ready (CrashLoopBackOff)'),
+            (UP, 'w-3: pod not ready (CrashLoopBackOff)'),
+        ]
+        result = _summarize_pod_reasons(statuses, 4)
+        assert '4 pods' in result
+        assert 'CrashLoopBackOff' in result
+
+    def test_mixed_node_and_pod_issues(self):
+        statuses = [
+            (UP, 'w-0: pod not ready; node node-1 is NotReady'),
+            (UP, 'w-1: pod not ready; node node-1 is NotReady'),
+            (UP, 'w-2: pod not ready (CrashLoopBackOff)'),
+        ]
+        result = _summarize_pod_reasons(statuses, 6)
+        assert 'node-1' in result
+        assert 'NotReady' in result
+        assert 'CrashLoopBackOff' in result
+
+    def test_cordoned_node(self):
+        statuses = [
+            (UP, 'w-0: pod not ready; node node-1 is cordoned'),
+        ]
+        result = _summarize_pod_reasons(statuses, 2)
+        assert 'node-1' in result
+        assert 'cordoned' in result

--- a/tests/unit_tests/test_backend_utils_summarize.py
+++ b/tests/unit_tests/test_backend_utils_summarize.py
@@ -1,8 +1,11 @@
 """Tests for _summarize_pod_reasons in backend_utils."""
 from sky.backends.backend_utils import _summarize_pod_reasons
+from sky.provision.kubernetes.instance import NodeHealthInfo
 from sky.utils import status_lib
 
 UP = status_lib.ClusterStatus.UP
+
+N = NodeHealthInfo  # Short alias for readability
 
 
 class TestSummarizePodReasons:
@@ -18,10 +21,7 @@ class TestSummarizePodReasons:
             'worker-0': (UP, 'pod not ready (ContainersNotReady)'),
         }
         node_health = {
-            'gke-node-1': {
-                'issue': 'NotReady',
-                'pods': ['worker-0']
-            },
+            'gke-node-1': N(issue='NotReady', pods=['worker-0']),
         }
         result = _summarize_pod_reasons(statuses, 2, node_health)
         assert 'gke-node-1' in result
@@ -34,10 +34,7 @@ class TestSummarizePodReasons:
             'worker-1': (UP, 'pod not ready'),
         }
         node_health = {
-            'gke-node-1': {
-                'issue': 'NotReady',
-                'pods': ['worker-0', 'worker-1']
-            },
+            'gke-node-1': N(issue='NotReady', pods=['worker-0', 'worker-1']),
         }
         result = _summarize_pod_reasons(statuses, 4, node_health)
         assert 'gke-node-1' in result
@@ -50,18 +47,9 @@ class TestSummarizePodReasons:
             'w-2': (UP, 'pod not ready'),
         }
         node_health = {
-            'node-1': {
-                'issue': 'NotReady',
-                'pods': ['w-0']
-            },
-            'node-2': {
-                'issue': 'NotReady',
-                'pods': ['w-1']
-            },
-            'node-3': {
-                'issue': 'NotReady',
-                'pods': ['w-2']
-            },
+            'node-1': N(issue='NotReady', pods=['w-0']),
+            'node-2': N(issue='NotReady', pods=['w-1']),
+            'node-3': N(issue='NotReady', pods=['w-2']),
         }
         result = _summarize_pod_reasons(statuses, 6, node_health)
         assert '3 nodes are NotReady' in result
@@ -69,10 +57,7 @@ class TestSummarizePodReasons:
     def test_node_names_capped_at_3(self):
         statuses = {f'w-{i}': (UP, 'pod not ready') for i in range(5)}
         node_health = {
-            f'node-{i}': {
-                'issue': 'NotReady',
-                'pods': [f'w-{i}']
-            } for i in range(5)
+            f'node-{i}': N(issue='NotReady', pods=[f'w-{i}']) for i in range(5)
         }
         result = _summarize_pod_reasons(statuses, 10, node_health)
         assert '5 nodes are NotReady' in result
@@ -104,10 +89,7 @@ class TestSummarizePodReasons:
             'w-2': (UP, 'pod not ready (CrashLoopBackOff)'),
         }
         node_health = {
-            'node-1': {
-                'issue': 'NotReady',
-                'pods': ['w-0', 'w-1']
-            },
+            'node-1': N(issue='NotReady', pods=['w-0', 'w-1']),
         }
         result = _summarize_pod_reasons(statuses, 6, node_health)
         assert 'node-1' in result
@@ -119,10 +101,7 @@ class TestSummarizePodReasons:
             'w-0': (UP, 'pod not ready'),
         }
         node_health = {
-            'node-1': {
-                'issue': 'cordoned',
-                'pods': ['w-0']
-            },
+            'node-1': N(issue='cordoned', pods=['w-0']),
         }
         result = _summarize_pod_reasons(statuses, 2, node_health)
         assert 'node-1' in result
@@ -136,14 +115,8 @@ class TestSummarizePodReasons:
             'w-2': (UP, 'pod not ready'),
         }
         node_health = {
-            'node-1': {
-                'issue': 'NotReady',
-                'pods': ['w-0', 'w-1']
-            },
-            'node-2': {
-                'issue': 'cordoned',
-                'pods': ['w-2']
-            },
+            'node-1': N(issue='NotReady', pods=['w-0', 'w-1']),
+            'node-2': N(issue='cordoned', pods=['w-2']),
         }
         result = _summarize_pod_reasons(statuses, 6, node_health)
         assert '2 out of 6 pods' in result
@@ -156,10 +129,7 @@ class TestSummarizePodReasons:
             'w-1': (UP, 'pod not ready (CrashLoopBackOff)'),
         }
         node_health = {
-            'node-1': {
-                'issue': 'NotReady',
-                'pods': ['w-0']
-            },
+            'node-1': N(issue='NotReady', pods=['w-0']),
         }
         result = _summarize_pod_reasons(statuses, 4, node_health)
         assert 'node-1' in result
@@ -178,10 +148,7 @@ class TestStatusReasonIntegration:
             'head': (UP, None),
         }
         node_health = {
-            'node-1': {
-                'issue': 'NotReady',
-                'pods': ['w-0']
-            },
+            'node-1': N(issue='NotReady', pods=['w-0']),
         }
         summary = _summarize_pod_reasons(statuses, 2, node_health)
         ray_cluster_unhealthy = True

--- a/tests/unit_tests/test_backend_utils_summarize.py
+++ b/tests/unit_tests/test_backend_utils_summarize.py
@@ -4,12 +4,6 @@ from sky.utils import status_lib
 
 UP = status_lib.ClusterStatus.UP
 
-# _summarize_pod_reasons takes:
-#   node_statuses: List[Tuple[ClusterStatus, Optional[str]]]
-#   total_nodes: int
-# The reason strings follow the format from query_instances:
-#   '{pod_name}: {reason}; node {node_name} is {issue}'
-
 
 class TestSummarizePodReasons:
     """Tests for _summarize_pod_reasons."""
@@ -21,40 +15,71 @@ class TestSummarizePodReasons:
     def test_single_node_issue(self):
         statuses = [
             (UP, None),
-            (UP, 'worker-0: pod not ready (ContainersNotReady); '
-             'node gke-node-1 is NotReady'),
+            (UP, 'worker-0: pod not ready (ContainersNotReady)'),
         ]
-        result = _summarize_pod_reasons(statuses, 2)
+        node_health = {
+            'gke-node-1': {
+                'issue': 'NotReady',
+                'pods': ['worker-0']
+            },
+        }
+        result = _summarize_pod_reasons(statuses, 2, node_health)
         assert 'gke-node-1' in result
         assert 'NotReady' in result
         assert '1 out of 2 pods' in result
 
     def test_multiple_pods_same_node(self):
         statuses = [
-            (UP, 'worker-0: pod not ready; node gke-node-1 is NotReady'),
-            (UP, 'worker-1: pod not ready; node gke-node-1 is NotReady'),
+            (UP, 'worker-0: pod not ready'),
+            (UP, 'worker-1: pod not ready'),
         ]
-        result = _summarize_pod_reasons(statuses, 4)
+        node_health = {
+            'gke-node-1': {
+                'issue': 'NotReady',
+                'pods': ['worker-0', 'worker-1']
+            },
+        }
+        result = _summarize_pod_reasons(statuses, 4, node_health)
         assert 'gke-node-1' in result
         assert '2 out of 4 pods' in result
 
     def test_multiple_nodes_down(self):
         statuses = [
-            (UP, 'w-0: pod not ready; node node-1 is NotReady'),
-            (UP, 'w-1: pod not ready; node node-2 is NotReady'),
-            (UP, 'w-2: pod not ready; node node-3 is NotReady'),
+            (UP, 'w-0: pod not ready'),
+            (UP, 'w-1: pod not ready'),
+            (UP, 'w-2: pod not ready'),
         ]
-        result = _summarize_pod_reasons(statuses, 6)
+        node_health = {
+            'node-1': {
+                'issue': 'NotReady',
+                'pods': ['w-0']
+            },
+            'node-2': {
+                'issue': 'NotReady',
+                'pods': ['w-1']
+            },
+            'node-3': {
+                'issue': 'NotReady',
+                'pods': ['w-2']
+            },
+        }
+        result = _summarize_pod_reasons(statuses, 6, node_health)
         assert '3 nodes are NotReady' in result
 
     def test_node_names_capped_at_3(self):
-        statuses = [(UP, f'w-{i}: pod not ready; node node-{i} is NotReady')
-                    for i in range(5)]
-        result = _summarize_pod_reasons(statuses, 10)
+        statuses = [(UP, f'w-{i}: pod not ready') for i in range(5)]
+        node_health = {
+            f'node-{i}': {
+                'issue': 'NotReady',
+                'pods': [f'w-{i}']
+            } for i in range(5)
+        }
+        result = _summarize_pod_reasons(statuses, 10, node_health)
         assert '5 nodes are NotReady' in result
         assert '+ 2 more' in result
 
     def test_pod_only_issue_single(self):
+        """Pod issue with no node health data."""
         statuses = [
             (UP, None),
             (UP, 'worker-0: pod not ready (CrashLoopBackOff)'),
@@ -75,34 +100,79 @@ class TestSummarizePodReasons:
         assert 'CrashLoopBackOff' in result
 
     def test_mixed_node_and_pod_issues(self):
+        """Node issues + pod-only issues in same cluster."""
         statuses = [
-            (UP, 'w-0: pod not ready; node node-1 is NotReady'),
-            (UP, 'w-1: pod not ready; node node-1 is NotReady'),
+            (UP, 'w-0: pod not ready'),
+            (UP, 'w-1: pod not ready'),
             (UP, 'w-2: pod not ready (CrashLoopBackOff)'),
         ]
-        result = _summarize_pod_reasons(statuses, 6)
+        node_health = {
+            'node-1': {
+                'issue': 'NotReady',
+                'pods': ['w-0', 'w-1']
+            },
+        }
+        result = _summarize_pod_reasons(statuses, 6, node_health)
         assert 'node-1' in result
         assert 'NotReady' in result
         assert 'CrashLoopBackOff' in result
+        # w-0 and w-1 should NOT appear in pod-level section
+        # (they're explained by node-1)
 
     def test_cordoned_node(self):
         statuses = [
-            (UP, 'w-0: pod not ready; node node-1 is cordoned'),
+            (UP, 'w-0: pod not ready'),
         ]
-        result = _summarize_pod_reasons(statuses, 2)
+        node_health = {
+            'node-1': {
+                'issue': 'cordoned',
+                'pods': ['w-0']
+            },
+        }
+        result = _summarize_pod_reasons(statuses, 2, node_health)
         assert 'node-1' in result
         assert 'cordoned' in result
 
     def test_mixed_issue_types_per_issue_pod_count(self):
         """Pod counts should be per issue type, not global."""
         statuses = [
-            (UP, 'w-0: pod not ready; node node-1 is NotReady'),
-            (UP, 'w-1: pod not ready; node node-1 is NotReady'),
-            (UP, 'w-2: pod not ready; node node-2 is cordoned'),
+            (UP, 'w-0: pod not ready'),
+            (UP, 'w-1: pod not ready'),
+            (UP, 'w-2: pod not ready'),
         ]
-        result = _summarize_pod_reasons(statuses, 6)
+        node_health = {
+            'node-1': {
+                'issue': 'NotReady',
+                'pods': ['w-0', 'w-1']
+            },
+            'node-2': {
+                'issue': 'cordoned',
+                'pods': ['w-2']
+            },
+        }
+        result = _summarize_pod_reasons(statuses, 6, node_health)
         assert '2 out of 6 pods' in result  # NotReady affects 2 pods
         assert '1 out of 6 pods' in result  # cordoned affects 1 pod
+
+    def test_node_explained_pods_excluded_from_pod_summary(self):
+        """Pods explained by node issues should not appear in pod section."""
+        statuses = [
+            (UP, 'w-0: pod not ready (ContainersNotReady)'),
+            (UP, 'w-1: pod not ready (CrashLoopBackOff)'),
+        ]
+        node_health = {
+            'node-1': {
+                'issue': 'NotReady',
+                'pods': ['w-0']
+            },
+        }
+        result = _summarize_pod_reasons(statuses, 4, node_health)
+        # w-0 is explained by node-1, w-1 is pod-level
+        assert 'node-1' in result
+        assert 'CrashLoopBackOff' in result
+        # w-0 should only appear in the node section, not the pod section
+        parts = result.split('; ')
+        assert len(parts) == 2
 
 
 class TestStatusReasonIntegration:
@@ -111,10 +181,16 @@ class TestStatusReasonIntegration:
 
     def test_status_reason_replaces_ray_message(self):
         statuses = [
-            (UP, 'w-0: pod not ready; node node-1 is NotReady'),
+            (UP, 'w-0: pod not ready (ContainersNotReady)'),
             (UP, None),
         ]
-        summary = _summarize_pod_reasons(statuses, 2)
+        node_health = {
+            'node-1': {
+                'issue': 'NotReady',
+                'pods': ['w-0']
+            },
+        }
+        summary = _summarize_pod_reasons(statuses, 2, node_health)
         ray_cluster_unhealthy = True
         ray_status_details = '1/2 ready'
         if ray_cluster_unhealthy:

--- a/tests/unit_tests/test_backend_utils_summarize.py
+++ b/tests/unit_tests/test_backend_utils_summarize.py
@@ -93,6 +93,17 @@ class TestSummarizePodReasons:
         assert 'node-1' in result
         assert 'cordoned' in result
 
+    def test_mixed_issue_types_per_issue_pod_count(self):
+        """Pod counts should be per issue type, not global."""
+        statuses = [
+            (UP, 'w-0: pod not ready; node node-1 is NotReady'),
+            (UP, 'w-1: pod not ready; node node-1 is NotReady'),
+            (UP, 'w-2: pod not ready; node node-2 is cordoned'),
+        ]
+        result = _summarize_pod_reasons(statuses, 6)
+        assert '2/6 pods' in result  # NotReady affects 2 pods
+        assert '1/6 pods' in result  # cordoned affects 1 pod
+
 
 class TestStatusReasonIntegration:
     """Verify that _summarize_pod_reasons output is used correctly

--- a/tests/unit_tests/test_backend_utils_summarize.py
+++ b/tests/unit_tests/test_backend_utils_summarize.py
@@ -12,6 +12,7 @@ UP = status_lib.ClusterStatus.UP
 
 
 class TestSummarizePodReasons:
+    """Tests for _summarize_pod_reasons."""
 
     def test_no_reasons_returns_empty(self):
         statuses = [(UP, None), (UP, None)]

--- a/tests/unit_tests/test_backend_utils_summarize.py
+++ b/tests/unit_tests/test_backend_utils_summarize.py
@@ -9,14 +9,14 @@ class TestSummarizePodReasons:
     """Tests for _summarize_pod_reasons."""
 
     def test_no_reasons_returns_empty(self):
-        statuses = [(UP, None), (UP, None)]
+        statuses = {'head': (UP, None), 'worker-0': (UP, None)}
         assert _summarize_pod_reasons(statuses, 2) == ''
 
     def test_single_node_issue(self):
-        statuses = [
-            (UP, None),
-            (UP, 'worker-0: pod not ready (ContainersNotReady)'),
-        ]
+        statuses = {
+            'head': (UP, None),
+            'worker-0': (UP, 'pod not ready (ContainersNotReady)'),
+        }
         node_health = {
             'gke-node-1': {
                 'issue': 'NotReady',
@@ -29,10 +29,10 @@ class TestSummarizePodReasons:
         assert '1 out of 2 pods' in result
 
     def test_multiple_pods_same_node(self):
-        statuses = [
-            (UP, 'worker-0: pod not ready'),
-            (UP, 'worker-1: pod not ready'),
-        ]
+        statuses = {
+            'worker-0': (UP, 'pod not ready'),
+            'worker-1': (UP, 'pod not ready'),
+        }
         node_health = {
             'gke-node-1': {
                 'issue': 'NotReady',
@@ -44,11 +44,11 @@ class TestSummarizePodReasons:
         assert '2 out of 4 pods' in result
 
     def test_multiple_nodes_down(self):
-        statuses = [
-            (UP, 'w-0: pod not ready'),
-            (UP, 'w-1: pod not ready'),
-            (UP, 'w-2: pod not ready'),
-        ]
+        statuses = {
+            'w-0': (UP, 'pod not ready'),
+            'w-1': (UP, 'pod not ready'),
+            'w-2': (UP, 'pod not ready'),
+        }
         node_health = {
             'node-1': {
                 'issue': 'NotReady',
@@ -67,7 +67,7 @@ class TestSummarizePodReasons:
         assert '3 nodes are NotReady' in result
 
     def test_node_names_capped_at_3(self):
-        statuses = [(UP, f'w-{i}: pod not ready') for i in range(5)]
+        statuses = {f'w-{i}': (UP, 'pod not ready') for i in range(5)}
         node_health = {
             f'node-{i}': {
                 'issue': 'NotReady',
@@ -80,32 +80,29 @@ class TestSummarizePodReasons:
 
     def test_pod_only_issue_single(self):
         """Pod issue with no node health data."""
-        statuses = [
-            (UP, None),
-            (UP, 'worker-0: pod not ready (CrashLoopBackOff)'),
-        ]
+        statuses = {
+            'head': (UP, None),
+            'worker-0': (UP, 'pod not ready (CrashLoopBackOff)'),
+        }
         result = _summarize_pod_reasons(statuses, 2)
         assert 'worker-0' in result
         assert 'CrashLoopBackOff' in result
 
     def test_pod_only_issue_multiple_same_reason(self):
-        statuses = [
-            (UP, 'w-0: pod not ready (CrashLoopBackOff)'),
-            (UP, 'w-1: pod not ready (CrashLoopBackOff)'),
-            (UP, 'w-2: pod not ready (CrashLoopBackOff)'),
-            (UP, 'w-3: pod not ready (CrashLoopBackOff)'),
-        ]
+        statuses = {
+            f'w-{i}': (UP, 'pod not ready (CrashLoopBackOff)') for i in range(4)
+        }
         result = _summarize_pod_reasons(statuses, 4)
         assert '4 pods' in result
         assert 'CrashLoopBackOff' in result
 
     def test_mixed_node_and_pod_issues(self):
         """Node issues + pod-only issues in same cluster."""
-        statuses = [
-            (UP, 'w-0: pod not ready'),
-            (UP, 'w-1: pod not ready'),
-            (UP, 'w-2: pod not ready (CrashLoopBackOff)'),
-        ]
+        statuses = {
+            'w-0': (UP, 'pod not ready'),
+            'w-1': (UP, 'pod not ready'),
+            'w-2': (UP, 'pod not ready (CrashLoopBackOff)'),
+        }
         node_health = {
             'node-1': {
                 'issue': 'NotReady',
@@ -116,13 +113,11 @@ class TestSummarizePodReasons:
         assert 'node-1' in result
         assert 'NotReady' in result
         assert 'CrashLoopBackOff' in result
-        # w-0 and w-1 should NOT appear in pod-level section
-        # (they're explained by node-1)
 
     def test_cordoned_node(self):
-        statuses = [
-            (UP, 'w-0: pod not ready'),
-        ]
+        statuses = {
+            'w-0': (UP, 'pod not ready'),
+        }
         node_health = {
             'node-1': {
                 'issue': 'cordoned',
@@ -135,11 +130,11 @@ class TestSummarizePodReasons:
 
     def test_mixed_issue_types_per_issue_pod_count(self):
         """Pod counts should be per issue type, not global."""
-        statuses = [
-            (UP, 'w-0: pod not ready'),
-            (UP, 'w-1: pod not ready'),
-            (UP, 'w-2: pod not ready'),
-        ]
+        statuses = {
+            'w-0': (UP, 'pod not ready'),
+            'w-1': (UP, 'pod not ready'),
+            'w-2': (UP, 'pod not ready'),
+        }
         node_health = {
             'node-1': {
                 'issue': 'NotReady',
@@ -151,15 +146,15 @@ class TestSummarizePodReasons:
             },
         }
         result = _summarize_pod_reasons(statuses, 6, node_health)
-        assert '2 out of 6 pods' in result  # NotReady affects 2 pods
-        assert '1 out of 6 pods' in result  # cordoned affects 1 pod
+        assert '2 out of 6 pods' in result
+        assert '1 out of 6 pods' in result
 
     def test_node_explained_pods_excluded_from_pod_summary(self):
         """Pods explained by node issues should not appear in pod section."""
-        statuses = [
-            (UP, 'w-0: pod not ready (ContainersNotReady)'),
-            (UP, 'w-1: pod not ready (CrashLoopBackOff)'),
-        ]
+        statuses = {
+            'w-0': (UP, 'pod not ready (ContainersNotReady)'),
+            'w-1': (UP, 'pod not ready (CrashLoopBackOff)'),
+        }
         node_health = {
             'node-1': {
                 'issue': 'NotReady',
@@ -167,10 +162,8 @@ class TestSummarizePodReasons:
             },
         }
         result = _summarize_pod_reasons(statuses, 4, node_health)
-        # w-0 is explained by node-1, w-1 is pod-level
         assert 'node-1' in result
         assert 'CrashLoopBackOff' in result
-        # w-0 should only appear in the node section, not the pod section
         parts = result.split('; ')
         assert len(parts) == 2
 
@@ -180,10 +173,10 @@ class TestStatusReasonIntegration:
     when building the init_reason for ray_cluster_unhealthy."""
 
     def test_status_reason_replaces_ray_message(self):
-        statuses = [
-            (UP, 'w-0: pod not ready (ContainersNotReady)'),
-            (UP, None),
-        ]
+        statuses = {
+            'w-0': (UP, 'pod not ready (ContainersNotReady)'),
+            'head': (UP, None),
+        }
         node_health = {
             'node-1': {
                 'issue': 'NotReady',
@@ -202,7 +195,7 @@ class TestStatusReasonIntegration:
         assert 'node-1' in init_reason
 
     def test_empty_summary_falls_back_to_ray(self):
-        statuses = [(UP, None), (UP, None)]
+        statuses = {'head': (UP, None), 'worker': (UP, None)}
         summary = _summarize_pod_reasons(statuses, 2)
         ray_cluster_unhealthy = True
         ray_status_details = '1/2 ready'

--- a/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
+++ b/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
@@ -2,8 +2,7 @@
 from typing import Optional
 from unittest import mock
 
-import pytest
-
+from sky.provision.kubernetes import instance as k8s_instance
 from sky.provision.kubernetes.instance import _check_nodes_health
 from sky.provision.kubernetes.instance import _get_pod_health_issues
 
@@ -52,6 +51,7 @@ def _make_pod(conditions, container_statuses=None):
 
 
 class TestGetPodHealthIssues:
+    """Tests for _get_pod_health_issues."""
 
     def test_healthy_pod_returns_none(self):
         pod = _make_pod(
@@ -157,6 +157,7 @@ def _make_k8s_node(name: str, ready: bool):
 
 
 class TestCheckNodesHealth:
+    """Tests for _check_nodes_health."""
 
     @mock.patch('sky.utils.plugin_extensions.NodeInfoSource.get')
     def test_node_info_source_detects_not_ready(self, mock_nis_get):
@@ -190,7 +191,7 @@ class TestCheckNodesHealth:
     @mock.patch('sky.adaptors.kubernetes.core_api')
     @mock.patch('sky.utils.plugin_extensions.NodeInfoSource.get',
                 return_value=None)
-    def test_fallback_to_k8s_api(self, mock_nis_get, mock_core_api):
+    def test_fallback_to_k8s_api(self, mock_nis_get, mock_core_api):  # pylint: disable=unused-argument
         mock_core_api.return_value.read_node.side_effect = [
             _make_k8s_node('node-1', ready=True),
             _make_k8s_node('node-2', ready=False),
@@ -203,7 +204,7 @@ class TestCheckNodesHealth:
     @mock.patch('sky.adaptors.kubernetes.core_api')
     @mock.patch('sky.utils.plugin_extensions.NodeInfoSource.is_registered',
                 return_value=False)
-    def test_fallback_when_not_registered(self, mock_registered, mock_core_api):
+    def test_fallback_when_not_registered(self, mock_registered, mock_core_api):  # pylint: disable=unused-argument
         mock_core_api.return_value.read_node.return_value = _make_k8s_node(
             'node-1', ready=False)
         result = _check_nodes_health('ctx', {'node-1'})
@@ -212,8 +213,10 @@ class TestCheckNodesHealth:
     @mock.patch('sky.adaptors.kubernetes.core_api')
     @mock.patch('sky.utils.plugin_extensions.NodeInfoSource.get',
                 return_value=None)
-    def test_fallback_read_node_exception_is_swallowed(self, mock_nis_get,
-                                                       mock_core_api):
+    def test_fallback_read_node_exception_is_swallowed(
+            self,
+            mock_nis_get,  # pylint: disable=unused-argument
+            mock_core_api):
         mock_core_api.return_value.read_node.side_effect = Exception('timeout')
         result = _check_nodes_health('ctx', {'node-1'})
         assert result == {}
@@ -228,9 +231,6 @@ class TestCheckNodesHealth:
         result = _check_nodes_health('ctx', {'node-1'})
         assert 'node-1' in result
         assert 'node-2' not in result
-
-
-from sky.provision.kubernetes import instance as k8s_instance
 
 
 def _make_full_pod(name: str,
@@ -261,6 +261,7 @@ def _make_full_pod(name: str,
 
 
 class TestQueryInstancesHealthIntegration:
+    """Integration tests for query_instances with health checks."""
 
     @mock.patch('sky.provision.kubernetes.instance._check_nodes_health')
     @mock.patch('sky.provision.kubernetes.instance.list_namespaced_pod')

--- a/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
+++ b/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
@@ -228,3 +228,83 @@ class TestCheckNodesHealth:
         result = _check_nodes_health('ctx', {'node-1'})
         assert 'node-1' in result
         assert 'node-2' not in result
+
+
+from sky.provision.kubernetes import instance as k8s_instance
+
+
+def _make_full_pod(name: str,
+                   phase: str,
+                   node_name: str,
+                   ready: bool = True,
+                   waiting_reason: Optional[str] = None,
+                   deletion_timestamp=None):
+    """Create a pod object matching the Kubernetes API client format."""
+    pod = mock.MagicMock()
+    pod.metadata.name = name
+    pod.metadata.deletion_timestamp = deletion_timestamp
+    pod.metadata.labels = {}
+    pod.status.phase = phase
+    pod.spec.node_name = node_name
+
+    ready_cond = _make_condition('Ready',
+                                 'True' if ready else 'False',
+                                 reason='' if ready else 'ContainersNotReady')
+    pod.status.conditions = [ready_cond]
+    pod.status.container_statuses = [
+        _make_container_status(
+            ready=ready,
+            waiting_reason=waiting_reason if not ready else None,
+        )
+    ]
+    return pod
+
+
+class TestQueryInstancesHealthIntegration:
+
+    @mock.patch('sky.provision.kubernetes.instance._check_nodes_health')
+    @mock.patch('sky.provision.kubernetes.instance.list_namespaced_pod')
+    def test_running_unhealthy_pod_gets_reason(self, mock_list_pods,
+                                               mock_check_nodes):
+        mock_list_pods.return_value = [
+            _make_full_pod('head', 'Running', 'node-1', ready=True),
+            _make_full_pod('worker-0', 'Running', 'node-2', ready=False),
+        ]
+        mock_check_nodes.return_value = {'node-2': 'NotReady'}
+
+        result = k8s_instance.query_instances(
+            cluster_name='test-cluster',
+            cluster_name_on_cloud='test-cluster',
+            provider_config={
+                'namespace': 'default',
+                'context': 'test-ctx',
+                'services': [],
+            },
+        )
+        # Head pod should have no reason
+        assert result['head'][1] is None
+        # Worker pod should have health reason with node info
+        assert result['worker-0'][1] is not None
+        assert 'ContainersNotReady' in result['worker-0'][1]
+        assert 'node-2' in result['worker-0'][1]
+        assert 'NotReady' in result['worker-0'][1]
+
+    @mock.patch('sky.provision.kubernetes.instance._check_nodes_health')
+    @mock.patch('sky.provision.kubernetes.instance.list_namespaced_pod')
+    def test_healthy_pods_no_node_check(self, mock_list_pods, mock_check_nodes):
+        mock_list_pods.return_value = [
+            _make_full_pod('head', 'Running', 'node-1', ready=True),
+            _make_full_pod('worker-0', 'Running', 'node-2', ready=True),
+        ]
+        mock_check_nodes.return_value = {}
+
+        k8s_instance.query_instances(
+            cluster_name='test-cluster',
+            cluster_name_on_cloud='test-cluster',
+            provider_config={
+                'namespace': 'default',
+                'context': 'test-ctx',
+                'services': [],
+            },
+        )
+        mock_check_nodes.assert_not_called()

--- a/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
+++ b/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 
+from sky.provision.kubernetes.instance import _check_nodes_health
 from sky.provision.kubernetes.instance import _get_pod_health_issues
 
 
@@ -124,3 +125,106 @@ class TestGetPodHealthIssues:
             ],
         )
         assert _get_pod_health_issues(pod) is None
+
+
+def _make_node_info(is_ready: bool, is_cordoned: bool = False):
+    """Create a mock KubernetesNodeInfo."""
+    info = mock.MagicMock()
+    info.is_ready = is_ready
+    info.is_cordoned = is_cordoned
+    return info
+
+
+def _make_nodes_info(node_dict):
+    """Create a mock KubernetesNodesInfo from {name: (ready, cordoned)}."""
+    info = mock.MagicMock()
+    info.node_info_dict = {
+        name: _make_node_info(ready, cordoned)
+        for name, (ready, cordoned) in node_dict.items()
+    }
+    return info
+
+
+def _make_k8s_node(name: str, ready: bool):
+    """Create a mock k8s V1Node for read_node fallback."""
+    node = mock.MagicMock()
+    node.metadata.name = name
+    cond = mock.MagicMock()
+    cond.type = 'Ready'
+    cond.status = 'True' if ready else 'False'
+    node.status.conditions = [cond]
+    return node
+
+
+class TestCheckNodesHealth:
+
+    @mock.patch('sky.utils.plugin_extensions.NodeInfoSource.get')
+    def test_node_info_source_detects_not_ready(self, mock_nis_get):
+        mock_nis_get.return_value = _make_nodes_info({
+            'node-1': (True, False),
+            'node-2': (False, False),
+        })
+        result = _check_nodes_health('ctx', {'node-1', 'node-2'})
+        assert 'node-2' in result
+        assert 'NotReady' in result['node-2']
+        assert 'node-1' not in result
+
+    @mock.patch('sky.utils.plugin_extensions.NodeInfoSource.get')
+    def test_node_info_source_detects_cordoned(self, mock_nis_get):
+        mock_nis_get.return_value = _make_nodes_info({
+            'node-1': (True, True),
+        })
+        result = _check_nodes_health('ctx', {'node-1'})
+        assert 'node-1' in result
+        assert 'cordoned' in result['node-1']
+
+    @mock.patch('sky.utils.plugin_extensions.NodeInfoSource.get')
+    def test_all_healthy_returns_empty(self, mock_nis_get):
+        mock_nis_get.return_value = _make_nodes_info({
+            'node-1': (True, False),
+            'node-2': (True, False),
+        })
+        result = _check_nodes_health('ctx', {'node-1', 'node-2'})
+        assert result == {}
+
+    @mock.patch('sky.adaptors.kubernetes.core_api')
+    @mock.patch('sky.utils.plugin_extensions.NodeInfoSource.get',
+                return_value=None)
+    def test_fallback_to_k8s_api(self, mock_nis_get, mock_core_api):
+        mock_core_api.return_value.read_node.side_effect = [
+            _make_k8s_node('node-1', ready=True),
+            _make_k8s_node('node-2', ready=False),
+        ]
+        result = _check_nodes_health('ctx', {'node-1', 'node-2'})
+        assert 'node-2' in result
+        assert 'NotReady' in result['node-2']
+        assert 'node-1' not in result
+
+    @mock.patch('sky.adaptors.kubernetes.core_api')
+    @mock.patch('sky.utils.plugin_extensions.NodeInfoSource.is_registered',
+                return_value=False)
+    def test_fallback_when_not_registered(self, mock_registered, mock_core_api):
+        mock_core_api.return_value.read_node.return_value = _make_k8s_node(
+            'node-1', ready=False)
+        result = _check_nodes_health('ctx', {'node-1'})
+        assert 'node-1' in result
+
+    @mock.patch('sky.adaptors.kubernetes.core_api')
+    @mock.patch('sky.utils.plugin_extensions.NodeInfoSource.get',
+                return_value=None)
+    def test_fallback_read_node_exception_is_swallowed(self, mock_nis_get,
+                                                       mock_core_api):
+        mock_core_api.return_value.read_node.side_effect = Exception('timeout')
+        result = _check_nodes_health('ctx', {'node-1'})
+        assert result == {}
+
+    @mock.patch('sky.utils.plugin_extensions.NodeInfoSource.get')
+    def test_filters_to_requested_nodes(self, mock_nis_get):
+        mock_nis_get.return_value = _make_nodes_info({
+            'node-1': (False, False),
+            'node-2': (False, False),
+            'node-3': (True, False),
+        })
+        result = _check_nodes_health('ctx', {'node-1'})
+        assert 'node-1' in result
+        assert 'node-2' not in result

--- a/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
+++ b/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
@@ -1,0 +1,126 @@
+"""Tests for Kubernetes pod health issue detection."""
+from typing import Optional
+from unittest import mock
+
+import pytest
+
+from sky.provision.kubernetes.instance import _get_pod_health_issues
+
+
+def _make_condition(type_: str,
+                    status: str,
+                    reason: str = '',
+                    message: str = ''):
+    """Create a mock pod condition."""
+    cond = mock.MagicMock()
+    cond.type = type_
+    cond.status = status
+    cond.reason = reason
+    cond.message = message
+    return cond
+
+
+def _make_container_status(ready: bool,
+                           waiting_reason: Optional[str] = None,
+                           terminated_exit_code: Optional[int] = None,
+                           name: str = 'ray-node'):
+    """Create a mock container status."""
+    cs = mock.MagicMock()
+    cs.name = name
+    cs.ready = ready
+
+    if waiting_reason is not None:
+        cs.state.waiting.reason = waiting_reason
+        cs.state.terminated = None
+    elif terminated_exit_code is not None:
+        cs.state.terminated.exit_code = terminated_exit_code
+        cs.state.terminated.reason = f'exit({terminated_exit_code})'
+        cs.state.waiting = None
+    else:
+        cs.state.waiting = None
+        cs.state.terminated = None
+    return cs
+
+
+def _make_pod(conditions, container_statuses=None):
+    """Create a mock pod object."""
+    pod = mock.MagicMock()
+    pod.status.conditions = conditions
+    pod.status.container_statuses = container_statuses or []
+    return pod
+
+
+class TestGetPodHealthIssues:
+
+    def test_healthy_pod_returns_none(self):
+        pod = _make_pod(
+            conditions=[_make_condition('Ready', 'True')],
+            container_statuses=[_make_container_status(ready=True)],
+        )
+        assert _get_pod_health_issues(pod) is None
+
+    def test_ready_false_returns_reason(self):
+        pod = _make_pod(
+            conditions=[
+                _make_condition('Ready', 'False', reason='ContainersNotReady')
+            ],
+            container_statuses=[_make_container_status(ready=False)],
+        )
+        result = _get_pod_health_issues(pod)
+        assert result is not None
+        assert 'ContainersNotReady' in result
+
+    def test_crashloopbackoff(self):
+        pod = _make_pod(
+            conditions=[
+                _make_condition('Ready', 'False', reason='ContainersNotReady')
+            ],
+            container_statuses=[
+                _make_container_status(ready=False,
+                                       waiting_reason='CrashLoopBackOff'),
+            ],
+        )
+        result = _get_pod_health_issues(pod)
+        assert result is not None
+        assert 'CrashLoopBackOff' in result
+
+    def test_image_pull_backoff(self):
+        pod = _make_pod(
+            conditions=[
+                _make_condition('Ready', 'False', reason='ContainersNotReady')
+            ],
+            container_statuses=[
+                _make_container_status(ready=False,
+                                       waiting_reason='ImagePullBackOff'),
+            ],
+        )
+        result = _get_pod_health_issues(pod)
+        assert result is not None
+        assert 'ImagePullBackOff' in result
+
+    def test_container_terminated_nonzero(self):
+        pod = _make_pod(
+            conditions=[
+                _make_condition('Ready', 'False', reason='ContainersNotReady')
+            ],
+            container_statuses=[
+                _make_container_status(ready=False, terminated_exit_code=137),
+            ],
+        )
+        result = _get_pod_health_issues(pod)
+        assert result is not None
+        assert '137' in result
+
+    def test_no_conditions_returns_none(self):
+        pod = _make_pod(conditions=None)
+        assert _get_pod_health_issues(pod) is None
+
+    def test_ready_true_but_container_waiting(self):
+        pod = _make_pod(
+            conditions=[_make_condition('Ready', 'True')],
+            container_statuses=[
+                _make_container_status(ready=False,
+                                       waiting_reason='ContainerCreating'),
+            ],
+        )
+        assert _get_pod_health_issues(pod) is None

--- a/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
+++ b/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
@@ -186,16 +186,20 @@ class TestCheckNodesHealth:
             'node-2': (True, False),
         })
         result = _check_nodes_health('ctx', {'node-1', 'node-2'})
-        assert result == {}
+        assert not result
 
     @mock.patch('sky.adaptors.kubernetes.core_api')
     @mock.patch('sky.utils.plugin_extensions.NodeInfoSource.get',
                 return_value=None)
     def test_fallback_to_k8s_api(self, mock_nis_get, mock_core_api):  # pylint: disable=unused-argument
-        mock_core_api.return_value.read_node.side_effect = [
-            _make_k8s_node('node-1', ready=True),
-            _make_k8s_node('node-2', ready=False),
-        ]
+        # Use a function for side_effect since run_in_parallel
+        # may call read_node in any order.
+        node_map = {
+            'node-1': _make_k8s_node('node-1', ready=True),
+            'node-2': _make_k8s_node('node-2', ready=False),
+        }
+        mock_core_api.return_value.read_node.side_effect = (
+            lambda name, **kw: node_map[name])
         result = _check_nodes_health('ctx', {'node-1', 'node-2'})
         assert 'node-2' in result
         assert 'NotReady' in result['node-2']
@@ -219,7 +223,7 @@ class TestCheckNodesHealth:
             mock_core_api):
         mock_core_api.return_value.read_node.side_effect = Exception('timeout')
         result = _check_nodes_health('ctx', {'node-1'})
-        assert result == {}
+        assert not result
 
     @mock.patch('sky.utils.plugin_extensions.NodeInfoSource.get')
     def test_filters_to_requested_nodes(self, mock_nis_get):

--- a/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
+++ b/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
@@ -278,17 +278,15 @@ def _make_full_pod(name: str,
 
 
 class TestQueryInstancesHealthIntegration:
-    """Integration tests for query_instances with health checks."""
+    """Integration tests for query_instances with pod health checks."""
 
-    @mock.patch('sky.provision.kubernetes.instance._check_nodes_health')
     @mock.patch('sky.provision.kubernetes.instance.list_namespaced_pod')
-    def test_running_unhealthy_pod_gets_reason(self, mock_list_pods,
-                                               mock_check_nodes):
+    def test_running_unhealthy_pod_gets_reason(self, mock_list_pods):
+        """query_instances sets reason for Running pods with Ready=False."""
         mock_list_pods.return_value = [
             _make_full_pod('head', 'Running', 'node-1', ready=True),
             _make_full_pod('worker-0', 'Running', 'node-2', ready=False),
         ]
-        mock_check_nodes.return_value = {'node-2': 'NotReady'}
 
         result = k8s_instance.query_instances(
             cluster_name='test-cluster',
@@ -301,22 +299,19 @@ class TestQueryInstancesHealthIntegration:
         )
         # Head pod should have no reason
         assert result['head'][1] is None
-        # Worker pod should have health reason with node info
+        # Worker pod should have pod-level health reason
         assert result['worker-0'][1] is not None
         assert 'ContainersNotReady' in result['worker-0'][1]
-        assert 'node-2' in result['worker-0'][1]
-        assert 'NotReady' in result['worker-0'][1]
 
-    @mock.patch('sky.provision.kubernetes.instance._check_nodes_health')
     @mock.patch('sky.provision.kubernetes.instance.list_namespaced_pod')
-    def test_healthy_pods_no_node_check(self, mock_list_pods, mock_check_nodes):
+    def test_healthy_pods_no_reason(self, mock_list_pods):
+        """All healthy pods should have None reason."""
         mock_list_pods.return_value = [
             _make_full_pod('head', 'Running', 'node-1', ready=True),
             _make_full_pod('worker-0', 'Running', 'node-2', ready=True),
         ]
-        mock_check_nodes.return_value = {}
 
-        k8s_instance.query_instances(
+        result = k8s_instance.query_instances(
             cluster_name='test-cluster',
             cluster_name_on_cloud='test-cluster',
             provider_config={
@@ -325,4 +320,5 @@ class TestQueryInstancesHealthIntegration:
                 'services': [],
             },
         )
-        mock_check_nodes.assert_not_called()
+        assert result['head'][1] is None
+        assert result['worker-0'][1] is None

--- a/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
+++ b/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
@@ -149,6 +149,7 @@ def _make_k8s_node(name: str, ready: bool):
     """Create a mock k8s V1Node for read_node fallback."""
     node = mock.MagicMock()
     node.metadata.name = name
+    node.spec.unschedulable = False
     cond = mock.MagicMock()
     cond.type = 'Ready'
     cond.status = 'True' if ready else 'False'
@@ -206,9 +207,9 @@ class TestCheckNodesHealth:
         assert 'node-1' not in result
 
     @mock.patch('sky.adaptors.kubernetes.core_api')
-    @mock.patch('sky.utils.plugin_extensions.NodeInfoSource.is_registered',
-                return_value=False)
-    def test_fallback_when_not_registered(self, mock_registered, mock_core_api):  # pylint: disable=unused-argument
+    @mock.patch('sky.utils.plugin_extensions.NodeInfoSource.get',
+                return_value=None)
+    def test_fallback_when_not_registered(self, mock_nis_get, mock_core_api):  # pylint: disable=unused-argument
         mock_core_api.return_value.read_node.return_value = _make_k8s_node(
             'node-1', ready=False)
         result = _check_nodes_health('ctx', {'node-1'})
@@ -224,6 +225,18 @@ class TestCheckNodesHealth:
         mock_core_api.return_value.read_node.side_effect = Exception('timeout')
         result = _check_nodes_health('ctx', {'node-1'})
         assert not result
+
+    @mock.patch('sky.adaptors.kubernetes.core_api')
+    @mock.patch('sky.utils.plugin_extensions.NodeInfoSource.get',
+                return_value=None)
+    def test_fallback_detects_cordoned_node(self, mock_nis_get, mock_core_api):  # pylint: disable=unused-argument
+        """K8s API fallback detects cordoned (unschedulable) nodes."""
+        node = _make_k8s_node('node-1', ready=True)
+        node.spec.unschedulable = True
+        mock_core_api.return_value.read_node.return_value = node
+        result = _check_nodes_health('ctx', {'node-1'})
+        assert 'node-1' in result
+        assert 'cordoned' in result['node-1']
 
     @mock.patch('sky.utils.plugin_extensions.NodeInfoSource.get')
     def test_filters_to_requested_nodes(self, mock_nis_get):


### PR DESCRIPTION
When Kubernetes nodes go down (reboot, failure, preemption), SkyPilot detects the cluster as unhealthy but emits a generic event that doesn't explain the root cause:

```
Cluster is abnormal because ray cluster is unhealthy (2/3 ready). Transitioned to INIT.
```

This PR surfaces Kubernetes-level diagnostics (pod conditions, node health) in the status event so users can determine the root cause without manually investigating. When k8s information is available, it replaces the generic ray message:

```
Cluster is abnormal because node computeinstance-e00d1xkkq9cqh086nn is NotReady, affecting 1/3 pods. Transitioned to INIT.
```

When no k8s-level explanation is available (e.g., network issue between pods), it falls back to the existing ray message.

**How it works:**
- `_get_pod_health_issues()` checks Running pods for health issues (Ready=False, CrashLoopBackOff, ImagePullBackOff, non-zero exit codes) — zero cost since we already have the pod objects
- `_check_nodes_health()` checks if the nodes hosting unhealthy pods are NotReady or cordoned — only triggered when a pod reports issues. Uses the `NodeInfoSource` plugin extension when available (fast cached path), falls back to `read_node` API calls
- `_summarize_pod_reasons()` groups per-pod reasons into concise messages: node-level issues deduplicated by node with pod counts, pod-level issues grouped by reason, names capped at 3

**Performance:** Zero overhead for healthy clusters. Pod condition checks are free (already have pod objects). Node health checks only run when a pod is unhealthy.

Tested:

- [x] Code formatting: `bash format.sh` — passes, pylint 10/10
- [x] Any manual or new tests for this PR:
  - 27 unit tests covering `_get_pod_health_issues`, `_check_nodes_health`, `_summarize_pod_reasons`, `query_instances` integration, and message construction
  - E2E verified on multi-node Kubernetes cluster:
    - Stopped kubelet on a worker node → node goes NotReady → message shows `node X is NotReady, affecting N/M pods`
    - Killed raylet in worker (pods fine) → fallback: `ray cluster is unhealthy (2/3 ready)`
    - Deleted worker pod → `one or more nodes terminated`
    - Drained worker node → `one or more nodes terminated` + DEBUG: `Disrupted: EvictionByEvictionAPI`
- [ ] All smoke tests: `/smoke-test`
- [ ] Relevant individual tests: `/smoke-test -k test_name`
- [x] Backward compatibility: `/quicktest-core`