### PR TITLE
[RunPod] Fix KeyError in query_instances for unmapped statuses

### DIFF
--- a/sky/provision/runpod/instance.py
+++ b/sky/provision/runpod/instance.py
@@ -256,7 +256,7 @@ def query_instances(
     statuses: Dict[str, Tuple[Optional['status_lib.ClusterStatus'],
                               Optional[str]]] = {}
     for inst_id, inst in instances.items():
-        status = status_map[inst['status']]
+        status = status_map.get(inst['status'])
         if non_terminated_only and status is None:
             continue
         statuses[inst_id] = (status, None)


### PR DESCRIPTION
## Bug

\`sky/provision/runpod/instance.py:query_instances\` looks up each pod's status via direct dict indexing:

\`\`\`python
status_map = {
    'CREATED': status_lib.ClusterStatus.INIT,
    'RESTARTING': status_lib.ClusterStatus.INIT,
    'PAUSED': status_lib.ClusterStatus.INIT,
    'RUNNING': status_lib.ClusterStatus.UP,
}
...
for inst_id, inst in instances.items():
    status = status_map[inst['status']]
    if non_terminated_only and status is None:
        continue
\`\`\`

## Root cause

\`query_instances\` calls \`_filter_instances(cluster_name_on_cloud, None)\`, so the loop iterates every pod the API returns — including ones in states that are not in the four-key map. RunPod pods end up in \`EXITED\` after \`terminate_pod\`, and statuses like \`DEAD\` / \`PROVISIONING\` surface transiently. Any such value raises \`KeyError\` and aborts the whole status fetch, even though the trailing \`non_terminated_only\` branch was meant to drop them silently.

## Fix

Use \`status_map.get(inst['status'])\` so unmapped values fall through as \`None\` and are filtered out by the existing \`non_terminated_only\` check. This matches the defensive pattern already used in \`sky/provision/fluidstack/instance.py\` and \`sky/provision/lambda_cloud/instance.py\`.