### PR TITLE
[Kubernetes] Fix volumeMounts patchMergeKey from name to mountPath

### DIFF
--- a/sky/utils/config_utils.py
+++ b/sky/utils/config_utils.py
@@ -22,7 +22,7 @@ _PATCH_MERGE_KEYS = {
     'initContainers': 'name',
     'ephemeralContainers': 'name',
     'volumes': 'name',
-    'volumeMounts': 'name',
+    'volumeMounts': 'mountPath',
     'resourceClaims': 'name',
     'env': 'name',
     'hostAliases': 'ip',

--- a/tests/unit_tests/test_sky/utils/test_config_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_config_utils.py
@@ -346,12 +346,92 @@ def test_k8s_config_merge_with_multiple_volumes():
     vol3 = next(v for v in base_config['volumes'] if v['name'] == 'vol3')
     assert vol3['hostPath'] == '/path3'
 
-    # Check volumeMounts
-    assert len(base_config['volumeMounts']) == 3
-    mount1 = next(m for m in base_config['volumeMounts'] if m['name'] == 'vol1')
-    assert mount1['mountPath'] == '/new-mnt1'
-    mount3 = next(m for m in base_config['volumeMounts'] if m['name'] == 'vol3')
-    assert mount3['mountPath'] == '/mnt3'
+    # Check volumeMounts - mountPath is the merge key per K8s API spec,
+    # so vol1 at /new-mnt1 is a new entry (different mountPath from /mnt1),
+    # giving us 4 total: /mnt1, /mnt2, /new-mnt1, /mnt3
+    assert len(base_config['volumeMounts']) == 4
+    expected_mounts = [
+        ('vol1', '/mnt1'),
+        ('vol2', '/mnt2'),
+        ('vol1', '/new-mnt1'),
+        ('vol3', '/mnt3'),
+    ]
+    actual_mounts = [
+        (m['name'], m['mountPath']) for m in base_config['volumeMounts']
+    ]
+    assert sorted(actual_mounts) == sorted(expected_mounts)
+
+
+def test_k8s_config_merge_volumemounts_same_name_different_subpath():
+    """Two volumeMounts sharing a volume name but different
+    mountPath/subPath must both survive the merge. This is the
+    standard K8s pattern for projecting Secret keys into paths."""
+    base_config = {
+        'volumes': [{
+            'name': 'git-creds',
+            'secret': {
+                'secretName': 'creds'
+            }
+        }],
+        'volumeMounts': []
+    }
+
+    override_config = {
+        'volumeMounts': [{
+            'name': 'git-creds',
+            'mountPath': '/home/sky/.gitconfig',
+            'subPath': 'gitconfig',
+            'readOnly': True
+        }, {
+            'name': 'git-creds',
+            'mountPath': '/home/sky/.git-credentials',
+            'subPath': 'credentials',
+            'readOnly': True
+        }]
+    }
+
+    config_utils.merge_k8s_configs(base_config, override_config)
+
+    assert len(base_config['volumeMounts']) == 2
+    expected_mounts = [
+        ('git-creds', '/home/sky/.gitconfig'),
+        ('git-creds', '/home/sky/.git-credentials'),
+    ]
+    actual_mounts = [
+        (m['name'], m['mountPath']) for m in base_config['volumeMounts']
+    ]
+    assert sorted(actual_mounts) == sorted(expected_mounts)
+
+
+def test_k8s_config_merge_volumemounts_same_name_base_and_override():
+    """Override adds a volumeMount with same volume name as base but different
+    mountPath. Both must survive."""
+    base_config = {
+        'volumeMounts': [{
+            'name': 'shared-vol',
+            'mountPath': '/data/a',
+            'subPath': 'a'
+        }]
+    }
+    override_config = {
+        'volumeMounts': [{
+            'name': 'shared-vol',
+            'mountPath': '/data/b',
+            'subPath': 'b'
+        }]
+    }
+
+    config_utils.merge_k8s_configs(base_config, override_config)
+
+    assert len(base_config['volumeMounts']) == 2
+    expected_mounts = [
+        ('shared-vol', '/data/a'),
+        ('shared-vol', '/data/b'),
+    ]
+    actual_mounts = [
+        (m['name'], m['mountPath']) for m in base_config['volumeMounts']
+    ]
+    assert sorted(actual_mounts) == sorted(expected_mounts)
 
 
 def test_nested_config_override_precedence():


### PR DESCRIPTION
## Summary

- Fix `_PATCH_MERGE_KEYS` in `sky/utils/config_utils.py` to use `mountPath` instead of `name` as the strategic merge key for `volumeMounts`, matching the [Kubernetes API spec](https://github.com/kubernetes/kubernetes/blob/b2f73c0d6b42/staging/src/k8s.io/api/core/v1/types.go#L3025-L3029)
- The old behavior silently dropped `volumeMounts` entries that shared a volume `name` but had different `mountPath`/`subPath` values, breaking the standard K8s pattern for projecting individual Secret or ConfigMap keys into specific filesystem paths

Fixes #9357

## Test plan

Added two unit tests to `tests/unit_tests/test_sky/utils/test_config_utils.py`:

- `test_k8s_config_merge_volumemounts_same_name_different_subpath` — two mounts from same volume (empty base), both survive
- `test_k8s_config_merge_volumemounts_same_name_base_and_override` — override adds mount with same volume name as base but different mountPath, both survive

Updated existing `test_k8s_config_merge_with_multiple_volumes` to reflect correct merge-by-mountPath semantics.

```bash
uv run pytest tests/unit_tests/test_sky/utils/test_config_utils.py -v
# 24 passed

uv run pytest tests/unit_tests/kubernetes/test_kubernetes_utils.py -v
# 134 passed
```