### PR TITLE
[Volume] Infer access_mode from existing PVC for use_existing volumes

### DIFF
--- a/sky/provision/kubernetes/volume.py
+++ b/sky/provision/kubernetes/volume.py
@@ -668,6 +668,19 @@ def _populate_config_from_pvc(config: models.VolumeConfig,
         if pvc_storage_class:
             config.config['storage_class_name'] = pvc_storage_class
 
+    # Populate access_mode from PVC (immutable, so PVC is source of truth)
+    pvc_access_modes = getattr(pvc_obj.spec, 'access_modes', None)
+    if pvc_access_modes:
+        pvc_access_mode = pvc_access_modes[0]
+        current_access_mode = config.config.get('access_mode')
+        if current_access_mode != pvc_access_mode:
+            if current_access_mode is not None:
+                logger.debug(
+                    f'PVC {pvc_name} has access mode {pvc_access_mode} '
+                    f'but config access_mode is {current_access_mode}, '
+                    f'overriding with the PVC access mode.')
+            config.config['access_mode'] = pvc_access_mode
+
     # Populate size if not set (prefer bound capacity, fallback to requested)
     pvc_size = None
     size_quantity = None

--- a/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
@@ -1140,6 +1140,82 @@ class TestPopulateConfigFromPVC:
 
         assert config.config.get('storage_class_name') == 'fast-ssd'
         assert config.size == '100'  # Converted from '100Gi' to string
+        assert config.config.get('access_mode') == 'ReadWriteOnce'
+
+    def test_populate_access_mode_inferred(self):
+        """Test access_mode is inferred from PVC when not set in config."""
+        config = models.VolumeConfig(
+            _version=1,
+            name='test-vol',
+            type='k8s-pvc',
+            cloud='kubernetes',
+            region='my-context',
+            zone=None,
+            name_on_cloud='test-pvc',
+            size=None,
+            config={},
+        )
+        mock_pvc = MockPVC('test-pvc',
+                           'my-namespace',
+                           access_modes=['ReadWriteMany'])
+        k8s_volume._populate_config_from_pvc(config, mock_pvc)
+        assert config.config.get('access_mode') == 'ReadWriteMany'
+
+    def test_populate_access_mode_override_with_warning(self):
+        """Test access_mode is overridden when PVC differs from config."""
+        config = models.VolumeConfig(
+            _version=1,
+            name='test-vol',
+            type='k8s-pvc',
+            cloud='kubernetes',
+            region='my-context',
+            zone=None,
+            name_on_cloud='test-pvc',
+            size=None,
+            config={'access_mode': 'ReadWriteOnce'},
+        )
+        mock_pvc = MockPVC('test-pvc',
+                           'my-namespace',
+                           access_modes=['ReadWriteMany'])
+        k8s_volume._populate_config_from_pvc(config, mock_pvc)
+        assert config.config.get('access_mode') == 'ReadWriteMany'
+
+    def test_populate_access_mode_matching(self):
+        """Test no change when PVC access_mode matches config."""
+        config = models.VolumeConfig(
+            _version=1,
+            name='test-vol',
+            type='k8s-pvc',
+            cloud='kubernetes',
+            region='my-context',
+            zone=None,
+            name_on_cloud='test-pvc',
+            size=None,
+            config={'access_mode': 'ReadWriteOnce'},
+        )
+        mock_pvc = MockPVC('test-pvc',
+                           'my-namespace',
+                           access_modes=['ReadWriteOnce'])
+        k8s_volume._populate_config_from_pvc(config, mock_pvc)
+        assert config.config.get('access_mode') == 'ReadWriteOnce'
+
+    def test_populate_access_mode_empty(self):
+        """Test no change when PVC has no access_modes."""
+        config = models.VolumeConfig(
+            _version=1,
+            name='test-vol',
+            type='k8s-pvc',
+            cloud='kubernetes',
+            region='my-context',
+            zone=None,
+            name_on_cloud='test-pvc',
+            size=None,
+            config={'access_mode': 'ReadWriteOnce'},
+        )
+        mock_pvc = MockPVC('test-pvc', 'my-namespace')
+        mock_pvc.spec.access_modes = None
+        k8s_volume._populate_config_from_pvc(config, mock_pvc)
+        assert config.config.get('access_mode') == 'ReadWriteOnce'
 
     def test_populate_config_from_pvc_preserve_existing(self):
         """Test that existing config values are not overwritten."""


### PR DESCRIPTION
## Summary
- When `use_existing: true`, automatically infer `access_mode` from the existing PVC rather than defaulting to `ReadWriteOnce`

## Context
- `_populate_config_from_pvc()` already infers `storage_class_name` and `size` from the PVC, but was missing `access_mode`
- The default `access_mode` (`ReadWriteOnce`) is set before the PVC lookup, so a PVC with `ReadWriteMany` would be recorded as `ReadWriteOnce`

## Test plan
- [x] All 11 `TestPopulateConfigFromPVC` tests pass
- [x] Manual: `sky volume apply` with `use_existing: true` on a RWX PVC, verify `sky volume ls` shows correct access_mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)