### PR TITLE
ci: add contextual risk scoring to Trivy vulnerability scan

### DIFF
--- a/.github/workflows/image-vulnerability.yml
+++ b/.github/workflows/image-vulnerability.yml
@@ -79,11 +79,14 @@ jobs:
           input-format: trivy
           sbom-serial-number: "urn:uuid:d4f0e8a2-3b1c-4e5f-9a7d-2c8b6e1f0d3a"
           llm-provider: mock
+          enrich: "true"
 
-      - name: Upload VEX artifact
+      - name: Upload enriched report and VEX
         if: always() && steps.vens.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
-          name: vens-vex-${{ github.sha }}
-          path: ${{ steps.vens.outputs.vex-file }}
+          name: vens-results-${{ github.sha }}
+          path: |
+            ${{ steps.vens.outputs.enriched-report }}
+            ${{ steps.vens.outputs.vex-file }}
           retention-days: 30

--- a/.github/workflows/image-vulnerability.yml
+++ b/.github/workflows/image-vulnerability.yml
@@ -66,3 +66,24 @@ jobs:
             printf '%s\n' "${critical_vulns[@]}"
             exit 1
           fi
+
+      - name: Contextual risk scoring (vens)
+        if: always()
+        id: vens
+        continue-on-error: true
+        uses: venslabs/vens-action@v0.1.0
+        with:
+          version: v0.3.2
+          config-file: .vens/config.yaml
+          input-report: trivy-results.json
+          input-format: trivy
+          sbom-serial-number: "urn:uuid:d4f0e8a2-3b1c-4e5f-9a7d-2c8b6e1f0d3a"
+          llm-provider: mock
+
+      - name: Upload VEX artifact
+        if: always() && steps.vens.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: vens-vex-${{ github.sha }}
+          path: ${{ steps.vens.outputs.vex-file }}
+          retention-days: 30

--- a/.vens/config.yaml
+++ b/.vens/config.yaml
@@ -1,0 +1,11 @@
+project:
+  name: "skypilot"
+  description: "Framework for running ML and batch jobs on any cloud (AWS, GCP, Azure, Lambda, etc.)"
+context:
+  exposure: "internet"
+  data_sensitivity: "medium"
+  business_criticality: "high"
+  notes: >-
+    The Docker image is the SkyPilot API server. It bundles cloud CLIs
+    (gcloud, aws, az, kubectl), Python 3.10, and SkyPilot itself.
+    Handles cloud credentials and cluster orchestration at runtime.


### PR DESCRIPTION
Your Trivy scan already produces JSON and gates on HIGH/CRITICAL. This
appends two steps that score each CVE using OWASP Risk Rating based on
SkyPilot's deployment context (internet-facing API server, cloud
credential handling) and uploads the result as a CycloneDX VEX artifact.

What changed:
- `.vens/config.yaml` describing SkyPilot's risk profile
- Two steps appended to the existing workflow (after Trivy evaluation)
- Uses `llm-provider: mock` — no API key, no cost, no external calls
- `continue-on-error: true` — cannot break the existing gate

The VEX shows which CVEs matter in your context vs. noise. To get
deeper analysis later, swap `mock` for a real LLM provider.

https://github.com/marketplace/actions/vens-action