### PR TITLE
[Docs] Use https for Slack badge and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
     <img alt="GitHub Release" src="https://img.shields.io/github/release/skypilot-org/skypilot.svg">
   </a>
 
-  <a href="http://slack.skypilot.co">
+  <a href="https://slack.skypilot.co">
     <img alt="Join Slack" src="https://img.shields.io/badge/SkyPilot-Join%20Slack-blue?logo=slack">
   </a>
 
@@ -191,7 +191,7 @@ SkyPilot adopters: [Testimonials and Case Studies](https://blog.skypilot.co/case
 Partners and integrations: [Community Spotlights](https://blog.skypilot.co/community/)
 
 Follow updates:
-- [Slack](http://slack.skypilot.co)
+- [Slack](https://slack.skypilot.co)
 - [X / Twitter](https://twitter.com/skypilot_org)
 - [LinkedIn](https://www.linkedin.com/company/skypilot-oss/)
 - [SkyPilot Blog](https://blog.skypilot.co/) ([Introductory blog post](https://blog.skypilot.co/introducing-skypilot/))
@@ -210,7 +210,7 @@ We are excited to hear your feedback:
 * For issues and feature requests, please [open a GitHub issue](https://github.com/skypilot-org/skypilot/issues/new).
 * For questions, please use [GitHub Discussions](https://github.com/skypilot-org/skypilot/discussions).
 
-For general discussions, join us on the [SkyPilot Slack](http://slack.skypilot.co).
+For general discussions, join us on the [SkyPilot Slack](https://slack.skypilot.co).
 
 ## Contributing
 We welcome all contributions to the project! See [CONTRIBUTING](CONTRIBUTING.md) for how to get involved.

--- a/charts/skypilot/README.md
+++ b/charts/skypilot/README.md
@@ -2,7 +2,7 @@
 
 [![Documentation](https://img.shields.io/badge/docs-gray?logo=readthedocs&logoColor=f5f5f5)](https://docs.skypilot.co/)
 [![GitHub Release](https://img.shields.io/github/release/skypilot-org/skypilot.svg)](https://github.com/skypilot-org/skypilot/releases)
-[![Join Slack](https://img.shields.io/badge/SkyPilot-Join%20Slack-blue?logo=slack)](http://slack.skypilot.co)
+[![Join Slack](https://img.shields.io/badge/SkyPilot-Join%20Slack-blue?logo=slack)](https://slack.skypilot.co)
 [![Downloads](https://img.shields.io/pypi/dm/skypilot)](https://github.com/skypilot-org/skypilot/releases)
 
 ## Run AI on Any Infra — Unified, Faster, Cheaper

--- a/docs/source/docs/index.rst
+++ b/docs/source/docs/index.rst
@@ -18,7 +18,7 @@ SkyPilot: Run AI on Any Infrastructure
 
    <p style="text-align:center">
    <a class="github-button" href="https://github.com/skypilot-org/skypilot" data-show-count="true" data-size="large" aria-label="Star skypilot-org/skypilot on GitHub">Star</a>
-   <a class="reference external image-reference" style="vertical-align:9.5px" href="http://slack.skypilot.co"><img src="https://img.shields.io/badge/SkyPilot-Join%20Slack-blue?logo=slack" style="height:27px"></a>
+   <a class="reference external image-reference" style="vertical-align:9.5px" href="https://slack.skypilot.co"><img src="https://img.shields.io/badge/SkyPilot-Join%20Slack-blue?logo=slack" style="height:27px"></a>
    <script async defer src="https://buttons.github.io/buttons.js"></script>
    </p>
 


### PR DESCRIPTION
## Summary
- Switch the Slack badge link in the docs landing page, top-level README, and Helm chart README from `http://slack.skypilot.co` to `https://`
- Also updates the other `http://slack.skypilot.co` references in the top-level README for consistency

## Test plan
- [ ] Render `docs/source/docs/index.rst` and confirm the Slack badge points to `https://slack.skypilot.co`
- [ ] Preview `README.md` and `charts/skypilot/README.md` on GitHub and click the Slack badges to verify they resolve over HTTPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)