### PR TITLE
[Core] Skip re-install of unchanged plugin wheels

### DIFF
--- a/sky/server/plugin_utils.py
+++ b/sky/server/plugin_utils.py
@@ -5,7 +5,9 @@ to remote clusters.
 """
 import os
 import pathlib
-from typing import Dict, Optional, Tuple
+import re
+import shlex
+from typing import Dict, List, Optional, Tuple
 
 from sky import sky_logging
 from sky.server import plugins
@@ -15,6 +17,81 @@ logger = sky_logging.init_logger(__name__)
 
 # Remote directory for plugin wheels
 _REMOTE_PLUGINS_WHEEL_DIR = '~/.sky/plugins/wheels'
+# Stamp file listing wheel filenames already installed on the controller.
+_REMOTE_STAMP_FILE = '~/.sky/plugins/.installed_wheels'
+# Lock serializing concurrent plugin installs across parallel launches on the
+# same controller. Without this, two `sky jobs launch` invocations racing
+# through the run phase can half-rewrite site-packages while other plugin
+# imports are in flight, producing transient ImportError.
+_REMOTE_INSTALL_LOCK = '~/.sky/plugins/.install.lock'
+# Timeout (seconds) to wait for the install lock before giving up.
+_INSTALL_LOCK_TIMEOUT = 600
+
+
+def _wheel_name_prefix(wheel_filename: str) -> str:
+    """Return the ``{name}-`` prefix of a wheel filename.
+
+    PEP 427 wheel filenames are ``{name}-{version}(-{build})?-{py}-{abi}-
+    {platform}.whl`` with hyphens in the distribution name replaced by
+    underscores, so the name portion is whatever precedes the first
+    ``-<digit>``.
+    """
+    match = re.match(r'^(.+?)-\d', wheel_filename)
+    if match:
+        return f'{match.group(1)}-'
+    # Fallback: first hyphen-delimited token. Shouldn't normally trigger.
+    return wheel_filename.split('-', 1)[0] + '-'
+
+
+def _build_guarded_install_script(entries: List[Tuple[str, str, str]]) -> str:
+    """Build a shell script that installs each wheel at most once.
+
+    For each wheel, the script:
+    1. Takes an exclusive flock so concurrent launches don't race.
+    2. Skips the install if the exact wheel filename is already recorded in
+       the stamp file.
+    3. On install, replaces any prior entry for the same package name in the
+       stamp file and prunes stale wheel files for that package.
+
+    Args:
+        entries: list of ``(wheel_filename, package_prefix, remote_path)``.
+    """
+    install_blocks = []
+    for wheel_name, pkg_prefix, remote_wheel in entries:
+        q_wheel = shlex.quote(wheel_name)
+        q_prefix = shlex.quote(pkg_prefix)
+        q_prefix_glob = shlex.quote(f'{pkg_prefix}*.whl')
+        # remote_wheel starts with '~' which must be left unquoted so the
+        # shell expands it; the filename portion cannot contain shell
+        # metacharacters by PEP 427.
+        install_blocks.append(f"""\
+  if grep -Fxq {q_wheel} "$_sky_stamp"; then
+    echo "Plugin wheel {wheel_name} already installed, skipping."
+  else
+    echo "Installing plugin wheel {wheel_name}..."
+    {constants.SKY_UV_PIP_CMD} install {remote_wheel}
+    _sky_tmp=$(mktemp)
+    grep -v "^"{q_prefix} "$_sky_stamp" > "$_sky_tmp" || true
+    echo {q_wheel} >> "$_sky_tmp"
+    mv "$_sky_tmp" "$_sky_stamp"
+    find {_REMOTE_PLUGINS_WHEEL_DIR} -maxdepth 1 \\
+      -name {q_prefix_glob} ! -name {q_wheel} -delete 2>/dev/null || true
+  fi""")
+
+    body = '\n'.join(install_blocks)
+    return f"""(
+  set -e
+  mkdir -p ~/.sky/plugins {_REMOTE_PLUGINS_WHEEL_DIR}
+  exec 9>{_REMOTE_INSTALL_LOCK}
+  flock -w {_INSTALL_LOCK_TIMEOUT} 9 || {{
+    echo "Failed to acquire plugin install lock within \
+{_INSTALL_LOCK_TIMEOUT}s" >&2
+    exit 1
+  }}
+  _sky_stamp={_REMOTE_STAMP_FILE}
+  touch "$_sky_stamp"
+{body}
+)"""
 
 
 def get_plugin_mounts_and_commands() -> Tuple[Dict[str, str], str]:
@@ -24,6 +101,12 @@ def get_plugin_mounts_and_commands() -> Tuple[Dict[str, str], str]:
     config (plugins.yaml), finds all .whl files in that directory,
     and returns both the file mounts for uploading them to remote clusters and
     the shell commands for installing them.
+
+    The install commands are idempotent: wheels whose filename is already
+    recorded on the controller (in ``~/.sky/plugins/.installed_wheels``) are
+    skipped, and concurrent installs are serialized via ``flock`` so that
+    parallel launches don't race through the install step and break in-flight
+    plugin imports with partial site-packages state.
 
     Returns:
         A tuple of:
@@ -64,7 +147,7 @@ def get_plugin_mounts_and_commands() -> Tuple[Dict[str, str], str]:
         return {}, ''
 
     file_mounts: Dict[str, str] = {}
-    commands = []
+    entries: List[Tuple[str, str, str]] = []
 
     for wheel_path in wheel_files:
         # File mount: upload the wheel file directly to the remote cluster
@@ -72,15 +155,10 @@ def get_plugin_mounts_and_commands() -> Tuple[Dict[str, str], str]:
         remote_wheel_path = (f'{_REMOTE_PLUGINS_WHEEL_DIR}/'
                              f'{wheel_path.name}')
         file_mounts[remote_wheel_path] = str(wheel_path)
+        entries.append((wheel_path.name, _wheel_name_prefix(wheel_path.name),
+                        remote_wheel_path))
 
-        # Installation command: install the wheel on the remote cluster
-        # Use ~ which will be expanded by the shell when the command runs.
-        # Note: We don't quote the path so that ~ gets expanded by the shell
-        install_cmd = (f'{constants.SKY_UV_PIP_CMD} install '
-                       f'{remote_wheel_path}')
-        commands.append(install_cmd)
-
-    return file_mounts, ' && '.join(commands)
+    return file_mounts, _build_guarded_install_script(entries)
 
 
 def get_filtered_plugins_config_path() -> Optional[str]:

--- a/sky/server/plugin_utils.py
+++ b/sky/server/plugin_utils.py
@@ -5,7 +5,6 @@ to remote clusters.
 """
 import os
 import pathlib
-import re
 import shlex
 from typing import Dict, List, Optional, Tuple
 
@@ -33,13 +32,8 @@ def _wheel_name_prefix(wheel_filename: str) -> str:
 
     PEP 427 wheel filenames are ``{name}-{version}(-{build})?-{py}-{abi}-
     {platform}.whl`` with hyphens in the distribution name replaced by
-    underscores, so the name portion is whatever precedes the first
-    ``-<digit>``.
+    underscores, so the name portion is whatever precedes the first hyphen.
     """
-    match = re.match(r'^(.+?)-\d', wheel_filename)
-    if match:
-        return f'{match.group(1)}-'
-    # Fallback: first hyphen-delimited token. Shouldn't normally trigger.
     return wheel_filename.split('-', 1)[0] + '-'
 
 
@@ -70,7 +64,7 @@ def _build_guarded_install_script(entries: List[Tuple[str, str, str]]) -> str:
   else
     echo "Installing plugin wheel {wheel_name}..."
     {constants.SKY_UV_PIP_CMD} install {remote_wheel}
-    _sky_tmp=$(mktemp)
+    _sky_tmp=$(mktemp "$_sky_stamp.XXXXXX")
     grep -v "^"{q_prefix} "$_sky_stamp" > "$_sky_tmp" || true
     echo {q_wheel} >> "$_sky_tmp"
     mv "$_sky_tmp" "$_sky_stamp"

--- a/sky/server/plugin_utils.py
+++ b/sky/server/plugin_utils.py
@@ -16,14 +16,8 @@ logger = sky_logging.init_logger(__name__)
 
 # Remote directory for plugin wheels
 _REMOTE_PLUGINS_WHEEL_DIR = '~/.sky/plugins/wheels'
-# Stamp file listing wheel filenames already installed on the controller.
 _REMOTE_STAMP_FILE = '~/.sky/plugins/.installed_wheels'
-# Lock serializing concurrent plugin installs across parallel launches on the
-# same controller. Without this, two `sky jobs launch` invocations racing
-# through the run phase can half-rewrite site-packages while other plugin
-# imports are in flight, producing transient ImportError.
 _REMOTE_INSTALL_LOCK = '~/.sky/plugins/.install.lock'
-# Timeout (seconds) to wait for the install lock before giving up.
 _INSTALL_LOCK_TIMEOUT = 600
 
 
@@ -37,7 +31,7 @@ def _wheel_name_prefix(wheel_filename: str) -> str:
     return wheel_filename.split('-', 1)[0] + '-'
 
 
-def _build_guarded_install_script(entries: List[Tuple[str, str, str]]) -> str:
+def _build_guarded_install_script(wheels: List[Tuple[str, str]]) -> str:
     """Build a shell script that installs each wheel at most once.
 
     For each wheel, the script:
@@ -48,13 +42,12 @@ def _build_guarded_install_script(entries: List[Tuple[str, str, str]]) -> str:
        stamp file and prunes stale wheel files for that package.
 
     Args:
-        entries: list of ``(wheel_filename, package_prefix, remote_path)``.
+        wheels: list of ``(wheel_filename, remote_path)`` pairs.
     """
     install_blocks = []
-    for wheel_name, pkg_prefix, remote_wheel in entries:
+    for wheel_name, remote_wheel in wheels:
         q_wheel = shlex.quote(wheel_name)
-        q_prefix = shlex.quote(pkg_prefix)
-        q_prefix_glob = shlex.quote(f'{pkg_prefix}*.whl')
+        q_prefix = shlex.quote(_wheel_name_prefix(wheel_name))
         # remote_wheel starts with '~' which must be left unquoted so the
         # shell expands it; the filename portion cannot contain shell
         # metacharacters by PEP 427.
@@ -64,12 +57,7 @@ def _build_guarded_install_script(entries: List[Tuple[str, str, str]]) -> str:
   else
     echo "Installing plugin wheel {wheel_name}..."
     {constants.SKY_UV_PIP_CMD} install {remote_wheel}
-    _sky_tmp=$(mktemp "$_sky_stamp.XXXXXX")
-    grep -v "^"{q_prefix} "$_sky_stamp" > "$_sky_tmp" || true
-    echo {q_wheel} >> "$_sky_tmp"
-    mv "$_sky_tmp" "$_sky_stamp"
-    find {_REMOTE_PLUGINS_WHEEL_DIR} -maxdepth 1 \\
-      -name {q_prefix_glob} ! -name {q_wheel} -delete 2>/dev/null || true
+    _sky_record {q_prefix} {q_wheel}
   fi""")
 
     body = '\n'.join(install_blocks)
@@ -84,6 +72,15 @@ def _build_guarded_install_script(entries: List[Tuple[str, str, str]]) -> str:
   }}
   _sky_stamp={_REMOTE_STAMP_FILE}
   touch "$_sky_stamp"
+  _sky_record() {{
+    local _t
+    _t=$(mktemp "$_sky_stamp.XXXXXX")
+    grep -v "^$1" "$_sky_stamp" > "$_t" || true
+    echo "$2" >> "$_t"
+    mv "$_t" "$_sky_stamp"
+    find {_REMOTE_PLUGINS_WHEEL_DIR} -maxdepth 1 \\
+      -name "$1*.whl" ! -name "$2" -delete 2>/dev/null || true
+  }}
 {body}
 )"""
 
@@ -141,7 +138,7 @@ def get_plugin_mounts_and_commands() -> Tuple[Dict[str, str], str]:
         return {}, ''
 
     file_mounts: Dict[str, str] = {}
-    entries: List[Tuple[str, str, str]] = []
+    wheels: List[Tuple[str, str]] = []
 
     for wheel_path in wheel_files:
         # File mount: upload the wheel file directly to the remote cluster
@@ -149,10 +146,9 @@ def get_plugin_mounts_and_commands() -> Tuple[Dict[str, str], str]:
         remote_wheel_path = (f'{_REMOTE_PLUGINS_WHEEL_DIR}/'
                              f'{wheel_path.name}')
         file_mounts[remote_wheel_path] = str(wheel_path)
-        entries.append((wheel_path.name, _wheel_name_prefix(wheel_path.name),
-                        remote_wheel_path))
+        wheels.append((wheel_path.name, remote_wheel_path))
 
-    return file_mounts, _build_guarded_install_script(entries)
+    return file_mounts, _build_guarded_install_script(wheels)
 
 
 def get_filtered_plugins_config_path() -> Optional[str]:

--- a/sky/templates/jobs-controller.yaml.j2
+++ b/sky/templates/jobs-controller.yaml.j2
@@ -44,7 +44,7 @@ run: |
   {{ sky_activate_python_env }}
   # Install plugin wheels if any
   {%- if plugins_wheel_install_commands %}
-  {{plugins_wheel_install_commands}}
+  {{ plugins_wheel_install_commands | indent(2) }}
   # Move the temporary plugins config to the final location if it exists
   if [ -f {{remote_plugins_config_path}}.tmp ]; then
     mv {{remote_plugins_config_path}}.tmp {{remote_plugins_config_path}}

--- a/sky/templates/sky-serve-controller.yaml.j2
+++ b/sky/templates/sky-serve-controller.yaml.j2
@@ -61,7 +61,7 @@ run: |
   {{ sky_activate_python_env }}
   # Install plugin wheels if any
   {%- if plugins_wheel_install_commands %}
-  {{plugins_wheel_install_commands}}
+  {{ plugins_wheel_install_commands | indent(2) }}
   # Move the temporary plugins config to the final location if it exists
   if [ -f {{remote_plugins_config_path}}.tmp ]; then
     mv {{remote_plugins_config_path}}.tmp {{remote_plugins_config_path}}

--- a/tests/unit_tests/test_sky/server/test_plugin_utils.py
+++ b/tests/unit_tests/test_sky/server/test_plugin_utils.py
@@ -92,8 +92,11 @@ def test_get_plugin_mounts_and_commands(monkeypatch, tmp_path):
     assert 'another_plugin-0.0.2-py3-none-any.whl' in commands
     # Path should use ~ for shell expansion (not quoted)
     assert '~/.sky/plugins/wheels' in commands
-    # Should have && between commands
-    assert ' && ' in commands
+    # Concurrent launches must be serialized via flock, and installs must be
+    # gated on a stamp file so same-version rebuilds are skipped.
+    assert 'flock' in commands
+    assert '.installed_wheels' in commands
+    assert 'grep -Fxq' in commands
 
 
 def test_get_plugin_mounts_and_commands_no_wheel_path(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

On every controller launch (`sky jobs launch`, `sky serve up`, etc.), the controller's `run` phase unconditionally `uv pip install`s every plugin wheel listed in `controller_wheel_path`. Two problems with this:

1. **Wasted work** when the wheel hasn't changed since the last launch.
2. **Flaky imports** — parallel launches can race through the install step and briefly leave `site-packages` in a half-rewritten state, causing transient `ImportError` in other plugin-using processes on the same controller.

`get_plugin_mounts_and_commands()` now emits a guarded install script that:

- Takes an exclusive `flock` on `~/.sky/plugins/.install.lock`, serializing concurrent launches through the install critical section.
- Checks a stamp file (`~/.sky/plugins/.installed_wheels`) listing already-installed wheel filenames; if the current wheel's filename is listed, the install is skipped.
- On install, replaces any prior stamp entry for the same package and `find`-deletes older wheels of that package so the wheel directory doesn't grow unbounded across upgrades.

Idempotency relies on the wheel filename encoding the build identity via its PEP 440 version (including any local-version segment such as `+<sha>`), which is how plugin producers already distinguish builds.

The two controller templates (`jobs-controller.yaml.j2`, `sky-serve-controller.yaml.j2`) pipe `plugins_wheel_install_commands` through `| indent(2)` so the now-multiline install block preserves YAML block-scalar indentation.

## Test plan

- [x] `_wheel_name_prefix` parses both plain (`pkg-1.2.3-...`) and local-version (`pkg-1.2.3+abc-...`) wheel filenames.
- [x] Rendered `jobs-controller.yaml.j2` with a representative wheel; `yaml.safe_load` accepts the result.
- [x] `bash format.sh` passes (black / yapf / isort / mypy / pylint).
- [ ] Smoke test on a real jobs controller: launch once, verify plugin wheel installs; launch again with same wheel, verify the install step prints `already installed, skipping.` and does not call `uv pip install`.
- [ ] Race test: two concurrent `sky jobs launch` invocations on the same controller after a version bump — only one `Installing plugin wheel ...` log line should appear, and no transient `ImportError` should be observed in parallel plugin-using processes.