### PR TITLE
[Core] Make wheel builds reproducible across processes

### DIFF
--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -154,10 +154,10 @@ def _build_sky_wheel() -> pathlib.Path:
         # SOURCE_DATE_EPOCH is a standardized env var for reproducible builds
         # (https://reproducible-builds.org/docs/source-date-epoch/). Forces
         # pip to use a fixed timestamp in zip entries instead of file mtimes.
-        # env['SOURCE_DATE_EPOCH'] = '0'
+        env['SOURCE_DATE_EPOCH'] = '0'
         # PYTHONHASHSEED=0 makes pip emit Requires-Dist metadata in
         # deterministic order (dict/set iteration depends on hash seed).
-        # env['PYTHONHASHSEED'] = '0'
+        env['PYTHONHASHSEED'] = '0'
         try:
             subprocess.run([
                 sys.executable, '-m', 'pip', 'wheel', '--no-deps', norm_path,

--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -148,8 +148,8 @@ def _build_sky_wheel() -> pathlib.Path:
         # Ensure reproducible wheel builds across processes and machines:
         # Without these, API server replicas produce wheels with different
         # hashes for identical source, which may cause unnecessary wheel
-        # reinstallations on sky clusters, as SKYPILOT_WHEEL_INSTALLATION_COMMANDS
-        # check for the sky wheel hash.
+        # reinstallations on sky clusters, as
+        # SKYPILOT_WHEEL_INSTALLATION_COMMANDS check for the wheel hash.
         env = os.environ.copy()
         # SOURCE_DATE_EPOCH is a standardized env var for reproducible builds
         # (https://reproducible-builds.org/docs/source-date-epoch/). Forces

--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -144,6 +144,20 @@ def _build_sky_wheel() -> pathlib.Path:
         # TODO(#5046): Consider adding native UV support for building wheels.
         # Use `python -m pip` instead of `pip3` for better compatibility across
         # different environments (conda, venv, UV, system Python, etc.)
+        #
+        # Ensure reproducible wheel builds across processes and machines:
+        # Without these, API server replicas produce wheels with different
+        # hashes for identical source, which may cause unnecessary wheel
+        # reinstallations on sky clusters, as SKYPILOT_WHEEL_INSTALLATION_COMMANDS
+        # check for the sky wheel hash.
+        env = os.environ.copy()
+        # SOURCE_DATE_EPOCH is a standardized env var for reproducible builds
+        # (https://reproducible-builds.org/docs/source-date-epoch/). Forces
+        # pip to use a fixed timestamp in zip entries instead of file mtimes.
+        # env['SOURCE_DATE_EPOCH'] = '0'
+        # PYTHONHASHSEED=0 makes pip emit Requires-Dist metadata in
+        # deterministic order (dict/set iteration depends on hash seed).
+        # env['PYTHONHASHSEED'] = '0'
         try:
             subprocess.run([
                 sys.executable, '-m', 'pip', 'wheel', '--no-deps', norm_path,
@@ -152,7 +166,8 @@ def _build_sky_wheel() -> pathlib.Path:
             ],
                            capture_output=True,
                            check=True,
-                           text=True)
+                           text=True,
+                           env=env)
         except subprocess.CalledProcessError as e:
             error_msg = e.stderr
             if 'No module named pip' in error_msg:

--- a/tests/test_wheels.py
+++ b/tests/test_wheels.py
@@ -180,8 +180,9 @@ def test_wheel_build_reproducible():
     separate processes building the same source can produce different wheel
     hashes due to non-deterministic metadata ordering and zip timestamps.
 
-    We simulate this by running each build in a separate subprocess with a
-    different PYTHONHASHSEED, just like different API server replicas would.
+    We simulate this by running each build in a separate subprocess,
+    just like different API server replicas would. Each subprocess gets
+    a naturally randomized PYTHONHASHSEED.
     """
     build_script = (
         'import shutil, os; '

--- a/tests/test_wheels.py
+++ b/tests/test_wheels.py
@@ -193,18 +193,21 @@ def test_wheel_build_reproducible():
 
     try:
         result1 = subprocess.run([sys.executable, '-c', build_script],
-                                 capture_output=True, text=True, check=True)
+                                 capture_output=True,
+                                 text=True,
+                                 check=True)
         hash1 = result1.stdout.strip().splitlines()[-1]
 
         result2 = subprocess.run([sys.executable, '-c', build_script],
-                                 capture_output=True, text=True, check=True)
+                                 capture_output=True,
+                                 text=True,
+                                 check=True)
         hash2 = result2.stdout.strip().splitlines()[-1]
 
         assert hash1 == hash2, (
             f'Wheel build is not reproducible across processes: '
             f'{hash1} != {hash2}. '
             'Check that SOURCE_DATE_EPOCH and PYTHONHASHSEED are set in the '
-            'pip wheel subprocess environment in _build_sky_wheel().'
-        )
+            'pip wheel subprocess environment in _build_sky_wheel().')
     finally:
         shutil.rmtree(wheel_utils.WHEEL_DIR, ignore_errors=True)

--- a/tests/test_wheels.py
+++ b/tests/test_wheels.py
@@ -170,3 +170,40 @@ def test_python_m_pip_usage():
 
         # Verify we're NOT using pip3
         assert 'pip3' not in call_args
+
+
+def test_wheel_build_reproducible():
+    """Test that wheel builds are reproducible across separate processes.
+
+    PYTHONHASHSEED is randomized per-process, so without the fix (setting
+    SOURCE_DATE_EPOCH and PYTHONHASHSEED in the pip subprocess env), two
+    separate processes building the same source can produce different wheel
+    hashes due to non-deterministic metadata ordering and zip timestamps.
+
+    We simulate this by running each build in a separate subprocess with a
+    different PYTHONHASHSEED, just like different API server replicas would.
+    """
+    build_script = (
+        'import shutil, os; '
+        'from sky.backends import wheel_utils; '
+        'shutil.rmtree(str(wheel_utils.WHEEL_DIR), ignore_errors=True); '
+        '_, h = wheel_utils.build_sky_wheel(); '
+        'print(h)')
+
+    try:
+        result1 = subprocess.run([sys.executable, '-c', build_script],
+                                 capture_output=True, text=True, check=True)
+        hash1 = result1.stdout.strip().splitlines()[-1]
+
+        result2 = subprocess.run([sys.executable, '-c', build_script],
+                                 capture_output=True, text=True, check=True)
+        hash2 = result2.stdout.strip().splitlines()[-1]
+
+        assert hash1 == hash2, (
+            f'Wheel build is not reproducible across processes: '
+            f'{hash1} != {hash2}. '
+            'Check that SOURCE_DATE_EPOCH and PYTHONHASHSEED are set in the '
+            'pip wheel subprocess environment in _build_sky_wheel().'
+        )
+    finally:
+        shutil.rmtree(wheel_utils.WHEEL_DIR, ignore_errors=True)


### PR DESCRIPTION
## Summary

`pip wheel` produces non-deterministic output due to:
1. **Zip entry timestamps** reflect file mtimes (differ across builds at different times)
2. **[`Requires-Dist`](https://packaging.python.org/en/latest/specifications/core-metadata/#requires-dist-multiple-use) metadata ordering** depends on `PYTHONHASHSEED` (randomized per-process). Because for dictionaries, the order in which the keys are stored is not deterministic.

For example, the `[all]` extra in SkyPilot's wheel METADATA contains ~40 `Requires-Dist` entries like:
```
Requires-Dist: azure-mgmt-network>=27.0.0; extra == "all"
Requires-Dist: pydo>=0.3.0; extra == "all"
Requires-Dist: botocore>=1.29.10; extra == "all"
Requires-Dist: google-cloud-storage; extra == "all"
...
```
These are the same dependencies but emitted in different order by each process, because `pip` iterates over a dict/set whose order depends on the per-process hash seed.

This causes API server replicas to produce different wheel hashes for identical source code. The jobs controller scheduler compares wheel hashes to detect code changes (`sky/jobs/scheduler.py:222-240`), so hash mismatches trigger unnecessary controller resets — killing all running controllers and re-queuing in-flight jobs.

**Fix**: Set `SOURCE_DATE_EPOCH=0` and `PYTHONHASHSEED=0` in the `pip wheel` subprocess environment.

- [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/docs/source-date-epoch/) is a standardized env var for reproducible builds — forces pip to use a fixed timestamp in zip entries.
- `PYTHONHASHSEED=0` makes pip emit metadata in deterministic dict iteration order.

Reference: https://stackoverflow.com/questions/34437764/python-wheel-same-source-code-but-different-md5sum

## Test plan

- New unit test `test_wheel_build_reproducible`: builds wheels in two separate subprocesses (simulating different replicas with different `PYTHONHASHSEED`) and asserts identical hashes.
  - **Fix commented out → test fails** (this commit)
  - **Fix enabled → test passes** (follow-up commit)
- Manually verified on live EKS cluster: two API server replicas produce identical wheel hashes with the fix, different without.