### PR TITLE
[Dashboard] Show Ti units for volume sizes >= 1024Gi

### DIFF
--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -366,8 +366,9 @@ function VolumesTable({
   };
 
   const formatSize = (size) => {
-    if (!size) return '-';
-    return size;
+    if (size == null) return '-';
+    if (size >= 1024) return `${+(size / 1024).toFixed(1)}Ti`;
+    return `${size}Gi`;
   };
 
   const formatTimestamp = (timestamp) => {

--- a/sky/dashboard/src/data/connectors/volumes.js
+++ b/sky/dashboard/src/data/connectors/volumes.js
@@ -29,7 +29,7 @@ export async function getVolumes() {
           region: volume.region,
           zone: volume.zone,
           infra: infra,
-          size: volume.size != null ? (volume.size >= 1024 ? `${+(volume.size / 1024).toFixed(1)}Ti` : `${volume.size}Gi`) : '-',
+          size: volume.size,
           config: volume.config,
           storage_class: volume.config?.storage_class_name || '-',
           access_mode: volume.config?.access_mode || '-',

--- a/sky/dashboard/src/data/connectors/volumes.js
+++ b/sky/dashboard/src/data/connectors/volumes.js
@@ -29,7 +29,7 @@ export async function getVolumes() {
           region: volume.region,
           zone: volume.zone,
           infra: infra,
-          size: volume.size != null ? `${volume.size}Gi` : '-',
+          size: volume.size != null ? (volume.size >= 1024 ? `${+(volume.size / 1024).toFixed(1)}Ti` : `${volume.size}Gi`) : '-',
           config: volume.config,
           storage_class: volume.config?.storage_class_name || '-',
           access_mode: volume.config?.access_mode || '-',


### PR DESCRIPTION
Display volume sizes in Ti when >= 1024Gi (e.g., 2.5Ti) with up to one significant decimal digit.

<img width="1339" height="645" alt="image" src="https://github.com/user-attachments/assets/2a41665a-f5dd-4fa0-adb2-622165342307" />


<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
