### PR TITLE
[GPU Metrics] Add GPU model filter to DCGM cluster grafana dashboard

### DIFF
--- a/charts/skypilot/manifests/dcgm-cluster-dashboard.json
+++ b/charts/skypilot/manifests/dcgm-cluster-dashboard.json
@@ -85,7 +85,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(avg by (node, gpu, cluster) (DCGM_FI_DEV_GPU_TEMP{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}))",
+          "expr": "avg(avg by (node, gpu, cluster) (DCGM_FI_DEV_GPU_TEMP{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\", modelName=~\"$modelName\"}))",
           "interval": "",
           "legendFormat": "",
           "range": true,
@@ -169,7 +169,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(avg by (node, gpu, cluster) (DCGM_FI_DEV_POWER_USAGE{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}))",
+          "expr": "sum(avg by (node, gpu, cluster) (DCGM_FI_DEV_POWER_USAGE{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\", modelName=~\"$modelName\"}))",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -283,7 +283,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(increase(avg by (node, gpu, cluster) (DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}))[1h]) / 3600000)",
+          "expr": "sum(increase(avg by (node, gpu, cluster) (DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\", modelName=~\"$modelName\"}))[1h]) / 3600000)",
           "instant": false,
           "interval": "",
           "legendFormat": "Last 1h",
@@ -296,7 +296,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(increase(avg by (node, gpu, cluster) (DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}))[24h]) / 3600000)",
+          "expr": "sum(increase(avg by (node, gpu, cluster) (DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\", modelName=~\"$modelName\"}))[24h]) / 3600000)",
           "hide": false,
           "instant": false,
           "legendFormat": "Last 24h",
@@ -428,7 +428,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "avg by (node, gpu, cluster) (DCGM_FI_DEV_POWER_USAGE{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"})",
+          "expr": "avg by (node, gpu, cluster) (DCGM_FI_DEV_POWER_USAGE{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\", modelName=~\"$modelName\"})",
           "interval": "",
           "legendFormat": "{{node}} - GPU {{gpu}}",
           "range": true,
@@ -543,7 +543,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "avg by (node, gpu, cluster) (DCGM_FI_DEV_FB_USED{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"})",
+          "expr": "avg by (node, gpu, cluster) (DCGM_FI_DEV_FB_USED{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\", modelName=~\"$modelName\"})",
           "interval": "",
           "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
           "range": true,
@@ -660,7 +660,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "avg by (node, gpu, cluster) (DCGM_FI_DEV_FB_USED{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}) / (avg by (node, gpu, cluster) (DCGM_FI_DEV_FB_USED{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}) + avg by (node, gpu, cluster) (DCGM_FI_DEV_FB_FREE{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}))",
+          "expr": "avg by (node, gpu, cluster) (DCGM_FI_DEV_FB_USED{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\", modelName=~\"$modelName\"}) / (avg by (node, gpu, cluster) (DCGM_FI_DEV_FB_USED{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\", modelName=~\"$modelName\"}) + avg by (node, gpu, cluster) (DCGM_FI_DEV_FB_FREE{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\", modelName=~\"$modelName\"}))",
           "interval": "",
           "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
           "range": true,
@@ -777,7 +777,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "avg by (node, gpu, cluster) (DCGM_FI_DEV_GPU_UTIL{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"})",
+          "expr": "avg by (node, gpu, cluster) (DCGM_FI_DEV_GPU_UTIL{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\", modelName=~\"$modelName\"})",
           "interval": "",
           "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
           "range": true,
@@ -894,7 +894,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "avg by (node, gpu, cluster) (DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"})",
+          "expr": "avg by (node, gpu, cluster) (DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\", modelName=~\"$modelName\"})",
           "interval": "",
           "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
           "range": true,
@@ -1009,7 +1009,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "avg by (node, gpu, cluster) (DCGM_FI_DEV_GPU_TEMP{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"})",
+          "expr": "avg by (node, gpu, cluster) (DCGM_FI_DEV_GPU_TEMP{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\", modelName=~\"$modelName\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
@@ -1124,7 +1124,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "avg by (node, gpu, cluster) (DCGM_FI_DEV_SM_CLOCK{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}) * 1000000",
+          "expr": "avg by (node, gpu, cluster) (DCGM_FI_DEV_SM_CLOCK{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\", modelName=~\"$modelName\"}) * 1000000",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1429,6 +1429,35 @@
         "refresh": 1,
         "regex": "/gpu=\"([^\"]+)/",
         "sort": 3,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(DCGM_FI_DEV_GPU_UTIL, modelName)",
+        "includeAll": true,
+        "label": "GPU Model",
+        "multi": true,
+        "name": "modelName",
+        "options": [],
+        "query": {
+          "query": "label_values(DCGM_FI_DEV_GPU_UTIL, modelName)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
         "type": "query"
       },
       {


### PR DESCRIPTION
## Summary

- Add a `modelName` template variable to the DCGM Kubernetes cluster dashboard so panels can be filtered by GPU SKU (e.g. H100, H200, A100).
- Include `modelName=~"$modelName"` in the label selectors of the 11 DCGM panel queries alongside the existing `$host`, `$gpu`, and `$cluster` filters.
- Default is "All" so existing embedded-panel URLs and behavior are preserved.

The `modelName` label is already emitted on DCGM metrics and shown in panel legend formats (e.g. `{{node}} - {{modelName}} GPU {{gpu}}`), but there was previously no template variable for it, so there was no way to narrow a dashboard to a specific GPU SKU. AMD panels are unaffected.

## Test plan

- [ ] Load the DCGM Kubernetes cluster dashboard in Grafana with a Prometheus data source scraping DCGM exporters and verify the new "GPU Model" dropdown appears in the variable bar and is populated with the distinct `modelName` values present in the series.
- [ ] Select a single model (e.g. `NVIDIA H100 80GB HBM3`) and confirm all DCGM panels narrow to that model.
- [ ] Select "All" and confirm all panels return to showing every model.
- [ ] Pass `var-modelName=H100` as a URL parameter on an embedded solo panel (`d-solo/...`) and confirm the panel filters correctly.
- [ ] Confirm AMD-backed panels (amd_gpu_* metrics) are unaffected when the variable changes.