### PR TITLE
[Dashboard] Make cluster/job log panels adaptive to viewport height

### DIFF
--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -838,7 +838,7 @@ function ProvisionLogs({ clusterName, numNodes }) {
               <span>No provision logs available.</span>
             </div>
           ) : (
-            <div className="max-h-96 overflow-y-auto">
+            <div className="max-h-[50vh] min-h-[200px] overflow-y-auto">
               <LogFilter logs={displayLines} />
             </div>
           )}

--- a/sky/dashboard/src/pages/clusters/[cluster]/[job].js
+++ b/sky/dashboard/src/pages/clusters/[cluster]/[job].js
@@ -368,7 +368,7 @@ export function JobDetailPage() {
                       <span>Loading...</span>
                     </div>
                   ) : (
-                    <div className="max-h-[calc(100vh-572px)] overflow-y-auto">
+                    <div className="max-h-[max(200px,calc(100vh_-_572px))] overflow-y-auto">
                       <LogFilter logs={displayLines} />
                     </div>
                   )}

--- a/sky/dashboard/src/pages/clusters/[cluster]/[job].js
+++ b/sky/dashboard/src/pages/clusters/[cluster]/[job].js
@@ -368,7 +368,7 @@ export function JobDetailPage() {
                       <span>Loading...</span>
                     </div>
                   ) : (
-                    <div className="max-h-96 overflow-y-auto">
+                    <div className="max-h-[calc(100vh-572px)] overflow-y-auto">
                       <LogFilter logs={displayLines} />
                     </div>
                   )}


### PR DESCRIPTION
## Summary

On tall monitors, the log panels on the cluster detail and job detail pages were capped at `max-h-96` (384px), leaving large empty space below and requiring scrolling to read more than ~20 lines of logs.

- **Cluster detail** (`ProvisionLogs`): cap at `50vh` with a `200px` minimum, so the panel grows with the window but stays secondary to the page content.
- **Job detail** logs: use `max-h-[calc(100vh-572px)]` so the panel fills the remaining viewport below the Details card, while staying adaptive (short log output does not stretch the dark background to the bottom of the screen).

Before:
<img width="1301" height="1521" alt="Before - Screenshot 2026-04-16 at 16 28 31" src="https://github.com/user-attachments/assets/5d756e2c-834a-48f4-a760-6159ebe8e93e" />

After:
<img width="1307" height="1523" alt="Screenshot 2026-04-16 at 16 31 49" src="https://github.com/user-attachments/assets/595455ca-222a-4eae-97e3-1af68e120860" />



## Test plan

- [ ] Build the dashboard: `npm --prefix sky/dashboard install && npm --prefix sky/dashboard run build`
- [ ] `sky api stop && sky api start`
- [ ] Open `/dashboard/clusters/<name>` on a tall monitor; expand `Provision Logs`. Verify the panel grows beyond the old 384px cap up to ~50% of the viewport, and no longer feels cramped.
- [ ] Open `/dashboard/clusters/<name>/<job-id>`. Verify:
  - With many log lines, the Logs card fills the remaining viewport and the card's bottom border is visible.
  - With few log lines, the panel shrinks to content and does not stretch the dark background to the bottom of the screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)