### PR TITLE
Avoid catalog lookup in Resources.to_yaml_config()

### DIFF
--- a/sky/resources.py
+++ b/sky/resources.py
@@ -2504,9 +2504,18 @@ class Resources:
         infra = self.infra.to_str()
         add_if_not_none('infra', infra)
 
+        # NOTE: prefer raw `self._<field>` attributes over the derived
+        # properties (`self.<field>`) when serializing. Several properties
+        # (e.g. `memory`, `accelerators`, `cpus`) fall back to deriving
+        # values from the instance-type catalog, which reads CSVs via
+        # pandas and requires cloud-specific deps. That work is
+        # unnecessary at serialization time -- any consumer that needs
+        # the derived value can re-derive it from `instance_type` -- and
+        # it pulls heavy imports into client-only code paths (e.g. the
+        # SDK's pre-flight `validate()` on a thin client without pandas).
         add_if_not_none('instance_type', self.instance_type)
         add_if_not_none('cpus', self._cpus)
-        add_if_not_none('memory', self.memory)
+        add_if_not_none('memory', self._memory)
         add_if_not_none('accelerators', self._accelerators)
         add_if_not_none('accelerator_args', self.accelerator_args)
 

--- a/tests/unit_tests/test_client_thin_install.py
+++ b/tests/unit_tests/test_client_thin_install.py
@@ -1,0 +1,99 @@
+"""Regression tests for thin-client installs that lack heavy deps.
+
+See https://github.com/skypilot-org/skypilot/pull/9373.
+"""
+import subprocess
+import sys
+import textwrap
+
+
+def test_client_validate_does_not_import_pandas():
+    """Client-side `sdk.validate(dag)` must not import pandas.
+
+    Thin-client installs (e.g. a CLI bundled with a stripped standalone
+    Python that ships only the deps needed to POST to a remote API server)
+    may not have pandas. The server owns the instance-type catalog and
+    re-derives any instance-type-dependent fields it needs.
+
+    We enforce this invariant in a subprocess with a `sys.meta_path`
+    finder that raises `ImportError` for any `pandas*` import. Any client
+    path that reaches pandas (directly or via a LazyImport first access)
+    causes the subprocess to exit nonzero. Subprocess isolation avoids
+    pollution from other tests that may have already imported pandas
+    into the parent process's `sys.modules`.
+
+    The test mocks only the HTTP transport and the server health check so
+    that `sdk.validate()` can run end-to-end without a live server --
+    everything else about the call is real: decorators, user-specified
+    yaml handling, DAG serialization, admin-policy plumbing, version
+    negotiation, etc.
+    """
+    script = textwrap.dedent('''
+        import sys
+
+        class _PandasBlocker:
+            """Finder that refuses every pandas-related import."""
+
+            def find_spec(self, name, path=None, target=None):
+                if name == "pandas" or name.startswith("pandas."):
+                    raise ImportError(
+                        f"pandas import blocked: {name!r}. Client code "
+                        "must not import pandas. "
+                        "See skypilot-org/skypilot#9373."
+                    )
+                return None
+
+        sys.meta_path.insert(0, _PandasBlocker())
+
+        # `import sky` itself must not import pandas. If it does, this
+        # raises here and the test surfaces the failing import.
+        import sky
+        import sky.client.sdk as sdk
+        from unittest import mock
+
+        class _FakeResponse:
+            status_code = 200
+
+            def json(self):
+                return {}
+
+        task = sky.Task(run="echo hi")
+        task.set_resources(
+            sky.Resources(cloud=sky.AWS(), instance_type="m6a.4xlarge"))
+        dag = sky.Dag()
+        dag.add(task)
+
+        # Mock the HTTP + server-health primitives only. Everything
+        # between the client-facing API and the wire is real code.
+        with mock.patch(
+                "sky.server.common.make_authenticated_request",
+                return_value=_FakeResponse(),
+        ), mock.patch(
+                "sky.server.common.check_server_healthy_or_start_fn",
+                return_value=None,
+        ):
+            sdk.validate(dag)
+
+        leaked = [
+            m for m in sys.modules
+            if m == "pandas" or m.startswith("pandas.")
+        ]
+        assert not leaked, f"pandas leaked into sys.modules: {leaked}"
+        print("OK")
+    ''')
+
+    result = subprocess.run([sys.executable, '-c', script],
+                            capture_output=True,
+                            text=True,
+                            timeout=60)
+    # The script prints `OK` as its final line after all assertions pass.
+    # Skypilot may emit debug logs earlier in stdout (depending on log
+    # level), so check the last non-empty line rather than equality.
+    last_line = next(
+        (line for line in reversed(result.stdout.splitlines()) if line.strip()),
+        '')
+    assert result.returncode == 0 and last_line.strip() == 'OK', (
+        'Subprocess failed. Client-side code appears to import pandas.\n'
+        f'returncode: {result.returncode}\n'
+        f'stdout:\n{result.stdout}\n'
+        f'stderr:\n{result.stderr}\n')


### PR DESCRIPTION
## Summary

`Resources.to_yaml_config()` currently emits `memory` by reading the `self.memory` **property**, whose getter falls back to deriving memory from the instance-type catalog when `_memory` is unset:

https://github.com/skypilot-org/skypilot/blob/master/sky/resources.py#L630-L645

That derivation ends up in `sky/catalog/aws_catalog.py::_fetch_and_apply_az_mapping`, which reads a CSV via pandas. As a result, a plain `to_yaml_config()` call on a `Resources(cloud='aws', instance_type='<type>')` object imports pandas and hits the catalog on disk — just to serialize YAML.

This is problematic for thin client installs that only need to send requests to a remote API server (no local planning/optimization). The SDK's `sky.client.sdk.validate()` serializes the DAG before sending, producing:

```
ModuleNotFoundError: No module named 'pandas'
```

on `sky launch --infra aws --instance-type <type>` when pandas isn't installed.

## Change

Serialize the raw `self._memory` instead of the derived property, mirroring how `cpus` already works in the same function (`self._cpus` on the next line). Any consumer that wants the derived value can re-compute it from `instance_type` using its own catalog (the server already does this). Adds a comment at the top of the serialization block warning future contributors about the same trap for `cpus`, `accelerators`, and `local_disk`, whose properties have the same pattern.

## Why it's safe

- Live `Resources` objects still return the derived value via `.memory` as before — nothing about the property has changed.
- Round-trip: YAML → `Resources` has `_memory=None` + `_instance_type` set, so later `.memory` access re-derives.
- The `cpus` field has been using `self._cpus` in `to_yaml_config()` already, and the backend's `ResourceHandle` is documented to always have `cpus=None` (https://github.com/skypilot-org/skypilot/blob/master/sky/resources.py#L617-L619) — so downstream code already handles "field missing from YAML" for cpus. Memory is brought into line.

## What changes for consumers that only read the YAML dict

If a consumer (e.g. an admin-policy plugin, usage tracking) reads the dict and expects `memory` to be populated when the user only specified `instance_type`, it will now see `None`. That seems like the more honest representation — the user didn't ask for a specific memory value, the catalog did. If preserving the old behavior matters for a specific caller, that caller can derive memory from `instance_type` itself.

## Test plan

- [ ] Existing unit/smoke tests pass.
- [ ] `Resources(cloud=AWS(), instance_type='m6a.4xlarge').to_yaml_config()` no longer imports pandas (can be verified by running in a venv without pandas installed).
- [ ] `sky launch --infra aws --instance-type m6a.4xlarge` from a pandas-less client environment reaches the server without a `ModuleNotFoundError`.
- [ ] Round-trip: `Resources → to_yaml_config → Resources.from_yaml_config → .memory` returns the same derived value as the original on a host with the catalog available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)