### PR TITLE
[Dashboard] Default managed jobs sort to job_id

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -478,7 +478,8 @@ export function ManagedJobsTable({
 
   // Convert sortConfig to API format
   const sortBy = React.useMemo(
-    () => sortConfig.key || 'job_id',
+    () =>
+      sortConfig.key === 'id' || !sortConfig.key ? 'job_id' : sortConfig.key,
     [sortConfig.key]
   );
   const sortOrder = React.useMemo(() => {

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -478,7 +478,7 @@ export function ManagedJobsTable({
 
   // Convert sortConfig to API format
   const sortBy = React.useMemo(
-    () => sortConfig.key || 'submitted_at',
+    () => sortConfig.key || 'job_id',
     [sortConfig.key]
   );
   const sortOrder = React.useMemo(() => {

--- a/sky/dashboard/src/lib/jobs-cache-manager.js
+++ b/sky/dashboard/src/lib/jobs-cache-manager.js
@@ -40,7 +40,7 @@ class JobsCacheManager {
     const {
       page = 1,
       limit = 10,
-      sortBy = 'submitted_at',
+      sortBy = 'job_id',
       sortOrder = 'desc',
       allUsers = true,
       jobIdMatch,
@@ -286,7 +286,7 @@ class JobsCacheManager {
     const {
       page = 1,
       limit = 10,
-      sortBy = 'submitted_at',
+      sortBy = 'job_id',
       sortOrder = 'desc',
       statuses,
       ...filterOptions


### PR DESCRIPTION
## Summary

The managed jobs table defaulted to sorting by `submitted_at`, which is `NULL` for tasks that never started (e.g., `PENDING` jobs). In PostgreSQL, sorting NULLs first on `DESC` interleaves task rows across jobs, which scrambles the client-side group-by-first-occurrence logic and produces non-monotonic job order in the table.

`job_id` is monotonically assigned at submission, never NULL, and gives the newest-first ordering users expect. Users can still click the **Submitted** column header to sort by `submitted_at` explicitly.

## Changes

- `sky/dashboard/src/components/jobs.jsx`: default `sortBy` to `job_id` when no sort column is selected.
- `sky/dashboard/src/lib/jobs-cache-manager.js`: same default in both cache-key and plugin-path destructuring so cache keys and fetches agree.

## Test plan

- [ ] Managed jobs table loads with newest job first on initial render (no column clicks).
- [ ] Clicking the **Submitted** column still sorts by `submitted_at` as before.
- [ ] Table order matches `sky jobs queue` output for a deployment with PENDING jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)