### PR TITLE
Fixed upload cache smoke test on a persisted server

### DIFF
--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -156,6 +156,10 @@ def test_concurrent_file_mounts_launch(generic_cloud: str):
     name = smoke_tests_utils.get_cluster_name()
     test_commands = [
         *smoke_tests_utils.STORAGE_SETUP_COMMANDS,
+        # Write random content so the blob hash is unique per test run,
+        # avoiding false "already exists" from a previous run's cache.
+        f'echo {name} > ~/tmpfile',
+        f'echo {name} > ~/tmp-workdir/foo',
         # Launch two clusters concurrently with the same file mounts.
         (f'sky launch -y -c {name}-1 --infra {generic_cloud} '
          f'{smoke_tests_utils.LOW_RESOURCE_ARG} '

--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -204,6 +204,10 @@ def test_concurrent_file_mounts_jobs_launch(generic_cloud: str):
     job2_name = f'{name}-job2'
     test_commands = [
         *smoke_tests_utils.STORAGE_SETUP_COMMANDS,
+        # Write random content so the blob hash is unique per test run,
+        # avoiding false "already exists" from a previous run's cache.
+        f'echo {name} > ~/tmpfile',
+        f'echo {name} > ~/tmp-workdir/foo',
         # Launch two managed jobs concurrently with the same file mounts.
         (f'sky jobs launch -y -d -n {job1_name} --infra {generic_cloud} '
          f'{smoke_tests_utils.LOW_RESOURCE_ARG} '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Add random content in file mounts so that the first upload is never cached.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
