### PR TITLE
Fixed k8s pod name not matching in smoke test

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1242,7 +1242,7 @@ def test_task_labels_kubernetes():
                     '--selector inlinelabel1=inlinevalue1 '
                     '--selector inlinelabel2=inlinevalue2 '
                     '-o jsonpath=\'{.items[*].metadata.name}\' | '
-                    f'grep \'^{name}\'')
+                    f'grep \'^{common_utils.make_cluster_name_on_cloud(name, sky.Kubernetes.max_cluster_name_length())}\'')
             ],
             f'sky down -y {name} && '
             f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}',

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1242,7 +1242,8 @@ def test_task_labels_kubernetes():
                     '--selector inlinelabel1=inlinevalue1 '
                     '--selector inlinelabel2=inlinevalue2 '
                     '-o jsonpath=\'{.items[*].metadata.name}\' | '
-                    f'grep \'^{common_utils.make_cluster_name_on_cloud(name, sky.Kubernetes.max_cluster_name_length())}\'')
+                    f'grep \'^{common_utils.make_cluster_name_on_cloud(name, sky.Kubernetes.max_cluster_name_length())}\''
+                )
             ],
             f'sky down -y {name} && '
             f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}',

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -515,13 +515,20 @@ def test_managed_jobs_recovery_kubernetes_multinode():
     name = smoke_tests_utils.get_cluster_name()
     name_on_cloud = common_utils.make_cluster_name_on_cloud(
         name, jobs.JOBS_CLUSTER_NAME_PREFIX_LENGTH, add_user_hash=False)
+    user_hash = common_utils.get_user_hash()
+    # Use a short stable prefix plus user_hash anchor. When the user
+    # hash is long (e.g., 19 chars for service accounts),
+    # make_cluster_name_on_cloud truncates the display name to fit
+    # within K8s's 42-char limit, so name_on_cloud is no longer a
+    # prefix of the actual pod name.
+    stable_prefix = name_on_cloud[:10]
     terminate_head_cmd = (
         f'kubectl get pods --no-headers -o custom-columns=":metadata.name" | '
-        f'grep -- "{name_on_cloud}-[0-9]*-{common_utils.get_user_hash()}-head" | '
+        f'grep -- "{stable_prefix}" | grep -- "{user_hash}-head" | '
         f'xargs kubectl delete pod')
     terminate_worker_cmd = (
         f'kubectl get pods --no-headers -o custom-columns=":metadata.name" | '
-        f'grep -- "{name_on_cloud}-[0-9]*-{common_utils.get_user_hash()}-worker" | '
+        f'grep -- "{stable_prefix}" | grep -- "{user_hash}-worker" | '
         f'xargs kubectl delete pod')
     test = smoke_tests_utils.Test(
         'managed_jobs_recovery_kubernetes',

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -521,7 +521,7 @@ def test_managed_jobs_recovery_kubernetes_multinode():
     # make_cluster_name_on_cloud truncates the display name to fit
     # within K8s's 42-char limit, so name_on_cloud is no longer a
     # prefix of the actual pod name.
-    stable_prefix = name_on_cloud[:10]
+    stable_prefix = name_on_cloud[:15]
     terminate_head_cmd = (
         f'kubectl get pods --no-headers -o custom-columns=":metadata.name" | '
         f'grep -- "{stable_prefix}" | grep -- "{user_hash}-head" | '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

When using service account to run smoke test, the pod name would be truncated so we cannot do full name matching.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
