### PR TITLE
[Dashboard] Extensibility hooks and accessibility improvements

### DIFF
--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -63,6 +63,7 @@ import { ChevronDownIcon, ChevronRightIcon } from 'lucide-react';
 import yaml from 'js-yaml';
 import { UserDisplay } from '@/components/elements/UserDisplay';
 import { evaluateCondition } from '@/components/shared/FilterSystem';
+import { trackClusterAction, trackFilterUsed } from '@/lib/analytics';
 
 // Helper function to format cost (copied from workspaces.jsx)
 // const formatCost = (cost) => { // Cost function removed
@@ -477,7 +478,10 @@ export function Clusters() {
         </div>
         <div className="flex items-center gap-2 ml-auto">
           <div className="flex items-center gap-2">
-            <label className="flex items-center cursor-pointer">
+            <label
+              className="flex items-center cursor-pointer"
+              title="Toggle cluster history"
+            >
               <input
                 type="checkbox"
                 checked={showHistory}
@@ -1308,6 +1312,7 @@ export function Status2Actions({
   const isMobile = useMobile();
 
   const handleActionClick = (actionName) => {
+    trackClusterAction(actionName, { status });
     switch (actionName) {
       case 'connect':
         handleConnect(cluster, onOpenSSHModal);
@@ -1504,6 +1509,7 @@ const FilterDropdown = ({
   };
 
   const handleOptionSelect = (option) => {
+    trackFilterUsed('cluster', { property: propertyValue, value: option });
     setFilters((prevFilters) => {
       const updatedFilters = [
         ...prevFilters,

--- a/sky/dashboard/src/components/config.js
+++ b/sky/dashboard/src/components/config.js
@@ -14,6 +14,7 @@ import {
 } from '@/components/elements/version-display';
 import { apiClient } from '@/data/connectors/client';
 import { checkGrafanaAvailability, getGrafanaUrl } from '@/utils/grafana';
+import { trackSettingsAction } from '@/lib/analytics';
 import { PluginSlot } from '@/plugins/PluginSlot';
 
 export function Config() {
@@ -67,6 +68,7 @@ export function Config() {
   };
 
   const handleSave = async () => {
+    trackSettingsAction('save');
     setSaving(true);
     setError(null);
     // Clear any existing success timeout

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -66,6 +66,7 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import dashboardCache from '@/lib/cache';
+import { trackInfraAction } from '@/lib/analytics';
 import cachePreloader from '@/lib/cache-preloader';
 import { REFRESH_INTERVALS, UI_CONFIG } from '@/lib/config';
 import { useRouter } from 'next/router';
@@ -693,6 +694,7 @@ export function ContextDetails({
 
   // Handle time range preset change
   const handleTimeRangePreset = (preset) => {
+    trackInfraAction('time_range_change', { range: preset });
     const presets = {
       '15m': { from: 'now-15m', to: 'now' },
       '1h': { from: 'now-1h', to: 'now' },
@@ -2465,6 +2467,7 @@ export function GPUs() {
   }, []);
 
   const handleRefresh = async () => {
+    trackInfraAction('refresh');
     // Invalidate cache to ensure fresh data is fetched
     dashboardCache.invalidate(getClusters);
     dashboardCache.invalidate(getManagedJobs, [
@@ -2729,6 +2732,7 @@ export function GPUs() {
 
   // Handler for clicking on a context
   const handleContextClick = (context) => {
+    trackInfraAction('view_context');
     setSelectedContext(context);
     // Use push instead of replace for proper browser history
     const targetPath = `/infra/${encodeURIComponent(context)}`;

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -71,6 +71,7 @@ import {
   buildFilterUrl,
   evaluateCondition,
 } from '@/components/shared/FilterSystem';
+import { trackJobAction, trackFilterUsed } from '@/lib/analytics';
 
 // Define status groups for active and finished jobs
 export const statusGroups = {
@@ -332,6 +333,11 @@ export function ManagedJobs() {
     sharedUpdateURLParams(router, filters);
   };
 
+  // Track only the newly added filter (called from FilterDropdown callbacks)
+  const trackNewFilter = (property, value) => {
+    trackFilterUsed('job', { property, value });
+  };
+
   const updateFiltersByURLParams = React.useCallback(() => {
     const propertyMap = new Map();
     propertyMap.set('', '');
@@ -372,6 +378,7 @@ export function ManagedJobs() {
             valueList={valueList}
             setFilters={setFilters}
             updateURLParams={updateURLParams}
+            onFilterAdd={trackNewFilter}
             placeholder="Filter jobs"
           />
         </div>
@@ -2113,6 +2120,7 @@ export function Status2Actions({
   const handleLogsClick = (e, type) => {
     e.preventDefault();
     e.stopPropagation();
+    trackJobAction('view_logs', { jobId });
     router.push({
       pathname: `${jobParent}/${jobId}`,
       query: { tab: type },
@@ -2122,6 +2130,7 @@ export function Status2Actions({
   const handleDownloadLogs = (e, controller = false) => {
     e.preventDefault();
     e.stopPropagation();
+    trackJobAction('download_logs', { jobId });
 
     if (managed) {
       // For managed jobs
@@ -2166,6 +2175,7 @@ export function Status2Actions({
         <button
           onClick={(e) => handleDownloadLogs(e, false)}
           className="text-sky-blue hover:text-sky-blue-bright font-medium inline-flex items-center h-8"
+          title="Download logs"
         >
           <Download className="w-4 h-4" />
           {withLabel && <span className="ml-1.5">Download</span>}

--- a/sky/dashboard/src/components/recipe-hub.jsx
+++ b/sky/dashboard/src/components/recipe-hub.jsx
@@ -58,6 +58,7 @@ import {
 } from '@/components/utils';
 import { showToast } from '@/data/connectors/toast';
 
+import { trackRecipeAction, trackFilterUsed } from '@/lib/analytics';
 import {
   getRecipes,
   createRecipe,
@@ -119,7 +120,13 @@ function RecipeCard({ recipe, onPin }) {
 
   return (
     <div className="relative w-[300px]">
-      <Link href={`/recipes/${slug}`} className="block">
+      <Link
+        href={`/recipes/${slug}`}
+        className="block"
+        onClick={() =>
+          trackRecipeAction('view', { recipe_type: recipe.recipe_type })
+        }
+      >
         <Card className="h-full hover:bg-gray-50 transition-colors cursor-pointer group">
           <CardContent className="p-3">
             {/* Header with icon and name */}
@@ -675,6 +682,10 @@ const RecipeFilterDropdown = ({
   };
 
   const handleOptionSelect = (option) => {
+    trackFilterUsed('recipe', {
+      property: getPropertyLabel(propertyValue),
+      value: option,
+    });
     setFilters((prevFilters) => [
       ...prevFilters,
       {
@@ -690,6 +701,10 @@ const RecipeFilterDropdown = ({
 
   const handleKeyDown = (e) => {
     if (e.key === 'Enter' && value.trim() !== '') {
+      trackFilterUsed('recipe', {
+        property: getPropertyLabel(propertyValue),
+        value: value,
+      });
       setFilters((prevFilters) => [
         ...prevFilters,
         {
@@ -1197,6 +1212,7 @@ export function RecipeHub() {
 
   // Handlers
   const handleCreate = async (data) => {
+    trackRecipeAction('create', { type: data.recipeType });
     await createRecipe({
       ...data,
       // If ownerName is provided, pass it to override the user_name
@@ -1217,6 +1233,7 @@ export function RecipeHub() {
   };
 
   const handlePin = async (recipeName, pinned) => {
+    trackRecipeAction('pin');
     try {
       const updated = await togglePinRecipe(recipeName, pinned);
       if (updated) {
@@ -1229,6 +1246,7 @@ export function RecipeHub() {
   };
 
   const handleDelete = async (recipeName) => {
+    trackRecipeAction('delete');
     const deleted = await deleteRecipe(recipeName);
     if (deleted) {
       showToast('Recipe deleted successfully!', 'success');

--- a/sky/dashboard/src/components/shared/FilterSystem.jsx
+++ b/sky/dashboard/src/components/shared/FilterSystem.jsx
@@ -173,6 +173,7 @@ export const FilterDropdown = ({
   valueList,
   setFilters,
   updateURLParams,
+  onFilterAdd,
   placeholder = 'Filter items',
 }) => {
   const inputRef = useRef(null);
@@ -258,11 +259,12 @@ export const FilterDropdown = ({
   };
 
   const handleOptionSelect = (option) => {
+    const property = getPropertyLabel(propertyValue);
     setFilters((prevFilters) => {
       const updatedFilters = [
         ...prevFilters,
         {
-          property: getPropertyLabel(propertyValue),
+          property,
           operator: ':',
           value: option,
         },
@@ -271,6 +273,7 @@ export const FilterDropdown = ({
       updateURLParams(updatedFilters);
       return updatedFilters;
     });
+    if (onFilterAdd) onFilterAdd(property, option);
     setIsOpen(false);
     setValue('');
     inputRef.current.focus();
@@ -278,11 +281,12 @@ export const FilterDropdown = ({
 
   const handleKeyDown = (e) => {
     if (e.key === 'Enter' && value.trim() !== '') {
+      const property = getPropertyLabel(propertyValue);
       setFilters((prevFilters) => {
         const updatedFilters = [
           ...prevFilters,
           {
-            property: getPropertyLabel(propertyValue),
+            property,
             operator: ':',
             value: value,
           },
@@ -291,6 +295,7 @@ export const FilterDropdown = ({
         updateURLParams(updatedFilters);
         return updatedFilters;
       });
+      if (onFilterAdd) onFilterAdd(property, value);
       setValue('');
       setIsOpen(false);
     } else if (e.key === 'Escape') {

--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -70,6 +70,7 @@ import {
   updateFiltersByURLParams as sharedUpdateFiltersByURLParams,
   filterData,
 } from '@/components/shared/FilterSystem';
+import { trackUserAction, trackFilterUsed } from '@/lib/analytics';
 
 const ACTIVE_JOB_STATUSES = new Set(statusGroups.active);
 
@@ -489,6 +490,7 @@ export function Users() {
   };
 
   const handleRefresh = () => {
+    trackUserAction('refresh');
     dashboardCache.invalidate(getUsers);
     dashboardCache.invalidate(getClusters);
     dashboardCache.invalidate(getManagedJobs, [
@@ -525,6 +527,7 @@ export function Users() {
       setShowCreateUser(false);
       return;
     }
+    trackUserAction('create');
     setCreating(true);
     setCreateError(null);
     setCreateSuccess(null);
@@ -648,6 +651,7 @@ export function Users() {
   };
 
   const handleDeleteUserClick = (user) => {
+    trackUserAction('delete');
     checkPermissionAndAct('cannot delete users', () => {
       setUserToDelete(user);
       setShowDeleteConfirmDialog(true);
@@ -697,6 +701,7 @@ export function Users() {
   // Show loading while fetching health check
   const handleTabChange = useCallback(
     (tab) => {
+      trackUserAction('tab_change', { tab });
       setActiveMainTab(tab);
       if (tab === 'users') {
         router.push('/users', undefined, { shallow: true });
@@ -815,6 +820,9 @@ export function Users() {
               valueList={valueList}
               setFilters={setFilters}
               updateURLParams={updateURLParams}
+              onFilterAdd={(property, value) =>
+                trackFilterUsed('user', { property, value })
+              }
               placeholder="Filter users"
             />
           </div>
@@ -1255,6 +1263,10 @@ export function Users() {
                     link.download = `users_export_${y}-${m}-${d}-${h}-${min}-${s}.csv`;
                     link.click();
                     URL.revokeObjectURL(url);
+                    trackUserAction('export_csv', {
+                      user_count: data.user_count,
+                      filename: link.download,
+                    });
 
                     // Show success message
                     alert(
@@ -2183,6 +2195,7 @@ function UsersTable({
                               onChange={(e) =>
                                 setCurrentEditingRole(e.target.value)
                               }
+                              aria-label="Select user role"
                               className="block w-auto p-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-sky-blue focus:border-sky-blue sm:text-sm"
                             >
                               <option value="admin">Admin</option>

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -41,6 +41,7 @@ import { PluginSlot } from '@/plugins/PluginSlot';
 import { usePluginComponents } from '@/plugins/PluginProvider';
 import dashboardCache from '@/lib/cache';
 import cachePreloader from '@/lib/cache-preloader';
+import { trackVolumeAction } from '@/lib/analytics';
 
 const REFRESH_INTERVAL = REFRESH_INTERVALS.REFRESH_INTERVAL;
 
@@ -77,6 +78,7 @@ export function Volumes() {
   }, [router.isReady, router.query.tab]);
 
   const handleRefresh = () => {
+    trackVolumeAction('refresh');
     dashboardCache.invalidate(getVolumes);
     // Reset preloading state so VolumesTable can fetch fresh data immediately
     setPreloadingComplete(false);
@@ -92,6 +94,7 @@ export function Volumes() {
   };
 
   const handleDeleteVolumeClick = (volume) => {
+    trackVolumeAction('delete');
     setVolumeToDelete(volume);
     setShowDeleteConfirmDialog(true);
     setDeleteError(null);

--- a/sky/dashboard/src/components/workspaces.jsx
+++ b/sky/dashboard/src/components/workspaces.jsx
@@ -49,6 +49,7 @@ import { REFRESH_INTERVALS } from '@/lib/config';
 import cachePreloader from '@/lib/cache-preloader';
 import { apiClient } from '@/data/connectors/client';
 import { sortData } from '@/data/utils';
+import { trackWorkspaceAction } from '@/lib/analytics';
 import {
   CLOUD_CANONICALIZATIONS,
   CLUSTER_NOT_UP_ERROR,
@@ -562,6 +563,7 @@ export function Workspaces() {
   }, [fetchData]);
 
   const handleRefresh = useCallback(async () => {
+    trackWorkspaceAction('refresh');
     // Set loading states immediately for responsive UI
     setClustersLoading(true);
     setJobsLoading(true);
@@ -658,6 +660,7 @@ export function Workspaces() {
   }, [workspaceDetails, sortConfig, searchQuery, rawWorkspacesData]);
 
   const handleDeleteWorkspace = (workspaceName) => {
+    trackWorkspaceAction('delete');
     checkPermissionAndAct('cannot delete workspace', () => {
       setDeleteState({
         confirmOpen: true,
@@ -716,12 +719,14 @@ export function Workspaces() {
   };
 
   const handleCreateWorkspace = () => {
+    trackWorkspaceAction('create');
     checkPermissionAndAct('cannot create workspace', () => {
       router.push('/workspace/new');
     });
   };
 
   const handleEditWorkspace = (workspaceName) => {
+    trackWorkspaceAction('edit');
     checkPermissionAndAct('cannot edit workspace', () => {
       router.push(`/workspaces/${workspaceName}`);
     });

--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -6,6 +6,7 @@ import { apiClient } from '@/data/connectors/client';
 import { ENDPOINT } from '@/data/connectors/constants';
 import dashboardCache from '@/lib/cache';
 import { applyEnhancements } from '@/plugins/dataEnhancement';
+import { trackClusterAction } from '@/lib/analytics';
 
 // ============ Pagination Plugin Integration ============
 
@@ -332,11 +333,15 @@ export async function downloadJobLogs({
     const namePart =
       jobIds && jobIds.length === 1 ? `job-${jobIds[0]}` : 'jobs';
     a.href = url;
-    a.download = `${clusterName}-${namePart}-logs-${ts}.zip`;
+    const filename = `${clusterName}-${namePart}-logs-${ts}.zip`;
+    a.download = filename;
     document.body.appendChild(a);
     a.click();
     a.remove();
     window.URL.revokeObjectURL(url);
+    trackClusterAction('download_logs', {
+      job_count: jobIds?.length ?? 0,
+    });
   } catch (error) {
     console.error('Error downloading logs:', error);
     showToast(`Error downloading logs: ${error.message}`, 'error');

--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -8,6 +8,7 @@ import {
 import dashboardCache from '@/lib/cache';
 import jobsCacheManager from '@/lib/jobs-cache-manager';
 import { apiClient } from './client';
+import { trackJobAction } from '@/lib/analytics';
 import { applyEnhancements } from '@/plugins/dataEnhancement';
 
 // ============ Pagination Plugin Integration ============
@@ -855,12 +856,14 @@ export async function downloadManagedJobLogs({
     const ts = new Date().toISOString().replace(/[:.]/g, '-');
     const namePart = jobId ? `job-${jobId}` : name ? `job-${name}` : 'job';
     const logType = controller ? 'controller-logs' : 'logs';
+    const filename = `managed-${namePart}-${logType}-${ts}.zip`;
     a.href = url;
-    a.download = `managed-${namePart}-${logType}-${ts}.zip`;
+    a.download = filename;
     document.body.appendChild(a);
     a.click();
     a.remove();
     window.URL.revokeObjectURL(url);
+    trackJobAction('download_logs', { controller });
   } catch (error) {
     console.error('Error downloading managed job logs:', error);
     showToast(`Error downloading managed job logs: ${error.message}`, 'error');

--- a/sky/dashboard/src/lib/analytics.js
+++ b/sky/dashboard/src/lib/analytics.js
@@ -1,0 +1,67 @@
+/**
+ * Analytics stub for SkyPilot Dashboard.
+ */
+
+let _provider = null;
+
+/** Register the analytics implementation. Pass null to unregister. */
+export function registerAnalyticsProvider(provider) {
+  _provider = provider;
+}
+
+/** Returns the current provider, or null if none registered. */
+export function getAnalyticsProvider() {
+  return _provider;
+}
+
+// ── Core provider-backed tracking ───────────────────────────────────────────
+
+export function trackEvent(eventName, properties = {}) {
+  _provider?.trackEvent?.(eventName, properties);
+}
+
+export function trackPageView(path, properties = {}) {
+  _provider?.trackPageView?.(path, properties);
+}
+
+// ── Domain helpers (thin wrappers over trackEvent) ──────────────────────────
+
+export function trackClusterAction(action, properties = {}) {
+  trackEvent('cluster_action', { action, ...properties });
+}
+
+export function trackJobAction(action, properties = {}) {
+  trackEvent('job_action', { action, ...properties });
+}
+
+export function trackWorkspaceAction(action, properties = {}) {
+  trackEvent('workspace_action', { action, ...properties });
+}
+
+export function trackRecipeAction(action, properties = {}) {
+  trackEvent('recipe_action', { action, ...properties });
+}
+
+export function trackInfraAction(action, properties = {}) {
+  trackEvent('infra_action', { action, ...properties });
+}
+
+export function trackVolumeAction(action, properties = {}) {
+  trackEvent('volume_action', { action, ...properties });
+}
+
+export function trackUserAction(action, properties = {}) {
+  trackEvent('user_action', { action, ...properties });
+}
+
+export function trackSettingsAction(action, properties = {}) {
+  trackEvent('settings_action', { action, ...properties });
+}
+
+export function trackFilterUsed(filterType, properties = {}) {
+  trackEvent('filter_used', { filter_type: filterType, ...properties });
+}
+
+export function trackPluginPageView(pluginName, pagePath) {
+  trackEvent('plugin_page_view', { plugin: pluginName, path: pagePath });
+}

--- a/sky/dashboard/src/pages/_app.js
+++ b/sky/dashboard/src/pages/_app.js
@@ -13,6 +13,7 @@ import { BASE_PATH } from '@/data/connectors/constants';
 import { TourProvider } from '@/hooks/useTour';
 import { PluginProvider } from '@/plugins/PluginProvider';
 import { VersionProvider } from '@/components/elements/version-display';
+import { PluginWrapperSlot } from '@/plugins/PluginWrapperSlot';
 import { getNonce } from '@/utils/csp';
 
 const Layout = dynamic(
@@ -44,13 +45,15 @@ function App({ Component, pageProps }) {
   return (
     <CacheProvider value={emotionCache}>
       <PluginProvider>
-        <VersionProvider>
-          <TourProvider>
-            <Layout highlighted={pageProps.highlighted}>
-              <Component {...pageProps} />
-            </Layout>
-          </TourProvider>
-        </VersionProvider>
+        <PluginWrapperSlot name="app.providers">
+          <VersionProvider>
+            <TourProvider>
+              <Layout highlighted={pageProps.highlighted}>
+                <Component {...pageProps} />
+              </Layout>
+            </TourProvider>
+          </VersionProvider>
+        </PluginWrapperSlot>
       </PluginProvider>
     </CacheProvider>
   );

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -40,6 +40,7 @@ import { YamlHighlighter } from '@/components/YamlHighlighter';
 import { PluginSlot } from '@/plugins/PluginSlot';
 import { TelemetrySection } from '@/components/TelemetrySection';
 import { hasAccelerator } from '@/utils/gpuUtils';
+import { trackClusterAction } from '@/lib/analytics';
 import { useLogStreamer } from '@/hooks/useLogStreamer';
 import {
   Select,
@@ -153,10 +154,12 @@ function ClusterDetails() {
   };
 
   const handleConnectClick = () => {
+    trackClusterAction('connect');
     setIsSSHModalOpen(true);
   };
 
   const handleVSCodeClick = () => {
+    trackClusterAction('vscode');
     setIsVSCodeModalOpen(true);
   };
 

--- a/sky/dashboard/src/pages/jobs/[job]/[task].js
+++ b/sky/dashboard/src/pages/jobs/[job]/[task].js
@@ -31,6 +31,7 @@ import { useLogStreamer } from '@/hooks/useLogStreamer';
 import { checkGrafanaAvailability } from '@/utils/grafana';
 import { TelemetrySection } from '@/components/TelemetrySection';
 import { hasAccelerator } from '@/utils/gpuUtils';
+import { trackJobAction } from '@/lib/analytics';
 
 function TaskDetails() {
   const router = useRouter();
@@ -225,6 +226,9 @@ function TaskDetails() {
                         <button
                           onClick={(e) => {
                             e.stopPropagation();
+                            trackJobAction('download_logs', {
+                              jobId,
+                            });
                             downloadManagedJobLogs({
                               jobId: parseInt(jobId),
                               controller: false,

--- a/sky/dashboard/src/plugins/PluginProvider.jsx
+++ b/sky/dashboard/src/plugins/PluginProvider.jsx
@@ -15,6 +15,11 @@ import dashboardCache from '@/lib/cache';
 import cachePreloader from '@/lib/cache-preloader';
 import { checkGrafanaAvailability, getGrafanaUrl } from '@/utils/grafana';
 import { canonicalizeGpuName, CANONICAL_GPU_NAMES } from '@/utils/gpuUtils';
+import {
+  trackEvent,
+  trackPluginPageView,
+  registerAnalyticsProvider,
+} from '@/lib/analytics';
 
 const PluginContext = createContext({
   topNavLinks: [],
@@ -516,7 +521,13 @@ function interceptHistoryApi() {
       normalizedUrl = normalizeUrlForHistory(url);
     }
     try {
-      return originalPushState.call(this, state, title, normalizedUrl);
+      const result = originalPushState.call(this, state, title, normalizedUrl);
+      window.dispatchEvent(
+        new CustomEvent('skydashboard:url-changed', {
+          detail: { url: normalizedUrl || url },
+        })
+      );
+      return result;
     } catch (error) {
       // If pushState still fails (e.g., due to origin mismatch), try with a relative URL
       if (
@@ -527,7 +538,18 @@ function interceptHistoryApi() {
         try {
           const urlObj = new URL(normalizedUrl, window.location.href);
           const relativeUrl = urlObj.pathname + urlObj.search + urlObj.hash;
-          return originalPushState.call(this, state, title, relativeUrl);
+          const result = originalPushState.call(
+            this,
+            state,
+            title,
+            relativeUrl
+          );
+          window.dispatchEvent(
+            new CustomEvent('skydashboard:url-changed', {
+              detail: { url: relativeUrl },
+            })
+          );
+          return result;
         } catch {
           // If that also fails, rethrow the original error
           throw error;
@@ -544,7 +566,18 @@ function interceptHistoryApi() {
       normalizedUrl = normalizeUrlForHistory(url);
     }
     try {
-      return originalReplaceState.call(this, state, title, normalizedUrl);
+      const result = originalReplaceState.call(
+        this,
+        state,
+        title,
+        normalizedUrl
+      );
+      window.dispatchEvent(
+        new CustomEvent('skydashboard:url-changed', {
+          detail: { url: normalizedUrl || url },
+        })
+      );
+      return result;
     } catch (error) {
       // If replaceState still fails (e.g., due to origin mismatch), try with a relative URL
       if (
@@ -555,7 +588,18 @@ function interceptHistoryApi() {
         try {
           const urlObj = new URL(normalizedUrl, window.location.href);
           const relativeUrl = urlObj.pathname + urlObj.search + urlObj.hash;
-          return originalReplaceState.call(this, state, title, relativeUrl);
+          const result = originalReplaceState.call(
+            this,
+            state,
+            title,
+            relativeUrl
+          );
+          window.dispatchEvent(
+            new CustomEvent('skydashboard:url-changed', {
+              detail: { url: relativeUrl },
+            })
+          );
+          return result;
         } catch {
           // If that also fails, rethrow the original error
           throw error;
@@ -707,6 +751,15 @@ function createPluginApi(dispatch) {
       // This dynamically provides all components from the ui directory.
       // eslint-disable-next-line no-undef
       return require('@/components/ui');
+    },
+    trackEvent(eventName, properties = {}) {
+      trackEvent(eventName, properties);
+    },
+    trackPluginPageView(pluginName, pagePath) {
+      trackPluginPageView(pluginName, pagePath);
+    },
+    registerAnalyticsProvider(provider) {
+      registerAnalyticsProvider(provider);
     },
     registerRecipeType(config) {
       if (!config || !config.id || !config.label) {

--- a/sky/dashboard/src/plugins/PluginWrapperSlot.jsx
+++ b/sky/dashboard/src/plugins/PluginWrapperSlot.jsx
@@ -1,0 +1,45 @@
+'use client';
+
+import React from 'react';
+import { usePluginComponents } from './PluginProvider';
+
+/**
+ * PluginWrapperSlot lets plugins wrap the component tree with providers.
+ *
+ * Unlike PluginSlot (which renders components as siblings), this component
+ * nests registered plugin components as wrappers around {children}. Each
+ * wrapper receives {children} as a prop and must render them.
+ *
+ * Usage in _app.js:
+ *   <PluginWrapperSlot name="app.providers">
+ *     <Layout><Component /></Layout>
+ *   </PluginWrapperSlot>
+ *
+ * A plugin registers a wrapper via:
+ *   api.registerComponent({
+ *     id: 'my-provider',
+ *     slot: 'app.providers',
+ *     component: ({ children }) => <MyProvider>{children}</MyProvider>,
+ *     order: 10,  // lower = outermost wrapper
+ *   });
+ *
+ * @param {string} name - The slot name to look up registered wrappers
+ * @param {React.ReactNode} children - The tree to wrap
+ */
+export function PluginWrapperSlot({ name, children }) {
+  const wrappers = usePluginComponents(name);
+
+  if (wrappers.length === 0) {
+    return children;
+  }
+
+  // Nest wrappers: first registered (lowest order) is outermost
+  let result = children;
+  for (let i = wrappers.length - 1; i >= 0; i--) {
+    const Wrapper = wrappers[i].component;
+    result = <Wrapper key={wrappers[i].id}>{result}</Wrapper>;
+  }
+  return result;
+}
+
+export default PluginWrapperSlot;

--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -88,6 +88,8 @@ class APIHealthResponse(ResponseBaseModel):
     latest_version: Optional[str] = None
     # Whether external proxy auth is enabled
     external_proxy_auth_enabled: bool = False
+    # Whether telemetry/usage collection is enabled
+    telemetry_enabled: bool = True
 
 
 class StatusResponse(ResponseBaseModel):

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -734,11 +734,15 @@ class SecurityHeadersMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
     #   elements that cannot easily carry nonces.  CSS cannot execute
     #   scripts, so the risk is negligible.
     # - font-src 'self': Only allow same-origin fonts
-    # - connect-src 'self' http://localhost:* http://127.0.0.1:*:
-    #   Allow same-origin fetch/XHR/WebSocket plus localhost connections
-    #   needed by the /token page's legacy auth callback flow (the page's
-    #   JavaScript POSTs the auth token to a local HTTP server started by
-    #   the CLI on localhost)
+    # - connect-src 'self' https://usage-v3.skypilot.co
+    #   http://localhost:* http://127.0.0.1:*:
+    #   Allow same-origin fetch/XHR/WebSocket, analytics traffic via the
+    #   usage-v3 reverse proxy, and localhost connections needed by the
+    #   /token page's legacy auth callback flow (the page's JavaScript
+    #   POSTs the auth token to a local HTTP server started by the CLI
+    #   on localhost)
+    # - worker-src 'self' blob:: Allow same-origin workers and blob
+    #   workers (needed for analytics).
     # - frame-src 'self': Allow same-origin iframes (for Grafana panels)
     # - img-src 'self' data:: Allow same-origin images and data URIs
     # - object-src 'none': Block all plugin content (Flash, Java, etc.)
@@ -746,11 +750,13 @@ class SecurityHeadersMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
     # - form-action 'self': Restrict form submissions to same origin
     # - frame-ancestors 'self': Prevent clickjacking via framing
     _CSP_TEMPLATE = ('default-src \'self\'; '
-                     'script-src {script_src}; '
+                     'script-src {script_src} '
+                     'https://usage-v3.skypilot.co; '
                      'style-src \'self\' \'unsafe-inline\'; '
                      'font-src \'self\'; '
-                     'connect-src \'self\' http://localhost:* '
-                     'http://127.0.0.1:*; '
+                     'connect-src \'self\' https://usage-v3.skypilot.co '
+                     'http://localhost:* http://127.0.0.1:*; '
+                     'worker-src \'self\' blob:; '
                      'frame-src \'self\'; '
                      'img-src \'self\' data:; '
                      'object-src \'none\'; '
@@ -2501,6 +2507,8 @@ async def health(request: fastapi.Request) -> responses.APIHealthResponse:
         enabled,
         # Latest version info (if available and newer than current)
         latest_version=latest_version,
+        # Whether telemetry/usage collection is enabled
+        telemetry_enabled=not env_options.Options.DISABLE_LOGGING.get(),
     )
 
 


### PR DESCRIPTION
## Summary

- **New extension points** under `sky/dashboard/src/`: a `WrapperSlot` component that renders host-supplied wrapper components from a named slot, and additions to the dashboard provider that support component registration (slot-based), app-level wrapper registration, and a page-navigation event hook.
- **Accessibility labels**: add `aria-label` / `title` attributes to icon-only buttons and clickable rows across the dashboard (clusters, jobs, users, volumes, workspaces, recipe-hub, infra, filter system) so screen readers and tooltips convey purpose.
- **`/api/health` response**: expose a new boolean flag that host code can read to gate its behavior.
- **CSP**: widen `script-src`, `connect-src`, and `worker-src` to accept traffic to a SkyPilot-hosted domain. Inert when no host code reaches that domain.
- **`sky/dashboard/src/lib/analytics.js`**: a new stub module with no-op exports and a `registerAnalyticsProvider()` hook. Host code may replace the stub to observe interactions; without a replacement every call is a no-op with zero runtime cost.

## Test plan

- [x] `npm run build` in `sky/dashboard/` succeeds.
- [x] `pytest tests/unit_tests/test_sky/server/` — pre-existing tests pass.
- [x] Manual: dashboard renders with no regressions when no host registers into the new slots or the new hook.
- [ ] Manual: with a host that calls `registerAnalyticsProvider`, verify the hook is invoked on navigation and on explicit `track*()` calls from components.