### PR TITLE
Fix gc_task_logs_for_job copy-paste bugs (disabled-log, redundant interval call)

### DIFF
--- a/sky/jobs/log_gc.py
+++ b/sky/jobs/log_gc.py
@@ -85,11 +85,11 @@ def gc_task_logs_for_job():
             except Exception as e:  # pylint: disable=broad-except
                 logger.error(f'Error GC task logs for job: {e}', exc_info=True)
         else:
-            logger.info('Controller logs GC is disabled')
+            logger.info('Task logs GC is disabled')
 
         interval = _next_gc_interval(task_logs_retention)
         logger.info(f'Next task logs GC is scheduled after {interval} seconds')
-        time.sleep(_next_gc_interval(task_logs_retention))
+        time.sleep(interval)
 
 
 def _clean_controller_logs_with_retention(retention_seconds: int,


### PR DESCRIPTION
### Bug
Two copy-paste bugs inside `gc_task_logs_for_job` in `sky/jobs/log_gc.py` that the sibling `gc_controller_logs_for_job` already handles correctly.

https://github.com/skypilot-org/skypilot/blob/b0fb862/sky/jobs/log_gc.py#L69-L92

```python
def gc_task_logs_for_job():
    """Garbage collect task logs for job."""
    while True:
        ...
        if task_logs_retention >= 0:
            ...
        else:
            logger.info('Controller logs GC is disabled')

        interval = _next_gc_interval(task_logs_retention)
        logger.info(f'Next task logs GC is scheduled after {interval} seconds')
        time.sleep(_next_gc_interval(task_logs_retention))
```

1. When `task_logs_retention` is negative, the branch logs `'Controller logs GC is disabled'`, but the surrounding function only governs task-log GC. The message mislabels the disabled subsystem.
2. `time.sleep()` recomputes `_next_gc_interval(task_logs_retention)` instead of reusing the `interval` variable that was just computed and logged. Any future change that makes `_next_gc_interval` non-deterministic (e.g. adds jitter) would leave the logged "scheduled after N seconds" and the actual sleep duration out of sync.

### Root cause
Both lines were copy-pasted from `gc_controller_logs_for_job` — which correctly logs `'Controller logs GC is disabled'` and calls `time.sleep(interval)` — but not updated for the task-log variant.

### Fix
Log `'Task logs GC is disabled'` when task-log GC is off, and sleep on the already-computed `interval` so the two `gc_*_for_job` functions behave consistently.