### PR TITLE
Fix ThreadSafeDict.items()/values() returning non-thread-safe views

### DIFF
--- a/sky/utils/thread_utils.py
+++ b/sky/utils/thread_utils.py
@@ -64,11 +64,11 @@ class ThreadSafeDict(Generic[KeyType, ValueType]):
 
     def items(self):
         with self._lock:
-            return self._dict.items()
+            return list(self._dict.items())
 
     def values(self):
         with self._lock:
-            return self._dict.values()
+            return list(self._dict.values())
 
     @overload
     def get(self, key: KeyType, default: ValueType) -> ValueType:


### PR DESCRIPTION
### Bug
`ThreadSafeDict.items()` and `ThreadSafeDict.values()` acquire the internal lock, call `dict.items()`/`dict.values()`, then release the lock and return the resulting view. Because `dict_items` / `dict_values` are live views backed by the underlying dict, callers that iterate the returned view after the lock is released race with concurrent mutations and can raise `RuntimeError: dictionary changed size during iteration` (or observe inconsistent state).

https://github.com/skypilot-org/skypilot/blob/b0fb862/sky/utils/thread_utils.py#L65-L71

```python
def items(self):
    with self._lock:
        return self._dict.items()

def values(self):
    with self._lock:
        return self._dict.values()
```

This is not hypothetical — `sky/serve/replica_managers.py` already tries to snapshot the returned view:

```python
launch_thread_pool_snapshot = list(self._launch_thread_pool.items())
...
down_thread_pool_snapshot = list(self._down_thread_pool.items())
```

But the `list(...)` call runs outside the lock (the lock was released when `items()` returned), so the list materialization itself is still racy with other threads that mutate the same `ThreadSafeDict`.

### Root cause
Returning a live view effectively exposes the unlocked underlying dict to the caller.

### Fix
Materialize the view into a `list` while still holding the lock, so the returned value is an independent snapshot that can be iterated safely without holding the lock. No change to existing call sites is required — `list(items_view)` already idempotently accepts a list.