### PR TITLE
[Dashboard] Detect W&B Dedicated Cloud run URLs

### DIFF
--- a/docs/source/running-jobs/external-links.rst
+++ b/docs/source/running-jobs/external-links.rst
@@ -19,7 +19,7 @@ Supported services
 
 SkyPilot automatically detects URLs from the following services in your job logs:
 
-- **Weights & Biases (W&B)**: Run URLs (e.g., ``https://wandb.ai/<entity>/<project>/runs/<run_id>``)
+- **Weights & Biases (W&B)**: Run URLs on W&B SaaS (e.g., ``https://wandb.ai/<entity>/<project>/runs/<run_id>``) and W&B Dedicated Cloud tenants (e.g., ``https://<tenant>.wandb.io/<entity>/<project>/runs/<run_id>``)
 
 When your job prints a URL from a supported service to stdout or stderr, the dashboard will automatically extract it and display it in the "External Links" section.
 

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -838,7 +838,8 @@ function ControllerLogsSection({
 // Each pattern has a name (used as link label) and a regex to match entire tokens
 // Patterns use ^ and $ anchors for exact token matching
 const URL_PATTERNS = {
-  'W&B Run': /^https:\/\/wandb\.ai\/[^\/]+\/[^\/]+\/runs\/[^\/]+$/,
+  // Matches W&B SaaS (wandb.ai) and Dedicated Cloud tenants (<tenant>.wandb.io).
+  'W&B Run': /^https:\/\/(?:wandb\.ai|[^/]+\.wandb\.io)\/[^/]+\/[^/]+\/runs\/[^/]+$/,
 };
 
 function JobDetailsContent({

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -839,7 +839,8 @@ function ControllerLogsSection({
 // Patterns use ^ and $ anchors for exact token matching
 const URL_PATTERNS = {
   // Matches W&B SaaS (wandb.ai) and Dedicated Cloud tenants (<tenant>.wandb.io).
-  'W&B Run': /^https:\/\/(?:wandb\.ai|[^/]+\.wandb\.io)\/[^/]+\/[^/]+\/runs\/[^/]+$/,
+  'W&B Run':
+    /^https:\/\/(?:wandb\.ai|[^/]+\.wandb\.io)\/[^/]+\/[^/]+\/runs\/[^/]+$/,
 };
 
 function JobDetailsContent({


### PR DESCRIPTION
## Summary

- The managed-jobs dashboard scrapes job logs for W&B run URLs and surfaces them under **External Links**, but the regex in `sky/dashboard/src/pages/jobs/[job].js` only matched `wandb.ai`.
- W&B Dedicated Cloud gives each paying tenant its own subdomain under `wandb.io` (e.g. `https://<tenant>.wandb.io/<entity>/<project>/runs/<id>`), so Dedicated Cloud users never saw the link auto-extracted.
- Broaden the regex to accept `wandb.ai` **or** `<tenant>.wandb.io` while keeping the `/entity/project/runs/id$` path shape as the anchor that prevents false positives. Update `docs/source/running-jobs/external-links.rst` to match.

Self-hosted W&B Server (arbitrary domains) is intentionally out of scope — that requires a config-driven allowlist and is a separate PR.

## Test plan

Regex validated via Node against positive and negative cases:

- [x] `https://wandb.ai/me/proj/runs/abc123` → matches
- [x] `https://tenant.wandb.io/e/p/runs/xyz` → matches (new)
- [x] `https://wandb.ai/me/proj/sweeps/xyz` → rejected (not a run URL)
- [x] `https://wandb.io/me/proj/runs/abc` → rejected (no tenant subdomain)
- [x] `https://evil.com/wandb.ai/me/proj/runs/abc` → rejected (host anchor works)
- [x] `https://sub.wandb.io/e/p/runs/r/extra` → rejected (trailing path)
- [x] `http://wandb.ai/me/proj/runs/abc` → rejected (requires https)
- [x] `https://wandb.ai/me/proj/runs/` → rejected (empty run id)

Manual UI check: launch a managed job that prints a matching URL to stdout, confirm the link appears under **External Links** on the job detail page (for both SaaS and Dedicated Cloud shapes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)