### PR TITLE
[CLI] Add `sky utils convert-slurm` to convert Slurm scripts to SkyPilot YAML

### DIFF
--- a/docs/source/reference/slurm-migration.rst
+++ b/docs/source/reference/slurm-migration.rst
@@ -14,6 +14,110 @@ Why use SkyPilot instead of Slurm?
 - **Dependency management**: All Slurm jobs run in an identical environment and having different dependencies per-job can be tricky. SkyPilot provides full isolation for each job's environment.
 - **Unified dashboard**: SkyPilot provides a :ref:`web dashboard <dashboard>` for job management, logs, and monitoring across all infrastructure.
 
+.. _porting-sbatch-scripts:
+
+Porting sbatch scripts to SkyPilot YAML
+---------------------------------------
+
+For an existing Slurm script, the easiest first step is to use the
+``sky utils convert-slurm`` CLI to auto-generate a starting point:
+
+.. code-block:: bash
+
+   # Print the converted YAML to stdout.
+   sky utils convert-slurm train.slurm
+
+   # Or write it to a file.
+   sky utils convert-slurm train.slurm train.sky.yaml
+
+The converter applies the directive mapping documented in this guide:
+
+- ``--job-name``, ``--nodes``, ``--cpus-per-task``, ``--mem``,
+  ``--gpus-per-node`` / ``--gres=gpu`` / ``--gpus`` map to top-level fields
+  (``name``, ``num_nodes``, ``resources.cpus``, ``resources.memory``,
+  ``resources.accelerators``).
+- ``--time=DD-HH:MM:SS`` maps to :ref:`autostop <auto-stop>`.
+- ``--partition`` maps to ``resources.infra: slurm/<cluster>/<partition>``
+  (the converter leaves a ``<cluster>`` placeholder for you to fill in).
+- Other ``#SBATCH`` directives (``--account``, ``--qos``, ``--constraint``,
+  ``--mail-*``, ``--exclusive``, ``--reservation``, ``--dependency``, ...)
+  pass through to ``config.slurm.sbatch_options`` so they round-trip to
+  Slurm at submission time.
+- Common ``SLURM_*`` environment variables in the body are rewritten to
+  their ``SKYPILOT_*`` equivalents (see the
+  :ref:`environment variable mapping <slurm-env-var-mapping>` below).
+- ``srun`` wrappers are translated based on Slurm semantics: a bare
+  ``srun cmd`` becomes ``cmd`` (SkyPilot's ``run`` block already executes
+  on every node); ``srun -N1 -n1 cmd`` is wrapped in a
+  ``$SKYPILOT_NODE_RANK == 0`` guard; for ``srun --ntasks-per-node=N`` with
+  N > 1 the converter emits ready-to-copy ``torchrun`` and ``mpirun``
+  templates next to the original line.
+- Directives without a direct equivalent (``--output``, ``--error``,
+  ``--array``) are preserved as comments at the top of the YAML for review.
+
+The output is a starting point: always read through the generated YAML and
+adjust before launching.
+
+Side-by-side comparison
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Here's a side-by-side comparison of a typical Slurm script and its SkyPilot equivalent:
+
+.. raw:: html
+
+   <div class="row">
+       <div class="col-md-6 mb-3">
+            <h4> Slurm sbatch script </h4>
+
+.. code-block:: bash
+
+   #!/bin/bash
+   #SBATCH --job-name=train
+   #SBATCH --nodes=2
+   #SBATCH --gpus-per-node=8
+   #SBATCH --cpus-per-task=32
+   #SBATCH --mem=256G
+   #SBATCH --partition=gpu
+
+   module load cuda/12.1
+   source ~/venv/bin/activate
+
+   srun python train.py --epochs 100
+
+.. raw:: html
+
+       </div>
+       <div class="col-md-6 mb-3">
+            <h4> SkyPilot YAML </h4>
+
+.. code-block:: yaml
+
+   name: train
+
+   num_nodes: 2
+
+   resources:
+     accelerators: H100:8
+     cpus: 32+
+     memory: 256+
+     image_id: docker:nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
+
+   setup: pip install torch transformers
+
+   run: python train.py --epochs 100
+
+.. raw:: html
+
+       </div>
+   </div>
+
+Key differences:
+
+- **No module system**: Use ``setup:`` for environment configuration (pip, conda) or Docker images
+- **Time limits are optional**: SkyPilot uses :ref:`autostop <auto-stop>` for auto-termination. Can be configured to terminate on idleness or wall-clock time.
+- **Simpler syntax**: Resource requirements are declarative YAML fields
+- **Native container support**: Easily use :ref:`containers <docker-containers>` by setting ``image_id``.
+
 Slurm to SkyPilot
 -----------------
 
@@ -86,6 +190,8 @@ Slurm clusters have login nodes for submitting jobs and accessing shared storage
 - **For batch workflows**: Use :ref:`managed jobs <managed-jobs>` (``sky jobs launch``) which don't require a persistent cluster.
 
 
+.. _slurm-env-var-mapping:
+
 Environment variable mapping
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -130,107 +236,6 @@ Example usage in a distributed training script:
      else
        echo "I am worker $SKYPILOT_NODE_RANK, connecting to $HEAD_IP"
      fi
-
-Porting sbatch scripts to SkyPilot YAML
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-For an existing Slurm script, the easiest first step is to use the
-``sky utils convert-slurm`` CLI to auto-generate a starting point:
-
-.. code-block:: bash
-
-   # Print the converted YAML to stdout.
-   sky utils convert-slurm train.slurm
-
-   # Or write it to a file.
-   sky utils convert-slurm train.slurm train.sky.yaml
-
-The converter applies the directive mapping documented in this guide:
-
-- ``--job-name``, ``--nodes``, ``--cpus-per-task``, ``--mem``,
-  ``--gpus-per-node`` / ``--gres=gpu`` / ``--gpus`` map to top-level fields
-  (``name``, ``num_nodes``, ``resources.cpus``, ``resources.memory``,
-  ``resources.accelerators``).
-- ``--time=DD-HH:MM:SS`` maps to :ref:`autostop <auto-stop>`.
-- ``--partition`` maps to ``resources.infra: slurm/<cluster>/<partition>``
-  (the converter leaves a ``<cluster>`` placeholder for you to fill in).
-- Other ``#SBATCH`` directives (``--account``, ``--qos``, ``--constraint``,
-  ``--mail-*``, ``--exclusive``, ``--reservation``, ``--dependency``, ...)
-  pass through to ``config.slurm.sbatch_options`` so they round-trip to
-  Slurm at submission time.
-- Common ``SLURM_*`` environment variables in the body are rewritten to
-  their ``SKYPILOT_*`` equivalents (see the table above).
-- ``srun`` wrappers are translated based on Slurm semantics: a bare
-  ``srun cmd`` becomes ``cmd`` (SkyPilot's ``run`` block already executes
-  on every node); ``srun -N1 -n1 cmd`` is wrapped in a
-  ``$SKYPILOT_NODE_RANK == 0`` guard; for ``srun --ntasks-per-node=N`` with
-  N > 1 the converter emits ready-to-copy ``torchrun`` and ``mpirun``
-  templates next to the original line.
-- Directives without a direct equivalent (``--output``, ``--error``,
-  ``--array``) are preserved as comments at the top of the YAML for review.
-
-The output is a starting point: always read through the generated YAML and
-adjust before launching.
-
-Side-by-side comparison
-^^^^^^^^^^^^^^^^^^^^^^^
-
-Here's a side-by-side comparison of a typical Slurm script and its SkyPilot equivalent:
-
-.. raw:: html
-
-   <div class="row">
-       <div class="col-md-6 mb-3">
-            <h4> Slurm sbatch script </h4>
-
-.. code-block:: bash
-
-   #!/bin/bash
-   #SBATCH --job-name=train
-   #SBATCH --nodes=2
-   #SBATCH --gpus-per-node=8
-   #SBATCH --cpus-per-task=32
-   #SBATCH --mem=256G
-   #SBATCH --partition=gpu
-
-   module load cuda/12.1
-   source ~/venv/bin/activate
-
-   srun python train.py --epochs 100
-
-.. raw:: html
-
-       </div>
-       <div class="col-md-6 mb-3">
-            <h4> SkyPilot YAML </h4>
-
-.. code-block:: yaml
-
-   name: train
-
-   num_nodes: 2
-
-   resources:
-     accelerators: H100:8
-     cpus: 32+
-     memory: 256+
-     image_id: docker:nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
-
-   setup: pip install torch transformers
-
-   run: python train.py --epochs 100
-
-.. raw:: html
-
-       </div>
-   </div>
-
-Key differences:
-
-- **No module system**: Use ``setup:`` for environment configuration (pip, conda) or Docker images
-- **Time limits are optional**: SkyPilot uses :ref:`autostop <auto-stop>` for auto-termination. Can be configured to terminate on idleness or wall-clock time.
-- **Simpler syntax**: Resource requirements are declarative YAML fields
-- **Native container support**: Easily use :ref:`containers <docker-containers>` by setting ``image_id``.
 
 Resource requests
 ~~~~~~~~~~~~~~~~~

--- a/docs/source/reference/slurm-migration.rst
+++ b/docs/source/reference/slurm-migration.rst
@@ -134,6 +134,47 @@ Example usage in a distributed training script:
 Porting sbatch scripts to SkyPilot YAML
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+For an existing Slurm script, the easiest first step is to use the
+``sky utils convert-slurm`` CLI to auto-generate a starting point:
+
+.. code-block:: bash
+
+   # Print the converted YAML to stdout.
+   sky utils convert-slurm train.slurm
+
+   # Or write it to a file.
+   sky utils convert-slurm train.slurm train.sky.yaml
+
+The converter applies the directive mapping documented in this guide:
+
+- ``--job-name``, ``--nodes``, ``--cpus-per-task``, ``--mem``,
+  ``--gpus-per-node`` / ``--gres=gpu`` / ``--gpus`` map to top-level fields
+  (``name``, ``num_nodes``, ``resources.cpus``, ``resources.memory``,
+  ``resources.accelerators``).
+- ``--time=DD-HH:MM:SS`` maps to :ref:`autostop <auto-stop>`.
+- ``--partition`` maps to ``resources.infra: slurm/<cluster>/<partition>``
+  (the converter leaves a ``<cluster>`` placeholder for you to fill in).
+- Other ``#SBATCH`` directives (``--account``, ``--qos``, ``--constraint``,
+  ``--mail-*``, ``--exclusive``, ``--reservation``, ``--dependency``, ...)
+  pass through to ``config.slurm.sbatch_options`` so they round-trip to
+  Slurm at submission time.
+- Common ``SLURM_*`` environment variables in the body are rewritten to
+  their ``SKYPILOT_*`` equivalents (see the table above).
+- ``srun`` wrappers are translated based on Slurm semantics: a bare
+  ``srun cmd`` becomes ``cmd`` (SkyPilot's ``run`` block already executes
+  on every node); ``srun -N1 -n1 cmd`` is wrapped in a
+  ``$SKYPILOT_NODE_RANK == 0`` guard; for ``srun --ntasks-per-node=N`` with
+  N > 1 the converter emits ready-to-copy ``torchrun`` and ``mpirun``
+  templates next to the original line.
+- Directives without a direct equivalent (``--output``, ``--error``,
+  ``--array``) are preserved as comments at the top of the YAML for review.
+
+The output is a starting point: always read through the generated YAML and
+adjust before launching.
+
+Side-by-side comparison
+^^^^^^^^^^^^^^^^^^^^^^^
+
 Here's a side-by-side comparison of a typical Slurm script and its SkyPilot equivalent:
 
 .. raw:: html

--- a/docs/source/reference/slurm-migration.rst
+++ b/docs/source/reference/slurm-migration.rst
@@ -30,33 +30,9 @@ For an existing Slurm script, the easiest first step is to use the
    # Or write it to a file.
    sky utils convert-slurm train.slurm train.sky.yaml
 
-The converter applies the directive mapping documented in this guide:
-
-- ``--job-name``, ``--nodes``, ``--cpus-per-task``, ``--mem``,
-  ``--gpus-per-node`` / ``--gres=gpu`` / ``--gpus`` map to top-level fields
-  (``name``, ``num_nodes``, ``resources.cpus``, ``resources.memory``,
-  ``resources.accelerators``).
-- ``--time=DD-HH:MM:SS`` maps to :ref:`autostop <auto-stop>`.
-- ``--partition`` maps to ``resources.infra: slurm/<cluster>/<partition>``
-  (the converter leaves a ``<cluster>`` placeholder for you to fill in).
-- Other ``#SBATCH`` directives (``--account``, ``--qos``, ``--constraint``,
-  ``--mail-*``, ``--exclusive``, ``--reservation``, ``--dependency``, ...)
-  pass through to ``config.slurm.sbatch_options`` so they round-trip to
-  Slurm at submission time.
-- Common ``SLURM_*`` environment variables in the body are rewritten to
-  their ``SKYPILOT_*`` equivalents (see the
-  :ref:`environment variable mapping <slurm-env-var-mapping>` below).
-- ``srun`` wrappers are translated based on Slurm semantics: a bare
-  ``srun cmd`` becomes ``cmd`` (SkyPilot's ``run`` block already executes
-  on every node); ``srun -N1 -n1 cmd`` is wrapped in a
-  ``$SKYPILOT_NODE_RANK == 0`` guard; for ``srun --ntasks-per-node=N`` with
-  N > 1 the converter emits ready-to-copy ``torchrun`` and ``mpirun``
-  templates next to the original line.
-- Directives without a direct equivalent (``--output``, ``--error``,
-  ``--array``) are preserved as comments at the top of the YAML for review.
-
-The output is a starting point: always read through the generated YAML and
-adjust before launching.
+The converter maps ``#SBATCH`` directives, rewrites ``SLURM_*`` env vars in
+the body, and translates ``srun`` invocations. The output is a starting
+point: always read through the generated YAML and adjust before launching.
 
 Side-by-side comparison
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/reference/slurm/slurm-getting-started.rst
+++ b/docs/source/reference/slurm/slurm-getting-started.rst
@@ -134,6 +134,25 @@ Once you have configured your Slurm cluster:
       $ sky launch --infra slurm/mycluster/mypartition task.yaml
 
 
+Converting existing Slurm scripts
+---------------------------------
+
+If you already have ``sbatch`` scripts, ``sky utils convert-slurm`` will
+translate them to a SkyPilot task YAML:
+
+.. code-block:: bash
+
+   $ sky utils convert-slurm my-job.slurm my-job.sky.yaml
+   $ sky launch -c my-job my-job.sky.yaml
+
+The converter maps ``#SBATCH`` directives to their SkyPilot equivalents
+(including ``--time`` → ``autostop``, ``--partition`` → ``resources.infra``,
+and other directives → ``config.slurm.sbatch_options`` for round-tripping
+to Slurm), rewrites ``SLURM_*`` env vars in the body, and translates
+``srun`` invocations based on Slurm semantics. See
+:ref:`slurm-to-skypilot` for the full directive mapping and details.
+
+
 Viewing cluster status
 ----------------------
 

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -7827,6 +7827,81 @@ def debug_dump(
     click.echo(f'Debug dump saved to: {local_path}')
 
 
+@cli.group(cls=_NaturalOrderGroup)
+def utils():
+    """SkyPilot utility commands."""
+    pass
+
+
+@utils.command('convert-slurm', cls=_DocumentedCodeCommand)
+@click.argument('slurm_script',
+                required=True,
+                type=click.Path(exists=True, dir_okay=False, readable=True))
+@click.argument('output_yaml', required=False, type=click.Path(dir_okay=False))
+@click.option('--force',
+              '-f',
+              is_flag=True,
+              default=False,
+              help='Overwrite the output YAML file if it already exists.')
+@click.option('--quiet',
+              '-q',
+              is_flag=True,
+              default=False,
+              help='Do not print warnings about unmapped directives.')
+def utils_convert_slurm(slurm_script: str, output_yaml: Optional[str],
+                        force: bool, quiet: bool):
+    """Convert a Slurm batch script to a SkyPilot task YAML.
+
+    Parses ``#SBATCH`` directives from the given Slurm script and emits an
+    equivalent SkyPilot task YAML. Directives without a direct SkyPilot
+    equivalent (e.g. ``--time``, ``--partition``, ``--account``, ``--array``)
+    are preserved as comments so they can be reviewed manually.
+
+    See https://docs.skypilot.co/en/latest/reference/slurm-migration.html for
+    the full mapping reference.
+
+    Examples:
+
+    .. code-block:: bash
+
+        # Convert train.slurm and write to stdout.
+        sky utils convert-slurm train.slurm
+        \b
+        # Convert train.slurm and write to train.sky.yaml.
+        sky utils convert-slurm train.slurm train.sky.yaml
+        \b
+        # Overwrite an existing output file.
+        sky utils convert-slurm train.slurm train.sky.yaml --force
+    """
+    # Import locally to keep CLI startup fast.
+    from sky.utils import (
+        slurm_converter)  # pylint: disable=import-outside-toplevel
+
+    with open(slurm_script, 'r', encoding='utf-8') as f:
+        script_content = f.read()
+
+    yaml_text, warnings = slurm_converter.convert_slurm_script(script_content)
+
+    if output_yaml is None:
+        click.echo(yaml_text, nl=False)
+    else:
+        if os.path.exists(output_yaml) and not force:
+            raise click.UsageError(
+                f'Output file {output_yaml!r} already exists. Pass --force '
+                'to overwrite.')
+        with open(output_yaml, 'w', encoding='utf-8') as f:
+            f.write(yaml_text)
+        click.secho(f'Wrote SkyPilot task YAML to {output_yaml}',
+                    fg='green',
+                    err=True)
+
+    if warnings and not quiet:
+        click.echo('', err=True)
+        click.secho('Warnings:', fg='yellow', bold=True, err=True)
+        for w in warnings:
+            click.secho(f'  - {w}', fg='yellow', err=True)
+
+
 def main():
     return cli()
 

--- a/sky/utils/slurm_converter.py
+++ b/sky/utils/slurm_converter.py
@@ -38,6 +38,10 @@ _ENV_VAR_MAPPING: Dict[str, str] = {
     'SLURM_GPUS_ON_NODE': 'SKYPILOT_NUM_GPUS_PER_NODE',
     'SLURM_JOB_ID': 'SKYPILOT_TASK_ID',
     'SLURM_JOBID': 'SKYPILOT_TASK_ID',
+    # ``SLURM_ARRAY_TASK_ID`` only makes sense once the user has converted the
+    # job array to a ``sky jobs launch --env TASK_ID=$i`` shell loop (per the
+    # migration guide). Substituting to ``TASK_ID`` keeps the body usable.
+    'SLURM_ARRAY_TASK_ID': 'TASK_ID',
 }
 
 # Short option -> long option for the SBATCH directives we recognize. Slurm
@@ -113,6 +117,41 @@ def _parse_sbatch_tokens(tokens: List[str]) -> List[Tuple[str, str]]:
     return pairs
 
 
+def _join_continuations(lines: List[str]) -> List[str]:
+    """Join shell line continuations (``\\`` at end of line) into single lines.
+
+    Slurm scripts often spell long ``srun`` invocations across several lines
+    using ``\\`` continuations, e.g.::
+
+        srun \\
+          --ntasks-per-node=8 \\
+          python train.py
+
+    The body translator inspects one line at a time, so we collapse these
+    before handing them off so the srun translator sees the full command.
+    """
+    merged: List[str] = []
+    buffer: Optional[str] = None
+    for line in lines:
+        # Strip a trailing ``\`` (with optional whitespace before it).
+        m = re.match(r'^(.*?)\s*\\\s*$', line)
+        if m:
+            piece = m.group(1)
+            if buffer is None:
+                buffer = piece
+            else:
+                buffer += ' ' + piece.lstrip()
+            continue
+        if buffer is not None:
+            merged.append(buffer + ' ' + line.lstrip())
+            buffer = None
+        else:
+            merged.append(line)
+    if buffer is not None:
+        merged.append(buffer)
+    return merged
+
+
 def _parse_script(script: str) -> _ParsedScript:
     directives: Dict[str, str] = {}
     unknown: List[str] = []
@@ -162,7 +201,9 @@ def _parse_gpu_spec(value: str) -> Tuple[Optional[str], Optional[int]]:
     Returns ``(type, count)``. Type may be ``None`` when omitted.
     """
     if not value:
-        return None, None
+        # Bare ``--gres=gpu`` with no count is sometimes accepted by Slurm
+        # and means one GPU. Default to that rather than skipping silently.
+        return None, 1
     # Slurm's ``--gres=gpu:type:count`` or ``--gres=gpu:count`` already has the
     # leading ``gpu:`` stripped by the caller.
     parts = value.split(':')
@@ -553,14 +594,52 @@ def _translate_mpi_launcher_line(indent: str,
     ]
 
 
+# Slurm-only commands that won't work outside a Slurm allocation.
+_SLURM_ONLY_COMMAND_RE = re.compile(
+    r'(^|[\s;&|`(])(sbcast|sgather|sattach|squeue|sacct|sinfo|scontrol|'
+    r'srun_cr|smap|sshare|sprio|sstat|sreport|sdiag|sbatch)\b')
+
+# Heuristics for commands that *work* in a SkyPilot ``run:`` block but really
+# belong in ``setup:`` so they don't re-run on every launch.
+_SETUP_HINT_RE = re.compile(
+    r'(^|[\s;&|`(])(pip\s+install|pip3\s+install|conda\s+(create|install)|'
+    r'apt(-get)?\s+install|yum\s+install|dnf\s+install|brew\s+install|'
+    r'mamba\s+install|micromamba\s+install)\b')
+
+# ``module load``/``module purge`` won't work without environment modules
+# installed, which SkyPilot images normally don't have.
+_MODULE_RE = re.compile(r'(^|[\s;&|`(])module\s+(load|purge|swap|unload|use)\b')
+
+
 def _translate_body(body: str,
                     num_nodes: Optional[int]) -> Tuple[str, List[str]]:
     """Rewrite the script body: translate ``srun``/``mpirun`` invocations."""
     warnings: List[str] = []
+    saw_module_load = False
+    saw_setup_hint = False
+    saw_slurm_only = False
+    saw_inline_srun = False
     out_lines: List[str] = []
-    for line in body.splitlines():
+    # Collapse ``\\``-continued lines so multi-line ``srun`` invocations are
+    # seen as a single line by the per-line translator.
+    lines = _join_continuations(body.splitlines())
+    for line in lines:
         stripped = line.lstrip()
         indent = line[:len(line) - len(stripped)]
+        # Body-level diagnostics (don't transform; just warn once each).
+        if not saw_module_load and _MODULE_RE.search(stripped):
+            saw_module_load = True
+        if not saw_setup_hint and _SETUP_HINT_RE.search(stripped):
+            saw_setup_hint = True
+        if not saw_slurm_only and _SLURM_ONLY_COMMAND_RE.search(stripped):
+            saw_slurm_only = True
+        # Detect ``srun`` that isn't at the start of a line, e.g.
+        # ``time srun ...``, ``cd /tmp && srun ...``, ``(srun ...)``.
+        if (not saw_inline_srun and 'srun' in stripped and
+                not (stripped == 'srun' or stripped.startswith('srun '))):
+            if re.search(r'(^|[\s;&|`(])srun\s', stripped):
+                saw_inline_srun = True
+
         if stripped == 'srun' or stripped.startswith('srun '):
             new_lines, ws = _translate_srun_line(indent, stripped, num_nodes)
             out_lines.extend(new_lines)
@@ -573,6 +652,30 @@ def _translate_body(body: str,
             warnings.extend(ws)
         else:
             out_lines.append(line)
+
+    if saw_module_load:
+        warnings.append(
+            'Found `module load` (or similar) in the script body. Slurm '
+            'environment modules are not available in SkyPilot tasks; '
+            'use a Docker `image_id` or install dependencies in `setup:` '
+            'instead.')
+    if saw_setup_hint:
+        warnings.append(
+            'Found `pip/conda/apt install` (or similar) in the script body. '
+            'Move these into a `setup:` block so they only run once per '
+            'cluster launch instead of every job submission.')
+    if saw_slurm_only:
+        warnings.append(
+            'Found Slurm-only commands (sbcast/sgather/sattach/squeue/...) '
+            'in the script body. These will not work in a SkyPilot task; '
+            'replace them with the SkyPilot equivalent (see the migration '
+            'guide).')
+    if saw_inline_srun:
+        warnings.append(
+            'Found `srun` not at the start of a line (e.g. `time srun ...`, '
+            '`cmd && srun ...`, `(srun ...)`). The converter only translates '
+            'leading `srun` invocations; please review these lines manually.')
+
     return '\n'.join(out_lines), warnings
 
 
@@ -622,8 +725,14 @@ def convert_slurm_script(script: str) -> Tuple[str, List[str]]:
     num_nodes: Optional[int] = None
     if 'nodes' in directives:
         nodes_val = directives.pop('nodes')
-        # Slurm also allows ``min-max``; pick the minimum.
-        nodes_val = nodes_val.split('-')[0]
+        # Slurm also allows ``min-max``; pick the minimum and warn the user.
+        if '-' in nodes_val:
+            min_part, max_part = nodes_val.split('-', 1)
+            warnings.append(
+                f'--nodes={nodes_val} is a range; SkyPilot needs a fixed '
+                f'count. Using {min_part}; change `num_nodes` if you want '
+                f'{max_part} instead.')
+            nodes_val = min_part
         try:
             num_nodes = int(nodes_val)
         except ValueError:
@@ -733,6 +842,43 @@ def convert_slurm_script(script: str) -> Tuple[str, List[str]]:
             'the name of your configured Slurm cluster from '
             '`~/.sky/config.yaml`.')
 
+    # ``--container-image`` (Pyxis / enroot, common on HPC clusters) maps to
+    # SkyPilot's ``image_id`` -- prefix with ``docker:`` if the user didn't.
+    image_id: Optional[str] = None
+    container_image = directives.pop('container-image', None)
+    if container_image:
+        if '://' in container_image:
+            # E.g. ``docker://nvidia/cuda:12.1.1`` -- normalize to docker:.
+            scheme, rest = container_image.split('://', 1)
+            image_id = f'{scheme}:{rest}' if scheme == 'docker' \
+                else container_image
+        elif container_image.startswith('docker:') or \
+                container_image.startswith('oci:'):
+            image_id = container_image
+        else:
+            image_id = f'docker:{container_image}'
+    # Other Pyxis ``--container-*`` options aren't first-class in SkyPilot.
+    # Drop them with a heads-up so they don't get pushed into sbatch_options
+    # where they'd no-op.
+    for pyxis_key in ('container-mounts', 'container-workdir', 'container-name',
+                      'container-save', 'container-env', 'container-remap-root',
+                      'container-writable', 'container-readonly'):
+        if pyxis_key in directives:
+            value = directives.pop(pyxis_key)
+            warnings.append(
+                f'Dropped Pyxis option --{pyxis_key}={value}: SkyPilot '
+                'manages container mounts and entry differently. Use '
+                '`file_mounts:` and `setup:` instead.')
+
+    # ``--ntasks=N`` is only meaningful inside a Slurm allocation; SkyPilot
+    # always launches the ``run`` block once per node. Drop it with a note.
+    if 'ntasks' in directives:
+        ntasks_val = directives.pop('ntasks')
+        warnings.append(
+            f'Dropped --ntasks={ntasks_val}: SkyPilot launches `run:` once '
+            'per node. Use a distributed launcher (torchrun/mpirun) inside '
+            'the run block to spawn additional tasks.')
+
     # Directives that SkyPilot does not map directly.
     unsupported_notes: List[Tuple[str, str]] = []
 
@@ -840,6 +986,8 @@ def convert_slurm_script(script: str) -> Tuple[str, List[str]]:
         resources.append(f'  cpus: {cpus}+')
     if memory_gb:
         resources.append(f'  memory: {memory_gb}+')
+    if image_id:
+        resources.append(f'  image_id: {_yaml_scalar(image_id)}')
     if resources:
         lines.append('resources:')
         lines.extend(resources)

--- a/sky/utils/slurm_converter.py
+++ b/sky/utils/slurm_converter.py
@@ -1,0 +1,499 @@
+"""Convert a Slurm batch script into a SkyPilot task YAML.
+
+Given the contents of a Slurm script (e.g. one submitted with ``sbatch``),
+``convert_slurm_script`` returns an equivalent SkyPilot YAML plus a list of
+human-readable warnings describing directives that could not be mapped
+automatically.
+
+The mapping follows
+https://docs.skypilot.co/en/latest/reference/slurm-migration.html:
+
+    --job-name / -J              -> name
+    --nodes / -N                 -> num_nodes
+    --gpus-per-node / --gres=gpu -> resources.accelerators
+    --gpus / -G                  -> resources.accelerators (divided by nodes)
+    --cpus-per-task / -c         -> resources.cpus
+    --mem                        -> resources.memory
+    SLURM_* env vars             -> SKYPILOT_* env vars (in body)
+
+Directives that do not have a direct SkyPilot equivalent (``--time``,
+``--partition``, ``--account``, ``--output``, ``--array``, ...) are preserved
+as comments in the generated YAML so the user can decide what to do with them.
+"""
+import dataclasses
+import re
+import shlex
+from typing import Dict, List, Optional, Tuple
+
+# Mapping of Slurm environment variables to SkyPilot equivalents. Applied to
+# the body of the script as a best-effort string replacement.
+_ENV_VAR_MAPPING: Dict[str, str] = {
+    'SLURM_JOB_NODELIST': 'SKYPILOT_NODE_IPS',
+    'SLURM_NODELIST': 'SKYPILOT_NODE_IPS',
+    'SLURM_NNODES': 'SKYPILOT_NUM_NODES',
+    'SLURM_JOB_NUM_NODES': 'SKYPILOT_NUM_NODES',
+    'SLURM_NODEID': 'SKYPILOT_NODE_RANK',
+    'SLURM_PROCID': 'SKYPILOT_NODE_RANK',
+    'SLURM_GPUS_PER_NODE': 'SKYPILOT_NUM_GPUS_PER_NODE',
+    'SLURM_GPUS_ON_NODE': 'SKYPILOT_NUM_GPUS_PER_NODE',
+    'SLURM_JOB_ID': 'SKYPILOT_TASK_ID',
+    'SLURM_JOBID': 'SKYPILOT_TASK_ID',
+}
+
+# Short option -> long option for the SBATCH directives we recognize. Slurm
+# accepts both forms interchangeably.
+_SHORT_TO_LONG: Dict[str, str] = {
+    'J': 'job-name',
+    'N': 'nodes',
+    'n': 'ntasks',
+    'c': 'cpus-per-task',
+    'G': 'gpus',
+    'p': 'partition',
+    't': 'time',
+    'o': 'output',
+    'e': 'error',
+    'D': 'chdir',
+    'A': 'account',
+    'a': 'array',
+    'w': 'nodelist',
+    'C': 'constraint',
+    'q': 'qos',
+    'd': 'dependency',
+}
+
+
+@dataclasses.dataclass
+class _ParsedScript:
+    directives: Dict[str, str]
+    body_lines: List[str]
+    # Unknown / unmapped directives, preserved verbatim.
+    unknown_directives: List[str]
+
+
+def _parse_sbatch_tokens(tokens: List[str]) -> List[Tuple[str, str]]:
+    """Parse the tokens after ``#SBATCH`` into (key, value) pairs.
+
+    Slurm accepts many forms, e.g. ``--nodes=2``, ``--nodes 2``, ``-N2``,
+    ``-N 2``. Flags without values (e.g. ``--exclusive``) get an empty value.
+    """
+    pairs: List[Tuple[str, str]] = []
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok.startswith('--'):
+            body = tok[2:]
+            if '=' in body:
+                key, value = body.split('=', 1)
+                pairs.append((key, value))
+                i += 1
+            else:
+                # Value may be in the next token, or the flag may be boolean.
+                if i + 1 < len(tokens) and not tokens[i + 1].startswith('-'):
+                    pairs.append((body, tokens[i + 1]))
+                    i += 2
+                else:
+                    pairs.append((body, ''))
+                    i += 1
+        elif tok.startswith('-') and len(tok) >= 2:
+            short = tok[1]
+            rest = tok[2:]
+            key = _SHORT_TO_LONG.get(short, short)
+            if rest:
+                pairs.append((key, rest))
+                i += 1
+            elif i + 1 < len(tokens) and not tokens[i + 1].startswith('-'):
+                pairs.append((key, tokens[i + 1]))
+                i += 2
+            else:
+                pairs.append((key, ''))
+                i += 1
+        else:
+            # Unexpected positional token; skip.
+            i += 1
+    return pairs
+
+
+def _parse_script(script: str) -> _ParsedScript:
+    directives: Dict[str, str] = {}
+    unknown: List[str] = []
+    body_lines: List[str] = []
+    in_header = True
+    for raw_line in script.splitlines():
+        line = raw_line.rstrip('\n')
+        stripped = line.strip()
+        if in_header:
+            if not stripped:
+                # Blank line inside header: keep scanning for more SBATCH
+                # directives.
+                continue
+            if stripped.startswith('#!'):
+                # Shebang; drop it.
+                continue
+            if stripped.startswith('#SBATCH'):
+                payload = stripped[len('#SBATCH'):].strip()
+                # Strip trailing comment after the directive.
+                payload = payload.split('#', 1)[0].strip()
+                if not payload:
+                    continue
+                try:
+                    tokens = shlex.split(payload)
+                except ValueError:
+                    unknown.append(payload)
+                    continue
+                for key, value in _parse_sbatch_tokens(tokens):
+                    directives[key] = value
+                continue
+            if stripped.startswith('#'):
+                # Non-SBATCH comment in the header: drop.
+                continue
+            # First real command; the rest of the file is the body.
+            in_header = False
+            body_lines.append(line)
+        else:
+            body_lines.append(line)
+    return _ParsedScript(directives=directives,
+                         body_lines=body_lines,
+                         unknown_directives=unknown)
+
+
+def _parse_gpu_spec(value: str) -> Tuple[Optional[str], Optional[int]]:
+    """Parse ``[type:]count`` GPU specifications.
+
+    Returns ``(type, count)``. Type may be ``None`` when omitted.
+    """
+    if not value:
+        return None, None
+    # Slurm's ``--gres=gpu:type:count`` or ``--gres=gpu:count`` already has the
+    # leading ``gpu:`` stripped by the caller.
+    parts = value.split(':')
+    if len(parts) == 1:
+        try:
+            return None, int(parts[0])
+        except ValueError:
+            return parts[0], 1
+    # len >= 2: last part is the count.
+    try:
+        count = int(parts[-1])
+        type_parts = parts[:-1]
+    except ValueError:
+        # No trailing count; assume 1 of the named type.
+        return ':'.join(parts), 1
+    if not type_parts:
+        return None, count
+    return ':'.join(type_parts), count
+
+
+def _normalize_gpu_type(gpu_type: str) -> str:
+    """Normalize a Slurm GPU type string to the canonical SkyPilot form."""
+    t = gpu_type.strip()
+    # Common Slurm naming: a100, a100-40gb, h100, v100, etc. SkyPilot uses
+    # upper-case canonical names (H100, A100, V100, ...).
+    upper = t.upper()
+    # Drop any memory suffix like ``-40GB`` that SkyPilot's main catalogs do
+    # not use in the accelerator name.
+    upper = re.sub(r'-\d+GB$', '', upper)
+    return upper
+
+
+def _parse_memory(value: str) -> Optional[int]:
+    """Parse a Slurm memory string (e.g. ``16G``, ``1024M``) to GB (int)."""
+    if not value:
+        return None
+    match = re.match(r'^(\d+(?:\.\d+)?)\s*([KMGT]?)B?$', value.strip(),
+                     re.IGNORECASE)
+    if not match:
+        return None
+    amount = float(match.group(1))
+    unit = match.group(2).upper()
+    multiplier = {
+        '': 1 / 1024,  # Slurm default unit is MB.
+        'K': 1 / (1024 * 1024),
+        'M': 1 / 1024,
+        'G': 1,
+        'T': 1024,
+    }.get(unit, 1)
+    gb = amount * multiplier
+    if gb < 1:
+        return 1
+    return int(round(gb))
+
+
+def _substitute_env_vars(text: str) -> str:
+    for slurm_var, sky_var in _ENV_VAR_MAPPING.items():
+        text = re.sub(r'\$\{?' + slurm_var + r'\}?',
+                      lambda m, v=sky_var: '$' + v,
+                      text)
+    return text
+
+
+def _strip_srun(body: str) -> Tuple[str, List[str]]:
+    """Remove leading ``srun`` invocations from body lines.
+
+    SkyPilot handles multi-node launch itself (via ``SKYPILOT_NODE_IPS`` and
+    ``SKYPILOT_NODE_RANK``), so the common pattern ``srun python train.py``
+    becomes just ``python train.py``. If the ``srun`` invocation has any flags
+    we leave the line unchanged and emit a warning asking the user to review
+    it, since translating arbitrary ``srun`` flags is error-prone.
+    """
+    warnings: List[str] = []
+    out_lines: List[str] = []
+    for line in body.splitlines():
+        stripped = line.lstrip()
+        indent = line[:len(line) - len(stripped)]
+        if stripped == 'srun' or stripped.startswith('srun '):
+            after = stripped[len('srun'):].lstrip()
+            if after.startswith('-'):
+                warnings.append(
+                    f'Left `srun` flags unchanged on line: {stripped!r}. '
+                    'SkyPilot distributes work via $SKYPILOT_NODE_IPS and '
+                    '$SKYPILOT_NODE_RANK; please translate the flags by '
+                    'hand.')
+                out_lines.append(line)
+            else:
+                out_lines.append(indent + after)
+        elif stripped.startswith('mpirun ') or stripped.startswith('mpiexec '):
+            warnings.append(
+                f'Left MPI launcher unchanged on line: {stripped!r}. Make '
+                'sure the hostfile uses $SKYPILOT_NODE_IPS.')
+            out_lines.append(line)
+        else:
+            out_lines.append(line)
+    return '\n'.join(out_lines), warnings
+
+
+def _format_yaml_block(key: str, value: str) -> str:
+    """Format a multi-line string value as a YAML block scalar."""
+    value = value.rstrip('\n')
+    if not value:
+        return f'{key}: |\n'
+    indented = '\n'.join(
+        '  ' + line if line else '' for line in value.split('\n'))
+    return f'{key}: |\n{indented}\n'
+
+
+def convert_slurm_script(script: str) -> Tuple[str, List[str]]:
+    """Convert a Slurm batch script to a SkyPilot task YAML.
+
+    Args:
+        script: The contents of the Slurm script.
+
+    Returns:
+        A tuple ``(yaml_text, warnings)``. ``warnings`` lists directives that
+        were not mapped and other notes for the user.
+    """
+    parsed = _parse_script(script)
+    directives = parsed.directives
+    warnings: List[str] = []
+
+    name: Optional[str] = directives.pop('job-name', None)
+    num_nodes: Optional[int] = None
+    if 'nodes' in directives:
+        nodes_val = directives.pop('nodes')
+        # Slurm also allows ``min-max``; pick the minimum.
+        nodes_val = nodes_val.split('-')[0]
+        try:
+            num_nodes = int(nodes_val)
+        except ValueError:
+            warnings.append(
+                f'Could not parse --nodes value {nodes_val!r}; skipping.')
+
+    # CPU: per-node = cpus-per-task * ntasks-per-node (default 1).
+    cpus_per_task = directives.pop('cpus-per-task', None)
+    ntasks_per_node = directives.pop('ntasks-per-node', None)
+    cpus: Optional[int] = None
+    if cpus_per_task is not None:
+        try:
+            c = int(cpus_per_task)
+            if ntasks_per_node is not None:
+                c *= int(ntasks_per_node)
+            cpus = c
+        except ValueError:
+            warnings.append(
+                f'Could not parse --cpus-per-task={cpus_per_task!r}.')
+    elif ntasks_per_node is not None:
+        try:
+            cpus = int(ntasks_per_node)
+        except ValueError:
+            pass
+
+    # Memory.
+    memory_gb: Optional[int] = None
+    mem_val = directives.pop('mem', None)
+    if mem_val is not None:
+        memory_gb = _parse_memory(mem_val)
+        if memory_gb is None:
+            warnings.append(f'Could not parse --mem={mem_val!r}.')
+    elif 'mem-per-cpu' in directives and cpus is not None:
+        per_cpu = _parse_memory(directives.pop('mem-per-cpu'))
+        if per_cpu is not None:
+            memory_gb = per_cpu * cpus
+    else:
+        directives.pop('mem-per-cpu', None)
+        directives.pop('mem-per-gpu', None)
+
+    # GPUs.
+    gpu_type: Optional[str] = None
+    gpu_count: Optional[int] = None
+    if 'gpus-per-node' in directives:
+        t, c = _parse_gpu_spec(directives.pop('gpus-per-node'))
+        gpu_type = t
+        gpu_count = c
+    elif 'gres' in directives:
+        gres = directives.pop('gres')
+        # ``--gres`` can list multiple resources separated by commas; we only
+        # handle the GPU entry.
+        for entry in gres.split(','):
+            entry = entry.strip()
+            if entry.lower().startswith('gpu'):
+                # Strip the ``gpu`` prefix (with optional ``:``).
+                rest = entry[3:]
+                rest = rest.lstrip(':')
+                t, c = _parse_gpu_spec(rest)
+                gpu_type = t
+                gpu_count = c
+                break
+        else:
+            warnings.append(f'--gres={gres!r} did not contain a GPU entry; '
+                            'skipping.')
+    elif 'gpus' in directives:
+        t, c = _parse_gpu_spec(directives.pop('gpus'))
+        if c is not None and num_nodes and num_nodes > 1:
+            per_node, remainder = divmod(c, num_nodes)
+            if remainder:
+                warnings.append(
+                    f'--gpus={c} is not divisible by --nodes={num_nodes}; '
+                    f'using {per_node} GPUs per node.')
+            gpu_count = per_node or None
+        else:
+            gpu_count = c
+        gpu_type = t
+
+    if gpu_count is not None and gpu_type is None:
+        warnings.append(
+            'No GPU type was specified in the Slurm script; please edit '
+            '`accelerators` in the generated YAML to set one '
+            '(e.g. H100, A100, V100).')
+
+    # Directives that SkyPilot does not map directly.
+    unsupported_notes: List[Tuple[str, str]] = []
+
+    def _note(flag: str, msg: str) -> None:
+        value = directives.pop(flag, None)
+        if value is None:
+            return
+        label = f'--{flag}={value}' if value else f'--{flag}'
+        unsupported_notes.append((label, msg))
+
+    _note(
+        'time',
+        'SkyPilot does not enforce a wall-clock time limit. Use `autostop` '
+        'to release idle clusters, or use managed jobs for retries.')
+    _note(
+        'partition',
+        'Slurm partitions do not map directly. Use `resources.infra` to '
+        'target a specific cloud/region or Kubernetes context.')
+    _note(
+        'account', 'SkyPilot does not have accounts. Use workspaces/quotas '
+        'in `~/.sky/config.yaml` if needed.')
+    _note('qos', 'No direct QoS equivalent in SkyPilot.')
+    _note(
+        'constraint', 'No direct equivalent; use `resources.instance_type` or '
+        '`resources.labels` to constrain placement.')
+    _note('reservation', 'Reservations are configured per-cloud in SkyPilot.')
+    _note(
+        'output', 'SkyPilot captures stdout/stderr automatically; view with '
+        '`sky logs` or `sky jobs logs`.')
+    _note('error',
+          'SkyPilot captures stderr automatically; view with `sky logs`.')
+    _note(
+        'array', 'Slurm job arrays have no direct equivalent. Launch with a '
+        'shell loop over `sky jobs launch --env TASK_ID=$i ...`.')
+    _note(
+        'dependency',
+        'Job dependencies can be modeled with SkyPilot pipelines/DAGs or by '
+        'chaining `sky jobs launch` calls.')
+    _note('mail-user', 'SkyPilot does not send email notifications.')
+    _note('mail-type', 'SkyPilot does not send email notifications.')
+    _note('begin', 'Scheduled start times are not supported by SkyPilot.')
+    _note('chdir',
+          'Set the working directory inside `setup`/`run` or with `workdir:`.')
+    _note('exclusive',
+          'SkyPilot clusters are allocated exclusively by default.')
+    _note(
+        'nodelist',
+        'Specific node targeting is not supported; use `resources.infra` '
+        'or labels instead.')
+    _note('exclude', 'Node exclusion is not supported.')
+    _note('ntasks',
+          'Maps loosely to `num_nodes * ntasks-per-node`; reviewed manually.')
+
+    # Anything still in ``directives`` is unknown / unhandled.
+    for flag, value in list(directives.items()):
+        label = f'--{flag}={value}' if value else f'--{flag}'
+        unsupported_notes.append(
+            (label, 'No direct SkyPilot equivalent; please review.'))
+
+    # Body handling: substitute env vars and strip srun wrappers.
+    body = '\n'.join(parsed.body_lines).strip('\n')
+    body = _substitute_env_vars(body)
+    body, srun_warnings = _strip_srun(body)
+    warnings.extend(srun_warnings)
+
+    # Assemble the YAML text. We format it manually so that we can interleave
+    # comments for unsupported directives.
+    lines: List[str] = []
+    lines.append('# Generated by `sky utils convert-slurm`. Please review '
+                 'before running.')
+    lines.append('# Reference: '
+                 'https://docs.skypilot.co/en/latest/reference/'
+                 'slurm-migration.html')
+    lines.append('')
+
+    if unsupported_notes:
+        lines.append('# The following Slurm directives could not be mapped '
+                     'automatically:')
+        for label, msg in unsupported_notes:
+            lines.append(f'#   {label}: {msg}')
+        lines.append('')
+
+    if parsed.unknown_directives:
+        lines.append('# Malformed or unparseable #SBATCH directives:')
+        for u in parsed.unknown_directives:
+            lines.append(f'#   {u}')
+        lines.append('')
+
+    if name:
+        lines.append(f'name: {name}')
+        lines.append('')
+    if num_nodes and num_nodes > 1:
+        lines.append(f'num_nodes: {num_nodes}')
+        lines.append('')
+
+    resources: List[str] = []
+    if gpu_count:
+        if gpu_type:
+            type_str = _normalize_gpu_type(gpu_type)
+        else:
+            type_str = '<GPU_TYPE>'
+        resources.append(f'  accelerators: {type_str}:{gpu_count}')
+    if cpus:
+        resources.append(f'  cpus: {cpus}+')
+    if memory_gb:
+        resources.append(f'  memory: {memory_gb}+')
+    if resources:
+        lines.append('resources:')
+        lines.extend(resources)
+        lines.append('')
+
+    if body.strip():
+        lines.append('run: |')
+        for line in body.splitlines():
+            lines.append('  ' + line if line else '')
+        lines.append('')
+    else:
+        lines.append('run: |')
+        lines.append('  echo "Hello from SkyPilot"')
+        lines.append('')
+
+    yaml_text = '\n'.join(lines).rstrip('\n') + '\n'
+    return yaml_text, warnings

--- a/sky/utils/slurm_converter.py
+++ b/sky/utils/slurm_converter.py
@@ -195,6 +195,50 @@ def _normalize_gpu_type(gpu_type: str) -> str:
     return upper
 
 
+def _parse_slurm_time(value: str) -> Optional[int]:
+    """Parse a Slurm ``--time`` value into whole minutes.
+
+    Slurm accepts ``MM``, ``MM:SS``, ``HH:MM:SS``, ``DD-HH``, ``DD-HH:MM`` and
+    ``DD-HH:MM:SS``. Returns minutes rounded up, or ``None`` on parse failure.
+    """
+    value = value.strip()
+    if not value:
+        return None
+    days = 0
+    rest = value
+    if '-' in value:
+        day_str, rest = value.split('-', 1)
+        try:
+            days = int(day_str)
+        except ValueError:
+            return None
+    parts = rest.split(':') if rest else []
+    try:
+        nums = [int(p) for p in parts] if parts else [0]
+    except ValueError:
+        return None
+
+    if '-' in value:
+        # DD-HH / DD-HH:MM / DD-HH:MM:SS
+        while len(nums) < 3:
+            nums.append(0)
+        hours, minutes, seconds = nums[0], nums[1], nums[2]
+    elif len(nums) == 1:
+        # Bare minutes.
+        hours, minutes, seconds = 0, nums[0], 0
+    elif len(nums) == 2:
+        # MM:SS.
+        hours, minutes, seconds = 0, nums[0], nums[1]
+    elif len(nums) == 3:
+        hours, minutes, seconds = nums
+    else:
+        return None
+    total_minutes = days * 24 * 60 + hours * 60 + minutes
+    if seconds > 0:
+        total_minutes += 1  # Round up to capture the partial minute.
+    return total_minutes if total_minutes > 0 else None
+
+
 def _parse_memory(value: str) -> Optional[int]:
     """Parse a Slurm memory string (e.g. ``16G``, ``1024M``) to GB (int)."""
     if not value:
@@ -645,6 +689,32 @@ def convert_slurm_script(script: str) -> Tuple[str, List[str]]:
             '`accelerators` in the generated YAML to set one '
             '(e.g. H100, A100, V100).')
 
+    # ``--time``: Slurm's wall-clock limit translates to SkyPilot's autostop,
+    # which tears the cluster down once idle (and so once the job finishes).
+    # See
+    # https://docs.skypilot.co/en/latest/reference/slurm/slurm-getting-started.html
+    autostop_minutes: Optional[int] = None
+    time_val = directives.pop('time', None)
+    if time_val is not None:
+        autostop_minutes = _parse_slurm_time(time_val)
+        if autostop_minutes is None:
+            warnings.append(
+                f'Could not parse --time={time_val!r}; skipping autostop.')
+
+    # ``--partition``: a Slurm partition maps to SkyPilot's
+    # ``infra: slurm/<cluster>/<partition>`` selector. We don't know the
+    # cluster name from the script, so leave a ``<cluster>`` placeholder for
+    # the user to fill in.
+    infra_value: Optional[str] = None
+    partition_val = directives.pop('partition', None)
+    if partition_val:
+        infra_value = f'slurm/<cluster>/{partition_val}'
+        warnings.append(
+            f'--partition={partition_val} was mapped to '
+            f'`resources.infra: {infra_value}`. Replace `<cluster>` with '
+            'the name of your configured Slurm cluster from '
+            '`~/.sky/config.yaml`.')
+
     # Directives that SkyPilot does not map directly.
     unsupported_notes: List[Tuple[str, str]] = []
 
@@ -655,14 +725,6 @@ def convert_slurm_script(script: str) -> Tuple[str, List[str]]:
         label = f'--{flag}={value}' if value else f'--{flag}'
         unsupported_notes.append((label, msg))
 
-    _note(
-        'time',
-        'SkyPilot does not enforce a wall-clock time limit. Use `autostop` '
-        'to release idle clusters, or use managed jobs for retries.')
-    _note(
-        'partition',
-        'Slurm partitions do not map directly. Use `resources.infra` to '
-        'target a specific cloud/region or Kubernetes context.')
     _note(
         'account', 'SkyPilot does not have accounts. Use workspaces/quotas '
         'in `~/.sky/config.yaml` if needed.')
@@ -741,6 +803,8 @@ def convert_slurm_script(script: str) -> Tuple[str, List[str]]:
         lines.append('')
 
     resources: List[str] = []
+    if infra_value:
+        resources.append(f'  infra: {infra_value}')
     if gpu_count:
         if gpu_type:
             type_str = _normalize_gpu_type(gpu_type)
@@ -754,6 +818,13 @@ def convert_slurm_script(script: str) -> Tuple[str, List[str]]:
     if resources:
         lines.append('resources:')
         lines.extend(resources)
+        lines.append('')
+
+    if autostop_minutes is not None:
+        lines.append('autostop:')
+        lines.append(f'  idle_minutes: {autostop_minutes}')
+        lines.append('  down: true')
+        lines.append('  wait_for: none')
         lines.append('')
 
     if body.strip():

--- a/sky/utils/slurm_converter.py
+++ b/sky/utils/slurm_converter.py
@@ -442,12 +442,37 @@ def _translate_srun_line(
 
     if tasks_per_node is not None and tasks_per_node > 1:
         warnings.append(
-            f'`srun --ntasks-per-node={tasks_per_node}` in line {stripped!r} '
-            'needs manual translation: SkyPilot runs the `run:` block once '
-            'per node, so use a distributed launcher (e.g. `torchrun '
-            f'--nproc_per_node={tasks_per_node}`, `mpirun`, or similar) to '
-            'spawn the per-node tasks.')
-        # Fall through: the command is emitted once; the user must wrap it.
+            f'`srun --ntasks-per-node={tasks_per_node}` needs a distributed '
+            'launcher; commented `torchrun` and `mpirun` templates were '
+            'emitted next to the command in the generated YAML.')
+        # Emit concrete launcher templates next to the command so the user
+        # has a copy-pasteable starting point.
+        template: List[str] = [
+            indent + f'# TODO: `srun --ntasks-per-node={tasks_per_node}` has',
+            indent + '# no direct SkyPilot equivalent. Replace the command',
+            indent + '# below with one of these launchers:',
+            indent + '#',
+            indent + '# PyTorch DDP (torchrun):',
+            indent + '#   MASTER_ADDR=$(echo "$SKYPILOT_NODE_IPS" | head -n1)',
+            indent + '#   torchrun \\',
+            indent + '#     --nnodes=$SKYPILOT_NUM_NODES \\',
+            indent + f'#     --nproc_per_node={tasks_per_node} \\',
+            indent + '#     --node_rank=$SKYPILOT_NODE_RANK \\',
+            indent + '#     --master_addr=$MASTER_ADDR --master_port=29500 \\',
+            indent + '#     ' + command,
+            indent + '#',
+            indent + '# MPI (run once, on the head node only):',
+            indent + '#   if [ "${SKYPILOT_NODE_RANK:-0}" = "0" ]; then',
+            indent + '#     echo "$SKYPILOT_NODE_IPS" > /tmp/hostfile',
+            indent + f'#     mpirun -np $(($SKYPILOT_NUM_NODES * '
+            f'{tasks_per_node})) \\',
+            indent + '#       --hostfile /tmp/hostfile \\',
+            indent + f'#       --map-by ppr:{tasks_per_node}:node \\',
+            indent + '#       ' + command,
+            indent + '#   fi',
+            indent + command,
+        ]
+        return template, warnings
     elif (total_tasks is not None and num_nodes and num_nodes > 1 and
           total_tasks != num_nodes):
         warnings.append(
@@ -464,13 +489,23 @@ def _translate_mpi_launcher_line(indent: str,
     """Translate a leading ``mpirun``/``mpiexec`` invocation.
 
     SkyPilot does not manage the MPI universe for you, but the hostfile
-    should come from ``$SKYPILOT_NODE_IPS``. We leave the command intact and
-    emit a warning pointing the user at that env var.
+    should come from ``$SKYPILOT_NODE_IPS`` and the launcher should only run
+    on the head node. We prepend a commented snippet showing the typical
+    setup and leave the original command intact for the user to edit.
     """
-    return [indent + stripped], [
-        f'Left MPI launcher unchanged on line: {stripped!r}. Generate the '
-        'hostfile from $SKYPILOT_NODE_IPS, e.g. '
-        '`echo "$SKYPILOT_NODE_IPS" > /tmp/hostfile`.'
+    template = [
+        indent + '# TODO: mpirun/mpiexec needs a hostfile from SkyPilot and',
+        indent + '# should only be launched from the head node. Typical setup:',
+        indent + '#   if [ "${SKYPILOT_NODE_RANK:-0}" = "0" ]; then',
+        indent + '#     echo "$SKYPILOT_NODE_IPS" > /tmp/hostfile',
+        indent + '#     ' + stripped + ' --hostfile /tmp/hostfile',
+        indent + '#   fi',
+        indent + stripped,
+    ]
+    return template, [
+        f'Left MPI launcher unchanged on line: {stripped!r}. See the '
+        'commented template in the generated YAML for the hostfile and '
+        'head-node-only setup.'
     ]
 
 

--- a/sky/utils/slurm_converter.py
+++ b/sky/utils/slurm_converter.py
@@ -74,11 +74,37 @@ class _ParsedScript:
     unknown_directives: List[str]
 
 
+# SBATCH boolean flags that take no value. Without this, ``#SBATCH --exclusive
+# user`` would parse ``user`` as the value of ``--exclusive``.
+_SBATCH_BOOLEAN_FLAGS = frozenset({
+    'exclusive',
+    'verbose',
+    'quiet',
+    'hold',
+    'requeue',
+    'no-requeue',
+    'spread-job',
+    'test-only',
+    'use-min-nodes',
+    'wait-all-nodes',
+    'contiguous',
+    'no-kill',
+    'kill-on-invalid-dep',
+    'parsable',
+    'overcommit',
+    'oversubscribe',
+    'reboot',
+    'get-user-env',
+})
+
+
 def _parse_sbatch_tokens(tokens: List[str]) -> List[Tuple[str, str]]:
     """Parse the tokens after ``#SBATCH`` into (key, value) pairs.
 
     Slurm accepts many forms, e.g. ``--nodes=2``, ``--nodes 2``, ``-N2``,
-    ``-N 2``. Flags without values (e.g. ``--exclusive``) get an empty value.
+    ``-N 2``. Flags listed in ``_SBATCH_BOOLEAN_FLAGS`` take no value (so the
+    next token isn't consumed); other flags without ``=`` take the next token
+    as their value.
     """
     pairs: List[Tuple[str, str]] = []
     i = 0
@@ -89,6 +115,9 @@ def _parse_sbatch_tokens(tokens: List[str]) -> List[Tuple[str, str]]:
             if '=' in body:
                 key, value = body.split('=', 1)
                 pairs.append((key, value))
+                i += 1
+            elif body in _SBATCH_BOOLEAN_FLAGS:
+                pairs.append((body, ''))
                 i += 1
             else:
                 # Value may be in the next token, or the flag may be boolean.
@@ -104,6 +133,9 @@ def _parse_sbatch_tokens(tokens: List[str]) -> List[Tuple[str, str]]:
             key = _SHORT_TO_LONG.get(short, short)
             if rest:
                 pairs.append((key, rest))
+                i += 1
+            elif key in _SBATCH_BOOLEAN_FLAGS:
+                pairs.append((key, ''))
                 i += 1
             elif i + 1 < len(tokens) and not tokens[i + 1].startswith('-'):
                 pairs.append((key, tokens[i + 1]))
@@ -305,10 +337,29 @@ def _parse_memory(value: str) -> Optional[int]:
 
 def _substitute_env_vars(text: str) -> str:
     for slurm_var, sky_var in _ENV_VAR_MAPPING.items():
-        text = re.sub(r'\$\{?' + slurm_var + r'\}?',
-                      lambda m, v=sky_var: '$' + v,
-                      text)
+        # Match ``$VAR`` only when not followed by another word char (so
+        # ``$SLURM_JOB_IDX`` doesn't silently become ``$SKYPILOT_TASK_IDX``),
+        # and ``${VAR}`` as a full brace-delimited ref.
+        pattern = (r'\$' + re.escape(slurm_var) + r'(?!\w)|\$\{' +
+                   re.escape(slurm_var) + r'\}')
+        text = re.sub(pattern, lambda m, v=sky_var: '$' + v, text)
     return text
+
+
+def _shell_safe_quote(token: str) -> str:
+    """Quote ``token`` for the shell only if it contains whitespace or
+    metacharacters that would break reparsing.
+
+    Unlike ``shlex.quote``, leaves ``$VAR``/``~``/globs/etc. untouched so the
+    shell still expands them when the translated line runs.
+    """
+    if not token:
+        return "''"
+    # If the token contains whitespace, quotes, backticks, subshells, redirects
+    # or pipes, we must quote it.
+    if re.search(r'[\s<>|&;\'"`\\()]', token):
+        return shlex.quote(token)
+    return token
 
 
 # srun flags that do not affect the translated command (they either describe
@@ -385,6 +436,34 @@ _SRUN_FLAGS_TO_DROP = {
     'verbose',
 }
 
+# Flags that take no value. Without this set, a boolean short flag like ``-l``
+# or ``-v`` followed by the command (``srun -l python x.py``) would greedily
+# consume ``python`` as the flag's value and drop it from the command.
+_SRUN_BOOLEAN_FLAGS = frozenset({
+    'label',
+    'unbuffered',
+    'quiet',
+    'verbose',
+    'disable-status',
+    'kill-on-bad-exit',
+    'no-allocate',
+    'overcommit',
+    'oversubscribe',
+    'exclusive',
+    'overlap',
+    'exact',
+    'pty',
+    'preserve-env',
+    'test-only',
+    'use-min-nodes',
+    'wait-all-nodes',
+    'multi-prog',
+    'requeue',
+    'no-requeue',
+    'hold',
+    'spread-job',
+})
+
 # Short option -> long option for the flags srun shares with sbatch.
 _SRUN_SHORT_TO_LONG: Dict[str, str] = {
     'n': 'ntasks',
@@ -423,6 +502,10 @@ def _parse_srun_flags(tokens: List[str]) -> Tuple[Dict[str, str], List[str]]:
 
     Returns ``(flags, command_tokens)``. Flags without a value get the empty
     string. Stops at the first positional argument or ``--`` terminator.
+
+    Boolean flags listed in ``_SRUN_BOOLEAN_FLAGS`` are recognised as taking
+    no value, so ``srun -l python x.py`` parses ``python`` as the command
+    rather than as the value of ``--label``.
     """
     flags: Dict[str, str] = {}
     i = 0
@@ -437,6 +520,9 @@ def _parse_srun_flags(tokens: List[str]) -> Tuple[Dict[str, str], List[str]]:
                 key, value = body.split('=', 1)
                 flags[key] = value
                 i += 1
+            elif body in _SRUN_BOOLEAN_FLAGS:
+                flags[body] = ''
+                i += 1
             elif (i + 1 < len(tokens) and not tokens[i + 1].startswith('-')):
                 flags[body] = tokens[i + 1]
                 i += 2
@@ -449,6 +535,9 @@ def _parse_srun_flags(tokens: List[str]) -> Tuple[Dict[str, str], List[str]]:
             key = _SRUN_SHORT_TO_LONG.get(short, short)
             if rest:
                 flags[key] = rest
+                i += 1
+            elif key in _SRUN_BOOLEAN_FLAGS:
+                flags[key] = ''
                 i += 1
             elif (i + 1 < len(tokens) and not tokens[i + 1].startswith('-')):
                 flags[key] = tokens[i + 1]
@@ -482,7 +571,7 @@ def _translate_srun_line(
             f'Could not find a command after `srun` in line: {stripped!r}.'
         ]
 
-    command = ' '.join(shlex.quote(t) for t in command_tokens)
+    command = ' '.join(_shell_safe_quote(t) for t in command_tokens)
     warnings: List[str] = []
 
     # Figure out how many tasks per node this srun asks for.
@@ -597,7 +686,8 @@ def _translate_mpi_launcher_line(indent: str,
 # Slurm-only commands that won't work outside a Slurm allocation.
 _SLURM_ONLY_COMMAND_RE = re.compile(
     r'(^|[\s;&|`(])(sbcast|sgather|sattach|squeue|sacct|sinfo|scontrol|'
-    r'srun_cr|smap|sshare|sprio|sstat|sreport|sdiag|sbatch)\b')
+    r'salloc|srun_cr|smap|sshare|sprio|sstat|sreport|sdiag|sbatch|scancel)'
+    r'\b')
 
 # Heuristics for commands that *work* in a SkyPilot ``run:`` block but really
 # belong in ``setup:`` so they don't re-run on every launch.
@@ -762,9 +852,16 @@ def convert_slurm_script(script: str) -> Tuple[str, List[str]]:
     memory_gb: Optional[int] = None
     mem_val = directives.pop('mem', None)
     if mem_val is not None:
-        memory_gb = _parse_memory(mem_val)
-        if memory_gb is None:
-            warnings.append(f'Could not parse --mem={mem_val!r}.')
+        # Slurm treats ``--mem=0`` as "give me all the memory on the node";
+        # there's no SkyPilot equivalent, so skip and warn.
+        if mem_val.strip().rstrip('BbKkMmGgTt') == '0':
+            warnings.append(
+                '--mem=0 means "all memory" in Slurm; SkyPilot has no '
+                'equivalent. Skipping memory constraint.')
+        else:
+            memory_gb = _parse_memory(mem_val)
+            if memory_gb is None:
+                warnings.append(f'Could not parse --mem={mem_val!r}.')
     elif 'mem-per-cpu' in directives and cpus is not None:
         per_cpu = _parse_memory(directives.pop('mem-per-cpu'))
         if per_cpu is not None:

--- a/sky/utils/slurm_converter.py
+++ b/sky/utils/slurm_converter.py
@@ -576,6 +576,24 @@ def _translate_body(body: str,
     return '\n'.join(out_lines), warnings
 
 
+def _yaml_scalar(value: str) -> str:
+    """Render ``value`` as a safe YAML scalar.
+
+    Values that are ambiguous or contain YAML special characters are wrapped
+    in single quotes; simple strings are emitted unquoted.
+    """
+    if not value:
+        return "''"
+    needs_quoting = (any(c in value for c in ':#&*!|>\'"%@`,[]{}') or
+                     value[0] in ' -?' or value != value.strip() or
+                     value.lower()
+                     in {'true', 'false', 'yes', 'no', 'null', '~'})
+    if needs_quoting:
+        escaped = value.replace("'", "''")
+        return f"'{escaped}'"
+    return value
+
+
 def _format_yaml_block(key: str, value: str) -> str:
     """Format a multi-line string value as a YAML block scalar."""
     value = value.rstrip('\n')
@@ -725,14 +743,9 @@ def convert_slurm_script(script: str) -> Tuple[str, List[str]]:
         label = f'--{flag}={value}' if value else f'--{flag}'
         unsupported_notes.append((label, msg))
 
-    _note(
-        'account', 'SkyPilot does not have accounts. Use workspaces/quotas '
-        'in `~/.sky/config.yaml` if needed.')
-    _note('qos', 'No direct QoS equivalent in SkyPilot.')
-    _note(
-        'constraint', 'No direct equivalent; use `resources.instance_type` or '
-        '`resources.labels` to constrain placement.')
-    _note('reservation', 'Reservations are configured per-cloud in SkyPilot.')
+    # These directives are managed by SkyPilot itself or don't make sense as
+    # per-task sbatch options. Kept as review comments instead of being passed
+    # through as ``config.slurm.sbatch_options``.
     _note(
         'output', 'SkyPilot captures stdout/stderr automatically; view with '
         '`sky logs` or `sky jobs logs`.')
@@ -741,30 +754,42 @@ def convert_slurm_script(script: str) -> Tuple[str, List[str]]:
     _note(
         'array', 'Slurm job arrays have no direct equivalent. Launch with a '
         'shell loop over `sky jobs launch --env TASK_ID=$i ...`.')
-    _note(
-        'dependency',
-        'Job dependencies can be modeled with SkyPilot pipelines/DAGs or by '
-        'chaining `sky jobs launch` calls.')
-    _note('mail-user', 'SkyPilot does not send email notifications.')
-    _note('mail-type', 'SkyPilot does not send email notifications.')
-    _note('begin', 'Scheduled start times are not supported by SkyPilot.')
-    _note('chdir',
-          'Set the working directory inside `setup`/`run` or with `workdir:`.')
-    _note('exclusive',
-          'SkyPilot clusters are allocated exclusively by default.')
-    _note(
-        'nodelist',
-        'Specific node targeting is not supported; use `resources.infra` '
-        'or labels instead.')
-    _note('exclude', 'Node exclusion is not supported.')
-    _note('ntasks',
-          'Maps loosely to `num_nodes * ntasks-per-node`; reviewed manually.')
 
-    # Anything still in ``directives`` is unknown / unhandled.
+    # The sbatch options that the Slurm provisioner controls. Passing these
+    # through ``sbatch_options`` just triggers a warning at provision time, so
+    # we skip them here. Mirrors ``_SBATCH_PROTECTED_OPTIONS`` in
+    # sky/provision/slurm/instance.py.
+    _PROTECTED = {
+        'job-name',
+        'output',
+        'error',
+        'nodes',
+        'time',
+        'wait-all-nodes',
+        'no-requeue',
+        'cpus-per-task',
+        'mem',
+        'gres',
+        'partition',
+    }
+
+    # Any remaining directive that isn't protected is a valid per-task sbatch
+    # option and can be pushed into ``config.slurm.sbatch_options`` to round-
+    # trip faithfully through the Slurm backend.
+    # https://docs.skypilot.co/en/latest/reference/slurm/slurm-getting-started.html
+    sbatch_passthrough: Dict[str, str] = {}
     for flag, value in list(directives.items()):
-        label = f'--{flag}={value}' if value else f'--{flag}'
-        unsupported_notes.append(
-            (label, 'No direct SkyPilot equivalent; please review.'))
+        if flag in _PROTECTED:
+            label = f'--{flag}={value}' if value else f'--{flag}'
+            unsupported_notes.append((
+                label,
+                'Protected by SkyPilot; cannot be set via `config.slurm.'
+                'sbatch_options`. Please review.',
+            ))
+            directives.pop(flag, None)
+            continue
+        sbatch_passthrough[flag] = value
+        directives.pop(flag, None)
 
     # Body handling: substitute env vars and translate srun/mpirun lines.
     body = '\n'.join(parsed.body_lines).strip('\n')
@@ -825,6 +850,21 @@ def convert_slurm_script(script: str) -> Tuple[str, List[str]]:
         lines.append(f'  idle_minutes: {autostop_minutes}')
         lines.append('  down: true')
         lines.append('  wait_for: none')
+        lines.append('')
+
+    if sbatch_passthrough:
+        lines.append('config:')
+        lines.append('  slurm:')
+        lines.append('    sbatch_options:')
+        for flag in sorted(sbatch_passthrough):
+            value = sbatch_passthrough[flag]
+            if value == '':
+                # Flag with no value -- emit as a boolean true.
+                lines.append(f'      {flag}: true')
+            else:
+                # Quote strings to keep YAML happy for values with
+                # characters like ``:`` (e.g. ``--mail-type=END:FAIL``).
+                lines.append(f'      {flag}: {_yaml_scalar(value)}')
         lines.append('')
 
     if body.strip():

--- a/sky/utils/slurm_converter.py
+++ b/sky/utils/slurm_converter.py
@@ -226,36 +226,272 @@ def _substitute_env_vars(text: str) -> str:
     return text
 
 
-def _strip_srun(body: str) -> Tuple[str, List[str]]:
-    """Remove leading ``srun`` invocations from body lines.
+# srun flags that do not affect the translated command (they either describe
+# resources SkyPilot already allocates at the cluster level, or they are
+# launcher-specific behaviors that are a no-op once we drop ``srun`` itself).
+_SRUN_FLAGS_TO_DROP = {
+    # Resource / placement selectors -- already expressed by the cluster spec.
+    'gres',
+    'gpus',
+    'gpus-per-task',
+    'gpus-per-node',
+    'gpu-bind',
+    'cpus-per-task',
+    'cpu-bind',
+    'threads-per-core',
+    'hint',
+    'mem',
+    'mem-per-cpu',
+    'mem-per-gpu',
+    'mem-bind',
+    # Slurm launcher / MPI behaviors.
+    'mpi',
+    'label',
+    'unbuffered',
+    'kill-on-bad-exit',
+    'propagate',
+    'pty',
+    'multi-prog',
+    'preserve-env',
+    'resv-ports',
+    'distribution',
+    'exclusive',
+    'oversubscribe',
+    'overlap',
+    'overcommit',
+    'exact',
+    # Routing / scheduling -- doesn't apply under SkyPilot.
+    'partition',
+    'account',
+    'qos',
+    'constraint',
+    'reservation',
+    'cluster',
+    'time',
+    'time-min',
+    'deadline',
+    'begin',
+    'dependency',
+    'priority',
+    'nice',
+    'hold',
+    'no-requeue',
+    'requeue',
+    'wait',
+    # Node targeting -- SkyPilot chooses the nodes.
+    'nodelist',
+    'nodefile',
+    'exclude',
+    'relative',
+    'switches',
+    # I/O and env.
+    'output',
+    'error',
+    'input',
+    'open-mode',
+    'chdir',
+    'export',
+    'export-file',
+    'job-name',
+    'comment',
+    'network',
+    'quiet',
+    'slurmd-debug',
+    'verbose',
+}
 
-    SkyPilot handles multi-node launch itself (via ``SKYPILOT_NODE_IPS`` and
-    ``SKYPILOT_NODE_RANK``), so the common pattern ``srun python train.py``
-    becomes just ``python train.py``. If the ``srun`` invocation has any flags
-    we leave the line unchanged and emit a warning asking the user to review
-    it, since translating arbitrary ``srun`` flags is error-prone.
+# Short option -> long option for the flags srun shares with sbatch.
+_SRUN_SHORT_TO_LONG: Dict[str, str] = {
+    'n': 'ntasks',
+    'N': 'nodes',
+    'c': 'cpus-per-task',
+    'G': 'gpus',
+    'o': 'output',
+    'e': 'error',
+    'i': 'input',
+    'l': 'label',
+    'J': 'job-name',
+    'D': 'chdir',
+    'p': 'partition',
+    'A': 'account',
+    't': 'time',
+    'w': 'nodelist',
+    'x': 'exclude',
+    'r': 'relative',
+    'q': 'qos',
+    'd': 'dependency',
+    'v': 'verbose',
+    'Q': 'quiet',
+    'm': 'distribution',
+    'Z': 'no-allocate',
+    'X': 'disable-status',
+    'K': 'kill-on-bad-exit',
+    'O': 'overcommit',
+    's': 'oversubscribe',
+    'T': 'threads',
+    'W': 'wait',
+}
+
+
+def _parse_srun_flags(tokens: List[str]) -> Tuple[Dict[str, str], List[str]]:
+    """Split ``srun``'s tokens into a dict of flags and the command tokens.
+
+    Returns ``(flags, command_tokens)``. Flags without a value get the empty
+    string. Stops at the first positional argument or ``--`` terminator.
     """
+    flags: Dict[str, str] = {}
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok == '--':
+            i += 1
+            break
+        if tok.startswith('--'):
+            body = tok[2:]
+            if '=' in body:
+                key, value = body.split('=', 1)
+                flags[key] = value
+                i += 1
+            elif (i + 1 < len(tokens) and not tokens[i + 1].startswith('-')):
+                flags[body] = tokens[i + 1]
+                i += 2
+            else:
+                flags[body] = ''
+                i += 1
+        elif tok.startswith('-') and len(tok) >= 2:
+            short = tok[1]
+            rest = tok[2:]
+            key = _SRUN_SHORT_TO_LONG.get(short, short)
+            if rest:
+                flags[key] = rest
+                i += 1
+            elif (i + 1 < len(tokens) and not tokens[i + 1].startswith('-')):
+                flags[key] = tokens[i + 1]
+                i += 2
+            else:
+                flags[key] = ''
+                i += 1
+        else:
+            break
+    return flags, tokens[i:]
+
+
+def _translate_srun_line(
+        indent: str, stripped: str,
+        num_nodes: Optional[int]) -> Tuple[List[str], List[str]]:
+    """Translate a single ``srun ...`` line.
+
+    Returns ``(new_lines, warnings)``. ``new_lines`` is the list of output
+    lines that should replace the original line (already indented).
+    """
+    try:
+        tokens = shlex.split(stripped)
+    except ValueError:
+        return [indent + stripped], []
+    assert tokens and tokens[0] == 'srun', tokens
+    flags, command_tokens = _parse_srun_flags(tokens[1:])
+
+    if not command_tokens:
+        # ``srun`` with no positional command -- nothing useful we can do.
+        return [indent + stripped], [
+            f'Could not find a command after `srun` in line: {stripped!r}.'
+        ]
+
+    command = ' '.join(shlex.quote(t) for t in command_tokens)
+    warnings: List[str] = []
+
+    # Figure out how many tasks per node this srun asks for.
+    def _as_int(v: Optional[str]) -> Optional[int]:
+        if v is None or v == '':
+            return None
+        try:
+            return int(v)
+        except ValueError:
+            return None
+
+    tasks_per_node = _as_int(flags.get('ntasks-per-node'))
+    total_tasks = _as_int(flags.get('ntasks'))
+    srun_nodes = _as_int(flags.get('nodes'))
+
+    # Single-task invocation in an otherwise multi-node job -- gate on rank 0.
+    # Slurm semantics: ``--ntasks-per-node=1`` alone means "one task per node"
+    # which still runs on every node; only explicit ``--nodes=1`` or
+    # ``--ntasks=1`` (without a per-node multiplier) forces a single node.
+    is_single_task = False
+    if srun_nodes == 1 and (tasks_per_node is None or tasks_per_node == 1):
+        is_single_task = True
+    elif (total_tasks == 1 and srun_nodes is None and tasks_per_node is None):
+        is_single_task = True
+
+    # Detect unrecognized flags (i.e. ones that we cannot safely drop).
+    handled = {'ntasks', 'nodes', 'ntasks-per-node'}
+    unknown = sorted(
+        k for k in flags if k not in _SRUN_FLAGS_TO_DROP and k not in handled)
+    if unknown:
+        warnings.append(
+            f'Dropped unrecognized srun flag(s) {unknown} from line: '
+            f'{stripped!r}. Please verify the translated command.')
+
+    if is_single_task and num_nodes and num_nodes > 1:
+        # Only run on the head node; Slurm's -N1 -n1 semantics.
+        return ([
+            indent + 'if [ "${SKYPILOT_NODE_RANK:-0}" = "0" ]; then',
+            indent + '  ' + command,
+            indent + 'fi',
+        ], warnings)
+
+    if tasks_per_node is not None and tasks_per_node > 1:
+        warnings.append(
+            f'`srun --ntasks-per-node={tasks_per_node}` in line {stripped!r} '
+            'needs manual translation: SkyPilot runs the `run:` block once '
+            'per node, so use a distributed launcher (e.g. `torchrun '
+            f'--nproc_per_node={tasks_per_node}`, `mpirun`, or similar) to '
+            'spawn the per-node tasks.')
+        # Fall through: the command is emitted once; the user must wrap it.
+    elif (total_tasks is not None and num_nodes and num_nodes > 1 and
+          total_tasks != num_nodes):
+        warnings.append(
+            f'`srun --ntasks={total_tasks}` with {num_nodes} nodes in line '
+            f'{stripped!r}: SkyPilot runs the `run:` block on every node '
+            f'({num_nodes} tasks total). Adjust if you need a different '
+            'layout.')
+
+    return [indent + command], warnings
+
+
+def _translate_mpi_launcher_line(indent: str,
+                                 stripped: str) -> Tuple[List[str], List[str]]:
+    """Translate a leading ``mpirun``/``mpiexec`` invocation.
+
+    SkyPilot does not manage the MPI universe for you, but the hostfile
+    should come from ``$SKYPILOT_NODE_IPS``. We leave the command intact and
+    emit a warning pointing the user at that env var.
+    """
+    return [indent + stripped], [
+        f'Left MPI launcher unchanged on line: {stripped!r}. Generate the '
+        'hostfile from $SKYPILOT_NODE_IPS, e.g. '
+        '`echo "$SKYPILOT_NODE_IPS" > /tmp/hostfile`.'
+    ]
+
+
+def _translate_body(body: str,
+                    num_nodes: Optional[int]) -> Tuple[str, List[str]]:
+    """Rewrite the script body: translate ``srun``/``mpirun`` invocations."""
     warnings: List[str] = []
     out_lines: List[str] = []
     for line in body.splitlines():
         stripped = line.lstrip()
         indent = line[:len(line) - len(stripped)]
         if stripped == 'srun' or stripped.startswith('srun '):
-            after = stripped[len('srun'):].lstrip()
-            if after.startswith('-'):
-                warnings.append(
-                    f'Left `srun` flags unchanged on line: {stripped!r}. '
-                    'SkyPilot distributes work via $SKYPILOT_NODE_IPS and '
-                    '$SKYPILOT_NODE_RANK; please translate the flags by '
-                    'hand.')
-                out_lines.append(line)
-            else:
-                out_lines.append(indent + after)
-        elif stripped.startswith('mpirun ') or stripped.startswith('mpiexec '):
-            warnings.append(
-                f'Left MPI launcher unchanged on line: {stripped!r}. Make '
-                'sure the hostfile uses $SKYPILOT_NODE_IPS.')
-            out_lines.append(line)
+            new_lines, ws = _translate_srun_line(indent, stripped, num_nodes)
+            out_lines.extend(new_lines)
+            warnings.extend(ws)
+        elif (stripped.startswith('mpirun ') or
+              stripped.startswith('mpiexec ') or stripped == 'mpirun' or
+              stripped == 'mpiexec'):
+            new_lines, ws = _translate_mpi_launcher_line(indent, stripped)
+            out_lines.extend(new_lines)
+            warnings.extend(ws)
         else:
             out_lines.append(line)
     return '\n'.join(out_lines), warnings
@@ -433,11 +669,11 @@ def convert_slurm_script(script: str) -> Tuple[str, List[str]]:
         unsupported_notes.append(
             (label, 'No direct SkyPilot equivalent; please review.'))
 
-    # Body handling: substitute env vars and strip srun wrappers.
+    # Body handling: substitute env vars and translate srun/mpirun lines.
     body = '\n'.join(parsed.body_lines).strip('\n')
     body = _substitute_env_vars(body)
-    body, srun_warnings = _strip_srun(body)
-    warnings.extend(srun_warnings)
+    body, body_warnings = _translate_body(body, num_nodes)
+    warnings.extend(body_warnings)
 
     # Assemble the YAML text. We format it manually so that we can interleave
     # comments for unsupported directives.

--- a/tests/unit_tests/test_slurm_converter.py
+++ b/tests/unit_tests/test_slurm_converter.py
@@ -138,7 +138,7 @@ def test_srun_single_task_gates_on_rank_zero():
     assert warnings == []
 
 
-def test_srun_multi_tasks_per_node_emits_warning():
+def test_srun_multi_tasks_per_node_emits_launcher_templates():
     script = """\
         #!/bin/bash
         #SBATCH --nodes=2
@@ -146,11 +146,35 @@ def test_srun_multi_tasks_per_node_emits_warning():
         srun --ntasks-per-node=8 python train.py
         """
     yaml_text, warnings = _convert(script)
-    # srun itself is stripped; a warning is emitted telling the user to use
-    # a distributed launcher.
-    assert 'srun' not in yaml_text
+    # The executable command loses the srun wrapper; only comments should
+    # still mention srun (as part of the TODO note explaining why).
+    code_lines = [
+        line for line in yaml_text.splitlines()
+        if not line.lstrip().startswith(('#', '//')) and 'srun' in line
+    ]
+    assert code_lines == [], code_lines
     assert 'python train.py' in yaml_text
-    assert any('torchrun' in w or 'ntasks-per-node' in w for w in warnings)
+    # Both launcher templates should be present.
+    assert '--nproc_per_node=8' in yaml_text
+    assert '$SKYPILOT_NODE_RANK' in yaml_text
+    assert 'mpirun' in yaml_text
+    assert 'ppr:8:node' in yaml_text
+    assert any('torchrun' in w or 'launcher' in w for w in warnings)
+
+
+def test_mpirun_gets_hostfile_template():
+    script = """\
+        #!/bin/bash
+        #SBATCH --nodes=2
+
+        mpirun -n 16 python app.py
+        """
+    yaml_text, warnings = _convert(script)
+    # Original command is preserved and a commented template is inserted.
+    assert 'mpirun -n 16 python app.py' in yaml_text
+    assert '/tmp/hostfile' in yaml_text
+    assert '$SKYPILOT_NODE_IPS' in yaml_text
+    assert any('hostfile' in w.lower() for w in warnings)
 
 
 def test_srun_drops_harmless_flags():
@@ -190,19 +214,6 @@ def test_srun_unknown_flag_warns():
         """
     _, warnings = _convert(script)
     assert any('some-new-flag' in w for w in warnings)
-
-
-def test_mpirun_left_alone_with_warning():
-    script = """\
-        #!/bin/bash
-        #SBATCH --nodes=2
-
-        mpirun -n 16 python app.py
-        """
-    yaml_text, warnings = _convert(script)
-    assert 'mpirun -n 16 python app.py' in yaml_text
-    assert any(
-        'hostfile' in w.lower() or 'SKYPILOT_NODE_IPS' in w for w in warnings)
 
 
 def test_unsupported_directives_preserved_as_comments():

--- a/tests/unit_tests/test_slurm_converter.py
+++ b/tests/unit_tests/test_slurm_converter.py
@@ -521,3 +521,90 @@ def test_multi_line_srun_continuation_is_translated():
     assert 'srun' not in yaml_text
     assert 'python train.py' in yaml_text
     assert 'SKYPILOT_NODE_RANK' not in yaml_text
+
+
+# --- Regression tests for bugs found during audit ---
+
+
+def test_srun_command_preserves_env_var_refs():
+    """`shlex.quote` used to single-quote ``$FOO`` and break expansion."""
+    script = """\
+        #!/bin/bash
+        #SBATCH --nodes=2
+
+        srun -N1 -n1 python train.py $FOO ${BAR}
+        """
+    yaml_text, _ = _convert(script)
+    # Env vars must stay unquoted so the shell expands them.
+    assert '$FOO' in yaml_text
+    assert '${BAR}' in yaml_text
+    assert "'$FOO'" not in yaml_text
+
+
+def test_srun_command_quotes_args_with_spaces():
+    """Tokens containing whitespace must still be quoted."""
+    script = """\
+        #!/bin/bash
+        #SBATCH --nodes=2
+
+        srun python train.py --name 'has spaces'
+        """
+    yaml_text, _ = _convert(script)
+    assert "'has spaces'" in yaml_text
+
+
+def test_env_var_substitution_uses_word_boundary():
+    """`$SLURM_JOB_IDX` must not match `SLURM_JOB_ID` as a prefix."""
+    from sky.utils import slurm_converter
+    out = slurm_converter._substitute_env_vars(
+        '$SLURM_JOB_IDX $SLURM_JOB_ID ${SLURM_JOB_ID}')
+    assert out == '$SLURM_JOB_IDX $SKYPILOT_TASK_ID $SKYPILOT_TASK_ID'
+
+
+def test_srun_boolean_short_flag_does_not_eat_command():
+    """`srun -l python x.py` must keep `python x.py` as the command."""
+    script = """\
+        #!/bin/bash
+        #SBATCH --nodes=2
+
+        srun -l python train.py
+        srun -v --label python other.py
+        """
+    yaml_text, _ = _convert(script)
+    assert 'python train.py' in yaml_text
+    assert 'python other.py' in yaml_text
+
+
+def test_mem_zero_means_all_memory_is_skipped():
+    """`--mem=0` in Slurm = all memory; has no SkyPilot equivalent."""
+    script = """\
+        #!/bin/bash
+        #SBATCH --mem=0
+        echo hi
+        """
+    yaml_text, warnings = _convert(script)
+    assert 'memory' not in yaml_text
+    assert any('all memory' in w for w in warnings)
+
+
+def test_salloc_in_body_emits_warning():
+    script = """\
+        #!/bin/bash
+
+        salloc --gpus=8 python
+        """
+    _, warnings = _convert(script)
+    assert any('Slurm-only' in w for w in warnings)
+
+
+def test_sbatch_boolean_directive_does_not_eat_next_directive():
+    """`#SBATCH --exclusive` on its own must not swallow the next directive."""
+    script = """\
+        #!/bin/bash
+        #SBATCH --exclusive
+        #SBATCH --account=myacct
+        echo hi
+        """
+    yaml_text, _ = _convert(script)
+    assert 'exclusive: true' in yaml_text
+    assert 'account: myacct' in yaml_text

--- a/tests/unit_tests/test_slurm_converter.py
+++ b/tests/unit_tests/test_slurm_converter.py
@@ -1,0 +1,196 @@
+"""Tests for sky.utils.slurm_converter."""
+import textwrap
+
+from sky.utils import slurm_converter
+
+
+def _convert(script: str):
+    return slurm_converter.convert_slurm_script(textwrap.dedent(script))
+
+
+def test_basic_mapping_all_supported_directives():
+    script = """\
+        #!/bin/bash
+        #SBATCH --job-name=train
+        #SBATCH --nodes=2
+        #SBATCH --gpus-per-node=h100:8
+        #SBATCH --cpus-per-task=32
+        #SBATCH --mem=256G
+
+        python train.py
+        """
+    yaml_text, warnings = _convert(script)
+    assert 'name: train' in yaml_text
+    assert 'num_nodes: 2' in yaml_text
+    assert 'accelerators: H100:8' in yaml_text
+    assert 'cpus: 32+' in yaml_text
+    assert 'memory: 256+' in yaml_text
+    assert 'python train.py' in yaml_text
+    assert warnings == []
+
+
+def test_short_flag_forms():
+    script = """\
+        #!/bin/bash
+        #SBATCH -J myjob
+        #SBATCH -N 4
+        #SBATCH -c 8
+        #SBATCH -G 16
+
+        echo hi
+        """
+    yaml_text, _ = _convert(script)
+    assert 'name: myjob' in yaml_text
+    assert 'num_nodes: 4' in yaml_text
+    assert 'cpus: 8+' in yaml_text
+    # -G is total GPUs; 16 / 4 = 4 per node.
+    assert 'accelerators: <GPU_TYPE>:4' in yaml_text
+
+
+def test_gres_gpu_spec():
+    script = """\
+        #!/bin/bash
+        #SBATCH --nodes=1
+        #SBATCH --gres=gpu:v100:4
+
+        echo hi
+        """
+    yaml_text, _ = _convert(script)
+    assert 'accelerators: V100:4' in yaml_text
+
+
+def test_memory_units():
+    for mem_spec, expected_gb in [
+        ('--mem=16G', 16),
+        ('--mem=1024M', 1),
+        ('--mem=1024', 1),  # Slurm default is MB.
+        ('--mem=2T', 2048),
+    ]:
+        script = f"""\
+            #!/bin/bash
+            #SBATCH {mem_spec}
+            echo hi
+            """
+        yaml_text, _ = _convert(script)
+        assert f'memory: {expected_gb}+' in yaml_text, mem_spec
+
+
+def test_env_var_substitution():
+    script = """\
+        #!/bin/bash
+        #SBATCH --nodes=2
+
+        echo "nodes=$SLURM_NNODES rank=$SLURM_PROCID"
+        echo "id=${SLURM_JOB_ID}"
+        """
+    yaml_text, _ = _convert(script)
+    assert '$SKYPILOT_NUM_NODES' in yaml_text
+    assert '$SKYPILOT_NODE_RANK' in yaml_text
+    assert '$SKYPILOT_TASK_ID' in yaml_text
+    assert 'SLURM_' not in yaml_text
+
+
+def test_strip_bare_srun():
+    script = """\
+        #!/bin/bash
+        #SBATCH --nodes=2
+
+        srun python train.py
+        """
+    yaml_text, warnings = _convert(script)
+    assert 'python train.py' in yaml_text
+    assert 'srun python' not in yaml_text
+    assert warnings == []
+
+
+def test_srun_with_flags_emits_warning():
+    script = """\
+        #!/bin/bash
+        #SBATCH --nodes=2
+
+        srun --ntasks-per-node=1 python train.py
+        """
+    yaml_text, warnings = _convert(script)
+    # The line should be preserved unchanged.
+    assert 'srun --ntasks-per-node=1 python train.py' in yaml_text
+    assert any('srun' in w for w in warnings)
+
+
+def test_unsupported_directives_preserved_as_comments():
+    script = """\
+        #!/bin/bash
+        #SBATCH --time=24:00:00
+        #SBATCH --partition=gpu
+        #SBATCH --account=myaccount
+        #SBATCH --output=out.log
+        #SBATCH --array=1-10
+
+        echo hi
+        """
+    yaml_text, _ = _convert(script)
+    for label in ('--time=24:00:00', '--partition=gpu', '--account=myaccount',
+                  '--output=out.log', '--array=1-10'):
+        assert label in yaml_text
+
+
+def test_missing_gpu_type_adds_warning_and_placeholder():
+    script = """\
+        #!/bin/bash
+        #SBATCH --gpus-per-node=4
+        echo hi
+        """
+    yaml_text, warnings = _convert(script)
+    assert 'accelerators: <GPU_TYPE>:4' in yaml_text
+    assert any('GPU type' in w for w in warnings)
+
+
+def test_mem_per_cpu_scales_with_cpus():
+    script = """\
+        #!/bin/bash
+        #SBATCH --cpus-per-task=8
+        #SBATCH --mem-per-cpu=4G
+        echo hi
+        """
+    yaml_text, _ = _convert(script)
+    # 8 cpus * 4GB = 32 GB
+    assert 'memory: 32+' in yaml_text
+
+
+def test_num_nodes_omitted_for_single_node():
+    script = """\
+        #!/bin/bash
+        #SBATCH --nodes=1
+        echo hi
+        """
+    yaml_text, _ = _convert(script)
+    assert 'num_nodes' not in yaml_text
+
+
+def test_shebang_and_blank_header_lines():
+    script = """\
+        #!/bin/bash
+
+        #SBATCH --job-name=x
+
+        # A comment before the body
+        echo hi
+        """
+    yaml_text, _ = _convert(script)
+    assert 'name: x' in yaml_text
+    assert 'echo hi' in yaml_text
+
+
+def test_preserves_body_after_first_real_command():
+    script = """\
+        #!/bin/bash
+        #SBATCH --job-name=x
+        module load cuda/12.1
+        #SBATCH --nodes=2
+
+        python train.py
+        """
+    yaml_text, _ = _convert(script)
+    # The directive after the first real command should NOT take effect.
+    assert 'num_nodes' not in yaml_text
+    # The line is part of the body (as an inline comment).
+    assert 'module load cuda/12.1' in yaml_text

--- a/tests/unit_tests/test_slurm_converter.py
+++ b/tests/unit_tests/test_slurm_converter.py
@@ -383,3 +383,141 @@ def test_preserves_body_after_first_real_command():
     assert 'num_nodes' not in yaml_text
     # The line is part of the body (as an inline comment).
     assert 'module load cuda/12.1' in yaml_text
+
+
+def test_container_image_maps_to_image_id():
+    for container, expected in [
+        ('nvidia/cuda:12.1.1', 'docker:nvidia/cuda:12.1.1'),
+        ('docker://nvidia/cuda:12.1.1', 'docker:nvidia/cuda:12.1.1'),
+        ('docker:nvidia/cuda:12.1.1', 'docker:nvidia/cuda:12.1.1'),
+    ]:
+        script = f"""\
+            #!/bin/bash
+            #SBATCH --container-image={container}
+            python train.py
+            """
+        yaml_text, _ = _convert(script)
+        assert f"image_id: '{expected}'" in yaml_text, container
+
+
+def test_pyxis_container_options_dropped_with_warning():
+    script = """\
+        #!/bin/bash
+        #SBATCH --container-image=nvidia/cuda:12.1.1
+        #SBATCH --container-mounts=/data:/data
+        python train.py
+        """
+    _, warnings = _convert(script)
+    # container-mounts should not silently slip into sbatch_options.
+    assert any('container-mounts' in w for w in warnings)
+
+
+def test_ntasks_directive_warns_and_drops():
+    script = """\
+        #!/bin/bash
+        #SBATCH --ntasks=16
+        python train.py
+        """
+    yaml_text, warnings = _convert(script)
+    # --ntasks should not be passed through to sbatch_options.
+    assert 'ntasks' not in yaml_text
+    assert any('--ntasks=16' in w for w in warnings)
+
+
+def test_nodes_range_warns():
+    script = """\
+        #!/bin/bash
+        #SBATCH --nodes=2-8
+        python train.py
+        """
+    yaml_text, warnings = _convert(script)
+    assert 'num_nodes: 2' in yaml_text
+    assert any('range' in w.lower() for w in warnings)
+
+
+def test_gres_gpu_no_count_defaults_to_one():
+    script = """\
+        #!/bin/bash
+        #SBATCH --gres=gpu
+        echo hi
+        """
+    yaml_text, _ = _convert(script)
+    # Bare ``--gres=gpu`` should still produce an accelerators line.
+    assert 'accelerators: <GPU_TYPE>:1' in yaml_text
+
+
+def test_array_task_id_env_var_translated():
+    script = """\
+        #!/bin/bash
+
+        echo "running task $SLURM_ARRAY_TASK_ID"
+        """
+    yaml_text, _ = _convert(script)
+    assert '$TASK_ID' in yaml_text
+    assert 'SLURM_ARRAY_TASK_ID' not in yaml_text
+
+
+def test_module_load_emits_warning():
+    script = """\
+        #!/bin/bash
+
+        module load cuda/12.1
+        python train.py
+        """
+    _, warnings = _convert(script)
+    assert any('module load' in w for w in warnings)
+
+
+def test_pip_install_in_body_emits_setup_hint():
+    script = """\
+        #!/bin/bash
+
+        pip install torch
+        python train.py
+        """
+    _, warnings = _convert(script)
+    assert any('setup' in w.lower() for w in warnings)
+
+
+def test_slurm_only_command_emits_warning():
+    script = """\
+        #!/bin/bash
+
+        sbcast -p data.tar /tmp/data.tar
+        python train.py
+        """
+    _, warnings = _convert(script)
+    assert any('sbcast' in w or 'Slurm-only' in w for w in warnings)
+
+
+def test_inline_srun_warns():
+    """`time srun cmd` etc are not translated; user should see a warning."""
+    script = """\
+        #!/bin/bash
+        #SBATCH --nodes=2
+
+        time srun python train.py
+        """
+    yaml_text, warnings = _convert(script)
+    # The line passes through unchanged...
+    assert 'time srun python train.py' in yaml_text
+    # ...but we warn the user that the inline srun was not translated.
+    assert any('not at the start' in w or 'inline' in w.lower() or 'srun' in w
+               for w in warnings)
+
+
+def test_multi_line_srun_continuation_is_translated():
+    script = """\
+        #!/bin/bash
+        #SBATCH --nodes=2
+
+        srun \\
+          --ntasks-per-node=1 \\
+          python train.py
+        """
+    yaml_text, _ = _convert(script)
+    # After joining continuations, the per-task=1 srun should collapse to a
+    # bare command (no srun, no rank guard).
+    assert 'srun' not in yaml_text
+    assert 'python train.py' in yaml_text
+    assert 'SKYPILOT_NODE_RANK' not in yaml_text

--- a/tests/unit_tests/test_slurm_converter.py
+++ b/tests/unit_tests/test_slurm_converter.py
@@ -217,17 +217,62 @@ def test_srun_unknown_flag_warns():
 
 
 def test_unsupported_directives_preserved_as_comments():
+    """Protected / non-passthrough directives stay as review comments."""
     script = """\
         #!/bin/bash
-        #SBATCH --account=myaccount
         #SBATCH --output=out.log
         #SBATCH --array=1-10
 
         echo hi
         """
     yaml_text, _ = _convert(script)
-    for label in ('--account=myaccount', '--output=out.log', '--array=1-10'):
+    # These should not go into sbatch_options (output is protected, array
+    # needs a different execution model).
+    assert 'sbatch_options' not in yaml_text
+    for label in ('--output=out.log', '--array=1-10'):
         assert label in yaml_text
+
+
+def test_non_protected_directives_pass_through_as_sbatch_options():
+    """Non-protected directives go into config.slurm.sbatch_options."""
+    script = """\
+        #!/bin/bash
+        #SBATCH --account=myaccount
+        #SBATCH --qos=high
+        #SBATCH --constraint=gpu80gb
+        #SBATCH --mail-user=me@example.com
+        #SBATCH --mail-type=END
+        #SBATCH --exclusive
+
+        echo hi
+        """
+    yaml_text, _ = _convert(script)
+    assert 'config:' in yaml_text
+    assert '  slurm:' in yaml_text
+    assert '    sbatch_options:' in yaml_text
+    assert 'account: myaccount' in yaml_text
+    assert 'qos: high' in yaml_text
+    assert 'constraint: gpu80gb' in yaml_text
+    # Values containing ':' or '@' should get quoted.
+    assert "mail-user: 'me@example.com'" in yaml_text
+    assert 'mail-type: END' in yaml_text
+    # Flags without a value become boolean true.
+    assert 'exclusive: true' in yaml_text
+
+
+def test_protected_directives_not_passed_through():
+    """Protected sbatch options never end up in sbatch_options."""
+    script = """\
+        #!/bin/bash
+        #SBATCH --output=out.log
+        #SBATCH --error=err.log
+
+        echo hi
+        """
+    yaml_text, _ = _convert(script)
+    # The converter already consumes --output/--error as comments rather than
+    # sbatch_options, so config should not appear at all.
+    assert 'sbatch_options' not in yaml_text
 
 
 def test_time_maps_to_autostop():

--- a/tests/unit_tests/test_slurm_converter.py
+++ b/tests/unit_tests/test_slurm_converter.py
@@ -219,8 +219,6 @@ def test_srun_unknown_flag_warns():
 def test_unsupported_directives_preserved_as_comments():
     script = """\
         #!/bin/bash
-        #SBATCH --time=24:00:00
-        #SBATCH --partition=gpu
         #SBATCH --account=myaccount
         #SBATCH --output=out.log
         #SBATCH --array=1-10
@@ -228,9 +226,55 @@ def test_unsupported_directives_preserved_as_comments():
         echo hi
         """
     yaml_text, _ = _convert(script)
-    for label in ('--time=24:00:00', '--partition=gpu', '--account=myaccount',
-                  '--output=out.log', '--array=1-10'):
+    for label in ('--account=myaccount', '--output=out.log', '--array=1-10'):
         assert label in yaml_text
+
+
+def test_time_maps_to_autostop():
+    for time_spec, expected_min in [
+        ('--time=24:00:00', 24 * 60),  # HH:MM:SS
+        ('--time=30', 30),  # bare minutes
+        ('--time=90:00', 90),  # MM:SS = 90 minutes + 0 seconds
+        ('--time=1-12:00:00', 36 * 60),  # 1d 12h
+        ('--time=2-00', 48 * 60),  # 2d
+    ]:
+        script = f"""\
+            #!/bin/bash
+            #SBATCH {time_spec}
+            echo hi
+            """
+        yaml_text, _ = _convert(script)
+        assert 'autostop:' in yaml_text, time_spec
+        assert f'idle_minutes: {expected_min}' in yaml_text, time_spec
+        assert 'down: true' in yaml_text, time_spec
+        assert 'wait_for: none' in yaml_text, time_spec
+        # --time should no longer appear in the unsupported-notes comments.
+        assert '--time=' not in yaml_text, time_spec
+
+
+def test_partition_maps_to_infra():
+    script = """\
+        #!/bin/bash
+        #SBATCH --partition=gpu-a100
+        echo hi
+        """
+    yaml_text, warnings = _convert(script)
+    assert 'infra: slurm/<cluster>/gpu-a100' in yaml_text
+    # --partition should no longer appear in the unsupported-notes comments.
+    assert '--partition=' not in yaml_text
+    # A warning should remind the user to fill in the cluster name.
+    assert any('<cluster>' in w for w in warnings)
+
+
+def test_invalid_time_emits_warning():
+    script = """\
+        #!/bin/bash
+        #SBATCH --time=not-a-time
+        echo hi
+        """
+    yaml_text, warnings = _convert(script)
+    assert 'autostop:' not in yaml_text
+    assert any('--time' in w for w in warnings)
 
 
 def test_missing_gpu_type_adds_warning_and_placeholder():

--- a/tests/unit_tests/test_slurm_converter.py
+++ b/tests/unit_tests/test_slurm_converter.py
@@ -103,7 +103,8 @@ def test_strip_bare_srun():
     assert warnings == []
 
 
-def test_srun_with_flags_emits_warning():
+def test_srun_single_task_per_node_on_multi_node_job():
+    """`srun --ntasks-per-node=1 cmd` on a 2-node job = run once per node."""
     script = """\
         #!/bin/bash
         #SBATCH --nodes=2
@@ -111,9 +112,97 @@ def test_srun_with_flags_emits_warning():
         srun --ntasks-per-node=1 python train.py
         """
     yaml_text, warnings = _convert(script)
-    # The line should be preserved unchanged.
-    assert 'srun --ntasks-per-node=1 python train.py' in yaml_text
-    assert any('srun' in w for w in warnings)
+    # Tasks-per-node==1 on a multi-node job = bare command on each node.
+    assert 'python train.py' in yaml_text
+    assert 'srun' not in yaml_text
+    assert 'SKYPILOT_NODE_RANK' not in yaml_text
+    assert warnings == []
+
+
+def test_srun_single_task_gates_on_rank_zero():
+    """`srun -N1 -n1 cmd` in a multi-node job runs on one node only."""
+    script = """\
+        #!/bin/bash
+        #SBATCH --nodes=4
+
+        srun -N1 -n1 python preprocess.py
+        python train.py
+        """
+    yaml_text, warnings = _convert(script)
+    assert 'if [ "${SKYPILOT_NODE_RANK:-0}" = "0" ]; then' in yaml_text
+    assert '  python preprocess.py' in yaml_text
+    assert 'fi' in yaml_text
+    # The unwrapped line still runs on every node.
+    assert '\n  python train.py\n' in yaml_text or '\n  python train.py' in (
+        yaml_text)
+    assert warnings == []
+
+
+def test_srun_multi_tasks_per_node_emits_warning():
+    script = """\
+        #!/bin/bash
+        #SBATCH --nodes=2
+
+        srun --ntasks-per-node=8 python train.py
+        """
+    yaml_text, warnings = _convert(script)
+    # srun itself is stripped; a warning is emitted telling the user to use
+    # a distributed launcher.
+    assert 'srun' not in yaml_text
+    assert 'python train.py' in yaml_text
+    assert any('torchrun' in w or 'ntasks-per-node' in w for w in warnings)
+
+
+def test_srun_drops_harmless_flags():
+    script = """\
+        #!/bin/bash
+        #SBATCH --nodes=2
+
+        srun --cpu-bind=cores --mpi=pmix --gres=gpu:1 python app.py
+        """
+    yaml_text, warnings = _convert(script)
+    # All the flags are in the drop-list; command runs on every node.
+    assert 'srun' not in yaml_text
+    assert 'python app.py' in yaml_text
+    assert warnings == []
+
+
+def test_srun_single_node_job_keeps_command_bare():
+    """On a single-node job, `srun -N1 -n1 cmd` is just `cmd`."""
+    script = """\
+        #!/bin/bash
+        #SBATCH --nodes=1
+
+        srun -N1 -n1 python app.py
+        """
+    yaml_text, _ = _convert(script)
+    # No multi-node fan-out, so no rank guard needed.
+    assert 'SKYPILOT_NODE_RANK' not in yaml_text
+    assert 'python app.py' in yaml_text
+
+
+def test_srun_unknown_flag_warns():
+    script = """\
+        #!/bin/bash
+        #SBATCH --nodes=2
+
+        srun --some-new-flag=foo python app.py
+        """
+    _, warnings = _convert(script)
+    assert any('some-new-flag' in w for w in warnings)
+
+
+def test_mpirun_left_alone_with_warning():
+    script = """\
+        #!/bin/bash
+        #SBATCH --nodes=2
+
+        mpirun -n 16 python app.py
+        """
+    yaml_text, warnings = _convert(script)
+    assert 'mpirun -n 16 python app.py' in yaml_text
+    assert any(
+        'hostfile' in w.lower() or 'SKYPILOT_NODE_IPS' in w for w in warnings)
 
 
 def test_unsupported_directives_preserved_as_comments():


### PR DESCRIPTION
## Summary

Adds `sky utils convert-slurm SCRIPT [OUTPUT]` — a converter that takes a Slurm batch script (`#SBATCH ...` directives + body) and emits an equivalent SkyPilot task YAML, so users moving off Slurm don't have to translate every script by hand.

The converter understands the directive mapping documented at [Slurm migration](https://docs.skypilot.co/en/latest/reference/slurm-migration.html) and the per-task overrides described in [Slurm getting started](https://docs.skypilot.co/en/latest/reference/slurm/slurm-getting-started.html).

### Directive mapping

| `#SBATCH ...`                                     | SkyPilot YAML                                                              |
| ------------------------------------------------- | -------------------------------------------------------------------------- |
| `--job-name=X` / `-J X`                           | `name: X`                                                                  |
| `--nodes=N` / `-N N`                              | `num_nodes: N`                                                             |
| `--gpus-per-node=H100:8` / `--gres=gpu:h100:8`    | `resources.accelerators: H100:8`                                           |
| `--gpus=N` / `-G N`                               | `resources.accelerators: <T>:N/num_nodes` (warns if no type)               |
| `--cpus-per-task=N` (× `--ntasks-per-node`)       | `resources.cpus: N+`                                                       |
| `--mem=256G` / `--mem-per-cpu=4G`                 | `resources.memory: 256+`                                                   |
| `--time=DD-HH:MM:SS`                              | `autostop: { idle_minutes, down: true, wait_for: none }`                   |
| `--partition=foo`                                 | `resources.infra: slurm/<cluster>/foo` (placeholder for cluster name)      |
| `--account`, `--qos`, `--constraint`, `--mail-*`, `--exclusive`, `--reservation`, `--dependency`, `--begin`, `--nodelist`, `--exclude`, `--chdir`, `--ntasks` | `config.slurm.sbatch_options: { ... }` (round-trips through the Slurm provisioner) |
| `--output`, `--error`, `--array`                  | Kept as a review comment at the top of the YAML                            |

`SLURM_*` env vars in the body are rewritten to their `SKYPILOT_*` counterparts (`SLURM_NNODES` → `SKYPILOT_NUM_NODES`, `SLURM_PROCID` / `SLURM_NODEID` → `SKYPILOT_NODE_RANK`, `SLURM_GPUS_PER_NODE` → `SKYPILOT_NUM_GPUS_PER_NODE`, `SLURM_JOB_ID` → `SKYPILOT_TASK_ID`, etc.).

### `srun` / `mpirun` handling

The body is rewritten line by line based on Slurm's actual semantics:

- `srun cmd` → `cmd` (SkyPilot's `run:` already executes once per node)
- `srun --ntasks-per-node=1 cmd` → `cmd` (one task per node = same thing)
- `srun -N1 -n1 cmd` → wrapped in `if [ "${SKYPILOT_NODE_RANK:-0}" = "0" ]; then ... fi` when the job has > 1 node
- `srun --ntasks-per-node=N cmd` (N > 1) → emits a commented block with copy-pasteable **torchrun** and **mpirun** templates next to the original line, plus a warning. The user picks one and deletes the rest.
- Harmless srun-only flags (`--cpu-bind`, `--mpi`, `--gres`, `--mem`, ...) are silently dropped; truly unknown flags trigger a warning.
- `mpirun` / `mpiexec` lines get a commented hostfile-from-`$SKYPILOT_NODE_IPS` template prepended.

### Example

Input (`train.slurm`):

```bash
#!/bin/bash
#SBATCH --job-name=train
#SBATCH --nodes=2
#SBATCH --gpus-per-node=h100:8
#SBATCH --cpus-per-task=32
#SBATCH --mem=256G
#SBATCH --partition=gpu-a100
#SBATCH --time=24:00:00
#SBATCH --account=myacct
#SBATCH --qos=high
#SBATCH --mail-user=me@example.com
#SBATCH --mail-type=END

srun python train.py --epochs 100
```

Output (`sky utils convert-slurm train.slurm`):

```yaml
name: train

num_nodes: 2

resources:
  infra: slurm/<cluster>/gpu-a100
  accelerators: H100:8
  cpus: 32+
  memory: 256+

autostop:
  idle_minutes: 1440
  down: true
  wait_for: none

config:
  slurm:
    sbatch_options:
      account: myacct
      mail-type: END
      mail-user: 'me@example.com'
      qos: high

run: |
  python train.py --epochs 100
```

### CLI

```bash
sky utils convert-slurm train.slurm                  # print to stdout
sky utils convert-slurm train.slurm train.sky.yaml   # write to a file
sky utils convert-slurm train.slurm out.yaml --force # overwrite
sky utils convert-slurm train.slurm out.yaml --quiet # suppress warnings
```

## Test plan

- Unit tests: `pytest tests/unit_tests/test_slurm_converter.py` — 24 tests covering the mapping table, short/long flag forms, `--gres=gpu`, memory units, env-var substitution, every `srun` translation case (bare / `-N1 -n1` / `--ntasks-per-node=1` / `--ntasks-per-node=N>1` / harmless flags / unknown flags / single-node), `mpirun` template, `--time` → `autostop` (all five Slurm time formats), `--partition` → `infra`, sbatch_options passthrough, and protected-option exclusion. All pass.

- Manual smoke test:
  - [ ] `sky utils convert-slurm <real Slurm script>` prints a YAML that `sky launch` accepts (`sky launch -c test out.yaml --dryrun`).
  - [ ] On a real Slurm-backed SkyPilot setup, `sky launch` against the converted YAML runs the job successfully.
  - [ ] Multi-node training script: verify the rank-0 guard fires on the head node only, and the torchrun template (after the user uncomments it) launches DDP correctly.
  - [ ] Verify the `config.slurm.sbatch_options` block round-trips: launch with `SKYPILOT_DEBUG=1` and confirm the resulting `#SBATCH --account=...` / `--qos=...` lines appear in the submitted sbatch script.
