### PR TITLE
[CI] Lowercase branch slug when triggering ReadTheDocs build

### DIFF
--- a/.github/workflows/readthedocs-manual-pr-build.yml
+++ b/.github/workflows/readthedocs-manual-pr-build.yml
@@ -77,11 +77,12 @@ jobs:
           # Trigger a build for the PR branch on ReadTheDocs
           # The branch needs to exist as a version on ReadTheDocs
 
-          # ReadTheDocs automatically replaces forward slashes with dashes when generating version slugs
+          # ReadTheDocs automatically replaces forward slashes with dashes and
+          # lowercases letters when generating version slugs.
           # See: https://docs.readthedocs.com/platform/latest/versions.html
           # So we need to match that behavior when calling the API
           # Then URL-encode the sanitized branch name for the API call
-          SANITIZED_BRANCH=$(echo -n "${BRANCH_NAME}" | sed 's/\//-/g')
+          SANITIZED_BRANCH=$(echo -n "${BRANCH_NAME}" | sed 's/\//-/g' | tr '[:upper:]' '[:lower:]')
           VERSION_SLUG=$(echo -n "${SANITIZED_BRANCH}" | jq -sRr @uri)
 
           echo "Triggering ReadTheDocs build for project: ${READTHEDOCS_PROJECT}, branch: ${BRANCH_NAME}"
@@ -191,11 +192,12 @@ jobs:
             const branch = '${{ steps.get-branch.outputs.result }}';
             const projectSlug = process.env.READTHEDOCS_PROJECT;
 
-            // ReadTheDocs automatically replaces forward slashes with dashes when generating version slugs
+            // ReadTheDocs automatically replaces forward slashes with dashes
+            // and lowercases letters when generating version slugs.
             // See: https://docs.readthedocs.com/platform/latest/versions.html
             // So we need to match that behavior for the documentation URL
             // Then URL-encode the sanitized branch name for the documentation URL
-            const sanitizedBranch = branch.replace(/\//g, '-');
+            const sanitizedBranch = branch.replace(/\//g, '-').toLowerCase();
             const encodedBranch = encodeURIComponent(sanitizedBranch);
 
             // Add label to track that a preview was built
@@ -247,11 +249,12 @@ jobs:
           READTHEDOCS_PROJECT: ${{ secrets.READTHEDOCS_PROJECT }}
           BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
-          # ReadTheDocs automatically replaces forward slashes with dashes when generating version slugs
+          # ReadTheDocs automatically replaces forward slashes with dashes and
+          # lowercases letters when generating version slugs.
           # See: https://docs.readthedocs.com/platform/latest/versions.html
           # So we need to match that behavior when calling the API
           # Then URL-encode the sanitized branch name for the API call
-          SANITIZED_BRANCH=$(echo -n "${BRANCH_NAME}" | sed 's/\//-/g')
+          SANITIZED_BRANCH=$(echo -n "${BRANCH_NAME}" | sed 's/\//-/g' | tr '[:upper:]' '[:lower:]')
           VERSION_SLUG=$(echo -n "${SANITIZED_BRANCH}" | jq -sRr @uri)
 
           echo "Deactivating ReadTheDocs preview for branch: ${BRANCH_NAME}"


### PR DESCRIPTION
## Summary

The `readthedocs-manual-pr-build` workflow (triggered by `/build-docs` comments on PRs) builds the RTD version slug from the PR branch name with:

```bash
SANITIZED_BRANCH=$(echo -n "${BRANCH_NAME}" | sed 's/\//-/g')
```

RTD, however, slugifies version names by **both** replacing `/` → `-` **and** lowercasing all letters (Django `slugify`). So for any branch with an uppercase letter, the workflow's `PATCH /api/v3/.../versions/<slug>/` returns 404 (e.g. branch `claude/slurm-to-skypilot-converter-fggF9` → workflow queries `...converter-fggF9`, but the actual RTD slug is `...converter-fggf9`), and the workflow then posts `❌ Failed to trigger ReadTheDocs build`.

This adds `tr '[:upper:]' '[:lower:]'` after the `sed` in both the trigger and cleanup jobs, and `.toLowerCase()` after `.replace(/\//g, '-')` in the JS step that builds the preview URL, so the slug the workflow uses matches the one RTD actually creates.

Repro / verification of the existing failure: [run 24585570329](https://github.com/skypilot-org/skypilot/actions/runs/24585570329) for branch `claude/slurm-to-skypilot-converter-fggF9`, which fails at the second `PATCH` with `"No Version matches the given query."`. The correct slug on RTD is `claude-slurm-to-skypilot-converter-fggf9` (confirmed by maintainer).

## Test plan

- [x] Manually run the sanitization locally and confirm the slug matches RTD:
  ```bash
  $ echo -n 'claude/slurm-to-skypilot-converter-fggF9' | sed 's/\//-/g' | tr '[:upper:]' '[:lower:]'
  claude-slurm-to-skypilot-converter-fggf9
  ```
- [ ] After merge, comment `/build-docs` on an existing PR with a mixed-case branch (e.g. #9384) and confirm the workflow activates the version and triggers a build successfully instead of 404'ing.
- [ ] Close that PR and confirm the `cleanup-rtd-preview` job also uses the lowercased slug (visible in its log output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)