### PR TITLE
[Kubernetes] Allow configurable ingress-nginx namespace

### DIFF
--- a/sky/provision/kubernetes/network.py
+++ b/sky/provision/kubernetes/network.py
@@ -293,7 +293,9 @@ def _query_ports_for_ingress(
 ) -> Dict[int, List[common.Endpoint]]:
     context = provider_config.get(
         'context', kubernetes_utils.get_current_kube_config_context_name())
-    ingress_details = network_utils.get_ingress_external_ip_and_ports(context)
+    ingress_namespace = network_utils.get_ingress_namespace(context)
+    ingress_details = network_utils.get_ingress_external_ip_and_ports(
+        context, namespace=ingress_namespace)
     external_ip, external_ports = ingress_details
     if external_ip is None:
         return {}

--- a/sky/provision/kubernetes/network_utils.py
+++ b/sky/provision/kubernetes/network_utils.py
@@ -24,6 +24,21 @@ logger = sky_logging.init_logger(__name__)
 
 _INGRESS_TEMPLATE_NAME = 'kubernetes-ingress.yml.j2'
 _LOADBALANCER_TEMPLATE_NAME = 'kubernetes-loadbalancer.yml.j2'
+_DEFAULT_INGRESS_NAMESPACE = 'ingress-nginx'
+
+
+def get_ingress_namespace(context: Optional[str]) -> str:
+    """Returns the namespace where the ingress-nginx controller is installed.
+
+    Reads the configured namespace from ``kubernetes.ingress_namespace``
+    (optionally overridden per-context via ``kubernetes.context_configs``),
+    falling back to the upstream default (``ingress-nginx``).
+    """
+    return skypilot_config.get_effective_region_config(
+        cloud='kubernetes',
+        region=context,
+        keys=('ingress_namespace',),
+        default_value=_DEFAULT_INGRESS_NAMESPACE)
 
 
 def get_port_mode(
@@ -242,7 +257,7 @@ def ingress_controller_exists(context: Optional[str],
 
 def get_ingress_external_ip_and_ports(
     context: Optional[str],
-    namespace: str = 'ingress-nginx'
+    namespace: str = _DEFAULT_INGRESS_NAMESPACE,
 ) -> Tuple[Optional[str], Optional[Tuple[int, int]]]:
     """Returns external ip and ports for the ingress controller."""
     core_api = kubernetes.core_api(context)

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1454,6 +1454,9 @@ _CONTEXT_CONFIG_SCHEMA_KUBERNETES = {
             type.value for type in kubernetes_enums.KubernetesPortMode
         ],
     },
+    'ingress_namespace': {
+        'type': 'string',
+    },
     **_CONTEXT_CONFIG_SCHEMA_MINIMAL,
     'autoscaler': {
         'type': 'string',

--- a/tests/unit_tests/test_sky/provision/test_kubernetes_network.py
+++ b/tests/unit_tests/test_sky/provision/test_kubernetes_network.py
@@ -1,0 +1,64 @@
+"""Tests for sky.provision.kubernetes.network."""
+from unittest import mock
+
+from sky.provision.kubernetes import network
+from sky.provision.kubernetes import network_utils
+
+
+def test_get_ingress_namespace_returns_default_when_unset(monkeypatch):
+    """Without config, get_ingress_namespace() falls back to 'ingress-nginx'."""
+    monkeypatch.setattr(
+        'sky.skypilot_config.get_effective_region_config',
+        lambda cloud, region, keys, default_value, **kwargs: default_value,
+    )
+    assert network_utils.get_ingress_namespace('ctx') == 'ingress-nginx'
+
+
+def test_get_ingress_namespace_reads_configured_value(monkeypatch):
+    """get_ingress_namespace() returns the user-configured namespace."""
+
+    def fake_get(cloud, region, keys, default_value, **kwargs):
+        assert cloud == 'kubernetes'
+        assert region == 'my-ctx'
+        assert keys == ('ingress_namespace',)
+        return 'custom-ns'
+
+    monkeypatch.setattr('sky.skypilot_config.get_effective_region_config',
+                        fake_get)
+    assert network_utils.get_ingress_namespace('my-ctx') == 'custom-ns'
+
+
+def test_query_ports_for_ingress_uses_configured_namespace(monkeypatch):
+    """_query_ports_for_ingress passes the configured namespace to the
+    ingress lookup (instead of the hardcoded 'ingress-nginx')."""
+    from sky.provision.kubernetes import utils as kubernetes_utils
+    monkeypatch.setattr(kubernetes_utils,
+                        'get_current_kube_config_context_name',
+                        lambda: 'fallback-ctx')
+    monkeypatch.setattr(kubernetes_utils, 'get_kube_config_context_namespace',
+                        lambda ctx: 'workload-ns')
+    monkeypatch.setattr(network_utils, 'get_ingress_namespace',
+                        lambda context: 'custom-ingress-ns')
+
+    captured = {}
+
+    def fake_get_ingress(context, namespace='ingress-nginx'):
+        captured['context'] = context
+        captured['namespace'] = namespace
+        return None, None  # no external ip -> early return
+
+    monkeypatch.setattr(network_utils, 'get_ingress_external_ip_and_ports',
+                        fake_get_ingress)
+
+    result = network._query_ports_for_ingress(
+        cluster_name_on_cloud='test-cluster',
+        ports=[8080],
+        provider_config={
+            'context': 'my-ctx',
+            'namespace': 'workload-ns',
+        },
+    )
+
+    assert result == {}
+    assert captured['context'] == 'my-ctx'
+    assert captured['namespace'] == 'custom-ingress-ns'


### PR DESCRIPTION
## Summary

Fixes #9150.

`sky status --endpoints` currently assumes the `ingress-nginx` controller lives in the `ingress-nginx` namespace. Users who deploy the controller in a non-standard namespace (e.g. via Helm into a shared `networking` namespace) get no endpoints back even though the controller works fine.

The underlying helper `network_utils.get_ingress_external_ip_and_ports()` already accepts a `namespace` parameter, but the only caller (`_query_ports_for_ingress` in `network.py`) never passes one — so the hardcoded default wins.

This PR adds a configurable namespace:

- New string key `ingress_namespace` in the kubernetes config schema (also honored under `context_configs.<context>` for per-cluster overrides).
- New helper `network_utils.get_ingress_namespace(context)` that reads it via ``skypilot_config.get_effective_region_config`` with a fallback to ``'ingress-nginx'`` — same pattern as the existing ``get_port_mode``.
- `_query_ports_for_ingress` now passes the resolved namespace through to `get_ingress_external_ip_and_ports`.

Behavior is unchanged for users who don't set the new key (the default is still `ingress-nginx`).

Example `~/.sky/config.yaml`:

```yaml
kubernetes:
  ingress_namespace: my-networking
  # or per-context:
  context_configs:
    my-cluster:
      ingress_namespace: networking
```

## Tested

- Added `tests/unit_tests/test_sky/provision/test_kubernetes_network.py` with three unit tests:
  - `get_ingress_namespace` falls back to `'ingress-nginx'` when unset
  - `get_ingress_namespace` returns the user-configured value
  - `_query_ports_for_ingress` forwards the configured namespace to `get_ingress_external_ip_and_ports` (regression test for the hardcoded namespace)
- Ran the new tests locally: `pytest tests/unit_tests/test_sky/provision/test_kubernetes_network.py` — 3 passed.
- Manual verification: on a cluster with ingress-nginx installed in a custom namespace, set `kubernetes.ingress_namespace: <custom-ns>` in `~/.sky/config.yaml` and confirmed `sky status --endpoints` now returns the ingress endpoints.