### PR TITLE
[WIP][Pool][Jobs] Fix consolidation mode interaction with pool

### DIFF
--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -28,6 +28,7 @@ from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import common as adaptors_common
 from sky.jobs import state as managed_job_state
+from sky.jobs import utils as managed_job_utils
 from sky.serve import constants
 from sky.serve import serve_state
 from sky.serve import spot_placer
@@ -240,15 +241,14 @@ def _validate_consolidation_mode_config(current_is_consolidation_mode: bool,
 
 @annotations.lru_cache(scope='request', maxsize=1)
 def is_consolidation_mode(pool: bool = False) -> bool:
-    # Use jobs config for pool consolidation mode.
-    controller = controller_utils.get_controller_for_pool(pool).value
-    consolidation_mode = skypilot_config.get_nested(
-        (controller.controller_type, 'controller', 'consolidation_mode'),
-        default_value=False)
     if os.environ.get(skylet_constants.OVERRIDE_CONSOLIDATION_MODE) is not None:
-        # if we are in the job controller, we must always be in consolidation
-        # mode.
         return True
+
+    if pool:
+        return managed_job_utils.is_consolidation_mode()
+
+    consolidation_mode = skypilot_config.get_nested(
+        ('serve', 'controller', 'consolidation_mode'), default_value=False)
     # We should only do this check on API server, as the controller will not
     # have related config and will always seemingly disabled for consolidation
     # mode. Check #6611 for more details.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fix the following bug:

1. create a api server (w/ default consolidation mode)
2. launch several jobs
3. launch a pool, which use serve.is_consolidation_mode, and think we are not in consolidation mode, and this creates a jobs controller
4. all of my previous jobs cannot be seen anymore (as now we have a job controller)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
