### PR TITLE
[Dashboard][Volumes] imported-PVC safety, purge, auto-mount metadata

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1003,6 +1003,14 @@ def write_cluster_config(
                         f'ReadWriteMany PVC volumes are supported for '
                         f'auto_mounts. Skipping.')
                     continue
+                # Mirror the explicit `volume_mounts` path (see
+                # `VolumeMount.pre_mount`): record the attachment timestamp
+                # and IN_USE status so the Volumes dashboard surfaces the
+                # "Last Use" column correctly for auto-mounted volumes.
+                global_user_state.update_volume(
+                    volume_name,
+                    last_attached_at=int(time.time()),
+                    status=status_lib.VolumeStatus.IN_USE)
                 for path in mount_paths:
                     if path.startswith('/'):
                         mount_path = path

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1007,10 +1007,13 @@ def write_cluster_config(
                 # `VolumeMount.pre_mount`): record the attachment timestamp
                 # and IN_USE status so the Volumes dashboard surfaces the
                 # "Last Use" column correctly for auto-mounted volumes.
-                global_user_state.update_volume(
-                    volume_name,
-                    last_attached_at=int(time.time()),
-                    status=status_lib.VolumeStatus.IN_USE)
+                # Skip on dryrun so `sky launch --dryrun` does not mutate
+                # volume metadata.
+                if not dryrun:
+                    global_user_state.update_volume(
+                        volume_name,
+                        last_attached_at=int(time.time()),
+                        status=status_lib.VolumeStatus.IN_USE)
                 for path in mount_paths:
                     if path.startswith('/'):
                         mount_path = path

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -280,7 +280,9 @@ export function Volumes() {
                   <AlertTriangleIcon className="w-4 h-4 text-amber-600 mt-0.5 flex-shrink-0" />
                   <div className="text-sm text-amber-800 space-y-2">
                     <p className="m-0">
-                      <strong>Force remove won&apos;t delete the underlying volume.</strong>{' '}
+                      <strong>
+                        Force remove won&apos;t delete the underlying volume.
+                      </strong>{' '}
                       Removing the SkyPilot entry means this volume will no
                       longer appear here, but{' '}
                       {volumeToDelete?.type === 'k8s-pvc' &&
@@ -293,7 +295,8 @@ export function Volumes() {
                           {volumeToDelete.namespace &&
                             volumeToDelete.namespace !== '-' && (
                               <>
-                                {' '}in namespace{' '}
+                                {' '}
+                                in namespace{' '}
                                 <code className="bg-amber-100 px-1 rounded">
                                   {volumeToDelete.namespace}
                                 </code>
@@ -363,7 +366,9 @@ export function Volumes() {
                     </Button>
                     <Button
                       onClick={handlePurgeVolumeConfirm}
-                      disabled={!purgeConfirmed || deleteLoading || purgeLoading}
+                      disabled={
+                        !purgeConfirmed || deleteLoading || purgeLoading
+                      }
                       className="bg-amber-600 hover:bg-amber-700 text-white"
                     >
                       {purgeLoading ? 'Removing...' : 'Force Remove'}

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -21,7 +21,7 @@ import {
 import { getVolumes, deleteVolume } from '@/data/connectors/volumes';
 import { REFRESH_INTERVALS } from '@/lib/config';
 import { sortData } from '@/data/utils';
-import { RotateCwIcon, Trash2Icon } from 'lucide-react';
+import { RotateCwIcon, Trash2Icon, AlertTriangleIcon } from 'lucide-react';
 import { useMobile } from '@/hooks/useMobile';
 import { Card } from '@/components/ui/card';
 import {
@@ -53,6 +53,9 @@ export function Volumes() {
   const [volumeToDelete, setVolumeToDelete] = useState(null);
   const [deleteError, setDeleteError] = useState(null);
   const [deleteLoading, setDeleteLoading] = useState(false);
+  const [showPurgeUI, setShowPurgeUI] = useState(false);
+  const [purgeConfirmed, setPurgeConfirmed] = useState(false);
+  const [purgeLoading, setPurgeLoading] = useState(false);
   const [preloadingComplete, setPreloadingComplete] = useState(false);
   const [lastFetchedTime, setLastFetchedTime] = useState(null);
   const [activeTab, setActiveTab] = useState('volumes');
@@ -95,6 +98,8 @@ export function Volumes() {
     setVolumeToDelete(volume);
     setShowDeleteConfirmDialog(true);
     setDeleteError(null);
+    setShowPurgeUI(false);
+    setPurgeConfirmed(false);
   };
 
   const handleDeleteVolumeConfirm = async () => {
@@ -110,6 +115,8 @@ export function Volumes() {
       }
       setShowDeleteConfirmDialog(false);
       setVolumeToDelete(null);
+      setShowPurgeUI(false);
+      setPurgeConfirmed(false);
       handleRefresh();
     } catch (error) {
       setDeleteError(error);
@@ -118,10 +125,35 @@ export function Volumes() {
     }
   };
 
+  const handlePurgeVolumeConfirm = async () => {
+    if (!volumeToDelete) return;
+
+    setPurgeLoading(true);
+    setDeleteError(null);
+
+    try {
+      const result = await deleteVolume(volumeToDelete.name, { purge: true });
+      if (!result.success) {
+        throw new Error(result.msg);
+      }
+      setShowDeleteConfirmDialog(false);
+      setVolumeToDelete(null);
+      setShowPurgeUI(false);
+      setPurgeConfirmed(false);
+      handleRefresh();
+    } catch (error) {
+      setDeleteError(error);
+    } finally {
+      setPurgeLoading(false);
+    }
+  };
+
   const handleCancelDelete = () => {
     setShowDeleteConfirmDialog(false);
     setVolumeToDelete(null);
     setDeleteError(null);
+    setShowPurgeUI(false);
+    setPurgeConfirmed(false);
   };
 
   useEffect(() => {
@@ -233,21 +265,111 @@ export function Volumes() {
                 onDismiss={() => setDeleteError(null)}
               />
 
+              {deleteError && !showPurgeUI && (
+                <button
+                  type="button"
+                  onClick={() => setShowPurgeUI(true)}
+                  className="text-sm text-amber-700 hover:text-amber-800 underline self-start bg-transparent border-0 p-0 cursor-pointer"
+                >
+                  Force remove from SkyPilot records
+                </button>
+              )}
+
+              {showPurgeUI && (
+                <div className="bg-amber-50 border border-amber-200 rounded-md p-3 flex items-start gap-2 mb-2">
+                  <AlertTriangleIcon className="w-4 h-4 text-amber-600 mt-0.5 flex-shrink-0" />
+                  <div className="text-sm text-amber-800 space-y-2">
+                    <p className="m-0">
+                      <strong>Force remove won&apos;t delete the underlying volume.</strong>{' '}
+                      Removing the SkyPilot entry means this volume will no
+                      longer appear here, but{' '}
+                      {volumeToDelete?.type === 'k8s-pvc' &&
+                      volumeToDelete?.name_on_cloud ? (
+                        <>
+                          the Kubernetes PVC{' '}
+                          <code className="bg-amber-100 px-1 rounded">
+                            {volumeToDelete.name_on_cloud}
+                          </code>
+                          {volumeToDelete.namespace &&
+                            volumeToDelete.namespace !== '-' && (
+                              <>
+                                {' '}in namespace{' '}
+                                <code className="bg-amber-100 px-1 rounded">
+                                  {volumeToDelete.namespace}
+                                </code>
+                              </>
+                            )}{' '}
+                          may still exist and continue consuming resources.
+                          Delete it manually with{' '}
+                          <code className="bg-amber-100 px-1 rounded">
+                            kubectl delete pvc
+                            {volumeToDelete.namespace &&
+                            volumeToDelete.namespace !== '-'
+                              ? ` -n ${volumeToDelete.namespace}`
+                              : ''}{' '}
+                            {volumeToDelete.name_on_cloud}
+                          </code>{' '}
+                          once it&apos;s no longer in use.
+                        </>
+                      ) : (
+                        <>
+                          the underlying cloud resource may still exist and
+                          continue consuming resources. Clean it up manually
+                          once it&apos;s no longer in use.
+                        </>
+                      )}
+                    </p>
+                    <label className="flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={purgeConfirmed}
+                        onChange={(e) => setPurgeConfirmed(e.target.checked)}
+                        disabled={purgeLoading}
+                        className="cursor-pointer"
+                      />
+                      <span>
+                        I understand this may not delete the underlying volume
+                      </span>
+                    </label>
+                  </div>
+                </div>
+              )}
+
               <DialogFooter>
                 <Button
                   variant="outline"
                   onClick={handleCancelDelete}
-                  disabled={deleteLoading}
+                  disabled={deleteLoading || purgeLoading}
                 >
                   Cancel
                 </Button>
-                <Button
-                  variant="destructive"
-                  onClick={handleDeleteVolumeConfirm}
-                  disabled={deleteLoading}
-                >
-                  {deleteLoading ? 'Deleting...' : 'Delete'}
-                </Button>
+                {!showPurgeUI && (
+                  <Button
+                    variant="destructive"
+                    onClick={handleDeleteVolumeConfirm}
+                    disabled={deleteLoading}
+                  >
+                    {deleteLoading ? 'Deleting...' : 'Delete'}
+                  </Button>
+                )}
+                {showPurgeUI && (
+                  <>
+                    <Button
+                      variant="destructive"
+                      onClick={handleDeleteVolumeConfirm}
+                      disabled={deleteLoading || purgeLoading}
+                    >
+                      {deleteLoading ? 'Deleting...' : 'Retry Delete'}
+                    </Button>
+                    <Button
+                      onClick={handlePurgeVolumeConfirm}
+                      disabled={!purgeConfirmed || deleteLoading || purgeLoading}
+                      className="bg-amber-600 hover:bg-amber-700 text-white"
+                    >
+                      {purgeLoading ? 'Removing...' : 'Force Remove'}
+                    </Button>
+                  </>
+                )}
               </DialogFooter>
             </DialogContent>
           </Dialog>

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -184,6 +184,11 @@ export function Volumes() {
             {!loading && lastFetchedTime && (
               <LastUpdatedTimestamp timestamp={lastFetchedTime} />
             )}
+            <PluginSlot
+              name="volumes.header-actions"
+              context={{ onVolumeChange: handleRefresh }}
+              wrapperClassName="contents"
+            />
             <button
               onClick={handleRefresh}
               disabled={loading}
@@ -248,7 +253,10 @@ export function Volumes() {
           </Dialog>
         </>
       ) : (
-        <PluginSlot name="volumes.tab-content" context={{ activeTab }} />
+        <PluginSlot
+          name="volumes.tab-content"
+          context={{ activeTab, onTabChange: handleTabChange }}
+        />
       )}
     </>
   );

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -216,11 +216,6 @@ export function Volumes() {
             {!loading && lastFetchedTime && (
               <LastUpdatedTimestamp timestamp={lastFetchedTime} />
             )}
-            <PluginSlot
-              name="volumes.header-actions"
-              context={{ onVolumeChange: handleRefresh }}
-              wrapperClassName="contents"
-            />
             <button
               onClick={handleRefresh}
               disabled={loading}
@@ -229,6 +224,11 @@ export function Volumes() {
               <RotateCwIcon className="h-4 w-4 mr-1.5" />
               {!isMobile && <span>Refresh</span>}
             </button>
+            <PluginSlot
+              name="volumes.header-actions"
+              context={{ onVolumeChange: handleRefresh }}
+              wrapperClassName="contents"
+            />
           </div>
         )}
       </div>

--- a/sky/dashboard/src/data/connectors/volumes.js
+++ b/sky/dashboard/src/data/connectors/volumes.js
@@ -50,11 +50,12 @@ export async function getVolumes() {
   }
 }
 
-export async function deleteVolume(volumeName) {
+export async function deleteVolume(volumeName, { purge = false } = {}) {
   let msg = '';
   try {
     const response = await apiClient.post('/volumes/delete', {
       names: [volumeName],
+      purge,
     });
     if (!response.ok) {
       console.error(

--- a/sky/provision/kubernetes/volume.py
+++ b/sky/provision/kubernetes/volume.py
@@ -117,9 +117,18 @@ def delete_volume(config: models.VolumeConfig) -> models.VolumeConfig:
 
 
 def _delete_pvc_volume(config: models.VolumeConfig) -> models.VolumeConfig:
-    """Deletes a PVC volume."""
+    """Deletes a PVC volume.
+
+    If the volume was registered with ``use_existing=True``, the underlying
+    PVC is left intact (SkyPilot did not create it, and another SkyPilot
+    instance may also have it registered).
+    """
     context, namespace = _get_context_namespace(config)
     pvc_name = config.name_on_cloud
+    if config.config.get('use_existing'):
+        logger.info(f'Leaving PVC {pvc_name} in namespace {namespace} intact '
+                    f'(use_existing=True)')
+        return config
     kubernetes_utils.delete_k8s_resource_with_retry(
         delete_func=lambda pvc_name=pvc_name: kubernetes.core_api(
             context).delete_namespaced_persistent_volume_claim(

--- a/sky/provision/kubernetes/volume.py
+++ b/sky/provision/kubernetes/volume.py
@@ -127,7 +127,7 @@ def _delete_pvc_volume(config: models.VolumeConfig) -> models.VolumeConfig:
     pvc_name = config.name_on_cloud
     if config.config.get('use_existing'):
         logger.info(f'Leaving PVC {pvc_name} in namespace {namespace} intact '
-                    f'(use_existing=True)')
+                    f'since volume was imported from an existing PVC.')
         return config
     kubernetes_utils.delete_k8s_resource_with_retry(
         delete_func=lambda pvc_name=pvc_name: kubernetes.core_api(

--- a/tests/unit_tests/test_sky/provision/test_kubernetes_volume.py
+++ b/tests/unit_tests/test_sky/provision/test_kubernetes_volume.py
@@ -1,0 +1,47 @@
+"""Tests for sky.provision.kubernetes.volume delete behavior."""
+from unittest import mock
+
+from sky import models
+from sky.provision.kubernetes import volume as volume_provision
+
+
+def _make_pvc_config(use_existing: bool) -> models.VolumeConfig:
+    return models.VolumeConfig(
+        name='test-vol',
+        type='k8s-pvc',
+        cloud='kubernetes',
+        region='my-context',
+        zone=None,
+        name_on_cloud='real-pvc',
+        size='5',
+        config={
+            'namespace': 'default',
+            'use_existing': use_existing,
+        },
+    )
+
+
+def test_delete_pvc_volume_destructive_when_not_use_existing():
+    config = _make_pvc_config(use_existing=False)
+    with mock.patch.object(volume_provision, 'kubernetes') as mock_k8s, \
+         mock.patch.object(volume_provision,
+                           'kubernetes_utils') as mock_k8s_utils:
+        volume_provision._delete_pvc_volume(config)
+        mock_k8s_utils.delete_k8s_resource_with_retry.assert_called_once()
+        # The PVC delete lambda should have been passed in.
+        _, kwargs = mock_k8s_utils.delete_k8s_resource_with_retry.call_args
+        assert kwargs['resource_type'] == 'pvc'
+        assert kwargs['resource_name'] == 'real-pvc'
+
+
+def test_delete_pvc_volume_preserves_pvc_when_use_existing():
+    config = _make_pvc_config(use_existing=True)
+    with mock.patch.object(volume_provision, 'kubernetes') as mock_k8s, \
+         mock.patch.object(volume_provision,
+                           'kubernetes_utils') as mock_k8s_utils:
+        result = volume_provision._delete_pvc_volume(config)
+        # Must NOT have attempted to delete the PVC.
+        mock_k8s_utils.delete_k8s_resource_with_retry.assert_not_called()
+        mock_k8s.core_api.assert_not_called()
+        # Still returns the config so the caller can proceed to unregister.
+        assert result is config


### PR DESCRIPTION
## Summary

Bundles five related Volumes-page improvements:

- **Non-destructive delete for imported PVCs** — `_delete_pvc_volume` now skips the underlying K8s PVC delete when the volume was registered with `use_existing=True`. Matches K8s ownership expectations and avoids orphaning a registration when the same PVC is registered from multiple API servers.
- **Force-remove (purge) from the dashboard** — surfaces a purge affordance when a normal volume delete fails, so users can unregister a stuck record from the DB without shelling into the cluster.
- **Header-actions slot ordering** — render the plugin slot to the right of Refresh so contributed actions sit rightmost.
- **Keep `last_attached_at` in sync for auto-mounted volumes** — volumes pulled in via the `auto_mounts` config bypassed `VolumeMount.pre_mount`, so the Volumes dashboard "Last Use" column stayed blank even while the volume was actively attached. The write is now mirrored in `write_cluster_config`'s auto-mount branch.

## Test plan

- [x] `pytest tests/unit_tests/provision/kubernetes/test_volume.py` — covers `_delete_pvc_volume` skip behavior with `use_existing=True`.
- [x] Manual: import a PVC created via `kubectl`, delete the SkyPilot volume, confirm the PVC remains in the cluster.
- [x] Manual: delete a volume whose K8s backing resource is already gone, confirm the purge path unregisters the DB record.
- [x] Manual: launch a cluster that mounts a volume via `auto_mounts` config, refresh the Volumes dashboard, confirm "Last Use" populates.
- [x] Manual: a dummy plugin that registers a component in `volumes.header-actions` renders to the right of the Refresh button when on the Volumes tab.