### PR TITLE
[o11y] Better Kubernetes provisioning failure reasons

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -226,17 +226,23 @@ def _get_kubernetes_hint(reason: str,
                          context: Optional[str] = None) -> Optional[str]:
     """Return a hint for the given Kubernetes failure reason, or None.
 
-    Hints may contain a `{dashboard_url}` placeholder, which is substituted
+    Hints may contain a literal `{dashboard_url}` token, which is replaced
     with the SkyPilot dashboard infra page URL — scoped to the failing
-    context when one is available.
+    context when one is available. If URL resolution fails for any reason,
+    the token is replaced with a generic fallback so we never raise from
+    failure-rendering code (which would mask the original provision error).
     """
     for substrings, hint in _KUBERNETES_FAILURE_HINTS:
         if any(s in reason for s in substrings):
             if '{dashboard_url}' in hint:
-                starting_page = f'infra/{context}' if context else 'infra'
-                dashboard_url = server_common.get_dashboard_url(
-                    server_common.get_server_url(), starting_page=starting_page)
-                hint = hint.format(dashboard_url=dashboard_url)
+                try:
+                    starting_page = (f'infra/{context}' if context else 'infra')
+                    dashboard_url = server_common.get_dashboard_url(
+                        server_common.get_server_url(),
+                        starting_page=starting_page)
+                except Exception:  # pylint: disable=broad-except
+                    dashboard_url = 'the SkyPilot dashboard infra page'
+                hint = hint.replace('{dashboard_url}', dashboard_url)
             return hint
     return None
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -914,6 +914,7 @@ class RetryingVmProvisioner(object):
         to_provision: resources_lib.Resources,
         requested_resources: Set[resources_lib.Resources],
         insufficient_resources: Optional[List[str]],
+        last_error_reason: Optional[str] = None,
     ) -> str:
         insufficent_resource_msg = ('' if insufficient_resources is None else
                                     f' ({", ".join(insufficient_resources)})')
@@ -937,6 +938,8 @@ class RetryingVmProvisioner(object):
                             f'{requested_resources}. ')
         else:
             message += (f'{to_provision.cloud} for {requested_resources}. ')
+        if last_error_reason:
+            message += f'Reason: {last_error_reason}'
         return message
 
     def _retry_zones(  # pylint: disable=line-too-long
@@ -1018,6 +1021,7 @@ class RetryingVmProvisioner(object):
                 f'https://docs.skypilot.co/en/latest/cloud-setup/quota.html.')
 
         insufficient_resources = None
+        last_error_reason: Optional[str] = None
         for zones in self._yield_zones(to_provision, num_nodes, cluster_name,
                                        prev_cluster_status,
                                        prev_cluster_ever_up):
@@ -1245,6 +1249,7 @@ class RetryingVmProvisioner(object):
                     except config_lib.KubernetesError as e:
                         if e.insufficent_resources:
                             insufficient_resources = e.insufficent_resources
+                        last_error_reason = str(e)
                         # NOTE: We try to cleanup the cluster even if the previous
                         # cluster does not exist. Also we are fast at
                         # cleaning up clusters now if there is no existing node.
@@ -1392,9 +1397,11 @@ class RetryingVmProvisioner(object):
                 CloudVmRayBackend().teardown_no_lock(
                     handle, terminate=terminate_or_stop, remove_from_db=False)
 
-        message = self._insufficient_resources_msg(to_provision,
-                                                   requested_resources,
-                                                   insufficient_resources)
+        message = self._insufficient_resources_msg(
+            to_provision,
+            requested_resources,
+            insufficient_resources,
+            last_error_reason=last_error_reason)
         # Do not failover to other locations if the cluster was ever up, since
         # the user can have some data on the cluster.
         raise exceptions.ResourcesUnavailableError(

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -56,6 +56,7 @@ from sky.provision.kubernetes import config as config_lib
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.provision.slurm import utils as slurm_utils
 from sky.serve import constants as serve_constants
+from sky.server import common as server_common
 from sky.server.requests import requests as requests_lib
 from sky.skylet import autostop_lib
 from sky.skylet import constants
@@ -215,15 +216,27 @@ _KUBERNETES_FAILURE_HINTS = [
      'Verify the image tag exists and registry credentials are configured.'),
     (['OOMKilled'], 'The container ran out of memory. '
      'Try requesting more with `memory: <size>` in resources.'),
-    (['Insufficient'], 'The cluster does not have enough free resources. '
-     'Check node allocations with `kubectl describe nodes`.'),
+    (['Insufficient'],
+     'The cluster does not have enough free resources. View node '
+     'allocations at {dashboard_url} or run `kubectl describe nodes`.'),
 ]
 
 
-def _get_kubernetes_hint(reason: str) -> Optional[str]:
-    """Return a hint for the given Kubernetes failure reason, or None."""
+def _get_kubernetes_hint(reason: str,
+                         context: Optional[str] = None) -> Optional[str]:
+    """Return a hint for the given Kubernetes failure reason, or None.
+
+    Hints may contain a `{dashboard_url}` placeholder, which is substituted
+    with the SkyPilot dashboard infra page URL — scoped to the failing
+    context when one is available.
+    """
     for substrings, hint in _KUBERNETES_FAILURE_HINTS:
         if any(s in reason for s in substrings):
+            if '{dashboard_url}' in hint:
+                starting_page = f'infra/{context}' if context else 'infra'
+                dashboard_url = server_common.get_dashboard_url(
+                    server_common.get_server_url(), starting_page=starting_page)
+                hint = hint.format(dashboard_url=dashboard_url)
             return hint
     return None
 
@@ -239,9 +252,9 @@ def _format_provision_failure_blocks(
                                                        simplified_only=True)[0]
         reason = str(exception)
         lines.append(f'\u2717 {infra} \u2014 {resource_str}')
-        lines.append(f'  {reason}')
+        lines.append(textwrap.indent(reason, '  '))
         if isinstance(resource.cloud, clouds.Kubernetes):
-            hint = _get_kubernetes_hint(reason)
+            hint = _get_kubernetes_hint(reason, context=resource.region)
             if hint:
                 lines.append(f'  Hint: {hint}')
         lines.append('')
@@ -980,7 +993,7 @@ class RetryingVmProvisioner(object):
         else:
             message += (f'{to_provision.cloud} for {requested_resources}. ')
         if last_error_reason:
-            message += f'Reason: {last_error_reason}'
+            message = message.rstrip() + f'\nReason: {last_error_reason}'
         return message
 
     def _retry_zones(  # pylint: disable=line-too-long

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -207,6 +207,43 @@ _EXCEPTION_MSG_AND_RETURNCODE_FOR_DUMP_INLINE_SCRIPT = [
 _RESOURCES_UNAVAILABLE_LOG = (
     'Reasons for provision failures (for details, please check the log above):')
 
+_PROVISION_FAILURE_HINTS = [
+    (['ImagePullBackOff', 'ErrImagePull'],
+     'Verify the image tag exists and registry credentials are configured.'),
+    (['OOMKilled'], 'The container ran out of memory. '
+     'Try requesting more with `memory: <size>` in resources.'),
+    (['Insufficient'], 'The cluster does not have enough free resources. '
+     'Check node allocations with `kubectl describe nodes`.'),
+]
+
+
+def _get_provision_hint(reason: str) -> Optional[str]:
+    """Return a hint for the given provision failure reason, or None."""
+    for substrings, hint in _PROVISION_FAILURE_HINTS:
+        if any(s in reason for s in substrings):
+            return hint
+    return None
+
+
+def _format_provision_failure_blocks(
+    resource_exceptions: Dict['resources_lib.Resources', Exception],) -> str:
+    """Format provision failures as blocks instead of a table."""
+    num_infra = len(resource_exceptions)
+    lines = [f'Provision failures (tried {num_infra} infra):\n']
+    for resource, exception in resource_exceptions.items():
+        infra = resource.infra.formatted_str()
+        resource_str = resources_utils.format_resource(resource,
+                                                       simplified_only=True)[0]
+        reason = str(exception)
+        lines.append(f'\u2717 {infra} \u2014 {resource_str}')
+        lines.append(f'  {reason}')
+        hint = _get_provision_hint(reason)
+        if hint:
+            lines.append(f'  Hint: {hint}')
+        lines.append('')
+    return '\n'.join(lines)
+
+
 # Number of seconds to wait locking the cluster before communicating with user.
 _CLUSTER_LOCK_TIMEOUT = 5.0
 
@@ -1836,19 +1873,9 @@ class RetryingVmProvisioner(object):
                 # possible resources or the requested resources is too
                 # restrictive. If we reach here, our failover logic finally
                 # ends here.
-                table = log_utils.create_table(['INFRA', 'RESOURCES', 'REASON'])
-                for (resource, exception) in resource_exceptions.items():
-                    table.add_row([
-                        resource.infra.formatted_str(),
-                        resources_utils.format_resource(
-                            resource, simplified_only=True)[0], exception
-                    ])
-                # Set the max width of REASON column to 80 to avoid the table
-                # being wrapped in a unreadable way.
-                # pylint: disable=protected-access
-                table._max_width = {'REASON': 80}
+                blocks = _format_provision_failure_blocks(resource_exceptions)
                 raise exceptions.ResourcesUnavailableError(
-                    _RESOURCES_UNAVAILABLE_LOG + '\n' + table.get_string(),
+                    _RESOURCES_UNAVAILABLE_LOG + '\n' + blocks,
                     failover_history=failover_history)
             best_resources = task.best_resources
             assert task in self._dag.tasks, 'Internal logic error.'

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -207,7 +207,10 @@ _EXCEPTION_MSG_AND_RETURNCODE_FOR_DUMP_INLINE_SCRIPT = [
 _RESOURCES_UNAVAILABLE_LOG = (
     'Reasons for provision failures (for details, please check the log above):')
 
-_PROVISION_FAILURE_HINTS = [
+# Hints currently only cover Kubernetes failure modes. Scoped to k8s blocks
+# in _format_provision_failure_blocks to avoid false positives on cloud
+# error messages (e.g., AWS "InsufficientInstanceCapacity").
+_KUBERNETES_FAILURE_HINTS = [
     (['ImagePullBackOff', 'ErrImagePull'],
      'Verify the image tag exists and registry credentials are configured.'),
     (['OOMKilled'], 'The container ran out of memory. '
@@ -217,9 +220,9 @@ _PROVISION_FAILURE_HINTS = [
 ]
 
 
-def _get_provision_hint(reason: str) -> Optional[str]:
-    """Return a hint for the given provision failure reason, or None."""
-    for substrings, hint in _PROVISION_FAILURE_HINTS:
+def _get_kubernetes_hint(reason: str) -> Optional[str]:
+    """Return a hint for the given Kubernetes failure reason, or None."""
+    for substrings, hint in _KUBERNETES_FAILURE_HINTS:
         if any(s in reason for s in substrings):
             return hint
     return None
@@ -237,11 +240,12 @@ def _format_provision_failure_blocks(
         reason = str(exception)
         lines.append(f'\u2717 {infra} \u2014 {resource_str}')
         lines.append(f'  {reason}')
-        hint = _get_provision_hint(reason)
-        if hint:
-            lines.append(f'  Hint: {hint}')
+        if isinstance(resource.cloud, clouds.Kubernetes):
+            hint = _get_kubernetes_hint(reason)
+            if hint:
+                lines.append(f'  Hint: {hint}')
         lines.append('')
-    return '\n'.join(lines)
+    return '\n'.join(lines).rstrip() + '\n'
 
 
 # Number of seconds to wait locking the cluster before communicating with user.

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -711,9 +711,10 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
             termination_reason = _get_pod_termination_reason(pod, cluster_name)
             logger.warning(
                 f'Pod {pod.metadata.name} terminated: {termination_reason}')
+            condensed = _condensed_pod_reason(pod)
             raise config_lib.KubernetesError(
-                f'Pod {pod.metadata.name} has terminated or failed '
-                f'unexpectedly. Run `sky logs --provision {cluster_name}` '
+                f'Pod {pod.metadata.name} failed: {condensed}. '
+                f'Run `sky logs --provision {cluster_name}` '
                 'for more details.')
 
         container_statuses = pod.status.container_statuses

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -716,9 +716,7 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
                 f'Pod {pod.metadata.name} terminated: {termination_reason}')
             condensed = _condensed_pod_reason(pod)
             raise config_lib.KubernetesError(
-                f'Pod {pod.metadata.name} failed: {condensed}. '
-                f'Run `sky logs --provision {cluster_name}` '
-                'for more details.')
+                f'Pod {pod.metadata.name} failed: {condensed}')
 
         container_statuses = pod.status.container_statuses
         # Continue if pod and all the containers within the

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -753,8 +753,7 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
                             msg = waiting.message if (
                                 waiting.message) else str(waiting)
                             raise config_lib.KubernetesError(
-                                'Failed to create container while launching '
-                                f'the node. Error details: {msg}.')
+                                f'{waiting.reason}: {msg}')
         return False, reason
 
     missing_pods_retry = 0

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -5,7 +5,7 @@ import json
 import re
 import sys
 import time
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, TYPE_CHECKING, Union
 
 from sky import exceptions
 from sky import global_user_state
@@ -30,6 +30,9 @@ from sky.utils import subprocess_utils
 from sky.utils import timeline
 from sky.utils import ux_utils
 from sky.utils.db import db_utils
+
+if TYPE_CHECKING:
+    from kubernetes.client import V1Pod
 
 POLL_INTERVAL = 2
 _TIMEOUT_FOR_POD_TERMINATION = 60  # 1 minutes
@@ -2105,7 +2108,7 @@ def _get_pod_termination_reason(pod: Any, cluster_name: str) -> str:
     return pod_reason
 
 
-def _condensed_pod_reason(pod: Any) -> str:
+def _condensed_pod_reason(pod: 'V1Pod') -> str:
     """Condense pod failure into a single-line user-facing summary.
 
     Checks pod conditions and container statuses to produce a concise

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -2104,6 +2104,51 @@ def _get_pod_termination_reason(pod: Any, cluster_name: str) -> str:
     return pod_reason
 
 
+def _condensed_pod_reason(pod: Any) -> str:
+    """Condense pod failure into a single-line user-facing summary.
+
+    Checks pod conditions and container statuses to produce a concise
+    reason string suitable for display in the provision failure output.
+    """
+    # Check pod conditions for preemption/disruption (highest priority).
+    if pod.status.conditions:
+        for condition in pod.status.conditions:
+            reason = condition.reason or 'Unknown reason'
+            message = condition.message or ''
+            if condition.type == 'TerminationTarget':
+                summary = f'Preempted by Kueue: {reason}'
+                if message:
+                    summary += f' ({message})'
+                return summary
+            if condition.type == 'DisruptionTarget':
+                summary = f'Disrupted: {reason}'
+                if message:
+                    summary += f' ({message})'
+                return summary
+
+    # Check container statuses for waiting states (ImagePullBackOff, etc.).
+    if pod.status.container_statuses:
+        for cs in pod.status.container_statuses:
+            if cs.state.waiting is not None:
+                waiting = cs.state.waiting
+                if waiting.reason and waiting.reason not in (
+                        'ContainerCreating', 'PodInitializing'):
+                    msg = waiting.message or ''
+                    return f'{waiting.reason}: {msg}'.rstrip(': ')
+
+    # Check container statuses for terminated states (OOMKilled, Error, etc.).
+    if pod.status.container_statuses:
+        for cs in pod.status.container_statuses:
+            if cs.state.terminated is not None:
+                terminated = cs.state.terminated
+                if terminated.exit_code != 0:
+                    reason = (terminated.reason or
+                              f'exit({terminated.exit_code})')
+                    return f'{reason} (exit code {terminated.exit_code})'
+
+    return 'Terminated unexpectedly'
+
+
 def _get_pod_events(context: Optional[str], namespace: str,
                     pod_name: str) -> List[Any]:
     """Get the events for a pod, sorted by timestamp, most recent first."""

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -2142,9 +2142,11 @@ def _condensed_pod_reason(pod: Any) -> str:
             if cs.state.terminated is not None:
                 terminated = cs.state.terminated
                 if terminated.exit_code != 0:
-                    reason = (terminated.reason or
-                              f'exit({terminated.exit_code})')
-                    return f'{reason} (exit code {terminated.exit_code})'
+                    if terminated.reason:
+                        return (f'{terminated.reason} '
+                                f'(exit code {terminated.exit_code})')
+                    return (f'Terminated with exit code '
+                            f'{terminated.exit_code}')
 
     return 'Terminated unexpectedly'
 

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 
 from sky import clouds
+from sky import exceptions as sky_exceptions
 from sky import resources
 from sky.backends import cloud_vm_ray_backend
 from sky.provision.kubernetes import config as config_lib
@@ -1728,3 +1729,72 @@ class TestInsufficientResourcesMsg:
         assert 'Failed to acquire resources' in msg
         assert 'my-context' in msg
         assert 'OOMKilled' not in msg
+
+
+@pytest.fixture()
+def mock_format_resource(monkeypatch):
+    """Mock format_resource to avoid needing real Resources objects."""
+    monkeypatch.setattr(
+        'sky.backends.cloud_vm_ray_backend.resources_utils.format_resource',
+        lambda resource, simplified_only=False:
+        ('H100:1, cpus=4, mem=16', None))
+
+
+class TestProvisionFailureBlocks:
+    """Tests for _format_provision_failure_blocks."""
+
+    def test_single_failure_block(self, mock_format_resource):
+        resource = mock.MagicMock()
+        resource.infra.formatted_str.return_value = 'Kubernetes (in-cluster)'
+        exc = sky_exceptions.ResourcesUnavailableError(
+            'Failed to acquire resources in context in-cluster. '
+            'Reason: OOMKilled (exit code 137)')
+        result = cloud_vm_ray_backend._format_provision_failure_blocks(
+            {resource: exc})
+        assert '\u2717 Kubernetes (in-cluster)' in result
+        assert 'OOMKilled' in result
+
+    def test_hint_for_image_pull(self, mock_format_resource):
+        resource = mock.MagicMock()
+        resource.infra.formatted_str.return_value = 'Kubernetes (in-cluster)'
+        exc = sky_exceptions.ResourcesUnavailableError(
+            'Reason: ImagePullBackOff: nvcr.io/foo:bad - manifest unknown')
+        result = cloud_vm_ray_backend._format_provision_failure_blocks(
+            {resource: exc})
+        assert 'Hint:' in result
+        assert 'image' in result.lower() or 'registry' in result.lower()
+
+    def test_hint_for_oom(self, mock_format_resource):
+        resource = mock.MagicMock()
+        resource.infra.formatted_str.return_value = 'Kubernetes (in-cluster)'
+        exc = sky_exceptions.ResourcesUnavailableError(
+            'Reason: OOMKilled (exit code 137)')
+        result = cloud_vm_ray_backend._format_provision_failure_blocks(
+            {resource: exc})
+        assert 'Hint:' in result
+        assert 'memory' in result.lower()
+
+    def test_no_hint_for_unknown(self, mock_format_resource):
+        resource = mock.MagicMock()
+        resource.infra.formatted_str.return_value = 'AWS (us-east-1)'
+        exc = sky_exceptions.ResourcesUnavailableError(
+            'Failed to acquire resources in us-east-1.')
+        result = cloud_vm_ray_backend._format_provision_failure_blocks(
+            {resource: exc})
+        assert 'Hint:' not in result
+
+    def test_multiple_failures(self, mock_format_resource):
+        r1 = mock.MagicMock()
+        r1.infra.formatted_str.return_value = 'Kubernetes (in-cluster)'
+        r2 = mock.MagicMock()
+        r2.infra.formatted_str.return_value = 'AWS (us-east-1)'
+        exc1 = sky_exceptions.ResourcesUnavailableError(
+            'Reason: OOMKilled (exit code 137)')
+        exc2 = sky_exceptions.ResourcesUnavailableError(
+            'No capacity in us-east-1.')
+        result = cloud_vm_ray_backend._format_provision_failure_blocks({
+            r1: exc1,
+            r2: exc2
+        })
+        assert '\u2717 Kubernetes (in-cluster)' in result
+        assert '\u2717 AWS (us-east-1)' in result

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -1743,9 +1743,20 @@ def mock_format_resource(monkeypatch):
 class TestProvisionFailureBlocks:
     """Tests for _format_provision_failure_blocks."""
 
-    def test_single_failure_block(self, mock_format_resource):
+    def _make_k8s_resource(self, infra_str='Kubernetes (in-cluster)'):
         resource = mock.MagicMock()
-        resource.infra.formatted_str.return_value = 'Kubernetes (in-cluster)'
+        resource.infra.formatted_str.return_value = infra_str
+        resource.cloud = clouds.Kubernetes()
+        return resource
+
+    def _make_aws_resource(self, infra_str='AWS (us-east-1)'):
+        resource = mock.MagicMock()
+        resource.infra.formatted_str.return_value = infra_str
+        resource.cloud = clouds.AWS()
+        return resource
+
+    def test_single_failure_block(self, mock_format_resource):
+        resource = self._make_k8s_resource()
         exc = sky_exceptions.ResourcesUnavailableError(
             'Failed to acquire resources in context in-cluster. '
             'Reason: OOMKilled (exit code 137)')
@@ -1755,8 +1766,7 @@ class TestProvisionFailureBlocks:
         assert 'OOMKilled' in result
 
     def test_hint_for_image_pull(self, mock_format_resource):
-        resource = mock.MagicMock()
-        resource.infra.formatted_str.return_value = 'Kubernetes (in-cluster)'
+        resource = self._make_k8s_resource()
         exc = sky_exceptions.ResourcesUnavailableError(
             'Reason: ImagePullBackOff: nvcr.io/foo:bad - manifest unknown')
         result = cloud_vm_ray_backend._format_provision_failure_blocks(
@@ -1765,8 +1775,7 @@ class TestProvisionFailureBlocks:
         assert 'image' in result.lower() or 'registry' in result.lower()
 
     def test_hint_for_oom(self, mock_format_resource):
-        resource = mock.MagicMock()
-        resource.infra.formatted_str.return_value = 'Kubernetes (in-cluster)'
+        resource = self._make_k8s_resource()
         exc = sky_exceptions.ResourcesUnavailableError(
             'Reason: OOMKilled (exit code 137)')
         result = cloud_vm_ray_backend._format_provision_failure_blocks(
@@ -1774,20 +1783,32 @@ class TestProvisionFailureBlocks:
         assert 'Hint:' in result
         assert 'memory' in result.lower()
 
-    def test_no_hint_for_unknown(self, mock_format_resource):
-        resource = mock.MagicMock()
-        resource.infra.formatted_str.return_value = 'AWS (us-east-1)'
+    def test_no_hint_for_unknown_k8s_failure(self, mock_format_resource):
+        """K8s block with no recognized failure substring gets no hint."""
+        resource = self._make_k8s_resource()
         exc = sky_exceptions.ResourcesUnavailableError(
-            'Failed to acquire resources in us-east-1.')
+            'Some unrecognized cluster failure.')
         result = cloud_vm_ray_backend._format_provision_failure_blocks(
             {resource: exc})
         assert 'Hint:' not in result
 
-    def test_multiple_failures(self, mock_format_resource):
-        r1 = mock.MagicMock()
-        r1.infra.formatted_str.return_value = 'Kubernetes (in-cluster)'
-        r2 = mock.MagicMock()
-        r2.infra.formatted_str.return_value = 'AWS (us-east-1)'
+    def test_no_hint_for_non_k8s_cloud(self, mock_format_resource):
+        """Hints don't fire for non-k8s clouds even if substring matches.
+
+        Prevents AWS messages like 'InsufficientInstanceCapacity' from
+        triggering the k8s 'kubectl describe nodes' hint.
+        """
+        resource = self._make_aws_resource()
+        exc = sky_exceptions.ResourcesUnavailableError(
+            'InsufficientInstanceCapacity: no A100 capacity in us-east-1.')
+        result = cloud_vm_ray_backend._format_provision_failure_blocks(
+            {resource: exc})
+        assert 'Hint:' not in result
+        assert 'kubectl' not in result
+
+    def test_multiple_failures_mixed_clouds(self, mock_format_resource):
+        r1 = self._make_k8s_resource()
+        r2 = self._make_aws_resource()
         exc1 = sky_exceptions.ResourcesUnavailableError(
             'Reason: OOMKilled (exit code 137)')
         exc2 = sky_exceptions.ResourcesUnavailableError(
@@ -1798,6 +1819,8 @@ class TestProvisionFailureBlocks:
         })
         assert '\u2717 Kubernetes (in-cluster)' in result
         assert '\u2717 AWS (us-east-1)' in result
+        # K8s block has the OOM hint
+        assert 'memory' in result.lower()
 
 
 class TestFullPipeline:

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -1670,6 +1670,18 @@ class TestCondensedPodReason:
         assert 'Error' in result
         assert 'exit code 1' in result
 
+    def test_terminated_no_reason(self):
+        """When terminated.reason is None, should show exit code cleanly."""
+        container = mock.MagicMock()
+        container.state.waiting = None
+        container.state.terminated = mock.MagicMock()
+        container.state.terminated.reason = None
+        container.state.terminated.exit_code = 137
+        pod = _make_mock_pod(conditions=[_make_condition('Ready', 'False')],
+                             container_statuses=[container])
+        result = instance._condensed_pod_reason(pod)
+        assert result == 'Terminated with exit code 137'
+
     def test_unknown_fallback(self):
         pod = _make_mock_pod(conditions=[_make_condition('Ready', 'False')],
                              container_statuses=[])

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -1743,10 +1743,13 @@ def mock_format_resource(monkeypatch):
 class TestProvisionFailureBlocks:
     """Tests for _format_provision_failure_blocks."""
 
-    def _make_k8s_resource(self, infra_str='Kubernetes (in-cluster)'):
+    def _make_k8s_resource(self,
+                           infra_str='Kubernetes (in-cluster)',
+                           region='in-cluster'):
         resource = mock.MagicMock()
         resource.infra.formatted_str.return_value = infra_str
         resource.cloud = clouds.Kubernetes()
+        resource.region = region
         return resource
 
     def _make_aws_resource(self, infra_str='AWS (us-east-1)'):
@@ -1783,6 +1786,23 @@ class TestProvisionFailureBlocks:
         assert 'Hint:' in result
         assert 'memory' in result.lower()
 
+    def test_hint_for_insufficient_includes_url_and_kubectl(
+            self, mock_format_resource, monkeypatch):
+        """Insufficient hint links the dashboard infra page scoped to the
+        failing context and also mentions `kubectl describe nodes`."""
+        monkeypatch.setattr(
+            'sky.backends.cloud_vm_ray_backend.server_common.get_server_url',
+            lambda: 'http://api.example.com')
+        resource = self._make_k8s_resource(region='my-cluster-context')
+        exc = sky_exceptions.ResourcesUnavailableError(
+            'Reason: Insufficient nvidia.com/gpu')
+        result = cloud_vm_ray_backend._format_provision_failure_blocks(
+            {resource: exc})
+        assert 'Hint:' in result
+        assert 'kubectl describe nodes' in result
+        assert ('http://api.example.com/dashboard/infra/my-cluster-context'
+                in result)
+
     def test_no_hint_for_unknown_k8s_failure(self, mock_format_resource):
         """K8s block with no recognized failure substring gets no hint."""
         resource = self._make_k8s_resource()
@@ -1796,7 +1816,7 @@ class TestProvisionFailureBlocks:
         """Hints don't fire for non-k8s clouds even if substring matches.
 
         Prevents AWS messages like 'InsufficientInstanceCapacity' from
-        triggering the k8s 'kubectl describe nodes' hint.
+        triggering the k8s insufficient-resources hint.
         """
         resource = self._make_aws_resource()
         exc = sky_exceptions.ResourcesUnavailableError(
@@ -1804,7 +1824,7 @@ class TestProvisionFailureBlocks:
         result = cloud_vm_ray_backend._format_provision_failure_blocks(
             {resource: exc})
         assert 'Hint:' not in result
-        assert 'kubectl' not in result
+        assert 'dashboard' not in result
 
     def test_multiple_failures_mixed_clouds(self, mock_format_resource):
         r1 = self._make_k8s_resource()

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -1803,6 +1803,30 @@ class TestProvisionFailureBlocks:
         assert ('http://api.example.com/dashboard/infra/my-cluster-context'
                 in result)
 
+    def test_hint_falls_back_when_url_resolution_fails(self,
+                                                       mock_format_resource,
+                                                       monkeypatch):
+        """If get_server_url raises, the hint should still render (with a
+        generic fallback) rather than crash the failure-rendering path."""
+
+        def _boom():
+            raise RuntimeError('no api server endpoint configured')
+
+        monkeypatch.setattr(
+            'sky.backends.cloud_vm_ray_backend.server_common.get_server_url',
+            _boom)
+        resource = self._make_k8s_resource(region='my-cluster-context')
+        exc = sky_exceptions.ResourcesUnavailableError(
+            'Reason: Insufficient nvidia.com/gpu')
+        result = cloud_vm_ray_backend._format_provision_failure_blocks(
+            {resource: exc})
+        assert 'Hint:' in result
+        assert 'kubectl describe nodes' in result
+        # Generic fallback text used when URL resolution fails.
+        assert 'SkyPilot dashboard infra page' in result
+        # Placeholder must not leak through.
+        assert '{dashboard_url}' not in result
+
     def test_no_hint_for_unknown_k8s_failure(self, mock_format_resource):
         """K8s block with no recognized failure substring gets no hint."""
         resource = self._make_k8s_resource()

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -1556,3 +1556,122 @@ class TestWaitForPodsToScheduleAutoscaleTimeout:
         assert clock.now < instance._AUTOSCALE_INITIAL_MIN_TIMEOUT_SECONDS, (
             f'No autoscaler configured → short user timeout must not be '
             f'bumped, but loop ran for {clock.now}s.')
+
+
+# ---------------------------------------------------------------------------
+# Helpers and tests for _condensed_pod_reason()
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_pod(phase='Failed',
+                   deletion_timestamp=None,
+                   conditions=None,
+                   container_statuses=None,
+                   init_container_statuses=None):
+    """Helper to build a mock pod with the given status fields."""
+    pod = mock.MagicMock()
+    pod.metadata.name = 'test-pod'
+    pod.metadata.deletion_timestamp = deletion_timestamp
+    pod.status.phase = phase
+    pod.status.start_time = None
+    pod.status.conditions = conditions or []
+    pod.status.container_statuses = container_statuses or []
+    pod.status.init_container_statuses = init_container_statuses or []
+    return pod
+
+
+def _make_condition(type_,
+                    reason,
+                    message='',
+                    status='True',
+                    last_transition_time=None):
+    cond = mock.MagicMock()
+    cond.type = type_
+    cond.reason = reason
+    cond.message = message
+    cond.status = status
+    cond.last_transition_time = last_transition_time
+    return cond
+
+
+def _make_container_status(name='main',
+                           terminated_reason=None,
+                           terminated_exit_code=None,
+                           terminated_finished_at=None,
+                           waiting_reason=None,
+                           waiting_message=None):
+    cs = mock.MagicMock()
+    cs.name = name
+    cs.state.terminated = None
+    cs.state.waiting = None
+    if terminated_reason is not None:
+        cs.state.terminated = mock.MagicMock()
+        cs.state.terminated.reason = terminated_reason
+        cs.state.terminated.exit_code = terminated_exit_code or 1
+        cs.state.terminated.finished_at = terminated_finished_at
+        cs.state.terminated.message = None
+    if waiting_reason is not None:
+        cs.state.waiting = mock.MagicMock()
+        cs.state.waiting.reason = waiting_reason
+        cs.state.waiting.message = waiting_message
+    return cs
+
+
+class TestCondensedPodReason:
+    """Tests for _condensed_pod_reason()."""
+
+    def test_oom_killed(self):
+        container = _make_container_status(terminated_reason='OOMKilled',
+                                           terminated_exit_code=137)
+        pod = _make_mock_pod(conditions=[_make_condition('Ready', 'False')],
+                             container_statuses=[container])
+        result = instance._condensed_pod_reason(pod)
+        assert 'OOMKilled' in result
+        assert '137' in result
+
+    def test_kueue_preemption(self):
+        conditions = [
+            _make_condition('Ready', 'False'),
+            _make_condition('TerminationTarget', 'PreemptedByWorkloadPriority',
+                            'Higher priority workload scheduled'),
+        ]
+        pod = _make_mock_pod(conditions=conditions)
+        result = instance._condensed_pod_reason(pod)
+        assert 'Preempted by Kueue' in result
+        assert 'PreemptedByWorkloadPriority' in result
+
+    def test_disruption(self):
+        conditions = [
+            _make_condition('Ready', 'False'),
+            _make_condition('DisruptionTarget', 'EvictionByKueue',
+                            'Preempted to accommodate a higher priority'),
+        ]
+        pod = _make_mock_pod(conditions=conditions)
+        result = instance._condensed_pod_reason(pod)
+        assert 'Disrupted' in result
+
+    def test_image_pull_backoff_from_waiting(self):
+        container = _make_container_status(
+            waiting_reason='ImagePullBackOff',
+            waiting_message='Back-off pulling image "nvcr.io/foo:bad"')
+        pod = _make_mock_pod(phase='Failed',
+                             conditions=[_make_condition('Ready', 'False')],
+                             container_statuses=[container])
+        result = instance._condensed_pod_reason(pod)
+        assert 'ImagePullBackOff' in result
+        assert 'nvcr.io/foo:bad' in result
+
+    def test_crash_loop_from_terminated(self):
+        container = _make_container_status(terminated_reason='Error',
+                                           terminated_exit_code=1)
+        pod = _make_mock_pod(conditions=[_make_condition('Ready', 'False')],
+                             container_statuses=[container])
+        result = instance._condensed_pod_reason(pod)
+        assert 'Error' in result
+        assert 'exit code 1' in result
+
+    def test_unknown_fallback(self):
+        pod = _make_mock_pod(conditions=[_make_condition('Ready', 'False')],
+                             container_statuses=[])
+        result = instance._condensed_pod_reason(pod)
+        assert 'Terminated unexpectedly' in result

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -1687,3 +1687,44 @@ class TestCondensedPodReason:
                              container_statuses=[])
         result = instance._condensed_pod_reason(pod)
         assert 'Terminated unexpectedly' in result
+
+
+class TestInsufficientResourcesMsg:
+    """Tests for _insufficient_resources_msg with last_error_reason."""
+
+    def _make_provisioner(self):
+        provisioner = cloud_vm_ray_backend.RetryingVmProvisioner.__new__(
+            cloud_vm_ray_backend.RetryingVmProvisioner)
+        return provisioner
+
+    def test_includes_error_reason_for_k8s(self):
+        provisioner = self._make_provisioner()
+        k8s_resource = mock.MagicMock()
+        k8s_resource.zone = None
+        k8s_resource.region = 'my-context'
+        k8s_resource.cloud = clouds.Kubernetes()
+        requested = {k8s_resource}
+
+        msg = provisioner._insufficient_resources_msg(
+            k8s_resource,
+            requested,
+            None,
+            last_error_reason='OOMKilled (exit code 137)')
+        assert 'OOMKilled (exit code 137)' in msg
+        assert 'my-context' in msg
+
+    def test_no_error_reason_falls_back(self):
+        provisioner = self._make_provisioner()
+        k8s_resource = mock.MagicMock()
+        k8s_resource.zone = None
+        k8s_resource.region = 'my-context'
+        k8s_resource.cloud = clouds.Kubernetes()
+        requested = {k8s_resource}
+
+        msg = provisioner._insufficient_resources_msg(k8s_resource,
+                                                      requested,
+                                                      None,
+                                                      last_error_reason=None)
+        assert 'Failed to acquire resources' in msg
+        assert 'my-context' in msg
+        assert 'OOMKilled' not in msg

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -1798,3 +1798,60 @@ class TestProvisionFailureBlocks:
         })
         assert '\u2717 Kubernetes (in-cluster)' in result
         assert '\u2717 AWS (us-east-1)' in result
+
+
+class TestFullPipeline:
+    """Integration test: KubernetesError message → retry loop → block output."""
+
+    def test_oom_reason_reaches_block_output(self, mock_format_resource):
+        """Verify OOMKilled flows from exception through to block rendering."""
+        k8s_error = config_lib.KubernetesError(
+            'Pod test-pod failed: OOMKilled (exit code 137). '
+            'Run `sky logs --provision test-cluster` for more details.')
+        last_error_reason = str(k8s_error)
+
+        backend = cloud_vm_ray_backend.RetryingVmProvisioner.__new__(
+            cloud_vm_ray_backend.RetryingVmProvisioner)
+        k8s_resource = mock.MagicMock()
+        k8s_resource.zone = None
+        k8s_resource.region = 'my-context'
+        k8s_resource.cloud = clouds.Kubernetes()
+        msg = backend._insufficient_resources_msg(
+            k8s_resource, {k8s_resource},
+            None,
+            last_error_reason=last_error_reason)
+
+        exc = sky_exceptions.ResourcesUnavailableError(msg)
+        blocks = cloud_vm_ray_backend._format_provision_failure_blocks(
+            {k8s_resource: exc})
+        assert 'OOMKilled' in blocks
+        assert 'exit code 137' in blocks
+        assert 'Hint:' in blocks
+        assert 'memory' in blocks.lower()
+
+    def test_image_pull_reason_reaches_block_output(self, mock_format_resource):
+        """Verify ImagePullBackOff flows end-to-end."""
+        k8s_error = config_lib.KubernetesError(
+            'Pod test-pod failed: ImagePullBackOff: '
+            'Back-off pulling image "nvcr.io/nvidia/pytorch:bad-tag". '
+            'Run `sky logs --provision test-cluster` for more details.')
+        last_error_reason = str(k8s_error)
+
+        backend = cloud_vm_ray_backend.RetryingVmProvisioner.__new__(
+            cloud_vm_ray_backend.RetryingVmProvisioner)
+        k8s_resource = mock.MagicMock()
+        k8s_resource.zone = None
+        k8s_resource.region = 'my-context'
+        k8s_resource.cloud = clouds.Kubernetes()
+        msg = backend._insufficient_resources_msg(
+            k8s_resource, {k8s_resource},
+            None,
+            last_error_reason=last_error_reason)
+
+        exc = sky_exceptions.ResourcesUnavailableError(msg)
+        blocks = cloud_vm_ray_backend._format_provision_failure_blocks(
+            {k8s_resource: exc})
+        assert 'ImagePullBackOff' in blocks
+        assert 'nvcr.io/nvidia/pytorch:bad-tag' in blocks
+        assert 'Hint:' in blocks
+        assert 'image' in blocks.lower() or 'registry' in blocks.lower()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

## Summary

When `sky launch` fails on Kubernetes, the CLI's "Reasons for provision failures" table previously showed a generic `Failed to acquire resources in context X for {...}` message — leaving users to guess whether it was a bad image tag, no GPU capacity, OOM, or something else. The detection logic for specific failure modes already existed in `sky/provision/kubernetes/instance.py` but the information was lost at two plumbing points before reaching the user.

This PR fixes both gaps and replaces the table with a block format that scales with multi-line reasons.

**Before:**
```
INFRA                    RESOURCES                           REASON
Kubernetes (in-cluster)  (gpus=H100:1, cpus=4, mem=16, ...)  Failed to acquire resources in context in-cluster for {Kubernetes({'H100': 1},
                                                             image_id=docker:nvcr.io/nvidia/pytorch:26.01-py3-igpu)}.
```

**After (real output from a real cluster with a bad image):**
```
Provision failures (tried 1 infra):

✗ Kubernetes (my-cluster) — (cpus=1, mem=1, ...)
  Failed to acquire resources in context my-cluster for {Kubernetes(cpus=1, mem=1, ...)}.
  Reason: ErrImagePull: rpc error: code = NotFound desc = failed to pull and unpack image
  "nvcr.io/nvidia/pytorch:bad-tag": failed to resolve reference: not found
  Hint: Verify the image tag exists and registry credentials are configured.
```

## Key technical decisions

- **Two loss points, two fixes.** (1) The `KubernetesError` raised when a pod terminates now includes a condensed reason via a new `_condensed_pod_reason()` helper. (2) The retry loop in `cloud_vm_ray_backend.py` now extracts the error message into `last_error_reason` (same pattern as the existing `insufficient_resources` extraction) and threads it through `_insufficient_resources_msg()` into the final `ResourcesUnavailableError`.
- **Hints scoped to k8s blocks.** A small substring → hint map covers ImagePullBackOff/ErrImagePull, OOMKilled, and Insufficient resources. Scoped via `isinstance(resource.cloud, clouds.Kubernetes)` so AWS messages like `InsufficientInstanceCapacity` don't falsely trigger a `kubectl describe nodes` hint.
- **Block format applies to all clouds.** The PrettyTable rendering is replaced for everyone — non-k8s clouds see the same generic message as before, just reformatted from a table cell into a block. No quality change for those clouds; the same `last_error_reason` plumbing can be extended to GCP/AWS in a follow-up.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

## Test plan

- [x] **Unit tests:** 57 tests in `tests/unit_tests/kubernetes/test_provision.py` cover `_condensed_pod_reason` (each failure category + fallback), `_insufficient_resources_msg` (with/without `last_error_reason`), `_format_provision_failure_blocks` (single block, hints firing/not firing per cloud, multi-cloud mixing), and an end-to-end pipeline simulation.
- [x] **Backend regression:** all 57 tests in `tests/unit_tests/test_sky/backends/` pass.
- [x] **Real cluster — single infra:** triggered ImagePullBackOff with a bad image tag → block format renders, `ErrImagePull:` reason prefixed, hint fires.
- [x] **Real cluster — multi-infra failover (two k8s contexts):** same launch tried on both contexts → two distinct blocks with their own reasons and hints; single `View logs:` line above; no duplicate `sky logs --provision` trailers.
- [x] Code formatting: pre-commit hooks (yapf, isort, mypy, pylint) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)