### PR TITLE
[Dashboard][Volumes] Plugin-extendable columns, imported-PVC delete notice, purge, auto-mount metadata

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -978,6 +978,7 @@ def write_cluster_config(
             default_value=None)
         if auto_mounts_config:
             home_dir = kubernetes_utils.DEFAULT_HOME_DIRECTORY
+            attached_auto_mount_volumes: Set[str] = set()
             for entry in auto_mounts_config:
                 volume_name = entry['volume_name']
                 mount_paths = entry.get('mount_paths', [])
@@ -1003,17 +1004,6 @@ def write_cluster_config(
                         f'ReadWriteMany PVC volumes are supported for '
                         f'auto_mounts. Skipping.')
                     continue
-                # Mirror the explicit `volume_mounts` path (see
-                # `VolumeMount.pre_mount`): record the attachment timestamp
-                # and IN_USE status so the Volumes dashboard surfaces the
-                # "Last Use" column correctly for auto-mounted volumes.
-                # Skip on dryrun so `sky launch --dryrun` does not mutate
-                # volume metadata.
-                if not dryrun:
-                    global_user_state.update_volume(
-                        volume_name,
-                        last_attached_at=int(time.time()),
-                        status=status_lib.VolumeStatus.IN_USE)
                 for path in mount_paths:
                     if path.startswith('/'):
                         mount_path = path
@@ -1037,6 +1027,22 @@ def write_cluster_config(
                         source='auto_mounts config',
                         volume_desc=f'auto-mount volume {volume_name!r}')
                     volume_mount_vars.append(vol_info)
+                    attached_auto_mount_volumes.add(volume_name)
+            # Mirror the explicit `volume_mounts` path (see
+            # `VolumeMount.pre_mount`): record the attachment timestamp and
+            # IN_USE status so the Volumes dashboard surfaces the "Last
+            # Use" column correctly for auto-mounted volumes. Run this
+            # after the loop so that a conflict raised by
+            # `conflict_checker.check` leaves volume metadata untouched.
+            # Skip on dryrun so `sky launch --dryrun` does not mutate
+            # volume metadata.
+            if not dryrun and attached_auto_mount_volumes:
+                now = int(time.time())
+                for vol_name in attached_auto_mount_volumes:
+                    global_user_state.update_volume(
+                        vol_name,
+                        last_attached_at=now,
+                        status=status_lib.VolumeStatus.IN_USE)
 
     runcmd = skypilot_config.get_effective_region_config(
         cloud=str(to_provision.cloud).lower(),

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1003,6 +1003,14 @@ def write_cluster_config(
                         f'ReadWriteMany PVC volumes are supported for '
                         f'auto_mounts. Skipping.')
                     continue
+                # Mirror the explicit `volume_mounts` path (see
+                # `VolumeMount.pre_mount`): record the attachment timestamp
+                # and IN_USE status so the Volumes dashboard surfaces the
+                # "Last Use" column correctly for auto-mounted volumes.
+                global_user_state.update_volume(
+                    volume_name,
+                    last_attached_at=int(time.time()),
+                    status=status_lib.VolumeStatus.IN_USE)
                 for path in mount_paths:
                     if path.startswith('/'):
                         mount_path = path

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1007,10 +1007,13 @@ def write_cluster_config(
                 # `VolumeMount.pre_mount`): record the attachment timestamp
                 # and IN_USE status so the Volumes dashboard surfaces the
                 # "Last Use" column correctly for auto-mounted volumes.
-                global_user_state.update_volume(
-                    volume_name,
-                    last_attached_at=int(time.time()),
-                    status=status_lib.VolumeStatus.IN_USE)
+                # Skip on dryrun so `sky launch --dryrun` does not mutate
+                # volume metadata.
+                if not dryrun:
+                    global_user_state.update_volume(
+                        volume_name,
+                        last_attached_at=int(time.time()),
+                        status=status_lib.VolumeStatus.IN_USE)
                 for path in mount_paths:
                     if path.startswith('/'):
                         mount_path = path

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -157,6 +157,11 @@ export function Volumes() {
     setPurgeConfirmed(false);
   };
 
+  const handleBackFromPurge = () => {
+    setShowPurgeUI(false);
+    setPurgeConfirmed(false);
+  };
+
   useEffect(() => {
     const preloadData = async () => {
       try {
@@ -256,15 +261,28 @@ export function Volumes() {
           >
             <DialogContent className="sm:max-w-md">
               <DialogHeader>
-                <DialogTitle>Delete Volume</DialogTitle>
+                <DialogTitle>
+                  {showPurgeUI ? 'Force remove volume' : 'Delete Volume'}
+                </DialogTitle>
                 <DialogDescription>
-                  Are you sure you want to delete volume &quot;
-                  {volumeToDelete?.name || 'this volume'}&quot;? This action
-                  cannot be undone.
+                  {showPurgeUI ? (
+                    <>
+                      Remove &quot;
+                      {volumeToDelete?.name || 'this volume'}&quot; from
+                      SkyPilot records. The underlying volume will not be
+                      deleted.
+                    </>
+                  ) : (
+                    <>
+                      Are you sure you want to delete volume &quot;
+                      {volumeToDelete?.name || 'this volume'}&quot;? This
+                      action cannot be undone.
+                    </>
+                  )}
                 </DialogDescription>
               </DialogHeader>
 
-              {volumeToDelete?.config?.use_existing && (
+              {!showPurgeUI && volumeToDelete?.config?.use_existing && (
                 <div className="bg-sky-50 border border-sky-200 rounded-md p-3 my-3 flex items-start gap-2">
                   <AlertTriangleIcon className="w-4 h-4 text-sky-600 mt-0.5 flex-shrink-0" />
                   <div className="text-sm text-sky-900">
@@ -297,20 +315,12 @@ export function Volumes() {
                 </div>
               )}
 
-              <ErrorDisplay
-                error={deleteError}
-                title="Deletion Failed"
-                onDismiss={() => setDeleteError(null)}
-              />
-
-              {deleteError && !showPurgeUI && (
-                <button
-                  type="button"
-                  onClick={() => setShowPurgeUI(true)}
-                  className="text-sm text-amber-700 hover:text-amber-800 underline self-start bg-transparent border-0 p-0 cursor-pointer"
-                >
-                  Force remove from SkyPilot records
-                </button>
+              {!showPurgeUI && (
+                <ErrorDisplay
+                  error={deleteError}
+                  title="Deletion Failed"
+                  onDismiss={() => setDeleteError(null)}
+                />
               )}
 
               {showPurgeUI && (
@@ -318,9 +328,6 @@ export function Volumes() {
                   <AlertTriangleIcon className="w-4 h-4 text-amber-600 mt-0.5 flex-shrink-0" />
                   <div className="text-sm text-amber-800 space-y-2">
                     <p className="m-0">
-                      <strong>
-                        Force remove won&apos;t delete the underlying volume.
-                      </strong>{' '}
                       Removing the SkyPilot entry means this volume will no
                       longer appear here, but{' '}
                       {volumeToDelete?.type === 'k8s-pvc' &&
@@ -377,36 +384,50 @@ export function Volumes() {
               )}
 
               <DialogFooter>
-                <Button
-                  variant="outline"
-                  onClick={handleCancelDelete}
-                  disabled={deleteLoading || purgeLoading}
-                >
-                  Cancel
-                </Button>
                 {!showPurgeUI && (
-                  <Button
-                    variant="destructive"
-                    onClick={handleDeleteVolumeConfirm}
-                    disabled={deleteLoading}
-                  >
-                    {deleteLoading ? 'Deleting...' : 'Delete'}
-                  </Button>
+                  <>
+                    <Button
+                      variant="outline"
+                      onClick={handleCancelDelete}
+                      disabled={deleteLoading}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      variant="destructive"
+                      onClick={handleDeleteVolumeConfirm}
+                      disabled={deleteLoading}
+                    >
+                      {deleteLoading
+                        ? 'Deleting...'
+                        : deleteError
+                          ? 'Retry Delete'
+                          : 'Delete'}
+                    </Button>
+                    {deleteError && (
+                      <Button
+                        variant="outline"
+                        onClick={() => setShowPurgeUI(true)}
+                        disabled={deleteLoading}
+                        className="border-amber-600 text-amber-700 hover:bg-amber-50 hover:text-amber-800"
+                      >
+                        Force remove
+                      </Button>
+                    )}
+                  </>
                 )}
                 {showPurgeUI && (
                   <>
                     <Button
-                      variant="destructive"
-                      onClick={handleDeleteVolumeConfirm}
-                      disabled={deleteLoading || purgeLoading}
+                      variant="outline"
+                      onClick={handleBackFromPurge}
+                      disabled={purgeLoading}
                     >
-                      {deleteLoading ? 'Deleting...' : 'Retry Delete'}
+                      Back
                     </Button>
                     <Button
                       onClick={handlePurgeVolumeConfirm}
-                      disabled={
-                        !purgeConfirmed || deleteLoading || purgeLoading
-                      }
+                      disabled={!purgeConfirmed || purgeLoading}
                       className="bg-amber-600 hover:bg-amber-700 text-white"
                     >
                       {purgeLoading ? 'Removing...' : 'Force Remove'}

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -59,6 +59,7 @@ export function Volumes() {
   const [preloadingComplete, setPreloadingComplete] = useState(false);
   const [lastFetchedTime, setLastFetchedTime] = useState(null);
   const [activeTab, setActiveTab] = useState('volumes');
+  const [volumesData, setVolumesData] = useState([]);
   const pluginTabs = usePluginComponents('volumes.tabs');
 
   const handleTabChange = useCallback(
@@ -226,7 +227,10 @@ export function Volumes() {
             </button>
             <PluginSlot
               name="volumes.header-actions"
-              context={{ onVolumeChange: handleRefresh }}
+              context={{
+                onVolumeChange: handleRefresh,
+                volumes: volumesData,
+              }}
               wrapperClassName="contents"
             />
           </div>
@@ -241,6 +245,7 @@ export function Volumes() {
             setLoading={setLoading}
             refreshDataRef={refreshDataRef}
             onDeleteVolume={handleDeleteVolumeClick}
+            onDataChange={setVolumesData}
             preloadingComplete={preloadingComplete}
           />
 
@@ -427,6 +432,7 @@ function VolumesTable({
   setLoading,
   refreshDataRef,
   onDeleteVolume,
+  onDataChange,
   preloadingComplete,
 }) {
   const [data, setData] = useState([]);
@@ -445,15 +451,21 @@ function VolumesTable({
     try {
       const volumesData = await dashboardCache.get(getVolumes);
       setData(volumesData);
+      if (onDataChange) {
+        onDataChange(volumesData);
+      }
     } catch (error) {
       console.error('Failed to fetch volumes:', error);
       setData([]);
+      if (onDataChange) {
+        onDataChange([]);
+      }
     } finally {
       setLoading(false);
       setLocalLoading(false);
       setIsInitialLoad(false);
     }
-  }, [setLoading]);
+  }, [setLoading, onDataChange]);
 
   // Use useMemo to compute sorted data
   const sortedData = useMemo(() => {
@@ -925,5 +937,6 @@ VolumesTable.propTypes = {
     current: PropTypes.func,
   }).isRequired,
   onDeleteVolume: PropTypes.func.isRequired,
+  onDataChange: PropTypes.func,
   preloadingComplete: PropTypes.bool.isRequired,
 };

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -662,7 +662,7 @@ function VolumesTable({
     isPlugin: true,
     renderHeader: () => {
       const baseClasses = col.header.sortKey
-        ? 'sortable whitespace-nowrap'
+        ? 'sortable whitespace-nowrap cursor-pointer hover:bg-gray-50'
         : 'whitespace-nowrap';
       const className = `${baseClasses}${col.header.className ? ' ' + col.header.className : ''}`;
       return (

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -263,7 +263,7 @@ export function Volumes() {
               </DialogHeader>
 
               {volumeToDelete?.config?.use_existing && (
-                <div className="bg-sky-50 border border-sky-200 rounded-md p-3 flex items-start gap-2">
+                <div className="bg-sky-50 border border-sky-200 rounded-md p-3 my-3 flex items-start gap-2">
                   <AlertTriangleIcon className="w-4 h-4 text-sky-600 mt-0.5 flex-shrink-0" />
                   <div className="text-sm text-sky-900">
                     This volume was imported from an existing{' '}

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -280,7 +280,9 @@ export function Volumes() {
                   <AlertTriangleIcon className="w-4 h-4 text-amber-600 mt-0.5 flex-shrink-0" />
                   <div className="text-sm text-amber-800 space-y-2">
                     <p className="m-0">
-                      <strong>Force remove won&apos;t delete the underlying volume.</strong>{' '}
+                      <strong>
+                        Force remove won&apos;t delete the underlying volume.
+                      </strong>{' '}
                       Removing the SkyPilot entry means this volume will no
                       longer appear here, but{' '}
                       {volumeToDelete?.type === 'k8s-pvc' &&
@@ -293,7 +295,8 @@ export function Volumes() {
                           {volumeToDelete.namespace &&
                             volumeToDelete.namespace !== '-' && (
                               <>
-                                {' '}in namespace{' '}
+                                {' '}
+                                in namespace{' '}
                                 <code className="bg-amber-100 px-1 rounded">
                                   {volumeToDelete.namespace}
                                 </code>
@@ -363,7 +366,9 @@ export function Volumes() {
                     </Button>
                     <Button
                       onClick={handlePurgeVolumeConfirm}
-                      disabled={!purgeConfirmed || deleteLoading || purgeLoading}
+                      disabled={
+                        !purgeConfirmed || deleteLoading || purgeLoading
+                      }
                       className="bg-amber-600 hover:bg-amber-700 text-white"
                     >
                       {purgeLoading ? 'Removing...' : 'Force Remove'}

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -38,10 +38,7 @@ import { useRouter } from 'next/router';
 import { TimestampWithTooltip, LastUpdatedTimestamp } from '@/components/utils';
 import { StatusBadge } from '@/components/elements/StatusBadge';
 import { PluginSlot } from '@/plugins/PluginSlot';
-import {
-  usePluginComponents,
-  useTableColumns,
-} from '@/plugins/PluginProvider';
+import { usePluginComponents, useTableColumns } from '@/plugins/PluginProvider';
 import dashboardCache from '@/lib/cache';
 import cachePreloader from '@/lib/cache-preloader';
 
@@ -267,10 +264,8 @@ export function Volumes() {
                   <AlertTriangleIcon className="w-4 h-4 text-sky-600 mt-0.5 flex-shrink-0" />
                   <div className="text-sm text-sky-900">
                     This volume was imported from an existing{' '}
-                    {volumeToDelete?.type === 'k8s-pvc'
-                      ? 'PVC'
-                      : 'resource'}
-                    . Deleting it only removes it from SkyPilot
+                    {volumeToDelete?.type === 'k8s-pvc' ? 'PVC' : 'resource'}.
+                    Deleting it only removes it from SkyPilot
                     {volumeToDelete?.type === 'k8s-pvc' &&
                     volumeToDelete?.name_on_cloud ? (
                       <>

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -21,7 +21,7 @@ import {
 import { getVolumes, deleteVolume } from '@/data/connectors/volumes';
 import { REFRESH_INTERVALS } from '@/lib/config';
 import { sortData } from '@/data/utils';
-import { RotateCwIcon, Trash2Icon } from 'lucide-react';
+import { RotateCwIcon, Trash2Icon, AlertTriangleIcon } from 'lucide-react';
 import { useMobile } from '@/hooks/useMobile';
 import { Card } from '@/components/ui/card';
 import {
@@ -53,6 +53,9 @@ export function Volumes() {
   const [volumeToDelete, setVolumeToDelete] = useState(null);
   const [deleteError, setDeleteError] = useState(null);
   const [deleteLoading, setDeleteLoading] = useState(false);
+  const [showPurgeUI, setShowPurgeUI] = useState(false);
+  const [purgeConfirmed, setPurgeConfirmed] = useState(false);
+  const [purgeLoading, setPurgeLoading] = useState(false);
   const [preloadingComplete, setPreloadingComplete] = useState(false);
   const [lastFetchedTime, setLastFetchedTime] = useState(null);
   const [activeTab, setActiveTab] = useState('volumes');
@@ -95,6 +98,8 @@ export function Volumes() {
     setVolumeToDelete(volume);
     setShowDeleteConfirmDialog(true);
     setDeleteError(null);
+    setShowPurgeUI(false);
+    setPurgeConfirmed(false);
   };
 
   const handleDeleteVolumeConfirm = async () => {
@@ -110,6 +115,8 @@ export function Volumes() {
       }
       setShowDeleteConfirmDialog(false);
       setVolumeToDelete(null);
+      setShowPurgeUI(false);
+      setPurgeConfirmed(false);
       handleRefresh();
     } catch (error) {
       setDeleteError(error);
@@ -118,10 +125,35 @@ export function Volumes() {
     }
   };
 
+  const handlePurgeVolumeConfirm = async () => {
+    if (!volumeToDelete) return;
+
+    setPurgeLoading(true);
+    setDeleteError(null);
+
+    try {
+      const result = await deleteVolume(volumeToDelete.name, { purge: true });
+      if (!result.success) {
+        throw new Error(result.msg);
+      }
+      setShowDeleteConfirmDialog(false);
+      setVolumeToDelete(null);
+      setShowPurgeUI(false);
+      setPurgeConfirmed(false);
+      handleRefresh();
+    } catch (error) {
+      setDeleteError(error);
+    } finally {
+      setPurgeLoading(false);
+    }
+  };
+
   const handleCancelDelete = () => {
     setShowDeleteConfirmDialog(false);
     setVolumeToDelete(null);
     setDeleteError(null);
+    setShowPurgeUI(false);
+    setPurgeConfirmed(false);
   };
 
   useEffect(() => {
@@ -233,21 +265,111 @@ export function Volumes() {
                 onDismiss={() => setDeleteError(null)}
               />
 
+              {deleteError && !showPurgeUI && (
+                <button
+                  type="button"
+                  onClick={() => setShowPurgeUI(true)}
+                  className="text-sm text-amber-700 hover:text-amber-800 underline self-start bg-transparent border-0 p-0 cursor-pointer"
+                >
+                  Force remove from SkyPilot records
+                </button>
+              )}
+
+              {showPurgeUI && (
+                <div className="bg-amber-50 border border-amber-200 rounded-md p-3 flex items-start gap-2 mb-2">
+                  <AlertTriangleIcon className="w-4 h-4 text-amber-600 mt-0.5 flex-shrink-0" />
+                  <div className="text-sm text-amber-800 space-y-2">
+                    <p className="m-0">
+                      <strong>Force remove won&apos;t delete the underlying volume.</strong>{' '}
+                      Removing the SkyPilot entry means this volume will no
+                      longer appear here, but{' '}
+                      {volumeToDelete?.type === 'k8s-pvc' &&
+                      volumeToDelete?.name_on_cloud ? (
+                        <>
+                          the Kubernetes PVC{' '}
+                          <code className="bg-amber-100 px-1 rounded">
+                            {volumeToDelete.name_on_cloud}
+                          </code>
+                          {volumeToDelete.namespace &&
+                            volumeToDelete.namespace !== '-' && (
+                              <>
+                                {' '}in namespace{' '}
+                                <code className="bg-amber-100 px-1 rounded">
+                                  {volumeToDelete.namespace}
+                                </code>
+                              </>
+                            )}{' '}
+                          may still exist and continue consuming resources.
+                          Delete it manually with{' '}
+                          <code className="bg-amber-100 px-1 rounded">
+                            kubectl delete pvc
+                            {volumeToDelete.namespace &&
+                            volumeToDelete.namespace !== '-'
+                              ? ` -n ${volumeToDelete.namespace}`
+                              : ''}{' '}
+                            {volumeToDelete.name_on_cloud}
+                          </code>{' '}
+                          once it&apos;s no longer in use.
+                        </>
+                      ) : (
+                        <>
+                          the underlying cloud resource may still exist and
+                          continue consuming resources. Clean it up manually
+                          once it&apos;s no longer in use.
+                        </>
+                      )}
+                    </p>
+                    <label className="flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={purgeConfirmed}
+                        onChange={(e) => setPurgeConfirmed(e.target.checked)}
+                        disabled={purgeLoading}
+                        className="cursor-pointer"
+                      />
+                      <span>
+                        I understand this may not delete the underlying volume
+                      </span>
+                    </label>
+                  </div>
+                </div>
+              )}
+
               <DialogFooter>
                 <Button
                   variant="outline"
                   onClick={handleCancelDelete}
-                  disabled={deleteLoading}
+                  disabled={deleteLoading || purgeLoading}
                 >
                   Cancel
                 </Button>
-                <Button
-                  variant="destructive"
-                  onClick={handleDeleteVolumeConfirm}
-                  disabled={deleteLoading}
-                >
-                  {deleteLoading ? 'Deleting...' : 'Delete'}
-                </Button>
+                {!showPurgeUI && (
+                  <Button
+                    variant="destructive"
+                    onClick={handleDeleteVolumeConfirm}
+                    disabled={deleteLoading}
+                  >
+                    {deleteLoading ? 'Deleting...' : 'Delete'}
+                  </Button>
+                )}
+                {showPurgeUI && (
+                  <>
+                    <Button
+                      variant="destructive"
+                      onClick={handleDeleteVolumeConfirm}
+                      disabled={deleteLoading || purgeLoading}
+                    >
+                      {deleteLoading ? 'Deleting...' : 'Retry Delete'}
+                    </Button>
+                    <Button
+                      onClick={handlePurgeVolumeConfirm}
+                      disabled={!purgeConfirmed || deleteLoading || purgeLoading}
+                      className="bg-amber-600 hover:bg-amber-700 text-white"
+                    >
+                      {purgeLoading ? 'Removing...' : 'Force Remove'}
+                    </Button>
+                  </>
+                )}
               </DialogFooter>
             </DialogContent>
           </Dialog>

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -38,7 +38,10 @@ import { useRouter } from 'next/router';
 import { TimestampWithTooltip, LastUpdatedTimestamp } from '@/components/utils';
 import { StatusBadge } from '@/components/elements/StatusBadge';
 import { PluginSlot } from '@/plugins/PluginSlot';
-import { usePluginComponents } from '@/plugins/PluginProvider';
+import {
+  usePluginComponents,
+  useTableColumns,
+} from '@/plugins/PluginProvider';
 import dashboardCache from '@/lib/cache';
 import cachePreloader from '@/lib/cache-preloader';
 
@@ -515,6 +518,152 @@ function VolumesTable({
     }
   };
 
+  const pluginColumns = useTableColumns('volumes');
+
+  const sortableHeader = (label, sortKey) => (
+    <TableHead
+      className="sortable whitespace-nowrap cursor-pointer hover:bg-gray-50"
+      onClick={() => requestSort(sortKey)}
+    >
+      {label}
+      {getSortDirection(sortKey)}
+    </TableHead>
+  );
+
+  const baseColumns = [
+    {
+      id: 'name',
+      order: 0,
+      renderHeader: () => sortableHeader('Name', 'name'),
+      renderCell: (volume) => (
+        <TableCell>
+          <Link
+            href={`/volumes/${encodeURIComponent(volume.name)}`}
+            className="text-blue-600"
+          >
+            {volume.name}
+          </Link>
+        </TableCell>
+      ),
+    },
+    {
+      id: 'infra',
+      order: 10,
+      renderHeader: () => sortableHeader('Infra', 'infra'),
+      renderCell: (volume) => <TableCell>{volume.infra || 'N/A'}</TableCell>,
+    },
+    {
+      id: 'status',
+      order: 20,
+      renderHeader: () => sortableHeader('Status', 'status'),
+      renderCell: (volume) => (
+        <TableCell>
+          <StatusBadge
+            status={volume.status}
+            statusTooltip={volume.error_message || volume.status}
+          />
+        </TableCell>
+      ),
+    },
+    {
+      id: 'size',
+      order: 30,
+      renderHeader: () => sortableHeader('Size', 'size'),
+      renderCell: (volume) => <TableCell>{formatSize(volume.size)}</TableCell>,
+    },
+    {
+      id: 'user_name',
+      order: 40,
+      renderHeader: () => sortableHeader('User', 'user_name'),
+      renderCell: (volume) => (
+        <TableCell>{volume.user_name || 'N/A'}</TableCell>
+      ),
+    },
+    {
+      id: 'last_attached_at',
+      order: 50,
+      renderHeader: () => sortableHeader('Last Use', 'last_attached_at'),
+      renderCell: (volume) => (
+        <TableCell>{formatTimestamp(volume.last_attached_at)}</TableCell>
+      ),
+    },
+    {
+      id: 'type',
+      order: 60,
+      renderHeader: () => sortableHeader('Type', 'type'),
+      renderCell: (volume) => <TableCell>{volume.type || 'N/A'}</TableCell>,
+    },
+    {
+      id: 'usedby_clusters',
+      order: 70,
+      renderHeader: () => sortableHeader('Used By', 'usedby_clusters'),
+      renderCell: (volume) => (
+        <TableCell>
+          <UsedByCell
+            clusters={volume.usedby_clusters}
+            pods={volume.usedby_pods}
+          />
+        </TableCell>
+      ),
+    },
+    {
+      id: 'actions',
+      order: 1000,
+      renderHeader: () => <TableHead>Actions</TableHead>,
+      renderCell: (volume) => (
+        <TableCell>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onDeleteVolume(volume)}
+            className="text-red-600 hover:text-red-700 hover:bg-red-50"
+            title="Delete volume"
+          >
+            <Trash2Icon className="w-4 h-4" />
+          </Button>
+        </TableCell>
+      ),
+    },
+  ];
+
+  const pluginColumnDefs = pluginColumns.map((col) => ({
+    id: col.id,
+    order: col.header.order,
+    isPlugin: true,
+    renderHeader: () => {
+      const baseClasses = col.header.sortKey
+        ? 'sortable whitespace-nowrap'
+        : 'whitespace-nowrap';
+      const className = `${baseClasses}${col.header.className ? ' ' + col.header.className : ''}`;
+      return (
+        <TableHead
+          className={className}
+          onClick={
+            col.header.sortKey
+              ? () => requestSort(col.header.sortKey)
+              : undefined
+          }
+        >
+          {col.header.label}
+          {col.header.sortKey ? getSortDirection(col.header.sortKey) : ''}
+        </TableHead>
+      );
+    },
+    renderCell: (volume) => {
+      const cellContent = col.cell.render(volume, { item: volume });
+      return (
+        <TableCell className={col.cell.className || ''}>
+          {cellContent}
+        </TableCell>
+      );
+    },
+  }));
+
+  const visibleColumns = [...baseColumns, ...pluginColumnDefs].sort(
+    (a, b) => a.order - b.order
+  );
+  const totalColSpan = visibleColumns.length;
+
   return (
     <div>
       <Card>
@@ -522,62 +671,16 @@ function VolumesTable({
           <Table className="min-w-full">
             <TableHeader>
               <TableRow>
-                <TableHead
-                  className="sortable whitespace-nowrap cursor-pointer hover:bg-gray-50"
-                  onClick={() => requestSort('name')}
-                >
-                  Name{getSortDirection('name')}
-                </TableHead>
-                <TableHead
-                  className="sortable whitespace-nowrap cursor-pointer hover:bg-gray-50"
-                  onClick={() => requestSort('infra')}
-                >
-                  Infra{getSortDirection('infra')}
-                </TableHead>
-                <TableHead
-                  className="sortable whitespace-nowrap cursor-pointer hover:bg-gray-50"
-                  onClick={() => requestSort('status')}
-                >
-                  Status{getSortDirection('status')}
-                </TableHead>
-                <TableHead
-                  className="sortable whitespace-nowrap cursor-pointer hover:bg-gray-50"
-                  onClick={() => requestSort('size')}
-                >
-                  Size{getSortDirection('size')}
-                </TableHead>
-                <TableHead
-                  className="sortable whitespace-nowrap cursor-pointer hover:bg-gray-50"
-                  onClick={() => requestSort('user_name')}
-                >
-                  User{getSortDirection('user_name')}
-                </TableHead>
-                <TableHead
-                  className="sortable whitespace-nowrap cursor-pointer hover:bg-gray-50"
-                  onClick={() => requestSort('last_attached_at')}
-                >
-                  Last Use{getSortDirection('last_attached_at')}
-                </TableHead>
-                <TableHead
-                  className="sortable whitespace-nowrap cursor-pointer hover:bg-gray-50"
-                  onClick={() => requestSort('type')}
-                >
-                  Type{getSortDirection('type')}
-                </TableHead>
-                <TableHead
-                  className="sortable whitespace-nowrap cursor-pointer hover:bg-gray-50"
-                  onClick={() => requestSort('usedby_clusters')}
-                >
-                  Used By{getSortDirection('usedby_clusters')}
-                </TableHead>
-                <TableHead>Actions</TableHead>
+                {visibleColumns.map((col) =>
+                  React.cloneElement(col.renderHeader(), { key: col.id })
+                )}
               </TableRow>
             </TableHeader>
             <TableBody>
               {loading || !preloadingComplete ? (
                 <TableRow>
                   <TableCell
-                    colSpan={11}
+                    colSpan={totalColSpan}
                     className="text-center py-6 text-gray-500"
                   >
                     <div className="flex justify-center items-center">
@@ -589,50 +692,17 @@ function VolumesTable({
               ) : paginatedData.length > 0 ? (
                 paginatedData.map((volume) => (
                   <TableRow key={volume.name}>
-                    <TableCell>
-                      <Link
-                        href={`/volumes/${encodeURIComponent(volume.name)}`}
-                        className="text-blue-600"
-                      >
-                        {volume.name}
-                      </Link>
-                    </TableCell>
-                    <TableCell>{volume.infra || 'N/A'}</TableCell>
-                    <TableCell>
-                      <StatusBadge
-                        status={volume.status}
-                        statusTooltip={volume.error_message || volume.status}
-                      />
-                    </TableCell>
-                    <TableCell>{formatSize(volume.size)}</TableCell>
-                    <TableCell>{volume.user_name || 'N/A'}</TableCell>
-                    <TableCell>
-                      {formatTimestamp(volume.last_attached_at)}
-                    </TableCell>
-                    <TableCell>{volume.type || 'N/A'}</TableCell>
-                    <TableCell>
-                      <UsedByCell
-                        clusters={volume.usedby_clusters}
-                        pods={volume.usedby_pods}
-                      />
-                    </TableCell>
-                    <TableCell>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => onDeleteVolume(volume)}
-                        className="text-red-600 hover:text-red-700 hover:bg-red-50"
-                        title="Delete volume"
-                      >
-                        <Trash2Icon className="w-4 h-4" />
-                      </Button>
-                    </TableCell>
+                    {visibleColumns.map((col) =>
+                      React.cloneElement(col.renderCell(volume), {
+                        key: col.id,
+                      })
+                    )}
                   </TableRow>
                 ))
               ) : (
                 <TableRow>
                   <TableCell
-                    colSpan={11}
+                    colSpan={totalColSpan}
                     className="text-center py-6 text-gray-500"
                   >
                     No volumes found

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -184,6 +184,11 @@ export function Volumes() {
             {!loading && lastFetchedTime && (
               <LastUpdatedTimestamp timestamp={lastFetchedTime} />
             )}
+            <PluginSlot
+              name="volumes.header-actions"
+              context={{ onVolumeChange: handleRefresh }}
+              wrapperClassName="contents"
+            />
             <button
               onClick={handleRefresh}
               disabled={loading}
@@ -248,7 +253,10 @@ export function Volumes() {
           </Dialog>
         </>
       ) : (
-        <PluginSlot name="volumes.tab-content" context={{ activeTab }} />
+        <PluginSlot
+          name="volumes.tab-content"
+          context={{ activeTab, onTabChange: handleTabChange }}
+        />
       )}
     </>
   );

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -262,6 +262,41 @@ export function Volumes() {
                 </DialogDescription>
               </DialogHeader>
 
+              {volumeToDelete?.config?.use_existing && (
+                <div className="bg-sky-50 border border-sky-200 rounded-md p-3 flex items-start gap-2">
+                  <AlertTriangleIcon className="w-4 h-4 text-sky-600 mt-0.5 flex-shrink-0" />
+                  <div className="text-sm text-sky-900">
+                    This volume was imported from an existing{' '}
+                    {volumeToDelete?.type === 'k8s-pvc'
+                      ? 'PVC'
+                      : 'resource'}
+                    . Deleting it only removes it from SkyPilot
+                    {volumeToDelete?.type === 'k8s-pvc' &&
+                    volumeToDelete?.name_on_cloud ? (
+                      <>
+                        ; the underlying PVC{' '}
+                        <code className="bg-sky-100 px-1 rounded">
+                          {volumeToDelete.name_on_cloud}
+                        </code>
+                        {volumeToDelete.namespace &&
+                          volumeToDelete.namespace !== '-' && (
+                            <>
+                              {' '}
+                              in namespace{' '}
+                              <code className="bg-sky-100 px-1 rounded">
+                                {volumeToDelete.namespace}
+                              </code>
+                            </>
+                          )}{' '}
+                        will be left intact.
+                      </>
+                    ) : (
+                      <>; the underlying resource will be left intact.</>
+                    )}
+                  </div>
+                </div>
+              )}
+
               <ErrorDisplay
                 error={deleteError}
                 title="Deletion Failed"

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -216,11 +216,6 @@ export function Volumes() {
             {!loading && lastFetchedTime && (
               <LastUpdatedTimestamp timestamp={lastFetchedTime} />
             )}
-            <PluginSlot
-              name="volumes.header-actions"
-              context={{ onVolumeChange: handleRefresh }}
-              wrapperClassName="contents"
-            />
             <button
               onClick={handleRefresh}
               disabled={loading}
@@ -229,6 +224,11 @@ export function Volumes() {
               <RotateCwIcon className="h-4 w-4 mr-1.5" />
               {!isMobile && <span>Refresh</span>}
             </button>
+            <PluginSlot
+              name="volumes.header-actions"
+              context={{ onVolumeChange: handleRefresh }}
+              wrapperClassName="contents"
+            />
           </div>
         )}
       </div>

--- a/sky/dashboard/src/components/volumes.jsx
+++ b/sky/dashboard/src/components/volumes.jsx
@@ -275,8 +275,8 @@ export function Volumes() {
                   ) : (
                     <>
                       Are you sure you want to delete volume &quot;
-                      {volumeToDelete?.name || 'this volume'}&quot;? This
-                      action cannot be undone.
+                      {volumeToDelete?.name || 'this volume'}&quot;? This action
+                      cannot be undone.
                     </>
                   )}
                 </DialogDescription>
@@ -324,7 +324,7 @@ export function Volumes() {
               )}
 
               {showPurgeUI && (
-                <div className="bg-amber-50 border border-amber-200 rounded-md p-3 flex items-start gap-2 mb-2">
+                <div className="bg-amber-50 border border-amber-200 rounded-md p-3 my-3 flex items-start gap-2">
                   <AlertTriangleIcon className="w-4 h-4 text-amber-600 mt-0.5 flex-shrink-0" />
                   <div className="text-sm text-amber-800 space-y-2">
                     <p className="m-0">
@@ -376,7 +376,8 @@ export function Volumes() {
                         className="cursor-pointer"
                       />
                       <span>
-                        I understand this may not delete the underlying volume
+                        I understand force removal may not delete the underlying
+                        volume
                       </span>
                     </label>
                   </div>

--- a/sky/dashboard/src/data/connectors/volumes.js
+++ b/sky/dashboard/src/data/connectors/volumes.js
@@ -50,11 +50,12 @@ export async function getVolumes() {
   }
 }
 
-export async function deleteVolume(volumeName) {
+export async function deleteVolume(volumeName, { purge = false } = {}) {
   let msg = '';
   try {
     const response = await apiClient.post('/volumes/delete', {
       names: [volumeName],
+      purge,
     });
     if (!response.ok) {
       console.error(

--- a/sky/provision/kubernetes/volume.py
+++ b/sky/provision/kubernetes/volume.py
@@ -117,9 +117,18 @@ def delete_volume(config: models.VolumeConfig) -> models.VolumeConfig:
 
 
 def _delete_pvc_volume(config: models.VolumeConfig) -> models.VolumeConfig:
-    """Deletes a PVC volume."""
+    """Deletes a PVC volume.
+
+    If the volume was registered with ``use_existing=True``, the underlying
+    PVC is left intact (SkyPilot did not create it, and another SkyPilot
+    instance may also have it registered).
+    """
     context, namespace = _get_context_namespace(config)
     pvc_name = config.name_on_cloud
+    if config.config.get('use_existing'):
+        logger.info(f'Leaving PVC {pvc_name} in namespace {namespace} intact '
+                    f'(use_existing=True)')
+        return config
     kubernetes_utils.delete_k8s_resource_with_retry(
         delete_func=lambda pvc_name=pvc_name: kubernetes.core_api(
             context).delete_namespaced_persistent_volume_claim(

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1431,9 +1431,11 @@ def test_volumes_on_kubernetes():
             smoke_tests_utils.run_cloud_cmd_on_cluster(
                 name,
                 'pvcs=$(kubectl get pvc) && echo "$pvcs" && pvc=$(echo "$pvcs" | grep "pvc0"); if [ -n "$pvc" ]; then echo "pvc for volume pvc0 not deleted" && exit 1; else echo "pvc for volume pvc0 deleted"; fi && '
-                'pvc=$(echo "$pvcs" | grep "existing0"); if [ -n "$pvc" ]; then echo "pvc for volume existing0 not deleted" && exit 1; else echo "pvc for volume existing0 deleted"; fi && '
+                # existing0 was imported with use_existing=True; the underlying PVC is preserved on delete.
+                'pvc=$(echo "$pvcs" | grep "existing0"); if [ -z "$pvc" ]; then echo "pvc for imported volume existing0 was unexpectedly deleted" && exit 1; else echo "pvc for imported volume existing0 preserved"; fi && '
                 'pvc=$(echo "$pvcs" | grep "pvc1"); if [ -n "$pvc" ]; then echo "pvc for volume pvc1 not deleted" && exit 1; else echo "pvc for volume pvc1 deleted"; fi && '
-                'pvc=$(echo "$pvcs" | grep "vol-existing1"); if [ -n "$pvc" ]; then echo "pvc for volume vol-existing1 not deleted" && exit 1; else echo "pvc for volume vol-existing1 deleted"; fi && '
+                # vol-existing1 wraps an imported PVC named "existing1" (matched by label); that PVC is preserved on delete.
+                'pvc=$(echo "$pvcs" | grep "existing1"); if [ -z "$pvc" ]; then echo "pvc for imported volume vol-existing1 was unexpectedly deleted" && exit 1; else echo "pvc for imported volume vol-existing1 preserved"; fi && '
                 f'pvc=$(echo "$pvcs" | grep "{name}"); if [ -n "$pvc" ]; then echo "pvc for ephemeral volume of cluster {name} not deleted" && exit 1; else echo "pvc for ephemeral volume of cluster {name} deleted"; fi',
             ),
         ],

--- a/tests/unit_tests/test_sky/provision/test_kubernetes_volume.py
+++ b/tests/unit_tests/test_sky/provision/test_kubernetes_volume.py
@@ -1,0 +1,47 @@
+"""Tests for sky.provision.kubernetes.volume delete behavior."""
+from unittest import mock
+
+from sky import models
+from sky.provision.kubernetes import volume as volume_provision
+
+
+def _make_pvc_config(use_existing: bool) -> models.VolumeConfig:
+    return models.VolumeConfig(
+        name='test-vol',
+        type='k8s-pvc',
+        cloud='kubernetes',
+        region='my-context',
+        zone=None,
+        name_on_cloud='real-pvc',
+        size='5',
+        config={
+            'namespace': 'default',
+            'use_existing': use_existing,
+        },
+    )
+
+
+def test_delete_pvc_volume_destructive_when_not_use_existing():
+    config = _make_pvc_config(use_existing=False)
+    with mock.patch.object(volume_provision, 'kubernetes') as mock_k8s, \
+         mock.patch.object(volume_provision,
+                           'kubernetes_utils') as mock_k8s_utils:
+        volume_provision._delete_pvc_volume(config)
+        mock_k8s_utils.delete_k8s_resource_with_retry.assert_called_once()
+        # The PVC delete lambda should have been passed in.
+        _, kwargs = mock_k8s_utils.delete_k8s_resource_with_retry.call_args
+        assert kwargs['resource_type'] == 'pvc'
+        assert kwargs['resource_name'] == 'real-pvc'
+
+
+def test_delete_pvc_volume_preserves_pvc_when_use_existing():
+    config = _make_pvc_config(use_existing=True)
+    with mock.patch.object(volume_provision, 'kubernetes') as mock_k8s, \
+         mock.patch.object(volume_provision,
+                           'kubernetes_utils') as mock_k8s_utils:
+        result = volume_provision._delete_pvc_volume(config)
+        # Must NOT have attempted to delete the PVC.
+        mock_k8s_utils.delete_k8s_resource_with_retry.assert_not_called()
+        mock_k8s.core_api.assert_not_called()
+        # Still returns the config so the caller can proceed to unregister.
+        assert result is config


### PR DESCRIPTION
Supersedes #9388 (will be closed); includes its full scope plus the Volumes-table
plugin extension API and an imported-PVC delete notice.

## Summary

Bundles Volumes-page improvements:

- **Plugin-extendable columns on the Volumes table** — adds a `registerTableColumn`
  plugin API and a `useTableColumns` hook, and wires them into `volumes.jsx` so
  plugins can contribute extra columns at a chosen order. Normalizes the column
  config (id, table, header{label, sortKey, className, order}, cell{render,
  className}, conditions) and sorts registered columns by `order`.
- **Imported-PVC delete notice** — when deleting a volume whose config has
  `use_existing=True`, the delete dialog now shows a banner clarifying that the
  underlying PVC will be left intact. Banner has vertical margin so it reads as a
  distinct block above the Cancel/Delete row.
- **Non-destructive delete for imported PVCs** — `_delete_pvc_volume` skips the
  underlying K8s PVC delete when the volume was registered with
  `use_existing=True`. Matches K8s ownership expectations and avoids orphaning
  a registration when the same PVC is registered from multiple API servers.
- **Force-remove (purge) from the dashboard** — surfaces a purge affordance when
  a normal volume delete fails, so users can unregister a stuck record from the
  DB without shelling into the cluster.
- **Header-actions slot ordering** — renders the plugin slot to the right of
  Refresh so contributed actions sit rightmost.
- **Keep `last_attached_at` in sync for auto-mounted volumes** — volumes pulled in
  via the `auto_mounts` config bypassed `VolumeMount.pre_mount`, so the Volumes
  dashboard "Last Use" column stayed blank even while the volume was actively
  attached. The write is now mirrored in `write_cluster_config`'s auto-mount
  branch, and skipped on dryrun.

## Test plan

- [x] `pytest tests/unit_tests/provision/kubernetes/test_volume.py` — covers
  `_delete_pvc_volume` skip behavior with `use_existing=True`.
- [x] Manual: import a PVC created via `kubectl`, delete the SkyPilot volume,
  confirm the PVC remains in the cluster and the delete dialog shows the
  imported-PVC notice with vertical spacing.
- [x] Manual: delete a volume whose K8s backing resource is already gone,
  confirm the purge path unregisters the DB record.
- [x] Manual: launch a cluster that mounts a volume via `auto_mounts` config,
  refresh the Volumes dashboard, confirm "Last Use" populates.
- [x] Manual: a plugin registering a column via `registerTableColumn` on the
  `volumes` table renders its header and cell at the expected `order`; sort and
  pagination remain functional.
- [x] Manual: header-actions plugin slot renders to the right of Refresh on the
  Volumes tab.