### PR TITLE
[Cudo] Fix KeyError in query_instances for unmapped statuses

### DIFF
--- a/sky/provision/cudo/instance.py
+++ b/sky/provision/cudo/instance.py
@@ -217,7 +217,7 @@ def query_instances(
     statuses: Dict[str, Tuple[Optional['status_lib.ClusterStatus'],
                               Optional[str]]] = {}
     for inst_id, inst in instances.items():
-        status = status_map[inst['status']]
+        status = status_map.get(inst['status'])
         if non_terminated_only and status is None:
             continue
         statuses[inst_id] = (status, None)


### PR DESCRIPTION
## Bug

`sky/provision/cudo/instance.py:query_instances` indexes `status_map` directly on each VM's `short_state`:

```python
status_map = {
    'init': status_lib.ClusterStatus.INIT,
    'pend': status_lib.ClusterStatus.INIT,
    'prol': status_lib.ClusterStatus.INIT,
    'boot': status_lib.ClusterStatus.INIT,
    'runn': status_lib.ClusterStatus.UP,
    'stop': status_lib.ClusterStatus.STOPPED,
    'susp': status_lib.ClusterStatus.STOPPED,
    'done': status_lib.ClusterStatus.STOPPED,
    'poff': status_lib.ClusterStatus.STOPPED,
}
...
for inst_id, inst in instances.items():
    status = status_map[inst['status']]
    if non_terminated_only and status is None:
        continue
```

## Root cause

`_filter_instances(cluster_name_on_cloud, None)` returns every VM the Cudo API knows about — including ones in states that are not in this nine-key map. The sibling `cudo_wrapper.py` already enumerates Cudo states beyond the map (e.g. `'unde'`, `'fail'`, and `'epil'` during termination), and any such value raises `KeyError` and aborts the entire status fetch even though the trailing `non_terminated_only` branch was meant to drop them silently.

## Why the fix is correct

Switching to `status_map.get(inst['status'])` lets unmapped short states fall through as `None`, where the existing `if non_terminated_only and status is None: continue` filter drops them cleanly. This is the same defensive pattern already used in `sky/provision/fluidstack/instance.py` and `sky/provision/lambda_cloud/instance.py`, and the same one-line fix applied to RunPod (#9356) and Vast (#9319).