### PR TITLE
[Nebius] Fix KeyError in query_instances for unmapped statuses

### DIFF
--- a/sky/provision/nebius/instance.py
+++ b/sky/provision/nebius/instance.py
@@ -274,7 +274,7 @@ def query_instances(
     statuses: Dict[str, Tuple[Optional['status_lib.ClusterStatus'],
                               Optional[str]]] = {}
     for inst_id, inst in instances.items():
-        status = status_map[inst['status']]
+        status = status_map.get(inst['status'])
         if non_terminated_only and status is None:
             continue
         statuses[inst_id] = (status, None)


### PR DESCRIPTION
## Bug

\`sky/provision/nebius/instance.py:query_instances\` indexes \`status_map\` directly on each instance's status:

\`\`\`python
status_map = {
    'STARTING': status_lib.ClusterStatus.INIT,
    'RUNNING': status_lib.ClusterStatus.UP,
    'STOPPED': status_lib.ClusterStatus.STOPPED,
    'STOPPING': status_lib.ClusterStatus.STOPPED,
    'DELETING': status_lib.ClusterStatus.STOPPED,
}
...
for inst_id, inst in instances.items():
    status = status_map[inst['status']]
    if non_terminated_only and status is None:
        continue
\`\`\`

## Root cause

\`_filter_instances(provider_config['region'], cluster_name_on_cloud, None)\` returns every VM Nebius reports, including ones in states that are not in this five-key map (e.g. \`DELETED\`, \`ERROR\`, \`MIGRATING\`, or any future state Nebius introduces). Any such value raises \`KeyError\` and aborts the whole status fetch, even though the \`non_terminated_only\` branch on the next line was clearly meant to drop them silently.

## Why the fix is correct

Switching to \`status_map.get(inst['status'])\` returns \`None\` for unmapped statuses, and the existing \`if non_terminated_only and status is None: continue\` guard cleanly filters them out. This is the same one-line fix already merged/opened for the other SkyPilot provider adapters with the same pattern:

- [Cudo] #9394
- [RunPod] #9356
- [Vast] #9319

and matches the defensive \`.get()\` pattern already used in \`sky/provision/fluidstack/instance.py\` and \`sky/provision/lambda_cloud/instance.py\`.