### PR TITLE
[Docs] Speed up incremental docs build (~15x on no-op, ~10x on one-line edit)

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -j auto
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -39,18 +39,24 @@ if ! check_file_age "source/compute/show-gpus-h100-8.txt"; then
     sky gpus list H100:8 > source/compute/show-gpus-h100-8.txt
 fi
 
-rm -rf build docs
-
 # Add command line argument parsing
 AUTO_BUILD=false
+CLEAN=false
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --watch|-w) AUTO_BUILD=true ;;
         --port|-p) PORT=$2; shift ;;
+        --clean|-c) CLEAN=true ;;
         *) echo "Unknown parameter: $1"; exit 1 ;;
     esac
     shift
 done
+
+# Only clear the build cache on explicit request. Incremental Sphinx builds
+# are much faster and still rebuild pages whose sources changed.
+if [ "$CLEAN" = true ]; then
+    rm -rf build docs
+fi
 
 if [ "$AUTO_BUILD" = true ]; then
     # Use sphinx-autobuild for automatic rebuilding
@@ -62,8 +68,6 @@ if [ "$AUTO_BUILD" = true ]; then
         --ignore "**/llms.txt" \
         --port ${PORT:-8000}
 else
-    rm -rf build docs
-
     # Set build environment (only if not already set by GitHub Actions)
     if [ -z "$SPHINX_BUILD_PRODUCTION" ]; then
         export SPHINX_BUILD_LOCAL=true

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -63,7 +63,14 @@ if [ "$AUTO_BUILD" = true ]; then
     # Ignore gallery directory and llms.txt to prevent unnecessary rebuilds
     export SPHINX_BUILD_LOCAL=true
     export SPHINX_PORT=${PORT:-8000}
+    # Share the doctree cache with `make html` (which writes to
+    # build/doctrees) so the initial watch-mode build is incremental.
+    # Without -d, sphinx defaults to build/html/.doctrees and ignores the
+    # existing cache. -j auto enables parallel reads/writes, matching the
+    # Makefile default.
     sphinx-autobuild source build/html \
+        -d build/doctrees \
+        -j auto \
         --ignore "*.md" \
         --ignore "**/llms.txt" \
         --port ${PORT:-8000}

--- a/docs/source/extension/dynamic_llms_txt.py
+++ b/docs/source/extension/dynamic_llms_txt.py
@@ -41,8 +41,14 @@ def generate_llms_txt(app: Sphinx, exception: Exception) -> None:
     output_path = Path(app.outdir) / "llms.txt"
     output_path.write_text(llms_content)
 
-    # Update source copy
+    # Update source copy — skip if unchanged so the next incremental build
+    # does not see llms.txt as a new source modification.
     source_path = Path(app.srcdir) / "llms.txt"
+    try:
+        if source_path.read_text() == llms_content:
+            return
+    except (FileNotFoundError, UnicodeDecodeError):
+        pass
     source_path.write_text(llms_content)
 
 

--- a/docs/source/extension/linting.py
+++ b/docs/source/extension/linting.py
@@ -198,4 +198,8 @@ def check_sentence_case(app: Sphinx, docname: str, source: list):
 def setup(app: Sphinx):
     """Extension setup"""
     app.connect('source-read', check_sentence_case)
-    return {'version': '0.1'}
+    return {
+        'version': '0.1',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/docs/source/extension/markdown_export.py
+++ b/docs/source/extension/markdown_export.py
@@ -26,8 +26,8 @@ def export_markdown_files(app, exception):
         # .html — sphinx only refreshes .html mtime when the page actually
         # needs regenerating, so this avoids invoking pandoc on every
         # unchanged page (~32s on this codebase).
-        if md_path.exists() and md_path.stat().st_mtime >= html_path.stat(
-        ).st_mtime:
+        if md_path.exists(
+        ) and md_path.stat().st_mtime >= html_path.stat().st_mtime:
             continue
 
         if source_path.suffix in ['.md', '.rst']:

--- a/docs/source/extension/markdown_export.py
+++ b/docs/source/extension/markdown_export.py
@@ -22,6 +22,14 @@ def export_markdown_files(app, exception):
         source_path = Path(app.srcdir) / app.env.doc2path(docname, base=False)
         md_path = Path(app.outdir) / f"{docname}.html.md"
 
+        # Skip pages whose exported .md is already newer than the rebuilt
+        # .html — sphinx only refreshes .html mtime when the page actually
+        # needs regenerating, so this avoids invoking pandoc on every
+        # unchanged page (~32s on this codebase).
+        if md_path.exists() and md_path.stat().st_mtime >= html_path.stat(
+        ).st_mtime:
+            continue
+
         if source_path.suffix in ['.md', '.rst']:
             try:
                 process_source_file(source_path, md_path)

--- a/docs/source/generate_examples.py
+++ b/docs/source/generate_examples.py
@@ -47,6 +47,7 @@ def _git_tracked_files() -> frozenset:
     entries = result.stdout.split(b'\x00')
     return frozenset(e.decode() for e in entries if e)
 
+
 # Scan this subdir and its subdirs.
 EXAMPLE_DIRS = [
     ROOT_DIR / 'llm',

--- a/docs/source/generate_examples.py
+++ b/docs/source/generate_examples.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dataclasses
+import functools
 import itertools
 import pathlib
 import re
@@ -11,6 +12,40 @@ from typing import Optional
 
 ROOT_DIR = pathlib.Path(__file__).parent.parent.parent.resolve()
 ROOT_DIR_RELATIVE = '../../../..'
+
+
+def _write_if_changed(path: pathlib.Path, content: str) -> None:
+    """Write ``content`` to ``path`` only if the on-disk content differs.
+
+    Avoids bumping the mtime on unchanged generated files so that Sphinx's
+    incremental build does not re-read every generated page on every run.
+    """
+    try:
+        if path.read_text() == content:
+            return
+    except (FileNotFoundError, UnicodeDecodeError):
+        pass
+    path.write_text(content)
+
+
+@functools.lru_cache(maxsize=1)
+def _git_tracked_files() -> frozenset:
+    """Return the set of git-tracked paths (relative to ROOT_DIR).
+
+    Batches the lookup into one subprocess call — calling ``git ls-files
+    --error-unmatch`` per file used to cost ~12s on this repo.
+    """
+    result = subprocess.run(
+        ['git', 'ls-files', '-z'],
+        cwd=ROOT_DIR,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        return frozenset()
+    entries = result.stdout.split(b'\x00')
+    return frozenset(e.decode() for e in entries if e)
 
 # Scan this subdir and its subdirs.
 EXAMPLE_DIRS = [
@@ -86,8 +121,7 @@ def preprocess_github_markdown_file(source_path: str,
         flags=re.DOTALL,
     )
 
-    with open(dest_path, 'w') as f:
-        f.write(text)
+    _write_if_changed(pathlib.Path(dest_path), text)
 
 
 @dataclasses.dataclass
@@ -149,30 +183,17 @@ class Example:
         if self.path.is_file():
             return []
 
-        # Get all files in the directory
-        all_files = [
-            file for file in self.path.rglob('*')
-            if file.is_file() and file != self.main_file
-        ]
-
-        # Filter for git-tracked files only
+        tracked = _git_tracked_files()
         git_tracked_files = []
-        for file in all_files:
-            try:
-                # Use git ls-files to check if the file is tracked
-                result = subprocess.run([
-                    'git', 'ls-files', '--error-unmatch',
-                    str(file.relative_to(ROOT_DIR))
-                ],
-                                        cwd=ROOT_DIR,
-                                        stdout=subprocess.PIPE,
-                                        stderr=subprocess.PIPE,
-                                        check=False)
-                if result.returncode == 0:  # Return code 0 means file is tracked
-                    git_tracked_files.append(file)
-            except Exception:
-                # Skip files that cause errors
+        for file in self.path.rglob('*'):
+            if not file.is_file() or file == self.main_file:
                 continue
+            try:
+                rel = str(file.relative_to(ROOT_DIR))
+            except ValueError:
+                continue
+            if rel in tracked:
+                git_tracked_files.append(file)
 
         return git_tracked_files
 
@@ -230,23 +251,53 @@ class Example:
 def generate_examples(app=None, *args, **kwargs):
     EXAMPLE_DOC_DIR.mkdir(parents=True, exist_ok=True)
 
+    generated: set = set()
     for example_dir in EXAMPLE_DIRS:
-        _work(example_dir)
+        generated.update(_work(example_dir))
+
+    # Remove stale files from previous runs so that untracked remnants
+    # (e.g., examples that were since removed or never committed) do not
+    # leak into the built docs.
+    for f in EXAMPLE_DOC_DIR.glob('*.md'):
+        if f.name not in generated:
+            f.unlink()
+    markdown_contents_dir = EXAMPLE_DOC_DIR / 'markdown_contents'
+    if markdown_contents_dir.is_dir():
+        kept = {pathlib.Path(n).stem + '.md' for n in generated}
+        for f in markdown_contents_dir.glob('*.md'):
+            if f.name not in kept:
+                f.unlink()
+
+
+def _is_tracked(path: pathlib.Path) -> bool:
+    try:
+        rel = str(path.relative_to(ROOT_DIR))
+    except ValueError:
+        return False
+    return rel in _git_tracked_files()
 
 
 def _work(example_dir: pathlib.Path):
     examples = []
 
-    # Find uncategorised examples
+    # Find uncategorised examples. Skip untracked remnants so that stray
+    # local files (e.g., example directories left over from experiments) do
+    # not leak into the generated docs.
     globs = [example_dir.glob(pattern) for pattern in _GLOB_PATTERNS]
     for path in itertools.chain(*globs):
+        if not _is_tracked(path):
+            continue
         examples.append(Example(path))
 
-    # Find examples in subdirectories (up to 3 levels deep)
+    # Find examples in subdirectories (up to 3 levels deep).
     for path in example_dir.glob("*/*.md"):
+        if not _is_tracked(path):
+            continue
         examples.append(Example(path.parent))
 
     for path in example_dir.glob("*/*/*.md"):
+        if not _is_tracked(path):
+            continue
         examples.append(Example(path.parent))
 
     # Check for stem collisions using full directory names
@@ -264,10 +315,12 @@ def _work(example_dir: pathlib.Path):
             '_', ' ').title())  # Update title accordingly
 
     # Generate the example documentation using the updated stem
+    generated = set()
     for example in sorted(examples, key=lambda e: e.path.name):
         doc_path = EXAMPLE_DOC_DIR / f'{example.path.stem}.md'
-        with open(doc_path, 'w+') as f:
-            f.write(example.generate())
+        _write_if_changed(doc_path, example.generate())
+        generated.add(doc_path.name)
+    return generated
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Docs builds were slow even on trivial edits (~60s for a one-line change locally, ~71s on CI) because several sources were unconditionally invalidating Sphinx's incremental cache on every run, and one extension was re-invoking pandoc over all pages regardless of changes. After these fixes, a no-op local rebuild takes **3.5s** and a one-line edit takes **6s**. On CI (where every run starts fresh), the doc-build job is ~34% faster.

### Local timings (218-page build)

| Scenario | Before | After | Speedup |
|---|---|---|---|
| Clean build (`--clean`) | 80s | 50s | 1.6× |
| No-op rebuild | 60s | **3.5s** | **17×** |
| One-line edit | 60s | **6s** | **10×** |

### Remote CI comparison (`doc-build (3.10)` "Build documentation" step)

CI always starts from a clean checkout, so the incremental fixes don't help there — the clean-build fixes (parallelism + batched `git ls-files`) do.

| | Duration |
|---|---|
| **master** (10 recent runs) | median **71s** (range 64–75s) |
| **this PR** (3 runs) | 46–50s (median **48s**) |
| **Remote CI speedup** | **~34%** (~24s faster per run) |

### Root causes & fixes

| # | File | Problem | Fix | Impact |
|---|---|---|---|---|
| 1 | `docs/source/extension/markdown_export.py` | Ran `pypandoc.convert_file` over all ~216 pages on every `build-finished`, regardless of whether anything changed (~32s of 35s local incremental wall time). | Skip pages whose exported `.html.md` is newer than the rebuilt `.html` — Sphinx only bumps `.html` mtime when a page actually regenerates. | **Biggest local win**: dominates incremental time. |
| 2 | `docs/build.sh` | Unconditional `rm -rf build docs` on every invocation wiped Sphinx's doctree cache, forcing a full rebuild every time. | Only clean on explicit `--clean` / `-c` flag. | Enables local incremental at all. |
| 3 | `docs/source/generate_examples.py` | Rewrote all ~130 generated example `.md` files every run even when content was unchanged, bumping mtimes and triggering Sphinx to re-read them. | `_write_if_changed()` helper — skip write when on-disk content matches. | Stops local cache churn. |
| 4 | `docs/source/extension/dynamic_llms_txt.py` | Rewrote `source/llms.txt` on every build — this is a source file, so the next build saw it as modified. | Skip write when content unchanged. | Stops local cache churn. |
| 5 | `docs/source/generate_examples.py` | Ran `git ls-files --error-unmatch` as a subprocess per file (~545 forks, ~12s). | Single batched `git ls-files -z` call, cached with `lru_cache`. | **Biggest CI win**: ~12s → 0.2s on every clean build. |
| 6 | `docs/Makefile` | No parallelism. | `SPHINXOPTS ?= -j auto`. | ~30% faster clean builds (helps both local and CI). |
| 7 | `docs/source/extension/linting.py` | Not declared parallel-safe → with `-j auto`, Sphinx warns and falls back to serial. | Declare `parallel_read_safe: True` (extension only hooks `source-read`). | Keeps the `-j auto` gain in effect. |
| 8 | `docs/source/generate_examples.py` | Picked up untracked local remnants (e.g., `examples/huggingface-tmp/`) as real examples, polluting the build. | Filter to git-tracked paths only; clean stale outputs from `generated-examples/` whose sources are gone. | Prevents bogus pages + extra cache churn. |

## Test plan

- [ ] `bash docs/build.sh` — cold run completes and populates `build/doctrees/environment.pickle`.
- [ ] `bash docs/build.sh` again with no source changes — finishes in a few seconds, prints `0 added, 0 changed, 0 removed`.
- [ ] Edit any `.rst`/`.md` source file and rerun — only that page and its dependents rebuild.
- [ ] `bash docs/build.sh --clean` — clean-build path still works end-to-end.
- [ ] `build/html/llms.txt` present and `validate_llms_txt.py` passes.
- [ ] `source/llms.txt` and `source/generated-examples/*.md` mtimes do **not** advance when their content is unchanged across runs (regression guard).
- [ ] CI doc-build completes at ~45–50s vs master's ~71s.