### PR TITLE
[Docker] Use BuildKit cache mount for dashboard build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,6 @@ RUN cd /skypilot && \
 FROM python:3.10.19-slim
 
 ARG INSTALL_FROM_SOURCE=true
-ENV UV_LINK_MODE=copy
 
 # Copy Google Cloud SDK from Stage 1
 COPY --from=gcloud-apt-install /usr/lib/google-cloud-sdk /opt/google-cloud-sdk
@@ -116,12 +115,12 @@ RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
 # Install Nebius CLI
 RUN curl -sSL https://storage.eu-north1.nebius.cloud/cli/install.sh | NEBIUS_INSTALL_FOLDER=/usr/local/bin bash
 # Install uv
-RUN --mount=type=cache,target=/root/.cache/uv,id=skypilot-uv-cache \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
     ~/.local/bin/uv pip install --prerelease allow azure-cli --system && \
     # Upgrade setuptools in base image to mitigate CVE-2024-6345
     ~/.local/bin/uv pip install --system --upgrade setuptools==78.1.1 && \
-    rm -rf ~/.cache/pip && \
+    ~/.local/bin/uv cache clean && \
+    rm -rf ~/.cache/pip ~/.cache/uv && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -129,8 +128,7 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=skypilot-uv-cache \
 COPY --from=process-source /skypilot /skypilot
 
 # Install SkyPilot and set up dashboard based on installation method
-RUN --mount=type=cache,target=/root/.cache/uv,id=skypilot-uv-cache \
-    cd /skypilot && \
+RUN cd /skypilot && \
     if [ "$INSTALL_FROM_SOURCE" = "true" ]; then \
         echo "Installing from source in editable mode" && \
         ~/.local/bin/uv pip install -e ".[all]" --system; \
@@ -145,10 +143,9 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=skypilot-uv-cache \
         ~/.local/bin/uv pip install "${WHEEL_FILE}[all]" --system && \
         echo "Skipping dashboard build for wheel installation"; \
     fi && \
-    ~/.local/bin/uv cache prune --ci && \
-    # Cleanup non-mounted caches to reduce the image size. The uv cache lives
-    # on the BuildKit cache mount and is not committed into the image.
-    rm -rf ~/.cache/pip && \
+    # Cleanup all caches to reduce the image size
+    ~/.local/bin/uv cache clean && \
+    rm -rf ~/.cache/pip ~/.cache/uv && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     # Remove the empty /skypilot dir for backward compatibility

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.20
+# syntax=docker/dockerfile:1
 
 # Stage 1: Install Google Cloud SDK using APT
 FROM python:3.10.19-slim AS gcloud-apt-install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.20
+
 # Stage 1: Install Google Cloud SDK using APT
 FROM python:3.10.19-slim AS gcloud-apt-install
 
@@ -41,7 +43,8 @@ RUN if [ "$INSTALL_FROM_SOURCE" = "true" ]; then \
 
 COPY sky/dashboard /skypilot/sky/dashboard
 
-RUN if [ "$INSTALL_FROM_SOURCE" = "true" ]; then \
+RUN --mount=type=cache,id=dashboard-next-cache,target=/skypilot/sky/dashboard/.next/cache \
+    if [ "$INSTALL_FROM_SOURCE" = "true" ]; then \
         echo "Building dashboard in Stage 2" && \
         NEXT_BASE_PATH=${NEXT_BASE_PATH} npm --prefix sky/dashboard run build && \
         echo "Cleaning up dashboard build-time dependencies" && \
@@ -67,6 +70,7 @@ RUN cd /skypilot && \
 FROM python:3.10.19-slim
 
 ARG INSTALL_FROM_SOURCE=true
+ENV UV_LINK_MODE=copy
 
 # Copy Google Cloud SDK from Stage 1
 COPY --from=gcloud-apt-install /usr/lib/google-cloud-sdk /opt/google-cloud-sdk
@@ -112,12 +116,12 @@ RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
 # Install Nebius CLI
 RUN curl -sSL https://storage.eu-north1.nebius.cloud/cli/install.sh | NEBIUS_INSTALL_FOLDER=/usr/local/bin bash
 # Install uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
+RUN --mount=type=cache,target=/root/.cache/uv,id=skypilot-uv-cache \
+    curl -LsSf https://astral.sh/uv/install.sh | sh && \
     ~/.local/bin/uv pip install --prerelease allow azure-cli --system && \
     # Upgrade setuptools in base image to mitigate CVE-2024-6345
     ~/.local/bin/uv pip install --system --upgrade setuptools==78.1.1 && \
-    ~/.local/bin/uv cache clean && \
-    rm -rf ~/.cache/pip ~/.cache/uv && \
+    rm -rf ~/.cache/pip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -125,7 +129,8 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
 COPY --from=process-source /skypilot /skypilot
 
 # Install SkyPilot and set up dashboard based on installation method
-RUN cd /skypilot && \
+RUN --mount=type=cache,target=/root/.cache/uv,id=skypilot-uv-cache \
+    cd /skypilot && \
     if [ "$INSTALL_FROM_SOURCE" = "true" ]; then \
         echo "Installing from source in editable mode" && \
         ~/.local/bin/uv pip install -e ".[all]" --system; \
@@ -140,9 +145,10 @@ RUN cd /skypilot && \
         ~/.local/bin/uv pip install "${WHEEL_FILE}[all]" --system && \
         echo "Skipping dashboard build for wheel installation"; \
     fi && \
-    # Cleanup all caches to reduce the image size
-    ~/.local/bin/uv cache clean && \
-    rm -rf ~/.cache/pip ~/.cache/uv && \
+    ~/.local/bin/uv cache prune --ci && \
+    # Cleanup non-mounted caches to reduce the image size. The uv cache lives
+    # on the BuildKit cache mount and is not committed into the image.
+    rm -rf ~/.cache/pip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     # Remove the empty /skypilot dir for backward compatibility


### PR DESCRIPTION
## Summary
- add a BuildKit cache mount for the dashboard Next.js build cache
- keep the cache off-image so the final image size does not grow

## Why
The Docker source build runs an expensive dashboard build step:
- `NEXT_BASE_PATH=... npm --prefix sky/dashboard run build`

This change uses a BuildKit cache mount for:
- `sky/dashboard/.next/cache`

The mount is external BuildKit state, so it is reusable across builds but is not committed into the final image filesystem.

## Benchmarking
Measured locally on the same `buildx` builder using source-diff rebuilds after one tiny backend source edit and one tiny dashboard source edit.

Step-level local comparison:
- dashboard `next build`: `35.6s -> 27.4s`

CI comparison from release Docker build logs:
- before this change, dashboard build step ran `next build`: `61.8s`
- with this change and restored BuildKit cache, the dashboard build step was reused/materialized in: `27.6s`, roughly a `2.2x` speedup for this step

## Why don't we do this for uv cache too?

A previous version of this PR also tried caching the uv cache with a BuildKit cache mount. That experiment used `UV_LINK_MODE=copy` because the uv cache mount is external BuildKit state and is not committed into the image; copying installed files into the target environment avoids leaving the final image dependent on files from the temporary mounted cache. Based on benchmarking results, caching the uv cache this way does not result in any speed up; in fact it increased the total time, most likely because copy mode made the install more copy-heavy:
- pre-mount Dockerfile (`origin/master`) source-diff rebuild: `59.94s`
- previous branch state with both dashboard and uv cache mounts: `63.16s`
- final editable install `uv pip install -e ".[all]"`: `19.4s -> 31.7s`

The uv cache mount was therefore removed from this PR.

## Notes
- the mounted dashboard cache directory is external BuildKit state, so it is not committed into the final image layers
- this change does not try to make dashboard-only changes skip the final editable install entirely; it only reuses Next.js cache state across rebuilds
