### PR TITLE
[Core] Fix stop_safe_status inverted thread-safety guard

### DIFF
--- a/sky/utils/rich_utils.py
+++ b/sky/utils/rich_utils.py
@@ -242,7 +242,7 @@ def stop_safe_status():
     stream logs from user program and do not want it to interfere with the
     spinner display.
     """
-    if _is_thread_safe():
+    if not _is_thread_safe():
         return
     server_status = _get_server_status()
     if server_status is not None:


### PR DESCRIPTION
## Bug

`sky/utils/rich_utils.stop_safe_status()` never actually stops the
server-side rich status spinner, so any code that tries to quiet the
spinner before streaming user-program logs keeps getting interleaved
spinner output.

## Root cause

The function currently returns early when the context *is* thread-safe:

```python
def stop_safe_status():
    if _is_thread_safe():
        return
    server_status = _get_server_status()
    if server_status is not None:
        server_status.stop()
```

But `_is_thread_safe()` being `True` is exactly the state in which a
server-side status *exists* — `safe_status()` only installs one inside
the `annotations.is_on_api_server and _is_thread_safe()` branch.
`force_update_status()` (the sibling helper updating the same status)
has the matching guard:

```python
def force_update_status(msg: str):
    if not _is_thread_safe():
        return
    server_status = _get_server_status()
    if server_status is not None:
        server_status.update(msg)
```

So `stop_safe_status()` has the guard inverted:

- In thread-safe contexts (where a status actually exists), it returns
  before reaching `server_status.stop()`, so the spinner keeps
  running.
- In non-thread-safe contexts (where no server status was ever set),
  `_get_server_status()` is `None`, so the body is a no-op anyway.

Net effect: `stop_safe_status()` is dead code in every code path.

## Why the fix is correct

Flipping the guard to `if not _is_thread_safe(): return` makes
`stop_safe_status()` symmetric with `safe_status()` /
`force_update_status()`: all three operate on the server-side status
only while in the thread-safe context that created it. The `if
server_status is not None:` inner check already handles the "no status
installed" case, so behaviour is unchanged except when there is an
active server status to stop — which is the documented purpose of the
function.

## Change

`sky/utils/rich_utils.py`: `if _is_thread_safe(): return` →
`if not _is_thread_safe(): return` in `stop_safe_status`. One-line
change.