### PR TITLE
[IBM] Raise a clear error when VPC fingerprint collision has no matching key

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -285,10 +285,11 @@ def setup_ibm_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
                                  f'matching existing public key.')
                     break
             else:
-                raise Exception(
+                raise RuntimeError(
                     'IBM VPC reports a key with the same fingerprint '
                     'already exists, but no listed key matches the '
-                    'local public key.') from e
+                    'local public key. Please check your IBM Cloud '
+                    'console to resolve this conflict.') from e
         elif 'Key with name already exists' in e.message:
             raise Exception("""a key with chosen name
                 already registered in the specified region""") from e

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -284,6 +284,11 @@ def setup_ibm_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
                     logger.debug(f'Reusing key:{key["name"]}, '
                                  f'matching existing public key.')
                     break
+            else:
+                raise Exception(
+                    'IBM VPC reports a key with the same fingerprint '
+                    'already exists, but no listed key matches the '
+                    'local public key.') from e
         elif 'Key with name already exists' in e.message:
             raise Exception("""a key with chosen name
                 already registered in the specified region""") from e


### PR DESCRIPTION
## Bug

`setup_ibm_authentication` in `sky/authentication.py` crashes with
`UnboundLocalError: local variable 'vpc_key_id' referenced before
assignment` instead of a useful message when IBM VPC reports an
existing key by the same fingerprint but no listed key actually
matches the local public key.

## Root cause

```python
try:
    res = client.create_key(...).get_result()
    vpc_key_id = res['id']
    ...
except ibm.ibm_cloud_sdk_core.ApiException as e:
    if 'Key with fingerprint already exists' in e.message:
        for key in client.list_keys().result['keys']:
            if (ssh_key_data in key['public_key'] or
                    key['public_key'] in ssh_key_data):
                vpc_key_id = key['id']
                ...
                break
    elif 'Key with name already exists' in e.message:
        raise Exception(...) from e
    else:
        raise Exception('Failed to register a key') from e

config['auth']['ssh_private_key'] = private_key_path
for node_type in config['available_node_types']:
    config['available_node_types'][node_type]['node_config'][
        'key_id'] = vpc_key_id
```

`vpc_key_id` is only bound on two paths:
- the `try` body's happy path, or
- a loop iteration in the fingerprint-collision branch that actually
  matches (`break`).

If the fingerprint branch is taken but the loop finishes without
matching anything (stale listing, partial public-key text, etc.), the
function falls through to `config[...]['key_id'] = vpc_key_id` with
`vpc_key_id` unbound, and the caller sees the cryptic Python
`UnboundLocalError` instead of a useful message.

## Why the fix is correct

- Mirrors the sibling `'Key with name already exists'` branch which
  already raises a clear `Exception(...) from e`.
- `for/else` fires only when the loop did **not** break, so the
  existing match-and-break path is unaffected.
- Replaces the obscure crash with an actionable message that
  identifies the concrete inconsistency (VPC thinks the fingerprint
  exists but no listed key matches).

## Change

`sky/authentication.py`: add a `for ... else: raise Exception(...) from e`
to the fingerprint-collision branch of `setup_ibm_authentication`.
Five-line addition.