### PR TITLE
[SSH] Install Prometheus + node-exporter in `sky ssh up`

### DIFF
--- a/sky/ssh_node_pools/deploy/deploy.py
+++ b/sky/ssh_node_pools/deploy/deploy.py
@@ -1009,6 +1009,27 @@ def deploy_single_cluster(cluster_name,
     else:
         logger.debug('No GPUs detected. Skipping GPU Operator installation.')
 
+    # Install Prometheus + node-exporter in the `skypilot` namespace so the
+    # API server's /gpu-metrics endpoint can federate DCGM + node-level
+    # metrics. Runs on every pool (GPU or CPU) because node-level metrics
+    # are always useful.
+    force_update_status(f'Installing Prometheus [{cluster_name}]')
+    prom_cmd = _prometheus_install_cmd(askpass_block)
+    prom_result = deploy_utils.run_remote(head_node,
+                                          prom_cmd,
+                                          ssh_user,
+                                          ssh_key,
+                                          use_ssh_config=head_use_ssh_config,
+                                          print_output=True)
+    if prom_result is None:
+        # Log and continue — the cluster is still usable without Prometheus.
+        logger.error(
+            f'{colorama.Fore.RED}Failed to install Prometheus. The cluster '
+            f'will still work, but /gpu-metrics federation will not find '
+            f'metrics until Prometheus is installed manually.{RESET_ALL}')
+    else:
+        success_message('Prometheus installed with node-exporter enabled.')
+
     # The env var KUBECONFIG ensures sky check uses the right kubeconfig
     os.environ['KUBECONFIG'] = kubeconfig_path
     deploy_utils.run_command(['sky', 'check', 'ssh'], shell=False)
@@ -1064,6 +1085,64 @@ def _dcgm_exporter_service_cmd(askpass_block: str, selector: str) -> str:
 cat <<'DCGM_SVC' | kubectl --kubeconfig ~/.kube/config apply -f -
 {svc_yaml}
 DCGM_SVC
+"""
+
+
+def _prometheus_install_cmd(askpass_block: str) -> str:
+    """Build the shell command to install prometheus-community/prometheus.
+
+    Installs into the `skypilot` namespace with node-exporter enabled so
+    the API server's /gpu-metrics endpoint can federate DCGM + node-level
+    metrics. Uses `helm upgrade --install` for idempotency.
+
+    The plain prometheus chart is used deliberately — kube-prometheus-stack
+    prefixes pod/namespace labels with `exported_` which breaks SkyPilot's
+    PromQL queries.
+
+    The command runs on the pool's head node, where `~/.kube/config` is the
+    kubeconfig k3s writes at install time with `current-context` pointing at
+    this cluster — so helm does not need `--kube-context`. Helm is installed
+    inline if missing (CPU-only pools skip the gpu-operator step that would
+    otherwise install it). The helm exit code is captured and propagated
+    explicitly so a failure isn't masked by the `rm -f` of the temp file.
+    """
+    return f"""{askpass_block}
+if ! command -v helm &> /dev/null; then
+    curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 &&
+    chmod 700 get_helm.sh &&
+    ./get_helm.sh &&
+    rm get_helm.sh
+fi
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts || true
+helm repo update prometheus-community
+PROM_VALUES_FILE=$(mktemp /tmp/skypilot-prom-values.XXXXXX.yaml)
+cat <<'PROM_VALUES' > "$PROM_VALUES_FILE"
+server:
+  persistentVolume:
+    enabled: true
+    size: 50Gi
+  retention: "1000d"
+  retentionSize: "43GB"
+kube-state-metrics:
+  enabled: true
+  metricLabelsAllowlist:
+    - pods=[skypilot-cluster,skypilot-cluster-name]
+prometheus-node-exporter:
+  enabled: true
+prometheus-pushgateway:
+  enabled: false
+alertmanager:
+  enabled: false
+PROM_VALUES
+helm upgrade --install skypilot-prometheus \\
+    prometheus-community/prometheus \\
+    --kubeconfig ~/.kube/config \\
+    --namespace skypilot \\
+    --create-namespace \\
+    -f "$PROM_VALUES_FILE"
+HELM_RET=$?
+rm -f "$PROM_VALUES_FILE"
+exit $HELM_RET
 """
 
 

--- a/tests/unit_tests/test_ssh_node_pools_deploy.py
+++ b/tests/unit_tests/test_ssh_node_pools_deploy.py
@@ -1,0 +1,69 @@
+"""Unit tests for sky/ssh_node_pools/deploy/deploy.py helpers."""
+
+from sky.ssh_node_pools.deploy import deploy
+
+
+def test_prometheus_install_cmd_contains_required_fields():
+    askpass_block = 'echo "askpass"'
+    cmd = deploy._prometheus_install_cmd(askpass_block)
+
+    # Must include the askpass block verbatim (consistent with sibling helpers).
+    assert askpass_block in cmd
+
+    # Must self-install helm if missing — the gpu-operator path installs
+    # helm for GPU pools, but CPU-only pools skip that step.
+    assert 'command -v helm' in cmd
+    assert 'get-helm-3' in cmd
+
+    # Must use the prometheus-community repo and the plain prometheus chart
+    # (NOT kube-prometheus-stack — see spec "Do NOT use kube-prometheus-stack").
+    assert 'prometheus-community' in cmd
+    assert 'prometheus-community/prometheus' in cmd
+    assert 'kube-prometheus-stack' not in cmd
+
+    # Repo-scoped update is cheaper than a global `helm repo update`.
+    assert 'helm repo update prometheus-community' in cmd
+
+    # Must be idempotent (upgrade --install).
+    assert 'helm upgrade --install' in cmd
+
+    # Must target the correct kubeconfig on the remote head node.
+    assert '--kubeconfig ~/.kube/config' in cmd
+    assert '--namespace skypilot' in cmd
+    assert '--create-namespace' in cmd
+
+    # Release name hardcoded.
+    assert 'skypilot-prometheus' in cmd
+
+    # Must NOT pass --kube-context. The command runs on the pool's head node,
+    # where `~/.kube/config` only has the default context k3s wrote — any
+    # `ssh-<pool>` context name only exists in the client's merged kubeconfig.
+    # The sibling `_dcgm_exporter_service_cmd` correctly omits it.
+    assert '--kube-context' not in cmd
+
+    # Values file must be created via mktemp so concurrent pool deploys don't
+    # race on a shared path.
+    assert 'mktemp' in cmd
+
+    # Helm exit code must be explicitly captured and re-raised. The rm-after-
+    # helm pattern would otherwise mask a helm failure with a clean exit 0.
+    assert 'HELM_RET=$?' in cmd
+    assert 'exit $HELM_RET' in cmd
+
+    # Must enable node-exporter (the deliberate deviation from the skill example).
+    assert 'prometheus-node-exporter' in cmd
+
+    # pushgateway and alertmanager explicitly disabled.
+    assert 'prometheus-pushgateway' in cmd
+    assert 'alertmanager' in cmd
+
+
+def test_prometheus_install_cmd_node_exporter_enabled_not_disabled():
+    """Regression: guard against ever flipping node-exporter to disabled."""
+    cmd = deploy._prometheus_install_cmd('')
+    # Find the prometheus-node-exporter section and verify it's enabled: true,
+    # not enabled: false.
+    ne_section = cmd[cmd.index('prometheus-node-exporter'):]
+    # The first 'enabled:' after the node-exporter key must be 'true'.
+    enabled_line = ne_section[ne_section.index('enabled:'):].splitlines()[0]
+    assert enabled_line.strip() == 'enabled: true'


### PR DESCRIPTION
## Summary
- Adds a per-pool Prometheus install step in `sky ssh up`
- Helm release `skypilot-prometheus` in namespace `skypilot`, with node-exporter enabled
- Runs on every pool (GPU or CPU); idempotent via `helm upgrade --install`
- Uses the plain `prometheus-community/prometheus` chart — not `kube-prometheus-stack`, which prefixes pod/namespace labels with `exported_` and breaks existing PromQL queries

## Motivation

After `sky ssh up` completes, the cluster has DCGM-exporter running (via the GPU operator) and a Service with Prometheus scrape annotations — but no Prometheus. Users are left to install Prometheus manually before metrics can be scraped. This PR makes the cluster immediately ready for metrics collection by installing a minimal Prometheus with node-exporter enabled in the `skypilot` namespace.

## Test plan

- [x] `pytest tests/unit_tests/test_ssh_node_pools_deploy.py -v --noconftest` — PASS (2/2)
- [ ] Manual: after `sky ssh up` against a test pool, verify
  `kubectl --context <ssh-pool> -n skypilot get svc skypilot-prometheus-server` and
  `kubectl --context <ssh-pool> -n skypilot get ds -l app.kubernetes.io/name=prometheus-node-exporter`
  both return the expected resources.
- [ ] Manual: verify Prometheus is scraping DCGM and node-exporter by port-forwarding
  and querying `DCGM_FI_DEV_GPU_TEMP` and `node_memory_MemTotal_bytes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)