### PR TITLE
[Core] Improve user-facing error messages for launch misconfigurations

### DIFF
--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -299,7 +299,7 @@ def validate_region_zone_impl(
     """
 
     def _get_candidate_str(loc: str, all_loc: List[str]) -> str:
-        candidate_loc = difflib.get_close_matches(loc, all_loc, n=5, cutoff=0.9)
+        candidate_loc = difflib.get_close_matches(loc, all_loc, n=5, cutoff=0.6)
         candidate_loc = sorted(candidate_loc)
         candidate_strs = ''
         if candidate_loc:

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -32,6 +32,7 @@ from sky.utils import kubernetes_enums
 from sky.utils import registry
 from sky.utils import resources_utils
 from sky.utils import schemas
+from sky.utils import ux_utils
 from sky.utils import volume as volume_lib
 
 logger = sky_logging.init_logger(__name__)
@@ -430,8 +431,17 @@ class Kubernetes(clouds.Cloud):
     def get_vcpus_mem_from_instance_type(
             cls, instance_type: str) -> Tuple[Optional[float], Optional[float]]:
         """Returns the #vCPUs and memory that the instance type offers."""
-        k = kubernetes_utils.KubernetesInstanceType.from_instance_type(
-            instance_type)
+        try:
+            k = kubernetes_utils.KubernetesInstanceType.from_instance_type(
+                instance_type)
+        except ValueError:
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(
+                    f'Invalid Kubernetes instance type: {instance_type!r}. '
+                    'Kubernetes instance types use the format '
+                    '"<cpus>CPU--<mem>GB" or '
+                    '"<cpus>CPU--<mem>GB--<accelerator>:<count>" '
+                    '(e.g. "4CPU--16GB", "4CPU--16GB--H100:1").') from None
         return k.cpus, k.memory
 
     @classmethod

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -913,15 +913,19 @@ def validate_schema(obj, schema, err_msg_prefix='', skip_none=True):
                 known_fields = set(e.schema.get('properties', {}).keys())
                 assert isinstance(e.instance,
                                   dict), 'Instance must be a dictionary'
+                sub_msgs = []
                 for field in e.instance:
                     if field not in known_fields:
                         most_similar_field = difflib.get_close_matches(
                             field, known_fields, 1)
                         if most_similar_field:
-                            err_msg += (f'Instead of {field!r}, did you mean '
-                                        f'{most_similar_field[0]!r}?')
+                            sub_msgs.append(
+                                f'Instead of {field!r}, did you mean '
+                                f'{most_similar_field[0]!r}?')
                         else:
-                            err_msg += f'Found unsupported field {field!r}.'
+                            sub_msgs.append(
+                                f'Found unsupported field {field!r}.')
+                err_msg += ' '.join(sub_msgs)
         else:
             message = e.message
             # Object in jsonschema is represented as dict in Python. Replace

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -927,13 +927,20 @@ def validate_schema(obj, schema, err_msg_prefix='', skip_none=True):
                                 f'Found unsupported field {field!r}.')
                 err_msg += ' '.join(sub_msgs)
         else:
-            message = e.message
+            # When the error came from an anyOf/oneOf branch, jsonschema's
+            # default message is the unhelpful "X is not valid under any of
+            # the given schemas" with json_path truncated at the branch
+            # boundary. best_match recurses into the sub-error context for
+            # anyOf/oneOf nodes specifically (see its docstring) and
+            # surfaces the deepest, most-specific sub-error.
+            best = jsonschema.exceptions.best_match([e])
+            message = best.message
             # Object in jsonschema is represented as dict in Python. Replace
             # 'object' with 'dict' for better readability.
             message = message.replace('type \'object\'', 'type \'dict\'')
             # Example e.json_path value: '$.resources'
             err_msg = (err_msg_prefix + message +
-                       f'. Check problematic field(s): {e.json_path}')
+                       f'. Check problematic field(s): {best.json_path}')
 
     if err_msg:
         with ux_utils.print_exception_no_traceback():

--- a/sky/utils/registry.py
+++ b/sky/utils/registry.py
@@ -1,5 +1,6 @@
 """Registry for classes to be discovered"""
 
+import difflib
 import typing
 from typing import Callable, Dict, List, Optional, Set, Type, Union
 
@@ -42,11 +43,18 @@ class _Registry(dict, typing.Generic[T]):
         if search_name in self._aliases:
             return self[self._aliases[search_name]]
 
+        known_names = [*self.keys(), *self._aliases.keys()]
+        suggestion = difflib.get_close_matches(search_name,
+                                               known_names,
+                                               n=1,
+                                               cutoff=0.6)
+        suggestion_msg = (f' Did you mean {suggestion[0]!r}?'
+                          if suggestion else '')
         with ux_utils.print_exception_no_traceback():
             raise ValueError(
                 f'{self._registry_name.capitalize()} {name!r} is not a '
                 f'valid {self._registry_name} among '
-                f'{[*self.keys(), *self._aliases.keys()]}')
+                f'{known_names}.{suggestion_msg}')
 
     def type_register(self,
                       name: str,

--- a/sky/utils/resources_utils.py
+++ b/sky/utils/resources_utils.py
@@ -146,11 +146,11 @@ def normalize_local_disk(local_disk: str) -> str:
                 raise ValueError()
         except ValueError:
             with ux_utils.print_exception_no_traceback():
-                raise ValueError(  # pylint: disable=raise-missing-from
+                raise ValueError(
                     f'Invalid local_disk: {local_disk!r}. '
                     'Expected "mode:size[+]", "mode", or "size[+]". Mode '
                     'must be "nvme" or "ssd", size must be positive (GB), '
-                    'optionally with "+".')
+                    'optionally with "+".') from None
 
     if len(parts) == 1:
         part = parts[0]
@@ -164,13 +164,16 @@ def normalize_local_disk(local_disk: str) -> str:
     elif len(parts) == 2:
         mode, size_str = parts
         if mode not in ('nvme', 'ssd'):
-            raise ValueError(f'Invalid local_disk mode: {mode!r}. '
-                             'Must be "nvme" or "ssd".')
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(f'Invalid local_disk mode: {mode!r}. '
+                                 'Must be "nvme" or "ssd".')
         _check_size(size_str)
     else:
-        raise ValueError(f'Invalid local_disk format: {local_disk!r}. '
-                         'Expected "mode:size[+]", "mode", or "size[+]". '
-                         'Examples: "nvme:1000+", "ssd:500", "nvme", "1000+".')
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError(
+                f'Invalid local_disk format: {local_disk!r}. '
+                'Expected "mode:size[+]", "mode", or "size[+]". '
+                'Examples: "nvme:1000+", "ssd:500", "nvme", "1000+".')
 
     return f'{mode}:{size_str}'
 
@@ -519,9 +522,11 @@ def parse_memory_resource(resource_qty_str: Union[str, int, float],
     """
     assert unit in constants.MEMORY_SIZE_UNITS, f'Invalid unit: {unit}'
 
-    error_msg = (f'"{field_name}" field should be a '
-                 f'{constants.MEMORY_SIZE_PATTERN}+?,'
-                 f' got {resource_qty_str}')
+    plus_hint = ' or "<number>+" for "at least"' if allow_plus else ''
+    error_msg = (f'"{field_name}" field should be a number (e.g. "16") or '
+                 f'"<number><unit>" where unit is one of KB/MB/GB/TB/PB '
+                 f'(e.g. "16GB"){plus_hint}. '
+                 f'Got: {resource_qty_str!r}')
 
     resource_str = str(resource_qty_str)
 
@@ -532,7 +537,8 @@ def parse_memory_resource(resource_qty_str: Union[str, int, float],
             resource_str = resource_str[:-1]
             plus = '+'
         else:
-            raise ValueError(error_msg)
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(error_msg)
 
     x = ''
     if resource_str.endswith('x'):
@@ -540,7 +546,8 @@ def parse_memory_resource(resource_qty_str: Union[str, int, float],
             resource_str = resource_str[:-1]
             x = 'x'
         else:
-            raise ValueError(error_msg)
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(error_msg)
 
     try:
         # We assume it is already in the wanted units to maintain backwards
@@ -564,7 +571,8 @@ def parse_memory_resource(resource_qty_str: Union[str, int, float],
             except ValueError:
                 continue
 
-    raise ValueError(error_msg)
+    with ux_utils.print_exception_no_traceback():
+        raise ValueError(error_msg)
 
 
 def _parse_time_with_units(time: str, time_units: Dict[str, int]) -> int:

--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -613,7 +613,8 @@ def test_infer_cloud_from_region_or_zone(enable_all_clouds):
     # Typo, fuzzy hint.
     with pytest.raises(ValueError) as e:
         _test_resources_launch(zone='us-west-2-a', cloud=sky.AWS())
-    assert ('Did you mean one of these: \'us-west-2a\'?' in str(e.value))
+    err = str(e.value)
+    assert 'Did you mean one of these:' in err and 'us-west-2a' in err
 
     # Detailed hints.
     # ValueError: Invalid (region None, zone 'us-west-2-a') for any cloud among
@@ -642,6 +643,51 @@ def test_infer_cloud_from_region_or_zone(enable_all_clouds):
     assert (
         'Invalid (region \'us-east1\', zone \'us-west2-a\') for any cloud among'
         in str(e.value))
+
+
+def test_invalid_region_suggests_close_match(enable_all_clouds):
+    """Close-typo regions like 'us-east' should suggest 'us-east-1'.
+
+    Previously the fuzzy-match cutoff was 0.9, which required near-identical
+    strings and missed common typos where the user omitted the numeric suffix.
+    """
+    with pytest.raises(ValueError) as e:
+        _test_resources_launch(region='us-east', cloud=sky.AWS())
+    msg = str(e.value)
+    assert "Invalid region 'us-east'" in msg
+    assert 'Did you mean one of these' in msg
+    assert 'us-east-1' in msg
+
+
+def test_invalid_zone_returns_multiple_close_matches(enable_all_clouds):
+    """At the widened cutoff, close typos should surface several candidates.
+
+    'us-west-2-a' (extra hyphen) is roughly equidistant from the whole
+    us-west-2 zone family, so the user should see more than just the
+    nearest match. This locks in the wider candidate set made possible
+    by lowering the difflib cutoff.
+    """
+    with pytest.raises(ValueError) as e:
+        _test_resources_launch(zone='us-west-2-a', cloud=sky.AWS())
+    msg = str(e.value)
+    assert 'Did you mean one of these' in msg
+    # Multiple sibling zones should be offered, not only the closest.
+    for zone in ('us-west-2a', 'us-west-2b', 'us-west-2c'):
+        assert zone in msg, f'Expected {zone!r} in suggestion, got: {msg!r}'
+
+
+def test_invalid_cloud_name_suggests_close_match():
+    """Typo'd cloud names like 'gpc' should suggest 'gcp'.
+
+    Previously the cloud registry only dumped the full list of valid clouds
+    with no close-match hint.
+    """
+    with pytest.raises(ValueError) as e:
+        registry.CLOUD_REGISTRY.from_str('gpc')
+    msg = str(e.value)
+    assert "'gpc'" in msg
+    assert 'Did you mean' in msg
+    assert "'gcp'" in msg
 
 
 def test_ordered_resources(enable_all_clouds):

--- a/tests/test_yaml_parser.py
+++ b/tests/test_yaml_parser.py
@@ -187,6 +187,32 @@ def test_replace_envs_in_workdir(tmpdir, tmp_path):
     assert task.workdir == tmpdir
 
 
+def test_anyof_error_points_at_inner_problem(tmp_path):
+    """Schema errors inside an anyOf/oneOf should name the real issue.
+
+    Previously the validator surfaced the outer 'is not valid under any of
+    the given schemas' message and truncated the JSON path at the anyOf
+    boundary, which gave users no clue what was wrong. With
+    jsonschema.exceptions.best_match, the inner type-mismatch error should
+    be reported instead.
+    """
+    config_path = _create_config_file(
+        textwrap.dedent("""\
+            resources:
+                cpus: 2
+                autostop:
+                    idle_minutes: "ten"
+            """), tmp_path)
+    with pytest.raises(InvalidSkyPilotConfigError) as e:
+        Task.from_yaml(config_path)
+    msg = e.value.args[0]
+    # Must not fall back to the outer anyOf message.
+    assert 'not valid under any of the given schemas' not in msg
+    # Must name the real issue: idle_minutes expected an integer.
+    assert 'integer' in msg
+    assert 'ten' in msg
+
+
 def test_multiple_unknown_fields_separator(tmp_path):
     """Multiple typos at the same level should not be concatenated together.
 

--- a/tests/test_yaml_parser.py
+++ b/tests/test_yaml_parser.py
@@ -185,3 +185,26 @@ def test_replace_envs_in_workdir(tmpdir, tmp_path):
             """), tmp_path)
     task = Task.from_yaml(config_path)
     assert task.workdir == tmpdir
+
+
+def test_multiple_unknown_fields_separator(tmp_path):
+    """Multiple typos at the same level should not be concatenated together.
+
+    Previously the error read '...did you mean X?Instead of...' with no
+    whitespace separator between the two suggestions.
+    """
+    config_path = _create_config_file(
+        textwrap.dedent("""\
+            setups: echo hello
+            env:
+                FOO: bar
+            """), tmp_path)
+    with pytest.raises(InvalidSkyPilotConfigError) as e:
+        Task.from_yaml(config_path)
+    msg = e.value.args[0]
+    # Both suggestions must be present...
+    assert "did you mean 'setup'" in msg
+    assert "did you mean 'envs'" in msg
+    # ...and they must be separated by at least whitespace or a newline
+    # so the message is readable. The old broken form was '...?Instead'.
+    assert '?Instead' not in msg

--- a/tests/unit_tests/kubernetes/test_instance_type.py
+++ b/tests/unit_tests/kubernetes/test_instance_type.py
@@ -4,6 +4,7 @@ Tests verify correct instance type parsing and formatting.
 """
 import pytest
 
+from sky.clouds import kubernetes as kubernetes_cloud
 from sky.provision.kubernetes.utils import KubernetesInstanceType
 
 
@@ -60,7 +61,7 @@ def test_kubernetes_instance_type():
 
 def test_gpu_name_underscore_preservation():
     """Test that GPU names with underscores are preserved exactly as-is.
-    
+
     This specifically tests the fix for CoreWeave H100_NVLINK_80GB support
     where underscores were incorrectly converted to spaces during parsing.
     """
@@ -95,3 +96,20 @@ def test_gpu_name_underscore_preservation():
         assert original_name in instance.name, (
             f"Instance type string '{instance.name}' should contain "
             f"original accelerator name '{original_name}'")
+
+
+def test_get_vcpus_mem_suppresses_internal_traceback():
+    """A non-Kubernetes instance name should raise a clean ValueError.
+
+    Previously, passing e.g. an AWS instance_type to a Kubernetes cloud
+    (or hitting this path during dryrun YAML serialization) leaked the
+    internal KubernetesInstanceType regex-mismatch traceback. The
+    message should name the offending value and be raised without a
+    chained internal exception.
+    """
+    with pytest.raises(ValueError) as e:
+        kubernetes_cloud.Kubernetes.get_vcpus_mem_from_instance_type('m5.large')
+    # Must clearly mention the offending input.
+    assert 'm5.large' in str(e.value)
+    # No chained 'during handling of another exception' context.
+    assert e.value.__suppress_context__ is True

--- a/tests/unit_tests/test_sky/utils/test_resources_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_resources_utils.py
@@ -224,6 +224,36 @@ class TestNormalizeLocalDisk:
         with pytest.raises(ValueError, match='Invalid local_disk'):
             resources_utils.normalize_local_disk('fakessd')
 
+    def test_non_numeric_size_suppresses_chained_exception(self):
+        """The user-facing ValueError should not be chained from the
+        internal float() ValueError. Previously the traceback printed both
+        'could not convert string to float' and the user-friendly message.
+        """
+        with pytest.raises(ValueError) as e:
+            resources_utils.normalize_local_disk('foo')
+        assert e.value.__suppress_context__ is True
+
+
+class TestParseMemoryResource:
+    """Tests for parse_memory_resource error message quality."""
+
+    def test_invalid_input_has_readable_error(self):
+        """Error for invalid memory input should be human-readable.
+
+        Previously the message concatenated the raw regex pattern and a
+        stray '+?,' suffix, yielding
+        '"memory" field should be a ^[0-9]+(kb|ki|...)?$+?, got xyz'.
+        """
+        with pytest.raises(ValueError) as e:
+            resources_utils.parse_memory_resource('xyz', 'memory')
+        msg = str(e.value)
+        # The garbled '+?' suffix should not appear in the user-facing error.
+        assert '?$+?' not in msg
+        assert '?$' not in msg
+        # The field name and the offending value should both be named.
+        assert 'memory' in msg
+        assert 'xyz' in msg
+
 
 class TestParseLocalDiskStr:
     """Tests for parse_local_disk_str function."""


### PR DESCRIPTION
Three small improvements to the errors users see when ``sky launch`` / ``sky jobs launch`` fails validation on a misconfigured field. Pure message-layer — no behavior change.

## Examples

### 1. "Did you mean?" polish

<details><summary>Multiple typos at the same level: missing separator</summary>

```yaml
setups: echo hi
env:
    FOO: bar
```

**Before:**
```
Invalid task YAML: Instead of 'setups', did you mean 'setup'?Instead of 'env', did you mean 'envs'?
```

**After:**
```
Invalid task YAML: Instead of 'setups', did you mean 'setup'? Instead of 'env', did you mean 'envs'?
```

</details>

<details><summary>Typo'd cloud name: no close-match hint</summary>

`sky launch --infra gpc`

**Before:**
```
ValueError: Cloud 'gpc' is not a valid cloud among ['gcp', 'verda', 'aws', 'azure', ...]
```

**After:**
```
ValueError: Cloud 'gpc' is not a valid cloud among ['gcp', 'verda', 'aws', 'azure', ...]. Did you mean 'gcp'?
```

</details>

<details><summary>Typo'd region: fuzzy-match cutoff too strict</summary>

`sky launch --infra aws/us-east`

**Before:**
```
ValueError: Invalid region 'us-east'
List of supported aws regions: 'af-south-1, ap-east-1, ..., us-east-1, us-east-2, us-west-1, us-west-2'
```

**After:**
```
ValueError: Invalid region 'us-east'
Did you mean one of these: 'ap-east-1, us-east-1, us-east-2, us-west-1, us-west-2'?
```

</details>

### 2. Clean up error messages for memory / local_disk / Kubernetes instance types

<details><summary>Memory: raw regex leaked into user-facing message + traceback</summary>

`sky launch --memory xyz`

**Before:**
```
Traceback (most recent call last):
  File ".../sky/resources.py", line 808, in _set_memory
    ...
  File ".../sky/utils/resources_utils.py", line 567, in parse_memory_resource
    raise ValueError(error_msg)
ValueError: "memory" field should be a ^[0-9]+(kb|ki|mb|mi|gb|gi|tb|ti|pb|pi|KB|KI|MB|MI|GB|GI|TB|TI|PB|PI|Kb|Ki|Mb|Mi|Gb|Gi|Tb|Ti|Pb|Pi)?$+?, got xyz
```

**After:**
```
ValueError: "memory" field should be a number (e.g. "16") or "<number><unit>" where unit is one of KB/MB/GB/TB/PB (e.g. "16GB") or "<number>+" for "at least". Got: 'xyz'
```

</details>

<details><summary>local_disk: chained internal ValueError leaked</summary>

`sky launch --local-disk foo`

**Before:**
```
ValueError: could not convert string to float: 'foo'

During handling of the above exception, another exception occurred:

ValueError: Invalid local_disk: 'foo'. Expected "mode:size[+]", "mode", or "size[+]". Mode must be "nvme" or "ssd", size must be positive (GB), optionally with "+".
```

**After:**
```
ValueError: Invalid local_disk: 'foo'. Expected "mode:size[+]", "mode", or "size[+]". Mode must be "nvme" or "ssd", size must be positive (GB), optionally with "+".
```

</details>

<details><summary>Kubernetes instance type: regex-mismatch traceback</summary>

`sky launch --instance-type m5.large --infra k8s`

**Before:**
```
Traceback (most recent call last):
  File ".../sky/task.py", line 1746, in to_yaml_config
    ...
  File ".../sky/clouds/kubernetes.py", line 433, in get_vcpus_mem_from_instance_type
    k = kubernetes_utils.KubernetesInstanceType.from_instance_type(...)
  File ".../sky/provision/kubernetes/utils.py", line 2855, in from_instance_type
    raise ValueError(f'Invalid instance name: {name}')
ValueError: Invalid instance name: m5.large
```

**After:**
```
ValueError: Invalid Kubernetes instance type: 'm5.large'. Kubernetes instance types use the format "<cpus>CPU--<mem>GB" or "<cpus>CPU--<mem>GB--<accelerator>:<count>" (e.g. "4CPU--16GB", "4CPU--16GB--H100:1").
```

</details>

### 3. Unwrap anyOf/oneOf schema errors

<details><summary>`anyOf` hid the real problem under a generic wrapper</summary>

```yaml
resources:
    cpus: 2
    autostop:
        idle_minutes: "ten"
```

**Before:**
```
InvalidSkyPilotConfigError: Invalid resources YAML: {'idle_minutes': 'ten'} is not valid under any of the given schemas. Check problematic field(s): $.autostop
```

**After:**
```
InvalidSkyPilotConfigError: Invalid resources YAML: 'ten' is not of type 'integer'. Check problematic field(s): $.autostop.idle_minutes
```

The same unwrap applies to other ``anyOf``/``oneOf`` fields in the schema (e.g. ``workdir``, ``resources.accelerators``, ``resources.secrets``).

</details>

## Trade-offs

- Lowering the region/zone ``difflib`` cutoff from 0.9 → 0.6 widens the suggestion list — e.g. ``us-west-2-a`` now suggests ``us-west-1a, us-west-2a, us-west-2b, us-west-2c, us-west-2d`` rather than just ``us-west-2a``. I think catching common "forgot the numeric suffix" typos (``us-east`` → ``us-east-1``) is worth the longer list. One pre-existing assertion in ``test_infer_cloud_from_region_or_zone`` was adjusted to tolerate either phrasing.
- The ``anyOf`` unwrap changes the text of a whole category of schema errors. I audited existing assertions; the single smoke test that checks a schema suggestion message uses a single-field path unaffected by this change.

Tested:

- [x] Code formatting: ``bash format.sh`` / pre-commit hooks
- [x] Unit tests added for each change; ran ``pytest tests/test_yaml_parser.py tests/test_optimizer_dryruns.py tests/unit_tests/test_sky/utils/test_resources_utils.py tests/unit_tests/kubernetes/test_instance_type.py`` locally
- [x] Verified end-to-end via live ``sky launch --dryrun`` for each of the seven error paths above
