### PR TITLE
[Jobs] Fix log_tail fork bomb on HA controller pod restart

### DIFF
--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -1114,12 +1114,13 @@ available_node_types:
               # open file handlers with write access
               # closes if none exist
               monitor_file() {
-                tail -f $file &
+                local file="$1"
+                tail -f "$file" &
                 TAIL_PID=$!
                 while kill -0 $TAIL_PID 2> /dev/null; do
                   # only two PIDs should be accessing the file
                   # the log appender and log tailer
-                  if [ $(mylsof $file | wc -l) -lt 2 ]; then
+                  if [ $(mylsof "$file" | wc -l) -lt 2 ]; then
                     kill $TAIL_PID
                     break
                   fi
@@ -1131,7 +1132,13 @@ available_node_types:
               }
 
               log_tail() {
-                FILE_PATTERN="~/sky_logs/*/tasks/*.log"
+                # Use a bash glob (not `ls $(eval echo ...)`) so we are
+                # safe against ARG_MAX at very high file counts and against
+                # spaces in $HOME or in any path component. nullglob makes
+                # an empty match a no-op instead of yielding the literal
+                # pattern. log_tail is launched via `log_tail &`, so this
+                # runs in its own subshell and the shopt does not leak.
+                shopt -s nullglob
 
                 # O(1) membership set. Replaces an `echo $str | grep -q` check
                 # that was O(n) per file (O(n^2) across the outer loop).
@@ -1142,29 +1149,30 @@ available_node_types:
                 # the PVC retains task logs from all prior (completed) jobs;
                 # tailing them all spawns a tail+mylsof loop per file, and
                 # mylsof's /proc/*/fd/* scan grows with the process count,
-                # producing runaway fork growth. nullglob is off by default,
-                # so the `ls` guard handles the empty-glob case.
-                if ls $(eval echo $FILE_PATTERN) 1> /dev/null 2>&1; then
-                  for f in $(eval echo $FILE_PATTERN); do
-                    already_monitored[$f]=1
-                  done
-                fi
+                # producing runaway fork growth.
+                for f in "$HOME"/sky_logs/*/tasks/*.log; do
+                  already_monitored["$f"]=1
+                done
 
-                while ! ls $(eval echo $FILE_PATTERN) 1> /dev/null 2>&1; do
+                # Wait until at least one log file exists.
+                while true; do
+                  for f in "$HOME"/sky_logs/*/tasks/*.log; do
+                    break 2
+                  done
                   sleep 1
                 done
 
                 # Infinite loop to continuously check for new files
                 while true; do
-                  for file in $(eval echo $FILE_PATTERN); do
+                  for file in "$HOME"/sky_logs/*/tasks/*.log; do
                     if [[ -n "${already_monitored[$file]:-}" ]]; then
                       # File is already being monitored
                       continue
                     fi
 
                     # Monitor the new file
-                    monitor_file $file &
-                    already_monitored[$file]=1
+                    monitor_file "$file" &
+                    already_monitored["$file"]=1
                   done
                   sleep 0.1
                 done

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -1132,24 +1132,39 @@ available_node_types:
 
               log_tail() {
                 FILE_PATTERN="~/sky_logs/*/tasks/*.log"
+
+                # O(1) membership set. Replaces an `echo $str | grep -q` check
+                # that was O(n) per file (O(n^2) across the outer loop).
+                local -A already_monitored
+
+                # Pre-seed with every file that exists at startup so we do NOT
+                # spawn monitor_file for them. On an HA controller pod restart
+                # the PVC retains task logs from all prior (completed) jobs;
+                # tailing them all spawns a tail+mylsof loop per file, and
+                # mylsof's /proc/*/fd/* scan grows with the process count,
+                # producing runaway fork growth. nullglob is off by default,
+                # so the `ls` guard handles the empty-glob case.
+                if ls $(eval echo $FILE_PATTERN) 1> /dev/null 2>&1; then
+                  for f in $(eval echo $FILE_PATTERN); do
+                    already_monitored[$f]=1
+                  done
+                fi
+
                 while ! ls $(eval echo $FILE_PATTERN) 1> /dev/null 2>&1; do
                   sleep 1
                 done
 
-                # Keep track of already monitored files
-                already_monitored=""
-
                 # Infinite loop to continuously check for new files
                 while true; do
                   for file in $(eval echo $FILE_PATTERN); do
-                    if echo $already_monitored | grep -q $file; then
+                    if [[ -n "${already_monitored[$file]:-}" ]]; then
                       # File is already being monitored
                       continue
                     fi
 
                     # Monitor the new file
                     monitor_file $file &
-                    already_monitored="${already_monitored} ${file}"
+                    already_monitored[$file]=1
                   done
                   sleep 0.1
                 done


### PR DESCRIPTION
## Summary

On HA jobs controller pod restart, `log_tail()` in `sky/templates/kubernetes-ray.yml.j2` treats every file matching `~/sky_logs/*/tasks/*.log` as new and spawns a `tail -f` + `mylsof` loop per file. The PVC retains task logs from all prior jobs (including completed ones), so thousands of stale logs each get their own `monitor_file` child. `mylsof` scans `/proc/*/fd/*` per tick, and its cost grows with the process count — producing runaway fork growth, CPU saturation, and very high load average on the replacement pod.

## Fix

- Pre-seed `already_monitored` with every file present at startup so they are **not** tailed. Those jobs are already complete; their stdout has already been written to the log files on the PVC — there is no live writer to follow.
- Switch `already_monitored` from a space-separated string checked with `echo \$str | grep -q` to a bash associative array, replacing the O(n)-per-file membership test (O(n²) across the outer loop) with O(1).

New files created after startup are still picked up and tailed as before.

## Evidence

Reproduced on a real HA jobs controller (consolidation disabled, NFS PVC) at two scales:

| Scenario | Pre-existing log files | `tail -f` count | `readlink -e` in flight | Process count | load1 |
|---|---|---|---|---|---|
| Unpatched, 15 s after log_tail start | ~1,000 (still climbing) | 421 | 1,697 | 2,968 | 163.30 |
| Unpatched, ~14,000 files | 14,000 | saturated | saturated | runaway | 619 |
| **Patched**, 14,000 files | 14,000 | **0** | 0 | ~20 | **2.38** |
| **Patched**, 40,000 files | 40,000 | **0** (10 samples over 90 s) | **0** | 10 – 20 | 0.57 – 1.63 |
| Patched, new file created post-startup, 14k pre-existing | — | 1 (within 2 s) | — | — | — |

At 14k the fork bomb is completely eliminated and new-file tailing is preserved. At 40k the replacement pod reached `1/1 Ready` in ~20 s and remained stable with zero tail/readlink processes; HA recovery (Ray, controller setup, in-progress job restore) completed normally in 70 s.

**Caveat at extreme scale.** On the 40k PVC (Azure NFS Premium) `log_tail`'s initial globbing of `~/sky_logs/*/tasks/*.log` is bottlenecked by NFS metadata latency (~15 ms per stat × 40k = ~10 min per full glob). The patched function pre-seeds `already_monitored` and enters its main loop, but the first pass through the glob is slow at this scale. This is a pre-existing limitation of the glob-per-iteration design — not introduced by this fix — and it only surfaces now because the fork-bomb was previously masking it. The important property the fix delivers at 40k is **no runaway fork growth and no CPU saturation**: the pod stays healthy and all controller services remain responsive. A follow-up could replace repeated globbing with e.g. `inotifywait` on `~/sky_logs`; that is out of scope for this bug fix.

## Test plan

- [x] Repro the spike on an unpatched HA controller pod with ~14k stale task logs on the PVC (load1 → 163, then 619)
- [x] Apply the fix and confirm tails=0 / load1 ≈ 2 on restart with the same 14k stale logs
- [x] Confirm a log file created *after* the pod is Ready is still picked up by `log_tail` within a couple of seconds (14k scale)
- [x] Repeat on a **fresh HA controller** with **40k** pre-existing stale log files on the PVC: pod reaches Ready in ~20 s, HA recovery completes in 70 s, tails=0 and load stays sub-2 across the measurement window
- [x] Confirm normal (non-HA) k8s cluster still streams task logs to `kubectl logs` for a fresh pod with no pre-existing logs — all 20 lines of task output appeared in `kubectl logs`, and `tail` processes cleaned up on task completion

## Risk / scope

Scope is limited to the `log_tail()` shell function in `sky/templates/kubernetes-ray.yml.j2`. Behavior for fresh pods (no pre-existing matching files, e.g. normal non-HA k8s clusters and first-time HA controller provisioning) is unchanged: the pre-seed loop is a no-op when the glob matches nothing, and new log files are monitored as before. Only the HA-restart-with-retained-PVC case changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)