### PR TITLE
[Core] Expose zone field on StatusResponse

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -3733,6 +3733,8 @@ def get_clusters(
                                if handle.launched_resources.cloud else None)
             record['region'] = (f'{handle.launched_resources.region}'
                                 if handle.launched_resources.region else None)
+            record['zone'] = (f'{handle.launched_resources.zone}'
+                              if handle.launched_resources.zone else None)
             record['cpus'] = (f'{handle.launched_resources.cpus}'
                               if handle.launched_resources.cpus else None)
             record['memory'] = (f'{handle.launched_resources.memory}'

--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -126,6 +126,7 @@ class StatusResponse(ResponseBaseModel):
     nodes: int
     cloud: Optional[str] = None
     region: Optional[str] = None
+    zone: Optional[str] = None
     cpus: Optional[str] = None
     memory: Optional[str] = None
     accelerators: Optional[str] = None

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -10,7 +10,7 @@ from sky.skylet import constants
 # based on version info is needed.
 # For more details and code guidelines, refer to:
 # https://docs.skypilot.co/en/latest/developers/CONTRIBUTING.html#backward-compatibility-guidelines
-API_VERSION = 48  # mount config read_only support
+API_VERSION = 49  # expose zone field on StatusResponse
 
 # The minimum peer API version that the code should still work with.
 # Notes (dev):


### PR DESCRIPTION
## Summary

Adds `zone` to the flat `StatusResponse` response model so JSON consumers can render the availability zone the cluster was launched in.

Previously, `zone` was only accessible via `handle.launched_resources.zone`. Python's `sky status` works because `_get_infra` reads the handle directly, but JSON-based consumers had no way to get the zone without deserializing the pickled handle.

## Changes

- `sky/schemas/api/responses.py`: add `zone: Optional[str]` to `StatusResponse`.
- `sky/backends/backend_utils.py`: populate `record['zone']` from `handle.launched_resources.zone` in `_update_records_with_resources`, alongside the existing `cloud` and `region` fields.
- `sky/server/constants.py`: bump `API_VERSION` to 49.

## Backward compatibility

| Direction | Behavior |
|---|---|
| Old server → new client | `zone` absent from JSON → decoded as `None`. Callers fall back to `region`. No crash. |
| New server → old client | Extra field ignored via `ResponseBaseModel`'s `extra='ignore'` config. No crash. |

No version-gated serializer is needed — both directions degrade gracefully.

## Test plan

- [x] `sky status` existing path unchanged (cloud/region still present)
- [ ] Manual: launch cluster with `--infra aws/*/us-east-2b`, call the status endpoint, confirm response contains `"zone": "us-east-2b"`
- [ ] Pydantic model_validate roundtrip