### PR TITLE
[Dashboard] Unify filter bar sizing and styling across list pages

### DIFF
--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -466,7 +466,7 @@ export function Clusters() {
             Sky Clusters
           </Link>
         </div>
-        <div className="w-full sm:w-auto max-w-lg">
+        <div className="w-full sm:w-auto max-w-xl">
           <FilterDropdown
             propertyList={PROPERTY_OPTIONS}
             valueList={optionValues}

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -372,7 +372,7 @@ export function ManagedJobs() {
             Managed Jobs
           </Link>
         </div>
-        <div className="w-full sm:w-auto max-w-lg">
+        <div className="w-full sm:w-auto max-w-xl">
           <FilterDropdown
             propertyList={PROPERTY_OPTIONS}
             valueList={valueList}

--- a/sky/dashboard/src/components/recipe-hub.jsx
+++ b/sky/dashboard/src/components/recipe-hub.jsx
@@ -322,7 +322,7 @@ function AllRecipesSection({ recipes, onPin, onDelete }) {
       {/* Filter Bar */}
       <div className="flex flex-wrap items-center gap-2 mb-3">
         <span className="text-base text-gray-700">All Recipes</span>
-        <div className="w-full sm:w-auto">
+        <div className="w-full sm:w-auto max-w-xl">
           <RecipeFilterDropdown
             propertyList={RECIPE_PROPERTY_OPTIONS}
             valueList={optionValues}

--- a/sky/dashboard/src/components/shared/FilterSystem.jsx
+++ b/sky/dashboard/src/components/shared/FilterSystem.jsx
@@ -339,7 +339,7 @@ export const FilterDropdown = ({
           onChange={handleValueChange}
           onFocus={handleInputFocus}
           onKeyDown={handleKeyDown}
-          className="h-8 w-full px-3 pr-8 text-sm border-none rounded-l-none rounded-r-md focus:ring-0 focus:outline-none"
+          className="h-8 w-full sm:w-96 px-3 pr-8 text-sm border-none rounded-l-none rounded-r-md focus:ring-0 focus:outline-none"
           autoComplete="off"
         />
         {value && (

--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -814,7 +814,7 @@ export function Users() {
       {/* Filter/Search and Create Service Account Row */}
       <div className="flex items-center justify-between mb-4">
         {activeMainTab === 'users' ? (
-          <div className="w-full sm:w-auto max-w-md">
+          <div className="w-full sm:w-auto max-w-xl">
             <FilterDropdown
               propertyList={PROPERTY_OPTIONS}
               valueList={valueList}

--- a/sky/dashboard/src/components/workspaces.jsx
+++ b/sky/dashboard/src/components/workspaces.jsx
@@ -839,13 +839,13 @@ export function Workspaces() {
 
       {/* Search and Create Workspace Row */}
       <div className="flex items-center justify-between mb-4">
-        <div className="relative flex-1 max-w-md">
+        <div className="relative flex-1 sm:flex-none">
           <input
             type="text"
             placeholder="Filter workspaces"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="h-8 w-full px-3 pr-8 text-sm border border-gray-300 rounded-md focus:ring-1 focus:ring-sky-500 focus:border-sky-500 outline-none"
+            className="h-8 w-full sm:w-96 px-3 pr-8 text-sm border border-gray-300 rounded-md focus:ring-0 focus:outline-none"
           />
           {searchQuery && (
             <button


### PR DESCRIPTION
## Summary

Makes the filter bars on Clusters, Jobs, Users, Recipes, and Workspaces
pages visually consistent. Fixes two specific regressions along the way:

- **Right border clipped on Clusters/Jobs** (introduced by #9350). The
  `max-w-lg` (512px) cap added there is ~3–4px narrower than the
  FilterDropdown's contents (`md:w-32` Select + `sm:w-96` input + 2px
  border), so the rounded-right input painted over the container's 1px
  right border. Bumping the cap to `max-w-xl` (576px) gives ~60px
  headroom while still preserving #9350's bound that prevents the wrapper
  from flipping to `max-content` and blowing out to the full row.
- **Blue halo around the Workspaces filter input on focus.** Workspaces
  was the only page using `focus:ring-1 focus:ring-sky-500 focus:border-sky-500`;
  every other filter bar uses `focus:ring-0 focus:outline-none`. Matched
  the existing pattern.

## Filter bar state before and after

| Page | Filter component | Input width | Outer cap | Right border |
| --- | --- | --- | --- | --- |
| Clusters | local \`FilterDropdown\` | 384px | \`max-w-lg\` → **\`max-w-xl\`** | hidden → **visible** |
| Jobs | shared \`FilterDropdown\` | ~200px (intrinsic) → **384px** | \`max-w-lg\` → **\`max-w-xl\`** | hidden → **visible** |
| Users | shared \`FilterDropdown\` | ~200px → **384px** | \`max-w-md\` → **\`max-w-xl\`** | visible (unchanged) |
| Recipes | local \`RecipeFilterDropdown\` | 384px | (none) → **\`max-w-xl\`** | visible (unchanged) |
| Workspaces | plain \`<input>\` | \`w-full\` unbounded → **\`sm:w-96\` (384px)** | n/a | blue halo on focus → **no ring** |

Net effect: every filter input is 384px (\`sm:w-96\`) on sm+, every wrapper
with a container cap uses \`max-w-xl\` (576px), and no focus ring anywhere.

## Test plan

Reproduce each observation at viewport ≥ sm (e.g. 1440×900):

- [x] \`/dashboard/clusters\`: filter bar shows a complete rounded rectangle
      with all four borders. Container ends 1px past the input.
- [x] \`/dashboard/jobs\`: same; \`Filter jobs\` input is now the same width
      as \`Filter clusters\` (was visibly narrower before).
- [x] \`/dashboard/users\`: same; \`Filter users\` now matches the others.
- [x] \`/dashboard/recipes\`: filter bar matches Clusters; new \`max-w-xl\`
      cap prevents the bar from expanding to full row width on re-render,
      matching the protection #9350 added for the other pages.
- [x] \`/dashboard/workspaces\`: filter input is 384px, gray border
      unchanged on focus (no sky-blue halo or border color change).
- [x] Cycling property options (\`Status\`, \`Cluster\`, …, \`Workspace\`) on
      Clusters/Jobs/Users/Recipes does not shift the filter bar — the
      Select trigger is fixed at \`md:w-32\` (128px), independent of the
      selected label.
- [x] On a wide viewport, switching between pages and back — a scenario
      where the browser can otherwise resolve the filter wrapper to
      \`max-content\` — does not blow the bar out to the full row on any of
      the five pages; it stays capped at \`max-w-xl\` (576px).