### PR TITLE
fix: replace bare except with except Exception in verify_llms_links.py

### DIFF
--- a/docs/verify_llms_links.py
+++ b/docs/verify_llms_links.py
@@ -33,7 +33,7 @@ def main():
     if base_url.startswith("http://127.0.0.1"):
         try:
             requests.get(base_url, timeout=1)
-        except:
+        except Exception:
             print(f"WARNING: No server at {base_url}")
 
     failures = []


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` on line 36 (PEP 8 E722).

Bare except clauses catch all exceptions including SystemExit and KeyboardInterrupt, which can mask critical signals. Using `except Exception:` is the recommended practice as it only catches standard errors while allowing system-level exceptions to propagate.

No behavior change — this block only prints a warning message.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
