### PR TITLE
fix: replace bare except with except Exception in redisvl example

### DIFF
--- a/examples/redisvl-vector-search/app.py
+++ b/examples/redisvl-vector-search/app.py
@@ -85,7 +85,7 @@ async def health():
     try:
         redis_client.ping()
         return {"status": "healthy", "papers": index.info().get("num_docs", 0)}
-    except:
+    except Exception:
         return {"status": "unhealthy"}
 
 


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in the health check endpoint (PEP 8 E722).

Bare except clauses catch all exceptions including SystemExit and KeyboardInterrupt, which can mask critical signals. Using `except Exception:` only catches standard errors while allowing system-level exceptions to propagate normally.

No behavior change — this block returns an unhealthy status on any standard error.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
