### PR TITLE
fix: replace bare except with except Exception in streamlit_app.py

### DIFF
--- a/examples/redisvl-vector-search/streamlit_app.py
+++ b/examples/redisvl-vector-search/streamlit_app.py
@@ -36,7 +36,7 @@ with st.sidebar:
                 st.error("System offline")
         else:
             st.error("API error")
-    except:
+    except Exception:
         st.error("Connection failed")
 
 


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in the Streamlit app's connection error handler (PEP 8 E722). Bare except clauses catch SystemExit and KeyboardInterrupt, which can mask critical signals. No behavior change - this block displays a connection error message.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
