### PR TITLE
[Core] Exclude pycache from built SkyPilot wheel

### DIFF
--- a/sky/setup_files/MANIFEST.in
+++ b/sky/setup_files/MANIFEST.in
@@ -28,3 +28,10 @@ recursive-include sky/recipes/examples *.yaml
 recursive-include sky_templates/ray *
 recursive-include sky_templates *.py
 include sky_templates/README.md
+
+# Exclude compiled bytecode - these are platform-specific, regenerated on
+# import, and cause non-deterministic wheels when the source tree contains
+# __pycache__ from editable installs (pip install -e).
+global-exclude __pycache__
+global-exclude *.pyc
+global-exclude *.pyo


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

## Summary

- The wheel built by `wheel_utils.py` can include `__pycache__/*.pyc` files when SkyPilot is installed in editable mode (`pip install -e .`), because `MANIFEST.in` uses `recursive-include sky/schemas/db *` which matches all files including compiled bytecode.
- This causes non-deterministic wheels: different environments (or the same environment at different times) produce wheels with different contents, leading to unnecessary cluster reprovisioning due to config hash mismatches.

## Details

`.pyc` files are generated at runtime when Python imports modules. When SkyPilot is installed in editable mode (as in the API server Docker image), these files are written directly into the source tree. The wheel builder symlinks the source tree into a temp directory and runs `pip wheel`, which picks up the `.pyc` files through the `recursive-include sky/schemas/db *` wildcard in `MANIFEST.in`.

Since the config hash used by `skip_unnecessary_provisioning` includes the wheel file contents, different wheels produce different hashes, defeating the provisioning skip optimization. This can cause repeated full runtime setup (SSH, file sync, pip install, ray start) on clusters that are already healthy.

The fix adds standard `global-exclude` directives to `MANIFEST.in` to exclude `__pycache__`, `*.pyc`, and `*.pyo` from the built wheel. This is the standard Python packaging pattern — compiled bytecode is platform-specific and regenerated on import, so it should never be distributed in a wheel.

Note: PR #9368 addressed a different reproducibility issue (zip metadata timestamps and dict ordering via `SOURCE_DATE_EPOCH` and `PYTHONHASHSEED`). This fix addresses the file *selection* layer in setuptools, which is controlled by `MANIFEST.in`.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
