### PR TITLE
fix: replace bare except with except Exception in eval_head.py

### DIFF
--- a/llm/distributed-rl-eval/src/eval_head.py
+++ b/llm/distributed-rl-eval/src/eval_head.py
@@ -72,7 +72,7 @@ class EvaluationHead:
             try:
                 self.model.load_state_dict(torch.load(model_path))
                 print(f"✓ Loaded model from {model_path}")
-            except:
+            except Exception:
                 print(f"✗ Could not load model, using random weights")
 
         self.model.eval()  # Set to evaluation mode
@@ -600,7 +600,7 @@ class EvaluationHead:
         for ws in self.websockets:
             try:
                 await ws.send_text(stats_message)
-            except:
+            except Exception:
                 disconnected.add(ws)
 
         # Remove disconnected clients


### PR DESCRIPTION
Replace two bare except: clauses with except Exception: in the eval head server (PEP 8 E722). Line 75: model loading fallback. Line 603: websocket stats broadcast. Bare except catches SystemExit and KeyboardInterrupt which can mask critical signals. No behavior change.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
