### PR TITLE
Deterministic config hash

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -235,6 +235,9 @@ _RAY_YAML_KEYS_TO_REMOVE_FOR_HASH = [
     # the cluster exists, it will only include the zone that the cluster is
     # actually in.
     ('provider', 'availability_zone'),
+    # The security group name includes a hostname-derived hash
+    # (user_and_hostname_hash) that varies across API server restart
+    ('provider', 'security_group'),
 ]
 
 _ACK_MESSAGE = 'ack'

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -324,7 +324,7 @@ def _get_cloud_dependencies_installation_commands(
     k8s_and_ssh_label = ' and '.join(sorted(enabled_k8s_and_ssh))
     k8s_dependencies_installed = False
 
-    for cloud in enabled_clouds:
+    for cloud in sorted(enabled_clouds, key=repr):
         cloud_python_dependencies: List[str] = copy.deepcopy(
             dependencies.extras_require[cloud.canonical_name()])
 

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -419,7 +419,8 @@ def _get_cloud_dependencies_installation_commands(
         if sc.lower() in constants.STORAGE_ONLY_CLOUDS:
             python_packages.update(dependencies.extras_require[sc.lower()])
 
-    packages_string = ' '.join([f'"{package}"' for package in python_packages])
+    packages_string = ' '.join(
+        [f'"{package}"' for package in sorted(python_packages)])
     step_prefix = prefix_str.replace('<step>', str(len(commands) + 1))
     commands.append(
         f'echo -en "\\r{step_prefix}cloud python packages{empty_str}" && '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously, python package is a set which does not produce deterministic package list

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
