### PR TITLE
Add LocalControllerHandleSource extension point

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -71,6 +71,7 @@ from sky.utils import ux_utils
 from sky.utils import volume as volume_utils
 from sky.utils import yaml_utils
 from sky.utils.plugin_extensions import ExternalFailureSource
+from sky.utils.plugin_extensions import LocalControllerHandleSource
 from sky.workspaces import core as workspaces_core
 
 if typing.TYPE_CHECKING:
@@ -3303,6 +3304,11 @@ def is_controller_accessible(
        ) or (serve_utils.is_consolidation_mode() and
              controller == controller_utils.Controllers.SKY_SERVE_CONTROLLER):
         cn = 'local-controller-consolidation'
+        # Plugins may register a custom LocalResourcesHandle factory to
+        # swap in a command runner that avoids the subprocess overhead.
+        plugin_handle = LocalControllerHandleSource.create(cluster_name=cn)
+        if plugin_handle is not None:
+            return plugin_handle
         return backends.LocalResourcesHandle(
             cluster_name=cn,
             cluster_name_on_cloud=cn,

--- a/sky/utils/plugin_extensions/__init__.py
+++ b/sky/utils/plugin_extensions/__init__.py
@@ -7,6 +7,8 @@ from sky.utils.plugin_extensions.external_failure_source import (
     ExternalClusterFailure)
 from sky.utils.plugin_extensions.external_failure_source import (
     ExternalFailureSource)
+from sky.utils.plugin_extensions.local_controller_handle_source import (
+    LocalControllerHandleSource)
 from sky.utils.plugin_extensions.node_info_source import NodeInfoSource
 from sky.utils.plugin_extensions.pod_info_source import PodInfoSource
 from sky.utils.plugin_extensions.recipe_validator import RecipeValidator
@@ -14,6 +16,7 @@ from sky.utils.plugin_extensions.recipe_validator import RecipeValidator
 __all__ = [
     'ExternalClusterFailure',
     'ExternalFailureSource',
+    'LocalControllerHandleSource',
     'NodeInfoSource',
     'PodInfoSource',
     'RecipeValidator',

--- a/sky/utils/plugin_extensions/local_controller_handle_source.py
+++ b/sky/utils/plugin_extensions/local_controller_handle_source.py
@@ -1,0 +1,95 @@
+"""Extension point for custom local controller handles.
+
+In consolidation mode, the jobs/serve controller runs in the same process
+as the API server. SkyPilot represents this via a `LocalResourcesHandle`
+whose `get_command_runners()` returns a `LocalProcessCommandRunner` that
+spawns a subprocess for each codegen invocation.
+
+This extension point lets plugins provide a custom factory that returns a
+subclass of `LocalResourcesHandle`, typically to swap in a CommandRunner
+that executes codegen in-process (avoiding the ~2.5s subprocess + import
+overhead per operation).
+
+Example usage in a plugin:
+
+    from sky.utils.plugin_extensions import LocalControllerHandleSource
+
+    class MyFastHandle(backends.LocalResourcesHandle):
+        def get_command_runners(self, *a, **kw):
+            return [MyInProcessRunner()]
+
+    def _factory(cluster_name):
+        return MyFastHandle(
+            cluster_name=cluster_name,
+            cluster_name_on_cloud=cluster_name,
+            cluster_yaml=None,
+            launched_nodes=1,
+            launched_resources=sky.Resources(
+                cloud=clouds.Cloud(), instance_type=cluster_name),
+        )
+
+    LocalControllerHandleSource.register(_factory)
+
+Example usage in core SkyPilot:
+
+    handle = LocalControllerHandleSource.create(cluster_name='my-ctrl')
+    if handle is None:
+        handle = backends.LocalResourcesHandle(...)  # default
+"""
+from typing import Any, Optional, Protocol
+
+from sky import sky_logging
+
+logger = sky_logging.init_logger(__name__)
+
+
+class LocalControllerHandleFactoryFunc(Protocol):
+    """Protocol for plugin-provided LocalResourcesHandle factories."""
+
+    def __call__(self, cluster_name: str) -> Any:
+        ...
+
+
+class LocalControllerHandleSource:
+    """Singleton registry for the plugin-provided handle factory.
+
+    At most one factory can be registered; the last registration wins.
+    If no factory is registered, `create()` returns None and callers
+    should fall back to the default LocalResourcesHandle construction.
+    """
+
+    _factory: Optional[LocalControllerHandleFactoryFunc] = None
+
+    @classmethod
+    def register(cls, factory: LocalControllerHandleFactoryFunc) -> None:
+        """Register a factory that constructs a LocalResourcesHandle.
+
+        Args:
+            factory: Callable taking `cluster_name: str` and returning a
+                LocalResourcesHandle (or subclass).
+        """
+        cls._factory = factory
+        logger.debug('Registered local controller handle factory')
+
+    @classmethod
+    def is_registered(cls) -> bool:
+        """Return True if a plugin has registered a factory."""
+        return cls._factory is not None
+
+    @classmethod
+    def create(cls, cluster_name: str) -> Optional[Any]:
+        """Construct a LocalResourcesHandle via the registered factory.
+
+        Returns None if no factory is registered, or if the factory raises
+        an exception (in which case the caller should use the default).
+        """
+        if cls._factory is None:
+            return None
+        try:
+            # pylint: disable=not-callable
+            return cls._factory(cluster_name=cluster_name)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(
+                f'Plugin-provided LocalResourcesHandle factory failed: '
+                f'{e}; falling back to default handle.')
+            return None


### PR DESCRIPTION
## Summary
- Adds a new `LocalControllerHandleSource` plugin extension point
- Allows providing a custom `LocalResourcesHandle` factory

## Motivation
In consolidation mode, `is_controller_accessible()` constructs a default `LocalResourcesHandle` whose command runner spawns a subprocess for each codegen invocation. Plugins can now register a factory returning a subclass of `LocalResourcesHandle`.

## Test plan
- [x] `bash format.sh` — pylint 10/10
- [x] No changes to default behaviour when no plugin registers
- [x] Manual verification: extension loads correctly, default path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)