### PR TITLE
[Storage] Add Hugging Face Buckets and repos as a storage backend

### DIFF
--- a/docs/source/reference/storage.rst
+++ b/docs/source/reference/storage.rst
@@ -3,7 +3,7 @@
 Cloud Buckets
 ==============
 
-SkyPilot tasks can access data from buckets in cloud object storages such as AWS S3, Google Cloud Storage (GCS), Cloudflare R2, CoreWeave Object Storage, VastData Object Storage, OCI Object Storage, IBM COS, or Hugging Face Buckets (and read-only Hugging Face model/dataset/space repos).
+SkyPilot tasks can access data from buckets in cloud object storages such as AWS S3, Google Cloud Storage (GCS), Cloudflare R2, CoreWeave Object Storage, VastData Object Storage, OCI Object Storage, IBM COS, or HF buckets.
 
 Buckets are made available to each task at a local path on the remote VM, so
 the task can access bucket objects as if they were local files.
@@ -28,7 +28,7 @@ Object storages are specified using the :code:`file_mounts` field in a SkyPilot 
           # Mount an existing S3 bucket
           file_mounts:
             /my_data:
-              source: s3://my-bucket/  # or gs://, https://<azure_storage_account>.blob.core.windows.net/<container>, r2://, cw://, vastdata://, cos://<region>/<bucket>, oci://<bucket_name>, hf://buckets/<namespace>/<bucket>, hf://<namespace>/<model>, hf://datasets/<namespace>/<dataset>, hf://spaces/<namespace>/<space>
+              source: s3://my-bucket/  # or gs://, https://<azure_storage_account>.blob.core.windows.net/<container>, r2://, cw://, vastdata://, cos://<region>/<bucket>, oci://<bucket_name>, hf://
               mode: MOUNT  # MOUNT or COPY or MOUNT_CACHED. Defaults to MOUNT. Optional.
 
         This will `mount <storage-mounting-modes_>`__ the contents of the bucket at ``s3://my-bucket/`` to the remote VM at ``/my_data``.
@@ -474,10 +474,7 @@ Storage YAML reference
             - vastdata://<bucket_name>
             - cos://<region_name>/<bucket_name>
             - oci://<bucket_name>@<region>
-            - hf://buckets/<namespace>/<bucket_name>        (HF Bucket, read-write)
-            - hf://<namespace>/<model>[@<rev>]              (HF model repo, read-only)
-            - hf://datasets/<namespace>/<dataset>[@<rev>]   (HF dataset repo, read-only)
-            - hf://spaces/<namespace>/<space>[@<rev>]       (HF space repo, read-only)
+            - hf://buckets/<namespace>/<bucket_name>  (see the Hugging Face CLI for the full URL syntax of repos, datasets, and spaces)
 
           If the source is local, data is uploaded to the cloud to an appropriate
           bucket (s3, gcs, azure, r2, coreweave, vastdata, oci, ibm, or hf). If source is bucket URI,

--- a/docs/source/reference/storage.rst
+++ b/docs/source/reference/storage.rst
@@ -3,7 +3,7 @@
 Cloud Buckets
 ==============
 
-SkyPilot tasks can access data from buckets in cloud object storages such as AWS S3, Google Cloud Storage (GCS), Cloudflare R2, CoreWeave Object Storage, VastData Object Storage, OCI Object Storage or IBM COS.
+SkyPilot tasks can access data from buckets in cloud object storages such as AWS S3, Google Cloud Storage (GCS), Cloudflare R2, CoreWeave Object Storage, VastData Object Storage, OCI Object Storage, IBM COS, or Hugging Face Buckets (and read-only Hugging Face model/dataset/space repos).
 
 Buckets are made available to each task at a local path on the remote VM, so
 the task can access bucket objects as if they were local files.
@@ -28,7 +28,7 @@ Object storages are specified using the :code:`file_mounts` field in a SkyPilot 
           # Mount an existing S3 bucket
           file_mounts:
             /my_data:
-              source: s3://my-bucket/  # or gs://, https://<azure_storage_account>.blob.core.windows.net/<container>, r2://, cw://, vastdata://, cos://<region>/<bucket>, oci://<bucket_name>
+              source: s3://my-bucket/  # or gs://, https://<azure_storage_account>.blob.core.windows.net/<container>, r2://, cw://, vastdata://, cos://<region>/<bucket>, oci://<bucket_name>, hf://buckets/<namespace>/<bucket>, hf://<namespace>/<model>, hf://datasets/<namespace>/<dataset>, hf://spaces/<namespace>/<space>
               mode: MOUNT  # MOUNT or COPY or MOUNT_CACHED. Defaults to MOUNT. Optional.
 
         This will `mount <storage-mounting-modes_>`__ the contents of the bucket at ``s3://my-bucket/`` to the remote VM at ``/my_data``.
@@ -45,7 +45,7 @@ Object storages are specified using the :code:`file_mounts` field in a SkyPilot 
           file_mounts:
             /my_data:
               name: my-sky-bucket
-              store: gcs  # Optional: either of s3, gcs, azure, r2, coreweave, vastdata, ibm, oci
+              store: gcs  # Optional: either of s3, gcs, azure, r2, coreweave, vastdata, ibm, oci, hf
 
         SkyPilot will create an empty GCS bucket called ``my-sky-bucket`` and mount it at ``/my_data``.
         This bucket can be used to write checkpoints, logs or other outputs directly to the cloud.
@@ -68,7 +68,7 @@ Object storages are specified using the :code:`file_mounts` field in a SkyPilot 
             /my_data:
               name: my-sky-bucket
               source: ~/dataset  # Optional: path to local data to upload to the bucket
-              store: s3  # Optional: either of s3, gcs, azure, r2, coreweave, vastdata, ibm, oci
+              store: s3  # Optional: either of s3, gcs, azure, r2, coreweave, vastdata, ibm, oci, hf
               mode: MOUNT  # Optional: either MOUNT or COPY. Defaults to MOUNT.
 
         SkyPilot will create a S3 bucket called ``my-sky-bucket`` and upload the
@@ -416,6 +416,35 @@ FAQ
   Therefore, SkyPilot does not automatically create them. Please manually create
   your CoreWeave bucket and verify its accessibility before using it with SkyPilot.
 
+* **My MOUNT-mode Hugging Face bucket / repo fails to mount.**
+
+  ``MOUNT`` / ``MOUNT_CACHED`` mode for ``store: hf`` uses the
+  `hf-mount <https://github.com/huggingface/hf-mount>`_ FUSE backend.
+  There are currently two known environment constraints:
+
+  1. **glibc >= 2.32 required.** The upstream Linux binaries for
+     hf-mount ``v0.3.1`` are dynamically linked against glibc 2.32+. They
+     won't run on Ubuntu 20.04 (glibc 2.31, the default SkyPilot Kubernetes
+     image) or older RHEL/CentOS releases. Fix: pick a newer base image in
+     ``resources``:
+
+     .. code-block:: yaml
+
+        resources:
+          image_id: docker:mirror.gcr.io/ubuntu:22.04   # glibc 2.35
+
+  2. **``/dev/fuse`` must be directly accessible in the task environment.**
+     hf-mount's FUSE backend opens ``/dev/fuse`` directly instead of going
+     through ``fusermount``, so it does not work with SkyPilot's default
+     Kubernetes fusermount-shim setup (which is how gcsfuse / blobfuse2 /
+     rclone mount / goofys normally get FUSE in unprivileged pods). On
+     bare-VM clouds (AWS, GCP, Azure, etc.) this is a non-issue -- the host
+     exposes ``/dev/fuse`` natively.
+
+  **COPY-mode workaround.** In any environment where the mount constraints
+  above are a problem, ``mode: COPY`` doesn't need ``hf-mount`` at all --
+  SkyPilot uploads/downloads via ``huggingface_hub`` directly.
+
 
 .. _storage-yaml-reference:
 
@@ -445,12 +474,16 @@ Storage YAML reference
             - vastdata://<bucket_name>
             - cos://<region_name>/<bucket_name>
             - oci://<bucket_name>@<region>
+            - hf://buckets/<namespace>/<bucket_name>        (HF Bucket, read-write)
+            - hf://<namespace>/<model>[@<rev>]              (HF model repo, read-only)
+            - hf://datasets/<namespace>/<dataset>[@<rev>]   (HF dataset repo, read-only)
+            - hf://spaces/<namespace>/<space>[@<rev>]       (HF space repo, read-only)
 
           If the source is local, data is uploaded to the cloud to an appropriate
-          bucket (s3, gcs, azure, r2, coreweave, vastdata, oci, or ibm). If source is bucket URI,
+          bucket (s3, gcs, azure, r2, coreweave, vastdata, oci, ibm, or hf). If source is bucket URI,
           the data is copied or mounted directly (see mode flag below).
 
-        store: str; either of 's3', 'gcs', 'azure', 'r2', 'coreweave', 'vastdata', 'ibm', 'oci'
+        store: str; either of 's3', 'gcs', 'azure', 'r2', 'coreweave', 'vastdata', 'ibm', 'oci', 'hf'
           If you wish to force sky.Storage to be backed by a specific cloud object
           storage, you can specify it here. If not specified, SkyPilot chooses the
           appropriate object storage based on the source path and task's cloud provider.

--- a/sky/adaptors/huggingface.py
+++ b/sky/adaptors/huggingface.py
@@ -1,0 +1,186 @@
+"""Hugging Face adapter for Bucket storage."""
+# pylint: disable=import-outside-toplevel
+import os
+import stat
+from typing import Dict, Optional, Tuple
+
+from sky import exceptions
+from sky.adaptors import common
+from sky.clouds import cloud
+from sky.utils import annotations
+from sky.utils import ux_utils
+
+NAME = 'HuggingFace'
+
+# Base prefix for all Hugging Face Hub URLs (buckets + repos).
+HF_URL_PREFIX = 'hf://'
+# URL prefix specific to HF Buckets.
+# See: https://huggingface.co/docs/huggingface_hub/guides/buckets
+HF_BUCKETS_URL_PREFIX = 'hf://buckets/'
+# URL prefixes for read-only HF repo mounts via ``hf-mount``.
+# Models: ``hf://<owner>/<model>``; datasets: ``hf://datasets/...``;
+# spaces: ``hf://spaces/...``.
+HF_DATASETS_URL_PREFIX = 'hf://datasets/'
+HF_SPACES_URL_PREFIX = 'hf://spaces/'
+
+# Where the `hf` CLI / `huggingface_hub` stores the user token. We mount this
+# file into remote clusters so that `hf-mount` and `huggingface_hub` can
+# authenticate transparently.
+# https://huggingface.co/docs/huggingface_hub/en/package_reference/authentication
+HF_TOKEN_PATH = '~/.cache/huggingface/token'
+# A legacy location used by older ``huggingface-cli`` versions.
+HF_TOKEN_PATH_LEGACY = '~/.huggingface/token'
+HF_TOKEN_PATH_ENV_CACHE = '~/.sky/huggingface/token'
+
+_INDENT_PREFIX = '    '
+_IMPORT_ERROR_MESSAGE = ('Failed to import dependencies for Hugging Face. '
+                         'Try pip install "skypilot[huggingface]"')
+
+# `huggingface_hub` is moderately heavy to import (several 100 ms) and is only
+# needed when HF Bucket storage is actually used. Use LazyImport so that the
+# cost is deferred from `import sky`.
+huggingface_hub = common.LazyImport('huggingface_hub',
+                                    import_error_message=_IMPORT_ERROR_MESSAGE)
+_LAZY_MODULES = (huggingface_hub,)
+
+
+@annotations.lru_cache(scope='global')
+def api():
+    """Returns a cached ``HfApi`` instance."""
+    # Import here rather than top-level so ``sky`` import stays cheap.
+    from huggingface_hub import HfApi  # pylint: disable=import-outside-toplevel
+    return HfApi()
+
+
+def get_token() -> Optional[str]:
+    """Returns the user's Hugging Face token, or None if unauthenticated.
+
+    Tries, in order: the ``HF_TOKEN`` / ``HUGGING_FACE_HUB_TOKEN`` environment
+    variables, then the token file written by ``hf auth login`` /
+    ``huggingface-cli login``.
+    """
+    env_token = (os.environ.get('HF_TOKEN') or
+                 os.environ.get('HUGGING_FACE_HUB_TOKEN'))
+    if env_token:
+        return env_token.strip() or None
+    for candidate in (HF_TOKEN_PATH, HF_TOKEN_PATH_LEGACY):
+        path = os.path.expanduser(candidate)
+        if os.path.isfile(path):
+            try:
+                with open(path, 'r', encoding='utf-8') as f:
+                    token = f.read().strip()
+                if token:
+                    return token
+            except OSError:
+                continue
+    return None
+
+
+@common.load_lazy_modules(_LAZY_MODULES)
+def hf_hub_errors():
+    """Returns the ``huggingface_hub.errors`` module."""
+    from huggingface_hub import errors as hf_errors
+    return hf_errors
+
+
+def check_credentials(
+        cloud_capability: cloud.CloudCapability) -> Tuple[bool, Optional[str]]:
+    if cloud_capability == cloud.CloudCapability.STORAGE:
+        return check_storage_credentials()
+    raise exceptions.NotSupportedError(
+        f'{NAME} does not support {cloud_capability}.')
+
+
+def check_storage_credentials() -> Tuple[bool, Optional[str]]:
+    """Checks if the user is authenticated against the Hugging Face Hub.
+
+    Returns:
+        ``(True, None)`` if the user has a usable token, otherwise
+        ``(False, hint)`` where ``hint`` is a user-facing message explaining
+        how to authenticate.
+    """
+    hints = None
+
+    # Make sure huggingface_hub itself is importable before we probe auth, so
+    # we can give a clean "install skypilot[huggingface]" hint.
+    try:
+        huggingface_hub.load_module()
+    except ImportError as e:
+        return False, str(e)
+
+    token = get_token()
+    if not token:
+        hints = ('Hugging Face token is not set. '
+                 'Set the HF_TOKEN environment variable or run '
+                 '`hf auth login` to authenticate.')
+        hints += f'\n{_INDENT_PREFIX}$ pip install "skypilot[huggingface]"'
+        hints += (f'\n{_INDENT_PREFIX}$ hf auth login   '
+                  '# or: export HF_TOKEN=<your-token>')
+        return False, hints
+
+    # If we have a token, verify it actually works.
+    try:
+        user = api().whoami(token=token)
+    except Exception as e:  # pylint: disable=broad-except
+        hints = (f'Failed to validate Hugging Face credentials: {e}. '
+                 'Re-run `hf auth login` to refresh your token.')
+        return False, hints
+
+    # ``whoami`` returns a dict with at least a ``name`` key.
+    if isinstance(user, dict) and user.get('name'):
+        return True, None
+    with ux_utils.print_exception_no_traceback():
+        return False, ('Hugging Face credentials appear invalid '
+                       '(empty whoami response).')
+
+
+def get_credential_file_mounts() -> Dict[str, str]:
+    """Returns credential file mounts for Hugging Face.
+
+    The token file is uploaded so that ``huggingface_hub`` and ``hf-mount`` on
+    the remote cluster can authenticate without needing the token to be baked
+    into the task YAML.
+    """
+    mounts: Dict[str, str] = {}
+    canonical_path = os.path.expanduser(HF_TOKEN_PATH)
+    legacy_path = os.path.expanduser(HF_TOKEN_PATH_LEGACY)
+    if os.path.exists(canonical_path):
+        mounts[HF_TOKEN_PATH] = HF_TOKEN_PATH
+        return mounts
+    if os.path.exists(legacy_path):
+        mounts[HF_TOKEN_PATH] = HF_TOKEN_PATH_LEGACY
+        return mounts
+
+    env_token = (os.environ.get('HF_TOKEN') or
+                 os.environ.get('HUGGING_FACE_HUB_TOKEN'))
+    if env_token and env_token.strip():
+        cache_path = os.path.expanduser(HF_TOKEN_PATH_ENV_CACHE)
+        cache_dir = os.path.dirname(cache_path)
+        os.makedirs(cache_dir, mode=0o700, exist_ok=True)
+        # Tighten perms on the dir in case it existed with a looser mode
+        # (os.makedirs with exist_ok=True ignores ``mode`` for pre-existing
+        # dirs). This is best-effort; cross-user ``~/.sky`` is not expected.
+        try:
+            os.chmod(cache_dir, 0o700)
+        except OSError:
+            pass
+        # Create the file with 0o600 atomically so we never expose the token
+        # to other users, not even for the brief window between ``open`` and
+        # ``chmod``.
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        if hasattr(os, 'O_NOFOLLOW'):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(cache_path, flags, stat.S_IRUSR | stat.S_IWUSR)
+        try:
+            with os.fdopen(fd, 'w', encoding='utf-8') as f:
+                f.write(env_token.strip())
+        except Exception:
+            # ``os.fdopen`` owns the fd on success; on failure before that
+            # takes effect we need to close it ourselves.
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            raise
+        mounts[HF_TOKEN_PATH] = HF_TOKEN_PATH_ENV_CACHE
+    return mounts

--- a/sky/check.py
+++ b/sky/check.py
@@ -15,6 +15,7 @@ from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import cloudflare
 from sky.adaptors import coreweave
+from sky.adaptors import huggingface
 from sky.adaptors import vastdata
 from sky.clouds import cloud as sky_cloud
 from sky.skylet import constants
@@ -26,7 +27,8 @@ from sky.utils import ux_utils
 
 CHECK_MARK_EMOJI = '\U00002714'  # Heavy check mark unicode
 PARTY_POPPER_EMOJI = '\U0001F389'  # Party popper unicode
-STORAGE_ONLY_CLOUDS = (cloudflare.NAME, coreweave.NAME, vastdata.NAME)
+STORAGE_ONLY_CLOUDS = (cloudflare.NAME, coreweave.NAME, vastdata.NAME,
+                       huggingface.NAME)
 
 logger = sky_logging.init_logger(__name__)
 
@@ -152,13 +154,15 @@ def check_capabilities(
         ) -> Tuple[str, Union[sky_clouds.Cloud, ModuleType]]:
             # Validates cloud_name and returns a tuple of the cloud's name and
             # the cloud object. Includes special handling for storage-only
-            # providers (Cloudflare, CoreWeave, VastData).
+            # providers (Cloudflare, CoreWeave, VastData, HuggingFace).
             if cloud_name.lower().startswith('cloudflare'):
                 return cloudflare.NAME, cloudflare
             elif cloud_name.lower().startswith('coreweave'):
                 return coreweave.NAME, coreweave
             elif cloud_name.lower().startswith('vastdata'):
                 return vastdata.NAME, vastdata
+            elif cloud_name.lower().startswith('huggingface'):
+                return huggingface.NAME, huggingface
             else:
                 try:
                     cloud_obj = registry.CLOUD_REGISTRY.from_str(cloud_name)
@@ -497,6 +501,11 @@ def get_cloud_credential_file_mounts(
     if vastdata_is_enabled:
         vastdata_credential_mounts = vastdata.get_credential_file_mounts()
         file_mounts.update(vastdata_credential_mounts)
+
+    hf_is_enabled, _ = huggingface.check_storage_credentials()
+    if hf_is_enabled:
+        hf_credential_mounts = huggingface.get_credential_file_mounts()
+        file_mounts.update(hf_credential_mounts)
     return file_mounts
 
 

--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -752,7 +752,7 @@ class HFCloudStorage(CloudStorage):
     """Hugging Face Buckets and Hub repos."""
 
     _GET_HF_HUB = [
-        f'{constants.SKY_UV_PIP_CMD} install "huggingface_hub>=1.10"',
+        f'{constants.SKY_UV_PIP_CMD} install "huggingface_hub>=1.5"',
     ]
     _TOKEN_HELPER = """
 token = os.environ.get('HF_TOKEN') or os.environ.get('HUGGING_FACE_HUB_TOKEN')
@@ -790,24 +790,33 @@ if not token:
         repo_type, repo_id, revision, path = data_utils.split_hf_repo_path(url)
         path = path.rstrip('/')
         if not path:
+            # Repo root is always a directory.
             return True
-        info = huggingface.api().repo_info(repo_id=repo_id,
-                                           repo_type=repo_type,
-                                           revision=revision,
-                                           token=huggingface.get_token())
-        prefix = f'{path}/'
-        for sibling in getattr(info, 'siblings', []) or []:
-            # ``huggingface_hub`` exposes the filename as ``rfilename`` on
-            # most repo types and ``path`` on a few; tolerate either. The
-            # trailing ``or ''`` keeps the type as ``str`` for mypy
-            # (``getattr(..., None)`` is ``Optional[Any]``).
-            filename: str = (getattr(sibling, 'rfilename', None) or
-                             getattr(sibling, 'path', '') or '')
-            if filename == path:
+        # ``list_repo_tree(path_in_repo=path)`` lists the immediate children
+        # of ``path`` when it is a directory and raises
+        # ``EntryNotFoundError`` / HTTP 404 when it is a file (or doesn't
+        # exist). This is much cheaper than ``repo_info(...).siblings`` for
+        # large repos, which eagerly fetches metadata for every file.
+        try:
+            list(huggingface.api().list_repo_tree(
+                repo_id=repo_id,
+                repo_type=repo_type,
+                revision=revision,
+                path_in_repo=path,
+                recursive=False,
+                token=huggingface.get_token()))
+            return True
+        except Exception as e:  # pylint: disable=broad-except
+            errors = huggingface.hf_hub_errors()
+            not_found_types = tuple(cls for cls in (
+                getattr(errors, 'EntryNotFoundError', None),
+                getattr(errors, 'RepositoryNotFoundError', None),
+            ) if cls is not None)
+            status_code = getattr(getattr(e, 'response', None), 'status_code',
+                                  None)
+            if isinstance(e, not_found_types) or status_code == 404:
                 return False
-            if filename.startswith(prefix):
-                return True
-        return True
+            raise
 
     @classmethod
     def _python_command(cls, code: str) -> str:

--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -19,6 +19,7 @@ from sky.adaptors import aws
 from sky.adaptors import azure
 from sky.adaptors import cloudflare
 from sky.adaptors import coreweave
+from sky.adaptors import huggingface
 from sky.adaptors import ibm
 from sky.adaptors import nebius
 from sky.adaptors import oci
@@ -747,6 +748,130 @@ class VastDataCloudStorage(CloudStorage):
         return ' && '.join(all_commands)
 
 
+class HFCloudStorage(CloudStorage):
+    """Hugging Face Buckets and Hub repos."""
+
+    _GET_HF_HUB = [
+        f'{constants.SKY_UV_PIP_CMD} install "huggingface_hub>=1.10"',
+    ]
+    _TOKEN_HELPER = """
+token = os.environ.get('HF_TOKEN') or os.environ.get('HUGGING_FACE_HUB_TOKEN')
+if not token:
+    for candidate in ('~/.cache/huggingface/token', '~/.huggingface/token'):
+        path = os.path.expanduser(candidate)
+        if os.path.exists(path):
+            with open(path, encoding='utf-8') as f:
+                token = f.read().strip() or None
+            if token:
+                break
+"""
+
+    def is_directory(self, url: str) -> bool:
+        if data_utils.is_hf_bucket_path(url):
+            bucket_id, path = data_utils.split_hf_path(url)
+            path = path.rstrip('/')
+            if not path:
+                return True
+            entries = list(huggingface.api().list_bucket_tree(
+                bucket_id,
+                prefix=path,
+                recursive=False,
+                token=huggingface.get_token()))
+            prefix = f'{path}/'
+            for entry in entries:
+                entry_path = getattr(entry, 'path', '').rstrip('/')
+                if entry_path == path and getattr(entry, 'type',
+                                                  'file') == 'file':
+                    return False
+                if entry_path.startswith(prefix):
+                    return True
+            return True
+
+        repo_type, repo_id, revision, path = data_utils.split_hf_repo_path(url)
+        path = path.rstrip('/')
+        if not path:
+            return True
+        info = huggingface.api().repo_info(repo_id=repo_id,
+                                           repo_type=repo_type,
+                                           revision=revision,
+                                           token=huggingface.get_token())
+        prefix = f'{path}/'
+        for sibling in getattr(info, 'siblings', []) or []:
+            # ``huggingface_hub`` exposes the filename as ``rfilename`` on
+            # most repo types and ``path`` on a few; tolerate either. The
+            # trailing ``or ''`` keeps the type as ``str`` for mypy
+            # (``getattr(..., None)`` is ``Optional[Any]``).
+            filename: str = (getattr(sibling, 'rfilename', None) or
+                             getattr(sibling, 'path', '') or '')
+            if filename == path:
+                return False
+            if filename.startswith(prefix):
+                return True
+        return True
+
+    @classmethod
+    def _python_command(cls, code: str) -> str:
+        python = f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/python'
+        return ' && '.join(cls._GET_HF_HUB +
+                           [f'{python} -c {shlex.quote(code)}'])
+
+    def make_sync_dir_command(self, source: str, destination: str) -> str:
+        if data_utils.is_hf_bucket_path(source):
+            code = '\n'.join([
+                'import os',
+                'from huggingface_hub import HfApi',
+                self._TOKEN_HELPER,
+                (f'HfApi().sync_bucket({source!r}, {destination!r}, '
+                 'token=token, quiet=True)'),
+            ])
+            return self._python_command(code)
+
+        repo_type, repo_id, revision, sub_path = data_utils.split_hf_repo_path(
+            source)
+        allow_patterns = None
+        if sub_path:
+            allow_patterns = [f'{sub_path.rstrip("/")}/*']
+        code = '\n'.join([
+            'import os',
+            'from huggingface_hub import snapshot_download',
+            self._TOKEN_HELPER,
+            (f'snapshot_download(repo_id={repo_id!r}, repo_type={repo_type!r}, '
+             f'revision={revision!r}, local_dir={destination!r}, '
+             f'allow_patterns={allow_patterns!r}, token=token)'),
+        ])
+        return self._python_command(code)
+
+    def make_sync_file_command(self, source: str, destination: str) -> str:
+        if data_utils.is_hf_bucket_path(source):
+            bucket_id, path = data_utils.split_hf_path(source)
+            code = '\n'.join([
+                'import os',
+                'from huggingface_hub import HfApi',
+                self._TOKEN_HELPER,
+                (f'HfApi().download_bucket_files({bucket_id!r}, '
+                 f'files=[({path!r}, {destination!r})], token=token)'),
+            ])
+            return self._python_command(code)
+
+        repo_type, repo_id, revision, path = data_utils.split_hf_repo_path(
+            source)
+        code = '\n'.join([
+            'import os',
+            'import shutil',
+            'import tempfile',
+            'from huggingface_hub import hf_hub_download',
+            self._TOKEN_HELPER,
+            'tmp_dir = tempfile.mkdtemp()',
+            (f'downloaded = hf_hub_download(repo_id={repo_id!r}, '
+             f'repo_type={repo_type!r}, revision={revision!r}, '
+             f'filename={path!r}, local_dir=tmp_dir, token=token)'),
+            (f'os.makedirs(os.path.dirname({destination!r}) or ".", '
+             'exist_ok=True)'),
+            f'shutil.copy2(downloaded, {destination!r})',
+        ])
+        return self._python_command(code)
+
+
 def get_storage_from_path(url: str) -> CloudStorage:
     """Returns a CloudStorage by identifying the scheme:// in a URL."""
     result = urllib.parse.urlsplit(url)
@@ -766,6 +891,7 @@ _REGISTRY = {
     'nebius': NebiusCloudStorage(),
     'cw': CoreWeaveCloudStorage(),
     'vastdata': VastDataCloudStorage(),
+    'hf': HFCloudStorage(),
     # TODO: This is a hack, as Azure URL starts with https://, we should
     # refactor the registry to be able to take regex, so that Azure blob can
     # be identified with `https://(.*?)\.blob\.core\.windows\.net`

--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -21,6 +21,7 @@ from sky.adaptors import azure
 from sky.adaptors import cloudflare
 from sky.adaptors import coreweave
 from sky.adaptors import gcp
+from sky.adaptors import huggingface
 from sky.adaptors import ibm
 from sky.adaptors import nebius
 from sky.adaptors import oci
@@ -110,6 +111,121 @@ def split_nebius_path(nebius_path: str) -> Tuple[str, str]:
     bucket = path_parts.pop(0)
     key = '/'.join(path_parts)
     return bucket, key
+
+
+def is_hf_path(source: str) -> bool:
+    """Returns True iff the source is a Hugging Face URL (bucket or repo)."""
+    return source.startswith(huggingface.HF_URL_PREFIX)
+
+
+def is_hf_bucket_path(source: str) -> bool:
+    """Returns True iff the source is a Hugging Face Bucket URL."""
+    return source.startswith(huggingface.HF_BUCKETS_URL_PREFIX)
+
+
+def split_hf_path(hf_path: str) -> Tuple[str, str]:
+    """Splits an HF Buckets URL into (bucket_id, sub_path).
+
+    ``bucket_id`` follows the ``<namespace>/<bucket-name>`` format (e.g.
+    ``user/my-bucket``); ``sub_path`` is the path *within* the bucket, which
+    may be empty.
+
+    Accepts both the canonical form ``hf://buckets/<ns>/<name>[/<path>]`` and
+    the short form ``<ns>/<name>[/<path>]``.
+    """
+    prefix = huggingface.HF_BUCKETS_URL_PREFIX
+    trimmed = hf_path[len(prefix):] if hf_path.startswith(prefix) else hf_path
+    parts = trimmed.split('/', 2)
+    if len(parts) < 2 or not parts[0] or not parts[1]:
+        raise ValueError(
+            f'Hugging Face bucket URL {hf_path!r} must be of the form '
+            f'"{prefix}<namespace>/<bucket-name>[/<sub-path>]".')
+    bucket_id = f'{parts[0]}/{parts[1]}'
+    sub_path = parts[2] if len(parts) == 3 else ''
+    return bucket_id, sub_path
+
+
+def split_hf_repo_path(hf_path: str) -> Tuple[str, str, Optional[str], str]:
+    """Splits an HF repo URL into ``(repo_type, repo_id, revision, sub_path)``.
+
+    ``repo_type`` is one of ``'model'``, ``'dataset'``, or ``'space'``.
+    ``repo_id`` is ``<namespace>/<name>``. ``revision`` is the optional
+    ``@<rev>`` portion (``None`` if unspecified). ``sub_path`` is the path
+    *within* the repo (possibly empty).
+
+    Accepts:
+        - ``hf://<ns>/<model>[@<rev>][/<path>]`` (model)
+        - ``hf://datasets/<ns>/<ds>[@<rev>][/<path>]``
+        - ``hf://spaces/<ns>/<sp>[@<rev>][/<path>]``
+    """
+    if not hf_path.startswith(huggingface.HF_URL_PREFIX):
+        raise ValueError(f'Hugging Face repo URL {hf_path!r} must start with '
+                         f'"{huggingface.HF_URL_PREFIX}".')
+    body = hf_path[len(huggingface.HF_URL_PREFIX):]
+
+    repo_type = 'model'
+    if body.startswith('datasets/'):
+        repo_type = 'dataset'
+        body = body[len('datasets/'):]
+    elif body.startswith('spaces/'):
+        repo_type = 'space'
+        body = body[len('spaces/'):]
+    elif body.startswith('buckets/'):
+        raise ValueError(f'{hf_path!r} is a bucket URL, not a repo URL.')
+
+    parts = body.split('/', 2)
+    if len(parts) < 2 or not parts[0] or not parts[1]:
+        raise ValueError(
+            f'Hugging Face repo URL {hf_path!r} must be of the form '
+            '"hf://<ns>/<repo>[@<revision>][/<sub-path>]" '
+            '(optionally prefixed with "datasets/" or "spaces/").')
+    namespace, name_rev = parts[0], parts[1]
+    sub_path = parts[2] if len(parts) == 3 else ''
+
+    # Extract optional ``@<revision>`` suffix from the repo name.
+    revision: Optional[str] = None
+    if '@' in name_rev:
+        name, revision = name_rev.split('@', 1)
+        if not revision:
+            revision = None
+    else:
+        name = name_rev
+    if not name:
+        raise ValueError(
+            f'Hugging Face repo URL {hf_path!r} has an empty repo name.')
+    repo_id = f'{namespace}/{name}'
+    return repo_type, repo_id, revision, sub_path
+
+
+def verify_hf_bucket(bucket_id: str) -> bool:
+    """Returns True iff the HF bucket ``<namespace>/<bucket-name>`` exists.
+
+    Uses :meth:`huggingface_hub.HfApi.bucket_info`. Only treats explicit
+    "not found" signals (``RepositoryNotFoundError``, ``EntryNotFoundError``,
+    or an HTTP 404) as absence. Other failures — auth errors, rate limits,
+    network issues — are re-raised so callers can surface them rather than
+    silently "creating a new bucket".
+    """
+    token = huggingface.get_token()
+    try:
+        huggingface.api().bucket_info(bucket_id, token=token)
+        return True
+    except Exception as e:  # pylint: disable=broad-except
+        errors = huggingface.hf_hub_errors()
+        explicit_not_found_types: Tuple[type, ...] = tuple(cls for cls in (
+            getattr(errors, 'RepositoryNotFoundError', None),
+            getattr(errors, 'EntryNotFoundError', None),
+        ) if cls is not None)
+        if isinstance(e, explicit_not_found_types):
+            return False
+        # ``HfHubHTTPError`` exposes ``.response.status_code``; only a 404
+        # indicates "bucket does not exist". 401/403/5xx/etc should propagate.
+        response = getattr(e, 'response', None)
+        status_code = getattr(response, 'status_code',
+                              None) if response is not None else None
+        if status_code == 404:
+            return False
+        raise
 
 
 def split_cos_path(s3_path: str) -> Tuple[str, str, str]:

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -45,6 +45,21 @@ _BLOBFUSE_CACHE_DIR = ('~/.sky/blobfuse2_cache/'
 # https://github.com/rclone/rclone/releases
 RCLONE_VERSION = 'v1.68.2'
 
+# https://github.com/huggingface/hf-mount/releases - mounts HF Buckets /
+# repos via FUSE or NFS. We default to the FUSE backend since (a) SkyPilot
+# already ensures FUSE is set up on every image that supports MOUNT-mode
+# storage (gcsfuse, blobfuse2, rclone mount, goofys all rely on it) and
+# (b) hf-mount's NFS backend requires the host kernel to support NFS client
+# mounts, which is not universally true on Kubernetes nodes.
+#
+# Note: the published v0.3.1 Linux binaries are linked against glibc >= 2.32,
+# so this requires an image with glibc 2.32+ (e.g. Ubuntu 22.04). On the
+# default SkyPilot k8s image (Ubuntu 20.04, glibc 2.31) users must specify
+# ``image_id: docker:mirror.gcr.io/ubuntu:22.04`` (or similar) in resources.
+HF_MOUNT_VERSION = 'v0.3.1'
+HF_MOUNT_REPO = 'huggingface/hf-mount'
+HF_MOUNT_TOKEN_FILE = '~/.cache/huggingface/token'
+
 # A wrapper for goofys to choose the logging mechanism based on environment.
 _GOOFYS_WRAPPER = ('$(if [ -S /dev/log ] ; then '
                    'echo "goofys"; '
@@ -276,6 +291,125 @@ def get_gcs_mount_cmd(bucket_name: str,
                  f'--rename-dir-limit {_RENAME_DIR_LIMIT} '
                  f'{bucket_sub_path_arg}'
                  f'{bucket_name} {mount_path}')
+    return mount_cmd
+
+
+def get_hf_mount_install_cmd() -> str:
+    """Returns a command to install ``hf-mount`` for HF Bucket / repo mounts.
+
+    Installs ``hf-mount`` (the user-facing CLI) and ``hf-mount-fuse`` (the
+    FUSE backend binary) to ``/usr/local/bin``. We use the FUSE backend
+    because SkyPilot's mount-mode storage already assumes a FUSE-capable
+    host, and FUSE support is more ubiquitous on Kubernetes nodes than
+    kernel NFS-client support.
+
+    Also installs ``fuse3`` on Linux hosts that don't already have it, via
+    the reusable :data:`FUSE3_INSTALL_CMD`. On macOS the binary relies on
+    macFUSE, which the operator must install manually.
+    """
+    base_url = (f'https://github.com/{HF_MOUNT_REPO}/releases/download/'
+                f'{HF_MOUNT_VERSION}')
+    # pylint: disable=line-too-long
+    install_cmd = (
+        # hf-mount's FUSE backend needs libfuse3 (provides fusermount3).
+        # ``FUSE3_INSTALL_CMD`` is already used by rclone/blobfuse2 mounts
+        # and is a no-op if fuse3 is already installed.
+        f'{FUSE3_INSTALL_CMD} && '
+        'ARCH=$(uname -m) && '
+        'if [ "$ARCH" = "aarch64" ]; then '
+        '  ARCH_TAG="aarch64"; '
+        'elif [ "$ARCH" = "arm64" ]; then '
+        '  ARCH_TAG="arm64"; '
+        'else '
+        '  ARCH_TAG="x86_64"; '
+        'fi && '
+        'OS=$(uname -s | tr "[:upper:]" "[:lower:]") && '
+        'if [ "$OS" = "darwin" ]; then '
+        '  PLATFORM="apple-darwin"; '
+        'else '
+        '  PLATFORM="linux"; '
+        'fi && '
+        f'sudo curl -fsSL {base_url}/hf-mount-${{ARCH_TAG}}-${{PLATFORM}} '
+        '-o /usr/local/bin/hf-mount && '
+        f'sudo curl -fsSL {base_url}/hf-mount-fuse-${{ARCH_TAG}}-${{PLATFORM}} '
+        '-o /usr/local/bin/hf-mount-fuse && '
+        'sudo chmod +x /usr/local/bin/hf-mount /usr/local/bin/hf-mount-fuse')
+    return install_cmd
+
+
+def get_hf_mount_version_check_cmd() -> str:
+    """Returns a command that succeeds iff the installed hf-mount matches."""
+    # ``hf-mount --version`` prints e.g. ``hf-mount 0.3.1``.
+    version = HF_MOUNT_VERSION.lstrip('v')
+    return f'hf-mount --version 2>/dev/null | grep -q "{version}"'
+
+
+def get_hf_mount_cmd(hf_id: str,
+                     mount_path: str,
+                     _bucket_sub_path: Optional[str] = None,
+                     read_only: bool = False,
+                     token_file: Optional[str] = None,
+                     mode: str = 'bucket',
+                     revision: Optional[str] = None) -> str:
+    """Returns a command to mount an HF Bucket/repo via ``hf-mount``.
+
+    Uses the FUSE backend (``--fuse``). hf-mount defaults to NFS, but the
+    NFS backend requires host-kernel NFS-client support, which isn't
+    guaranteed on k8s nodes. FUSE is already a hard requirement for every
+    other MOUNT-mode storage in SkyPilot.
+
+    Args:
+        hf_id: HF identifier. For buckets this is ``namespace/name``; for
+            repos this is ``namespace/repo`` (or ``datasets/ns/repo``,
+            ``spaces/ns/repo``).
+        mount_path: Local path to mount at.
+        _bucket_sub_path: Optional sub-path within the bucket/repo.
+            ``hf-mount`` accepts this by appending it to the id.
+        read_only: Whether to mount as read-only. Repos are always mounted
+            read-only regardless of this flag.
+        token_file: Path to a file containing the HF token. Defaults to the
+            standard ``huggingface_hub`` location. ``hf-mount`` re-reads this
+            file on every request, which supports credential rotation.
+        mode: One of ``'bucket'`` (read-write) or ``'repo'`` (read-only).
+        revision: Optional git revision for repo mounts (e.g. ``'main'`` or
+            a tag/commit). Ignored for buckets.
+    """
+    if mode not in ('bucket', 'repo'):
+        raise ValueError(
+            f'hf-mount mode must be "bucket" or "repo", got {mode!r}.')
+    if token_file is None:
+        token_file = HF_MOUNT_TOKEN_FILE
+    arg = hf_id
+    if _bucket_sub_path:
+        arg = f'{hf_id}/{_bucket_sub_path}'
+    # Backend-specific flags for the daemon launched by ``hf-mount start``.
+    # These must come *after* ``start`` and *before* any backend-passthrough
+    # args (``--token-file`` etc.), because ``hf-mount start`` uses clap's
+    # "trailing var args" to forward unrecognized options to the backend
+    # binary. Once clap sees an argument it doesn't recognize (e.g.
+    # ``--token-file``), it stops option-parsing and forwards everything
+    # else verbatim, so a late ``--fuse`` would silently fall through as a
+    # backend arg and the daemon would default to NFS.
+    flags = ' --fuse'
+    backend_flags = ''
+    if read_only and mode == 'bucket':
+        # ``hf-mount`` repos are always read-only, no flag needed.
+        backend_flags += ' --read-only'
+    extra = ''
+    if mode == 'repo' and revision:
+        extra = f' --revision {shlex.quote(revision)}'
+    # ``hf-mount start`` detaches into a background daemon and returns
+    # quickly. The daemon logs to ``~/.hf-mount/logs/`` and records its PID
+    # in ``~/.hf-mount/pids/``.
+    token_file_cmd = (f'TOKEN_FILE=$(eval echo {shlex.quote(token_file)}); '
+                      'TOKEN_FILE_ARG=""; '
+                      'if [ -f "$TOKEN_FILE" ]; then '
+                      'TOKEN_FILE_ARG="--token-file $TOKEN_FILE"; '
+                      'fi; ')
+    mount_cmd = (f'{token_file_cmd}'
+                 f'hf-mount start{flags} $TOKEN_FILE_ARG'
+                 f'{backend_flags} '
+                 f'{mode} {shlex.quote(arg)} {shlex.quote(mount_path)}{extra}')
     return mount_cmd
 
 
@@ -621,6 +755,8 @@ def _get_mount_binary(mount_cmd: str) -> str:
         return 'gcsfuse'
     elif 'blobfuse2' in mount_cmd:
         return 'blobfuse2'
+    elif 'hf-mount' in mount_cmd:
+        return 'hf-mount'
     else:
         assert 'rclone' in mount_cmd
         return 'rclone'
@@ -744,6 +880,22 @@ def get_mounting_script(
                     fi
                 else
                     echo "Rclone log directory $RCLONE_LOG_DIR not found"
+                fi
+            elif [ "$MOUNT_BINARY" = "hf-mount" ]; then
+                echo "Looking for hf-mount log files..."
+                # hf-mount writes logs under ~/.hf-mount/logs/.
+                HF_MOUNT_LOG_DIR="$HOME/.hf-mount/logs"
+                if [ -d "$HF_MOUNT_LOG_DIR" ]; then
+                    HF_MOUNT_LOGS=$(ls -t "$HF_MOUNT_LOG_DIR"/*.log 2>/dev/null | head -1)
+                    if [ -n "$HF_MOUNT_LOGS" ]; then
+                        echo "=== hf-mount log file contents ==="
+                        tail -50 "$HF_MOUNT_LOGS"
+                        echo "=== End of hf-mount log file ==="
+                    else
+                        echo "No hf-mount log file found in $HF_MOUNT_LOG_DIR"
+                    fi
+                else
+                    echo "hf-mount log directory $HF_MOUNT_LOG_DIR not found"
                 fi
             fi
             # TODO(kevin): Print logs from blobfuse2, etc too for observability.

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -5782,11 +5782,14 @@ class HuggingFaceStore(AbstractStore):
                              config: Optional[MountCachedConfig] = None) -> str:
         """Returns a command to mount the HF bucket/repo with local caching.
 
-        ``hf-mount`` already provides an on-disk chunk cache (see its
-        ``--cache-dir``/``--cache-size`` flags), so this is the same mount
-        command as :meth:`mount_command`. ``MountCachedConfig`` options that
-        don't map to ``hf-mount`` are ignored.
+        ``hf-mount`` already provides an on-disk chunk cache (configured via
+        its own ``--cache-dir`` / ``--cache-size`` flags; not currently
+        exposed), so this reuses :meth:`mount_command`. Of
+        ``MountCachedConfig``'s fields, only ``read_only`` maps cleanly to
+        ``hf-mount`` (as ``--read-only`` on bucket mounts; repo mounts are
+        always read-only). The rclone-specific fields (``transfers``,
+        ``buffer_size``, ``vfs_*``) have no ``hf-mount`` equivalent and are
+        silently ignored.
         """
-        # hf-mount caching is configured via --cache-dir/--cache-size.
-        del config
-        return self.mount_command(mount_path)
+        read_only = bool(config.read_only) if config is not None else False
+        return self.mount_command(mount_path, read_only=read_only)

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -25,6 +25,7 @@ from sky.adaptors import azure
 from sky.adaptors import cloudflare
 from sky.adaptors import coreweave
 from sky.adaptors import gcp
+from sky.adaptors import huggingface
 from sky.adaptors import ibm
 from sky.adaptors import nebius
 from sky.adaptors import oci
@@ -66,6 +67,7 @@ STORE_ENABLED_CLOUDS: List[str] = [
     cloudflare.NAME,
     coreweave.NAME,
     vastdata.NAME,
+    huggingface.NAME,
 ]
 
 # Maximum number of concurrent rsync upload processes
@@ -107,6 +109,10 @@ def get_cached_enabled_storage_cloud_names_or_refresh(
     if vastdata_is_enabled:
         enabled_clouds.append(vastdata.NAME)
 
+    hf_is_enabled, _ = huggingface.check_storage_credentials()
+    if hf_is_enabled:
+        enabled_clouds.append(huggingface.NAME)
+
     if raise_if_no_cloud_access and not enabled_clouds:
         raise exceptions.NoCloudAccessError(
             'No cloud access available for storage. '
@@ -142,6 +148,7 @@ class StoreType(enum.Enum):
     NEBIUS = 'NEBIUS'
     COREWEAVE = 'COREWEAVE'
     VASTDATA = 'VASTDATA'
+    HF = 'HF'
     VOLUME = 'VOLUME'
 
     @classmethod
@@ -184,6 +191,8 @@ class StoreType(enum.Enum):
             return StoreType.AZURE
         elif cloud_lower == str(clouds.OCI()).lower():
             return StoreType.OCI
+        elif cloud_lower == huggingface.NAME.lower():
+            return StoreType.HF
         elif cloud_lower == str(clouds.Lambda()).lower():
             with ux_utils.print_exception_no_traceback():
                 raise ValueError('Lambda Cloud does not provide cloud storage.')
@@ -210,6 +219,8 @@ class StoreType(enum.Enum):
             return str(clouds.IBM())
         elif self == StoreType.OCI:
             return str(clouds.OCI())
+        elif self == StoreType.HF:
+            return huggingface.NAME
         else:
             raise ValueError(f'Unknown store type: {self}')
 
@@ -226,6 +237,8 @@ class StoreType(enum.Enum):
             return StoreType.IBM
         elif isinstance(store, OciStore):
             return StoreType.OCI
+        elif isinstance(store, HuggingFaceStore):
+            return StoreType.HF
         else:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(f'Unknown store type: {store}')
@@ -243,6 +256,8 @@ class StoreType(enum.Enum):
             return 'cos://'
         elif self == StoreType.OCI:
             return 'oci://'
+        elif self == StoreType.HF:
+            return huggingface.HF_BUCKETS_URL_PREFIX
         else:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(f'Unknown store type: {self}')
@@ -284,6 +299,8 @@ class StoreType(enum.Enum):
         storage_account_name = None
         region = None
         for store_type in StoreType:
+            if store_type == StoreType.VOLUME:
+                continue
             if store_url.startswith(store_type.store_prefix()):
                 if store_type == StoreType.AZURE:
                     storage_account_name, bucket_name, sub_path = \
@@ -293,6 +310,8 @@ class StoreType(enum.Enum):
                         store_url)
                 elif store_type == StoreType.GCS:
                     bucket_name, sub_path = data_utils.split_gcs_path(store_url)
+                elif store_type == StoreType.HF:
+                    bucket_name, sub_path = data_utils.split_hf_path(store_url)
                 else:
                     # Check compatible stores
                     for compatible_store_type, store_class in \
@@ -1088,6 +1107,8 @@ class Storage(object):
                         self.add_store(StoreType.IBM)
                     elif self.source.startswith('oci://'):
                         self.add_store(StoreType.OCI)
+                    elif data_utils.is_hf_path(self.source):
+                        self.add_store(StoreType.HF)
 
                     s3_compatible_store_type: Optional[StoreType] = (
                         StoreType.find_s3_compatible_config_by_prefix(
@@ -1182,12 +1203,15 @@ class Storage(object):
                 is_local_source = True
             elif split_path.scheme in [
                     's3', 'gs', 'https', 'r2', 'cos', 'oci', 'nebius', 'cw',
-                    'vastdata'
+                    'vastdata', 'hf'
             ]:
                 is_local_source = False
                 # Storage mounting does not support mounting specific files from
-                # cloud store - ensure path points to only a directory
-                if mode in MOUNTABLE_STORAGE_MODES:
+                # cloud store - ensure path points to only a directory.
+                # ``hf://`` is exempt because hf-mount supports mounting
+                # sub-paths within a bucket or repo.
+                if (mode in MOUNTABLE_STORAGE_MODES and
+                        split_path.scheme != 'hf'):
                     if (split_path.scheme != 'https' and
                         ((split_path.scheme != 'cos' and
                           split_path.path.strip('/') != '') or
@@ -1208,7 +1232,7 @@ class Storage(object):
                     raise exceptions.StorageSourceError(
                         f'Supported paths: local, s3://, gs://, https://, '
                         f'r2://, cos://, oci://, nebius://, cw://, '
-                        f'vastdata://. Got: {source}')
+                        f'vastdata://, hf://. Got: {source}')
         return source, is_local_source
 
     def _validate_storage_spec(self, name: Optional[str]) -> None:
@@ -1233,6 +1257,7 @@ class Storage(object):
                     'nebius',
                     'cw',
                     'vastdata',
+                    'hf',
             ]:
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.StorageNameError(
@@ -1281,7 +1306,17 @@ class Storage(object):
                 else:
                     assert isinstance(source, str)
                     # Set name to source bucket name and continue
-                    if source.startswith('cos://'):
+                    if data_utils.is_hf_path(source):
+                        if data_utils.is_hf_bucket_path(source):
+                            name, sub_path = data_utils.split_hf_path(source)
+                        else:
+                            repo_type, repo_id, _, sub_path = (
+                                data_utils.split_hf_repo_path(source))
+                            name = HuggingFaceStore.hf_id_from_repo_parts(
+                                repo_type, repo_id)
+                        if sub_path and self._bucket_sub_path is None:
+                            self._bucket_sub_path = sub_path
+                    elif source.startswith('cos://'):
                         # cos url requires custom parsing
                         name = data_utils.split_cos_path(source)[0]
                     elif data_utils.is_az_container_endpoint(source):
@@ -1362,6 +1397,12 @@ class Storage(object):
                         _bucket_sub_path=self._bucket_sub_path)
                 elif s_type == StoreType.OCI:
                     store = OciStore.from_metadata(
+                        s_metadata,
+                        source=self.source,
+                        sync_on_reconstruction=self.sync_on_reconstruction,
+                        _bucket_sub_path=self._bucket_sub_path)
+                elif s_type == StoreType.HF:
+                    store = HuggingFaceStore.from_metadata(
                         s_metadata,
                         source=self.source,
                         sync_on_reconstruction=self.sync_on_reconstruction,
@@ -1478,6 +1519,8 @@ class Storage(object):
             store_cls = IBMCosStore
         elif store_type == StoreType.OCI:
             store_cls = OciStore
+        elif store_type == StoreType.HF:
+            store_cls = HuggingFaceStore
         else:
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.StorageSpecError(
@@ -5202,3 +5245,548 @@ class VastDataStore(S3CompatibleStore):
             config)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cached_cmd)
+
+
+class HuggingFaceStore(AbstractStore):
+    """HuggingFaceStore backs Storage objects with Hugging Face resources.
+
+    Supports two kinds of sources:
+
+    1. **Buckets** (read-write) -- Xet-backed S3-like object storage. Bucket
+       ids are ``<namespace>/<bucket-name>`` (e.g. ``my-user/my-bucket``).
+
+    2. **Repos** (read-only) -- models, datasets, and spaces. Source URLs:
+
+       - ``hf://<ns>/<model>[@<rev>][/<sub-path>]``
+       - ``hf://datasets/<ns>/<name>[@<rev>][/<sub-path>]``
+       - ``hf://spaces/<ns>/<name>[@<rev>][/<sub-path>]``
+
+       Repo mounts are always read-only; repo-typed stores are never
+       ``is_sky_managed``.
+
+    Bucket operations go through the ``huggingface_hub`` Python SDK; mounts
+    are performed with the ``hf-mount`` NFS backend.
+    """
+
+    _NAME_PATTERN = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9._\-]{0,95}$')
+
+    # HF repo type values recognized by ``hf-mount`` and ``huggingface_hub``,
+    # mapped to the URL path segment that prefixes ``<ns>/<name>`` in an
+    # ``hf://`` URL and in the ``hf-mount`` CLI argument. Models have no
+    # prefix; datasets/spaces do.
+    _REPO_TYPE_TO_URL_PREFIX: Dict[str, str] = {
+        'model': '',
+        'dataset': 'datasets/',
+        'space': 'spaces/',
+    }
+
+    @classmethod
+    def hf_id_from_repo_parts(cls, repo_type: str, repo_id: str) -> str:
+        """Builds the ``hf-mount``-style id from a repo_type and repo_id.
+
+        Examples:
+            ``('model', 'openai/gpt2')`` -> ``'openai/gpt2'``
+            ``('dataset', 'ns/ds')``     -> ``'datasets/ns/ds'``
+            ``('space', 'ns/app')``      -> ``'spaces/ns/app'``
+        """
+        return f'{cls._REPO_TYPE_TO_URL_PREFIX.get(repo_type, "")}{repo_id}'
+
+    @classmethod
+    def strip_repo_type_prefix(cls, hf_id: str) -> str:
+        """Returns the bare ``ns/name`` from a prefixed id.
+
+        Inverse of :meth:`hf_id_from_repo_parts` for any recognized prefix;
+        returns ``hf_id`` unchanged for model ids (which have no prefix).
+        """
+        for prefix in cls._REPO_TYPE_TO_URL_PREFIX.values():
+            if prefix and hf_id.startswith(prefix):
+                return hf_id[len(prefix):]
+        return hf_id
+
+    def __init__(self,
+                 name: str,
+                 source: Optional[SourceType],
+                 region: Optional[str] = None,
+                 is_sky_managed: Optional[bool] = None,
+                 sync_on_reconstruction: Optional[bool] = True,
+                 _bucket_sub_path: Optional[str] = None):
+        # Classify bucket vs repo up front so we can dispatch in _validate /
+        # validate_name / initialize. ``_repo_type`` is None for buckets and
+        # one of the keys of ``_REPO_TYPE_TO_URL_PREFIX`` for repos.
+        self._repo_type: Optional[str] = None
+        self._revision: Optional[str] = None
+        # ``_hf_id`` is the identifier passed to ``hf-mount`` (bucket id for
+        # buckets; for repos it's e.g. ``datasets/ns/name`` — matching the
+        # argument format ``hf-mount repo`` expects).
+        self._hf_id: str = ''
+        # HF Buckets/repos do not have user-selectable regions.
+        super().__init__(name, source, region, is_sky_managed,
+                         sync_on_reconstruction, _bucket_sub_path)
+
+    @property
+    def is_repo(self) -> bool:
+        return self._repo_type is not None
+
+    def _classify(self) -> None:
+        """Populates ``_repo_type``/``_revision``/``_hf_id`` from source/name.
+
+        For repo mode, ``self.name`` must either be unset or match the
+        canonical HF identifier derived from the source URL — mismatches
+        are refused so misconfigurations fail loud.
+        """
+        if isinstance(self.source, str) and self.source.startswith(
+                huggingface.HF_URL_PREFIX) and not self.source.startswith(
+                    huggingface.HF_BUCKETS_URL_PREFIX):
+            repo_type, repo_id, revision, sub_path = (
+                data_utils.split_hf_repo_path(self.source))
+            if sub_path and getattr(self, '_bucket_sub_path', None) is None:
+                self.bucket_sub_path = sub_path
+            self._repo_type = repo_type
+            self._revision = revision
+            self._hf_id = self.hf_id_from_repo_parts(repo_type, repo_id)
+            if not self.name:
+                self.name = self._hf_id
+            elif self.name != self._hf_id:
+                with ux_utils.print_exception_no_traceback():
+                    raise exceptions.StorageSpecError(
+                        f'HF {self._repo_type} source {self.source!r} does '
+                        f'not match storage name {self.name!r}. Expected '
+                        f'name to be {self._hf_id!r} (or leave it unset).')
+        else:
+            # Bucket mode: ``self.name`` is the bucket id (ns/bucket).
+            self._repo_type = None
+            self._hf_id = self.name
+
+    def _validate(self) -> None:
+        self._classify()
+        if self.source is not None and isinstance(self.source, str):
+            if self.is_repo:
+                # Repo mode: source must be an hf:// URL matching the id.
+                if not data_utils.is_hf_path(self.source):
+                    raise exceptions.StorageSpecError(
+                        f'Hugging Face repo source {self.source!r} must start '
+                        f'with "{huggingface.HF_URL_PREFIX}".')
+                # Repo mounts are always read-only; COPY-mode upload isn't
+                # meaningful for a repo source.
+            elif data_utils.is_hf_bucket_path(self.source):
+                source_bucket_id, sub_path = data_utils.split_hf_path(
+                    self.source)
+                if sub_path and getattr(self, '_bucket_sub_path', None) is None:
+                    self.bucket_sub_path = sub_path
+                assert self.name == source_bucket_id, (
+                    f'HF bucket is specified as path ({self.source}); '
+                    f'storage name ({self.name!r}) must match the bucket id '
+                    f'({source_bucket_id!r}).')
+            elif re.search(r'^\w+://', self.source):
+                # A non-HF cloud URI; we don't support cross-cloud upload into
+                # HF Buckets in v1 (server-side Xet copy is HF<->HF only).
+                raise NotImplementedError(
+                    f'Moving data from {self.source} to a Hugging Face Bucket '
+                    'is not supported yet. Please download the data locally '
+                    'first, or use `hf buckets sync`.')
+            # Otherwise treat the source as a local path (validated by
+            # Storage._validate_source).
+
+        # Validate name.
+        self.name = self.validate_name(self.name, repo_type=self._repo_type)
+
+        if self.is_repo:
+            try:
+                huggingface.huggingface_hub.load_module()
+            except ImportError as e:
+                with ux_utils.print_exception_no_traceback():
+                    raise exceptions.ResourcesUnavailableError(str(e)) from e
+        elif not _is_storage_cloud_enabled(huggingface.NAME):
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.ResourcesUnavailableError(
+                    'Storage \'store: hf\' specified, but Hugging Face '
+                    'credentials are not configured. Run `sky check` and set '
+                    'HF_TOKEN or run `hf auth login` to authenticate.')
+
+    @classmethod
+    def validate_name(cls, name: str, repo_type: Optional[str] = None) -> str:
+        """Validates a Hugging Face bucket or repo identifier.
+
+        Bucket ids are ``<namespace>/<bucket-name>``. Repo ids may additionally
+        be prefixed with ``datasets/`` or ``spaces/``.
+        """
+
+        def _raise(msg: str):
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.StorageNameError(msg)
+
+        if not isinstance(name, str) or not name:
+            _raise('Hugging Face name must be specified in the form '
+                   '"<namespace>/<name>" (e.g. "my-user/my-bucket").')
+
+        # Accept full handles for convenience.
+        if name.startswith(huggingface.HF_BUCKETS_URL_PREFIX):
+            name = name[len(huggingface.HF_BUCKETS_URL_PREFIX):]
+        elif name.startswith(huggingface.HF_URL_PREFIX):
+            name = name[len(huggingface.HF_URL_PREFIX):]
+
+        # For repo mode, strip the type prefix matching the declared
+        # ``repo_type`` before validating segments. Prefixes belonging to
+        # *other* repo types (e.g. ``datasets/`` with ``repo_type='space'``)
+        # are not stripped, so such mismatches fall through to the segment
+        # count check and raise.
+        core = name
+        if repo_type:
+            expected_prefix = cls._REPO_TYPE_TO_URL_PREFIX.get(repo_type, '')
+            if expected_prefix and core.startswith(expected_prefix):
+                core = core[len(expected_prefix):]
+
+        parts = core.split('/')
+        if len(parts) != 2 or not parts[0] or not parts[1]:
+            kind = 'repo' if repo_type else 'bucket'
+            _raise(
+                f'Invalid Hugging Face {kind} name {name!r}. Expected format: '
+                '"<namespace>/<name>".')
+
+        for segment_kind, segment in (('namespace', parts[0]), ('name',
+                                                                parts[1])):
+            if not cls._NAME_PATTERN.match(segment):
+                kind = 'repo' if repo_type else 'bucket'
+                _raise(f'Invalid Hugging Face {kind} {segment_kind} '
+                       f'{segment!r}: must match '
+                       f'{cls._NAME_PATTERN.pattern} (letters, digits, '
+                       '".", "_", "-"; must not start with "." or "-").')
+        return name
+
+    def initialize(self) -> None:
+        """Initializes the HF bucket (creating if needed) or the repo handle.
+
+        Raises:
+            StorageBucketCreateError: If bucket creation fails.
+            StorageBucketGetError: If fetching an existing bucket/repo fails.
+            StorageInitError: If the HF SDK is not available or the user is
+              not authenticated (for private repos / any bucket).
+        """
+        token = huggingface.get_token()
+        # For public repos, authentication is optional.
+        if not token and not self.is_repo:
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.StorageInitError(
+                    'Hugging Face token not found. Set HF_TOKEN or run '
+                    '`hf auth login`.')
+        self._token = token
+        self._api = huggingface.api()
+        if self.is_repo:
+            # Repos are never sky-managed; we only fetch metadata to verify
+            # the repo exists and is accessible.
+            self.bucket = self._get_repo_info()
+            if self.is_sky_managed is None:
+                self.is_sky_managed = False
+        else:
+            self.bucket, is_new_bucket = self._get_bucket()
+            if self.is_sky_managed is None:
+                self.is_sky_managed = is_new_bucket
+
+    def _get_repo_info(self) -> StorageHandle:
+        """Fetches repo metadata; raises if the repo is missing/inaccessible."""
+        errors = huggingface.hf_hub_errors()
+        assert self._repo_type is not None
+        try:
+            # ``HfApi.repo_info`` takes the raw ``ns/name`` id plus a
+            # ``repo_type`` kwarg ("model", "dataset", or "space").
+            repo_id = self.strip_repo_type_prefix(self._hf_id)
+            return self._api.repo_info(repo_id=repo_id,
+                                       repo_type=self._repo_type,
+                                       revision=self._revision,
+                                       token=self._token)
+        except Exception as e:  # pylint: disable=broad-except
+            not_found_types = tuple(cls for cls in (
+                getattr(errors, 'RepositoryNotFoundError', None),
+                getattr(errors, 'GatedRepoError', None),
+                getattr(errors, 'RevisionNotFoundError', None),
+            ) if cls is not None)
+            if isinstance(e, not_found_types):
+                with ux_utils.print_exception_no_traceback():
+                    raise exceptions.StorageBucketGetError(
+                        f'Hugging Face {self._repo_type} '
+                        f'{self._hf_id!r} not found or inaccessible: '
+                        f'{e}') from e
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.StorageBucketGetError(
+                    f'Failed to connect to Hugging Face {self._repo_type} '
+                    f'{self._hf_id!r}: {e}') from e
+
+    def _get_bucket(self) -> Tuple[StorageHandle, bool]:
+        """Gets the bucket, creating it if needed and allowed.
+
+        Returns:
+            (bucket_info, is_new_bucket)
+        """
+        errors = huggingface.hf_hub_errors()
+        try:
+            info = self._api.bucket_info(self.name, token=self._token)
+            self._validate_existing_bucket()
+            return info, False
+        except Exception as e:  # pylint: disable=broad-except
+            not_found_types = tuple(cls for cls in (
+                getattr(errors, 'RepositoryNotFoundError', None),
+                getattr(errors, 'EntryNotFoundError', None),
+            ) if cls is not None)
+            is_not_found = isinstance(e, not_found_types)
+            # ``HfHubHTTPError`` exposes ``.response.status_code``; treat 404
+            # and 403/401 separately.
+            status_code = None
+            response = getattr(e, 'response', None)
+            if response is not None:
+                status_code = getattr(response, 'status_code', None)
+            if status_code == 404:
+                is_not_found = True
+
+            if is_not_found:
+                if isinstance(self.source, str) and data_utils.is_hf_path(
+                        self.source):
+                    with ux_utils.print_exception_no_traceback():
+                        raise exceptions.StorageBucketGetError(
+                            'Attempted to connect to a non-existent HF '
+                            f'bucket as a source: {self.source}') from e
+                if self.sync_on_reconstruction:
+                    info = self._create_hf_bucket(self.name)
+                    return info, True
+                raise exceptions.StorageExternalDeletionError(
+                    'Attempted to fetch a non-existent HF bucket: '
+                    f'{self.name}') from e
+            if status_code in (401, 403):
+                with ux_utils.print_exception_no_traceback():
+                    raise exceptions.StorageBucketGetError(
+                        _BUCKET_FAIL_TO_CONNECT_MESSAGE.format(
+                            name=self.name)) from e
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.StorageBucketGetError(
+                    f'Failed to connect to HF bucket {self.name!r}: '
+                    f'{e}') from e
+
+    def _create_hf_bucket(self, bucket_id: str) -> StorageHandle:
+        """Creates an HF bucket with ``exist_ok=True`` for idempotency."""
+        try:
+            self._api.create_bucket(bucket_id, exist_ok=True, token=self._token)
+            info = self._api.bucket_info(bucket_id, token=self._token)
+        except Exception as e:  # pylint: disable=broad-except
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.StorageBucketCreateError(
+                    f'Failed to create HF bucket {bucket_id!r}: {e}') from e
+        logger.info(f'  {colorama.Style.DIM}Created HF bucket '
+                    f'{bucket_id!r}{colorama.Style.RESET_ALL}')
+        return info
+
+    def upload(self) -> None:
+        """Uploads source to the HF bucket.
+
+        Supports:
+            - A single local directory (syncs its contents into the bucket).
+            - A list of local files/directories.
+            - A pre-existing HF bucket URI (no-op).
+
+        Repo-backed stores are read-only: ``upload()`` is a no-op iff the
+        source is the corresponding ``hf://`` URL, and an error otherwise, so
+        that misconfigurations (e.g. a local ``source`` paired with a repo
+        URL) never silently discard data.
+        """
+        if self.is_repo:
+            is_repo_source = (isinstance(self.source, str) and
+                              data_utils.is_hf_path(self.source) and
+                              not data_utils.is_hf_bucket_path(self.source))
+            if self.source is None or is_repo_source:
+                # No local data to upload; the source IS the HF repo.
+                return
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.StorageUploadError(
+                    f'Cannot upload to Hugging Face {self._repo_type} '
+                    f'{self._hf_id!r}: repos are read-only. Only Hugging Face '
+                    'Buckets (hf://buckets/...) support uploads. Got '
+                    f'source={self.source!r}.')
+        try:
+            if isinstance(self.source, list):
+                self._sync_local_sources(self.source, create_dirs=True)
+            elif self.source is not None:
+                if data_utils.is_hf_bucket_path(self.source):
+                    # Already an HF bucket; nothing to do.
+                    return
+                self._sync_local_sources([self.source])
+        except exceptions.StorageUploadError:
+            raise
+        except Exception as e:  # pylint: disable=broad-except
+            raise exceptions.StorageUploadError(
+                f'Upload failed for store {self.name}') from e
+
+    def _sync_local_sources(self,
+                            source_path_list: List[Path],
+                            create_dirs: bool = False) -> None:
+        """Uploads local files/directories to the HF bucket.
+
+        Uses ``sync_bucket`` for directories (it only transfers changed files)
+        and ``batch_bucket_files`` for individual files.
+        """
+        sub_path = self._bucket_sub_path or ''
+
+        log_path = sky_logging.generate_tmp_logging_file_path(
+            _STORAGE_LOG_FILE_NAME)
+        dest = f'{huggingface.HF_BUCKETS_URL_PREFIX}{self.name}'
+        if sub_path:
+            dest = f'{dest}/{sub_path}'
+
+        if len(source_path_list) > 1:
+            source_message = f'{len(source_path_list)} paths'
+        else:
+            source_message = str(source_path_list[0])
+        sync_path = f'{source_message} -> {dest}'
+
+        with rich_utils.safe_status(
+                ux_utils.spinner_message(f'Syncing {sync_path}',
+                                         log_path=log_path)):
+            files_to_add: List[Tuple[str, str]] = []
+            for raw_path in source_path_list:
+                path = os.path.abspath(os.path.expanduser(str(raw_path)))
+                if os.path.isdir(path):
+                    dir_dest = dest
+                    if create_dirs:
+                        dir_dest = f'{dest}/{os.path.basename(path)}'
+                    self._api.sync_bucket(path,
+                                          dir_dest,
+                                          token=self._token,
+                                          quiet=True)
+                elif os.path.isfile(path):
+                    remote_name = os.path.basename(path)
+                    if sub_path:
+                        remote_name = f'{sub_path}/{remote_name}'
+                    files_to_add.append((path, remote_name))
+                else:
+                    with ux_utils.print_exception_no_traceback():
+                        raise exceptions.StorageUploadError(
+                            f'Local source path does not exist: {path}')
+            if files_to_add:
+                self._api.batch_bucket_files(self.name,
+                                             add=files_to_add,
+                                             token=self._token)
+        logger.info(
+            ux_utils.finishing_message(f'Storage synced: {sync_path}',
+                                       log_path))
+
+    def delete(self) -> None:
+        if self.is_repo:
+            # Repos are external resources; nothing to delete.
+            return
+        if self._bucket_sub_path is not None and not self.is_sky_managed:
+            return self._delete_sub_path()
+        try:
+            self._api.delete_bucket(self.name,
+                                    missing_ok=True,
+                                    token=self._token)
+        except Exception as e:  # pylint: disable=broad-except
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.StorageBucketDeleteError(
+                    f'Failed to delete HF bucket {self.name!r}: {e}') from e
+        logger.info(f'{colorama.Fore.GREEN}Deleted HF bucket '
+                    f'{self.name}.{colorama.Style.RESET_ALL}')
+
+    def _delete_sub_path(self) -> None:
+        assert self._bucket_sub_path is not None, 'bucket_sub_path is not set'
+        assert not self.is_repo, 'sub-path delete is not supported for repos'
+        sub_path = self._bucket_sub_path.rstrip('/')
+        # Collect all files under the sub-path and delete them in one batch.
+        try:
+            entries = list(
+                self._api.list_bucket_tree(self.name,
+                                           prefix=sub_path,
+                                           recursive=True,
+                                           token=self._token))
+            file_paths = [
+                e.path for e in entries if getattr(e, 'type', 'file') == 'file'
+            ]
+            if file_paths:
+                self._api.batch_bucket_files(self.name,
+                                             delete=file_paths,
+                                             token=self._token)
+        except Exception as e:  # pylint: disable=broad-except
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.StorageBucketDeleteError(
+                    f'Failed to delete objects under '
+                    f'{self.name}/{sub_path}: {e}') from e
+        logger.info(f'{colorama.Fore.GREEN}Deleted objects in HF bucket '
+                    f'{self.name}/{sub_path}.{colorama.Style.RESET_ALL}')
+
+    def get_handle(self) -> StorageHandle:
+        return self.bucket
+
+    def download_remote_dir(self, local_path: str) -> None:
+        """Downloads the contents of the HF bucket/repo into ``local_path``.
+
+        For buckets, uses ``sync_bucket``. For repos, uses
+        ``snapshot_download``.
+        """
+        os.makedirs(os.path.expanduser(local_path), exist_ok=True)
+        expanded = os.path.expanduser(local_path)
+        if self.is_repo:
+            # ``snapshot_download`` takes the bare ``ns/name`` id with the
+            # repo type as a separate kwarg.
+            self._api.snapshot_download(
+                repo_id=self.strip_repo_type_prefix(self._hf_id),
+                repo_type=self._repo_type,
+                revision=self._revision,
+                local_dir=expanded,
+                allow_patterns=self._allow_patterns_for_sub_path(),
+                token=self._token)
+            return
+        src = f'{huggingface.HF_BUCKETS_URL_PREFIX}{self.name}'
+        if self._bucket_sub_path:
+            src = f'{src}/{self._bucket_sub_path}'
+        self._api.sync_bucket(src, expanded, token=self._token, quiet=True)
+
+    def _download_file(self, remote_path: str, local_path: str) -> None:
+        """Downloads a single file from the HF bucket/repo to ``local_path``."""
+        if self.is_repo:
+            self._api.hf_hub_download(
+                repo_id=self.strip_repo_type_prefix(self._hf_id),
+                repo_type=self._repo_type,
+                revision=self._revision,
+                filename=remote_path,
+                local_dir=os.path.dirname(local_path) or '.',
+                token=self._token)
+            return
+        # ``download_bucket_files`` accepts (remote_path, local_path) pairs.
+        self._api.download_bucket_files(self.name,
+                                        files=[(remote_path, local_path)],
+                                        token=self._token)
+
+    def _allow_patterns_for_sub_path(self) -> Optional[List[str]]:
+        """Translates ``_bucket_sub_path`` into ``snapshot_download`` glob."""
+        if not self._bucket_sub_path:
+            return None
+        return [f'{self._bucket_sub_path.rstrip("/")}/*']
+
+    def mount_command(self, mount_path: str, read_only: bool = False) -> str:
+        """Returns a command to mount the HF bucket/repo at ``mount_path``.
+
+        Uses the ``hf-mount`` NFS backend. The token file is expected to be
+        available on the remote host (it is synced via
+        ``huggingface.get_credential_file_mounts``).
+        """
+        install_cmd = mounting_utils.get_hf_mount_install_cmd()
+        mount_cmd = mounting_utils.get_hf_mount_cmd(
+            hf_id=self._hf_id,
+            mount_path=mount_path,
+            _bucket_sub_path=self._bucket_sub_path,
+            read_only=read_only,
+            mode='repo' if self.is_repo else 'bucket',
+            revision=self._revision)
+        version_check_cmd = mounting_utils.get_hf_mount_version_check_cmd()
+        return mounting_utils.get_mounting_command(mount_path, install_cmd,
+                                                   mount_cmd, version_check_cmd)
+
+    def mount_cached_command(self,
+                             mount_path: str,
+                             config: Optional[MountCachedConfig] = None) -> str:
+        """Returns a command to mount the HF bucket/repo with local caching.
+
+        ``hf-mount`` already provides an on-disk chunk cache (see its
+        ``--cache-dir``/``--cache-size`` flags), so this is the same mount
+        command as :meth:`mount_command`. ``MountCachedConfig`` options that
+        don't map to ``hf-mount`` are ignored.
+        """
+        # hf-mount caching is configured via --cache-dir/--cache-size.
+        del config
+        return self.mount_command(mount_path)

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -207,11 +207,15 @@ cloud_dependencies: Dict[str, List[str]] = {
     'lambda': [],  # No dependencies needed for lambda
     'cloudflare': aws_dependencies,
     'coreweave': aws_dependencies + kubernetes_dependencies,
-    # Hugging Face Buckets require huggingface_hub>=1.10 (first version with
-    # the buckets API), which in turn requires Python >=3.10. On Python 3.9
-    # the extra is effectively a no-op and using `store: hf` will raise a
-    # clear ImportError at runtime.
-    'huggingface': ['huggingface_hub>=1.10; python_version>="3.10"'],
+    # Hugging Face Buckets require huggingface_hub>=1.5 (first version with
+    # the full buckets API: create_bucket / bucket_info / sync_bucket /
+    # batch_bucket_files / list_bucket_tree / download_bucket_files).
+    # 1.9+ drops Python 3.9 support, so pin to <1.9 there while letting
+    # Python 3.10+ install the latest.
+    'huggingface': [
+        'huggingface_hub>=1.5; python_version>="3.10"',
+        'huggingface_hub>=1.5,<1.9; python_version<"3.10"',
+    ],
     'scp': local_ray,
     'oci': ['oci'],
     'kubernetes': kubernetes_dependencies,

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -207,6 +207,11 @@ cloud_dependencies: Dict[str, List[str]] = {
     'lambda': [],  # No dependencies needed for lambda
     'cloudflare': aws_dependencies,
     'coreweave': aws_dependencies + kubernetes_dependencies,
+    # Hugging Face Buckets require huggingface_hub>=1.10 (first version with
+    # the buckets API), which in turn requires Python >=3.10. On Python 3.9
+    # the extra is effectively a no-op and using `store: hf` will raise a
+    # clear ImportError at runtime.
+    'huggingface': ['huggingface_hub>=1.10; python_version>="3.10"'],
     'scp': local_ray,
     'oci': ['oci'],
     'kubernetes': kubernetes_dependencies,

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -706,4 +706,4 @@ SSH_DISABLE_LATENCY_MEASUREMENT_ENV_VAR = (
 MAX_NODE_NAME_LINEAGE = 10
 
 # Clouds that provide storage only (no compute).
-STORAGE_ONLY_CLOUDS = ['cloudflare', 'coreweave', 'vastdata']
+STORAGE_ONLY_CLOUDS = ['cloudflare', 'coreweave', 'vastdata', 'huggingface']

--- a/sky/task.py
+++ b/sky/task.py
@@ -1742,6 +1742,18 @@ class Task:
                     self.update_file_mounts({
                         mnt_path: blob_path,
                     })
+                elif store_type is storage_lib.StoreType.HF:
+                    if storage.source is not None and not isinstance(
+                            storage.source, list) and data_utils.is_hf_path(
+                                storage.source):
+                        blob_path = storage.source
+                    else:
+                        blob_path = 'hf://buckets/' + storage.name
+                        blob_path = storage.get_bucket_sub_path_prefix(
+                            blob_path)
+                    self.update_file_mounts({
+                        mnt_path: blob_path,
+                    })
                 else:
                     with ux_utils.print_exception_no_traceback():
                         raise ValueError(f'Storage Type {store_type} '

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,6 +98,7 @@ all_clouds_in_smoke_tests = [
     'shadeform',
     'coreweave',
     'vastdata',
+    'huggingface',
     'slurm',
     'mithril',
     'verda',
@@ -131,6 +132,7 @@ cloud_to_pytest_keyword = {
     'seeweb': 'seeweb',
     'coreweave': 'coreweave',
     'vastdata': 'vastdata',
+    'huggingface': 'huggingface',
     'slurm': 'slurm',
     'mithril': 'mithril',
     'verda': 'verda',
@@ -344,7 +346,7 @@ def _get_cloud_to_run(config) -> List[str]:
 
     for cloud in all_clouds_in_smoke_tests:
         if config.getoption(f'--{cloud}'):
-            if cloud in ['cloudflare', 'coreweave', 'vastdata']:
+            if cloud in ['cloudflare', 'coreweave', 'vastdata', 'huggingface']:
                 cloud_to_run.append(default_clouds_to_run[0])
             else:
                 cloud_to_run.append(cloud)
@@ -412,6 +414,9 @@ def pytest_collection_modifyitems(config, items):
                 if config.getoption('--coreweave') and cloud == 'coreweave':
                     continue
                 if config.getoption('--vastdata') and cloud == 'vastdata':
+                    continue
+                if (config.getoption('--huggingface') and
+                        cloud == 'huggingface'):
                     continue
                 item.add_marker(skip_marks[cloud])
 

--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -42,6 +42,7 @@ from sky import skypilot_config
 from sky.adaptors import azure
 from sky.adaptors import cloudflare
 from sky.adaptors import coreweave
+from sky.adaptors import huggingface
 from sky.adaptors import ibm
 from sky.adaptors import nebius
 from sky.adaptors import vastdata
@@ -831,6 +832,58 @@ def test_vastdata_storage_mounts(generic_cloud: str):
 
         test = smoke_tests_utils.Test(
             'vastdata_storage_mounts',
+            test_commands,
+            f'sky down -y {name}; sky storage delete -y {storage_name}',
+            timeout=20 * 60,
+        )
+        smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.huggingface
+def test_huggingface_storage_mounts(generic_cloud: str):
+    """End-to-end smoke test for HF Buckets + HF repo mounts.
+
+    The YAML exercises:
+      - COPY-mode upload (dir and list-of-files) to a new HF bucket.
+      - MOUNT / MOUNT_CACHED modes to the same bucket (read-write).
+      - MOUNT mode for a public model repo (read-only, auth optional).
+      - MOUNT mode for a public dataset repo at ``@main``.
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    # HF bucket names must be ``<namespace>/<bucket>``. Use the logged-in
+    # namespace so this works across test environments.
+    user = huggingface.api().whoami(token=huggingface.get_token())
+    namespace = user['name']
+    bucket_name = f'sky-test-{int(time.time())}'
+    storage_name = f'{namespace}/{bucket_name}'
+
+    template_str = pathlib.Path(
+        'tests/test_yamls/test_huggingface_storage_mounting.yaml').read_text()
+    template = jinja2.Template(template_str)
+    content = template.render(storage_name=storage_name)
+    with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
+        f.write(content)
+        f.flush()
+        file_path = f.name
+        # Post-launch verification: uploaded files should be listable via
+        # ``huggingface_hub`` against the HF Bucket.
+        verify_py = (
+            'python3 -c "from huggingface_hub import HfApi; import os;'
+            ' token=os.environ.get(\\"HF_TOKEN\\") or'
+            ' open(os.path.expanduser(\\"~/.cache/huggingface/token\\"))'
+            '.read().strip();'
+            f' entries=list(HfApi().list_bucket_tree({storage_name!r},'
+            ' recursive=True, token=token));'
+            ' names=[e.path for e in entries];'
+            ' assert any(\\"hello.txt\\" in n for n in names), names"')
+        test_commands = [
+            *smoke_tests_utils.STORAGE_SETUP_COMMANDS,
+            f'sky launch -y -c {name} --infra {generic_cloud} {file_path}',
+            f'sky logs {name} 1 --status',  # Ensure job succeeded.
+            verify_py,
+        ]
+        test = smoke_tests_utils.Test(
+            'huggingface_storage_mounts',
             test_commands,
             f'sky down -y {name}; sky storage delete -y {storage_name}',
             timeout=20 * 60,

--- a/tests/test_yamls/test_huggingface_storage_mounting.yaml
+++ b/tests/test_yamls/test_huggingface_storage_mounting.yaml
@@ -1,0 +1,64 @@
+file_mounts:
+  # HF Bucket: COPY mode with a source directory.
+  /mount_bucket_copy:
+    name: {{storage_name}}
+    source: ~/tmp-workdir
+    store: hf
+    mode: COPY
+
+  # HF Bucket: COPY mode with a list of files as source.
+  /mount_bucket_copy_lof:
+    name: {{storage_name}}
+    source: ['~/tmp-workdir/tmp file', '~/tmp-workdir/tmp file2']
+    store: hf
+    mode: COPY
+
+  # HF Bucket: MOUNT mode (read-write via hf-mount NFS backend).
+  /mount_bucket_mount:
+    name: {{storage_name}}
+    source: ~/tmp-workdir
+    store: hf
+    mode: MOUNT
+
+  # HF Bucket: MOUNT_CACHED mode (also served by hf-mount's built-in cache).
+  /mount_bucket_mount_cached:
+    name: {{storage_name}}
+    source: ~/tmp-workdir
+    store: hf
+    mode: MOUNT_CACHED
+
+  # HF Repo: mount a public model as a read-only filesystem.
+  /mount_hf_model:
+    source: hf://openai-community/gpt2
+    store: hf
+    mode: MOUNT
+
+  # HF Repo: mount a public dataset with an explicit revision.
+  /mount_hf_dataset:
+    source: hf://datasets/open-index/hacker-news@main
+    store: hf
+    mode: MOUNT
+
+run: |
+  set -ex
+
+  # Check bucket contents via each mode.
+  ls -ltr /mount_bucket_copy/foo
+  ls -ltr /mount_bucket_copy/tmp\ file
+  ls -ltr /mount_bucket_copy_lof/tmp\ file
+  ls -ltr /mount_bucket_copy_lof/tmp\ file2
+  ls -ltr /mount_bucket_mount/foo
+  ls -ltr /mount_bucket_mount/tmp\ file
+
+  # Symlinks are not copied to buckets.
+  ! ls /mount_bucket_copy/circle-link
+  ! ls /mount_bucket_mount/circle-link
+
+  # Writes to a bucket in MOUNT / MOUNT_CACHED mode should succeed.
+  echo "hello" > /mount_bucket_mount/hello.txt
+  echo "hello2" > /mount_bucket_mount_cached/hello2.txt
+
+  # HF repo mounts are read-only: reads work, writes should fail.
+  ls /mount_hf_model/config.json
+  ls /mount_hf_dataset | head -n 1
+  ! echo "should fail" > /mount_hf_model/should-fail.txt

--- a/tests/unit_tests/test_sky/storage/test_huggingface.py
+++ b/tests/unit_tests/test_sky/storage/test_huggingface.py
@@ -1,0 +1,556 @@
+"""Unit tests for the Hugging Face Buckets storage backend."""
+# pylint: disable=protected-access
+from unittest import mock
+
+import pytest
+
+from sky import cloud_stores
+from sky import exceptions
+from sky import task as task_lib
+from sky.adaptors import huggingface
+from sky.data import data_utils
+from sky.data import mounting_utils
+from sky.data import storage
+
+
+class TestSplitHfPath:
+    """Tests for data_utils.split_hf_path."""
+
+    def test_full_handle(self):
+        bucket_id, sub_path = data_utils.split_hf_path(
+            'hf://buckets/ns/bucket/path/to/file.txt')
+        assert bucket_id == 'ns/bucket'
+        assert sub_path == 'path/to/file.txt'
+
+    def test_handle_no_sub_path(self):
+        bucket_id, sub_path = data_utils.split_hf_path('hf://buckets/ns/bucket')
+        assert bucket_id == 'ns/bucket'
+        assert sub_path == ''
+
+    def test_handle_trailing_slash(self):
+        bucket_id, sub_path = data_utils.split_hf_path(
+            'hf://buckets/ns/bucket/')
+        assert bucket_id == 'ns/bucket'
+        assert sub_path == ''
+
+    def test_short_form(self):
+        bucket_id, sub_path = data_utils.split_hf_path('ns/bucket/x/y.txt')
+        assert bucket_id == 'ns/bucket'
+        assert sub_path == 'x/y.txt'
+
+    def test_missing_bucket_raises(self):
+        with pytest.raises(ValueError, match='hf://buckets/'):
+            data_utils.split_hf_path('hf://buckets/ns')
+
+    def test_empty_segment_raises(self):
+        with pytest.raises(ValueError):
+            data_utils.split_hf_path('hf://buckets//bucket')
+
+
+class TestIsHfPath:
+    """Tests for data_utils.is_hf_path and is_hf_bucket_path."""
+
+    @pytest.mark.parametrize('url', [
+        'hf://buckets/ns/bucket',
+        'hf://ns/model',
+        'hf://datasets/ns/ds',
+        'hf://spaces/ns/app',
+    ])
+    def test_any_hf_url(self, url):
+        assert data_utils.is_hf_path(url) is True
+
+    def test_s3_url(self):
+        assert data_utils.is_hf_path('s3://some-bucket') is False
+
+    def test_plain_string(self):
+        assert data_utils.is_hf_path('not-a-url') is False
+
+    def test_bucket_path(self):
+        assert data_utils.is_hf_bucket_path('hf://buckets/ns/bucket') is True
+        assert data_utils.is_hf_bucket_path('hf://ns/model') is False
+
+
+class TestSplitHfRepoPath:
+    """Tests for data_utils.split_hf_repo_path."""
+
+    def test_model_simple(self):
+        rt, rid, rev, sub = data_utils.split_hf_repo_path(
+            'hf://openai/gpt-oss-20b')
+        assert rt == 'model'
+        assert rid == 'openai/gpt-oss-20b'
+        assert rev is None
+        assert sub == ''
+
+    def test_model_with_revision(self):
+        rt, rid, rev, sub = data_utils.split_hf_repo_path(
+            'hf://openai-community/gpt2@v1.0')
+        assert rt == 'model'
+        assert rid == 'openai-community/gpt2'
+        assert rev == 'v1.0'
+        assert sub == ''
+
+    def test_model_with_sub_path(self):
+        rt, rid, rev, sub = data_utils.split_hf_repo_path(
+            'hf://openai-community/gpt2/onnx')
+        assert rt == 'model'
+        assert rid == 'openai-community/gpt2'
+        assert rev is None
+        assert sub == 'onnx'
+
+    def test_dataset(self):
+        rt, rid, rev, _ = data_utils.split_hf_repo_path(
+            'hf://datasets/open-index/hacker-news')
+        assert rt == 'dataset'
+        assert rid == 'open-index/hacker-news'
+        assert rev is None
+
+    def test_space_with_revision_and_sub_path(self):
+        rt, rid, rev, sub = data_utils.split_hf_repo_path(
+            'hf://spaces/me/demo@main/assets/img.png')
+        assert rt == 'space'
+        assert rid == 'me/demo'
+        assert rev == 'main'
+        assert sub == 'assets/img.png'
+
+    def test_rejects_buckets_url(self):
+        with pytest.raises(ValueError, match='bucket URL'):
+            data_utils.split_hf_repo_path('hf://buckets/ns/bucket')
+
+    def test_rejects_non_hf(self):
+        with pytest.raises(ValueError):
+            data_utils.split_hf_repo_path('s3://foo/bar')
+
+
+class TestStoreTypeHf:
+    """Tests for StoreType.HF enum behavior."""
+
+    def test_enum_value(self):
+        assert storage.StoreType.HF.value == 'HF'
+
+    def test_store_prefix(self):
+        assert storage.StoreType.HF.store_prefix() == 'hf://buckets/'
+
+    def test_from_cloud(self):
+        assert (storage.StoreType.from_cloud(
+            huggingface.NAME) == storage.StoreType.HF)
+        assert (storage.StoreType.from_cloud(
+            huggingface.NAME.lower()) == storage.StoreType.HF)
+
+    def test_to_cloud(self):
+        assert storage.StoreType.HF.to_cloud() == huggingface.NAME
+
+    def test_roundtrip_via_url(self):
+        """StoreType.get_fields_from_store_url should accept HF handles."""
+        result = storage.StoreType.get_fields_from_store_url(
+            'hf://buckets/my-user/my-bucket/sub/path')
+        store_type, bucket_name, sub_path, acct, region = result
+        assert store_type == storage.StoreType.HF
+        assert bucket_name == 'my-user/my-bucket'
+        assert sub_path == 'sub/path'
+        assert acct is None
+        assert region is None
+
+
+class TestValidateName:
+    """Tests for HuggingFaceStore.validate_name."""
+
+    @pytest.mark.parametrize('name', [
+        'user/bucket',
+        'my-org/some_bucket',
+        'a/b',
+        'Alice/Bob2',
+        'org123/bucket.v2',
+        'user/bucket-with-dashes',
+    ])
+    def test_valid_bucket_names(self, name):
+        assert storage.HuggingFaceStore.validate_name(name) == name
+
+    def test_accepts_full_handle(self):
+        result = storage.HuggingFaceStore.validate_name(
+            'hf://buckets/user/bucket')
+        assert result == 'user/bucket'
+
+    @pytest.mark.parametrize('name', [
+        'just-one-part',
+        '/no-namespace',
+        'ns/',
+        '.leading-dot/ok',
+        'ok/.leading-dot',
+        '-leading-dash/ok',
+        'ns/has space',
+        'ns//bucket',
+        'ns/bucket/extra',
+        '',
+    ])
+    def test_invalid_names_raise(self, name):
+        with pytest.raises(exceptions.StorageNameError):
+            storage.HuggingFaceStore.validate_name(name)
+
+    @pytest.mark.parametrize('name, repo_type', [
+        ('openai/gpt2', 'model'),
+        ('datasets/open-index/hacker-news', 'dataset'),
+        ('spaces/me/demo', 'space'),
+    ])
+    def test_valid_repo_names(self, name, repo_type):
+        assert (storage.HuggingFaceStore.validate_name(
+            name, repo_type=repo_type) == name)
+
+
+class TestHfClassifyAndValidate:
+    """Tests for classify/validate flow (bucket vs repo dispatch)."""
+
+    def _make(self, name, source):
+        # Build *without* running initialize() by short-circuiting validate
+        # after classify; we just want to verify classification.
+        obj = storage.HuggingFaceStore.__new__(storage.HuggingFaceStore)
+        obj.name = name
+        obj.source = source
+        obj._repo_type = None
+        obj._revision = None
+        obj._hf_id = ''
+        obj._classify()
+        return obj
+
+    def test_classify_bucket_from_source(self):
+        o = self._make('ns/bucket', 'hf://buckets/ns/bucket')
+        assert not o.is_repo
+        assert o._hf_id == 'ns/bucket'
+
+    def test_classify_model(self):
+        o = self._make('', 'hf://openai/gpt2')
+        assert o.is_repo
+        assert o._repo_type == 'model'
+        assert o._hf_id == 'openai/gpt2'
+        assert o.name == 'openai/gpt2'
+
+    def test_classify_dataset_with_revision(self):
+        o = self._make('', 'hf://datasets/ns/ds@main/sub')
+        assert o._repo_type == 'dataset'
+        assert o._hf_id == 'datasets/ns/ds'
+        assert o._revision == 'main'
+
+    def test_classify_rejects_name_source_mismatch(self):
+        with pytest.raises(exceptions.StorageSpecError,
+                           match='does not match storage name'):
+            self._make('wrong/name', 'hf://openai/gpt2')
+
+
+class TestUploadGuards:
+    """Tests that upload() fails loud for repo + local-source misconfigs."""
+
+    def _make_repo_store(self):
+        obj = storage.HuggingFaceStore.__new__(storage.HuggingFaceStore)
+        obj.name = 'openai/gpt2'
+        obj.source = 'hf://openai/gpt2'
+        obj._repo_type = 'model'
+        obj._revision = None
+        obj._hf_id = 'openai/gpt2'
+        obj._bucket_sub_path = None
+        return obj
+
+    def test_noop_when_source_is_repo_url(self):
+        o = self._make_repo_store()
+        o.upload()  # no-op, no exception
+
+    def test_raises_on_local_source(self):
+        o = self._make_repo_store()
+        o.source = '/tmp/local'
+        with pytest.raises(exceptions.StorageUploadError,
+                           match='repos are read-only'):
+            o.upload()
+
+    def test_raises_on_list_source(self):
+        o = self._make_repo_store()
+        o.source = ['/tmp/a', '/tmp/b']
+        with pytest.raises(exceptions.StorageUploadError,
+                           match='repos are read-only'):
+            o.upload()
+
+
+class TestVerifyHfBucket:
+    """Tests for data_utils.verify_hf_bucket."""
+
+    @mock.patch('sky.data.data_utils.huggingface.api')
+    @mock.patch('sky.data.data_utils.huggingface.get_token', return_value='t')
+    def test_existing_bucket(self, mock_token, mock_api):
+        del mock_token  # unused; patch fixture
+        mock_api.return_value.bucket_info.return_value = mock.MagicMock()
+        assert data_utils.verify_hf_bucket('ns/bucket') is True
+
+    @mock.patch('sky.data.data_utils.huggingface.hf_hub_errors')
+    @mock.patch('sky.data.data_utils.huggingface.api')
+    @mock.patch('sky.data.data_utils.huggingface.get_token', return_value='t')
+    def test_missing_bucket(self, mock_token, mock_api, mock_errors):
+        del mock_token  # unused; patch fixture
+
+        class _NotFound(Exception):
+            pass
+
+        errs = mock.MagicMock()
+        errs.RepositoryNotFoundError = _NotFound
+        errs.EntryNotFoundError = _NotFound
+        mock_errors.return_value = errs
+        mock_api.return_value.bucket_info.side_effect = _NotFound('missing')
+        assert data_utils.verify_hf_bucket('ns/bucket') is False
+
+    @staticmethod
+    def _make_errors_mock():
+        """Returns a mock ``hf_hub_errors`` module with real exception types.
+
+        ``verify_hf_bucket`` calls ``isinstance(e, explicit_not_found_types)``,
+        so the attributes have to be real types (not ``MagicMock``).
+        """
+
+        class _NotFound(Exception):
+            pass
+
+        errs = mock.MagicMock()
+        errs.RepositoryNotFoundError = _NotFound
+        errs.EntryNotFoundError = _NotFound
+        return errs
+
+    @mock.patch('sky.data.data_utils.huggingface.hf_hub_errors')
+    @mock.patch('sky.data.data_utils.huggingface.api')
+    @mock.patch('sky.data.data_utils.huggingface.get_token', return_value='t')
+    def test_http_404_treated_as_missing(self, mock_token, mock_api,
+                                         mock_errors):
+        del mock_token  # unused; patch fixture
+        mock_errors.return_value = self._make_errors_mock()
+        # HTTP-style exception exposing ``response.status_code``.
+        http_err = Exception('Not Found')
+        http_err.response = mock.MagicMock(status_code=404)
+        mock_api.return_value.bucket_info.side_effect = http_err
+        assert data_utils.verify_hf_bucket('ns/bucket') is False
+
+    @mock.patch('sky.data.data_utils.huggingface.hf_hub_errors')
+    @mock.patch('sky.data.data_utils.huggingface.api')
+    @mock.patch('sky.data.data_utils.huggingface.get_token', return_value='t')
+    def test_http_403_propagates(self, mock_token, mock_api, mock_errors):
+        del mock_token  # unused; patch fixture
+        mock_errors.return_value = self._make_errors_mock()
+        # Auth error: must NOT be swallowed as "not found", otherwise a caller
+        # would silently try to re-create an existing private bucket.
+        http_err = Exception('Forbidden')
+        http_err.response = mock.MagicMock(status_code=403)
+        mock_api.return_value.bucket_info.side_effect = http_err
+        with pytest.raises(Exception, match='Forbidden'):
+            data_utils.verify_hf_bucket('ns/bucket')
+
+    @mock.patch('sky.data.data_utils.huggingface.hf_hub_errors')
+    @mock.patch('sky.data.data_utils.huggingface.api')
+    @mock.patch('sky.data.data_utils.huggingface.get_token', return_value='t')
+    def test_network_error_propagates(self, mock_token, mock_api, mock_errors):
+        del mock_token  # unused; patch fixture
+        mock_errors.return_value = self._make_errors_mock()
+        mock_api.return_value.bucket_info.side_effect = ConnectionError('boom')
+        with pytest.raises(ConnectionError):
+            data_utils.verify_hf_bucket('ns/bucket')
+
+
+class TestHfMountCommands:
+    """Tests for mounting_utils.get_hf_mount_* helpers."""
+
+    def test_install_cmd_mentions_release(self):
+        cmd = mounting_utils.get_hf_mount_install_cmd()
+        assert mounting_utils.HF_MOUNT_VERSION in cmd
+        # We use the FUSE backend binary; NFS isn't fetched.
+        assert 'hf-mount-fuse' in cmd
+        assert 'hf-mount-nfs' not in cmd
+        # Must bootstrap fuse3 on hosts that don't already have it (minimal
+        # container images such as the stock ubuntu image don't).
+        assert 'fuse3' in cmd
+
+    def test_mount_cmd_default(self):
+        cmd = mounting_utils.get_hf_mount_cmd('user/bucket', '/mnt/data')
+        assert 'hf-mount start' in cmd
+        assert 'bucket user/bucket /mnt/data' in cmd
+        assert '--token-file' in cmd
+        # We always request the FUSE backend; hf-mount defaults to NFS
+        # otherwise, which needs kernel NFS-client support.
+        assert '--fuse' in cmd
+        assert '--read-only' not in cmd
+        # ``hf-mount start`` uses clap trailing-var-args to forward unknown
+        # options to the backend binary, and stops option parsing at the
+        # first unknown arg. If ``--fuse`` comes AFTER ``--token-file``
+        # (injected dynamically from ``$TOKEN_FILE_ARG``), the daemon
+        # silently falls back to NFS and fails with "failed to exec
+        # hf-mount-nfs". Pin the order so this regression can't sneak back.
+        fuse_idx = cmd.find('--fuse')
+        token_arg_idx = cmd.find('$TOKEN_FILE_ARG')
+        assert fuse_idx != -1 and token_arg_idx != -1
+        assert fuse_idx < token_arg_idx, (
+            f'--fuse must appear before $TOKEN_FILE_ARG in the generated '
+            f'mount command, otherwise the NFS backend will be chosen. '
+            f'Got: {cmd!r}')
+
+    def test_mount_cmd_read_only(self):
+        cmd = mounting_utils.get_hf_mount_cmd('user/bucket',
+                                              '/mnt/data',
+                                              read_only=True)
+        assert '--read-only' in cmd
+        assert '--fuse' in cmd
+
+    def test_mount_cmd_sub_path(self):
+        cmd = mounting_utils.get_hf_mount_cmd('user/bucket',
+                                              '/mnt/data',
+                                              _bucket_sub_path='logs')
+        # shlex.quote only adds quotes when the argument contains special
+        # characters; plain ``user/bucket/logs`` is passed verbatim.
+        assert 'user/bucket/logs' in cmd
+
+    def test_mount_cmd_repo_mode(self):
+        cmd = mounting_utils.get_hf_mount_cmd('openai/gpt2',
+                                              '/mnt/model',
+                                              mode='repo',
+                                              revision='v1.0')
+        assert 'repo openai/gpt2 /mnt/model' in cmd
+        assert '--revision v1.0' in cmd
+        assert '--fuse' in cmd
+        # Repos are always read-only for hf-mount; no flag needed.
+        assert '--read-only' not in cmd
+
+    def test_mount_cmd_dataset_mode(self):
+        cmd = mounting_utils.get_hf_mount_cmd('datasets/ns/ds',
+                                              '/mnt/data',
+                                              mode='repo')
+        assert 'repo datasets/ns/ds /mnt/data' in cmd
+
+    def test_mount_cmd_invalid_mode(self):
+        with pytest.raises(ValueError, match='hf-mount mode'):
+            mounting_utils.get_hf_mount_cmd('x/y', '/mnt', mode='invalid')
+
+
+class TestStorageIntegration:
+    """Tests for public Storage/Task integration paths."""
+
+    @mock.patch(
+        'sky.data.storage.global_user_state.get_handle_from_storage_name',
+        return_value=None)
+    @mock.patch('sky.data.storage.huggingface.huggingface_hub.load_module')
+    @mock.patch('sky.data.storage.huggingface.get_token', return_value=None)
+    @mock.patch('sky.data.storage.huggingface.api')
+    def test_public_repo_construct_without_credentials(self, mock_api,
+                                                       mock_token, mock_load,
+                                                       mock_handle):
+        del mock_token, mock_load, mock_handle
+        mock_api.return_value.repo_info.return_value = mock.MagicMock()
+        storage_obj = storage.Storage.from_yaml_config({
+            'source': 'hf://openai-community/gpt2',
+            'store': 'hf',
+            'mode': 'MOUNT',
+        })
+
+        storage_obj.construct()
+
+        assert storage_obj.name == 'openai-community/gpt2'
+        assert storage.StoreType.HF in storage_obj.stores
+        mock_api.return_value.repo_info.assert_called_once_with(
+            repo_id='openai-community/gpt2',
+            repo_type='model',
+            revision=None,
+            token=None)
+
+    @mock.patch(
+        'sky.data.storage.global_user_state.get_handle_from_storage_name',
+        return_value=None)
+    @mock.patch('sky.data.storage._is_storage_cloud_enabled', return_value=True)
+    @mock.patch('sky.data.storage.huggingface.get_token', return_value='token')
+    @mock.patch('sky.data.storage.huggingface.api')
+    def test_bucket_source_construct_infers_name_and_sub_path(
+            self, mock_api, mock_token, mock_enabled, mock_handle):
+        del mock_token, mock_enabled, mock_handle
+        mock_api.return_value.bucket_info.return_value = mock.MagicMock()
+        storage_obj = storage.Storage.from_yaml_config({
+            'source': 'hf://buckets/ns/bucket/path/to/data',
+            'store': 'hf',
+            'mode': 'MOUNT',
+        })
+
+        storage_obj.construct()
+
+        assert storage_obj.name == 'ns/bucket'
+        assert storage_obj._bucket_sub_path == 'path/to/data'
+        hf_store = storage_obj.stores[storage.StoreType.HF]
+        assert hf_store is not None
+        assert hf_store._bucket_sub_path == 'path/to/data'
+
+    def test_copy_mode_translates_hf_bucket_to_file_mount(self):
+        storage_obj = storage.Storage(name='ns/bucket',
+                                      source=['/tmp/a'],
+                                      stores=[storage.StoreType.HF],
+                                      mode=storage.StorageMode.COPY)
+        storage_obj.stores = {storage.StoreType.HF: mock.MagicMock()}
+        storage_obj.construct = mock.Mock()
+        task = task_lib.Task()
+        task.storage_mounts = {'/mnt/data': storage_obj}
+        task.storage_plans = {}
+
+        task.sync_storage_mounts()
+
+        assert task.file_mounts['/mnt/data'] == 'hf://buckets/ns/bucket'
+
+    def test_copy_mode_keeps_hf_repo_source(self):
+        storage_obj = storage.Storage(name='openai-community/gpt2',
+                                      source='hf://openai-community/gpt2',
+                                      stores=[storage.StoreType.HF],
+                                      mode=storage.StorageMode.COPY)
+        storage_obj.stores = {storage.StoreType.HF: mock.MagicMock()}
+        storage_obj.construct = mock.Mock()
+        task = task_lib.Task()
+        task.storage_mounts = {'/mnt/model': storage_obj}
+        task.storage_plans = {}
+
+        task.sync_storage_mounts()
+
+        assert task.file_mounts['/mnt/model'] == 'hf://openai-community/gpt2'
+
+
+class TestHfCredentials:
+    """Tests for HF token file normalization."""
+
+    def test_env_token_is_written_to_canonical_remote_mount(
+            self, tmp_path, monkeypatch):
+        monkeypatch.setenv('HOME', str(tmp_path))
+        monkeypatch.setenv('HF_TOKEN', 'token-from-env')
+
+        mounts = huggingface.get_credential_file_mounts()
+
+        assert mounts == {
+            huggingface.HF_TOKEN_PATH: huggingface.HF_TOKEN_PATH_ENV_CACHE
+        }
+        token_path = tmp_path / '.sky' / 'huggingface' / 'token'
+        assert token_path.read_text(encoding='utf-8') == 'token-from-env'
+
+    def test_legacy_token_mounts_to_canonical_remote_path(
+            self, tmp_path, monkeypatch):
+        monkeypatch.setenv('HOME', str(tmp_path))
+        legacy_dir = tmp_path / '.huggingface'
+        legacy_dir.mkdir()
+        (legacy_dir / 'token').write_text('legacy-token', encoding='utf-8')
+
+        mounts = huggingface.get_credential_file_mounts()
+
+        assert mounts == {
+            huggingface.HF_TOKEN_PATH: huggingface.HF_TOKEN_PATH_LEGACY
+        }
+
+
+class TestHfCloudStorage:
+    """Tests for HF COPY-mode cloud store commands."""
+
+    def test_registry_includes_hf(self):
+        assert isinstance(cloud_stores.get_storage_from_path('hf://x/y'),
+                          cloud_stores.HFCloudStorage)
+
+    def test_bucket_file_download_command(self):
+        command = cloud_stores.HFCloudStorage().make_sync_file_command(
+            'hf://buckets/ns/bucket/file.txt', '/tmp/file.txt')
+        assert 'huggingface_hub' in command
+        assert 'download_bucket_files' in command
+
+    def test_repo_dir_download_command(self):
+        command = cloud_stores.HFCloudStorage().make_sync_dir_command(
+            'hf://datasets/ns/ds@main/subdir', '/tmp/ds')
+        assert 'snapshot_download' in command
+        assert "'dataset'" in command
+        assert 'subdir/*' in command

--- a/tests/unit_tests/test_sky/storage/test_huggingface.py
+++ b/tests/unit_tests/test_sky/storage/test_huggingface.py
@@ -554,3 +554,81 @@ class TestHfCloudStorage:
         assert 'snapshot_download' in command
         assert "'dataset'" in command
         assert 'subdir/*' in command
+
+    @mock.patch('sky.cloud_stores.huggingface.get_token', return_value=None)
+    @mock.patch('sky.cloud_stores.huggingface.api')
+    def test_repo_is_directory_uses_list_repo_tree(self, mock_api, mock_token):
+        """Directory check must go through list_repo_tree, not repo_info.
+
+        repo_info eagerly fetches metadata for every file in the repo
+        (siblings), which is slow on large repos. list_repo_tree only
+        fetches the specified path.
+        """
+        del mock_token
+        mock_api.return_value.list_repo_tree.return_value = iter([])
+        result = cloud_stores.HFCloudStorage().is_directory(
+            'hf://openai-community/gpt2/onnx')
+        assert result is True
+        mock_api.return_value.list_repo_tree.assert_called_once()
+        mock_api.return_value.repo_info.assert_not_called()
+
+    @mock.patch('sky.cloud_stores.huggingface.hf_hub_errors')
+    @mock.patch('sky.cloud_stores.huggingface.get_token', return_value=None)
+    @mock.patch('sky.cloud_stores.huggingface.api')
+    def test_repo_is_directory_file_path_returns_false(self, mock_api,
+                                                       mock_token, mock_errors):
+        """File paths should raise EntryNotFoundError -> returns False."""
+        del mock_token
+
+        class _EntryNotFound(Exception):
+            pass
+
+        errs = mock.MagicMock()
+        errs.EntryNotFoundError = _EntryNotFound
+        errs.RepositoryNotFoundError = _EntryNotFound
+        mock_errors.return_value = errs
+        mock_api.return_value.list_repo_tree.side_effect = _EntryNotFound(
+            'not found')
+        assert cloud_stores.HFCloudStorage().is_directory(
+            'hf://openai-community/gpt2/config.json') is False
+
+
+class TestHfMountCachedCommand:
+    """Tests for HuggingFaceStore.mount_cached_command propagation."""
+
+    def _make_bucket_store(self):
+        obj = storage.HuggingFaceStore.__new__(storage.HuggingFaceStore)
+        obj.name = 'ns/bucket'
+        obj.source = None
+        obj._repo_type = None
+        obj._revision = None
+        obj._hf_id = 'ns/bucket'
+        obj._bucket_sub_path = None
+        return obj
+
+    def test_mount_cached_no_config(self):
+        o = self._make_bucket_store()
+        cmd = o.mount_cached_command('/mnt/data', config=None)
+        # No --read-only flag when config is unset.
+        assert '--read-only' not in cmd
+
+    def test_mount_cached_with_read_only(self):
+        o = self._make_bucket_store()
+        cfg = storage.MountCachedConfig(read_only=True)
+        cmd = o.mount_cached_command('/mnt/data', config=cfg)
+        assert '--read-only' in cmd
+
+    def test_mount_cached_ignores_rclone_only_fields(self):
+        """rclone-specific fields should not produce any hf-mount args."""
+        o = self._make_bucket_store()
+        cfg = storage.MountCachedConfig(
+            transfers=16,
+            buffer_size='128M',
+            vfs_cache_max_size='10G',
+            vfs_read_chunk_streams=8,
+        )
+        cmd = o.mount_cached_command('/mnt/data', config=cfg)
+        # None of these rclone flags should appear in the hf-mount command.
+        for flag in ('--transfers', '--buffer-size', '--vfs-cache-max-size',
+                     '--vfs-read-chunk-streams'):
+            assert flag not in cmd


### PR DESCRIPTION
## Summary

Adds a new `hf` storage type that wraps Hugging Face Buckets (Xet-backed S3-like object storage, read-write) and, via the same handle, also supports mounting HF model/dataset/space repos read-only.

All bucket lifecycle operations (create/upload/download/delete) go through `huggingface_hub` (>=1.10). `MOUNT` / `MOUNT_CACHED` modes install and invoke [`hf-mount`](https://github.com/huggingface/hf-mount) with its FUSE backend, which aligns with SkyPilot's existing FUSE-based mount infrastructure (`gcsfuse` / `blobfuse2` / `rclone mount` / `goofys`).

### URL formats

```text
hf://buckets/<ns>/<bucket>[/<sub>]        (bucket, rw)
hf://<ns>/<model>[@<rev>][/<sub>]         (repo, ro)
hf://datasets/<ns>/<ds>[@<rev>][/<sub>]   (repo, ro)
hf://spaces/<ns>/<sp>[@<rev>][/<sub>]     (repo, ro)
```

### Other notes

- **Auth**: reads `HF_TOKEN` from env or the HF CLI token file and propagates it to clusters via the existing credential-file-mounts pipeline.
- **Fail-loud uploads**: uploading to a repo with a local `source` raises `StorageUploadError` instead of silently no-op'ing, so misconfigurations surface immediately.
- **glibc constraint**: the published `v0.3.1` `hf-mount` Linux binaries are linked against glibc >= 2.32, so `MOUNT`-mode tasks on the default SkyPilot Kubernetes image (Ubuntu 20.04, glibc 2.31) need an explicit newer base image via `resources.image_id` (e.g. `docker:mirror.gcr.io/ubuntu:22.04`). `COPY` mode works on any image. See `docs/source/reference/storage.rst`.

## Test plan

### Unit tests

73 unit tests covering:

- URL parsing (`data_utils.split_hf_path`, `split_hf_repo_path`, `is_hf_path`, `is_hf_bucket_path`)
- Name validation (bucket + repo, including invalid inputs and full-handle acceptance)
- `HuggingFaceStore` classify/upload guards (repo + local source misconfigurations)
- Public `Storage` construction paths (bucket source with sub-path, public repo without credentials)
- `COPY`-mode translation to file-mounts (for both buckets and repos)
- Credential propagation (env-var token, legacy token file, canonical token file)
- `cloud_stores.HFCloudStorage` download command generation
- `hf-mount` command generator, including `--fuse`/`fuse3` bootstrap assertions and the critical `--fuse`-before-`$TOKEN_FILE_ARG` ordering (clap trailing-var-args would otherwise forward `--fuse` as a backend arg and silently fall back to NFS)

Run with:

```bash
uv run --with-editable .[huggingface] --with pytest --with pytest-xdist \
  --with pytest-env --with buildkite-test-collector --with boto3 \
  pytest tests/unit_tests/test_sky/storage/test_huggingface.py -q -n 0
```

### Formatters and linters

- [x] `bash format.sh` clean (`black`, `yapf`, `isort`, `mypy` — `Success: no issues found in 545 source files`, `pylint 10.00/10`, dashboard ESLint clean)
- [x] `git diff --check`, `yapf --diff`, `isort --diff`

### End-to-end (Kubernetes)

- [x] Create bucket → upload dir + files (COPY mode via `HfApi.sync_bucket`)
- [x] Pod starts, HF token file propagated to pod at `~/.cache/huggingface`
- [x] Pod lists bucket via `huggingface_hub`, downloads `hello.txt`
- [x] Pod writes `pod-wrote.txt` back via `batch_bucket_files`
- [x] Re-list shows pod-written file, re-download confirms content
- [x] Clean teardown (`sky down` + `HfApi.delete_bucket`)
- [x] `MOUNT` mode via `hf-mount --fuse` on Ubuntu 22.04
