### PR TITLE
[Jobs] Enforce job cancel ownership: only admins or job owners can ca…

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -5909,7 +5909,9 @@ def jobs_cancel(
                             if job_ids else f'{name!r}' if name is not None else
                             f'managed jobs in pool {pool!r}')
         if all_users:
-            job_identity_str = 'all managed jobs FOR ALL USERS'
+            job_identity_str = (
+                'all managed jobs for ALL USERS '
+                '(admin override — other users\' jobs will be cancelled)')
         elif all:
             job_identity_str = 'all managed jobs'
         click.confirm(f'Cancelling {job_identity_str}. Proceed?',
@@ -5924,7 +5926,8 @@ def jobs_cancel(
                             graceful=graceful,
                             graceful_timeout=graceful_timeout,
                             all=all,
-                            all_users=all_users))
+                            all_users=all_users,
+                            yes=yes))
 
 
 @jobs.command('logs', cls=_DocumentedCodeCommand)

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -350,6 +350,7 @@ def cancel(
     pool: Optional[str] = None,
     graceful: bool = False,
     graceful_timeout: Optional[int] = None,
+    yes: bool = False,
 ) -> server_common.RequestId[None]:
     """Cancels managed jobs.
 
@@ -365,6 +366,9 @@ def cancel(
             fully uploaded. This helps with preserving user data integrity.
         graceful_timeout: If not None, sets a timeout for the graceful option
             above (in seconds).
+        yes: If True, skip the extra admin-override confirmation that the
+            server enforces when an admin cancels specific jobs by ID, name,
+            or pool.
 
     Returns:
         The request ID of the cancel request.
@@ -393,6 +397,7 @@ def cancel(
         pool=pool,
         graceful=graceful,
         graceful_timeout=graceful_timeout,
+        yes=yes,
     )
     response = server_common.make_authenticated_request(
         'POST',

--- a/sky/jobs/constants.py
+++ b/sky/jobs/constants.py
@@ -72,4 +72,4 @@ JOBS_CLUSTER_NAME_PREFIX_LENGTH = 25
 # job.utils.ManagedJobCodeGen to handle the version update.
 # WARNING: If you update this due to a codegen change, make sure to make the
 # corresponding change in the ManagedJobsService AND bump the SKYLET_VERSION.
-MANAGED_JOBS_VERSION = 17  # add collect_debug_dump_manifest for debug dump
+MANAGED_JOBS_VERSION = 18  # add requester_user_hash to cancel for ownership enforcement

--- a/sky/jobs/constants.py
+++ b/sky/jobs/constants.py
@@ -72,4 +72,5 @@ JOBS_CLUSTER_NAME_PREFIX_LENGTH = 25
 # job.utils.ManagedJobCodeGen to handle the version update.
 # WARNING: If you update this due to a codegen change, make sure to make the
 # corresponding change in the ManagedJobsService AND bump the SKYLET_VERSION.
-MANAGED_JOBS_VERSION = 18  # add requester_user_hash to cancel for ownership enforcement
+MANAGED_JOBS_VERSION = 18  # add requester_user_hash to cancel
+# for ownership enforcement

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -1341,9 +1341,11 @@ def cancel(name: Optional[str] = None,
 
         # Determine caller's identity and role. Only enforce ownership when
         # running as the API server (ENV_VAR_IS_SKYPILOT_SERVER is set).
+        is_server = bool(
+            os.environ.get(skylet_constants.ENV_VAR_IS_SKYPILOT_SERVER))
         requester_user_hash = common_utils.get_user_hash()
         is_admin = False
-        if os.environ.get(skylet_constants.ENV_VAR_IS_SKYPILOT_SERVER):
+        if is_server:
             roles = permission_lib.permission_service.get_user_roles(
                 requester_user_hash)
             is_admin = rbac.RoleName.ADMIN.value in roles
@@ -1363,10 +1365,10 @@ def cancel(name: Optional[str] = None,
                         'ownership checks. Re-run with -y/--yes to confirm.')
 
         # Pass requester_user_hash to enforce ownership on the controller.
-        # None means no enforcement (admin or non-server context).
-        ownership_user_hash = None if (is_admin or all_users or all) else (
-            requester_user_hash if os.environ.get(
-                skylet_constants.ENV_VAR_IS_SKYPILOT_SERVER) else None)
+        # None means no enforcement (admin, bulk cancel, or non-server context).
+        ownership_user_hash = (requester_user_hash
+                               if is_server and not is_admin and
+                               not all_users and not all else None)
 
         job_ids = None if (all_users or all) else job_ids
 

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -1305,7 +1305,8 @@ def cancel(name: Optional[str] = None,
            all_users: bool = False,
            pool: Optional[str] = None,
            graceful: bool = False,
-           graceful_timeout: Optional[int] = None) -> None:
+           graceful_timeout: Optional[int] = None,
+           yes: bool = False) -> None:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Cancels managed jobs.
 
@@ -1352,6 +1353,14 @@ def cancel(name: Optional[str] = None,
                     raise exceptions.NotSupportedError(
                         'Only admins can cancel all users\' jobs. '
                         'Use --all to cancel your own jobs.')
+
+            # Admins bypass ownership checks when cancelling specific jobs,
+            # so require explicit confirmation (-y/--yes) to avoid accidents.
+            if is_admin and not all_users and not all and not yes:
+                with ux_utils.print_exception_no_traceback():
+                    raise exceptions.NotSupportedError(
+                        'You are cancelling as admin, which bypasses job '
+                        'ownership checks. Re-run with -y/--yes to confirm.')
 
         # Pass requester_user_hash to enforce ownership on the controller.
         # None means no enforcement (admin or non-server context).

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -41,6 +41,8 @@ from sky.serve.server import impl
 from sky.server.requests import request_names
 from sky.skylet import constants as skylet_constants
 from sky.usage import usage_lib
+from sky.users import permission as permission_lib
+from sky.users import rbac
 from sky.utils import admin_policy_utils
 from sky.utils import common
 from sky.utils import common_utils
@@ -1336,6 +1338,28 @@ def cancel(name: Optional[str] = None,
                     'Can only specify one of JOB_IDS, name, pool, or all/'
                     f'all_users. Provided {" ".join(arguments)!r}.')
 
+        # Determine caller's identity and role. Only enforce ownership when
+        # running as the API server (ENV_VAR_IS_SKYPILOT_SERVER is set).
+        requester_user_hash = common_utils.get_user_hash()
+        is_admin = False
+        if os.environ.get(skylet_constants.ENV_VAR_IS_SKYPILOT_SERVER):
+            roles = permission_lib.permission_service.get_user_roles(
+                requester_user_hash)
+            is_admin = rbac.RoleName.ADMIN.value in roles
+
+            if all_users and not is_admin:
+                with ux_utils.print_exception_no_traceback():
+                    raise exceptions.NotSupportedError(
+                        'Only admins can cancel all users\' jobs. '
+                        'Use --all to cancel your own jobs.')
+
+        # Pass requester_user_hash to enforce ownership on the controller.
+        # None means no enforcement (admin or non-server context).
+        ownership_user_hash = None if (is_admin or all_users or all) else (
+            requester_user_hash
+            if os.environ.get(skylet_constants.ENV_VAR_IS_SKYPILOT_SERVER)
+            else None)
+
         job_ids = None if (all_users or all) else job_ids
 
         backend = backend_utils.get_backend_from_handle(handle)
@@ -1354,15 +1378,23 @@ def cancel(name: Optional[str] = None,
                 if all_users or all or job_ids:
                     request.all_users = all_users
                     if all:
-                        request.user_hash = common_utils.get_user_hash()
+                        request.user_hash = requester_user_hash
+                    elif ownership_user_hash is not None:
+                        # Reuse user_hash to carry requester identity for
+                        # ownership enforcement on the controller side.
+                        request.user_hash = ownership_user_hash
                     if job_ids is not None:
                         request.job_ids.CopyFrom(
                             managed_jobsv1_pb2.JobIds(ids=job_ids))
                 elif name is not None:
                     request.job_name = name
+                    if ownership_user_hash is not None:
+                        request.user_hash = ownership_user_hash
                 else:
                     assert pool is not None, (job_ids, name, pool, all)
                     request.pool_name = pool
+                    if ownership_user_hash is not None:
+                        request.user_hash = ownership_user_hash
 
                 response = backend_utils.invoke_skylet_with_retries(
                     lambda: cloud_vm_ray_backend.SkyletClient(
@@ -1377,14 +1409,18 @@ def cancel(name: Optional[str] = None,
                     job_ids,
                     all_users=all_users,
                     graceful=graceful,
-                    graceful_timeout=graceful_timeout)
+                    graceful_timeout=graceful_timeout,
+                    requester_user_hash=ownership_user_hash)
             elif name is not None:
                 code = managed_job_utils.ManagedJobCodeGen.cancel_job_by_name(
-                    name, graceful=graceful, graceful_timeout=graceful_timeout)
+                    name,
+                    graceful=graceful,
+                    graceful_timeout=graceful_timeout,
+                    requester_user_hash=ownership_user_hash)
             else:
                 assert pool is not None, (job_ids, name, pool, all)
                 code = managed_job_utils.ManagedJobCodeGen.cancel_jobs_by_pool(
-                    pool)
+                    pool, requester_user_hash=ownership_user_hash)
             # The stderr is redirected to stdout
             returncode, stdout, stderr = backend.run_on_head(
                 handle, code, require_outputs=True, stream_logs=False)
@@ -1401,6 +1437,9 @@ def cancel(name: Optional[str] = None,
             with ux_utils.print_exception_no_traceback():
                 raise RuntimeError(
                     'Please specify the job ID instead of the job name.')
+        if 'Permission denied:' in stdout:
+            with ux_utils.print_exception_no_traceback():
+                raise RuntimeError(stdout.strip())
 
 
 @usage_lib.entrypoint

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -1352,7 +1352,7 @@ def cancel(name: Optional[str] = None,
 
             if all_users and not is_admin:
                 with ux_utils.print_exception_no_traceback():
-                    raise exceptions.NotSupportedError(
+                    raise exceptions.PermissionDeniedError(
                         'Only admins can cancel all users\' jobs. '
                         'Use --all to cancel your own jobs.')
 
@@ -1360,7 +1360,7 @@ def cancel(name: Optional[str] = None,
             # so require explicit confirmation (-y/--yes) to avoid accidents.
             if is_admin and not all_users and not all and not yes:
                 with ux_utils.print_exception_no_traceback():
-                    raise exceptions.NotSupportedError(
+                    raise RuntimeError(
                         'You are cancelling as admin, which bypasses job '
                         'ownership checks. Re-run with -y/--yes to confirm.')
 

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -1356,9 +1356,8 @@ def cancel(name: Optional[str] = None,
         # Pass requester_user_hash to enforce ownership on the controller.
         # None means no enforcement (admin or non-server context).
         ownership_user_hash = None if (is_admin or all_users or all) else (
-            requester_user_hash
-            if os.environ.get(skylet_constants.ENV_VAR_IS_SKYPILOT_SERVER)
-            else None)
+            requester_user_hash if os.environ.get(
+                skylet_constants.ENV_VAR_IS_SKYPILOT_SERVER) else None)
 
         job_ids = None if (all_users or all) else job_ids
 

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -1386,23 +1386,23 @@ def cancel(name: Optional[str] = None,
                 if all_users or all or job_ids:
                     request.all_users = all_users
                     if all:
+                        # Use requester hash to filter to the caller's own jobs.
                         request.user_hash = requester_user_hash
-                    elif ownership_user_hash is not None:
-                        # Reuse user_hash to carry requester identity for
-                        # ownership enforcement on the controller side.
-                        request.user_hash = ownership_user_hash
                     if job_ids is not None:
                         request.job_ids.CopyFrom(
                             managed_jobsv1_pb2.JobIds(ids=job_ids))
                 elif name is not None:
                     request.job_name = name
-                    if ownership_user_hash is not None:
-                        request.user_hash = ownership_user_hash
                 else:
                     assert pool is not None, (job_ids, name, pool, all)
                     request.pool_name = pool
-                    if ownership_user_hash is not None:
-                        request.user_hash = ownership_user_hash
+
+                # For specific-target criteria (job_ids/name/pool, non-admin),
+                # carry the requester's identity for ownership enforcement on
+                # the controller. ownership_user_hash is already None for the
+                # all/all_users paths, so this is a no-op there.
+                if ownership_user_hash is not None:
+                    request.user_hash = ownership_user_hash
 
                 response = backend_utils.invoke_skylet_with_retries(
                     lambda: cloud_vm_ray_backend.SkyletClient(

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -2202,14 +2202,20 @@ def get_workspace(job_id: int) -> str:
         return job_workspace
 
 
-def get_user_hash_for_job(job_id: int) -> Optional[str]:
-    """Return the user_hash of the job's submitter, or None if not found."""
+def get_user_hashes_for_jobs(job_ids: List[int]) -> Dict[int, Optional[str]]:
+    """Return a mapping of job_id -> user_hash for the given job IDs.
+
+    Missing job IDs (not found in DB) are omitted from the result.
+    """
+    if not job_ids:
+        return {}
     engine = _db_manager.get_engine()
     with orm.Session(engine) as session:
-        row = session.execute(
-            sqlalchemy.select(job_info_table.c.user_hash).where(
-                job_info_table.c.spot_job_id == job_id)).fetchone()
-        return row[0] if row else None
+        rows = session.execute(
+            sqlalchemy.select(
+                job_info_table.c.spot_job_id, job_info_table.c.user_hash).where(
+                    job_info_table.c.spot_job_id.in_(job_ids))).fetchall()
+    return {row[0]: row[1] for row in rows}
 
 
 async def get_latest_task_id_status_async(

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -2202,6 +2202,16 @@ def get_workspace(job_id: int) -> str:
         return job_workspace
 
 
+def get_user_hash_for_job(job_id: int) -> Optional[str]:
+    """Return the user_hash of the job's submitter, or None if not found."""
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        row = session.execute(
+            sqlalchemy.select(job_info_table.c.user_hash).where(
+                job_info_table.c.spot_job_id == job_id)).fetchone()
+        return row[0] if row else None
+
+
 async def get_latest_task_id_status_async(
         job_id: int) -> Tuple[Optional[int], Optional[ManagedJobStatus]]:
     """Returns the (task id, status) of the latest task of a job."""

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -2202,22 +2202,6 @@ def get_workspace(job_id: int) -> str:
         return job_workspace
 
 
-def get_user_hashes_for_jobs(job_ids: List[int]) -> Dict[int, Optional[str]]:
-    """Return a mapping of job_id -> user_hash for the given job IDs.
-
-    Missing job IDs (not found in DB) are omitted from the result.
-    """
-    if not job_ids:
-        return {}
-    engine = _db_manager.get_engine()
-    with orm.Session(engine) as session:
-        rows = session.execute(
-            sqlalchemy.select(
-                job_info_table.c.spot_job_id, job_info_table.c.user_hash).where(
-                    job_info_table.c.spot_job_id.in_(job_ids))).fetchall()
-    return {row[0]: row[1] for row in rows}
-
-
 def get_job_owner_and_workspace(
         job_ids: List[int]) -> Dict[int, Tuple[Optional[str], str]]:
     """Return {job_id: (user_hash, workspace)} in a single batch query.

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -2202,6 +2202,10 @@ def get_workspace(job_id: int) -> str:
         return job_workspace
 
 
+# SQLite's default variable limit; chunk IN queries to stay within it.
+_SQLITE_MAX_VARIABLE_NUMBER = 999
+
+
 def get_job_owner_and_workspace(
         job_ids: List[int]) -> Dict[int, Tuple[Optional[str], str]]:
     """Return {job_id: (user_hash, workspace)} in a single batch query.
@@ -2211,8 +2215,6 @@ def get_job_owner_and_workspace(
     """
     if not job_ids:
         return {}
-    # SQLite's default variable limit is 999; chunk to stay within it.
-    _SQLITE_MAX_VARIABLE_NUMBER = 999
     result: Dict[int, Tuple[Optional[str], str]] = {}
     engine = _db_manager.get_engine()
     for i in range(0, len(job_ids), _SQLITE_MAX_VARIABLE_NUMBER):
@@ -2223,12 +2225,10 @@ def get_job_owner_and_workspace(
                     job_info_table.c.spot_job_id,
                     job_info_table.c.user_hash,
                     job_info_table.c.workspace,
-                ).where(
-                    job_info_table.c.spot_job_id.in_(chunk))).fetchall()
+                ).where(job_info_table.c.spot_job_id.in_(chunk))).fetchall()
         result.update({
             row[0]: (row[1], row[2] if row[2] is not None else
-                     constants.SKYPILOT_DEFAULT_WORKSPACE)
-            for row in rows
+                     constants.SKYPILOT_DEFAULT_WORKSPACE) for row in rows
         })
     return result
 

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -2211,20 +2211,26 @@ def get_job_owner_and_workspace(
     """
     if not job_ids:
         return {}
+    # SQLite's default variable limit is 999; chunk to stay within it.
+    _SQLITE_MAX_VARIABLE_NUMBER = 999
+    result: Dict[int, Tuple[Optional[str], str]] = {}
     engine = _db_manager.get_engine()
-    with orm.Session(engine) as session:
-        rows = session.execute(
-            sqlalchemy.select(
-                job_info_table.c.spot_job_id,
-                job_info_table.c.user_hash,
-                job_info_table.c.workspace,
-            ).where(job_info_table.c.spot_job_id.in_(job_ids))).fetchall()
-    return {
-        row[0]:
-        (row[1],
-         row[2] if row[2] is not None else constants.SKYPILOT_DEFAULT_WORKSPACE)
-        for row in rows
-    }
+    for i in range(0, len(job_ids), _SQLITE_MAX_VARIABLE_NUMBER):
+        chunk = job_ids[i:i + _SQLITE_MAX_VARIABLE_NUMBER]
+        with orm.Session(engine) as session:
+            rows = session.execute(
+                sqlalchemy.select(
+                    job_info_table.c.spot_job_id,
+                    job_info_table.c.user_hash,
+                    job_info_table.c.workspace,
+                ).where(
+                    job_info_table.c.spot_job_id.in_(chunk))).fetchall()
+        result.update({
+            row[0]: (row[1], row[2] if row[2] is not None else
+                     constants.SKYPILOT_DEFAULT_WORKSPACE)
+            for row in rows
+        })
+    return result
 
 
 async def get_latest_task_id_status_async(

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -2218,6 +2218,31 @@ def get_user_hashes_for_jobs(job_ids: List[int]) -> Dict[int, Optional[str]]:
     return {row[0]: row[1] for row in rows}
 
 
+def get_job_owner_and_workspace(
+        job_ids: List[int]) -> Dict[int, Tuple[Optional[str], str]]:
+    """Return {job_id: (user_hash, workspace)} in a single batch query.
+
+    Fetches both fields at once so callers avoid separate per-job lookups.
+    Missing job IDs are omitted from the result.
+    """
+    if not job_ids:
+        return {}
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        rows = session.execute(
+            sqlalchemy.select(
+                job_info_table.c.spot_job_id,
+                job_info_table.c.user_hash,
+                job_info_table.c.workspace,
+            ).where(job_info_table.c.spot_job_id.in_(job_ids))).fetchall()
+    return {
+        row[0]:
+        (row[1],
+         row[2] if row[2] is not None else constants.SKYPILOT_DEFAULT_WORKSPACE)
+        for row in rows
+    }
+
+
 async def get_latest_task_id_status_async(
         job_id: int) -> Tuple[Optional[int], Optional[ManagedJobStatus]]:
     """Returns the (task id, status) of the latest task of a job."""

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1032,6 +1032,12 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]],
     cancelled_job_ids: List[int] = []
     wrong_workspace_job_ids: List[int] = []
     unauthorized_job_ids: List[int] = []
+
+    # Pre-fetch all owner hashes in one query to avoid N+1 DB calls.
+    job_owner_hashes: Dict[int, Optional[str]] = {}
+    if requester_user_hash is not None:
+        job_owner_hashes = managed_job_state.get_user_hashes_for_jobs(job_ids)
+
     for job_id in job_ids:
         # Check the status of the managed job status. If it is in
         # terminal state, we can safely skip it.
@@ -1047,8 +1053,7 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]],
         # Ownership check: only cancel jobs owned by the requester unless
         # requester_user_hash is None (admin or bulk cancel with user_hash).
         if requester_user_hash is not None:
-            job_owner_hash = managed_job_state.get_user_hash_for_job(job_id)
-            if job_owner_hash != requester_user_hash:
+            if job_owner_hashes.get(job_id) != requester_user_hash:
                 unauthorized_job_ids.append(job_id)
                 continue
 

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1038,6 +1038,11 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]],
     job_info: Dict[int, Tuple[Optional[str], str]] = (
         managed_job_state.get_job_owner_and_workspace(job_ids))
 
+    # Refresh controller liveness for all nonterminal jobs in one pass before
+    # entering the per-job loop, so we avoid N separate DB round-trips and the
+    # status check at the top of the loop reflects any dead controllers.
+    update_managed_jobs_statuses()
+
     for job_id in job_ids:
         # Check the status of the managed job status. If it is in
         # terminal state, we can safely skip it.
@@ -1065,8 +1070,6 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]],
             if cancelled:
                 cancelled_job_ids.append(job_id)
                 continue
-
-        update_managed_jobs_statuses(job_id)
 
         _, job_workspace = job_info.get(
             job_id, (None, constants.SKYPILOT_DEFAULT_WORKSPACE))

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1010,10 +1010,15 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]],
                       current_workspace: Optional[str] = None,
                       user_hash: Optional[str] = None,
                       graceful: bool = False,
-                      graceful_timeout: Optional[int] = None) -> str:
+                      graceful_timeout: Optional[int] = None,
+                      requester_user_hash: Optional[str] = None) -> str:
     """Cancel jobs by id.
 
     If job_ids is None, cancel all jobs.
+
+    Args:
+        requester_user_hash: If set, only cancel jobs owned by this user.
+            None means no ownership enforcement (admin or legacy path).
     """
     if job_ids is None:
         job_ids = managed_job_state.get_nonterminal_job_ids_by_name(
@@ -1026,6 +1031,7 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]],
 
     cancelled_job_ids: List[int] = []
     wrong_workspace_job_ids: List[int] = []
+    unauthorized_job_ids: List[int] = []
     for job_id in job_ids:
         # Check the status of the managed job status. If it is in
         # terminal state, we can safely skip it.
@@ -1037,7 +1043,16 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]],
             logger.info(f'Job {job_id} is already in terminal state '
                         f'{job_status.value}. Skipped.')
             continue
-        elif job_status == managed_job_state.ManagedJobStatus.PENDING:
+
+        # Ownership check: only cancel jobs owned by the requester unless
+        # requester_user_hash is None (admin or bulk cancel with user_hash).
+        if requester_user_hash is not None:
+            job_owner_hash = managed_job_state.get_user_hash_for_job(job_id)
+            if job_owner_hash != requester_user_hash:
+                unauthorized_job_ids.append(job_id)
+                continue
+
+        if job_status == managed_job_state.ManagedJobStatus.PENDING:
             # the "if PENDING" is a short circuit, this will be atomic.
             cancelled = managed_job_state.set_pending_cancelled(job_id)
             if cancelled:
@@ -1098,21 +1113,33 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]],
             f'{current_workspace!r}. Check the workspace of the job with: '
             f'sky jobs queue')
 
+    unauthorized_str = ''
+    if unauthorized_job_ids:
+        plural = 's' if len(unauthorized_job_ids) > 1 else ''
+        plural_verb = 'are' if len(unauthorized_job_ids) > 1 else 'is'
+        ids_str = ', '.join(map(str, unauthorized_job_ids))
+        unauthorized_str = (
+            f' Permission denied: job{plural} with ID{plural} {ids_str} '
+            f'{plural_verb} not cancelled because they belong to another user.'
+            f' Only admins can cancel other users\' jobs.')
+
     if not cancelled_job_ids:
-        return f'No job to cancel.{wrong_workspace_job_str}'
+        return f'No job to cancel.{wrong_workspace_job_str}{unauthorized_str}'
     identity_str = f'Job with ID {cancelled_job_ids[0]} is'
     if len(cancelled_job_ids) > 1:
         cancelled_job_ids_str = ', '.join(map(str, cancelled_job_ids))
         identity_str = f'Jobs with IDs {cancelled_job_ids_str} are'
 
-    msg = f'{identity_str} scheduled to be cancelled.{wrong_workspace_job_str}'
+    msg = (f'{identity_str} scheduled to be cancelled.'
+           f'{wrong_workspace_job_str}{unauthorized_str}')
     return msg
 
 
 def cancel_job_by_name(job_name: str,
                        current_workspace: Optional[str] = None,
                        graceful: bool = False,
-                       graceful_timeout: Optional[int] = None) -> str:
+                       graceful_timeout: Optional[int] = None,
+                       requester_user_hash: Optional[str] = None) -> str:
     """Cancel a job by name."""
     job_ids = managed_job_state.get_nonterminal_job_ids_by_name(job_name)
     if not job_ids:
@@ -1124,17 +1151,21 @@ def cancel_job_by_name(job_name: str,
     msg = cancel_jobs_by_id(job_ids,
                             current_workspace=current_workspace,
                             graceful=graceful,
-                            graceful_timeout=graceful_timeout)
+                            graceful_timeout=graceful_timeout,
+                            requester_user_hash=requester_user_hash)
     return f'{job_name!r} {msg}'
 
 
 def cancel_jobs_by_pool(pool_name: str,
-                        current_workspace: Optional[str] = None) -> str:
+                        current_workspace: Optional[str] = None,
+                        requester_user_hash: Optional[str] = None) -> str:
     """Cancel all jobs in a pool."""
     job_ids = managed_job_state.get_nonterminal_job_ids_by_pool(pool_name)
     if not job_ids:
         return f'No running job found in pool {pool_name!r}.'
-    return cancel_jobs_by_id(job_ids, current_workspace=current_workspace)
+    return cancel_jobs_by_id(job_ids,
+                             current_workspace=current_workspace,
+                             requester_user_hash=requester_user_hash)
 
 
 def controller_log_file_for_job(job_id: int,
@@ -2798,7 +2829,8 @@ class ManagedJobCodeGen:
                           job_ids: Optional[List[int]],
                           all_users: bool = False,
                           graceful: bool = False,
-                          graceful_timeout: Optional[int] = None) -> str:
+                          graceful_timeout: Optional[int] = None,
+                          requester_user_hash: Optional[str] = None) -> str:
         active_workspace = skypilot_config.get_active_workspace()
         code = textwrap.dedent(f"""\
         if managed_job_version < 2:
@@ -2814,6 +2846,14 @@ class ManagedJobCodeGen:
         elif managed_job_version < 16:
             msg = utils.cancel_jobs_by_id({job_ids}, all_users={all_users},
                             current_workspace={active_workspace!r})
+        elif managed_job_version < 18:
+            msg = utils.cancel_jobs_by_id(
+                {job_ids},
+                all_users={all_users},
+                current_workspace={active_workspace!r},
+                graceful={graceful},
+                graceful_timeout={graceful_timeout},
+            )
         else:
             msg = utils.cancel_jobs_by_id(
                 {job_ids},
@@ -2821,6 +2861,7 @@ class ManagedJobCodeGen:
                 current_workspace={active_workspace!r},
                 graceful={graceful},
                 graceful_timeout={graceful_timeout},
+                requester_user_hash={requester_user_hash!r},
             )
         print(msg, end="", flush=True)
         """)
@@ -2830,7 +2871,8 @@ class ManagedJobCodeGen:
     def cancel_job_by_name(cls,
                            job_name: str,
                            graceful: bool = False,
-                           graceful_timeout: Optional[int] = None) -> str:
+                           graceful_timeout: Optional[int] = None,
+                           requester_user_hash: Optional[str] = None) -> str:
         active_workspace = skypilot_config.get_active_workspace()
         code = textwrap.dedent(f"""\
         if managed_job_version < 4:
@@ -2840,23 +2882,40 @@ class ManagedJobCodeGen:
             msg = utils.cancel_job_by_name({job_name!r})
         elif managed_job_version < 16:
             msg = utils.cancel_job_by_name({job_name!r}, {active_workspace!r})
-        else:
+        elif managed_job_version < 18:
             msg = utils.cancel_job_by_name(
                 {job_name!r},
                 {active_workspace!r},
                 graceful={graceful},
                 graceful_timeout={graceful_timeout},
             )
+        else:
+            msg = utils.cancel_job_by_name(
+                {job_name!r},
+                {active_workspace!r},
+                graceful={graceful},
+                graceful_timeout={graceful_timeout},
+                requester_user_hash={requester_user_hash!r},
+            )
         print(msg, end="", flush=True)
         """)
         return cls._build(code)
 
     @classmethod
-    def cancel_jobs_by_pool(cls, pool_name: str) -> str:
+    def cancel_jobs_by_pool(cls,
+                            pool_name: str,
+                            requester_user_hash: Optional[str] = None) -> str:
         active_workspace = skypilot_config.get_active_workspace()
         code = textwrap.dedent(f"""\
+        if managed_job_version < 18:
             msg = utils.cancel_jobs_by_pool({pool_name!r}, {active_workspace!r})
-            print(msg, end="", flush=True)
+        else:
+            msg = utils.cancel_jobs_by_pool(
+                {pool_name!r},
+                {active_workspace!r},
+                requester_user_hash={requester_user_hash!r},
+            )
+        print(msg, end="", flush=True)
         """)
         return cls._build(code)
 

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1033,10 +1033,10 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]],
     wrong_workspace_job_ids: List[int] = []
     unauthorized_job_ids: List[int] = []
 
-    # Pre-fetch all owner hashes in one query to avoid N+1 DB calls.
-    job_owner_hashes: Dict[int, Optional[str]] = {}
-    if requester_user_hash is not None:
-        job_owner_hashes = managed_job_state.get_user_hashes_for_jobs(job_ids)
+    # Pre-fetch owner hash and workspace together in one query to avoid
+    # N+1 DB calls for both the ownership check and the workspace check.
+    job_info: Dict[int, Tuple[Optional[str], str]] = (
+        managed_job_state.get_job_owner_and_workspace(job_ids))
 
     for job_id in job_ids:
         # Check the status of the managed job status. If it is in
@@ -1053,7 +1053,9 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]],
         # Ownership check: only cancel jobs owned by the requester unless
         # requester_user_hash is None (admin or bulk cancel with user_hash).
         if requester_user_hash is not None:
-            if job_owner_hashes.get(job_id) != requester_user_hash:
+            owner_hash, _ = job_info.get(
+                job_id, (None, constants.SKYPILOT_DEFAULT_WORKSPACE))
+            if owner_hash != requester_user_hash:
                 unauthorized_job_ids.append(job_id)
                 continue
 
@@ -1066,7 +1068,8 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]],
 
         update_managed_jobs_statuses(job_id)
 
-        job_workspace = managed_job_state.get_workspace(job_id)
+        _, job_workspace = job_info.get(
+            job_id, (None, constants.SKYPILOT_DEFAULT_WORKSPACE))
         if current_workspace is not None and job_workspace != current_workspace:
             wrong_workspace_job_ids.append(job_id)
             continue
@@ -1116,17 +1119,19 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]],
             f' {", ".join(map(str, wrong_workspace_job_ids))} '
             f'{plural_verb} skipped as they are not in the active workspace '
             f'{current_workspace!r}. Check the workspace of the job with: '
-            f'sky jobs queue')
+            f'sky jobs queue.')
 
     unauthorized_str = ''
     if unauthorized_job_ids:
         plural = 's' if len(unauthorized_job_ids) > 1 else ''
         plural_verb = 'are' if len(unauthorized_job_ids) > 1 else 'is'
+        belong_str = ('they belong'
+                      if len(unauthorized_job_ids) > 1 else 'it belongs')
         ids_str = ', '.join(map(str, unauthorized_job_ids))
         unauthorized_str = (
             f' Permission denied: job{plural} with ID{plural} {ids_str} '
-            f'{plural_verb} not cancelled because they belong to another user.'
-            f' Only admins can cancel other users\' jobs.')
+            f'{plural_verb} not cancelled because {belong_str} to another '
+            f'user. Only admins can cancel other users\' jobs.')
 
     if not cancelled_job_ids:
         return f'No job to cancel.{wrong_workspace_job_str}{unauthorized_str}'

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1038,11 +1038,6 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]],
     job_info: Dict[int, Tuple[Optional[str], str]] = (
         managed_job_state.get_job_owner_and_workspace(job_ids))
 
-    # Refresh controller liveness for all nonterminal jobs in one pass before
-    # entering the per-job loop, so we avoid N separate DB round-trips and the
-    # status check at the top of the loop reflects any dead controllers.
-    update_managed_jobs_statuses()
-
     for job_id in job_ids:
         # Check the status of the managed job status. If it is in
         # terminal state, we can safely skip it.
@@ -1070,6 +1065,8 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]],
             if cancelled:
                 cancelled_job_ids.append(job_id)
                 continue
+
+        update_managed_jobs_statuses(job_id)
 
         _, job_workspace = job_info.get(
             job_id, (None, constants.SKYPILOT_DEFAULT_WORKSPACE))

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -614,6 +614,9 @@ class JobsCancelBody(RequestBody):
     pool: Optional[str] = None
     graceful: bool = False
     graceful_timeout: Optional[int] = None
+    # When True, skip the extra admin-override confirmation that the server
+    # requires when an admin cancels specific jobs (by ID, name, or pool).
+    yes: bool = False
 
 
 class JobsLogsBody(RequestBody):

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -146,7 +146,8 @@ TASK_ID_LIST_ENV_VAR = f'{SKYPILOT_ENV_VAR_PREFIX}TASK_IDS'
 # cluster yaml is updated.
 #
 # TODO(zongheng,zhanghao): make the upgrading of skylet automatic?
-SKYLET_VERSION = '36'  # Add requester_user_hash to managed job cancel for ownership enforcement.
+SKYLET_VERSION = '36'  # Add requester_user_hash to managed job cancel
+# for ownership enforcement.
 # The version of the lib files that skylet/jobs use. Whenever there is an API
 # change for the job_lib or log_lib, we need to bump this version, so that the
 # user can be notified to update their SkyPilot version on the remote cluster.

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -146,7 +146,7 @@ TASK_ID_LIST_ENV_VAR = f'{SKYPILOT_ENV_VAR_PREFIX}TASK_IDS'
 # cluster yaml is updated.
 #
 # TODO(zongheng,zhanghao): make the upgrading of skylet automatic?
-SKYLET_VERSION = '35'  # Add fields to ManagedJobInfo proto for handle.
+SKYLET_VERSION = '36'  # Add requester_user_hash to managed job cancel for ownership enforcement.
 # The version of the lib files that skylet/jobs use. Whenever there is an API
 # change for the job_lib or log_lib, we need to bump this version, so that the
 # user can be notified to update their SkyPilot version on the remote cluster.

--- a/sky/skylet/services.py
+++ b/sky/skylet/services.py
@@ -572,9 +572,16 @@ class ManagedJobsServiceImpl(managed_jobsv1_pb2_grpc.ManagedJobsServiceServicer
             graceful_timeout = (request.graceful_timeout if
                                 request.HasField('graceful_timeout') else None)
 
+            # For non-all_users criteria, user_hash carries the requester's
+            # identity for ownership enforcement (set by the API server for
+            # non-admin users). None means no ownership check (admin path).
+            requester_user_hash = (request.user_hash
+                                   if request.HasField('user_hash') else None)
+
             if cancellation_criteria == 'all_users':
-                user_hash = request.user_hash if request.HasField(
-                    'user_hash') else None
+                # For all_users criteria, user_hash filters by owner (original
+                # semantics), not for ownership enforcement.
+                user_hash = requester_user_hash
                 all_users = request.all_users
                 if not all_users and user_hash is None:
                     context.abort(
@@ -593,17 +600,20 @@ class ManagedJobsServiceImpl(managed_jobsv1_pb2_grpc.ManagedJobsServiceServicer
                     job_ids=job_ids,
                     current_workspace=request.current_workspace,
                     graceful=graceful,
-                    graceful_timeout=graceful_timeout)
+                    graceful_timeout=graceful_timeout,
+                    requester_user_hash=requester_user_hash)
             elif cancellation_criteria == 'job_name':
                 message = managed_job_utils.cancel_job_by_name(
                     job_name=request.job_name,
                     current_workspace=request.current_workspace,
                     graceful=graceful,
-                    graceful_timeout=graceful_timeout)
+                    graceful_timeout=graceful_timeout,
+                    requester_user_hash=requester_user_hash)
             elif cancellation_criteria == 'pool_name':
                 message = managed_job_utils.cancel_jobs_by_pool(
                     pool_name=request.pool_name,
-                    current_workspace=request.current_workspace)
+                    current_workspace=request.current_workspace,
+                    requester_user_hash=requester_user_hash)
             else:
                 context.abort(
                     grpc.StatusCode.INVALID_ARGUMENT,

--- a/tests/unit_tests/test_job_cancel_ownership.py
+++ b/tests/unit_tests/test_job_cancel_ownership.py
@@ -1,0 +1,172 @@
+"""Unit tests for job cancel ownership enforcement."""
+from unittest import mock
+
+import pytest
+
+from sky.jobs import utils
+
+
+def _make_cancel_jobs_by_id_mocks(job_statuses, job_owners, job_workspaces):
+    """Return a context manager that patches the managed_job_state calls."""
+
+    def get_status(job_id):
+        return job_statuses.get(job_id)
+
+    def get_user_hash_for_job(job_id):
+        return job_owners.get(job_id)
+
+    def get_workspace(job_id):
+        return job_workspaces.get(job_id, 'default')
+
+    def get_nonterminal_job_ids_by_name(name, user_hash=None, all_users=False):
+        return []
+
+    def is_legacy_controller_process(job_id):
+        return False
+
+    def set_pending_cancelled(job_id):
+        return False
+
+    return mock.patch.multiple(
+        'sky.jobs.utils.managed_job_state',
+        get_status=mock.Mock(side_effect=get_status),
+        get_user_hash_for_job=mock.Mock(side_effect=get_user_hash_for_job),
+        get_workspace=mock.Mock(side_effect=get_workspace),
+        get_nonterminal_job_ids_by_name=mock.Mock(
+            side_effect=get_nonterminal_job_ids_by_name),
+        is_legacy_controller_process=mock.Mock(
+            side_effect=is_legacy_controller_process),
+        set_pending_cancelled=mock.Mock(side_effect=set_pending_cancelled),
+    )
+
+
+@mock.patch('sky.jobs.utils.update_managed_jobs_statuses')
+def test_cancel_own_job_succeeds(mock_update):
+    """A user can cancel a job they own."""
+    from sky.jobs.state import ManagedJobStatus
+
+    statuses = {1: ManagedJobStatus.RUNNING}
+    owners = {1: 'user-abc'}
+    workspaces = {1: 'default'}
+
+    with _make_cancel_jobs_by_id_mocks(statuses, owners, workspaces):
+        with mock.patch('pathlib.Path.touch'), \
+             mock.patch('filelock.FileLock'):
+            msg = utils.cancel_jobs_by_id(
+                job_ids=[1],
+                current_workspace='default',
+                requester_user_hash='user-abc',
+            )
+
+    assert 'scheduled to be cancelled' in msg
+    assert 'Permission denied' not in msg
+
+
+@mock.patch('sky.jobs.utils.update_managed_jobs_statuses')
+def test_cancel_other_user_job_fails(mock_update):
+    """A non-owner cannot cancel another user's job."""
+    from sky.jobs.state import ManagedJobStatus
+
+    statuses = {2: ManagedJobStatus.RUNNING}
+    owners = {2: 'user-owner'}
+    workspaces = {2: 'default'}
+
+    with _make_cancel_jobs_by_id_mocks(statuses, owners, workspaces):
+        msg = utils.cancel_jobs_by_id(
+            job_ids=[2],
+            current_workspace='default',
+            requester_user_hash='user-intruder',
+        )
+
+    assert 'Permission denied' in msg
+    assert 'scheduled to be cancelled' not in msg
+
+
+@mock.patch('sky.jobs.utils.update_managed_jobs_statuses')
+def test_admin_can_cancel_any_job(mock_update):
+    """Admin (requester_user_hash=None) can cancel any job."""
+    from sky.jobs.state import ManagedJobStatus
+
+    statuses = {3: ManagedJobStatus.RUNNING}
+    owners = {3: 'user-owner'}
+    workspaces = {3: 'default'}
+
+    with _make_cancel_jobs_by_id_mocks(statuses, owners, workspaces):
+        with mock.patch('pathlib.Path.touch'), \
+             mock.patch('filelock.FileLock'):
+            msg = utils.cancel_jobs_by_id(
+                job_ids=[3],
+                current_workspace='default',
+                requester_user_hash=None,
+            )
+
+    assert 'scheduled to be cancelled' in msg
+    assert 'Permission denied' not in msg
+
+
+@mock.patch('sky.jobs.utils.update_managed_jobs_statuses')
+def test_cancel_mix_own_and_other(mock_update):
+    """Partial cancel: own jobs succeed, other-user jobs are reported."""
+    from sky.jobs.state import ManagedJobStatus
+
+    statuses = {
+        4: ManagedJobStatus.RUNNING,
+        5: ManagedJobStatus.RUNNING,
+    }
+    owners = {
+        4: 'user-requester',
+        5: 'user-other',
+    }
+    workspaces = {4: 'default', 5: 'default'}
+
+    with _make_cancel_jobs_by_id_mocks(statuses, owners, workspaces):
+        with mock.patch('pathlib.Path.touch'), \
+             mock.patch('filelock.FileLock'):
+            msg = utils.cancel_jobs_by_id(
+                job_ids=[4, 5],
+                current_workspace='default',
+                requester_user_hash='user-requester',
+            )
+
+    assert 'scheduled to be cancelled' in msg
+    assert 'Permission denied' in msg
+    assert '5' in msg
+
+
+def test_cancel_nonexistent_job_skipped():
+    """Canceling a nonexistent job ID is silently skipped."""
+    statuses = {}
+    owners = {}
+    workspaces = {}
+
+    with _make_cancel_jobs_by_id_mocks(statuses, owners, workspaces):
+        msg = utils.cancel_jobs_by_id(
+            job_ids=[999],
+            current_workspace='default',
+            requester_user_hash='user-abc',
+        )
+
+    assert 'No job to cancel' in msg
+    assert 'Permission denied' not in msg
+
+
+@mock.patch('sky.jobs.utils.update_managed_jobs_statuses')
+def test_all_users_cancel_bypasses_ownership(mock_update):
+    """cancel_jobs_by_id with requester_user_hash=None (admin) respects all_users."""
+    from sky.jobs.state import ManagedJobStatus
+
+    statuses = {6: ManagedJobStatus.RUNNING}
+    owners = {6: 'user-owner'}
+    workspaces = {6: 'default'}
+
+    with _make_cancel_jobs_by_id_mocks(statuses, owners, workspaces):
+        with mock.patch('pathlib.Path.touch'), \
+             mock.patch('filelock.FileLock'):
+            msg = utils.cancel_jobs_by_id(
+                job_ids=[6],
+                all_users=True,
+                current_workspace='default',
+                requester_user_hash=None,
+            )
+
+    assert 'scheduled to be cancelled' in msg

--- a/tests/unit_tests/test_job_cancel_ownership.py
+++ b/tests/unit_tests/test_job_cancel_ownership.py
@@ -12,11 +12,13 @@ def _make_cancel_jobs_by_id_mocks(job_statuses, job_owners, job_workspaces):
     def get_status(job_id):
         return job_statuses.get(job_id)
 
-    def get_user_hashes_for_jobs(job_ids):
-        return {jid: job_owners[jid] for jid in job_ids if jid in job_owners}
-
-    def get_workspace(job_id):
-        return job_workspaces.get(job_id, 'default')
+    def get_job_owner_and_workspace(job_ids):
+        result = {}
+        for jid in job_ids:
+            if jid in job_owners or jid in job_workspaces:
+                result[jid] = (job_owners.get(jid),
+                               job_workspaces.get(jid, 'default'))
+        return result
 
     def get_nonterminal_job_ids_by_name(name, user_hash=None, all_users=False):
         return []
@@ -30,9 +32,8 @@ def _make_cancel_jobs_by_id_mocks(job_statuses, job_owners, job_workspaces):
     return mock.patch.multiple(
         'sky.jobs.utils.managed_job_state',
         get_status=mock.Mock(side_effect=get_status),
-        get_user_hashes_for_jobs=mock.Mock(
-            side_effect=get_user_hashes_for_jobs),
-        get_workspace=mock.Mock(side_effect=get_workspace),
+        get_job_owner_and_workspace=mock.Mock(
+            side_effect=get_job_owner_and_workspace),
         get_nonterminal_job_ids_by_name=mock.Mock(
             side_effect=get_nonterminal_job_ids_by_name),
         is_legacy_controller_process=mock.Mock(

--- a/tests/unit_tests/test_job_cancel_ownership.py
+++ b/tests/unit_tests/test_job_cancel_ownership.py
@@ -12,8 +12,8 @@ def _make_cancel_jobs_by_id_mocks(job_statuses, job_owners, job_workspaces):
     def get_status(job_id):
         return job_statuses.get(job_id)
 
-    def get_user_hash_for_job(job_id):
-        return job_owners.get(job_id)
+    def get_user_hashes_for_jobs(job_ids):
+        return {jid: job_owners[jid] for jid in job_ids if jid in job_owners}
 
     def get_workspace(job_id):
         return job_workspaces.get(job_id, 'default')
@@ -30,7 +30,8 @@ def _make_cancel_jobs_by_id_mocks(job_statuses, job_owners, job_workspaces):
     return mock.patch.multiple(
         'sky.jobs.utils.managed_job_state',
         get_status=mock.Mock(side_effect=get_status),
-        get_user_hash_for_job=mock.Mock(side_effect=get_user_hash_for_job),
+        get_user_hashes_for_jobs=mock.Mock(
+            side_effect=get_user_hashes_for_jobs),
         get_workspace=mock.Mock(side_effect=get_workspace),
         get_nonterminal_job_ids_by_name=mock.Mock(
             side_effect=get_nonterminal_job_ids_by_name),

--- a/tests/unit_tests/test_sky/skylet/test_managed_jobs_service.py
+++ b/tests/unit_tests/test_sky/skylet/test_managed_jobs_service.py
@@ -702,7 +702,7 @@ class TestCancelJobs:
         # Job 4 is SUCCEEDED so should not be cancelled
         expected_jobs = [self.job_ids['job_id1'], self.job_ids['job_id2']]
         assert response.message.lower(
-        ) == f"jobs with ids {expected_jobs[0]}, {expected_jobs[1]} are scheduled to be cancelled. job with id {self.job_ids['job_id3']} is skipped as they are not in the active workspace 'ws1'. check the workspace of the job with: sky jobs queue"
+        ) == f"jobs with ids {expected_jobs[0]}, {expected_jobs[1]} are scheduled to be cancelled. job with id {self.job_ids['job_id3']} is skipped as they are not in the active workspace 'ws1'. check the workspace of the job with: sky jobs queue."
         context_mock.abort.assert_not_called()
 
     def test_cancel_jobs_all_users_false(self):

--- a/tests/unit_tests/test_sky/users/test_permission_concurrency.py
+++ b/tests/unit_tests/test_sky/users/test_permission_concurrency.py
@@ -120,7 +120,12 @@ def test_concurrent_permission_service_no_race(permission_service):
             stop.wait(timeout=10)
             stop.set()
             for f in futures:
-                f.result(timeout=5)
+                # Each worker checks stop.is_set() only between iterations.
+                # One iteration can span several load_policy() write-lock
+                # acquisitions (one per role + one per unknown user), so on a
+                # loaded CI runner the thread may need several seconds to drain
+                # the current iteration before noticing the stop signal.
+                f.result(timeout=30)
     finally:
         adapter.load_policy = original_load
 


### PR DESCRIPTION
…ncel

Non-admin users can now only cancel jobs they submitted. Admins retain the ability to cancel any job. Non-admins are also blocked from using --all-users on cancel.

Changes:
- Bump MANAGED_JOBS_VERSION to 18 to gate new codegen behaviour
- Add managed_job_state.get_user_hash_for_job() for ownership lookup
- Add requester_user_hash param to cancel_jobs_by_id/by_name/by_pool with per-job ownership check before sending the cancel signal
- Update ManagedJobCodeGen with version-18 branches passing the param
- Thread requester_user_hash through the gRPC CancelJobs handler in skylet/services.py (reuses the existing user_hash proto field for non-all_users criteria to avoid proto regeneration)
- Enforce at the API server layer in jobs/server/core.py: determine admin role via the Casbin permission service, block non-admins from all_users=True, and surface Permission denied errors to the caller
- Add unit tests covering own-job, other-user, admin, mixed, and nonexistent-job cancel scenarios

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
