### PR TITLE
[Core] Fix config_hash non-determinism across API server workers

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1487,8 +1487,14 @@ def _deterministic_cluster_yaml_hash(tmp_yaml_path: str) -> str:
 
     config_hash = hashlib.sha256()
 
+    # Sort keys so the hashed representation is stable across processes.
+    # Otherwise dict insertion order (which can reflect per-process set
+    # iteration under PYTHONHASHSEED) leaks into the hash and causes the
+    # same logical config to hash to different values on different API
+    # server workers.
     yaml_hash = hashlib.sha256(
-        yaml_utils.dump_yaml_str(yaml_config).encode('utf-8'))
+        yaml_utils.dump_yaml_str(yaml_config,
+                                 sort_keys=True).encode('utf-8'))
     config_hash.update(yaml_hash.digest())
 
     file_mounts = yaml_config.get('file_mounts', {})

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1493,8 +1493,7 @@ def _deterministic_cluster_yaml_hash(tmp_yaml_path: str) -> str:
     # same logical config to hash to different values on different API
     # server workers.
     yaml_hash = hashlib.sha256(
-        yaml_utils.dump_yaml_str(yaml_config,
-                                 sort_keys=True).encode('utf-8'))
+        yaml_utils.dump_yaml_str(yaml_config, sort_keys=True).encode('utf-8'))
     config_hash.update(yaml_hash.digest())
 
     file_mounts = yaml_config.get('file_mounts', {})

--- a/sky/utils/yaml_utils.py
+++ b/sky/utils/yaml_utils.py
@@ -134,10 +134,15 @@ def dump_yaml(path: str,
         f.write(contents)
 
 
-def dump_yaml_str(config: Union[List[Dict[str, Any]], Dict[str, Any]]) -> str:
+def dump_yaml_str(config: Union[List[Dict[str, Any]], Dict[str, Any]],
+                  sort_keys: bool = False) -> str:
     """Dumps a YAML string.
     Args:
         config: the configuration to dump.
+        sort_keys: if True, sort dict keys in the output. Use this when the
+            output must be deterministic across processes (e.g. for hashing),
+            since Python dict iteration order can reflect non-deterministic
+            upstream state like set iteration under PYTHONHASHSEED.
     Returns:
         The YAML string.
     """
@@ -156,5 +161,5 @@ def dump_yaml_str(config: Union[List[Dict[str, Any]], Dict[str, Any]]) -> str:
         dump_func = yaml.dump  # type: ignore
     return dump_func(config,
                      Dumper=LineBreakDumper,
-                     sort_keys=False,
+                     sort_keys=sort_keys,
                      default_flow_style=False)


### PR DESCRIPTION
## Summary

Consecutive cluster/job launches sometimes triggered a full re-provision even when nothing had changed. The root cause is that the `config_hash` SkyPilot stores for a cluster can differ between API server worker processes for the same logical config — so a later launch routed to a different worker compares its freshly-computed hash against the stored one, finds a mismatch, and re-provisions.

`_deterministic_cluster_yaml_hash` in `sky/backends/backend_utils.py` feeds the rendered cluster YAML into SHA-256 via `yaml_utils.dump_yaml_str(...)`, which used `sort_keys=False`. Dict insertion order in the YAML therefore depends on upstream construction order, which in several code paths is derived from set iteration. CPython randomizes string-set iteration per process via `PYTHONHASHSEED`, so two workers emit the same logical YAML with slightly different key order and produce different hashes.

#9415 fixed two known instances of this pattern (`enabled_clouds`, `python_packages`) by sorting at the source, but any remaining set- or dict-iteration-order leak along the render path reintroduces the bug. This PR fixes it at the hash boundary instead: `dump_yaml_str` now takes a `sort_keys` parameter, and the hash site passes `sort_keys=True`. This makes the hashed representation stable regardless of upstream iteration order, covering both the currently-known sites and future ones.

- `sky/utils/yaml_utils.py`: `dump_yaml_str` gets a `sort_keys: bool = False` parameter (default preserves existing behavior for all other callers).
- `sky/backends/backend_utils.py`: call `dump_yaml_str(..., sort_keys=True)` inside `_deterministic_cluster_yaml_hash`.

## Test plan

- [x] Back-to-back `sky.jobs.launch` calls for the same task. Before this change the second launch logs `==================== Provisioning ====================`; after, it logs `Skipping provisioning of cluster with matching config hash.`
- [x] Verified `config_hash` is stable across repeated computations on identical inputs and across concurrent API server worker processes.
- [ ] `/quicktest-core`
- [ ] `/smoke-test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->