### PR TITLE
[Slurm] Preserve SLURM_CONF* env vars when launching task srun

### DIFF
--- a/sky/backends/task_codegen.py
+++ b/sky/backends/task_codegen.py
@@ -917,10 +917,19 @@ class SlurmCodeGen(TaskCodeGen):
                     # SLURM_CPU_BIND, SLURM_NNODES, and SLURM_NODELIST constrain
                     # the inner srun to the parent step's allocation. This causes
                     # "CPU binding outside of job step allocation" errors.
-                    # Unsetting all SLURM_* variables allows this srun to access the full job
-                    # allocation. See:
+                    # Unsetting SLURM_* variables allows this srun to access the
+                    # full job allocation. See:
                     # https://support.schedmd.com/show_bug.cgi?id=14298
                     # https://github.com/huggingface/datatrove/issues/248
+                    #
+                    # Preserve SLURM_CONF* (SLURM_CONF, SLURM_CONF_SERVER): srun
+                    # needs these to locate slurmctld when /etc/slurm/slurm.conf
+                    # is not present and DNS SRV discovery is unavailable. On
+                    # sites that distribute the config via SLURM_CONF, stripping
+                    # it causes srun to fail with:
+                    #   resolve_ctls_from_dns_srv: res_nsearch error: Unknown host
+                    #   fetch_config: DNS SRV lookup failed
+                    #   fatal: Could not establish a configuration source
                     cmd_parts = []
                     # Only unset SKY_RUNTIME_DIR for container runs. For non-container
                     # runs, we want to inherit the node-local SKY_RUNTIME_DIR set by
@@ -934,7 +943,7 @@ class SlurmCodeGen(TaskCodeGen):
                     ])
                     bash_cmd = shlex.quote(' '.join(cmd_parts))
                     srun_cmd = (
-                        "unset $(env | awk -F= '/^SLURM_/ {{print $1}}') && "
+                        "unset $(env | awk -F= '/^SLURM_/ && $1 !~ /^SLURM_CONF/ {{print $1}}') && "
                         f'srun --export=ALL --quiet --unbuffered --kill-on-bad-exit --jobid={self._slurm_job_id} '
                         f'--job-name=sky-{self.job_id}{{job_suffix}} --ntasks-per-node=1{container_flags} {{extra_flags}} '
                         f'/bin/bash -c {{bash_cmd}}'

--- a/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_codegen_with_container.py
+++ b/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_codegen_with_container.py
@@ -545,7 +545,7 @@ if script or False:
         ])
         bash_cmd = shlex.quote(' '.join(cmd_parts))
         srun_cmd = (
-            "unset $(env | awk -F= '/^SLURM_/ {print $1}') && "
+            "unset $(env | awk -F= '/^SLURM_/ && $1 !~ /^SLURM_CONF/ {print $1}') && "
             f'srun --export=ALL --quiet --unbuffered --kill-on-bad-exit --jobid=12345 '
             f'--job-name=sky-2{job_suffix} --ntasks-per-node=1 --container-remap-root --container-name=test-cluster:exec {extra_flags} '
             f'/bin/bash -c {bash_cmd}'

--- a/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_codegen_with_container.py
+++ b/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_codegen_with_container.py
@@ -528,10 +528,19 @@ if script or False:
         # SLURM_CPU_BIND, SLURM_NNODES, and SLURM_NODELIST constrain
         # the inner srun to the parent step's allocation. This causes
         # "CPU binding outside of job step allocation" errors.
-        # Unsetting all SLURM_* variables allows this srun to access the full job
-        # allocation. See:
+        # Unsetting SLURM_* variables allows this srun to access the
+        # full job allocation. See:
         # https://support.schedmd.com/show_bug.cgi?id=14298
         # https://github.com/huggingface/datatrove/issues/248
+        #
+        # Preserve SLURM_CONF* (SLURM_CONF, SLURM_CONF_SERVER): srun
+        # needs these to locate slurmctld when /etc/slurm/slurm.conf
+        # is not present and DNS SRV discovery is unavailable. On
+        # sites that distribute the config via SLURM_CONF, stripping
+        # it causes srun to fail with:
+        #   resolve_ctls_from_dns_srv: res_nsearch error: Unknown host
+        #   fetch_config: DNS SRV lookup failed
+        #   fatal: Could not establish a configuration source
         cmd_parts = []
         # Only unset SKY_RUNTIME_DIR for container runs. For non-container
         # runs, we want to inherit the node-local SKY_RUNTIME_DIR set by

--- a/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_single_node_with_gpu.py
+++ b/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_single_node_with_gpu.py
@@ -530,10 +530,19 @@ if script or True:
         # SLURM_CPU_BIND, SLURM_NNODES, and SLURM_NODELIST constrain
         # the inner srun to the parent step's allocation. This causes
         # "CPU binding outside of job step allocation" errors.
-        # Unsetting all SLURM_* variables allows this srun to access the full job
-        # allocation. See:
+        # Unsetting SLURM_* variables allows this srun to access the
+        # full job allocation. See:
         # https://support.schedmd.com/show_bug.cgi?id=14298
         # https://github.com/huggingface/datatrove/issues/248
+        #
+        # Preserve SLURM_CONF* (SLURM_CONF, SLURM_CONF_SERVER): srun
+        # needs these to locate slurmctld when /etc/slurm/slurm.conf
+        # is not present and DNS SRV discovery is unavailable. On
+        # sites that distribute the config via SLURM_CONF, stripping
+        # it causes srun to fail with:
+        #   resolve_ctls_from_dns_srv: res_nsearch error: Unknown host
+        #   fetch_config: DNS SRV lookup failed
+        #   fatal: Could not establish a configuration source
         cmd_parts = []
         # Only unset SKY_RUNTIME_DIR for container runs. For non-container
         # runs, we want to inherit the node-local SKY_RUNTIME_DIR set by

--- a/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_single_node_with_gpu.py
+++ b/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_single_node_with_gpu.py
@@ -547,7 +547,7 @@ if script or True:
         ])
         bash_cmd = shlex.quote(' '.join(cmd_parts))
         srun_cmd = (
-            "unset $(env | awk -F= '/^SLURM_/ {print $1}') && "
+            "unset $(env | awk -F= '/^SLURM_/ && $1 !~ /^SLURM_CONF/ {print $1}') && "
             f'srun --export=ALL --quiet --unbuffered --kill-on-bad-exit --jobid=12345 '
             f'--job-name=sky-2{job_suffix} --ntasks-per-node=1 {extra_flags} '
             f'/bin/bash -c {bash_cmd}'


### PR DESCRIPTION
On Slurm, the task codegen strips all `SLURM_*` environment variables before invoking the inner `srun` that launches the user task, to avoid the parent step's allocation-layout variables (`SLURM_CPU_BIND`, `SLURM_NNODES`, `SLURM_NODELIST`) leaking into the child and causing `CPU binding outside of job step allocation` errors (see https://support.schedmd.com/show_bug.cgi?id=14298, https://github.com/huggingface/datatrove/issues/248).

The blanket strip is too broad: it also removes `SLURM_CONF` and `SLURM_CONF_SERVER`, which `srun` needs to locate `slurmctld` on sites that distribute the Slurm config via an env var rather than `/etc/slurm/slurm.conf`. Unprivileged users on shared HPC clusters typically cannot write `/etc/slurm/slurm.conf`, so they rely on `SLURM_CONF`. Losing it causes `srun` to fall through to DNS SRV discovery and fail with:

```
srun: error: resolve_ctls_from_dns_srv: res_nsearch error: Unknown host
srun: error: fetch_config: DNS SRV lookup failed
srun: fatal: Could not establish a configuration source
```

In SkyPilot this surfaces as `Job N's setup failed with return code 1` in the driver output regardless of whether the user defined a `setup:` block, because both the exclusive-allocation srun and the `--overlap` setup srun go through the same `build_task_runner_cmd` path.

This PR switches the awk filter from the blanket `/^SLURM_/` to `/^SLURM_/ && $1 !~ /^SLURM_CONF/`, preserving both `SLURM_CONF` and `SLURM_CONF_SERVER` while still stripping every step-layout / binding var the original unset was targeting (`SLURM_CPU_BIND`, `SLURM_NNODES`, `SLURM_NODELIST`, `SLURM_STEP_*`, etc.).

Using a regex negated-match (`!~ /^SLURM_CONF/`) rather than a string equality (`!= "SLURM_CONF"`) also sidesteps a nested-quoting pitfall: this string is embedded inside a Python `textwrap.dedent(f"""...""")` block and rendered into the generated driver script, and inner double quotes do not survive that pipeline cleanly.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

### Testing details

- `pytest tests/unit_tests/test_sky/backends/test_task_codegen.py` → **18 passed**. The two Slurm snapshot goldens (`tests/unit_tests/test_sky/backends/testdata/slurm_codegen/`) were regenerated to match the updated codegen output.
- `bash format.sh` clean: yapf / isort / black unchanged, mypy `no issues found in 544 source files`, pylint `10.00/10`.
- Manual verification on a Slurm site where `SLURM_CONF` is exported (no `/etc/slurm/slurm.conf` present): prior to this patch, `sky launch` failed with the `resolve_ctls_from_dns_srv` error above; after the patch the task runs to completion.
