### PR TITLE
[Dashboard] Dedupe in-flight fetches for system info endpoints

### DIFF
--- a/sky/dashboard/src/lib/fetch-dedupe.js
+++ b/sky/dashboard/src/lib/fetch-dedupe.js
@@ -1,0 +1,90 @@
+// Dedupe a strict allowlist of idempotent dashboard GETs that are fetched
+// from many independent bundles (dashboard core + plugin frontends).
+// In-flight coalescing eliminates the duplicates that fire within the same
+// tick; a short TTL absorbs later calls triggered by route changes and
+// late-mounting providers.
+
+// Suffix match lets this work for any ENDPOINT base path (e.g.
+// `/internal/dashboard`, or a custom basePath in multi-tenant deploys).
+const TTL_MS = {
+  '/internal/dashboard/api/health': 30_000,
+  '/internal/dashboard/api/plugins': 60_000,
+  '/internal/dashboard/users/role': 30_000,
+};
+
+const cache = new Map();
+const inflight = new Map();
+
+function matchPath(input) {
+  try {
+    const urlStr = typeof input === 'string' ? input : input && input.url;
+    if (!urlStr) return null;
+    const u = new URL(urlStr, window.location.origin);
+    for (const suffix of Object.keys(TTL_MS)) {
+      if (u.pathname.endsWith(suffix)) return suffix;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function responseFromCached(entry) {
+  return new Response(entry.body, {
+    status: entry.status,
+    headers: entry.headersEntries,
+  });
+}
+
+export function installFetchDedupe() {
+  if (typeof window === 'undefined') return;
+  if (window.__skyFetchDedupeInstalled) return;
+  window.__skyFetchDedupeInstalled = true;
+
+  const origFetch = window.fetch.bind(window);
+
+  window.fetch = async function dedupedFetch(input, init) {
+    const method = (
+      (init && init.method) ||
+      (typeof input === 'object' && input && input.method) ||
+      'GET'
+    ).toUpperCase();
+    if (method !== 'GET') return origFetch(input, init);
+
+    const path = matchPath(input);
+    if (!path) return origFetch(input, init);
+
+    const now = Date.now();
+    const cached = cache.get(path);
+    if (cached && now - cached.ts < TTL_MS[path]) {
+      return responseFromCached(cached);
+    }
+
+    const pending = inflight.get(path);
+    if (pending) return pending.then((r) => r.clone());
+
+    const p = (async () => {
+      const resp = await origFetch(input, init);
+      if (resp.ok) {
+        try {
+          const body = await resp.clone().text();
+          cache.set(path, {
+            body,
+            status: resp.status,
+            headersEntries: Array.from(resp.headers.entries()),
+            ts: Date.now(),
+          });
+        } catch {
+          // Body unreadable (streamed/consumed); skip caching, still
+          // return the original response to the caller.
+        }
+      }
+      return resp;
+    })().finally(() => {
+      inflight.delete(path);
+    });
+
+    inflight.set(path, p);
+    return p.then((r) => r.clone());
+  };
+}

--- a/sky/dashboard/src/lib/fetch-dedupe.js
+++ b/sky/dashboard/src/lib/fetch-dedupe.js
@@ -17,7 +17,13 @@ const inflight = new Map();
 
 function matchPath(input) {
   try {
-    const urlStr = typeof input === 'string' ? input : input && input.url;
+    // fetch() accepts a string, a Request (has .url), or a URL (has .href).
+    const urlStr =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input && input.url;
     if (!urlStr) return null;
     const u = new URL(urlStr, window.location.origin);
     for (const suffix of Object.keys(TTL_MS)) {

--- a/sky/dashboard/src/pages/_app.js
+++ b/sky/dashboard/src/pages/_app.js
@@ -15,6 +15,7 @@ import { PluginProvider } from '@/plugins/PluginProvider';
 import { VersionProvider } from '@/components/elements/version-display';
 import { PluginWrapperSlot } from '@/plugins/PluginWrapperSlot';
 import { getNonce } from '@/utils/csp';
+import { installFetchDedupe } from '@/lib/fetch-dedupe';
 
 const Layout = dynamic(
   () => import('@/components/elements/layout').then((mod) => mod.Layout),
@@ -27,6 +28,9 @@ const Layout = dynamic(
 if (typeof window !== 'undefined') {
   window.React = React;
   window.ReactDOM = { ...ReactDOMAll, ...ReactDOM };
+  // Must run before any plugin <script> is injected by PluginProvider so
+  // plugin-side fetches for these endpoints also coalesce.
+  installFetchDedupe();
 }
 
 // Create an Emotion cache with the CSP nonce so that dynamically injected


### PR DESCRIPTION
Several dashboard components (sidebar, version display, plugin manifest loader) each independently fetch `/api/health`, `/api/plugins`, and `/users/role` on mount. With plugins loaded, each of these URLs can fire 4–6 times per page load, adding hundreds of ms of wait and wasted bytes.

Install a tiny fetch interceptor at `_app.js` load time that:

- in-flight-coalesces concurrent GETs to the same URL, and
- short-TTL-caches the response (30s for health/role, 60s for plugins).

Scoped to a strict allowlist of three idempotent paths so the behavior change is easy to reason about. Plugin-side fetches are also covered because the interceptor is installed before any plugin `<script>` tag is injected by `PluginProvider`.

Measured on a local dashboard with plugins loaded:

- `/api/health`:   6× -> 1×
- `/api/plugins`:  4× -> 1×
- `/users/role`:   4× -> 1×
- End of last response: 1735 ms -> 1557 ms (~10% faster locally; larger
  savings expected over a real network where each saved call was 100–300
  ms of wait time).



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
