### PR TITLE
[Nebius] Use managed disks to create instances

### DIFF
--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -53,9 +53,7 @@ def nebius_profile_in_aws_cred_and_config() -> bool:
 
 def _write_nebius_temp_credential_file(prefix: str, value: str) -> str:
     """Materialize effective Nebius config into a temporary uploadable file."""
-    with tempfile.NamedTemporaryFile(prefix=prefix,
-                                     delete=False,
-                                     mode='w',
+    with tempfile.NamedTemporaryFile(prefix=prefix, mode='w',
                                      encoding='utf-8') as temp_file:
         temp_file.write(value)
         temp_file.write('\n')
@@ -495,19 +493,15 @@ class Nebius(clouds.Cloud):
         tenant_id_path = nebius.tenant_id_path()
         tenant_id = nebius.get_tenant_id()
         if tenant_id is not None:
+            # NOTE: We can't guarantee that the file will be deleted eventually,
+            # but it doesn't contain sensitive information and should be cleaned
+            # up by the OS eventually.
             credential_file_mounts[tenant_id_path] = (
                 _write_nebius_temp_credential_file('nebius-tenant-id-',
                                                    tenant_id))
 
-        iam_token_path = nebius.iam_token_path()
-        iam_token = nebius.get_iam_token()
-        if iam_token is not None:
-            credential_file_mounts[iam_token_path] = (
-                _write_nebius_temp_credential_file('nebius-iam-token-',
-                                                   iam_token))
-
         for filepath in nebius.get_credential_file_paths():
-            if filepath in (tenant_id_path, iam_token_path):
+            if filepath == tenant_id_path:
                 continue
             credential_file_mounts[filepath] = filepath
         if nebius_profile_in_aws_cred_and_config():

--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -55,8 +55,6 @@ class Nebius(clouds.Cloud):
     """Nebius GPU Cloud"""
     _REPR = 'Nebius'
     _CLOUD_UNSUPPORTED_FEATURES = {
-        clouds.CloudImplementationFeatures.AUTODOWN:
-            ('Autodown not supported. Can\'t delete OS disk.'),
         clouds.CloudImplementationFeatures.CLONE_DISK_FROM_CLUSTER:
             (f'Migrating disk is currently not supported on {_REPR}.'),
         clouds.CloudImplementationFeatures.CUSTOM_NETWORK_TIER:

--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -1,6 +1,7 @@
 """ Nebius Cloud. """
 import json
 import os
+import tempfile
 import typing
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
@@ -48,6 +49,17 @@ def nebius_profile_in_aws_cred_and_config() -> bool:
 
     return (nebius_profile_exists_in_credentials and
             nebius_profile_exists_in_config)
+
+
+def _write_nebius_temp_credential_file(prefix: str, value: str) -> str:
+    """Materialize effective Nebius config into a temporary uploadable file."""
+    with tempfile.NamedTemporaryFile(prefix=prefix,
+                                     delete=False,
+                                     mode='w',
+                                     encoding='utf-8') as temp_file:
+        temp_file.write(value)
+        temp_file.write('\n')
+        return temp_file.name
 
 
 @registry.CLOUD_REGISTRY.register
@@ -479,10 +491,25 @@ class Nebius(clouds.Cloud):
         return (False, hints) if hints else (True, hints)
 
     def get_credential_file_mounts(self) -> Dict[str, str]:
-        credential_file_mounts = {
-            filepath: filepath
-            for filepath in nebius.get_credential_file_paths()
-        }
+        credential_file_mounts = {}
+        tenant_id_path = nebius.tenant_id_path()
+        tenant_id = nebius.get_tenant_id()
+        if tenant_id is not None:
+            credential_file_mounts[tenant_id_path] = (
+                _write_nebius_temp_credential_file('nebius-tenant-id-',
+                                                   tenant_id))
+
+        iam_token_path = nebius.iam_token_path()
+        iam_token = nebius.get_iam_token()
+        if iam_token is not None:
+            credential_file_mounts[iam_token_path] = (
+                _write_nebius_temp_credential_file('nebius-iam-token-',
+                                                   iam_token))
+
+        for filepath in nebius.get_credential_file_paths():
+            if filepath in (tenant_id_path, iam_token_path):
+                continue
+            credential_file_mounts[filepath] = filepath
         if nebius_profile_in_aws_cred_and_config():
             credential_file_mounts['~/.aws/credentials'] = '~/.aws/credentials'
             credential_file_mounts['~/.aws/config'] = '~/.aws/config'

--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -53,7 +53,9 @@ def nebius_profile_in_aws_cred_and_config() -> bool:
 
 def _write_nebius_temp_credential_file(prefix: str, value: str) -> str:
     """Materialize effective Nebius config into a temporary uploadable file."""
-    with tempfile.NamedTemporaryFile(prefix=prefix, mode='w',
+    with tempfile.NamedTemporaryFile(prefix=prefix,
+                                     mode='w',
+                                     delete=False,
                                      encoding='utf-8') as temp_file:
         temp_file.write(value)
         temp_file.write('\n')

--- a/sky/provision/nebius/instance.py
+++ b/sky/provision/nebius/instance.py
@@ -173,7 +173,7 @@ def wait_instances(region: str, cluster_name_on_cloud: str,
                     f'{len(stopped_instances)} instances are stopped.')
         if state == status_lib.ClusterStatus.STOPPED:
             running_instances = _filter_instances(region, cluster_name_on_cloud,
-                                                  ['RUNNIG'])
+                                                  ['RUNNING'])
 
             if running_instances:
                 raise RuntimeError(
@@ -189,10 +189,10 @@ def stop_instances(
     assert provider_config is not None
     exist_instances = _filter_instances(provider_config['region'],
                                         cluster_name_on_cloud, ['RUNNING'])
-    for instance in exist_instances:
-        if worker_only and instance.endswith('-head'):
+    for instance_id, instance in exist_instances.items():
+        if worker_only and instance['name'].endswith('-head'):
             continue
-        utils.stop(instance)
+        utils.stop(instance_id)
 
 
 def terminate_instances(
@@ -218,7 +218,8 @@ def terminate_instances(
                     f'Failed to terminate instance {inst_id}: '
                     f'{common_utils.format_exception(e, use_bracket=False)}'
                 ) from e
-    utils.delete_cluster(cluster_name_on_cloud, provider_config['region'])
+    if not worker_only:
+        utils.delete_cluster(cluster_name_on_cloud, provider_config['region'])
 
 
 def get_cluster_info(

--- a/sky/provision/nebius/utils.py
+++ b/sky/provision/nebius/utils.py
@@ -283,45 +283,15 @@ def launch(cluster_name_on_cloud: str,
                 f'Requested {disk_size} GiB, rounding up to '
                 f'{actual_disk_size} GiB.')
 
-    service = nebius.compute().DiskServiceClient(nebius.sdk())
-
-    spec = nebius.compute().DiskSpec(
+    disk_spec = nebius.compute().DiskSpec(
         size_gibibytes=actual_disk_size,
         type=_disk_tier_to_disk_type(disk_tier),
     )
     if image_id_or_family.startswith('computeimage-'):
-        spec.source_image_id = image_id_or_family
+        disk_spec.source_image_id = image_id_or_family
     else:
-        spec.source_image_family = nebius.compute().SourceImageFamily(
+        disk_spec.source_image_family = nebius.compute().SourceImageFamily(
             image_family=image_id_or_family)
-
-    disk = nebius.sync_call(
-        service.create(nebius.compute().CreateDiskRequest(
-            metadata=nebius.nebius_common().ResourceMetadata(
-                parent_id=project_id,
-                name=disk_name,
-            ),
-            spec=spec)))
-    disk_id = disk.resource_id
-    retry_count = 0
-    while retry_count < nebius.MAX_RETRIES_TO_DISK_CREATE:
-        disk = nebius.sync_call(
-            service.get_by_name(nebius.nebius_common().GetByNameRequest(
-                parent_id=project_id,
-                name=disk_name,
-            )))
-        if disk.status.state.name == 'READY':
-            break
-        logger.debug(f'Waiting for disk {disk_name} to be ready.')
-        time.sleep(POLL_INTERVAL)
-        retry_count += 1
-
-    if retry_count == nebius.MAX_RETRIES_TO_DISK_CREATE:
-        raise TimeoutError(
-            f'Exceeded maximum retries '
-            f'({nebius.MAX_RETRIES_TO_DISK_CREATE * POLL_INTERVAL}'
-            f' seconds) while waiting for disk {disk_name}'
-            f' to be ready.')
 
     filesystems_spec = []
     if filesystems:
@@ -349,8 +319,10 @@ def launch(cluster_name_on_cloud: str,
                     boot_disk=nebius.compute().AttachedDiskSpec(
                         attach_mode=nebius.compute(
                         ).AttachedDiskSpec.AttachMode.READ_WRITE,
-                        existing_disk=nebius.compute().ExistingDisk(
-                            id=disk_id)),
+                        managed_disk=nebius.compute().ManagedDisk(
+                            spec=disk_spec,
+                            name=disk_name,
+                        )),
                     cloud_init_user_data=user_data,
                     resources=nebius.compute().ResourcesSpec(platform=platform,
                                                              preset=preset),
@@ -428,16 +400,7 @@ def launch(cluster_name_on_cloud: str,
                 f' seconds) while waiting for instance {instance_name}'
                 f' to be ready.')
     except nebius.request_error() as e:
-        # Handle ResourceExhausted quota limit error. In this case, we need to
-        # clean up the disk as VM creation failed and we can't proceed.
-        # It cannot be handled by the caller (provisioner)'s teardown logic,
-        # as we cannot retrieve the disk id, after the instance creation
-        # fails
         logger.warning(f'Failed to launch instance {instance_name}: {e}')
-        service = nebius.compute().DiskServiceClient(nebius.sdk())
-        nebius.sync_call(
-            service.delete(nebius.compute().DeleteDiskRequest(id=disk_id)))
-        logger.debug(f'Disk {disk_id} deleted.')
         raise e
     return instance_id
 
@@ -447,9 +410,15 @@ def remove(instance_id: str) -> None:
     service = nebius.compute().InstanceServiceClient(nebius.sdk())
     result = nebius.sync_call(
         service.get(nebius.compute().GetInstanceRequest(id=instance_id)))
-    disk_id = result.spec.boot_disk.existing_disk.id
     nebius.sync_call(
         service.delete(nebius.compute().DeleteInstanceRequest(id=instance_id)))
+
+    if result.spec.boot_disk.existing_disk is None:
+        return
+    # Instances create by older versions might still be using
+    # attached disks rather than managed disks
+    disk_id = result.spec.boot_disk.existing_disk.id
+
     retry_count = 0
     # The instance begins deleting and attempts to delete the disk.
     # Must wait until the disk is unlocked and becomes deletable.

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -249,7 +249,7 @@ cloud_dependencies: Dict[str, List[str]] = {
     'nebius': [
         # Nebius requires grpcio and protobuf, so we need to include
         # our constraints here.
-        'nebius>=0.3.12',
+        'nebius>=0.3.59',
         GRPC,
         PROTOBUF,
     ] + aws_dependencies,

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2809,7 +2809,6 @@ def test_remote_server_api_login():
 # ---------- Testing Autostopping ----------
 @pytest.mark.no_fluidstack  # FluidStack does not support stopping in SkyPilot implementation
 @pytest.mark.no_vast  # Vast does not support num_nodes > 1 yet
-@pytest.mark.no_nebius  # Nebius does not support autodown
 @pytest.mark.no_hyperbolic  # Hyperbolic does not support num_nodes > 1 yet
 @pytest.mark.no_kubernetes  # Kubernetes does not autostop yet
 @pytest.mark.no_shadeform  # Shadeform does not support num_nodes > 1 yet
@@ -2850,7 +2849,6 @@ def test_autostop_with_unhealthy_ray_cluster(generic_cloud: str):
 # ---------- Testing Autodowning ----------
 @pytest.mark.no_fluidstack  # FluidStack does not support stopping in SkyPilot implementation
 @pytest.mark.no_vast  # Vast does not support num_nodes > 1 yet
-@pytest.mark.no_nebius  # Nebius does not support autodown
 @pytest.mark.no_hyperbolic  # Hyperbolic does not support num_nodes > 1 yet
 @pytest.mark.no_shadeform  # Shadeform does not support num_nodes > 1 yet
 @pytest.mark.no_seeweb  # Seeweb does not support autostop


### PR DESCRIPTION
Nebius now supports creating an instance directly together with its boot disk. This PR switches to this feature to speed up instance creation/deletion, and to increase robustness.

This PR also fixes a bug where the Nebius tenant_id and iam_token were propagated to running SkyPilot instances only from the `~/.nebius/NEBIUS_*.txt` files, ignoring any overrides in the SkyPilot config.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - `tests/test_smoke.py::test_autodown` now supports and passes with `--generic-cloud nebius`
  - Manually tested if old instances with dedicated attached disk are cleaned up correctly
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
  - `tests/test_smoke.py::test_nebius_image_family`
  - `tests/test_smoke.py::test_nebius_docker_image`
  - `tests/test_smoke.py::test_nebius_docker_image`
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)