### PR TITLE
Support tune probe timeout

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -257,6 +257,11 @@ spec:
             path: /api/health
             port: 46580
           periodSeconds: 30
+          {{- with .Values.apiService.probes }}
+          {{- if and .liveness .liveness.timeoutSeconds }}
+          timeoutSeconds: {{ .liveness.timeoutSeconds }}
+          {{- end }}
+          {{- end }}
         readinessProbe:
           httpGet:
             path: /api/health
@@ -275,6 +280,11 @@ spec:
           failureThreshold: 3
           periodSeconds: 5
           initialDelaySeconds: 5
+          {{- with .Values.apiService.probes }}
+          {{- if and .readiness .readiness.timeoutSeconds }}
+          timeoutSeconds: {{ .readiness.timeoutSeconds }}
+          {{- end }}
+          {{- end }}
         volumeMounts:
         {{- if and .Values.storage.enabled (eq .Values.apiService.upgradeStrategy "RollingUpdate") }}
         # For RollingUpdate with storage enabled, use emptyDir for ~/.sky to avoid

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -122,6 +122,27 @@
                 "preDeployHook": {
                     "type": "string"
                 },
+                "probes": {
+                    "type": "object",
+                    "properties": {
+                        "liveness": {
+                            "type": "object",
+                            "properties": {
+                                "timeoutSeconds": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "readiness": {
+                            "type": "object",
+                            "properties": {
+                                "timeoutSeconds": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                },
                 "replicas": {
                     "type": "integer"
                 },

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -69,6 +69,18 @@ apiService:
   # The default value is 60 seconds.
   terminationGracePeriodSeconds: 60
 
+  # Tunable parameters for the API server liveness and readiness probes. Only
+  # `timeoutSeconds` is exposed here; other probe fields (periodSeconds,
+  # failureThreshold, etc.) are kept at their chart defaults.
+  # Under heavy request load the `/api/health` handler can occasionally exceed
+  # the default 1s probe timeout and cause the pod to be restarted; bump these
+  # values (e.g. to 3-5) if you see the pod flapping on probes.
+  probes:
+    liveness:
+      timeoutSeconds: 1
+    readiness:
+      timeoutSeconds: 1
+
   # Set ~/.sky/config.yaml content on the API server
   # This value is IGNORED during an helm upgrade if there is an existing config
   # due to the potential accidental loss of existing config. Use the SkyPilot dashboard to update the config.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Make the timeout tunable, in some resource constrained env with high load we may need longer timeout.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
