### PR TITLE
[Docs] Bump copyright year to 2026

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@ import generate_examples
 # -- Project information
 
 project = 'SkyPilot'
-copyright = '2025, SkyPilot Team'
+copyright = '2026, SkyPilot Team'
 author = 'the SkyPilot authors'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
## Summary
- Bumps the Sphinx `copyright` in `docs/source/conf.py` from 2025 to 2026 so every doc page footer renders "© Copyright 2026, SkyPilot Team."

## Test plan
- [ ] `/build-docs` — confirm the RTD preview footer shows 2026.