### PR TITLE
Allow AWS EFA with custom AMIs

### DIFF
--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -97,11 +97,11 @@ _EFA_DOCKER_RUN_OPTIONS = [
     '--ulimit memlock=-1:-1',
 ]
 
-# AWS EFA image name.
-# Refer to https://docs.aws.amazon.com/dlami/latest/devguide/aws-deep-learning-base-gpu-ami-ubuntu-22-04.html for latest version. # pylint: disable=line-too-long
-# TODO(hailong): may need to update the version later.
-_EFA_IMAGE_NAME = 'Deep Learning Base OSS Nvidia Driver GPU AMI' \
-' (Ubuntu 22.04) 20250808'
+# AWS EFA image name pattern.
+# AWS documents this wildcard in the DLAMI Ubuntu 22.04 AWSCLI Query.
+# AWS publishes these AMIs with a YYYYMMDD suffix.
+_EFA_IMAGE_NAME_PATTERN = ('Deep Learning Base OSS Nvidia Driver GPU AMI'
+                           ' (Ubuntu 22.04) ????????')
 
 # For functions that needs caching per AWS profile.
 _AWS_PROFILE_SCOPED_FUNC_CACHE_SIZE = 5
@@ -144,7 +144,8 @@ def aws_profile_aware_lru_cache(*lru_cache_args,
             aws_profile = aws.get_workspace_profile()
             return cached_impl(aws_profile, *args, **kwargs)
 
-        wrapper.cache_clear = cached_impl.cache_clear  # type: ignore[attr-defined]
+        wrapper.cache_clear = (  # type: ignore[attr-defined]
+            cached_impl.cache_clear)
         return wrapper
 
     return decorator
@@ -162,17 +163,21 @@ def _get_efa_image_id(region_name: str) -> Optional[str]:
     """Get the EFA image id for the given region."""
     try:
         client = aws.client('ec2', region_name=region_name)
-        response = client.describe_images(Filters=[{
-            'Name': 'name',
-            'Values': [_EFA_IMAGE_NAME]
-        }])
+        response = client.describe_images(
+            Owners=['amazon'],
+            Filters=[{
+                'Name': 'name',
+                'Values': [_EFA_IMAGE_NAME_PATTERN]
+            }, {
+                'Name': 'state',
+                'Values': ['available']
+            }])
         if 'Images' not in response:
             return None
-        if len(response['Images']) == 0:
+        imgs = response['Images']
+        if len(imgs) == 0:
             return None
-        available_images = [
-            img for img in response['Images'] if img['State'] == 'available'
-        ]
+        available_images = [img for img in imgs if img['State'] == 'available']
         if len(available_images) == 0:
             return None
         sorted_images = sorted(available_images,
@@ -195,7 +200,8 @@ def _get_max_efa_interfaces(instance_type: str, region_name: str) -> int:
         client = aws.client('ec2', region_name=region_name)
         response = client.describe_instance_types(
             # TODO(cooperc): fix the types for mypy 1.16
-            # Boto3 type stubs expect Literal instance types; using str list here.
+            # Boto3 type stubs expect Literal instance types; using str list
+            # here.
             InstanceTypes=[instance_type],  # type: ignore
             Filters=[{
                 'Name': 'network-info.efa-supported',

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1400,24 +1400,50 @@ class Resources:
                         self._region: nebius_constants.INFINIBAND_IMAGE_ID
                     }
             elif self._image_id:
-                # Custom image specified - validate it's a docker image
-                # Check if any of the specified images are not docker images
+                # Custom image specified - validate network tier constraints.
+                docker_images = []
                 non_docker_images = []
                 for region, image_id in self._image_id.items():
-                    if not image_id.startswith('docker:'):
+                    if image_id.startswith('docker:'):
+                        docker_images.append(f'{image_id} (region: {region})')
+                    else:
                         non_docker_images.append(
                             f'{image_id} (region: {region})')
 
                 if non_docker_images:
-                    with ux_utils.print_exception_no_traceback():
-                        raise ValueError(
-                            f'When using network_tier=BEST, image_id '
-                            f'must be a docker image. '
-                            f'Found non-docker images: '
-                            f'{", ".join(non_docker_images)}. '
-                            f'Please either: (1) use a docker image '
-                            f'(prefix with "docker:"), or '
-                            f'(2) leave image_id empty to use the default')
+                    if isinstance(self._cloud, clouds.AWS):
+                        if docker_images:
+                            with ux_utils.print_exception_no_traceback():
+                                raise ValueError(
+                                    'When using network_tier=BEST, image_id '
+                                    'must not mix docker and non-docker '
+                                    'images. '
+                                    'Found docker images: '
+                                    f'{", ".join(docker_images)}. '
+                                    'Found non-docker images: '
+                                    f'{", ".join(non_docker_images)}.')
+                        else:
+                            logger.warning(
+                                f'{colorama.Fore.YELLOW}'
+                                'When using network_tier=BEST with a custom '
+                                'image_id, SkyPilot will attach EFA network '
+                                'interfaces on EFA-supported instance types, '
+                                'but will not install or validate the image\'s '
+                                'networking setup. Found custom images: '
+                                f'{", ".join(non_docker_images)}. '
+                                'Make sure the image has the required '
+                                'networking stack.'
+                                f'{colorama.Style.RESET_ALL}')
+                    else:
+                        with ux_utils.print_exception_no_traceback():
+                            raise ValueError(
+                                f'When using network_tier=BEST, image_id '
+                                f'must be a docker image. '
+                                f'Found non-docker images: '
+                                f'{", ".join(non_docker_images)}. '
+                                f'Please either: (1) use a docker image '
+                                f'(prefix with "docker:"), or '
+                                f'(2) leave image_id empty to use the default')
 
         if self._image_id is None:
             return


### PR DESCRIPTION
Fixes #8746

<!-- Describe the changes in this PR -->

On AWS currently, Skypilot forces an ancient AMI if EFA is to be enabled (20250808). This causes performance regressions and makes it difficult to utilize B200/B300 GPUs at optimal performance with the latest drivers.

  This PR updates AWS EFA handling for `network_tier: best` in two ways:

  1. Allows custom non-Docker `image_id` values on AWS when requesting `network_tier: best`. SkyPilot will still attach
  EFA network interfaces for EFA-supported instance types, but now emits a warning that the custom image’s networking
  setup is not installed or validated by SkyPilot.
  2. Replaces the hardcoded AWS EFA DLAMI name with a wildcard `describe_images` lookup, so SkyPilot selects the latest
  available Deep Learning Base OSS Nvidia Driver GPU AMI for the region.

  <!-- Describe the tests ran -->
  <!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

  Tested (run the relevant ones):

  - [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
  - [ ] Any manual or new tests for this PR (please specify below)
    - Ran `git diff --check`
  - [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
  - [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
  - [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

  <!-- CI commands (/-prefixed) can only be triggered by repo members -->