### PR TITLE
[API] Defer DISABLE_LOGGING snapshot in server-heartbeat daemon

### DIFF
--- a/sky/server/daemons.py
+++ b/sky/server/daemons.py
@@ -6,7 +6,7 @@ import shutil
 import sys
 import time
 import typing
-from typing import Callable
+from typing import Callable, Optional
 
 from sky import sky_logging
 from sky import skypilot_config
@@ -61,10 +61,19 @@ def _rotate_daemon_log(log_path: str) -> None:
         pass
 
 
-# Snapshot at import time, before run_event() overrides DISABLE_LOGGING.
-# Each executor process imports this module during executor_initializer(),
-# so this captures the user's original env setting.
-_user_disabled_usage_collection = env_options.Options.DISABLE_LOGGING.get()
+# Populated lazily on the first run_event() call per process.
+#
+# Why not snapshot at import time: importing this module can happen before
+# the process has finished its startup initialization, so an import-time
+# read of env_options.Options.DISABLE_LOGGING may not reflect the final
+# intended value.
+#
+# Why not read inside the event: run_event() overrides DISABLE_LOGGING to
+# silence per-daemon usage messages, so a read at gate time would always
+# see the override rather than the user's original setting.
+#
+# Initializing inside run_event, before the override, threads the needle.
+_user_disabled_usage_collection: Optional[bool] = None
 
 
 def _default_should_skip():
@@ -109,6 +118,12 @@ class InternalRequestDaemon:
 
     def run_event(self):
         """Run the event."""
+        global _user_disabled_usage_collection
+        # Capture the original DISABLE_LOGGING value once per process,
+        # before we override it below.
+        if _user_disabled_usage_collection is None:
+            _user_disabled_usage_collection = (
+                env_options.Options.DISABLE_LOGGING.get())
 
         # Disable logging for periodic refresh to avoid the usage message being
         # sent multiple times.


### PR DESCRIPTION
## Summary

The server-heartbeat daemon gate reads `env_options.Options.DISABLE_LOGGING` once at module import time and caches it in `_user_disabled_usage_collection`. Import of `sky.server.daemons` can happen before a process has finished its startup initialization, so the cached value may not reflect the final intended configuration.

This PR moves that read out of module-import time and into the first `run_event()` call per process. The read still happens **before** `run_event()` overrides `DISABLE_LOGGING` for its own per-daemon logging, so the gate still observes the caller's setting rather than the daemon's self-imposed override. User-intent semantics at the gate are unchanged.

Nothing else in the file references `_user_disabled_usage_collection`, and the executor's `ProcessPoolExecutor(initializer=executor_initializer)` contract guarantees `executor_initializer` completes before any submitted event is dispatched into the worker — so deferring the read to the first `run_event` call is safe.

## Test plan

- [ ] Start the API server with no `SKYPILOT_DISABLE_USAGE_COLLECTION` env var; confirm heartbeats continue to be emitted at the 10 min cadence.
- [ ] Start the API server with `SKYPILOT_DISABLE_USAGE_COLLECTION=1`; confirm the heartbeat daemon sleeps silently and no heartbeats are emitted.
- [ ] Unit: `pytest tests/unit_tests/` — exercises module import path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)