### PR TITLE
fix(ci): un-ignore tests/smoke_tests/docker for Dockerfile_test

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,11 @@ docs
 examples
 llm
 tests
+# Re-include the files referenced by tests/smoke_tests/docker/Dockerfile_test
+# (entrypoint.sh and stop_sky_resource.sh); without this exemption, the
+# top-level `tests` ignore above makes Dockerfile_test unbuildable because
+# .dockerignore applies to every docker build invoked from the repo root.
+!tests/smoke_tests/docker
 .github
 sky/dashboard/node_modules
 sky/dashboard/.next


### PR DESCRIPTION
## Summary

Restore `tests/smoke_tests/docker/Dockerfile_test` as a buildable Docker image. PR #9325 added `tests` to `.dockerignore` to shrink the top-level `Dockerfile`'s build context, but because `.dockerignore` applies to **every** docker build invoked from the repo root, that change also excluded the two files `Dockerfile_test` needs:

- `tests/smoke_tests/docker/entrypoint.sh`
- `tests/smoke_tests/docker/stop_sky_resource.sh`

## Reproduction (current `master`, post-#9325)

```
docker build -t sky-remote-test-image \
  --build-arg USERNAME=buildkite \
  -f tests/smoke_tests/docker/Dockerfile_test .
```

Fails at:

```
#27 [stage-1 22/23] COPY tests/smoke_tests/docker/stop_sky_resource.sh /home/buildkite/stop_sky_resource.sh
ERROR: failed to compute cache key: failed to calculate checksum of ref ...:
  "/tests/smoke_tests/docker/stop_sky_resource.sh": not found
```

## Fix

Add an exemption for the single subdirectory `Dockerfile_test` reads from:

```diff
 tests
+!tests/smoke_tests/docker
```

Everything else under `tests/` stays excluded, so #9325's cache-size win for the main `Dockerfile` is preserved.

## Test plan

- [x] `docker build -f tests/smoke_tests/docker/Dockerfile_test .` succeeds on this branch
- [x] Build context for main `Dockerfile` still excludes `tests/*` except the whitelisted subdirectory