### PR TITLE
fix: use `is None` instead of `== None` (PEP 8 E711)

### DIFF
--- a/sky/backends/task_codegen.py
+++ b/sky/backends/task_codegen.py
@@ -520,7 +520,7 @@ class RayCodeGen(TaskCodeGen):
                 for i in range(len(setup_returncodes)):
                     returncode = setup_returncodes[i]
                     pid = setup_pids[i]
-                    if pid == None:
+                    if pid is None:
                         pid = os.getpid()
                     if returncode != 0 and returncode != CANCELLED_RETURN_CODE:
                         success = False


### PR DESCRIPTION
## Summary

Use identity check `is None` instead of equality check `== None` in `sky/backends/task_codegen.py` (line 523), as recommended by PEP 8 (E711).

Singletons like `None` should be compared using `is` or `is not`, never equality operators. The `is` operator checks identity, which is both more correct and slightly faster.

**Change:**
```python
# Before
if pid == None:

# After
if pid is None:
```

## Testing

No behavior change — this is a correctness/style fix only. `None` is a singleton, so `is None` and `== None` produce identical results in all cases.