### PR TITLE
[K8s] Accept `quota.queue` as alias of `kueue.local_queue_name`

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -716,12 +716,10 @@ class Kubernetes(clouds.Cloud):
                 default_value=None))
 
         k8s_kueue_local_queue_name = (
-            skypilot_config.get_effective_workspace_region_config(
+            skypilot_config.get_effective_queue_name(
                 # TODO(kyuds): Support SSH node pools as well.
                 cloud='kubernetes',
                 region=context,
-                keys=('kueue', 'local_queue_name'),
-                default_value=None,
                 override_configs=resources.cluster_config_overrides))
 
         # Check DWS configuration for GKE.

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -846,31 +846,33 @@ def get_effective_queue_name(
     """
     if workspace is None:
         workspace = get_active_workspace()
-    config = _get_loaded_config()
 
-    def _lookup_at(base_keys: Tuple[str, ...]) -> Optional[Any]:
-        for queue_keys in _QUEUE_NAME_KEYS:
-            value = config.get_nested(keys=base_keys + queue_keys,
-                                      default_value=None,
-                                      override_configs=override_configs)
-            if value is not None:
-                return value
-        return None
+    # `override_configs` are cloud-level; looking up relative to a scope
+    # (rather than prefixing the scope into `keys`) ensures they apply at
+    # the correct depth even when the scope is a workspace subtree.
+    scope_configs: List[config_utils.Config] = []
+    if workspace is not None:
+        ws_config = get_nested(keys=('workspaces', workspace),
+                               default_value=None)
+        if ws_config is not None:
+            scope_configs.append(config_utils.Config(ws_config))
+    scope_configs.append(config_utils.Config(_get_loaded_config()))
 
-    scope_prefixes: List[Tuple[str, ...]] = []
-    if workspace is not None and config.get_nested(
-            keys=('workspaces', workspace), default_value=None) is not None:
-        scope_prefixes.append(('workspaces', workspace))
-    scope_prefixes.append(())
-
-    for prefix in scope_prefixes:
+    for scope_config in scope_configs:
         if region is not None:
-            value = _lookup_at(prefix + (cloud, 'context_configs', region))
+            for queue_keys in _QUEUE_NAME_KEYS:
+                value = scope_config.get_nested(
+                    keys=(cloud, 'context_configs', region) + queue_keys,
+                    default_value=None,
+                    override_configs=override_configs)
+                if value is not None:
+                    return value
+        for queue_keys in _QUEUE_NAME_KEYS:
+            value = scope_config.get_nested(keys=(cloud,) + queue_keys,
+                                            default_value=None,
+                                            override_configs=override_configs)
             if value is not None:
                 return value
-        value = _lookup_at(prefix + (cloud,))
-        if value is not None:
-            return value
     return None
 
 

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -823,7 +823,55 @@ def replace_skypilot_config(new_configs: config_utils.Config) -> Iterator[None]:
         yield
 
 
-_QUEUE_NAME_KEYS: List[Tuple[str, ...]] = [('kueue', 'local_queue_name')]
+_QUEUE_NAME_KEYS: List[Tuple[str, ...]] = [
+    # Order matters: `get_effective_queue_name` returns the first hit at a
+    # given scope, so `quota.queue` wins over `kueue.local_queue_name` when
+    # both are set.
+    ('quota', 'queue'),
+    ('kueue', 'local_queue_name'),
+]
+
+
+def get_effective_queue_name(
+        cloud: str,
+        region: Optional[str] = None,
+        workspace: Optional[str] = None,
+        override_configs: Optional[Dict[str, Any]] = None) -> Optional[str]:
+    """Returns the effective Kueue local queue name from config.
+
+    Supports two equivalent spellings, ``kueue.local_queue_name`` and
+    ``quota.queue``. Scope precedence (workspace > global; context > cloud)
+    takes priority over spelling; within the same scope, ``quota.queue``
+    wins over ``kueue.local_queue_name`` when both are set.
+    """
+    if workspace is None:
+        workspace = get_active_workspace()
+    config = _get_loaded_config()
+
+    def _lookup_at(base_keys: Tuple[str, ...]) -> Optional[Any]:
+        for queue_keys in _QUEUE_NAME_KEYS:
+            value = config.get_nested(keys=base_keys + queue_keys,
+                                      default_value=None,
+                                      override_configs=override_configs)
+            if value is not None:
+                return value
+        return None
+
+    scope_prefixes: List[Tuple[str, ...]] = []
+    if workspace is not None and config.get_nested(
+            keys=('workspaces', workspace), default_value=None) is not None:
+        scope_prefixes.append(('workspaces', workspace))
+    scope_prefixes.append(())
+
+    for prefix in scope_prefixes:
+        if region is not None:
+            value = _lookup_at(prefix + (cloud, 'context_configs', region))
+            if value is not None:
+                return value
+        value = _lookup_at(prefix + (cloud,))
+        if value is not None:
+            return value
+    return None
 
 
 def register_queue_name_key(key: Tuple[str, ...]) -> None:

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -859,18 +859,23 @@ def get_effective_queue_name(
     scope_configs.append(config_utils.Config(_get_loaded_config()))
 
     for scope_config in scope_configs:
+        if override_configs is not None:
+            # Merge overrides once per scope so the per-key lookups below
+            # don't re-run `_recursive_update` for every spelling.
+            scope_config = config_utils.Config(
+                scope_config.get_nested(keys=(),
+                                        default_value={},
+                                        override_configs=override_configs))
         if region is not None:
             for queue_keys in _QUEUE_NAME_KEYS:
                 value = scope_config.get_nested(
                     keys=(cloud, 'context_configs', region) + queue_keys,
-                    default_value=None,
-                    override_configs=override_configs)
+                    default_value=None)
                 if value is not None:
                     return value
         for queue_keys in _QUEUE_NAME_KEYS:
             value = scope_config.get_nested(keys=(cloud,) + queue_keys,
-                                            default_value=None,
-                                            override_configs=override_configs)
+                                            default_value=None)
             if value is not None:
                 return value
     return None

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -2301,6 +2301,16 @@ def get_config_schema():
                                 },
                             },
                         },
+                        'quota': {
+                            'type': 'object',
+                            'required': [],
+                            'additionalProperties': False,
+                            'properties': {
+                                'queue': {
+                                    'type': 'string',
+                                },
+                            },
+                        },
                         'context_configs': {
                             'type': 'object',
                             'required': [],
@@ -2324,6 +2334,16 @@ def get_config_schema():
                                         'additionalProperties': False,
                                         'properties': {
                                             'local_queue_name': {
+                                                'type': 'string',
+                                            },
+                                        },
+                                    },
+                                    'quota': {
+                                        'type': 'object',
+                                        'required': [],
+                                        'additionalProperties': False,
+                                        'properties': {
+                                            'queue': {
                                                 'type': 'string',
                                             },
                                         },

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1481,6 +1481,18 @@ _CONTEXT_CONFIG_SCHEMA_KUBERNETES = {
             },
         },
     },
+    # Alias of `kueue.local_queue_name`; `quota.queue` takes precedence
+    # when both are set.
+    'quota': {
+        'type': 'object',
+        'required': [],
+        'additionalProperties': False,
+        'properties': {
+            'queue': {
+                'type': 'string',
+            },
+        },
+    },
     'dws': {
         'type': 'object',
         'required': [],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1332,6 +1332,84 @@ def test_get_effective_queue_name(monkeypatch, tmp_path) -> None:
         workspace='workspaceA') == 'workspaceA-queue-via-quota'
 
 
+def test_get_effective_queue_name_workspace_override(monkeypatch,
+                                                     tmp_path) -> None:
+    """Cloud-level `override_configs` must apply inside workspace scope.
+
+    Regression test for a bug where `get_effective_queue_name` prefixed
+    the workspace path onto the lookup keys, so `override_configs` (which
+    mirror the cloud-level config schema and do not carry a `workspaces`
+    section) never took effect when the active workspace had its own
+    queue setting.
+    """
+    with open(tmp_path / 'ws_override.yaml', 'w', encoding='utf-8') as f:
+        f.write("""\
+        kubernetes:
+            kueue:
+                local_queue_name: global-queue
+        workspaces:
+            workspaceA:
+                kubernetes:
+                    kueue:
+                        local_queue_name: workspaceA-queue
+                    context_configs:
+                        contextA:
+                            kueue:
+                                local_queue_name: workspaceA-contextA-queue
+        """)
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH',
+                        tmp_path / 'ws_override.yaml')
+    skypilot_config.reload_config()
+
+    cloud_level_override = {
+        'kubernetes': {
+            'kueue': {
+                'local_queue_name': 'override-queue'
+            }
+        }
+    }
+
+    # Baseline: without override, the workspace's cloud-level value wins.
+    assert skypilot_config.get_effective_queue_name(
+        cloud='kubernetes', workspace='workspaceA') == 'workspaceA-queue'
+
+    # Bug scenario: cloud-level override (no `workspaces` section) should
+    # replace the workspace's cloud-level value. Previously the override
+    # was merged at config-root depth and silently ignored.
+    assert skypilot_config.get_effective_queue_name(
+        cloud='kubernetes',
+        workspace='workspaceA',
+        override_configs=cloud_level_override) == 'override-queue'
+
+    # Alias spelling in the override still overrides the legacy spelling
+    # at workspace scope.
+    assert skypilot_config.get_effective_queue_name(
+        cloud='kubernetes',
+        workspace='workspaceA',
+        override_configs={
+            'kubernetes': {
+                'quota': {
+                    'queue': 'override-quota-q'
+                }
+            }
+        }) == 'override-quota-q'
+
+    # Context-level value at the workspace scope still wins over a
+    # cloud-level override, because per-context is a more specific scope.
+    assert skypilot_config.get_effective_queue_name(
+        cloud='kubernetes',
+        region='contextA',
+        workspace='workspaceA',
+        override_configs=cloud_level_override) == 'workspaceA-contextA-queue'
+
+    # Override still applies when falling back to the global scope
+    # (workspace does not override the key).
+    assert skypilot_config.get_effective_queue_name(
+        cloud='kubernetes',
+        workspace='nonexistent-ws',
+        override_configs=cloud_level_override) == 'override-queue'
+
+
 def _make_config(d: dict) -> config_utils.Config:
     """Helper to build a Config from a plain dict."""
     cfg = config_utils.Config()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1281,6 +1281,57 @@ def test_kubernetes_kueue_configs(monkeypatch, tmp_path) -> None:
     assert contexts[1] == 'contextB'
 
 
+def test_get_effective_queue_name(monkeypatch, tmp_path) -> None:
+    """`quota.queue` is accepted as an alias of `kueue.local_queue_name`."""
+    with open(tmp_path / 'quota_queue.yaml', 'w', encoding='utf-8') as f:
+        f.write("""\
+        kubernetes:
+            quota:
+                queue: default-queue-via-quota
+            context_configs:
+                contextA:
+                    quota:
+                        queue: contextA-queue-via-quota
+                contextB:
+                    kueue:
+                        local_queue_name: contextB-queue-via-kueue
+                contextC:
+                    # Both set: quota.queue wins at the same scope.
+                    quota:
+                        queue: contextC-queue-via-quota
+                    kueue:
+                        local_queue_name: contextC-queue-via-kueue
+        workspaces:
+            workspaceA:
+                kubernetes:
+                    quota:
+                        queue: workspaceA-queue-via-quota
+        """)
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH',
+                        tmp_path / 'quota_queue.yaml')
+    skypilot_config.reload_config()
+
+    # Cloud-level `quota.queue`.
+    assert skypilot_config.get_effective_queue_name(
+        cloud='kubernetes', workspace='default') == 'default-queue-via-quota'
+    # Context-level `quota.queue`.
+    assert skypilot_config.get_effective_queue_name(
+        cloud='kubernetes', region='contextA',
+        workspace='default') == 'contextA-queue-via-quota'
+    # Context-level `kueue.local_queue_name` still works.
+    assert skypilot_config.get_effective_queue_name(
+        cloud='kubernetes', region='contextB',
+        workspace='default') == 'contextB-queue-via-kueue'
+    # When both are set at the same scope, `quota.queue` wins.
+    assert skypilot_config.get_effective_queue_name(
+        cloud='kubernetes', region='contextC',
+        workspace='default') == 'contextC-queue-via-quota'
+    # Workspace-level `quota.queue`.
+    assert skypilot_config.get_effective_queue_name(
+        cloud='kubernetes',
+        workspace='workspaceA') == 'workspaceA-queue-via-quota'
+
+
 def _make_config(d: dict) -> config_utils.Config:
     """Helper to build a Config from a plain dict."""
     cfg = config_utils.Config()
@@ -1298,10 +1349,16 @@ class TestRemoveQueueNameFromConfig:
                 'kueue': {
                     'local_queue_name': 'root-q'
                 },
+                'quota': {
+                    'queue': 'root-quota-q'
+                },
                 'context_configs': {
                     'ctx1': {
                         'kueue': {
                             'local_queue_name': 'ctx1-q'
+                        },
+                        'quota': {
+                            'queue': 'ctx1-quota-q'
                         }
                     }
                 }
@@ -1312,10 +1369,16 @@ class TestRemoveQueueNameFromConfig:
                         'kueue': {
                             'local_queue_name': 'ws1-q'
                         },
+                        'quota': {
+                            'queue': 'ws1-quota-q'
+                        },
                         'context_configs': {
                             'ctx2': {
                                 'kueue': {
                                     'local_queue_name': 'ws1-ctx2-q'
+                                },
+                                'quota': {
+                                    'queue': 'ws1-ctx2-quota-q'
                                 }
                             }
                         }
@@ -1328,12 +1391,17 @@ class TestRemoveQueueNameFromConfig:
                 current = skypilot_config.to_dict()
                 for keys in [
                     ('kubernetes', 'kueue', 'local_queue_name'),
+                    ('kubernetes', 'quota', 'queue'),
                     ('kubernetes', 'context_configs', 'ctx1', 'kueue',
                      'local_queue_name'),
+                    ('kubernetes', 'context_configs', 'ctx1', 'quota', 'queue'),
                     ('workspaces', 'ws1', 'kubernetes', 'kueue',
                      'local_queue_name'),
+                    ('workspaces', 'ws1', 'kubernetes', 'quota', 'queue'),
                     ('workspaces', 'ws1', 'kubernetes', 'context_configs',
                      'ctx2', 'kueue', 'local_queue_name'),
+                    ('workspaces', 'ws1', 'kubernetes', 'context_configs',
+                     'ctx2', 'quota', 'queue'),
                 ]:
                     assert current.get_nested(
                         keys, 'NOT_SET') is None, (f'Expected None at {keys}')


### PR DESCRIPTION
    Add `kubernetes.quota.queue` (and per-context
    `kubernetes.context_configs.<context>.quota.queue`) as an equivalent
    spelling of `kubernetes.kueue.local_queue_name`. Both resolve to the
    same Kueue local queue name. Scope precedence (workspace > global,
    context > cloud) is preserved; at the same scope `quota.queue` wins
    when both are set.

    A new `skypilot_config.get_effective_queue_name()` helper consolidates
    the lookup across scopes and spellings, and `quota.queue` is included
    in `_QUEUE_NAME_KEYS` so `remove_queue_name_from_config` strips it
    alongside the existing key.

    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
