### PR TITLE
[Helm] Add SkyPilot History Grafana dashboard

### DIFF
--- a/charts/skypilot/manifests/compute-overview-dashboard.json
+++ b/charts/skypilot/manifests/compute-overview-dashboard.json
@@ -223,6 +223,7 @@
               }
             ]
           },
+          "decimals": 1,
           "unit": "percent"
         },
         "overrides": [
@@ -268,8 +269,7 @@
       "options": {
         "legend": {
           "calcs": [
-            "mean",
-            "lastNotNull"
+            "mean"
           ],
           "displayMode": "list",
           "placement": "bottom",

--- a/charts/skypilot/manifests/compute-overview-dashboard.json
+++ b/charts/skypilot/manifests/compute-overview-dashboard.json
@@ -502,7 +502,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "SkyPilot Compute Overview",
+  "title": "SkyPilot Usage Trends",
   "uid": "skypilot-compute-overview",
   "version": 1
 }

--- a/charts/skypilot/manifests/compute-overview-dashboard.json
+++ b/charts/skypilot/manifests/compute-overview-dashboard.json
@@ -308,7 +308,7 @@
           "refId": "B"
         }
       ],
-      "title": "Utilization & Allocation Over Time",
+      "title": "",
       "type": "timeseries"
     },
     {

--- a/charts/skypilot/manifests/compute-overview-dashboard.json
+++ b/charts/skypilot/manifests/compute-overview-dashboard.json
@@ -159,7 +159,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg_over_time((sum(kube_pod_container_resource_requests{resource=\"nvidia.com/gpu\", cluster=~\"$cluster\"}) / sum(kube_node_status_allocatable{resource=\"nvidia.com/gpu\", cluster=~\"$cluster\"}) * 100)[$__range:])",
+          "expr": "avg_over_time((sum(kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"}) / sum(kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"}) * 100)[$__range:])",
           "instant": false,
           "legendFormat": "",
           "range": true,
@@ -301,7 +301,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(kube_pod_container_resource_requests{resource=\"nvidia.com/gpu\", cluster=~\"$cluster\"}) / sum(kube_node_status_allocatable{resource=\"nvidia.com/gpu\", cluster=~\"$cluster\"}) * 100",
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"}) / sum(kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"}) * 100",
           "instant": false,
           "legendFormat": "GPU Allocation",
           "range": true,

--- a/charts/skypilot/manifests/compute-overview-dashboard.json
+++ b/charts/skypilot/manifests/compute-overview-dashboard.json
@@ -159,7 +159,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg_over_time((sum(kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"}) / sum(kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"}) * 100)[$__range:])",
+          "expr": "avg_over_time((sum(max by (cluster, namespace, pod, container) (kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) / sum(max by (cluster, node) (kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) * 100)[$__range:])",
           "instant": false,
           "legendFormat": "",
           "range": true,
@@ -289,7 +289,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"}) / sum(kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"}) * 100",
+          "expr": "sum(max by (cluster, namespace, pod, container) (kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) / sum(max by (cluster, node) (kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) * 100",
           "instant": false,
           "legendFormat": "GPU Allocation",
           "range": true,

--- a/charts/skypilot/manifests/compute-overview-dashboard.json
+++ b/charts/skypilot/manifests/compute-overview-dashboard.json
@@ -173,7 +173,7 @@
       "datasource": {
         "uid": "$datasource"
       },
-      "description": "GPU utilization and allocation percentage over time. When no cluster is selected, series are averaged across all clusters (labeled 'in-cluster' when the cluster label is empty).",
+      "description": "GPU allocation and utilization percentage over time. When no cluster is selected, series are averaged across all clusters (labeled 'in-cluster' when the cluster label is empty).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -308,7 +308,7 @@
           "refId": "B"
         }
       ],
-      "title": "Utilization & Allocation Over Time",
+      "title": "Allocation & Utilization Over Time",
       "type": "timeseries"
     },
     {

--- a/charts/skypilot/manifests/compute-overview-dashboard.json
+++ b/charts/skypilot/manifests/compute-overview-dashboard.json
@@ -502,7 +502,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "SkyPilot Usage Trends",
+  "title": "SkyPilot Trends",
   "uid": "skypilot-compute-overview",
   "version": 1
 }

--- a/charts/skypilot/manifests/compute-overview-dashboard.json
+++ b/charts/skypilot/manifests/compute-overview-dashboard.json
@@ -308,7 +308,7 @@
           "refId": "B"
         }
       ],
-      "title": "",
+      "title": "Utilization & Allocation Over Time",
       "type": "timeseries"
     },
     {

--- a/charts/skypilot/manifests/compute-overview-dashboard.json
+++ b/charts/skypilot/manifests/compute-overview-dashboard.json
@@ -310,6 +310,145 @@
       ],
       "title": "Utilization & Allocation Over Time",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "description": "Mean power draw across all selected GPUs over the selected time range, with a sparkline of the trend.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#0891B2",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#0891B2",
+                "value": null
+              }
+            ]
+          },
+          "unit": "kwatt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 0,
+        "y": 20
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(DCGM_FI_DEV_POWER_USAGE{cluster=~\"$cluster\"}) / 1000",
+          "instant": false,
+          "legendFormat": "Power (kW)",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Power Draw",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "description": "Average GPU temperature across the selected fleet over the time range. Thresholds: <65°C green, 65-75°C amber, >75°C red.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#16A34A",
+                "value": null
+              },
+              {
+                "color": "#F59E0B",
+                "value": 65
+              },
+              {
+                "color": "#DC2626",
+                "value": 75
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 0,
+        "y": 30
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg(DCGM_FI_DEV_GPU_TEMP{cluster=~\"$cluster\"})",
+          "instant": false,
+          "legendFormat": "Temperature",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Temperature",
+      "type": "stat"
     }
   ],
   "preload": false,

--- a/charts/skypilot/manifests/compute-overview-dashboard.json
+++ b/charts/skypilot/manifests/compute-overview-dashboard.json
@@ -502,7 +502,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "SkyPilot Trends",
+  "title": "SkyPilot History",
   "uid": "skypilot-compute-overview",
   "version": 1
 }

--- a/charts/skypilot/manifests/compute-overview-dashboard.json
+++ b/charts/skypilot/manifests/compute-overview-dashboard.json
@@ -82,10 +82,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "avg_over_time(avg(DCGM_FI_DEV_GPU_UTIL{cluster=~\"$cluster\"})[$__range:])",
+          "expr": "avg(DCGM_FI_DEV_GPU_UTIL{cluster=~\"$cluster\"})",
           "instant": false,
           "legendFormat": "",
           "range": true,
@@ -156,10 +156,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "avg_over_time((sum(max by (cluster, namespace, pod, container) (kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) / sum(max by (cluster, node) (kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) * 100)[$__range:])",
+          "expr": "sum(max by (cluster, namespace, pod, container) (kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) / sum(max by (cluster, node) (kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) * 100",
           "instant": false,
           "legendFormat": "",
           "range": true,
@@ -173,7 +173,7 @@
       "datasource": {
         "uid": "$datasource"
       },
-      "description": "GPU allocation and utilization percentage over time. When no cluster is selected, series are averaged across all clusters (labeled 'in-cluster' when the cluster label is empty).",
+      "description": "GPU allocation and utilization percentage over time, aggregated across all clusters matching the cluster filter.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -286,7 +286,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "sum(max by (cluster, namespace, pod, container) (kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) / sum(max by (cluster, node) (kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) * 100",
@@ -298,7 +298,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "avg(DCGM_FI_DEV_GPU_UTIL{cluster=~\"$cluster\"})",
@@ -364,7 +364,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "sum(DCGM_FI_DEV_POWER_USAGE{cluster=~\"$cluster\"}) / 1000",
@@ -437,7 +437,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "avg(DCGM_FI_DEV_GPU_TEMP{cluster=~\"$cluster\"})",

--- a/charts/skypilot/manifests/compute-overview-dashboard.json
+++ b/charts/skypilot/manifests/compute-overview-dashboard.json
@@ -1,0 +1,369 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Fleet-level GPU utilization and allocation metrics aggregated across clusters. Used by the Compute Overview section in the GPU Manager plugin. DO NOT EDIT.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "description": "Average GPU utilization across all selected clusters over the selected time range.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 30
+              },
+              {
+                "color": "green",
+                "value": 50
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg_over_time(avg(DCGM_FI_DEV_GPU_UTIL{cluster=~\"$cluster\"})[$__range:])",
+          "instant": false,
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GPU Utilization",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "description": "Percentage of total GPU capacity currently requested by running pods, averaged over the selected time range.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 30
+              },
+              {
+                "color": "green",
+                "value": 50
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 0,
+        "y": 10
+      },
+      "id": 2,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg_over_time((sum(kube_pod_container_resource_requests{resource=\"nvidia.com/gpu\", cluster=~\"$cluster\"}) / sum(kube_node_status_allocatable{resource=\"nvidia.com/gpu\", cluster=~\"$cluster\"}) * 100)[$__range:])",
+          "instant": false,
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GPU Allocation",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "description": "GPU utilization and allocation percentage over time. When no cluster is selected, series are averaged across all clusters (labeled 'in-cluster' when the cluster label is empty).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GPU Utilization"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GPU Allocation"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#EAB839",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 20,
+        "w": 18,
+        "x": 6,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg(DCGM_FI_DEV_GPU_UTIL{cluster=~\"$cluster\"})",
+          "instant": false,
+          "legendFormat": "GPU Utilization",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"nvidia.com/gpu\", cluster=~\"$cluster\"}) / sum(kube_node_status_allocatable{resource=\"nvidia.com/gpu\", cluster=~\"$cluster\"}) * 100",
+          "instant": false,
+          "legendFormat": "GPU Allocation",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Utilization & Allocation Over Time",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "includeAll": false,
+        "label": "Datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "text": ".*",
+          "value": ".*"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "",
+        "multi": false,
+        "name": "cluster",
+        "options": [
+          {
+            "selected": true,
+            "text": ".*",
+            "value": ".*"
+          }
+        ],
+        "query": ".*",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "SkyPilot Compute Overview",
+  "uid": "skypilot-compute-overview",
+  "version": 1
+}

--- a/charts/skypilot/manifests/compute-overview-dashboard.json
+++ b/charts/skypilot/manifests/compute-overview-dashboard.json
@@ -289,9 +289,9 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(DCGM_FI_DEV_GPU_UTIL{cluster=~\"$cluster\"})",
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"}) / sum(kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"}) * 100",
           "instant": false,
-          "legendFormat": "GPU Utilization",
+          "legendFormat": "GPU Allocation",
           "range": true,
           "refId": "A"
         },
@@ -301,9 +301,9 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"}) / sum(kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"}) * 100",
+          "expr": "avg(DCGM_FI_DEV_GPU_UTIL{cluster=~\"$cluster\"})",
           "instant": false,
-          "legendFormat": "GPU Allocation",
+          "legendFormat": "GPU Utilization",
           "range": true,
           "refId": "B"
         }

--- a/charts/skypilot/templates/compute-overview-dashboard-grafana-configmap.yaml
+++ b/charts/skypilot/templates/compute-overview-dashboard-grafana-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.grafana.enabled .Values.grafana.sidecar.dashboards.enabled }}
+{{- $fullName := include "skypilot.fullname" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullName }}-compute-overview-dashboard
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ $fullName }}-api
+    grafana_dashboard: "true"
+data:
+  compute-overview-dashboard.json: |
+{{ .Files.Get "manifests/compute-overview-dashboard.json" | indent 4 }}
+{{- end }}

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -675,6 +675,16 @@ prometheus:
         regex: ;(.+)
         target_label: node
         replacement: $1
+    # Scrape the in-release kube-state-metrics service for cluster-level GPU
+    # capacity + demand metrics (kube_pod_container_resource_requests,
+    # kube_node_status_allocatable). Required for the /gpu-metrics federate to
+    # forward allocation data upstream, and for the Compute Overview dashboard
+    # to render the Allocation gauge and timeseries.
+    - job_name: 'kube-state-metrics'
+      static_configs:
+        - targets: ['{{ include "skypilot.fullname" . }}-kube-state-metrics.{{ .Release.Namespace }}.svc.cluster.local:8080']
+      scrape_interval: 30s
+      scrape_timeout: 10s
     {{ if .Values.useDedicatedScrapeConfig }}
     - job_name: 'skypilot-api-server-metrics'
       honor_labels: true

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -675,16 +675,6 @@ prometheus:
         regex: ;(.+)
         target_label: node
         replacement: $1
-    # Scrape the in-release kube-state-metrics service for cluster-level GPU
-    # capacity + demand metrics (kube_pod_container_resource_requests,
-    # kube_node_status_allocatable). Required for the /gpu-metrics federate to
-    # forward allocation data upstream, and for the Compute Overview dashboard
-    # to render the Allocation gauge and timeseries.
-    - job_name: 'kube-state-metrics'
-      static_configs:
-        - targets: ['{{ include "skypilot.fullname" . }}-kube-state-metrics.{{ .Release.Namespace }}.svc.cluster.local:8080']
-      scrape_interval: 30s
-      scrape_timeout: 10s
     {{ if .Values.useDedicatedScrapeConfig }}
     - job_name: 'skypilot-api-server-metrics'
       honor_labels: true

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -513,6 +513,10 @@ async def get_metrics_for_context(context: str) -> str:
         'node_cpu_seconds_total{mode="idle"}',
         'container_cpu_usage_seconds_total{container!="",container!="POD"}',
         'container_memory_working_set_bytes{container!="",container!="POD"}',
+        # GPU allocation metrics — pod requests + node capacity for nvidia/amd
+        # GPUs. Enables cluster-wide % allocated computations.
+        'kube_pod_container_resource_requests{resource=~"nvidia.com/gpu|amd.com/gpu"}',  # pylint: disable=line-too-long
+        'kube_node_status_allocatable{resource=~"nvidia.com/gpu|amd.com/gpu"}',
     ]
 
     # TODO(rohan): don't hardcode the namespace and service name

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -515,8 +515,12 @@ async def get_metrics_for_context(context: str) -> str:
         'container_memory_working_set_bytes{container!="",container!="POD"}',
         # GPU allocation metrics — pod requests + node capacity for nvidia/amd
         # GPUs. Enables cluster-wide % allocated computations.
-        'kube_pod_container_resource_requests{resource=~"nvidia.com/gpu|amd.com/gpu"}',  # pylint: disable=line-too-long
-        'kube_node_status_allocatable{resource=~"nvidia.com/gpu|amd.com/gpu"}',
+        # NOTE: kube-state-metrics sanitizes resource names by replacing
+        # `.` and `/` with `_`, so the label value is `nvidia_com_gpu` (not
+        # `nvidia.com/gpu`). Getting this wrong causes the match to return 0
+        # series while the scrape still succeeds.
+        'kube_pod_container_resource_requests{resource=~"nvidia_com_gpu|amd_com_gpu"}',  # pylint: disable=line-too-long
+        'kube_node_status_allocatable{resource=~"nvidia_com_gpu|amd_com_gpu"}',
     ]
 
     # TODO(rohan): don't hardcode the namespace and service name


### PR DESCRIPTION
## Summary

Adds a fleet-level Grafana dashboard (`skypilot-compute-overview` UID, title "SkyPilot History") for tracking GPU utilization and allocation across clusters, plus power and temperature KPIs. The dashboard is shipped as a Helm-templated `ConfigMap` so it's picked up by Grafana's sidecar.

Five panels:

- **GPU Utilization gauge** — `avg(DCGM_FI_DEV_GPU_UTIL{cluster=~"$cluster"})`, gauge calc averages over the selected range
- **GPU Allocation gauge** — `sum(max by (cluster, namespace, pod, container) (kube_pod_container_resource_requests{resource="nvidia_com_gpu", cluster=~"$cluster"})) / sum(max by (cluster, node) (kube_node_status_allocatable{resource="nvidia_com_gpu", cluster=~"$cluster"})) * 100`
  - The `max by` deduplication guards against duplicate kube-state-metrics scrape targets (e.g. when both an old and new KSM are running)
  - Uses KSM-sanitized label `nvidia_com_gpu` (KSM strips the dot+slash from `nvidia.com/gpu`)
- **Allocation & Utilization timeseries** — both metrics on a shared 0–100% axis
- **Power Draw stat** — `sum(DCGM_FI_DEV_POWER_USAGE{cluster=~"$cluster"}) / 1000` (kW)
- **Temperature stat** — `avg(DCGM_FI_DEV_GPU_TEMP{cluster=~"$cluster"})`, thresholds at 65 °C and 75 °C

The dashboard exposes:
- A `datasource` template var so it works against any Prometheus datasource UID
- A hidden `cluster` template var (textbox, regex `.*`) so external pages can scope via `var-cluster=<name>` in the URL

Thresholds on both gauges: 0–30 red, 30–50 amber, 50–100 green — higher is better (indicates the fleet is being utilized/allocated).

## Test plan

- [x] `helm template` renders the ConfigMap
- [x] Dashboard JSON passes `python3 -m json.tool` validation
- [x] Dashboard loads in Grafana with all five panels, threshold arcs, and dual-line timeseries
- [x] `cluster=~"$cluster"` regex correctly scopes when `var-cluster=<name>` is supplied via URL, and matches everything when unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)