### PR TITLE
[SSH] Enable hostPID on nvidia-device-plugin DaemonSet

### DIFF
--- a/sky/ssh_node_pools/deploy/deploy.py
+++ b/sky/ssh_node_pools/deploy/deploy.py
@@ -934,7 +934,8 @@ def deploy_single_cluster(cluster_name,
             --set 'toolkit.env[2].name=CONTAINERD_RUNTIME_CLASS' \\
             --set 'toolkit.env[2].value=nvidia' \\
             --set 'devicePlugin.env[0].name=DP_DISABLE_HEALTHCHECKS' \\
-            --set 'devicePlugin.env[0].value=all' &&
+            --set 'devicePlugin.env[0].value=all' \\
+            --set 'devicePlugin.enableHostPID=true' &&
             echo 'Waiting for GPU operator installation...' &&
             while ! kubectl describe nodes --kubeconfig ~/.kube/config | grep -q 'nvidia.com/gpu:' || ! kubectl describe nodes --kubeconfig ~/.kube/config | grep -q 'nvidia.com/gpu.product'; do
                 echo 'Waiting for GPU operator...'


### PR DESCRIPTION
## Summary

\`sky ssh up\` installs the NVIDIA GPU Operator chart and sets a few helm values for K3s containerd paths + device-plugin healthchecks. This PR adds one more: \`devicePlugin.enableHostPID=true\`.

By default the chart leaves the device-plugin pod in its own PID namespace. With \`hostPID: true\` the pod can observe host-side GPU process state, which is needed for downstream tooling that walks host PIDs from inside the device-plugin container (per-process GPU attribution, MIG-sub-instance hooks, etc.).

## Test plan

- [x] Diff is one helm flag; no logic change.
- [ ] On next \`sky ssh up\` against a fresh GPU pool, verify:
  - \`kubectl get ds nvidia-device-plugin-daemonset -n gpu-operator -o jsonpath='{.spec.template.spec.hostPID}'\` returns \`true\`.
  - GPU resources still register: \`kubectl get nodes -o custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\\.com/gpu\` shows non-zero.
  - A \`sky launch --gpus H100:1\` lands and runs as before.

## Behavior on existing clusters

This only affects future \`sky ssh up\` runs. Operators with existing pools who want this can \`helm upgrade gpu-operator -n gpu-operator nvidia/gpu-operator --reuse-values --set devicePlugin.enableHostPID=true\`. That triggers a rolling restart of the device-plugin DaemonSet (one node at a time). Running GPU workloads are unaffected — kubelet doesn't recall device allocations when the device-plugin restarts; only new GPU pod scheduling stalls briefly (~10-30s) on whichever node is currently rolling.