### PR TITLE
[Dashboard] Add jobs.detail.logs and jobs.detail.controllerlogs plugin slots

### DIFF
--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -60,6 +60,7 @@ import { UserDisplay } from '@/components/elements/UserDisplay';
 import { YamlHighlighter } from '@/components/YamlHighlighter';
 import dashboardCache from '@/lib/cache';
 import { PluginSlot } from '@/plugins/PluginSlot';
+import { usePluginComponents } from '@/plugins/PluginProvider';
 import { checkGrafanaAvailability } from '@/utils/grafana';
 import { TelemetrySection } from '@/components/TelemetrySection';
 import { hasAccelerator } from '@/utils/gpuUtils';
@@ -1010,6 +1011,17 @@ function JobDetailsContent({
     console.error('Error streaming controller logs:', error);
   }, []);
 
+  // If a plugin registers a component for the logs slot, it owns the
+  // entire log panel (its own streamer, its own rendering). Skip the
+  // OSS streamer to avoid double-fetching.
+  const logsSlotPluginComponents = usePluginComponents('jobs.detail.logs');
+  const controllerLogsSlotPluginComponents = usePluginComponents(
+    'jobs.detail.controllerlogs'
+  );
+  const logsSlotOverridden = logsSlotPluginComponents.length > 0;
+  const controllerLogsSlotOverridden =
+    controllerLogsSlotPluginComponents.length > 0;
+
   const {
     lines: logs,
     isLoading: streamingLogsLoading,
@@ -1017,7 +1029,11 @@ function JobDetailsContent({
   } = useLogStreamer({
     streamFn: streamManagedJobLogs,
     streamArgs: logStreamArgs,
-    enabled: activeTab === 'logs' && !isPending && !isRecovering,
+    enabled:
+      activeTab === 'logs' &&
+      !isPending &&
+      !isRecovering &&
+      !logsSlotOverridden,
     refreshTrigger: activeTab === 'logs' ? refreshFlag : 0,
     onError: handleLogsError,
   });
@@ -1029,7 +1045,10 @@ function JobDetailsContent({
   } = useLogStreamer({
     streamFn: streamManagedJobLogs,
     streamArgs: controllerStreamArgs,
-    enabled: activeTab === 'controllerlogs' && !isPreStart,
+    enabled:
+      activeTab === 'controllerlogs' &&
+      !isPreStart &&
+      !controllerLogsSlotOverridden,
     refreshTrigger: activeTab === 'controllerlogs' ? refreshFlag : 0,
     onError: handleControllerLogsError,
   });
@@ -1137,7 +1156,7 @@ function JobDetailsContent({
   }, [activeTab, logs, controllerLogs, scrollToBottom]);
 
   if (activeTab === 'logs') {
-    return (
+    const defaultLogsContent = (
       <div className="max-h-96 overflow-y-auto" ref={logsContainerRef}>
         {isPending ? (
           <div className="bg-[#f7f7f7] flex items-center justify-center py-4 text-gray-500">
@@ -1158,10 +1177,28 @@ function JobDetailsContent({
         )}
       </div>
     );
+    // Plugin override: a registered plugin component owns the entire log
+    // panel (its own streamer, its own rendering). We pass enough context
+    // (jobId, taskId, status) for the plugin to drive `/jobs/logs` itself.
+    return (
+      <PluginSlot
+        name="jobs.detail.logs"
+        context={{
+          jobId: jobData.id,
+          taskId: selectedTaskIndex,
+          status: jobData.status,
+          isPending,
+          isRecovering,
+          selectedNode,
+          isController: false,
+        }}
+        fallback={defaultLogsContent}
+      />
+    );
   }
 
   if (activeTab === 'controllerlogs') {
-    return (
+    const defaultControllerLogsContent = (
       <div
         className="max-h-96 overflow-y-auto"
         ref={controllerLogsContainerRef}
@@ -1184,6 +1221,18 @@ function JobDetailsContent({
           <LogFilter logs={controllerLogs} controller={true} />
         )}
       </div>
+    );
+    return (
+      <PluginSlot
+        name="jobs.detail.controllerlogs"
+        context={{
+          jobId: jobData.id,
+          status: jobData.status,
+          isPreStart,
+          isController: true,
+        }}
+        fallback={defaultControllerLogsContent}
+      />
     );
   }
 


### PR DESCRIPTION
## Summary

Wrap the job detail page's Logs and Controller Logs panels in `PluginSlot` so a plugin can fully replace the default `LogFilter`-based rendering with a custom log viewer (e.g. one that does live tailing, filters by level, supports search, etc.).

When no plugin is registered, the existing rendering runs unchanged via the slot's `fallback` — default behaviour is unchanged for OSS users.

Also gates the OSS `useLogStreamer` with `usePluginComponents` so a plugin override doesn't pay for a redundant fetch.

## Diff

`+53 / -4` in `sky/dashboard/src/pages/jobs/[job].js`. Two slots added:

```jsx
<PluginSlot
  name="jobs.detail.logs"
  context={{ jobId, taskId, status, isPending, isRecovering, selectedNode, isController: false }}
  fallback={defaultLogsContent}
/>

<PluginSlot
  name="jobs.detail.controllerlogs"
  context={{ jobId, status, isPreStart, isController: true }}
  fallback={defaultControllerLogsContent}
/>
```

The slot context exposes everything a plugin needs to drive its own streamer: the job id, task id, status (so the plugin can decide whether to live-tail), and the existing pending/recovering gating flags so the plugin can mirror the OSS waiting messages when appropriate.

## Test plan

- [ ] OSS users with no registered plugin: log panels render exactly as today (`LogFilter` with the existing `useLogStreamer` flow)
- [ ] A test plugin that registers a component into `jobs.detail.logs` replaces the entire panel and `useLogStreamer` does not fire
- [ ] Same for `jobs.detail.controllerlogs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)