### PR TITLE
[CLI] Display autostop in hours when minutes divisible by 60

### DIFF
--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -108,7 +108,11 @@ const formatAutostop = (autostop, toDown) => {
   let separation = '';
 
   if (autostop >= 0) {
-    autostopStr = autostop + 'm';
+    if (autostop > 0 && autostop % 60 === 0) {
+      autostopStr = autostop / 60 + 'h';
+    } else {
+      autostopStr = autostop + 'm';
+    }
     separation = ' ';
   }
 

--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -20,6 +20,7 @@ import {
   REFRESH_INTERVAL,
   TimestampWithTooltip,
   LastUpdatedTimestamp,
+  formatAutostop,
 } from '@/components/utils';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
@@ -101,31 +102,6 @@ const PROPERTY_OPTIONS = [
     value: 'labels',
   },
 ];
-
-// Helper function to format autostop information, similar to _get_autostop in CLI utils
-const formatAutostop = (autostop, toDown) => {
-  let autostopStr = '';
-  let separation = '';
-
-  if (autostop >= 0) {
-    if (autostop > 0 && autostop % 60 === 0) {
-      autostopStr = autostop / 60 + 'h';
-    } else {
-      autostopStr = autostop + 'm';
-    }
-    separation = ' ';
-  }
-
-  if (toDown) {
-    autostopStr += `${separation}(down)`;
-  }
-
-  if (autostopStr === '') {
-    autostopStr = '-';
-  }
-
-  return autostopStr;
-};
 
 // Helper function to format username for display (reuse from users.jsx)
 const formatUserDisplay = (username, userId) => {

--- a/sky/dashboard/src/components/utils.jsx
+++ b/sky/dashboard/src/components/utils.jsx
@@ -262,6 +262,33 @@ export const LastUpdatedTimestamp = ({ timestamp, className = '' }) => {
   );
 };
 
+// Helper function to format autostop information, similar to _get_autostop in
+// CLI utils. Renders the idle time as `Nh` when the value is a positive
+// multiple of 60 minutes; otherwise as `Nm`.
+export function formatAutostop(autostop, toDown) {
+  let autostopStr = '';
+  let separation = '';
+
+  if (autostop >= 0) {
+    if (autostop > 0 && autostop % 60 === 0) {
+      autostopStr = `${autostop / 60}h`;
+    } else {
+      autostopStr = `${autostop}m`;
+    }
+    separation = ' ';
+  }
+
+  if (toDown) {
+    autostopStr += `${separation}(down)`;
+  }
+
+  if (autostopStr === '') {
+    autostopStr = '-';
+  }
+
+  return autostopStr;
+}
+
 // Format duration from seconds to a readable format
 export function formatDuration(durationInSeconds) {
   if (!durationInSeconds && durationInSeconds !== 0) return '-';

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -56,7 +56,11 @@ const formatAutostop = (autostop, toDown) => {
   let separation = '';
 
   if (autostop >= 0) {
-    autostopStr = autostop + 'm';
+    if (autostop > 0 && autostop % 60 === 0) {
+      autostopStr = autostop / 60 + 'h';
+    } else {
+      autostopStr = autostop + 'm';
+    }
     separation = ' ';
   }
 

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -25,6 +25,7 @@ import {
   CustomTooltip as Tooltip,
   NonCapitalizedTooltip,
   formatFullTimestamp,
+  formatAutostop,
   LogFilter,
 } from '@/components/utils';
 import { checkGrafanaAvailability } from '@/utils/grafana';
@@ -49,31 +50,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-
-// Helper function to format autostop information, similar to _get_autostop in CLI utils
-const formatAutostop = (autostop, toDown) => {
-  let autostopStr = '';
-  let separation = '';
-
-  if (autostop >= 0) {
-    if (autostop > 0 && autostop % 60 === 0) {
-      autostopStr = autostop / 60 + 'h';
-    } else {
-      autostopStr = autostop + 'm';
-    }
-    separation = ' ';
-  }
-
-  if (toDown) {
-    autostopStr += `${separation}(down)`;
-  }
-
-  if (autostopStr === '') {
-    autostopStr = '-';
-  }
-
-  return autostopStr;
-};
 
 function ClusterDetails() {
   const router = useRouter();

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -203,8 +203,12 @@ def show_cost_report_table(cluster_records: List[_ClusterCostReportRecord],
             autostop = controller_record.get('autostop', None)
             autostop_str = ''
             if autostop is not None:
+                if autostop > 0 and autostop % 60 == 0:
+                    idle_str = f'{autostop // 60}h'
+                else:
+                    idle_str = f'{autostop}min'
                 autostop_str = (f'{colorama.Style.DIM} (will be autostopped if '
-                                f'idle for {autostop}min)'
+                                f'idle for {idle_str})'
                                 f'{colorama.Style.RESET_ALL}')
             click.echo(f'\n{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
                        f'{controller_name}{colorama.Style.RESET_ALL}'

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -315,7 +315,11 @@ def _get_autostop(cluster_record: _ClusterRecord, truncate: bool = True) -> str:
     separation = ''
     if cluster_record['autostop'] >= 0:
         # TODO(zhwu): check the status of the autostop cluster.
-        autostop_str = str(cluster_record['autostop']) + 'm'
+        autostop_minutes = cluster_record['autostop']
+        if autostop_minutes > 0 and autostop_minutes % 60 == 0:
+            autostop_str = f'{autostop_minutes // 60}h'
+        else:
+            autostop_str = f'{autostop_minutes}m'
         separation = ' '
 
     if cluster_record['to_down']:

--- a/tests/unit_tests/test_sky/utils/test_cli_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_cli_utils.py
@@ -205,21 +205,33 @@ def test_get_command():
 def test_get_autostop():
     """Test autostop display in status table."""
     mock_record = {
-        'autostop': 300,  # 5 minutes
+        'autostop': 300,  # multiple of 60 minutes -> rendered in hours
         'to_down': False,
     }
 
-    # Test normal autostop
+    # Multiples of 60 minutes are rendered in hours.
     autostop_str = status_utils._get_autostop(mock_record)
-    assert autostop_str == '300m'
+    assert autostop_str == '5h'
 
-    # Test autostop with to_down
+    # Hours rendering is preserved with to_down.
     mock_record['to_down'] = True
     autostop_str = status_utils._get_autostop(mock_record)
-    assert autostop_str == '300m (down)'
+    assert autostop_str == '5h (down)'
+
+    # Non-multiples of 60 stay in minutes.
+    mock_record['autostop'] = 90
+    mock_record['to_down'] = False
+    autostop_str = status_utils._get_autostop(mock_record)
+    assert autostop_str == '90m'
+
+    # 0 stays in minutes (immediate autostop).
+    mock_record['autostop'] = 0
+    autostop_str = status_utils._get_autostop(mock_record)
+    assert autostop_str == '0m'
 
     # Test no autostop
     mock_record['autostop'] = -1
+    mock_record['to_down'] = True
     autostop_str = status_utils._get_autostop(mock_record)
     assert autostop_str == '(down)'
 


### PR DESCRIPTION
## Summary
- Render the autostop column as `Nh` (e.g. `1h`, `2h`) when the configured idle time is a positive multiple of 60 minutes; otherwise keep `Nm`.
- Updated three surfaces so they stay consistent: the CLI `sky status` table, the dashboard clusters table, and the dashboard cluster detail page.
- `0` stays as `0m` (immediate autostop) and the `(down)` marker is preserved.

## Test plan
- [x] `sky status` on a cluster with `--idle-minutes-to-autostop 60` shows `1h` (and `1h (down)` when used with `--down`).
- [x] `sky status` on a cluster with `--idle-minutes-to-autostop 90` still shows `90m`.
- [x] `sky status` on a cluster with `--idle-minutes-to-autostop 0` still shows `0m`.
- [x] Dashboard `/clusters` table renders the same values for the autostop column.
- [x] Dashboard cluster detail page renders the same value in the autostop field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)