### PR TITLE
[Chart] Persist the whole sky_logs dir

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -295,14 +295,11 @@ spec:
         - name: state-volume
           mountPath: /root/.ssh # To preserve the SSH keys for the user when using the API server
           subPath: .ssh
-        # Mount only the specific subdirectories needed for managed job logs, not the entire sky_logs folder
-        # This avoids persisting transient cluster logs (sky-*) and api_server logs
+        # Mount the entire sky_logs folder because the request
+        # logs have been moved out of this directory
         - name: state-volume
-          mountPath: /root/sky_logs/jobs_controller # Controller logs for `sky jobs logs --controller`
-          subPath: sky_logs/jobs_controller
-        - name: state-volume
-          mountPath: /root/sky_logs/managed_jobs # Task execution logs for managed jobs
-          subPath: sky_logs/managed_jobs
+          mountPath: /root/sky_logs
+          subPath: sky_logs
         {{- end }}
         - name: skypilot-config
           mountPath: /var/skypilot/config

--- a/charts/skypilot/tests/deployment_test.yaml
+++ b/charts/skypilot/tests/deployment_test.yaml
@@ -329,9 +329,15 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: state-volume
+            mountPath: /root/sky_logs
+            subPath: sky_logs
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: state-volume
             mountPath: /root/sky_logs/jobs_controller
             subPath: sky_logs/jobs_controller
-      - contains:
+      - notContains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: state-volume
@@ -354,6 +360,12 @@ tests:
             name: state-volume
             mountPath: /root/sky_logs/managed_jobs
             subPath: sky_logs/managed_jobs
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: state-volume
+            mountPath: /root/sky_logs
+            subPath: sky_logs
 
   - it: should honor fullnameOverride for deployment names and labels
     set:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Persist the whole sky_logs dir, since we have moved the request logs out of it.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Fresh helm installation, `sky_logs` dir is persisted `/dev/sdd        9.8G  1.7M  9.8G   1% /root/sky_logs`
  - Upgrade from previous installation, `sky_logs` dir is persisted, and the logs in `sky_logs/managed_jobs` `sky_logs/jobs_controller` are preserved after upgrade
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
