### PR TITLE
[Docs] Add new badge for Batch Inference sidebar entry

### DIFF
--- a/docs/source/_static/custom.js
+++ b/docs/source/_static/custom.js
@@ -37,7 +37,6 @@ document.addEventListener('DOMContentLoaded', () => {
         { selector: '.toctree-l2 > a', text: 'HTTPS Encryption' },
         { selector: '.toctree-l2 > a', text: 'Upgrading API Server' },
         { selector: '.toctree-l1 > a', text: 'Using a Pool of Workers' },
-        { selector: '.toctree-l1 > a', text: 'Sky Batch' },
         { selector: '.toctree-l1 > a', text: 'Batch Inference' },
         { selector: '.toctree-l1 > a', text: 'Job Groups' },
         { selector: '.toctree-l1 > a', text: 'Using Slurm' },

--- a/docs/source/_static/custom.js
+++ b/docs/source/_static/custom.js
@@ -38,6 +38,7 @@ document.addEventListener('DOMContentLoaded', () => {
         { selector: '.toctree-l2 > a', text: 'Upgrading API Server' },
         { selector: '.toctree-l1 > a', text: 'Using a Pool of Workers' },
         { selector: '.toctree-l1 > a', text: 'Sky Batch' },
+        { selector: '.toctree-l1 > a', text: 'Batch Inference' },
         { selector: '.toctree-l1 > a', text: 'Job Groups' },
         { selector: '.toctree-l1 > a', text: 'Using Slurm' },
         { selector: '.toctree-l1 > a', text: 'SkyPilot Recipes' },


### PR DESCRIPTION
## Summary

- Tag the **Batch Inference** sidebar link (`examples/batch/index.html`) with the `new-item` badge in `docs/source/_static/custom.js`.

## Test plan

- [ ] Build docs and confirm the "Batch Inference" entry under the Jobs section in the sidebar shows the "new" badge.
- [ ] `/build-docs` ReadTheDocs preview renders the badge on https://docs.skypilot.co/en/docs-batch-inference-new-badge/examples/batch/index.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)