### PR TITLE
[Core] Add load_context for plugins

### DIFF
--- a/sky/jobs/constants.py
+++ b/sky/jobs/constants.py
@@ -72,4 +72,4 @@ JOBS_CLUSTER_NAME_PREFIX_LENGTH = 25
 # job.utils.ManagedJobCodeGen to handle the version update.
 # WARNING: If you update this due to a codegen change, make sure to make the
 # corresponding change in the ManagedJobsService AND bump the SKYLET_VERSION.
-MANAGED_JOBS_VERSION = 19  # add cancel_managed_jobs dispatcher
+MANAGED_JOBS_VERSION = 20  # codegen plugin loader passes PluginContext

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -2389,7 +2389,8 @@ async def main(controller_uuid: str):
 
     context_utils.hijack_sys_attrs()
 
-    plugins.load_plugins(plugins.ExtensionContext())
+    plugins.load_plugins(
+        plugins.ExtensionContext(context=plugins.PluginContext.CONTROLLER))
 
     controller = ControllerManager(controller_uuid)
 

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -2791,11 +2791,18 @@ class ManagedJobCodeGen:
         managed_job_version = managed_job_constants.MANAGED_JOBS_VERSION
 
         # Plugins are only loaded for managed jobs version 13 and above.
-        if managed_job_version >= 13:
+        # Context-aware loading (PluginContext) was introduced in version 20.
+        if managed_job_version >= 20:
             from sky import sky_logging as _sky_logging
             from sky.server import plugins
             # Suppress logging during plugin loading to prevent installation
             # logs from leaking into codegen output.
+            with _sky_logging.silent():
+                plugins.load_plugins(plugins.ExtensionContext(
+                    context=plugins.PluginContext.CONTROLLER))
+        elif managed_job_version >= 13:
+            from sky import sky_logging as _sky_logging
+            from sky.server import plugins
             with _sky_logging.silent():
                 plugins.load_plugins(plugins.ExtensionContext())
         """)

--- a/sky/server/plugins.py
+++ b/sky/server/plugins.py
@@ -119,7 +119,7 @@ class ExtensionContext:
     def __init__(
         self,
         # Default exists for backward compatibility.
-        context: PluginContext = PluginContext.MAIN,
+        context: PluginContext = PluginContext.UVICORN,
         app: Optional[FastAPI] = None,
     ):
         self.context = context

--- a/sky/server/plugins.py
+++ b/sky/server/plugins.py
@@ -222,13 +222,7 @@ class BasePlugin(abc.ABC):
     """Base class for all SkyPilot server plugins."""
 
     # Process contexts in which this plugin should be loaded. Defaults to all
-    # known contexts so existing plugins keep loading everywhere. Override in
-    # subclasses to restrict, e.g. to skip the controller process:
-    #
-    #     class CredentialsPlugin(BasePlugin):
-    #         load_contexts = frozenset({
-    #             PluginContext.API_SERVER, PluginContext.EXECUTOR,
-    #         })
+    # known contexts so existing plugins keep loading everywhere.
     load_contexts: ClassVar[FrozenSet[PluginContext]] = ALL_PLUGIN_CONTEXTS
 
     @classmethod

--- a/sky/server/plugins.py
+++ b/sky/server/plugins.py
@@ -46,7 +46,7 @@ class PluginContext(enum.Enum):
     # The API server's main process (the entrypoint that runs bootstrap:
     # DB init, request reset, RBAC pre-load, then uvicorn.run). No FastAPI
     # ``app`` is exposed here. Use this for plugins that need to register
-    # backends BEFORE main-process bootstrap consumes them (e.g. HAPlugin).
+    # backends BEFORE main-process bootstrap consumes them.
     MAIN = 'main'
     # A uvicorn worker process (or the main process when uvicorn runs
     # in-process with ``--deploy=false`` / single worker, on the second

--- a/sky/server/plugins.py
+++ b/sky/server/plugins.py
@@ -1,10 +1,11 @@
 """Load plugins for the SkyPilot API server."""
 import abc
 import dataclasses
+import enum
 import importlib
 import os
 import typing
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, ClassVar, Dict, FrozenSet, List, Optional, Tuple
 
 from fastapi import FastAPI
 
@@ -33,6 +34,29 @@ _PLUGINS_CONFIG_ENV_VAR = (
     f'{skylet_constants.SKYPILOT_SERVER_ENV_VAR_PREFIX}PLUGINS_CONFIG')
 _REMOTE_PLUGINS_CONFIG_ENV_VAR = (
     f'{skylet_constants.SKYPILOT_SERVER_ENV_VAR_PREFIX}REMOTE_PLUGINS_CONFIG')
+
+
+class PluginContext(enum.Enum):
+    """The process context in which plugins are being loaded.
+
+    Used by plugins to declare via ``BasePlugin.load_contexts`` which process
+    types they want to be installed in. Plugins that don't override
+    ``load_contexts`` load in every context (backward compatible).
+    """
+    # The API server process (both the main process and uvicorn workers).
+    # Plugins can branch on ``ExtensionContext.app`` to distinguish whether
+    # they are running where the FastAPI app is available.
+    API_SERVER = 'api_server'
+    # A request executor worker subprocess that runs sky API request bodies.
+    EXECUTOR = 'executor'
+    # A jobs/serve controller process, including the codegen prefix that runs
+    # on the remote managed-jobs controller cluster.
+    CONTROLLER = 'controller'
+
+
+# All known contexts. Used as the default for ``BasePlugin.load_contexts`` so
+# that plugins which don't opt in stay loaded in every context.
+ALL_PLUGIN_CONTEXTS: FrozenSet[PluginContext] = frozenset(PluginContext)
 
 
 class ManagedSecretsProvider(abc.ABC):
@@ -86,7 +110,8 @@ class ExtensionContext:
         ]
     """
 
-    def __init__(self, app: Optional[FastAPI] = None):
+    def __init__(self, context: PluginContext, app: Optional[FastAPI] = None):
+        self.context = context
         self.app = app
         self.rbac_rules: List[Tuple[str, RBACRule]] = []
         self._managed_secrets_provider: Optional[ManagedSecretsProvider] = None
@@ -190,6 +215,21 @@ class RBACRule:
 
 class BasePlugin(abc.ABC):
     """Base class for all SkyPilot server plugins."""
+
+    # Process contexts in which this plugin should be loaded. Defaults to all
+    # known contexts so existing plugins keep loading everywhere. Override in
+    # subclasses to restrict, e.g. to skip the controller process:
+    #
+    #     class CredentialsPlugin(BasePlugin):
+    #         load_contexts = frozenset({
+    #             PluginContext.API_SERVER, PluginContext.EXECUTOR,
+    #         })
+    load_contexts: ClassVar[FrozenSet[PluginContext]] = ALL_PLUGIN_CONTEXTS
+
+    @classmethod
+    def should_load(cls, context: PluginContext) -> bool:
+        """Return whether this plugin should be loaded in the given context."""
+        return context in cls.load_contexts
 
     @property
     def name(self) -> Optional[str]:
@@ -453,6 +493,10 @@ def load_plugins(extension_context: ExtensionContext):
         if not issubclass(plugin_cls, BasePlugin):
             raise TypeError(
                 f'Plugin {class_path} must inherit from BasePlugin.')
+        if not plugin_cls.should_load(extension_context.context):
+            logger.debug(f'Skipping plugin {class_path}: not enabled for '
+                         f'context {extension_context.context.value}')
+            continue
         parameters = plugin_config.get('parameters') or {}
         plugin = plugin_cls(**parameters)
         plugin.install(extension_context)
@@ -495,6 +539,10 @@ def load_plugin_rbac_rules() -> Dict[str, List[Dict[str, str]]]:
             module = importlib.import_module(module_path)
             plugin_cls = getattr(module, class_name)
             if not issubclass(plugin_cls, BasePlugin):
+                continue
+            # RBAC is an API-server concern; skip plugins that don't load
+            # there, even if they declare rbac_rules.
+            if not plugin_cls.should_load(PluginContext.API_SERVER):
                 continue
             parameters = plugin_config.get('parameters') or {}
             plugin = plugin_cls(**parameters)

--- a/sky/server/plugins.py
+++ b/sky/server/plugins.py
@@ -43,10 +43,16 @@ class PluginContext(enum.Enum):
     types they want to be installed in. Plugins that don't override
     ``load_contexts`` load in every context (backward compatible).
     """
-    # The API server process (both the main process and uvicorn workers).
-    # Plugins can branch on ``ExtensionContext.app`` to distinguish whether
-    # they are running where the FastAPI app is available.
-    API_SERVER = 'api_server'
+    # The API server's main process (the entrypoint that runs bootstrap:
+    # DB init, request reset, RBAC pre-load, then uvicorn.run). No FastAPI
+    # ``app`` is exposed here. Use this for plugins that need to register
+    # backends BEFORE main-process bootstrap consumes them (e.g. HAPlugin).
+    MAIN = 'main'
+    # A uvicorn worker process (or the main process when uvicorn runs
+    # in-process with ``--deploy=false`` / single worker, on the second
+    # plugin load). Has the FastAPI ``app`` available; use this for
+    # registering routes / middleware.
+    UVICORN = 'uvicorn'
     # A request executor worker subprocess that runs sky API request bodies.
     EXECUTOR = 'executor'
     # A jobs/serve controller process, including the codegen prefix that runs
@@ -113,7 +119,7 @@ class ExtensionContext:
     def __init__(
         self,
         # Default exists for backward compatibility.
-        context: PluginContext = PluginContext.API_SERVER,
+        context: PluginContext = PluginContext.MAIN,
         app: Optional[FastAPI] = None,
     ):
         self.context = context
@@ -540,8 +546,9 @@ def load_plugin_rbac_rules() -> Dict[str, List[Dict[str, str]]]:
             if not issubclass(plugin_cls, BasePlugin):
                 continue
             # RBAC is an API-server concern; skip plugins that don't load
-            # there, even if they declare rbac_rules.
-            if not plugin_cls.should_load(PluginContext.API_SERVER):
+            # in either API-server context, even if they declare rbac_rules.
+            if not (plugin_cls.should_load(PluginContext.MAIN) or
+                    plugin_cls.should_load(PluginContext.UVICORN)):
                 continue
             parameters = plugin_config.get('parameters') or {}
             plugin = plugin_cls(**parameters)

--- a/sky/server/plugins.py
+++ b/sky/server/plugins.py
@@ -110,7 +110,12 @@ class ExtensionContext:
         ]
     """
 
-    def __init__(self, context: PluginContext, app: Optional[FastAPI] = None):
+    def __init__(
+        self,
+        # Default exists for backward compatibility.
+        context: PluginContext = PluginContext.API_SERVER,
+        app: Optional[FastAPI] = None,
+    ):
         self.context = context
         self.app = app
         self.rbac_rules: List[Tuple[str, RBACRule]] = []

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -159,7 +159,8 @@ def executor_initializer(proc_group: str):
     setproctitle.setproctitle(f'SkyPilot:executor:{proc_group}:'
                               f'{multiprocessing.current_process().pid}')
     # Load plugins for executor process.
-    plugins.load_plugins(plugins.ExtensionContext())
+    plugins.load_plugins(
+        plugins.ExtensionContext(context=plugins.PluginContext.EXECUTOR))
     # Executor never stops, unless the whole process is killed.
     threading.Thread(target=metrics_lib.process_monitor,
                      args=(f'worker:{proc_group}', threading.Event()),

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -945,7 +945,9 @@ app.add_middleware(SecurityHeadersMiddleware)
 # TODO(aylei): move uvicorn app out of the top-level module to avoid
 # duplicate app initialization.
 if __name__ == 'sky.server.server':
-    plugins.load_plugins(plugins.ExtensionContext(app=app))
+    plugins.load_plugins(
+        plugins.ExtensionContext(context=plugins.PluginContext.API_SERVER,
+                                 app=app))
 
 app.include_router(jobs_rest.router, prefix='/jobs', tags=['jobs'])
 app.include_router(serve_rest.router, prefix='/serve', tags=['serve'])
@@ -3202,7 +3204,8 @@ if __name__ == '__main__':
     # will also run uvicorn server when num_worker=1 and then the plugins will
     # be installed twice in main process (second time with the uvicorn app).
     # This is okay since plugin install is considered idempotent.
-    plugins.load_plugins(plugins.ExtensionContext())
+    plugins.load_plugins(
+        plugins.ExtensionContext(context=plugins.PluginContext.API_SERVER))
 
     # Show the privacy policy if it is not already shown. We place it here so
     # that it is shown only when the API server is started.

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -946,7 +946,7 @@ app.add_middleware(SecurityHeadersMiddleware)
 # duplicate app initialization.
 if __name__ == 'sky.server.server':
     plugins.load_plugins(
-        plugins.ExtensionContext(context=plugins.PluginContext.API_SERVER,
+        plugins.ExtensionContext(context=plugins.PluginContext.UVICORN,
                                  app=app))
 
 app.include_router(jobs_rest.router, prefix='/jobs', tags=['jobs'])
@@ -3205,7 +3205,7 @@ if __name__ == '__main__':
     # be installed twice in main process (second time with the uvicorn app).
     # This is okay since plugin install is considered idempotent.
     plugins.load_plugins(
-        plugins.ExtensionContext(context=plugins.PluginContext.API_SERVER))
+        plugins.ExtensionContext(context=plugins.PluginContext.MAIN))
 
     # Show the privacy policy if it is not already shown. We place it here so
     # that it is shown only when the API server is started.

--- a/tests/unit_tests/test_sky/server/test_plugins.py
+++ b/tests/unit_tests/test_sky/server/test_plugins.py
@@ -43,7 +43,8 @@ def test_load_plugins_registers_and_installs(monkeypatch, tmp_path):
     monkeypatch.setattr(plugins, '_PLUGINS', {})
 
     app = FastAPI()
-    ctx = plugins.ExtensionContext(app=app)
+    ctx = plugins.ExtensionContext(context=plugins.PluginContext.API_SERVER,
+                                   app=app)
 
     plugins.load_plugins(ctx)
     loaded_plugins = plugins.get_plugins()
@@ -53,6 +54,101 @@ def test_load_plugins_registers_and_installs(monkeypatch, tmp_path):
     assert isinstance(plugin, DummyPlugin)
     assert plugin.value == 42
     assert installed['ctx'] is ctx
+
+
+def test_load_plugins_filters_by_context(monkeypatch, tmp_path):
+    """Plugins are skipped when their load_contexts excludes the current one."""
+    module_name = 'sky_test_context_filtered_plugin'
+    api_calls = {'count': 0}
+    controller_calls = {'count': 0}
+
+    class ApiOnlyPlugin(plugins.BasePlugin):
+        load_contexts = frozenset({plugins.PluginContext.API_SERVER})
+
+        def install(self, extension_context):
+            api_calls['count'] += 1
+
+    class ControllerOnlyPlugin(plugins.BasePlugin):
+        load_contexts = frozenset({plugins.PluginContext.CONTROLLER})
+
+        def install(self, extension_context):
+            controller_calls['count'] += 1
+
+    ApiOnlyPlugin.__module__ = module_name
+    ControllerOnlyPlugin.__module__ = module_name
+    module = types.ModuleType(module_name)
+    module.ApiOnlyPlugin = ApiOnlyPlugin
+    module.ControllerOnlyPlugin = ControllerOnlyPlugin
+    monkeypatch.setitem(sys.modules, module_name, module)
+
+    config = {
+        'plugins': [
+            {
+                'class': f'{module_name}.ApiOnlyPlugin'
+            },
+            {
+                'class': f'{module_name}.ControllerOnlyPlugin'
+            },
+        ],
+    }
+    config_path = tmp_path / 'plugins.yaml'
+    config_path.write_text(yaml.safe_dump(config))
+    monkeypatch.setenv(plugins._PLUGINS_CONFIG_ENV_VAR, str(config_path))
+
+    # API_SERVER context: only ApiOnlyPlugin runs.
+    monkeypatch.setattr(plugins, '_PLUGINS', {})
+    plugins.load_plugins(
+        plugins.ExtensionContext(context=plugins.PluginContext.API_SERVER))
+    assert api_calls['count'] == 1
+    assert controller_calls['count'] == 0
+    loaded = plugins.get_plugins()
+    assert len(loaded) == 1
+    assert isinstance(loaded[0], ApiOnlyPlugin)
+
+    # CONTROLLER context: only ControllerOnlyPlugin runs.
+    monkeypatch.setattr(plugins, '_PLUGINS', {})
+    plugins.load_plugins(
+        plugins.ExtensionContext(context=plugins.PluginContext.CONTROLLER))
+    assert api_calls['count'] == 1
+    assert controller_calls['count'] == 1
+    loaded = plugins.get_plugins()
+    assert len(loaded) == 1
+    assert isinstance(loaded[0], ControllerOnlyPlugin)
+
+    # EXECUTOR context: neither runs (both opted out).
+    monkeypatch.setattr(plugins, '_PLUGINS', {})
+    plugins.load_plugins(
+        plugins.ExtensionContext(context=plugins.PluginContext.EXECUTOR))
+    assert api_calls['count'] == 1
+    assert controller_calls['count'] == 1
+    assert plugins.get_plugins() == []
+
+
+def test_load_plugins_default_loads_in_all_contexts(monkeypatch, tmp_path):
+    """A plugin without load_contexts overridden loads in every context."""
+    module_name = 'sky_test_default_contexts_plugin'
+    install_count = {'count': 0}
+
+    class DefaultPlugin(plugins.BasePlugin):
+
+        def install(self, extension_context):
+            install_count['count'] += 1
+
+    DefaultPlugin.__module__ = module_name
+    module = types.ModuleType(module_name)
+    module.DefaultPlugin = DefaultPlugin
+    monkeypatch.setitem(sys.modules, module_name, module)
+
+    config = {'plugins': [{'class': f'{module_name}.DefaultPlugin'}]}
+    config_path = tmp_path / 'plugins.yaml'
+    config_path.write_text(yaml.safe_dump(config))
+    monkeypatch.setenv(plugins._PLUGINS_CONFIG_ENV_VAR, str(config_path))
+
+    for context in plugins.PluginContext:
+        monkeypatch.setattr(plugins, '_PLUGINS', {})
+        plugins.load_plugins(plugins.ExtensionContext(context=context))
+
+    assert install_count['count'] == len(plugins.PluginContext)
 
 
 def test_server_import_loads_plugins(monkeypatch):

--- a/tests/unit_tests/test_sky/server/test_plugins.py
+++ b/tests/unit_tests/test_sky/server/test_plugins.py
@@ -43,7 +43,7 @@ def test_load_plugins_registers_and_installs(monkeypatch, tmp_path):
     monkeypatch.setattr(plugins, '_PLUGINS', {})
 
     app = FastAPI()
-    ctx = plugins.ExtensionContext(context=plugins.PluginContext.API_SERVER,
+    ctx = plugins.ExtensionContext(context=plugins.PluginContext.UVICORN,
                                    app=app)
 
     plugins.load_plugins(ctx)
@@ -63,7 +63,7 @@ def test_load_plugins_filters_by_context(monkeypatch, tmp_path):
     controller_calls = {'count': 0}
 
     class ApiOnlyPlugin(plugins.BasePlugin):
-        load_contexts = frozenset({plugins.PluginContext.API_SERVER})
+        load_contexts = frozenset({plugins.PluginContext.UVICORN})
 
         def install(self, extension_context):
             api_calls['count'] += 1
@@ -98,7 +98,7 @@ def test_load_plugins_filters_by_context(monkeypatch, tmp_path):
     # API_SERVER context: only ApiOnlyPlugin runs.
     monkeypatch.setattr(plugins, '_PLUGINS', {})
     plugins.load_plugins(
-        plugins.ExtensionContext(context=plugins.PluginContext.API_SERVER))
+        plugins.ExtensionContext(context=plugins.PluginContext.UVICORN))
     assert api_calls['count'] == 1
     assert controller_calls['count'] == 0
     loaded = plugins.get_plugins()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Currently, all the plugins will be loaded in the API server main process, executor workers, jobs controller process, and codegen scripts for the `sky jobs` commands, which is not reasonable since some of them are not necessary for the jobs controller process and the codegen scripts.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
