### PR TITLE
[Core] Pin click<8.3.0 in controller runtime ray install

### DIFF
--- a/sky/catalog/images/provisioners/skypilot.sh
+++ b/sky/catalog/images/provisioners/skypilot.sh
@@ -56,8 +56,10 @@ PYTHON_EXEC=$(echo ~/skypilot-runtime)/bin/python
 $PYTHON_EXEC -m pip install "skypilot-nightly[remote]"
 
 # Install Ray
+# Pin click<8.3.0: click 8.3.0+ breaks Ray CLI due to deepcopy issues with
+# Sentinel values. See https://github.com/ray-project/ray/issues/56747.
 RAY_ADDRESS=127.0.0.1:6380
-$PYTHON_EXEC -m pip install --exists-action w -U "ray[default]==2.9.3"
+$PYTHON_EXEC -m pip install --exists-action w -U "ray[default]==2.9.3" "click<8.3.0"
 export PATH=$PATH:$HOME/.local/bin
 source ~/skypilot-runtime/bin/activate
 which ray > ~/.sky/ray_path || exit 1

--- a/sky/server/plugin_utils.py
+++ b/sky/server/plugin_utils.py
@@ -51,12 +51,17 @@ def _build_guarded_install_script(wheels: List[Tuple[str, str]]) -> str:
         # remote_wheel starts with '~' which must be left unquoted so the
         # shell expands it; the filename portion cannot contain shell
         # metacharacters by PEP 427.
+        # Pin click<8.3.0 alongside the plugin wheel: click 8.3.0+ breaks
+        # Ray CLI via copy.deepcopy on Click's Sentinel values
+        # (https://github.com/ray-project/ray/issues/56747). Plugin wheels
+        # may transitively pull a newer click and silently upgrade it,
+        # which breaks ray on the controller.
         install_blocks.append(f"""\
   if grep -Fxq {q_wheel} "$_sky_stamp"; then
     echo "Plugin wheel {wheel_name} already installed, skipping."
   else
     echo "Installing plugin wheel {wheel_name}..."
-    {constants.SKY_UV_PIP_CMD} install {remote_wheel}
+    {constants.SKY_UV_PIP_CMD} install {remote_wheel} "click<8.3.0"
     _sky_record {q_prefix} {q_wheel}
   fi""")
 

--- a/sky/server/plugin_utils.py
+++ b/sky/server/plugin_utils.py
@@ -51,17 +51,12 @@ def _build_guarded_install_script(wheels: List[Tuple[str, str]]) -> str:
         # remote_wheel starts with '~' which must be left unquoted so the
         # shell expands it; the filename portion cannot contain shell
         # metacharacters by PEP 427.
-        # Pin click<8.3.0 alongside the plugin wheel: click 8.3.0+ breaks
-        # Ray CLI via copy.deepcopy on Click's Sentinel values
-        # (https://github.com/ray-project/ray/issues/56747). Plugin wheels
-        # may transitively pull a newer click and silently upgrade it,
-        # which breaks ray on the controller.
         install_blocks.append(f"""\
   if grep -Fxq {q_wheel} "$_sky_stamp"; then
     echo "Plugin wheel {wheel_name} already installed, skipping."
   else
     echo "Installing plugin wheel {wheel_name}..."
-    {constants.SKY_UV_PIP_CMD} install {remote_wheel} "click<8.3.0"
+    {constants.SKY_UV_PIP_CMD} install {remote_wheel}
     _sky_record {q_prefix} {q_wheel}
   fi""")
 

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -292,7 +292,9 @@ RAY_INSTALLATION_COMMANDS = (
     f'|| {RAY_STATUS} || '
     # The pydantic-core==2.41.3 for arm seems corrupted
     # so we need to avoid that specific version.
-    f'{SKY_UV_PIP_CMD} install -U "ray[default]=={SKY_REMOTE_RAY_VERSION}" "pydantic-core==2.41.1"; '  # pylint: disable=line-too-long
+    # Pin click<8.3.0: click 8.3.0+ breaks Ray CLI due to deepcopy issues
+    # with Sentinel values. See https://github.com/ray-project/ray/issues/56747.
+    f'{SKY_UV_PIP_CMD} install -U "ray[default]=={SKY_REMOTE_RAY_VERSION}" "pydantic-core==2.41.1" "click<8.3.0"; '  # pylint: disable=line-too-long
     # In some envs, e.g. pip does not have permission to write under /opt/conda
     # ray package will be installed under ~/.local/bin. If the user's PATH does
     # not include ~/.local/bin (the pip install will have the output: `WARNING:

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -274,6 +274,13 @@ RAY_INSTALLATION_COMMANDS = (
     # causing the error:
     #   ImportError: cannot import name 'packaging' from 'pkg_resources'"
     f'{SKY_UV_PIP_CMD} install "setuptools<70"; '
+    # Always pin click<8.3.0: click 8.3.0+ breaks Ray CLI due to deepcopy
+    # issues with Sentinel values. We force this even when ray is already
+    # installed (e.g. baked into the SkyPilot AMI), since the ray-version
+    # idempotency guard below would otherwise skip the install and leave
+    # click at whatever the AMI shipped.
+    # See: https://github.com/ray-project/ray/issues/56747
+    f'{SKY_UV_PIP_CMD} install "click<8.3.0"; '
     # Backward compatibility for ray upgrade (#3248): do not upgrade ray if the
     # ray cluster is already running, to avoid the ray cluster being restarted.
     #

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -419,6 +419,11 @@ def _get_cloud_dependencies_installation_commands(
         if sc.lower() in constants.STORAGE_ONLY_CLOUDS:
             python_packages.update(dependencies.extras_require[sc.lower()])
 
+    # Pin click<8.3.0: typer>=0.25.0 requires click>=8.2.1 with no upper
+    # bound, which lets uv resolve click to 8.3.x. click 8.3.0+ breaks Ray
+    # CLI on the controller via copy.deepcopy on Click's Sentinel values.
+    # See https://github.com/ray-project/ray/issues/56747.
+    python_packages.add('click<8.3.0')
     packages_string = ' '.join(
         [f'"{package}"' for package in sorted(python_packages)])
     step_prefix = prefix_str.replace('<step>', str(len(commands) + 1))


### PR DESCRIPTION
## Summary

Cloud-deps install on jobs/serve controller silently upgrades `click` to 8.3.3, breaking Ray 2.9.3's CLI (`add_command_alias` does `copy.deepcopy(command)` which 8.3+ Sentinel objects don't survive — see [ray-project/ray#56747](https://github.com/ray-project/ray/issues/56747)). Symptom: `RuntimeError: Failed to start ray on the head node` → `ValueError: ... is not a valid Sentinel` on every controller, recently observed in:

- quicktest-core [#3054](https://buildkite.com/skypilot-1/quicktest-core/builds/3054) (`test_managed_jobs`)
- smoke-tests [#10079](https://buildkite.com/skypilot-1/smoke-tests/builds/10079) (`test_ignore_exclusions`)
- smoke-tests [#10077](https://buildkite.com/skypilot-1/smoke-tests/builds/10077) — 8 `test_managed_jobs` / `test_pool_*` jobs failing on master AWS

Same code passed on Apr 25 (build 10064); started failing Apr 27. Not a SkyPilot commit regression — PyPI drift.

## Root cause

`sky/utils/controller_utils.py:_get_cloud_dependencies_installation_commands` builds an unconstrained `uv pip install <combined cloud extras>`. With buildkite's enabled clouds (`aws, azure, gcp, lambda, nebius, runpod, slurm, kubernetes, ssh`), the dep graph pulls:

```
runpod → fastapi[all] → fastapi-cli[standard] → fastapi-cloud-cli → typer → click>=8.2.1 (no upper)
```

uv picks the latest click satisfying all constraints — 8.3.3 — bumping click from the 8.1.8 left by `RAY_SKYPILOT_INSTALLATION_COMMANDS`. Any subsequent `ray ...` on the controller then crashes.

Why now: latent since typer 0.23.0 (Feb 11) bumped `click>=8.2.1` (no upper). typer 0.25.0 (Apr 26) and fastapi-cloud-cli 0.17.1 (Apr 27 13:38 UTC, ~5 min after build 10077 started) likely invalidated uv resolution cache and tipped resolution into the bad combination.

## Reproduction (local mac with master)

```bash
uv venv --seed --python 3.10 /tmp/repro && source /tmp/repro/bin/activate
uv pip install "click==8.1.8" "ray[default]==2.9.3"
# baseline: click==8.1.8, ray --version works
uv pip install <buildkite cloud extras: aws+azure+gcp+lambda+nebius+runpod+slurm+kubernetes+ssh>
# result: + typer==0.25.0; click 8.1.8 -> 8.3.3
ray --version
# -> ValueError: ... is not a valid Sentinel  (same traceback as buildkite)
```

With the fix (`click<8.3.0` added to the install): uv backtracks to click 8.2.1 (satisfies typer's `>=8.2.1` and our `<8.3.0`); ray works.

## Changes

- `sky/utils/controller_utils.py` — add `click<8.3.0` to the controller cloud-deps install (the actual buildkite fix)
- `sky/skylet/constants.py:RAY_INSTALLATION_COMMANDS` — pin `click<8.3.0` alongside ray install (defense for fresh controllers without SkyPilot AMI)
- `sky/skylet/constants.py:RAY_INSTALLATION_COMMANDS` — force `uv pip install "click<8.3.0"` *before* the ray-version idempotency guard (defense for AMI-baked / cached state where the ray install would otherwise be skipped)
- `sky/catalog/images/provisioners/skypilot.sh` — pin `click<8.3.0` alongside the ray install in the AMI provisioner so future re-bakes don't ship 8.3.x

## Test plan

- [ ] `/smoke-test -k test_ignore_exclusions` (master AWS) — should pass after fix
- [ ] `/smoke-test -k test_managed_jobs` — should pass
- [ ] `/quicktest-core` — backward-compat tests against PyPI base will still hit the bug since the fix isn't in the released wheel; this is expected until the next release