### PR TITLE
Narrow upload v2 lock

### DIFF
--- a/sky/server/blob/blob_storage.py
+++ b/sky/server/blob/blob_storage.py
@@ -98,6 +98,10 @@ class BlobStorage(abc.ABC):
         """
         return True
 
+    def assemble_on_upload(self) -> bool:
+        """Whether to concatenate chunks into a single zip during upload."""
+        return True
+
     @abc.abstractmethod
     def blobs_dir(self, user_id: str) -> pathlib.Path:
         """Return the base blobs directory for a user."""

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1380,13 +1380,16 @@ async def _receive_and_assemble_chunks(
     chunk_index: int,
     total_chunks: int,
     extract: bool = True,
+    assemble: bool = True,
 ) -> Optional[payloads.UploadZipFileResponse]:
-    """Receive chunks, assemble into a zip file, and extract.
+    """Receive chunks, optionally assemble into a zip file, and extract.
 
     Returns:
         None if the upload is completed,
         A response to tell the client to upload more chunks otherwise.
     """
+    if extract and not assemble:
+        raise ValueError('extract=True requires assemble=True')
     # Field _body would be set if the request body has been received, fail fast
     # to surface potential memory issues, i.e. catch the issue in our smoke
     # test.
@@ -1444,21 +1447,23 @@ async def _receive_and_assemble_chunks(
             return payloads.UploadZipFileResponse(
                 status=responses.UploadStatus.UPLOADING.value,
                 missing_chunks=missing_chunks)
-        zip_file_path = base_dir / f'{zip_name}.zip'
-        async with aiofiles.open(zip_file_path, 'wb') as zip_file:
-            for chunk in range(total_chunks):
-                async with aiofiles.open(chunk_dir / f'part{chunk}', 'rb') as f:
-                    while True:
-                        # Use 64KB buffer to avoid memory overflow, same size
-                        # as shutil.copyfileobj.
-                        data = await f.read(64 * 1024)
-                        if not data:
-                            break
-                        await zip_file.write(data)
+        if assemble:
+            zip_file_path = base_dir / f'{zip_name}.zip'
+            async with aiofiles.open(zip_file_path, 'wb') as zip_file:
+                for chunk in range(total_chunks):
+                    async with aiofiles.open(chunk_dir / f'part{chunk}',
+                                             'rb') as f:
+                        while True:
+                            # Use 64KB buffer to avoid memory overflow, same
+                            # size as shutil.copyfileobj.
+                            data = await f.read(64 * 1024)
+                            if not data:
+                                break
+                            await zip_file.write(data)
     logger.info(f'Uploaded zip file: {zip_file_path}')
     if extract:
         await unzip_file(zip_file_path, base_dir)
-    if total_chunks > 1:
+    if total_chunks > 1 and assemble:
         await asyncio.to_thread(shutil.rmtree, chunk_dir)
     return None
 
@@ -1567,7 +1572,8 @@ async def upload_blob(request: fastapi.Request, user_hash: str, upload_id: str,
             request=request,
             chunk_index=chunk_index,
             total_chunks=total_chunks,
-            extract=storage.extract_on_upload())
+            extract=storage.extract_on_upload(),
+            assemble=storage.assemble_on_upload())
         if result is not None:
             return result
         # Atomic rename of the extracted staging dir to the final

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1409,13 +1409,17 @@ async def _receive_and_assemble_chunks(
         raise ValueError(
             f'Invalid total_chunks: {total_chunks}. Please use a valid integer.'
         )
+    # Write chunk to a unique private path first, so concurrent uploads for
+    # a same blob does not interleave with each other.
     if total_chunks == 1:
         await anyio.Path(base_dir).mkdir(parents=True, exist_ok=True)
-        zip_file_path = base_dir / f'{zip_name}.zip'
+        final_path = base_dir / f'{zip_name}.zip'
+        zip_file_path = base_dir / f'{zip_name}.tmp.{uuid.uuid4().hex}.zip'
     else:
         chunk_dir = base_dir / zip_name
         await anyio.Path(chunk_dir).mkdir(parents=True, exist_ok=True)
-        zip_file_path = chunk_dir / f'part{chunk_index}.incomplete'
+        final_path = chunk_dir / f'part{chunk_index}'
+        zip_file_path = chunk_dir / f'part{chunk_index}.tmp.{uuid.uuid4().hex}'
 
     try:
         async with aiofiles.open(zip_file_path, 'wb') as f:
@@ -1437,11 +1441,22 @@ async def _receive_and_assemble_chunks(
                     f'{common_utils.format_exception(e)}'))
 
     def get_missing_chunks(total_chunks: int) -> Set[str]:
-        return set(f'part{i}' for i in range(total_chunks)) - set(
-            p.name for p in chunk_dir.glob('part*'))
+        existing = set()
+        for p in chunk_dir.glob('part*'):
+            # Filter out tmp files (e.g. ``part0.tmp.<hex>``) that may
+            # belong to in-flight concurrent writers.  Only renamed
+            # final names ``part{N}`` count toward completion.
+            name = p.name
+            suffix = name[len('part'):] if name.startswith('part') else ''
+            if suffix.isdigit():
+                existing.add(name)
+        return set(f'part{i}' for i in range(total_chunks)) - existing
+
+    # Rename the writer-unique tmp file to its final name.
+    os.rename(str(zip_file_path), str(final_path))
+    zip_file_path = final_path
 
     if total_chunks > 1:
-        zip_file_path.rename(zip_file_path.with_suffix(''))
         missing_chunks = get_missing_chunks(total_chunks)
         if missing_chunks:
             return payloads.UploadZipFileResponse(
@@ -1557,27 +1572,26 @@ async def upload_blob(request: fastapi.Request, user_hash: str, upload_id: str,
         return payloads.UploadZipFileResponse(
             status=responses.UploadStatus.COMPLETED.value)
 
+    # Receive the chunk WITHOUT holding the upload lock. Each chunk
+    # is received to a private path first to avoid concurrent uploads
+    # interleave with each other.
+    staging_dir = storage.get_staging_dir(user_id, upload_id)
+    result = await _receive_and_assemble_chunks(
+        base_dir=staging_dir,
+        zip_name='staging',
+        request=request,
+        chunk_index=chunk_index,
+        total_chunks=total_chunks,
+        extract=storage.extract_on_upload(),
+        assemble=storage.assemble_on_upload())
+    if result is not None:
+        return result
+
+    # Atomic publish
     async with storage.acquire_upload_lock(user_id, upload_id):
-        # Re-check after acquiring the lock: another upload may have
-        # completed while we were waiting.
         if target_dir.exists():
             return payloads.UploadZipFileResponse(
                 status=responses.UploadStatus.COMPLETED.value)
-
-        # Receive chunks, assemble, and extract into staging dir.
-        staging_dir = storage.get_staging_dir(user_id, upload_id)
-        result = await _receive_and_assemble_chunks(
-            base_dir=staging_dir,
-            zip_name='staging',
-            request=request,
-            chunk_index=chunk_index,
-            total_chunks=total_chunks,
-            extract=storage.extract_on_upload(),
-            assemble=storage.assemble_on_upload())
-        if result is not None:
-            return result
-        # Atomic rename of the extracted staging dir to the final
-        # directory (same filesystem).
         await storage.store_blob(user_id, upload_id, staging_dir)
         logger.info(f'Uploaded blob: {target_dir}')
     return payloads.UploadZipFileResponse(

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1463,17 +1463,10 @@ async def _receive_and_assemble_chunks(
                 status=responses.UploadStatus.UPLOADING.value,
                 missing_chunks=missing_chunks)
     logger.info(f'Uploaded chunk: {zip_file_path}')
-    # Assemble + extract are not idempotent across concurrent callers
-    # (they mutate shared paths on disk).  Callers that may have
-    # multiple chunks land "all present" simultaneously must serialize
-    # this step with their own lock — see the upload-lock-protected
-    # section in /upload_v2.  ``/upload`` uses a unique upload_id per
-    # request so no contention exists there.
-    if assemble or extract:
+    if assemble:
         await _finalize_chunked_upload(base_dir=base_dir,
                                        zip_name=zip_name,
                                        total_chunks=total_chunks,
-                                       assemble=assemble,
                                        extract=extract)
     return None
 
@@ -1482,21 +1475,10 @@ async def _finalize_chunked_upload(
     base_dir: pathlib.Path,
     zip_name: str,
     total_chunks: int,
-    assemble: bool,
     extract: bool,
 ) -> None:
-    """Assemble parts into a single zip and/or extract it.
-
-    Mutates shared paths under ``base_dir`` (writes ``{zip_name}.zip``,
-    extracts into ``base_dir``, removes the parts dir).  Two callers
-    racing on the same ``(base_dir, zip_name)`` would corrupt the
-    output and waste work, so the caller MUST serialize this — e.g. by
-    holding ``BlobStorage.acquire_upload_lock`` for the upload — and
-    must guarantee all chunks have been received before calling.
-    """
-    if extract and not assemble:
-        raise ValueError('extract=True requires assemble=True')
-    if total_chunks > 1 and assemble:
+    """Assemble parts into a single zip and optionally extract it."""
+    if total_chunks > 1:
         chunk_dir = base_dir / zip_name
         zip_file_path = base_dir / f'{zip_name}.zip'
         async with aiofiles.open(zip_file_path, 'wb') as zip_file:
@@ -1510,15 +1492,12 @@ async def _finalize_chunked_upload(
                             break
                         await zip_file.write(data)
     else:
-        # total_chunks == 1: the chunk body is already at
-        # ``{base_dir}/{zip_name}.zip`` (renamed by the receive step);
-        # for total_chunks > 1 with assemble=False the parts stay as
-        # individual ``part{N}`` files and there is no zip to extract.
+        # ``{base_dir}/{zip_name}.zip`` (renamed by the receive step).
         zip_file_path = base_dir / f'{zip_name}.zip'
 
     if extract:
         await unzip_file(zip_file_path, base_dir)
-    if total_chunks > 1 and assemble:
+    if total_chunks > 1:
         await asyncio.to_thread(shutil.rmtree, base_dir / zip_name)
 
 
@@ -1615,9 +1594,9 @@ async def upload_blob(request: fastapi.Request, user_hash: str, upload_id: str,
     # writes to a writer-unique tmp file, then atomic-renames to its
     # final ``part{N}`` name, so concurrent chunk POSTs (parallel
     # workers, retries, or two clients racing on the same content-
-    # hashed blob_id) don't need lock coordination here.  The
-    # assemble + extract + store_blob steps are not idempotent under
-    # concurrency and are run below under the lock.
+    # hashed blob_id) don't need lock coordination here.
+    # Note that we skip assemble and extract here since cocurrent chunk
+    # uploads will race, and we do finalize with the upload_lock instead.
     staging_dir = storage.get_staging_dir(user_id, upload_id)
     result = await _receive_and_assemble_chunks(base_dir=staging_dir,
                                                 zip_name='staging',
@@ -1636,12 +1615,10 @@ async def upload_blob(request: fastapi.Request, user_hash: str, upload_id: str,
             return payloads.UploadZipFileResponse(
                 status=responses.UploadStatus.COMPLETED.value)
         if storage.assemble_on_upload() or storage.extract_on_upload():
-            await _finalize_chunked_upload(
-                base_dir=staging_dir,
-                zip_name='staging',
-                total_chunks=total_chunks,
-                assemble=storage.assemble_on_upload(),
-                extract=storage.extract_on_upload())
+            await _finalize_chunked_upload(base_dir=staging_dir,
+                                           zip_name='staging',
+                                           total_chunks=total_chunks,
+                                           extract=storage.extract_on_upload())
         await storage.store_blob(user_id, upload_id, staging_dir)
         logger.info(f'Uploaded blob: {target_dir}')
     return payloads.UploadZipFileResponse(

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1462,25 +1462,64 @@ async def _receive_and_assemble_chunks(
             return payloads.UploadZipFileResponse(
                 status=responses.UploadStatus.UPLOADING.value,
                 missing_chunks=missing_chunks)
-        if assemble:
-            zip_file_path = base_dir / f'{zip_name}.zip'
-            async with aiofiles.open(zip_file_path, 'wb') as zip_file:
-                for chunk in range(total_chunks):
-                    async with aiofiles.open(chunk_dir / f'part{chunk}',
-                                             'rb') as f:
-                        while True:
-                            # Use 64KB buffer to avoid memory overflow, same
-                            # size as shutil.copyfileobj.
-                            data = await f.read(64 * 1024)
-                            if not data:
-                                break
-                            await zip_file.write(data)
-    logger.info(f'Uploaded zip file: {zip_file_path}')
+    logger.info(f'Uploaded chunk: {zip_file_path}')
+    # Assemble + extract are not idempotent across concurrent callers
+    # (they mutate shared paths on disk).  Callers that may have
+    # multiple chunks land "all present" simultaneously must serialize
+    # this step with their own lock — see the upload-lock-protected
+    # section in /upload_v2.  ``/upload`` uses a unique upload_id per
+    # request so no contention exists there.
+    if assemble or extract:
+        await _finalize_chunked_upload(base_dir=base_dir,
+                                       zip_name=zip_name,
+                                       total_chunks=total_chunks,
+                                       assemble=assemble,
+                                       extract=extract)
+    return None
+
+
+async def _finalize_chunked_upload(
+    base_dir: pathlib.Path,
+    zip_name: str,
+    total_chunks: int,
+    assemble: bool,
+    extract: bool,
+) -> None:
+    """Assemble parts into a single zip and/or extract it.
+
+    Mutates shared paths under ``base_dir`` (writes ``{zip_name}.zip``,
+    extracts into ``base_dir``, removes the parts dir).  Two callers
+    racing on the same ``(base_dir, zip_name)`` would corrupt the
+    output and waste work, so the caller MUST serialize this — e.g. by
+    holding ``BlobStorage.acquire_upload_lock`` for the upload — and
+    must guarantee all chunks have been received before calling.
+    """
+    if extract and not assemble:
+        raise ValueError('extract=True requires assemble=True')
+    if total_chunks > 1 and assemble:
+        chunk_dir = base_dir / zip_name
+        zip_file_path = base_dir / f'{zip_name}.zip'
+        async with aiofiles.open(zip_file_path, 'wb') as zip_file:
+            for chunk in range(total_chunks):
+                async with aiofiles.open(chunk_dir / f'part{chunk}', 'rb') as f:
+                    while True:
+                        # Use 64KB buffer to avoid memory overflow, same
+                        # size as shutil.copyfileobj.
+                        data = await f.read(64 * 1024)
+                        if not data:
+                            break
+                        await zip_file.write(data)
+    else:
+        # total_chunks == 1: the chunk body is already at
+        # ``{base_dir}/{zip_name}.zip`` (renamed by the receive step);
+        # for total_chunks > 1 with assemble=False the parts stay as
+        # individual ``part{N}`` files and there is no zip to extract.
+        zip_file_path = base_dir / f'{zip_name}.zip'
+
     if extract:
         await unzip_file(zip_file_path, base_dir)
     if total_chunks > 1 and assemble:
-        await asyncio.to_thread(shutil.rmtree, chunk_dir)
-    return None
+        await asyncio.to_thread(shutil.rmtree, base_dir / zip_name)
 
 
 # TODO(aylei): for backward compatibility, remove after v0.14.0
@@ -1572,26 +1611,37 @@ async def upload_blob(request: fastapi.Request, user_hash: str, upload_id: str,
         return payloads.UploadZipFileResponse(
             status=responses.UploadStatus.COMPLETED.value)
 
-    # Receive the chunk WITHOUT holding the upload lock. Each chunk
-    # is received to a private path first to avoid concurrent uploads
-    # interleave with each other.
+    # Receive the chunk WITHOUT holding the upload lock.  Each chunk
+    # writes to a writer-unique tmp file, then atomic-renames to its
+    # final ``part{N}`` name, so concurrent chunk POSTs (parallel
+    # workers, retries, or two clients racing on the same content-
+    # hashed blob_id) don't need lock coordination here.  The
+    # assemble + extract + store_blob steps are not idempotent under
+    # concurrency and are run below under the lock.
     staging_dir = storage.get_staging_dir(user_id, upload_id)
-    result = await _receive_and_assemble_chunks(
-        base_dir=staging_dir,
-        zip_name='staging',
-        request=request,
-        chunk_index=chunk_index,
-        total_chunks=total_chunks,
-        extract=storage.extract_on_upload(),
-        assemble=storage.assemble_on_upload())
+    result = await _receive_and_assemble_chunks(base_dir=staging_dir,
+                                                zip_name='staging',
+                                                request=request,
+                                                chunk_index=chunk_index,
+                                                total_chunks=total_chunks,
+                                                extract=False,
+                                                assemble=False)
     if result is not None:
         return result
 
-    # Atomic publish
+    # All chunks present — finalize and publish under the upload
+    # lock so exactly one caller does the assemble/extract/rename.
     async with storage.acquire_upload_lock(user_id, upload_id):
         if target_dir.exists():
             return payloads.UploadZipFileResponse(
                 status=responses.UploadStatus.COMPLETED.value)
+        if storage.assemble_on_upload() or storage.extract_on_upload():
+            await _finalize_chunked_upload(
+                base_dir=staging_dir,
+                zip_name='staging',
+                total_chunks=total_chunks,
+                assemble=storage.assemble_on_upload(),
+                extract=storage.extract_on_upload())
         await storage.store_blob(user_id, upload_id, staging_dir)
         logger.info(f'Uploaded blob: {target_dir}')
     return payloads.UploadZipFileResponse(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously, the server will hold a lock for `upload_id` in upload chunks to avoid unnecessary chunk load an extraction, but this in turn make chunk upload serialized, so:

- The bandwidth between client and server cannot be fully utilized
- `/upload_v2` operation will wait on the upload_id for a long time when the chunk number of a single upload is high, introducing a risk that the connection might be kicked off by LoadBalancers

Benchmark: on a machine with `200MB/s` outbound bandwidth, `sky launch` with a 10GB file mounts:

* Before PR: 183s in upload stage
* After PR: 86s in upload stage


`/upload_v2` P95 before PR: 

<img width="512" height="304" alt="image" src="https://github.com/user-attachments/assets/180b2722-fde2-4340-ac57-cd8ea1c848d3" />

`/upload_v2` P95 after PR:

<img width="427" height="316" alt="image" src="https://github.com/user-attachments/assets/649f051b-5353-4dbf-a323-814721224b5d" />

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
