### PR TITLE
[fusermount-server] Close /dev/fuse fd after passing to client via SCM_RIGHTS

### DIFF
--- a/.github/workflows/fusermount-server-image.yaml
+++ b/.github/workflows/fusermount-server-image.yaml
@@ -6,7 +6,7 @@ on:
       tag:
         description: 'Docker image tag'
         required: false
-        default: '0.2.1'
+        default: '0.2.2'
 
 jobs:
   build:

--- a/addons/fuse-proxy/pkg/server/server.go
+++ b/addons/fuse-proxy/pkg/server/server.go
@@ -115,25 +115,23 @@ func (s *Server) handleConnection(conn net.Conn) {
 	if err != nil {
 		log.Errorf("Failed to marshal response: %v", err)
 	}
+	// Close the /dev/fuse fd after SendMsg hands it to the client via
+	// SCM_RIGHTS. If we keep ours open, the kernel's fuse_dev_release
+	// never sees dev_count drop to 0 when rclone dies, so fuse_conn_kill
+	// is skipped and in-flight FUSE requests stay wedged in
+	// request_wait_answer — making the pod un-killable.
+	if fd > 0 {
+		defer func() {
+			if err := syscall.Close(fd); err != nil {
+				log.Errorf("Failed to close fuse fd %d: %v", fd, err)
+			} else {
+				log.Infof("Closed fuse fd %d", fd)
+			}
+		}()
+	}
 	if err := mfcputil.SendMsg(unixConn, fd, b); err != nil {
 		log.Errorf("Failed to send response: %v", err)
-		// Still close the fd on error path
-		if fd > 0 {
-			syscall.Close(fd)
-		}
 		return
-	}
-	// Close the /dev/fuse fd now that SendMsg has handed it to the
-	// client via SCM_RIGHTS. If we keep ours open, the kernel's
-	// fuse_dev_release never sees dev_count drop to 0 when rclone
-	// dies, so fuse_conn_kill is skipped and in-flight FUSE requests
-	// stay wedged in request_wait_answer — making the pod un-killable.
-	if fd > 0 {
-		if err := syscall.Close(fd); err != nil {
-			log.Errorf("Failed to close fuse fd %d: %v", fd, err)
-		} else {
-			log.Infof("Closed fuse fd %d", fd)
-		}
 	}
 }
 

--- a/addons/fuse-proxy/pkg/server/server.go
+++ b/addons/fuse-proxy/pkg/server/server.go
@@ -117,7 +117,23 @@ func (s *Server) handleConnection(conn net.Conn) {
 	}
 	if err := mfcputil.SendMsg(unixConn, fd, b); err != nil {
 		log.Errorf("Failed to send response: %v", err)
+		// Still close the fd on error path
+		if fd > 0 {
+			syscall.Close(fd)
+		}
 		return
+	}
+	// Close the /dev/fuse fd now that SendMsg has handed it to the
+	// client via SCM_RIGHTS. If we keep ours open, the kernel's
+	// fuse_dev_release never sees dev_count drop to 0 when rclone
+	// dies, so fuse_conn_kill is skipped and in-flight FUSE requests
+	// stay wedged in request_wait_answer — making the pod un-killable.
+	if fd > 0 {
+		if err := syscall.Close(fd); err != nil {
+			log.Errorf("Failed to close fuse fd %d: %v", fd, err)
+		} else {
+			log.Infof("Closed fuse fd %d", fd)
+		}
 	}
 }
 

--- a/sky/provision/kubernetes/manifests/fusermount-server-daemonset.yaml
+++ b/sky/provision/kubernetes/manifests/fusermount-server-daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         effect: NoExecute
       containers:
       - name: server
-        image: berkeleyskypilot/fusermount-server:0.2.1
+        image: berkeleyskypilot/fusermount-server:0.2.2
         securityContext:
           privileged: true
         volumeMounts:

--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -26,6 +26,7 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+import textwrap
 import time
 from typing import Dict, Optional, TextIO
 import urllib.parse
@@ -665,6 +666,106 @@ def test_slurm_storage_mounts_cached(image_id: Optional[str]):
                 timeout=20 * 60,  # 20 mins
             )
             smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.kubernetes
+def test_kubernetes_ensure_no_fd_leak_fusermount_server():
+    """Verify fusermount-server closes /dev/fuse fds after MOUNT_CACHED mounts.
+
+    Each MOUNT_CACHED mount passes a /dev/fuse fd to the client via SCM_RIGHTS.
+    A prior bug (fixed in #9463) left the server's copy open, leaking one fd
+    per mount. This test launches two clusters, checks the fd count after each,
+    and asserts no /dev/fuse fds are leaked.
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    storage_name = f'sky-test-{int(time.time())}'
+    cloud = 'kubernetes'
+    yaml_content = textwrap.dedent(f"""\
+        resources:
+          cloud: kubernetes
+          cpus: 2+
+
+        file_mounts:
+          /data:
+            name: {storage_name}
+            source: ~/tmp-workdir
+            mode: MOUNT_CACHED
+
+        run: |
+          ls /data
+          echo "MOUNT_READY"
+          sleep infinity
+    """)
+    with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
+        f.write(yaml_content)
+        f.flush()
+        yaml_path = f.name
+        name1 = f'{name}-1'
+        name2 = f'{name}-2'
+
+        # Count /dev/fuse fds in the fusermount-server pod on the same node
+        # as a given workload pod. Uses per-fd readlink with timeout to avoid
+        # blocking on stuck fds.
+        # Look up the workload pod via the skypilot-cluster-name
+        # annotation (raw cluster name, no hash suffix).
+        get_node = (
+            'NODE=$(kubectl get pods -o'
+            ' custom-columns=NAME:.metadata.name,'
+            'NODE:.spec.nodeName,'
+            'ANN:.metadata.annotations.skypilot-cluster-name'
+            ' --no-headers |'
+            """ awk -v n="{cluster}" '$NF==n{{print $2}}' |"""
+            ' head -1) && echo "node=$NODE"')
+        get_fuse_pod = (
+            'FUSE_POD=$(kubectl get pods -n skypilot-system'
+            ' -l app=fusermount-server'
+            ' --field-selector spec.nodeName=$NODE'
+            ' -o jsonpath=\'{{.items[0].metadata.name}}\') &&'
+            ' echo "fuse_pod=$FUSE_POD"')
+        count_fuse_fds = (
+            'COUNT=$(kubectl exec -n skypilot-system $FUSE_POD --'
+            ' sh -c \''
+            'c=0; for i in $(seq 0 50); do'
+            ' [ -e /proc/1/fd/$i ] &&'
+            ' t=$(timeout 1 readlink /proc/1/fd/$i 2>/dev/null) &&'
+            ' case "$t" in *fuse*) c=$((c+1));; esac;'
+            ' done; echo $c\') &&'
+            ' echo "fuse_fd_count=$COUNT" &&'
+            ' [ "$COUNT" -eq 0 ]')
+        fuse_fd_check = (f'{get_node} && {get_fuse_pod} && {count_fuse_fds}')
+
+        wait_mount = ('for i in $(seq 1 60); do'
+                      ' sky logs {cluster} 1 --no-follow 2>&1'
+                      ' | grep -q MOUNT_READY'
+                      ' && break || sleep 5;'
+                      ' done')
+        test_commands = [
+            *smoke_tests_utils.STORAGE_SETUP_COMMANDS,
+            smoke_tests_utils.launch_cluster_for_cloud_cmd(cloud, name),
+            # Launch first cluster with MOUNT_CACHED
+            f'sky launch -y -c {name1} -d {yaml_path}',
+            wait_mount.format(cluster=name1),
+            # After first mount: assert 0 leaked fuse fds
+            smoke_tests_utils.run_cloud_cmd_on_cluster(
+                name, fuse_fd_check.format(cluster=name1)),
+            # Launch second cluster with MOUNT_CACHED
+            f'sky launch -y -c {name2} -d {yaml_path}',
+            wait_mount.format(cluster=name2),
+            # After second mount: still 0 leaked fuse fds
+            smoke_tests_utils.run_cloud_cmd_on_cluster(
+                name, fuse_fd_check.format(cluster=name2)),
+        ]
+        clean_command = (
+            f'sky down -y {name1} {name2}; '
+            f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}; '
+            f'sky storage delete -y {storage_name}')
+        test = smoke_tests_utils.Test(
+            'kubernetes_ensure_no_fd_leak_fusermount_server',
+            test_commands,
+            clean_command,
+            timeout=15 * 60,
+        )
+        smoke_tests_utils.run_one_test(test)
 
 
 @pytest.mark.kubernetes

--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -708,20 +708,18 @@ def test_kubernetes_ensure_no_fd_leak_fusermount_server():
         # blocking on stuck fds.
         # Look up the workload pod via the skypilot-cluster-name
         # annotation (raw cluster name, no hash suffix).
-        get_node = (
-            'NODE=$(kubectl get pods -o'
-            ' custom-columns=NAME:.metadata.name,'
-            'NODE:.spec.nodeName,'
-            'ANN:.metadata.annotations.skypilot-cluster-name'
-            ' --no-headers |'
-            """ awk -v n="{cluster}" '$NF==n{{print $2}}' |"""
-            ' head -1) && echo "node=$NODE"')
-        get_fuse_pod = (
-            'FUSE_POD=$(kubectl get pods -n skypilot-system'
-            ' -l app=fusermount-server'
-            ' --field-selector spec.nodeName=$NODE'
-            ' -o jsonpath=\'{{.items[0].metadata.name}}\') &&'
-            ' echo "fuse_pod=$FUSE_POD"')
+        get_node = ('NODE=$(kubectl get pods -o'
+                    ' custom-columns=NAME:.metadata.name,'
+                    'NODE:.spec.nodeName,'
+                    'ANN:.metadata.annotations.skypilot-cluster-name'
+                    ' --no-headers |'
+                    """ awk -v n="{cluster}" '$NF==n{{print $2}}' |"""
+                    ' head -1) && echo "node=$NODE"')
+        get_fuse_pod = ('FUSE_POD=$(kubectl get pods -n skypilot-system'
+                        ' -l app=fusermount-server'
+                        ' --field-selector spec.nodeName=$NODE'
+                        ' -o jsonpath=\'{{.items[0].metadata.name}}\') &&'
+                        ' echo "fuse_pod=$FUSE_POD"')
         count_fuse_fds = (
             'COUNT=$(kubectl exec -n skypilot-system $FUSE_POD --'
             ' sh -c \''


### PR DESCRIPTION
Similar to https://github.com/skypilot-org/skypilot/pull/7398

## Summary
- Fix fd leak in fusermount-server: after `SendMsg` passes the `/dev/fuse` fd to the client via `SCM_RIGHTS`, the server's local copy was never closed
- This leaked fd prevents the kernel from aborting orphaned FUSE connections when rclone dies (`dev_count` never reaches 0, so `fuse_conn_kill` is skipped), leaving readers wedged in `request_wait_answer` and making pods un-killable on `sky down`
- Also close the fd on the `SendMsg` error path to avoid leaks on failure

## Reproducing the fd leak

Each `MOUNT_CACHED` mount passes a `/dev/fuse` fd from fusermount to the client (rclone shim) via `SCM_RIGHTS`. On `0.2.1`, the server's local copy is never closed.

**Setup:** any SkyPilot YAML with `mode: MOUNT_CACHED` on a Kubernetes cluster with the fusermount-server daemonset.

```bash
# Find the fusermount-server pod
FUSE_POD=$(kubectl get pods -n skypilot-system -l app=fusermount-server \
  --field-selector spec.nodeName=<your-node> \
  -o jsonpath='{.items[0].metadata.name}')

# Baseline: 0 fuse fds
kubectl exec -n skypilot-system $FUSE_POD -- sh -c \
  'for i in $(seq 0 30); do [ -e /proc/1/fd/$i ] && \
   t=$(timeout 1 readlink /proc/1/fd/$i 2>/dev/null) && \
   echo "$t" | grep -q fuse && echo "fd=$i -> $t"; done'
# (empty)

# Launch two clusters with MOUNT_CACHED
sky launch -c test1 my-cached-mount.yaml -y
sky launch -c test2 my-cached-mount.yaml -y

# Check again: 2 leaked /dev/fuse fds
kubectl exec -n skypilot-system $FUSE_POD -- sh -c \
  'for i in $(seq 0 30); do [ -e /proc/1/fd/$i ] && \
   t=$(timeout 1 readlink /proc/1/fd/$i 2>/dev/null) && \
   echo "$t" | grep -q fuse && echo "fd=$i -> $t"; done'
# fd=14 -> /dev/fuse
# fd=17 -> /dev/fuse

# Delete both workloads — fds persist
sky down -y test1 test2

# Still 2 leaked fds (rclone is dead, pods are gone)
# fd=14 -> /dev/fuse
# fd=17 -> /dev/fuse
```

These fds accumulate forever (we observed 93 on a 3-day-old node). They prevent the kernel from aborting orphaned FUSE connections: when rclone dies, `fuse_dev_release` decrements `dev_count` but it never reaches 0 because the server still holds its copy, so `fuse_conn_kill` is skipped and any process blocked in a FUSE read stays in uninterruptible sleep (D-state) indefinitely.

With this fix, the fuse fd count stays at 0 after every mount.

## Test plan
- [x] Manual verification: launched MOUNT_CACHED workload, confirmed `Closed fuse fd` in server logs, verified 0 fuse fds in `/proc/1/fd`
- [x] Manual teardown during active training (step 152, 6.5 GiB VRAM): `sky down` completed in 16s, post-teardown node shows 0 MiB VRAM, 0 FUSE connections, 0 zombie processes
- [x] 50-iteration stress test: 18/18 completed cycles CLEAN (0 MiB VRAM, 0 defunct, 0 fuse waiters), 0 ZOMBIES

🤖 Generated with [Claude Code](https://claude.com/claude-code)