### PR TITLE
[Core] Strip secrets: prefix in _parse_secret_name to fix managed_secrets round-trip

### DIFF
--- a/sky/task.py
+++ b/sky/task.py
@@ -255,8 +255,7 @@ def _parse_secret_name(raw_name: str):
     function, so we strip here to avoid the prefix accumulating across
     YAML round-trips.
     """
-    if raw_name.startswith('secrets:'):
-        raw_name = raw_name[len('secrets:'):]
+    raw_name = common_utils.removeprefix(raw_name, 'secrets:')
     for prefix in ('personal.', 'workspace.', 'global.'):
         if raw_name.startswith(prefix):
             return raw_name[len(prefix):], prefix[:-1]

--- a/sky/task.py
+++ b/sky/task.py
@@ -240,11 +240,23 @@ def get_plaintext_secrets(secrets: Dict[str, SecretStr]) -> Dict[str, str]:
 
 
 def _parse_secret_name(raw_name: str):
-    """Parse 'scope.NAME' into (name, scope_override).
+    """Parse '[secrets:]scope.NAME' into (name, scope_override).
 
     Supports prefixes: personal., workspace., global.
-    Returns (name, None) if no prefix found.
+    Returns (name, None) if no scope prefix found.
+
+    Strips a leading ``secrets:`` if present so the parse is symmetric with
+    the YAML emission in ``_to_yaml_config``: refs with no inline mount
+    path are written as ``secrets:NAME`` (or ``secrets:scope.NAME``) into
+    either the ``secrets:`` array or the ``managed_secrets:`` field. The
+    ``secrets:`` array form strips the prefix at its call site; the
+    ``managed_secrets:`` form (used when the task also carries inline
+    secrets, e.g. an injected service-account token) routes through this
+    function, so we strip here to avoid the prefix accumulating across
+    YAML round-trips.
     """
+    if raw_name.startswith('secrets:'):
+        raw_name = raw_name[len('secrets:'):]
     for prefix in ('personal.', 'workspace.', 'global.'):
         if raw_name.startswith(prefix):
             return raw_name[len(prefix):], prefix[:-1]

--- a/tests/unit_tests/test_sky/test_task.py
+++ b/tests/unit_tests/test_sky/test_task.py
@@ -1319,6 +1319,64 @@ def test_multinode_rwo_volume_raises():
             t.resolve_and_validate_volumes()
 
 
+def test_managed_secret_refs_round_trip_with_inline_secrets():
+    """managed_secret_refs must keep their bare name across YAML round-trips
+    even when the task also carries inline ``_secrets``.
+
+    Regression test for the ``Secret not found: secrets:secrets:NAME`` bug:
+    when inline secrets are present (e.g. via the
+    ``SKYPILOT_SERVICE_ACCOUNT_TOKEN`` injection in
+    ``sky/jobs/server/core.py`` for ``api_server_access`` jobs),
+    ``_to_yaml_config`` routes refs into the ``managed_secrets:`` field
+    with a ``secrets:`` prefix. Path 2 (``managed_secrets:``) parsing must
+    strip that prefix so the round-trip is symmetric — otherwise each
+    serialize/parse cycle (e.g. one for the controller, one for
+    ``recovery_strategy.sdk.launch``) accumulates another ``secrets:``
+    layer and the SecretsManager plugin fails to resolve the ref.
+    """
+    # pylint: disable=protected-access
+    config = {
+        'run': 'echo hello',
+        'secrets': ['secrets:my_secret'],
+    }
+    task_obj = task.Task.from_yaml_config(config)
+    assert len(task_obj._managed_secret_refs) == 1
+    assert task_obj._managed_secret_refs[0].name == 'my_secret'
+
+    # Simulate the inline-secret injection path used by api_server_access:
+    # this forces ``config['secrets']`` to be a dict on serialize, which
+    # routes refs into the ``managed_secrets:`` field.
+    task_obj._secrets['INJECTED_TOKEN'] = SecretStr('token-value')
+
+    # First round-trip.
+    yaml_config = task_obj._to_yaml_config()
+    assert isinstance(yaml_config.get('secrets'), dict)
+    assert yaml_config.get('managed_secrets') == ['secrets:my_secret']
+
+    task_obj2 = task.Task.from_yaml_config(yaml_config)
+    assert len(task_obj2._managed_secret_refs) == 1
+    assert task_obj2._managed_secret_refs[0].name == 'my_secret'
+
+    # Second round-trip — pre-fix this would yield ``secrets:secrets:my_secret``.
+    yaml_config2 = task_obj2._to_yaml_config()
+    assert yaml_config2.get('managed_secrets') == ['secrets:my_secret']
+
+    task_obj3 = task.Task.from_yaml_config(yaml_config2)
+    assert task_obj3._managed_secret_refs[0].name == 'my_secret'
+
+
+def test_managed_secret_name_with_scope_and_secrets_prefix():
+    """``_parse_secret_name`` strips ``secrets:`` and a scope prefix together."""
+    # pylint: disable=protected-access
+    from sky.task import (_parse_secret_name)  # pylint: disable=import-outside-toplevel
+    assert _parse_secret_name('foo') == ('foo', None)
+    assert _parse_secret_name('secrets:foo') == ('foo', None)
+    assert _parse_secret_name('personal.foo') == ('foo', 'personal')
+    assert _parse_secret_name('secrets:personal.foo') == ('foo', 'personal')
+    assert _parse_secret_name('secrets:workspace.foo') == ('foo', 'workspace')
+    assert _parse_secret_name('secrets:global.foo') == ('foo', 'global')
+
+
 def test_multinode_rwx_volume_passes():
     """Multi-node with ReadWriteMany volume should pass."""
     t = task.Task()

--- a/tests/unit_tests/test_sky/test_task.py
+++ b/tests/unit_tests/test_sky/test_task.py
@@ -1368,8 +1368,8 @@ def test_managed_secret_refs_round_trip_with_inline_secrets():
 def test_managed_secret_name_with_scope_and_secrets_prefix():
     """``_parse_secret_name`` strips ``secrets:`` and a scope prefix together."""
     # pylint: disable=protected-access
-    from sky.task import (
-        _parse_secret_name)  # pylint: disable=import-outside-toplevel
+    # pylint: disable=import-outside-toplevel
+    from sky.task import _parse_secret_name
     assert _parse_secret_name('foo') == ('foo', None)
     assert _parse_secret_name('secrets:foo') == ('foo', None)
     assert _parse_secret_name('personal.foo') == ('foo', 'personal')

--- a/tests/unit_tests/test_sky/test_task.py
+++ b/tests/unit_tests/test_sky/test_task.py
@@ -1368,7 +1368,8 @@ def test_managed_secret_refs_round_trip_with_inline_secrets():
 def test_managed_secret_name_with_scope_and_secrets_prefix():
     """``_parse_secret_name`` strips ``secrets:`` and a scope prefix together."""
     # pylint: disable=protected-access
-    from sky.task import (_parse_secret_name)  # pylint: disable=import-outside-toplevel
+    from sky.task import (
+        _parse_secret_name)  # pylint: disable=import-outside-toplevel
     assert _parse_secret_name('foo') == ('foo', None)
     assert _parse_secret_name('secrets:foo') == ('foo', None)
     assert _parse_secret_name('personal.foo') == ('foo', 'personal')


### PR DESCRIPTION
## Summary

Fix a pre-existing YAML round-trip bug in `_parse_secret_name`: when a task carries both `_managed_secret_refs` (from `secrets: [secrets:NAME]` array form) and inline `_secrets` (e.g. the `SKYPILOT_SERVICE_ACCOUNT_TOKEN` injected for `api_server_access` jobs in `sky/jobs/server/core.py`), `_to_yaml_config` routes the refs into the `managed_secrets:` field with a leading `secrets:` prefix. The reverse parse path (Path 2 in `task.py`) only stripped scope prefixes (`personal./workspace./global.`), so each serialize → parse cycle accumulated another `secrets:` layer.

User-visible failure: `sky jobs launch` of a task using `secrets: - secrets:my_secret` would fail on the controller with:

```
ValueError: Secret not found: secrets:secrets:my_secret. No matching secret in user/default, workspace/default, or global.
```

The fix: `_parse_secret_name` now strips a leading `secrets:` if present, making it symmetric with the emission side.

## Test plan

- [x] `pytest tests/unit_tests/test_sky/test_task.py` — 60/60 passing (including 2 new regression tests)
- [x] `bash format.sh --files sky/task.py tests/unit_tests/test_sky/test_task.py` clean (pylint 10/10 on `sky/task.py`)
- [x] Manual: `sky jobs launch task.yaml` where `task.yaml` has `secrets: [secrets:NAME]` on a deployment with `api_server_access=true` (the path that triggers token injection)
- [x] Manual: `sky jobs launch task.yaml` where `task.yaml` has `secrets: [secrets:NAME]` on a deployment with `api_server_access=false`
- [x] Manual `sky launch` with (api_server_access=false/false) and without secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)