### PR TITLE
[Test] Fix self-kill in test_managed_jobs_recovery_kubernetes_multinode

### DIFF
--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -581,14 +581,18 @@ def test_managed_jobs_recovery_kubernetes_multinode():
     # within K8s's 42-char limit, so name_on_cloud is no longer a
     # prefix of the actual pod name.
     stable_prefix = name_on_cloud[:15]
+    # Exclude the cloud-cmd helper cluster: its head/worker pods share the
+    # same {stable_prefix} and {user_hash} suffix, so without this filter
+    # `kubectl delete` would also kill the pod running this very command,
+    # producing exit code 137 and a spurious test failure.
     terminate_head_cmd = (
         f'kubectl get pods --no-headers -o custom-columns=":metadata.name" | '
-        f'grep -- "{stable_prefix}" | grep -- "{user_hash}-head" | '
-        f'xargs kubectl delete pod')
+        f'grep -- "{stable_prefix}" | grep -v -- "-cloud-cmd" | '
+        f'grep -- "{user_hash}-head" | xargs kubectl delete pod')
     terminate_worker_cmd = (
         f'kubectl get pods --no-headers -o custom-columns=":metadata.name" | '
-        f'grep -- "{stable_prefix}" | grep -- "{user_hash}-worker" | '
-        f'xargs kubectl delete pod')
+        f'grep -- "{stable_prefix}" | grep -v -- "-cloud-cmd" | '
+        f'grep -- "{user_hash}-worker" | xargs kubectl delete pod')
     test = smoke_tests_utils.Test(
         'managed_jobs_recovery_kubernetes',
         [


### PR DESCRIPTION
## Summary

- The `kubectl delete pod` filter introduced in #9378 was too broad: it also matched the `*-cloud-cmd-*-head` pod of the helper cluster used to run cloud commands. Because the very `sky exec ... | xargs kubectl delete pod` command is running inside that helper pod, the pod kills itself, the SSH session dies, and `sky logs ... --status` returns exit code 137 — failing the whole test even when the managed-job recovery logic is healthy.
- Fix: add `grep -v -- "-cloud-cmd"` to both `terminate_head_cmd` and `terminate_worker_cmd` so only the managed-job cluster's pods match.

Failed build that surfaced this: https://buildkite.com/skypilot-1/smoke-tests/builds/10103 (job `test_managed_jobs_recovery_kubernetes_multinode on kubernetes`, log shows both `t-jobs-recovery-k-2d-a2-1-<hash>-head` and `t-jobs-recovery-k-2d-a2-cloud-cmd-<hash>-head` getting deleted, then `command terminated with exit code 137`).

## Test plan

- [ ] `/smoke-test --kubernetes --remote-server -k test_managed_jobs_recovery_kubernetes_multinode` passes on this PR.
- [ ] Manual sanity check on the new grep: only `*-N-<user_hash>-head` (managed-job pods) match, not `*-cloud-cmd-<user_hash>-head` (helper cluster pod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)