### PR TITLE
server: fix incorrect headers passed by oauth2-proxy

### DIFF
--- a/sky/server/auth/oauth2_proxy.py
+++ b/sky/server/auth/oauth2_proxy.py
@@ -23,6 +23,17 @@ from sky.utils import common_utils
 
 logger = sky_logging.init_logger(__name__)
 
+HOP_BY_HOP_HEADERS = {
+    'connection',
+    'keep-alive',
+    'proxy-authenticate',
+    'proxy-authorization',
+    'te',
+    'trailer',
+    'transfer-encoding',
+    'upgrade',
+}
+
 
 @middleware_utils.websocket_aware
 class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
@@ -71,10 +82,15 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                         allow_redirects=False,
                 ) as response:
                     response_body = await response.read()
+                    response_headers = {
+                        name: value
+                        for name, value in response.headers.items()
+                        if name.lower() not in HOP_BY_HOP_HEADERS
+                    }
                     fastapi_response = fastapi.responses.Response(
                         content=response_body,
                         status_code=response.status,
-                        headers=dict(response.headers),
+                        headers=response_headers,
                     )
                     # Forward cookies from OAuth2 proxy response to client
                     for cookie_name, cookie in response.cookies.items():

--- a/sky/server/auth/oauth2_proxy.py
+++ b/sky/server/auth/oauth2_proxy.py
@@ -23,7 +23,7 @@ from sky.utils import common_utils
 
 logger = sky_logging.init_logger(__name__)
 
-HOP_BY_HOP_HEADERS = {
+HOP_BY_HOP_HEADERS = frozenset({
     'connection',
     'keep-alive',
     'proxy-authenticate',
@@ -32,7 +32,7 @@ HOP_BY_HOP_HEADERS = {
     'trailer',
     'transfer-encoding',
     'upgrade',
-}
+})
 
 
 @middleware_utils.websocket_aware


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
SkyPilot API server passes replies from oauth2-proxy with all its headers, which may lead to confusing situations, such as having both `Content-Lentgth` and `Transfer-Encoding` headers in the same reply, which lead to protocol errors in a reverse proxy.

It's considered a good practice to ignore hop-by-hop headers in such cases.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
