### PR TITLE
[Jobs] Fix queue v1 encoder crash when status is already a string

### DIFF
--- a/sky/server/requests/serializers/encoders.py
+++ b/sky/server/requests/serializers/encoders.py
@@ -154,7 +154,7 @@ def encode_status_kubernetes(
 @register_encoder('jobs.queue')
 def encode_jobs_queue(jobs: List[dict],) -> List[Dict[str, Any]]:
     for job in jobs:
-        job['status'] = job['status'].value
+        job['status'] = getattr(job['status'], 'value', job['status'])
     return jobs
 
 


### PR DESCRIPTION
The `encode_jobs_queue` encoder unconditionally calls `.value` on `job['status']`, assuming it is always an enum. When a custom ManagedJobRunner returns dicts where status has already been converted to a string (e.g. via `get_managed_job_queue()`), this raises `AttributeError: 'str' object has no attribute 'value'`.

Guard the `.value` call so the encoder handles both enum and string status values.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
