### PR TITLE
[Test] Hot-patch backward compat env with click<8.3.0 pin

### DIFF
--- a/tests/smoke_tests/backward_compat/hotpatch_click_pin.py
+++ b/tests/smoke_tests/backward_compat/hotpatch_click_pin.py
@@ -1,0 +1,149 @@
+"""Hot-patch for backward compat: pin click<8.3.0 in the old SkyPilot install.
+
+Old SkyPilot versions installed from PyPI lack PR #9459's click<8.3.0 pin.
+Without it, when the old sky launches a managed-jobs / serve controller, the
+controller's skypilot-runtime venv resolves click to 8.3.x (typer 0.25.x
+transitively requires click>=8.2.1 with no upper bound, so uv picks the
+latest = 8.3.3). ray 2.9.3's `add_command_alias` then crashes on import:
+
+    File ".../site-packages/ray/scripts/scripts.py", line 2440, in <module>
+      add_command_alias(up, name="create_or_update", hidden=True)
+    File ".../scripts.py", line 2430, in add_command_alias
+      new_command = copy.deepcopy(command)
+    ValueError: <object object at 0x...> is not a valid Sentinel
+
+which surfaces in the test as
+'RuntimeError: Failed to start ray on the head node' and the controller is
+stuck in INIT.
+
+This script patches two files in the old env's installed sky package:
+1. sky/skylet/constants.py — adds an unconditional `uv pip install
+   "click<8.3.0"` to RAY_INSTALLATION_COMMANDS, and appends "click<8.3.0"
+   to the `ray[default]==... pydantic-core==...` install line. The
+   unconditional pre-install protects the case where ray is already baked
+   into the SkyPilot AMI and the version-guard skips the ray install.
+2. sky/utils/controller_utils.py — adds 'click<8.3.0' to the cloud-deps
+   install set, so typer/fastapi-cli don't bump click after the ray install.
+
+The patch is idempotent: if the old version already has the fix, it skips.
+
+See https://github.com/ray-project/ray/issues/56747 for the upstream issue.
+
+TODO: Remove this file once the base version tested against in backward
+compat tests is newer than 2026-04-28 (which includes commit a1a1f0bef from
+PR #9459).
+"""
+import pathlib
+import re
+import sys
+
+import sky
+
+
+def _patch_constants(constants_path: pathlib.Path) -> bool:
+    """Patch constants.py to pin click<8.3.0 in RAY_INSTALLATION_COMMANDS."""
+    src = constants_path.read_text()
+
+    if 'click<8.3.0' in src:
+        print(f'[hotpatch] {constants_path} already pins click<8.3.0, '
+              'skipping')
+        return False
+
+    # Patch 1: insert an unconditional click pin right after the setuptools
+    # pin. This protects controllers booting from a SkyPilot AMI where ray is
+    # already installed and the version-guard would skip the ray reinstall.
+    insert = (
+        '    # [hotpatch] Pin click<8.3.0: click 8.3.0+ breaks Ray CLI via\n'
+        '    # copy.deepcopy on Sentinel values. See ray#56747 / sky#9459.\n'
+        '    f\'{SKY_UV_PIP_CMD} install "click<8.3.0"; \'\n')
+    src, n1 = re.subn(
+        r'(\s+f\'\{SKY_UV_PIP_CMD\} install "setuptools<70"; \'\n)',
+        lambda m: m.group(1) + insert,
+        src,
+    )
+
+    # Patch 2: also append "click<8.3.0" to the `ray[default]==... pydantic-
+    # core==...` install line so a fresh ray install doesn't pull click
+    # 8.3.x as a transitive dependency.
+    src, n2 = re.subn(
+        r'("pydantic-core==2\.41\.1")',
+        r'\1 "click<8.3.0"',
+        src,
+    )
+
+    if n1 == 0 or n2 == 0:
+        print(f'[hotpatch] WARNING: Could not fully patch {constants_path} '
+              f'(setuptools-anchor: {n1}, pydantic-anchor: {n2} '
+              'replacements). The old version structure may differ.')
+        return False
+
+    constants_path.write_text(src)
+    print(f'[hotpatch] Patched {constants_path} with click<8.3.0 pin in '
+          'RAY_INSTALLATION_COMMANDS')
+    return True
+
+
+def _patch_controller_utils(controller_utils_path: pathlib.Path) -> bool:
+    """Patch controller_utils.py to add click<8.3.0 to cloud-deps install."""
+    src = controller_utils_path.read_text()
+
+    if "python_packages.add('click<8.3.0')" in src or 'click<8.3.0' in src:
+        print(f'[hotpatch] {controller_utils_path} already pins click<8.3.0, '
+              'skipping')
+        return False
+
+    # Insert the click pin right before `packages_string = ' '.join(`. Using
+    # the literal opening of the join() call as anchor — this string is
+    # stable across recent SkyPilot releases.
+    insert = (
+        '    # [hotpatch] Pin click<8.3.0: typer 0.25 transitively pulls\n'
+        '    # click>=8.2.1 with no upper bound, which lets uv resolve to\n'
+        '    # 8.3.x and breaks Ray on the controller. See sky#9459.\n'
+        "    python_packages.add('click<8.3.0')\n")
+    src, n = re.subn(
+        r"(\n)(    packages_string = ' '\.join\(\n)",
+        lambda m: m.group(1) + insert + m.group(2),
+        src,
+    )
+
+    if n == 0:
+        print(f'[hotpatch] WARNING: Could not find packages_string anchor in '
+              f'{controller_utils_path}. The old version structure may differ.')
+        return False
+
+    controller_utils_path.write_text(src)
+    print(f'[hotpatch] Patched {controller_utils_path} with click<8.3.0 pin '
+          'in cloud-deps install')
+    return True
+
+
+def main():
+    sky_dir = pathlib.Path(sky.__file__).parent
+
+    constants_path = sky_dir / 'skylet' / 'constants.py'
+    controller_utils_path = sky_dir / 'utils' / 'controller_utils.py'
+
+    if not constants_path.exists():
+        print(f'[hotpatch] ERROR: {constants_path} not found', file=sys.stderr)
+        sys.exit(1)
+
+    if not controller_utils_path.exists():
+        print(f'[hotpatch] ERROR: {controller_utils_path} not found',
+              file=sys.stderr)
+        sys.exit(1)
+
+    print(f'[hotpatch] Sky package at: {sky_dir}')
+
+    patched = False
+    patched |= _patch_constants(constants_path)
+    patched |= _patch_controller_utils(controller_utils_path)
+
+    if patched:
+        print('[hotpatch] Successfully applied click<8.3.0 pin (PR #9459)')
+    else:
+        print('[hotpatch] No patches needed (already fixed or unsupported '
+              'version)')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -168,6 +168,18 @@ class TestBackwardCompatibility:
             f'{self.ACTIVATE_BASE} && python '
             f'{pathlib.Path(__file__).parent / "hotpatch_me_south_1.py"}')
 
+        # Hot-patch old env with click<8.3.0 pin (PR #9459).
+        # Old SkyPilot versions don't pin click<8.3.0 in RAY_INSTALLATION_COMMANDS
+        # or the cloud-deps install. typer 0.25.x transitively pulls click>=8.2.1
+        # with no upper bound, so uv resolves click to 8.3.x on the controller.
+        # ray 2.9.3 then crashes on import via copy.deepcopy on Click Sentinels,
+        # surfacing as 'Failed to start ray on the head node'.
+        # TODO: Remove hotpatch once the base version tested against is
+        # newer than 2026-04-28 (which includes commit a1a1f0bef).
+        self._run_cmd(
+            f'{self.ACTIVATE_BASE} && python '
+            f'{pathlib.Path(__file__).parent / "hotpatch_click_pin.py"}')
+
         # Install current version in current environment
         self._run_cmd(
             f'{self.ACTIVATE_CURRENT} && '


### PR DESCRIPTION
## Summary

- Backward compat tests against `--base-branch pypi/skypilot` are failing because the old PyPI sky doesn't have PR #9459's `click<8.3.0` pin. When the old sky launches a controller, typer 0.25.x transitively pulls `click>=8.2.1` with no upper bound, uv resolves to click 8.3.3, and ray 2.9.3 crashes on import via `copy.deepcopy` on Click Sentinels (`ValueError: <object object at 0x...> is not a valid Sentinel`).
- Add `hotpatch_click_pin.py` (mirroring the existing `hotpatch_me_south_1.py` pattern) that backports the click pin into the old installed sky package. Idempotent regex patches into `sky/skylet/constants.py` (RAY_INSTALLATION_COMMANDS) and `sky/utils/controller_utils.py` (`_get_cloud_dependencies_installation_commands`).
- Wire the hotpatch into `test_backward_compat.py:session_setup` right after the existing me-south-1 hotpatch.

Reproduces exactly the failure in [quicktest-core build #3066](https://buildkite.com/skypilot-1/quicktest-core/builds/3066) — `test_managed_jobs` and `test_client_server_compatibility_old_server`, both `--base-branch pypi/skypilot`. Logs show `+ click==8.3.3` landing in the controller venv and ray dying with the Sentinel error before the controller can come up. Once the base version released to PyPI is newer than 2026-04-28 (i.e. includes commit a1a1f0bef from #9459), this hotpatch can be removed.

## Test plan

- [x] Apply `hotpatch_click_pin.py` to pre-#9459 source (`git show a1a1f0bef^:sky/skylet/constants.py` and `controller_utils.py`):
  - Patches succeed, output parses with `ast.parse`, `click<8.3.0` appears in both files.
  - Second invocation reports `already pins click<8.3.0, skipping` for both files (idempotent).
- [x] Apply against current master source — reports already-pinned, no-op.
- [x] `bash format.sh --files tests/smoke_tests/backward_compat/hotpatch_click_pin.py tests/smoke_tests/backward_compat/test_backward_compat.py` passes mypy/yapf/black/isort with no new pylint warning categories beyond what `hotpatch_me_south_1.py` already has.
- [ ] Re-trigger `/quicktest-core` against this branch with `--base-branch pypi/skypilot` to confirm the failure is gone end-to-end. (Reviewer to run; my fork can't trigger.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)