### PR TITLE
[Core] Carry accelerator info in heartbeat

### DIFF
--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -4,6 +4,7 @@ import functools
 import hashlib
 import json
 import os
+import shlex
 import time
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -518,7 +519,31 @@ def start_skylet_on_head_node(
                 env_vars['SKYPILOT_POD_CPU_CORE_LIMIT'] = str(vcpus)
             if mem is not None:
                 env_vars['SKYPILOT_POD_MEMORY_GB_LIMIT'] = str(mem)
-        return '; '.join([f'export {k}={v}' for k, v in env_vars.items()])
+
+        # Cluster placement and accelerator context for skylet's heartbeat
+        # event (sky/skylet/events.py:UsageHeartbeatReportEvent). cloud /
+        # region / zone come from launched_resources directly — they
+        # reflect the actual placement and aren't on cluster_info.
+        env_vars['SKYPILOT_HEARTBEAT_NUM_NODES'] = str(
+            cluster_info.num_instances)
+        if launched_resources.cloud is not None:
+            env_vars['SKYPILOT_HEARTBEAT_CLOUD'] = str(launched_resources.cloud)
+        if launched_resources.region is not None:
+            env_vars['SKYPILOT_HEARTBEAT_REGION'] = launched_resources.region
+        if launched_resources.zone is not None:
+            env_vars['SKYPILOT_HEARTBEAT_ZONE'] = launched_resources.zone
+        accelerators = launched_resources.accelerators or {}
+        if accelerators:
+            gpu_type, count = next(iter(accelerators.items()))
+            env_vars['SKYPILOT_HEARTBEAT_GPU_TYPE'] = str(gpu_type)
+            env_vars['SKYPILOT_HEARTBEAT_GPUS_PER_NODE'] = str(int(count))
+
+        # Quote values so shell metacharacters in any field (e.g. an
+        # exotic K8s context derived region/zone, a hyphenated GPU type,
+        # or a future env var that carries a path or sentence) cannot
+        # break the export. shlex.quote is a no-op on plain alphanumerics.
+        return '; '.join(
+            f'export {k}={shlex.quote(v)}' for k, v in env_vars.items())
 
     runners = provision.get_command_runners(cluster_info.provider_name,
                                             cluster_info, **ssh_credentials)
@@ -530,7 +555,8 @@ def start_skylet_on_head_node(
     # access the path to the cloud CLIs.
     set_usage_run_id_cmd = _set_usage_run_id_cmd()
     # Set the skypilot environment variables, including the usage type, debug
-    # info, and other options.
+    # info, other options, and cluster identity / accelerator context for
+    # skylet's heartbeat event.
     set_skypilot_env_var_cmd = _set_skypilot_env_var_cmd()
     returncode, stdout, stderr = head_runner.run(
         f'{set_usage_run_id_cmd}; {set_skypilot_env_var_cmd}; '

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -520,18 +520,28 @@ def start_skylet_on_head_node(
             if mem is not None:
                 env_vars['SKYPILOT_POD_MEMORY_GB_LIMIT'] = str(mem)
 
-        # Cluster placement and accelerator context for skylet's heartbeat
-        # event (sky/skylet/events.py:UsageHeartbeatReportEvent). cloud /
-        # region / zone come from launched_resources directly — they
-        # reflect the actual placement and aren't on cluster_info.
+        # Cluster placement, accelerator, and provenance context for
+        # skylet's heartbeat event (sky/skylet/events.py:
+        # UsageHeartbeatReportEvent). cloud / region / zone / instance_type
+        # / use_spot come from launched_resources directly — they reflect
+        # the actual placement and aren't on cluster_info. The user hash
+        # comes from the orchestrator process so the heartbeat carries
+        # the launching user, not whatever identity the head node would
+        # generate on its own.
         env_vars['SKYPILOT_HEARTBEAT_NUM_NODES'] = str(
             cluster_info.num_instances)
+        env_vars['SKYPILOT_HEARTBEAT_USER'] = common_utils.get_user_hash()
+        env_vars['SKYPILOT_HEARTBEAT_USE_SPOT'] = (
+            '1' if launched_resources.use_spot else '0')
         if launched_resources.cloud is not None:
             env_vars['SKYPILOT_HEARTBEAT_CLOUD'] = str(launched_resources.cloud)
         if launched_resources.region is not None:
             env_vars['SKYPILOT_HEARTBEAT_REGION'] = launched_resources.region
         if launched_resources.zone is not None:
             env_vars['SKYPILOT_HEARTBEAT_ZONE'] = launched_resources.zone
+        if launched_resources.instance_type is not None:
+            env_vars['SKYPILOT_HEARTBEAT_INSTANCE_TYPE'] = (
+                launched_resources.instance_type)
         accelerators = launched_resources.accelerators or {}
         if accelerators:
             gpu_type, count = next(iter(accelerators.items()))

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -5,6 +5,7 @@ import re
 import subprocess
 import time
 import traceback
+from typing import Optional
 
 import psutil
 
@@ -155,7 +156,25 @@ class UsageHeartbeatReportEvent(SkyletEvent):
     EVENT_INTERVAL_SECONDS = 600
 
     def _run(self):
-        usage_lib.send_heartbeat(interval_seconds=self.EVENT_INTERVAL_SECONDS)
+        # Cluster placement and accelerator context are exported into
+        # skylet's environment by start_skylet_on_head_node at
+        # provisioning time. Forward whatever is set.
+        def _int_env(name: str) -> Optional[int]:
+            value = os.environ.get(name)
+            try:
+                return int(value) if value not in (None, '') else None
+            except ValueError:
+                return None
+
+        usage_lib.send_heartbeat(
+            interval_seconds=self.EVENT_INTERVAL_SECONDS,
+            cloud=os.environ.get('SKYPILOT_HEARTBEAT_CLOUD'),
+            region=os.environ.get('SKYPILOT_HEARTBEAT_REGION'),
+            zone=os.environ.get('SKYPILOT_HEARTBEAT_ZONE'),
+            gpu_type=os.environ.get('SKYPILOT_HEARTBEAT_GPU_TYPE'),
+            num_nodes=_int_env('SKYPILOT_HEARTBEAT_NUM_NODES'),
+            gpus_per_node=_int_env('SKYPILOT_HEARTBEAT_GPUS_PER_NODE'),
+        )
 
 
 class AutostopEvent(SkyletEvent):

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -162,14 +162,16 @@ class UsageHeartbeatReportEvent(SkyletEvent):
         # whatever is set.
         def _int_env(name: str) -> Optional[int]:
             value = os.environ.get(name)
+            if value is None or value == '':
+                return None
             try:
-                return int(value) if value not in (None, '') else None
+                return int(value)
             except ValueError:
                 return None
 
         def _bool_env(name: str) -> Optional[bool]:
             value = os.environ.get(name)
-            if value in (None, ''):
+            if value is None or value == '':
                 return None
             return value not in ('0', 'false', 'False', 'FALSE')
 

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -156,15 +156,22 @@ class UsageHeartbeatReportEvent(SkyletEvent):
     EVENT_INTERVAL_SECONDS = 600
 
     def _run(self):
-        # Cluster placement and accelerator context are exported into
-        # skylet's environment by start_skylet_on_head_node at
-        # provisioning time. Forward whatever is set.
+        # Cluster placement, accelerator, and provenance context are
+        # exported into skylet's environment by
+        # start_skylet_on_head_node at provisioning time. Forward
+        # whatever is set.
         def _int_env(name: str) -> Optional[int]:
             value = os.environ.get(name)
             try:
                 return int(value) if value not in (None, '') else None
             except ValueError:
                 return None
+
+        def _bool_env(name: str) -> Optional[bool]:
+            value = os.environ.get(name)
+            if value in (None, ''):
+                return None
+            return value not in ('0', 'false', 'False', 'FALSE')
 
         usage_lib.send_heartbeat(
             interval_seconds=self.EVENT_INTERVAL_SECONDS,
@@ -174,6 +181,9 @@ class UsageHeartbeatReportEvent(SkyletEvent):
             gpu_type=os.environ.get('SKYPILOT_HEARTBEAT_GPU_TYPE'),
             num_nodes=_int_env('SKYPILOT_HEARTBEAT_NUM_NODES'),
             gpus_per_node=_int_env('SKYPILOT_HEARTBEAT_GPUS_PER_NODE'),
+            user=os.environ.get('SKYPILOT_HEARTBEAT_USER'),
+            use_spot=_bool_env('SKYPILOT_HEARTBEAT_USE_SPOT'),
+            instance_type=os.environ.get('SKYPILOT_HEARTBEAT_INSTANCE_TYPE'),
         )
 
 

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -306,6 +306,15 @@ class HeartbeatMessageToReport(MessageToReport):
         # This interval_seconds is mainly for recording the heartbeat interval
         # in the heartbeat message, so that the collector can use it.
         self.interval_seconds = interval_seconds
+        # Optional cluster placement and accelerator context. Populated
+        # by ``send_heartbeat`` callers that have this info; left as
+        # ``None`` otherwise.
+        self.cloud: Optional[str] = None
+        self.region: Optional[str] = None
+        self.zone: Optional[str] = None
+        self.gpu_type: Optional[str] = None
+        self.num_nodes: Optional[int] = None
+        self.gpus_per_node: Optional[int] = None
 
     def get_properties(self) -> Dict[str, Any]:
         properties = super().get_properties()
@@ -551,8 +560,43 @@ def store_exception(e: Union[Exception, SystemExit, KeyboardInterrupt]) -> None:
             common_utils.format_exception(e))
 
 
-def send_heartbeat(interval_seconds: int = 600):
+def send_heartbeat(
+    interval_seconds: int = 600,
+    cloud: Optional[str] = None,
+    region: Optional[str] = None,
+    zone: Optional[str] = None,
+    gpu_type: Optional[str] = None,
+    num_nodes: Optional[int] = None,
+    gpus_per_node: Optional[int] = None,
+):
+    """Send one heartbeat record.
+
+    Args:
+        interval_seconds: cadence at which this caller emits heartbeats.
+        cloud: cloud the cluster is running on.
+        region: cloud region the cluster is running in.
+        zone: cloud zone the cluster is running in (when applicable).
+        gpu_type: accelerator type (e.g. ``H100``).
+        num_nodes: current alive node count for the cluster.
+        gpus_per_node: accelerators allocated per node.
+
+    All cluster/accelerator fields are optional. When set, they are
+    written onto the singleton heartbeat message and reset after each
+    send so values do not leak between calls.
+    """
     messages.heartbeat.interval_seconds = interval_seconds
+    if cloud is not None:
+        messages.heartbeat.cloud = cloud
+    if region is not None:
+        messages.heartbeat.region = region
+    if zone is not None:
+        messages.heartbeat.zone = zone
+    if gpu_type is not None:
+        messages.heartbeat.gpu_type = gpu_type
+    if num_nodes is not None:
+        messages.heartbeat.num_nodes = num_nodes
+    if gpus_per_node is not None:
+        messages.heartbeat.gpus_per_node = gpus_per_node
     _send_to_loki(MessageType.HEARTBEAT)
 
 

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -306,15 +306,18 @@ class HeartbeatMessageToReport(MessageToReport):
         # This interval_seconds is mainly for recording the heartbeat interval
         # in the heartbeat message, so that the collector can use it.
         self.interval_seconds = interval_seconds
-        # Optional cluster placement and accelerator context. Populated
-        # by ``send_heartbeat`` callers that have this info; left as
-        # ``None`` otherwise.
+        # Optional cluster placement, accelerator, and provenance context.
+        # Populated by ``send_heartbeat`` callers that have this info; left
+        # as ``None`` otherwise.
         self.cloud: Optional[str] = None
         self.region: Optional[str] = None
         self.zone: Optional[str] = None
         self.gpu_type: Optional[str] = None
         self.num_nodes: Optional[int] = None
         self.gpus_per_node: Optional[int] = None
+        self.user: Optional[str] = None
+        self.use_spot: Optional[bool] = None
+        self.instance_type: Optional[str] = None
 
     def get_properties(self) -> Dict[str, Any]:
         properties = super().get_properties()
@@ -568,6 +571,9 @@ def send_heartbeat(
     gpu_type: Optional[str] = None,
     num_nodes: Optional[int] = None,
     gpus_per_node: Optional[int] = None,
+    user: Optional[str] = None,
+    use_spot: Optional[bool] = None,
+    instance_type: Optional[str] = None,
 ):
     """Send one heartbeat record.
 
@@ -579,10 +585,14 @@ def send_heartbeat(
         gpu_type: accelerator type (e.g. ``H100``).
         num_nodes: current alive node count for the cluster.
         gpus_per_node: accelerators allocated per node.
+        user: hash of the user who launched the cluster, propagated from
+            the orchestrator.
+        use_spot: whether the cluster was launched on spot resources.
+        instance_type: cloud instance type used for the cluster.
 
-    All cluster/accelerator fields are optional. When set, they are
-    written onto the singleton heartbeat message and reset after each
-    send so values do not leak between calls.
+    All cluster/accelerator/provenance fields are optional. When set,
+    they are written onto the singleton heartbeat message and reset
+    after each send so values do not leak between calls.
     """
     messages.heartbeat.interval_seconds = interval_seconds
     if cloud is not None:
@@ -597,6 +607,12 @@ def send_heartbeat(
         messages.heartbeat.num_nodes = num_nodes
     if gpus_per_node is not None:
         messages.heartbeat.gpus_per_node = gpus_per_node
+    if user is not None:
+        messages.heartbeat.user = user
+    if use_spot is not None:
+        messages.heartbeat.use_spot = use_spot
+    if instance_type is not None:
+        messages.heartbeat.instance_type = instance_type
     _send_to_loki(MessageType.HEARTBEAT)
 
 


### PR DESCRIPTION
## Summary

Add optional `cloud`, `region`, `zone`, `gpu_type`, `num_nodes`, `gpus_per_node` kwargs to `usage_lib.send_heartbeat` (and matching fields on `HeartbeatMessageToReport`). `start_skylet_on_head_node` exports the values available at provisioning time as `SKYPILOT_HEARTBEAT_*` env vars (shlex-quoted); `UsageHeartbeatReportEvent._run` forwards them.

Backward compatible — all fields default to `None`.

## Test plan

- [x] Manually verified existing and new heartbeat payloads.