### PR TITLE
add missing required GCP Instance types in the catalog

### DIFF
--- a/sky/catalog/data_fetchers/fetch_gcp.py
+++ b/sky/catalog/data_fetchers/fetch_gcp.py
@@ -196,6 +196,9 @@ SERIES_TO_DESCRIPTION = {
     'f1': 'Micro Instance with burstable CPU',
     'g1': 'Small Instance with 1 VCPU',
     'g2': 'G2 Instance',
+    'g4': 'G4 Instance',
+    'h4d': 'H4D Instance',
+    'h3': 'H3 Instance',
     'm1': 'Memory-optimized Instance',
     # FIXME(woosuk): Support M2 series.
     'm3': 'M3 Memory-optimized Instance',
@@ -203,8 +206,11 @@ SERIES_TO_DESCRIPTION = {
     'n2': 'N2 Instance',
     'n2d': 'N2D AMD Instance',
     'n4': 'N4 Instance',
+    'n4a': 'N4A Instance',
+    'n4d': 'N4D Instance',
     't2a': 'T2A Arm Instance',
     't2d': 'T2D AMD Instance',
+    'z3': 'Z3 Instance',
 }
 
 creds, project_id = google.auth.default()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Added few missing GCP instance types int he catalog.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [X] Any manual or new tests for this PR (please specify below)
    - [X] python -m sky.catalog.data_fetchers.fetch_gcp
    After running this cmd, i can see the `g4, h4d, h3, n4a, n4d, z3 `instance types in the `vms.csv` file
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
