### PR TITLE
[Core] Fix cluster re-provisioning unexpectedly and write ssh key atomically

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -240,6 +240,29 @@ _RAY_YAML_KEYS_TO_REMOVE_FOR_HASH = [
     ('provider', 'security_group'),
 ]
 
+# Filenames in `file_mounts` whose content sha256 should NOT participate in the
+# cluster yaml hash computed by `_deterministic_cluster_yaml_hash`. These are
+# transient on-disk caches whose bytes drift across replicas / time without any
+# user-meaningful semantic change (e.g., gcloud token refreshes), and including
+# them in the hash makes `sky launch --fast` re-provision unexpectedly.
+#
+# These files are still uploaded to the cluster as part of file_mounts -- we
+# only skip them from the deterministic hash used for the --fast cache key.
+# The cluster's gcloud will tolerate a slightly-stale cache (refresh tokens
+# are long-lived; access tokens auto-refresh on use).
+_FILE_MOUNT_BASENAMES_SKIP_HASH = frozenset({
+    # gcloud OAuth credentials cache (refresh tokens + token metadata).
+    'credentials.db',
+    'credentials.db-journal',
+    'credentials.db-wal',
+    'credentials.db-shm',
+    # gcloud short-lived access token cache (1 hour TTL, auto-refreshed).
+    'access_tokens.db',
+    'access_tokens.db-journal',
+    'access_tokens.db-wal',
+    'access_tokens.db-shm',
+})
+
 _ACK_MESSAGE = 'ack'
 _FORWARDING_FROM_MESSAGE = 'Forwarding from'
 
@@ -1483,7 +1506,9 @@ def _deterministic_cluster_yaml_hash(tmp_yaml_path: str) -> str:
         # case we hash the contents of the symlink destination.
         if os.path.isfile(expanded_src):
             config_hash.update('file'.encode('utf-8'))
-            config_hash.update(_hash_file(expanded_src))
+            if os.path.basename(expanded_src) not in (
+                    _FILE_MOUNT_BASENAMES_SKIP_HASH):
+                config_hash.update(_hash_file(expanded_src))
 
         # This can also be a symlink to a directory. os.walk will treat it as a
         # normal directory and list the contents of the symlink destination.
@@ -1513,8 +1538,14 @@ def _deterministic_cluster_yaml_hash(tmp_yaml_path: str) -> str:
                 # contents.
                 for filename in filenames:
                     config_hash.update(filename.encode('utf-8') + b'\0')
-                    config_hash.update(
-                        _hash_file(os.path.join(dirpath, filename)))
+                    # Filename is recorded above (so an add/remove of a
+                    # transient cache file is still detected); we just don't
+                    # hash the file content for the skip-list, because that
+                    # content drifts independently of any user-meaningful
+                    # change (see _FILE_MOUNT_BASENAMES_SKIP_HASH).
+                    if filename not in _FILE_MOUNT_BASENAMES_SKIP_HASH:
+                        config_hash.update(
+                            _hash_file(os.path.join(dirpath, filename)))
                 config_hash.update(b'\0')
 
         else:

--- a/sky/utils/cluster_utils.py
+++ b/sky/utils/cluster_utils.py
@@ -571,11 +571,9 @@ class SSHConfigHelper:
         cluster_config_path = os.path.expanduser(
             cls.ssh_cluster_path.format(cluster_name))
 
-        with open(cluster_config_path,
-                  'w',
-                  encoding='utf-8',
-                  opener=functools.partial(os.open, mode=0o644)) as f:
-            f.write(codegen)
+        # Atomic write: shared FS readers never see a
+        # torn / zero-byte stanza file mid-update.
+        common_utils.atomic_write_text(cluster_config_path, codegen, mode=0o644)
 
         # Also add to Windows SSH config if running in WSL
         # This enables VSCode on Windows to connect to clusters launched in WSL

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -18,6 +18,7 @@ import shlex
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 import typing
 from typing import Any, Callable, Dict, List, Optional, Union
@@ -1367,3 +1368,41 @@ def get_display_node_names(node_names_json: Optional[str]) -> Optional[str]:
     except (json.JSONDecodeError, TypeError):
         # Backward compat: return as-is if not valid JSON
         return node_names_json
+
+
+def atomic_write_text(path: str, content: str, mode: int = 0o644) -> None:
+    """Write text to ``path`` atomically using tmp + rename.
+
+    On shared filesystems (NFS / EFS / k8s PVC) ``open(path, 'w')`` (which
+    uses ``O_TRUNC``) creates a window where readers on other nodes can
+    observe a zero-byte or partially-written file.  ``rename()`` is atomic
+    across the common shared FS implementations, so writers stage the
+    content to a sibling tmp file under the same directory and then rename
+    it into place; readers always see either the old inode or the new
+    inode, never a torn write.
+
+    The tmp file's basename is prefixed with a dot so that glob patterns
+    like ``Include ~/.sky/generated/ssh/*`` (which by default skip
+    dotfiles) do not pick up an in-progress tmp file.
+
+    Args:
+        path: The destination file path.  The parent directory must
+            already exist.
+        content: The text content to write.  Encoded as UTF-8.
+        mode: The Unix file permission bits to apply to the destination
+            file.  Defaults to 0o644.
+    """
+    parent_dir = os.path.dirname(path) or '.'
+    fd, tmp_path = tempfile.mkstemp(prefix='.', suffix='.tmp', dir=parent_dir)
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as f:
+            f.write(content)
+        # mkstemp creates with mode 0o600; chmod to the requested mode.
+        os.chmod(tmp_path, mode)
+        os.rename(tmp_path, path)
+    except BaseException:
+        try:
+            os.remove(tmp_path)
+        except FileNotFoundError:
+            pass
+        raise

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -1385,6 +1385,11 @@ def atomic_write_text(path: str, content: str, mode: int = 0o644) -> None:
     like ``Include ~/.sky/generated/ssh/*`` (which by default skip
     dotfiles) do not pick up an in-progress tmp file.
 
+    On any failure -- including SIGINT / SystemExit during the write --
+    the tmp file is removed via ``try/finally`` so we do not leak dotfile
+    fragments into the destination directory.  The original exception is
+    propagated unchanged.
+
     Args:
         path: The destination file path.  The parent directory must
             already exist.
@@ -1394,15 +1399,17 @@ def atomic_write_text(path: str, content: str, mode: int = 0o644) -> None:
     """
     parent_dir = os.path.dirname(path) or '.'
     fd, tmp_path = tempfile.mkstemp(prefix='.', suffix='.tmp', dir=parent_dir)
+    success = False
     try:
         with os.fdopen(fd, 'w', encoding='utf-8') as f:
             f.write(content)
         # mkstemp creates with mode 0o600; chmod to the requested mode.
         os.chmod(tmp_path, mode)
         os.rename(tmp_path, path)
-    except BaseException:
-        try:
-            os.remove(tmp_path)
-        except FileNotFoundError:
-            pass
-        raise
+        success = True
+    finally:
+        if not success:
+            try:
+                os.remove(tmp_path)
+            except FileNotFoundError:
+                pass

--- a/tests/unit_tests/test_sky/utils/test_common_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_common_utils.py
@@ -777,3 +777,28 @@ class TestAtomicWriteText:
 
         assert (tmp_path /
                 'relative-file').read_text(encoding='utf-8') == 'content'
+
+    def test_cleanup_temp_on_keyboard_interrupt(self, tmp_path, monkeypatch):
+        """``KeyboardInterrupt`` (and any ``BaseException``) during the
+        write must still trigger tmp cleanup -- otherwise a Ctrl-C
+        during ``atomic_write_text`` would leak a hidden ``.<rand>.tmp``
+        file into the destination directory, and successive interrupts
+        could pile up dotfiles.
+
+        Implementation note: the function uses ``try/finally`` with a
+        success flag (rather than ``except Exception``) precisely so
+        that ``BaseException`` subclasses do trigger cleanup.
+        """
+
+        def boom(*args, **kwargs):
+            raise KeyboardInterrupt('user pressed Ctrl-C')
+
+        monkeypatch.setattr(common_utils.os, 'chmod', boom)
+
+        target = tmp_path / 'interrupted'
+        with pytest.raises(KeyboardInterrupt):
+            common_utils.atomic_write_text(str(target), 'content')
+
+        assert not target.exists()
+        # Crucially: no hidden .tmp file left behind in the directory.
+        assert list(tmp_path.iterdir()) == []

--- a/tests/unit_tests/test_sky/utils/test_common_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_common_utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextvars
 import os
+import tempfile
 from unittest import mock
 
 import pytest
@@ -613,3 +614,166 @@ async def test_set_request_context_coroutine_is_context_safe():
     # Process-scope var should not be unchanged
     assert common_utils.get_current_user().name == original_user.name
     assert common_utils.get_current_user().id == original_user.id
+
+
+class TestAtomicWriteText:
+    """Tests for ``common_utils.atomic_write_text``."""
+
+    def test_writes_content_with_default_mode(self, tmp_path):
+        target = tmp_path / 'cluster-stanza'
+        common_utils.atomic_write_text(str(target), 'Host my-cluster\n')
+
+        assert target.read_text(encoding='utf-8') == 'Host my-cluster\n'
+        # Default mode is 0o644.
+        assert (target.stat().st_mode & 0o777) == 0o644
+
+    def test_writes_content_with_explicit_mode(self, tmp_path):
+        target = tmp_path / 'private-key'
+        common_utils.atomic_write_text(str(target),
+                                       'PRIVATE KEY CONTENT\n',
+                                       mode=0o600)
+
+        assert target.read_text(encoding='utf-8') == 'PRIVATE KEY CONTENT\n'
+        assert (target.stat().st_mode & 0o777) == 0o600
+
+    def test_overwrites_existing_file(self, tmp_path):
+        target = tmp_path / 'existing'
+        target.write_text('old content', encoding='utf-8')
+
+        common_utils.atomic_write_text(str(target), 'new content')
+
+        assert target.read_text(encoding='utf-8') == 'new content'
+
+    def test_unicode_content(self, tmp_path):
+        target = tmp_path / 'unicode'
+        # Mixed ASCII + non-ASCII, including a 4-byte emoji.
+        content = 'Host α-cluster 🚀\n  HostName 1.2.3.4\n'
+        common_utils.atomic_write_text(str(target), content)
+
+        assert target.read_text(encoding='utf-8') == content
+        # On disk the encoded bytes should be UTF-8.
+        assert target.read_bytes() == content.encode('utf-8')
+
+    def test_swap_to_new_inode(self, tmp_path):
+        """Atomic rename swaps the directory entry to a new inode.
+
+        This is the property that makes the write torn-read-safe on
+        shared filesystems: a reader holding an open fd on the old file
+        keeps reading the old content until it closes; the new content
+        appears at the path only after rename succeeds.
+        """
+        target = tmp_path / 'swap'
+        target.write_text('original', encoding='utf-8')
+        original_inode = target.stat().st_ino
+
+        common_utils.atomic_write_text(str(target), 'replaced')
+
+        new_inode = target.stat().st_ino
+        # mkstemp+rename always allocates a fresh inode for the
+        # replacement, so the inode must differ.
+        assert new_inode != original_inode
+        assert target.read_text(encoding='utf-8') == 'replaced'
+
+    def test_no_temp_files_left_behind_on_success(self, tmp_path):
+        target = tmp_path / 'clean'
+        common_utils.atomic_write_text(str(target), 'done')
+
+        # Only the target file should exist; no leftover .tmp sidecars.
+        assert sorted(p.name for p in tmp_path.iterdir()) == ['clean']
+
+    def test_temp_file_is_dotfile(self, tmp_path, monkeypatch):
+        """Temp file basename must start with '.' so glob '*' skips it.
+
+        SkyPilot's ssh config uses ``Include ~/.sky/generated/ssh/*``;
+        a non-dot tmp file would be picked up while writes are in
+        flight, breaking ssh config parsing.
+        """
+        observed_tmp_names = []
+        real_mkstemp = tempfile.mkstemp
+
+        def spy_mkstemp(*args, **kwargs):
+            fd, path = real_mkstemp(*args, **kwargs)
+            observed_tmp_names.append(os.path.basename(path))
+            return fd, path
+
+        monkeypatch.setattr(common_utils.tempfile, 'mkstemp', spy_mkstemp)
+
+        target = tmp_path / 'stanza'
+        common_utils.atomic_write_text(str(target), 'data')
+
+        assert observed_tmp_names, 'mkstemp should have been called once'
+        for name in observed_tmp_names:
+            assert name.startswith('.'), (
+                f'tmp file {name!r} must start with "." so glob "*" '
+                'does not pick it up mid-write')
+
+    def test_cleanup_temp_on_chmod_failure(self, tmp_path, monkeypatch):
+        """If chmod fails (or any post-write step fails), the partially
+        written tmp file must be removed so it does not linger as a
+        dotfile in the destination directory.
+        """
+
+        def boom(*args, **kwargs):
+            raise PermissionError('simulated chmod failure')
+
+        monkeypatch.setattr(common_utils.os, 'chmod', boom)
+
+        target = tmp_path / 'never-renamed'
+        with pytest.raises(PermissionError, match='simulated chmod failure'):
+            common_utils.atomic_write_text(str(target), 'content')
+
+        # Target file must NOT exist (rename never happened).
+        assert not target.exists()
+        # And no tmp leftovers either.
+        assert list(tmp_path.iterdir()) == []
+
+    def test_cleanup_temp_on_write_failure(self, tmp_path, monkeypatch):
+        """If the write itself fails, the empty tmp file from mkstemp
+        must still be cleaned up.
+        """
+
+        class BoomFile:
+
+            def __init__(self, fd):
+                self._fd = fd
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                # Close the underlying fd so the tmp file is not held
+                # open when the cleanup tries to remove it.
+                os.close(self._fd)
+                return False
+
+            def write(self, *_args, **_kwargs):
+                raise IOError('disk full')
+
+        real_fdopen = os.fdopen
+
+        def fdopen_spy(fd, *args, **kwargs):
+            del args, kwargs
+            return BoomFile(fd)
+
+        monkeypatch.setattr(common_utils.os, 'fdopen', fdopen_spy)
+
+        target = tmp_path / 'never-written'
+        with pytest.raises(IOError, match='disk full'):
+            common_utils.atomic_write_text(str(target), 'content')
+
+        assert not target.exists()
+        assert list(tmp_path.iterdir()) == []
+        # Sanity: real_fdopen still callable (no global state leaked).
+        assert real_fdopen is os.fdopen or callable(real_fdopen)
+
+    def test_target_in_cwd_with_no_dirname(self, tmp_path, monkeypatch):
+        """When the path has no parent dir component, fall back to '.'.
+
+        Otherwise tempfile.mkstemp(dir='') would raise.
+        """
+        monkeypatch.chdir(tmp_path)
+
+        common_utils.atomic_write_text('relative-file', 'content')
+
+        assert (tmp_path /
+                'relative-file').read_text(encoding='utf-8') == 'content'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
- Skip gcloud cache dbs when calculating cluster config hash to avoid triggering cluster re-provisioning when launching cluster with fast flag
- Write the cluster SSH config atomically, especially when it's in NFS

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
