### PR TITLE
helm: make probe configurable

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -252,17 +252,26 @@ spec:
           {{- end }}
         ports:
         - containerPort: 46580
+        {{- /* Resolve probe overrides defensively: a user setting
+                apiService.probes (or .liveness / .readiness) to null must
+                not blow up template rendering. ``default dict`` at each
+                level makes the field accessors null-safe; the per-field
+                ``| default`` then supplies the historical default. */}}
+        {{- $probes := .Values.apiService.probes | default dict }}
+        {{- $liveness := $probes.liveness | default dict }}
+        {{- $readiness := $probes.readiness | default dict }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.apiService.probes.liveness.path | default "/api/health" }}
-            port: {{ .Values.apiService.probes.liveness.port | default 46580 }}
-          periodSeconds: {{ .Values.apiService.probes.liveness.periodSeconds | default 30 }}
-          failureThreshold: {{ .Values.apiService.probes.liveness.failureThreshold | default 3 }}
-          timeoutSeconds: {{ .Values.apiService.probes.liveness.timeoutSeconds | default 1 }}
+            path: {{ $liveness.path | default "/api/health" }}
+            port: {{ $liveness.port | default 46580 }}
+          periodSeconds: {{ $liveness.periodSeconds | default 30 }}
+          failureThreshold: {{ $liveness.failureThreshold | default 3 }}
+          initialDelaySeconds: {{ $liveness.initialDelaySeconds | default 0 }}
+          timeoutSeconds: {{ $liveness.timeoutSeconds | default 1 }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.apiService.probes.readiness.path | default "/api/health" }}
-            port: {{ .Values.apiService.probes.readiness.port | default 46580 }}
+            path: {{ $readiness.path | default "/api/health" }}
+            port: {{ $readiness.port | default 46580 }}
           {{- if eq .Values.apiService.upgradeStrategy "RollingUpdate" }}
           # When using RollingUpdate strategy, be more patient with the new
           # API server to avoid flaky serving where one of the server process
@@ -274,10 +283,10 @@ spec:
           # other replica to serve requests anyway.
           successThreshold: 1
           {{- end }}
-          failureThreshold: {{ .Values.apiService.probes.readiness.failureThreshold | default 3 }}
-          periodSeconds: {{ .Values.apiService.probes.readiness.periodSeconds | default 5 }}
-          initialDelaySeconds: {{ .Values.apiService.probes.readiness.initialDelaySeconds | default 5 }}
-          timeoutSeconds: {{ .Values.apiService.probes.readiness.timeoutSeconds | default 1 }}
+          failureThreshold: {{ $readiness.failureThreshold | default 3 }}
+          periodSeconds: {{ $readiness.periodSeconds | default 5 }}
+          initialDelaySeconds: {{ $readiness.initialDelaySeconds | default 5 }}
+          timeoutSeconds: {{ $readiness.timeoutSeconds | default 1 }}
         volumeMounts:
         {{- if and .Values.storage.enabled (eq .Values.apiService.upgradeStrategy "RollingUpdate") }}
         # For RollingUpdate with storage enabled, use emptyDir for ~/.sky to avoid

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -254,18 +254,15 @@ spec:
         - containerPort: 46580
         livenessProbe:
           httpGet:
-            path: /api/health
-            port: 46580
-          periodSeconds: 30
-          {{- with .Values.apiService.probes }}
-          {{- if and .liveness .liveness.timeoutSeconds }}
-          timeoutSeconds: {{ .liveness.timeoutSeconds }}
-          {{- end }}
-          {{- end }}
+            path: {{ .Values.apiService.probes.liveness.path | default "/api/health" }}
+            port: {{ .Values.apiService.probes.liveness.port | default 46580 }}
+          periodSeconds: {{ .Values.apiService.probes.liveness.periodSeconds | default 30 }}
+          failureThreshold: {{ .Values.apiService.probes.liveness.failureThreshold | default 3 }}
+          timeoutSeconds: {{ .Values.apiService.probes.liveness.timeoutSeconds | default 1 }}
         readinessProbe:
           httpGet:
-            path: /api/health
-            port: 46580
+            path: {{ .Values.apiService.probes.readiness.path | default "/api/health" }}
+            port: {{ .Values.apiService.probes.readiness.port | default 46580 }}
           {{- if eq .Values.apiService.upgradeStrategy "RollingUpdate" }}
           # When using RollingUpdate strategy, be more patient with the new
           # API server to avoid flaky serving where one of the server process
@@ -277,14 +274,10 @@ spec:
           # other replica to serve requests anyway.
           successThreshold: 1
           {{- end }}
-          failureThreshold: 3
-          periodSeconds: 5
-          initialDelaySeconds: 5
-          {{- with .Values.apiService.probes }}
-          {{- if and .readiness .readiness.timeoutSeconds }}
-          timeoutSeconds: {{ .readiness.timeoutSeconds }}
-          {{- end }}
-          {{- end }}
+          failureThreshold: {{ .Values.apiService.probes.readiness.failureThreshold | default 3 }}
+          periodSeconds: {{ .Values.apiService.probes.readiness.periodSeconds | default 5 }}
+          initialDelaySeconds: {{ .Values.apiService.probes.readiness.initialDelaySeconds | default 5 }}
+          timeoutSeconds: {{ .Values.apiService.probes.readiness.timeoutSeconds | default 1 }}
         volumeMounts:
         {{- if and .Values.storage.enabled (eq .Values.apiService.upgradeStrategy "RollingUpdate") }}
         # For RollingUpdate with storage enabled, use emptyDir for ~/.sky to avoid

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -252,11 +252,6 @@ spec:
           {{- end }}
         ports:
         - containerPort: 46580
-        {{- /* Resolve probe overrides defensively: a user setting
-                apiService.probes (or .liveness / .readiness) to null must
-                not blow up template rendering. ``default dict`` at each
-                level makes the field accessors null-safe; the per-field
-                ``| default`` then supplies the historical default. */}}
         {{- $probes := .Values.apiService.probes | default dict }}
         {{- $liveness := $probes.liveness | default dict }}
         {{- $readiness := $probes.readiness | default dict }}

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -252,22 +252,14 @@ spec:
           {{- end }}
         ports:
         - containerPort: 46580
-        {{- $probes := .Values.apiService.probes | default dict }}
-        {{- $liveness := $probes.liveness | default dict }}
-        {{- $readiness := $probes.readiness | default dict }}
+        {{- with .Values.apiService.livenessProbe }}
         livenessProbe:
-          httpGet:
-            path: {{ $liveness.path | default "/api/health" }}
-            port: {{ $liveness.port | default 46580 }}
-          periodSeconds: {{ $liveness.periodSeconds | default 30 }}
-          failureThreshold: {{ $liveness.failureThreshold | default 3 }}
-          initialDelaySeconds: {{ $liveness.initialDelaySeconds | default 0 }}
-          timeoutSeconds: {{ $liveness.timeoutSeconds | default 1 }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.apiService.readinessProbe }}
         readinessProbe:
-          httpGet:
-            path: {{ $readiness.path | default "/api/health" }}
-            port: {{ $readiness.port | default 46580 }}
-          {{- if eq .Values.apiService.upgradeStrategy "RollingUpdate" }}
+          {{- if not (hasKey . "successThreshold") }}
+          {{- if eq $.Values.apiService.upgradeStrategy "RollingUpdate" }}
           # When using RollingUpdate strategy, be more patient with the new
           # API server to avoid flaky serving where one of the server process
           # returns ready of the healthz check endpoint while others may still
@@ -278,10 +270,9 @@ spec:
           # other replica to serve requests anyway.
           successThreshold: 1
           {{- end }}
-          failureThreshold: {{ $readiness.failureThreshold | default 3 }}
-          periodSeconds: {{ $readiness.periodSeconds | default 5 }}
-          initialDelaySeconds: {{ $readiness.initialDelaySeconds | default 5 }}
-          timeoutSeconds: {{ $readiness.timeoutSeconds | default 1 }}
+          {{- end }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         {{- if and .Values.storage.enabled (eq .Values.apiService.upgradeStrategy "RollingUpdate") }}
         # For RollingUpdate with storage enabled, use emptyDir for ~/.sky to avoid

--- a/charts/skypilot/tests/deployment_test.yaml
+++ b/charts/skypilot/tests/deployment_test.yaml
@@ -1020,3 +1020,88 @@ tests:
           any: true
           content:
             name: logrotate
+
+  # Tests for configurable liveness and readiness probes
+  - it: should use default probe paths and ports when probes are not overridden
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /api/health
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 46580
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.periodSeconds
+          value: 30
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 3
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /api/health
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 46580
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 3
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
+          value: 1
+
+  - it: should honor custom probe path, port, and timing overrides
+    set:
+      apiService.probes.liveness.path: /livez
+      apiService.probes.liveness.port: 46581
+      apiService.probes.liveness.periodSeconds: 60
+      apiService.probes.liveness.failureThreshold: 5
+      apiService.probes.liveness.timeoutSeconds: 3
+      apiService.probes.readiness.path: /readyz
+      apiService.probes.readiness.port: 46581
+      apiService.probes.readiness.periodSeconds: 10
+      apiService.probes.readiness.failureThreshold: 2
+      apiService.probes.readiness.initialDelaySeconds: 15
+      apiService.probes.readiness.timeoutSeconds: 2
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /livez
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 46581
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.periodSeconds
+          value: 60
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
+          value: 3
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /readyz
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 46581
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 2
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+          value: 15
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
+          value: 2

--- a/charts/skypilot/tests/deployment_test.yaml
+++ b/charts/skypilot/tests/deployment_test.yaml
@@ -1021,9 +1021,12 @@ tests:
           content:
             name: logrotate
 
-  # Tests for configurable liveness and readiness probes
-  - it: should use default probe paths and ports when probes are not overridden
+  # Tests for the apiService.livenessProbe / apiService.readinessProbe values
+  - it: should render the default probe specs that match the historical chart output
     asserts:
+      # Liveness — historical defaults: httpGet only, periodSeconds 30,
+      # timeoutSeconds 1. failureThreshold and initialDelaySeconds were
+      # not set; k8s defaults apply (3, 0).
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
           value: /api/health
@@ -1034,14 +1037,14 @@ tests:
           path: spec.template.spec.containers[0].livenessProbe.periodSeconds
           value: 30
       - equal:
-          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
-          value: 3
-      - equal:
-          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
-          value: 0
-      - equal:
           path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
           value: 1
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+      # Readiness — historical defaults plus successThreshold injected
+      # based on upgradeStrategy (RollingUpdate=3 by default; Recreate=1).
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /api/health
@@ -1061,20 +1064,50 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
           value: 1
 
-  - it: should honor custom probe path, port, and timing overrides
+  - it: should set readiness successThreshold to 1 under Recreate strategy
     set:
-      apiService.probes.liveness.path: /livez
-      apiService.probes.liveness.port: 46581
-      apiService.probes.liveness.periodSeconds: 60
-      apiService.probes.liveness.failureThreshold: 5
-      apiService.probes.liveness.initialDelaySeconds: 30
-      apiService.probes.liveness.timeoutSeconds: 3
-      apiService.probes.readiness.path: /readyz
-      apiService.probes.readiness.port: 46581
-      apiService.probes.readiness.periodSeconds: 10
-      apiService.probes.readiness.failureThreshold: 2
-      apiService.probes.readiness.initialDelaySeconds: 15
-      apiService.probes.readiness.timeoutSeconds: 2
+      apiService.upgradeStrategy: Recreate
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.successThreshold
+          value: 1
+
+  - it: should set readiness successThreshold to 3 under RollingUpdate strategy
+    set:
+      apiService.dbConnectionString: postgres://test
+      apiService.upgradeStrategy: RollingUpdate
+      storage.accessMode: ReadWriteMany
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.successThreshold
+          value: 3
+
+  - it: should honor explicit successThreshold override on readinessProbe
+    set:
+      apiService.readinessProbe.successThreshold: 7
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.successThreshold
+          value: 7
+
+  - it: should render the entire user-provided probe specs verbatim
+    set:
+      apiService.livenessProbe:
+        httpGet:
+          path: /livez
+          port: 46581
+        periodSeconds: 60
+        failureThreshold: 5
+        initialDelaySeconds: 30
+        timeoutSeconds: 3
+      apiService.readinessProbe:
+        httpGet:
+          path: /readyz
+          port: 46581
+        failureThreshold: 2
+        periodSeconds: 10
+        initialDelaySeconds: 15
+        timeoutSeconds: 2
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
@@ -1101,11 +1134,11 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.port
           value: 46581
       - equal:
-          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
-          value: 10
-      - equal:
           path: spec.template.spec.containers[0].readinessProbe.failureThreshold
           value: 2
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 10
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
           value: 15
@@ -1113,31 +1146,30 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
           value: 2
 
-  - it: should render defaults when apiService.probes is set to null
+  - it: should accept exec / tcpSocket probe types via raw spec passthrough
     set:
-      apiService.probes: null
+      apiService.livenessProbe:
+        exec:
+          command: ["/bin/true"]
+        periodSeconds: 30
+      apiService.readinessProbe:
+        tcpSocket:
+          port: 46580
+        periodSeconds: 5
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
-          value: /api/health
+          path: spec.template.spec.containers[0].livenessProbe.exec.command[0]
+          value: /bin/true
       - equal:
-          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
-          value: 46580
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
-          value: /api/health
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
           value: 46580
 
-  - it: should render defaults when probes.liveness and probes.readiness are null
+  - it: should omit the probes entirely when set to null
     set:
-      apiService.probes.liveness: null
-      apiService.probes.readiness: null
+      apiService.livenessProbe: null
+      apiService.readinessProbe: null
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
-          value: /api/health
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
-          value: 5
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe

--- a/charts/skypilot/tests/deployment_test.yaml
+++ b/charts/skypilot/tests/deployment_test.yaml
@@ -1037,6 +1037,9 @@ tests:
           path: spec.template.spec.containers[0].livenessProbe.failureThreshold
           value: 3
       - equal:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+          value: 0
+      - equal:
           path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
           value: 1
       - equal:
@@ -1064,6 +1067,7 @@ tests:
       apiService.probes.liveness.port: 46581
       apiService.probes.liveness.periodSeconds: 60
       apiService.probes.liveness.failureThreshold: 5
+      apiService.probes.liveness.initialDelaySeconds: 30
       apiService.probes.liveness.timeoutSeconds: 3
       apiService.probes.readiness.path: /readyz
       apiService.probes.readiness.port: 46581
@@ -1085,6 +1089,9 @@ tests:
           path: spec.template.spec.containers[0].livenessProbe.failureThreshold
           value: 5
       - equal:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+          value: 30
+      - equal:
           path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
           value: 3
       - equal:
@@ -1105,3 +1112,32 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
           value: 2
+
+  - it: should render defaults when apiService.probes is set to null
+    set:
+      apiService.probes: null
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /api/health
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 46580
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /api/health
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 46580
+
+  - it: should render defaults when probes.liveness and probes.readiness are null
+    set:
+      apiService.probes.liveness: null
+      apiService.probes.readiness: null
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /api/health
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+          value: 5

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -89,6 +89,31 @@
                         "null"
                     ]
                 },
+                "livenessProbe": {
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "properties": {
+                        "httpGet": {
+                            "type": "object",
+                            "properties": {
+                                "path": {
+                                    "type": "string"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
+                },
                 "logs": {
                     "type": "object",
                     "properties": {
@@ -122,17 +147,36 @@
                 "preDeployHook": {
                     "type": "string"
                 },
-                "livenessProbe": {
-                    "type": [
-                        "object",
-                        "null"
-                    ]
-                },
                 "readinessProbe": {
                     "type": [
                         "object",
                         "null"
-                    ]
+                    ],
+                    "properties": {
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "httpGet": {
+                            "type": "object",
+                            "properties": {
+                                "path": {
+                                    "type": "string"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
                 },
                 "replicas": {
                     "type": "integer"

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -122,56 +122,17 @@
                 "preDeployHook": {
                     "type": "string"
                 },
-                "probes": {
-                    "type": "object",
-                    "properties": {
-                        "liveness": {
-                            "type": "object",
-                            "properties": {
-                                "failureThreshold": {
-                                    "type": "integer"
-                                },
-                                "initialDelaySeconds": {
-                                    "type": "integer"
-                                },
-                                "path": {
-                                    "type": "string"
-                                },
-                                "periodSeconds": {
-                                    "type": "integer"
-                                },
-                                "port": {
-                                    "type": "integer"
-                                },
-                                "timeoutSeconds": {
-                                    "type": "integer"
-                                }
-                            }
-                        },
-                        "readiness": {
-                            "type": "object",
-                            "properties": {
-                                "failureThreshold": {
-                                    "type": "integer"
-                                },
-                                "initialDelaySeconds": {
-                                    "type": "integer"
-                                },
-                                "path": {
-                                    "type": "string"
-                                },
-                                "periodSeconds": {
-                                    "type": "integer"
-                                },
-                                "port": {
-                                    "type": "integer"
-                                },
-                                "timeoutSeconds": {
-                                    "type": "integer"
-                                }
-                            }
-                        }
-                    }
+                "livenessProbe": {
+                    "type": [
+                        "object",
+                        "null"
+                    ]
+                },
+                "readinessProbe": {
+                    "type": [
+                        "object",
+                        "null"
+                    ]
                 },
                 "replicas": {
                     "type": "integer"

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -128,6 +128,18 @@
                         "liveness": {
                             "type": "object",
                             "properties": {
+                                "path": {
+                                    "type": "string"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                },
+                                "periodSeconds": {
+                                    "type": "integer"
+                                },
+                                "failureThreshold": {
+                                    "type": "integer"
+                                },
                                 "timeoutSeconds": {
                                     "type": "integer"
                                 }
@@ -136,6 +148,21 @@
                         "readiness": {
                             "type": "object",
                             "properties": {
+                                "path": {
+                                    "type": "string"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                },
+                                "periodSeconds": {
+                                    "type": "integer"
+                                },
+                                "failureThreshold": {
+                                    "type": "integer"
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "integer"
+                                },
                                 "timeoutSeconds": {
                                     "type": "integer"
                                 }

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -140,6 +140,9 @@
                                 "failureThreshold": {
                                     "type": "integer"
                                 },
+                                "initialDelaySeconds": {
+                                    "type": "integer"
+                                },
                                 "timeoutSeconds": {
                                     "type": "integer"
                                 }

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -128,19 +128,19 @@
                         "liveness": {
                             "type": "object",
                             "properties": {
-                                "path": {
-                                    "type": "string"
-                                },
-                                "port": {
-                                    "type": "integer"
-                                },
-                                "periodSeconds": {
-                                    "type": "integer"
-                                },
                                 "failureThreshold": {
                                     "type": "integer"
                                 },
                                 "initialDelaySeconds": {
+                                    "type": "integer"
+                                },
+                                "path": {
+                                    "type": "string"
+                                },
+                                "periodSeconds": {
+                                    "type": "integer"
+                                },
+                                "port": {
                                     "type": "integer"
                                 },
                                 "timeoutSeconds": {
@@ -151,19 +151,19 @@
                         "readiness": {
                             "type": "object",
                             "properties": {
-                                "path": {
-                                    "type": "string"
-                                },
-                                "port": {
-                                    "type": "integer"
-                                },
-                                "periodSeconds": {
-                                    "type": "integer"
-                                },
                                 "failureThreshold": {
                                     "type": "integer"
                                 },
                                 "initialDelaySeconds": {
+                                    "type": "integer"
+                                },
+                                "path": {
+                                    "type": "string"
+                                },
+                                "periodSeconds": {
+                                    "type": "integer"
+                                },
+                                "port": {
                                     "type": "integer"
                                 },
                                 "timeoutSeconds": {

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -82,6 +82,7 @@ apiService:
       port: 46580
       periodSeconds: 30
       failureThreshold: 3
+      initialDelaySeconds: 0
       timeoutSeconds: 1
     readiness:
       path: /api/health

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -69,16 +69,26 @@ apiService:
   # The default value is 60 seconds.
   terminationGracePeriodSeconds: 60
 
-  # Tunable parameters for the API server liveness and readiness probes. Only
-  # `timeoutSeconds` is exposed here; other probe fields (periodSeconds,
-  # failureThreshold, etc.) are kept at their chart defaults.
+  # Tunable parameters for the API server liveness and readiness probes.
+  # Defaults preserve the historical behavior; HA orchestrators that expose
+  # their own /readyz or /livez endpoints can override `path` and `port` to
+  # point the probes at a dedicated health surface.
   # Under heavy request load the `/api/health` handler can occasionally exceed
-  # the default 1s probe timeout and cause the pod to be restarted; bump these
-  # values (e.g. to 3-5) if you see the pod flapping on probes.
+  # the default 1s probe timeout and cause the pod to be restarted; bump
+  # `timeoutSeconds` (e.g. to 3-5) if you see the pod flapping on probes.
   probes:
     liveness:
+      path: /api/health
+      port: 46580
+      periodSeconds: 30
+      failureThreshold: 3
       timeoutSeconds: 1
     readiness:
+      path: /api/health
+      port: 46580
+      periodSeconds: 5
+      failureThreshold: 3
+      initialDelaySeconds: 5
       timeoutSeconds: 1
 
   # Set ~/.sky/config.yaml content on the API server

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -69,28 +69,41 @@ apiService:
   # The default value is 60 seconds.
   terminationGracePeriodSeconds: 60
 
-  # Tunable parameters for the API server liveness and readiness probes.
-  # Defaults preserve the historical behavior; HA orchestrators that expose
-  # their own /readyz or /livez endpoints can override `path` and `port` to
-  # point the probes at a dedicated health surface.
-  # Under heavy request load the `/api/health` handler can occasionally exceed
-  # the default 1s probe timeout and cause the pod to be restarted; bump
-  # `timeoutSeconds` (e.g. to 3-5) if you see the pod flapping on probes.
-  probes:
-    liveness:
+  # Liveness and readiness probe configuration for the API server container.
+  # The full Kubernetes probe spec is rendered as-is into the deployment, so
+  # any field supported by ``v1.Probe`` (httpGet/exec/tcpSocket, periodSeconds,
+  # failureThreshold, initialDelaySeconds, timeoutSeconds, etc.) can be set
+  # here without further chart changes.
+  #
+  # Defaults match the chart's historical rendered output exactly, so an
+  # in-place ``helm upgrade`` against the same values does not trigger a
+  # pod rollout.  HA orchestrators that expose their own /readyz or /livez
+  # endpoints can override ``httpGet.path`` and ``httpGet.port`` to point
+  # the probes at a dedicated health surface.
+  #
+  # Under heavy request load the ``/api/health`` handler can occasionally
+  # exceed the default 1s probe timeout and cause the pod to be restarted;
+  # bump ``timeoutSeconds`` (e.g. to 3-5) if you see the pod flapping.
+  #
+  # ``readinessProbe.successThreshold`` is injected by the deployment
+  # template based on ``apiService.upgradeStrategy`` (RollingUpdate=3,
+  # Recreate=1) when not explicitly set here.
+  # @schema type: [object, null]
+  livenessProbe:
+    httpGet:
       path: /api/health
       port: 46580
-      periodSeconds: 30
-      failureThreshold: 3
-      initialDelaySeconds: 0
-      timeoutSeconds: 1
-    readiness:
+    periodSeconds: 30
+    timeoutSeconds: 1
+  # @schema type: [object, null]
+  readinessProbe:
+    httpGet:
       path: /api/health
       port: 46580
-      periodSeconds: 5
-      failureThreshold: 3
-      initialDelaySeconds: 5
-      timeoutSeconds: 1
+    failureThreshold: 3
+    periodSeconds: 5
+    initialDelaySeconds: 5
+    timeoutSeconds: 1
 
   # Set ~/.sky/config.yaml content on the API server
   # This value is IGNORED during an helm upgrade if there is an existing config

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -70,24 +70,6 @@ apiService:
   terminationGracePeriodSeconds: 60
 
   # Liveness and readiness probe configuration for the API server container.
-  # The full Kubernetes probe spec is rendered as-is into the deployment, so
-  # any field supported by ``v1.Probe`` (httpGet/exec/tcpSocket, periodSeconds,
-  # failureThreshold, initialDelaySeconds, timeoutSeconds, etc.) can be set
-  # here without further chart changes.
-  #
-  # Defaults match the chart's historical rendered output exactly, so an
-  # in-place ``helm upgrade`` against the same values does not trigger a
-  # pod rollout.  HA orchestrators that expose their own /readyz or /livez
-  # endpoints can override ``httpGet.path`` and ``httpGet.port`` to point
-  # the probes at a dedicated health surface.
-  #
-  # Under heavy request load the ``/api/health`` handler can occasionally
-  # exceed the default 1s probe timeout and cause the pod to be restarted;
-  # bump ``timeoutSeconds`` (e.g. to 3-5) if you see the pod flapping.
-  #
-  # ``readinessProbe.successThreshold`` is injected by the deployment
-  # template based on ``apiService.upgradeStrategy`` (RollingUpdate=3,
-  # Recreate=1) when not explicitly set here.
   # @schema type: [object, null]
   livenessProbe:
     httpGet:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Make liveness/readiness probe configurable for chart.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
