### PR TITLE
Increased scrape timeout

### DIFF
--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -696,6 +696,8 @@ prometheus:
     {{ if .Values.useDedicatedScrapeConfig }}
     - job_name: 'skypilot-api-server-metrics'
       honor_labels: true
+      scrape_interval: 30s
+      scrape_timeout: 30s
       kubernetes_sd_configs:
         - role: pod
           namespaces:

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -697,7 +697,7 @@ prometheus:
     - job_name: 'skypilot-api-server-metrics'
       honor_labels: true
       scrape_interval: 30s
-      scrape_timeout: 30s
+      scrape_timeout: 20s
       kubernetes_sd_configs:
         - role: pod
           namespaces:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Increased the scrape timeout of API server metrics

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
