### PR TITLE
[Secrets] Fix Secrets Parsing

### DIFF
--- a/sky/task.py
+++ b/sky/task.py
@@ -1959,7 +1959,11 @@ class Task:
                 if isinstance(existing, dict):
                     # Mixed: inline dict already set. Put refs in
                     # managed_secrets field to keep YAML valid.
-                    managed_secrets_field.extend(ref_list)
+                    # The 'secrets:' prefix is only used by the secrets
+                    # array form; managed_secrets entries are bare names.
+                    managed_secrets_field.extend(
+                        e[len('secrets:'):] if e.startswith('secrets:') else e
+                        for e in ref_list)
                 else:
                     config['secrets'] = ref_list
 

--- a/tests/unit_tests/test_sky/test_task.py
+++ b/tests/unit_tests/test_sky/test_task.py
@@ -231,6 +231,30 @@ def test_to_yaml_config_preserves_other_fields():
     assert 'resources' in config_redacted
 
 
+def test_yaml_config_roundtrip_inline_and_managed_secrets():
+    """Mixed inline + managed secret refs must survive to_yaml/from_yaml.
+
+    Reproduces a case where the 'secrets:' prefix used by the array form
+    leaked into the managed_secrets field, and the resulting refs were
+    parsed with 'secrets:' as part of the name.
+    """
+    config = {
+        'run': 'echo hi',
+        'secrets': {
+            'HF_TOKEN': 'hello',
+            'secrets:TEST_TOKEN': None,
+        },
+    }
+    t1 = task.Task.from_yaml_config(config)
+    assert [r.name for r in t1._managed_secret_refs] == ['TEST_TOKEN']
+
+    serialized = t1.to_yaml_config()
+    assert serialized.get('managed_secrets') == ['TEST_TOKEN']
+
+    t2 = task.Task.from_yaml_config(serialized)
+    assert [r.name for r in t2._managed_secret_refs] == ['TEST_TOKEN']
+
+
 def test_update_secrets():
     """Test the update_secrets method."""
     task_obj = task.Task(run='echo hello')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixes an issue with secrets parsing when values would not be properly resolved.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
