### PR TITLE
[DB] Use async_creator to hand asyncpg the libpq DSN

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -74,7 +74,9 @@ install_requires = [
     'aiofiles',
     'httpx',
     'setproctitle',
-    'sqlalchemy>=2.0.0',
+    # 2.0.16 introduced create_async_engine(async_creator=...), which we
+    # rely on in sky/utils/db/db_utils.py to hand asyncpg the libpq DSN.
+    'sqlalchemy>=2.0.16',
     'psycopg2-binary',
     'aiosqlite',
     'asyncpg',

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -492,6 +492,37 @@ def get_max_connections():
     return _max_connections
 
 
+def _make_asyncpg_creator(dsn: str) -> Callable[[], Any]:
+    """Build a SQLAlchemy ``async_creator`` that hands asyncpg a libpq DSN.
+
+    SQLAlchemy's asyncpg dialect normally parses the URL into kwargs and calls
+    ``asyncpg.connect(**kwargs)``. asyncpg's kwarg path accepts ``ssl=`` only;
+    the libpq query-param names (``sslmode``, ``sslcert``, ``sslkey``,
+    ``sslrootcert``, ``sslcrl``) are recognized only when asyncpg parses them
+    out of a DSN string itself (see ``asyncpg.connect_utils.
+    _parse_connect_dsn_and_args``). Leaving e.g. ``?sslmode=require`` in the
+    URL therefore raises ``connect() got an unexpected keyword argument
+    'sslmode'``.
+
+    Bypassing SQLAlchemy's URL disassembly via ``async_creator`` lets asyncpg
+    parse the DSN itself, so every libpq URI param is handled natively without
+    us having to translate. The creator takes no arguments per SQLAlchemy's
+    contract — connection params come from the captured DSN, not the URL
+    passed to ``create_async_engine`` (which is used only for dialect
+    selection).
+
+    Refs: https://github.com/sqlalchemy/sqlalchemy/issues/6275#issuecomment-820227148,
+          https://github.com/MagicStack/asyncpg/issues/737
+    """
+    # pylint: disable=import-outside-toplevel
+    import asyncpg
+
+    async def _connect() -> Any:
+        return await asyncpg.connect(dsn)
+
+    return _connect
+
+
 @typing.overload
 def get_engine(
         db_name: Optional[str],
@@ -520,6 +551,12 @@ def get_engine(
     if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
         conn_string = os.environ.get(constants.ENV_VAR_DB_CONNECTION_URI)
     if conn_string:
+        # Capture the original libpq DSN for asyncpg before we rewrite the
+        # scheme for SQLAlchemy. asyncpg parses libpq URI query params
+        # (sslmode/sslcert/sslkey/sslrootcert/sslcrl) natively when given a
+        # DSN string; SQLAlchemy's asyncpg dialect does not. See
+        # _make_asyncpg_creator.
+        asyncpg_dsn = conn_string
         if async_engine:
             conn_string = conn_string.replace('postgresql://',
                                               'postgresql+asyncpg://')
@@ -542,7 +579,11 @@ def get_engine(
                     # Refer to https://docs.sqlalchemy.org/en/21/orm/extensions/asyncio.html#using-multiple-asyncio-event-loops for more details. # pylint: disable=line-too-long
                     _postgres_engine_cache[conn_string] = (
                         sqlalchemy_async.create_async_engine(
-                            conn_string, poolclass=sqlalchemy.NullPool))
+                            # The URL is used only for dialect selection;
+                            # all connection params come from async_creator.
+                            'postgresql+asyncpg://',
+                            poolclass=sqlalchemy.NullPool,
+                            async_creator=_make_asyncpg_creator(asyncpg_dsn)))
                 elif _max_connections == 0:
                     _postgres_engine_cache[conn_string] = (
                         sqlalchemy.create_engine(conn_string,

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -552,20 +552,12 @@ def get_engine(
     if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
         conn_string = os.environ.get(constants.ENV_VAR_DB_CONNECTION_URI)
     if conn_string:
-        # Capture the original libpq DSN for asyncpg before we rewrite the
-        # scheme for SQLAlchemy. asyncpg parses libpq URI query params
-        # (sslmode/sslcert/sslkey/sslrootcert/sslcrl) natively when given a
-        # DSN string; SQLAlchemy's asyncpg dialect does not. See
-        # _make_asyncpg_creator.
-        asyncpg_dsn = conn_string
-        if async_engine:
-            conn_string = conn_string.replace('postgresql://',
-                                              'postgresql+asyncpg://')
+        # Cache key distinguishes sync vs async: the async engine is built via
+        # async_creator and never uses conn_string for connection params, so
+        # we don't rewrite the scheme — we just key the cache differently.
+        cache_key = f'async:{conn_string}' if async_engine else conn_string
         with _db_creation_lock:
-            # We use the same cache for both sync and async engines
-            # because we change the conn_string in the async case,
-            # so they would not overlap.
-            if conn_string not in _postgres_engine_cache:
+            if cache_key not in _postgres_engine_cache:
                 engine_type = 'sync' if not async_engine else 'async'
                 logger.debug(
                     f'Creating a new postgres {engine_type} engine with '
@@ -578,20 +570,20 @@ def get_engine(
                     # context (e.g., a thread). NullPool creates a fresh
                     # connection per operation, avoiding this issue.
                     # Refer to https://docs.sqlalchemy.org/en/21/orm/extensions/asyncio.html#using-multiple-asyncio-event-loops for more details. # pylint: disable=line-too-long
-                    _postgres_engine_cache[conn_string] = (
+                    _postgres_engine_cache[cache_key] = (
                         sqlalchemy_async.create_async_engine(
                             # The URL is used only for dialect selection;
                             # all connection params come from async_creator.
                             'postgresql+asyncpg://',
                             poolclass=sqlalchemy.NullPool,
-                            async_creator=_make_asyncpg_creator(asyncpg_dsn)))
+                            async_creator=_make_asyncpg_creator(conn_string)))
                 elif _max_connections == 0:
-                    _postgres_engine_cache[conn_string] = (
+                    _postgres_engine_cache[cache_key] = (
                         sqlalchemy.create_engine(conn_string,
                                                  poolclass=sqlalchemy.NullPool))
                 else:
                     # Sync engines can safely use QueuePool for connection reuse
-                    _postgres_engine_cache[conn_string] = (
+                    _postgres_engine_cache[cache_key] = (
                         sqlalchemy.create_engine(
                             conn_string,
                             poolclass=sqlalchemy.pool.QueuePool,
@@ -599,7 +591,7 @@ def get_engine(
                             max_overflow=max(0, 5 - _max_connections),
                             pool_pre_ping=True,
                             pool_recycle=1800))
-            engine = _postgres_engine_cache[conn_string]
+            engine = _postgres_engine_cache[cache_key]
     else:
         assert db_name is not None, 'db_name must be provided for SQLite'
         db_path = runtime_utils.get_runtime_dir_path(f'.sky/{db_name}.db')

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -552,9 +552,9 @@ def get_engine(
     if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
         conn_string = os.environ.get(constants.ENV_VAR_DB_CONNECTION_URI)
     if conn_string:
-        # Cache key distinguishes sync vs async: the async engine is built via
-        # async_creator and never uses conn_string for connection params, so
-        # we don't rewrite the scheme — we just key the cache differently.
+        # We use the same cache for both sync and async engines
+        # because we prefix the cache key in the async case,
+        # so they would not overlap.
         cache_key = f'async:{conn_string}' if async_engine else conn_string
         with _db_creation_lock:
             if cache_key not in _postgres_engine_cache:

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -511,8 +511,9 @@ def _make_asyncpg_creator(dsn: str) -> Callable[[], Any]:
     passed to ``create_async_engine`` (which is used only for dialect
     selection).
 
-    Refs: https://github.com/sqlalchemy/sqlalchemy/issues/6275#issuecomment-820227148,
-          https://github.com/MagicStack/asyncpg/issues/737
+    Refs:
+      https://github.com/sqlalchemy/sqlalchemy/issues/6275
+      https://github.com/MagicStack/asyncpg/issues/737
     """
     # pylint: disable=import-outside-toplevel
     import asyncpg

--- a/tests/unit_tests/test_sky/utils/test_db_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_db_utils.py
@@ -260,10 +260,11 @@ class TestGetEngine:
 
             mock_create.assert_called_once()
             call_args = mock_create.call_args
-            # Connection string should be modified for asyncpg
-            assert call_args[0][
-                0] == 'postgresql+asyncpg://user:pass@localhost/db'
+            # URL is just the dialect placeholder; all connection params
+            # are supplied via async_creator (see _make_asyncpg_creator).
+            assert call_args[0][0] == 'postgresql+asyncpg://'
             assert call_args[1]['poolclass'] == sqlalchemy.NullPool
+            assert callable(call_args[1].get('async_creator'))
             assert engine == mock_engine
 
     def test_postgres_engine_caching(self, monkeypatch):

--- a/tests/unit_tests/test_sky/utils/test_db_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_db_utils.py
@@ -267,6 +267,57 @@ class TestGetEngine:
             assert callable(call_args[1].get('async_creator'))
             assert engine == mock_engine
 
+    @pytest.mark.asyncio
+    async def test_postgres_async_engine_does_not_leak_libpq_kwargs_to_asyncpg(
+            self, monkeypatch):
+        """End-to-end check: with a sslmode-bearing URI, real SQLAlchemy
+        must not forward libpq query params as kwargs to asyncpg.connect.
+
+        Without the fix in ``get_engine``, SQLAlchemy's asyncpg dialect
+        parses the URL into kwargs and calls
+        ``asyncpg.connect(host=..., port=..., ..., sslmode='require')``,
+        which asyncpg rejects with
+        ``unexpected keyword argument 'sslmode'``. We exercise the real
+        SQLAlchemy stack with ``asyncpg.connect`` mocked at the boundary
+        and inspect how it was actually called.
+
+        See https://github.com/sqlalchemy/sqlalchemy/issues/6275.
+        """
+        libpq_uri = 'postgresql://user:pass@localhost/db?sslmode=require'
+        monkeypatch.setenv('IS_SKYPILOT_SERVER', 'true')
+        monkeypatch.setenv('SKYPILOT_DB_CONNECTION_URI', libpq_uri)
+
+        # Mock asyncpg.connect at the integration boundary. Returning an
+        # AsyncMock connection lets SQLAlchemy's adapter wrap it without
+        # immediately exploding; downstream operations on the mock may
+        # fail, but we only care about how asyncpg.connect itself was
+        # invoked (the failure point of the bug).
+        with mock.patch('asyncpg.connect',
+                        new_callable=mock.AsyncMock) as mock_connect:
+            mock_connect.return_value = mock.AsyncMock()
+
+            engine = db_utils.get_engine(db_name='ignored', async_engine=True)
+
+            try:
+                async with engine.connect():
+                    pass
+            except Exception:  # pylint: disable=broad-except
+                # SQLAlchemy will likely fail to use the mocked connection
+                # past the connect() call. That's fine — asyncpg.connect
+                # has already been invoked and the call args captured.
+                pass
+
+        mock_connect.assert_called()
+        _, call_kwargs = mock_connect.call_args_list[0]
+        forbidden_libpq_kwargs = {
+            'sslmode', 'sslcert', 'sslkey', 'sslrootcert', 'sslcrl'
+        }
+        leaked = forbidden_libpq_kwargs & set(call_kwargs)
+        assert not leaked, (
+            f'libpq query params leaked as kwargs to asyncpg.connect: '
+            f'{sorted(leaked)}. asyncpg only accepts these inside a DSN '
+            f'string. Full call kwargs: {call_kwargs!r}')
+
     def test_postgres_engine_caching(self, monkeypatch):
         """Test Postgres sync engines are cached and reused."""
         monkeypatch.setenv('IS_SKYPILOT_SERVER', 'true')


### PR DESCRIPTION
## Summary

Fixes a connect-time failure when the Postgres `db_connection_uri` contains libpq query params such as `?sslmode=require`. The async engine raises:

```
connect() got an unexpected keyword argument 'sslmode'
```

asyncpg only recognizes libpq URI params (`sslmode`, `sslcert`, `sslkey`, `sslrootcert`, `sslcrl`) when it parses them out of a DSN string itself — see [`asyncpg.connect_utils._parse_connect_dsn_and_args`](https://github.com/MagicStack/asyncpg/blob/master/asyncpg/connect_utils.py). Its kwarg path accepts only `ssl=`. SQLAlchemy's asyncpg dialect, however, dismantles the URL into kwargs and calls `asyncpg.connect(**kwargs)` ([`opts.update(url.query)`](https://github.com/sqlalchemy/sqlalchemy/blob/main/lib/sqlalchemy/dialects/postgresql/asyncpg.py)), so the libpq params land as unknown kwargs and asyncpg rejects them.

This is a long-standing known limitation:
- https://github.com/sqlalchemy/sqlalchemy/issues/6275
- https://github.com/MagicStack/asyncpg/issues/737

The fix uses SQLAlchemy's [`async_creator`](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.create_async_engine) hook to bypass URL disassembly and hand asyncpg the original DSN. asyncpg then parses the libpq URI itself, so every libpq param is handled natively — no translation table, no `sslmode` → `ssl` mapping, no SSLContext construction in our code.

This is the [approach recommended by a SQLAlchemy maintainer in #6275](https://github.com/sqlalchemy/sqlalchemy/issues/6275#issuecomment-820227148).

The sync engine path is unchanged — psycopg2 already handles `sslmode` natively.

## Repro (before this PR)

```bash
export SKYPILOT_DB_CONNECTION_URI='postgresql://user:pass@host:5432/db?sslmode=require'
# Any code path using _db_manager.get_async_engine(), e.g. the
# job-event retention daemon in sky/jobs/state.py, fails with:
#   Error running job event retention daemon:
#   connect() got an unexpected keyword argument 'sslmode'
```

## Test plan

- [x] Unit: existing `tests/unit_tests/utils/db/` suite still passes
- [x] Integration with managed Postgres requiring TLS (Cloud SQL / RDS):
  - [x] Set `SKYPILOT_DB_CONNECTION_URI` to a URL containing `?sslmode=require` and confirm the API server starts and the job-event retention daemon runs without the `unexpected keyword argument 'sslmode'` error
  - [x] Confirm sync engine connections still work (no regression for the psycopg2 path)
- [x] Verify async engine connections work without query params (plain `postgresql://...`) — sanity check for the no-DSN-params case