### PR TITLE
[Helm] History dashboard: exclude cw-hpc-verification from allocation

### DIFF
--- a/charts/skypilot/manifests/compute-overview-dashboard.json
+++ b/charts/skypilot/manifests/compute-overview-dashboard.json
@@ -159,7 +159,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(max by (cluster, namespace, pod, container) (kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) / sum(max by (cluster, node) (kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) * 100",
+          "expr": "sum(max by (cluster, namespace, pod, container) (kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\", namespace!=\"cw-hpc-verification\"})) / sum(max by (cluster, node) (kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) * 100",
           "instant": false,
           "legendFormat": "",
           "range": true,
@@ -289,7 +289,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(max by (cluster, namespace, pod, container) (kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) / sum(max by (cluster, node) (kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) * 100",
+          "expr": "sum(max by (cluster, namespace, pod, container) (kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\", namespace!=\"cw-hpc-verification\"})) / sum(max by (cluster, node) (kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) * 100",
           "instant": false,
           "legendFormat": "GPU Allocation",
           "range": true,


### PR DESCRIPTION
## Summary

The GPU Allocation gauge + timeseries on the History dashboard currently sum `kube_pod_container_resource_requests` across **all** pods. On clusters running preemptible verification daemons (notably CoreWeave's `hpc-verification` pod, which holds all 8 GPUs on each H200 node while running hardware health checks), this inflates the reported allocation: the dashboard reads 100% even though the same GPUs are immediately available to a real workload because the verification pod is designed to evict.

`sky/provision/kubernetes/utils.py:should_exclude_pod_from_gpu_allocation()` already filters this exact namespace out of the "available accelerators" calculation that backs the cluster nodes table:

```python
def should_exclude_pod_from_gpu_allocation(pod) -> bool:
    """Some cloud providers run low priority test/verification pods that
    request GPUs but should not count against real GPU availability since
    they are designed to be evicted when higher priority workloads need
    resources."""
    if pod.metadata.namespace == 'cw-hpc-verification':
        return True
    return False
```

This PR mirrors that single-namespace exclusion in the two Prometheus queries on the History dashboard so the gauge / timeseries view agrees with the per-node availability view:

```promql
kube_pod_container_resource_requests{
  resource="nvidia_com_gpu",
  cluster=~"$cluster",
  namespace!="cw-hpc-verification"
}
```

## Test plan

- [x] `helm template` renders the ConfigMap; dashboard JSON passes `python3 -m json.tool`
- [ ] Deploy to a tenant with the `cw-hpc-verification` pod active. Allocation gauge / timeseries should drop by the GPU count of that pod (e.g. 8 GPUs × number of CoreWeave nodes). Result should match what the nodes table reports.
- [ ] Tenants without `cw-hpc-verification` should be unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)