### PR TITLE
[CI] Document `/smoke-test --shared-server` in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,7 @@ Tested (run the relevant ones):
 - [ ] Any manual or new tests for this PR (please specify below)
 - [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
 - [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
+- [ ] Run against an ephemeral GKE+Postgres API server: `/smoke-test --shared-server -k test_name` (CI; alias for `/shared-gke-postgres`)
 - [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)
 
 <!-- CI commands (/-prefixed) can only be triggered by repo members -->


### PR DESCRIPTION
## Summary

Adds a checklist line in `.github/pull_request_template.md` for the `/smoke-test --shared-server` CI alias. This alias routes to the shared GKE+Postgres pipeline (an alias for `/shared-gke-postgres`); same pytest selectors as `/smoke-test`, just differs in where the API server lives.

## Why

Useful when a change needs a real Postgres-backed API server but doesn't need fresh per-cloud creds — quicker feedback than the standard `/smoke-test` flow. Putting it in the PR template surfaces it in the place reviewers and authors already look.

## Test plan

- [x] Markdown renders cleanly.
- [ ] After merge, comment `/smoke-test --shared-server -k test_minimal` on a PR and confirm the routing works.

## Notes

The lambda-side wiring is in a separate (private) repo and lands together with this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)