### PR TITLE
[AWS] Fix default security group auth error not caught after 0.12 VPC refactor

### DIFF
--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -124,8 +124,7 @@ def bootstrap_instances(
                                           [], enable_efa)
                 logger.debug('Default security group created.')
             except exceptions.NoClusterLaunchedError as e:
-                if 'not authorized to perform: ec2:CreateSecurityGroup' in str(
-                        e):
+                if 'UnauthorizedOperation' in str(e):
                     # User does not have permission to create the default
                     # security group.
                     logger.debug('User does not have permission to create '


### PR DESCRIPTION
**Bug:** `sky launch` fails with `ResourcesUnavailableError` when `aws.security_group_name` is configured and the user lacks `ec2:CreateTags` on `security-group/*`.

**Root cause:** In `sky/provision/aws/config.py`, the best-effort creation of the *default* security group has a catch block that silently ignores permission errors:

```python
if 'not authorized to perform: ec2:CreateSecurityGroup' in str(e):
    pass  # silently skip
else:
    raise e  # ← falls through for ec2:CreateTags errors
```

Since the 0.12 VPC refactor, `_get_or_create_vpc_security_group` passes `TagSpecifications` to `CreateSecurityGroup`. AWS now evaluates `ec2:CreateTags` *before* creating the resource and returns an `UnauthorizedOperation` error naming `ec2:CreateTags`, not `ec2:CreateSecurityGroup`. The old string check does not match and the exception is re-raised.

**Why the fix is correct:** The comment in the source explicitly states this creation is best-effort ("If the default security group is not created, we will need to block on instance termination"). Any `UnauthorizedOperation` from this block is about security-group creation; broadening the match to `'UnauthorizedOperation'` covers both the `CreateSecurityGroup` and `CreateTags` variants without masking unrelated errors (the `try` block only calls `_configure_security_group` for the default SG).

Fixes #9466