### PR TITLE
Reduce metrics cardinality

### DIFF
--- a/charts/skypilot/manifests/api-server-overview.json
+++ b/charts/skypilot/manifests/api-server-overview.json
@@ -1742,10 +1742,10 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum by(le, pid) (rate(sky_apiserver_event_loop_lag_seconds_bucket{app=\"$app\"}[2m])))",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(sky_apiserver_event_loop_lag_seconds_bucket{app=\"$app\"}[2m])))",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{pid}}",
+          "legendFormat": "p99",
           "range": true,
           "refId": "A"
         }
@@ -1841,7 +1841,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(1, sum by(le, pid) (rate(sky_apiserver_event_loop_lag_seconds_bucket{app=\"$app\"}[2m])))",
+          "expr": "max by(pid) (sky_apiserver_event_loop_lag_max_seconds{app=\"$app\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "{{pid}}",
@@ -2264,10 +2264,10 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le, pid) (rate(sky_apiserver_event_loop_lag_seconds_bucket{app=\"$app\"}[2m])))",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(sky_apiserver_event_loop_lag_seconds_bucket{app=\"$app\"}[2m])))",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{pid}}",
+          "legendFormat": "p95",
           "range": true,
           "refId": "A"
         }

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -43,20 +43,18 @@ logger = sky_logging.init_logger(__name__)
 METRICS_ENABLED = os.environ.get(constants.ENV_VAR_SERVER_METRICS_ENABLED,
                                  'false').lower() == 'true'
 
+# Latency buckets shared by histograms that observe seconds. Kept compact to
+# bound time-series cardinality (each labeled series multiplies by len(buckets))
+# while preserving the 1000s upper bound for slow-call precision.
+_LATENCY_BUCKETS = (0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30,
+                    60, 120, 300, 600, 1000, float('inf'))
+
 # Time spent processing a piece of code, refer to time_it().
 SKY_APISERVER_CODE_DURATION_SECONDS = prom.Histogram(
     'sky_apiserver_code_duration_seconds',
     'Time spent processing code',
     ['name', 'group'],
-    buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.125, 0.15, 0.25,
-             0.35, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5, 2.75, 3, 3.5, 4, 4.5,
-             5, 7.5, 10.0, 12.5, 15.0, 17.5, 20.0, 25.0, 30.0, 35.0, 40.0, 45.0,
-             50.0, 55.0, 60.0, 80.0, 120.0, 140.0, 160.0, 180.0, 200.0, 220.0,
-             240.0, 260.0, 280.0, 300.0, 320.0, 340.0, 360.0, 380.0, 400.0,
-             420.0, 440.0, 460.0, 480.0, 500.0, 520.0, 540.0, 560.0, 580.0,
-             600.0, 620.0, 640.0, 660.0, 680.0, 700.0, 720.0, 740.0, 760.0,
-             780.0, 800.0, 820.0, 840.0, 860.0, 880.0, 900.0, 920.0, 940.0,
-             960.0, 980.0, 1000.0, float('inf')),
+    buckets=_LATENCY_BUCKETS,
 )
 
 # Total number of API server requests, grouped by path, method, and status.
@@ -83,30 +81,26 @@ SKY_APISERVER_REQUEST_DURATION_SECONDS = prom.Histogram(
     'sky_apiserver_request_duration_seconds',
     'Time spent processing API server requests',
     ['path', 'method', 'status'],
-    buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.125, 0.15, 0.25,
-             0.35, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5, 2.75, 3, 3.5, 4, 4.5,
-             5, 7.5, 10.0, 12.5, 15.0, 17.5, 20.0, 25.0, 30.0, 35.0, 40.0, 45.0,
-             50.0, 55.0, 60.0, 80.0, 120.0, 140.0, 160.0, 180.0, 200.0, 220.0,
-             240.0, 260.0, 280.0, 300.0, 320.0, 340.0, 360.0, 380.0, 400.0,
-             420.0, 440.0, 460.0, 480.0, 500.0, 520.0, 540.0, 560.0, 580.0,
-             600.0, 620.0, 640.0, 660.0, 680.0, 700.0, 720.0, 740.0, 760.0,
-             780.0, 800.0, 820.0, 840.0, 860.0, 880.0, 900.0, 920.0, 940.0,
-             960.0, 980.0, 1000.0, float('inf')),
+    buckets=_LATENCY_BUCKETS,
 )
 
+# Aggregated across all worker processes — the prometheus_client multiprocess
+# collector sums per-process histograms automatically. For per-process
+# visibility, see SKY_APISERVER_EVENT_LOOP_LAG_MAX_SECONDS below.
 SKY_APISERVER_EVENT_LOOP_LAG_SECONDS = prom.Histogram(
     'sky_apiserver_event_loop_lag_seconds',
     'Scheduling delay of the server event loop',
+    buckets=_LATENCY_BUCKETS,
+)
+
+# Per-process peak event loop lag observed in the most recent 30s tumbling
+# window. Kept as a low-cardinality companion to the (pid-less) lag histogram
+# so operators can still attribute spikes to a specific worker.
+SKY_APISERVER_EVENT_LOOP_LAG_MAX_SECONDS = prom.Gauge(
+    'sky_apiserver_event_loop_lag_max_seconds',
+    'Peak event loop lag in the last 30 seconds for each process',
     ['pid'],
-    buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.125, 0.15, 0.25,
-             0.35, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5, 2.75, 3, 3.5, 4, 4.5,
-             5, 7.5, 10.0, 12.5, 15.0, 17.5, 20.0, 25.0, 30.0, 35.0, 40.0, 45.0,
-             50.0, 55.0, 60.0, 80.0, 120.0, 140.0, 160.0, 180.0, 200.0, 220.0,
-             240.0, 260.0, 280.0, 300.0, 320.0, 340.0, 360.0, 380.0, 400.0,
-             420.0, 440.0, 460.0, 480.0, 500.0, 520.0, 540.0, 560.0, 580.0,
-             600.0, 620.0, 640.0, 660.0, 680.0, 700.0, 720.0, 740.0, 760.0,
-             780.0, 800.0, 820.0, 840.0, 860.0, 880.0, 900.0, 920.0, 940.0,
-             960.0, 980.0, 1000.0, float('inf')),
+    multiprocess_mode='liveall',
 )
 
 SKY_APISERVER_WEBSOCKET_CONNECTIONS = prom.Gauge(
@@ -161,15 +155,7 @@ SKY_APISERVER_WEBSOCKET_SSH_LATENCY_SECONDS = prom.Histogram(
      'overhead from sending through the k8s port-forward tunnel, or '
      'ssh server lag on the destination pod.'),
     ['pid'],
-    buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.125, 0.15, 0.25,
-             0.35, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5, 2.75, 3, 3.5, 4, 4.5,
-             5, 7.5, 10.0, 12.5, 15.0, 17.5, 20.0, 25.0, 30.0, 35.0, 40.0, 45.0,
-             50.0, 55.0, 60.0, 80.0, 120.0, 140.0, 160.0, 180.0, 200.0, 220.0,
-             240.0, 260.0, 280.0, 300.0, 320.0, 340.0, 360.0, 380.0, 400.0,
-             420.0, 440.0, 460.0, 480.0, 500.0, 520.0, 540.0, 560.0, 580.0,
-             600.0, 620.0, 640.0, 660.0, 680.0, 700.0, 720.0, 740.0, 760.0,
-             780.0, 800.0, 820.0, 840.0, 860.0, 880.0, 900.0, 920.0, 940.0,
-             960.0, 980.0, 1000.0, float('inf')),
+    buckets=_LATENCY_BUCKETS,
 )
 
 SKY_APISERVER_LONG_EXECUTORS = prom.Gauge(

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -154,7 +154,6 @@ SKY_APISERVER_WEBSOCKET_SSH_LATENCY_SECONDS = prom.Histogram(
      'to the client. This does not include: latency to reach the pod, '
      'overhead from sending through the k8s port-forward tunnel, or '
      'ssh server lag on the destination pod.'),
-    ['pid'],
     buckets=_LATENCY_BUCKETS,
 )
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -658,8 +658,9 @@ async def loop_lag_monitor(loop: asyncio.AbstractEventLoop,
     lag_threshold = perf_utils.get_loop_lag_threshold()
     # Tumbling 30s window peak per process — paired with the pid-less lag
     # histogram so we keep per-worker visibility without histogram cardinality.
+    # Uses loop.time() (monotonic) so NTP adjustments cannot warp the window.
     lag_max_window_seconds = 30.0
-    lag_max_window_end = time.time() + lag_max_window_seconds
+    lag_max_window_end = loop.time() + lag_max_window_seconds
     lag_max_in_window = 0.0
 
     def tick():
@@ -670,9 +671,8 @@ async def loop_lag_monitor(loop: asyncio.AbstractEventLoop,
             logger.warning(f'Event loop lag {lag} seconds exceeds threshold '
                            f'{lag_threshold} seconds.')
         metrics_utils.SKY_APISERVER_EVENT_LOOP_LAG_SECONDS.observe(lag)
-        wall = time.time()
-        if wall >= lag_max_window_end:
-            lag_max_window_end = wall + lag_max_window_seconds
+        if now >= lag_max_window_end:
+            lag_max_window_end = now + lag_max_window_seconds
             lag_max_in_window = lag
         else:
             lag_max_in_window = max(lag_max_in_window, lag)

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -656,16 +656,28 @@ async def loop_lag_monitor(loop: asyncio.AbstractEventLoop,
 
     pid = str(os.getpid())
     lag_threshold = perf_utils.get_loop_lag_threshold()
+    # Tumbling 30s window peak per process — paired with the pid-less lag
+    # histogram so we keep per-worker visibility without histogram cardinality.
+    lag_max_window_seconds = 30.0
+    lag_max_window_end = time.time() + lag_max_window_seconds
+    lag_max_in_window = 0.0
 
     def tick():
-        nonlocal target
+        nonlocal target, lag_max_window_end, lag_max_in_window
         now = loop.time()
         lag = max(0.0, now - target)
         if lag_threshold is not None and lag > lag_threshold:
             logger.warning(f'Event loop lag {lag} seconds exceeds threshold '
                            f'{lag_threshold} seconds.')
-        metrics_utils.SKY_APISERVER_EVENT_LOOP_LAG_SECONDS.labels(
-            pid=pid).observe(lag)
+        metrics_utils.SKY_APISERVER_EVENT_LOOP_LAG_SECONDS.observe(lag)
+        wall = time.time()
+        if wall >= lag_max_window_end:
+            lag_max_window_end = wall + lag_max_window_seconds
+            lag_max_in_window = lag
+        else:
+            lag_max_in_window = max(lag_max_in_window, lag)
+        metrics_utils.SKY_APISERVER_EVENT_LOOP_LAG_MAX_SECONDS.labels(
+            pid=pid).set(lag_max_in_window)
         target = now + interval
         loop.call_at(target, tick)
 

--- a/sky/server/websocket_utils.py
+++ b/sky/server/websocket_utils.py
@@ -2,7 +2,6 @@
 
 import asyncio
 from enum import IntEnum
-import os
 import struct
 from typing import Awaitable, Callable, Optional
 
@@ -93,8 +92,8 @@ async def run_websocket_proxy(
                             '!Q',
                             message[type_size:type_size + latency_size])[0]
                         latency_seconds = avg_latency_ms / 1000
-                        metrics_utils.SKY_APISERVER_WEBSOCKET_SSH_LATENCY_SECONDS.labels(  # pylint: disable=line-too-long
-                            pid=os.getpid()).observe(latency_seconds)
+                        metrics_utils.SKY_APISERVER_WEBSOCKET_SSH_LATENCY_SECONDS.observe(  # pylint: disable=line-too-long
+                            latency_seconds)
                         continue
                     else:
                         raise ValueError(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The cardinality of skypilot metrics can be quite high, especially:

- `event_loop_lag_bucket`, 86 buckets * 500 process = 43K time-series
- `code_duration_bucket`, 86 buckets * 145 name = 12.4K time-series

This PR reduce the bucket number from 86 to 17 (the upper bound 1000s is kept), and remove the pid label from `event_loop_lag_bucket`, to still reflect the abnormal lag in each process, a new metrics `sky_apiserver_event_loop_lag_max_seconds` is added.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
