### PR TITLE
[Core] Allow plugins to register `plugins.<name>:` config sections

### DIFF
--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -54,6 +54,8 @@ def register_plugin_property(name: str, schema: Dict[str, Any]) -> None:
         schema: The JSON Schema for the property
             (e.g., {'type': 'object', 'properties': {...}}).
     """
+    if name in _extra_plugin_properties:
+        raise ValueError(f'Plugin property {name!r} is already registered.')
     _extra_plugin_properties[name] = schema
 
 

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -44,16 +44,7 @@ _extra_plugin_properties: Dict[str, Any] = {}
 
 
 def register_plugin_property(name: str, schema: Dict[str, Any]) -> None:
-    """Register a sub-property of the top-level `plugins:` config section.
-
-    Each plugin owns one key under `plugins:`. e.g. the HA plugin
-    registers ``'ha'`` and reads its config from ``plugins.ha.<...>``.
-
-    Args:
-        name: The plugin's key under `plugins:`.
-        schema: The JSON Schema for the property
-            (e.g., {'type': 'object', 'properties': {...}}).
-    """
+    """Register a sub-property of the top-level `plugins:` config section."""
     if name in _extra_plugin_properties:
         raise ValueError(f'Plugin property {name!r} is already registered.')
     _extra_plugin_properties[name] = schema
@@ -2531,16 +2522,13 @@ def get_config_schema():
             'daemons': daemon_schema,
             'data': data_schema,
             **cloud_configs,
-            # Reserved namespace for plugin-specific config. Each plugin
-            # owns one key under `plugins:` and registers its sub-schema
-            # via register_plugin_property(). additionalProperties=True
-            # so that disabling a plugin (its register call no longer
-            # runs) does not invalidate an existing config block — the
-            # server should not refuse to start just because some
-            # `plugins.<retired>:` entry is sitting in the user's config.
+            # For plugin-specific config.
             'plugins': {
                 'type': 'object',
                 'required': [],
+                # Allow unknown properties since a plugin can be turned off
+                # and the previously valid config should not block server
+                # from reading the config file.
                 'additionalProperties': True,
                 'properties': _extra_plugin_properties,
             },

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -38,6 +38,24 @@ def register_job_recovery_property(name: str, schema: Dict[str, Any]) -> None:
 
 _extra_kubernetes_properties: Dict[str, Any] = {}
 
+# Registry for plugin-provided properties under the top-level
+# `plugins:` config section. Keyed by plugin name.
+_extra_plugin_properties: Dict[str, Any] = {}
+
+
+def register_plugin_property(name: str, schema: Dict[str, Any]) -> None:
+    """Register a sub-property of the top-level `plugins:` config section.
+
+    Each plugin owns one key under `plugins:`. e.g. the HA plugin
+    registers ``'ha'`` and reads its config from ``plugins.ha.<...>``.
+
+    Args:
+        name: The plugin's key under `plugins:`.
+        schema: The JSON Schema for the property
+            (e.g., {'type': 'object', 'properties': {...}}).
+    """
+    _extra_plugin_properties[name] = schema
+
 
 def _allow_additional_properties() -> bool:
     """Return True if schemas should allow additional properties.
@@ -2511,5 +2529,18 @@ def get_config_schema():
             'daemons': daemon_schema,
             'data': data_schema,
             **cloud_configs,
+            # Reserved namespace for plugin-specific config. Each plugin
+            # owns one key under `plugins:` and registers its sub-schema
+            # via register_plugin_property(). additionalProperties=True
+            # so that disabling a plugin (its register call no longer
+            # runs) does not invalidate an existing config block — the
+            # server should not refuse to start just because some
+            # `plugins.<retired>:` entry is sitting in the user's config.
+            'plugins': {
+                'type': 'object',
+                'required': [],
+                'additionalProperties': True,
+                'properties': _extra_plugin_properties,
+            },
         },
     }


### PR DESCRIPTION
## Summary

Adds `register_plugin_property(name, schema)` so plugins can declare config schemas without landing changes in core, and reserves a top-level `plugins:` namespace in the skypilot config schema for them.

```yaml
# user config
plugins:
  myplugin:
    threshold: 0.9
    nested:
      knob: foo
```

```python
# in the plugin module
from sky.utils import schemas
schemas.register_plugin_property('myplugin', {
    'type': 'object',
    'additionalProperties': False,
    'properties': {
        'threshold': {'type': 'number'},
        'nested': {'type': 'object', 'additionalProperties': True},
    },
})
```


Schema correctness checks (covered by manual jsonschema verification, happy to add a unit test if useful):

- `plugins.<registered>.<known>` ✓ accepted
- `plugins.<registered>.<unknown>` ✗ rejected
- `plugins.<unregistered>` ✓ accepted: this to allow the config still get loaded if the plugin get disabled.