### PR TITLE
Fixing launchable resources when docker login is defined

### DIFF
--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1439,7 +1439,7 @@ class Optimizer:
                 for resources in task.resources:
                     # Check if there exists launchable resources
                     local_task.set_resources(resources)
-                    requested_resources = next(iter(local_task.resources))
+                    requested_resources = list(local_task.resources)[0]
                     launchable_resources_map, _, _, _ = (
                         _fill_in_launchable_resources(
                             task=local_task,

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1439,12 +1439,13 @@ class Optimizer:
                 for resources in task.resources:
                     # Check if there exists launchable resources
                     local_task.set_resources(resources)
+                    requested_resources = next(iter(local_task.resources))
                     launchable_resources_map, _, _, _ = (
                         _fill_in_launchable_resources(
                             task=local_task,
                             blocked_resources=blocked_resources,
                             quiet=False))
-                    if launchable_resources_map.get(resources, []):
+                    if launchable_resources_map.get(requested_resources, []):
                         break
 
         local_graph = local_dag.get_graph()

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1439,6 +1439,12 @@ class Optimizer:
                 for resources in task.resources:
                     # Check if there exists launchable resources
                     local_task.set_resources(resources)
+                    # set_resources() may copy the Resources object, e.g. to
+                    # attach Docker login config. _fill_in_launchable_resources
+                    # keys its result by the post-processed resource in
+                    # local_task.resources, so use that singleton resource
+                    # instead of the original loop variable.
+                    assert len(local_task.resources) == 1, local_task.resources
                     requested_resources = list(local_task.resources)[0]
                     launchable_resources_map, _, _, _ = (
                         _fill_in_launchable_resources(

--- a/tests/unit_tests/test_optimizer.py
+++ b/tests/unit_tests/test_optimizer.py
@@ -1,0 +1,121 @@
+"""Unit tests for sky.optimizer."""
+from unittest import mock
+
+from sky import dag as dag_lib
+from sky import optimizer
+from sky import resources as resources_lib
+from sky import task as task_lib
+
+
+def _optimize_ordered_task_with_mock_launchable(dag, launchable_call_indexes):
+    fill_calls = []
+
+    def fake_fill_in_launchable_resources(task, blocked_resources, quiet):
+        del blocked_resources, quiet
+        requested_resources = next(iter(task.resources))
+        call_index = len(fill_calls)
+        fill_calls.append(requested_resources)
+        launchable_resources = ([requested_resources] if call_index
+                                in launchable_call_indexes else [])
+        return {requested_resources: launchable_resources}, {}, [], {}
+
+    def fake_optimize_by_dp(topo_order, node_to_cost_map, minimize_cost):
+        del node_to_cost_map, minimize_cost
+        task_node = topo_order[0]
+        return {task_node: next(iter(task_node.resources))}, 0
+
+    with mock.patch('sky.optimizer._fill_in_launchable_resources',
+                    side_effect=fake_fill_in_launchable_resources), \
+            mock.patch.object(optimizer.Optimizer,
+                              '_estimate_nodes_cost_or_time',
+                              return_value=({}, {})), \
+            mock.patch.object(optimizer.Optimizer,
+                              '_optimize_by_dp',
+                              side_effect=fake_optimize_by_dp), \
+            mock.patch.object(optimizer.Optimizer,
+                              '_compute_total_time',
+                              return_value=0):
+        optimizer.Optimizer._optimize_dag(  # pylint: disable=protected-access
+            dag, quiet=True)
+
+    return fill_calls
+
+
+def test_ordered_resources_without_docker_login_stops_at_first_launchable():
+    """Ensure ordered resources stop at the first launchable candidate."""
+    with dag_lib.Dag() as dag:
+        task = task_lib.Task(name='ordered-no-docker')
+        task.set_resources([
+            resources_lib.Resources(infra='aws/us-east-2',
+                                    accelerators='A100:8',
+                                    use_spot=True),
+            resources_lib.Resources(infra='aws/us-east-2',
+                                    accelerators='L4:4',
+                                    use_spot=True),
+        ])
+
+    fill_calls = _optimize_ordered_task_with_mock_launchable(
+        dag, launchable_call_indexes={0})
+
+    assert len(fill_calls) == 1
+    assert task.best_resources.accelerators == {'A100': 8}
+
+
+def test_ordered_resources_with_docker_login_stops_at_first_launchable():
+    """Ensure ordered resources use the post-set_resources launchable key."""
+    with dag_lib.Dag() as dag:
+        task = task_lib.Task(
+            name='ordered-docker',
+            secrets={
+                'SKYPILOT_DOCKER_SERVER': 'registry.example.com',
+                'SKYPILOT_DOCKER_USERNAME': 'user',
+                'SKYPILOT_DOCKER_PASSWORD': 'password',
+            })
+        task.set_resources([
+            resources_lib.Resources(infra='aws/us-east-2',
+                                    accelerators='A100:8',
+                                    image_id='docker:repo/image:tag',
+                                    use_spot=True),
+            resources_lib.Resources(infra='aws/us-east-2',
+                                    accelerators='L4:4',
+                                    image_id='docker:repo/image:tag',
+                                    use_spot=True),
+        ])
+
+    fill_calls = _optimize_ordered_task_with_mock_launchable(
+        dag, launchable_call_indexes={0})
+
+    assert len(fill_calls) == 1
+    assert task.best_resources.accelerators == {'A100': 8}
+
+
+def test_ordered_resources_with_docker_login_uses_first_launchable():
+    """Ensure ordered resources continue to the first launchable candidate."""
+    with dag_lib.Dag() as dag:
+        task = task_lib.Task(
+            name='ordered-docker-first-unavailable',
+            secrets={
+                'SKYPILOT_DOCKER_SERVER': 'registry.example.com',
+                'SKYPILOT_DOCKER_USERNAME': 'user',
+                'SKYPILOT_DOCKER_PASSWORD': 'password',
+            })
+        task.set_resources([
+            resources_lib.Resources(infra='aws/us-east-2',
+                                    accelerators='A100:8',
+                                    image_id='docker:repo/image:tag',
+                                    use_spot=True),
+            resources_lib.Resources(infra='aws/us-east-2',
+                                    accelerators='H100:8',
+                                    image_id='docker:repo/image:tag',
+                                    use_spot=True),
+            resources_lib.Resources(infra='aws/us-east-2',
+                                    accelerators='L4:4',
+                                    image_id='docker:repo/image:tag',
+                                    use_spot=True),
+        ])
+
+    fill_calls = _optimize_ordered_task_with_mock_launchable(
+        dag, launchable_call_indexes={1})
+
+    assert len(fill_calls) == 2
+    assert task.best_resources.accelerators == {'H100': 8}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes `resources.ordered` selection when Docker image login config is present.

When probing ordered resources, `Task.set_resources()` may copy the candidate `Resources` object to attach Docker login config. `_fill_in_launchable_resources()` then returns results keyed by the copied resource, but the optimizer was checking the map with the original resource object. This caused the optimizer to miss a launchable candidate and continue to later ordered candidates.

This PR updates the ordered-resource probe to look up launchability using the resource currently stored on `local_task` after `set_resources()`.

Also adds unit coverage for:
- ordered resources without Docker login config
- ordered resources with Docker login config
- Docker login config where the first ordered candidate is unavailable and the second is launchable

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR:
  - `.venv/bin/python -m pytest tests/unit_tests/test_optimizer.py`
  - Manually tested the behavior and works perfectly. We are already using this version in-house
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->

Fixes #9481
