### PR TITLE
[Test] Bump test_cancel_pytorch wait-for-RUNNING timeout 150s -> 360s

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2071,7 +2071,7 @@ def test_cancel_pytorch(generic_cloud: str, accelerator: Dict[str, str]):
                 cluster_name=name,
                 job_id='1',
                 job_status=[sky.JobStatus.RUNNING, sky.JobStatus.SUCCEEDED],
-                timeout=150),
+                timeout=360),
             # Wait the GPU process to start.
             'sleep 90',
             f'sky exec {name} --num-nodes 2 \'s=$(nvidia-smi); echo "$s"; echo "$s" | grep python || '


### PR DESCRIPTION
## Summary

Bump `test_cancel_pytorch`'s 150s timeout for the `SETTING_UP -> RUNNING` wait to 360s. The setup phase downloads ~1.7GB of `torch==1.12.1+cu113` plus 170MB of CIFAR-10 on each of 2 g4dn.xlarge nodes. On healthy AWS instances setup completes in ~28s, but on slower instances setup can exceed 150s and the test times out — same code, same commit can fail twice at 150s and pass at 35s on the next retry.

## Failure

`test_cancel_pytorch on aws with param accelerator0` failed twice in [smoke-tests/10174](https://buildkite.com/skypilot-1/smoke-tests/builds/10174):
```
Timeout after 150 seconds waiting for job status '(RUNNING|SUCCEEDED)'
[cancel-pytorch] Failed (returned 1).
```

Then passed on the third retry in the same build. Build [10118](https://buildkite.com/skypilot-1/smoke-tests/builds/10118) on the same example yaml passed at 34.5s.

## Diagnosis

SSH'd into a passing retry's cluster (`44.199.211.114`, smoke-tests/10174) while the test was live and measured:

| Step | Time | Speed |
|------|------|-------|
| Setup phase total (`setup.log` birth -> modify) | **28s** | — |
| `pytorch.org` wheel (1.7GB) from cluster | 25.7s | 71 MB/s |
| `cs.toronto.edu` cifar-10 (170MB) from cluster | 3.2s | 52 MB/s |
| Wait loop detects RUNNING | 35s | — |

So when the cluster is healthy, the setup finishes well under 150s with margin. The flake is per-EC2-instance variability (cold EBS / noisy neighbor / transient PyPI slowness), not a code regression — two back-to-back failures + a same-build pass on the same commit & instance type confirms it.

## Test plan

- [x] Verified the slow-tail repro (smoke-tests/10174 attempts 1 & 2 timed out at 150s) and the fast-path (attempt 3 reached RUNNING in 35s, test passed in 355s).
- [x] Confirmed the outer `Test(timeout=20*60)` budget absorbs 360s.
- The fast path (~35s) is unchanged; only the timeout cliff moves from 150s -> 360s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)