### PR TITLE
[Jobs] Use per-context usage run id

### DIFF
--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -87,12 +87,23 @@ def _set_usage_run_id_cmd() -> str:
     We use a function instead of a constant so that the usage run id is the
     latest one when the function is called.
     """
+    # Prefer the contextual env var over the process-wide singleton. When
+    # multiple operations share a single process (e.g. the consolidated
+    # managed jobs controller serving many jobs concurrently), each can
+    # override USAGE_RUN_ID_ENV_VAR in its own context to make the launched
+    # cluster's heartbeat report a unique run id. os.environ is hijacked to
+    # be context aware via sky.utils.context.ContextualEnviron, so this read
+    # picks up the per-context override when one is set, and falls back to
+    # the process singleton otherwise.
+    run_id = os.environ.get(usage_constants.USAGE_RUN_ID_ENV_VAR)
+    if run_id is None:
+        run_id = usage_lib.messages.usage.run_id
     return (
         f'cat {usage_constants.USAGE_RUN_ID_FILE} 2> /dev/null || '
         # The run id is retrieved locally for the current run, so that the
         # remote cluster will be set with the same run id as the initial
         # launch operation.
-        f'echo "{usage_lib.messages.usage.run_id}" > '
+        f'echo "{run_id}" > '
         f'{usage_constants.USAGE_RUN_ID_FILE}')
 
 

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -84,8 +84,19 @@ def request_body_env_vars() -> dict:
             env_vars[env_var] = os.environ[env_var]
     env_vars[constants.USER_ID_ENV_VAR] = common_utils.get_user_hash()
     env_vars[constants.USER_ENV_VAR] = common_utils.get_local_user_name()
-    env_vars[
-        usage_constants.USAGE_RUN_ID_ENV_VAR] = usage_lib.messages.usage.run_id
+    # Prefer the contextual env var so internal API calls (e.g. sky.launch
+    # invoked by a managed jobs JobController coroutine) carry the per-job
+    # client run id rather than the caller process's usage_lib.messages.usage
+    # singleton. In consolidation mode the controller process serves many
+    # jobs, so the singleton is fixed and would otherwise cause every
+    # internal launch to share the same run id, breaking the join from
+    # worker-cluster heartbeats back to the originating launch command.
+    contextual_run_id = os.environ.get(usage_constants.USAGE_RUN_ID_ENV_VAR)
+    if contextual_run_id is not None:
+        env_vars[usage_constants.USAGE_RUN_ID_ENV_VAR] = contextual_run_id
+    else:
+        env_vars[usage_constants.USAGE_RUN_ID_ENV_VAR] = (
+            usage_lib.messages.usage.run_id)
     # Send client user hash for basic auth at API server case, so the server
     # can include it in its own usage report.
     if common.basic_auth_enabled and common.client_user_hash is not None:

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -35,6 +35,7 @@ from sky.server.blob import blob_storage as bs
 from sky.setup_files import dependencies
 from sky.skylet import constants
 from sky.skylet import log_lib
+from sky.usage import constants as usage_constants
 from sky.utils import annotations
 from sky.utils import command_runner
 from sky.utils import common
@@ -625,6 +626,15 @@ def controller_only_vars_to_fill(controller: Controllers) -> Dict[str, str]:
     if override_concurrent_launches is not None:
         env_vars[constants.SERVE_OVERRIDE_CONCURRENT_LAUNCHES] = str(
             int(override_concurrent_launches))
+    # Forward the client's usage run id so the controller (and the worker
+    # clusters it provisions) report heartbeats under the same run id as
+    # the originating launch operation. Without this, in consolidation mode
+    # the controller process would fall back to its own
+    # usage_lib.messages.usage singleton, which is shared across all jobs
+    # served by that process and so cannot distinguish between them.
+    client_usage_run_id = os.environ.get(usage_constants.USAGE_RUN_ID_ENV_VAR)
+    if client_usage_run_id is not None:
+        env_vars[usage_constants.USAGE_RUN_ID_ENV_VAR] = client_usage_run_id
     vars_to_fill['controller_envs'] = env_vars
     return vars_to_fill
 

--- a/tests/unit_tests/test_controller_utils.py
+++ b/tests/unit_tests/test_controller_utils.py
@@ -822,6 +822,63 @@ def test_controller_cluster_name_client_side(controller_type: str):
     assert proc.exitcode == 0, f'Subprocess test failed with exit code {proc.exitcode}'
 
 
+@pytest.mark.parametrize('controller_type', ['jobs', 'serve'])
+def test_controller_envs_forward_usage_run_id(controller_type: str,
+                                              monkeypatch):
+    """The client's usage run id is forwarded into controller_envs.
+
+    Regression test for the consolidation-mode bug where a single
+    controller process serves many jobs and so cannot rely on its own
+    usage_lib.messages.usage singleton to identify which client run a
+    worker cluster's heartbeat belongs to.
+    """
+    from sky.usage import constants as usage_constants
+
+    def mock_get_cloud_dependencies_installation_commands(controller):
+        return ['echo "Installing dependencies"']
+
+    monkeypatch.setattr(
+        'sky.utils.controller_utils._get_cloud_dependencies_installation_commands',
+        mock_get_cloud_dependencies_installation_commands)
+    monkeypatch.setenv(usage_constants.USAGE_RUN_ID_ENV_VAR, 'client-run-xyz')
+
+    controller = controller_utils.Controllers.from_type(controller_type)
+    result = controller_utils.shared_controller_vars_to_fill(
+        controller, '/remote/path/to/config', {})
+
+    envs = result['controller_envs']
+    assert envs.get(usage_constants.USAGE_RUN_ID_ENV_VAR) == 'client-run-xyz'
+
+    if 'local_user_config_path' in result and result['local_user_config_path']:
+        os.unlink(result['local_user_config_path'])
+
+
+@pytest.mark.parametrize('controller_type', ['jobs', 'serve'])
+def test_controller_envs_skip_unset_usage_run_id(controller_type: str,
+                                                 monkeypatch):
+    """When the client did not supply a run id, controller_envs omits it
+    rather than forwarding an empty string."""
+    from sky.usage import constants as usage_constants
+
+    def mock_get_cloud_dependencies_installation_commands(controller):
+        return ['echo "Installing dependencies"']
+
+    monkeypatch.setattr(
+        'sky.utils.controller_utils._get_cloud_dependencies_installation_commands',
+        mock_get_cloud_dependencies_installation_commands)
+    monkeypatch.delenv(usage_constants.USAGE_RUN_ID_ENV_VAR, raising=False)
+
+    controller = controller_utils.Controllers.from_type(controller_type)
+    result = controller_utils.shared_controller_vars_to_fill(
+        controller, '/remote/path/to/config', {})
+
+    envs = result['controller_envs']
+    assert usage_constants.USAGE_RUN_ID_ENV_VAR not in envs
+
+    if 'local_user_config_path' in result and result['local_user_config_path']:
+        os.unlink(result['local_user_config_path'])
+
+
 _JOBS_SIGNAL_CONST = (
     'sky.jobs.constants.JOBS_CONSOLIDATION_RELOADED_SIGNAL_FILE')
 

--- a/tests/unit_tests/test_sky/provision/test_instance_setup.py
+++ b/tests/unit_tests/test_sky/provision/test_instance_setup.py
@@ -1,0 +1,92 @@
+"""Unit tests for sky.provision.instance_setup."""
+import asyncio
+import os
+from unittest.mock import patch
+
+import pytest
+
+from sky.provision import instance_setup
+from sky.usage import constants as usage_constants
+from sky.usage import usage_lib
+from sky.utils import context
+
+
+@pytest.fixture
+def _contextual_environ():
+    """Replace os.environ with ContextualEnviron for the test."""
+    original_environ = os.environ
+    os.environ = context.ContextualEnviron(original_environ)
+    yield
+    os.environ = original_environ
+
+
+class TestSetUsageRunIdCmd:
+    """Tests that _set_usage_run_id_cmd picks up the per-context run id.
+
+    In consolidation mode, the managed jobs controller process serves many
+    jobs concurrently. Reading the run id from the process-wide
+    usage_lib.messages.usage singleton would cause every worker cluster's
+    skylet heartbeat to report the same run id. The fix is to prefer
+    USAGE_RUN_ID_ENV_VAR via os.environ (hijacked to be SkyPilotContext
+    aware), which is sourced from the client's run id forwarded through
+    the controller's env file, so each request scopes its own run id.
+    """
+
+    @pytest.mark.asyncio
+    async def test_uses_contextual_env_var_when_set(self, _contextual_environ):
+        """Env var override takes priority over the process singleton."""
+        # context.initialize creates a SkyPilotContext, which constructs an
+        # asyncio.Event; on Python 3.9 that requires a running event loop,
+        # so the test is async to keep pytest-asyncio's loop available.
+        ctx = context.initialize()
+        ctx.override_envs({usage_constants.USAGE_RUN_ID_ENV_VAR: 'ctx-run-id'})
+
+        with patch.object(usage_lib.messages.usage, 'run_id',
+                          'singleton-run-id'):
+            cmd = instance_setup._set_usage_run_id_cmd()
+
+        assert 'echo "ctx-run-id"' in cmd
+        assert 'singleton-run-id' not in cmd
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_singleton_when_env_unset(
+            self, _contextual_environ):
+        """Without an env override, the process singleton is used."""
+        context.initialize()  # context with no USAGE_RUN_ID_ENV_VAR override
+
+        with patch.object(usage_lib.messages.usage, 'run_id',
+                          'singleton-run-id'):
+            cmd = instance_setup._set_usage_run_id_cmd()
+
+        assert 'echo "singleton-run-id"' in cmd
+
+    @pytest.mark.asyncio
+    async def test_concurrent_contexts_get_isolated_run_ids(
+            self, _contextual_environ):
+        """Regression test for consolidation-mode run id sharing.
+
+        Two concurrent coroutines, each in its own SkyPilotContext, should
+        each see the run id they set, not each other's or the singleton's.
+        """
+
+        @context.contextual_async
+        async def get_cmd_with_run_id(run_id: str, delay: float) -> str:
+            ctx = context.get()
+            assert ctx is not None
+            ctx.override_envs({usage_constants.USAGE_RUN_ID_ENV_VAR: run_id})
+            # Force interleaving so both coroutines have set their override
+            # before either reads it back.
+            await asyncio.sleep(delay)
+            return instance_setup._set_usage_run_id_cmd()
+
+        with patch.object(usage_lib.messages.usage, 'run_id',
+                          'singleton-run-id'):
+            cmd_a, cmd_b = await asyncio.gather(
+                get_cmd_with_run_id('run-id-a', delay=0.05),
+                get_cmd_with_run_id('run-id-b', delay=0.0),
+            )
+
+        assert 'echo "run-id-a"' in cmd_a, cmd_a
+        assert 'echo "run-id-b"' in cmd_b, cmd_b
+        assert 'singleton-run-id' not in cmd_a
+        assert 'singleton-run-id' not in cmd_b

--- a/tests/unit_tests/test_sky/server/requests/test_payloads.py
+++ b/tests/unit_tests/test_sky/server/requests/test_payloads.py
@@ -1,8 +1,14 @@
 """Unit tests for sky.server.requests.payloads module."""
+import os
+
+import pytest
+
 from sky import skypilot_config
 from sky.server.requests import payloads
 from sky.skylet import constants
+from sky.usage import constants as usage_constants
 from sky.usage import usage_lib
+from sky.utils import context
 
 
 def test_request_body_env_vars_includes_expected_keys(monkeypatch):
@@ -56,3 +62,48 @@ def test_request_body_env_vars_client_user_hash_none_with_basic_auth(
 
     env_vars = payloads.request_body_env_vars()
     assert constants.CLIENT_USER_HASH_ENV_VAR not in env_vars
+
+
+@pytest.mark.asyncio
+async def test_request_body_env_vars_uses_contextual_run_id_when_set(
+        monkeypatch):
+    """In a JobController-style context, the per-context run id wins over
+    the process-wide singleton.
+
+    The internal sky.launch invoked by a managed jobs JobController must
+    carry the per-job client run id end-to-end so worker-cluster heartbeats
+    can be joined back to the launch command. With the controller process
+    serving many jobs in consolidation mode, the process singleton would
+    otherwise be the same for every internal launch.
+
+    Async because context.initialize constructs a SkyPilotContext, which
+    instantiates an asyncio.Event. On Python 3.9 that requires a running
+    event loop, so we let pytest-asyncio supply one.
+    """
+    monkeypatch.setattr(usage_lib.messages.usage, 'run_id', 'singleton-run-id')
+    monkeypatch.setattr(payloads.common, 'is_api_server_local', lambda: True)
+
+    original_environ = os.environ
+    os.environ = context.ContextualEnviron(original_environ)
+    try:
+        ctx = context.initialize()
+        ctx.override_envs({usage_constants.USAGE_RUN_ID_ENV_VAR: 'ctx-run-id'})
+        env_vars = payloads.request_body_env_vars()
+    finally:
+        os.environ = original_environ
+
+    assert env_vars[usage_constants.USAGE_RUN_ID_ENV_VAR] == 'ctx-run-id'
+
+
+def test_request_body_env_vars_falls_back_to_singleton_run_id(monkeypatch):
+    """Without a context override, the process singleton is still used.
+
+    Preserves CLI / direct-SDK behavior where no SkyPilotContext is
+    established and the singleton is initialized at module load.
+    """
+    monkeypatch.setattr(usage_lib.messages.usage, 'run_id', 'singleton-run-id')
+    monkeypatch.setattr(payloads.common, 'is_api_server_local', lambda: True)
+    monkeypatch.delenv(usage_constants.USAGE_RUN_ID_ENV_VAR, raising=False)
+
+    env_vars = payloads.request_body_env_vars()
+    assert env_vars[usage_constants.USAGE_RUN_ID_ENV_VAR] == 'singleton-run-id'


### PR DESCRIPTION
## Summary

- Prefer the contextual `SKYPILOT_USAGE_RUN_ID` over the process-wide singleton in `request_body_env_vars`, `_set_usage_run_id_cmd`, and the controller env file, so the run id flows per-request rather than per-process.

## Test plan

- [x] Added unit tests for env-var priority, singleton fallback, and propagation through `controller_envs` / `request_body_env_vars`.