### PR TITLE
[Core] Fix Identity Check

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2156,7 +2156,12 @@ def _check_owner_identity_with_record(cluster_name: str,
                 _raise_identity_error()
         else:
             identity = user_identities[0]
+            context = None
         global_user_state.set_owner_identity_for_cluster(cluster_name, identity)
+        msg = f'Successfully patched {cluster_name} owner identity to {identity}'
+        if context is not None:
+            msg += f' (launched on context {context})'
+        logger.debug(msg)
         return
 
     assert isinstance(owner_identity, list)

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2142,20 +2142,22 @@ def _check_owner_identity_with_record(cluster_name: str,
                 f'{cluster_name!r} ({cloud}) is owned by account '
                 f'{owner_identity!r}, but ' + err_msg)
 
-    if owner_identity is None and is_k8s_cloud:
-        config = global_user_state.get_cluster_yaml_dict(handle.cluster_yaml)
-        provider_config = config['provider']
-        context = provider_config.get('context')
-        assert isinstance(context, str)
-        try:
-            identity = clouds.Kubernetes.get_identity_from_context_name(context)
-            global_user_state.set_owner_identity_for_cluster(
-                cluster_name, identity)
-            logger.debug(f'Successfully patched {cluster_name} owner identity '
-                         f'to {identity} (launched on {context}).')
-            return
-        except exceptions.CloudUserIdentityError:
-            _raise_identity_error()
+    if owner_identity is None:
+        if is_k8s_cloud:
+            config = global_user_state.get_cluster_yaml_dict(
+                handle.cluster_yaml)
+            provider_config = config['provider']
+            context = provider_config.get('context')
+            assert isinstance(context, str)
+            try:
+                identity = clouds.Kubernetes.get_identity_from_context_name(
+                    context)
+            except exceptions.CloudUserIdentityError:
+                _raise_identity_error()
+        else:
+            identity = user_identities[0]
+        global_user_state.set_owner_identity_for_cluster(cluster_name, identity)
+        return
 
     assert isinstance(owner_identity, list)
     # It is OK if the owner identity is shorter, which will happen when


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

There was an issue where `owner_identity` is `None` in non-kubernetes cloud situations, causing the identity check to crash on `assert isinstance(owner_identity, list)`. This PR brings back the owner identity patching for non-k8s clouds as well.

Related: #9190

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
