### PR TITLE
[Core] Make usage_lib.messages per-context

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -2087,6 +2087,19 @@ class ControllerManager:
                     'Failed to load environment variables for job %s: '
                     '%s', job_id, e)
 
+        # Install a fresh per-job usage MessageCollection so the run id and
+        # other identity fields reflect the per-job env we just loaded into
+        # ``ctx``. Without this, in consolidation mode the controller
+        # subprocess inherits a MessageCollection that was created at
+        # module import time (when class-body decorators like
+        # ``@usage_lib.messages.usage.update_runtime('provision')`` in
+        # ``sky/backends/backend.py`` first accessed the proxy) and bound
+        # the run id to whoever first spawned the controller; subsequent
+        # JobController coroutines would all share that one MC instead of
+        # their own per-job state. The override is scoped to this
+        # coroutine's contextvars Context.
+        usage_lib.install_fresh_messages_for_current_context()
+
         cancelling = False
         graceful, graceful_timeout = False, None
         try:

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -1,6 +1,7 @@
 """Logging events to Grafana Loki."""
 
 import contextlib
+import contextvars
 import datetime
 import enum
 import json
@@ -9,6 +10,7 @@ import time
 import traceback
 import typing
 from typing import Any, Callable, ClassVar, Dict, List, Optional, Union
+import uuid
 
 from typing_extensions import ParamSpec
 
@@ -88,7 +90,15 @@ class UsageMessageToReport(MessageToReport):
         # auth is enabled at the API server level.
         self.client_user_hash: Optional[str] = os.environ.get(
             skylet_constants.CLIENT_USER_HASH_ENV_VAR)
-        self.run_id: str = common_utils.get_usage_run_id()
+        # Read SKYPILOT_USAGE_RUN_ID directly. ``os.environ`` is hijacked
+        # to be SkyPilotContext aware, so this read picks up per-context
+        # overrides (e.g. those installed by ``ctx.override_envs`` in
+        # ``sky.jobs.controller.run_job_loop``) and is re-evaluated on
+        # every fresh construction — including when
+        # ``messages.reset(USAGE)`` rebuilds the message after a
+        # decorated entrypoint exits.
+        self.run_id: str = (os.environ.get(constants.USAGE_RUN_ID_ENV_VAR) or
+                            str(uuid.uuid4()))
         self.sky_version: str = sky.__version__
         self.sky_commit: str = sky.__commit__
 
@@ -433,7 +443,97 @@ class MessageCollection:
         return self._messages.values()
 
 
-messages = MessageCollection()
+# Per-context MessageCollection. Reads/writes to ``messages`` go through
+# this ContextVar so that asynchronous tasks (e.g. concurrent JobController
+# coroutines in the consolidated managed jobs controller process) each get
+# their own message state instead of stomping on a process-wide singleton.
+#
+# Lazy creation: the first access in any contextvars Context creates a
+# MessageCollection and installs it via ``ContextVar.set`` — that set is
+# scoped to the current Context, so siblings (e.g. distinct
+# @contextual_async coroutines, each running inside its own copied
+# Context) get independent instances. Synchronous callers in the same
+# Context (e.g. plain CLI use) continue to share one collection.
+_messages_var: contextvars.ContextVar[Optional[MessageCollection]] = (
+    contextvars.ContextVar('usage_messages', default=None))
+
+
+def _get_messages() -> MessageCollection:
+    """Return the MessageCollection for the current context.
+
+    Lazily creates a fresh MessageCollection the first time it is
+    accessed in a given contextvars Context, so different async tasks
+    (whose Contexts are independent copies) see independent collections.
+    """
+    ctx_messages = _messages_var.get()
+    if ctx_messages is None:
+        ctx_messages = MessageCollection()
+        _messages_var.set(ctx_messages)
+    return ctx_messages
+
+
+def install_fresh_messages_for_current_context() -> None:
+    """Install a freshly-initialized MessageCollection in this Context.
+
+    Use this at boundaries where the caller has just established a new
+    per-task identity (e.g. a managed job's controller coroutine after
+    loading the per-job env file). It overrides any MessageCollection
+    inherited from a parent Context — for example, one created at
+    module import time, when class-body decorators like
+    ``@usage_lib.messages.usage.update_runtime('provision')`` first
+    accessed the proxy and triggered lazy creation against the process
+    env (which carries the run id of whoever first spawned this
+    process, not of the per-task caller).
+
+    The override is scoped to the current contextvars Context, so
+    sibling tasks (each with their own Context via
+    ``@context.contextual_async``) keep their own collections. The new
+    collection's ``UsageMessageToReport.__init__`` reads
+    ``SKYPILOT_USAGE_RUN_ID`` directly from ``os.environ`` (which is
+    SkyPilotContext aware), so the new run id reflects the per-task
+    env that was just installed via ``ctx.override_envs``. Subsequent
+    ``messages.reset(USAGE)`` calls inside this Context (e.g. from
+    ``_send_to_loki`` after ``sdk.api_start``'s entrypoint context
+    manager exits) will likewise re-read env via the same path and
+    keep the per-task run id stable across resets.
+    """
+    _messages_var.set(MessageCollection())
+
+
+class _MessagesProxy:
+    """Module-level facade that delegates to the per-context collection.
+
+    Existing call sites read/write ``messages.usage.foo`` etc.; this proxy
+    forwards each access to the MessageCollection associated with the
+    current context, so callers do not need to change.
+    """
+
+    @property
+    def usage(self) -> UsageMessageToReport:
+        return _get_messages().usage
+
+    @property
+    def heartbeat(self) -> HeartbeatMessageToReport:
+        return _get_messages().heartbeat
+
+    @property
+    def server_heartbeat(self) -> ServerHeartbeatMessage:
+        return _get_messages().server_heartbeat
+
+    def reset(self, message_type: MessageType) -> None:
+        _get_messages().reset(message_type)
+
+    def __getitem__(self, key: MessageType) -> MessageToReport:
+        return _get_messages()[key]
+
+    def items(self):
+        return _get_messages().items()
+
+    def values(self):
+        return _get_messages().values()
+
+
+messages = _MessagesProxy()
 
 
 def _send_to_loki(message_type: MessageType):
@@ -460,8 +560,16 @@ def _send_to_loki(message_type: MessageType):
         'schema_version': message.schema_version,
     }
     if message_type == MessageType.USAGE:
-        prom_labels['new_cluster'] = (message.original_cluster_status != 'UP'
-                                      and message.final_cluster_status == 'UP')
+        # Narrow ``message`` to UsageMessageToReport for the type checker;
+        # ``messages[message_type]`` returns the abstract MessageToReport
+        # base type. ``messages.usage`` is annotated as
+        # UsageMessageToReport, and refers to the same per-context
+        # instance that ``messages[message_type]`` returned for
+        # ``MessageType.USAGE``.
+        usage_message = messages.usage
+        prom_labels['new_cluster'] = (
+            usage_message.original_cluster_status != 'UP' and
+            usage_message.final_cluster_status == 'UP')
 
     headers = {'Content-type': 'application/json'}
     payload = {

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -31,8 +31,6 @@ from sky import models
 from sky import sky_logging
 from sky.adaptors import common as adaptors_common
 from sky.skylet import constants
-from sky.usage import constants as usage_constants
-from sky.utils import annotations
 from sky.utils import context
 from sky.utils import ux_utils
 from sky.utils import validator
@@ -79,20 +77,6 @@ class ProcessStatus(enum.Enum):
 
     # The process failed
     FAILED = 'FAILED'
-
-
-@annotations.lru_cache(scope='request')
-def get_usage_run_id() -> str:
-    """Returns a unique run id for each 'run'.
-
-    A run is defined as the lifetime of a process that has imported `sky`
-    and has called its CLI or programmatic APIs. For example, two successive
-    `sky launch` are two runs.
-    """
-    usage_run_id = os.getenv(usage_constants.USAGE_RUN_ID_ENV_VAR)
-    if usage_run_id is not None:
-        return usage_run_id
-    return str(uuid.uuid4())
 
 
 def is_valid_user_hash(user_hash: Optional[str]) -> bool:

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -35,6 +35,7 @@ from sky.server.blob import blob_storage as bs
 from sky.setup_files import dependencies
 from sky.skylet import constants
 from sky.skylet import log_lib
+from sky.usage import constants as usage_constants
 from sky.utils import annotations
 from sky.utils import command_runner
 from sky.utils import common
@@ -625,6 +626,15 @@ def controller_only_vars_to_fill(controller: Controllers) -> Dict[str, str]:
     if override_concurrent_launches is not None:
         env_vars[constants.SERVE_OVERRIDE_CONCURRENT_LAUNCHES] = str(
             int(override_concurrent_launches))
+    # Forward the client's usage run id so the controller (and the worker
+    # clusters it provisions) report heartbeats under the same run id as
+    # the originating launch operation. Without this, in consolidation mode
+    # the controller process would fall back to its own
+    # usage_lib.messages.usage singleton, which is shared across all jobs
+    # served by that process and so cannot distinguish between them.
+    client_usage_run_id = os.environ.get(usage_constants.USAGE_RUN_ID_ENV_VAR)
+    if client_usage_run_id is not None:
+        env_vars[usage_constants.USAGE_RUN_ID_ENV_VAR] = client_usage_run_id
     vars_to_fill['controller_envs'] = env_vars
     return vars_to_fill
 
@@ -991,9 +1001,6 @@ def maybe_translate_local_file_mounts_and_sync_up(task: 'task_lib.Task',
 
     # We use uuid to generate a unique run id for the job, so that the bucket/
     # subdirectory name is unique across different jobs/services.
-    # We should not use common_utils.get_usage_run_id() here, because when
-    # Python API is used, the run id will be the same across multiple
-    # jobs.launch/serve.up calls after the sky is imported.
     run_id = _generate_run_uuid()
     user_hash = common_utils.get_user_hash()
     original_file_mounts = task.file_mounts if task.file_mounts else {}

--- a/tests/unit_tests/test_controller_utils.py
+++ b/tests/unit_tests/test_controller_utils.py
@@ -822,6 +822,63 @@ def test_controller_cluster_name_client_side(controller_type: str):
     assert proc.exitcode == 0, f'Subprocess test failed with exit code {proc.exitcode}'
 
 
+@pytest.mark.parametrize('controller_type', ['jobs', 'serve'])
+def test_controller_envs_forward_usage_run_id(controller_type: str,
+                                              monkeypatch):
+    """The client's usage run id is forwarded into controller_envs.
+
+    Regression test for the consolidation-mode bug where a single
+    controller process serves many jobs and so cannot rely on its own
+    usage_lib.messages.usage singleton to identify which client run a
+    worker cluster's heartbeat belongs to.
+    """
+    from sky.usage import constants as usage_constants
+
+    def mock_get_cloud_dependencies_installation_commands(controller):
+        return ['echo "Installing dependencies"']
+
+    monkeypatch.setattr(
+        'sky.utils.controller_utils._get_cloud_dependencies_installation_commands',
+        mock_get_cloud_dependencies_installation_commands)
+    monkeypatch.setenv(usage_constants.USAGE_RUN_ID_ENV_VAR, 'client-run-xyz')
+
+    controller = controller_utils.Controllers.from_type(controller_type)
+    result = controller_utils.shared_controller_vars_to_fill(
+        controller, '/remote/path/to/config', {})
+
+    envs = result['controller_envs']
+    assert envs.get(usage_constants.USAGE_RUN_ID_ENV_VAR) == 'client-run-xyz'
+
+    if 'local_user_config_path' in result and result['local_user_config_path']:
+        os.unlink(result['local_user_config_path'])
+
+
+@pytest.mark.parametrize('controller_type', ['jobs', 'serve'])
+def test_controller_envs_skip_unset_usage_run_id(controller_type: str,
+                                                 monkeypatch):
+    """When the client did not supply a run id, controller_envs omits it
+    rather than forwarding an empty string."""
+    from sky.usage import constants as usage_constants
+
+    def mock_get_cloud_dependencies_installation_commands(controller):
+        return ['echo "Installing dependencies"']
+
+    monkeypatch.setattr(
+        'sky.utils.controller_utils._get_cloud_dependencies_installation_commands',
+        mock_get_cloud_dependencies_installation_commands)
+    monkeypatch.delenv(usage_constants.USAGE_RUN_ID_ENV_VAR, raising=False)
+
+    controller = controller_utils.Controllers.from_type(controller_type)
+    result = controller_utils.shared_controller_vars_to_fill(
+        controller, '/remote/path/to/config', {})
+
+    envs = result['controller_envs']
+    assert usage_constants.USAGE_RUN_ID_ENV_VAR not in envs
+
+    if 'local_user_config_path' in result and result['local_user_config_path']:
+        os.unlink(result['local_user_config_path'])
+
+
 _JOBS_SIGNAL_CONST = (
     'sky.jobs.constants.JOBS_CONSOLIDATION_RELOADED_SIGNAL_FILE')
 

--- a/tests/unit_tests/test_sky/usage/test_usage_lib.py
+++ b/tests/unit_tests/test_sky/usage/test_usage_lib.py
@@ -1,0 +1,187 @@
+"""Unit tests for the per-context behavior of sky.usage.usage_lib.messages."""
+import asyncio
+import contextvars
+
+import pytest
+
+from sky.usage import usage_lib
+from sky.utils import context
+
+
+def _reset_module_state():
+    """Reset per-context state between tests.
+
+    Tests share the test runner's contextvars Context, so a value set by
+    one test would otherwise leak into the next. Clearing
+    ``_messages_var`` makes each test start with an empty Context.
+    """
+    usage_lib._messages_var.set(None)
+
+
+def test_proxy_returns_same_instance_within_one_context():
+    """Within one contextvars Context, lazy creation is idempotent."""
+    _reset_module_state()
+
+    a = usage_lib._get_messages()
+    b = usage_lib._get_messages()
+    assert a is b
+    # Mutations are visible across reads of the same instance.
+    a.usage.run_id = 'mutated'
+    assert b.usage.run_id == 'mutated'
+
+
+def test_proxy_attribute_access_round_trips():
+    """messages.usage / messages.heartbeat go through the proxy."""
+    _reset_module_state()
+
+    # Read a few fields to make sure attribute proxying works.
+    assert usage_lib.messages.usage.run_id is not None
+    assert usage_lib.messages.heartbeat.interval_seconds > 0
+
+
+@pytest.mark.asyncio
+async def test_concurrent_contextual_async_get_isolated_messages():
+    """Each @contextual_async coroutine has its own MessageCollection.
+
+    Regression for the consolidation-mode bug: the consolidated managed
+    jobs controller process serves many JobController coroutines, and a
+    process-wide MessageCollection would let one job's mutations leak
+    into another job's telemetry payload. With the proxy, each
+    @contextual_async invocation runs inside its own copied
+    contextvars Context and so triggers an independent lazy creation of
+    its MessageCollection.
+    """
+    _reset_module_state()
+
+    seen_ids = []
+
+    @context.contextual_async
+    async def write_and_read(tag: str, delay: float) -> str:
+        # First access triggers lazy creation in this coroutine's
+        # copied contextvars Context.
+        usage_lib.messages.usage.run_id = f'run-{tag}'
+        seen_ids.append(id(usage_lib._get_messages()))
+        # Yield so the sibling coroutine has a chance to run between
+        # our write and our read.
+        await asyncio.sleep(delay)
+        return usage_lib.messages.usage.run_id
+
+    a, b = await asyncio.gather(
+        write_and_read('a', delay=0.05),
+        write_and_read('b', delay=0.0),
+    )
+
+    # Each coroutine sees its own write — no cross-contamination.
+    assert a == 'run-a', a
+    assert b == 'run-b', b
+    # And the underlying MessageCollections are distinct objects.
+    assert len(set(seen_ids)) == 2, seen_ids
+
+
+@pytest.mark.asyncio
+async def test_reset_isolates_to_current_context():
+    """messages.reset(USAGE) only resets the current context's collection."""
+    _reset_module_state()
+
+    sibling_run_ids = []
+
+    @context.contextual_async
+    async def sibling_observe(delay: float) -> str:
+        usage_lib.messages.usage.run_id = 'sibling-run'
+        await asyncio.sleep(delay)
+        return usage_lib.messages.usage.run_id
+
+    @context.contextual_async
+    async def reset_and_observe(delay: float) -> str:
+        usage_lib.messages.usage.run_id = 'reset-run'
+        await asyncio.sleep(delay)
+        usage_lib.messages.reset(usage_lib.MessageType.USAGE)
+        # After reset the current context has a fresh UsageMessageToReport;
+        # its run_id should NOT be 'reset-run' anymore.
+        return usage_lib.messages.usage.run_id
+
+    sibling_id, post_reset_id = await asyncio.gather(
+        sibling_observe(delay=0.05),
+        reset_and_observe(delay=0.0),
+    )
+
+    # Sibling kept its run id across the other coroutine's reset.
+    assert sibling_id == 'sibling-run'
+    # The reset coroutine sees a fresh UsageMessageToReport, not its
+    # earlier 'reset-run'.
+    assert post_reset_id != 'reset-run'
+
+
+def test_messages_proxy_supports_collection_protocol():
+    """The proxy exposes __getitem__ / items / values like the original."""
+    _reset_module_state()
+
+    by_index = usage_lib.messages[usage_lib.MessageType.USAGE]
+    by_attr = usage_lib.messages.usage
+    assert by_index is by_attr
+
+    keys = {k for k, _ in usage_lib.messages.items()}
+    assert usage_lib.MessageType.USAGE in keys
+    assert usage_lib.MessageType.HEARTBEAT in keys
+    assert usage_lib.MessageType.SERVER_HEARTBEAT in keys
+
+    values = list(usage_lib.messages.values())
+    assert len(values) == 3
+
+
+def test_install_fresh_messages_overrides_inherited_collection(monkeypatch):
+    """install_fresh_messages_for_current_context replaces an inherited MC.
+
+    Regression: in consolidation mode, class-body decorators like
+    ``@usage_lib.messages.usage.update_runtime('provision')`` trigger
+    lazy MC creation at module import time, against the controller
+    process's startup env. Subsequent JobController coroutines
+    inherit that MC via ContextVar copy and would otherwise share it.
+    install_fresh_messages_for_current_context lets a per-task entry
+    point install its own MC after establishing a per-task env.
+    """
+    _reset_module_state()
+
+    # Simulate a "parent" creating an MC against env=startup-run.
+    monkeypatch.setenv(usage_lib.constants.USAGE_RUN_ID_ENV_VAR, 'startup-run')
+    inherited = usage_lib._get_messages()
+    assert inherited.usage.run_id == 'startup-run'
+
+    # Now flip the env (mimicking dotenv into ctx.override_envs from a
+    # per-job env file) and install a fresh MC.
+    monkeypatch.setenv(usage_lib.constants.USAGE_RUN_ID_ENV_VAR, 'per-task-run')
+    usage_lib.install_fresh_messages_for_current_context()
+
+    refreshed = usage_lib._get_messages()
+    assert refreshed is not inherited
+    assert refreshed.usage.run_id == 'per-task-run'
+
+
+@pytest.mark.asyncio
+async def test_install_fresh_messages_isolates_concurrent_tasks(monkeypatch):
+    """When the parent Context already has an MC, two
+    @contextual_async children that each call install_fresh_messages
+    do not see each other's state — even though they would otherwise
+    inherit the parent's MC."""
+    _reset_module_state()
+
+    # Create a parent MC so children would otherwise inherit it.
+    monkeypatch.setenv(usage_lib.constants.USAGE_RUN_ID_ENV_VAR, 'parent-run')
+    _ = usage_lib._get_messages()
+
+    @context.contextual_async
+    async def per_task(run_id: str, delay: float) -> str:
+        # Set the env first (mimicking the env-file load), then install
+        # a fresh MC, then read back through the proxy.
+        monkeypatch.setenv(usage_lib.constants.USAGE_RUN_ID_ENV_VAR, run_id)
+        usage_lib.install_fresh_messages_for_current_context()
+        await asyncio.sleep(delay)
+        return usage_lib.messages.usage.run_id
+
+    a, b = await asyncio.gather(
+        per_task('task-a', delay=0.05),
+        per_task('task-b', delay=0.0),
+    )
+
+    assert a == 'task-a', a
+    assert b == 'task-b', b


### PR DESCRIPTION
## Summary

- Wrap module-level `MessageCollection` in a `ContextVar`-backed proxy so each contextvars Context lazily gets its own instance, preventing concurrent async tasks from sharing message state. Existing call sites are unchanged.

## Test plan

- [x] Added unit tests for lazy idempotency, isolation across concurrent `@contextual_async` coroutines, scoped `reset`, and the collection protocol surface.