### PR TITLE
add -o json option to cost-report

### DIFF
--- a/agent/skills/skypilot/references/cli-reference.md
+++ b/agent/skills/skypilot/references/cli-reference.md
@@ -183,6 +183,7 @@ Show estimated costs for launched clusters.
 - `--config` — Path to a config file or a single key-value pair. To add multiple key-value pairs add multiple flags (e.g. --config nested.key1=val1 --config nested.key2=val2).
 - `--all`, `-a` — Show all cluster information.
 - `--days` (default: `30`) — Show clusters from the last N days. Default is 30 days. If set to 0, show all clusters.
+- `--output`, `-o` (default: `table`) — Output format. Choices: table, json. Default: table.
 
 ## Job Queue Commands
 

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -2345,8 +2345,12 @@ def status_kubernetes(verbose: bool):
               type=int,
               help='Show clusters from the last N days. Default is 30 days. '
               'If set to 0, show all clusters.')
+@flags.output_format_option()
 @usage_lib.entrypoint
-def cost_report(all: bool, days: int):  # pylint: disable=redefined-builtin
+def cost_report(
+        all: bool,
+        days: int,  # pylint: disable=redefined-builtin
+        output_format: str):
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Show estimated costs for launched clusters.
 
@@ -2390,6 +2394,21 @@ def cost_report(all: bool, days: int):  # pylint: disable=redefined-builtin
                 controllers[controller_name] = cluster_record
         else:
             normal_cluster_records.append(cluster_record)
+
+    if output_format == flags.OUTPUT_FORMAT_JSON:
+        all_records = list(normal_cluster_records)
+        for cluster_record in controllers.values():
+            all_records.append(cluster_record)
+        json_records = []
+        for record in all_records:
+            r = dict(record)
+            if r.get('resources') is not None:
+                r['resources'] = str(r['resources'])
+            if r.get('status') is not None:
+                r['status'] = r['status'].value
+            json_records.append(r)
+        click.echo(json.dumps(json_records, indent=2))
+        return
 
     total_cost = status_utils.get_total_cost_of_displayed_records(
         normal_cluster_records, all)

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -2348,9 +2348,9 @@ def status_kubernetes(verbose: bool):
 @flags.output_format_option()
 @usage_lib.entrypoint
 def cost_report(
-        all: bool,
-        days: int,  # pylint: disable=redefined-builtin
-        output_format: str):
+        all: bool,  # pylint: disable=redefined-builtin
+        days: int,
+        output_format: str = 'table'):
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Show estimated costs for launched clusters.
 

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -2403,7 +2403,7 @@ def cost_report(
         for record in all_records:
             r = dict(record)
             if r.get('resources') is not None:
-                r['resources'] = str(r['resources'])
+                r['resources'] = r['resources'].to_yaml_config()
             if r.get('status') is not None:
                 r['status'] = r['status'].value
             json_records.append(r)

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -2404,7 +2404,8 @@ def cost_report(
             r = dict(record)
             if r.get('resources') is not None:
                 r['resources'] = r['resources'].to_yaml_config()
-            r['status'] = r.get('status', 'TERMINATED')
+            status = r.get('status')
+            r['status'] = status.value if status is not None else 'TERMINATED'
             json_records.append(r)
         click.echo(json.dumps(json_records, indent=2))
         return

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -2404,8 +2404,7 @@ def cost_report(
             r = dict(record)
             if r.get('resources') is not None:
                 r['resources'] = r['resources'].to_yaml_config()
-            status = r.get('status')
-            r['status'] = status.value if status is not None else 'TERMINATED'
+            r['status'] = r['status'].value if r.get('status') is not None else 'TERMINATED'
             json_records.append(r)
         click.echo(json.dumps(json_records, indent=2))
         return

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -2403,8 +2403,11 @@ def cost_report(
         for record in all_records:
             r = dict(record)
             if r.get('resources') is not None:
-                r['resources'] = r['resources'].to_yaml_config()
-            r['status'] = r['status'].value if r.get('status') is not None else 'TERMINATED'
+                r['resources'] = r['resources'].to_yaml_config(
+                    redact_secrets=True)
+            record_status = r.get('status')
+            r['status'] = (record_status.value
+                           if record_status is not None else 'TERMINATED')
             json_records.append(r)
         click.echo(json.dumps(json_records, indent=2))
         return

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -2404,8 +2404,7 @@ def cost_report(
             r = dict(record)
             if r.get('resources') is not None:
                 r['resources'] = r['resources'].to_yaml_config()
-            if r.get('status') is not None:
-                r['status'] = r['status'].value
+            r['status'] = r.get('status', 'TERMINATED')
             json_records.append(r)
         click.echo(json.dumps(json_records, indent=2))
         return

--- a/tests/unit_tests/test_sky/test_cli_json_output.py
+++ b/tests/unit_tests/test_sky/test_cli_json_output.py
@@ -1,7 +1,7 @@
 """Tests for CLI -o json output support.
 
 Tests for sky status -o json, sky jobs queue -o json, sky gpus list -o json,
-sky api status -o json, and sky queue -o json.
+sky api status -o json, sky queue -o json, and sky cost-report -o json.
 """
 import json
 from unittest import mock
@@ -402,3 +402,79 @@ class TestQueueJsonOutput:
         assert result.exit_code == 0, result.output
         parsed = json.loads(result.output)
         assert parsed == {}
+
+
+class TestCostReportJsonOutput:
+    """Tests for `sky cost-report -o json` output format."""
+
+    def _make_cost_report_record(self, name='mycluster', **kwargs):
+        mock_resources = mock.Mock()
+        mock_resources.__str__ = lambda self: 'AWS(m5.xlarge)'
+        mock_resources.get_cost = mock.Mock(return_value=0.192)
+        defaults = dict(
+            name=name,
+            launched_at=1700000000,
+            duration=3600,
+            num_nodes=1,
+            resources=mock_resources,
+            cluster_hash='abc123',
+            usage_intervals=[(1700000000, 1700003600)],
+            total_cost=0.192,
+            status=status_lib.ClusterStatus.UP,
+            cloud='AWS',
+            region='us-east-1',
+            resources_str='1xAWS(m5.xlarge)',
+        )
+        defaults.update(kwargs)
+        return defaults
+
+    def test_json_output_valid(self, monkeypatch):
+        """Test that -o json produces valid JSON."""
+        records = [self._make_cost_report_record()]
+
+        monkeypatch.setattr('sky.client.sdk.cost_report',
+                            lambda *a, **kw: 'mock_req')
+        monkeypatch.setattr('sky.client.sdk.get', lambda *a, **kw: records)
+        monkeypatch.setattr('sky.utils.controller_utils.Controllers.from_name',
+                            lambda *a, **kw: None)
+
+        runner = cli_testing.CliRunner()
+        result = runner.invoke(command.cost_report, ['-o', 'json'])
+
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert len(parsed) == 1
+        assert parsed[0]['name'] == 'mycluster'
+        assert parsed[0]['status'] == 'UP'
+        assert parsed[0]['total_cost'] == 0.192
+        assert parsed[0]['resources'] == 'AWS(m5.xlarge)'
+
+    def test_json_output_no_table_text(self, monkeypatch):
+        """Test that -o json suppresses table output."""
+        monkeypatch.setattr('sky.client.sdk.cost_report',
+                            lambda *a, **kw: 'mock_req')
+        monkeypatch.setattr('sky.client.sdk.get', lambda *a, **kw: [])
+        monkeypatch.setattr('sky.utils.controller_utils.Controllers.from_name',
+                            lambda *a, **kw: None)
+
+        runner = cli_testing.CliRunner()
+        result = runner.invoke(command.cost_report, ['-o', 'json'])
+
+        assert result.exit_code == 0, result.output
+        assert 'Total Cost' not in result.output
+        assert 'experimental' not in result.output
+
+    def test_json_output_empty(self, monkeypatch):
+        """Test JSON output with no clusters."""
+        monkeypatch.setattr('sky.client.sdk.cost_report',
+                            lambda *a, **kw: 'mock_req')
+        monkeypatch.setattr('sky.client.sdk.get', lambda *a, **kw: [])
+        monkeypatch.setattr('sky.utils.controller_utils.Controllers.from_name',
+                            lambda *a, **kw: None)
+
+        runner = cli_testing.CliRunner()
+        result = runner.invoke(command.cost_report, ['-o', 'json'])
+
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert parsed == []

--- a/tests/unit_tests/test_sky/test_cli_json_output.py
+++ b/tests/unit_tests/test_sky/test_cli_json_output.py
@@ -411,6 +411,10 @@ class TestCostReportJsonOutput:
         mock_resources = mock.Mock()
         mock_resources.__str__ = lambda self: 'AWS(m5.xlarge)'
         mock_resources.get_cost = mock.Mock(return_value=0.192)
+        mock_resources.to_yaml_config = mock.Mock(return_value={
+            'infra': 'AWS',
+            'instance_type': 'm5.xlarge',
+        })
         defaults = dict(
             name=name,
             launched_at=1700000000,
@@ -447,7 +451,10 @@ class TestCostReportJsonOutput:
         assert parsed[0]['name'] == 'mycluster'
         assert parsed[0]['status'] == 'UP'
         assert parsed[0]['total_cost'] == 0.192
-        assert parsed[0]['resources'] == 'AWS(m5.xlarge)'
+        assert parsed[0]['resources'] == {
+            'infra': 'AWS',
+            'instance_type': 'm5.xlarge',
+        }
 
     def test_json_output_no_table_text(self, monkeypatch):
         """Test that -o json suppresses table output."""


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
adds a `-o json` output for the cost-report cli to address https://github.com/skypilot-org/skypilot/issues/9499#issuecomment-4356558923


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->
Added unittests for the new json output which are similar to the other unittests for json output

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->