### PR TITLE
[Dashboard] Persist layout settle state across LayoutContent remounts

### DIFF
--- a/sky/dashboard/src/components/elements/layout.jsx
+++ b/sky/dashboard/src/components/elements/layout.jsx
@@ -34,10 +34,18 @@ function DefaultNavbarLayout({ children }) {
   );
 }
 
+// Once plugins have settled in any LayoutContent instance, remember it on the
+// window so a remount (e.g. when a plugin registers an app-level wrapper into
+// PluginWrapperSlot, restructuring the tree) skips the gate immediately
+// instead of flashing bg-gray-50 for another settle cycle.
+const PLUGINS_SETTLED_FLAG = '__skydashboardPluginsSettled';
+
 function LayoutContent({ children, highlighted }) {
   const isMobile = useMobile();
   const { reportUpgrade, clearUpgrade } = useUpgradeDetection();
-  const [pluginsSettled, setPluginsSettled] = useState(false);
+  const [pluginsSettled, setPluginsSettled] = useState(
+    () => typeof window !== 'undefined' && window[PLUGINS_SETTLED_FLAG] === true
+  );
 
   // Install the fetch interceptor on mount
   useEffect(() => {
@@ -51,10 +59,17 @@ function LayoutContent({ children, highlighted }) {
   // a chance to register before falling back to the default top bar.
   // A safety timeout prevents blocking indefinitely if plugin loading hangs.
   useEffect(() => {
-    const timer = setTimeout(() => setPluginsSettled(true), 1000);
+    if (pluginsSettled) return undefined;
+    const settle = () => {
+      if (typeof window !== 'undefined') {
+        window[PLUGINS_SETTLED_FLAG] = true;
+      }
+      setPluginsSettled(true);
+    };
+    const timer = setTimeout(settle, 1000);
     const handler = () => {
       clearTimeout(timer);
-      setPluginsSettled(true);
+      settle();
     };
     window.addEventListener(EVENT_NAVIGATION_READY, handler, { once: true });
     window.addEventListener(EVENT_PLUGINS_LOADED, handler, { once: true });
@@ -63,7 +78,7 @@ function LayoutContent({ children, highlighted }) {
       window.removeEventListener(EVENT_NAVIGATION_READY, handler);
       window.removeEventListener(EVENT_PLUGINS_LOADED, handler);
     };
-  }, []);
+  }, [pluginsSettled]);
 
   if (!pluginsSettled) {
     return <div className="min-h-screen bg-gray-50" />;


### PR DESCRIPTION
## Summary

`LayoutContent` guards the layout with a local `pluginsSettled` state. When a plugin registers an app-level wrapper into `PluginWrapperSlot` (`slot: 'app.providers'`) after the first commit, React unmounts and remounts the descendant subtree, including `Layout` — `pluginsSettled` resets to `false` and the gate renders an empty `bg-gray-50` div a second time before settling again.

Visible result on hard refresh: page paints, briefly flashes `bg-gray-50` (~150 ms), then paints again.

This change persists `pluginsSettled` on `window` once it goes true, and seeds `useState` from that flag on each mount. After the first settle, a remount skips the gate.

## Test plan

- [ ] In a build that registers an `app.providers` wrapper from a plugin, hard-refresh any dashboard page. Before: brief `bg-gray-50` flash between two settled paints. After: single blank-to-content transition.
- [ ] Without any `app.providers` wrapper registered, gate behavior is unchanged: appears once at first paint, clears on `skydashboard:navigation-ready` (or 1 s timer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)