### PR TITLE
[Test] Skip batch tests on shared API server pipelines

### DIFF
--- a/tests/smoke_tests/test_batch.py
+++ b/tests/smoke_tests/test_batch.py
@@ -15,6 +15,14 @@ from smoke_tests import smoke_tests_utils
 
 from sky import skypilot_config
 
+# 1. TODO(lloyd): Marking the batch tests below as no_remote_server because
+# they all run `sky jobs pool apply`, and on shared API server environments
+# (e.g. the shared GKE pipeline) the controller has limited memory which
+# caps concurrent services at 1. Multiple Buildkite jobs in parallel race
+# for that single slot and fail with "Max number of services reached: 1/1".
+# Remove this when consolidation mode is enabled by default or we have an
+# option to not allow shared env tests.
+
 
 def _storage_cmds(generic_cloud: str, bucket: str):
     """Return cloud-specific storage command fragments for batch tests.
@@ -38,6 +46,7 @@ def _storage_cmds(generic_cloud: str, bucket: str):
 
 # ---------- Test simple batch (text doubling) ----------
 @pytest.mark.batch
+@pytest.mark.no_remote_server  # see note 1 above
 def test_batch_simple(generic_cloud: str):
     name = smoke_tests_utils.get_cluster_name()
     bucket = f'sky-batch-smpl-{name}'
@@ -132,6 +141,7 @@ def test_batch_simple(generic_cloud: str):
 @pytest.mark.batch
 @pytest.mark.resource_heavy
 @pytest.mark.no_kubernetes  # pool.yaml hardcodes L4 GPU; K8s CI clusters may not have it
+@pytest.mark.no_remote_server  # see note 1 above
 def test_batch_diffusion(generic_cloud: str):
     name = smoke_tests_utils.get_cluster_name()
     bucket = f'sky-batch-diff-{name}'
@@ -215,6 +225,7 @@ def test_batch_diffusion(generic_cloud: str):
 
 # ---------- Test custom formats (range input, text + JSON file output) --------
 @pytest.mark.batch
+@pytest.mark.no_remote_server  # see note 1 above
 def test_batch_custom_formats(generic_cloud: str):
     name = smoke_tests_utils.get_cluster_name()
     bucket = f'sky-batch-cfmt-{name}'
@@ -293,6 +304,7 @@ def test_batch_custom_formats(generic_cloud: str):
 
 # ---------- Test batch cancel ----------
 @pytest.mark.batch
+@pytest.mark.no_remote_server  # see note 1 above
 def test_batch_cancel(generic_cloud: str):
     name = smoke_tests_utils.get_cluster_name()
     bucket = f'sky-batch-cncl-{name}'


### PR DESCRIPTION
## Summary
- Mark all 4 batch smoke tests as `@pytest.mark.no_remote_server` so they don't run on pipelines that share a single API server across parallel test jobs.
- Add a top-level note comment explaining the reason (mirrors the existing pattern in `tests/smoke_tests/test_pools.py`).

## Root cause
All four batch tests (`test_batch_simple`, `test_batch_diffusion`, `test_batch_custom_formats`, `test_batch_cancel`) run `sky jobs pool apply`. On the shared GKE nightly pipeline the API server pod is small (4 GB), and in consolidation mode `_get_number_of_services()` divides usable memory by service-monitoring memory after reserving for controllers and API workers — capping concurrent services at 1.

The shared GKE pipeline runs each test as its own Buildkite job in parallel against one shared API server. They race for the single slot — whoever calls `pool apply` first wins, the others fail with:

```
RuntimeError: Max number of services reached: 1/1 services are running.
The jobs controller is running in consolidation mode, sharing memory with
the API server.
```

Surfaced to users as `RuntimeError: Failed to wait for pool initialization`.

## Evidence (nightly run [25209242019](https://github.com/skypilot-org/skypilot/actions/runs/25209242019), Buildkite [shared-gke #328](https://buildkite.com/skypilot-1/nightly-build-shared-gke-api-server/builds/328))
- `test_batch_custom_formats` — 4/4 attempts failed
- `test_batch_cancel` — 3/3 attempts failed
- Earlier waves at ~10:23 UTC had both tests fail concurrently — `test_batch_cancel` won the slot, `test_batch_custom_formats` lost (and vice versa later).

## How `no_remote_server` solves this
`tests/conftest.py:447-455` skips `no_remote_server` tests when:
1. `--remote-server` is set, OR
2. `--env-file` is set and the env file contains `api_server` config (i.e. the shared-gke pipeline).

These tests will continue to run on pure-Kubernetes, AWS, GCP, etc. pipelines where each test gets its own per-test API server.

## Test plan
- [ ] Verify all four tests still run on `--kubernetes` (per-test API server, the failures here weren't seen).
- [ ] Verify they're skipped on the shared-gke pipeline by inspecting the next nightly's `nightly-build-shared-gke-api-server` build job list — these test names should not appear.
- [ ] Confirm no `Max number of services reached` errors in the next shared-gke run.

## Notes
- This file's pylint baseline on master is -13.33/10 (pre-existing issues with f-string interpolation, unused imports, and intentionally double-quoted f-strings embedding shell single-quotes around lines 338-351). This PR adds only a comment + 4 decorator lines; no new lint warnings introduced. Cleaning up the pre-existing issues would risk changing shell semantics in `test_batch_cancel` and is left for a follow-up.
- Companion PR #9506 fixes the unrelated `test_cli_auto_retry` retry-progress bug also surfaced by this nightly run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)