### PR TITLE
[CI] Temporarily disable flaky test_optimizer_random_dag

### DIFF
--- a/.github/workflows/pytest-optimizer.yml
+++ b/.github/workflows/pytest-optimizer.yml
@@ -21,7 +21,14 @@ jobs:
           - "tests/test_optimizer_dryruns.py -k \"partial\""
           - "tests/test_optimizer_dryruns.py -k \"not partial and not accelerator_memory and not accelerator_manufacturer\""
           - "tests/test_optimizer_dryruns.py -k \"accelerator_memory or accelerator_manufacturer\""
-          - tests/test_optimizer_random_dag.py
+          # TODO(lloyd): Re-enable once test_optimizer_random_dag is stable.
+          # The test is currently flaky on master with assertion failures
+          # like `assert abs(objective - min_objective) < 2` — the
+          # numerical tolerance is too tight for the randomized DAG it
+          # generates. Because matrix `fail-fast` defaults to true, this
+          # broken job cancels the Optimizer Dryruns Parts 1-3 jobs on
+          # every PR, blocking unrelated changes from merging.
+          # - tests/test_optimizer_random_dag.py
         include:
           - test-path: "tests/test_optimizer_dryruns.py -k \"partial\""
             test-name: "Optimizer Dryruns Part 1"
@@ -29,8 +36,8 @@ jobs:
             test-name: "Optimizer Dryruns Part 2"
           - test-path: "tests/test_optimizer_dryruns.py -k \"accelerator_memory or accelerator_manufacturer\""
             test-name: "Optimizer Dryruns Part 3"
-          - test-path: tests/test_optimizer_random_dag.py
-            test-name: "Optimizer Random DAG Tests"
+          # - test-path: tests/test_optimizer_random_dag.py
+          #   test-name: "Optimizer Random DAG Tests"
     runs-on: ubuntu-latest
     name: "Python Tests - ${{ matrix.test-name }}"
     steps:


### PR DESCRIPTION
## Summary
Temporarily comment out the `tests/test_optimizer_random_dag.py` entry from the optimizer test matrix. It's currently flaky on master and is **cancelling unrelated PRs** because the matrix uses the default `fail-fast: true`.

## Why
`tests/test_optimizer_random_dag.py::test_optimizer` fails on master with assertions like:

```
tests/test_optimizer_random_dag.py:177: in compare_optimization_results
    assert abs(objective - min_objective) < 2
E   assert 2.1601760379716097 < 2
E    +  where 2.1601760379716097 = abs((198.33843049595825 - 196.17825445798664))
```

The tolerance (`< 2`) is too tight for the randomized DAG the test generates — the optimizer's solution can legitimately differ from brute-force by slightly more than 2 cost units, especially as the catalog grows.

Since the optimizer matrix in `.github/workflows/pytest-optimizer.yml` doesn't set `fail-fast: false`, when this job fails GitHub cancels the still-running Parts 1, 2, and 3 — making them appear failing in CI even though they would have passed.

Example impact (PR #9507): all three Dryruns Parts show "fail" with log line `##[error]The operation was canceled.` — they never failed on their own merits.

## What this PR does
- Comments out the Random DAG entry in both the `test-path` matrix list and the `include` mapping.
- Adds a TODO with the reason and a restore-when condition.

That's it — single-file, ~10 line diff in `.github/workflows/pytest-optimizer.yml`.

## Follow-ups (out of scope here)
- Fix `test_optimizer_random_dag` (loosen tolerance, or seed the RNG, or both) — owner TBD.
- Consider adding `fail-fast: false` to this matrix permanently so a single broken job doesn't cancel siblings in the future.

## Test plan
- [ ] CI on this PR shows only Parts 1, 2, 3 (no Random DAG entry).
- [ ] Parts 1, 2, 3 all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)