### PR TITLE
[Test] examples: fall back to wayback mirror when CIFAR-10 host is down

### DIFF
--- a/examples/resnet_distributed_torch.yaml
+++ b/examples/resnet_distributed_torch.yaml
@@ -21,7 +21,9 @@ setup: |
         exit 0
     fi
     cd data && \
-    wget -c --quiet https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz
+    (wget -c --quiet https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz \
+        || wget --quiet -O cifar-10-python.tar.gz \
+            "https://web.archive.org/web/20241225200100im_/https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz")
     tar -xvzf cifar-10-python.tar.gz
 
 run: |

--- a/examples/resnet_distributed_torch_scripts/setup.sh
+++ b/examples/resnet_distributed_torch_scripts/setup.sh
@@ -16,5 +16,7 @@ pip install -r requirements.txt torch==1.12.1+cu113 --extra-index-url https://do
 mkdir -p data
 mkdir -p saved_models
 cd data
-wget -c --quiet https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz
+wget -c --quiet https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz \
+    || wget --quiet -O cifar-10-python.tar.gz \
+        "https://web.archive.org/web/20241225200100im_/https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz"
 tar -xvzf cifar-10-python.tar.gz


### PR DESCRIPTION
## Summary

`examples/resnet_distributed_torch.yaml` and `examples/resnet_distributed_torch_scripts/setup.sh` both `wget` `cifar-10-python.tar.gz` from `https://www.cs.toronto.edu/~kriz/`. That host has been returning **HTTP 503 Service Unavailable** since around 2026-05-02, which breaks `test_cancel_pytorch` on every cloud (gcp, aws, kubernetes, kubernetes+remote-server) — confirmed on master nightly builds (#10232, #10231, #10229, #10228) which all fail at exactly this `wget` step with exit code 8 and `FAILED_SETUP`.

Reproduced locally on Kubernetes:
```
+ wget -c --quiet https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz
ERROR: Job 1's setup failed. Failed workers: (pid=2539, returncode=8).
✓ Job finished (status: FAILED_SETUP).
```

`curl -I` against the URL today:
```
HTTP/1.1 503 Service Unavailable
Date: Sun, 03 May 2026 17:32:51 GMT
Server: Apache/2.4.58 (Ubuntu)
Last-Modified: Sat, 02 May 2026 09:26:10 GMT
```

## Fix

Add a fallback to a Wayback Machine snapshot from 2024-12-25 (the latest snapshot pre-outage that serves the file directly):

```
https://web.archive.org/web/20241225200100im_/https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz
```

The snapshot serves the original `cifar-10-python.tar.gz` over HTTPS:
- `Content-Type: application/x-gzip`
- `Content-Length: 170,498,071` (~163 MiB — same size as upstream)
- Internal layout matches: `cifar-10-batches-py/{data_batch_1..5,test_batch,batches.meta,readme.html}`

Verified end-to-end:
```
curl -L -o cifar.tgz "https://web.archive.org/web/20241225200100im_/https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz"
tar tzf cifar.tgz | head
# cifar-10-batches-py/
# cifar-10-batches-py/data_batch_4
# cifar-10-batches-py/readme.html
# cifar-10-batches-py/test_batch
# ...
```

The primary URL is still tried first, so once cs.toronto.edu is back the fallback is dormant.

## Why not torchvision's downloader

`torchvision.datasets.CIFAR10(download=True)` hits the same `cs.toronto.edu` URL and has no fallback either, so it fails identically. Fixing the example's wget is the targeted change for the smoke-test breakage.

## Test plan
- [x] `curl -I` confirmed cs.toronto.edu returns 503 and Wayback snapshot returns 200 (163 MiB, application/x-gzip)
- [x] `tar tzf` confirmed Wayback snapshot has the canonical `cifar-10-batches-py/` layout
- [ ] CI: `/smoke-test -k test_cancel_pytorch` once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)