### PR TITLE
[Dashboard] Show torn-down cluster on detail page when URL holds the name

### DIFF
--- a/sky/core.py
+++ b/sky/core.py
@@ -388,7 +388,8 @@ def endpoints(cluster: str,
 def cost_report(
         days: Optional[int] = None,
         dashboard_summary_response: bool = False,
-        cluster_hashes: Optional[List[str]] = None) -> List[Dict[str, Any]]:
+        cluster_hashes: Optional[List[str]] = None,
+        cluster_names: Optional[List[str]] = None) -> List[Dict[str, Any]]:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Get all cluster cost reports, including those that have been downed.
 
@@ -426,6 +427,17 @@ def cost_report(
         days: Number of days to look back from now. Active clusters are always
             included. Historical clusters are only included if they were last
             used within the past 'days' days. Defaults to 30 days.
+        dashboard_summary_response: If True, return an abbreviated payload
+            suitable for dashboard list views. Has no effect when
+            cluster_hashes or cluster_names is provided (filtered queries
+            always return the full record).
+        cluster_hashes: If provided, only include clusters whose hash is in
+            this list.
+        cluster_names: If provided, only include clusters whose name is in
+            this list. When both cluster_hashes and cluster_names are
+            provided, rows matching either are returned (logical OR). Note
+            that a single cluster name may map to multiple history records
+            when the name is reused across launches.
 
     Returns:
         A list of dicts, with each dict containing the cost information of a
@@ -434,12 +446,14 @@ def cost_report(
     if days is None:
         days = constants.COST_REPORT_DEFAULT_DAYS
 
-    abbreviate_response = dashboard_summary_response and cluster_hashes is None
+    abbreviate_response = (dashboard_summary_response and
+                           cluster_hashes is None and cluster_names is None)
 
     cluster_reports = global_user_state.get_clusters_from_history(
         days=days,
         abbreviate_response=abbreviate_response,
-        cluster_hashes=cluster_hashes)
+        cluster_hashes=cluster_hashes,
+        cluster_names=cluster_names)
     logger.debug(
         f'{len(cluster_reports)} clusters found from history with {days} days.')
 

--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -155,7 +155,11 @@ export async function getClusters({ clusterNames = null } = {}) {
   }
 }
 
-export async function getClusterHistory(clusterHash = null, days = 30) {
+export async function getClusterHistory(
+  clusterHash = null,
+  days = 30,
+  clusterName = null
+) {
   try {
     const requestBody = {
       days: days,
@@ -165,6 +169,13 @@ export async function getClusterHistory(clusterHash = null, days = 30) {
     // If a specific cluster hash is provided, include it in the request
     if (clusterHash) {
       requestBody.cluster_hashes = [clusterHash];
+    }
+    // The server filters on hash OR name when both are set, which lets the
+    // dashboard look up a cluster by either identifier in a single call.
+    // This avoids fetching the entire history (potentially tens of
+    // thousands of rows) just to resolve a name-keyed URL.
+    if (clusterName) {
+      requestBody.cluster_names = [clusterName];
     }
 
     const history = await apiClient.fetch('/cost_report', requestBody);

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -102,12 +102,32 @@ function ClusterDetails() {
 
       setHistoryLoading(true);
       try {
-        const historyData = await dashboardCache.get(getClusterHistory, [
-          cluster,
-        ]);
-        const foundHistoryCluster = historyData.find(
-          (c) => c.cluster_hash === cluster || c.cluster === cluster
+        // The URL parameter may be either a cluster hash (when navigated
+        // from the historical clusters list) or a cluster name (when the
+        // user opened the active cluster page and the cluster was later
+        // torn down via `sky down`). Try the hash lookup first since it
+        // returns the full record; if that misses, fall back to scanning
+        // recent history by name.
+        const byHash = await dashboardCache.get(getClusterHistory, [cluster]);
+        let foundHistoryCluster = byHash.find(
+          (c) => c.cluster_hash === cluster
         );
+        if (!foundHistoryCluster) {
+          const allHistory = await dashboardCache.get(getClusterHistory, []);
+          const matchByName = allHistory.find((c) => c.cluster === cluster);
+          if (matchByName) {
+            // Re-fetch the full record by hash so fields omitted from the
+            // abbreviated response (e.g. last_creation_yaml,
+            // last_creation_command) are populated.
+            const fullData = await dashboardCache.get(getClusterHistory, [
+              matchByName.cluster_hash,
+            ]);
+            foundHistoryCluster =
+              fullData.find(
+                (c) => c.cluster_hash === matchByName.cluster_hash
+              ) || matchByName;
+          }
+        }
         if (foundHistoryCluster) {
           setHistoryData(foundHistoryCluster);
           setIsHistoricalCluster(true);

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -105,29 +105,21 @@ function ClusterDetails() {
         // The URL parameter may be either a cluster hash (when navigated
         // from the historical clusters list) or a cluster name (when the
         // user opened the active cluster page and the cluster was later
-        // torn down via `sky down`). Try the hash lookup first since it
-        // returns the full record; if that misses, fall back to scanning
-        // recent history by name.
-        const byHash = await dashboardCache.get(getClusterHistory, [cluster]);
-        let foundHistoryCluster = byHash.find(
-          (c) => c.cluster_hash === cluster
-        );
-        if (!foundHistoryCluster) {
-          const allHistory = await dashboardCache.get(getClusterHistory, []);
-          const matchByName = allHistory.find((c) => c.cluster === cluster);
-          if (matchByName) {
-            // Re-fetch the full record by hash so fields omitted from the
-            // abbreviated response (e.g. last_creation_yaml,
-            // last_creation_command) are populated.
-            const fullData = await dashboardCache.get(getClusterHistory, [
-              matchByName.cluster_hash,
-            ]);
-            foundHistoryCluster =
-              fullData.find(
-                (c) => c.cluster_hash === matchByName.cluster_hash
-              ) || matchByName;
-          }
-        }
+        // torn down via `sky down`). Send both filters; the server returns
+        // rows matching either, which resolves the cluster in a single
+        // round trip without fetching the entire history (which can
+        // contain tens of thousands of rows).
+        const historyData = await dashboardCache.get(getClusterHistory, [
+          cluster,
+          30,
+          cluster,
+        ]);
+        // Prefer an exact hash match; otherwise fall back to a name match.
+        // A reused cluster name can produce multiple history rows, in which
+        // case the most recent (server-ordered by launched_at desc) wins.
+        const foundHistoryCluster =
+          historyData.find((c) => c.cluster_hash === cluster) ||
+          historyData.find((c) => c.cluster === cluster);
         if (foundHistoryCluster) {
           setHistoryData(foundHistoryCluster);
           setIsHistoricalCluster(true);

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1966,7 +1966,8 @@ def get_cluster_names(exclude_managed_clusters: bool = False,) -> List[str]:
 def get_clusters_from_history(
         days: Optional[int] = None,
         abbreviate_response: bool = False,
-        cluster_hashes: Optional[List[str]] = None) -> List[Dict[str, Any]]:
+        cluster_hashes: Optional[List[str]] = None,
+        cluster_names: Optional[List[str]] = None) -> List[Dict[str, Any]]:
     """Get cluster reports from history.
 
     Args:
@@ -1974,6 +1975,13 @@ def get_clusters_from_history(
               currently active) that were last used within the past 'days'
               days. Active clusters are always included regardless of this
               parameter.
+        cluster_hashes: If specified, only include clusters whose hash is in
+              this list.
+        cluster_names: If specified, only include clusters whose name is in
+              this list. When both cluster_hashes and cluster_names are
+              specified, rows matching either are returned (logical OR).
+              Note that a single cluster name can map to multiple history
+              records when a name is reused across launches.
 
     Returns:
         List of cluster records with history information.
@@ -2034,9 +2042,15 @@ def get_clusters_from_history(
         query = query.order_by(
             sqlalchemy.desc(cluster_history_table.c.launched_at))
 
+        identifier_filters = []
         if cluster_hashes is not None:
-            query = query.filter(
+            identifier_filters.append(
                 cluster_history_table.c.cluster_hash.in_(cluster_hashes))
+        if cluster_names is not None:
+            identifier_filters.append(
+                cluster_history_table.c.name.in_(cluster_names))
+        if identifier_filters:
+            query = query.filter(sqlalchemy.or_(*identifier_filters))
         rows = query.all()
 
     usage_intervals_dict = {}

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -915,6 +915,11 @@ class CostReportBody(RequestBody):
     # we use hashes instead of names to avoid the case where
     # the name is not unique
     cluster_hashes: Optional[List[str]] = None
+    # Filter by cluster name. Useful for the dashboard, which routes a
+    # torn-down cluster's detail page by name (the URL param is the
+    # cluster name, not the hash). When both cluster_hashes and
+    # cluster_names are set, rows matching either are returned.
+    cluster_names: Optional[List[str]] = None
     # Only return fields that are needed for the dashboard
     # summary page
     dashboard_summary_response: bool = False

--- a/tests/unit_tests/test_sky/test_cost_report.py
+++ b/tests/unit_tests/test_sky/test_cost_report.py
@@ -23,7 +23,8 @@ class TestCostReportCore(unittest.TestCase):
             # Should call with default 30 days
             mock_get_history.assert_called_once_with(days=30,
                                                      abbreviate_response=False,
-                                                     cluster_hashes=None)
+                                                     cluster_hashes=None,
+                                                     cluster_names=None)
             self.assertEqual(result, [])
 
     def test_cost_report_custom_days(self):
@@ -37,7 +38,8 @@ class TestCostReportCore(unittest.TestCase):
             # Should call with custom 7 days
             mock_get_history.assert_called_once_with(days=7,
                                                      abbreviate_response=False,
-                                                     cluster_hashes=None)
+                                                     cluster_hashes=None,
+                                                     cluster_names=None)
             self.assertEqual(result, [])
 
     def test_cost_report_none_days(self):
@@ -51,8 +53,43 @@ class TestCostReportCore(unittest.TestCase):
             # Should call with default 30 days when None is passed
             mock_get_history.assert_called_once_with(days=30,
                                                      abbreviate_response=False,
-                                                     cluster_hashes=None)
+                                                     cluster_hashes=None,
+                                                     cluster_names=None)
             self.assertEqual(result, [])
+
+    def test_cost_report_with_cluster_names_filter(self):
+        """Test cost_report forwards cluster_names to history and disables
+        abbreviation when a name filter is provided."""
+        with mock.patch('sky.global_user_state.get_clusters_from_history'
+                       ) as mock_get_history:
+            mock_get_history.return_value = []
+
+            core.cost_report(dashboard_summary_response=True,
+                             cluster_names=['my-cluster'])
+
+            # When filtering by name, abbreviate_response must be False so
+            # the dashboard receives full records (yaml/command fields).
+            mock_get_history.assert_called_once_with(
+                days=30,
+                abbreviate_response=False,
+                cluster_hashes=None,
+                cluster_names=['my-cluster'])
+
+    def test_cost_report_with_both_hash_and_name_filters(self):
+        """Test cost_report forwards both filters when both are given."""
+        with mock.patch('sky.global_user_state.get_clusters_from_history'
+                       ) as mock_get_history:
+            mock_get_history.return_value = []
+
+            core.cost_report(dashboard_summary_response=True,
+                             cluster_hashes=['abc'],
+                             cluster_names=['my-cluster'])
+
+            mock_get_history.assert_called_once_with(
+                days=30,
+                abbreviate_response=False,
+                cluster_hashes=['abc'],
+                cluster_names=['my-cluster'])
 
     def test_cost_report_with_pickle_errors(self):
         """Test cost_report handles pickle errors gracefully when loading historical data."""
@@ -70,7 +107,8 @@ class TestCostReportCore(unittest.TestCase):
             self.assertEqual(result, [])
             mock_get_history.assert_called_once_with(days=30,
                                                      abbreviate_response=False,
-                                                     cluster_hashes=None)
+                                                     cluster_hashes=None,
+                                                     cluster_names=None)
 
 
 class TestCostReportStatusUtils(unittest.TestCase):


### PR DESCRIPTION
## Summary

- **Bug:** After `sky launch <name>` → open the cluster detail page → `sky down <name>` → refresh, the page shows "Cluster not found in active clusters or history." The cluster *is* in history, but the URL holds the cluster **name** (set when the user navigated from the active list), and `/cost_report` only filtered by hash.
- **Fix:** Add a `cluster_names` filter to `cost_report` and have the detail page send both the hash and the name. Server returns rows matching either (logical OR), so the page resolves whichever identifier is in the URL in one round trip.
- **Backward compatible:** `CostReportBody` adds an optional field; older servers silently drop it (`extra='ignore'`). No `API_VERSION` bump.

### Files

- `sky/server/requests/payloads.py` — `CostReportBody.cluster_names: Optional[List[str]]`.
- `sky/core.py` — `cost_report(..., cluster_names=...)`. Abbreviation auto-disables when either filter is set.
- `sky/global_user_state.py` — `get_clusters_from_history` filters `or_(hash IN (...), name IN (...))` in one SQL query. Existing `launched_at DESC` order means the most recent row wins on name reuse.
- `sky/dashboard/src/data/connectors/clusters.jsx` — `getClusterHistory(hash, days, name)`.
- `sky/dashboard/src/pages/clusters/[cluster].js` — sends both filters; prefers hash match, falls back to name match.

## Edge case (known)

Cluster names are not globally unique — they can be reused across users:

| Time | Event |
|------|-------|
| T0 | User A's `foo` (H1) torn down → H1 in history |
| T1 | User B launches `foo` (H3) → active |
| T2 | User B tears down `foo` (H3) → H3 in history |
| T3 | User A navigates to `/clusters/foo` → active lookup misses |
| T4 | Fix returns `[H3, H1]`, picks H3 (most recent) → User A sees User B's record |

Out of scope here; addressing it would mean keying the URL on hash from the active page, or scoping the name filter by `user_hash`/`workspace`. The single-user case (the common one) is fully addressed.

## Tested

19/19 unit tests pass in `tests/unit_tests/test_sky/test_cost_report.py` (incl. 2 new tests for the `cluster_names` filter).

End-to-end against a local API server built from this branch: navigated to `/clusters/<torn-down-name>` and confirmed the **Historical Cluster Details** card renders (status `TERMINATED`, duration, entrypoint). Network panel shows one `POST /cost_report` carrying both `cluster_hashes` and `cluster_names`; response is the single filtered row (~640 bytes), not the full history. Bug-vs-fix verified at the server: master-era body (only `cluster_hashes`) returns `[]`; this branch's body (both filters) returns the row.

**Reviewer steps:**

\`\`\`bash
git fetch origin claude/fix-cluster-history-display-vWxZI
git checkout claude/fix-cluster-history-display-vWxZI
npm --prefix sky/dashboard install
npm --prefix sky/dashboard run build
sky api stop && sky api start
\`\`\`

1. \`sky launch -c test-pod --infra k8s -- sleep 1000\`.
2. Open dashboard → click \`test-pod\` in **Sky Clusters** → URL becomes \`/clusters/test-pod\`.
3. In another terminal: \`sky down test-pod -y\`.
4. Refresh the tab. **Before:** "Cluster not found…" **With this PR:** "Historical Cluster Details" card.
5. Regression: open a torn-down cluster from the historical list (URL contains the hash) — still loads.
6. DevTools → Network: one \`POST /cost_report\` carries both \`cluster_hashes\` and \`cluster_names\`; response is filtered server-side.