### PR TITLE
[Dashboard] Show only terminated clusters in cluster-history view

### DIFF
--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -612,8 +612,6 @@ export function useClusterData(options = {}) {
   const fetchClientSide = useCallback(async () => {
     console.log('[useClusterData] Using client-side pagination');
 
-    const activeClusters = await dashboardCache.get(getClusters);
-
     let allClusters;
     if (showHistory) {
       let historyClusters = [];
@@ -626,22 +624,14 @@ export function useClusterData(options = {}) {
         console.error('Error fetching cluster history:', historyError);
       }
 
-      const markedActive = activeClusters.map((c) => ({
-        ...c,
-        isHistorical: false,
-      }));
-      const markedHistory = historyClusters.map((c) => ({
-        ...c,
-        isHistorical: true,
-      }));
-
-      allClusters = [...markedActive];
-      markedHistory.forEach((hist) => {
-        if (!activeClusters.some((a) => a.cluster_hash === hist.cluster_hash)) {
-          allClusters.push(hist);
-        }
-      });
+      // "Show history" surfaces only truly terminated clusters within the
+      // selected time window. cost_report also returns active clusters, so
+      // drop anything still present in cluster_table (status !== TERMINATED).
+      allClusters = historyClusters
+        .filter((c) => c.status === 'TERMINATED')
+        .map((c) => ({ ...c, isHistorical: true }));
     } else {
+      const activeClusters = await dashboardCache.get(getClusters);
       allClusters = activeClusters.map((c) => ({
         ...c,
         isHistorical: false,


### PR DESCRIPTION
## Summary

The "Show history" toggle on the Clusters page surfaced currently-running clusters too. Root cause: `cost_report` (the history source) intentionally returns active rows alongside historical ones, and the frontend merged that with `getClusters()` rather than filtering down.

In `useClusterData.fetchClientSide`, when `showHistory` is on, fetch `cost_report` and keep only rows where the mapped status is `TERMINATED` — which is set only when the cluster has no row in `cluster_table` (truly downed). Active clusters are no longer fetched in this mode.

Frontend-only change. `sky cost-report` CLI semantics are unchanged. Server-side pagination plugin path (`fetchServerSide`) is untouched — that contract is owned by the plugin.

## Test plan

Local box with mixed history (1 UP, 1 INIT, 3 TERMINATED in cost_report):

- [x] Toggle off: UP + INIT clusters listed (existing behavior)
- [x] Toggle on: only the 3 TERMINATED rows; UP and INIT hidden
- [x] DevTools Network in history mode: `/cost_report` hit, `/status` not hit
- [ ] STOPPED cluster present: should appear with toggle off, hidden with toggle on
- [ ] Day-range select (1/5/10/30) still narrows the history list
- [ ] Filter bar (workspace/user/infra) derives from history-only set when toggle is on