### PR TITLE
Preserve .gitignore negation during workdir sync

### DIFF
--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -63,11 +63,11 @@ def _run_git_ls_files_for_ignored_paths(
         src_dir_path: str,
         git_dir: Optional[str] = None,
         use_standard_excludes: bool = True) -> List[str]:
+    cmd = ['git', '-c', 'safe.directory=*']
     if git_dir is None:
-        git_dir_args = f'-C {shlex.quote(src_dir_path)}'
+        cmd += ['-C', src_dir_path]
     else:
-        git_dir_args = (f'--git-dir={shlex.quote(git_dir)} '
-                        f'--work-tree={shlex.quote(src_dir_path)}')
+        cmd += ['--git-dir', git_dir, '--work-tree', src_dir_path]
     if use_standard_excludes:
         exclude_args = '--exclude-standard'
     else:
@@ -78,17 +78,17 @@ def _run_git_ls_files_for_ignored_paths(
     # is True. Otherwise, only .gitignore files are used.
     # -z: filenames terminated by \0 instead of \n
     # --others: show untracked files
-    # --ignore: out of untracked files, only show ignored files
-    # --exclude-standard: use standard exclude rules (required for --ignore);
+    # --ignored: out of untracked files, only show ignored files
+    # --exclude-standard: use standard exclude rules (required for --ignored);
     # --exclude-per-directory: use per-directory .gitignore files only.
     # --directory: if an entire directory is ignored, collapse to a single
     #              entry rather than listing every single file
     # Since we are using --others instead of --cached, this will not show
     # files that are tracked but also present in .gitignore.
-    filter_cmd = (f'git -c safe.directory="*" {git_dir_args} '
-                  f'ls-files -z --others --ignore {exclude_args} --directory')
-    output = subprocess.run(filter_cmd,
-                            shell=True,
+    cmd += [
+        'ls-files', '-z', '--others', '--ignored', exclude_args, '--directory'
+    ]
+    output = subprocess.run(cmd,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,
                             check=True,
@@ -105,16 +105,15 @@ def _get_excluded_files_from_gitignore_without_repo(
         src_dir_path: str) -> List[str]:
     """Evaluates .gitignore for a directory outside a Git repository."""
     with tempfile.TemporaryDirectory(prefix='skypilot_gitignore_') as temp_dir:
-        subprocess.run(f'git init --quiet {shlex.quote(temp_dir)}',
-                       shell=True,
+        subprocess.run(['git', 'init', '--quiet', temp_dir],
                        stdout=subprocess.PIPE,
                        stderr=subprocess.PIPE,
                        check=True,
                        text=True)
-        return _run_git_ls_files_for_ignored_paths(
-            src_dir_path,
-            git_dir=os.path.join(temp_dir, '.git'),
-            use_standard_excludes=False)
+        return _run_git_ls_files_for_ignored_paths(src_dir_path,
+                                                   git_dir=os.path.join(
+                                                       temp_dir, '.git'),
+                                                   use_standard_excludes=False)
 
 
 def get_excluded_files_from_gitignore(src_dir_path: str) -> List[str]:

--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -5,6 +5,7 @@ import pathlib
 import shlex
 import stat
 import subprocess
+import tempfile
 from typing import List, Optional, Set, TextIO, Union
 import warnings
 import zipfile
@@ -58,12 +59,74 @@ def get_excluded_files_from_skyignore(src_dir_path: str) -> List[str]:
     return list(excluded_list)
 
 
+def _run_git_ls_files_for_ignored_paths(
+        src_dir_path: str,
+        git_dir: Optional[str] = None,
+        use_standard_excludes: bool = True) -> List[str]:
+    if git_dir is None:
+        git_dir_args = f'-C {shlex.quote(src_dir_path)}'
+    else:
+        git_dir_args = (f'--git-dir={shlex.quote(git_dir)} '
+                        f'--work-tree={shlex.quote(src_dir_path)}')
+    if use_standard_excludes:
+        exclude_args = '--exclude-standard'
+    else:
+        exclude_args = '--exclude-per-directory=.gitignore'
+
+    # This command outputs a list to be excluded according to .gitignore,
+    # .git/info/exclude, and global exclude config when use_standard_excludes
+    # is True. Otherwise, only .gitignore files are used.
+    # -z: filenames terminated by \0 instead of \n
+    # --others: show untracked files
+    # --ignore: out of untracked files, only show ignored files
+    # --exclude-standard: use standard exclude rules (required for --ignore);
+    # --exclude-per-directory: use per-directory .gitignore files only.
+    # --directory: if an entire directory is ignored, collapse to a single
+    #              entry rather than listing every single file
+    # Since we are using --others instead of --cached, this will not show
+    # files that are tracked but also present in .gitignore.
+    filter_cmd = (f'git -c safe.directory="*" {git_dir_args} '
+                  f'ls-files -z --others --ignore {exclude_args} --directory')
+    output = subprocess.run(filter_cmd,
+                            shell=True,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            check=True,
+                            text=True)
+    # Don't catch any errors here. Callers decide which failures are expected
+    # enough to degrade gracefully.
+
+    output_list = output.stdout.split('\0')
+    # Trim the empty string at the end.
+    return output_list[:-1]
+
+
+def _get_excluded_files_from_gitignore_without_repo(
+        src_dir_path: str) -> List[str]:
+    """Evaluates .gitignore for a directory outside a Git repository."""
+    with tempfile.TemporaryDirectory(prefix='skypilot_gitignore_') as temp_dir:
+        subprocess.run(f'git init --quiet {shlex.quote(temp_dir)}',
+                       shell=True,
+                       stdout=subprocess.PIPE,
+                       stderr=subprocess.PIPE,
+                       check=True,
+                       text=True)
+        return _run_git_ls_files_for_ignored_paths(
+            src_dir_path,
+            git_dir=os.path.join(temp_dir, '.git'),
+            use_standard_excludes=False)
+
+
 def get_excluded_files_from_gitignore(src_dir_path: str) -> List[str]:
     """ Lists files and patterns ignored by git in the source directory
 
     Runs `git ls-files --ignored ...` which returns a list of excluded files and
-    patterns read from .gitignore and .git/info/exclude using git.
-    This will also be run for all submodules under the src_dir_path.
+    patterns read from .gitignore and .git/info/exclude using git. This will
+    also be run for all submodules under the src_dir_path.
+
+    If src_dir_path is not in a Git repository, this uses temporary Git
+    metadata to evaluate any .gitignore files with Git's pattern
+    semantics without modifying src_dir_path.
 
     Returns:
         List[str] containing files and folders to be ignored. There won't be any
@@ -97,14 +160,9 @@ def get_excluded_files_from_gitignore(src_dir_path: str) -> List[str]:
 
         if (e.returncode == exceptions.GIT_FATAL_EXIT_CODE and
                 'not a git repository' in e.stderr):
-            # If git failed because we aren't in a git repository, but there is
-            # a .gitignore, warn the user that it will be ignored.
-            if os.path.exists(gitignore_path):
-                logger.warning('Detected a .gitignore file, but '
-                               f'{src_dir_path} is not a git repository. The '
-                               '.gitignore file will be ignored. '
-                               f'{_USE_SKYIGNORE_HINT}')
-            # Otherwise, this is fine and we can exit early.
+            if os.path.isdir(expand_src_dir_path):
+                return _get_excluded_files_from_gitignore_without_repo(
+                    expand_src_dir_path)
             return []
 
         if e.returncode == exceptions.COMMAND_NOT_FOUND_EXIT_CODE:
@@ -135,31 +193,7 @@ def get_excluded_files_from_gitignore(src_dir_path: str) -> List[str]:
     for repo in all_git_repos:
         # repo is the path relative to src_dir_path. Get the full path.
         repo_path = os.path.join(expand_src_dir_path, repo)
-        # This command outputs a list to be excluded according to .gitignore,
-        # .git/info/exclude, and global exclude config.
-        # -z: filenames terminated by \0 instead of \n
-        # --others: show untracked files
-        # --ignore: out of untracked files, only show ignored files
-        # --exclude-standard: use standard exclude rules (required for --ignore)
-        # --directory: if an entire directory is ignored, collapse to a single
-        #              entry rather than listing every single file
-        # Since we are using --others instead of --cached, this will not show
-        # files that are tracked but also present in .gitignore.
-        filter_cmd = (f'git -c safe.directory="*" '
-                      f'-C {shlex.quote(repo_path)} ls-files -z '
-                      '--others --ignore --exclude-standard --directory')
-        output = subprocess.run(filter_cmd,
-                                shell=True,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE,
-                                check=True,
-                                text=True)
-        # Don't catch any errors. We would only expect to see errors during the
-        # first git invocation - so if we see any here, crash.
-
-        output_list = output.stdout.split('\0')
-        # trim the empty string at the end
-        output_list = output_list[:-1]
+        output_list = _run_git_ls_files_for_ignored_paths(repo_path)
 
         for item in output_list:
 

--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -62,7 +62,8 @@ def get_excluded_files_from_skyignore(src_dir_path: str) -> List[str]:
 def _run_git_ls_files_for_ignored_paths(
         src_dir_path: str,
         git_dir: Optional[str] = None,
-        use_standard_excludes: bool = True) -> List[str]:
+        use_standard_excludes: bool = True,
+        env: Optional[dict] = None) -> List[str]:
     cmd = ['git', '-c', 'safe.directory=*']
     if git_dir is None:
         cmd += ['-C', src_dir_path]
@@ -92,7 +93,8 @@ def _run_git_ls_files_for_ignored_paths(
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,
                             check=True,
-                            text=True)
+                            text=True,
+                            env=env)
     # Don't catch any errors here. Callers decide which failures are expected
     # enough to degrade gracefully.
 
@@ -103,17 +105,31 @@ def _run_git_ls_files_for_ignored_paths(
 
 def _get_excluded_files_from_gitignore_without_repo(
         src_dir_path: str) -> List[str]:
-    """Evaluates .gitignore for a directory outside a Git repository."""
+    """Evaluates .gitignore for a directory outside a Git repository.
+
+    Uses a temporary git repo so we can delegate pattern evaluation to git.
+    We isolate the temporary repo from the user's global git config so that
+    global excludes (core.excludesFile) and template directories
+    (init.templateDir) do not leak patterns into the result.
+    """
+    # Prevent git init from reading the user's global/system config, which
+    # could inject exclude patterns via core.excludesFile or populate
+    # .git/info/exclude via init.templateDir.
+    isolated_env = os.environ.copy()
+    isolated_env['GIT_CONFIG_NOSYSTEM'] = '1'
+    isolated_env['GIT_CONFIG_GLOBAL'] = os.devnull
     with tempfile.TemporaryDirectory(prefix='skypilot_gitignore_') as temp_dir:
         subprocess.run(['git', 'init', '--quiet', temp_dir],
                        stdout=subprocess.PIPE,
                        stderr=subprocess.PIPE,
                        check=True,
-                       text=True)
+                       text=True,
+                       env=isolated_env)
         return _run_git_ls_files_for_ignored_paths(src_dir_path,
                                                    git_dir=os.path.join(
                                                        temp_dir, '.git'),
-                                                   use_standard_excludes=False)
+                                                   use_standard_excludes=False,
+                                                   env=isolated_env)
 
 
 def get_excluded_files_from_gitignore(src_dir_path: str) -> List[str]:
@@ -154,9 +170,6 @@ def get_excluded_files_from_gitignore(src_dir_path: str) -> List[str]:
                                            check=True,
                                            text=True)
     except subprocess.CalledProcessError as e:
-        gitignore_path = os.path.join(expand_src_dir_path,
-                                      constants.GIT_IGNORE_FILE)
-
         if (e.returncode == exceptions.GIT_FATAL_EXIT_CODE and
                 'not a git repository' in e.stderr):
             if os.path.isdir(expand_src_dir_path):
@@ -164,6 +177,8 @@ def get_excluded_files_from_gitignore(src_dir_path: str) -> List[str]:
                     expand_src_dir_path)
             return []
 
+        gitignore_path = os.path.join(expand_src_dir_path,
+                                      constants.GIT_IGNORE_FILE)
         if e.returncode == exceptions.COMMAND_NOT_FOUND_EXIT_CODE:
             # Git is not installed. This is fine, skip the check.
             # If .gitignore is present, warn the user.

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -2,6 +2,7 @@
 import enum
 import fcntl
 import hashlib
+import importlib
 import os
 import pathlib
 import pty
@@ -23,7 +24,6 @@ import colorama
 
 from sky import exceptions
 from sky import sky_logging
-from sky.data import storage_utils
 from sky.skylet import constants
 from sky.skylet import log_lib
 from sky.utils import auth_utils
@@ -479,18 +479,22 @@ class CommandRunner:
             # filter treats all patterns as excludes, silently ignoring
             # negation. By delegating to git, we get proper semantics.
             try:
+                # Import here to avoid a circular import during `import sky`:
+                # command_runner -> sky.data -> storage -> clouds/provision.
+                storage_utils = importlib.import_module(
+                    'sky.data.storage_utils')
                 excluded_files = (
                     storage_utils.get_excluded_files_from_gitignore(
                         str(resolved_source)))
                 if excluded_files:
                     with tempfile.NamedTemporaryFile(
-                        mode='w',
-                        prefix='skypilot_rsync_exclude_',
-                        suffix='.txt',
-                        delete=False) as exclude_tmp_file:
+                            mode='w',
+                            prefix='skypilot_rsync_exclude_',
+                            suffix='.txt',
+                            delete=False,
+                            encoding='utf-8') as exclude_tmp_file:
                         exclude_tmp_file_path = exclude_tmp_file.name
-                        exclude_tmp_file.write('\n'.join(excluded_files) +
-                                               '\n')
+                        exclude_tmp_file.write('\n'.join(excluded_files) + '\n')
                     rsync_command.append(
                         RSYNC_EXCLUDE_OPTION.format(
                             shlex.quote(exclude_tmp_file_path)))
@@ -498,15 +502,15 @@ class CommandRunner:
                 # If git-based exclusion fails unexpectedly, fall back to
                 # rsync's native filter. This is best-effort because native
                 # rsync filters do not support Git negation semantics.
-                logger.debug('Failed to get git-based excludes, falling back '
-                             'to rsync filter.',
-                             exc_info=True)
+                logger.debug(
+                    'Failed to get git-based excludes, falling back '
+                    'to rsync filter.',
+                    exc_info=True)
                 rsync_command.append(RSYNC_FILTER_GITIGNORE)
                 if (resolved_source / GIT_EXCLUDE).exists():
                     rsync_command.append(
                         RSYNC_EXCLUDE_OPTION.format(
-                            shlex.quote(
-                                str(resolved_source / GIT_EXCLUDE))))
+                            shlex.quote(str(resolved_source / GIT_EXCLUDE))))
         elif up:
             # Source is a file or does not exist locally; let rsync surface
             # source errors and avoid evaluating directory ignore files.

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -23,6 +23,7 @@ import colorama
 
 from sky import exceptions
 from sky import sky_logging
+from sky.data import storage_utils
 from sky.skylet import constants
 from sky.skylet import log_lib
 from sky.utils import auth_utils
@@ -56,8 +57,10 @@ RSYNC_DISPLAY_OPTION = '-Pavz'
 # Note that "-" is mandatory for rsync and means all patterns in the ignore
 # files are treated as *exclude* patterns.  Non-exclude patterns, e.g., "!
 # do_not_exclude" doesn't work, even though git allows it.
-# TODO(cooperc): Avoid using this, and prefer utils in storage_utils instead for
-# consistency between bucket upload and rsync.
+# For .gitignore uploads, we use storage_utils.get_excluded_files_from_gitignore
+# which delegates to `git ls-files` for correct negation pattern handling. The
+# .gitignore filter below is still used as a best-effort fallback and for
+# downloads.
 RSYNC_FILTER_SKYIGNORE = f'--filter=\'dir-merge,- {constants.SKY_IGNORE_FILE}\''
 RSYNC_FILTER_GITIGNORE = f'--filter=\'dir-merge,- {constants.GIT_IGNORE_FILE}\''
 # The git exclude file to support.
@@ -467,21 +470,52 @@ class CommandRunner:
         # --filter
         # The source is a local path, so we need to resolve it.
         resolved_source = pathlib.Path(source).expanduser().resolve()
+        exclude_tmp_file_path = None
         if (resolved_source / constants.SKY_IGNORE_FILE).exists():
             rsync_command.append(RSYNC_FILTER_SKYIGNORE)
-        else:
-            rsync_command.append(RSYNC_FILTER_GITIGNORE)
-            if up:
-                # Build --exclude-from argument.
-                if (resolved_source / GIT_EXCLUDE).exists():
-                    # Ensure file exists; otherwise, rsync will error out.
-                    #
-                    # We shlex.quote() because the path may contain spaces:
-                    #   'my dir/.git/info/exclude'
-                    # Without quoting rsync fails.
+        elif up and resolved_source.is_dir():
+            # For uploads, use git ls-files to correctly handle .gitignore
+            # negation patterns (e.g., "!important.txt"). Rsync's dir-merge
+            # filter treats all patterns as excludes, silently ignoring
+            # negation. By delegating to git, we get proper semantics.
+            try:
+                excluded_files = (
+                    storage_utils.get_excluded_files_from_gitignore(
+                        str(resolved_source)))
+                if excluded_files:
+                    with tempfile.NamedTemporaryFile(
+                        mode='w',
+                        prefix='skypilot_rsync_exclude_',
+                        suffix='.txt',
+                        delete=False) as exclude_tmp_file:
+                        exclude_tmp_file_path = exclude_tmp_file.name
+                        exclude_tmp_file.write('\n'.join(excluded_files) +
+                                               '\n')
                     rsync_command.append(
                         RSYNC_EXCLUDE_OPTION.format(
-                            shlex.quote(str(resolved_source / GIT_EXCLUDE))))
+                            shlex.quote(exclude_tmp_file_path)))
+            except Exception:  # pylint: disable=broad-except
+                # If git-based exclusion fails unexpectedly, fall back to
+                # rsync's native filter. This is best-effort because native
+                # rsync filters do not support Git negation semantics.
+                logger.debug('Failed to get git-based excludes, falling back '
+                             'to rsync filter.',
+                             exc_info=True)
+                rsync_command.append(RSYNC_FILTER_GITIGNORE)
+                if (resolved_source / GIT_EXCLUDE).exists():
+                    rsync_command.append(
+                        RSYNC_EXCLUDE_OPTION.format(
+                            shlex.quote(
+                                str(resolved_source / GIT_EXCLUDE))))
+        elif up:
+            # Source is a file or does not exist locally; let rsync surface
+            # source errors and avoid evaluating directory ignore files.
+            pass
+        else:
+            # For downloads, use rsync's native filter as before. Download-side
+            # .gitignore files are on the remote source and cannot be evaluated
+            # locally with git.
+            rsync_command.append(RSYNC_FILTER_GITIGNORE)
 
         if rsh_option is not None:
             rsync_command.append(f'-e {shlex.quote(rsh_option)}')
@@ -528,19 +562,27 @@ class CommandRunner:
         command = ' '.join(rsync_command)
         logger.debug(f'Running rsync command: {command}')
 
-        backoff = common_utils.Backoff(initial_backoff=5, max_backoff_factor=5)
-        assert max_retry > 0, f'max_retry {max_retry} must be positive.'
-        while max_retry >= 0:
-            returncode, stdout, stderr = log_lib.run_with_log(
-                command,
-                log_path=log_path,
-                stream_logs=stream_logs,
-                shell=True,
-                require_outputs=True)
-            if returncode == 0:
-                break
-            max_retry -= 1
-            time.sleep(backoff.current_backoff())
+        try:
+            backoff = common_utils.Backoff(initial_backoff=5,
+                                           max_backoff_factor=5)
+            assert max_retry > 0, f'max_retry {max_retry} must be positive.'
+            while max_retry >= 0:
+                returncode, stdout, stderr = log_lib.run_with_log(
+                    command,
+                    log_path=log_path,
+                    stream_logs=stream_logs,
+                    shell=True,
+                    require_outputs=True)
+                if returncode == 0:
+                    break
+                max_retry -= 1
+                time.sleep(backoff.current_backoff())
+        finally:
+            if exclude_tmp_file_path is not None:
+                try:
+                    os.unlink(exclude_tmp_file_path)
+                except OSError:
+                    pass
 
         direction = 'up' if up else 'down'
         error_msg = (f'Failed to rsync {direction}: {source} -> {target}. '

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -494,18 +494,36 @@ class CommandRunner:
                             delete=False,
                             encoding='utf-8') as exclude_tmp_file:
                         exclude_tmp_file_path = exclude_tmp_file.name
-                        exclude_tmp_file.write('\n'.join(excluded_files) + '\n')
+                        exclude_tmp_file.write('\0'.join(excluded_files) + '\0')
+                    # --from0 is a global rsync flag that makes all
+                    # --exclude-from files NUL-delimited. This is safe
+                    # here because we only add one --exclude-from file.
+                    rsync_command.append('--from0')
                     rsync_command.append(
                         RSYNC_EXCLUDE_OPTION.format(
                             shlex.quote(exclude_tmp_file_path)))
-            except Exception:  # pylint: disable=broad-except
-                # If git-based exclusion fails unexpectedly, fall back to
-                # rsync's native filter. This is best-effort because native
-                # rsync filters do not support Git negation semantics.
-                logger.debug(
-                    'Failed to get git-based excludes, falling back '
-                    'to rsync filter.',
-                    exc_info=True)
+                else:
+                    # git ls-files returned no excludes (e.g. .gitignore
+                    # has only comments or is empty). Fall back to rsync's
+                    # native filter so .git/info/exclude is still honored.
+                    rsync_command.append(RSYNC_FILTER_GITIGNORE)
+                    if (resolved_source / GIT_EXCLUDE).exists():
+                        rsync_command.append(
+                            RSYNC_EXCLUDE_OPTION.format(
+                                shlex.quote(str(resolved_source /
+                                                GIT_EXCLUDE))))
+            except (subprocess.CalledProcessError, OSError) as exc:
+                # CalledProcessError: git command failed unexpectedly
+                #   (expected failures like "not a repo" or "git not found"
+                #   are already handled inside
+                #   get_excluded_files_from_gitignore and won't reach here).
+                # OSError: temp file I/O failure or git binary not found.
+                logger.warning(
+                    'Failed to get git-based excludes for '
+                    f'{str(resolved_source)!r} ({type(exc).__name__}: '
+                    f'{exc}), falling back to rsync native filter. '
+                    '.gitignore negation patterns (e.g., '
+                    '"!important.txt") will not be honored.')
                 rsync_command.append(RSYNC_FILTER_GITIGNORE)
                 if (resolved_source / GIT_EXCLUDE).exists():
                     rsync_command.append(
@@ -518,7 +536,9 @@ class CommandRunner:
         else:
             # For downloads, use rsync's native filter as before. Download-side
             # .gitignore files are on the remote source and cannot be evaluated
-            # locally with git.
+            # locally with git. Note: this means .gitignore negation patterns
+            # (e.g., "!important.txt") are NOT supported for downloads — rsync
+            # treats all filter patterns as excludes.
             rsync_command.append(RSYNC_FILTER_GITIGNORE)
 
         if rsh_option is not None:

--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -1065,7 +1065,7 @@ exclude.py
         # For .gitignore, verify negation patterns work on the cluster.
         if ignore_file == constants.GIT_IGNORE_FILE:
             test_commands.append(
-                f'sky exec {name} -- bash -c '
+                f'sky exec {name} -- '
                 f'"test -f ~/sky_workdir/important.log && '
                 f'test -f ~/sky_workdir/keep_dir/important.log"')
 

--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -1014,6 +1014,15 @@ def test_ignore_exclusions(generic_cloud: str, ignore_file: str):
             'nested/exclude_subdir/test.sh',  # Directory excluded
         ]
 
+        # For .gitignore, also test negation patterns (e.g., !important.log).
+        # Negation only works for .gitignore (via git ls-files); rsync's
+        # dir-merge filter used by .skyignore treats all patterns as excludes.
+        if ignore_file == constants.GIT_IGNORE_FILE:
+            files += [
+                'important.log',  # Negated: excluded by *.log, kept by !important.log
+                'keep_dir/important.log',  # Same negation in subdirectory
+            ]
+
         # Create directories
         for dir_name in dirs:
             os.makedirs(os.path.join(temp_dir, dir_name), exist_ok=True)
@@ -1024,7 +1033,7 @@ def test_ignore_exclusions(generic_cloud: str, ignore_file: str):
             with open(full_path, 'w', encoding='utf-8') as f:
                 f.write(f'Content for {file_path}')
 
-        # Create .skyignore file
+        # Create ignore file
         ignore_content = """
 # Exclude specific files
 exclude.py
@@ -1033,6 +1042,11 @@ exclude.py
 # Exclude directories
 /exclude_dir
 /nested/exclude_subdir
+"""
+        if ignore_file == constants.GIT_IGNORE_FILE:
+            ignore_content += """
+# Negate: keep important.log despite *.log
+!important.log
 """
         with open(os.path.join(temp_dir, ignore_file), 'w',
                   encoding='utf-8') as f:
@@ -1046,7 +1060,16 @@ exclude.py
             # Test with sky launch
             f'sky launch -y -c {name} --infra {generic_cloud} {smoke_tests_utils.LOW_RESOURCE_ARG} --workdir {temp_dir} {yaml_path}',
             f'sky logs {name} 1 --status',  # Ensure the job succeeded
+        ]
 
+        # For .gitignore, verify negation patterns work on the cluster.
+        if ignore_file == constants.GIT_IGNORE_FILE:
+            test_commands.append(
+                f'sky exec {name} -- bash -c '
+                f'"test -f ~/sky_workdir/important.log && '
+                f'test -f ~/sky_workdir/keep_dir/important.log"')
+
+        test_commands += [
             # Test with sky jobs launch
             f'sky jobs launch -y -n {jobs_name} --infra {generic_cloud} --workdir {temp_dir} {yaml_path}',
             smoke_tests_utils.

--- a/tests/unit_tests/test_sky/storage/test_storage_utils.py
+++ b/tests/unit_tests/test_sky/storage/test_storage_utils.py
@@ -369,22 +369,94 @@ temp/
         assert os.path.join('submod', 'data.txt') in norm_excluded_files
 
 
-def test_get_excluded_files_no_git():
+def test_get_excluded_files_non_git_dir():
     with tempfile.TemporaryDirectory() as temp_dir:
         # Create .gitignore but don't initialize git
         with open(os.path.join(temp_dir, '.gitignore'), 'w') as f:
-            f.write('*.pyc\n')
+            f.write('*.pyc\n!important.pyc\n')
 
-        with mock.patch('sky.data.storage_utils.logger') as mock_logger:
+        for filename in ['test.pyc', 'important.pyc', 'test.py']:
+            with open(os.path.join(temp_dir, filename), 'w') as f:
+                f.write('content')
+
+        excluded_files = storage_utils.get_excluded_files_from_gitignore(
+            temp_dir)
+        norm_excluded_files = [os.path.normpath(f) for f in excluded_files]
+
+        assert 'test.pyc' in norm_excluded_files
+        assert 'important.pyc' not in norm_excluded_files
+        assert 'test.py' not in norm_excluded_files
+
+
+def test_get_excluded_files_non_git_dir_nested_gitignore():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        subdir = os.path.join(temp_dir, 'subdir')
+        os.makedirs(subdir)
+        with open(os.path.join(subdir, '.gitignore'), 'w') as f:
+            f.write('*.tmp\n')
+        with open(os.path.join(subdir, 'ignored.tmp'), 'w') as f:
+            f.write('content')
+        with open(os.path.join(subdir, 'kept.txt'), 'w') as f:
+            f.write('content')
+
+        excluded_files = storage_utils.get_excluded_files_from_gitignore(
+            temp_dir)
+        norm_excluded_files = [os.path.normpath(f) for f in excluded_files]
+
+        assert os.path.join('subdir', 'ignored.tmp') in norm_excluded_files
+        assert os.path.join('subdir', 'kept.txt') not in norm_excluded_files
+
+
+def test_get_excluded_files_non_git_dir_ignores_global_gitignore():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_dir = os.path.join(temp_dir, 'source')
+        os.makedirs(source_dir)
+        global_ignore_path = os.path.join(temp_dir, 'global-ignore')
+        git_config_path = os.path.join(temp_dir, 'gitconfig')
+        with open(global_ignore_path, 'w') as f:
+            f.write('*.global\n')
+        with open(git_config_path, 'w') as f:
+            f.write(f'[core]\n\texcludesFile = {global_ignore_path}\n')
+        with open(os.path.join(source_dir, '.gitignore'), 'w') as f:
+            f.write('*.local\n')
+
+        for filename in ['ignored.global', 'ignored.local', 'kept.txt']:
+            with open(os.path.join(source_dir, filename), 'w') as f:
+                f.write('content')
+
+        with mock.patch.dict(os.environ, {'GIT_CONFIG_GLOBAL': git_config_path}):
             excluded_files = storage_utils.get_excluded_files_from_gitignore(
-                temp_dir)
+                source_dir)
+        norm_excluded_files = [os.path.normpath(f) for f in excluded_files]
 
-        assert excluded_files == []
-        mock_logger.warning.assert_called_once()
-        assert '.gitignore file will be ignored' in mock_logger.warning.call_args[
-            0][0]
-        assert storage_utils._USE_SKYIGNORE_HINT in mock_logger.warning.call_args[
-            0][0]
+        assert 'ignored.local' in norm_excluded_files
+        assert 'ignored.global' not in norm_excluded_files
+        assert 'kept.txt' not in norm_excluded_files
+
+
+def test_get_excluded_files_git_repo_uses_global_gitignore():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_dir = os.path.join(temp_dir, 'source')
+        global_ignore_path = os.path.join(temp_dir, 'global-ignore')
+        git_config_path = os.path.join(temp_dir, 'gitconfig')
+        os.makedirs(source_dir)
+        subprocess.run(['git', 'init'], cwd=source_dir, check=True)
+        with open(global_ignore_path, 'w') as f:
+            f.write('*.global\n')
+        with open(git_config_path, 'w') as f:
+            f.write(f'[core]\n\texcludesFile = {global_ignore_path}\n')
+
+        for filename in ['ignored.global', 'kept.txt']:
+            with open(os.path.join(source_dir, filename), 'w') as f:
+                f.write('content')
+
+        with mock.patch.dict(os.environ, {'GIT_CONFIG_GLOBAL': git_config_path}):
+            excluded_files = storage_utils.get_excluded_files_from_gitignore(
+                source_dir)
+        norm_excluded_files = [os.path.normpath(f) for f in excluded_files]
+
+        assert 'ignored.global' in norm_excluded_files
+        assert 'kept.txt' not in norm_excluded_files
 
 
 def test_get_excluded_files_git_not_installed():

--- a/tests/unit_tests/test_sky/storage/test_storage_utils.py
+++ b/tests/unit_tests/test_sky/storage/test_storage_utils.py
@@ -424,7 +424,8 @@ def test_get_excluded_files_non_git_dir_ignores_global_gitignore():
             with open(os.path.join(source_dir, filename), 'w') as f:
                 f.write('content')
 
-        with mock.patch.dict(os.environ, {'GIT_CONFIG_GLOBAL': git_config_path}):
+        with mock.patch.dict(os.environ,
+                             {'GIT_CONFIG_GLOBAL': git_config_path}):
             excluded_files = storage_utils.get_excluded_files_from_gitignore(
                 source_dir)
         norm_excluded_files = [os.path.normpath(f) for f in excluded_files]
@@ -450,7 +451,8 @@ def test_get_excluded_files_git_repo_uses_global_gitignore():
             with open(os.path.join(source_dir, filename), 'w') as f:
                 f.write('content')
 
-        with mock.patch.dict(os.environ, {'GIT_CONFIG_GLOBAL': git_config_path}):
+        with mock.patch.dict(os.environ,
+                             {'GIT_CONFIG_GLOBAL': git_config_path}):
             excluded_files = storage_utils.get_excluded_files_from_gitignore(
                 source_dir)
         norm_excluded_files = [os.path.normpath(f) for f in excluded_files]

--- a/tests/unit_tests/test_sky/storage/test_storage_utils.py
+++ b/tests/unit_tests/test_sky/storage/test_storage_utils.py
@@ -435,6 +435,44 @@ def test_get_excluded_files_non_git_dir_ignores_global_gitignore():
         assert 'kept.txt' not in norm_excluded_files
 
 
+def test_get_excluded_files_non_git_dir_ignores_template_dir():
+    """Ensures init.templateDir cannot leak patterns via .git/info/exclude."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_dir = os.path.join(temp_dir, 'source')
+        os.makedirs(source_dir)
+
+        # Create a git template that populates .git/info/exclude
+        template_dir = os.path.join(temp_dir, 'git-template')
+        info_dir = os.path.join(template_dir, 'info')
+        os.makedirs(info_dir)
+        with open(os.path.join(info_dir, 'exclude'), 'w') as f:
+            f.write('*.secret\n')
+
+        git_config_path = os.path.join(temp_dir, 'gitconfig')
+        with open(git_config_path, 'w') as f:
+            f.write(f'[init]\n\ttemplateDir = {template_dir}\n')
+
+        with open(os.path.join(source_dir, '.gitignore'), 'w') as f:
+            f.write('*.local\n')
+
+        for filename in ['leaked.secret', 'ignored.local', 'kept.txt']:
+            with open(os.path.join(source_dir, filename), 'w') as f:
+                f.write('content')
+
+        with mock.patch.dict(os.environ, {
+                'GIT_CONFIG_GLOBAL': git_config_path,
+                'GIT_CONFIG_NOSYSTEM': '1'
+        }):
+            excluded_files = storage_utils.get_excluded_files_from_gitignore(
+                source_dir)
+        norm_excluded_files = [os.path.normpath(f) for f in excluded_files]
+
+        assert 'ignored.local' in norm_excluded_files
+        # The templateDir's exclude pattern should NOT leak through
+        assert 'leaked.secret' not in norm_excluded_files
+        assert 'kept.txt' not in norm_excluded_files
+
+
 def test_get_excluded_files_git_repo_uses_global_gitignore():
     with tempfile.TemporaryDirectory() as temp_dir:
         source_dir = os.path.join(temp_dir, 'source')

--- a/tests/unit_tests/test_sky/utils/test_command_runner.py
+++ b/tests/unit_tests/test_sky/utils/test_command_runner.py
@@ -435,8 +435,7 @@ def test_rsync_up_uses_git_excludes_for_gitignore_negation() -> None:
                   'w',
                   encoding='utf-8') as f:
             f.write('secret\n')
-        with open(os.path.join(source, '.gitignore'),
-                  'w',
+        with open(os.path.join(source, '.gitignore'), 'w',
                   encoding='utf-8') as f:
             f.write('scripts/*\n!scripts/entrypoint.sh\n')
 
@@ -481,8 +480,7 @@ def test_rsync_up_uses_gitignore_negation_outside_git_repo() -> None:
                   'w',
                   encoding='utf-8') as f:
             f.write('secret\n')
-        with open(os.path.join(source, '.gitignore'),
-                  'w',
+        with open(os.path.join(source, '.gitignore'), 'w',
                   encoding='utf-8') as f:
             f.write('scripts/*\n!scripts/entrypoint.sh\n')
 

--- a/tests/unit_tests/test_sky/utils/test_command_runner.py
+++ b/tests/unit_tests/test_sky/utils/test_command_runner.py
@@ -3,7 +3,9 @@
 from contextlib import suppress
 import os
 import select
+import shlex
 import socket
+import subprocess
 import tempfile
 import threading
 import time
@@ -405,6 +407,93 @@ def test_kubernetes_runner_rsync_does_not_set_exec_container_envvar_by_default(
         runner.rsync('/tmp/src', '/tmp/dst', up=True, stream_logs=False)
 
     assert 'SKYPILOT_K8S_EXEC_CONTAINER=' not in captured['command']
+
+
+def test_rsync_up_uses_git_excludes_for_gitignore_negation() -> None:
+    captured = {}
+
+    def fake_run_with_log(command: str, *args, **kwargs):
+        captured['command'] = command
+        for token in shlex.split(command):
+            if token.startswith('--exclude-from='):
+                exclude_path = token.split('=', 1)[1]
+                captured['exclude_path'] = exclude_path
+                with open(exclude_path, 'r', encoding='utf-8') as f:
+                    captured['excluded_files'] = f.read().splitlines()
+                break
+        return 0, '', ''
+
+    with tempfile.TemporaryDirectory() as source, \
+            tempfile.TemporaryDirectory() as target:
+        scripts_dir = os.path.join(source, 'scripts')
+        os.makedirs(scripts_dir)
+        with open(os.path.join(scripts_dir, 'entrypoint.sh'),
+                  'w',
+                  encoding='utf-8') as f:
+            f.write('#!/bin/sh\necho ok\n')
+        with open(os.path.join(scripts_dir, 'secret.txt'),
+                  'w',
+                  encoding='utf-8') as f:
+            f.write('secret\n')
+        with open(os.path.join(source, '.gitignore'),
+                  'w',
+                  encoding='utf-8') as f:
+            f.write('scripts/*\n!scripts/entrypoint.sh\n')
+
+        subprocess.run(['git', 'init'], cwd=source, check=True)
+        subprocess.run(['git', 'add', 'scripts/entrypoint.sh'],
+                       cwd=source,
+                       check=True)
+
+        with mock.patch.object(command_runner.log_lib,
+                               'run_with_log',
+                               side_effect=fake_run_with_log):
+            runner = command_runner.LocalProcessCommandRunner()
+            runner.rsync(source, target, up=True, stream_logs=False)
+
+    assert command_runner.RSYNC_FILTER_GITIGNORE not in captured['command']
+    assert captured['excluded_files'] == ['scripts/secret.txt']
+    assert not os.path.exists(captured['exclude_path'])
+
+
+def test_rsync_up_uses_gitignore_negation_outside_git_repo() -> None:
+    captured = {}
+
+    def fake_run_with_log(command: str, *args, **kwargs):
+        captured['command'] = command
+        for token in shlex.split(command):
+            if token.startswith('--exclude-from='):
+                exclude_path = token.split('=', 1)[1]
+                with open(exclude_path, 'r', encoding='utf-8') as f:
+                    captured['excluded_files'] = f.read().splitlines()
+                break
+        return 0, '', ''
+
+    with tempfile.TemporaryDirectory() as source, \
+            tempfile.TemporaryDirectory() as target:
+        scripts_dir = os.path.join(source, 'scripts')
+        os.makedirs(scripts_dir)
+        with open(os.path.join(scripts_dir, 'entrypoint.sh'),
+                  'w',
+                  encoding='utf-8') as f:
+            f.write('#!/bin/sh\necho ok\n')
+        with open(os.path.join(scripts_dir, 'secret.txt'),
+                  'w',
+                  encoding='utf-8') as f:
+            f.write('secret\n')
+        with open(os.path.join(source, '.gitignore'),
+                  'w',
+                  encoding='utf-8') as f:
+            f.write('scripts/*\n!scripts/entrypoint.sh\n')
+
+        with mock.patch.object(command_runner.log_lib,
+                               'run_with_log',
+                               side_effect=fake_run_with_log):
+            runner = command_runner.LocalProcessCommandRunner()
+            runner.rsync(source, target, up=True, stream_logs=False)
+
+    assert command_runner.RSYNC_FILTER_GITIGNORE not in captured['command']
+    assert captured['excluded_files'] == ['scripts/secret.txt']
 
 
 def test_get_pod_primary_container_prefers_ray_node() -> None:

--- a/tests/unit_tests/test_sky/utils/test_command_runner.py
+++ b/tests/unit_tests/test_sky/utils/test_command_runner.py
@@ -419,7 +419,9 @@ def test_rsync_up_uses_git_excludes_for_gitignore_negation() -> None:
                 exclude_path = token.split('=', 1)[1]
                 captured['exclude_path'] = exclude_path
                 with open(exclude_path, 'r', encoding='utf-8') as f:
-                    captured['excluded_files'] = f.read().splitlines()
+                    content = f.read()
+                # File is NUL-delimited (--from0); split and drop trailing empty
+                captured['excluded_files'] = content.split('\0')[:-1]
                 break
         return 0, '', ''
 
@@ -451,6 +453,7 @@ def test_rsync_up_uses_git_excludes_for_gitignore_negation() -> None:
             runner.rsync(source, target, up=True, stream_logs=False)
 
     assert command_runner.RSYNC_FILTER_GITIGNORE not in captured['command']
+    assert '--from0' in captured['command']
     assert captured['excluded_files'] == ['scripts/secret.txt']
     assert not os.path.exists(captured['exclude_path'])
 
@@ -463,8 +466,11 @@ def test_rsync_up_uses_gitignore_negation_outside_git_repo() -> None:
         for token in shlex.split(command):
             if token.startswith('--exclude-from='):
                 exclude_path = token.split('=', 1)[1]
+                captured['exclude_path'] = exclude_path
                 with open(exclude_path, 'r', encoding='utf-8') as f:
-                    captured['excluded_files'] = f.read().splitlines()
+                    content = f.read()
+                # File is NUL-delimited (--from0); split and drop trailing empty
+                captured['excluded_files'] = content.split('\0')[:-1]
                 break
         return 0, '', ''
 
@@ -491,7 +497,49 @@ def test_rsync_up_uses_gitignore_negation_outside_git_repo() -> None:
             runner.rsync(source, target, up=True, stream_logs=False)
 
     assert command_runner.RSYNC_FILTER_GITIGNORE not in captured['command']
+    assert '--from0' in captured['command']
     assert captured['excluded_files'] == ['scripts/secret.txt']
+    assert not os.path.exists(captured['exclude_path'])
+
+
+def test_rsync_up_nul_delimited_with_multiple_excludes() -> None:
+    """Verifies the exclude file is NUL-delimited when multiple files match."""
+    captured = {}
+
+    def fake_run_with_log(command: str, *args, **kwargs):
+        captured['command'] = command
+        for token in shlex.split(command):
+            if token.startswith('--exclude-from='):
+                exclude_path = token.split('=', 1)[1]
+                with open(exclude_path, 'r', encoding='utf-8') as f:
+                    content = f.read()
+                captured['excluded_files'] = content.split('\0')[:-1]
+                break
+        return 0, '', ''
+
+    with tempfile.TemporaryDirectory() as source, \
+            tempfile.TemporaryDirectory() as target:
+        # Create multiple files that will be excluded
+        with open(os.path.join(source, '.gitignore'), 'w',
+                  encoding='utf-8') as f:
+            f.write('*.log\n*.tmp\n!keep.log\n')
+
+        for name in ['a.log', 'b.log', 'keep.log', 'c.tmp', 'keep.py']:
+            with open(os.path.join(source, name), 'w', encoding='utf-8') as f:
+                f.write('content')
+
+        subprocess.run(['git', 'init'], cwd=source, check=True)
+        subprocess.run(['git', 'add', 'keep.log'], cwd=source, check=True)
+
+        with mock.patch.object(command_runner.log_lib,
+                               'run_with_log',
+                               side_effect=fake_run_with_log):
+            runner = command_runner.LocalProcessCommandRunner()
+            runner.rsync(source, target, up=True, stream_logs=False)
+
+    assert '--from0' in captured['command']
+    excluded = sorted(captured['excluded_files'])
+    assert excluded == ['a.log', 'b.log', 'c.tmp']
 
 
 def test_get_pod_primary_container_prefers_ray_node() -> None:


### PR DESCRIPTION
## Summary

SkyPilot was passing .gitignore to rsync as an exclude-only filter. That means a pattern like:
```
scripts/*
!scripts/entrypoint.sh
```
works in Git, but not in SkyPilot’s rsync path. Git excludes `scripts/*` then re-includes `scripts/entrypoint.sh`. Rsync saw both lines as exclude rules, so it still skipped the entrypoint.

The fix avoids asking rsync to interpret `.gitignore`. It asks Git which paths are actually ignored, then passes only those concrete ignored paths to rsync.


## Test plan
`pytest tests/unit_tests/test_sky/storage/test_storage_utils.py tests/unit_tests/test_sky/utils/test_command_runner.py`
