### PR TITLE
[Core] Fold mkdir into rsync for internal file mounts

### DIFF
--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -590,30 +590,18 @@ def _internal_file_mounts(file_mounts: Dict,
         return
 
     for dst, src in file_mounts.items():
-        # TODO: We should use this trick to speed up file mounting:
-        # https://stackoverflow.com/questions/1636889/how-can-i-configure-rsync-to-create-target-directory-on-remote-server
         full_src = os.path.abspath(os.path.expanduser(src))
-
-        if os.path.isfile(full_src):
-            mkdir_command = f'mkdir -p {os.path.dirname(dst)}'
-        else:
-            mkdir_command = f'mkdir -p {dst}'
-        rc, stdout, stderr = runner.run_setup(mkdir_command,
-                                              log_path=log_path,
-                                              stream_logs=False,
-                                              require_outputs=True)
-        subprocess_utils.handle_returncode(
-            rc,
-            mkdir_command, ('Failed to run command before rsync '
-                            f'{src} -> {dst}.'),
-            stderr=stdout + stderr)
-
+        # Fold `mkdir -p` into the rsync invocation via `--rsync-path` so the
+        # destination directory is created in the same round-trip as rsync,
+        # avoiding an extra ssh / kubectl exec per file mount.
+        target_mkdir = os.path.dirname(dst) if os.path.isfile(full_src) else dst
         runner.rsync_setup(
             source=src,
             target=dst,
             up=True,
             log_path=log_path,
             stream_logs=False,
+            target_mkdir=target_mkdir,
         )
 
 

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -332,10 +332,21 @@ class CommandRunner:
     def __init__(self, node: Tuple[Any, Any], **kwargs):
         del kwargs  # Unused.
         self.node = node
+        # Cache the remote home dir lookup so concurrent operations on the
+        # same runner (e.g. parallel internal_file_mounts) only pay one
+        # round-trip for it.
+        self._remote_home_dir_cache: Optional[str] = None
+        self._remote_home_dir_lock = threading.Lock()
 
     @property
     def node_id(self) -> str:
         return '-'.join(str(x) for x in self.node)
+
+    def _get_remote_home_dir_cached(self) -> str:
+        with self._remote_home_dir_lock:
+            if self._remote_home_dir_cache is None:
+                self._remote_home_dir_cache = self.get_remote_home_dir()
+            return self._remote_home_dir_cache
 
     def get_remote_home_dir(self) -> str:
         # Use pattern matching to extract home directory.
@@ -494,7 +505,7 @@ class CommandRunner:
         # round-trip as the rsync itself. Saves one ssh / kubectl exec per
         # file mount.
         target_is_remote = up and node_destination is not None
-        if target_mkdir is not None and target_is_remote:
+        if target_mkdir and target_is_remote:
             resolved_target_mkdir = target_mkdir
             if target_mkdir.startswith('~'):
                 remote_home_dir = self.get_remote_home_dir_with_retry(
@@ -502,10 +513,20 @@ class CommandRunner:
                     get_remote_home_dir=get_remote_home_dir)
                 resolved_target_mkdir = target_mkdir.replace(
                     '~', remote_home_dir)
-            rsync_path_cmd = (
-                f'mkdir -p {shlex.quote(resolved_target_mkdir)} && rsync')
+            # If the resolved path still starts with `~` (the SSH default
+            # `get_remote_home_dir` returns `~` and defers expansion to the
+            # remote shell), shlex.quote would single-quote the leading
+            # tilde and prevent expansion. Quote only the suffix in that
+            # case.
+            if resolved_target_mkdir == '~':
+                quoted_mkdir = '~'
+            elif resolved_target_mkdir.startswith('~/'):
+                quoted_mkdir = '~/' + shlex.quote(resolved_target_mkdir[2:])
+            else:
+                quoted_mkdir = shlex.quote(resolved_target_mkdir)
+            rsync_path_cmd = f'mkdir -p {quoted_mkdir} && rsync'
             rsync_command.append(f'--rsync-path={shlex.quote(rsync_path_cmd)}')
-        elif target_mkdir is not None:
+        elif target_mkdir:
             # Local target: just create the directory locally before rsync.
             os.makedirs(os.path.expanduser(target_mkdir), exist_ok=True)
 
@@ -1476,16 +1497,6 @@ class KubernetesCommandRunner(CommandRunner):
         (self.namespace, self.context), self.pod_name = node
         self.deployment = deployment
         self.container = container
-        # Cache the remote home dir lookup so concurrent rsync calls (e.g.
-        # parallel internal_file_mounts) only pay one kubectl exec for it.
-        self._remote_home_dir_cache: Optional[str] = None
-        self._remote_home_dir_lock = threading.Lock()
-
-    def _get_remote_home_dir_cached(self) -> str:
-        with self._remote_home_dir_lock:
-            if self._remote_home_dir_cache is None:
-                self._remote_home_dir_cache = self.get_remote_home_dir()
-            return self._remote_home_dir_cache
 
     @property
     def node_id(self) -> str:
@@ -1725,7 +1736,7 @@ class KubernetesCommandRunner(CommandRunner):
         # so a `--rsync-path="mkdir -p X && rsync"` value would be treated as
         # a single command name.
         mkdir_env = ''
-        if target_mkdir is not None:
+        if target_mkdir:
             resolved_mkdir = target_mkdir
             if target_mkdir.startswith('~'):
                 resolved_mkdir = target_mkdir.replace(

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -455,7 +455,8 @@ class CommandRunner:
             stream_logs: bool = True,
             max_retry: int = 1,
             prefix_command: Optional[str] = None,
-            get_remote_home_dir: Callable[[], str] = lambda: '~') -> None:
+            get_remote_home_dir: Callable[[], str] = lambda: '~',
+            target_mkdir: Optional[str] = None) -> None:
         """Builds the rsync command."""
         # Build command.
         rsync_command = []
@@ -487,6 +488,26 @@ class CommandRunner:
             rsync_command.append(f'-e {shlex.quote(rsh_option)}')
         maybe_dest_prefix = ('' if node_destination is None else
                              f'{node_destination}:')
+
+        # Fold the remote `mkdir -p` into the rsync invocation via
+        # `--rsync-path`, so the destination directory is created in the same
+        # round-trip as the rsync itself. Saves one ssh / kubectl exec per
+        # file mount.
+        target_is_remote = up and node_destination is not None
+        if target_mkdir is not None and target_is_remote:
+            resolved_target_mkdir = target_mkdir
+            if target_mkdir.startswith('~'):
+                remote_home_dir = self.get_remote_home_dir_with_retry(
+                    max_retry=max_retry,
+                    get_remote_home_dir=get_remote_home_dir)
+                resolved_target_mkdir = target_mkdir.replace(
+                    '~', remote_home_dir)
+            rsync_path_cmd = (
+                f'mkdir -p {shlex.quote(resolved_target_mkdir)} && rsync')
+            rsync_command.append(f'--rsync-path={shlex.quote(rsync_path_cmd)}')
+        elif target_mkdir is not None:
+            # Local target: just create the directory locally before rsync.
+            os.makedirs(os.path.expanduser(target_mkdir), exist_ok=True)
 
         if up:
             resolved_target = target
@@ -652,6 +673,7 @@ class CommandRunner:
         log_path: str = os.devnull,
         stream_logs: bool = True,
         max_retry: int = 1,
+        target_mkdir: Optional[str] = None,
     ) -> None:
         """Uses 'rsync' to sync 'source' to 'target'.
 
@@ -664,6 +686,10 @@ class CommandRunner:
             stream_logs: Stream logs to the stdout/stderr.
             max_retry: The maximum number of retries for the rsync command.
               This value should be non-negative.
+            target_mkdir: If set, ensure this directory exists on the target
+              side before rsync runs. For remote uploads this is folded into
+              the rsync invocation via `--rsync-path` to avoid an extra
+              round-trip; for local targets it is created with `os.makedirs`.
 
         Raises:
             exceptions.CommandError: rsync command failed.
@@ -679,6 +705,7 @@ class CommandRunner:
         log_path: str = os.devnull,
         stream_logs: bool = True,
         max_retry: int = 1,
+        target_mkdir: Optional[str] = None,
     ) -> None:
         """Rsync files related to the job driver execution.
 
@@ -694,6 +721,7 @@ class CommandRunner:
             log_path: Redirect stdout/stderr to the log_path.
             stream_logs: Stream logs to the stdout/stderr.
             max_retry: Maximum retry attempts.
+            target_mkdir: See `rsync`.
 
         Raises:
             exceptions.CommandError: rsync command failed.
@@ -703,7 +731,8 @@ class CommandRunner:
                           up=up,
                           log_path=log_path,
                           stream_logs=stream_logs,
-                          max_retry=max_retry)
+                          max_retry=max_retry,
+                          target_mkdir=target_mkdir)
 
     def rsync_setup(
         self,
@@ -714,6 +743,7 @@ class CommandRunner:
         log_path: str = os.devnull,
         stream_logs: bool = True,
         max_retry: int = 1,
+        target_mkdir: Optional[str] = None,
     ) -> None:
         """Rsync files for setting up the SkyPilot runtime on the cluster.
 
@@ -728,6 +758,7 @@ class CommandRunner:
             log_path: Redirect stdout/stderr to the log_path.
             stream_logs: Stream logs to the stdout/stderr.
             max_retry: Maximum retry attempts.
+            target_mkdir: See `rsync`.
 
         Raises:
             exceptions.CommandError: rsync command failed.
@@ -737,7 +768,8 @@ class CommandRunner:
                           up=up,
                           log_path=log_path,
                           stream_logs=stream_logs,
-                          max_retry=max_retry)
+                          max_retry=max_retry,
+                          target_mkdir=target_mkdir)
 
     @classmethod
     def make_runner_list(
@@ -1363,6 +1395,7 @@ class SSHCommandRunner(CommandRunner):
         stream_logs: bool = True,
         max_retry: int = 1,
         get_remote_home_dir: Callable[[], str] = lambda: '~',
+        target_mkdir: Optional[str] = None,
     ) -> None:
         """Uses 'rsync' to sync 'source' to 'target'.
 
@@ -1377,6 +1410,7 @@ class SSHCommandRunner(CommandRunner):
               This value should be non-negative.
             get_remote_home_dir: A callable that returns the remote home
               directory. Defaults to '~'.
+            target_mkdir: See `CommandRunner.rsync`.
 
         Raises:
             exceptions.CommandError: rsync command failed.
@@ -1404,7 +1438,8 @@ class SSHCommandRunner(CommandRunner):
                     log_path=log_path,
                     stream_logs=stream_logs,
                     max_retry=max_retry,
-                    get_remote_home_dir=get_remote_home_dir)
+                    get_remote_home_dir=get_remote_home_dir,
+                    target_mkdir=target_mkdir)
 
 
 class KubernetesCommandRunner(CommandRunner):
@@ -1441,6 +1476,16 @@ class KubernetesCommandRunner(CommandRunner):
         (self.namespace, self.context), self.pod_name = node
         self.deployment = deployment
         self.container = container
+        # Cache the remote home dir lookup so concurrent rsync calls (e.g.
+        # parallel internal_file_mounts) only pay one kubectl exec for it.
+        self._remote_home_dir_cache: Optional[str] = None
+        self._remote_home_dir_lock = threading.Lock()
+
+    def _get_remote_home_dir_cached(self) -> str:
+        with self._remote_home_dir_lock:
+            if self._remote_home_dir_cache is None:
+                self._remote_home_dir_cache = self.get_remote_home_dir()
+            return self._remote_home_dir_cache
 
     @property
     def node_id(self) -> str:
@@ -1640,6 +1685,7 @@ class KubernetesCommandRunner(CommandRunner):
         log_path: str = os.devnull,
         stream_logs: bool = True,
         max_retry: int = 1,
+        target_mkdir: Optional[str] = None,
     ) -> None:
         """Uses 'rsync' to sync 'source' to 'target'.
 
@@ -1652,6 +1698,9 @@ class KubernetesCommandRunner(CommandRunner):
             stream_logs: Stream logs to the stdout/stderr.
             max_retry: The maximum number of retries for the rsync command.
               This value should be non-negative.
+            target_mkdir: See `CommandRunner.rsync`. For Kubernetes the mkdir
+              is folded into the same `kubectl exec` as rsync via
+              `SKYPILOT_K8S_RSYNC_MKDIR`, which `rsync_helper.sh` reads.
 
         Raises:
             exceptions.CommandError: rsync command failed.
@@ -1669,6 +1718,25 @@ class KubernetesCommandRunner(CommandRunner):
         encoded_namespace_context = (namespace_context.replace(
             '@', '%40').replace(':', '%3A').replace('/',
                                                     '%2F').replace('+', '%2B'))
+
+        # Resolve `~` in target_mkdir locally and pass the result through an
+        # env var consumed by rsync_helper.sh. We avoid `--rsync-path` here
+        # because rsync_helper.sh's `exec "$@"` does not shell-interpret `&&`,
+        # so a `--rsync-path="mkdir -p X && rsync"` value would be treated as
+        # a single command name.
+        mkdir_env = ''
+        if target_mkdir is not None:
+            resolved_mkdir = target_mkdir
+            if target_mkdir.startswith('~'):
+                resolved_mkdir = target_mkdir.replace(
+                    '~', self._get_remote_home_dir_cached())
+            mkdir_env = (
+                f'SKYPILOT_K8S_RSYNC_MKDIR={shlex.quote(resolved_mkdir)} ')
+
+        container_env = ('' if self.container is None else
+                         f'SKYPILOT_K8S_EXEC_CONTAINER='
+                         f'{shlex.quote(self.container)} ')
+
         self._rsync(
             source,
             target,
@@ -1678,13 +1746,17 @@ class KubernetesCommandRunner(CommandRunner):
             log_path=log_path,
             stream_logs=stream_logs,
             max_retry=max_retry,
-            prefix_command=(f'chmod +x {helper_path} && ' + (
-                '' if self.container is None else
-                f'SKYPILOT_K8S_EXEC_CONTAINER={shlex.quote(self.container)} ')),
+            prefix_command=(
+                f'chmod +x {helper_path} && {container_env}{mkdir_env}'),
             # rsync with `kubectl` as the rsh command will cause ~/xx parsed as
             # /~/xx, so we need to replace ~ with the remote home directory. We
             # only need to do this when ~ is at the beginning of the path.
-            get_remote_home_dir=self.get_remote_home_dir)
+            # Route through the cached lookup so parallel rsyncs to the same
+            # pod share one kubectl exec for the home dir.
+            get_remote_home_dir=self._get_remote_home_dir_cached,
+            # mkdir is handled via env var above; do not let _rsync emit a
+            # `--rsync-path` value, which rsync_helper.sh cannot parse.
+            target_mkdir=None)
 
 
 class LocalProcessCommandRunner(CommandRunner):
@@ -1769,6 +1841,7 @@ class LocalProcessCommandRunner(CommandRunner):
         log_path: str = os.devnull,
         stream_logs: bool = True,
         max_retry: int = 1,
+        target_mkdir: Optional[str] = None,
     ) -> None:
         """Use rsync to sync the source to the target."""
         self._rsync(source,
@@ -1778,7 +1851,8 @@ class LocalProcessCommandRunner(CommandRunner):
                     rsh_option=None,
                     log_path=log_path,
                     stream_logs=stream_logs,
-                    max_retry=max_retry)
+                    max_retry=max_retry,
+                    target_mkdir=target_mkdir)
 
 
 class SlurmCommandRunner(SSHCommandRunner):
@@ -1853,6 +1927,7 @@ class SlurmCommandRunner(SSHCommandRunner):
         log_path: str = os.devnull,
         stream_logs: bool = True,
         max_retry: int = 1,
+        target_mkdir: Optional[str] = None,
     ) -> None:
         """Rsyncs files via srun, either to host or into container.
 
@@ -1865,6 +1940,7 @@ class SlurmCommandRunner(SSHCommandRunner):
             log_path: Path for rsync logs.
             stream_logs: Whether to stream logs.
             max_retry: Maximum retry attempts.
+            target_mkdir: See `CommandRunner.rsync`.
         """
         ssh_command = ' '.join(
             self.ssh_base_command(ssh_mode=SshMode.NON_INTERACTIVE,
@@ -1902,7 +1978,8 @@ exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
                         log_path=log_path,
                         stream_logs=stream_logs,
                         max_retry=max_retry,
-                        get_remote_home_dir=lambda: remote_home_dir)
+                        get_remote_home_dir=lambda: remote_home_dir,
+                        target_mkdir=target_mkdir)
         finally:
             try:
                 os.unlink(rsh_script_path)
@@ -1960,6 +2037,7 @@ exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
         log_path: str = os.devnull,
         stream_logs: bool = True,
         max_retry: int = 1,
+        target_mkdir: Optional[str] = None,
     ) -> None:
         # Default: run in container if container_args set, otherwise on host
         in_container = self.container_args is not None
@@ -1969,7 +2047,8 @@ exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
                              in_container=in_container,
                              log_path=log_path,
                              stream_logs=stream_logs,
-                             max_retry=max_retry)
+                             max_retry=max_retry,
+                             target_mkdir=target_mkdir)
 
     @timeline.event
     @context_utils.cancellation_guard
@@ -2012,6 +2091,7 @@ exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
         log_path: str = os.devnull,
         stream_logs: bool = True,
         max_retry: int = 1,
+        target_mkdir: Optional[str] = None,
     ) -> None:
         # Host only: driver runs on host and uses srun internally.
         self._rsync_via_srun(source=source,
@@ -2020,7 +2100,8 @@ exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
                              in_container=False,
                              log_path=log_path,
                              stream_logs=stream_logs,
-                             max_retry=max_retry)
+                             max_retry=max_retry,
+                             target_mkdir=target_mkdir)
 
     def rsync_setup(
         self,
@@ -2031,6 +2112,7 @@ exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
         log_path: str = os.devnull,
         stream_logs: bool = True,
         max_retry: int = 1,
+        target_mkdir: Optional[str] = None,
     ) -> None:
         # Both host and container: ensure environment is consistent.
         self._rsync_via_srun(source=source,
@@ -2039,7 +2121,8 @@ exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
                              in_container=False,
                              log_path=log_path,
                              stream_logs=stream_logs,
-                             max_retry=max_retry)
+                             max_retry=max_retry,
+                             target_mkdir=target_mkdir)
         if self.container_args is not None:
             self._rsync_via_srun(source=source,
                                  target=target,
@@ -2047,4 +2130,5 @@ exec {ssh_command} srun --unbuffered --quiet --overlap {extra_srun_args}\\
                                  in_container=True,
                                  log_path=log_path,
                                  stream_logs=stream_logs,
-                                 max_retry=max_retry)
+                                 max_retry=max_retry,
+                                 target_mkdir=target_mkdir)

--- a/sky/utils/command_runner.pyi
+++ b/sky/utils/command_runner.pyi
@@ -116,6 +116,7 @@ class CommandRunner:
         log_path: str = ...,
         stream_logs: bool = ...,
         max_retry: int = ...,
+        target_mkdir: Optional[str] = ...,
     ) -> None:
         ...
 
@@ -170,7 +171,8 @@ class CommandRunner:
                      up: bool,
                      log_path: str = ...,
                      stream_logs: bool = ...,
-                     max_retry: int = ...) -> None:
+                     max_retry: int = ...,
+                     target_mkdir: Optional[str] = ...) -> None:
         ...
 
     def rsync_setup(self,
@@ -180,7 +182,8 @@ class CommandRunner:
                     up: bool,
                     log_path: str = ...,
                     stream_logs: bool = ...,
-                    max_retry: int = ...) -> None:
+                    max_retry: int = ...,
+                    target_mkdir: Optional[str] = ...) -> None:
         ...
 
     def port_forward_command(
@@ -304,6 +307,7 @@ class SSHCommandRunner(CommandRunner):
         stream_logs: bool = ...,
         max_retry: int = ...,
         get_remote_home_dir: Callable[[], str] = ...,
+        target_mkdir: Optional[str] = ...,
     ) -> None:
         ...
 
@@ -389,6 +393,7 @@ class KubernetesCommandRunner(CommandRunner):
         log_path: str = ...,
         stream_logs: bool = ...,
         max_retry: int = ...,
+        target_mkdir: Optional[str] = ...,
     ) -> None:
         ...
 

--- a/sky/utils/kubernetes/rsync_helper.sh
+++ b/sky/utils/kubernetes/rsync_helper.sh
@@ -56,6 +56,11 @@ else
     kubectl_cmd_base="kubectl exec \"$resource_type/$resource_name\" -n \"$namespace\" -c \"$container\" --context=\"$context\" --"
 fi
 
+# Optional: ensure a remote directory exists before invoking rsync, so that
+# `mkdir -p` and `rsync` happen in the same kubectl exec round-trip. Set by
+# the caller (e.g. internal_file_mounts) to avoid an extra exec per mount.
+mkdir_target="${SKYPILOT_K8S_RSYNC_MKDIR:-}"
+
 # Execute command on remote pod, waiting for rsync to be available first.
 # The waiting happens on the remote pod, not locally, which is more efficient
 # and reliable than polling from the local machine.
@@ -66,4 +71,8 @@ MAX_WAIT_COUNT=$((MAX_WAIT_TIME_SECONDS * 2))
 # Use --norc --noprofile to prevent bash from sourcing startup files that might
 # output to stdout and corrupt the rsync protocol. All debug output must go to
 # stderr (>&2) to keep stdout clean for rsync communication.
-eval "${kubectl_cmd_base% --} -i -- bash --norc --noprofile -c 'count=0; until which rsync >/dev/null 2>&1; do if [ \$count -ge $MAX_WAIT_COUNT ]; then echo \"Error when trying to rsync files to kubernetes cluster. Package installation may have failed.\" >&2; exit 1; fi; sleep 0.5; count=\$((count+1)); done; exec \"\$@\"' -- \"\$@\""
+#
+# We pass `mkdir_target` (which may be empty) as $1 to the inner bash -c, then
+# the rsync server args as $2..$N. The inner script creates the directory if
+# requested, then execs the rsync command.
+eval "${kubectl_cmd_base% --} -i -- bash --norc --noprofile -c 'count=0; until which rsync >/dev/null 2>&1; do if [ \$count -ge $MAX_WAIT_COUNT ]; then echo \"Error when trying to rsync files to kubernetes cluster. Package installation may have failed.\" >&2; exit 1; fi; sleep 0.5; count=\$((count+1)); done; mkdir_target=\"\$1\"; shift; if [ -n \"\$mkdir_target\" ]; then mkdir -p \"\$mkdir_target\" || exit 1; fi; exec \"\$@\"' bash \"\$mkdir_target\" \"\$@\""


### PR DESCRIPTION
## Summary
- Drops the per-mount `mkdir -p` round-trip in `internal_file_mounts` by folding it into the rsync invocation.
- SSH and local paths use rsync's `--rsync-path="mkdir -p X && rsync"`. The K8s path routes the target through `SKYPILOT_K8S_RSYNC_MKDIR`, which `rsync_helper.sh` reads and prepends to the inner kubectl exec script (rsync_helper.sh's `exec "$@"` does not shell-interpret `&&`, so `--rsync-path` with shell metacharacters cannot be used there).
- Caches the K8s remote home dir on the runner instance so target and `target_mkdir` `~`-resolution share one kubectl exec.

## Test plan
- [ ] `pytest tests/unit_tests/` passes locally.
- [ ] `sky launch` against AWS / GCP / Kubernetes — verify `internal_file_mounts` succeed and the per-mount `mkdir` exec no longer appears in debug logs.
- [ ] `sky launch` to a Kubernetes cluster with a target path under `~/...` — verify only one kubectl exec resolves the home dir per launch.