### PR TITLE
[Kubernetes] Speed up bootstrap_instances RBAC/service setup

### DIFF
--- a/sky/provision/kubernetes/config.py
+++ b/sky/provision/kubernetes/config.py
@@ -1,4 +1,5 @@
 """Kubernetes-specific configuration for the provisioner."""
+from concurrent import futures
 import copy
 import logging
 import math
@@ -24,31 +25,41 @@ def bootstrap_instances(
         config.provider_config)
     context = kubernetes_utils.get_context_from_config(config.provider_config)
 
-    _configure_services(namespace, context, config.provider_config)
+    # Each step below is independent at the K8s API level (RBAC references are
+    # resolved at evaluation time, not creation time), so we fan them out in a
+    # thread pool. The kubernetes client's underlying urllib3 pool is
+    # thread-safe.
+    tasks: List[Callable[[], None]] = []
+
+    tasks.append(
+        lambda: _configure_services(namespace, context, config.provider_config))
 
     requested_service_account = config.node_config['spec']['serviceAccountName']
-    if (requested_service_account ==
-            kubernetes_utils.DEFAULT_SERVICE_ACCOUNT_NAME):
+    setup_rbac = (requested_service_account ==
+                  kubernetes_utils.DEFAULT_SERVICE_ACCOUNT_NAME)
+
+    if setup_rbac:
         # If the user has requested a different service account (via pod_config
         # in ~/.sky/config.yaml), we assume they have already set up the
         # necessary roles and role bindings.
         # If not, set up the roles and bindings for skypilot-service-account
         # here.
-        _configure_autoscaler_service_account(namespace, context,
-                                              config.provider_config)
-        _configure_autoscaler_role(namespace,
-                                   context,
-                                   config.provider_config,
-                                   resource_field='autoscaler_role')
-        _configure_autoscaler_role_binding(
+        tasks.append(lambda: _configure_autoscaler_service_account(
+            namespace, context, config.provider_config))
+        tasks.append(lambda: _configure_autoscaler_role(namespace,
+                                                        context,
+                                                        config.provider_config,
+                                                        resource_field=
+                                                        'autoscaler_role'))
+        tasks.append(lambda: _configure_autoscaler_role_binding(
             namespace,
             context,
             config.provider_config,
-            resource_field='autoscaler_role_binding')
-        _configure_autoscaler_cluster_role(namespace, context,
-                                           config.provider_config)
-        _configure_autoscaler_cluster_role_binding(namespace, context,
-                                                   config.provider_config)
+            resource_field='autoscaler_role_binding'))
+        tasks.append(lambda: _configure_autoscaler_cluster_role(
+            namespace, context, config.provider_config))
+        tasks.append(lambda: _configure_autoscaler_cluster_role_binding(
+            namespace, context, config.provider_config))
         # SkyPilot system namespace is required for FUSE mounting. Here we just
         # create the namespace and set up the necessary permissions.
         #
@@ -63,35 +74,53 @@ def bootstrap_instances(
         #    using DEFAULT_SERVICE_ACCOUNT_NAME, it does not have the necessary
         #    permissions to create a role for itself to create the FUSE manager.
         # 4. The job fails to launch.
-        _configure_skypilot_system_namespace(config.provider_config)
+        tasks.append(lambda: _configure_skypilot_system_namespace(
+            config.provider_config))
         if config.provider_config.get('port_mode', 'loadbalancer') == 'ingress':
             logger.info('Port mode is set to ingress, setting up ingress role '
                         'and role binding.')
-            try:
-                _configure_autoscaler_role(
-                    namespace,
-                    context,
-                    config.provider_config,
-                    resource_field='autoscaler_ingress_role')
-                _configure_autoscaler_role_binding(
-                    namespace,
-                    context,
-                    config.provider_config,
-                    resource_field='autoscaler_ingress_role_binding')
-            except kubernetes.api_exception() as e:
-                # If namespace is not found, we will ignore the error
-                if e.status == 404:
-                    logger.info(
-                        'Namespace not found - is your nginx ingress installed?'
-                        ' Skipping ingress role and role binding setup.')
-                else:
-                    raise e
+
+            def _configure_ingress() -> None:
+                try:
+                    _configure_autoscaler_role(
+                        namespace,
+                        context,
+                        config.provider_config,
+                        resource_field='autoscaler_ingress_role')
+                    _configure_autoscaler_role_binding(
+                        namespace,
+                        context,
+                        config.provider_config,
+                        resource_field='autoscaler_ingress_role_binding')
+                except kubernetes.api_exception() as e:
+                    # If namespace is not found, we will ignore the error
+                    if e.status == 404:
+                        logger.info(
+                            'Namespace not found - is your nginx ingress '
+                            'installed? Skipping ingress role and role '
+                            'binding setup.')
+                    else:
+                        raise e
+
+            tasks.append(_configure_ingress)
 
     elif requested_service_account != 'default':
         logger.info(f'Using service account {requested_service_account!r}, '
                     'skipping role and role binding setup.')
+
     if config.provider_config.get('fuse_device_required', False):
-        _configure_fuse_mounting(config.provider_config)
+        tasks.append(lambda: _configure_fuse_mounting(config.provider_config))
+
+    if len(tasks) == 1:
+        tasks[0]()
+    else:
+        with futures.ThreadPoolExecutor(max_workers=len(tasks)) as executor:
+            # list() forces all futures to materialize so exceptions surface;
+            # the context manager waits for completion before returning.
+            for future in futures.as_completed(
+                [executor.submit(task) for task in tasks]):
+                future.result()
+
     return config
 
 
@@ -509,13 +538,6 @@ def _configure_skypilot_system_namespace(
     context = kubernetes_utils.get_context_from_config(provider_config)
     kubernetes_utils.create_namespace(skypilot_system_namespace, context)
 
-    # Note - this must be run only after the service account has been
-    # created in the cluster (in bootstrap_instances).
-    # Create the role in the skypilot-system namespace if it does not exist.
-    _configure_autoscaler_role(skypilot_system_namespace,
-                               context,
-                               provider_config,
-                               resource_field='autoscaler_skypilot_system_role')
     # We must create a unique role binding per-namespace that SkyPilot is
     # running in, so we override the name with a unique name identifying
     # the namespace. This is required for multi-tenant setups where
@@ -523,16 +545,29 @@ def _configure_skypilot_system_namespace(
     override_name = provider_config['autoscaler_skypilot_system_role_binding'][
         'metadata']['name'] + '-' + svc_account_namespace
 
-    # Create the role binding in the skypilot-system namespace, and have
-    # the subject namespace be the namespace that the SkyPilot service
-    # account is created in.
-    _configure_autoscaler_role_binding(
-        skypilot_system_namespace,
-        context,
-        provider_config,
-        resource_field='autoscaler_skypilot_system_role_binding',
-        override_name=override_name,
-        override_subject_namespace=svc_account_namespace)
+    # The role and role binding are independent K8s resources (the binding
+    # references the role by name; K8s does not require the role to exist at
+    # binding-creation time), so we create them in parallel.
+    with futures.ThreadPoolExecutor(max_workers=2) as executor:
+        role_future = executor.submit(
+            _configure_autoscaler_role,
+            skypilot_system_namespace,
+            context,
+            provider_config,
+            resource_field='autoscaler_skypilot_system_role')
+        # Create the role binding in the skypilot-system namespace, and have
+        # the subject namespace be the namespace that the SkyPilot service
+        # account is created in.
+        binding_future = executor.submit(
+            _configure_autoscaler_role_binding,
+            skypilot_system_namespace,
+            context,
+            provider_config,
+            resource_field='autoscaler_skypilot_system_role_binding',
+            override_name=override_name,
+            override_subject_namespace=svc_account_namespace)
+        role_future.result()
+        binding_future.result()
 
 
 def _configure_fuse_mounting(provider_config: Dict[str, Any]) -> None:
@@ -614,36 +649,48 @@ def _configure_services(namespace: str, context: Optional[str],
         return
 
     services = provider_config[service_field]
+
+    # Validate namespaces synchronously so InvalidNamespaceError still surfaces
+    # cleanly without thread-pool wrapping.
     for service in services:
         if 'namespace' not in service['metadata']:
             service['metadata']['namespace'] = namespace
         elif service['metadata']['namespace'] != namespace:
             raise InvalidNamespaceError(service_field, namespace)
 
+    def _reconcile(service: Dict[str, Any]) -> None:
         name = service['metadata']['name']
         field_selector = f'metadata.name={name}'
-        services = (kubernetes.core_api(context).list_namespaced_service(
+        existing = (kubernetes.core_api(context).list_namespaced_service(
             namespace, field_selector=field_selector).items)
-        if services:
-            assert len(services) == 1
-            existing_service = services[0]
-            # Convert to k8s object to compare
+        if existing:
+            assert len(existing) == 1
+            existing_service = existing[0]
             new_svc = kubernetes_utils.dict_to_k8s_object(service, 'V1Service')
             if new_svc.spec.ports == existing_service.spec.ports:
                 logger.info('_configure_services: '
                             f'{using_existing_msg("service", name)}')
                 return
-            else:
-                logger.info('_configure_services: '
-                            f'{updating_existing_msg("service", name)}')
-                kubernetes.core_api(context).patch_namespaced_service(
-                    name, namespace, service)
+            logger.info('_configure_services: '
+                        f'{updating_existing_msg("service", name)}')
+            kubernetes.core_api(context).patch_namespaced_service(
+                name, namespace, service)
         else:
             logger.info(
                 f'_configure_services: {not_found_msg("service", name)}')
             kubernetes.core_api(context).create_namespaced_service(
                 namespace, service)
             logger.info(f'_configure_services: {created_msg("service", name)}')
+
+    if len(services) <= 1:
+        for service in services:
+            _reconcile(service)
+        return
+
+    with futures.ThreadPoolExecutor(max_workers=len(services)) as executor:
+        for future in futures.as_completed(
+            [executor.submit(_reconcile, svc) for svc in services]):
+            future.result()
 
 
 class KubernetesError(Exception):

--- a/sky/provision/kubernetes/config.py
+++ b/sky/provision/kubernetes/config.py
@@ -268,12 +268,22 @@ def _get_resource(container_resources: Dict[str, Any], resource_name: str,
         return kubernetes_utils.parse_cpu_or_gpu_resource(resource_quantity)
 
 
+def _read_or_none(read_fn: Callable[[], Any]) -> Optional[Any]:
+    """Calls a K8s read_* method, returning None on 404."""
+    try:
+        return read_fn()
+    except kubernetes.api_exception() as e:
+        if e.status == 404:
+            return None
+        raise
+
+
 def _create_or_patch_resource(
     log_prefix: str,
     resource_field: str,
     name: str,
     create_fn: Callable[[], Any],
-    list_fn: Callable[[], Any],
+    read_fn: Callable[[], Any],
     patch_fn: Optional[Callable[[], None]],
     needs_update_fn: Optional[Callable[[Any], bool]],
 ) -> None:
@@ -282,9 +292,12 @@ def _create_or_patch_resource(
     If the resource doesn't exist, tries to create it. On 409 (concurrent
     creation), re-reads and falls through to compare/patch. If the resource
     exists (found initially or after 409), compares and patches if needed.
+
+    `read_fn` should call a K8s `read_*` method (a single-object GET that
+    raises 404 if missing); it's faster than `list_*` with a field_selector,
+    which forces a LIST scan on the apiserver.
     """
-    items = list_fn().items
-    existing = items[0] if items else None
+    existing = _read_or_none(read_fn)
 
     if existing is None:
         logger.info(f'{log_prefix}: '
@@ -296,7 +309,7 @@ def _create_or_patch_resource(
                 raise
             # Concurrently created by another process; re-read
             # and fall through to compare/patch below.
-            existing = list_fn().items[0]
+            existing = read_fn()
         else:
             logger.info(f'{log_prefix}: '
                         f'{created_msg(resource_field, name)}')
@@ -332,7 +345,6 @@ def _configure_autoscaler_service_account(
         raise InvalidNamespaceError(resource_field, namespace)
 
     name = account['metadata']['name']
-    field_selector = f'metadata.name={name}'
 
     _create_or_patch_resource(
         log_prefix=log_prefix,
@@ -340,9 +352,8 @@ def _configure_autoscaler_service_account(
         name=name,
         create_fn=lambda: kubernetes.core_api(
             context).create_namespaced_service_account(namespace, account),
-        list_fn=lambda: kubernetes.core_api(context).
-        list_namespaced_service_account(namespace,
-                                        field_selector=field_selector),
+        read_fn=lambda: kubernetes.core_api(context).
+        read_namespaced_service_account(name, namespace),
         # Nothing to compare/patch for service accounts.
         patch_fn=None,
         needs_update_fn=None,
@@ -372,7 +383,6 @@ def _configure_autoscaler_role(namespace: str, context: Optional[str],
         namespace = resource['metadata']['namespace']
 
     name = resource['metadata']['name']
-    field_selector = f'metadata.name={name}'
     new_role = kubernetes_utils.dict_to_k8s_object(resource, 'V1Role')
 
     _create_or_patch_resource(
@@ -381,8 +391,8 @@ def _configure_autoscaler_role(namespace: str, context: Optional[str],
         name=name,
         create_fn=lambda: kubernetes.auth_api(context).create_namespaced_role(
             namespace, resource),
-        list_fn=lambda: kubernetes.auth_api(context).list_namespaced_role(
-            namespace, field_selector=field_selector),
+        read_fn=lambda: kubernetes.auth_api(context).read_namespaced_role(
+            name, namespace),
         patch_fn=lambda: kubernetes.auth_api(context).patch_namespaced_role(
             name, namespace, resource),
         needs_update_fn=lambda existing: new_role.rules != existing.rules,
@@ -430,7 +440,6 @@ def _configure_autoscaler_role_binding(
     # Override name if provided
     resource['metadata']['name'] = override_name or resource['metadata']['name']
     name = resource['metadata']['name']
-    field_selector = f'metadata.name={name}'
     new_rb = kubernetes_utils.dict_to_k8s_object(resource, 'V1RoleBinding')
 
     _create_or_patch_resource(
@@ -439,9 +448,8 @@ def _configure_autoscaler_role_binding(
         name=name,
         create_fn=lambda: kubernetes.auth_api(
             context).create_namespaced_role_binding(rb_namespace, resource),
-        list_fn=lambda: kubernetes.auth_api(
-            context).list_namespaced_role_binding(
-                rb_namespace, field_selector=field_selector),
+        read_fn=lambda: kubernetes.auth_api(
+            context).read_namespaced_role_binding(name, rb_namespace),
         patch_fn=lambda: kubernetes.auth_api(context).
         patch_namespaced_role_binding(name, rb_namespace, resource),
         needs_update_fn=lambda existing:
@@ -466,7 +474,6 @@ def _configure_autoscaler_cluster_role(namespace, context,
         raise InvalidNamespaceError(resource_field, namespace)
 
     name = resource['metadata']['name']
-    field_selector = f'metadata.name={name}'
     new_cr = kubernetes_utils.dict_to_k8s_object(resource, 'V1ClusterRole')
 
     _create_or_patch_resource(
@@ -475,8 +482,7 @@ def _configure_autoscaler_cluster_role(namespace, context,
         name=name,
         create_fn=lambda: kubernetes.auth_api(context).create_cluster_role(
             resource),
-        list_fn=lambda: kubernetes.auth_api(context).list_cluster_role(
-            field_selector=field_selector),
+        read_fn=lambda: kubernetes.auth_api(context).read_cluster_role(name),
         patch_fn=lambda: kubernetes.auth_api(context).patch_cluster_role(
             name, resource),
         needs_update_fn=lambda existing: new_cr.rules != existing.rules,
@@ -506,7 +512,6 @@ def _configure_autoscaler_cluster_role_binding(
                 resource_field + f' subject {subject_name}', namespace)
 
     name = resource['metadata']['name']
-    field_selector = f'metadata.name={name}'
     new_binding = kubernetes_utils.dict_to_k8s_object(resource,
                                                       'V1ClusterRoleBinding')
 
@@ -516,8 +521,8 @@ def _configure_autoscaler_cluster_role_binding(
         name=name,
         create_fn=lambda: kubernetes.auth_api(
             context).create_cluster_role_binding(resource),
-        list_fn=lambda: kubernetes.auth_api(context).list_cluster_role_binding(
-            field_selector=field_selector),
+        read_fn=lambda: kubernetes.auth_api(context).read_cluster_role_binding(
+            name),
         patch_fn=lambda: kubernetes.auth_api(
             context).patch_cluster_role_binding(name, resource),
         needs_update_fn=lambda existing:
@@ -660,12 +665,9 @@ def _configure_services(namespace: str, context: Optional[str],
 
     def _reconcile(service: Dict[str, Any]) -> None:
         name = service['metadata']['name']
-        field_selector = f'metadata.name={name}'
-        existing = (kubernetes.core_api(context).list_namespaced_service(
-            namespace, field_selector=field_selector).items)
-        if existing:
-            assert len(existing) == 1
-            existing_service = existing[0]
+        existing_service = _read_or_none(lambda: kubernetes.core_api(
+            context).read_namespaced_service(name, namespace))
+        if existing_service is not None:
             new_svc = kubernetes_utils.dict_to_k8s_object(service, 'V1Service')
             if new_svc.spec.ports == existing_service.spec.ports:
                 logger.info('_configure_services: '

--- a/sky/provision/kubernetes/config.py
+++ b/sky/provision/kubernetes/config.py
@@ -1,20 +1,66 @@
 """Kubernetes-specific configuration for the provisioner."""
 from concurrent import futures
 import copy
+import hashlib
+import json
 import logging
 import math
 import os
-from typing import Any, Callable, Dict, List, Optional, Union
+import time
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from sky.adaptors import kubernetes
 from sky.provision import common
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.utils import yaml_utils
+from sky.utils.db import kv_cache
 
 logger = logging.getLogger(__name__)
 
 # Timeout for deleting a Kubernetes resource (in seconds).
 DELETION_TIMEOUT = 90
+
+# How long an RBAC verification stays cached. Bounds staleness if an admin
+# deletes a SkyPilot-managed role/binding outside of SkyPilot. Short enough
+# that the next launch will re-verify, long enough to cover bursts of
+# back-to-back launches.
+_RBAC_CACHE_TTL_SECONDS = 5 * 60
+
+# Fields in provider_config that influence the RBAC + system-namespace setup.
+# A change in any of these invalidates the cache via the content hash.
+# Cluster-specific fields (e.g. 'services') are deliberately excluded so
+# launching a new cluster name doesn't force a cache miss.
+_RBAC_FINGERPRINT_FIELDS: Tuple[str, ...] = (
+    'autoscaler_service_account',
+    'autoscaler_role',
+    'autoscaler_role_binding',
+    'autoscaler_cluster_role',
+    'autoscaler_cluster_role_binding',
+    'autoscaler_skypilot_system_role',
+    'autoscaler_skypilot_system_role_binding',
+    'autoscaler_ingress_role',
+    'autoscaler_ingress_role_binding',
+    'skypilot_system_namespace',
+    'port_mode',
+)
+
+
+def _rbac_cache_key(context: Optional[str], namespace: str,
+                    provider_config: Dict[str, Any]) -> str:
+    """Builds the kv_cache key for the RBAC + system-namespace setup.
+
+    The key fingerprints (context, user namespace, all RBAC inputs). Any
+    change to a cached resource definition or to which namespace the SA
+    lives in causes the next launch to miss and re-verify.
+    """
+    payload: Dict[str, Any] = {
+        f: provider_config.get(f) for f in _RBAC_FINGERPRINT_FIELDS
+    }
+    payload['namespace'] = namespace
+    fingerprint = hashlib.sha256(
+        json.dumps(payload, sort_keys=True,
+                   default=str).encode('utf-8')).hexdigest()
+    return f'k8s_provision_rbac:{context or ""}:{fingerprint}'
 
 
 def bootstrap_instances(
@@ -38,7 +84,19 @@ def bootstrap_instances(
     setup_rbac = (requested_service_account ==
                   kubernetes_utils.DEFAULT_SERVICE_ACCOUNT_NAME)
 
+    rbac_cache_key: Optional[str] = None
+    rbac_cache_hit = False
     if setup_rbac:
+        rbac_cache_key = _rbac_cache_key(context, namespace,
+                                         config.provider_config)
+        rbac_cache_hit = kv_cache.get_cache_entry(rbac_cache_key) is not None
+        if rbac_cache_hit:
+            logger.debug(
+                f'bootstrap_instances: RBAC setup recently verified for '
+                f'context={context!r} namespace={namespace!r}, skipping '
+                f'{len(_RBAC_FINGERPRINT_FIELDS)} K8s reads.')
+
+    if setup_rbac and not rbac_cache_hit:
         # If the user has requested a different service account (via pod_config
         # in ~/.sky/config.yaml), we assume they have already set up the
         # necessary roles and role bindings.
@@ -104,7 +162,7 @@ def bootstrap_instances(
 
             tasks.append(_configure_ingress)
 
-    elif requested_service_account != 'default':
+    elif not setup_rbac and requested_service_account != 'default':
         logger.info(f'Using service account {requested_service_account!r}, '
                     'skipping role and role binding setup.')
 
@@ -120,6 +178,13 @@ def bootstrap_instances(
             for future in futures.as_completed(
                 [executor.submit(task) for task in tasks]):
                 future.result()
+
+    # Only mark verified after the RBAC fanout completes without raising —
+    # if any task fails the executor re-raises and we never reach this line.
+    if setup_rbac and not rbac_cache_hit and rbac_cache_key is not None:
+        kv_cache.add_or_update_cache_entry(
+            rbac_cache_key, '1',
+            time.time() + _RBAC_CACHE_TTL_SECONDS)
 
     return config
 

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -954,21 +954,22 @@ class TestRbac409ConflictHandling:
         """Test 409 on create_namespaced_service_account re-reads and succeeds.
         """
         api_exc = _make_api_exception(409, 'Conflict')
+        not_found = _make_api_exception(404, 'Not Found')
         existing_sa = mock.MagicMock()
 
         core_api_mock = mock.MagicMock()
-        # First list returns empty -> "not found", second list (after 409)
+        # First read raises 404 -> "not found", second read (after 409)
         # returns the concurrently-created resource.
-        core_api_mock.list_namespaced_service_account.side_effect = [
-            mock.MagicMock(items=[]),
-            mock.MagicMock(items=[existing_sa]),
+        core_api_mock.read_namespaced_service_account.side_effect = [
+            not_found,
+            existing_sa,
         ]
         core_api_mock.create_namespaced_service_account.side_effect = api_exc
 
         monkeypatch.setattr('sky.adaptors.kubernetes.core_api',
                             lambda *args, **kwargs: core_api_mock)
         monkeypatch.setattr('sky.adaptors.kubernetes.api_exception',
-                            lambda *args, **kwargs: type(api_exc))
+                            lambda *args, **kwargs: FakeApiException)
 
         provider_config = _make_provider_config_for_rbac()
         # Should not raise
@@ -978,10 +979,10 @@ class TestRbac409ConflictHandling:
     def test_service_account_other_error_raised(self, monkeypatch):
         """Test that non-409 errors are still raised."""
         api_exc = _make_api_exception(500, 'Internal Server Error')
+        not_found = _make_api_exception(404, 'Not Found')
 
         core_api_mock = mock.MagicMock()
-        core_api_mock.list_namespaced_service_account.return_value = (
-            mock.MagicMock(items=[]))
+        core_api_mock.read_namespaced_service_account.side_effect = not_found
         core_api_mock.create_namespaced_service_account.side_effect = api_exc
 
         monkeypatch.setattr('sky.adaptors.kubernetes.core_api',
@@ -999,6 +1000,7 @@ class TestRbac409ConflictHandling:
         from sky.provision.kubernetes import utils as kubernetes_utils
 
         api_exc = _make_api_exception(409, 'Conflict')
+        not_found = _make_api_exception(404, 'Not Found')
         provider_config = _make_provider_config_for_rbac()
 
         # Build the expected k8s role object so we can match its rules.
@@ -1007,16 +1009,16 @@ class TestRbac409ConflictHandling:
         existing_role = self._make_existing_role(new_role.rules)
 
         auth_api_mock = mock.MagicMock()
-        auth_api_mock.list_namespaced_role.side_effect = [
-            mock.MagicMock(items=[]),
-            mock.MagicMock(items=[existing_role]),
+        auth_api_mock.read_namespaced_role.side_effect = [
+            not_found,
+            existing_role,
         ]
         auth_api_mock.create_namespaced_role.side_effect = api_exc
 
         monkeypatch.setattr('sky.adaptors.kubernetes.auth_api',
                             lambda *args, **kwargs: auth_api_mock)
         monkeypatch.setattr('sky.adaptors.kubernetes.api_exception',
-                            lambda *args, **kwargs: type(api_exc))
+                            lambda *args, **kwargs: FakeApiException)
 
         config_lib._configure_autoscaler_role('default', None, provider_config,
                                               'autoscaler_role')
@@ -1027,22 +1029,23 @@ class TestRbac409ConflictHandling:
         """Test 409 on create_namespaced_role re-reads and patches when rules
         differ."""
         api_exc = _make_api_exception(409, 'Conflict')
+        not_found = _make_api_exception(404, 'Not Found')
         provider_config = _make_provider_config_for_rbac()
 
         # Existing role has different rules than what we want.
         existing_role = self._make_existing_role(rules=['stale-rules'])
 
         auth_api_mock = mock.MagicMock()
-        auth_api_mock.list_namespaced_role.side_effect = [
-            mock.MagicMock(items=[]),
-            mock.MagicMock(items=[existing_role]),
+        auth_api_mock.read_namespaced_role.side_effect = [
+            not_found,
+            existing_role,
         ]
         auth_api_mock.create_namespaced_role.side_effect = api_exc
 
         monkeypatch.setattr('sky.adaptors.kubernetes.auth_api',
                             lambda *args, **kwargs: auth_api_mock)
         monkeypatch.setattr('sky.adaptors.kubernetes.api_exception',
-                            lambda *args, **kwargs: type(api_exc))
+                            lambda *args, **kwargs: FakeApiException)
 
         config_lib._configure_autoscaler_role('default', None, provider_config,
                                               'autoscaler_role')
@@ -1054,6 +1057,7 @@ class TestRbac409ConflictHandling:
         from sky.provision.kubernetes import utils as kubernetes_utils
 
         api_exc = _make_api_exception(409, 'Conflict')
+        not_found = _make_api_exception(404, 'Not Found')
         provider_config = _make_provider_config_for_rbac()
 
         new_rb = kubernetes_utils.dict_to_k8s_object(
@@ -1062,16 +1066,16 @@ class TestRbac409ConflictHandling:
                                                   new_rb.subjects)
 
         auth_api_mock = mock.MagicMock()
-        auth_api_mock.list_namespaced_role_binding.side_effect = [
-            mock.MagicMock(items=[]),
-            mock.MagicMock(items=[existing_rb]),
+        auth_api_mock.read_namespaced_role_binding.side_effect = [
+            not_found,
+            existing_rb,
         ]
         auth_api_mock.create_namespaced_role_binding.side_effect = api_exc
 
         monkeypatch.setattr('sky.adaptors.kubernetes.auth_api',
                             lambda *args, **kwargs: auth_api_mock)
         monkeypatch.setattr('sky.adaptors.kubernetes.api_exception',
-                            lambda *args, **kwargs: type(api_exc))
+                            lambda *args, **kwargs: FakeApiException)
 
         config_lib._configure_autoscaler_role_binding(
             'default', None, provider_config, 'autoscaler_role_binding')
@@ -1081,6 +1085,7 @@ class TestRbac409ConflictHandling:
         """Test 409 on create_namespaced_role_binding re-reads and patches when
         binding differs."""
         api_exc = _make_api_exception(409, 'Conflict')
+        not_found = _make_api_exception(404, 'Not Found')
         provider_config = _make_provider_config_for_rbac()
 
         # Existing binding has different subjects.
@@ -1088,16 +1093,16 @@ class TestRbac409ConflictHandling:
                                                   subjects=['stale-subject'])
 
         auth_api_mock = mock.MagicMock()
-        auth_api_mock.list_namespaced_role_binding.side_effect = [
-            mock.MagicMock(items=[]),
-            mock.MagicMock(items=[existing_rb]),
+        auth_api_mock.read_namespaced_role_binding.side_effect = [
+            not_found,
+            existing_rb,
         ]
         auth_api_mock.create_namespaced_role_binding.side_effect = api_exc
 
         monkeypatch.setattr('sky.adaptors.kubernetes.auth_api',
                             lambda *args, **kwargs: auth_api_mock)
         monkeypatch.setattr('sky.adaptors.kubernetes.api_exception',
-                            lambda *args, **kwargs: type(api_exc))
+                            lambda *args, **kwargs: FakeApiException)
 
         config_lib._configure_autoscaler_role_binding(
             'default', None, provider_config, 'autoscaler_role_binding')
@@ -1108,6 +1113,7 @@ class TestRbac409ConflictHandling:
         from sky.provision.kubernetes import utils as kubernetes_utils
 
         api_exc = _make_api_exception(409, 'Conflict')
+        not_found = _make_api_exception(404, 'Not Found')
         provider_config = _make_provider_config_for_rbac()
 
         new_cr = kubernetes_utils.dict_to_k8s_object(
@@ -1115,16 +1121,16 @@ class TestRbac409ConflictHandling:
         existing_cr = self._make_existing_role(new_cr.rules)
 
         auth_api_mock = mock.MagicMock()
-        auth_api_mock.list_cluster_role.side_effect = [
-            mock.MagicMock(items=[]),
-            mock.MagicMock(items=[existing_cr]),
+        auth_api_mock.read_cluster_role.side_effect = [
+            not_found,
+            existing_cr,
         ]
         auth_api_mock.create_cluster_role.side_effect = api_exc
 
         monkeypatch.setattr('sky.adaptors.kubernetes.auth_api',
                             lambda *args, **kwargs: auth_api_mock)
         monkeypatch.setattr('sky.adaptors.kubernetes.api_exception',
-                            lambda *args, **kwargs: type(api_exc))
+                            lambda *args, **kwargs: FakeApiException)
 
         config_lib._configure_autoscaler_cluster_role('default', None,
                                                       provider_config)
@@ -1134,21 +1140,22 @@ class TestRbac409ConflictHandling:
         """Test 409 on create_cluster_role re-reads and patches when rules
         differ."""
         api_exc = _make_api_exception(409, 'Conflict')
+        not_found = _make_api_exception(404, 'Not Found')
         provider_config = _make_provider_config_for_rbac()
 
         existing_cr = self._make_existing_role(rules=['stale-rules'])
 
         auth_api_mock = mock.MagicMock()
-        auth_api_mock.list_cluster_role.side_effect = [
-            mock.MagicMock(items=[]),
-            mock.MagicMock(items=[existing_cr]),
+        auth_api_mock.read_cluster_role.side_effect = [
+            not_found,
+            existing_cr,
         ]
         auth_api_mock.create_cluster_role.side_effect = api_exc
 
         monkeypatch.setattr('sky.adaptors.kubernetes.auth_api',
                             lambda *args, **kwargs: auth_api_mock)
         monkeypatch.setattr('sky.adaptors.kubernetes.api_exception',
-                            lambda *args, **kwargs: type(api_exc))
+                            lambda *args, **kwargs: FakeApiException)
 
         config_lib._configure_autoscaler_cluster_role('default', None,
                                                       provider_config)
@@ -1159,6 +1166,7 @@ class TestRbac409ConflictHandling:
         from sky.provision.kubernetes import utils as kubernetes_utils
 
         api_exc = _make_api_exception(409, 'Conflict')
+        not_found = _make_api_exception(404, 'Not Found')
         provider_config = _make_provider_config_for_rbac()
 
         new_binding = kubernetes_utils.dict_to_k8s_object(
@@ -1168,16 +1176,16 @@ class TestRbac409ConflictHandling:
                                                        new_binding.subjects)
 
         auth_api_mock = mock.MagicMock()
-        auth_api_mock.list_cluster_role_binding.side_effect = [
-            mock.MagicMock(items=[]),
-            mock.MagicMock(items=[existing_binding]),
+        auth_api_mock.read_cluster_role_binding.side_effect = [
+            not_found,
+            existing_binding,
         ]
         auth_api_mock.create_cluster_role_binding.side_effect = api_exc
 
         monkeypatch.setattr('sky.adaptors.kubernetes.auth_api',
                             lambda *args, **kwargs: auth_api_mock)
         monkeypatch.setattr('sky.adaptors.kubernetes.api_exception',
-                            lambda *args, **kwargs: type(api_exc))
+                            lambda *args, **kwargs: FakeApiException)
 
         config_lib._configure_autoscaler_cluster_role_binding(
             'default', None, provider_config)
@@ -1187,22 +1195,23 @@ class TestRbac409ConflictHandling:
         """Test 409 on create_cluster_role_binding re-reads and patches when
         binding differs."""
         api_exc = _make_api_exception(409, 'Conflict')
+        not_found = _make_api_exception(404, 'Not Found')
         provider_config = _make_provider_config_for_rbac()
 
         existing_binding = self._make_existing_binding(
             role_ref='stale-role-ref', subjects=['stale-subject'])
 
         auth_api_mock = mock.MagicMock()
-        auth_api_mock.list_cluster_role_binding.side_effect = [
-            mock.MagicMock(items=[]),
-            mock.MagicMock(items=[existing_binding]),
+        auth_api_mock.read_cluster_role_binding.side_effect = [
+            not_found,
+            existing_binding,
         ]
         auth_api_mock.create_cluster_role_binding.side_effect = api_exc
 
         monkeypatch.setattr('sky.adaptors.kubernetes.auth_api',
                             lambda *args, **kwargs: auth_api_mock)
         monkeypatch.setattr('sky.adaptors.kubernetes.api_exception',
-                            lambda *args, **kwargs: type(api_exc))
+                            lambda *args, **kwargs: FakeApiException)
 
         config_lib._configure_autoscaler_cluster_role_binding(
             'default', None, provider_config)

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -1218,6 +1218,189 @@ class TestRbac409ConflictHandling:
         auth_api_mock.patch_cluster_role_binding.assert_called_once()
 
 
+class TestRbacKvCache:
+    """Tests that bootstrap_instances skips RBAC reads when kv_cache hits.
+
+    The composite kv_cache entry fingerprints all RBAC + system-namespace
+    inputs (but not cluster-specific resources like services). On a hit,
+    none of the _configure_autoscaler_* helpers should be called.
+    """
+
+    @staticmethod
+    def _make_provision_config(provider_config):
+        from sky.provision import common as provision_common
+        return provision_common.ProvisionConfig(
+            provider_config=provider_config,
+            authentication_config={},
+            docker_config={},
+            node_config={
+                'spec': {
+                    'serviceAccountName': 'skypilot-service-account',
+                },
+            },
+            count=1,
+            tags={},
+            resume_stopped_nodes=False,
+            ports_to_open_on_launch=None,
+        )
+
+    @staticmethod
+    def _patch_helpers(monkeypatch):
+        """Replace each _configure_* helper with a tracking MagicMock."""
+        helpers = {}
+        for name in [
+                '_configure_services',
+                '_configure_autoscaler_service_account',
+                '_configure_autoscaler_role',
+                '_configure_autoscaler_role_binding',
+                '_configure_autoscaler_cluster_role',
+                '_configure_autoscaler_cluster_role_binding',
+                '_configure_skypilot_system_namespace',
+                '_configure_fuse_mounting',
+        ]:
+            stub = mock.MagicMock()
+            monkeypatch.setattr(config_lib, name, stub)
+            helpers[name] = stub
+        return helpers
+
+    def test_cache_miss_runs_rbac_and_writes_entry(self, monkeypatch):
+        """On cache miss, RBAC helpers run and a cache entry is written."""
+        provider_config = _make_provider_config_for_rbac()
+        provider_config['namespace'] = 'default'
+        helpers = self._patch_helpers(monkeypatch)
+
+        get_calls = []
+        write_calls = []
+        monkeypatch.setattr(
+            'sky.utils.db.kv_cache.get_cache_entry',
+            lambda key: get_calls.append(key) or None)  # always miss
+        monkeypatch.setattr(
+            'sky.utils.db.kv_cache.add_or_update_cache_entry',
+            lambda key, value, expires_at: write_calls.append(
+                (key, value, expires_at)))
+
+        monkeypatch.setattr(
+            'sky.provision.kubernetes.utils.get_namespace_from_config',
+            lambda _: 'default')
+        monkeypatch.setattr(
+            'sky.provision.kubernetes.utils.get_context_from_config',
+            lambda _: 'ctx')
+
+        config_lib.bootstrap_instances(
+            'region', 'cluster', self._make_provision_config(provider_config))
+
+        assert len(get_calls) == 1
+        helpers['_configure_services'].assert_called_once()
+        helpers['_configure_autoscaler_service_account'].assert_called_once()
+        helpers['_configure_autoscaler_cluster_role'].assert_called_once()
+        helpers['_configure_skypilot_system_namespace'].assert_called_once()
+        # Single cache write with the same key that was looked up.
+        assert len(write_calls) == 1
+        assert write_calls[0][0] == get_calls[0]
+        assert write_calls[0][1] == '1'
+
+    def test_cache_hit_skips_rbac_no_write(self, monkeypatch):
+        """On cache hit, only services run; RBAC helpers and write are skipped.
+        """
+        provider_config = _make_provider_config_for_rbac()
+        provider_config['namespace'] = 'default'
+        helpers = self._patch_helpers(monkeypatch)
+
+        write_calls = []
+        monkeypatch.setattr('sky.utils.db.kv_cache.get_cache_entry',
+                            lambda key: '1')
+        monkeypatch.setattr(
+            'sky.utils.db.kv_cache.add_or_update_cache_entry',
+            lambda key, value, expires_at: write_calls.append(key))
+
+        monkeypatch.setattr(
+            'sky.provision.kubernetes.utils.get_namespace_from_config',
+            lambda _: 'default')
+        monkeypatch.setattr(
+            'sky.provision.kubernetes.utils.get_context_from_config',
+            lambda _: 'ctx')
+
+        config_lib.bootstrap_instances(
+            'region', 'cluster', self._make_provision_config(provider_config))
+
+        helpers['_configure_services'].assert_called_once()
+        helpers['_configure_autoscaler_service_account'].assert_not_called()
+        helpers['_configure_autoscaler_role'].assert_not_called()
+        helpers['_configure_autoscaler_role_binding'].assert_not_called()
+        helpers['_configure_autoscaler_cluster_role'].assert_not_called()
+        helpers['_configure_autoscaler_cluster_role_binding'].assert_not_called(
+        )
+        helpers['_configure_skypilot_system_namespace'].assert_not_called()
+        assert not write_calls
+
+    def test_failed_rbac_does_not_write_cache(self, monkeypatch):
+        """If any RBAC helper raises, the cache must not be written."""
+        provider_config = _make_provider_config_for_rbac()
+        provider_config['namespace'] = 'default'
+        helpers = self._patch_helpers(monkeypatch)
+        helpers['_configure_autoscaler_role'].side_effect = RuntimeError('boom')
+
+        write_calls = []
+        monkeypatch.setattr('sky.utils.db.kv_cache.get_cache_entry',
+                            lambda key: None)
+        monkeypatch.setattr(
+            'sky.utils.db.kv_cache.add_or_update_cache_entry',
+            lambda key, value, expires_at: write_calls.append(key))
+
+        monkeypatch.setattr(
+            'sky.provision.kubernetes.utils.get_namespace_from_config',
+            lambda _: 'default')
+        monkeypatch.setattr(
+            'sky.provision.kubernetes.utils.get_context_from_config',
+            lambda _: 'ctx')
+
+        with pytest.raises(RuntimeError, match='boom'):
+            config_lib.bootstrap_instances(
+                'region', 'cluster',
+                self._make_provision_config(provider_config))
+        assert not write_calls
+
+    def test_cache_key_changes_with_definition(self):
+        """Changing a role rule changes the cache key (so a SkyPilot upgrade
+        that ships new RBAC rules naturally invalidates old cache entries)."""
+        provider_config_1 = _make_provider_config_for_rbac()
+        key_1 = config_lib._rbac_cache_key('ctx', 'default', provider_config_1)
+
+        provider_config_2 = _make_provider_config_for_rbac()
+        provider_config_2['autoscaler_role']['rules'][0]['verbs'].append(
+            'watch')
+        key_2 = config_lib._rbac_cache_key('ctx', 'default', provider_config_2)
+
+        assert key_1 != key_2
+
+    def test_cache_key_stable_for_unrelated_changes(self):
+        """Changing services (cluster-specific) must NOT change the cache key,
+        otherwise every new cluster name would force a cache miss."""
+        provider_config_1 = _make_provider_config_for_rbac()
+        provider_config_1['services'] = [{
+            'metadata': {
+                'name': 'sky-aaaa-head'
+            },
+            'spec': {
+                'ports': []
+            }
+        }]
+        key_1 = config_lib._rbac_cache_key('ctx', 'default', provider_config_1)
+
+        provider_config_2 = _make_provider_config_for_rbac()
+        provider_config_2['services'] = [{
+            'metadata': {
+                'name': 'sky-bbbb-head'
+            },
+            'spec': {
+                'ports': []
+            }
+        }]
+        key_2 = config_lib._rbac_cache_key('ctx', 'default', provider_config_2)
+
+        assert key_1 == key_2
+
+
 class TestRuntimeClassOverride:
     """Tests for runtimeClassName override behavior in GPU pod specs.
 


### PR DESCRIPTION
## Summary

Three layered optimizations to the K8s `bootstrap_instances` RBAC/service setup in `sky/provision/kubernetes/config.py`. Each commit is independent and can stand on its own; together they take the steady-state (warm) provisioning path from ~2.7 s of serial K8s API work down to ~1 sqlite SELECT plus the unavoidable 2 service reads/creates.

- **Parallelize bootstrap fanout.** The independent `_configure_*` steps each issue a list+create/patch round-trip and ran serially. Fan them out across a `ThreadPoolExecutor`. RBAC references resolve at evaluation time, so creation order between siblings doesn't matter. Also parallelizes the role/role-binding pair inside `_configure_skypilot_system_namespace` and the per-service loop in `_configure_services`.
- **Switch existence checks from `list_*` + `field_selector` to `read_*` + 404.** The apiserver served single-name lookups via a LIST scan; `read_*` is a direct etcd cache GET — same semantics, faster and simpler. The 409-then-re-read path now uses `read_fn()` directly. Existing 409-conflict unit tests updated to mock `read_*`.
- **Cache RBAC verification across launches via `kv_cache`.** The 8 RBAC + system-namespace reads always return the same answer for the same `(context, namespace, RBAC definitions)`. Record a successful verification under one composite kv_cache key (sha256 fingerprint of the namespace/installation-wide inputs), TTL 5 min. On a hit, the entire RBAC fanout is skipped — 8 K8s reads collapse to one local DB SELECT. Cluster-specific resources (services) are deliberately excluded so a new cluster name doesn't invalidate the entry. The fingerprint includes the full canonicalized RBAC definitions, so SkyPilot upgrades that ship new RBAC rules invalidate old entries automatically. The cache is only written if the executor returned without raising.

### Compatibility note

The kueue plugin's `patch_configure_services` wraps `_configure_services`, which is **not** covered by the kv_cache (it stays in the always-run set, since services are cluster-specific). Plugin-added Kueue work continues to run on every launch as designed.

## Test plan

Unit tests:
- [x] `pytest tests/unit_tests/kubernetes/test_provision.py` — all 64 tests pass (5 new tests in `TestRbacKvCache` covering miss-then-write, hit-skips-helpers, failure-doesn't-write, definition-change-invalidates, services-change-doesn't-invalidate; existing 9 RBAC 409-conflict tests updated for `read_*` mocking).
- [x] `bash format.sh --files sky/provision/kubernetes/config.py` — yapf, isort, mypy, pylint all clean (10.00/10).

Manual verification on EKS:
- [x] Cold launch (cache miss): `bootstrap_instances` runs the full parallel RBAC fanout. Walltime dropped from ~2.7 s to ~890 ms with parallelization, then to ~600 ms with `read_*`.
- [x] Warm launch (cache hit): RBAC log lines disappear; only the 2 service reconciliation lines appear. Verified by inspecting cluster provisioning logs across back-to-back launches.
- [x] Cache invalidation when RBAC definitions change: bumped a role rule manually, confirmed the next launch re-runs the full RBAC fanout (different fingerprint → cache miss).
- [x] Failure does not write cache: simulated an RBAC helper exception, confirmed no kv_cache entry persisted.

Suggested CI:
- [ ] `/smoke-test --kubernetes` to exercise the parallelized + cached paths end-to-end on a real cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)