### PR TITLE
[Kubernetes] Allow apt_mirrors to be specified in skypilot config

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -876,6 +876,17 @@ class Kubernetes(clouds.Cloud):
         deploy_vars['k8s_ipc_lock_capability'] = (
             network_type.requires_ipc_lock_capability())
 
+        # User-specified APT mirror candidates for pod package installs.
+        # None means unset (template uses built-in defaults); an empty list
+        # explicitly disables fallback mirrors.
+        deploy_vars['k8s_apt_mirrors'] = (
+            skypilot_config.get_effective_region_config(
+                cloud='kubernetes',
+                region=context,
+                keys=('apt_mirrors',),
+                default_value=None,
+                override_configs=resources.cluster_config_overrides))
+
         # Docker sidecar (DinD / BuildKit) support.
         raw_docker_cfg = skypilot_config.get_effective_region_config(
             cloud='kubernetes',

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -803,7 +803,24 @@ available_node_types:
                 update_apt_sources() {
                   local host=$1
                   local apt_file=$2
-                  $(prefix_cmd) sed -i -E "s|https?://[a-zA-Z0-9.-]+\.ubuntu\.com/ubuntu|http://$host/ubuntu|g" $apt_file
+                  # || true: a sed failure on one sources file (read-only fs,
+                  # immutable bit, full tmpfs) shouldn't kill the whole step;
+                  # restore_source will undo any partial edits on the next
+                  # iteration of the candidate-mirror loop.
+                  $(prefix_cmd) sed -i -E "s|https?://[a-zA-Z0-9.-]+\.ubuntu\.com/ubuntu|http://$host/ubuntu|g" "$apt_file" || true
+                }
+                # Surface /tmp/apt-update.log to the pod's stderr on failure.
+                # Without this, users only see the terse summary line — the
+                # actual apt error stays inside the (often torn-down) pod.
+                dump_apt_log() {
+                  local log=/tmp/apt-update.log
+                  if [ -f "$log" ]; then
+                    echo "=== /tmp/apt-update.log (last 200 lines) ===" >&2
+                    tail -n 200 "$log" >&2 || true
+                    echo "=== end /tmp/apt-update.log ===" >&2
+                  else
+                    echo "/tmp/apt-update.log not found" >&2
+                  fi
                 }
                 # Install both fuse2 and fuse3 for compatibility for all possible fuse adapters in advance,
                 # so that both fusemount and fusermount3 can be masked before enabling SSH access.
@@ -880,6 +897,7 @@ available_node_types:
                     fi
                     if [ "$found_sources" = "false" ]; then
                       echo "Error: no apt sources file found" >> /tmp/apt-update.log
+                      dump_apt_log
                       break
                     fi
                   fi
@@ -917,6 +935,7 @@ available_node_types:
 
                 if [ "$INSTALL_SUCCESS" = "false" ] && [ ! -z "$INSTALL_FIRST" ]; then
                   echo "Error: core package installation failed across all sources." >> /tmp/apt-update.log
+                  dump_apt_log
                   exit 1
                 fi;
 
@@ -934,7 +953,11 @@ available_node_types:
                   https://download.docker.com/linux/$(. /etc/os-release && echo "$ID") \
                   $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
                   | $(prefix_cmd) tee /etc/apt/sources.list.d/docker.list > /dev/null
-                apt_update_install_with_retries docker-ce-cli docker-buildx-plugin >> /tmp/apt-update.log 2>&1
+                apt_update_install_with_retries docker-ce-cli docker-buildx-plugin >> /tmp/apt-update.log 2>&1 || {
+                  echo "Error: failed to install Docker CLI / buildx plugin." >> /tmp/apt-update.log
+                  dump_apt_log
+                  exit 1
+                }
                 {% endif %}
 
                 {% if k8s_fuse_device_required %}

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -854,9 +854,11 @@ available_node_types:
                 # so we only add mirror candidates for ubuntu here.
                 # Selected from https://launchpad.net/ubuntu/+archivemirrors
                 # and results from apt-select
-                MIRROR_CANDIDATES=""
-                if [ "$APT_OS" = "ubuntu" ]; then
-                  MIRROR_CANDIDATES="mirrors.wikimedia.org mirror.umd.edu"
+                if [ -z "$MIRROR_CANDIDATES" ]; then
+                  MIRROR_CANDIDATES=""
+                  if [ "$APT_OS" = "ubuntu" ]; then
+                    MIRROR_CANDIDATES="mirrors.wikimedia.org mirror.umd.edu"
+                  fi
                 fi
 
                 INSTALL_SUCCESS=false

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -854,12 +854,14 @@ available_node_types:
                 # so we only add mirror candidates for ubuntu here.
                 # Selected from https://launchpad.net/ubuntu/+archivemirrors
                 # and results from apt-select
-                if [ -z "$MIRROR_CANDIDATES" ]; then
-                  MIRROR_CANDIDATES=""
-                  if [ "$APT_OS" = "ubuntu" ]; then
-                    MIRROR_CANDIDATES="mirrors.wikimedia.org mirror.umd.edu"
-                  fi
+                {% if k8s_apt_mirrors is not none %}
+                MIRROR_CANDIDATES="{{ k8s_apt_mirrors | join(' ') }}"
+                {% else %}
+                MIRROR_CANDIDATES=""
+                if [ "$APT_OS" = "ubuntu" ]; then
+                  MIRROR_CANDIDATES="mirrors.wikimedia.org mirror.umd.edu"
                 fi
+                {% endif %}
 
                 INSTALL_SUCCESS=false
                 backup_source

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1539,6 +1539,7 @@ _CONTEXT_CONFIG_SCHEMA_KUBERNETES = {
         'type': 'array',
         'items': {
             'type': 'string',
+            'pattern': '^[a-zA-Z0-9.-]+$',
         },
     },
     'set_pod_resource_limits': {

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1532,6 +1532,15 @@ _CONTEXT_CONFIG_SCHEMA_KUBERNETES = {
             'type': 'string'
         },
     },
+    'apt_mirrors': {
+        # List of APT mirror hostnames (or empty list to disable fallback
+        # mirrors entirely) to try in order when installing packages on a
+        # provisioned pod. When unset, SkyPilot uses a built-in default list.
+        'type': 'array',
+        'items': {
+            'type': 'string',
+        },
+    },
     'set_pod_resource_limits': {
         # Can be:
         # - false: do not set limits (default)

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes.py
@@ -1371,6 +1371,250 @@ class TestKubernetesMakeDeployResourcesVariables(unittest.TestCase):
         self.assertNotIn('k8s_ephemeral_storage', deploy_vars)
         self.assertNotIn('k8s_ephemeral_storage_limit', deploy_vars)
 
+    def _setup_mocks_for_apt_mirrors_test(
+            self, mock_detect_network_type, mock_get_image, mock_get_port_mode,
+            mock_get_workspace_cloud, mock_get_workspace_region_config,
+            mock_get_cloud_config_value, mock_is_exec_auth,
+            mock_get_accelerator_label_keys, mock_get_namespace,
+            mock_get_current_context, apt_mirrors_value):
+        """Helper to set up common mocks for apt_mirrors tests.
+
+        apt_mirrors_value is the value returned for the ('apt_mirrors',) key:
+        - None: simulates the user not setting apt_mirrors at all.
+        - list: simulates an explicit apt_mirrors list (possibly empty).
+        """
+        from sky.provision.kubernetes.utils import (
+            KubernetesHighPerformanceNetworkType)
+        mock_detect_network_type.return_value = (
+            KubernetesHighPerformanceNetworkType.NONE, None)
+
+        mock_get_current_context.return_value = "my-k8s-cluster"
+        mock_get_namespace.return_value = "default"
+        mock_get_accelerator_label_keys.return_value = []
+        mock_get_workspace_cloud.return_value.get.return_value = None
+        mock_is_exec_auth.return_value = (False, None)
+
+        def workspace_config_side_effect(cloud,
+                                         region,
+                                         keys,
+                                         default_value=None,
+                                         override_configs=None):
+            if keys == ('set_pod_resource_limits',):
+                return False
+            elif keys == ('kueue', 'local_queue_name'):
+                return None
+            return default_value
+
+        mock_get_workspace_region_config.side_effect = (
+            workspace_config_side_effect)
+
+        def config_side_effect(cloud,
+                               keys,
+                               region,
+                               default_value=None,
+                               override_configs=None):
+            if keys == ('apt_mirrors',):
+                return apt_mirrors_value
+            elif keys == ('remote_identity',):
+                return 'SERVICE_ACCOUNT'
+            elif keys == ('high_availability', 'storage_class_name'):
+                return None
+            elif keys == ('provision_timeout',):
+                return 600
+            return default_value
+
+        mock_get_cloud_config_value.side_effect = config_side_effect
+
+        mock_port_mode = mock.MagicMock()
+        mock_port_mode.value = "portforward"
+        mock_get_port_mode.return_value = mock_port_mode
+        mock_get_image.return_value = "test-image:latest"
+
+    # Markers in kubernetes-ray.yml.j2 that bracket the apt-mirror selection
+    # logic. Tests render only this slice so they don't depend on the full
+    # deploy-var contract of the rest of the template.
+    _APT_MIRROR_BEGIN_MARKER = '# Build candidate list:'
+    _APT_MIRROR_END_MARKER = 'INSTALL_SUCCESS=false'
+
+    def _render_kubernetes_ray_template(self, deploy_vars):
+        """Render only the apt-mirror snippet of kubernetes-ray.yml.j2.
+
+        Reads the live template, extracts the slice between the two markers,
+        and renders it through Jinja with the provided deploy_vars. This
+        keeps the test coupled to the actual template file (so a future
+        edit can't silently desync it) while avoiding having to provide
+        every unrelated deploy var the full template requires.
+        """
+        import jinja2
+
+        import sky
+        template_path = os.path.join(os.path.dirname(sky.__file__), 'templates',
+                                     'kubernetes-ray.yml.j2')
+        with open(template_path, 'r', encoding='utf-8') as fin:
+            full = fin.read()
+        begin = full.index(self._APT_MIRROR_BEGIN_MARKER)
+        end = full.index(self._APT_MIRROR_END_MARKER, begin)
+        snippet = full[begin:end]
+        return jinja2.Template(snippet).render(**deploy_vars)
+
+    @patch('sky.provision.kubernetes.utils.get_kubernetes_nodes')
+    @patch('sky.provision.kubernetes.utils.get_current_kube_config_context_name'
+          )
+    @patch('sky.provision.kubernetes.utils.get_kube_config_context_namespace')
+    @patch('sky.provision.kubernetes.utils.get_accelerator_label_keys')
+    @patch('sky.provision.kubernetes.utils.is_kubeconfig_exec_auth')
+    @patch('sky.skypilot_config.get_effective_region_config')
+    @patch('sky.skypilot_config.get_effective_workspace_region_config')
+    @patch('sky.skypilot_config.get_workspace_cloud')
+    @patch('sky.provision.kubernetes.network_utils.get_port_mode')
+    @patch('sky.catalog.get_image_id_from_tag')
+    @patch('sky.clouds.kubernetes.Kubernetes._detect_network_type')
+    def test_apt_mirrors_unset_uses_defaults(
+            self, mock_detect_network_type, mock_get_image, mock_get_port_mode,
+            mock_get_workspace_cloud, mock_get_workspace_region_config,
+            mock_get_cloud_config_value, mock_is_exec_auth,
+            mock_get_accelerator_label_keys, mock_get_namespace,
+            mock_get_current_context, mock_get_k8s_nodes):
+        """Unset apt_mirrors falls back to built-in ubuntu mirror defaults."""
+        self._setup_mocks_for_apt_mirrors_test(mock_detect_network_type,
+                                               mock_get_image,
+                                               mock_get_port_mode,
+                                               mock_get_workspace_cloud,
+                                               mock_get_workspace_region_config,
+                                               mock_get_cloud_config_value,
+                                               mock_is_exec_auth,
+                                               mock_get_accelerator_label_keys,
+                                               mock_get_namespace,
+                                               mock_get_current_context,
+                                               apt_mirrors_value=None)
+
+        k8s_cloud = kubernetes.Kubernetes()
+        deploy_vars = k8s_cloud.make_deploy_resources_variables(
+            resources=self.resources,
+            cluster_name=resources_utils.ClusterName(
+                display_name=self.cluster_name,
+                name_on_cloud=self.cluster_name),
+            region=self.region,
+            zones=None,
+            num_nodes=1,
+            dryrun=False)
+
+        self.assertIn('k8s_apt_mirrors', deploy_vars)
+        self.assertIsNone(deploy_vars['k8s_apt_mirrors'])
+
+        rendered = self._render_kubernetes_ray_template(deploy_vars)
+        # Default branch: empty MIRROR_CANDIDATES, then the ubuntu-only
+        # override populating the wikimedia/umd mirrors.
+        self.assertIn('MIRROR_CANDIDATES=""', rendered)
+        self.assertIn(
+            'MIRROR_CANDIDATES="mirrors.wikimedia.org mirror.umd.edu"',
+            rendered)
+        self.assertIn('if [ "$APT_OS" = "ubuntu" ]; then', rendered)
+
+    @patch('sky.provision.kubernetes.utils.get_kubernetes_nodes')
+    @patch('sky.provision.kubernetes.utils.get_current_kube_config_context_name'
+          )
+    @patch('sky.provision.kubernetes.utils.get_kube_config_context_namespace')
+    @patch('sky.provision.kubernetes.utils.get_accelerator_label_keys')
+    @patch('sky.provision.kubernetes.utils.is_kubeconfig_exec_auth')
+    @patch('sky.skypilot_config.get_effective_region_config')
+    @patch('sky.skypilot_config.get_effective_workspace_region_config')
+    @patch('sky.skypilot_config.get_workspace_cloud')
+    @patch('sky.provision.kubernetes.network_utils.get_port_mode')
+    @patch('sky.catalog.get_image_id_from_tag')
+    @patch('sky.clouds.kubernetes.Kubernetes._detect_network_type')
+    def test_apt_mirrors_user_list(
+            self, mock_detect_network_type, mock_get_image, mock_get_port_mode,
+            mock_get_workspace_cloud, mock_get_workspace_region_config,
+            mock_get_cloud_config_value, mock_is_exec_auth,
+            mock_get_accelerator_label_keys, mock_get_namespace,
+            mock_get_current_context, mock_get_k8s_nodes):
+        """User-specified apt_mirrors list overrides the default fallback."""
+        user_mirrors = ['mirror.example.com', 'foo.example.com']
+        self._setup_mocks_for_apt_mirrors_test(mock_detect_network_type,
+                                               mock_get_image,
+                                               mock_get_port_mode,
+                                               mock_get_workspace_cloud,
+                                               mock_get_workspace_region_config,
+                                               mock_get_cloud_config_value,
+                                               mock_is_exec_auth,
+                                               mock_get_accelerator_label_keys,
+                                               mock_get_namespace,
+                                               mock_get_current_context,
+                                               apt_mirrors_value=user_mirrors)
+
+        k8s_cloud = kubernetes.Kubernetes()
+        deploy_vars = k8s_cloud.make_deploy_resources_variables(
+            resources=self.resources,
+            cluster_name=resources_utils.ClusterName(
+                display_name=self.cluster_name,
+                name_on_cloud=self.cluster_name),
+            region=self.region,
+            zones=None,
+            num_nodes=1,
+            dryrun=False)
+
+        self.assertEqual(deploy_vars['k8s_apt_mirrors'], user_mirrors)
+
+        rendered = self._render_kubernetes_ray_template(deploy_vars)
+        self.assertIn('MIRROR_CANDIDATES="mirror.example.com foo.example.com"',
+                      rendered)
+        # Default ubuntu branch must not be emitted.
+        self.assertNotIn(
+            'MIRROR_CANDIDATES="mirrors.wikimedia.org mirror.umd.edu"',
+            rendered)
+
+    @patch('sky.provision.kubernetes.utils.get_kubernetes_nodes')
+    @patch('sky.provision.kubernetes.utils.get_current_kube_config_context_name'
+          )
+    @patch('sky.provision.kubernetes.utils.get_kube_config_context_namespace')
+    @patch('sky.provision.kubernetes.utils.get_accelerator_label_keys')
+    @patch('sky.provision.kubernetes.utils.is_kubeconfig_exec_auth')
+    @patch('sky.skypilot_config.get_effective_region_config')
+    @patch('sky.skypilot_config.get_effective_workspace_region_config')
+    @patch('sky.skypilot_config.get_workspace_cloud')
+    @patch('sky.provision.kubernetes.network_utils.get_port_mode')
+    @patch('sky.catalog.get_image_id_from_tag')
+    @patch('sky.clouds.kubernetes.Kubernetes._detect_network_type')
+    def test_apt_mirrors_empty_list_disables_fallback(
+            self, mock_detect_network_type, mock_get_image, mock_get_port_mode,
+            mock_get_workspace_cloud, mock_get_workspace_region_config,
+            mock_get_cloud_config_value, mock_is_exec_auth,
+            mock_get_accelerator_label_keys, mock_get_namespace,
+            mock_get_current_context, mock_get_k8s_nodes):
+        """Empty apt_mirrors list disables the built-in fallback mirrors."""
+        self._setup_mocks_for_apt_mirrors_test(mock_detect_network_type,
+                                               mock_get_image,
+                                               mock_get_port_mode,
+                                               mock_get_workspace_cloud,
+                                               mock_get_workspace_region_config,
+                                               mock_get_cloud_config_value,
+                                               mock_is_exec_auth,
+                                               mock_get_accelerator_label_keys,
+                                               mock_get_namespace,
+                                               mock_get_current_context,
+                                               apt_mirrors_value=[])
+
+        k8s_cloud = kubernetes.Kubernetes()
+        deploy_vars = k8s_cloud.make_deploy_resources_variables(
+            resources=self.resources,
+            cluster_name=resources_utils.ClusterName(
+                display_name=self.cluster_name,
+                name_on_cloud=self.cluster_name),
+            region=self.region,
+            zones=None,
+            num_nodes=1,
+            dryrun=False)
+
+        self.assertEqual(deploy_vars['k8s_apt_mirrors'], [])
+
+        rendered = self._render_kubernetes_ray_template(deploy_vars)
+        self.assertIn('MIRROR_CANDIDATES=""', rendered)
+        # Default ubuntu fallback must not be emitted.
+        self.assertNotIn(
+            'MIRROR_CANDIDATES="mirrors.wikimedia.org mirror.umd.edu"',
+            rendered)
+
 
 class TestEphemeralStorageValidation(unittest.TestCase):
     """Test that ephemeral_storage is rejected on non-Kubernetes clouds."""

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes.py
@@ -1616,6 +1616,82 @@ class TestKubernetesMakeDeployResourcesVariables(unittest.TestCase):
             rendered)
 
 
+class TestKubernetesRayTemplateAptErrorHandling(unittest.TestCase):
+    """Verify error-handling invariants of the apt setup in
+    sky/templates/kubernetes-ray.yml.j2 (sed tolerance, log dumping).
+
+    These are template-source invariants (independent of Jinja vars), so we
+    inspect the raw template text rather than rendering it.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        import sky
+        template_path = os.path.join(os.path.dirname(sky.__file__), 'templates',
+                                     'kubernetes-ray.yml.j2')
+        with open(template_path, 'r', encoding='utf-8') as f:
+            cls.template = f.read()
+
+    def _slice_between(self, begin_marker, end_marker):
+        begin = self.template.index(begin_marker)
+        end = self.template.index(end_marker, begin)
+        return self.template[begin:end]
+
+    def test_update_apt_sources_tolerates_sed_failure(self):
+        """sed in update_apt_sources must not abort the step on failure.
+
+        A sed error on one sources file (read-only fs, immutable bit, full
+        tmpfs) shouldn't kill the whole apt setup — restore_source undoes
+        partial edits on the next iteration of the candidate-mirror loop.
+        Also verifies $apt_file is quoted to tolerate unusual paths.
+        """
+        snippet = self._slice_between('update_apt_sources()', '}')
+        # The sed line must be quoted and tolerant of failure.
+        self.assertIn('"$apt_file"', snippet)
+        sed_line = next(
+            (line for line in snippet.splitlines() if 'sed -i -E' in line),
+            None)
+        self.assertIsNotNone(sed_line,
+                             'expected a sed -i -E line in update_apt_sources')
+        self.assertTrue(sed_line.rstrip().endswith('|| true'),
+                        f'sed line must end with `|| true`; got: {sed_line!r}')
+
+    def test_dump_apt_log_helper_defined(self):
+        """A dump_apt_log helper must be defined and tail the log to stderr.
+
+        Without surfacing /tmp/apt-update.log to the pod's stderr, users
+        only see the terse summary line and the real apt error is lost
+        when the pod is torn down.
+        """
+        self.assertIn('dump_apt_log()', self.template)
+        helper = self._slice_between('dump_apt_log()', '}')
+        self.assertIn('/tmp/apt-update.log', helper)
+        self.assertIn('tail', helper)
+        # Output must go to stderr (>&2) so it appears in pod logs.
+        self.assertIn('>&2', helper)
+
+    def test_dump_apt_log_called_on_no_sources_found(self):
+        """No-sources-found branch must dump the log before breaking."""
+        snippet = self._slice_between('no apt sources file found', 'break')
+        self.assertIn('dump_apt_log', snippet)
+
+    def test_dump_apt_log_called_on_all_mirrors_failed(self):
+        """Final 'all sources failed' branch must dump the log before exit."""
+        snippet = self._slice_between(
+            'core package installation failed across all sources', 'fi;')
+        self.assertIn('dump_apt_log', snippet)
+        # exit 1 must come after the dump.
+        self.assertLess(snippet.index('dump_apt_log'), snippet.index('exit 1'))
+
+    def test_dump_apt_log_called_on_docker_repo_install_failure(self):
+        """Docker CLI / buildx install path must also surface the log."""
+        snippet = self._slice_between('docker-ce-cli docker-buildx-plugin',
+                                      '{% endif %}')
+        self.assertIn('dump_apt_log', snippet)
+        self.assertIn('exit 1', snippet)
+        self.assertLess(snippet.index('dump_apt_log'), snippet.index('exit 1'))
+
+
 class TestEphemeralStorageValidation(unittest.TestCase):
     """Test that ephemeral_storage is rejected on non-Kubernetes clouds."""
 


### PR DESCRIPTION
## Summary

- Adds an `apt_mirrors` field to the Kubernetes section of SkyPilot config (top-level and per-context). When set, it overrides the built-in fallback mirror list (`mirrors.wikimedia.org`, `mirror.umd.edu`) used in `sky/templates/kubernetes-ray.yml.j2`. An empty list explicitly disables fallback mirrors.
- Improves error handling in the apt setup: `update_apt_sources` quotes `"$apt_file"` and tolerates `sed` failure (`|| true`) so a single read-only / immutable sources file can't kill the whole step. A new `dump_apt_log` helper tails `/tmp/apt-update.log` to stderr on failure (no-sources-found, all-mirrors-failed, and Docker repo install paths), so the real apt error surfaces in `kubectl logs` / `sky launch` output instead of dying with the pod.

Per @Michaelvll's review on the previous iteration, configuration is now via SkyPilot config rather than the prior `MIRROR_CANDIDATES` env-var hack. Example:

```yaml
kubernetes:
  apt_mirrors:
    - mirror.math.princeton.edu
    - mirrors.kernel.org
```

## Test plan

### Unit tests (added)

`tests/unit_tests/test_sky/clouds/test_kubernetes.py`:

- `TestKubernetesMakeDeployResourcesVariables`:
  - `test_apt_mirrors_unset_uses_defaults` — unset config → built-in ubuntu fallback rendered.
  - `test_apt_mirrors_user_list` — user list rendered into `MIRROR_CANDIDATES="…"`, default branch absent.
  - `test_apt_mirrors_empty_list_disables_fallback` — `apt_mirrors: []` renders empty `MIRROR_CANDIDATES=""`, no fallback.
- `TestKubernetesRayTemplateAptErrorHandling`:
  - `test_update_apt_sources_tolerates_sed_failure` — sed line ends with `|| true` and quotes `"$apt_file"`.
  - `test_dump_apt_log_helper_defined` — helper exists and tails to stderr.
  - `test_dump_apt_log_called_on_no_sources_found`
  - `test_dump_apt_log_called_on_all_mirrors_failed`
  - `test_dump_apt_log_called_on_docker_repo_install_failure`

Run: `pytest tests/unit_tests/test_sky/clouds/test_kubernetes.py` — 121 passed.

### Manual end-to-end on Kubernetes (image: `docker:ubuntu:24.04`)

1. **Default case (no `apt_mirrors` set).** Cluster launches normally. `/tmp/apt-update.log` shows successful `apt-get update` against image defaults (`archive.ubuntu.com`, `security.ubuntu.com`); the candidate loop succeeds on iteration 1 and the user-mirror branch is never reached. Confirms the unset path is non-regressive.

2. **Single user mirror with locally-forced fallback.** With `apt_mirrors: [mirror.math.princeton.edu]` and the empty-iteration of the candidate loop temporarily skipped (test scaffolding, reverted before submission), `/tmp/apt-update.log` showed `Trying APT mirror (ubuntu): mirror.math.princeton.edu` followed by apt actually fetching `Release` from `http://mirror.math.princeton.edu/ubuntu`. This confirmed end-to-end that the config plumbed through Jinja, the rendered loop honored the candidate, and `update_apt_sources` rewrote the sources file. The launch failed at `apt-get install` because the Princeton mirror does not carry the `noble` suite — unrelated to this PR; same failure would occur with that mirror on master.

3. **Multi-mirror fallback.** With:
   ```yaml
   kubernetes:
     apt_mirrors:
       - mirror.math.princeton.edu
       - mirrors.kernel.org
   ```
   the cluster launched successfully. `/tmp/apt-update.log` shows the Princeton candidate attempted first (and failing because it lacks `noble`), the candidate loop continuing, and `mirrors.kernel.org` then succeeding — `Get:` lines hit `http://mirrors.kernel.org/ubuntu noble …` and packages installed cleanly. Confirms iteration through the user-supplied list works as intended.

4. **Error-dump path.** During scenario 2's failure, the `=== /tmp/apt-update.log (last 200 lines) === … === end /tmp/apt-update.log ===` block appeared on the pod's stderr (visible in `kubectl logs`) before `exit 1`. Pre-PR, the same scenario would have surfaced only the terse `Error: core package installation failed across all sources.` line.

### Code formatting

- `bash format.sh --files sky/clouds/kubernetes.py sky/utils/schemas.py sky/templates/kubernetes-ray.yml.j2 tests/unit_tests/test_sky/clouds/test_kubernetes.py` — black, yapf, isort, mypy clean.

### CI checklist

- [x] Code formatting: \`bash format.sh\`
- [x] Manual tests for this PR (above)
- [ ] All smoke tests: \`/smoke-test\`
- [ ] Relevant individual tests: \`/smoke-test -k test_name\`
- [ ] Backward compatibility: \`/quicktest-core\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)