### PR TITLE
[Dashboard] Default Managed Jobs table sort to ID descending

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -452,8 +452,8 @@ export function ManagedJobsTable({
   lastFetchedTime,
 }) {
   const [sortConfig, setSortConfig] = useState({
-    key: null,
-    direction: 'ascending',
+    key: 'id',
+    direction: 'descending',
   });
   const [loading, setLocalLoading] = useState(false);
   const [isInitialLoad, setIsInitialLoad] = useState(true);


### PR DESCRIPTION
## Summary

The Managed Jobs table previously used the API default sort (`submitted_at desc`). When many jobs are submitted within the same second — batch submissions, load testing, scheduled runs — the secondary order from Postgres is non-deterministic, so paging through the table can show e.g. ID 1533 next to ID 1535 next to ID 1532 in the same page.

This PR changes the default \`sortConfig\` for \`ManagedJobsTable\` to \`{key: 'id', direction: 'descending'}\`. The result is the same view a user gets after a single click on the ID column header — stable, monotonically decreasing IDs across pages. Manually clicking a different column header still works exactly as before.

## Test plan

- [ ] Navigate to \`/dashboard/jobs\` with many jobs in the table; confirm IDs are strictly descending across page 1, 2, 3, …
- [ ] Click the ID column header once; confirm direction toggles to ascending.
- [ ] Click another column header (Name, User, Status); confirm sort changes accordingly.
- [ ] Refresh the page; confirm default sort returns to ID descending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)