### PR TITLE
[Vast] Don't pin search_offers to the catalog row's geolocation

### DIFF
--- a/sky/provision/vast/utils.py
+++ b/sky/provision/vast/utils.py
@@ -113,8 +113,6 @@ def launch(name: str,
 
     query = [
         'chunked=true',
-        'georegion=true',
-        f'geolocation="{region[-2:]}"',
         f'disk_space>={disk_size}',
         f'num_gpus={num_gpus}',
         f'gpu_name="{gpu_name}"',


### PR DESCRIPTION
The Vast catalog stores one snapshot row per (gpu, count) tuple, carrying
whatever geolocation that snapshot happened to come from. The provisioning
query then pins on it (`georegion=true` + `geolocation="XX"`), so Vast
rejects every live offer outside that single country — even when the
marketplace has plenty of matching machines elsewhere.

Concrete repro today:
- Catalog row for `2x-H100_SXM-32-65536` has `Region = "South Korea, KR, AS"`
  (the snapshot at catalog-build time).
- `vastai search offers 'gpu_name="H100 SXM" num_gpus=2'` returns 17 live
  offers worldwide; none in Asia (France, Japan, Czechia, Netherlands,
  Montana, Virginia, India, ...).
- Result: `sky launch` fails with
  `could not find an offer that satisfies "... geolocation=AS ..."`,
  even with `--retry-until-up`.

This drops the geo filters from the `search_offers` query so Vast returns
any rentable offer satisfying the GPU / disk / RAM requirements. The
Region column still drives the optimizer's price/region display; only
provisioning is no longer geographically constrained. As a side effect
the optimizer's "Considered resources" table can show a misleading region
(e.g. "South Korea") when the actual machine ends up elsewhere — happy
to follow up with a separate PR to overwrite the cluster's stored region
with the offer's real `geolocation` post-provision if that's of interest.

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Manual test: launching `H100:2` on Vast — before patch, provisioning fails on stale Asia pin; after patch, successfully provisions a France machine listed in `vastai search offers`.
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)