### PR TITLE
[Core] Fix ordered accelerator list ignoring user-specified priority

### DIFF
--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1439,19 +1439,12 @@ class Optimizer:
                 for resources in task.resources:
                     # Check if there exists launchable resources
                     local_task.set_resources(resources)
-                    # set_resources() may copy the Resources object, e.g. to
-                    # attach Docker login config. _fill_in_launchable_resources
-                    # keys its result by the post-processed resource in
-                    # local_task.resources, so use that singleton resource
-                    # instead of the original loop variable.
-                    assert len(local_task.resources) == 1, local_task.resources
-                    requested_resources = list(local_task.resources)[0]
                     launchable_resources_map, _, _, _ = (
                         _fill_in_launchable_resources(
                             task=local_task,
                             blocked_resources=blocked_resources,
                             quiet=False))
-                    if launchable_resources_map.get(requested_resources, []):
+                    if any(launchable_resources_map.values()):
                         break
 
         local_graph = local_dag.get_graph()

--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -761,6 +761,63 @@ def test_ordered_resources(enable_all_clouds):
         sys.stdout = original_stdout  # Restore original stdout
 
 
+def test_ordered_resources_with_docker_image(enable_all_clouds):
+    """Tests that ordered resources with docker images respect user order.
+
+    Regression test: when set_resources() transforms Resources objects through
+    _with_docker_login_config (which calls .copy()), the resulting objects have
+    different identity than the originals. Since Resources has no __eq__ or
+    __hash__, the old code's `launchable_resources_map.get(resources, [])`
+    lookup would always miss, causing the loop to fall through to the last
+    accelerator instead of selecting the first launchable one.
+    """
+    import copy
+    from unittest.mock import patch
+
+    original_fill = optimizer._fill_in_launchable_resources
+
+    def _fill_with_copied_keys(task, blocked_resources, quiet=False):
+        """Wraps _fill_in_launchable_resources to replace map keys with
+        copies, simulating what happens when set_resources() transforms
+        Resources through _with_docker_login_config's .copy() call."""
+        launchable, cloud_candidates, fuzzy, hints = original_fill(
+            task, blocked_resources, quiet)
+        # Replace each key with a deep copy to break object identity,
+        # simulating the .copy() path in _with_docker_login_config.
+        new_launchable = {}
+        for k, v in launchable.items():
+            new_launchable[copy.deepcopy(k)] = v
+        return new_launchable, cloud_candidates, fuzzy, hints
+
+    captured_output = io.StringIO()
+    captured_output.fileno = lambda: 1
+    original_stdout = sys.stdout
+    try:
+        sys.stdout = captured_output
+
+        with sky.Dag() as dag:
+            task = sky.Task('test_task')
+            task.set_resources([
+                sky.Resources(accelerators={'V100': 1}),
+                sky.Resources(accelerators={'T4': 1}),
+                sky.Resources(accelerators={'K80': 1}),
+            ])
+        with patch('sky.optimizer._fill_in_launchable_resources',
+                   side_effect=_fill_with_copied_keys):
+            dag = sky.optimize(dag)
+
+        output = captured_output.getvalue()
+        assert any(
+            'V100' in line and '\u2714' in line for line in output.splitlines()
+        ), ('Expected V100 (first in ordered list) to be chosen, but it was '
+            'not. This indicates the optimizer is not respecting user-specified '
+            'accelerator ordering when Resources objects lose identity '
+            '(e.g. due to docker image config transforms).\n'
+            f'Output:\n{output}')
+    finally:
+        sys.stdout = original_stdout
+
+
 def test_disk_tier_mismatch(enable_all_clouds):
     for cloud in registry.CLOUD_REGISTRY.values():
         for tier in cloud._SUPPORTED_DISK_TIERS:


### PR DESCRIPTION
 ## Summary
  - Fixes a bug where ordered accelerator lists (e.g. `[RTX3090, RTX5090]`) always select the **last** entry instead of trying them in the user-specified order
  - Root cause: `set_resources()` transforms `Resources` objects through `_with_docker_login_config()` which calls `.copy()`, creating new objects. Since `Resources` uses default Python object identity (no `__eq__`/`__hash__`), the
  `launchable_resources_map.get(resources, [])` lookup always misses, the loop never breaks, and it falls through to the last accelerator
  - One-line fix: check `any(v for v in launchable_resources_map.values())` instead of looking up a stale object reference. At this point in the loop the task has exactly one resource set, so this is equivalent to the intended check

  **Affects:** Any task with docker `image_id` (or RunPod docker username) that uses ordered accelerator lists. Tasks without docker images are unaffected because `_with_docker_login_config` returns early without copying.

  ## Test plan
  - Existing test `test_ordered_resources` continues to pass (but does not cover the docker image case)
  - Manual test on Kubernetes with ordered `[RTX3090, RTX5090]` accelerators and docker image: before the fix, RTX5090 was always chosen; after the fix, RTX3090 is correctly chosen first
  - A stronger test covering the docker image case should be added (the existing `test_ordered_resources` uses plain Resources without docker images)



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
