### PR TITLE
[CI] Fix shell injection in pytest.yml via untrusted github.event interpolation

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -84,24 +84,30 @@ jobs:
           uv pip install pytest pytest-xdist pytest-env>=0.6 pytest-asyncio memory-profiler==0.61.0 buildkite-test-collector
       - name: Set branch name and commit message
         id: set_env
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          MERGE_GROUP_HEAD_COMMIT_MESSAGE: ${{ github.event.merge_group.head_commit.message }}
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
+            echo "branch=$HEAD_REF" >> $GITHUB_OUTPUT
             {
               echo "message<<EOF"
-              echo "${{ github.event.pull_request.title }}"
+              echo "$PR_TITLE"
               echo "EOF"
             } >> $GITHUB_OUTPUT
           else
-            echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            echo "branch=$REF_NAME" >> $GITHUB_OUTPUT
             # For push events after merge, head_commit.message contains the merge commit message
             # which includes the PR title. For merge_group events, use merge_group.head_commit.message
             {
               echo "message<<EOF"
               if [ "${{ github.event_name }}" == "merge_group" ]; then
-                echo "${{ github.event.merge_group.head_commit.message }}"
+                echo "$MERGE_GROUP_HEAD_COMMIT_MESSAGE"
               else
-                echo "${{ github.event.head_commit.message }}"
+                echo "$HEAD_COMMIT_MESSAGE"
               fi
               echo "EOF"
             } >> $GITHUB_OUTPUT
@@ -110,10 +116,12 @@ jobs:
         env:
           TEST_PATH: ${{ matrix.test-path }}
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_ANALYTICS_TOKEN }}
+          BRANCH: ${{ steps.set_env.outputs.branch }}
+          COMMIT_MESSAGE: ${{ steps.set_env.outputs.message }}
         run: |
           source ~/test-env/bin/activate
-          export GITHUB_REF="${{ steps.set_env.outputs.branch }}"
-          export TEST_ANALYTICS_COMMIT_MESSAGE="${{ steps.set_env.outputs.message }}"
+          export GITHUB_REF="$BRANCH"
+          export TEST_ANALYTICS_COMMIT_MESSAGE="$COMMIT_MESSAGE"
           SKYPILOT_DISABLE_USAGE_COLLECTION=1 SKYPILOT_SKIP_CLOUD_IDENTITY_CHECK=1 eval "pytest -n 0 --dist no $TEST_PATH"
 
   failover-test:
@@ -148,24 +156,30 @@ jobs:
           uv pip install pytest pytest-xdist pytest-env>=0.6 pytest-asyncio memory-profiler==0.61.0 moto==5.1.2 buildkite-test-collector
       - name: Set branch name and commit message
         id: set_env
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          MERGE_GROUP_HEAD_COMMIT_MESSAGE: ${{ github.event.merge_group.head_commit.message }}
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
+            echo "branch=$HEAD_REF" >> $GITHUB_OUTPUT
             {
               echo "message<<EOF"
-              echo "${{ github.event.pull_request.title }}"
+              echo "$PR_TITLE"
               echo "EOF"
             } >> $GITHUB_OUTPUT
           else
-            echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            echo "branch=$REF_NAME" >> $GITHUB_OUTPUT
             # For push events after merge, head_commit.message contains the merge commit message
             # which includes the PR title. For merge_group events, use merge_group.head_commit.message
             {
               echo "message<<EOF"
               if [ "${{ github.event_name }}" == "merge_group" ]; then
-                echo "${{ github.event.merge_group.head_commit.message }}"
+                echo "$MERGE_GROUP_HEAD_COMMIT_MESSAGE"
               else
-                echo "${{ github.event.head_commit.message }}"
+                echo "$HEAD_COMMIT_MESSAGE"
               fi
               echo "EOF"
             } >> $GITHUB_OUTPUT
@@ -173,8 +187,10 @@ jobs:
       - name: Run tests with pytest
         env:
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_ANALYTICS_TOKEN }}
+          BRANCH: ${{ steps.set_env.outputs.branch }}
+          COMMIT_MESSAGE: ${{ steps.set_env.outputs.message }}
         run: |
           source ~/test-env/bin/activate
-          export GITHUB_REF="${{ steps.set_env.outputs.branch }}"
-          export TEST_ANALYTICS_COMMIT_MESSAGE="${{ steps.set_env.outputs.message }}"
+          export GITHUB_REF="$BRANCH"
+          export TEST_ANALYTICS_COMMIT_MESSAGE="$COMMIT_MESSAGE"
           SKYPILOT_DISABLE_USAGE_COLLECTION=1 SKYPILOT_SKIP_CLOUD_IDENTITY_CHECK=1 pytest -n 4 --dist worksteal ${{ matrix.test-path }}


### PR DESCRIPTION
Closes #9530.

The `set_env` steps in `unit-test` and `failover-test` jobs interpolated `${{ github.event.pull_request.title }}`, `${{ github.event.head_commit.message }}`, `${{ github.head_ref }}`, and similar untrusted contexts directly into bash `run:` scripts. When such a value contained backticks around a valid CLI command, bash performed command substitution on the runner — the script injection pattern documented in [GitHub's Security Hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable).

This change applies the recommended intermediate-environment-variable pattern: each `${{ ... }}` value is assigned to an `env:` entry and referenced as `$VAR` inside the script. Same `set_env` outputs (`branch`, `message`); same downstream consumer (`TEST_ANALYTICS_COMMIT_MESSAGE`); only the path from `${{ ... }}` → bash literal is replaced.

### Verification

[zizmor](https://docs.zizmor.sh) v1.24.1 with the `template-injection` audit:

| | findings (template-injection) |
|---|---|
| current `master` | 5 (4 High confidence) |
| this PR | **0** |

Other audits on the file (`artipacked`, `excessive-permissions`) flag separate hardening opportunities and are out of scope here.

### Notes on test reliability

The interpolated values feed `TEST_ANALYTICS_COMMIT_MESSAGE`, a Buildkite analytics tag — they do not affect test pass/fail logic. The fix preserves the captured value with no corruption (literal title/message instead of a backtick-mangled one), so analytics quality improves and test reliability is unchanged.

### Tested

- [x] Code formatting: workflow YAML only, no Python; not applicable.
- [x] Manual / new tests: `zizmor` run against the workflow before and after the change confirms `template-injection` findings drop from 5 to 0. Reproduction of the original bug is documented in #9530.
- [ ] All smoke tests: not run (this change is CI-only and does not touch test code).
- [ ] Relevant individual smoke tests: not applicable.
- [ ] Backward compatibility: not applicable (output schema and downstream consumer are unchanged).
