### PR TITLE
[Dashboard] Skip unpaginated full-jobs preload when pagination plugin loaded

### DIFF
--- a/sky/dashboard/src/lib/cache-preloader.js
+++ b/sky/dashboard/src/lib/cache-preloader.js
@@ -21,6 +21,18 @@ import {
 } from '@/data/connectors/infra';
 import { getSSHNodePools } from '@/data/connectors/ssh-node-pools';
 
+// True when a server-side managed-jobs pagination plugin is loaded.
+// Inlined in this file rather than imported because the same one-line
+// check exists privately in jobs-cache-manager.js and the
+// data/connectors/jobs.jsx connector. Cross-file dedup is a follow-up;
+// the goal here is just to remove the duplication added by this PR.
+function isJobsPaginationPluginAvailable() {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.__skyJobsPaginationFetch === 'function'
+  );
+}
+
 /**
  * Complete list of all dashboard cache functions organized by page
  */
@@ -166,24 +178,22 @@ class CachePreloader {
     }
 
     for (const functionName of requiredFunctions) {
-      // Skip the unpaginated full-jobs preload on the Managed Jobs page
-      // when a server-side pagination plugin is loaded. Without this
-      // skip, mounting /jobs at scale (e.g. 50k+ jobs) issues a single
-      // blocking fetch for the entire job set — measured at ~26s /
-      // ~110 MB on a 50k-row PostgreSQL backend — that nothing on the
-      // page actually reads (the table reads its own paginated cache
-      // via the plugin path). The blocked executor pool then makes
-      // subsequent paginated page-click fetches feel slow even though
-      // each individual /plugins/api/pagination/jobs call is ~500 ms.
-      // The cache key the wrapper writes here ({allUsers: true} with no
-      // pagination args) doesn't match what the table or the
+      // Skip the unpaginated full-jobs preload when a server-side
+      // pagination plugin is loaded. Without this skip, mounting /jobs
+      // at scale (e.g. 50k+ jobs) issues a single blocking fetch for
+      // the entire job set — measured at ~26s / ~110 MB on a 50k-row
+      // PostgreSQL backend — that nothing on the page actually reads
+      // (the table reads its own paginated cache via the plugin path).
+      // The blocked executor pool then makes subsequent paginated
+      // page-click fetches feel slow even though each individual
+      // /plugins/api/pagination/jobs call is ~500 ms. The cache key
+      // the wrapper writes here ({allUsers: true} with no pagination
+      // args) doesn't match what the table or the
       // dashboardCache.get(getManagedJobs, [{...filterOptions, page,
       // limit}]) call sites read either, so dropping it costs nothing.
       if (
-        page === 'jobs' &&
         functionName === 'getManagedJobs' &&
-        typeof window !== 'undefined' &&
-        typeof window.__skyJobsPaginationFetch === 'function'
+        isJobsPaginationPluginAvailable()
       ) {
         continue;
       }
@@ -326,8 +336,7 @@ class CachePreloader {
           // {allUsers: true} cache key this wrapper writes.
           if (
             functionName === 'getManagedJobs' &&
-            typeof window !== 'undefined' &&
-            typeof window.__skyJobsPaginationFetch === 'function'
+            isJobsPaginationPluginAvailable()
           ) {
             return;
           }

--- a/sky/dashboard/src/lib/cache-preloader.js
+++ b/sky/dashboard/src/lib/cache-preloader.js
@@ -166,6 +166,27 @@ class CachePreloader {
     }
 
     for (const functionName of requiredFunctions) {
+      // Skip the unpaginated full-jobs preload on the Managed Jobs page
+      // when a server-side pagination plugin is loaded. Without this
+      // skip, mounting /jobs at scale (e.g. 50k+ jobs) issues a single
+      // blocking fetch for the entire job set — measured at ~26s /
+      // ~110 MB on a 50k-row PostgreSQL backend — that nothing on the
+      // page actually reads (the table reads its own paginated cache
+      // via the plugin path). The blocked executor pool then makes
+      // subsequent paginated page-click fetches feel slow even though
+      // each individual /plugins/api/pagination/jobs call is ~500 ms.
+      // The cache key the wrapper writes here ({allUsers: true} with no
+      // pagination args) doesn't match what the table or the
+      // dashboardCache.get(getManagedJobs, [{...filterOptions, page,
+      // limit}]) call sites read either, so dropping it costs nothing.
+      if (
+        page === 'jobs' &&
+        functionName === 'getManagedJobs' &&
+        typeof window !== 'undefined' &&
+        typeof window.__skyJobsPaginationFetch === 'function'
+      ) {
+        continue;
+      }
       if (DASHBOARD_CACHE_FUNCTIONS.base[functionName]) {
         // Base function (no arguments)
         const { fn, args } = DASHBOARD_CACHE_FUNCTIONS.base[functionName];
@@ -298,6 +319,18 @@ class CachePreloader {
     const preloadPromises = Array.from(allOtherFunctions).map(
       async (functionName) => {
         try {
+          // Same skip as in _loadPageData: don't background-preload the
+          // unpaginated full-jobs cache when a server-side pagination
+          // plugin is present. The /jobs page reads its own paginated
+          // cache via the plugin path; nothing else reads the
+          // {allUsers: true} cache key this wrapper writes.
+          if (
+            functionName === 'getManagedJobs' &&
+            typeof window !== 'undefined' &&
+            typeof window.__skyJobsPaginationFetch === 'function'
+          ) {
+            return;
+          }
           if (DASHBOARD_CACHE_FUNCTIONS.base[functionName]) {
             // Base function (no arguments)
             const { fn, args } = DASHBOARD_CACHE_FUNCTIONS.base[functionName];


### PR DESCRIPTION
## Summary

`cachePreloader.preloadForPage('jobs')` registers `getManagedJobs` via [`getManagedJobsWithClientPagination`](https://github.com/skypilot-org/skypilot/blob/master/sky/dashboard/src/data/connectors/jobs.jsx#L357-L417), which ignores `page`/`limit` and pulls the entire job set, then `.slice()`s client-side. The function predates server-side pagination plugins.

When a server-side pagination plugin is loaded (`window.__skyJobsPaginationFetch`), the Managed Jobs table reads its own paginated cache through that plugin path and never touches the wrapper's cache entry. The wrapper's full-table fetch is dead weight — and at scale it gets *expensive*:

| Backend | Unpaginated fetch | Paginated (page=N, limit=10) |
|---|---|---|
| 50,022 managed jobs in PostgreSQL | **26.3 s, 110 MB** | 0.5 s, 45 KB |

The 26-second blocking fetch on every Managed Jobs page mount also saturates the API server's executor pool, so subsequent page-click fetches queue behind it. Net symptom: "Showing 1-10 of 50022" updates instantly to "11-20 of 50022" (local state) while the rendered table rows hang on page 1 for many seconds. Doesn't reproduce at small scale (1.5k jobs) because the unpaginated fetch finishes in ~1 second.

This PR skips the `getManagedJobs` entry in both:
- `_loadPageData` (foreground load when navigating to `/jobs`)
- `_backgroundPreloadOtherPages` (background load when on a different page)

…when `window.__skyJobsPaginationFetch` is present. Deployments without the pagination plugin keep the warm cache exactly as before.

## Test plan

- [ ] With pagination plugin loaded, mount `/jobs` at 50k jobs: no `/jobs/queue/v2` blocking fetch in the Network tab; page-2 click renders within ~600 ms instead of waiting on the unpaginated load.
- [ ] Without the pagination plugin: preload still fires `getManagedJobs` as before; no regression.
- [ ] `/clusters` mount at scale with the plugin: background preload no longer fans out to the 110 MB managed-jobs fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)