### PR TITLE
[Core] Add has_skylet to ProvisionRuntimeMetadata and guard autostop checks

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2681,9 +2681,11 @@ def _update_cluster_status(
         # run_ray_status_to_check_all_nodes_up() is slow due to calling `ray get
         # head-ip/worker-ips`.
 
-        # Check if the cluster is in the process of autostopping
+        # Check if the cluster is in the process of autostopping.
+        # Skip for clusters without skylet — they have no autostop.
         backend = get_backend_from_handle(handle)
-        if isinstance(backend, backends.CloudVmRayBackend):
+        if (handle.provision_runtime_metadata.has_skylet and
+                isinstance(backend, backends.CloudVmRayBackend)):
             if backend.is_definitely_autostopping(handle, stream_logs=False):
                 return _handle_autostopping_cluster(print_newline=False)
 
@@ -2849,7 +2851,8 @@ def _update_cluster_status(
                         f'{common_utils.format_exception(e)}')
 
             backend = get_backend_from_handle(handle)
-            if isinstance(backend, backends.CloudVmRayBackend):
+            if (handle.provision_runtime_metadata.has_skylet and
+                    isinstance(backend, backends.CloudVmRayBackend)):
                 # Check autostopping first, before head_node_alive check
                 # This ensures we detect AUTOSTOPPING even when Ray becomes
                 # unhealthy during hook execution, or if the actual nodes are

--- a/sky/provision/common.py
+++ b/sky/provision/common.py
@@ -95,6 +95,8 @@ class ProvisionRuntimeMetadata:
 
     # Whether ray is running on the cluster.
     has_ray: bool = True
+    # Whether skylet is running on the cluster.
+    has_skylet: bool = True
     # Whether the cluster runs a job queue (ray + skylet bookkeeping) that
     # can accept multiple ``sky exec`` submissions over its lifetime. False
     # for single-use clusters where the job is baked into the provisioned


### PR DESCRIPTION
## Summary
- Add `has_skylet` field to `ProvisionRuntimeMetadata` (defaults to `True`) so provisioners can declare whether skylet is running on the cluster.
- Guard both `is_definitely_autostopping` call sites in `_update_cluster_status` with `has_skylet`, since the autostop check requires gRPC/SSH to skylet. Without this guard, clusters provisioned without skylet hit a RuntimeError during status refresh.

## Test plan
- [x] Unit tests pass (`pytest tests/unit_tests/ -q`)
- [ ] Smoke test: verify standard managed jobs on AWS still work identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)