### PR TITLE
[GCP] Bump gcloud SDK to 567.0.0 for pyOpenSSL compatibility

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -64,7 +64,10 @@ _CREDENTIAL_FILES = [
 # NOTE: do not expanduser() on this path. It's used as a destination path on the
 # remote cluster.
 _GCLOUD_INSTALLATION_LOG = '~/.sky/logs/gcloud_installation.log'
-_GCLOUD_VERSION = '424.0.0'
+# Bump carefully: this determines the gsutil version on remote VMs.
+# 567.0.0 bundles gsutil 5.37 which fixes pyOpenSSL >= 24.3.0 compatibility
+# (OpenSSL.crypto.sign was removed in pyOpenSSL 24.3.0).
+_GCLOUD_VERSION = '567.0.0'
 # Need to be run with /bin/bash
 # We factor out the installation logic to keep it align in both spot
 # controller and cloud stores.

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -67,6 +67,7 @@ _GCLOUD_INSTALLATION_LOG = '~/.sky/logs/gcloud_installation.log'
 # Bump carefully: this determines the gsutil version on remote VMs.
 # 567.0.0 bundles gsutil 5.37 which fixes pyOpenSSL >= 24.3.0 compatibility
 # (OpenSSL.crypto.sign was removed in pyOpenSSL 24.3.0).
+# https://cloud.google.com/sdk/docs/release-notes#56700_2026-05-05
 _GCLOUD_VERSION = '567.0.0'
 # Need to be run with /bin/bash
 # We factor out the installation logic to keep it align in both spot


### PR DESCRIPTION
## Summary
- Bumps the pinned gcloud SDK version from 424.0.0 to 567.0.0 on remote VMs
- SDK 567.0.0 bundles gsutil 5.37, which replaces removed `OpenSSL.crypto.sign` with `cryptography` library equivalents
- Fixes GCS storage test failures (`TestStorageWithCredentials`) caused by PR #8070 dropping the `pyopenssl < 24.3.0` upper bound

## Context
PR #8070 removed the pyopenssl upper bound to unblock upgrading `cryptography >= 44.0.1` (CVE fix GHSA-79v4-65xg-pq4g). This broke gsutil on CI because the bundled gsutil 5.21 (from SDK 424.0.0) uses `OpenSSL.crypto.sign`, which was removed in pyOpenSSL 24.3.0.

## Remote VM gcloud usage surface area
The SDK installed on remote VMs is used for 4 things:
1. **gsutil** — storage sync (cp, rsync, ls, rm)
2. **gcloud auth activate-service-account** — credential setup for gsutil
3. **gcloud auth configure-docker** — for GCR/Artifact Registry image pulls
4. **gcloud components install gke-gcloud-auth-plugin** — on controllers with K8s enabled

All other gcloud commands (TPU create/delete, MIG wait-until, services enable, compute images, etc.) run locally on the API server using the user's own gcloud SDK, not the one being bumped here.

## Test plan
- [x] `/smoke-test --gcp` — 266/270 passed. 4 failures all unrelated to SDK bump:
  - `test_gcp_network_tier_with_gpu` — H100x8 capacity unavailable in asia-southeast1
  - `test_gcp_mig` — timed out after 900s provisioning 2-node L4 MIG (infra)
  - `test_file_mounts` — pre-existing code bug on master (`ValueError: relative path`)
  - `test_cli_auto_retry` — transient `Response ended prematurely` network errors
- [x] `test_workdir_with_pyproject` with `us-docker.pkg.dev` images passed — confirms `gcloud auth configure-docker` works with SDK 567.0.0
- [x] All `TestStorageWithCredentials` GCS tests passed (previously failing with `OpenSSL.crypto.sign` error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)