### PR TITLE
[Core] Fix regression: relative file_mount destinations rejected

### DIFF
--- a/sky/task.py
+++ b/sky/task.py
@@ -560,7 +560,6 @@ class Task:
 
     def _validate_mount_path(self, path: str, location: str):
         self._validate_path(path, location)
-        self._validate_mount_dest_is_absolute(path, location)
         # TODO(zhwu): /home/username/sky_workdir as the target path need
         # to be filtered out as well.
         if (path == constants.SKY_REMOTE_WORKDIR and self.workdir is not None):
@@ -1004,6 +1003,7 @@ class Task:
         volume_mounts: List[volume_lib.VolumeMount] = []
         for dst_path, vol in self._volumes.items():
             self._validate_mount_path(dst_path, location='volumes')
+            self._validate_mount_dest_is_absolute(dst_path, location='volumes')
             # Shortcut for `dst_path: volume_name` (external persistent volume)
             if isinstance(vol, str):
                 volume_mount = volume_lib.VolumeMount.resolve(dst_path, vol)

--- a/tests/test_yaml_parser.py
+++ b/tests/test_yaml_parser.py
@@ -216,14 +216,13 @@ def test_anyof_error_points_at_inner_problem(tmp_path):
     assert 'ten' in msg
 
 
-def test_file_mounts_dest_must_be_absolute(tmp_path):
-    """Relative file_mount destination paths used to be accepted silently.
+def test_file_mounts_relative_dest_accepted(tmp_path):
+    """Relative file_mount destinations are placed under ~/sky_workdir/.
 
-    A relative remote path is almost never what the user wants and was
-    previously stored verbatim, producing confusing behavior on the
-    remote machine. Reject it with a clear message.
+    The backend prepends SKY_REMOTE_WORKDIR to relative destinations
+    (cloud_vm_ray_backend.py), so they must not be rejected at
+    validation time.
     """
-    # Need a real source file so we don't fail on that check first.
     src = tmp_path / 'local.txt'
     src.write_text('hi')
     config_path = _create_config_file(
@@ -233,15 +232,11 @@ def test_file_mounts_dest_must_be_absolute(tmp_path):
                 relative/dest: {src}
             """), tmp_path)
     task = Task.from_yaml(config_path)
-    with pytest.raises(ValueError) as e:
-        task.expand_and_validate_file_mounts()
-    msg = str(e.value)
-    assert 'relative/dest' in msg
-    assert 'absolute' in msg
+    task.expand_and_validate_file_mounts()
+    assert 'relative/dest' in task.file_mounts
 
 
-def test_file_mounts_empty_task_is_not_triggered_by_file_mounts(tmp_path):
-    # Sanity: an absolute destination still works.
+def test_file_mounts_absolute_dest_accepted(tmp_path):
     src = tmp_path / 'local.txt'
     src.write_text('hi')
     config_path = _create_config_file(
@@ -251,6 +246,7 @@ def test_file_mounts_empty_task_is_not_triggered_by_file_mounts(tmp_path):
                 /remote/dest: {src}
             """), tmp_path)
     task = Task.from_yaml(config_path)
+    task.expand_and_validate_file_mounts()
     assert '/remote/dest' in task.file_mounts
 
 


### PR DESCRIPTION
## Summary
- #9423 added validation rejecting non-absolute `file_mounts` destination paths, but relative destinations are an intentionally supported feature — the backend prepends `~/sky_workdir/` to them (`cloud_vm_ray_backend.py:6118`)

https://github.com/skypilot-org/skypilot/blob/b7a9653f76440b3cc883b35b5ec1eb61245b4fe7/sky/backends/cloud_vm_ray_backend.py#L6113-L6119

- This broke `examples/using_file_mounts.yaml` and the `test_file_mounts` smoke test on all clouds.
- Fix: move the absolute-path check out of `_validate_mount_path` (shared by file_mounts and volumes) and apply it only to volume mounts, where relative paths genuinely don't work (they map directly to container `mountPath` with no workdir prepend).

## Test plan
- [x] `pytest tests/test_yaml_parser.py -n0 --noconftest` — all 22 tests pass
- [x] `/smoke-test --gcp` — `test_file_mounts` should pass again

🤖 Generated with [Claude Code](https://claude.com/claude-code)