### PR TITLE
[Core] Allow relative file_mounts destinations again

### DIFF
--- a/examples/using_file_mounts.yaml
+++ b/examples/using_file_mounts.yaml
@@ -56,7 +56,8 @@ file_mounts:
   #   c
   /tmp/workdir: ~/tmp-workdir
 
-  # Relative paths are under ~/ (after sync, ~/relative_dir/ exists).
+  # Relative paths are under ~/sky_workdir/ — the remote workdir
+  # (after sync, ~/sky_workdir/relative_dir/ exists).
   relative_dir: ~/tmp-workdir
   ./dotslash_relative_dir: ~/tmp-workdir
 

--- a/sky/task.py
+++ b/sky/task.py
@@ -560,7 +560,10 @@ class Task:
 
     def _validate_mount_path(self, path: str, location: str):
         self._validate_path(path, location)
-        self._validate_mount_dest_is_absolute(path, location)
+        # Note: file_mounts intentionally allow relative destinations —
+        # `cloud_vm_ray_backend` resolves them against ~/sky_workdir at
+        # provision time. Volumes do require absolute paths and call
+        # `_validate_mount_dest_is_absolute` separately.
         # TODO(zhwu): /home/username/sky_workdir as the target path need
         # to be filtered out as well.
         if (path == constants.SKY_REMOTE_WORKDIR and self.workdir is not None):
@@ -1004,6 +1007,7 @@ class Task:
         volume_mounts: List[volume_lib.VolumeMount] = []
         for dst_path, vol in self._volumes.items():
             self._validate_mount_path(dst_path, location='volumes')
+            self._validate_mount_dest_is_absolute(dst_path, location='volumes')
             # Shortcut for `dst_path: volume_name` (external persistent volume)
             if isinstance(vol, str):
                 volume_mount = volume_lib.VolumeMount.resolve(dst_path, vol)

--- a/sky/task.py
+++ b/sky/task.py
@@ -560,10 +560,6 @@ class Task:
 
     def _validate_mount_path(self, path: str, location: str):
         self._validate_path(path, location)
-        # Note: file_mounts intentionally allow relative destinations —
-        # `cloud_vm_ray_backend` resolves them against ~/sky_workdir at
-        # provision time. Volumes do require absolute paths and call
-        # `_validate_mount_dest_is_absolute` separately.
         # TODO(zhwu): /home/username/sky_workdir as the target path need
         # to be filtered out as well.
         if (path == constants.SKY_REMOTE_WORKDIR and self.workdir is not None):
@@ -584,14 +580,13 @@ class Task:
     def _validate_mount_dest_is_absolute(self, path: str, location: str):
         if data_utils.is_cloud_store_url(path):
             return
-        # Explicitly use POSIX semantics — `os.path.isabs` treats e.g.
-        # 'C:/foo' as absolute on Windows, but the remote side is always
-        # POSIX. Tilde is allowed as a common shorthand for the remote
-        # home directory (see Task docstring examples).
+        # POSIX semantics: `os.path.isabs` treats 'C:/foo' as absolute on
+        # Windows, but the remote side is always POSIX. Tilde counts as
+        # a shorthand for the remote home directory.
         if not (path.startswith('/') or path.startswith('~')):
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
-                    f'File mount destination must be an absolute path '
+                    f'Mount destination must be an absolute path '
                     f'(start with "/" or "~"). Got: {path!r} in {location}.')
 
     def expand_and_validate_workdir(self):

--- a/sky/task.py
+++ b/sky/task.py
@@ -580,13 +580,14 @@ class Task:
     def _validate_mount_dest_is_absolute(self, path: str, location: str):
         if data_utils.is_cloud_store_url(path):
             return
-        # POSIX semantics: `os.path.isabs` treats 'C:/foo' as absolute on
-        # Windows, but the remote side is always POSIX. Tilde counts as
-        # a shorthand for the remote home directory.
+        # Explicitly use POSIX semantics — `os.path.isabs` treats e.g.
+        # 'C:/foo' as absolute on Windows, but the remote side is always
+        # POSIX. Tilde is allowed as a common shorthand for the remote
+        # home directory (see Task docstring examples).
         if not (path.startswith('/') or path.startswith('~')):
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
-                    f'Mount destination must be an absolute path '
+                    f'File mount destination must be an absolute path '
                     f'(start with "/" or "~"). Got: {path!r} in {location}.')
 
     def expand_and_validate_workdir(self):

--- a/tests/test_yaml_parser.py
+++ b/tests/test_yaml_parser.py
@@ -216,14 +216,11 @@ def test_anyof_error_points_at_inner_problem(tmp_path):
     assert 'ten' in msg
 
 
-def test_file_mounts_dest_must_be_absolute(tmp_path):
-    """Relative file_mount destination paths used to be accepted silently.
-
-    A relative remote path is almost never what the user wants and was
-    previously stored verbatim, producing confusing behavior on the
-    remote machine. Reject it with a clear message.
+def test_file_mounts_relative_dest_is_accepted(tmp_path):
+    """Relative file_mount destinations are resolved against ~/sky_workdir
+    at provision time (see cloud_vm_ray_backend.py). Validation must not
+    reject them.
     """
-    # Need a real source file so we don't fail on that check first.
     src = tmp_path / 'local.txt'
     src.write_text('hi')
     config_path = _create_config_file(
@@ -233,11 +230,8 @@ def test_file_mounts_dest_must_be_absolute(tmp_path):
                 relative/dest: {src}
             """), tmp_path)
     task = Task.from_yaml(config_path)
-    with pytest.raises(ValueError) as e:
-        task.expand_and_validate_file_mounts()
-    msg = str(e.value)
-    assert 'relative/dest' in msg
-    assert 'absolute' in msg
+    task.expand_and_validate_file_mounts()
+    assert 'relative/dest' in task.file_mounts
 
 
 def test_file_mounts_empty_task_is_not_triggered_by_file_mounts(tmp_path):

--- a/tests/unit_tests/test_sky/test_task.py
+++ b/tests/unit_tests/test_sky/test_task.py
@@ -87,6 +87,20 @@ def test_validate_file_mounts():
         }
         task_obj.expand_and_validate_file_mounts()
 
+        # Relative destinations are resolved against ~/sky_workdir at
+        # provision time (see cloud_vm_ray_backend.py). Validation must
+        # not reject them.
+        task_obj.file_mounts = {
+            'relative_dir': d,
+            './dotslash_relative_dir': d,
+        }
+        task_obj.expand_and_validate_file_mounts()
+
+        # Trailing-slash destinations remain rejected.
+        task_obj.file_mounts = {'/remote/': d}
+        with pytest.raises(ValueError, match='cannot end with a slash'):
+            task_obj.expand_and_validate_file_mounts()
+
 
 def test_to_yaml_config_without_envs():
     """Test to_yaml_config() with no environment variables."""

--- a/tests/unit_tests/test_sky/test_task.py
+++ b/tests/unit_tests/test_sky/test_task.py
@@ -87,16 +87,14 @@ def test_validate_file_mounts():
         }
         task_obj.expand_and_validate_file_mounts()
 
-        # Relative destinations are resolved against ~/sky_workdir at
-        # provision time (see cloud_vm_ray_backend.py). Validation must
-        # not reject them.
+        # Test relative destinations (resolved against ~/sky_workdir).
         task_obj.file_mounts = {
             'relative_dir': d,
             './dotslash_relative_dir': d,
         }
         task_obj.expand_and_validate_file_mounts()
 
-        # Trailing-slash destinations remain rejected.
+        # Test trailing-slash destinations are still rejected.
         task_obj.file_mounts = {'/remote/': d}
         with pytest.raises(ValueError, match='cannot end with a slash'):
             task_obj.expand_and_validate_file_mounts()


### PR DESCRIPTION
## Summary

- PR #9423 added `_validate_mount_dest_is_absolute()` in `sky/task.py`, which rejected any `file_mounts` destination not starting with `/` or `~`. But the backend (`cloud_vm_ray_backend.py:6118-6119`) has explicit support for relative destinations: it resolves them against `~/sky_workdir` at provision time — added in PR #1315, *"Set relative dir root to workdir"*.
- `examples/using_file_mounts.yaml` documents this as a feature (`# Relative paths are under ~/...`), and the `test_file_mounts` smoke test (`tests/smoke_tests/test_mount_and_storage.py:60`) exercises it. That test went red on the first nightly after #9423 — failed [build #10301](https://buildkite.com/skypilot-1/smoke-tests/builds/10301#019dfad8-ef13-4391-a4c4-bbcfc40ecbab) vs. previously-passing [#10289](https://buildkite.com/skypilot-1/smoke-tests/builds/10289).
- This change moves the absolute-path check out of the shared `_validate_mount_path()` and into the volumes call site only. Volumes still require absolute paths (no workdir-relative handling). All other validation tightening from #9423 (disk_size, accelerator counts, `--num-jobs`, env-file existence, duplicate YAML keys, UTF-8) is unrelated and preserved.

## Failure on master before this fix

```
ValueError: File mount destination must be an absolute path
(start with "/" or "~"). Got: 'relative_dir' in
file_mounts.relative_dir: ~/tmp-workdir.
```

Triggered by:
```
sky launch -y -c t-file-mounts-69 --infra aws --cpus 2+ --memory 4+ examples/using_file_mounts.yaml
```

## Test plan

- [x] `pytest tests/unit_tests/test_sky/test_task.py` — 60 passed locally. New cases cover relative file_mount destinations (`'relative_dir'`, `'./dotslash_relative_dir'`) and confirm trailing-slash destinations are still rejected.
- [x] Local repro of the example YAML through `Task.expand_and_validate_file_mounts()` — fails on master (`b7a9653f7`), passes with this patch.
- [x] Bisect: restoring only `sky/task.py` from `bb04de94a^` (parent of #9423) and keeping the rest at HEAD also makes the example pass — confirms #9423 is solely responsible.
- [ ] Smoke: re-run `test_file_mounts` on AWS via `/smoke-test -k test_file_mounts --aws` once this PR lands a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)