### PR TITLE
[Skylet] Fix autostop ignoring active SSH after stop/start

### DIFF
--- a/sky/skylet/autostop_lib.py
+++ b/sky/skylet/autostop_lib.py
@@ -236,6 +236,22 @@ def set_last_active_time_to_now() -> None:
 def has_active_ssh_sessions() -> bool:
     """Check if any PTY traces back to sshd in the process tree."""
     try:
+        # psutil memoizes /dev/{tty*,pts/*} -> rdev at first call to
+        # Process.terminal() with no TTL (psutil._psposix.get_terminal_map).
+        # devpts entries are dynamic: if skylet's first tick runs while no
+        # SSH session is active (e.g. right after `sky stop` + `sky start`),
+        # the cache is frozen with no /dev/pts/* entries, and every later
+        # Process.terminal() returns None for PTY-attached processes.
+        # Clear the cache on each tick so newly-allocated PTYs are visible.
+        # See https://github.com/skypilot-org/skypilot/issues/9524.
+        # pylint: disable=protected-access
+        try:
+            cache_clear = psutil._psposix.get_terminal_map.cache_clear
+        except AttributeError:
+            pass
+        else:
+            cache_clear()
+        # pylint: enable=protected-access
         pts_to_pid: dict[str, int] = {}
         for proc in psutil.process_iter(['pid', 'terminal']):
             terminal = proc.info['terminal']

--- a/sky/skylet/autostop_lib.py
+++ b/sky/skylet/autostop_lib.py
@@ -248,20 +248,31 @@ def has_active_ssh_sessions() -> bool:
         try:
             cache_clear = psutil._psposix.get_terminal_map.cache_clear
         except AttributeError:
-            pass
+            logger.debug('[has_active_ssh] psutil._psposix.get_terminal_map'
+                         ' has no cache_clear; psutil internal API moved.')
         else:
             cache_clear()
         # pylint: enable=protected-access
         pts_to_pid: dict[str, int] = {}
-        for proc in psutil.process_iter(['pid', 'terminal']):
+        all_terminal_procs: list = []
+        for proc in psutil.process_iter(['pid', 'name', 'terminal']):
             terminal = proc.info['terminal']
+            if terminal:
+                all_terminal_procs.append(
+                    (proc.info['pid'], proc.info.get('name'), terminal))
             if terminal and terminal.startswith('/dev/pts/'):
                 pts_to_pid.setdefault(terminal, proc.info['pid'])
+        logger.debug(f'[has_active_ssh] processes with non-None terminal: '
+                     f'{all_terminal_procs}')
+        logger.debug(f'[has_active_ssh] pts_to_pid: {pts_to_pid}')
 
-        for pid in pts_to_pid.values():
+        for terminal, pid in pts_to_pid.items():
             try:
                 for parent in psutil.Process(pid).parents():
                     if parent.name() == 'sshd':
+                        logger.debug(
+                            f'[has_active_ssh] sshd ancestor found for '
+                            f'pid={pid} on {terminal} -> returning True')
                         return True
             except (psutil.NoSuchProcess, psutil.AccessDenied):
                 continue

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -543,24 +543,32 @@ def test_autostop_ssh_alive_after_stop_start(generic_cloud: str):
                 cluster_status=[sky.ClusterStatus.UP],
                 timeout=smoke_tests_utils.get_timeout(generic_cloud)),
 
-            # Give skylet at least one AutostopEvent tick (~60s) with no
-            # SSH attached so the (buggy) psutil cache locks in as empty.
+            # Arm autostop FIRST so AutostopEvent ticks actually call
+            # has_active_ssh_sessions() (otherwise they early-exit on
+            # boot_time mismatch and never touch psutil's terminal-map
+            # cache). idle_minutes=3 leaves a buffer past the assertion
+            # at T+270s so the post-SSH race cannot trigger a legit
+            # autostop before we kill SSH.
+            f'sky autostop -y {name} -i 3',
+            f'sky status | grep {name} | grep "3m"',
+
+            # Now wait 90s with NO SSH so skylet's first 1-2
+            # AutostopEvent ticks call has_active_ssh_sessions() while
+            # /dev/pts/ is empty, priming the buggy psutil cache as
+            # empty. Without this step (the bug we previously had in
+            # this test), the cache was first primed AFTER SSH was
+            # already up, so it happened to contain a working PTY entry
+            # and the test passed even on master.
             'sleep 90',
 
-            # Now arm autostop and open an interactive SSH that outlives
-            # the idle timeout. Without the fix, skylet's stale cache
-            # never sees this PTY and the cluster autostops mid-session.
-            f'sky autostop -y {name} -i 1',
-            f'sky status | grep {name} | grep "1m"',
-
-            # Background a `-tt` SSH that holds a remote PTY for 240s
-            # (4x idle_minutes), then assert UP at the 180s mark while
-            # SSH is still alive. This avoids the post-SSH race where
-            # the next AutostopEvent tick fires within ~60s and stops
-            # the cluster legitimately. With the bug, the stale psutil
-            # cache makes the cluster autostop within ~120s of arming;
-            # the assertion at 180s catches that.
-            f'ssh -tt {name} "sleep 240" </dev/null '
+            # Background a `-tt` SSH that holds a remote PTY past the
+            # idle window. With the bug, every later tick still sees no
+            # PTY (stale cache) -> at ~T_arm+180s idle hits 3 min and
+            # the cluster autostops despite the active SSH. Assertion
+            # at T_arm+90+180=T_arm+270s catches the STOPPED state.
+            # With the fix, every tick re-globs /dev/pts/, sees the SSH
+            # PTY, resets last_active, and the cluster stays UP.
+            f'ssh -tt {name} "sleep 300" </dev/null '
             f'>/tmp/sky-9524-ssh.out 2>&1 & '
             f'SSH_PID=$!; sleep 180; '
             f's=$(sky status -r {name}); echo "$s"; '
@@ -622,13 +630,14 @@ def test_autostop_ssh_alive_after_stop_start_with_docker_image(
                 cluster_name=name,
                 cluster_status=[sky.ClusterStatus.UP],
                 timeout=smoke_tests_utils.get_timeout(generic_cloud)),
+            # See test_autostop_ssh_alive_after_stop_start for the
+            # rationale of this ordering: arm autostop FIRST, then
+            # sleep 90s with no SSH so the buggy psutil cache locks
+            # empty before SSH starts.
+            f'sky autostop -y {name} -i 3',
+            f'sky status | grep {name} | grep "3m"',
             'sleep 90',
-            f'sky autostop -y {name} -i 1',
-            f'sky status | grep {name} | grep "1m"',
-
-            # Same background-SSH pattern as the non-docker variant —
-            # see that test for the rationale.
-            f'ssh -tt {name} "sleep 240" </dev/null '
+            f'ssh -tt {name} "sleep 300" </dev/null '
             f'>/tmp/sky-9524-ssh.out 2>&1 & '
             f'SSH_PID=$!; sleep 180; '
             f's=$(sky status -r {name}); echo "$s"; '

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -517,7 +517,6 @@ def test_autostop_ssh_alive_after_stop_start(generic_cloud: str):
     """
     name = smoke_tests_utils.get_cluster_name()
     autostop_timeout = 600 if generic_cloud == 'azure' else 250
-    # idle_minutes=1; wait_for defaults to jobs_and_ssh.
     test = smoke_tests_utils.Test(
         'test_autostop_ssh_alive_after_stop_start',
         [
@@ -554,11 +553,7 @@ def test_autostop_ssh_alive_after_stop_start(generic_cloud: str):
 
             # Now wait 90s with NO SSH so skylet's first 1-2
             # AutostopEvent ticks call has_active_ssh_sessions() while
-            # /dev/pts/ is empty, priming the buggy psutil cache as
-            # empty. Without this step (the bug we previously had in
-            # this test), the cache was first primed AFTER SSH was
-            # already up, so it happened to contain a working PTY entry
-            # and the test passed even on master.
+            # /dev/pts/ is empty, priming the buggy psutil cache as empty.
             'sleep 90',
 
             # Background a `-tt` SSH that holds a remote PTY past the

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -505,6 +505,157 @@ def test_autostop_with_docker_image(generic_cloud: str):
 @pytest.mark.no_hyperbolic
 @pytest.mark.no_shadeform
 @pytest.mark.no_seeweb
+def test_autostop_ssh_alive_after_stop_start(generic_cloud: str):
+    """Active SSH must prevent autostop after `sky stop` + `sky start`.
+
+    Regression test for https://github.com/skypilot-org/skypilot/issues/9524.
+    psutil's get_terminal_map() is module-globally memoized; if skylet's
+    first AutostopEvent tick after `sky start` runs with no SSH attached,
+    the cache freezes empty and any later SSH session is invisible. The
+    cluster then autostops despite an active interactive session even
+    when wait_for=jobs_and_ssh.
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    autostop_timeout = 600 if generic_cloud == 'azure' else 250
+    # idle_minutes=1; wait_for defaults to jobs_and_ssh.
+    test = smoke_tests_utils.Test(
+        'test_autostop_ssh_alive_after_stop_start',
+        [
+            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra {generic_cloud} '
+            f'{smoke_tests_utils.LOW_RESOURCE_ARG} '
+            f'tests/test_yamls/minimal.yaml) && '
+            f'{smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
+            f'sky logs {name} 1 --status',
+            f'sky status -r {name} | grep UP',
+
+            # The #9524 trigger: stop, then start. Crucially, do not SSH
+            # during `sky start` so /dev/pts/ is empty when skylet's first
+            # AutostopEvent tick fires (~60s after boot) and primes the
+            # buggy cache.
+            f'sky stop -y {name}',
+            smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(
+                cluster_name=name,
+                cluster_status=[sky.ClusterStatus.STOPPED],
+                timeout=autostop_timeout),
+            f'sky start -y {name}',
+            smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(
+                cluster_name=name,
+                cluster_status=[sky.ClusterStatus.UP],
+                timeout=smoke_tests_utils.get_timeout(generic_cloud)),
+
+            # Give skylet at least one AutostopEvent tick (~60s) with no
+            # SSH attached so the (buggy) psutil cache locks in as empty.
+            'sleep 90',
+
+            # Now arm autostop and open an interactive SSH that outlives
+            # the idle timeout. Without the fix, skylet's stale cache
+            # never sees this PTY and the cluster autostops mid-session.
+            f'sky autostop -y {name} -i 1',
+            f'sky status | grep {name} | grep "1m"',
+
+            # Background a `-tt` SSH that holds a remote PTY for 240s
+            # (4x idle_minutes), then assert UP at the 180s mark while
+            # SSH is still alive. This avoids the post-SSH race where
+            # the next AutostopEvent tick fires within ~60s and stops
+            # the cluster legitimately. With the bug, the stale psutil
+            # cache makes the cluster autostop within ~120s of arming;
+            # the assertion at 180s catches that.
+            f'ssh -tt {name} "sleep 240" </dev/null '
+            f'>/tmp/sky-9524-ssh.out 2>&1 & '
+            f'SSH_PID=$!; sleep 180; '
+            f's=$(sky status -r {name}); echo "$s"; '
+            f'echo "$s" | grep {name} | grep UP; rc=$?; '
+            f'kill $SSH_PID 2>/dev/null; '
+            f'wait $SSH_PID 2>/dev/null; exit $rc',
+
+            # SSH closed; cluster eventually autostops normally.
+            smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(
+                cluster_name=name,
+                cluster_status=[sky.ClusterStatus.STOPPED],
+                timeout=autostop_timeout),
+        ],
+        f'sky down -y {name}',
+        timeout=smoke_tests_utils.get_timeout(generic_cloud) +
+        2 * autostop_timeout,
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
+# See cloud exclusion explanations in test_autostop
+@pytest.mark.no_fluidstack
+@pytest.mark.no_lambda_cloud
+@pytest.mark.no_ibm
+@pytest.mark.no_kubernetes
+@pytest.mark.no_slurm
+@pytest.mark.no_hyperbolic
+@pytest.mark.no_shadeform
+@pytest.mark.no_seeweb
+def test_autostop_ssh_alive_after_stop_start_with_docker_image(
+        generic_cloud: str):
+    """#9524 regression test on a Docker-image cluster.
+
+    Same scenario as test_autostop_ssh_alive_after_stop_start, but the
+    cluster runs `image_id: docker:ubuntu:22.04`. The container's
+    entrypoint holds a PTY (see test_autostop_with_docker_image), which
+    must NOT be misclassified as an active SSH session, while a real
+    SSH session opened after `sky stop` + `sky start` MUST be detected.
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    autostop_timeout = 600 if generic_cloud == 'azure' else 250
+    test = smoke_tests_utils.Test(
+        'test_autostop_ssh_alive_after_stop_start_with_docker_image',
+        [
+            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra {generic_cloud} '
+            f'{smoke_tests_utils.LOW_RESOURCE_ARG} '
+            f'--image-id docker:ubuntu:22.04 '
+            f'tests/test_yamls/minimal.yaml) && '
+            f'{smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
+            f'sky logs {name} 1 --status',
+            f'sky status -r {name} | grep UP',
+            f'sky stop -y {name}',
+            smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(
+                cluster_name=name,
+                cluster_status=[sky.ClusterStatus.STOPPED],
+                timeout=autostop_timeout),
+            f'sky start -y {name}',
+            smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(
+                cluster_name=name,
+                cluster_status=[sky.ClusterStatus.UP],
+                timeout=smoke_tests_utils.get_timeout(generic_cloud)),
+            'sleep 90',
+            f'sky autostop -y {name} -i 1',
+            f'sky status | grep {name} | grep "1m"',
+
+            # Same background-SSH pattern as the non-docker variant —
+            # see that test for the rationale.
+            f'ssh -tt {name} "sleep 240" </dev/null '
+            f'>/tmp/sky-9524-ssh.out 2>&1 & '
+            f'SSH_PID=$!; sleep 180; '
+            f's=$(sky status -r {name}); echo "$s"; '
+            f'echo "$s" | grep {name} | grep UP; rc=$?; '
+            f'kill $SSH_PID 2>/dev/null; '
+            f'wait $SSH_PID 2>/dev/null; exit $rc',
+            smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(
+                cluster_name=name,
+                cluster_status=[sky.ClusterStatus.STOPPED],
+                timeout=autostop_timeout),
+        ],
+        f'sky down -y {name}',
+        timeout=smoke_tests_utils.get_timeout(generic_cloud) +
+        2 * autostop_timeout,
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
+# See cloud exclusion explanations in test_autostop
+@pytest.mark.no_fluidstack
+@pytest.mark.no_lambda_cloud
+@pytest.mark.no_ibm
+@pytest.mark.no_kubernetes
+@pytest.mark.no_slurm
+@pytest.mark.no_hyperbolic
+@pytest.mark.no_shadeform
+@pytest.mark.no_seeweb
 def test_launch_waits_for_autostopping(generic_cloud: str):
     """Test that launch waits for autostopping to complete.
 

--- a/tests/unit_tests/test_sky/skylet/test_autostop_lib.py
+++ b/tests/unit_tests/test_sky/skylet/test_autostop_lib.py
@@ -1,0 +1,206 @@
+"""Unit tests for skylet autostop_lib."""
+from unittest import mock
+
+import psutil
+import pytest
+
+from sky.skylet import autostop_lib
+
+
+def _fake_proc(pid, terminal=None):
+    proc = mock.MagicMock()
+    proc.info = {'pid': pid, 'terminal': terminal}
+    proc.pid = pid
+    return proc
+
+
+def _patch_process_iter(monkeypatch, procs):
+    monkeypatch.setattr(psutil,
+                        'process_iter',
+                        lambda fields=None: iter(list(procs)))
+
+
+class TestHasActiveSshSessions:
+    """Tests for has_active_ssh_sessions().
+
+    Regression coverage for
+    https://github.com/skypilot-org/skypilot/issues/9524 — psutil memoizes
+    /dev/{tty*,pts/*} -> rdev at first call and never invalidates, so a
+    skylet daemon that booted with no SSH session sees a frozen empty
+    /dev/pts map for its lifetime.
+    """
+
+    def test_clears_psutil_terminal_map_cache_each_call(self, monkeypatch):
+        """The fix must invalidate psutil's get_terminal_map cache."""
+        cache_clear = mock.MagicMock()
+        monkeypatch.setattr(psutil._psposix.get_terminal_map, 'cache_clear',
+                            cache_clear)
+        _patch_process_iter(monkeypatch, [])
+
+        autostop_lib.has_active_ssh_sessions()
+        autostop_lib.has_active_ssh_sessions()
+
+        assert cache_clear.call_count == 2
+
+    def test_returns_true_when_pty_ancestor_is_sshd(self, monkeypatch):
+        sshd = mock.MagicMock()
+        sshd.name.return_value = 'sshd'
+        not_sshd = mock.MagicMock()
+        not_sshd.name.return_value = 'systemd'
+
+        monkeypatch.setattr(psutil._psposix.get_terminal_map, 'cache_clear',
+                            mock.MagicMock())
+        _patch_process_iter(monkeypatch, [
+            _fake_proc(pid=1234, terminal='/dev/pts/0'),
+            _fake_proc(pid=999, terminal=None),
+        ])
+
+        proc_for_pid = mock.MagicMock()
+        proc_for_pid.parents.return_value = [not_sshd, sshd]
+        monkeypatch.setattr(psutil, 'Process', lambda pid: proc_for_pid)
+
+        assert autostop_lib.has_active_ssh_sessions() is True
+
+    def test_returns_false_when_no_pty_processes(self, monkeypatch):
+        monkeypatch.setattr(psutil._psposix.get_terminal_map, 'cache_clear',
+                            mock.MagicMock())
+        _patch_process_iter(monkeypatch, [
+            _fake_proc(pid=1, terminal=None),
+            _fake_proc(pid=2, terminal=None)
+        ])
+
+        assert autostop_lib.has_active_ssh_sessions() is False
+
+    def test_returns_false_when_pty_not_under_sshd(self, monkeypatch):
+        """A local tmux/screen PTY without sshd ancestor is not an SSH."""
+        monkeypatch.setattr(psutil._psposix.get_terminal_map, 'cache_clear',
+                            mock.MagicMock())
+        _patch_process_iter(monkeypatch,
+                            [_fake_proc(pid=1234, terminal='/dev/pts/0')])
+
+        tmux = mock.MagicMock()
+        tmux.name.return_value = 'tmux'
+        proc = mock.MagicMock()
+        proc.parents.return_value = [tmux]
+        monkeypatch.setattr(psutil, 'Process', lambda pid: proc)
+
+        assert autostop_lib.has_active_ssh_sessions() is False
+
+    def test_does_not_raise_if_psutil_private_api_changes(self, monkeypatch):
+        """If psutil rearranges _psposix, the fix must degrade gracefully."""
+
+        class _GetTerminalMapWithoutCacheClear:
+
+            def __call__(self):
+                return {}
+
+        monkeypatch.setattr(psutil._psposix, 'get_terminal_map',
+                            _GetTerminalMapWithoutCacheClear())
+        _patch_process_iter(monkeypatch, [])
+
+        # No exception even though cache_clear is missing.
+        assert autostop_lib.has_active_ssh_sessions() is False
+
+    def test_skips_pid_that_dies_between_iter_and_parents(self, monkeypatch):
+        """A PID disappearing during the parents() walk must not abort.
+
+        Covers the `except psutil.NoSuchProcess` branch: the inner loop
+        must `continue` so a subsequent live SSH PID is still detected.
+        """
+        monkeypatch.setattr(psutil._psposix.get_terminal_map, 'cache_clear',
+                            mock.MagicMock())
+        # Two distinct PTYs -> two PIDs to walk.
+        _patch_process_iter(monkeypatch, [
+            _fake_proc(pid=1234, terminal='/dev/pts/0'),
+            _fake_proc(pid=5678, terminal='/dev/pts/1'),
+        ])
+
+        sshd = mock.MagicMock()
+        sshd.name.return_value = 'sshd'
+        live_proc = mock.MagicMock()
+        live_proc.parents.return_value = [sshd]
+        dead_proc = mock.MagicMock()
+        dead_proc.parents.side_effect = psutil.NoSuchProcess(pid=1234)
+
+        # dict iteration over pts_to_pid is order-preserving (Python 3.7+),
+        # so 1234 is queried first, raises, we continue to 5678 and find
+        # sshd in its ancestry.
+        process_calls = {1234: dead_proc, 5678: live_proc}
+        monkeypatch.setattr(psutil, 'Process', lambda pid: process_calls[pid])
+
+        assert autostop_lib.has_active_ssh_sessions() is True
+        dead_proc.parents.assert_called_once()
+        live_proc.parents.assert_called_once()
+
+    def test_skips_pid_with_access_denied(self, monkeypatch):
+        """psutil.AccessDenied on parents() must also be swallowed."""
+        monkeypatch.setattr(psutil._psposix.get_terminal_map, 'cache_clear',
+                            mock.MagicMock())
+        _patch_process_iter(monkeypatch,
+                            [_fake_proc(pid=1234, terminal='/dev/pts/0')])
+        denied_proc = mock.MagicMock()
+        denied_proc.parents.side_effect = psutil.AccessDenied(pid=1234)
+        monkeypatch.setattr(psutil, 'Process', lambda pid: denied_proc)
+
+        # Only one PID, parents() denies; nothing else found -> False, no
+        # exception escapes.
+        assert autostop_lib.has_active_ssh_sessions() is False
+
+    def test_returns_false_on_unexpected_exception(self, monkeypatch):
+        """Outer broad-except: any unhandled error -> False + warning log.
+
+        Covers the safety-net branch so an unexpected psutil failure can
+        never crash the skylet daemon.
+        """
+        monkeypatch.setattr(psutil._psposix.get_terminal_map, 'cache_clear',
+                            mock.MagicMock())
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError('simulated psutil failure')
+
+        monkeypatch.setattr(psutil, 'process_iter', _boom)
+        # The `sky` logger has propagate=False, so use a direct mock on
+        # the module logger instead of caplog to observe the warning.
+        warning_mock = mock.MagicMock()
+        monkeypatch.setattr(autostop_lib.logger, 'warning', warning_mock)
+
+        result = autostop_lib.has_active_ssh_sessions()
+
+        assert result is False
+        warning_mock.assert_called_once()
+        msg = warning_mock.call_args.args[0]
+        assert 'Error checking active SSH sessions' in msg
+        assert 'simulated psutil failure' in msg
+
+    def test_invalidates_primed_empty_cache(self, monkeypatch):
+        """The fix must actually drop a primed empty terminal map.
+
+        Reproduces the post-`sky stop`/`sky start` state by forcing
+        psutil's @memoize cache to materialize as an empty dict, then
+        verifies has_active_ssh_sessions() leaves the cache empty (i.e.
+        cleared) so that a fresh call to get_terminal_map() would
+        re-glob /dev/pts/.
+        """
+        psutil._psposix.get_terminal_map.cache_clear()
+        with mock.patch('glob.glob', return_value=[]):
+            primed = psutil._psposix.get_terminal_map()
+        assert primed == {}, 'failed to prime the bug state'
+        # Confirm @memoize stored the empty result.
+        with mock.patch('glob.glob',
+                        side_effect=AssertionError('cache not used')):
+            assert psutil._psposix.get_terminal_map() == {}
+
+        _patch_process_iter(monkeypatch, [])
+        autostop_lib.has_active_ssh_sessions()
+
+        # After the fix runs, calling get_terminal_map() again must
+        # re-glob /dev/* — i.e. the cache was invalidated.
+        re_globbed = mock.MagicMock(return_value=[])
+        with mock.patch('glob.glob', re_globbed):
+            psutil._psposix.get_terminal_map()
+        assert re_globbed.called, (
+            'cache was not invalidated; glob.glob was not re-called')
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
## Summary

Fixes #9524.

After `sky stop` + `sky start`, autostop shuts the cluster down even while a user is actively SSHed in, ignoring `wait_for=jobs_and_ssh`.

**Root cause**: `psutil._psposix.get_terminal_map()` is decorated with `@memoize` (no TTL). It is built lazily by globbing `/dev/{tty*,pts/*}` on first call. devpts is dynamic — entries exist only while a PTY is allocated. If skylet's first `AutostopEvent` tick runs while no SSH session is active (the post-`sky stop`/`sky start` case), the cache is built empty and frozen for the daemon's lifetime. Every later `Process(pid).terminal()` for a PTY-attached process returns `None`, so `has_active_ssh_sessions()` returns `False` and the autostop timer is never reset.

The smoke test in #8932 likely passed because provisioning's own SSH was still attached when skylet first ticked, populating the cache with a working `pts/0` entry.

**Fix**: Clear the cache before each scan so newly-allocated PTYs are visible. The access to `psutil._psposix.get_terminal_map.cache_clear` is wrapped in `try/except AttributeError` so a future psutil refactor of the private path cannot crash skylet.

## Test plan

- [x] New unit test file `tests/unit_tests/test_sky/skylet/test_autostop_lib.py` covers `has_active_ssh_sessions()` end-to-end (9 tests, 100% line coverage of the function):
  - `test_clears_psutil_terminal_map_cache_each_call` — regression test verifying `cache_clear()` is invoked on every call.
  - `test_invalidates_primed_empty_cache` — primes psutil's `@memoize` cache to be empty (the #9524 bug state) and asserts the cache is actually invalidated after the call.
  - `test_returns_true_when_pty_ancestor_is_sshd` / `test_returns_false_when_no_pty_processes` / `test_returns_false_when_pty_not_under_sshd` — surrounding logic.
  - `test_skips_pid_that_dies_between_iter_and_parents` / `test_skips_pid_with_access_denied` — `psutil.NoSuchProcess` / `psutil.AccessDenied` swallowed, loop continues.
  - `test_returns_false_on_unexpected_exception` — outer broad-except safety net so an unexpected psutil failure cannot crash skylet.
  - `test_does_not_raise_if_psutil_private_api_changes` — function degrades gracefully if `psutil._psposix` is restructured upstream.
- [x] All 9 tests pass; both regression tests (`test_clears_psutil_terminal_map_cache_each_call`, `test_invalidates_primed_empty_cache`) verified to fail when the fix is reverted.
- [x] Manual repro on AWS EC2 cluster: `sky launch --autostop=120 --wait-for=jobs_and_ssh` → `sky stop` → `sky start` → SSH in → wait past `idle_minutes` → cluster stays up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)