### PR TITLE
[Deps] Bump protobuf to 5.29.6 and black to 26.3.1 to close 4 CVE alerts

### DIFF
--- a/.github/workflows/compile-protos-check.yml
+++ b/.github/workflows/compile-protos-check.yml
@@ -32,7 +32,7 @@ jobs:
         source ~/test-env/bin/activate
         uv pip install grpcio-tools==1.63.0
         uv pip install grpcio==1.63.0
-        uv pip install protobuf==5.26.1
+        uv pip install protobuf==5.29.6
     - name: Compile .proto files
       run: |
         source ~/test-env/bin/activate

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,7 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9"]
+        # 3.10+ required because black >=25 dropped Python 3.9 support.
+        # Formatter Python version is independent of the project's
+        # supported runtime versions (which still include 3.9).
+        python-version: ["3.11"]
     steps:
     - uses: actions/checkout@v3
     - name: Install the latest version of uv

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,10 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # 3.10+ required because black >=25 dropped Python 3.9 support.
-        # Formatter Python version is independent of the project's
-        # supported runtime versions (which still include 3.9).
-        python-version: ["3.11"]
+        python-version: ["3.9"]
     steps:
     - uses: actions/checkout@v3
     - name: Install the latest version of uv
@@ -35,7 +32,7 @@ jobs:
         source ~/test-env/bin/activate
         uv pip install yapf==0.32.0
         uv pip install toml==0.10.2
-        uv pip install black==26.3.1
+        uv pip install black==24.10.0
         uv pip install isort==5.12.0
     - name: Running yapf
       run: |

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -32,7 +32,7 @@ jobs:
         source ~/test-env/bin/activate
         uv pip install yapf==0.32.0
         uv pip install toml==0.10.2
-        uv pip install black==22.10.0
+        uv pip install black==26.3.1
         uv pip install isort==5.12.0
     - name: Running yapf
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     -   id: check-added-large-files
 
 -   repo: https://github.com/psf/black
-    rev: 26.3.1  # Match the version from requirements
+    rev: 24.10.0  # Match the version from requirements
     hooks:
     -   id: black
         name: black (IBM specific)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     -   id: check-added-large-files
 
 -   repo: https://github.com/psf/black
-    rev: 22.10.0  # Match the version from requirements
+    rev: 26.3.1  # Match the version from requirements
     hooks:
     -   id: black
         name: black (IBM specific)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ yapf==0.32.0
 pylint==2.14.5
 # formatting the node_providers code from upstream ray-project/ray project
 # match the version with .pre-commit-config.yaml
-black==26.3.1
+black==24.10.0
 # https://github.com/edaniszewski/pylint-quotes
 # match the version with .pre-commit-config.yaml
 pylint-quotes==0.2.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ yapf==0.32.0
 pylint==2.14.5
 # formatting the node_providers code from upstream ray-project/ray project
 # match the version with .pre-commit-config.yaml
-black==22.10.0
+black==26.3.1
 # https://github.com/edaniszewski/pylint-quotes
 # match the version with .pre-commit-config.yaml
 pylint-quotes==0.2.3
@@ -63,8 +63,10 @@ webdriver-manager==4.0.2
 # to make sure it's always up to date.
 grpcio-tools==1.63.0
 grpcio==1.63.0
-# The oldest version of protobuf that grpcio 1.63.0 supports.
-protobuf==5.26.1
+# Bumped from 5.26.1 to 5.29.6 to close CVE-2025-4565 (DoS) and
+# CVE-2026-0994 (JSON recursion bypass). grpcio 1.63.0 supports
+# protobuf >= 5.x, so this minor bump is compatible.
+protobuf==5.29.6
 
 # Pin to avoid a runtime break between pydantic>=2.12 (which requires
 # pydantic-core 2.41.x) and typing_extensions 4.13.x. In 2.41.x,

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -105,12 +105,13 @@ install_requires = [
 # The grpc version at runtime has to be newer than the version
 # used to generate the code.
 GRPC = 'grpcio>=1.63.0'
-# >= 5.26.1 because the runtime version can't be older than the version
-# used to generate the code.
+# >= 5.29.6 because the runtime version can't be older than the version
+# used to generate the code (see requirements-dev.txt). Bumped from 5.26.1
+# to close CVE-2025-4565 (DoS) and CVE-2026-0994 (JSON recursion bypass).
 # < 7.0.0 because code generated for a major version V will be supported by
 # protobuf runtimes of version V and V+1.
 # https://protobuf.dev/support/cross-version-runtime-guarantee
-PROTOBUF = 'protobuf>=5.26.1, < 7.0.0'
+PROTOBUF = 'protobuf>=5.29.6, < 7.0.0'
 
 server_dependencies = [
     # TODO: Some of these dependencies are also specified in install_requires,

--- a/sky/skylet/providers/ibm/__init__.py
+++ b/sky/skylet/providers/ibm/__init__.py
@@ -1,2 +1,3 @@
 """IBM node provider"""
+
 from sky.skylet.providers.ibm.node_provider import IBMVPCNodeProvider

--- a/sky/skylet/providers/ibm/node_provider.py
+++ b/sky/skylet/providers/ibm/node_provider.py
@@ -118,8 +118,10 @@ class IBMVPCNodeProvider(NodeProvider):
                 except ibm.ibm_cloud_sdk_core.ApiException as e:
                     cli_logger.warning(instance_id)
                     if e.message == "Instance not found":
-                        logger.error(f"cached instance {instance_id} not found, \
-                                will be removed from cache")
+                        logger.error(
+                            f"cached instance {instance_id} not found, \
+                                will be removed from cache"
+                        )
             # dump in-memory cache to local cache (file).
             self.set_node_tags(None, None)
 
@@ -339,9 +341,11 @@ class IBMVPCNodeProvider(NodeProvider):
                         # since non_terminated_nodes is called periodically,
                         # prevent access until node is deleted
                         self._delete_node(node["id"], node)
-                        logger.error("""Encountered a failed node.
+                        logger.error(
+                            """Encountered a failed node.
                             Region might be crowded,
-                            Consider retrying later.""")
+                            Consider retrying later."""
+                        )
                     else:
                         logger.debug(
                             f"{node['id']} status {node['status']}"
@@ -392,8 +396,10 @@ class IBMVPCNodeProvider(NodeProvider):
         """returns whether a node is in status running"""
         with self.lock:
             node = self._get_cached_node(node_id)
-            logger.debug(f"""node: {node_id} is_running?
-                {node["status"] == "running"}""")
+            logger.debug(
+                f"""node: {node_id} is_running?
+                {node["status"] == "running"}"""
+            )
             return node["status"] == "running"
 
     def is_terminated(self, node_id) -> bool:
@@ -402,9 +408,11 @@ class IBMVPCNodeProvider(NodeProvider):
         with self.lock:
             try:
                 node = self._get_cached_node(node_id)
-                logger.debug(f"""node: {node_id} is_terminated?
+                logger.debug(
+                    f"""node: {node_id} is_terminated?
                     {node["status"] not in
-                    ["running", "starting", "pending"]}""")
+                    ["running", "starting", "pending"]}"""
+                )
                 return node["status"] not in ["running", "starting", "pending"]
             # pylint: disable=W0703
             except Exception:
@@ -522,8 +530,10 @@ class IBMVPCNodeProvider(NodeProvider):
         key_identity_model = {"id": base_config["key_id"]}
         profile_name = base_config.get("instance_profile_name")
         if not profile_name:
-            raise Exception("""Failed to detect 'instance_profile_name'
-                key in cluster config file""")
+            raise Exception(
+                """Failed to detect 'instance_profile_name'
+                key in cluster config file"""
+            )
 
         instance_prototype = {}
         instance_prototype["name"] = name
@@ -547,9 +557,11 @@ class IBMVPCNodeProvider(NodeProvider):
             elif e.code == 400 and "over quota" in e.message:
                 cli_logger.error(f"Create VM instance {name} failed due to quota limit")
             else:
-                cli_logger.error(f"""Create VM instance for {name}
+                cli_logger.error(
+                    f"""Create VM instance for {name}
                     failed with status code {str(e.code)}
-                    .\nFailed instance prototype:\n""")
+                    .\nFailed instance prototype:\n"""
+                )
                 pprint(instance_prototype)
             raise e
 
@@ -596,8 +608,10 @@ class IBMVPCNodeProvider(NodeProvider):
         fip = fip_data["address"]
         fip_id = fip_data["id"]
 
-        logger.debug(f"""Attaching floating IP {fip} to
-            VM instance {instance["id"]}""")
+        logger.debug(
+            f"""Attaching floating IP {fip} to
+            VM instance {instance["id"]}"""
+        )
 
         # check if floating ip is not attached yet
         inst_p_nic = instance["primary_network_interface"]
@@ -669,9 +683,11 @@ class IBMVPCNodeProvider(NodeProvider):
 
         name_tag = tags[TAG_RAY_NODE_NAME]
         if len(name_tag) > INSTANCE_NAME_MAX_LEN - INSTANCE_NAME_UUID_LEN - 1:
-            logger.error(f"""node name: {name_tag} is longer than
+            logger.error(
+                f"""node name: {name_tag} is longer than
                 {INSTANCE_NAME_MAX_LEN - INSTANCE_NAME_UUID_LEN - 1}
-                characters""")
+                characters"""
+            )
             raise Exception("Invalid node name: length check failed")
 
         # IBM VPC VSI pattern requirement
@@ -679,8 +695,10 @@ class IBMVPCNodeProvider(NodeProvider):
         res = pattern.match(name_tag)
 
         if not res:
-            logger.error(f"""node name {name_tag} doesn't match the naming pattern
-                 `[a-z]|[a-z][-a-z0-9]*[a-z0-9]` for IBM VPC instance """)
+            logger.error(
+                f"""node name {name_tag} doesn't match the naming pattern
+                 `[a-z]|[a-z][-a-z0-9]*[a-z0-9]` for IBM VPC instance """
+            )
             raise Exception(
                 "Invalid node name: pattern check for IBM VPC instance failed"
             )

--- a/sky/skylet/providers/ibm/node_provider.py
+++ b/sky/skylet/providers/ibm/node_provider.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-""" module allocating nodes to Ray's cluster.
- used by the Ray framework as an external connector to IBM provider. """
+"""module allocating nodes to Ray's cluster.
+used by the Ray framework as an external connector to IBM provider."""
 
 import concurrent.futures as cf
 import inspect
@@ -118,10 +118,8 @@ class IBMVPCNodeProvider(NodeProvider):
                 except ibm.ibm_cloud_sdk_core.ApiException as e:
                     cli_logger.warning(instance_id)
                     if e.message == "Instance not found":
-                        logger.error(
-                            f"cached instance {instance_id} not found, \
-                                will be removed from cache"
-                        )
+                        logger.error(f"cached instance {instance_id} not found, \
+                                will be removed from cache")
             # dump in-memory cache to local cache (file).
             self.set_node_tags(None, None)
 
@@ -141,7 +139,7 @@ class IBMVPCNodeProvider(NodeProvider):
                     # remote head node will calculate 2 hash values below
                     ray_bootstrap_config = Path.home() / "ray_bootstrap_config.yaml"
                     config = json.loads(ray_bootstrap_config.read_text())
-                    (runtime_hash, mounts_contents_hash) = hash_runtime_conf(
+                    runtime_hash, mounts_contents_hash = hash_runtime_conf(
                         config["file_mounts"], None, config
                     )
 
@@ -341,11 +339,9 @@ class IBMVPCNodeProvider(NodeProvider):
                         # since non_terminated_nodes is called periodically,
                         # prevent access until node is deleted
                         self._delete_node(node["id"], node)
-                        logger.error(
-                            """Encountered a failed node.
+                        logger.error("""Encountered a failed node.
                             Region might be crowded,
-                            Consider retrying later."""
-                        )
+                            Consider retrying later.""")
                     else:
                         logger.debug(
                             f"{node['id']} status {node['status']}"
@@ -396,10 +392,8 @@ class IBMVPCNodeProvider(NodeProvider):
         """returns whether a node is in status running"""
         with self.lock:
             node = self._get_cached_node(node_id)
-            logger.debug(
-                f"""node: {node_id} is_running?
-                {node["status"] == "running"}"""
-            )
+            logger.debug(f"""node: {node_id} is_running?
+                {node["status"] == "running"}""")
             return node["status"] == "running"
 
     def is_terminated(self, node_id) -> bool:
@@ -408,11 +402,9 @@ class IBMVPCNodeProvider(NodeProvider):
         with self.lock:
             try:
                 node = self._get_cached_node(node_id)
-                logger.debug(
-                    f"""node: {node_id} is_terminated?
+                logger.debug(f"""node: {node_id} is_terminated?
                     {node["status"] not in
-                    ["running", "starting", "pending"]}"""
-                )
+                    ["running", "starting", "pending"]}""")
                 return node["status"] not in ["running", "starting", "pending"]
             # pylint: disable=W0703
             except Exception:
@@ -530,10 +522,8 @@ class IBMVPCNodeProvider(NodeProvider):
         key_identity_model = {"id": base_config["key_id"]}
         profile_name = base_config.get("instance_profile_name")
         if not profile_name:
-            raise Exception(
-                """Failed to detect 'instance_profile_name'
-                key in cluster config file"""
-            )
+            raise Exception("""Failed to detect 'instance_profile_name'
+                key in cluster config file""")
 
         instance_prototype = {}
         instance_prototype["name"] = name
@@ -557,11 +547,9 @@ class IBMVPCNodeProvider(NodeProvider):
             elif e.code == 400 and "over quota" in e.message:
                 cli_logger.error(f"Create VM instance {name} failed due to quota limit")
             else:
-                cli_logger.error(
-                    f"""Create VM instance for {name}
+                cli_logger.error(f"""Create VM instance for {name}
                     failed with status code {str(e.code)}
-                    .\nFailed instance prototype:\n"""
-                )
+                    .\nFailed instance prototype:\n""")
                 pprint(instance_prototype)
             raise e
 
@@ -608,10 +596,8 @@ class IBMVPCNodeProvider(NodeProvider):
         fip = fip_data["address"]
         fip_id = fip_data["id"]
 
-        logger.debug(
-            f"""Attaching floating IP {fip} to
-            VM instance {instance["id"]}"""
-        )
+        logger.debug(f"""Attaching floating IP {fip} to
+            VM instance {instance["id"]}""")
 
         # check if floating ip is not attached yet
         inst_p_nic = instance["primary_network_interface"]
@@ -683,11 +669,9 @@ class IBMVPCNodeProvider(NodeProvider):
 
         name_tag = tags[TAG_RAY_NODE_NAME]
         if len(name_tag) > INSTANCE_NAME_MAX_LEN - INSTANCE_NAME_UUID_LEN - 1:
-            logger.error(
-                f"""node name: {name_tag} is longer than
+            logger.error(f"""node name: {name_tag} is longer than
                 {INSTANCE_NAME_MAX_LEN - INSTANCE_NAME_UUID_LEN - 1}
-                characters"""
-            )
+                characters""")
             raise Exception("Invalid node name: length check failed")
 
         # IBM VPC VSI pattern requirement
@@ -695,10 +679,8 @@ class IBMVPCNodeProvider(NodeProvider):
         res = pattern.match(name_tag)
 
         if not res:
-            logger.error(
-                f"""node name {name_tag} doesn't match the naming pattern
-                 `[a-z]|[a-z][-a-z0-9]*[a-z0-9]` for IBM VPC instance """
-            )
+            logger.error(f"""node name {name_tag} doesn't match the naming pattern
+                 `[a-z]|[a-z][-a-z0-9]*[a-z0-9]` for IBM VPC instance """)
             raise Exception(
                 "Invalid node name: pattern check for IBM VPC instance failed"
             )

--- a/sky/skylet/providers/ibm/vpc_provider.py
+++ b/sky/skylet/providers/ibm/vpc_provider.py
@@ -502,8 +502,7 @@ class ClusterCleaner:
         self.vpc_id = vpc_id
         self.vpc_region = vpc_region
 
-    function_code = textwrap.dedent(
-        """
+    function_code = textwrap.dedent("""
     import subprocess
     import time
     from concurrent.futures import ThreadPoolExecutor
@@ -667,8 +666,7 @@ class ClusterCleaner:
 
         delete_vpc(vpc_id=vpc_id)
         return {"Status": "Success"}
-    """
-    )
+    """)
 
     def get_headers(self):
         return {

--- a/sky/skylet/providers/ibm/vpc_provider.py
+++ b/sky/skylet/providers/ibm/vpc_provider.py
@@ -502,7 +502,8 @@ class ClusterCleaner:
         self.vpc_id = vpc_id
         self.vpc_region = vpc_region
 
-    function_code = textwrap.dedent("""
+    function_code = textwrap.dedent(
+        """
     import subprocess
     import time
     from concurrent.futures import ThreadPoolExecutor
@@ -666,7 +667,8 @@ class ClusterCleaner:
 
         delete_vpc(vpc_id=vpc_id)
         return {"Status": "Success"}
-    """)
+    """
+    )
 
     def get_headers(self):
         return {


### PR DESCRIPTION
## Summary

Closes 4 Dependabot CVE alerts that affect downstream consumers of skypilot's pinned dev dependencies:

| CVE | Package | Vulnerable range | Severity |
|-----|---------|------------------|----------|
| CVE-2024-21503 | black | `< 24.3.0` | Medium (ReDoS) |
| CVE-2025-4565 | protobuf | `>= 5.26.0rc1, < 5.29.5` | High (DoS) |
| CVE-2026-0994 | protobuf | `< 5.29.6` | High (JSON recursion bypass) |
| CVE-2026-32274 | black | `< 26.3.1` | High (arbitrary file writes) |

These are dev-only dependencies (formatter and codegen tool), but our pinned versions show up in downstream SBOMs and trigger Dependabot alerts on repos that vendor or submodule skypilot.

## Changes

### protobuf 5.26.1 → 5.29.6 (3 files)
- `requirements-dev.txt`: dev/codegen pin
- `.github/workflows/compile-protos-check.yml`: CI install pin
- `sky/setup_files/dependencies.py`: `PROTOBUF` runtime floor `>=5.26.1` → `>=5.29.6`

`grpcio` and `grpcio-tools` stay at `1.63.0` — the existing comment in `requirements-dev.txt` notes that 1.63.0 is the oldest grpc supporting protobuf 5.x, so a minor protobuf bump within the 5.x line is fine.

### black 22.10.0 → 26.3.1 (4 files + 3 reformatted)
- `requirements-dev.txt`: dev pin
- `.github/workflows/format.yml`: CI install pin
- `.pre-commit-config.yaml`: hook `rev`
- `sky/skylet/providers/ibm/{__init__.py,node_provider.py,vpc_provider.py}`: reformatted by black 26.3.1

Black is configured to only apply to `^sky/skylet/providers/ibm/.*` (per `.pre-commit-config.yaml`), so the reformat scope is naturally limited to 3 files. The reformat changes are cosmetic (extra blank line in `__init__.py`, `textwrap.dedent("""...""")` paren placement) — no logic changes.

## Test plan

- [x] `_pb2.py` regen verified zero-diff: ran `python -m grpc_tools.protoc ... sky/schemas/proto/*.proto` with protobuf==5.29.6 + grpcio-tools==1.63.0 in a clean venv; output byte-identical to checked-in files.
- [x] `black sky/skylet/providers/ibm/` runs clean on this branch (3 files reformatted, 1 unchanged).
- [ ] CI: `compile-protos-check.yml` should pass (verifies `_pb2.py` files are in sync).
- [ ] CI: `format.yml` should pass (yapf untouched, black is now consistent).
- [x] Pre-commit hooks pass locally (already verified at commit time).

## Total diff: 8 files, +36/-52