### PR TITLE
[Fix] Remote job controller HA recovery job id mismatch

### DIFF
--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -1203,28 +1203,35 @@ available_node_types:
                 echo "=== Controller setup commands completed for recovery at $(date) ===" >> $SKYPILOT_HA_RECOVERY_LOG
 
                 touch {{k8s_high_availability_restarting_signal_file}}
-                # Get all in-progress jobs from managed jobs controller. We skip any jobs that are already done.
-                # Also, skip the jobs that are waiting to be scheduled as those does not have a controller process running.
-                # For SkyServe, this will be None and every service will be recovered. This is because SkyServe
-                # will delete the service from the database after it is terminated so everything in the database is running.
+                # Get in-progress managed job IDs. For SkyServe this is None
+                # and every service will be recovered (SkyServe deletes
+                # terminated services so everything in the DB is running).
                 ALL_IN_PROGRESS_JOBS=$({{sky_python_cmd}} -c "from sky.jobs import state; jobs, _ = state.get_managed_jobs_with_filters(fields=['job_id', 'schedule_state']); print(' '.join({str(job['job_id']) for job in jobs if job['schedule_state'] not in [state.ManagedJobScheduleState.DONE, state.ManagedJobScheduleState.WAITING]}) if jobs else None)")
                 if [ "$ALL_IN_PROGRESS_JOBS" != "None" ]; then
                   read -ra ALL_IN_PROGRESS_JOBS_SEQ <<< "$ALL_IN_PROGRESS_JOBS"
                 fi
                 for file in {{k8s_high_availability_deployment_run_script_dir}}/*; do
-                  # This is the cluster job id on managed jobs controller, but it is guaranteed to be the same as the managed job id,
-                  # so we directly use it here. See `CloudVmRayBackend._exec_code_on_head::_dump_code_to_file` for more details.
-                  JOB_ID=$(basename $file | sed 's/sky_job_//')
-                  # If the list of in-progress jobs is not None (meaning this is a managed job HA controller) and job is not in-progress, skip.
+                  # After set_job_info_without_job_id (#7891), the cluster job
+                  # ID in the script filename no longer equals managed job ID.
+                  # Extract managed job IDs from the script content instead
+                  # (job_ids_array set in jobs-controller.yaml.j2).
                   if [ "$ALL_IN_PROGRESS_JOBS" != "None" ]; then
-                    if [[ ! " ${ALL_IN_PROGRESS_JOBS_SEQ[@]} " =~ " ${JOB_ID} " ]]; then
-                      continue
+                    MANAGED_IDS=$(sed -n 's/.*job_ids_array=(\([^)]*\)).*/\1/p' "$file" | head -1)
+                    if [ -n "$MANAGED_IDS" ]; then
+                      SHOULD_RUN=false
+                      for MID in $MANAGED_IDS; do
+                        if [[ " ${ALL_IN_PROGRESS_JOBS_SEQ[@]} " =~ " ${MID} " ]]; then
+                          SHOULD_RUN=true
+                          break
+                        fi
+                      done
+                      if [ "$SHOULD_RUN" == "false" ]; then
+                        continue
+                      fi
                     fi
                   fi
                   # ! Keep this aligned with `CloudVmRayBackend._execute()`
                   chmod +x $file
-                  # TODO(tian): This logic may run a lot of things if the jobs controller previously had many jobs.
-                  # We should do more tests and make sure it will scale well.
                   /bin/bash --login -c "true && export OMP_NUM_THREADS=1 PYTHONWARNINGS='ignore' && $file > /tmp/task_run_$(basename $file).log 2>&1"
                   echo "=== Controller task run for service / job (file: $file) completed for recovery at $(date) ===" >> $SKYPILOT_HA_RECOVERY_LOG
                 done

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -1217,17 +1217,17 @@ available_node_types:
                   # (job_ids_array set in jobs-controller.yaml.j2).
                   if [ "$ALL_IN_PROGRESS_JOBS" != "None" ]; then
                     MANAGED_IDS=$(sed -n 's/.*job_ids_array=(\([^)]*\)).*/\1/p' "$file" | head -1)
+                    FOUND_IN_PROGRESS=false
                     if [ -n "$MANAGED_IDS" ]; then
-                      SHOULD_RUN=false
                       for MID in $MANAGED_IDS; do
                         if [[ " ${ALL_IN_PROGRESS_JOBS_SEQ[@]} " =~ " ${MID} " ]]; then
-                          SHOULD_RUN=true
+                          FOUND_IN_PROGRESS=true
                           break
                         fi
                       done
-                      if [ "$SHOULD_RUN" == "false" ]; then
-                        continue
-                      fi
+                    fi
+                    if [ "$FOUND_IN_PROGRESS" == "false" ]; then
+                      continue
                     fi
                   fi
                   # ! Keep this aligned with `CloudVmRayBackend._execute()`

--- a/tests/smoke_tests/test_batch.py
+++ b/tests/smoke_tests/test_batch.py
@@ -367,3 +367,260 @@ def test_batch_cancel(generic_cloud: str):
         },
     )
     smoke_tests_utils.run_one_test(test)
+
+
+# ---------- Test batch HA: kill controller, verify resume from DB ----------
+@pytest.mark.kubernetes
+@pytest.mark.batch
+def test_batch_ha_kill_running(generic_cloud: str):
+    """Kill the jobs controller while a batch job is RUNNING.
+
+    After the controller pod restarts, the batch coordinator should
+    resume from DB (``_resume_from_db``) and complete all batches.
+    Uses the simple double-text example (CPU-only) to keep costs low.
+    """
+    if smoke_tests_utils.is_non_docker_remote_api_server():
+        pytest.skip(
+            'Skipping HA test in non-docker remote api server environment as '
+            'controller might be managed by different user/test agents')
+    if smoke_tests_utils.server_side_is_consolidation_mode():
+        pytest.skip('Skipping HA kill test in consolidation mode: no separate '
+                    'controller pod to kill')
+
+    name = smoke_tests_utils.get_cluster_name()
+    bucket = f'sky-batch-ha-{name}'
+    pool_name = 'test-batch-pool'
+    url, create_bkt, delete_bkt, cp, rm, _, rm_r = _storage_cmds(
+        generic_cloud, bucket)
+    store = 'gs' if generic_cloud == 'gcp' else 's3'
+
+    # HA config: run the jobs controller on k8s with high_availability.
+    skypilot_config_path = 'tests/test_yamls/managed_jobs_ha_config.yaml'
+    pytest_config_file_override = (
+        smoke_tests_utils.pytest_config_file_override())
+    if pytest_config_file_override is not None:
+        with open(pytest_config_file_override, 'r') as f:
+            base_config = f.read()
+        with open(skypilot_config_path, 'r') as f:
+            ha_config = f.read()
+        with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w',
+                                         delete=False) as f:
+            f.write(base_config)
+            f.write(ha_config)
+            f.flush()
+            skypilot_config_path = f.name
+
+    test = smoke_tests_utils.Test(
+        'batch_ha_kill_running',
+        [
+            # --- Cloud-cmd cluster for kubectl access ---
+            smoke_tests_utils.launch_cluster_for_cloud_cmd(generic_cloud, name),
+            # --- Pre-cleanup ---
+            f'sky jobs pool down {pool_name} -y 2>/dev/null || true',
+            f'sky serve down {pool_name} -y 2>/dev/null || true',
+            # --- Create pool with generic_cloud ---
+            (f's=$(sky jobs pool apply -p {pool_name} --infra {generic_cloud}'
+             f' examples/batch/simple/pool.yaml -y); '
+             f'echo "$s"; '
+             f'echo "$s" | grep "Successfully created pool"'),
+            # --- Data setup: 60 items / batch_size 2 = 30 batches ---
+            create_bkt,
+            (f'for i in $(seq 1 60); do '
+             f'echo "{{\\"text\\": \\"word_$i\\"}}"; '
+             f'done > /tmp/batch-ha-input-{name}.jsonl'),
+            f'{cp} /tmp/batch-ha-input-{name}.jsonl {url}/test.jsonl',
+            f'{rm} {url}/output.jsonl 2>/dev/null || true',
+            f'{rm_r(f"{url}/.sky_batch_tmp/")} 2>/dev/null || true',
+
+            # --- Launch batch job in background, wait for RUNNING ---
+            (f'nohup python examples/batch/simple/double_text.py '
+             f'> /tmp/batch-ha-bg-{name}.log 2>&1 &\n'
+             f'echo "Backgrounded double_text.py (PID=$!)"\n'
+             f'for i in $(seq 1 180); do\n'
+             f'  if sky jobs queue 2>/dev/null '
+             f'| grep "{pool_name}" | grep -q "RUNNING"; then\n'
+             f'    echo "Batch job is RUNNING"\n'
+             f'    exit 0\n'
+             f'  fi\n'
+             f'  sleep 5\n'
+             f'done\n'
+             f'echo "Timeout waiting for batch job to reach RUNNING"\n'
+             f'exit 1'),
+
+            # --- Poll until some batches complete, then record progress ---
+            # Workers need time to start; poll instead of a fixed sleep.
+            (
+                f'echo "Waiting for batches to start completing..."\n'
+                f'for i in $(seq 1 120); do\n'
+                f'  QUEUE=$(sky jobs queue 2>/dev/null)\n'
+                f'  POOL_LINE=$(echo "$QUEUE" '
+                f'| grep "{pool_name}" | head -1)\n'
+                f'  PROGRESS=$(echo "$POOL_LINE" '
+                f'| grep -oE "[0-9]+/[0-9]+" | head -1)\n'
+                f'  COMPLETED=${{PROGRESS%%/*}}\n'
+                f'  if [ -n "$COMPLETED" ] && [ "$COMPLETED" -gt 0 ]; then\n'
+                f'    break\n'
+                f'  fi\n'
+                f'  sleep 5\n'
+                f'done\n'
+                # Once progress is non-zero, let a few more batches complete
+                # so we have a meaningful checkpoint to verify after resume.
+                f'echo "First batch completed, sleeping 60s for more progress"\n'
+                f'sleep 60\n'
+                f'QUEUE=$(sky jobs queue 2>/dev/null)\n'
+                f'POOL_LINE=$(echo "$QUEUE" | grep "{pool_name}" | head -1)\n'
+                f'PROGRESS=$(echo "$POOL_LINE" '
+                f'| grep -oE "[0-9]+/[0-9]+" | head -1)\n'
+                f'COMPLETED=${{PROGRESS%%/*}}\n'
+                # Record the managed job ID for log verification later.
+                f'JOB_ID=$(echo "$POOL_LINE" '
+                f'| awk \'$1 ~ /^[0-9]+$/ {{print $1}}\')\n'
+                f'echo "Progress before kill: $PROGRESS '
+                f'(completed=$COMPLETED, job_id=$JOB_ID)"\n'
+                f'if [ -z "$COMPLETED" ] || [ "$COMPLETED" -eq 0 ]; then\n'
+                f'  echo "ERROR: No batches completed"\n'
+                f'  exit 1\n'
+                f'fi\n'
+                f'echo "$COMPLETED" '
+                f'> /tmp/batch-ha-progress-{name}.txt\n'
+                f'echo "$JOB_ID" '
+                f'> /tmp/batch-ha-jobid-{name}.txt'),
+
+            # --- Kill controller pod ---
+            smoke_tests_utils.kill_and_wait_controller(name, 'jobs'),
+
+            # --- Verify resume preserves progress, then wait for SUCCEED ---
+            # Bound progress-based, not wall-clock based.  The HA
+            # guarantee is "resumed progress preserved AND forward
+            # progress continues" — bail fast if progress stalls for
+            # STALL_LIMIT iterations (~10 min), but keep polling as long
+            # as we keep seeing new batches complete.
+            (
+                f'COMPLETED_BEFORE=$(cat /tmp/batch-ha-progress-{name}.txt)\n'
+                f'echo "Completed before kill: $COMPLETED_BEFORE"\n'
+                f'VERIFIED=0\n'
+                f'LAST_PROGRESS=$COMPLETED_BEFORE\n'
+                f'STALL=0\n'
+                f'STALL_LIMIT=120\n'  # 120 * 5s = 10 min without progress
+                f'MAX_ITERS=600\n'  # hard cap: 50 min
+                f'for i in $(seq 1 $MAX_ITERS); do\n'
+                f'  LINE=$(sky jobs queue 2>/dev/null '
+                f'| grep "{pool_name}" | head -1)\n'
+                f'  if echo "$LINE" | grep -qE "FAILED"; then\n'
+                f'    echo "ERROR: Batch job FAILED after recovery"\n'
+                f'    echo "Job line: $LINE"\n'
+                f'    exit 1\n'
+                f'  fi\n'
+                f'  if echo "$LINE" | grep -qE "RUNNING|WINDING_DOWN|SUCCEEDED"; then\n'
+                f'    PROGRESS_AFTER=$(echo "$LINE" '
+                f'| grep -oE "[0-9]+/[0-9]+" | head -1)\n'
+                f'    COMPLETED_AFTER=${{PROGRESS_AFTER%%/*}}\n'
+                f'    if [ "$VERIFIED" -eq 0 ]; then\n'
+                f'      echo "Progress after recovery: $PROGRESS_AFTER"\n'
+                # When the job is in WINDING_DOWN, the progress column
+                # shows "Winding down" instead of "N/M", so
+                # COMPLETED_AFTER will be empty.  In that case all
+                # batches have been dispatched, so progress is
+                # preserved by definition.
+                f'      if [ -z "$COMPLETED_AFTER" ]; then\n'
+                f'        echo "Job is winding down, all batches dispatched"\n'
+                f'        VERIFIED=1\n'
+                # After resume the completed count must be >= what we
+                # recorded before the kill.  It can be slightly larger
+                # because batches may have finished between our last
+                # progress read and the actual kill.
+                f'      elif [ "$COMPLETED_AFTER" -ge "$COMPLETED_BEFORE" ]; then\n'
+                f'        echo "Resume verified: progress preserved '
+                f'($COMPLETED_BEFORE -> $COMPLETED_AFTER)"\n'
+                f'        VERIFIED=1\n'
+                f'      else\n'
+                f'        echo "ERROR: Progress went backwards after '
+                f'recovery ($COMPLETED_BEFORE -> $COMPLETED_AFTER)"\n'
+                f'        exit 1\n'
+                f'      fi\n'
+                f'    fi\n'
+                # Detect stalled progress once VERIFIED (skip during
+                # WINDING_DOWN where COMPLETED_AFTER is empty).
+                f'    if [ "$VERIFIED" -eq 1 ] && [ -n "$COMPLETED_AFTER" ]; then\n'
+                f'      if [ "$COMPLETED_AFTER" -gt "$LAST_PROGRESS" ]; then\n'
+                f'        LAST_PROGRESS=$COMPLETED_AFTER\n'
+                f'        STALL=0\n'
+                f'      else\n'
+                f'        STALL=$((STALL + 1))\n'
+                f'        if [ "$STALL" -ge "$STALL_LIMIT" ]; then\n'
+                f'          echo "ERROR: Job progress stalled at '
+                f'$LAST_PROGRESS/30 for $((STALL * 5))s after recovery"\n'
+                f'          exit 1\n'
+                f'        fi\n'
+                f'      fi\n'
+                f'    fi\n'
+                f'    if echo "$LINE" | grep -q "SUCCEEDED"; then\n'
+                f'      echo "Batch job SUCCEEDED after controller recovery"\n'
+                f'      exit 0\n'
+                f'    fi\n'
+                f'  fi\n'
+                f'  sleep 5\n'
+                f'done\n'
+                f'echo "Timeout waiting for SUCCEEDED after recovery"\n'
+                f'exit 1'),
+
+            # --- Verify controller logs show BATCH_RESUME with correct count ---
+            (
+                f'JOB_ID=$(cat /tmp/batch-ha-jobid-{name}.txt)\n'
+                f'COMPLETED_BEFORE=$(cat /tmp/batch-ha-progress-{name}.txt)\n'
+                f's=$(sky jobs logs --controller $JOB_ID --no-follow)\n'
+                f'echo "$s"\n'
+                # The BATCH_RESUME line is emitted by _resume_from_db:
+                # "BATCH_RESUME total=100 completed=N pending=M"
+                f'echo "$s" | grep "BATCH_RESUME" || '
+                f'{{ echo "ERROR: BATCH_RESUME not found in controller logs"; '
+                f'exit 1; }}\n'
+                f'RESUME_COMPLETED=$(echo "$s" | grep "BATCH_RESUME" '
+                f'| grep -oE "completed=[0-9]+" | cut -d= -f2)\n'
+                f'echo "Controller log: resumed with '
+                f'completed=$RESUME_COMPLETED (expected >= $COMPLETED_BEFORE)"\n'
+                f'if [ -z "$RESUME_COMPLETED" ] || '
+                f'[ "$RESUME_COMPLETED" -lt "$COMPLETED_BEFORE" ]; then\n'
+                f'  echo "ERROR: Resume completed count '
+                f'($RESUME_COMPLETED) < progress before kill '
+                f'($COMPLETED_BEFORE)"\n'
+                f'  exit 1\n'
+                f'fi'),
+
+            # --- Verify all 60 items processed correctly ---
+            f'{cp} {url}/output.jsonl /tmp/batch-ha-output-{name}.jsonl',
+            f'test $(wc -l < /tmp/batch-ha-output-{name}.jsonl) -eq 60',
+            (f"python3 << 'PYEOF'\n"
+             "import json\n"
+             f"path = '/tmp/batch-ha-output-{name}.jsonl'\n"
+             "results = [json.loads(l) for l in open(path)]\n"
+             "assert len(results) == 60, f'Expected 60, got {len(results)}'\n"
+             "texts = set()\n"
+             "for r in results:\n"
+             "    assert 'text' in r and 'output' in r, f'Bad record: {r}'\n"
+             "    assert r['output'] == r['text'] * 2, f'Wrong output: {r}'\n"
+             "    texts.add(r['text'])\n"
+             "expected = set(f'word_{i}' for i in range(1, 61))\n"
+             "assert texts == expected, (\n"
+             "    f'Missing: {expected - texts}, Extra: {texts - expected}')\n"
+             "print(f'All {len(results)} results valid after HA recovery')\n"
+             "PYEOF"),
+        ],
+        # Teardown: remove pool, bucket, temp files, cloud-cmd cluster.
+        (f'sky jobs pool down {pool_name} -y;'
+         f' sky serve down {pool_name} -y 2>/dev/null || true;'
+         f' {delete_bkt};'
+         f' rm -f /tmp/batch-ha-input-{name}.jsonl'
+         f' /tmp/batch-ha-output-{name}.jsonl'
+         f' /tmp/batch-ha-bg-{name}.log'
+         f' /tmp/batch-ha-progress-{name}.txt'
+         f' /tmp/batch-ha-jobid-{name}.txt;'
+         f' {smoke_tests_utils.down_cluster_for_cloud_cmd(name)}'),
+        timeout=60 * 60,
+        env={
+            'SKY_BATCH_BUCKET': bucket,
+            'SKY_BATCH_STORE': store,
+            skypilot_config.ENV_VAR_SKYPILOT_CONFIG: skypilot_config_path,
+        },
+    )
+    smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_batch.py
+++ b/tests/smoke_tests/test_batch.py
@@ -372,6 +372,7 @@ def test_batch_cancel(generic_cloud: str):
 # ---------- Test batch HA: kill controller, verify resume from DB ----------
 @pytest.mark.kubernetes
 @pytest.mark.batch
+@pytest.mark.no_remote_server  # see note 1 above
 def test_batch_ha_kill_running(generic_cloud: str):
     """Kill the jobs controller while a batch job is RUNNING.
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

#7891 breaks the assumption that on a remote job controller, the cluster job id always matches the managed job id. So in HA recovery, the job is sometimes not recovered.

The old code extracted the cluster job ID from the script filename (`sky_job_{id}`) and compared it against in-progress managed job IDs. After `set_job_info_without_job_id`, these IDs can differ (e.g., pool gets cluster_job_id=1, managed job gets cluster_job_id=2 but managed_job_id=1), causing the recovery to either run the wrong script or skip the correct one.

This PR fixes it by extracting managed job IDs directly from the script content (`job_ids_array` set in `jobs-controller.yaml.j2`) instead of relying on the filename. SkyServe behavior is unchanged.

## Test plan
- `pytest tests/smoke_tests/test_batch.py::test_batch_ha_kill_running --generic-cloud kubernetes --kubernetes` — passed (807s)
  - Pool created, 30-batch job submitted
  - 10/30 batches completed before controller pod kill
  - Recovery preserved progress (10 → 14), all 30 batches completed
  - BATCH_RESUME and output correctness verified


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
