### PR TITLE
[DO NOT MERGE] Test forward-compat for ProvisionRuntimeMetadata

### DIFF
--- a/sky/provision/common.py
+++ b/sky/provision/common.py
@@ -120,6 +120,8 @@ class ProvisionRuntimeMetadata:
     # Whether the user's ``run`` command has already been started on the
     # cluster by the provisioner.
     run_started: bool = False
+    # Test field for verifying forward-compatibility of unknown fields.
+    _backcompat_test_field: bool = False
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
## Summary
Adds a dummy field to `ProvisionRuntimeMetadata` to verify that the unknown-field filter (merged in #9547) correctly handles new→old client deserialization.

Trigger `/quicktest-core` to validate. Delete after confirming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)