### PR TITLE
fix(runpod): pass formatted image name to create_template instead of None

### DIFF
--- a/sky/provision/runpod/utils.py
+++ b/sky/provision/runpod/utils.py
@@ -261,12 +261,14 @@ def _create_template_for_docker_login(
     container_registry_auth_name = f'{cluster_name}-registry-auth'
     container_template_name = _construct_docker_login_template_name(
         cluster_name)
-    # The `name` argument is only for display purpose and the registry server
-    # will be splitted from the docker image name (Tested with AWS ECR).
-    # Here we only need the username and password to create the registry auth.
+    # Compute the fully-qualified image name (e.g. ghcr.io/org/image:tag)
+    # before creating the template. Passing image_name=None caused Python to
+    # serialize None as the literal string "None" in the GraphQL mutation
+    # (imageName: "None"), which the RunPod API now rejects as invalid.
     # TODO(tian): Now we create a template and a registry auth for each cluster.
     # Consider create one for each server and reuse them. Challenges including
     # calculate the reference count and delete them when no longer needed.
+    formatted_image = login_config.format_image(image_name)
     create_auth_resp = runpod.runpod.create_container_registry_auth(
         name=container_registry_auth_name,
         username=login_config.username,
@@ -275,10 +277,10 @@ def _create_template_for_docker_login(
     registry_auth_id = create_auth_resp['id']
     create_template_resp = runpod.runpod.create_template(
         name=container_template_name,
-        image_name=None,
+        image_name=formatted_image,
         registry_auth_id=registry_auth_id,
     )
-    return login_config.format_image(image_name), create_template_resp['id']
+    return formatted_image, create_template_resp['id']
 
 
 def launch(

--- a/tests/unit_tests/test_sky/provision/test_runpod_utils.py
+++ b/tests/unit_tests/test_sky/provision/test_runpod_utils.py
@@ -1,6 +1,7 @@
 """Unit tests for sky.provision.runpod.utils."""
 from unittest import mock
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/unit_tests/test_sky/provision/test_runpod_utils.py
+++ b/tests/unit_tests/test_sky/provision/test_runpod_utils.py
@@ -1,0 +1,79 @@
+"""Unit tests for sky.provision.runpod.utils."""
+from unittest import mock
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sky.provision.runpod import utils as runpod_utils
+
+
+class TestCreateTemplateForDockerLogin:
+
+    def test_no_docker_login_config_returns_image_unchanged(self):
+        image, template_id = runpod_utils._create_template_for_docker_login(
+            cluster_name='test-cluster',
+            image_name='my-org/my-image:tag',
+            docker_login_config=None,
+        )
+        assert image == 'my-org/my-image:tag'
+        assert template_id is None
+
+    def test_docker_login_config_passes_formatted_image_to_create_template(self):
+        """Regression test for #9546.
+
+        create_template must receive the fully-qualified image name, not None.
+        Passing None caused Python to serialize it as the literal string "None"
+        in the GraphQL mutation (imageName: "None"), which the RunPod API now
+        rejects as an invalid image name.
+        """
+        mock_auth_resp = {'id': 'auth-id-123'}
+        mock_template_resp = {'id': 'template-id-456'}
+
+        with patch('sky.provision.runpod.utils.runpod') as mock_runpod:
+            mock_runpod.runpod.create_container_registry_auth.return_value = (
+                mock_auth_resp)
+            mock_runpod.runpod.create_template.return_value = mock_template_resp
+
+            image, template_id = (
+                runpod_utils._create_template_for_docker_login(
+                    cluster_name='test-cluster',
+                    image_name='my-org/my-image:tag',
+                    docker_login_config={
+                        'username': 'user',
+                        'password': 'pass',
+                        'server': 'ghcr.io',
+                    },
+                ))
+
+        assert image == 'ghcr.io/my-org/my-image:tag'
+        assert template_id == 'template-id-456'
+
+        # The critical assertion: create_template must not receive None or
+        # the string "None" as image_name.
+        mock_runpod.runpod.create_template.assert_called_once_with(
+            name=mock.ANY,
+            image_name='ghcr.io/my-org/my-image:tag',
+            registry_auth_id='auth-id-123',
+        )
+
+    def test_image_already_has_server_prefix_not_doubled(self):
+        mock_auth_resp = {'id': 'auth-id-123'}
+        mock_template_resp = {'id': 'template-id-456'}
+
+        with patch('sky.provision.runpod.utils.runpod') as mock_runpod:
+            mock_runpod.runpod.create_container_registry_auth.return_value = (
+                mock_auth_resp)
+            mock_runpod.runpod.create_template.return_value = mock_template_resp
+
+            image, _ = runpod_utils._create_template_for_docker_login(
+                cluster_name='test-cluster',
+                image_name='ghcr.io/my-org/my-image:tag',
+                docker_login_config={
+                    'username': 'user',
+                    'password': 'pass',
+                    'server': 'ghcr.io',
+                },
+            )
+
+        # Server prefix should not be doubled.
+        assert image == 'ghcr.io/my-org/my-image:tag'

--- a/tests/unit_tests/test_sky/provision/test_runpod_utils.py
+++ b/tests/unit_tests/test_sky/provision/test_runpod_utils.py
@@ -18,7 +18,8 @@ class TestCreateTemplateForDockerLogin:
         assert image == 'my-org/my-image:tag'
         assert template_id is None
 
-    def test_docker_login_config_passes_formatted_image_to_create_template(self):
+    def test_docker_login_config_passes_formatted_image_to_create_template(
+            self):
         """Regression test for #9546.
 
         create_template must receive the fully-qualified image name, not None.


### PR DESCRIPTION
## Summary

Fixes #9546 — RunPod provisioning fails with `QueryError: Invalid container image name` when using a custom Docker image with `SKYPILOT_DOCKER_*` credentials.

**Root cause:** `_create_template_for_docker_login` in `sky/provision/runpod/utils.py` was calling `runpod.runpod.create_template(image_name=None)`. Python's f-string serialises `None` as the literal string `"None"` inside the GraphQL mutation body (`imageName: "None"`). The RunPod API recently tightened image name validation and now rejects `"None"` with `QueryError: Invalid container image name`.

**Fix:** Compute the fully-qualified image name (e.g. `ghcr.io/org/image:tag`) before the `create_template` call and pass it as `image_name`, which is the same value already returned to the caller. The logic is unchanged — only the order of operations shifts so `format_image` runs before, not after, `create_template`.

**Before:**
```python
create_template_resp = runpod.runpod.create_template(
    name=container_template_name,
    image_name=None,          # serialises to "None" in GraphQL
    registry_auth_id=registry_auth_id,
)
return login_config.format_image(image_name), create_template_resp['id']
```

**After:**
```python
formatted_image = login_config.format_image(image_name)
create_template_resp = runpod.runpod.create_template(
    name=container_template_name,
    image_name=formatted_image,   # valid image name passed
    registry_auth_id=registry_auth_id,
)
return formatted_image, create_template_resp['id']
```

## Test plan

- [x] Added unit tests in `tests/unit_tests/test_sky/provision/test_runpod_utils.py`:
  - `create_template` is called with the fully-qualified image name (regression guard for #9546)
  - No docker login config → image returned unchanged, no template created
  - Image that already carries the server prefix is not double-prefixed