### PR TITLE
[Kubernetes] Allow kubernetes.kueue.tas in user config

### DIFF
--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1490,6 +1490,25 @@ _CONTEXT_CONFIG_SCHEMA_KUBERNETES = {
             'local_queue_name': {
                 'type': 'string',
             },
+            # Topology-Aware Scheduling — applied to admitted Workloads
+            # via `kueue.x-k8s.io/podset-{required,preferred}-topology`
+            # PodTemplate annotations. Both fields are optional at the
+            # schema level so MLEs can override only what they need
+            # (e.g. `mode: off` without re-stating `label_key`); semantic
+            # validation (label_key must be set if mode != off) lives
+            # in the consumer that injects the annotations.
+            'tas': {
+                'type': 'object',
+                'additionalProperties': False,
+                'properties': {
+                    'label_key': {
+                        'type': 'string',
+                    },
+                    'mode': {
+                        'type': 'string',
+                    },
+                },
+            },
         },
     },
     # Alias of `kueue.local_queue_name`; `quota.queue` takes precedence


### PR DESCRIPTION
## Summary

Adds a `tas` block to the `kubernetes.kueue` config subschema for [Topology-Aware Scheduling](https://kueue.sigs.k8s.io/docs/concepts/topology_aware_scheduling/). Both fields (`label_key`, `mode`) are optional at the schema level so users can override one without restating the other.

## Test plan

- [x] Schema validation accepts both `kubernetes.kueue.tas: {label_key: ..., mode: ...}` and the partial `kubernetes.kueue.tas: {mode: "off"}`
- [x] `pytest tests/unit_tests/test_resources.py` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)