### PR TITLE
[Catalog] Fix Lambda fetcher KeyError on cpu_4x_generalx

### DIFF
--- a/sky/catalog/data_fetchers/fetch_lambda_cloud.py
+++ b/sky/catalog/data_fetchers/fetch_lambda_cloud.py
@@ -11,7 +11,7 @@ import argparse
 import csv
 import json
 import os
-from typing import Optional, Tuple
+from typing import Optional
 
 import requests
 
@@ -50,24 +50,18 @@ GPU_TO_MEMORY = {
     'H100': 81920,
     'GH200': 98304,
     'B200': 184320,  # 180 GB
-    'GENERAL': None
 }
 
 
-def name_to_gpu_and_cnt(name: str) -> Optional[Tuple[str, int]]:
-    """Extract GPU and count from instance type name.
+def name_to_gpu(name: str) -> str:
+    """Extract GPU type from instance type name.
 
     The instance type name is in the format:
       'gpu_{gpu_count}x_{gpu_name}_<suffix>'.
     """
-    # Edge case
     if name == 'gpu_8x_a100_80gb_sxm4':
-        return 'A100-80GB', 8
-    gpu = name.split('_')[2].upper()
-    if gpu == 'GENERAL':
-        return None
-    gpu_cnt = int(name.split('_')[1].replace('x', ''))
-    return gpu, gpu_cnt
+        return 'A100-80GB'
+    return name.split('_')[2].upper()
 
 
 def create_catalog(api_key: str, output_path: str) -> None:
@@ -84,20 +78,17 @@ def create_catalog(api_key: str, output_path: str) -> None:
         # We parse info.keys() in reverse order so gpu_1x_a100_sxm4 comes before
         # gpu_1x_a100 in the catalog (gpu_1x_a100_sxm4 has more availability).
         for vm in reversed(list(info.keys())):
-            gpu_and_cnt = name_to_gpu_and_cnt(vm)
-            gpu: Optional[str]
-            gpu_cnt: Optional[float]
-            if gpu_and_cnt is None:
-                gpu, gpu_cnt = None, None
-            else:
-                gpu = gpu_and_cnt[0]
-                gpu_cnt = float(gpu_and_cnt[1])
-            vcpus = float(info[vm]['instance_type']['specs']['vcpus'])
-            mem = float(info[vm]['instance_type']['specs']['memory_gib'])
+            specs = info[vm]['instance_type']['specs']
+            vcpus = float(specs['vcpus'])
+            mem = float(specs['memory_gib'])
             price = (float(info[vm]['instance_type']['price_cents_per_hour']) /
                      100)
+            gpu: Optional[str] = None
+            gpu_cnt: Optional[float] = None
             gpuinfo: Optional[str] = None
-            if gpu is not None:
+            if specs.get('gpus', 0) > 0:
+                gpu = name_to_gpu(vm)
+                gpu_cnt = float(specs['gpus'])
                 gpuinfo_dict = {
                     'Gpus': [{
                         'Name': gpu,

--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -284,7 +284,7 @@ def test_instance_type_from_cpu_memory(enable_all_clouds, capfd):
     assert 'r6i.2xlarge' in stdout  # AWS, 8 vCPUs, 64 GB memory
     assert 'Standard_E8s_v5' in stdout  # Azure, 8 vCPUs, 64 GB memory
     assert 'n4-highmem-8' in stdout  # GCP, 8 vCPUs, 64 GB memory
-    assert 'gpu_1x_a10' in stdout  # Lambda, 30 vCPUs, 200 GB memory
+    assert 'gpu_1x_a6000' in stdout  # Lambda, 14 vCPUs, 100 GB memory
 
     _test_resources_launch(cpus='4+', memory='4+')
     stdout, _ = capfd.readouterr()


### PR DESCRIPTION
## Summary
- Lambda added a new CPU instance type `cpu_4x_generalx` whose name causes a `KeyError` in the catalog fetcher — the parser extracts `GENERALX` but `GPU_TO_MEMORY` only has `GENERAL`.
- This has been failing the [skypilot-catalog CI](https://github.com/skypilot-org/skypilot-catalog/actions/workflows/update-lambda-catalog.yml) since May 4. One run succeeded during a transient empty API response and [wiped all Lambda VM data](https://github.com/skypilot-org/skypilot-catalog/commit/ceab6e78eec0aa2cb7e21115173dd46d1374ef37) from the catalog.
- Instead of patching the name-based heuristic, use the `specs.gpus` field from the API response to determine whether an instance has GPUs. This is robust against any future CPU instance naming conventions. GPU count also comes from `specs.gpus` now instead of parsing instance names.

## Test plan
- [x] Reproduced `KeyError: 'GENERALX'` locally against the live Lambda API
- [x] Verified fix produces a valid 425-row CSV with correct GPU and CPU rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)