### PR TITLE
[CI] Drop Black; let yapf+isort format IBM provider

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -32,28 +32,16 @@ jobs:
         source ~/test-env/bin/activate
         uv pip install yapf==0.32.0
         uv pip install toml==0.10.2
-        uv pip install black==24.10.0
         uv pip install isort==5.12.0
     - name: Running yapf
       run: |
         source ~/test-env/bin/activate
         yapf --diff --recursive ./ --exclude 'sky/skylet/ray_patches/**' \
-            --exclude 'sky/skylet/providers/ibm/**' \
             --exclude 'sky/schemas/generated/**' \
             --exclude 'tests/unit_tests/test_sky/backends/testdata/**'
-    - name: Running black
-      run: |
-        source ~/test-env/bin/activate
-        black --diff --check sky/skylet/providers/ibm/
-    - name: Running isort for black formatted files
-      run: |
-        source ~/test-env/bin/activate
-        isort --diff --check --profile black -l 88 -m 3 \
-            sky/skylet/providers/ibm/
     - name: Running isort for yapf formatted files
       run: |
         source ~/test-env/bin/activate
         isort --diff --check ./ --sg 'sky/skylet/ray_patches/**' \
-            --sg 'sky/skylet/providers/ibm/**' \
             --sg 'sky/schemas/generated/**' \
             --sg 'tests/unit_tests/test_sky/backends/testdata/**'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,28 +10,12 @@ repos:
         exclude: ^charts/
     -   id: check-added-large-files
 
--   repo: https://github.com/psf/black
-    rev: 24.10.0  # Match the version from requirements
-    hooks:
-    -   id: black
-        name: black (IBM specific)
-        files: "^sky/skylet/providers/ibm/.*"  # Match only files in the IBM directory
-
 -   repo: https://github.com/pycqa/isort
     rev: 5.12.0  # Match the version from requirements
     hooks:
-    # First isort command
     -   id: isort
         name: isort (general)
-        exclude: "(build/.*|sky/skylet/providers/ibm/.*|sky/schemas/generated/.*)"  # Matches "${ISORT_YAPF_EXCLUDES[@]}"
-    # Second isort command
-    -   id: isort
-        name: isort (IBM specific)
-        args:
-          - "--profile=black"
-          - "-l=88"
-          - "-m=3"
-        files: "^sky/skylet/providers/ibm/.*"  # Only match IBM-specific directory
+        exclude: "(build/.*|sky/schemas/generated/.*)"  # Matches "${ISORT_YAPF_EXCLUDES[@]}"
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.19.1  # Match the version from requirements
@@ -62,7 +46,7 @@ repos:
     hooks:
     -   id: yapf
         name: yapf
-        exclude: (sky/skylet/providers/ibm/.*|sky/schemas/generated/.*)  # Matches exclusions from the script
+        exclude: sky/schemas/generated/.*  # Matches exclusions from the script
         args: ['--recursive', '--parallel', '--in-place']  # Only necessary flags
         additional_dependencies: [toml==0.10.2] # Match the version from requirements
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,25 +93,22 @@ bash format.sh --files path/to/file.py  # Format specific files
 ```
 
 The script runs:
-1. **Black** - IBM-specific code only (`sky/skylet/providers/ibm/`)
-2. **YAPF** - Google style for all other Python code
-3. **isort** - Import sorting (Google profile)
-4. **mypy** - Type checking
-5. **pylint** - Linting with custom rules
+1. **YAPF** - Google style for all Python code
+2. **isort** - Import sorting (Google profile)
+3. **mypy** - Type checking
+4. **pylint** - Linting with custom rules
 
 ### Tool Versions (must match exactly)
 
 From `requirements-dev.txt`:
 - yapf==0.32.0
 - pylint==2.14.5
-- black==22.10.0
 - mypy==1.19.1
 - isort==5.12.0
 - pylint-quotes==0.2.3
 
 ### Excluded from Formatting
 
-- `sky/skylet/providers/ibm/` - Uses Black instead of YAPF
 - `sky/schemas/generated/` - Auto-generated protobuf files
 - `build/` - Build artifacts
 

--- a/format.sh
+++ b/format.sh
@@ -29,7 +29,6 @@ if ! command -v pip >/dev/null 2>&1; then
 fi
 PYLINT_QUOTES_VERSION=$($PIP_LIST_CMD | awk '/pylint-quotes/ {print $2}')
 MYPY_VERSION=$(mypy --version | awk '{print $2}')
-BLACK_VERSION=$(black --version | head -n 1 | awk '{print $2}')
 
 # # params: tool name, tool version, required version
 tool_version_check() {
@@ -43,7 +42,6 @@ tool_version_check "yapf" $YAPF_VERSION "$(grep yapf requirements-dev.txt | cut 
 tool_version_check "pylint" $PYLINT_VERSION "$(grep "pylint==" requirements-dev.txt | cut -d'=' -f3)"
 tool_version_check "pylint-quotes" $PYLINT_QUOTES_VERSION "$(grep "pylint-quotes==" requirements-dev.txt | cut -d'=' -f3)"
 tool_version_check "mypy" "$MYPY_VERSION" "$(grep mypy requirements-dev.txt | cut -d'=' -f3)"
-tool_version_check "black" "$BLACK_VERSION" "$(grep black requirements-dev.txt | cut -d'=' -f3)"
 
 YAPF_FLAGS=(
     '--recursive'
@@ -52,20 +50,14 @@ YAPF_FLAGS=(
 
 YAPF_EXCLUDES=(
     '--exclude' 'build/**'
-    '--exclude' 'sky/skylet/providers/ibm/**'
     '--exclude' 'sky/schemas/generated/**'
     '--exclude' 'tests/unit_tests/test_sky/backends/testdata/**'
 )
 
 ISORT_YAPF_EXCLUDES=(
     '--sg' 'build/**'
-    '--sg' 'sky/skylet/providers/ibm/**'
     '--sg' 'sky/schemas/generated/**'
     '--sg' 'tests/unit_tests/test_sky/backends/testdata/**'
-)
-
-BLACK_INCLUDES=(
-    'sky/skylet/providers/ibm'
 )
 
 PYLINT_FLAGS=(
@@ -102,9 +94,6 @@ format_all() {
     yapf --in-place "${YAPF_FLAGS[@]}" "${YAPF_EXCLUDES[@]}" sky tests examples llm
 }
 
-echo 'SkyPilot Black:'
-black "${BLACK_INCLUDES[@]}"
-
 ## This flag formats individual files. --files *must* be the first command line
 ## arg to use this option.
 if [[ "$1" == '--files' ]]; then
@@ -121,8 +110,6 @@ echo 'SkyPilot yapf: Done'
 
 echo 'SkyPilot isort:'
 isort sky tests examples llm docs "${ISORT_YAPF_EXCLUDES[@]}"
-
-isort --profile black -l 88 -m 3 "sky/skylet/providers/ibm"
 
 
 # Run mypy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,9 +3,6 @@
 yapf==0.32.0
 # match the version with .pre-commit-config.yaml
 pylint==2.14.5
-# formatting the node_providers code from upstream ray-project/ray project
-# match the version with .pre-commit-config.yaml
-black==24.10.0
 # https://github.com/edaniszewski/pylint-quotes
 # match the version with .pre-commit-config.yaml
 pylint-quotes==0.2.3

--- a/sky/skylet/providers/ibm/node_provider.py
+++ b/sky/skylet/providers/ibm/node_provider.py
@@ -19,33 +19,34 @@ used by the Ray framework as an external connector to IBM provider."""
 import concurrent.futures as cf
 import inspect
 import json
+from pathlib import Path
+from pprint import pformat
+from pprint import pprint
 import re
 import socket
 import threading
 import time
-from pathlib import Path
-from pprint import pformat, pprint
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 from ray.autoscaler._private.cli_logger import cli_logger
-from ray.autoscaler._private.util import hash_launch_conf, hash_runtime_conf
+from ray.autoscaler._private.util import hash_launch_conf
+from ray.autoscaler._private.util import hash_runtime_conf
 from ray.autoscaler.node_provider import NodeProvider
-from ray.autoscaler.tags import (
-    NODE_KIND_HEAD,
-    NODE_KIND_WORKER,
-    TAG_RAY_CLUSTER_NAME,
-    TAG_RAY_FILE_MOUNTS_CONTENTS,
-    TAG_RAY_LAUNCH_CONFIG,
-    TAG_RAY_NODE_KIND,
-    TAG_RAY_NODE_NAME,
-    TAG_RAY_NODE_STATUS,
-    TAG_RAY_RUNTIME_CONFIG,
-    TAG_RAY_USER_NODE_TYPE,
-)
+from ray.autoscaler.tags import NODE_KIND_HEAD
+from ray.autoscaler.tags import NODE_KIND_WORKER
+from ray.autoscaler.tags import TAG_RAY_CLUSTER_NAME
+from ray.autoscaler.tags import TAG_RAY_FILE_MOUNTS_CONTENTS
+from ray.autoscaler.tags import TAG_RAY_LAUNCH_CONFIG
+from ray.autoscaler.tags import TAG_RAY_NODE_KIND
+from ray.autoscaler.tags import TAG_RAY_NODE_NAME
+from ray.autoscaler.tags import TAG_RAY_NODE_STATUS
+from ray.autoscaler.tags import TAG_RAY_RUNTIME_CONFIG
+from ray.autoscaler.tags import TAG_RAY_USER_NODE_TYPE
 
 from sky.adaptors import ibm
-from sky.skylet.providers.ibm.utils import RAY_RECYCLABLE, get_logger
+from sky.skylet.providers.ibm.utils import get_logger
+from sky.skylet.providers.ibm.utils import RAY_RECYCLABLE
 from sky.skylet.providers.ibm.vpc_provider import IBMVPCProvider
 
 logger = get_logger("node_provider_")
@@ -67,14 +68,12 @@ def log_in_out(func):
         logger.debug(
             f"\n\nEnter {name} from {inspect.stack()[0][3]} "
             f"{inspect.stack()[1][3]} {inspect.stack()[2][3]} with args: "
-            f"entered with args:\n{pformat(args)} and kwargs {pformat(kwargs)}"
-        )
+            f"entered with args:\n{pformat(args)} and kwargs {pformat(kwargs)}")
         try:
             result = func(*args, **kwargs)
             logger.debug(
                 f"Leave {name} from {inspect.stack()[1][3]} with result "
-                f"Func Result:{pformat(result)}\n\n"
-            )
+                f"Func Result:{pformat(result)}\n\n")
         except Exception:
             cli_logger.error(f"Error in {name}")
             raise
@@ -120,8 +119,7 @@ class IBMVPCNodeProvider(NodeProvider):
                     if e.message == "Instance not found":
                         logger.error(
                             f"cached instance {instance_id} not found, \
-                                will be removed from cache"
-                        )
+                                will be removed from cache")
             # dump in-memory cache to local cache (file).
             self.set_node_tags(None, None)
 
@@ -132,27 +130,28 @@ class IBMVPCNodeProvider(NodeProvider):
             if self._get_node_type(name) == NODE_KIND_HEAD:
                 logger.debug(f"{name} is HEAD")
                 # pylint: disable=line-too-long
-                node = self.ibm_vpc_client.list_instances(name=name).get_result()[
-                    "instances"
-                ]
+                node = self.ibm_vpc_client.list_instances(
+                    name=name).get_result()["instances"]
                 if node:
                     logger.debug(f"{name} is node in vpc")
 
                     # remote head node will calculate 2 hash values below
-                    ray_bootstrap_config = Path.home() / "ray_bootstrap_config.yaml"
+                    ray_bootstrap_config = Path.home(
+                    ) / "ray_bootstrap_config.yaml"
                     config = json.loads(ray_bootstrap_config.read_text())
                     runtime_hash, mounts_contents_hash = hash_runtime_conf(
-                        config["file_mounts"], None, config
-                    )
+                        config["file_mounts"], None, config)
 
                     # launch_hash is used to verify the head node belongs
                     # to the cluster. e.g. checked when running --restart-only
                     head_node_config = {}
                     head_node_type = config.get("head_node_type")
                     if head_node_type:
-                        head_config = config["available_node_types"][head_node_type]
+                        head_config = config["available_node_types"][
+                            head_node_type]
                         head_node_config.update(head_config["node_config"])
-                    launch_hash = hash_launch_conf(head_node_config, config["auth"])
+                    launch_hash = hash_launch_conf(head_node_config,
+                                                   config["auth"])
 
                     head_tags = {
                         TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
@@ -192,9 +191,8 @@ class IBMVPCNodeProvider(NodeProvider):
         # vpc_tags may contain the following fields:
         # vpc_id, subnet_id, security_group_id
         self.vpc_tags = None
-        self.vpc_provider = IBMVPCProvider(
-            self.resource_group_id, self.region, self.cluster_name
-        )
+        self.vpc_provider = IBMVPCProvider(self.resource_group_id, self.region,
+                                           self.cluster_name)
         # cache of the cluster's nodes in the format: {node_id:node_tags}
         self.nodes_tags = {}
         # Cache of starting/running/pending(below PENDING_TIMEOUT)nodes.
@@ -210,7 +208,8 @@ class IBMVPCNodeProvider(NodeProvider):
 
         # if cache_stopped_nodes == true, nodes will be stopped
         #   instead of deleted to better accommodate future rise in demand
-        self.cache_stopped_nodes = provider_config.get("cache_stopped_nodes", True)
+        self.cache_stopped_nodes = provider_config.get("cache_stopped_nodes",
+                                                       True)
 
     def _get_node_type(self, name):
         """returns the type of node with the specified name.
@@ -245,12 +244,12 @@ class IBMVPCNodeProvider(NodeProvider):
         nodes = []
         found_new_node = False
         # filters specified are a subset of {cluster_name, node_type}
-        if {TAG_RAY_NODE_KIND, TAG_RAY_CLUSTER_NAME}.issuperset(set(filters.keys())):
+        if {TAG_RAY_NODE_KIND,
+                TAG_RAY_CLUSTER_NAME}.issuperset(set(filters.keys())):
             if self.vpc_tags:
                 # if possible, search within the vpc to narrow the search scope
                 result = self.ibm_vpc_client.list_instances(
-                    vpc_id=self.vpc_tags["vpc_id"]
-                ).get_result()
+                    vpc_id=self.vpc_tags["vpc_id"]).get_result()
             else:
                 result = self.ibm_vpc_client.list_instances().get_result()
             instances = result["instances"]
@@ -258,7 +257,8 @@ class IBMVPCNodeProvider(NodeProvider):
             # https://cloud.ibm.com/apidocs/vpc/latest?code=python#api-pagination
             while result.get("next"):
                 start = result["next"]["href"].split("start=")[1]
-                result = self.ibm_vpc_client.list_instances(start=start).get_result()
+                result = self.ibm_vpc_client.list_instances(
+                    start=start).get_result()
                 instances.extend(result["instances"])
 
             for instance in instances:
@@ -267,15 +267,14 @@ class IBMVPCNodeProvider(NodeProvider):
                     if not filters or kind == filters[TAG_RAY_NODE_KIND]:
                         nodes.append(instance)
                         with self.lock:
-                            node_tags = self.nodes_tags.setdefault(instance["id"], {})
+                            node_tags = self.nodes_tags.setdefault(
+                                instance["id"], {})
                             if not node_tags:
                                 found_new_node = True
-                            node_tags.update(
-                                {
-                                    TAG_RAY_CLUSTER_NAME: self.cluster_name,
-                                    TAG_RAY_NODE_KIND: kind,
-                                }
-                            )
+                            node_tags.update({
+                                TAG_RAY_CLUSTER_NAME: self.cluster_name,
+                                TAG_RAY_NODE_KIND: kind,
+                            })
             # update local tags cache
             if found_new_node:
                 self.set_node_tags(None, None)
@@ -289,23 +288,26 @@ class IBMVPCNodeProvider(NodeProvider):
                 for node_id, node_tags in self.nodes_tags.items():
                     # skipping nodes that don't match all specified filters,
                     # i.e. not all items in filters match those in self.nodes_tags
-                    if not all(item in node_tags.items() for item in filters.items()):
+                    if not all(item in node_tags.items()
+                               for item in filters.items()):
                         logger.debug(
                             f"specified filters: {filters} don't match node "
-                            f"tags: {node_tags}"
-                        )
+                            f"tags: {node_tags}")
                         continue
 
                     # append to result list nodes that do match the filters:
                     try:
                         # not using cache. see function docs for details.
-                        nodes.append(self.ibm_vpc_client.get_instance(node_id).result)
+                        nodes.append(
+                            self.ibm_vpc_client.get_instance(node_id).result)
                     except ibm.ibm_cloud_sdk_core.ApiException as e:
                         cli_logger.warning(node_id)
                         if "Instance not found" in e.message:
-                            logger.error(f"failed to find vsi {node_id}, skipping")
+                            logger.error(
+                                f"failed to find vsi {node_id}, skipping")
                             continue
-                        logger.error(f"failed to find instance {node_id}, raising")
+                        logger.error(
+                            f"failed to find instance {node_id}, raising")
                         raise e
 
         return nodes
@@ -341,29 +343,26 @@ class IBMVPCNodeProvider(NodeProvider):
                         # since non_terminated_nodes is called periodically,
                         # prevent access until node is deleted
                         self._delete_node(node["id"], node)
-                        logger.error(
-                            """Encountered a failed node.
+                        logger.error("""Encountered a failed node.
                             Region might be crowded,
-                            Consider retrying later."""
-                        )
+                            Consider retrying later.""")
                     else:
-                        logger.debug(
-                            f"{node['id']} status {node['status']}"
-                            f" not in {valid_statuses}, skipping"
-                        )
+                        logger.debug(f"{node['id']} status {node['status']}"
+                                     f" not in {valid_statuses}, skipping")
                         continue
 
             # remove instance hanging in pending state
             with self.lock:
                 if node["id"] in self.pending_nodes:
                     if node["status"] != "running":
-                        pending_time = time.time() - self.pending_nodes[node["id"]]
-                        logger.debug(f"{node['id']} is pending for {pending_time}")
+                        pending_time = time.time() - self.pending_nodes[
+                            node["id"]]
+                        logger.debug(
+                            f"{node['id']} is pending for {pending_time}")
                         if pending_time > PENDING_TIMEOUT:
                             logger.error(
                                 f"pending timeout {PENDING_TIMEOUT} reached, "
-                                f"deleting instance {node['id']}"
-                            )
+                                f"deleting instance {node['id']}")
                             self._delete_node(node["id"], node)
                             # avoid adding the node to cached_nodes
                             continue
@@ -374,8 +373,7 @@ class IBMVPCNodeProvider(NodeProvider):
             nic_id = node["network_interfaces"][0]["id"]
             # pylint: disable=line-too-long
             res = self.ibm_vpc_client.list_instance_network_interface_floating_ips(
-                node["id"], nic_id
-            ).get_result()
+                node["id"], nic_id).get_result()
             floating_ips = res["floating_ips"]
             if not floating_ips:
                 # not adding a node that's yet/failed to
@@ -396,10 +394,8 @@ class IBMVPCNodeProvider(NodeProvider):
         """returns whether a node is in status running"""
         with self.lock:
             node = self._get_cached_node(node_id)
-            logger.debug(
-                f"""node: {node_id} is_running?
-                {node["status"] == "running"}"""
-            )
+            logger.debug(f"""node: {node_id} is_running?
+                {node["status"] == "running"}""")
             return node["status"] == "running"
 
     def is_terminated(self, node_id) -> bool:
@@ -408,11 +404,9 @@ class IBMVPCNodeProvider(NodeProvider):
         with self.lock:
             try:
                 node = self._get_cached_node(node_id)
-                logger.debug(
-                    f"""node: {node_id} is_terminated?
+                logger.debug(f"""node: {node_id} is_terminated?
                     {node["status"] not in
-                    ["running", "starting", "pending"]}"""
-                )
+                    ["running", "starting", "pending"]}""")
                 return node["status"] not in ["running", "starting", "pending"]
             # pylint: disable=W0703
             except Exception:
@@ -448,7 +442,8 @@ class IBMVPCNodeProvider(NodeProvider):
         # if a bug occurred, or node data was fetched before primary_ip
         # was assigned, refetch node data from cloud.
         try:
-            primary_ip = node["network_interfaces"][0].get("primary_ip")["address"]
+            primary_ip = node["network_interfaces"][0].get(
+                "primary_ip")["address"]
             if primary_ip is None:
                 node = self._get_node(node_id)
         # pylint: disable=W0703
@@ -484,7 +479,8 @@ class IBMVPCNodeProvider(NodeProvider):
     def _get_instance_data(self, name):
         """Returns instance (node) information matching the specified name"""
 
-        instances_data = self.ibm_vpc_client.list_instances(name=name).get_result()
+        instances_data = self.ibm_vpc_client.list_instances(
+            name=name).get_result()
         if instances_data["instances"]:
             return instances_data["instances"][0]
         return None
@@ -503,7 +499,8 @@ class IBMVPCNodeProvider(NodeProvider):
         logger.info(f"Creating new VM instance {name}")
 
         if self.vpc_tags is None:
-            raise ValueError("vpc_tags must be initialized before creating instances")
+            raise ValueError(
+                "vpc_tags must be initialized before creating instances")
         vpc_tags = self.vpc_tags  # Help mypy with type narrowing
 
         security_group_identity_model = {"id": vpc_tags["security_group_id"]}
@@ -518,7 +515,8 @@ class IBMVPCNodeProvider(NodeProvider):
             "capacity": base_config.get("boot_volume_capacity", 100),
             "name": f"boot-volume-{uuid4().hex[:4]}",
             "profile": {
-                "name": base_config.get("volume_tier_name", VOLUME_TIER_NAME_DEFAULT)
+                "name": base_config.get("volume_tier_name",
+                                        VOLUME_TIER_NAME_DEFAULT)
             },
         }
 
@@ -530,10 +528,8 @@ class IBMVPCNodeProvider(NodeProvider):
         key_identity_model = {"id": base_config["key_id"]}
         profile_name = base_config.get("instance_profile_name")
         if not profile_name:
-            raise Exception(
-                """Failed to detect 'instance_profile_name'
-                key in cluster config file"""
-            )
+            raise Exception("""Failed to detect 'instance_profile_name'
+                key in cluster config file""")
 
         instance_prototype = {}
         instance_prototype["name"] = name
@@ -546,7 +542,8 @@ class IBMVPCNodeProvider(NodeProvider):
         instance_prototype["zone"] = {"name": self.zone}
         instance_prototype["boot_volume_attachment"] = boot_volume_attachment
         # pylint: disable=line-too-long
-        instance_prototype["primary_network_interface"] = primary_network_interface
+        instance_prototype[
+            "primary_network_interface"] = primary_network_interface
 
         try:
             with self.lock:
@@ -555,13 +552,12 @@ class IBMVPCNodeProvider(NodeProvider):
             if e.code == 400 and "already exists" in e.message:
                 return self._get_instance_data(name)
             elif e.code == 400 and "over quota" in e.message:
-                cli_logger.error(f"Create VM instance {name} failed due to quota limit")
-            else:
                 cli_logger.error(
-                    f"""Create VM instance for {name}
+                    f"Create VM instance {name} failed due to quota limit")
+            else:
+                cli_logger.error(f"""Create VM instance for {name}
                     failed with status code {str(e.code)}
-                    .\nFailed instance prototype:\n"""
-                )
+                    .\nFailed instance prototype:\n""")
                 pprint(instance_prototype)
             raise e
 
@@ -579,9 +575,8 @@ class IBMVPCNodeProvider(NodeProvider):
 
         if base_config.get("head_ip"):
             # pylint: disable=line-too-long
-            for ip in self.ibm_vpc_client.list_floating_ips().get_result()[
-                "floating_ips"
-            ]:
+            for ip in self.ibm_vpc_client.list_floating_ips().get_result(
+            )["floating_ips"]:
                 if ip["address"] == base_config["head_ip"]:
                     return ip
 
@@ -608,10 +603,8 @@ class IBMVPCNodeProvider(NodeProvider):
         fip = fip_data["address"]
         fip_id = fip_data["id"]
 
-        logger.debug(
-            f"""Attaching floating IP {fip} to
-            VM instance {instance["id"]}"""
-        )
+        logger.debug(f"""Attaching floating IP {fip} to
+            VM instance {instance["id"]}""")
 
         # check if floating ip is not attached yet
         inst_p_nic = instance["primary_network_interface"]
@@ -622,8 +615,7 @@ class IBMVPCNodeProvider(NodeProvider):
         else:
             # attach floating ip
             self.ibm_vpc_client.add_instance_network_interface_floating_ip(
-                instance["id"], instance["network_interfaces"][0]["id"], fip_id
-            )
+                instance["id"], instance["network_interfaces"][0]["id"], fip_id)
 
     def _stopped_nodes(self, tags):
         """
@@ -650,7 +642,8 @@ class IBMVPCNodeProvider(NodeProvider):
             for node_id in self.nodes_tags:
                 try:
                     node_tags = self.nodes_tags[node_id]
-                    if all(item in node_tags.items() for item in filter.items()):
+                    if all(item in node_tags.items()
+                           for item in filter.items()):
                         node = self.ibm_vpc_client.get_instance(node_id).result
                         state = node["status"]
                         if state in ["stopped", "stopping"]:
@@ -659,10 +652,8 @@ class IBMVPCNodeProvider(NodeProvider):
                     cli_logger.warning(
                         f"node: {node_id} from cache: 'nodes_tags' not found in VPC"
                     )
-                    if (
-                        isinstance(e, ibm.ibm_cloud_sdk_core.ApiException)
-                        and "Instance not found" in e.message
-                    ):
+                    if (isinstance(e, ibm.ibm_cloud_sdk_core.ApiException) and
+                            "Instance not found" in e.message):
                         continue
                     raise e
             return nodes
@@ -683,11 +674,9 @@ class IBMVPCNodeProvider(NodeProvider):
 
         name_tag = tags[TAG_RAY_NODE_NAME]
         if len(name_tag) > INSTANCE_NAME_MAX_LEN - INSTANCE_NAME_UUID_LEN - 1:
-            logger.error(
-                f"""node name: {name_tag} is longer than
+            logger.error(f"""node name: {name_tag} is longer than
                 {INSTANCE_NAME_MAX_LEN - INSTANCE_NAME_UUID_LEN - 1}
-                characters"""
-            )
+                characters""")
             raise Exception("Invalid node name: length check failed")
 
         # IBM VPC VSI pattern requirement
@@ -697,16 +686,13 @@ class IBMVPCNodeProvider(NodeProvider):
         if not res:
             logger.error(
                 f"""node name {name_tag} doesn't match the naming pattern
-                 `[a-z]|[a-z][-a-z0-9]*[a-z0-9]` for IBM VPC instance """
-            )
+                 `[a-z]|[a-z][-a-z0-9]*[a-z0-9]` for IBM VPC instance """)
             raise Exception(
-                "Invalid node name: pattern check for IBM VPC instance failed"
-            )
+                "Invalid node name: pattern check for IBM VPC instance failed")
 
         # append instance name with uuid
         name = "{name_tag}-{uuid}".format(
-            name_tag=name_tag, uuid=uuid4().hex[:INSTANCE_NAME_UUID_LEN]
-        )
+            name_tag=name_tag, uuid=uuid4().hex[:INSTANCE_NAME_UUID_LEN])
 
         # create instance in vpc
         instance = self._create_instance(name, base_config)
@@ -747,8 +733,7 @@ class IBMVPCNodeProvider(NodeProvider):
         # or fetch (for any node type) when restarting Ray
         if not self.vpc_tags:
             self.vpc_tags = self.vpc_provider.create_or_fetch_vpc(
-                self.region, self.zone
-            )
+                self.region, self.zone)
 
         stopped_nodes_dict = {}
         futures = []
@@ -763,8 +748,7 @@ class IBMVPCNodeProvider(NodeProvider):
                 cli_logger.print(
                     f"Reusing nodes {stopped_nodes_ids}. "
                     "To disable reuse, set `cache_stopped_nodes: False` "
-                    "under `provider` in the cluster configuration."
-                )
+                    "under `provider` in the cluster configuration.")
 
             for node in stopped_nodes:
                 logger.info(f"Starting instance {node['id']}")
@@ -785,7 +769,8 @@ class IBMVPCNodeProvider(NodeProvider):
         if count:
             with cf.ThreadPoolExecutor(count) as ex:
                 for _ in range(count):
-                    futures.append(ex.submit(self._create_node, base_config, tags))
+                    futures.append(
+                        ex.submit(self._create_node, base_config, tags))
 
             for future in cf.as_completed(futures):
                 created_node = future.result()
@@ -828,24 +813,22 @@ class IBMVPCNodeProvider(NodeProvider):
         # get vpc_id to delete if deleting head node which isn't a failed node
         # pylint: disable=line-too-long
         vpc_id_to_delete = None
-        if (
-            self._get_node_type(node["name"]) == NODE_KIND_HEAD
-            and node["status"] != "failed"
-        ):
+        if (self._get_node_type(node["name"]) == NODE_KIND_HEAD and
+                node["status"] != "failed"):
             if self.vpc_tags:
                 # if it was initialized it's sure to contain `vpc_id`
                 vpc_id_to_delete = self.vpc_tags["vpc_id"]
             else:
                 vpc_id_to_delete = self.ibm_vpc_client.get_instance(
-                    node_id
-                ).get_result()["vpc"]["id"]
+                    node_id).get_result()["vpc"]["id"]
 
             # if the request is executed by the remote head like in `sky autostop --down`
             # , in contrast to `sky down`, use cloud functions to delete the VPC
             # with its associated resources.
             hostname = socket.gethostname()  # returns the instance's (VSI) name
             if self._get_node_type(hostname) == NODE_KIND_HEAD:
-                self.vpc_provider.remote_cluster_removal(vpc_id_to_delete, self.region)
+                self.vpc_provider.remote_cluster_removal(
+                    vpc_id_to_delete, self.region)
 
         try:
             self.ibm_vpc_client.delete_instance(node_id)
@@ -906,8 +889,7 @@ class IBMVPCNodeProvider(NodeProvider):
                 cli_logger.print(
                     f"Stopping instance {node_id}. To terminate instead, "
                     "set `cache_stopped_nodes: False` "
-                    "under `provider` in the cluster configuration"
-                )
+                    "under `provider` in the cluster configuration")
 
                 self.ibm_vpc_client.create_instance_action(node_id, "stop")
             else:

--- a/sky/skylet/providers/ibm/utils.py
+++ b/sky/skylet/providers/ibm/utils.py
@@ -1,8 +1,8 @@
 """holds common utility function/constants to be used by the providers."""
 
 import logging
-import time
 from pathlib import Path
+import time
 
 RAY_RECYCLABLE = "ray-recyclable"
 
@@ -21,8 +21,7 @@ def get_logger(caller_name):
     logs_path = LOGS_FOLDER + caller_name + time.strftime("%Y-%m-%d--%H-%M-%S")
     # pylint: disable=line-too-long
     file_formatter = logging.Formatter(
-        "%(asctime)s %(levelname)-8s %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
-    )
+        "%(asctime)s %(levelname)-8s %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
 
     file_handler = logging.FileHandler(logs_path)
     file_handler.setFormatter(file_formatter)

--- a/sky/skylet/providers/ibm/vpc_provider.py
+++ b/sky/skylet/providers/ibm/vpc_provider.py
@@ -4,18 +4,19 @@ for Ray's cluster. used by the node_provider module to group the
 nodes under the same subnet, tagged by the same cluster name.
 """
 
+from concurrent.futures import ThreadPoolExecutor
 import copy
 import json
 import textwrap
 import time
-import uuid
-from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict
+import uuid
 
 import requests
 
 from sky.adaptors import ibm
-from sky.skylet.providers.ibm.utils import RAY_RECYCLABLE, get_logger
+from sky.skylet.providers.ibm.utils import get_logger
+from sky.skylet.providers.ibm.utils import RAY_RECYCLABLE
 
 # pylint: disable=line-too-long
 logger = get_logger("vpc_provider_")
@@ -61,7 +62,8 @@ class IBMVPCProvider:
         reused_vpc_data = None
         # pylint: disable=line-too-long
         vpcs_filtered_by_tags_and_region = self.search_client.search(
-            query=f"type:vpc AND tags:{self.cluster_name} AND region:{self.region}",
+            query=
+            f"type:vpc AND tags:{self.cluster_name} AND region:{self.region}",
             fields=["tags", "region", "type"],
             limit=1000,
         ).get_result()["items"]
@@ -76,7 +78,8 @@ class IBMVPCProvider:
             # using self.region since tagged vpc is in the same region
             subnets = self.get_vpc_subnets(reused_vpc_data, self.region)
             subnet_in_zone = next(
-                (subnet for subnet in subnets if subnet["zone"]["name"] == self.zone),
+                (subnet for subnet in subnets
+                 if subnet["zone"]["name"] == self.zone),
                 None,
             )
             # found a subnet in the required zone
@@ -85,15 +88,14 @@ class IBMVPCProvider:
                 public_gateway = subnet_in_zone.get("public_gateway")
                 if not public_gateway:
                     public_gateway = self.create_public_gateway(
-                        reused_vpc_data["id"], self.zone, subnet_in_zone
-                    )
+                        reused_vpc_data["id"], self.zone, subnet_in_zone)
             # tagged vpc found doesn't have a subnet in the required zone
             else:
-                subnet_data = self.create_subnet(reused_vpc_data["id"], self.zone)
+                subnet_data = self.create_subnet(reused_vpc_data["id"],
+                                                 self.zone)
                 subnet_id = subnet_data["id"]
                 public_gateway = self.create_public_gateway(
-                    reused_vpc_data["id"], self.zone, subnet_data
-                )
+                    reused_vpc_data["id"], self.zone, subnet_data)
 
             # add missing security group rules if needed
             security_group = reused_vpc_data.get("default_security_group")
@@ -133,7 +135,9 @@ class IBMVPCProvider:
             address_prefix_management="auto",
             classic_access=False,
             name=f"sky-vpc-{self.cluster_name}-{str(uuid.uuid4())[:5]}",
-            resource_group={"id": self.resource_group_id},
+            resource_group={
+                "id": self.resource_group_id
+            },
         ).get_result()
         subnet_data = self.create_subnet(vpc_data["id"], self.zone)
         self.create_public_gateway(vpc_data["id"], self.zone, subnet_data)
@@ -141,9 +145,9 @@ class IBMVPCProvider:
 
         # tag vpc with the cluster's name
         resource_model = {"resource_id": vpc_data["crn"]}
-        self.tagging_client.attach_tag(
-            resources=[resource_model], tag_names=[self.cluster_name], tag_type="user"
-        ).get_result()
+        self.tagging_client.attach_tag(resources=[resource_model],
+                                       tag_names=[self.cluster_name],
+                                       tag_type="user").get_result()
 
         return {
             "vpc_id": vpc_data["id"],
@@ -160,19 +164,15 @@ class IBMVPCProvider:
         # specified zone of a VPC (whose region has already been set)
         address_prefixes = res["address_prefixes"]
         ipv4_cidr_block = next(
-            (
-                address_prefix["cidr"]
-                for address_prefix in address_prefixes
-                if address_prefix["zone"]["name"] == zone_name
-            ),
+            (address_prefix["cidr"]
+             for address_prefix in address_prefixes
+             if address_prefix["zone"]["name"] == zone_name),
             None,
         )
         if not ipv4_cidr_block:
-            raise Exception(
-                "Failed to locate a cidr block "
-                f"Matching the zone name: {zone_name} to create "
-                "a subnet"
-            )
+            raise Exception("Failed to locate a cidr block "
+                            f"Matching the zone name: {zone_name} to create "
+                            "a subnet")
 
         subnet_prototype: Dict[str, Any] = {}
         subnet_prototype["zone"] = {"name": zone_name}
@@ -182,7 +182,8 @@ class IBMVPCProvider:
         subnet_prototype["vpc"] = {"id": vpc_id}
         subnet_prototype["ipv4_cidr_block"] = ipv4_cidr_block
 
-        subnet_data = self.vpc_client.create_subnet(subnet_prototype).get_result()
+        subnet_data = self.vpc_client.create_subnet(
+            subnet_prototype).get_result()
         return subnet_data
 
     def create_public_gateway(self, vpc_id, zone_name, subnet_data):
@@ -193,11 +194,11 @@ class IBMVPCProvider:
         gateway_prototype["name"] = f"{subnet_data['name']}-gw"
         gateway_prototype["resource_group"] = {"id": self.resource_group_id}
         gateway_data = self.vpc_client.create_public_gateway(
-            **gateway_prototype
-        ).get_result()
+            **gateway_prototype).get_result()
         gateway_id = gateway_data["id"]
 
-        self.vpc_client.set_subnet_public_gateway(subnet_data["id"], {"id": gateway_id})
+        self.vpc_client.set_subnet_public_gateway(subnet_data["id"],
+                                                  {"id": gateway_id})
         return gateway_id
 
     def create_sg_rules(self, vpc_data):
@@ -207,24 +208,20 @@ class IBMVPCProvider:
 
         # update sg name
         self.vpc_client.update_security_group(
-            sg_id, security_group_patch={"name": sg_name}
-        )
+            sg_id, security_group_patch={"name": sg_name})
 
         # open private tcp traffic between VSIs within the security group
         sg_rule_prototype = _build_security_group_rule_prototype_model(
-            "inbound_tcp_sg", sg_id=sg_id
-        )
+            "inbound_tcp_sg", sg_id=sg_id)
         self.vpc_client.create_security_group_rule(
-            sg_id, sg_rule_prototype
-        ).get_result()
+            sg_id, sg_rule_prototype).get_result()
 
         # add all other required rules configured by the specific backend
         for rule in REQUIRED_RULES.keys():
             sg_rule_prototype = _build_security_group_rule_prototype_model(rule)
             if sg_rule_prototype:
                 self.vpc_client.create_security_group_rule(
-                    sg_id, sg_rule_prototype
-                ).get_result()
+                    sg_id, sg_rule_prototype).get_result()
 
         return sg_id
 
@@ -264,10 +261,12 @@ class IBMVPCProvider:
         # pylint: disable=line-too-long
         tmp_vpc_client = ibm.client(region=region)
         subnets_attached_to_routing_table = tmp_vpc_client.list_subnets(
-            routing_table_id=vpc_data["default_routing_table"]["id"]
-        ).get_result()["subnets"]
+            routing_table_id=vpc_data["default_routing_table"]
+            ["id"]).get_result()["subnets"]
         if field:
-            return [subnet[field] for subnet in subnets_attached_to_routing_table]
+            return [
+                subnet[field] for subnet in subnets_attached_to_routing_table
+            ]
         else:
             return subnets_attached_to_routing_table
 
@@ -290,6 +289,7 @@ class IBMVPCProvider:
         tmp_vpc_client.delete_vpc(vpc_id)
 
     def delete_vms(self, vpc_client, vpc_id):
+
         def _poll_vpc_contains_vms(vpc_id):
             tries = 60
             sleep_interval = 3
@@ -301,18 +301,15 @@ class IBMVPCProvider:
                 else:
                     tries -= 1
                     time.sleep(sleep_interval)
-            raise Exception(
-                "Failed to delete VPC's instances within "
-                "the expected time frame. Cannot "
-                "continue to delete VPC."
-            )
+            raise Exception("Failed to delete VPC's instances within "
+                            "the expected time frame. Cannot "
+                            "continue to delete VPC.")
 
         def _del_instance(vm_data):
             # first delete ips created by node_provider
             nic_id = vm_data["network_interfaces"][0]["id"]
             res = vpc_client.list_instance_network_interface_floating_ips(
-                vm_data["id"], nic_id
-            ).get_result()
+                vm_data["id"], nic_id).get_result()
             floating_ips = res.get("floating_ips", [])
             for ip in floating_ips:
                 if ip["name"].startswith(RAY_RECYCLABLE):
@@ -335,6 +332,7 @@ class IBMVPCProvider:
             _poll_vpc_contains_vms(vpc_id)
 
     def delete_subnets(self, vpc_client, vpc_data, region):
+
         def _poll_subnet_deleted(subnet_id):
             tries = 10
             sleep_interval = 2
@@ -359,10 +357,12 @@ class IBMVPCProvider:
         """deletes all gateways attached to the specified vpc"""
         # pylint: disable=line-too-long
         gateways = vpc_client.list_public_gateways(
-            resource_group_id=self.resource_group_id
-        ).get_result()["public_gateways"]
+            resource_group_id=self.resource_group_id).get_result(
+            )["public_gateways"]
         gateways_ids_of_vpc = [
-            gateway["id"] for gateway in gateways if gateway["vpc"]["id"] == vpc_id
+            gateway["id"]
+            for gateway in gateways
+            if gateway["vpc"]["id"] == vpc_id
         ]
         for gateway_id in gateways_ids_of_vpc:
             # get_result() used for synchronization
@@ -377,11 +377,9 @@ class IBMVPCProvider:
                 logger.debug(f"missing {val}")
             for missing_rule in missing_rules.keys():
                 sg_rule_prototype = _build_security_group_rule_prototype_model(
-                    missing_rule, sec_group_id
-                )
+                    missing_rule, sec_group_id)
                 self.vpc_client.create_security_group_rule(
-                    sec_group_id, sg_rule_prototype
-                ).get_result()
+                    sec_group_id, sg_rule_prototype).get_result()
 
     def get_unsatisfied_security_group_rules(self, sg_id):
         """
@@ -395,7 +393,7 @@ class IBMVPCProvider:
             # pylint: disable=line-too-long
             # check outbound rules that are not associated with a specific IP address range
             if rule["direction"] == "outbound" and rule["remote"] == {
-                "cidr_block": "0.0.0.0/0"
+                    "cidr_block": "0.0.0.0/0"
             }:
                 if rule["protocol"] == "all":
                     # outbound is fine!
@@ -494,16 +492,14 @@ class ClusterCleaner:
     action_name = "skypilot-vpc-cleaner-action"
     # url to cloud function's namespaces in the chosen region: `namespace_region`
     cf_namespaces_url = (
-        f"https://{namespace_region}.functions.cloud.ibm.com/api/v1/namespaces"
-    )
+        f"https://{namespace_region}.functions.cloud.ibm.com/api/v1/namespaces")
 
     def __init__(self, resource_group_id, vpc_id, vpc_region) -> None:
         self.resource_group_id = resource_group_id
         self.vpc_id = vpc_id
         self.vpc_region = vpc_region
 
-    function_code = textwrap.dedent(
-        """
+    function_code = textwrap.dedent("""
     import subprocess
     import time
     from concurrent.futures import ThreadPoolExecutor
@@ -667,8 +663,7 @@ class ClusterCleaner:
 
         delete_vpc(vpc_id=vpc_id)
         return {"Status": "Success"}
-    """
-    )
+    """)
 
     def get_headers(self):
         return {
@@ -693,9 +688,9 @@ class ClusterCleaner:
                 "resource_plan_id": "functions-base-plan",
             }
 
-            res = requests.post(
-                self.cf_namespaces_url, headers=self.get_headers(), json=data
-            ).json()
+            res = requests.post(self.cf_namespaces_url,
+                                headers=self.get_headers(),
+                                json=data).json()
             if res.status_code != 200:
                 logger.error(res.text)
             namespace_id = res["id"]
@@ -727,7 +722,8 @@ class ClusterCleaner:
 
             #  request for namespaces is limited to 200 at a time, thus the request is fulfilled in increments of 200s.
             while collecting_namespaces:
-                namespace_metadata = _get_cloud_function_namespaces_metadata(offset)
+                namespace_metadata = _get_cloud_function_namespaces_metadata(
+                    offset)
                 if namespace_metadata["total_count"] == max_limit:
                     offset += max_limit
                 else:
@@ -735,23 +731,19 @@ class ClusterCleaner:
 
                 for name_space in namespace_metadata["namespaces"]:
                     if "name" in name_space:  # API based namespace
-                        namespaces.append(
-                            {
-                                "name": name_space["name"],
-                                "type": "API_based",
-                                "id": name_space["id"],
-                                "region": name_space["location"],
-                            }
-                        )
+                        namespaces.append({
+                            "name": name_space["name"],
+                            "type": "API_based",
+                            "id": name_space["id"],
+                            "region": name_space["location"],
+                        })
 
                     else:  # cloud foundry based namespace
-                        namespaces.append(
-                            {
-                                "name": name_space["id"],
-                                "type": "CF_based",
-                                "region": name_space["location"],
-                            }
-                        )
+                        namespaces.append({
+                            "name": name_space["id"],
+                            "type": "CF_based",
+                            "region": name_space["location"],
+                        })
 
             return namespaces
 
@@ -759,11 +751,9 @@ class ClusterCleaner:
         target_namespace_id = None
         if namespaces_in_region:
             target_namespace_id = next(
-                (
-                    namespace["id"]
-                    for namespace in namespaces_in_region
-                    if namespace["name"] == self.namespace_name
-                ),
+                (namespace["id"]
+                 for namespace in namespaces_in_region
+                 if namespace["name"] == self.namespace_name),
                 None,
             )
         if not target_namespace_id:
@@ -787,8 +777,13 @@ class ClusterCleaner:
         logger.info(f"creating action on namespace: {namespace_id}")
         # Define the function parameters
         function_params = {
-            "exec": {"kind": "python:3.9", "code": self.function_code},
-            "limits": {"timeout": 600000},
+            "exec": {
+                "kind": "python:3.9",
+                "code": self.function_code
+            },
+            "limits": {
+                "timeout": 600000
+            },
         }
         res = requests.put(
             f"{self.cf_namespaces_url}/{namespace_id}/actions/{self.action_name}?blocking=true&overwrite=true",


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
To avoid fixing the security issues of black all the time, which does not support Python 3.9 anymore:
- [CI] Drop Black; let yapf+isort format IBM provider
- [Format] Reformat sky/skylet/providers/ibm with yapf+isort

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
