### PR TITLE
[Test] Add smoke tests for managed job log capture

### DIFF
--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -143,35 +143,6 @@ def test_managed_jobs_cancelled_job_logs(generic_cloud: str):
 @pytest.mark.managed_jobs
 @pytest.mark.no_hyperbolic  # Hyperbolic doesn't support host controllers and auto-stop
 @pytest.mark.no_shadeform  # Shadeform does not support host controllers
-def test_managed_jobs_succeeded_job_logs(generic_cloud: str):
-    """Test that logs are captured for a successfully-completed managed job."""
-    name = smoke_tests_utils.get_cluster_name()
-    get_job_id_cmd = (f'sky jobs queue | grep {name} | head -1 | '
-                      f'awk \'{{print $1}}\'')
-    test = smoke_tests_utils.Test(
-        'managed_jobs_succeeded_logs',
-        [
-            f'sky jobs launch -n {name} --infra {generic_cloud} '
-            f'{smoke_tests_utils.LOW_RESOURCE_ARG} '
-            f'tests/test_yamls/minimal.yaml -y -d',
-            smoke_tests_utils.
-            get_cmd_wait_until_managed_job_status_contains_matching_job_name(
-                job_name=name,
-                job_status=[sky.ManagedJobStatus.SUCCEEDED],
-                timeout=360),
-            f's=$(sky jobs logs $({get_job_id_cmd}) --no-follow); '
-            f'echo "$s"; echo "$s" | grep "task run finish"',
-        ],
-        f'sky jobs cancel -y -n {name}',
-        env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
-        timeout=20 * 60,
-    )
-    smoke_tests_utils.run_one_test(test)
-
-
-@pytest.mark.managed_jobs
-@pytest.mark.no_hyperbolic  # Hyperbolic doesn't support host controllers and auto-stop
-@pytest.mark.no_shadeform  # Shadeform does not support host controllers
 def test_managed_jobs_failed_job_logs(generic_cloud: str):
     """Test that logs are captured for a managed job that fails in user code."""
     name = smoke_tests_utils.get_cluster_name()

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -143,6 +143,92 @@ def test_managed_jobs_cancelled_job_logs(generic_cloud: str):
 @pytest.mark.managed_jobs
 @pytest.mark.no_hyperbolic  # Hyperbolic doesn't support host controllers and auto-stop
 @pytest.mark.no_shadeform  # Shadeform does not support host controllers
+def test_managed_jobs_succeeded_job_logs(generic_cloud: str):
+    """Test that logs are captured for a successfully-completed managed job."""
+    name = smoke_tests_utils.get_cluster_name()
+    get_job_id_cmd = (f'sky jobs queue | grep {name} | head -1 | '
+                      f'awk \'{{print $1}}\'')
+    test = smoke_tests_utils.Test(
+        'managed_jobs_succeeded_logs',
+        [
+            f'sky jobs launch -n {name} --infra {generic_cloud} '
+            f'{smoke_tests_utils.LOW_RESOURCE_ARG} '
+            f'tests/test_yamls/minimal.yaml -y -d',
+            smoke_tests_utils.
+            get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                job_name=name,
+                job_status=[sky.ManagedJobStatus.SUCCEEDED],
+                timeout=360),
+            f's=$(sky jobs logs $({get_job_id_cmd}) --no-follow); '
+            f'echo "$s"; echo "$s" | grep "task run finish"',
+        ],
+        f'sky jobs cancel -y -n {name}',
+        env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
+        timeout=20 * 60,
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.managed_jobs
+@pytest.mark.no_hyperbolic  # Hyperbolic doesn't support host controllers and auto-stop
+@pytest.mark.no_shadeform  # Shadeform does not support host controllers
+def test_managed_jobs_failed_job_logs(generic_cloud: str):
+    """Test that logs are captured for a managed job that fails in user code."""
+    name = smoke_tests_utils.get_cluster_name()
+    get_job_id_cmd = (f'sky jobs queue | grep {name} | head -1 | '
+                      f'awk \'{{print $1}}\'')
+    test = smoke_tests_utils.Test(
+        'managed_jobs_failed_logs',
+        [
+            f'sky jobs launch -n {name} --infra {generic_cloud} '
+            f'{smoke_tests_utils.LOW_RESOURCE_ARG} -y -d '
+            f'-- "echo job ran before failing && exit 1"',
+            smoke_tests_utils.
+            get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                job_name=name,
+                job_status=[sky.ManagedJobStatus.FAILED],
+                timeout=360),
+            f's=$(sky jobs logs $({get_job_id_cmd}) --no-follow); '
+            f'echo "$s"; echo "$s" | grep "job ran before failing"',
+        ],
+        f'sky jobs cancel -y -n {name}',
+        env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
+        timeout=20 * 60,
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.managed_jobs
+@pytest.mark.no_hyperbolic  # Hyperbolic doesn't support host controllers and auto-stop
+@pytest.mark.no_shadeform  # Shadeform does not support host controllers
+def test_managed_jobs_running_logs(generic_cloud: str):
+    """Test that logs can be fetched while a managed job is still running."""
+    name = smoke_tests_utils.get_cluster_name()
+    test = smoke_tests_utils.Test(
+        'managed_jobs_running_logs',
+        [
+            f'sky jobs launch -n {name} --infra {generic_cloud} '
+            f'{smoke_tests_utils.LOW_RESOURCE_ARG} '
+            f'examples/managed_job.yaml -y -d',
+            smoke_tests_utils.
+            get_cmd_wait_until_managed_job_status_contains_matching_job_name(
+                job_name=name,
+                job_status=[sky.ManagedJobStatus.RUNNING],
+                timeout=360),
+            'sleep 10',
+            f's=$(sky jobs logs -n {name} --no-follow); '
+            f'echo "$s"; echo "$s" | grep "start counting"',
+        ],
+        f'sky jobs cancel -y -n {name}',
+        env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
+        timeout=20 * 60,
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.managed_jobs
+@pytest.mark.no_hyperbolic  # Hyperbolic doesn't support host controllers and auto-stop
+@pytest.mark.no_shadeform  # Shadeform does not support host controllers
 def test_pipeline_cancelled_logs(generic_cloud: str):
     """Test that logs are accessible after a pipeline job is cancelled."""
     name = smoke_tests_utils.get_cluster_name()

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -153,14 +153,15 @@ def test_managed_jobs_failed_job_logs(generic_cloud: str):
         [
             f'sky jobs launch -n {name} --infra {generic_cloud} '
             f'{smoke_tests_utils.LOW_RESOURCE_ARG} -y -d '
-            f'-- "echo job ran before failing && exit 1"',
+            f'-- "echo job ran before failing && exit 7"',
             smoke_tests_utils.
             get_cmd_wait_until_managed_job_status_contains_matching_job_name(
                 job_name=name,
                 job_status=[sky.ManagedJobStatus.FAILED],
                 timeout=360),
             f's=$(sky jobs logs $({get_job_id_cmd}) --no-follow); '
-            f'echo "$s"; echo "$s" | grep "job ran before failing"',
+            f'echo "$s"; echo "$s" | grep "job ran before failing" && '
+            f'echo "$s" | grep "failed with return code list" | grep "7"',
         ],
         f'sky jobs cancel -y -n {name}',
         env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,


### PR DESCRIPTION
## Summary

- Add two smoke tests covering managed job log retrieval for failed and mid-run states
- Existing smoke tests only cover log access after cancellation or success — these fill the gap for user-code failure and in-flight log fetching

### New tests

| Test | Scenario | Assertion |
|------|----------|-----------|
| `test_managed_jobs_failed_job_logs` | Job exits non-zero (`exit 1`) | Logs contain `"job ran before failing"` |
| `test_managed_jobs_running_logs` | Job still RUNNING | `--no-follow` fetch returns `"start counting"` |

## Test plan

- [ ] `/smoke-test --kubernetes` — verify on K8s (V1 path)
- [ ] `/smoke-test --aws` or `/smoke-test --gcp` — verify on cloud (legacy path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->