### PR TITLE
[Kubernetes] Enable per-task kubernetes.quota.* overrides

### DIFF
--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -508,6 +508,7 @@ OVERRIDEABLE_CONFIG_KEYS_IN_TASK: List[Tuple[str, ...]] = [
     ('kubernetes', 'provision_timeout'),
     ('kubernetes', 'dws'),
     ('kubernetes', 'kueue'),
+    ('kubernetes', 'quota'),
     ('kubernetes', 'remote_identity'),
     ('kubernetes', 'enable_docker'),
     ('azure', 'remote_identity'),

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1513,11 +1513,14 @@ _CONTEXT_CONFIG_SCHEMA_KUBERNETES = {
         },
     },
     # Alias of `kueue.local_queue_name`; `quota.queue` takes precedence
-    # when both are set.
+    # when both are set. Permissive so external schedulers (registered
+    # via plugins) can layer their own sub-fields under `quota` without
+    # requiring per-key OSS schema updates; sub-field validation is the
+    # consumer's responsibility.
     'quota': {
         'type': 'object',
         'required': [],
-        'additionalProperties': False,
+        'additionalProperties': True,
         'properties': {
             'queue': {
                 'type': 'string',
@@ -2349,7 +2352,10 @@ def get_config_schema():
                         'quota': {
                             'type': 'object',
                             'required': [],
-                            'additionalProperties': False,
+                            # Permissive — see the per-context quota block
+                            # below; mirrors that policy at the workspace
+                            # cloud level.
+                            'additionalProperties': True,
                             'properties': {
                                 'queue': {
                                     'type': 'string',
@@ -2386,7 +2392,10 @@ def get_config_schema():
                                     'quota': {
                                         'type': 'object',
                                         'required': [],
-                                        'additionalProperties': False,
+                                        # Permissive — see the per-context
+                                        # quota block under
+                                        # _CONTEXT_CONFIG_SCHEMA_KUBERNETES.
+                                        'additionalProperties': True,
                                         'properties': {
                                             'queue': {
                                                 'type': 'string',


### PR DESCRIPTION
- Add `('kubernetes', 'quota')` to `OVERRIDEABLE_CONFIG_KEYS_IN_TASK` so task YAMLs can override values under `kubernetes.quota.*` in their `config:` block. Required for plugins that layer their own sub-fields under `kubernetes.quota.*` and want per-task overrides to flow through `Resources.copy()`'s allowlist filter.

- Switch `kubernetes.quota.additionalProperties` from `False` to `True` (in both the per-context schema and the workspace-scoped variants) so external schedulers registered via plugins can layer sub-fields without requiring an OSS schema update per addition. Sub-field validation is the consumer's responsibility.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)