### PR TITLE
[Jobs] Pass returncode to ManagedJobRuntime.get_job_status

### DIFF
--- a/sky/jobs/runtime.py
+++ b/sky/jobs/runtime.py
@@ -39,6 +39,7 @@ class ManagedJobRuntime(Protocol):
         self,
         handle: Optional['cloud_vm_ray_backend.CloudVmRayResourceHandle'],
         cluster_name: str,
+        returncode: Optional[int] = None,
     ) -> Optional[Tuple[Optional['job_lib.JobStatus'], Optional[str]]]:
         """Query job status from the underlying runtime."""
         ...
@@ -161,10 +162,11 @@ def is_registered() -> bool:
 def get_job_status(
     handle: Optional['cloud_vm_ray_backend.CloudVmRayResourceHandle'],
     cluster_name: str,
+    returncode: Optional[int] = None,
 ) -> Optional[Tuple[Optional['job_lib.JobStatus'], Optional[str]]]:
     if _current is None:
         return None
-    return _current.get_job_status(handle, cluster_name)
+    return _current.get_job_status(handle, cluster_name, returncode=returncode)
 
 
 def get_job_submitted_at(

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1579,7 +1579,7 @@ def stream_logs_by_id(
                 assert cluster_name is not None, (job_id, task_id)
                 if managed_job_runtime.is_registered():
                     runtime_result = managed_job_runtime.get_job_status(
-                        handle, cluster_name)
+                        handle, cluster_name, returncode=returncode)
                     if runtime_result is not None:
                         job_status, _ = runtime_result
                 if job_status is None:


### PR DESCRIPTION
## Summary
- Add an optional `returncode` parameter to `ManagedJobRuntime.get_job_status()` and the module-level dispatch function.
- Thread the `returncode` from `stream_logs_by_id` into the runtime so implementations have context about how the log tailing exited.
- This allows runtimes to derive a job status from the exit code when the underlying cluster has already been torn down by the controller, avoiding a fallback to `backend.get_job_status` which assumes SSH/skylet access.

## Test plan
- [x] Existing unit tests pass
- [x] `test_managed_jobs_retry_logs` passes on Kubernetes
- [x] 20 parallel managed job launches with no failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)