### PR TITLE
[Nebius] Replace UFW with native security groups; implement open_ports

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -80,7 +80,7 @@ jobs:
           source ~/test-env/bin/activate
           uv pip install --prerelease=allow "azure-cli>=2.65.0"
           # Install limited dependencies only
-          uv pip install -e ".[kubernetes,aws,gcp,azure,nebius]"
+          uv pip install -e ".[kubernetes,aws,gcp,azure]"
           uv pip install pytest pytest-xdist pytest-env>=0.6 pytest-asyncio memory-profiler==0.61.0 buildkite-test-collector
       - name: Set branch name and commit message
         id: set_env

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -80,7 +80,7 @@ jobs:
           source ~/test-env/bin/activate
           uv pip install --prerelease=allow "azure-cli>=2.65.0"
           # Install limited dependencies only
-          uv pip install -e ".[kubernetes,aws,gcp,azure]"
+          uv pip install -e ".[kubernetes,aws,gcp,azure,nebius]"
           uv pip install pytest pytest-xdist pytest-env>=0.6 pytest-asyncio memory-profiler==0.61.0 buildkite-test-collector
       - name: Set branch name and commit message
         id: set_env

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -2470,6 +2470,63 @@ Example:
   nebius:
     domain: api.nebius.cloud:443
 
+.. _config-yaml-nebius-security-group-name:
+
+``nebius.security_group_name``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Security group (optional).
+
+Name of an existing Nebius security group to attach to launched VMs. If not
+specified, SkyPilot creates and manages a per-cluster security group named
+``sky-sg-<cluster-name-on-cloud>``.
+
+Note: the user-supplied security group must already exist in the **same Nebius
+network** as the subnet SkyPilot uses for the cluster. SkyPilot will not create
+the security group on your behalf when this option is set. You can check a
+security group's network in the Nebius console under VPC > Security Groups.
+
+The security group must already have at least one rule before launch. SkyPilot
+deliberately does not modify a user-managed security group — silently adding
+default rules (e.g., SSH from anywhere) would conflict with the "you own the
+rules" intent of BYO. Pre-configure at minimum:
+
+- An ingress rule allowing your operator CIDR to reach SSH on ports 22 and 10022
+- A self-referencing ingress rule for intra-cluster traffic (head/worker Ray
+  on 6379, 8265, 52365, the worker port range, etc.)
+- Any application ports your task declares via ``ports:``
+
+When ``security_group_name`` is set and the task declares ``ports:``, SkyPilot
+will warn at launch and skip ``open_ports`` — adding the matching ingress rules
+is the user's responsibility.
+
+Some example use cases are shown below.
+
+- ``<string>``: Use the named security group for all clusters.
+
+- ``<list of single-element dict>``: A list of single-element dictionaries
+  mapping from the cluster name (pattern) to the security group name to use.
+  The matching is done in the same order as the list.
+
+  NOTE: If none of the wildcard expressions match the cluster name, SkyPilot
+  will fall back to creating its own security group named
+  ``sky-sg-<cluster-name-on-cloud>``. To specify a default, use ``*`` as the
+  wildcard expression.
+
+Example:
+
+.. code-block:: yaml
+
+  nebius:
+    # Format 1 — single SG for all clusters
+    security_group_name: my-sg
+
+    # Format 2 — per-cluster pattern matching
+    security_group_name:
+      - my-training-*: my-training-sg
+      - sky-serve-controller-*: my-serving-sg
+      - "*": my-default-sg
+
 .. _config-yaml-vast:
 
 ``vast``

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -241,6 +241,7 @@ Below is the configuration syntax and some example values. See detailed explanat
     :ref:`ssh_proxy_command <config-yaml-nebius-ssh-proxy-command>`: ssh -W %h:%p user@host
     :ref:`tenant_id <config-yaml-nebius-tenant-id>`: tenant-1234567890
     :ref:`domain <config-yaml-nebius-domain>`: api.nebius.cloud:443
+    :ref:`security_group_name <config-yaml-nebius-security-group-name>`: my-sg
 
   :ref:`vast <config-yaml-vast>`:
     :ref:`datacenter_only <config-yaml-vast-datacenter-only>`: true

--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -1,4 +1,6 @@
-""" Nebius Cloud. """
+"""Nebius Cloud."""
+
+import fnmatch
 import hashlib
 import json
 import os
@@ -6,24 +8,17 @@ import tempfile
 import typing
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
-from sky import catalog
-from sky import clouds
-from sky import exceptions
-from sky import sky_logging
-from sky import skypilot_config
+from sky import catalog, clouds, exceptions, sky_logging, skypilot_config
 from sky.adaptors import nebius
 from sky.provision.nebius import constants as nebius_constants
 from sky.provision.nebius import utils
-from sky.utils import annotations
-from sky.utils import registry
-from sky.utils import resources_utils
-from sky.utils import ux_utils
+from sky.utils import annotations, registry, resources_utils, ux_utils
 
 if typing.TYPE_CHECKING:
     from sky import resources as resources_lib
     from sky.utils import volume as volume_lib
 
-_INDENT_PREFIX = '    '
+_INDENT_PREFIX = "    "
 
 logger = sky_logging.init_logger(__name__)
 
@@ -32,24 +27,23 @@ def nebius_profile_in_aws_cred_and_config() -> bool:
     """Checks if Nebius Object Storage profile is set in aws credentials
     and profile."""
 
-    credentials_path = os.path.expanduser('~/.aws/credentials')
+    credentials_path = os.path.expanduser("~/.aws/credentials")
     nebius_profile_exists_in_credentials = False
     if os.path.isfile(credentials_path):
-        with open(credentials_path, 'r', encoding='utf-8') as file:
+        with open(credentials_path, "r", encoding="utf-8") as file:
             for line in file:
-                if f'[{nebius.NEBIUS_PROFILE_NAME}]' in line:
+                if f"[{nebius.NEBIUS_PROFILE_NAME}]" in line:
                     nebius_profile_exists_in_credentials = True
 
-    config_path = os.path.expanduser('~/.aws/config')
+    config_path = os.path.expanduser("~/.aws/config")
     nebius_profile_exists_in_config = False
     if os.path.isfile(config_path):
-        with open(config_path, 'r', encoding='utf-8') as file:
+        with open(config_path, "r", encoding="utf-8") as file:
             for line in file:
-                if f'[profile {nebius.NEBIUS_PROFILE_NAME}]' in line:
+                if f"[profile {nebius.NEBIUS_PROFILE_NAME}]" in line:
                     nebius_profile_exists_in_config = True
 
-    return (nebius_profile_exists_in_credentials and
-            nebius_profile_exists_in_config)
+    return nebius_profile_exists_in_credentials and nebius_profile_exists_in_config
 
 
 def _write_nebius_temp_credential_file(prefix: str, value: str) -> str:
@@ -70,17 +64,17 @@ def _write_nebius_temp_credential_file(prefix: str, value: str) -> str:
     when they happen to share the same content -- one user's restrictive
     umask would otherwise lock the other user out.
     """
-    uid = os.getuid() if hasattr(os, 'getuid') else 'default'
-    digest = hashlib.sha1(value.encode('utf-8')).hexdigest()[:16]
-    path = os.path.join(tempfile.gettempdir(), f'{prefix}{uid}-{digest}')
-    expected = value + '\n'
+    uid = os.getuid() if hasattr(os, "getuid") else "default"
+    digest = hashlib.sha1(value.encode("utf-8")).hexdigest()[:16]
+    path = os.path.join(tempfile.gettempdir(), f"{prefix}{uid}-{digest}")
+    expected = value + "\n"
     try:
-        with open(path, 'r', encoding='utf-8') as existing:
+        with open(path, "r", encoding="utf-8") as existing:
             if existing.read() == expected:
                 return path
     except OSError:
         pass
-    with open(path, 'w', encoding='utf-8') as new_file:
+    with open(path, "w", encoding="utf-8") as new_file:
         new_file.write(expected)
     return path
 
@@ -88,20 +82,25 @@ def _write_nebius_temp_credential_file(prefix: str, value: str) -> str:
 @registry.CLOUD_REGISTRY.register
 class Nebius(clouds.Cloud):
     """Nebius GPU Cloud"""
-    _REPR = 'Nebius'
+
+    _REPR = "Nebius"
     _CLOUD_UNSUPPORTED_FEATURES = {
-        clouds.CloudImplementationFeatures.CLONE_DISK_FROM_CLUSTER:
-            (f'Migrating disk is currently not supported on {_REPR}.'),
-        clouds.CloudImplementationFeatures.CUSTOM_NETWORK_TIER:
-            ('Custom network tier is currently only supported for '
-             'H100:8 and H200:8 on Nebius.'),
-        clouds.CloudImplementationFeatures.HIGH_AVAILABILITY_CONTROLLERS:
-            ('High availability controllers are not supported on Nebius.'),
-        clouds.CloudImplementationFeatures.CUSTOM_MULTI_NETWORK:
-            ('Customized multiple network interfaces are not supported on '
-             f'{_REPR}.'),
-        clouds.CloudImplementationFeatures.LOCAL_DISK:
-            (f'Local disk is not supported on {_REPR}'),
+        clouds.CloudImplementationFeatures.CLONE_DISK_FROM_CLUSTER: (
+            f"Migrating disk is currently not supported on {_REPR}."
+        ),
+        clouds.CloudImplementationFeatures.CUSTOM_NETWORK_TIER: (
+            "Custom network tier is currently only supported for "
+            "H100:8 and H200:8 on Nebius."
+        ),
+        clouds.CloudImplementationFeatures.HIGH_AVAILABILITY_CONTROLLERS: (
+            "High availability controllers are not supported on Nebius."
+        ),
+        clouds.CloudImplementationFeatures.CUSTOM_MULTI_NETWORK: (
+            f"Customized multiple network interfaces are not supported on {_REPR}."
+        ),
+        clouds.CloudImplementationFeatures.LOCAL_DISK: (
+            f"Local disk is not supported on {_REPR}"
+        ),
     }
     # Nebius maximum instance name length defined as <= 63 as a hostname length
     # 63 - 8 - 5 = 50 characters since
@@ -113,17 +112,21 @@ class Nebius(clouds.Cloud):
     _BEST_DISK_TIER = resources_utils.DiskTier.HIGH
     _DEFAULT_DISK_TIER = resources_utils.DiskTier.MEDIUM
     # Nebius does not support ultra disk tier.
-    _SUPPORTED_DISK_TIERS = (set(resources_utils.DiskTier) -
-                             {resources_utils.DiskTier.ULTRA})
+    _SUPPORTED_DISK_TIERS = set(resources_utils.DiskTier) - {
+        resources_utils.DiskTier.ULTRA
+    }
 
     # Using the latest SkyPilot provisioner API to provision and check status.
     PROVISIONER_VERSION = clouds.ProvisionerVersion.SKYPILOT
     STATUS_VERSION = clouds.StatusVersion.SKYPILOT
+    # Ports are managed via Nebius security groups, mutated post-launch by
+    # `sky/provision/nebius/instance.py:open_ports`.
+    OPEN_PORTS_VERSION = clouds.OpenPortsVersion.UPDATABLE
 
     @classmethod
     def _unsupported_features_for_resources(
         cls,
-        resources: 'resources_lib.Resources',
+        resources: "resources_lib.Resources",
         region: Optional[str] = None,
     ) -> Dict[clouds.CloudImplementationFeatures, str]:
         unsupported = cls._CLOUD_UNSUPPORTED_FEATURES.copy()
@@ -131,13 +134,13 @@ class Nebius(clouds.Cloud):
         # Check if the accelerators support InfiniBand (H100 or H200) and 8 GPUs
         if resources.accelerators is not None:
             for acc_name, acc_count in resources.accelerators.items():
-                if acc_name.lower() in ('h100', 'h200') and acc_count == 8:
+                if acc_name.lower() in ("h100", "h200") and acc_count == 8:
                     # Remove CUSTOM_NETWORK_TIER from unsupported features for
                     # InfiniBand-capable accelerators. Refer to:
                     # https://docs.nebius.com/compute/clusters/gpu#fabrics
                     unsupported.pop(
-                        clouds.CloudImplementationFeatures.CUSTOM_NETWORK_TIER,
-                        None)
+                        clouds.CloudImplementationFeatures.CUSTOM_NETWORK_TIER, None
+                    )
                     break
 
         return unsupported
@@ -154,12 +157,13 @@ class Nebius(clouds.Cloud):
         use_spot: bool,
         region: Optional[str],
         zone: Optional[str],
-        resources: Optional['resources_lib.Resources'] = None,
+        resources: Optional["resources_lib.Resources"] = None,
     ) -> List[clouds.Region]:
-        assert zone is None, 'Nebius does not support zones.'
+        assert zone is None, "Nebius does not support zones."
         del accelerators, zone  # unused
         regions = catalog.get_region_zones_for_instance_type(
-            instance_type, use_spot, 'nebius')
+            instance_type, use_spot, "nebius"
+        )
 
         if region is not None:
             regions = [r for r in regions if r.name == region]
@@ -170,8 +174,7 @@ class Nebius(clouds.Cloud):
         cls,
         instance_type: str,
     ) -> Tuple[Optional[float], Optional[float]]:
-        return catalog.get_vcpus_mem_from_instance_type(instance_type,
-                                                        clouds='nebius')
+        return catalog.get_vcpus_mem_from_instance_type(instance_type, clouds="nebius")
 
     @classmethod
     def zones_provision_loop(
@@ -184,51 +187,52 @@ class Nebius(clouds.Cloud):
         use_spot: bool = False,
     ) -> Iterator[None]:
         del num_nodes  # unused
-        regions = cls.regions_with_offering(instance_type,
-                                            accelerators,
-                                            use_spot,
-                                            region=region,
-                                            zone=None)
+        regions = cls.regions_with_offering(
+            instance_type, accelerators, use_spot, region=region, zone=None
+        )
         for r in regions:
             assert r.zones is None, r
             yield r.zones
 
     @classmethod
     def check_disk_tier(
-            cls, instance_type: Optional[str],
-            disk_tier: Optional[resources_utils.DiskTier]) -> Tuple[bool, str]:
+        cls, instance_type: Optional[str], disk_tier: Optional[resources_utils.DiskTier]
+    ) -> Tuple[bool, str]:
         del instance_type
-        if (disk_tier is not None and
-                disk_tier == resources_utils.DiskTier.ULTRA):
+        if disk_tier is not None and disk_tier == resources_utils.DiskTier.ULTRA:
             return False, (
-                'Nebius disk_tier=ultra is not supported now. '
-                'Please use disk_tier={low, medium, high, best} instead.')
-        return True, ''
+                "Nebius disk_tier=ultra is not supported now. "
+                "Please use disk_tier={low, medium, high, best} instead."
+            )
+        return True, ""
 
     @classmethod
-    def check_disk_tier_enabled(cls, instance_type: Optional[str],
-                                disk_tier: resources_utils.DiskTier) -> None:
+    def check_disk_tier_enabled(
+        cls, instance_type: Optional[str], disk_tier: resources_utils.DiskTier
+    ) -> None:
         ok, msg = cls.check_disk_tier(instance_type, disk_tier)
         if not ok:
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.NotSupportedError(msg)
 
-    def instance_type_to_hourly_cost(self,
-                                     instance_type: str,
-                                     use_spot: bool,
-                                     region: Optional[str] = None,
-                                     zone: Optional[str] = None) -> float:
-        return catalog.get_hourly_cost(instance_type,
-                                       use_spot=use_spot,
-                                       region=region,
-                                       zone=zone,
-                                       clouds='nebius')
+    def instance_type_to_hourly_cost(
+        self,
+        instance_type: str,
+        use_spot: bool,
+        region: Optional[str] = None,
+        zone: Optional[str] = None,
+    ) -> float:
+        return catalog.get_hourly_cost(
+            instance_type, use_spot=use_spot, region=region, zone=zone, clouds="nebius"
+        )
 
-    def accelerators_to_hourly_cost(self,
-                                    accelerators: Dict[str, int],
-                                    use_spot: bool,
-                                    region: Optional[str] = None,
-                                    zone: Optional[str] = None) -> float:
+    def accelerators_to_hourly_cost(
+        self,
+        accelerators: Dict[str, int],
+        use_spot: bool,
+        region: Optional[str] = None,
+        zone: Optional[str] = None,
+    ) -> float:
         """Returns the hourly cost of the accelerators, in dollars/hour."""
         del accelerators, use_spot, region, zone  # unused
         return 0.0
@@ -265,15 +269,17 @@ class Nebius(clouds.Cloud):
             zone=zone,
             use_spot=use_spot,
             max_hourly_cost=max_hourly_cost,
-            clouds='nebius')
+            clouds="nebius",
+        )
 
     @classmethod
     def get_accelerators_from_instance_type(
         cls,
         instance_type: str,
     ) -> Optional[Dict[str, Union[int, float]]]:
-        return catalog.get_accelerators_from_instance_type(instance_type,
-                                                           clouds='nebius')
+        return catalog.get_accelerators_from_instance_type(
+            instance_type, clouds="nebius"
+        )
 
     @classmethod
     def get_zone_shell_cmd(cls) -> Optional[str]:
@@ -281,36 +287,34 @@ class Nebius(clouds.Cloud):
 
     def make_deploy_resources_variables(
         self,
-        resources: 'resources_lib.Resources',
+        resources: "resources_lib.Resources",
         cluster_name: resources_utils.ClusterName,
-        region: 'clouds.Region',
-        zones: Optional[List['clouds.Zone']],
+        region: "clouds.Region",
+        zones: Optional[List["clouds.Zone"]],
         num_nodes: int,
         dryrun: bool = False,
-        volume_mounts: Optional[List['volume_lib.VolumeMount']] = None,
+        volume_mounts: Optional[List["volume_lib.VolumeMount"]] = None,
     ) -> Dict[str, Any]:
-        del dryrun, cluster_name
-        assert zones is None, ('Nebius does not support zones', zones)
+        del dryrun
+        assert zones is None, ("Nebius does not support zones", zones)
 
         resources = resources.assert_launchable()
-        acc_dict = self.get_accelerators_from_instance_type(
-            resources.instance_type)
-        custom_resources = resources_utils.make_ray_custom_resources_str(
-            acc_dict)
-        platform, _ = resources.instance_type.split('_')
+        acc_dict = self.get_accelerators_from_instance_type(resources.instance_type)
+        custom_resources = resources_utils.make_ray_custom_resources_str(acc_dict)
+        platform, _ = resources.instance_type.split("_")
 
         # Selecting image_family by platform
         # https://docs.nebius.com/compute/storage/boot-disk-images
-        if platform.startswith('cpu'):
-            default_image_family = 'ubuntu24.04-driverless'
-        elif platform.startswith('gpu'):
-            default_image_family = 'ubuntu24.04-cuda13.0'
+        if platform.startswith("cpu"):
+            default_image_family = "ubuntu24.04-driverless"
+        elif platform.startswith("gpu"):
+            default_image_family = "ubuntu24.04-cuda13.0"
         else:
-            raise RuntimeError('Unsupported instance type for Nebius cloud:'
-                               f' {resources.instance_type}')
+            raise RuntimeError(
+                f"Unsupported instance type for Nebius cloud: {resources.instance_type}"
+            )
 
-        if (resources.image_id is None or
-                resources.extract_docker_image() is not None):
+        if resources.image_id is None or resources.extract_docker_image() is not None:
             image_id = default_image_family
         else:
             if None in resources.image_id:
@@ -319,39 +323,86 @@ class Nebius(clouds.Cloud):
                 image_id = resources.image_id[region.name]
 
         config_fs = skypilot_config.get_effective_region_config(
-            cloud='nebius',
-            region=region.name,
-            keys=('filesystems',),
-            default_value=[])
+            cloud="nebius", region=region.name, keys=("filesystems",), default_value=[]
+        )
         resources_vars_fs = []
         for i, fs in enumerate(config_fs):
-            resources_vars_fs.append({
-                'filesystem_id': fs['filesystem_id'],
-                'filesystem_attach_mode': fs.get('attach_mode', 'READ_WRITE'),
-                'filesystem_mount_path': fs.get(
-                    'mount_path', f'/mnt/filesystem-skypilot-{i + 1}'),
-                'filesystem_mount_tag': f'filesystem-skypilot-{i + 1}'
-            })
+            resources_vars_fs.append(
+                {
+                    "filesystem_id": fs["filesystem_id"],
+                    "filesystem_attach_mode": fs.get("attach_mode", "READ_WRITE"),
+                    "filesystem_mount_path": fs.get(
+                        "mount_path", f"/mnt/filesystem-skypilot-{i + 1}"
+                    ),
+                    "filesystem_mount_tag": f"filesystem-skypilot-{i + 1}",
+                }
+            )
 
         use_static_ip_address = skypilot_config.get_nested(
-            ('nebius', 'use_static_ip_address'), default_value=False)
+            ("nebius", "use_static_ip_address"), default_value=False
+        )
 
         def _get_disk_tier() -> resources_utils.DiskTier:
-            logger.debug(f'Getting disk tier for Nebius {resources.disk_tier}.')
+            logger.debug(f"Getting disk tier for Nebius {resources.disk_tier}.")
             return Nebius._translate_disk_tier(resources.disk_tier)
 
+        # Resolve BYO vs SkyPilot-managed security group. Mirrors the
+        # `aws.security_group_name` resolution in `sky.clouds.aws.AWS`.
+        # The result flows through the rendered
+        # Ray YAML (`provider.security_group`) to bootstrap_instances and
+        # terminate_instances, which branch on the ManagedBySkyPilot flag.
+        user_sg_config = skypilot_config.get_effective_region_config(
+            cloud="nebius",
+            region=region.name,
+            keys=("security_group_name",),
+            default_value=None,
+        )
+        user_sg: Optional[str] = None
+        if isinstance(user_sg_config, str):
+            user_sg = user_sg_config
+        elif isinstance(user_sg_config, list):
+            for profile in user_sg_config:
+                pattern, sg_name = next(iter(profile.items()))
+                if fnmatch.fnmatchcase(cluster_name.display_name, pattern):
+                    user_sg = sg_name
+                    break
+
+        if user_sg is None:
+            security_group = nebius_constants.SECURITY_GROUP_TEMPLATE.format(
+                cluster_name.name_on_cloud
+            )
+            security_group_managed_by_skypilot = True
+        else:
+            security_group = user_sg
+            security_group_managed_by_skypilot = False
+            if resources.ports is not None:
+                logger.warning(
+                    f"Skip opening ports {resources.ports} for cluster "
+                    f"{cluster_name.display_name!r}, as "
+                    f"`nebius.security_group_name` in `~/.sky/config.yaml` "
+                    f"is specified as {security_group!r}. Please ensure "
+                    f"the specified security group has the requested ports "
+                    f"configured; or, leave out "
+                    f"`nebius.security_group_name` in "
+                    f"`~/.sky/config.yaml`."
+                )
+
         resources_vars: Dict[str, Any] = {
-            'instance_type': resources.instance_type,
-            'custom_resources': custom_resources,
-            'use_static_ip_address': use_static_ip_address,
-            'region': region.name,
-            'image_id': image_id,
+            "instance_type": resources.instance_type,
+            "custom_resources": custom_resources,
+            "use_static_ip_address": use_static_ip_address,
+            "region": region.name,
+            "image_id": image_id,
             # Nebius does not support specific zones.
-            'zones': None,
-            'use_spot': resources.use_spot,
-            'filesystems': resources_vars_fs,
-            'network_tier': resources.network_tier,
-            'disk_tier': _get_disk_tier(),
+            "zones": None,
+            "use_spot": resources.use_spot,
+            "filesystems": resources_vars_fs,
+            "network_tier": resources.network_tier,
+            "disk_tier": _get_disk_tier(),
+            "security_group": security_group,
+            "security_group_managed_by_skypilot": str(
+                security_group_managed_by_skypilot
+            ).lower(),
         }
 
         docker_run_options = []
@@ -360,42 +411,47 @@ class Nebius(clouds.Cloud):
             # Nebius cloud's docker runtime information does not contain
             # 'nvidia-container-runtime', causing no GPU option to be added to
             # the docker run command. We patch this by adding it here.
-            docker_run_options.append('--gpus all')
+            docker_run_options.append("--gpus all")
 
             # Check for InfiniBand support with network_tier: best
             is_infiniband_capable = (
-                platform in nebius_constants.INFINIBAND_INSTANCE_PLATFORMS)
-            if (is_infiniband_capable and
-                    resources.network_tier == resources_utils.NetworkTier.BEST):
+                platform in nebius_constants.INFINIBAND_INSTANCE_PLATFORMS
+            )
+            if (
+                is_infiniband_capable
+                and resources.network_tier == resources_utils.NetworkTier.BEST
+            ):
                 # For Docker containers, add InfiniBand device access and
                 # IPC_LOCK capability
                 if resources.extract_docker_image() is not None:
                     docker_run_options.extend(
-                        nebius_constants.INFINIBAND_DOCKER_OPTIONS)
+                        nebius_constants.INFINIBAND_DOCKER_OPTIONS
+                    )
 
                     # Add InfiniBand environment variables to docker run options
-                    for env_var, env_value in (
-                            nebius_constants.INFINIBAND_ENV_VARS.items()):
-                        docker_run_options.extend(
-                            ['-e', f'{env_var}={env_value}'])
+                    for (
+                        env_var,
+                        env_value,
+                    ) in nebius_constants.INFINIBAND_ENV_VARS.items():
+                        docker_run_options.extend(["-e", f"{env_var}={env_value}"])
 
                 # For all InfiniBand-capable instances, add env variables
-                resources_vars[
-                    'env_vars'] = nebius_constants.INFINIBAND_ENV_VARS
+                resources_vars["env_vars"] = nebius_constants.INFINIBAND_ENV_VARS
 
         if docker_run_options:
-            resources_vars['docker_run_options'] = docker_run_options
+            resources_vars["docker_run_options"] = docker_run_options
 
         return resources_vars
 
     def _get_feasible_launchable_resources(
-        self, resources: 'resources_lib.Resources'
-    ) -> 'resources_utils.FeasibleResources':
+        self, resources: "resources_lib.Resources"
+    ) -> "resources_utils.FeasibleResources":
         """Returns a list of feasible resources for the given resources."""
         if resources.instance_type is not None:
             assert resources.is_launchable(), resources
-            ok, msg = Nebius.check_disk_tier(resources.instance_type,
-                                             resources.disk_tier)
+            ok, msg = Nebius.check_disk_tier(
+                resources.instance_type, resources.disk_tier
+            )
             if not ok:
                 return resources_utils.FeasibleResources([], [], msg)
             return resources_utils.FeasibleResources([resources], [], None)
@@ -424,71 +480,79 @@ class Nebius(clouds.Cloud):
                 region=resources.region,
                 zone=resources.zone,
                 use_spot=resources.use_spot,
-                max_hourly_cost=resources.max_hourly_cost)
+                max_hourly_cost=resources.max_hourly_cost,
+            )
             if default_instance_type is None:
                 # TODO: Add hints to all return values in this method to help
                 #  users understand why the resources are not launchable.
                 return resources_utils.FeasibleResources([], [], None)
             else:
                 return resources_utils.FeasibleResources(
-                    _make([default_instance_type]), [], None)
+                    _make([default_instance_type]), [], None
+                )
 
         assert len(accelerators) == 1, resources
         acc, acc_count = list(accelerators.items())[0]
-        (instance_list,
-         fuzzy_candidate_list) = catalog.get_instance_type_for_accelerator(
-             acc,
-             acc_count,
-             use_spot=resources.use_spot,
-             cpus=resources.cpus,
-             memory=resources.memory,
-             local_disk=resources.local_disk,
-             region=resources.region,
-             zone=resources.zone,
-             max_hourly_cost=resources.max_hourly_cost,
-             clouds='nebius')
+        (instance_list, fuzzy_candidate_list) = (
+            catalog.get_instance_type_for_accelerator(
+                acc,
+                acc_count,
+                use_spot=resources.use_spot,
+                cpus=resources.cpus,
+                memory=resources.memory,
+                local_disk=resources.local_disk,
+                region=resources.region,
+                zone=resources.zone,
+                max_hourly_cost=resources.max_hourly_cost,
+                clouds="nebius",
+            )
+        )
         if instance_list is None:
-            return resources_utils.FeasibleResources([], fuzzy_candidate_list,
-                                                     None)
-        return resources_utils.FeasibleResources(_make(instance_list),
-                                                 fuzzy_candidate_list, None)
+            return resources_utils.FeasibleResources([], fuzzy_candidate_list, None)
+        return resources_utils.FeasibleResources(
+            _make(instance_list), fuzzy_candidate_list, None
+        )
 
     @classmethod
     def _check_compute_credentials(
-            cls) -> Tuple[bool, Optional[Union[str, Dict[str, str]]]]:
+        cls,
+    ) -> Tuple[bool, Optional[Union[str, Dict[str, str]]]]:
         """Checks if the user has access credentials to
         Nebius's compute service."""
         token_cred_msg = (
-            f'{_INDENT_PREFIX}Credentials can be set up by running: \n'
-            f'{_INDENT_PREFIX}  $ nebius iam get-access-token > {nebius.iam_token_path()} \n'  # pylint: disable=line-too-long
-            f'{_INDENT_PREFIX} or generate  {nebius.credentials_path()} \n')
+            f"{_INDENT_PREFIX}Credentials can be set up by running: \n"
+            f"{_INDENT_PREFIX}  $ nebius iam get-access-token > {nebius.iam_token_path()} \n"  # pylint: disable=line-too-long
+            f"{_INDENT_PREFIX} or generate  {nebius.credentials_path()} \n"
+        )
 
         tenant_msg = (
-            f'{_INDENT_PREFIX} Copy your tenant ID from the web console and save it to file \n'  # pylint: disable=line-too-long
-            f'{_INDENT_PREFIX}  $ echo $NEBIUS_TENANT_ID_PATH > {nebius.tenant_id_path()} \n'  # pylint: disable=line-too-long
-            f'{_INDENT_PREFIX} Or if you have 1 tenant you can run:\n'  # pylint: disable=line-too-long
-            f'{_INDENT_PREFIX}  $ nebius --format json iam whoami|jq -r \'.user_profile.tenants[0].tenant_id\' > {nebius.tenant_id_path()} \n')  # pylint: disable=line-too-long
+            f"{_INDENT_PREFIX} Copy your tenant ID from the web console and save it to file \n"  # pylint: disable=line-too-long
+            f"{_INDENT_PREFIX}  $ echo $NEBIUS_TENANT_ID_PATH > {nebius.tenant_id_path()} \n"  # pylint: disable=line-too-long
+            f"{_INDENT_PREFIX} Or if you have 1 tenant you can run:\n"  # pylint: disable=line-too-long
+            f"{_INDENT_PREFIX}  $ nebius --format json iam whoami|jq -r '.user_profile.tenants[0].tenant_id' > {nebius.tenant_id_path()} \n"
+        )  # pylint: disable=line-too-long
         if not nebius.is_token_or_cred_file_exist():
-            return False, f'{token_cred_msg}'
+            return False, f"{token_cred_msg}"
         tenant_id = nebius.get_tenant_id()
         if tenant_id is None:
-            return False, f'{tenant_msg}'
+            return False, f"{tenant_msg}"
         sdk = nebius.sdk()
         try:
             service = nebius.iam().ProjectServiceClient(sdk)
-            service.list(
-                nebius.iam().ListProjectsRequest(parent_id=tenant_id)).wait()
+            service.list(nebius.iam().ListProjectsRequest(parent_id=tenant_id)).wait()
         except nebius.request_error() as e:
             return False, (
-                f'{e.status} \n'  # First line is indented by 4 spaces
-                f'{token_cred_msg} \n'
-                f'{tenant_msg}')
+                f"{e.status} \n"  # First line is indented by 4 spaces
+                f"{token_cred_msg} \n"
+                f"{tenant_msg}"
+            )
         return True, None
 
     @classmethod
-    @annotations.lru_cache(scope='request')
+    @annotations.lru_cache(scope="request")
     def _check_storage_credentials(
-            cls) -> Tuple[bool, Optional[Union[str, Dict[str, str]]]]:
+        cls,
+    ) -> Tuple[bool, Optional[Union[str, Dict[str, str]]]]:
         """Checks if the user has access credentials to Nebius Object Storage.
 
         Returns:
@@ -499,17 +563,20 @@ class Nebius(clouds.Cloud):
         """
         hints = None
         if not nebius_profile_in_aws_cred_and_config():
-            hints = (f'[{nebius.NEBIUS_PROFILE_NAME}] profile '
-                     'is not set in ~/.aws/credentials.')
+            hints = (
+                f"[{nebius.NEBIUS_PROFILE_NAME}] profile "
+                "is not set in ~/.aws/credentials."
+            )
         if hints:
-            hints += ' Run the following commands:'
+            hints += " Run the following commands:"
             if not nebius_profile_in_aws_cred_and_config():
                 hints += (
-                    f'\n{_INDENT_PREFIX}  $ pip install boto3'
-                    f'\n{_INDENT_PREFIX}  $ aws configure --profile nebius')
+                    f"\n{_INDENT_PREFIX}  $ pip install boto3"
+                    f"\n{_INDENT_PREFIX}  $ aws configure --profile nebius"
+                )
             hints += (
-                f'\n{_INDENT_PREFIX}For more info: '
-                'https://docs.skypilot.co/en/latest/getting-started/installation.html#nebius'  # pylint: disable=line-too-long
+                f"\n{_INDENT_PREFIX}For more info: "
+                "https://docs.skypilot.co/en/latest/getting-started/installation.html#nebius"  # pylint: disable=line-too-long
             )
         return (False, hints) if hints else (True, hints)
 
@@ -521,17 +588,17 @@ class Nebius(clouds.Cloud):
             # NOTE: We can't guarantee that the file will be deleted eventually,
             # but it doesn't contain sensitive information and should be cleaned
             # up by the OS eventually.
-            credential_file_mounts[tenant_id_path] = (
-                _write_nebius_temp_credential_file('nebius-tenant-id-',
-                                                   tenant_id))
+            credential_file_mounts[tenant_id_path] = _write_nebius_temp_credential_file(
+                "nebius-tenant-id-", tenant_id
+            )
 
         for filepath in nebius.get_credential_file_paths():
             if filepath == tenant_id_path:
                 continue
             credential_file_mounts[filepath] = filepath
         if nebius_profile_in_aws_cred_and_config():
-            credential_file_mounts['~/.aws/credentials'] = '~/.aws/credentials'
-            credential_file_mounts['~/.aws/config'] = '~/.aws/config'
+            credential_file_mounts["~/.aws/credentials"] = "~/.aws/credentials"
+            credential_file_mounts["~/.aws/config"] = "~/.aws/config"
         return credential_file_mounts
 
     @classmethod
@@ -541,22 +608,24 @@ class Nebius(clouds.Cloud):
         return None
 
     def instance_type_exists(self, instance_type: str) -> bool:
-        return catalog.instance_type_exists(instance_type, 'nebius')
+        return catalog.instance_type_exists(instance_type, "nebius")
 
     def validate_region_zone(self, region: Optional[str], zone: Optional[str]):
-        return catalog.validate_region_zone(region, zone, clouds='nebius')
+        return catalog.validate_region_zone(region, zone, clouds="nebius")
 
     @classmethod
     def get_user_identities(cls) -> Optional[List[List[str]]]:
         """Returns the email address + project id of the active user."""
         nebius_workspace_config = json.dumps(
-            skypilot_config.get_workspace_cloud('nebius'), sort_keys=True)
+            skypilot_config.get_workspace_cloud("nebius"), sort_keys=True
+        )
         return cls._get_user_identities(nebius_workspace_config)
 
     @classmethod
-    @annotations.lru_cache(scope='request', maxsize=5)
+    @annotations.lru_cache(scope="request", maxsize=5)
     def _get_user_identities(
-            cls, workspace_config: Optional[str]) -> Optional[List[List[str]]]:
+        cls, workspace_config: Optional[str]
+    ) -> Optional[List[List[str]]]:
         # We add workspace_config in args to avoid caching the identity for when
         # different workspace configs are used.
         del workspace_config  # Unused
@@ -564,40 +633,49 @@ class Nebius(clouds.Cloud):
         profile_client = nebius.iam().ProfileServiceClient(sdk)
         try:
             profile = nebius.sync_call(
-                profile_client.get(nebius.iam().GetProfileRequest(),
-                                   timeout=nebius.READ_TIMEOUT))
+                profile_client.get(
+                    nebius.iam().GetProfileRequest(), timeout=nebius.READ_TIMEOUT
+                )
+            )
         except Exception as e:
             raise exceptions.CloudUserIdentityError(
-                f'Error getting Nebius profile: {e}')
+                f"Error getting Nebius profile: {e}"
+            )
         if profile.user_profile is not None:
             if profile.user_profile.attributes is None:
                 raise exceptions.CloudUserIdentityError(
-                    'Nebius profile is a UserProfile, but has no attributes: '
-                    f'{profile.user_profile}')
+                    "Nebius profile is a UserProfile, but has no attributes: "
+                    f"{profile.user_profile}"
+                )
             if profile.user_profile.attributes.email is None:
                 raise exceptions.CloudUserIdentityError(
-                    'Nebius profile is a UserProfile, but has no email: '
-                    f'{profile.user_profile}')
+                    "Nebius profile is a UserProfile, but has no email: "
+                    f"{profile.user_profile}"
+                )
             return [[profile.user_profile.attributes.email]]
         if profile.service_account_profile is not None:
             if profile.service_account_profile.info is None:
                 raise exceptions.CloudUserIdentityError(
-                    'Nebius profile is a ServiceAccountProfile, but has no '
-                    f'info: {profile.service_account_profile}')
+                    "Nebius profile is a ServiceAccountProfile, but has no "
+                    f"info: {profile.service_account_profile}"
+                )
             if profile.service_account_profile.info.metadata is None:
                 raise exceptions.CloudUserIdentityError(
-                    'Nebius profile is a ServiceAccountProfile, but has no '
-                    f'metadata: {profile.service_account_profile}')
+                    "Nebius profile is a ServiceAccountProfile, but has no "
+                    f"metadata: {profile.service_account_profile}"
+                )
             if profile.service_account_profile.info.metadata.name is None:
                 raise exceptions.CloudUserIdentityError(
-                    'Nebius profile is a ServiceAccountProfile, but has no '
-                    f'name: {profile.service_account_profile}')
+                    "Nebius profile is a ServiceAccountProfile, but has no "
+                    f"name: {profile.service_account_profile}"
+                )
             return [[profile.service_account_profile.info.metadata.name]]
         if profile.anonymous_profile is not None:
             return None
-        unknown_profile_type = profile.which_field_in_oneof('profile')
+        unknown_profile_type = profile.which_field_in_oneof("profile")
         raise exceptions.CloudUserIdentityError(
-            f'Nebius profile is of an unknown type - {unknown_profile_type}')
+            f"Nebius profile is of an unknown type - {unknown_profile_type}"
+        )
 
     # pylint: disable=import-outside-toplevel
     @classmethod
@@ -608,26 +686,25 @@ class Nebius(clouds.Cloud):
         sdk = nebius.sdk()
         compute = nebius.compute()
         image_client = compute.ImageServiceClient(sdk)
-        if image_id.startswith('computeimage-'):
+        if image_id.startswith("computeimage-"):
             try:
-                image = image_client.get(
-                    compute.GetImageRequest(id=image_id)).wait()
+                image = image_client.get(compute.GetImageRequest(id=image_id)).wait()
             except RequestError as e:
                 if e.status.code == StatusCode.NOT_FOUND:
-                    raise ValueError(f'Image {image_id} does not exist') from e
+                    raise ValueError(f"Image {image_id} does not exist") from e
                 raise e
         else:
             parent_id = None
             if region is not None:
                 parent_id = utils.get_project_by_region(region)
             request = compute.GetImageLatestByFamilyRequest(
-                image_family=image_id, parent_id=parent_id)
+                image_family=image_id, parent_id=parent_id
+            )
             try:
                 image = image_client.get_latest_by_family(request).wait()
             except RequestError as e:
                 if e.status.code == StatusCode.NOT_FOUND:
-                    raise ValueError(
-                        f'Image family {image_id} does not exist') from e
+                    raise ValueError(f"Image family {image_id} does not exist") from e
                 raise e
 
         return image.status.min_disk_size_bytes / 1024**3

--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -1,5 +1,4 @@
-"""Nebius Cloud."""
-
+""" Nebius Cloud. """
 import fnmatch
 import hashlib
 import json
@@ -8,17 +7,24 @@ import tempfile
 import typing
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
-from sky import catalog, clouds, exceptions, sky_logging, skypilot_config
+from sky import catalog
+from sky import clouds
+from sky import exceptions
+from sky import sky_logging
+from sky import skypilot_config
 from sky.adaptors import nebius
 from sky.provision.nebius import constants as nebius_constants
 from sky.provision.nebius import utils
-from sky.utils import annotations, registry, resources_utils, ux_utils
+from sky.utils import annotations
+from sky.utils import registry
+from sky.utils import resources_utils
+from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
     from sky import resources as resources_lib
     from sky.utils import volume as volume_lib
 
-_INDENT_PREFIX = "    "
+_INDENT_PREFIX = '    '
 
 logger = sky_logging.init_logger(__name__)
 
@@ -27,23 +33,24 @@ def nebius_profile_in_aws_cred_and_config() -> bool:
     """Checks if Nebius Object Storage profile is set in aws credentials
     and profile."""
 
-    credentials_path = os.path.expanduser("~/.aws/credentials")
+    credentials_path = os.path.expanduser('~/.aws/credentials')
     nebius_profile_exists_in_credentials = False
     if os.path.isfile(credentials_path):
-        with open(credentials_path, "r", encoding="utf-8") as file:
+        with open(credentials_path, 'r', encoding='utf-8') as file:
             for line in file:
-                if f"[{nebius.NEBIUS_PROFILE_NAME}]" in line:
+                if f'[{nebius.NEBIUS_PROFILE_NAME}]' in line:
                     nebius_profile_exists_in_credentials = True
 
-    config_path = os.path.expanduser("~/.aws/config")
+    config_path = os.path.expanduser('~/.aws/config')
     nebius_profile_exists_in_config = False
     if os.path.isfile(config_path):
-        with open(config_path, "r", encoding="utf-8") as file:
+        with open(config_path, 'r', encoding='utf-8') as file:
             for line in file:
-                if f"[profile {nebius.NEBIUS_PROFILE_NAME}]" in line:
+                if f'[profile {nebius.NEBIUS_PROFILE_NAME}]' in line:
                     nebius_profile_exists_in_config = True
 
-    return nebius_profile_exists_in_credentials and nebius_profile_exists_in_config
+    return (nebius_profile_exists_in_credentials and
+            nebius_profile_exists_in_config)
 
 
 def _write_nebius_temp_credential_file(prefix: str, value: str) -> str:
@@ -64,17 +71,17 @@ def _write_nebius_temp_credential_file(prefix: str, value: str) -> str:
     when they happen to share the same content -- one user's restrictive
     umask would otherwise lock the other user out.
     """
-    uid = os.getuid() if hasattr(os, "getuid") else "default"
-    digest = hashlib.sha1(value.encode("utf-8")).hexdigest()[:16]
-    path = os.path.join(tempfile.gettempdir(), f"{prefix}{uid}-{digest}")
-    expected = value + "\n"
+    uid = os.getuid() if hasattr(os, 'getuid') else 'default'
+    digest = hashlib.sha1(value.encode('utf-8')).hexdigest()[:16]
+    path = os.path.join(tempfile.gettempdir(), f'{prefix}{uid}-{digest}')
+    expected = value + '\n'
     try:
-        with open(path, "r", encoding="utf-8") as existing:
+        with open(path, 'r', encoding='utf-8') as existing:
             if existing.read() == expected:
                 return path
     except OSError:
         pass
-    with open(path, "w", encoding="utf-8") as new_file:
+    with open(path, 'w', encoding='utf-8') as new_file:
         new_file.write(expected)
     return path
 
@@ -82,25 +89,20 @@ def _write_nebius_temp_credential_file(prefix: str, value: str) -> str:
 @registry.CLOUD_REGISTRY.register
 class Nebius(clouds.Cloud):
     """Nebius GPU Cloud"""
-
-    _REPR = "Nebius"
+    _REPR = 'Nebius'
     _CLOUD_UNSUPPORTED_FEATURES = {
-        clouds.CloudImplementationFeatures.CLONE_DISK_FROM_CLUSTER: (
-            f"Migrating disk is currently not supported on {_REPR}."
-        ),
-        clouds.CloudImplementationFeatures.CUSTOM_NETWORK_TIER: (
-            "Custom network tier is currently only supported for "
-            "H100:8 and H200:8 on Nebius."
-        ),
-        clouds.CloudImplementationFeatures.HIGH_AVAILABILITY_CONTROLLERS: (
-            "High availability controllers are not supported on Nebius."
-        ),
-        clouds.CloudImplementationFeatures.CUSTOM_MULTI_NETWORK: (
-            f"Customized multiple network interfaces are not supported on {_REPR}."
-        ),
-        clouds.CloudImplementationFeatures.LOCAL_DISK: (
-            f"Local disk is not supported on {_REPR}"
-        ),
+        clouds.CloudImplementationFeatures.CLONE_DISK_FROM_CLUSTER:
+            (f'Migrating disk is currently not supported on {_REPR}.'),
+        clouds.CloudImplementationFeatures.CUSTOM_NETWORK_TIER:
+            ('Custom network tier is currently only supported for '
+             'H100:8 and H200:8 on Nebius.'),
+        clouds.CloudImplementationFeatures.HIGH_AVAILABILITY_CONTROLLERS:
+            ('High availability controllers are not supported on Nebius.'),
+        clouds.CloudImplementationFeatures.CUSTOM_MULTI_NETWORK:
+            ('Customized multiple network interfaces are not supported on '
+             f'{_REPR}.'),
+        clouds.CloudImplementationFeatures.LOCAL_DISK:
+            (f'Local disk is not supported on {_REPR}'),
     }
     # Nebius maximum instance name length defined as <= 63 as a hostname length
     # 63 - 8 - 5 = 50 characters since
@@ -112,9 +114,8 @@ class Nebius(clouds.Cloud):
     _BEST_DISK_TIER = resources_utils.DiskTier.HIGH
     _DEFAULT_DISK_TIER = resources_utils.DiskTier.MEDIUM
     # Nebius does not support ultra disk tier.
-    _SUPPORTED_DISK_TIERS = set(resources_utils.DiskTier) - {
-        resources_utils.DiskTier.ULTRA
-    }
+    _SUPPORTED_DISK_TIERS = (set(resources_utils.DiskTier) -
+                             {resources_utils.DiskTier.ULTRA})
 
     # Using the latest SkyPilot provisioner API to provision and check status.
     PROVISIONER_VERSION = clouds.ProvisionerVersion.SKYPILOT
@@ -126,7 +127,7 @@ class Nebius(clouds.Cloud):
     @classmethod
     def _unsupported_features_for_resources(
         cls,
-        resources: "resources_lib.Resources",
+        resources: 'resources_lib.Resources',
         region: Optional[str] = None,
     ) -> Dict[clouds.CloudImplementationFeatures, str]:
         unsupported = cls._CLOUD_UNSUPPORTED_FEATURES.copy()
@@ -134,13 +135,13 @@ class Nebius(clouds.Cloud):
         # Check if the accelerators support InfiniBand (H100 or H200) and 8 GPUs
         if resources.accelerators is not None:
             for acc_name, acc_count in resources.accelerators.items():
-                if acc_name.lower() in ("h100", "h200") and acc_count == 8:
+                if acc_name.lower() in ('h100', 'h200') and acc_count == 8:
                     # Remove CUSTOM_NETWORK_TIER from unsupported features for
                     # InfiniBand-capable accelerators. Refer to:
                     # https://docs.nebius.com/compute/clusters/gpu#fabrics
                     unsupported.pop(
-                        clouds.CloudImplementationFeatures.CUSTOM_NETWORK_TIER, None
-                    )
+                        clouds.CloudImplementationFeatures.CUSTOM_NETWORK_TIER,
+                        None)
                     break
 
         return unsupported
@@ -157,13 +158,12 @@ class Nebius(clouds.Cloud):
         use_spot: bool,
         region: Optional[str],
         zone: Optional[str],
-        resources: Optional["resources_lib.Resources"] = None,
+        resources: Optional['resources_lib.Resources'] = None,
     ) -> List[clouds.Region]:
-        assert zone is None, "Nebius does not support zones."
+        assert zone is None, 'Nebius does not support zones.'
         del accelerators, zone  # unused
         regions = catalog.get_region_zones_for_instance_type(
-            instance_type, use_spot, "nebius"
-        )
+            instance_type, use_spot, 'nebius')
 
         if region is not None:
             regions = [r for r in regions if r.name == region]
@@ -174,7 +174,8 @@ class Nebius(clouds.Cloud):
         cls,
         instance_type: str,
     ) -> Tuple[Optional[float], Optional[float]]:
-        return catalog.get_vcpus_mem_from_instance_type(instance_type, clouds="nebius")
+        return catalog.get_vcpus_mem_from_instance_type(instance_type,
+                                                        clouds='nebius')
 
     @classmethod
     def zones_provision_loop(
@@ -187,52 +188,51 @@ class Nebius(clouds.Cloud):
         use_spot: bool = False,
     ) -> Iterator[None]:
         del num_nodes  # unused
-        regions = cls.regions_with_offering(
-            instance_type, accelerators, use_spot, region=region, zone=None
-        )
+        regions = cls.regions_with_offering(instance_type,
+                                            accelerators,
+                                            use_spot,
+                                            region=region,
+                                            zone=None)
         for r in regions:
             assert r.zones is None, r
             yield r.zones
 
     @classmethod
     def check_disk_tier(
-        cls, instance_type: Optional[str], disk_tier: Optional[resources_utils.DiskTier]
-    ) -> Tuple[bool, str]:
+            cls, instance_type: Optional[str],
+            disk_tier: Optional[resources_utils.DiskTier]) -> Tuple[bool, str]:
         del instance_type
-        if disk_tier is not None and disk_tier == resources_utils.DiskTier.ULTRA:
+        if (disk_tier is not None and
+                disk_tier == resources_utils.DiskTier.ULTRA):
             return False, (
-                "Nebius disk_tier=ultra is not supported now. "
-                "Please use disk_tier={low, medium, high, best} instead."
-            )
-        return True, ""
+                'Nebius disk_tier=ultra is not supported now. '
+                'Please use disk_tier={low, medium, high, best} instead.')
+        return True, ''
 
     @classmethod
-    def check_disk_tier_enabled(
-        cls, instance_type: Optional[str], disk_tier: resources_utils.DiskTier
-    ) -> None:
+    def check_disk_tier_enabled(cls, instance_type: Optional[str],
+                                disk_tier: resources_utils.DiskTier) -> None:
         ok, msg = cls.check_disk_tier(instance_type, disk_tier)
         if not ok:
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.NotSupportedError(msg)
 
-    def instance_type_to_hourly_cost(
-        self,
-        instance_type: str,
-        use_spot: bool,
-        region: Optional[str] = None,
-        zone: Optional[str] = None,
-    ) -> float:
-        return catalog.get_hourly_cost(
-            instance_type, use_spot=use_spot, region=region, zone=zone, clouds="nebius"
-        )
+    def instance_type_to_hourly_cost(self,
+                                     instance_type: str,
+                                     use_spot: bool,
+                                     region: Optional[str] = None,
+                                     zone: Optional[str] = None) -> float:
+        return catalog.get_hourly_cost(instance_type,
+                                       use_spot=use_spot,
+                                       region=region,
+                                       zone=zone,
+                                       clouds='nebius')
 
-    def accelerators_to_hourly_cost(
-        self,
-        accelerators: Dict[str, int],
-        use_spot: bool,
-        region: Optional[str] = None,
-        zone: Optional[str] = None,
-    ) -> float:
+    def accelerators_to_hourly_cost(self,
+                                    accelerators: Dict[str, int],
+                                    use_spot: bool,
+                                    region: Optional[str] = None,
+                                    zone: Optional[str] = None) -> float:
         """Returns the hourly cost of the accelerators, in dollars/hour."""
         del accelerators, use_spot, region, zone  # unused
         return 0.0
@@ -269,17 +269,15 @@ class Nebius(clouds.Cloud):
             zone=zone,
             use_spot=use_spot,
             max_hourly_cost=max_hourly_cost,
-            clouds="nebius",
-        )
+            clouds='nebius')
 
     @classmethod
     def get_accelerators_from_instance_type(
         cls,
         instance_type: str,
     ) -> Optional[Dict[str, Union[int, float]]]:
-        return catalog.get_accelerators_from_instance_type(
-            instance_type, clouds="nebius"
-        )
+        return catalog.get_accelerators_from_instance_type(instance_type,
+                                                           clouds='nebius')
 
     @classmethod
     def get_zone_shell_cmd(cls) -> Optional[str]:
@@ -287,34 +285,36 @@ class Nebius(clouds.Cloud):
 
     def make_deploy_resources_variables(
         self,
-        resources: "resources_lib.Resources",
+        resources: 'resources_lib.Resources',
         cluster_name: resources_utils.ClusterName,
-        region: "clouds.Region",
-        zones: Optional[List["clouds.Zone"]],
+        region: 'clouds.Region',
+        zones: Optional[List['clouds.Zone']],
         num_nodes: int,
         dryrun: bool = False,
-        volume_mounts: Optional[List["volume_lib.VolumeMount"]] = None,
+        volume_mounts: Optional[List['volume_lib.VolumeMount']] = None,
     ) -> Dict[str, Any]:
         del dryrun
-        assert zones is None, ("Nebius does not support zones", zones)
+        assert zones is None, ('Nebius does not support zones', zones)
 
         resources = resources.assert_launchable()
-        acc_dict = self.get_accelerators_from_instance_type(resources.instance_type)
-        custom_resources = resources_utils.make_ray_custom_resources_str(acc_dict)
-        platform, _ = resources.instance_type.split("_")
+        acc_dict = self.get_accelerators_from_instance_type(
+            resources.instance_type)
+        custom_resources = resources_utils.make_ray_custom_resources_str(
+            acc_dict)
+        platform, _ = resources.instance_type.split('_')
 
         # Selecting image_family by platform
         # https://docs.nebius.com/compute/storage/boot-disk-images
-        if platform.startswith("cpu"):
-            default_image_family = "ubuntu24.04-driverless"
-        elif platform.startswith("gpu"):
-            default_image_family = "ubuntu24.04-cuda13.0"
+        if platform.startswith('cpu'):
+            default_image_family = 'ubuntu24.04-driverless'
+        elif platform.startswith('gpu'):
+            default_image_family = 'ubuntu24.04-cuda13.0'
         else:
-            raise RuntimeError(
-                f"Unsupported instance type for Nebius cloud: {resources.instance_type}"
-            )
+            raise RuntimeError('Unsupported instance type for Nebius cloud:'
+                               f' {resources.instance_type}')
 
-        if resources.image_id is None or resources.extract_docker_image() is not None:
+        if (resources.image_id is None or
+                resources.extract_docker_image() is not None):
             image_id = default_image_family
         else:
             if None in resources.image_id:
@@ -323,40 +323,37 @@ class Nebius(clouds.Cloud):
                 image_id = resources.image_id[region.name]
 
         config_fs = skypilot_config.get_effective_region_config(
-            cloud="nebius", region=region.name, keys=("filesystems",), default_value=[]
-        )
+            cloud='nebius',
+            region=region.name,
+            keys=('filesystems',),
+            default_value=[])
         resources_vars_fs = []
         for i, fs in enumerate(config_fs):
-            resources_vars_fs.append(
-                {
-                    "filesystem_id": fs["filesystem_id"],
-                    "filesystem_attach_mode": fs.get("attach_mode", "READ_WRITE"),
-                    "filesystem_mount_path": fs.get(
-                        "mount_path", f"/mnt/filesystem-skypilot-{i + 1}"
-                    ),
-                    "filesystem_mount_tag": f"filesystem-skypilot-{i + 1}",
-                }
-            )
+            resources_vars_fs.append({
+                'filesystem_id': fs['filesystem_id'],
+                'filesystem_attach_mode': fs.get('attach_mode', 'READ_WRITE'),
+                'filesystem_mount_path': fs.get(
+                    'mount_path', f'/mnt/filesystem-skypilot-{i + 1}'),
+                'filesystem_mount_tag': f'filesystem-skypilot-{i + 1}'
+            })
 
         use_static_ip_address = skypilot_config.get_nested(
-            ("nebius", "use_static_ip_address"), default_value=False
-        )
+            ('nebius', 'use_static_ip_address'), default_value=False)
 
         def _get_disk_tier() -> resources_utils.DiskTier:
-            logger.debug(f"Getting disk tier for Nebius {resources.disk_tier}.")
+            logger.debug(f'Getting disk tier for Nebius {resources.disk_tier}.')
             return Nebius._translate_disk_tier(resources.disk_tier)
 
         # Resolve BYO vs SkyPilot-managed security group. Mirrors the
         # `aws.security_group_name` resolution in `sky.clouds.aws.AWS`.
-        # The result flows through the rendered
-        # Ray YAML (`provider.security_group`) to bootstrap_instances and
+        # The result flows through the rendered Ray YAML
+        # (`provider.security_group`) to bootstrap_instances and
         # terminate_instances, which branch on the ManagedBySkyPilot flag.
         user_sg_config = skypilot_config.get_effective_region_config(
-            cloud="nebius",
+            cloud='nebius',
             region=region.name,
-            keys=("security_group_name",),
-            default_value=None,
-        )
+            keys=('security_group_name',),
+            default_value=None)
         user_sg: Optional[str] = None
         if isinstance(user_sg_config, str):
             user_sg = user_sg_config
@@ -369,40 +366,37 @@ class Nebius(clouds.Cloud):
 
         if user_sg is None:
             security_group = nebius_constants.SECURITY_GROUP_TEMPLATE.format(
-                cluster_name.name_on_cloud
-            )
+                cluster_name.name_on_cloud)
             security_group_managed_by_skypilot = True
         else:
             security_group = user_sg
             security_group_managed_by_skypilot = False
             if resources.ports is not None:
                 logger.warning(
-                    f"Skip opening ports {resources.ports} for cluster "
-                    f"{cluster_name.display_name!r}, as "
-                    f"`nebius.security_group_name` in `~/.sky/config.yaml` "
-                    f"is specified as {security_group!r}. Please ensure "
-                    f"the specified security group has the requested ports "
-                    f"configured; or, leave out "
-                    f"`nebius.security_group_name` in "
-                    f"`~/.sky/config.yaml`."
-                )
+                    f'Skip opening ports {resources.ports} for cluster '
+                    f'{cluster_name.display_name!r}, as '
+                    f'`nebius.security_group_name` in `~/.sky/config.yaml` '
+                    f'is specified as {security_group!r}. Please ensure '
+                    f'the specified security group has the requested ports '
+                    f'configured; or, leave out '
+                    f'`nebius.security_group_name` in '
+                    f'`~/.sky/config.yaml`.')
 
         resources_vars: Dict[str, Any] = {
-            "instance_type": resources.instance_type,
-            "custom_resources": custom_resources,
-            "use_static_ip_address": use_static_ip_address,
-            "region": region.name,
-            "image_id": image_id,
+            'instance_type': resources.instance_type,
+            'custom_resources': custom_resources,
+            'use_static_ip_address': use_static_ip_address,
+            'region': region.name,
+            'image_id': image_id,
             # Nebius does not support specific zones.
-            "zones": None,
-            "use_spot": resources.use_spot,
-            "filesystems": resources_vars_fs,
-            "network_tier": resources.network_tier,
-            "disk_tier": _get_disk_tier(),
-            "security_group": security_group,
-            "security_group_managed_by_skypilot": str(
-                security_group_managed_by_skypilot
-            ).lower(),
+            'zones': None,
+            'use_spot': resources.use_spot,
+            'filesystems': resources_vars_fs,
+            'network_tier': resources.network_tier,
+            'disk_tier': _get_disk_tier(),
+            'security_group': security_group,
+            'security_group_managed_by_skypilot':
+                str(security_group_managed_by_skypilot).lower(),
         }
 
         docker_run_options = []
@@ -411,47 +405,42 @@ class Nebius(clouds.Cloud):
             # Nebius cloud's docker runtime information does not contain
             # 'nvidia-container-runtime', causing no GPU option to be added to
             # the docker run command. We patch this by adding it here.
-            docker_run_options.append("--gpus all")
+            docker_run_options.append('--gpus all')
 
             # Check for InfiniBand support with network_tier: best
             is_infiniband_capable = (
-                platform in nebius_constants.INFINIBAND_INSTANCE_PLATFORMS
-            )
-            if (
-                is_infiniband_capable
-                and resources.network_tier == resources_utils.NetworkTier.BEST
-            ):
+                platform in nebius_constants.INFINIBAND_INSTANCE_PLATFORMS)
+            if (is_infiniband_capable and
+                    resources.network_tier == resources_utils.NetworkTier.BEST):
                 # For Docker containers, add InfiniBand device access and
                 # IPC_LOCK capability
                 if resources.extract_docker_image() is not None:
                     docker_run_options.extend(
-                        nebius_constants.INFINIBAND_DOCKER_OPTIONS
-                    )
+                        nebius_constants.INFINIBAND_DOCKER_OPTIONS)
 
                     # Add InfiniBand environment variables to docker run options
-                    for (
-                        env_var,
-                        env_value,
-                    ) in nebius_constants.INFINIBAND_ENV_VARS.items():
-                        docker_run_options.extend(["-e", f"{env_var}={env_value}"])
+                    for env_var, env_value in (
+                            nebius_constants.INFINIBAND_ENV_VARS.items()):
+                        docker_run_options.extend(
+                            ['-e', f'{env_var}={env_value}'])
 
                 # For all InfiniBand-capable instances, add env variables
-                resources_vars["env_vars"] = nebius_constants.INFINIBAND_ENV_VARS
+                resources_vars[
+                    'env_vars'] = nebius_constants.INFINIBAND_ENV_VARS
 
         if docker_run_options:
-            resources_vars["docker_run_options"] = docker_run_options
+            resources_vars['docker_run_options'] = docker_run_options
 
         return resources_vars
 
     def _get_feasible_launchable_resources(
-        self, resources: "resources_lib.Resources"
-    ) -> "resources_utils.FeasibleResources":
+        self, resources: 'resources_lib.Resources'
+    ) -> 'resources_utils.FeasibleResources':
         """Returns a list of feasible resources for the given resources."""
         if resources.instance_type is not None:
             assert resources.is_launchable(), resources
-            ok, msg = Nebius.check_disk_tier(
-                resources.instance_type, resources.disk_tier
-            )
+            ok, msg = Nebius.check_disk_tier(resources.instance_type,
+                                             resources.disk_tier)
             if not ok:
                 return resources_utils.FeasibleResources([], [], msg)
             return resources_utils.FeasibleResources([resources], [], None)
@@ -480,79 +469,71 @@ class Nebius(clouds.Cloud):
                 region=resources.region,
                 zone=resources.zone,
                 use_spot=resources.use_spot,
-                max_hourly_cost=resources.max_hourly_cost,
-            )
+                max_hourly_cost=resources.max_hourly_cost)
             if default_instance_type is None:
                 # TODO: Add hints to all return values in this method to help
                 #  users understand why the resources are not launchable.
                 return resources_utils.FeasibleResources([], [], None)
             else:
                 return resources_utils.FeasibleResources(
-                    _make([default_instance_type]), [], None
-                )
+                    _make([default_instance_type]), [], None)
 
         assert len(accelerators) == 1, resources
         acc, acc_count = list(accelerators.items())[0]
-        (instance_list, fuzzy_candidate_list) = (
-            catalog.get_instance_type_for_accelerator(
-                acc,
-                acc_count,
-                use_spot=resources.use_spot,
-                cpus=resources.cpus,
-                memory=resources.memory,
-                local_disk=resources.local_disk,
-                region=resources.region,
-                zone=resources.zone,
-                max_hourly_cost=resources.max_hourly_cost,
-                clouds="nebius",
-            )
-        )
+        (instance_list,
+         fuzzy_candidate_list) = catalog.get_instance_type_for_accelerator(
+             acc,
+             acc_count,
+             use_spot=resources.use_spot,
+             cpus=resources.cpus,
+             memory=resources.memory,
+             local_disk=resources.local_disk,
+             region=resources.region,
+             zone=resources.zone,
+             max_hourly_cost=resources.max_hourly_cost,
+             clouds='nebius')
         if instance_list is None:
-            return resources_utils.FeasibleResources([], fuzzy_candidate_list, None)
-        return resources_utils.FeasibleResources(
-            _make(instance_list), fuzzy_candidate_list, None
-        )
+            return resources_utils.FeasibleResources([], fuzzy_candidate_list,
+                                                     None)
+        return resources_utils.FeasibleResources(_make(instance_list),
+                                                 fuzzy_candidate_list, None)
 
     @classmethod
     def _check_compute_credentials(
-        cls,
-    ) -> Tuple[bool, Optional[Union[str, Dict[str, str]]]]:
+            cls) -> Tuple[bool, Optional[Union[str, Dict[str, str]]]]:
         """Checks if the user has access credentials to
         Nebius's compute service."""
         token_cred_msg = (
-            f"{_INDENT_PREFIX}Credentials can be set up by running: \n"
-            f"{_INDENT_PREFIX}  $ nebius iam get-access-token > {nebius.iam_token_path()} \n"  # pylint: disable=line-too-long
-            f"{_INDENT_PREFIX} or generate  {nebius.credentials_path()} \n"
-        )
+            f'{_INDENT_PREFIX}Credentials can be set up by running: \n'
+            f'{_INDENT_PREFIX}  $ nebius iam get-access-token > {nebius.iam_token_path()} \n'  # pylint: disable=line-too-long
+            f'{_INDENT_PREFIX} or generate  {nebius.credentials_path()} \n')
 
         tenant_msg = (
-            f"{_INDENT_PREFIX} Copy your tenant ID from the web console and save it to file \n"  # pylint: disable=line-too-long
-            f"{_INDENT_PREFIX}  $ echo $NEBIUS_TENANT_ID_PATH > {nebius.tenant_id_path()} \n"  # pylint: disable=line-too-long
-            f"{_INDENT_PREFIX} Or if you have 1 tenant you can run:\n"  # pylint: disable=line-too-long
-            f"{_INDENT_PREFIX}  $ nebius --format json iam whoami|jq -r '.user_profile.tenants[0].tenant_id' > {nebius.tenant_id_path()} \n"
-        )  # pylint: disable=line-too-long
+            f'{_INDENT_PREFIX} Copy your tenant ID from the web console and save it to file \n'  # pylint: disable=line-too-long
+            f'{_INDENT_PREFIX}  $ echo $NEBIUS_TENANT_ID_PATH > {nebius.tenant_id_path()} \n'  # pylint: disable=line-too-long
+            f'{_INDENT_PREFIX} Or if you have 1 tenant you can run:\n'  # pylint: disable=line-too-long
+            f'{_INDENT_PREFIX}  $ nebius --format json iam whoami|jq -r \'.user_profile.tenants[0].tenant_id\' > {nebius.tenant_id_path()} \n')  # pylint: disable=line-too-long
         if not nebius.is_token_or_cred_file_exist():
-            return False, f"{token_cred_msg}"
+            return False, f'{token_cred_msg}'
         tenant_id = nebius.get_tenant_id()
         if tenant_id is None:
-            return False, f"{tenant_msg}"
+            return False, f'{tenant_msg}'
         sdk = nebius.sdk()
         try:
             service = nebius.iam().ProjectServiceClient(sdk)
-            service.list(nebius.iam().ListProjectsRequest(parent_id=tenant_id)).wait()
+            service.list(
+                nebius.iam().ListProjectsRequest(parent_id=tenant_id)).wait()
         except nebius.request_error() as e:
             return False, (
-                f"{e.status} \n"  # First line is indented by 4 spaces
-                f"{token_cred_msg} \n"
-                f"{tenant_msg}"
-            )
+                f'{e.status} \n'  # First line is indented by 4 spaces
+                f'{token_cred_msg} \n'
+                f'{tenant_msg}')
         return True, None
 
     @classmethod
-    @annotations.lru_cache(scope="request")
+    @annotations.lru_cache(scope='request')
     def _check_storage_credentials(
-        cls,
-    ) -> Tuple[bool, Optional[Union[str, Dict[str, str]]]]:
+            cls) -> Tuple[bool, Optional[Union[str, Dict[str, str]]]]:
         """Checks if the user has access credentials to Nebius Object Storage.
 
         Returns:
@@ -563,20 +544,17 @@ class Nebius(clouds.Cloud):
         """
         hints = None
         if not nebius_profile_in_aws_cred_and_config():
-            hints = (
-                f"[{nebius.NEBIUS_PROFILE_NAME}] profile "
-                "is not set in ~/.aws/credentials."
-            )
+            hints = (f'[{nebius.NEBIUS_PROFILE_NAME}] profile '
+                     'is not set in ~/.aws/credentials.')
         if hints:
-            hints += " Run the following commands:"
+            hints += ' Run the following commands:'
             if not nebius_profile_in_aws_cred_and_config():
                 hints += (
-                    f"\n{_INDENT_PREFIX}  $ pip install boto3"
-                    f"\n{_INDENT_PREFIX}  $ aws configure --profile nebius"
-                )
+                    f'\n{_INDENT_PREFIX}  $ pip install boto3'
+                    f'\n{_INDENT_PREFIX}  $ aws configure --profile nebius')
             hints += (
-                f"\n{_INDENT_PREFIX}For more info: "
-                "https://docs.skypilot.co/en/latest/getting-started/installation.html#nebius"  # pylint: disable=line-too-long
+                f'\n{_INDENT_PREFIX}For more info: '
+                'https://docs.skypilot.co/en/latest/getting-started/installation.html#nebius'  # pylint: disable=line-too-long
             )
         return (False, hints) if hints else (True, hints)
 
@@ -588,17 +566,17 @@ class Nebius(clouds.Cloud):
             # NOTE: We can't guarantee that the file will be deleted eventually,
             # but it doesn't contain sensitive information and should be cleaned
             # up by the OS eventually.
-            credential_file_mounts[tenant_id_path] = _write_nebius_temp_credential_file(
-                "nebius-tenant-id-", tenant_id
-            )
+            credential_file_mounts[tenant_id_path] = (
+                _write_nebius_temp_credential_file('nebius-tenant-id-',
+                                                   tenant_id))
 
         for filepath in nebius.get_credential_file_paths():
             if filepath == tenant_id_path:
                 continue
             credential_file_mounts[filepath] = filepath
         if nebius_profile_in_aws_cred_and_config():
-            credential_file_mounts["~/.aws/credentials"] = "~/.aws/credentials"
-            credential_file_mounts["~/.aws/config"] = "~/.aws/config"
+            credential_file_mounts['~/.aws/credentials'] = '~/.aws/credentials'
+            credential_file_mounts['~/.aws/config'] = '~/.aws/config'
         return credential_file_mounts
 
     @classmethod
@@ -608,24 +586,22 @@ class Nebius(clouds.Cloud):
         return None
 
     def instance_type_exists(self, instance_type: str) -> bool:
-        return catalog.instance_type_exists(instance_type, "nebius")
+        return catalog.instance_type_exists(instance_type, 'nebius')
 
     def validate_region_zone(self, region: Optional[str], zone: Optional[str]):
-        return catalog.validate_region_zone(region, zone, clouds="nebius")
+        return catalog.validate_region_zone(region, zone, clouds='nebius')
 
     @classmethod
     def get_user_identities(cls) -> Optional[List[List[str]]]:
         """Returns the email address + project id of the active user."""
         nebius_workspace_config = json.dumps(
-            skypilot_config.get_workspace_cloud("nebius"), sort_keys=True
-        )
+            skypilot_config.get_workspace_cloud('nebius'), sort_keys=True)
         return cls._get_user_identities(nebius_workspace_config)
 
     @classmethod
-    @annotations.lru_cache(scope="request", maxsize=5)
+    @annotations.lru_cache(scope='request', maxsize=5)
     def _get_user_identities(
-        cls, workspace_config: Optional[str]
-    ) -> Optional[List[List[str]]]:
+            cls, workspace_config: Optional[str]) -> Optional[List[List[str]]]:
         # We add workspace_config in args to avoid caching the identity for when
         # different workspace configs are used.
         del workspace_config  # Unused
@@ -633,49 +609,40 @@ class Nebius(clouds.Cloud):
         profile_client = nebius.iam().ProfileServiceClient(sdk)
         try:
             profile = nebius.sync_call(
-                profile_client.get(
-                    nebius.iam().GetProfileRequest(), timeout=nebius.READ_TIMEOUT
-                )
-            )
+                profile_client.get(nebius.iam().GetProfileRequest(),
+                                   timeout=nebius.READ_TIMEOUT))
         except Exception as e:
             raise exceptions.CloudUserIdentityError(
-                f"Error getting Nebius profile: {e}"
-            )
+                f'Error getting Nebius profile: {e}')
         if profile.user_profile is not None:
             if profile.user_profile.attributes is None:
                 raise exceptions.CloudUserIdentityError(
-                    "Nebius profile is a UserProfile, but has no attributes: "
-                    f"{profile.user_profile}"
-                )
+                    'Nebius profile is a UserProfile, but has no attributes: '
+                    f'{profile.user_profile}')
             if profile.user_profile.attributes.email is None:
                 raise exceptions.CloudUserIdentityError(
-                    "Nebius profile is a UserProfile, but has no email: "
-                    f"{profile.user_profile}"
-                )
+                    'Nebius profile is a UserProfile, but has no email: '
+                    f'{profile.user_profile}')
             return [[profile.user_profile.attributes.email]]
         if profile.service_account_profile is not None:
             if profile.service_account_profile.info is None:
                 raise exceptions.CloudUserIdentityError(
-                    "Nebius profile is a ServiceAccountProfile, but has no "
-                    f"info: {profile.service_account_profile}"
-                )
+                    'Nebius profile is a ServiceAccountProfile, but has no '
+                    f'info: {profile.service_account_profile}')
             if profile.service_account_profile.info.metadata is None:
                 raise exceptions.CloudUserIdentityError(
-                    "Nebius profile is a ServiceAccountProfile, but has no "
-                    f"metadata: {profile.service_account_profile}"
-                )
+                    'Nebius profile is a ServiceAccountProfile, but has no '
+                    f'metadata: {profile.service_account_profile}')
             if profile.service_account_profile.info.metadata.name is None:
                 raise exceptions.CloudUserIdentityError(
-                    "Nebius profile is a ServiceAccountProfile, but has no "
-                    f"name: {profile.service_account_profile}"
-                )
+                    'Nebius profile is a ServiceAccountProfile, but has no '
+                    f'name: {profile.service_account_profile}')
             return [[profile.service_account_profile.info.metadata.name]]
         if profile.anonymous_profile is not None:
             return None
-        unknown_profile_type = profile.which_field_in_oneof("profile")
+        unknown_profile_type = profile.which_field_in_oneof('profile')
         raise exceptions.CloudUserIdentityError(
-            f"Nebius profile is of an unknown type - {unknown_profile_type}"
-        )
+            f'Nebius profile is of an unknown type - {unknown_profile_type}')
 
     # pylint: disable=import-outside-toplevel
     @classmethod
@@ -686,25 +653,26 @@ class Nebius(clouds.Cloud):
         sdk = nebius.sdk()
         compute = nebius.compute()
         image_client = compute.ImageServiceClient(sdk)
-        if image_id.startswith("computeimage-"):
+        if image_id.startswith('computeimage-'):
             try:
-                image = image_client.get(compute.GetImageRequest(id=image_id)).wait()
+                image = image_client.get(
+                    compute.GetImageRequest(id=image_id)).wait()
             except RequestError as e:
                 if e.status.code == StatusCode.NOT_FOUND:
-                    raise ValueError(f"Image {image_id} does not exist") from e
+                    raise ValueError(f'Image {image_id} does not exist') from e
                 raise e
         else:
             parent_id = None
             if region is not None:
                 parent_id = utils.get_project_by_region(region)
             request = compute.GetImageLatestByFamilyRequest(
-                image_family=image_id, parent_id=parent_id
-            )
+                image_family=image_id, parent_id=parent_id)
             try:
                 image = image_client.get_latest_by_family(request).wait()
             except RequestError as e:
                 if e.status.code == StatusCode.NOT_FOUND:
-                    raise ValueError(f"Image family {image_id} does not exist") from e
+                    raise ValueError(
+                        f'Image family {image_id} does not exist') from e
                 raise e
 
         return image.status.min_disk_size_bytes / 1024**3

--- a/sky/provision/nebius/config.py
+++ b/sky/provision/nebius/config.py
@@ -1,11 +1,113 @@
 """Nebius configuration bootstrapping."""
 
+from sky import sky_logging
 from sky.provision import common
+from sky.provision.nebius import constants as nebius_constants
+from sky.provision.nebius import utils
+
+logger = sky_logging.init_logger(__name__)
 
 
 def bootstrap_instances(
         region: str, cluster_name: str,
         config: common.ProvisionConfig) -> common.ProvisionConfig:
-    """Bootstraps instances for the given cluster."""
-    del region, cluster_name  # unused
+    """Bootstraps instances for the given cluster.
+
+    Creates (or looks up) a cluster-specific security group, ensures the
+    default rule set is in place, and stashes the SG ID in `provider_config`
+    and `node_config` so `run_instances` can attach it via
+    `NetworkInterfaceSpec.security_groups` at VM creation time. This is what
+    enforces the firewall before the VM ever boots Ray.
+
+    `cluster_name` is `cluster_name_on_cloud` here (see
+    `sky/provision/provisioner.py`).
+    """
+    project_id = utils.get_project_by_region(region)
+    subnet_id = utils.get_subnet_id(region, project_id)
+    network_id = utils.get_network_id_from_subnet(subnet_id)
+
+    # Read the SG block emitted by `make_deploy_resources_variables` and
+    # templated into `provider.security_group` of the Ray YAML. Defaults
+    # cover the legacy code path where the template predates this feature.
+    sg_block = config.provider_config.get('security_group') or {}
+    sg_name = sg_block.get(
+        'GroupName',
+        nebius_constants.SECURITY_GROUP_TEMPLATE.format(cluster_name))
+    managed = bool(sg_block.get('ManagedBySkyPilot', True))
+
+    if managed:
+        sg_id = utils.get_or_create_security_group(project_id, sg_name,
+                                                   network_id)
+        utils.ensure_default_sg_rules(sg_id)
+    else:
+        # BYO security group: look it up; error clearly if not found, in
+        # a different network, or empty (no rules — would leave the
+        # cluster unreachable). Single RPC returns both the SG id and
+        # its network so we don't TOCTOU between two `get_by_name`s.
+        lookup = utils.get_security_group_id_and_network_by_name(
+            project_id, sg_name)
+        if lookup is None:
+            raise ValueError(
+                f'Nebius security group {sg_name!r} (configured via '
+                f'`nebius.security_group_name`) was not found in project '
+                f'{project_id}. Either create it first, point at an '
+                f'existing security group, or remove '
+                f'`nebius.security_group_name` from your config to let '
+                f'SkyPilot manage a security group for this cluster.')
+        sg_id, sg_network_id = lookup
+        if sg_network_id != network_id:
+            raise ValueError(
+                f'Nebius security group {sg_name!r} (network '
+                f'{sg_network_id!r}) is not in this cluster\'s network '
+                f'{network_id!r}. Cross-network NIC attachment is rejected '
+                f'by Nebius VPC. To fix, either: (a) create a security '
+                f'group named {sg_name!r} in network {network_id!r}, '
+                f'(b) set `nebius.security_group_name` to a security group '
+                f'that already exists in network {network_id!r}, or '
+                f'(c) remove `nebius.security_group_name` to let SkyPilot '
+                f'manage one.')
+        # Diverge from AWS: do NOT seed default rules into a BYO SG. The
+        # user opted into managing the rule set themselves; silently
+        # adding SSH-from-anywhere would break that contract and could
+        # turn an intentionally locked-down SG into an internet-exposed
+        # cluster. Refuse the launch with an explanatory error if the
+        # BYO SG is empty.
+        if not utils.list_security_rules(sg_id):
+            raise ValueError(
+                f'Nebius security group {sg_name!r} has no rules. SkyPilot '
+                f'will not seed default rules into a user-managed (BYO) '
+                f'security group. Add the rules your cluster needs '
+                f'(typically: SSH on 22 from your operator CIDR, '
+                f'intra-cluster traffic via a self-referencing rule, '
+                f'and any application ports) before launching, or remove '
+                f'`nebius.security_group_name` to let SkyPilot manage a '
+                f'security group for you.')
+
+    # Detect pre-SG clusters: existing instances whose NICs lack our SG.
+    # Nebius does not allow mutating a running NIC's security_groups, so we
+    # cannot migrate them in place. Warn the user; new nodes added in this
+    # provision (e.g. scale-up) will get the SG via NetworkInterfaceSpec.
+    legacy = []
+    for inst_id, info in utils.list_instances(project_id).items():
+        name = info.get('name') or ''
+        if not name.startswith(f'{cluster_name}-'):
+            continue
+        if sg_id not in info.get('security_group_ids', []):
+            legacy.append(inst_id)
+    if legacy:
+        logger.warning(
+            f'Cluster {cluster_name!r} has {len(legacy)} pre-existing '
+            f'instance(s) without SkyPilot security group {sg_name!r}. '
+            f'These instances were launched before network-level '
+            f'firewalling was added and rely on host UFW rules. They '
+            f'cannot be migrated in place. Run `sky down {cluster_name}` '
+            f'and relaunch to fully migrate. New worker nodes added in '
+            f'this provision will use the security group.')
+
+    config.provider_config['security_group'] = {
+        'GroupName': sg_name,
+        'GroupId': sg_id,
+        'ManagedBySkyPilot': managed,
+    }
+    config.node_config.setdefault('SecurityGroupIds', [sg_id])
     return config

--- a/sky/provision/nebius/constants.py
+++ b/sky/provision/nebius/constants.py
@@ -3,6 +3,12 @@ import math
 
 VERSION = 'v1'
 
+# Naming convention for SkyPilot-managed security groups. Mirrors AWS's
+# `sky-sg-{cluster}` template (`USER_PORTS_SECURITY_GROUP_NAME` in
+# `sky.clouds.aws`). Suffixed with `cluster_name_on_cloud` so SGs are
+# unique per cluster within a project.
+SECURITY_GROUP_TEMPLATE = 'sky-sg-{}'
+
 # Nebius requires disk sizes to be a multiple of 93 GiB
 # (99857989632 bytes = 93 * 1024^3).
 NEBIUS_DISK_SIZE_STEP_GIB = 93

--- a/sky/provision/nebius/instance.py
+++ b/sky/provision/nebius/instance.py
@@ -4,8 +4,10 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from sky import sky_logging
 from sky.provision import common
+from sky.provision.nebius import constants as nebius_constants
 from sky.provision.nebius import utils
 from sky.utils import common_utils
+from sky.utils import resources_utils
 from sky.utils import status_lib
 from sky.utils import ux_utils
 
@@ -142,7 +144,8 @@ def run_instances(region: str, cluster_name: str, cluster_name_on_cloud: str,
                 use_static_ip_address=config.provider_config.get(
                     'use_static_ip_address', False),
                 filesystems=config.node_config.get('filesystems', []),
-                network_tier=config.node_config.get('network_tier'))
+                network_tier=config.node_config.get('network_tier'),
+                security_group_ids=config.node_config.get('SecurityGroupIds'))
         except Exception as e:  # pylint: disable=broad-except
             logger.warning(f'run_instances error: {e}')
             raise
@@ -221,6 +224,31 @@ def terminate_instances(
     if not worker_only:
         utils.delete_cluster(cluster_name_on_cloud, provider_config['region'])
 
+    # Delete the cluster's SkyPilot-managed security group. Only when fully
+    # tearing down (worker_only=False) — partial scale-downs leave the SG
+    # in place since the head still uses it. delete_security_group drains
+    # rules first and retries SG-delete on dependency-violation, so it's
+    # safe even when VM termination above hasn't fully settled at the
+    # provider yet.
+    #
+    # Skip deletion when the user supplied a BYO SG (ManagedBySkyPilot=False).
+    # Mirrors the `ManagedBySkyPilot` guard in
+    # `sky.provision.aws.instance.cleanup_ports`. The flag flows
+    # through the rendered Ray YAML's `provider.security_group` block from
+    # `make_deploy_resources_variables`.
+    if not worker_only:
+        sg_block = provider_config.get('security_group') or {}
+        managed = bool(sg_block.get('ManagedBySkyPilot', True))
+        if managed:
+            project_id = utils.get_project_by_region(provider_config['region'])
+            sg_name = sg_block.get(
+                'GroupName',
+                nebius_constants.SECURITY_GROUP_TEMPLATE.format(
+                    cluster_name_on_cloud))
+            sg_id = utils.get_security_group_by_name(project_id, sg_name)
+            if sg_id is not None:
+                utils.delete_security_group(sg_id)
+
 
 def get_cluster_info(
         region: str,
@@ -288,9 +316,39 @@ def open_ports(
     provider_config: Optional[Dict[str, Any]] = None,
 ) -> None:
     """See sky/provision/__init__.py"""
-    logger.debug(f'Skip opening ports {ports} for Nebius instances, as all '
-                 'ports are open by default.')
-    del cluster_name_on_cloud, provider_config, ports
+    assert provider_config is not None, ports
+    sg_block = provider_config.get('security_group') or {}
+    managed = bool(sg_block.get('ManagedBySkyPilot', True))
+    if not managed:
+        # BYO SG: the user owns the rule set. We already warned at
+        # `make_deploy_resources_variables` time when ports were declared
+        # alongside `nebius.security_group_name`. Don't silently mutate
+        # the user's SG.
+        logger.info(
+            f'Skipping open_ports for cluster {cluster_name_on_cloud!r}: '
+            f'a user-managed (BYO) security group is configured. Add the '
+            f'ingress rules for {ports} to the security group manually.')
+        return
+    project_id = utils.get_project_by_region(provider_config['region'])
+    # Read the SG name from provider_config (set by bootstrap_instances).
+    # Fall back to the template for legacy clusters whose Ray YAML
+    # predates this PR — they may not have the security_group block.
+    sg_name = sg_block.get(
+        'GroupName',
+        nebius_constants.SECURITY_GROUP_TEMPLATE.format(cluster_name_on_cloud))
+    sg_id = utils.get_security_group_by_name(project_id, sg_name)
+    if sg_id is None:
+        # Pre-SG (legacy) cluster — no SG was created at provisioning time.
+        # Log and skip rather than create one for a cluster whose VMs cannot
+        # consume it (Nebius does not allow mutating a live NIC's SGs).
+        logger.warning(
+            f'Cannot open ports {ports}: SkyPilot security group '
+            f'{sg_name!r} not found. The cluster may predate network-level '
+            f'firewalling. Recreate it (`sky down` + `sky launch`) to '
+            f'enable port management.')
+        return
+    port_set = resources_utils.port_ranges_to_set(ports)
+    utils.add_ingress_tcp_ports(sg_id, port_set)
 
 
 def cleanup_ports(
@@ -298,4 +356,12 @@ def cleanup_ports(
     ports: List[str],
     provider_config: Optional[Dict[str, Any]] = None,
 ) -> None:
-    del cluster_name_on_cloud, ports, provider_config  # Unused.
+    """See sky/provision/__init__.py"""
+    # Intentional no-op. The cluster-specific security group is owned by
+    # the VM lifecycle, not the port lifecycle: it's created in
+    # `bootstrap_instances` and deleted in `terminate_instances` (when
+    # `worker_only=False`). Deleting it here would (a) tear down ingress
+    # for SSH and intra-cluster Ray traffic on a still-running cluster if
+    # this were ever called outside teardown, and (b) generate noisy
+    # FAILED_PRECONDITION retries while VMs still hold the NIC.
+    del cluster_name_on_cloud, ports, provider_config

--- a/sky/provision/nebius/instance.py
+++ b/sky/provision/nebius/instance.py
@@ -316,7 +316,7 @@ def open_ports(
     provider_config: Optional[Dict[str, Any]] = None,
 ) -> None:
     """See sky/provision/__init__.py"""
-    assert provider_config is not None, ports
+    assert provider_config is not None
     sg_block = provider_config.get('security_group') or {}
     managed = bool(sg_block.get('ManagedBySkyPilot', True))
     if not managed:

--- a/sky/provision/nebius/utils.py
+++ b/sky/provision/nebius/utils.py
@@ -1,6 +1,6 @@
 """Nebius library wrapper for SkyPilot."""
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set, Tuple
 import uuid
 
 from sky import sky_logging
@@ -15,6 +15,16 @@ logger = sky_logging.init_logger(__name__)
 POLL_INTERVAL = 5
 
 _MAX_OPERATIONS_TO_FETCH = 1000
+
+# Re-export for back-compat with existing callers in this module.
+SECURITY_GROUP_TEMPLATE = nebius_constants.SECURITY_GROUP_TEMPLATE
+
+# Nebius caps RuleIngress.destination_ports at 8 per rule, so we batch.
+_NEBIUS_PORTS_PER_RULE = 8
+
+# Backoff attempts when deleting an SG that's still attached to terminating
+# VMs. Mirrors AWS's BOTO_DELETE_MAX_ATTEMPTS (sky/provision/aws/instance.py).
+_SG_DELETE_MAX_ATTEMPTS = 6
 
 
 def retry(func):
@@ -105,6 +115,292 @@ def get_subnet_id(region: str, project_id: str) -> str:
     return sub_nets.items[0].metadata.id
 
 
+def get_network_id_from_subnet(subnet_id: str) -> str:
+    """Resolves a Nebius subnet id to its parent network id.
+
+    Security groups bind to a network (`SecurityGroupSpec.network_id`), but
+    SkyPilot only tracks subnet ids. This looks up the subnet and returns
+    its `spec.network_id`.
+    """
+    service = nebius.vpc().SubnetServiceClient(nebius.sdk())
+    subnet = nebius.sync_call(
+        service.get(nebius.vpc().GetSubnetRequest(id=subnet_id),
+                    timeout=nebius.READ_TIMEOUT))
+    return subnet.spec.network_id
+
+
+def get_security_group_by_name(project_id: str, sg_name: str) -> Optional[str]:
+    """Returns the SG id by name, or None if it doesn't exist."""
+    sg = _get_security_group_obj_by_name(project_id, sg_name)
+    return None if sg is None else sg.metadata.id
+
+
+def get_security_group_id_and_network_by_name(
+        project_id: str, sg_name: str) -> Optional[Tuple[str, str]]:
+    """Returns (sg_id, network_id) by name, or None if it doesn't exist.
+
+    Single-RPC variant used by `bootstrap_instances` to both look up a
+    BYO SG and validate it lives in the cluster's network. Avoids a
+    TOCTOU between two separate `get_by_name` + `get` calls.
+    """
+    sg = _get_security_group_obj_by_name(project_id, sg_name)
+    if sg is None:
+        return None
+    return sg.metadata.id, sg.spec.network_id
+
+
+def _get_security_group_obj_by_name(project_id: str, sg_name: str) -> Any:
+    """Returns the full SG object by name, or None if it doesn't exist."""
+    service = nebius.vpc().SecurityGroupServiceClient(nebius.sdk())
+    try:
+        return nebius.sync_call(
+            service.get_by_name(nebius.nebius_common().GetByNameRequest(
+                parent_id=project_id,
+                name=sg_name,
+            )))
+    except nebius.request_error():
+        return None
+
+
+def get_or_create_security_group(project_id: str, sg_name: str,
+                                 network_id: str) -> str:
+    """Returns the SG id, creating the SG (with no rules) if missing.
+
+    Idempotent: safe to call on every `bootstrap_instances`. Mirrors AWS's
+    `_get_or_create_vpc_security_group` in `sky.provision.aws.config`.
+    """
+    service = nebius.vpc().SecurityGroupServiceClient(nebius.sdk())
+    existing = get_security_group_by_name(project_id, sg_name)
+    if existing is not None:
+        return existing
+    try:
+        op = nebius.sync_call(
+            service.create(nebius.vpc().CreateSecurityGroupRequest(
+                metadata=nebius.nebius_common().ResourceMetadata(
+                    parent_id=project_id,
+                    name=sg_name,
+                ),
+                spec=nebius.vpc().SecurityGroupSpec(network_id=network_id))))
+        return op.resource_id
+    except nebius.request_error():
+        # Race: someone created it between our get_by_name and create.
+        # Re-fetch and return.
+        sg = nebius.sync_call(
+            service.get_by_name(nebius.nebius_common().GetByNameRequest(
+                parent_id=project_id,
+                name=sg_name,
+            )))
+        return sg.metadata.id
+
+
+def list_security_rules(sg_id: str) -> List[Any]:
+    """Lists all SecurityRule resources attached to the given SG."""
+    service = nebius.vpc().SecurityRuleServiceClient(nebius.sdk())
+    rules: List[Any] = []
+    page_token = ''
+    while True:
+        resp = nebius.sync_call(
+            service.list(nebius.vpc().ListSecurityRulesRequest(
+                parent_id=sg_id,
+                page_size=100,
+                page_token=page_token,
+            ),
+                         timeout=nebius.READ_TIMEOUT))
+        rules.extend(resp.items)
+        if not resp.next_page_token:
+            break
+        page_token = resp.next_page_token
+    return rules
+
+
+def _create_security_rule(sg_id: str, spec: Any, name_prefix: str) -> None:
+    """Creates a single rule under the given SG.
+
+    Nebius requires a non-empty `metadata.name` unique within the parent
+    SG; we synthesize it as `{prefix}-{uuid}` so re-runs never collide
+    with prior rules even if dedup-by-shape misses an edge case. The name
+    is operator-facing only (Nebius console); dedup uses the rule spec.
+    """
+    rule_name = f'{name_prefix}-{uuid.uuid4().hex[:8]}'
+    service = nebius.vpc().SecurityRuleServiceClient(nebius.sdk())
+    nebius.sync_call(
+        service.create(nebius.vpc().CreateSecurityRuleRequest(
+            metadata=nebius.nebius_common().ResourceMetadata(
+                parent_id=sg_id,
+                name=rule_name,
+            ),
+            spec=spec)))
+
+
+def _rule_signature(spec: Any) -> Tuple:
+    """Canonicalizes a rule spec for dedup comparison."""
+    # The proto's `s_match` oneof reports field-group name ('match'), not the
+    # set case — discriminate by which member is populated.
+    if spec.ingress is not None:
+        ing = spec.ingress
+        match = ('ingress', tuple(sorted(ing.source_cidrs or [])),
+                 tuple(sorted(ing.destination_ports or
+                              [])), ing.source_security_group_id or '')
+    else:
+        eg = spec.egress
+        match = ('egress', tuple(sorted(eg.destination_cidrs or [])),
+                 tuple(sorted(eg.destination_ports or
+                              [])), eg.destination_security_group_id or '')
+    return (int(spec.access), int(spec.protocol)) + match
+
+
+def ensure_default_sg_rules(sg_id: str) -> None:
+    """Idempotently applies the default rule set to the SG.
+
+    Default rules: intra-cluster (self-SG ref, all protocols/ports),
+    SSH 22 + 10022 from anywhere, egress allow-all. Mirrors the AWS default
+    SG shape — see the inbound-rules block in
+    `sky.provision.aws.config._configure_security_group`.
+    """
+    vpc = nebius.vpc()
+    desired = [
+        # Intra-cluster: any traffic from peers in the same SG.
+        ('intra-cluster',
+         vpc.SecurityRuleSpec(
+             access=vpc.RuleAccessAction.ALLOW,
+             protocol=vpc.RuleProtocol.ANY,
+             ingress=vpc.RuleIngress(source_security_group_id=sg_id),
+         )),
+        ('allow-ssh-22',
+         vpc.SecurityRuleSpec(
+             access=vpc.RuleAccessAction.ALLOW,
+             protocol=vpc.RuleProtocol.TCP,
+             ingress=vpc.RuleIngress(source_cidrs=['0.0.0.0/0'],
+                                     destination_ports=[22]),
+         )),
+        ('allow-ssh-10022',
+         vpc.SecurityRuleSpec(
+             access=vpc.RuleAccessAction.ALLOW,
+             protocol=vpc.RuleProtocol.TCP,
+             ingress=vpc.RuleIngress(source_cidrs=['0.0.0.0/0'],
+                                     destination_ports=[10022]),
+         )),
+        ('egress-allow-all',
+         vpc.SecurityRuleSpec(
+             access=vpc.RuleAccessAction.ALLOW,
+             protocol=vpc.RuleProtocol.ANY,
+             egress=vpc.RuleEgress(destination_cidrs=['0.0.0.0/0']),
+         )),
+    ]
+    existing_sigs = {
+        _rule_signature(r.spec) for r in list_security_rules(sg_id)
+    }
+    for name_prefix, spec in desired:
+        if _rule_signature(spec) not in existing_sigs:
+            _create_security_rule(sg_id, spec, name_prefix)
+
+
+def add_ingress_tcp_ports(sg_id: str, ports: Set[int]) -> None:
+    """Adds TCP ingress rules from 0.0.0.0/0 for the given ports.
+
+    Idempotent: skips ports already covered by existing rules. Packs up to
+    `_NEBIUS_PORTS_PER_RULE` ports per rule (Nebius caps RuleIngress at 8
+    destination_ports).
+    """
+    if not ports:
+        return
+    vpc = nebius.vpc()
+    already_open: Set[int] = set()
+    for rule in list_security_rules(sg_id):
+        spec = rule.spec
+        if int(spec.access) != int(vpc.RuleAccessAction.ALLOW):
+            continue
+        if int(spec.protocol) != int(vpc.RuleProtocol.TCP):
+            continue
+        if spec.ingress is None:
+            continue
+        ing = spec.ingress
+        if list(ing.source_cidrs or []) != ['0.0.0.0/0']:
+            continue
+        already_open.update(ing.destination_ports or [])
+
+    to_add = sorted(p for p in ports if p not in already_open)
+    for i in range(0, len(to_add), _NEBIUS_PORTS_PER_RULE):
+        batch = to_add[i:i + _NEBIUS_PORTS_PER_RULE]
+        spec = vpc.SecurityRuleSpec(
+            access=vpc.RuleAccessAction.ALLOW,
+            protocol=vpc.RuleProtocol.TCP,
+            ingress=vpc.RuleIngress(source_cidrs=['0.0.0.0/0'],
+                                    destination_ports=batch),
+        )
+        _create_security_rule(sg_id, spec,
+                              f'tcp-ingress-{batch[0]}-{batch[-1]}')
+
+
+def _delete_security_rule(rule_id: str) -> None:
+    """Deletes a single rule. Swallows NOT_FOUND."""
+    service = nebius.vpc().SecurityRuleServiceClient(nebius.sdk())
+    try:
+        nebius.sync_call(
+            service.delete(nebius.vpc().DeleteSecurityRuleRequest(id=rule_id)))
+    except nebius.request_error() as e:
+        if 'not found' in str(e).lower() or 'not_found' in str(e).lower():
+            return
+        raise
+
+
+def delete_security_group(sg_id: str) -> None:
+    """Deletes the SG, with rule-drain + retry on dependency errors.
+
+    Nebius will not delete an SG that still contains rules (rules must be
+    deleted first) or that is still attached to instances. We:
+      1. List + delete all rules in the SG, then poll until the rule list
+         is empty (Nebius deletes are async).
+      2. Attempt the SG delete with retry-on-dependency-violation (covers
+         the case where VMs are still terminating after `terminate_instances`
+         returned — mirrors the retry block in
+         `sky.provision.aws.instance.cleanup_ports`).
+
+    On exhaustion, log + return rather than raise: an orphaned SG is
+    preferable to a teardown failure.
+    """
+    sg_service = nebius.vpc().SecurityGroupServiceClient(nebius.sdk())
+
+    # Step 1: kick off async deletion of all rules.
+    for rule in list_security_rules(sg_id):
+        _delete_security_rule(rule.metadata.id)
+
+    # Wait for the rule list to drain. Nebius rule deletion is async; the
+    # SG delete in step 2 will fail with FAILED_PRECONDITION until the
+    # listing reflects an empty parent.
+    for _ in range(30):  # ~60s cap, similar to other waits in this module
+        if not list_security_rules(sg_id):
+            break
+        time.sleep(2)
+    else:
+        logger.warning(
+            f'Security group {sg_id} still has rules after rule-drain '
+            f'timeout; leaving as orphan.')
+        return
+
+    # Step 2: delete the SG with retry-on-dependency.
+    backoff = common_utils.Backoff()
+    for attempt in range(_SG_DELETE_MAX_ATTEMPTS):
+        try:
+            nebius.sync_call(
+                sg_service.delete(
+                    nebius.vpc().DeleteSecurityGroupRequest(id=sg_id)))
+            return
+        except nebius.request_error() as e:
+            msg = str(e).lower()
+            if 'not found' in msg or 'not_found' in msg:
+                return  # Already gone; treat as success.
+            if attempt + 1 == _SG_DELETE_MAX_ATTEMPTS:
+                logger.warning(
+                    f'Failed to delete security group {sg_id} after '
+                    f'{_SG_DELETE_MAX_ATTEMPTS} attempts: {e}. '
+                    f'Leaving as orphan; clean up manually if needed.')
+                return
+            logger.debug(f'SG {sg_id} delete attempt {attempt + 1} failed: '
+                         f'{e}. Retrying.')
+            time.sleep(backoff.current_backoff())
+
+
 def delete_cluster(name: str, region: str) -> None:
     """Delete a GPU cluster."""
     project_id = get_project_by_region(region)
@@ -145,7 +441,7 @@ def list_instances(project_id: str) -> Dict[str, Dict[str, Any]]:
 
     instance_dict: Dict[str, Dict[str, Any]] = {}
     for instance in instances:
-        info = {}
+        info: Dict[str, Any] = {}
         info['status'] = instance.status.state.name
         info['name'] = instance.metadata.name
         if instance.status.network_interfaces:
@@ -153,6 +449,13 @@ def list_instances(project_id: str) -> Dict[str, Dict[str, Any]]:
                 0].public_ip_address.address.split('/')[0]
             info['internal_ip'] = instance.status.network_interfaces[
                 0].ip_address.address.split('/')[0]
+        # Capture which security groups (if any) are attached to NIC 0. Used
+        # by bootstrap_instances to detect pre-SG (legacy) clusters that need
+        # to be recreated for full network-level firewalling.
+        info['security_group_ids'] = []
+        if instance.spec.network_interfaces:
+            sgs = instance.spec.network_interfaces[0].security_groups or []
+            info['security_group_ids'] = [sg.id for sg in sgs]
         instance_dict[instance.metadata.id] = info
 
     return instance_dict
@@ -217,7 +520,8 @@ def launch(cluster_name_on_cloud: str,
            disk_tier: str,
            use_static_ip_address: bool = False,
            use_spot: bool = False,
-           network_tier: Optional[resources_utils.NetworkTier] = None) -> str:
+           network_tier: Optional[resources_utils.NetworkTier] = None,
+           security_group_ids: Optional[List[str]] = None) -> str:
     # Each node must have a unique name to avoid conflicts between
     # multiple worker VMs. To ensure uniqueness,a UUID is appended
     # to the node name.
@@ -335,6 +639,10 @@ def launch(cluster_name_on_cloud: str,
                             public_ip_address=nebius.compute().PublicIPAddress(
                                 static=use_static_ip_address)
                             if associate_public_ip_address else None,
+                            security_groups=[
+                                nebius.compute().SecurityGroup(id=sg_id)
+                                for sg_id in (security_group_ids or [])
+                            ] or None,
                         )
                     ],
                     recovery_policy=nebius.compute().InstanceRecoveryPolicy.FAIL

--- a/sky/templates/nebius-ray.yml.j2
+++ b/sky/templates/nebius-ray.yml.j2
@@ -11,6 +11,9 @@ provider:
   region: "{{region}}"
   use_internal_ips: {{use_internal_ips}}
   use_static_ip_address: {{ use_static_ip_address }}
+  security_group:
+    GroupName: {{security_group}}
+    ManagedBySkyPilot: {{security_group_managed_by_skypilot}}
 
 {%- if docker_image is not none %}
 docker:
@@ -151,18 +154,6 @@ setup_commands:
     sudo dpkg --configure -a;
     mkdir -p ~/.ssh; touch ~/.ssh/config;
     {{ conda_installation_commands }}
-    sudo apt install -y ufw;
-    sudo ufw default allow incoming;
-    sudo ufw default allow outgoing;
-    sudo ufw allow from 10.0.0.0/8;
-    sudo ufw allow from 172.16.0.0/12;
-    sudo ufw deny 6379/tcp;
-    sudo ufw deny 8265/tcp;
-    sudo ufw deny 10001/tcp;
-    sudo ufw deny 11000:20000/tcp;
-    sudo ufw deny 6379:6390/tcp;
-    sudo ufw deny 8265:8270/tcp;
-    sudo ufw --force enable;
     {{ uv_installation_commands }}
     {{ ray_skypilot_installation_commands }}
     {{ copy_skypilot_templates_commands }}

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1279,7 +1279,8 @@ _LABELS_SCHEMA = {
 _PROPERTY_NAME_OR_CLUSTER_NAME_TO_PROPERTY = {
     'oneOf': [
         {
-            'type': 'string'
+            'type': 'string',
+            'minLength': 1,
         },
         {
             # A list of single-element dict to pretain the
@@ -1293,7 +1294,8 @@ _PROPERTY_NAME_OR_CLUSTER_NAME_TO_PROPERTY = {
             'items': {
                 'type': 'object',
                 'additionalProperties': {
-                    'type': 'string'
+                    'type': 'string',
+                    'minLength': 1,
                 },
                 'maxProperties': 1,
                 'minProperties': 1,
@@ -2060,6 +2062,8 @@ def get_config_schema():
                 'domain': {
                     'type': 'string',
                 },
+                'security_group_name':
+                    (_PROPERTY_NAME_OR_CLUSTER_NAME_TO_PROPERTY),
                 'region_configs': {
                     'type': 'object',
                     'required': [],

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -2340,6 +2340,426 @@ def test_lambda_cloud_open_ports():
                 # Don't fail the test if cleanup fails
 
 
+@pytest.mark.nebius
+# Smoke test verifies API integration; `list_security_rules` is the only
+# way to introspect SG state, hence the protected-access exception here.
+# pylint: disable=protected-access
+def test_nebius_security_group_lifecycle():
+    """Smoke test for Nebius security group helpers against the live API.
+
+    Cheap (no VM launch) but exercises every code path that interacts with
+    the Nebius VPC API. Catches API-contract bugs that the unit-test mocks
+    miss because they mock at our own helper boundary instead of at
+    `nebius.sync_call`. Specifically guards against:
+
+    - `CreateSecurityRuleRequest.metadata.name` being empty (Nebius rejects
+      with INVALID_ARGUMENT). Caught only by an end-to-end create call.
+    - `DeleteSecurityGroupRequest` being issued while child rules still
+      exist (Nebius rejects with FAILED_PRECONDITION:
+      "cannot be deleted because it contains rules"). Verified by
+      `delete_security_group` succeeding without manual rule cleanup.
+    - `add_ingress_tcp_ports` packing rules >8 ports (Nebius caps
+      `RuleIngress.destination_ports` at 8).
+
+    Requires Nebius credentials. Run with `pytest --nebius ...`.
+    """
+    # pylint: disable=import-outside-toplevel
+    import uuid
+
+    from sky.provision import common as provision_common
+    from sky.provision.nebius import config as nebius_config
+    from sky.provision.nebius import instance as nebius_instance
+    from sky.provision.nebius import utils as nebius_utils
+
+    region = 'eu-north1'
+    test_cluster = f'sg-smoke-{uuid.uuid4().hex[:6]}'
+    project_id = nebius_utils.get_project_by_region(region)
+    sg_name = nebius_utils.SECURITY_GROUP_TEMPLATE.format(test_cluster)
+    print(f'Smoke cluster name: {test_cluster}')
+
+    cfg = provision_common.ProvisionConfig(
+        provider_config={
+            'region': region,
+            'use_internal_ips': False
+        },
+        authentication_config={},
+        docker_config={},
+        node_config={},
+        count=1,
+        tags={},
+        resume_stopped_nodes=True,
+        ports_to_open_on_launch=None,
+    )
+
+    sg_id = None
+    try:
+        # bootstrap_instances exercises: subnet -> network resolution,
+        # SG create, default rule creation (4 rules, with the metadata.name
+        # that the unit tests didn't enforce).
+        cfg = nebius_config.bootstrap_instances(region, test_cluster, cfg)
+        sg_id = cfg.provider_config['security_group']['GroupId']
+        print(f'Created SG {sg_id}')
+
+        rules = nebius_utils.list_security_rules(sg_id)
+        assert len(rules) == 4, (
+            f'expected 4 default rules (intra-cluster, ssh-22, ssh-10022, '
+            f'egress-allow-all), got {len(rules)}')
+
+        # Re-running bootstrap must be idempotent (no duplicate rules).
+        nebius_config.bootstrap_instances(region, test_cluster, cfg)
+        assert len(nebius_utils.list_security_rules(sg_id)) == 4, (
+            'bootstrap_instances duplicated rules on second call')
+
+        # open_ports adds a single batched rule for the user-declared ports.
+        nebius_instance.open_ports(test_cluster, ['8080', '9000-9002'],
+                                   provider_config={'region': region})
+        rules = nebius_utils.list_security_rules(sg_id)
+        assert len(rules) == 5, (
+            f'expected 4 default + 1 user-port rule, got {len(rules)}')
+
+        # Re-running open_ports must be idempotent.
+        nebius_instance.open_ports(test_cluster, ['8080', '9000-9002'],
+                                   provider_config={'region': region})
+        assert len(nebius_utils.list_security_rules(sg_id)) == 5, (
+            'open_ports duplicated rules on second call')
+
+        # >8 ports must be batched across multiple rules (Nebius limit).
+        many_ports = [str(p) for p in range(7000, 7020)]  # 20 ports
+        nebius_instance.open_ports(test_cluster,
+                                   many_ports,
+                                   provider_config={'region': region})
+        # 4 default + 1 (8080,9000-9002) + ceil(20/8)=3 = 8
+        assert len(nebius_utils.list_security_rules(sg_id)) == 8, (
+            f'expected 8 rules after adding 20 batched ports, got '
+            f'{len(nebius_utils.list_security_rules(sg_id))}')
+
+        # cleanup_ports must NOT delete the SG. SG ownership belongs to
+        # the VM lifecycle (terminate_instances), not the port lifecycle.
+        nebius_instance.cleanup_ports(test_cluster, ['8080'],
+                                      provider_config={'region': region})
+        assert nebius_utils.get_security_group_by_name(
+            project_id, sg_name) == sg_id, (
+                'cleanup_ports must not delete the SG; deleting it on a '
+                'still-running cluster would break SSH and intra-cluster '
+                'Ray traffic.')
+
+    finally:
+        # delete_security_group exercises the rule-drain-then-delete path
+        # that the unit tests didn't cover (they mocked list_security_rules
+        # to return [] so the drain logic was never exercised against the
+        # real Nebius "cannot delete with rules" precondition).
+        if sg_id is not None:
+            print(f'Cleaning up SG {sg_id}')
+            nebius_utils.delete_security_group(sg_id)
+            time.sleep(2)
+            assert nebius_utils.get_security_group_by_name(
+                project_id, sg_name) is None, (
+                    f'delete_security_group failed to remove {sg_id}; '
+                    f'manual cleanup required.')
+
+
+@pytest.mark.nebius
+def test_nebius_byo_security_group_lifecycle():
+    """End-to-end smoke for `nebius.security_group_name` (BYO SG), happy path.
+
+    Bypasses `sky launch` (a separate
+    `test_nebius_security_group_attached_and_enforced` covers the full
+    launch). Verifies, against real Nebius:
+
+      1. Empty BYO SG -> bootstrap raises ValueError. We deliberately do
+         NOT seed default rules into a user-managed SG (diverges from AWS
+         by design): silently adding SSH-from-anywhere would break the
+         "BYO means you own the rule set" contract.
+      2. Pre-seeded BYO SG -> bootstrap looks it up successfully and
+         stashes the right ID in provider_config.
+      3. Re-running bootstrap on a non-empty BYO SG does not mutate
+         existing rules.
+      4. terminate_instances with ManagedBySkyPilot=False does NOT delete
+         the user's SG.
+      5. Missing BYO SG -> ValueError naming the SG and config key.
+
+    Wrong-network BYO is exercised by a separate test
+    (`test_nebius_byo_security_group_wrong_network`) because that one
+    requires creating + deleting a real Nebius network.
+
+    Cheap: ~15-25s, no VM launch. Skipped by default; runs only with
+    `pytest --nebius`.
+    """
+    # pylint: disable=import-outside-toplevel
+    import uuid
+
+    from sky.provision import common as provision_common
+    from sky.provision.nebius import config as nebius_config
+    from sky.provision.nebius import instance as nebius_instance
+    from sky.provision.nebius import utils as nebius_utils
+
+    region = 'eu-north1'
+    test_cluster = f'byo-smoke-{uuid.uuid4().hex[:6]}'
+    project_id = nebius_utils.get_project_by_region(region)
+    subnet_id = nebius_utils.get_subnet_id(region, project_id)
+    network_id = nebius_utils.get_network_id_from_subnet(subnet_id)
+
+    byo_sg_name = f'byo-test-{uuid.uuid4().hex[:6]}'
+    byo_sg_id = nebius_utils.get_or_create_security_group(
+        project_id, byo_sg_name, network_id)
+    print(f'Pre-created BYO SG: {byo_sg_id} ({byo_sg_name})')
+
+    def _byo_provision_config(sg_name=byo_sg_name):
+        return provision_common.ProvisionConfig(
+            provider_config={
+                'region': region,
+                'use_internal_ips': False,
+                'security_group': {
+                    'GroupName': sg_name,
+                    'ManagedBySkyPilot': False,
+                },
+            },
+            authentication_config={},
+            docker_config={},
+            node_config={},
+            count=1,
+            tags={},
+            resume_stopped_nodes=True,
+            ports_to_open_on_launch=None,
+        )
+
+    try:
+        # 1. Empty BYO SG -> ValueError.
+        try:
+            nebius_config.bootstrap_instances(region, test_cluster,
+                                              _byo_provision_config())
+            raise AssertionError(
+                'bootstrap should have raised ValueError for empty BYO SG')
+        except ValueError as e:
+            assert 'no rules' in str(e), str(e)
+            assert byo_sg_name in str(e), str(e)
+
+        # Seed the SG so subsequent assertions exercise the
+        # "BYO with rules -> use as-is" path.
+        nebius_utils.ensure_default_sg_rules(byo_sg_id)
+        rules = nebius_utils.list_security_rules(byo_sg_id)
+        assert rules, 'pre-seeded SG should now have rules'
+
+        # 2. Pre-seeded BYO SG: bootstrap resolves correctly.
+        cfg = nebius_config.bootstrap_instances(region, test_cluster,
+                                                _byo_provision_config())
+        out = cfg.provider_config['security_group']
+        assert out['GroupId'] == byo_sg_id
+        assert out['ManagedBySkyPilot'] is False
+
+        # 3. Re-running bootstrap on a non-empty BYO SG: no rule mutation.
+        rules_before = nebius_utils.list_security_rules(byo_sg_id)
+        nebius_config.bootstrap_instances(region, test_cluster,
+                                          _byo_provision_config())
+        rules_after = nebius_utils.list_security_rules(byo_sg_id)
+        assert len(rules_after) == len(rules_before), (
+            f'BYO SG rules should be unchanged; '
+            f'got {len(rules_before)} -> {len(rules_after)}')
+
+        # 4. terminate_instances with ManagedBySkyPilot=False MUST NOT
+        # delete the user's SG. We exercise this by calling terminate
+        # directly with no instances (filter returns empty), so the
+        # only possible side-effect is SG deletion - which must skip.
+        nebius_instance.terminate_instances(
+            test_cluster,
+            provider_config={
+                'region': region,
+                'security_group': {
+                    'GroupName': byo_sg_name,
+                    'ManagedBySkyPilot': False,
+                },
+            },
+            worker_only=False,
+        )
+        still_there = nebius_utils.get_security_group_by_name(
+            project_id, byo_sg_name)
+        assert still_there == byo_sg_id, (
+            f'BYO SG was deleted by terminate_instances despite '
+            f'ManagedBySkyPilot=False; got {still_there}')
+
+        # 5. Missing BYO SG: clear ValueError.
+        try:
+            nebius_config.bootstrap_instances(
+                region, 'nope',
+                _byo_provision_config('this-byo-sg-does-not-exist-zzz'))
+            raise AssertionError(
+                'bootstrap should have raised ValueError for missing BYO SG')
+        except ValueError as e:
+            assert 'this-byo-sg-does-not-exist-zzz' in str(e), str(e)
+            assert 'nebius.security_group_name' in str(e), str(e)
+
+    finally:
+        print(f'Cleaning up BYO SG {byo_sg_id}')
+        nebius_utils.delete_security_group(byo_sg_id)
+
+
+@pytest.mark.nebius
+def test_nebius_byo_security_group_wrong_network():
+    """BYO SG that lives in a different Nebius network than the cluster's
+    subnet must raise a clear, actionable ValueError before launch.
+
+    Split out from the main BYO smoke because creating + deleting a real
+    Nebius network is slow (~30-90s) and shouldn't slow the common-path
+    smoke. Skipped by default; runs only with `pytest --nebius`.
+    """
+    # pylint: disable=import-outside-toplevel
+    import uuid
+
+    from sky.adaptors import nebius as nebius_adaptor
+    from sky.provision import common as provision_common
+    from sky.provision.nebius import config as nebius_config
+    from sky.provision.nebius import utils as nebius_utils
+
+    region = 'eu-north1'
+    project_id = nebius_utils.get_project_by_region(region)
+    subnet_id = nebius_utils.get_subnet_id(region, project_id)
+    network_id = nebius_utils.get_network_id_from_subnet(subnet_id)
+
+    vpc = nebius_adaptor.vpc()
+    common_v1 = nebius_adaptor.nebius_common()
+    net_service = vpc.NetworkServiceClient(nebius_adaptor.sdk())
+    second_net_name = f'wrong-net-{uuid.uuid4().hex[:6]}'
+    second_net = nebius_adaptor.sync_call(
+        net_service.create(
+            vpc.CreateNetworkRequest(metadata=common_v1.ResourceMetadata(
+                parent_id=project_id, name=second_net_name),
+                                     spec=vpc.NetworkSpec()))).resource_id
+
+    wrong_sg_name = f'wrong-net-sg-{uuid.uuid4().hex[:6]}'
+    wrong_sg_id = nebius_utils.get_or_create_security_group(
+        project_id, wrong_sg_name, second_net)
+
+    try:
+        wrong_cfg = provision_common.ProvisionConfig(
+            provider_config={
+                'region': region,
+                'use_internal_ips': False,
+                'security_group': {
+                    'GroupName': wrong_sg_name,
+                    'ManagedBySkyPilot': False,
+                },
+            },
+            authentication_config={},
+            docker_config={},
+            node_config={},
+            count=1,
+            tags={},
+            resume_stopped_nodes=True,
+            ports_to_open_on_launch=None,
+        )
+        try:
+            nebius_config.bootstrap_instances(region, 'wrong-net-cluster',
+                                              wrong_cfg)
+            raise AssertionError(
+                'bootstrap should have raised ValueError for wrong-network '
+                'BYO SG')
+        except ValueError as e:
+            msg = str(e)
+            assert wrong_sg_name in msg, msg
+            assert network_id in msg, msg
+            assert second_net in msg, msg
+            assert 'remove `nebius.security_group_name`' in msg, msg
+    finally:
+        nebius_utils.delete_security_group(wrong_sg_id)
+        nebius_adaptor.sync_call(
+            net_service.delete(vpc.DeleteNetworkRequest(id=second_net)))
+
+
+@pytest.mark.nebius
+# pylint: disable=protected-access
+def test_nebius_security_group_attached_and_enforced():
+    """End-to-end CLI smoke: launch a real VM and verify the SG is
+    actually attached + actually enforced by the Nebius VPC data plane.
+
+    Complements `test_nebius_security_group_lifecycle` (SDK only) by
+    going through the full sky launch path. Catches regressions where:
+    - bootstrap_instances populates `node_config['SecurityGroupIds']`
+      correctly but `run_instances` drops them on the way to
+      `utils.launch()`.
+    - The SG exists with correct rules but VPC enforcement isn't actually
+      filtering external traffic to port 52365 (the CVE-2023-48022
+      attack surface this PR is closing).
+
+    Cheap: small CPU instance, ~3-5 min including teardown. Skipped by
+    default; runs only with `pytest --nebius`.
+    """
+    # pylint: disable=import-outside-toplevel
+    import socket as _socket
+
+    from sky.provision.nebius import utils as nebius_utils
+
+    name = smoke_tests_utils.get_cluster_name()
+    region = 'eu-north1'
+
+    def _verify_sg_attached_and_enforced():
+        # `cluster_name_on_cloud` is `name` plus a user-hash suffix that
+        # SkyPilot adds via `make_cluster_name_on_cloud`, so we can't
+        # compute the SG name from `name` alone. Instead, find this
+        # cluster's VMs by name-prefix and read the SG IDs directly off
+        # their NICs (the field populated in `list_instances` from
+        # `instance.spec.network_interfaces[0].security_groups`).
+        project_id = nebius_utils.get_project_by_region(region)
+        instances = nebius_utils.list_instances(project_id)
+        cluster_instances = {
+            i: info
+            for i, info in instances.items()
+            if info.get('name', '').startswith(name)
+        }
+        assert cluster_instances, (
+            f'no instances found whose name starts with {name!r}; '
+            f'all VM names in project: '
+            f'{[i.get("name") for i in instances.values()]}')
+
+        # Every VM in this cluster must have at least one SG attached.
+        # Empty `security_group_ids` means bootstrap or run_instances
+        # silently dropped them on the way to NetworkInterfaceSpec.
+        # (Don't assert on the SG name — under BYO config
+        # `nebius.security_group_name` the attached SG won't follow the
+        # `sky-sg-{cluster}` template; the meaningful check is that *some*
+        # SG is attached and that the external port-block below is real.)
+        for inst_id, info in cluster_instances.items():
+            assert info.get('security_group_ids'), (
+                f'instance {inst_id} ({info.get("name")}) has NO '
+                f'security groups attached; bootstrap or run_instances '
+                f'did not wire SecurityGroupIds through to the NIC.')
+
+        # Verify external port-block: pick the head node's public IP and
+        # try TCP-connecting to 52365. Must fail (refused or timeout).
+        head = next(
+            iter(i for i in cluster_instances.values()
+                 if i.get('name', '').endswith('-head')))
+        head_ip = head.get('external_ip')
+        assert head_ip, f'head has no external_ip: {head}'
+
+        sock = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+        sock.settimeout(5)
+        try:
+            sock.connect((head_ip, 52365))
+            sock.close()
+            raise AssertionError(
+                f'port 52365 (Ray dashboard agent) is REACHABLE on '
+                f'{head_ip} — the SG is not enforcing the external '
+                f'block. This is the CVE-2023-48022 attack surface.')
+        except (_socket.timeout, ConnectionRefusedError, OSError):
+            pass  # expected — connection refused / filtered
+        finally:
+            sock.close()
+
+    test = smoke_tests_utils.Test(
+        'nebius_sg_attached_and_enforced',
+        [
+            f'sky launch -y -c {name} --infra nebius '
+            f'{smoke_tests_utils.LOW_RESOURCE_ARG} '
+            f'tests/test_yamls/minimal.yaml',
+            f'sky logs {name} 1 --status',
+            _verify_sg_attached_and_enforced,
+        ],
+        f'sky down -y {name}',
+        timeout=smoke_tests_utils.get_timeout('nebius'),
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
 def test_cli_output(generic_cloud: str):
     """Test that CLI commands properly stream output."""
     name = smoke_tests_utils.get_cluster_name()

--- a/tests/unit_tests/test_nebius.py
+++ b/tests/unit_tests/test_nebius.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from sky import clouds
 from sky import resources as resources_lib
 from sky.clouds import nebius
+from sky.utils import resources_utils
 
 
 class TestNebiusNetworkTier:
@@ -65,7 +66,8 @@ class TestNebiusNetworkTier:
 
         deploy_vars = cloud.make_deploy_resources_variables(
             resources=resources,
-            cluster_name='test-cluster',
+            cluster_name=resources_utils.ClusterName(
+                display_name='test-cluster', name_on_cloud='test-cluster'),
             region=region,
             zones=None,
             num_nodes=1)
@@ -100,7 +102,8 @@ class TestNebiusNetworkTier:
 
         deploy_vars = cloud.make_deploy_resources_variables(
             resources=resources,
-            cluster_name='test-cluster',
+            cluster_name=resources_utils.ClusterName(
+                display_name='test-cluster', name_on_cloud='test-cluster'),
             region=region,
             zones=None,
             num_nodes=1)

--- a/tests/unit_tests/test_nebius_security_groups.py
+++ b/tests/unit_tests/test_nebius_security_groups.py
@@ -6,6 +6,7 @@ open_ports adds ingress rules idempotently, cleanup_ports deletes the SG
 on teardown with retry-on-dependency, and the legacy-cluster warn path.
 """
 # pylint: disable=line-too-long
+import importlib.util
 from unittest import mock
 
 import pytest
@@ -15,6 +16,17 @@ from sky.provision import common
 from sky.provision.nebius import config as nebius_config
 from sky.provision.nebius import instance as nebius_instance
 from sky.provision.nebius import utils as nebius_utils
+
+# CI's "Unit Tests" job installs only `[kubernetes,aws,gcp,azure]` extras
+# (`.github/workflows/pytest.yml`) — nebius is not in that list. Tests
+# that exercise the real Nebius SDK (proto construction or utils helpers
+# that build SecurityGroup/Rule requests) are gated on the SDK being
+# importable. Tests that fully mock at the helper boundary run regardless.
+_HAS_NEBIUS_SDK = importlib.util.find_spec('nebius') is not None
+nebius_sdk_required = pytest.mark.skipif(
+    not _HAS_NEBIUS_SDK,
+    reason='Nebius SDK not installed in this environment',
+)
 
 
 def _fake_rule(access, protocol, ingress=None, egress=None):
@@ -400,6 +412,7 @@ def test_terminate_skips_sg_delete_when_byo_bool_false():
 # --- add_ingress_tcp_ports (dedup) -----------------------------------------
 
 
+@nebius_sdk_required
 def test_add_ingress_tcp_ports_dedupes_against_existing():
     """Re-running with the same ports must issue zero new rules."""
 
@@ -420,6 +433,7 @@ def test_add_ingress_tcp_ports_dedupes_against_existing():
     mock_create.assert_not_called()
 
 
+@nebius_sdk_required
 def test_add_ingress_tcp_ports_batches_to_eight_per_rule():
 
     vpc = nebius_adaptor.vpc()
@@ -442,6 +456,7 @@ def test_add_ingress_tcp_ports_batches_to_eight_per_rule():
 # --- ensure_default_sg_rules -----------------------------------------------
 
 
+@nebius_sdk_required
 def test_ensure_default_sg_rules_creates_all_when_empty():
     with mock.patch.object(nebius_utils, 'list_security_rules',
                            return_value=[]), \
@@ -452,6 +467,7 @@ def test_ensure_default_sg_rules_creates_all_when_empty():
     assert mock_create.call_count == 4
 
 
+@nebius_sdk_required
 def test_ensure_default_sg_rules_idempotent_when_all_present():
     """Second call with all rules already present must add zero."""
 
@@ -491,6 +507,7 @@ def test_ensure_default_sg_rules_idempotent_when_all_present():
 # --- delete_security_group -------------------------------------------------
 
 
+@nebius_sdk_required
 def test_delete_sg_retries_on_dependency_then_succeeds():
     """First SG-delete attempt fails (VMs still attached), retry succeeds."""
     sg_delete_attempts = {'n': 0}
@@ -516,6 +533,7 @@ def test_delete_sg_retries_on_dependency_then_succeeds():
     assert sg_delete_attempts['n'] == 2  # one retry
 
 
+@nebius_sdk_required
 def test_delete_sg_swallows_not_found():
     """If the SG is already gone, return cleanly."""
 
@@ -532,6 +550,7 @@ def test_delete_sg_swallows_not_found():
         nebius_utils.delete_security_group('sg-gone')
 
 
+@nebius_sdk_required
 def test_delete_sg_logs_warning_on_retry_exhaustion():
     """After max attempts, log warning and return rather than raise."""
 
@@ -553,6 +572,7 @@ def test_delete_sg_logs_warning_on_retry_exhaustion():
     assert any('Failed to delete security group' in m for m in warn_calls)
 
 
+@nebius_sdk_required
 def test_delete_sg_drains_rules_first():
     """Rules must be deleted (and polled to drain) before SG delete."""
     fake_rule = mock.MagicMock()

--- a/tests/unit_tests/test_nebius_security_groups.py
+++ b/tests/unit_tests/test_nebius_security_groups.py
@@ -1,0 +1,572 @@
+"""Unit tests for Nebius security group management.
+
+Covers the move from host-level UFW (PR #8627 / hotfix #9562) to native
+Nebius security groups: bootstrap_instances creates+seeds the SG,
+open_ports adds ingress rules idempotently, cleanup_ports deletes the SG
+on teardown with retry-on-dependency, and the legacy-cluster warn path.
+"""
+# pylint: disable=line-too-long
+from unittest import mock
+
+import pytest
+
+from sky.adaptors import nebius as nebius_adaptor
+from sky.provision import common
+from sky.provision.nebius import config as nebius_config
+from sky.provision.nebius import instance as nebius_instance
+from sky.provision.nebius import utils as nebius_utils
+
+
+def _fake_rule(access, protocol, ingress=None, egress=None):
+    """Build a fake SecurityRule object with `.spec` for dedup tests."""
+    spec = mock.MagicMock()
+    spec.access = access
+    spec.protocol = protocol
+    spec.s_match = mock.MagicMock()
+    if ingress is not None:
+        spec.s_match.name = 'ingress'
+        spec.ingress = ingress
+        spec.egress = None
+    else:
+        spec.s_match.name = 'egress'
+        spec.egress = egress
+        spec.ingress = None
+    rule = mock.MagicMock()
+    rule.spec = spec
+    return rule
+
+
+def _fake_ingress(source_cidrs=None,
+                  destination_ports=None,
+                  source_security_group_id=None):
+    ing = mock.MagicMock()
+    ing.source_cidrs = source_cidrs or []
+    ing.destination_ports = destination_ports or []
+    ing.source_security_group_id = source_security_group_id
+    return ing
+
+
+def _fake_egress(destination_cidrs=None, destination_ports=None):
+    eg = mock.MagicMock()
+    eg.destination_cidrs = destination_cidrs or []
+    eg.destination_ports = destination_ports or []
+    eg.destination_security_group_id = None
+    return eg
+
+
+# --- bootstrap_instances ----------------------------------------------------
+
+
+def test_bootstrap_creates_sg_when_missing():
+    cfg = common.ProvisionConfig(
+        provider_config={'region': 'eu-north1'},
+        authentication_config={},
+        docker_config={},
+        node_config={},
+        count=1,
+        tags={},
+        resume_stopped_nodes=True,
+        ports_to_open_on_launch=None,
+    )
+    with mock.patch.object(nebius_utils, 'get_project_by_region',
+                           return_value='proj-abc'), \
+         mock.patch.object(nebius_utils, 'get_subnet_id',
+                           return_value='subnet-1'), \
+         mock.patch.object(nebius_utils, 'get_network_id_from_subnet',
+                           return_value='net-1'), \
+         mock.patch.object(nebius_utils, 'get_or_create_security_group',
+                           return_value='sg-new') as mock_create, \
+         mock.patch.object(nebius_utils, 'ensure_default_sg_rules') as mock_rules, \
+         mock.patch.object(nebius_utils, 'list_instances', return_value={}):
+        out = nebius_config.bootstrap_instances('eu-north1', 'mycluster', cfg)
+
+    expected_name = nebius_utils.SECURITY_GROUP_TEMPLATE.format('mycluster')
+    mock_create.assert_called_once_with('proj-abc', expected_name, 'net-1')
+    mock_rules.assert_called_once_with('sg-new')
+    assert out.provider_config['security_group']['GroupId'] == 'sg-new'
+    assert out.provider_config['security_group']['GroupName'] == expected_name
+    assert out.provider_config['security_group']['ManagedBySkyPilot'] is True
+    assert out.node_config['SecurityGroupIds'] == ['sg-new']
+
+
+def test_bootstrap_warns_for_legacy_instances():
+    cfg = common.ProvisionConfig(
+        provider_config={'region': 'eu-north1'},
+        authentication_config={},
+        docker_config={},
+        node_config={},
+        count=2,
+        tags={},
+        resume_stopped_nodes=True,
+        ports_to_open_on_launch=None,
+    )
+    legacy_instances = {
+        'i-old': {
+            'name': 'mycluster-aaaa-head',
+            'status': 'RUNNING',
+            'security_group_ids': [],  # no SG attached — legacy
+        },
+    }
+    with mock.patch.object(nebius_utils, 'get_project_by_region',
+                           return_value='proj-abc'), \
+         mock.patch.object(nebius_utils, 'get_subnet_id',
+                           return_value='subnet-1'), \
+         mock.patch.object(nebius_utils, 'get_network_id_from_subnet',
+                           return_value='net-1'), \
+         mock.patch.object(nebius_utils, 'get_or_create_security_group',
+                           return_value='sg-new'), \
+         mock.patch.object(nebius_utils, 'ensure_default_sg_rules'), \
+         mock.patch.object(nebius_utils, 'list_instances',
+                           return_value=legacy_instances), \
+         mock.patch.object(nebius_config, 'logger') as mock_logger:
+        out = nebius_config.bootstrap_instances('eu-north1', 'mycluster', cfg)
+
+    warn_calls = [c.args[0] for c in mock_logger.warning.call_args_list]
+    assert any('pre-existing instance' in m for m in warn_calls)
+    assert out.provider_config['security_group']['GroupId'] == 'sg-new'
+
+
+# --- open_ports / cleanup_ports --------------------------------------------
+
+
+def test_open_ports_resolves_sg_by_name_and_adds_ports():
+    with mock.patch.object(nebius_utils, 'get_project_by_region',
+                           return_value='proj-abc'), \
+         mock.patch.object(nebius_utils, 'get_security_group_by_name',
+                           return_value='sg-1') as mock_lookup, \
+         mock.patch.object(nebius_utils, 'add_ingress_tcp_ports') as mock_add:
+        nebius_instance.open_ports(
+            'mycluster',
+            ['8080', '9000-9002'],
+            provider_config={'region': 'eu-north1'},
+        )
+
+    mock_lookup.assert_called_once_with(
+        'proj-abc', nebius_utils.SECURITY_GROUP_TEMPLATE.format('mycluster'))
+    args, _ = mock_add.call_args
+    assert args[0] == 'sg-1'
+    assert args[1] == {8080, 9000, 9001, 9002}
+
+
+def test_open_ports_legacy_cluster_logs_and_returns():
+    with mock.patch.object(nebius_utils, 'get_project_by_region',
+                           return_value='proj-abc'), \
+         mock.patch.object(nebius_utils, 'get_security_group_by_name',
+                           return_value=None), \
+         mock.patch.object(nebius_utils, 'add_ingress_tcp_ports') as mock_add, \
+         mock.patch.object(nebius_instance, 'logger') as mock_logger:
+        nebius_instance.open_ports(
+            'legacy',
+            ['8080'],
+            provider_config={'region': 'eu-north1'},
+        )
+
+    mock_add.assert_not_called()
+    warn_calls = [c.args[0] for c in mock_logger.warning.call_args_list]
+    assert any('not found' in m for m in warn_calls)
+
+
+def test_open_ports_skips_for_byo_sg():
+    """BYO SG: open_ports must NOT mutate the user-managed SG. The user
+    owns the rule set; we already warned at launch time."""
+    with mock.patch.object(nebius_utils, 'get_project_by_region') as mock_proj, \
+         mock.patch.object(nebius_utils, 'get_security_group_by_name') as mock_lookup, \
+         mock.patch.object(nebius_utils, 'add_ingress_tcp_ports') as mock_add, \
+         mock.patch.object(nebius_instance, 'logger') as mock_logger:
+        nebius_instance.open_ports(
+            'mycluster',
+            ['8080'],
+            provider_config={
+                'region': 'eu-north1',
+                'security_group': {
+                    'GroupName': 'my-byo',
+                    'ManagedBySkyPilot': False,
+                },
+            },
+        )
+
+    mock_proj.assert_not_called()
+    mock_lookup.assert_not_called()
+    mock_add.assert_not_called()
+    info_calls = [c.args[0] for c in mock_logger.info.call_args_list]
+    assert any('user-managed (BYO) security group' in m for m in info_calls)
+
+
+def test_cleanup_ports_is_noop():
+    """SG deletion is the VM-lifecycle concern; cleanup_ports must not
+    touch the SG (which is still attached to live VMs at this point in
+    most invocation paths)."""
+    with mock.patch.object(nebius_utils, 'delete_security_group') as mock_del, \
+         mock.patch.object(nebius_utils, 'get_security_group_by_name') as mock_lookup:
+        nebius_instance.cleanup_ports(
+            'mycluster',
+            ['8080'],
+            provider_config={'region': 'eu-north1'},
+        )
+    mock_del.assert_not_called()
+    mock_lookup.assert_not_called()
+
+
+def test_terminate_instances_deletes_sg_on_full_teardown():
+    """SG deletion belongs to terminate_instances when worker_only=False."""
+    with mock.patch.object(nebius_instance, '_filter_instances',
+                           return_value={}), \
+         mock.patch.object(nebius_utils, 'delete_cluster'), \
+         mock.patch.object(nebius_utils, 'get_project_by_region',
+                           return_value='proj-abc'), \
+         mock.patch.object(nebius_utils, 'get_security_group_by_name',
+                           return_value='sg-2'), \
+         mock.patch.object(nebius_utils, 'delete_security_group') as mock_del:
+        nebius_instance.terminate_instances(
+            'mycluster',
+            provider_config={'region': 'eu-north1'},
+            worker_only=False,
+        )
+    mock_del.assert_called_once_with('sg-2')
+
+
+def test_terminate_instances_skips_sg_delete_for_worker_only():
+    """Partial scale-down must not delete the SG (head still uses it)."""
+    with mock.patch.object(nebius_instance, '_filter_instances',
+                           return_value={}), \
+         mock.patch.object(nebius_utils, 'delete_cluster'), \
+         mock.patch.object(nebius_utils, 'get_security_group_by_name') as mock_lookup, \
+         mock.patch.object(nebius_utils, 'delete_security_group') as mock_del:
+        nebius_instance.terminate_instances(
+            'mycluster',
+            provider_config={'region': 'eu-north1'},
+            worker_only=True,
+        )
+    mock_lookup.assert_not_called()
+    mock_del.assert_not_called()
+
+
+def test_terminate_instances_noop_for_legacy_cluster_sg():
+    """If no SG exists for the cluster (pre-PR launch), terminate cleanly
+    skips the SG-delete branch."""
+    with mock.patch.object(nebius_instance, '_filter_instances',
+                           return_value={}), \
+         mock.patch.object(nebius_utils, 'delete_cluster'), \
+         mock.patch.object(nebius_utils, 'get_project_by_region',
+                           return_value='proj-abc'), \
+         mock.patch.object(nebius_utils, 'get_security_group_by_name',
+                           return_value=None), \
+         mock.patch.object(nebius_utils, 'delete_security_group') as mock_del:
+        nebius_instance.terminate_instances(
+            'legacy',
+            provider_config={'region': 'eu-north1'},
+            worker_only=False,
+        )
+    mock_del.assert_not_called()
+
+
+# --- BYO security group (nebius.security_group_name config) ----------------
+
+
+def _make_byo_provision_config(group_name, managed=False):
+    """Helper: a ProvisionConfig with a templated BYO `security_group` block.
+
+    `managed` is a Python bool, matching what reaches the provisioner
+    after YAML deserialization of the rendered Ray YAML.
+    """
+    return common.ProvisionConfig(
+        provider_config={
+            'region': 'eu-north1',
+            'security_group': {
+                'GroupName': group_name,
+                'ManagedBySkyPilot': managed,
+            },
+        },
+        authentication_config={},
+        docker_config={},
+        node_config={},
+        count=1,
+        tags={},
+        resume_stopped_nodes=True,
+        ports_to_open_on_launch=None,
+    )
+
+
+def test_bootstrap_byo_sg_lookup_succeeds():
+    """BYO path: SG exists, network matches, has rules → no create call."""
+    cfg = _make_byo_provision_config('my-byo')
+    with mock.patch.object(nebius_utils, 'get_project_by_region',
+                           return_value='proj-abc'), \
+         mock.patch.object(nebius_utils, 'get_subnet_id',
+                           return_value='subnet-1'), \
+         mock.patch.object(nebius_utils, 'get_network_id_from_subnet',
+                           return_value='net-1'), \
+         mock.patch.object(nebius_utils,
+                           'get_security_group_id_and_network_by_name',
+                           return_value=('sg-byo', 'net-1')) as mock_lookup, \
+         mock.patch.object(nebius_utils, 'list_security_rules',
+                           return_value=[mock.MagicMock()]) as mock_list, \
+         mock.patch.object(nebius_utils, 'ensure_default_sg_rules') as mock_seed, \
+         mock.patch.object(nebius_utils, 'get_or_create_security_group') as mock_create, \
+         mock.patch.object(nebius_utils, 'list_instances', return_value={}):
+        out = nebius_config.bootstrap_instances('eu-north1', 'mycluster', cfg)
+
+    mock_create.assert_not_called()  # BYO: never create
+    mock_lookup.assert_called_once_with('proj-abc', 'my-byo')
+    mock_list.assert_called_once_with('sg-byo')
+    mock_seed.assert_not_called()  # BYO never seeds
+    assert out.provider_config['security_group']['GroupId'] == 'sg-byo'
+    assert out.provider_config['security_group']['GroupName'] == 'my-byo'
+    assert out.provider_config['security_group']['ManagedBySkyPilot'] is False
+    assert out.node_config['SecurityGroupIds'] == ['sg-byo']
+
+
+def test_bootstrap_byo_sg_empty_raises():
+    """BYO SG with zero rules must error (we don't silently seed defaults
+    into a user-managed SG — diverges from AWS by design)."""
+    cfg = _make_byo_provision_config('empty-byo')
+    with mock.patch.object(nebius_utils, 'get_project_by_region',
+                           return_value='proj-abc'), \
+         mock.patch.object(nebius_utils, 'get_subnet_id',
+                           return_value='subnet-1'), \
+         mock.patch.object(nebius_utils, 'get_network_id_from_subnet',
+                           return_value='net-1'), \
+         mock.patch.object(nebius_utils,
+                           'get_security_group_id_and_network_by_name',
+                           return_value=('sg-byo', 'net-1')), \
+         mock.patch.object(nebius_utils, 'list_security_rules',
+                           return_value=[]), \
+         mock.patch.object(nebius_utils, 'ensure_default_sg_rules') as mock_seed:
+        with pytest.raises(ValueError, match='no rules'):
+            nebius_config.bootstrap_instances('eu-north1', 'mycluster', cfg)
+    mock_seed.assert_not_called()
+
+
+def test_bootstrap_byo_sg_missing_raises():
+    """BYO SG that doesn't exist: clear ValueError naming the SG."""
+    cfg = _make_byo_provision_config('does-not-exist')
+    with mock.patch.object(nebius_utils, 'get_project_by_region',
+                           return_value='proj-abc'), \
+         mock.patch.object(nebius_utils, 'get_subnet_id',
+                           return_value='subnet-1'), \
+         mock.patch.object(nebius_utils, 'get_network_id_from_subnet',
+                           return_value='net-1'), \
+         mock.patch.object(nebius_utils,
+                           'get_security_group_id_and_network_by_name',
+                           return_value=None):
+        with pytest.raises(ValueError, match='does-not-exist'):
+            nebius_config.bootstrap_instances('eu-north1', 'mycluster', cfg)
+
+
+def test_bootstrap_byo_sg_wrong_network_raises():
+    """BYO SG in a different network: clear ValueError with both networks
+    + remediation hints."""
+    cfg = _make_byo_provision_config('wrong-net-byo')
+    with mock.patch.object(nebius_utils, 'get_project_by_region',
+                           return_value='proj-abc'), \
+         mock.patch.object(nebius_utils, 'get_subnet_id',
+                           return_value='subnet-1'), \
+         mock.patch.object(nebius_utils, 'get_network_id_from_subnet',
+                           return_value='net-cluster'), \
+         mock.patch.object(nebius_utils,
+                           'get_security_group_id_and_network_by_name',
+                           return_value=('sg-byo', 'net-different')):
+        with pytest.raises(ValueError) as exc_info:
+            nebius_config.bootstrap_instances('eu-north1', 'mycluster', cfg)
+    msg = str(exc_info.value)
+    assert 'wrong-net-byo' in msg
+    assert 'net-different' in msg
+    assert 'net-cluster' in msg
+    assert 'remove `nebius.security_group_name`' in msg
+
+
+def test_terminate_skips_sg_delete_when_byo_bool_false():
+    """ManagedBySkyPilot=False (bool form) must also skip SG delete."""
+    with mock.patch.object(nebius_instance, '_filter_instances',
+                           return_value={}), \
+         mock.patch.object(nebius_utils, 'delete_cluster'), \
+         mock.patch.object(nebius_utils, 'get_security_group_by_name') as mock_lookup, \
+         mock.patch.object(nebius_utils, 'delete_security_group') as mock_del:
+        nebius_instance.terminate_instances(
+            'mycluster',
+            provider_config={
+                'region': 'eu-north1',
+                'security_group': {
+                    'GroupName': 'my-byo',
+                    'ManagedBySkyPilot': False,
+                },
+            },
+            worker_only=False,
+        )
+    mock_lookup.assert_not_called()
+    mock_del.assert_not_called()
+
+
+# --- add_ingress_tcp_ports (dedup) -----------------------------------------
+
+
+def test_add_ingress_tcp_ports_dedupes_against_existing():
+    """Re-running with the same ports must issue zero new rules."""
+
+    vpc = nebius_adaptor.vpc()
+    existing = [
+        _fake_rule(
+            access=int(vpc.RuleAccessAction.ALLOW),
+            protocol=int(vpc.RuleProtocol.TCP),
+            ingress=_fake_ingress(source_cidrs=['0.0.0.0/0'],
+                                  destination_ports=[8080]),
+        ),
+    ]
+    with mock.patch.object(nebius_utils, 'list_security_rules',
+                           return_value=existing), \
+         mock.patch.object(nebius_utils, '_create_security_rule') as mock_create:
+        nebius_utils.add_ingress_tcp_ports('sg-1', {8080})
+
+    mock_create.assert_not_called()
+
+
+def test_add_ingress_tcp_ports_batches_to_eight_per_rule():
+
+    vpc = nebius_adaptor.vpc()
+    with mock.patch.object(nebius_utils, 'list_security_rules',
+                           return_value=[]), \
+         mock.patch.object(nebius_utils, '_create_security_rule') as mock_create:
+        nebius_utils.add_ingress_tcp_ports('sg-1', set(range(8000, 8020)))
+
+    # 20 ports, 8 per rule → 3 rules.
+    assert mock_create.call_count == 3
+    # Each rule's spec has at most 8 ports.
+    for call in mock_create.call_args_list:
+        spec = call.args[1]
+        assert len(spec.ingress.destination_ports) <= 8
+        assert int(spec.access) == int(vpc.RuleAccessAction.ALLOW)
+        assert int(spec.protocol) == int(vpc.RuleProtocol.TCP)
+        assert list(spec.ingress.source_cidrs) == ['0.0.0.0/0']
+
+
+# --- ensure_default_sg_rules -----------------------------------------------
+
+
+def test_ensure_default_sg_rules_creates_all_when_empty():
+    with mock.patch.object(nebius_utils, 'list_security_rules',
+                           return_value=[]), \
+         mock.patch.object(nebius_utils, '_create_security_rule') as mock_create:
+        nebius_utils.ensure_default_sg_rules('sg-1')
+
+    # Default rule set: intra-cluster + ssh22 + ssh10022 + egress-all.
+    assert mock_create.call_count == 4
+
+
+def test_ensure_default_sg_rules_idempotent_when_all_present():
+    """Second call with all rules already present must add zero."""
+
+    vpc = nebius_adaptor.vpc()
+    existing = [
+        _fake_rule(
+            access=int(vpc.RuleAccessAction.ALLOW),
+            protocol=int(vpc.RuleProtocol.ANY),
+            ingress=_fake_ingress(source_security_group_id='sg-1'),
+        ),
+        _fake_rule(
+            access=int(vpc.RuleAccessAction.ALLOW),
+            protocol=int(vpc.RuleProtocol.TCP),
+            ingress=_fake_ingress(source_cidrs=['0.0.0.0/0'],
+                                  destination_ports=[22]),
+        ),
+        _fake_rule(
+            access=int(vpc.RuleAccessAction.ALLOW),
+            protocol=int(vpc.RuleProtocol.TCP),
+            ingress=_fake_ingress(source_cidrs=['0.0.0.0/0'],
+                                  destination_ports=[10022]),
+        ),
+        _fake_rule(
+            access=int(vpc.RuleAccessAction.ALLOW),
+            protocol=int(vpc.RuleProtocol.ANY),
+            egress=_fake_egress(destination_cidrs=['0.0.0.0/0']),
+        ),
+    ]
+    with mock.patch.object(nebius_utils, 'list_security_rules',
+                           return_value=existing), \
+         mock.patch.object(nebius_utils, '_create_security_rule') as mock_create:
+        nebius_utils.ensure_default_sg_rules('sg-1')
+
+    mock_create.assert_not_called()
+
+
+# --- delete_security_group -------------------------------------------------
+
+
+def test_delete_sg_retries_on_dependency_then_succeeds():
+    """First SG-delete attempt fails (VMs still attached), retry succeeds."""
+    sg_delete_attempts = {'n': 0}
+
+    def fake_sync_call(*_args, **_kwargs):
+        # All sync_call invocations from delete_security_group are SG
+        # deletes (rule listing/deletion are mocked separately below).
+        sg_delete_attempts['n'] += 1
+        if sg_delete_attempts['n'] == 1:
+            err_cls = nebius_adaptor.request_error()
+            status = mock.MagicMock()
+            status.__str__ = lambda self: 'FAILED_PRECONDITION: in use by VM'
+            raise err_cls(status)
+        return None  # second attempt succeeds
+
+    with mock.patch.object(nebius_utils, 'list_security_rules',
+                           return_value=[]), \
+         mock.patch('sky.adaptors.nebius.sync_call', side_effect=fake_sync_call), \
+         mock.patch('sky.adaptors.nebius.sdk'), \
+         mock.patch('time.sleep'):
+        nebius_utils.delete_security_group('sg-1')
+
+    assert sg_delete_attempts['n'] == 2  # one retry
+
+
+def test_delete_sg_swallows_not_found():
+    """If the SG is already gone, return cleanly."""
+
+    def fake_sync_call(*_args, **_kwargs):
+        err_cls = nebius_adaptor.request_error()
+        status = mock.MagicMock()
+        status.__str__ = lambda self: 'NOT_FOUND: no such security group'
+        raise err_cls(status)
+
+    with mock.patch.object(nebius_utils, 'list_security_rules',
+                           return_value=[]), \
+         mock.patch('sky.adaptors.nebius.sync_call', side_effect=fake_sync_call), \
+         mock.patch('sky.adaptors.nebius.sdk'):
+        nebius_utils.delete_security_group('sg-gone')
+
+
+def test_delete_sg_logs_warning_on_retry_exhaustion():
+    """After max attempts, log warning and return rather than raise."""
+
+    def always_fail(*_args, **_kwargs):
+        err_cls = nebius_adaptor.request_error()
+        status = mock.MagicMock()
+        status.__str__ = lambda self: 'FAILED_PRECONDITION: in use'
+        raise err_cls(status)
+
+    with mock.patch.object(nebius_utils, 'list_security_rules',
+                           return_value=[]), \
+         mock.patch('sky.adaptors.nebius.sync_call', side_effect=always_fail), \
+         mock.patch('sky.adaptors.nebius.sdk'), \
+         mock.patch('time.sleep'), \
+         mock.patch.object(nebius_utils, 'logger') as mock_logger:
+        nebius_utils.delete_security_group('sg-stuck')
+
+    warn_calls = [c.args[0] for c in mock_logger.warning.call_args_list]
+    assert any('Failed to delete security group' in m for m in warn_calls)
+
+
+def test_delete_sg_drains_rules_first():
+    """Rules must be deleted (and polled to drain) before SG delete."""
+    fake_rule = mock.MagicMock()
+    fake_rule.metadata.id = 'vpcsecurityrule-abc'
+
+    # list_security_rules: first call returns 1 rule, then [] (drained).
+    list_results = iter([[fake_rule], []])
+
+    with mock.patch.object(nebius_utils, 'list_security_rules',
+                           side_effect=lambda _sg: next(list_results)), \
+         mock.patch.object(nebius_utils, '_delete_security_rule') as mock_del_rule, \
+         mock.patch('sky.adaptors.nebius.sync_call'), \
+         mock.patch('sky.adaptors.nebius.sdk'), \
+         mock.patch('time.sleep'):
+        nebius_utils.delete_security_group('sg-with-rules')
+
+    mock_del_rule.assert_called_once_with('vpcsecurityrule-abc')


### PR DESCRIPTION
## Summary

Replace UFW config on Nebius  with native Nebius security groups attached at VM creation. Properly implement `open_ports` / `cleanup_ports` so user-declared `ports:` in YAML works without relying on \"all ports open by default.\"

## Test plan

### Unit tests (`tests/unit_tests/test_nebius_security_groups.py`, 13 tests, all green)
- [x] `bootstrap_instances` creates SG when missing; reuses when `get_by_name` returns one.
- [x] `bootstrap_instances` warns (via logger mock) when existing instances lack the SG.
- [x] `ensure_default_sg_rules` adds 4 rules to an empty SG; adds 0 when all 4 are present (idempotent).
- [x] `open_ports([\"8080\",\"9000-9002\"])` resolves SG by name and calls `add_ingress_tcp_ports` with `{8080, 9000, 9001, 9002}`.
- [x] `add_ingress_tcp_ports` dedupes against existing rules; batches 20 ports into 3 rules of ≤8 ports each.
- [x] `cleanup_ports` deletes SG; no-ops for legacy clusters where SG doesn't exist.
- [x] `delete_security_group` retries on dependency violation; swallows NOT_FOUND; logs warning + returns on retry exhaustion (does not raise — teardown survives).
- [x] `format.sh` passes 10/10 pylint, no mypy issues.
- [x] Existing `tests/unit_tests/test_nebius.py` still passes (5 tests).

### Manual
- [x] `sky launch -c nb-fw --cloud nebius --gpus L40S:1 -- echo ok`; from external host `nc -w3 -zv $IP 52365` → refused; `nc -w3 -zv $IP 22` → open.
- [x] `sky launch nb-fw --cloud nebius --ports 8080 -- 'python -m http.server 8080 &'`; `curl http://$IP:8080/` → 200. Re-run; verify Nebius console shows N rules, not 2N.
- [x] 2-node Ray distributed task — verifies head ↔ worker can reach each other on Ray's internal ports via the self-SG-reference rule.
- [x] `sky down nb-fw` → SG `sky-sg-nb-fw-...` is gone in the Nebius console.
- [x] Legacy-cluster sanity: re-launch a cluster created before this PR; verify warning is logged and provision succeeds.