### PR TITLE
[K8s] Support GKE Autopilot: detect autopilot.enabled and trust NAP

### DIFF
--- a/docs/source/extension/linting.py
+++ b/docs/source/extension/linting.py
@@ -43,6 +43,7 @@ ALLOWED_TERMS = {
     'Sky',
     'Llama',
     'Llama2',
+    'Autopilot',
     'Pods',
     'Samsung',
     'Google',

--- a/docs/source/reference/kubernetes/kubernetes-deployment.rst
+++ b/docs/source/reference/kubernetes/kubernetes-deployment.rst
@@ -164,10 +164,7 @@ Deploying on Google Cloud GKE
 Using SkyPilot on GKE Autopilot
 """""""""""""""""""""""""""""""
 
-GKE Autopilot is supported with the limitations below. We recommend GKE Standard for
-production; use Autopilot only if you accept these caveats.
-
-Autopilot scales to zero when idle, so SkyPilot must defer node-fit decisions to
+GKE Autopilot scales to zero when idle, so SkyPilot must defer node-fit decisions to
 Autopilot. Set this in your config:
 
 .. code-block:: yaml
@@ -176,27 +173,19 @@ Autopilot. Set this in your config:
       autoscaler: gke
       provision_timeout: 600
 
-**Supported:**
-
-- ``sky launch`` for CPU and GPU jobs. SkyPilot's nodeSelector matches Autopilot's
-  ``cloud.google.com/gke-accelerator`` label, and Autopilot installs NVIDIA drivers
-  automatically. Initial GPU node provisioning takes ~3–5 minutes via Autopilot's
-  Node Auto-Provisioning.
-- ``LoadBalancer`` services for exposing ports.
-
-**Not supported** (blocked by Autopilot's GKE Warden policy):
+**Limitations:**
 
 - **Object storage mounts via SkyPilot's bundled FUSE** (``file_mounts`` with cloud
-  storage URIs in ``MOUNT`` mode) — uses a privileged DaemonSet and ``hostPath``. Use
-  the `GCS FUSE CSI driver <https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/cloud-storage-fuse-csi-driver>`_
+  storage URIs in ``MOUNT`` mode) — uses a privileged DaemonSet and ``hostPath``,
+  which Autopilot rejects. Use the
+  `GCS FUSE CSI driver <https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/cloud-storage-fuse-csi-driver>`_
   directly instead.
 - **Privileged or host-namespace features:** Docker-in-Docker, GPUDirect TCPX/TCPXO,
   BuildKit image builds, RDMA (``IPC_LOCK``), and SSH node pools.
 - **``k8s-hostpath`` volume type.**
-
-**Pod preemption.** Autopilot may evict pods to consolidate workloads. For long-running
-work, use :code:`sky jobs launch` instead of :code:`sky launch` so SkyPilot's managed
-jobs automatically recover from preemption.
+- **Pod preemption.** Autopilot may evict pods to consolidate workloads. For
+  long-running work, use :code:`sky jobs launch` so SkyPilot's managed jobs
+  automatically recover from preemption.
 
 .. _kubernetes-setup-eks:
 

--- a/docs/source/reference/kubernetes/kubernetes-deployment.rst
+++ b/docs/source/reference/kubernetes/kubernetes-deployment.rst
@@ -177,9 +177,9 @@ Autopilot. Set this in your config:
 
 - **Object storage mounts via SkyPilot's bundled FUSE** (``file_mounts`` with cloud
   storage URIs in ``MOUNT`` mode) — uses a privileged DaemonSet and ``hostPath``,
-  which Autopilot rejects. Use the
-  `GCS FUSE CSI driver <https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/cloud-storage-fuse-csi-driver>`_
-  directly instead.
+  which Autopilot rejects. Instead, mount a GCS bucket through a :ref:`SkyPilot volume
+  <volumes-all>` backed by the
+  `GCS FUSE CSI driver <https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/cloud-storage-fuse-csi-driver>`_.
 - **Privileged or host-namespace features:** Docker-in-Docker, GPUDirect TCPX/TCPXO,
   BuildKit image builds, RDMA (``IPC_LOCK``), and SSH node pools.
 - **``k8s-hostpath`` volume type.**

--- a/docs/source/reference/kubernetes/kubernetes-deployment.rst
+++ b/docs/source/reference/kubernetes/kubernetes-deployment.rst
@@ -162,7 +162,7 @@ Deploying on Google Cloud GKE
 .. _kubernetes-setup-gke-autopilot:
 
 Using SkyPilot on GKE Autopilot
-"""""""""""""""""""""""""""""""
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 GKE Autopilot scales to zero when idle, so SkyPilot must defer node-fit decisions to
 Autopilot. Set this in your config:

--- a/docs/source/reference/kubernetes/kubernetes-deployment.rst
+++ b/docs/source/reference/kubernetes/kubernetes-deployment.rst
@@ -182,7 +182,9 @@ Autopilot. Set this in your config:
   `GCS FUSE CSI driver <https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/cloud-storage-fuse-csi-driver>`_.
 - **Privileged or host-namespace features:** Docker-in-Docker, GPUDirect TCPX/TCPXO,
   BuildKit image builds, RDMA (``IPC_LOCK``), and SSH node pools.
-- **``k8s-hostpath`` volume type.**
+- **Mounting a directory from the Kubernetes node** (via SkyPilot's ``k8s-hostpath``
+  volume type or ``hostPath`` in ``pod_config`` overrides). Autopilot does not allow
+  workloads to access the node filesystem directly.
 - **Pod preemption.** Autopilot may evict pods to consolidate workloads. For
   long-running work, use :code:`sky jobs launch` so SkyPilot's managed jobs
   automatically recover from preemption.

--- a/docs/source/reference/kubernetes/kubernetes-deployment.rst
+++ b/docs/source/reference/kubernetes/kubernetes-deployment.rst
@@ -164,15 +164,11 @@ Deploying on Google Cloud GKE
 Using SkyPilot on GKE Autopilot
 """""""""""""""""""""""""""""""
 
-GKE Autopilot is partially supported. Basic CPU and GPU jobs can be launched, but
-several SkyPilot features are blocked by Autopilot's PodSecurity policy. We recommend
-GKE Standard clusters for production use; the limitations below apply if you choose
-Autopilot.
+GKE Autopilot is supported with the limitations below. We recommend GKE Standard for
+production; use Autopilot only if you accept these caveats.
 
-**Required configuration.** Autopilot has no fixed nodes — they are provisioned on demand
-when pods are submitted. Set the autoscaler config so SkyPilot defers node-fitting decisions
-to Autopilot, and increase the provision timeout because Autopilot provisioning takes
-several minutes:
+Autopilot scales to zero when idle, so SkyPilot must defer node-fit decisions to
+Autopilot. Set this in your config:
 
 .. code-block:: yaml
 
@@ -180,40 +176,27 @@ several minutes:
       autoscaler: gke
       provision_timeout: 600
 
-**What works:**
+**Supported:**
 
-- ``sky launch`` for CPU jobs (cold-start included). Autopilot accepts SkyPilot's pod spec
-  and auto-fills missing fields (e.g. ``ephemeral-storage``).
-- ``sky launch --gpus <type>`` for GPU jobs. SkyPilot's ``cloud.google.com/gke-accelerator``
-  nodeSelector matches Autopilot's GPU labels directly, and Autopilot installs NVIDIA
-  drivers automatically (verified with T4; ``nvidia-smi`` works out of the box). Initial
-  GPU node provisioning takes 3–5 minutes via Autopilot's Node Auto-Provisioning (NAP).
+- ``sky launch`` for CPU and GPU jobs. SkyPilot's nodeSelector matches Autopilot's
+  ``cloud.google.com/gke-accelerator`` label, and Autopilot installs NVIDIA drivers
+  automatically. Initial GPU node provisioning takes ~3–5 minutes via Autopilot's
+  Node Auto-Provisioning.
 - ``LoadBalancer`` services for exposing ports.
 
-**What does not work:**
+**Not supported** (blocked by Autopilot's GKE Warden policy):
 
 - **Object storage mounts via SkyPilot's bundled FUSE** (``file_mounts`` with cloud
-  storage URIs in ``MOUNT`` mode). SkyPilot deploys a privileged DaemonSet with a
-  ``hostPath`` volume to broker FUSE syscalls; both are rejected by Autopilot's
-  GKE Warden admission policy. Use the
-  `GCS FUSE CSI driver <https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/cloud-storage-fuse-csi-driver>`_
-  directly instead, or use a GKE Standard cluster.
-- **Privileged or host-namespace features:** Docker-in-Docker (``run`` blocks needing
-  Docker), GPUDirect TCPX/TCPXO high-speed networking, BuildKit image builds, RDMA
-  workloads requiring ``IPC_LOCK``, and SSH node pools (the bundled ``nvidia-device-plugin``
-  DaemonSet uses ``hostPID``). All are rejected by Autopilot.
-- **``k8s-hostpath`` volume type** is rejected by Autopilot.
+  storage URIs in ``MOUNT`` mode) — uses a privileged DaemonSet and ``hostPath``. Use
+  the `GCS FUSE CSI driver <https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/cloud-storage-fuse-csi-driver>`_
+  directly instead.
+- **Privileged or host-namespace features:** Docker-in-Docker, GPUDirect TCPX/TCPXO,
+  BuildKit image builds, RDMA (``IPC_LOCK``), and SSH node pools.
+- **``k8s-hostpath`` volume type.**
 
-**Other caveats:**
-
-- **Pod preemption by Autopilot's bin-packer.** Autopilot may evict a SkyPilot pod
-  shortly after it schedules in order to consolidate workloads, which can interrupt
-  cluster setup before Ray finishes starting. There is no fully reliable mitigation
-  today; if you hit this, retry ``sky launch``.
-- **Application-default credentials required.** When ``autoscaler: gke`` is set,
-  SkyPilot calls the GKE container API to inspect node pools. Run
-  ``gcloud auth application-default login`` on the API server host so this call
-  does not fail.
+**Pod preemption.** Autopilot may evict pods to consolidate workloads. For long-running
+work, use :code:`sky jobs launch` instead of :code:`sky launch` so SkyPilot's managed
+jobs automatically recover from preemption.
 
 .. _kubernetes-setup-eks:
 

--- a/docs/source/reference/kubernetes/kubernetes-deployment.rst
+++ b/docs/source/reference/kubernetes/kubernetes-deployment.rst
@@ -159,9 +159,61 @@ Deploying on Google Cloud GKE
        my-cluster-2               A100      2 of 2 free
        my-cluster-3               A100      0 of 2 free
 
-.. note::
-    GKE autopilot clusters are currently not supported. Only GKE standard clusters are supported.
+.. _kubernetes-setup-gke-autopilot:
 
+Using SkyPilot on GKE Autopilot
+"""""""""""""""""""""""""""""""
+
+GKE Autopilot is partially supported. Basic CPU and GPU jobs can be launched, but
+several SkyPilot features are blocked by Autopilot's PodSecurity policy. We recommend
+GKE Standard clusters for production use; the limitations below apply if you choose
+Autopilot.
+
+**Required configuration.** Autopilot has no fixed nodes — they are provisioned on demand
+when pods are submitted. Set the autoscaler config so SkyPilot defers node-fitting decisions
+to Autopilot, and increase the provision timeout because Autopilot provisioning takes
+several minutes:
+
+.. code-block:: yaml
+
+    kubernetes:
+      autoscaler: gke
+      provision_timeout: 600
+
+**What works:**
+
+- ``sky launch`` for CPU jobs (cold-start included). Autopilot accepts SkyPilot's pod spec
+  and auto-fills missing fields (e.g. ``ephemeral-storage``).
+- ``sky launch --gpus <type>`` for GPU jobs. SkyPilot's ``cloud.google.com/gke-accelerator``
+  nodeSelector matches Autopilot's GPU labels directly, and Autopilot installs NVIDIA
+  drivers automatically (verified with T4; ``nvidia-smi`` works out of the box). Initial
+  GPU node provisioning takes 3–5 minutes via Autopilot's Node Auto-Provisioning (NAP).
+- ``LoadBalancer`` services for exposing ports.
+
+**What does not work:**
+
+- **Object storage mounts via SkyPilot's bundled FUSE** (``file_mounts`` with cloud
+  storage URIs in ``MOUNT`` mode). SkyPilot deploys a privileged DaemonSet with a
+  ``hostPath`` volume to broker FUSE syscalls; both are rejected by Autopilot's
+  GKE Warden admission policy. Use the
+  `GCS FUSE CSI driver <https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/cloud-storage-fuse-csi-driver>`_
+  directly instead, or use a GKE Standard cluster.
+- **Privileged or host-namespace features:** Docker-in-Docker (``run`` blocks needing
+  Docker), GPUDirect TCPX/TCPXO high-speed networking, BuildKit image builds, RDMA
+  workloads requiring ``IPC_LOCK``, and SSH node pools (the bundled ``nvidia-device-plugin``
+  DaemonSet uses ``hostPID``). All are rejected by Autopilot.
+- **``k8s-hostpath`` volume type** is rejected by Autopilot.
+
+**Other caveats:**
+
+- **Pod preemption by Autopilot's bin-packer.** Autopilot may evict a SkyPilot pod
+  shortly after it schedules in order to consolidate workloads, which can interrupt
+  cluster setup before Ray finishes starting. There is no fully reliable mitigation
+  today; if you hit this, retry ``sky launch``.
+- **Application-default credentials required.** When ``autoscaler: gke`` is set,
+  SkyPilot calls the GKE container API to inspect node pools. Run
+  ``gcloud auth application-default login`` on the API server host so this call
+  does not fail.
 
 .. _kubernetes-setup-eks:
 

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -976,6 +976,18 @@ class GKEAutoscaler(Autoscaler):
             logger.debug(f'{e.message}', exc_info=True)
             return True
 
+        # GKE Autopilot uses Node Auto-Provisioning (NAP) to create node
+        # pools on demand for any requested instance type, including GPUs.
+        # The static node pool list returned by the API only reflects the
+        # CPU bootstrap pools and does not advertise what NAP can provision,
+        # so the per-pool fit check below would falsely reject GPU requests.
+        # Trust NAP to satisfy the request.
+        if cluster.get('autopilot', {}).get('enabled'):
+            logger.debug(f'Cluster {cluster_name} is Autopilot-managed; '
+                         'trusting Node Auto-Provisioning to satisfy '
+                         f'{instance_type}.')
+            return True
+
         # Check if any node pool with autoscaling enabled can
         # fit the instance type.
         node_pools = cluster.get('nodePools', [])

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -982,7 +982,9 @@ class GKEAutoscaler(Autoscaler):
         # CPU bootstrap pools and does not advertise what NAP can provision,
         # so the per-pool fit check below would falsely reject GPU requests.
         # Trust NAP to satisfy the request.
-        if cluster.get('autopilot', {}).get('enabled'):
+        # Use `is True` so a non-boolean value (e.g. accidentally a string)
+        # cannot inadvertently bypass the fit check on Standard clusters.
+        if cluster.get('autopilot', {}).get('enabled') is True:
             logger.debug(f'Cluster {cluster_name} is Autopilot-managed; '
                          'trusting Node Auto-Provisioning to satisfy '
                          f'{instance_type}.')


### PR DESCRIPTION
## Summary

- Replace the "GKE Autopilot is not supported" note with documented partial support: CPU and GPU `sky launch` work; FUSE mounts / privileged sidecars / `hostPath` are documented as blocked by Autopilot's GKE Warden.
- Make `GKEAutoscaler.can_create_new_instance_of_type` short-circuit to `True` when `cluster.autopilot.enabled` is set, so cold-start GPU launches aren't falsely rejected.

## Why

Autopilot creates GPU node pools on demand via Node Auto-Provisioning (NAP), so the GKE container API's `cluster.nodePools` only contains the bootstrap CPU pools. The existing fit logic walks those pools looking for a matching accelerator config, finds none, and filters the cluster out — even though Autopilot would provision the GPU on pod submit. CPU launches work today only by accident, because Autopilot's `ek-standard-*` machine types aren't in SkyPilot's catalog and the lookup raises `KeyError`, which the existing code treats as "assume yes."

## Test plan

- [x] On a live Autopilot cluster (`sky-autopilot-test` in `sky-dev-465`):
  - `GKEAutoscaler.can_create_new_instance_of_type(ctx, '2CPU--8GB--T4:1')` returns `False` before the patch, `True` after. Confirms the fix targets the right code path.
- [x] `sky launch -c ap-gpu --gpus T4:1 --cpus 2 --memory 8 -- 'nvidia-smi'` against the same cluster: pod scheduled on a T4 NAP node, `nvidia-smi` reported `Tesla T4, Driver 580.126.09, CUDA 13.0`, job exited `SUCCEEDED`.
- [x] `bash format.sh --files sky/provision/kubernetes/utils.py` clean: yapf no changes, isort no changes, mypy clean, pylint 10.00/10.

### Manual verification steps for reviewers

1. Create an Autopilot cluster: `gcloud container clusters create-auto <name> --region <region>`.
2. Run `gcloud auth application-default login` so the GKE container API call succeeds.
3. Add to `~/.sky/config.yaml`:
   ```yaml
   kubernetes:
     autoscaler: gke
     provision_timeout: 600
   ```
4. `sky launch --gpus T4:1 -- nvidia-smi` — without this patch fails with `No resource satisfying ...`; with the patch, succeeds after Autopilot provisions a T4 node (~3–5 min).

## Documented limitations (still apply)

The new `Using SkyPilot on GKE Autopilot` section in `kubernetes-deployment.rst` calls these out:

- Object-storage `file_mounts` via SkyPilot's bundled FUSE — privileged DaemonSet + hostPath, both rejected by Autopilot. Use the GCS FUSE CSI driver instead.
- Privileged or host-namespace features: DinD, GPUDirect TCPX/TCPXO, BuildKit, `IPC_LOCK` (RDMA), SSH node pools (`hostPID`).
- `k8s-hostpath` volume type.
- Autopilot's bin-packer can preempt the head pod mid-setup; observed once during testing. Retry usually succeeds.