### PR TITLE
[Test] Fix self-kill on managed-jobs recovery test with long user hash

### DIFF
--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -576,13 +576,21 @@ def test_managed_jobs_recovery_kubernetes_multinode():
     name = smoke_tests_utils.get_cluster_name()
     name_on_cloud = common_utils.make_cluster_name_on_cloud(
         name, jobs.JOBS_CLUSTER_NAME_PREFIX_LENGTH, add_user_hash=False)
-    stable_prefix = name_on_cloud[:15]
-    # Use label selector to narrow to skypilot pods, then sort by name
-    # and pick first/last to identify head vs non-head node.
+    # Match pods by the `skypilot-cluster-name` annotation, which holds the
+    # full untruncated cluster name. Filtering by pod name alone is not
+    # reliable: when the user hash is long (e.g. 19 chars for service
+    # accounts), the cloud-cmd cluster's name (`<test>-cloud-cmd`) gets
+    # truncated past the 42-char K8s limit and the `-cloud-cmd` suffix
+    # disappears from the pod name — but the annotation always preserves
+    # it, so `grep -v -- "-cloud-cmd"` against the annotation column is
+    # reliable. Excluding cloud-cmd is critical: the kubectl command runs
+    # from inside the cloud-cmd pod via `sky exec`, so a stray match would
+    # self-kill the helper pod and fail the test with exit code 137.
     _get_job_pods = (
-        f'kubectl get pods -l skypilot-cluster-name '
-        f'--no-headers -o custom-columns=":metadata.name" | '
-        f'grep -- "{stable_prefix}" | grep -v -- "-cloud-cmd" | sort')
+        'kubectl get pods --no-headers -o custom-columns='
+        '"NAME:.metadata.name,CLUSTER:.metadata.annotations.skypilot-cluster-name" | '
+        f'grep -- "{name_on_cloud}" | grep -v -- "-cloud-cmd" | '
+        'awk \'{print $1}\' | sort')
     terminate_head_cmd = f'{_get_job_pods} | head -1 | xargs kubectl delete pod'
     terminate_worker_cmd = (
         f'{_get_job_pods} | tail -1 | xargs kubectl delete pod')

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -587,7 +587,7 @@ def test_managed_jobs_recovery_kubernetes_multinode():
     # from inside the cloud-cmd pod via `sky exec`, so a stray match would
     # self-kill the helper pod and fail the test with exit code 137.
     _get_job_pods = (
-        'kubectl get pods --no-headers -o custom-columns='
+        'kubectl get pods -l skypilot-cluster-name --no-headers -o custom-columns='
         '"NAME:.metadata.name,CLUSTER:.metadata.annotations.skypilot-cluster-name" | '
         f'grep -- "{name_on_cloud}" | grep -v -- "-cloud-cmd" | '
         'awk \'{print $1}\' | sort')


### PR DESCRIPTION
## Summary
- `test_managed_jobs_recovery_kubernetes_multinode` could fail with `command terminated with exit code 137` when run under a user hash long enough (e.g. 19-char service-account hashes) to push `<test>-cloud-cmd` past the Kubernetes 42-char pod-name limit.
- Once the cluster name is truncated, the trailing `-cloud-cmd` suffix is dropped from the pod name, so `grep -v -- \"-cloud-cmd\"` against pod names no longer filters out the helper pod, and `kubectl delete` on the result kills the very pod running `sky exec`.
- Switch the filter to match against the \`skypilot-cluster-name\` annotation, which always holds the full untruncated cluster name (see \`sky/provision/kubernetes/instance.py\`: \"We cannot use a label because label values have both a length limit and charset limit ... Annotations are not subject to these limits.\"). The \`-cloud-cmd\` exclusion is now reliable regardless of user-hash length.

## Test plan
- [x] Verified the test passes against a remote API server when run under a user hash that triggers truncation (5m 27s, head + worker recovery cycles both succeed).
- [x] Confirmed the helper cloud-cmd pod (whose pod name no longer contains \`-cloud-cmd\` after truncation) is correctly excluded by the new annotation-based filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)