### PR TITLE
[Test] Make CIFAR-10 wget fall back to wayback when primary mirror is slow

### DIFF
--- a/examples/resnet_distributed_torch.yaml
+++ b/examples/resnet_distributed_torch.yaml
@@ -21,8 +21,8 @@ setup: |
         exit 0
     fi
     cd data && \
-    (wget -c --quiet https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz \
-        || wget --quiet -O cifar-10-python.tar.gz \
+    (wget -c --quiet --timeout=30 --tries=2 https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz \
+        || wget --quiet --timeout=30 --tries=2 -O cifar-10-python.tar.gz \
             "https://web.archive.org/web/20241225200100im_/https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz")
     tar -xvzf cifar-10-python.tar.gz
 

--- a/examples/resnet_distributed_torch.yaml
+++ b/examples/resnet_distributed_torch.yaml
@@ -21,8 +21,13 @@ setup: |
         exit 0
     fi
     cd data && \
-    (wget -c --quiet --timeout=30 --tries=2 https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz \
-        || wget --quiet --timeout=30 --tries=2 -O cifar-10-python.tar.gz \
+    # `--timeout=30` is wget's inactivity (read) timeout: catches stalls.
+    # `timeout 90s` is a hard wallclock cap: catches slow-but-steady mirrors
+    # (the toronto host has dipped to ~350 KB/s, which would never trip
+    # --timeout but would blow the 360s SETTING_UP budget). Together they
+    # ensure `||` actually fires and the wayback fallback gets used.
+    (timeout 90s wget -c --quiet --timeout=30 --tries=2 https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz \
+        || timeout 120s wget --quiet --timeout=30 --tries=2 -O cifar-10-python.tar.gz \
             "https://web.archive.org/web/20241225200100im_/https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz")
     tar -xvzf cifar-10-python.tar.gz
 


### PR DESCRIPTION
## Summary

Fix the recurring `test_cancel_pytorch` flake at the root, instead of bumping the SETTING_UP timeout for a third time.

The setup script in `examples/resnet_distributed_torch.yaml` downloads CIFAR-10 from cs.toronto.edu and chains a wayback-machine fallback via `||`. But neither `wget` had a `--timeout` flag — so a *slow* primary mirror never makes `wget` exit non-zero, and the fallback is unreachable in the most common failure mode.

This PR adds `--timeout=30 --tries=2` to both `wget` calls so a 30 s read stall fails over to the wayback mirror.

## Why bumping the timeout (again) is not the right fix

- `test_cancel_pytorch` waits up to **360 s** for the job to leave `SETTING_UP`.
- That budget was bumped from 150 s → 360 s only 9 days ago in #9496 for this exact flake.
- The cs.toronto.edu mirror serves the 162 MB CIFAR-10 tarball at ~350 KB/s on bad days. The download alone takes ~470 s wall time when the mirror is slow — over the 360 s budget by design.
- Recent runs sit right at the cliff edge:
  - Build [#10440](https://buildkite.com/skypilot-1/smoke-tests/builds/10440) (passed): SETTING_UP took **350.6 s** — 9 s margin.
  - Build [#10461](https://buildkite.com/skypilot-1/smoke-tests/builds/10461) (failed): SETTING_UP timed out at **367 s** with CIFAR 61% downloaded.
- Bumping the timeout would just move the cliff edge — the underlying mirror throughput is the actual problem.

## Direct evidence

Captured live on the failing AWS test cluster (build 10461) by SSH-ing into the buildkite host and the cluster's head node, then `ls`-ing the partial download:

| Time (UTC) | Bytes | % of 170,498,071 |
|---|---|---|
| 15:44:38 | 64,943,862 | 38% |
| 15:44:48 | 68,487,862 | 40% |
| 15:45:45 | 88,415,862 | 52% |
| 15:46:31 (timeout) | **103,999,862** | **61%** |

Sustained throughput ~**350 KB/s** across three windows. `curl` to the same host returns `HTTP/2 200` in 0.22 s, so connectivity is fine — only sustained throughput is poor.

## Test plan

- [ ] Smoke: `pytest tests/smoke_tests/test_cluster_job.py::test_cancel_pytorch --aws -k accelerator0`
- [ ] Manually verify wayback fallback is reached when primary is slow (e.g., simulate by pointing first wget at an unreachable host)
- [ ] Confirm the wayback mirror serves CIFAR-10 within the 360 s budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)