### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/sky/provision/vsphere/common/ssl_helper.py
+++ b/sky/provision/vsphere/common/ssl_helper.py
@@ -23,12 +23,8 @@ def get_unverified_context():
 
 
 def get_unverified_session():
-    """    Get a requests session with cert verification disabled.
-    Also disable the insecure warnings message.
-    Note this is not recommended in production code.
-    @return: a requests session with verification disabled.
+    """    Get a requests session.
+    @return: a requests session.
     """
     session = requests.session()
-    session.verify = False
-    requests.packages.urllib3.disable_warnings()  # type: ignore[attr-defined]
     return session

--- a/sky/ssh_node_pools/constants.py
+++ b/sky/ssh_node_pools/constants.py
@@ -1,6 +1,6 @@
 """Constants for SSH Node Pools"""
 # pylint: disable=line-too-long
-import os
+import os, secrets
 
 DEFAULT_KUBECONFIG_PATH = os.path.expanduser('~/.kube/config')
 SSH_CONFIG_PATH = os.path.expanduser('~/.ssh/config')
@@ -9,4 +9,18 @@ NODE_POOLS_KEY_DIR = os.path.expanduser('~/.sky/ssh_keys')
 DEFAULT_SSH_NODE_POOLS_PATH = os.path.expanduser('~/.sky/ssh_node_pools.yaml')
 
 # TODO (kyuds): make this configurable?
-K3S_TOKEN = 'mytoken'  # Any string can be used as the token
+def _get_k3s_token():
+    token_file = os.path.join(NODE_POOLS_INFO_DIR, 'k3s_token')
+    os.makedirs(NODE_POOLS_INFO_DIR, exist_ok=True)
+    if os.path.exists(token_file):
+        with open(token_file, 'r') as f:
+            token = f.read().strip()
+            if token:
+                return token
+    token = secrets.token_hex(32)
+    with open(token_file, 'w') as f:
+        f.write(token)
+    os.chmod(token_file, 0o600)
+    return token
+
+K3S_TOKEN = _get_k3s_token()


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `sky/ssh_node_pools/constants.py:L12`

A hardcoded token 'mytoken' is used for K3S cluster authentication in SSH node pools. This token is static and predictable, allowing anyone with knowledge of the default token to gain unauthorized access to the K3S cluster if the default is not overridden.

## Solution

Replace the hardcoded token with a randomly generated, cryptographically strong token. Use a secure method (e.g., secrets.token_hex()) to generate a unique token per cluster and store it securely (e.g., in a Kubernetes secret or environment variable). Avoid hardcoding secrets in source code.

## Changes

- `sky/ssh_node_pools/constants.py` (modified)
- `sky/provision/vsphere/common/ssl_helper.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->