### PR TITLE
[Dashboard] Surface launching reason on cluster status badge

### DIFF
--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -125,6 +125,8 @@ export async function getClusters({ clusterNames = null } = {}) {
         workspace: cluster.workspace,
         autostop: cluster.autostop,
         last_event: cluster.last_event,
+        statusTooltip:
+          cluster.status === 'INIT' ? cluster.launch_status_reason : null,
         to_down: cluster.to_down,
         cluster_name_on_cloud: cluster.cluster_name_on_cloud,
         labels: cluster.labels || {},

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -390,7 +390,12 @@ function ActiveTab({
                   <PluginSlot
                     name="clusters.detail.status.badge"
                     context={clusterData}
-                    fallback={<StatusBadge status={clusterData.status} />}
+                    fallback={
+                      <StatusBadge
+                        status={clusterData.status}
+                        statusTooltip={clusterData.statusTooltip}
+                      />
+                    }
                   />
                 </div>
               </div>

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -223,11 +223,11 @@ class ClusterEventType(enum.Enum):
     """Used to denote events that are directly related to
     a cluster's termination."""
 
+    # Progress milestones emitted during a cluster launch
+    # (e.g. 'Launching (Kubernetes cluster is autoscaling)',
+    # 'Launching (1 pod(s) pending due to Pulling)'). Read for the
+    # LAUNCHING-state badge tooltip on the dashboard.
     LAUNCH_PROGRESS = 'LAUNCH_PROGRESS'
-    """Progress milestones emitted during a cluster launch
-    (e.g. 'Launching (Kubernetes cluster is autoscaling)',
-    'Launching (1 pod(s) pending due to Pulling)'). Read for the
-    LAUNCHING-state badge tooltip on the dashboard."""
 
 
 # Table for cluster status change events.
@@ -1032,7 +1032,7 @@ def _get_last_or_terminal_cluster_event_multiple(
     return {row.cluster_hash: row.reason for row in rows}
 
 
-def _get_last_cluster_event_of_type_multiple(
+def get_last_cluster_event_of_type_multiple(
         cluster_hashes: Set[str],
         event_type: ClusterEventType) -> Dict[str, str]:
     """Returns the latest event of `event_type` per cluster_hash.
@@ -1964,7 +1964,7 @@ def get_clusters(
         for row in rows
         if status_lib.ClusterStatus[row.status] is status_lib.ClusterStatus.INIT
     }
-    launch_progress_dict = _get_last_cluster_event_of_type_multiple(
+    launch_progress_dict = get_last_cluster_event_of_type_multiple(
         init_cluster_hashes, ClusterEventType.LAUNCH_PROGRESS)
 
     # get last cluster event for each row

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1072,6 +1072,11 @@ async def cluster_event_retention_daemon():
                              f'{debug_retention_hours} hours.')
                 cleanup_cluster_events_with_retention(debug_retention_hours,
                                                       ClusterEventType.DEBUG)
+                # LAUNCH_PROGRESS shares debug retention semantics: short-lived
+                # observability info, no business-record value once the launch
+                # is over.
+                cleanup_cluster_events_with_retention(
+                    debug_retention_hours, ClusterEventType.LAUNCH_PROGRESS)
             if terminal_retention_hours >= 0:
                 logger.debug(
                     'Cleaning up terminal cluster events with retention '

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1960,8 +1960,9 @@ def get_clusters(
     # short-circuits on an empty set, so this is a no-op when no INIT
     # clusters are in the result.
     init_cluster_hashes = {
-        row.cluster_hash for row in rows if status_lib.ClusterStatus[row.status]
-        is status_lib.ClusterStatus.INIT
+        row.cluster_hash
+        for row in rows
+        if status_lib.ClusterStatus[row.status] is status_lib.ClusterStatus.INIT
     }
     launch_progress_dict = _get_last_cluster_event_of_type_multiple(
         init_cluster_hashes, ClusterEventType.LAUNCH_PROGRESS)

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1952,11 +1952,19 @@ def get_clusters(
     # and the existing last_event fill (summary_response=False only).
     cluster_hashes = {row.cluster_hash for row in rows}
 
-    # Always populate launch_status_reason for INIT clusters — needed by
-    # both the cluster list page (summary_response=True) and the detail
-    # page (summary_response=False).
+    # Only fetch launch-progress events for clusters actually in INIT.
+    # Keeps the zero-overhead promise for non-INIT callers (e.g. SSH
+    # WebSocket validation uses summary_response=True specifically to
+    # avoid cluster-event queries on the hot path; see comment near
+    # `_get_cluster_and_validate` in server.py). The helper
+    # short-circuits on an empty set, so this is a no-op when no INIT
+    # clusters are in the result.
+    init_cluster_hashes = {
+        row.cluster_hash for row in rows if status_lib.ClusterStatus[row.status]
+        is status_lib.ClusterStatus.INIT
+    }
     launch_progress_dict = _get_last_cluster_event_of_type_multiple(
-        cluster_hashes, ClusterEventType.LAUNCH_PROGRESS)
+        init_cluster_hashes, ClusterEventType.LAUNCH_PROGRESS)
 
     # get last cluster event for each row
     if not summary_response:

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1019,8 +1019,10 @@ def _get_last_or_terminal_cluster_event_multiple(
             cluster_event_table.c.cluster_hash, cluster_event_table.c.reason,
             row_number).filter(
                 cluster_event_table.c.cluster_hash.in_(cluster_hashes),
-                cluster_event_table.c.type !=
-                ClusterEventType.DEBUG.value).subquery()
+                cluster_event_table.c.type.notin_([
+                    ClusterEventType.DEBUG.value,
+                    ClusterEventType.LAUNCH_PROGRESS.value,
+                ])).subquery()
 
         # Select only the top-ranked event for each cluster
         rows = session.query(

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1032,6 +1032,39 @@ def _get_last_or_terminal_cluster_event_multiple(
     return {row.cluster_hash: row.reason for row in rows}
 
 
+def _get_last_cluster_event_of_type_multiple(
+        cluster_hashes: Set[str],
+        event_type: ClusterEventType) -> Dict[str, str]:
+    """Returns the latest event of `event_type` per cluster_hash.
+
+    Mirrors _get_last_or_terminal_cluster_event_multiple but filters to a
+    single event type (no TERMINAL-priority ordering).
+    """
+    if not cluster_hashes:
+        return {}
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        row_number = sqlalchemy.func.row_number().over(
+            partition_by=cluster_event_table.c.cluster_hash,
+            order_by=cluster_event_table.c.transitioned_at.desc()).label('rn')
+
+        ranked = session.query(
+            cluster_event_table.c.cluster_hash,
+            cluster_event_table.c.reason,
+            row_number,
+        ).filter(
+            cluster_event_table.c.cluster_hash.in_(cluster_hashes),
+            cluster_event_table.c.type == event_type.value,
+        ).subquery()
+
+        rows = session.query(
+            ranked.c.cluster_hash,
+            ranked.c.reason,
+        ).filter(ranked.c.rn == 1).all()
+
+    return {row.cluster_hash: row.reason for row in rows}
+
+
 def cleanup_cluster_events_with_retention(retention_hours: float,
                                           event_type: ClusterEventType) -> None:
     engine = _db_manager.get_engine()

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -223,6 +223,12 @@ class ClusterEventType(enum.Enum):
     """Used to denote events that are directly related to
     a cluster's termination."""
 
+    LAUNCH_PROGRESS = 'LAUNCH_PROGRESS'
+    """Progress milestones emitted during a cluster launch
+    (e.g. 'Launching (Kubernetes cluster is autoscaling)',
+    'Launching (1 pod(s) pending due to Pulling)'). Read for the
+    LAUNCHING-state badge tooltip on the dashboard."""
+
 
 # Table for cluster status change events.
 # starting_status: Status of the cluster at the start of the event.

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1948,9 +1948,18 @@ def get_clusters(
         current_user_name = (current_user.name
                              if current_user is not None else None)
 
+    # Hoisted: needed by both the new launch-progress fill (any response)
+    # and the existing last_event fill (summary_response=False only).
+    cluster_hashes = {row.cluster_hash for row in rows}
+
+    # Always populate launch_status_reason for INIT clusters — needed by
+    # both the cluster list page (summary_response=True) and the detail
+    # page (summary_response=False).
+    launch_progress_dict = _get_last_cluster_event_of_type_multiple(
+        cluster_hashes, ClusterEventType.LAUNCH_PROGRESS)
+
     # get last cluster event for each row
     if not summary_response:
-        cluster_hashes = {row.cluster_hash for row in rows}
         last_cluster_event_dict = _get_last_or_terminal_cluster_event_multiple(
             cluster_hashes)
 
@@ -1982,6 +1991,14 @@ def get_clusters(
                           if exclude_managed_clusters else bool(row.is_managed),
             'node_names': common_utils.get_display_node_names(row.node_names),
         }
+        # launch_status_reason is populated outside the summary_response
+        # gate so both the list page (summary_response=True) and detail
+        # page (summary_response=False) get the badge tooltip data.
+        if record['status'] is status_lib.ClusterStatus.INIT:
+            record['launch_status_reason'] = launch_progress_dict.get(
+                row.cluster_hash)
+        else:
+            record['launch_status_reason'] = None
         if not summary_response:
             record['last_creation_yaml'] = row.last_creation_yaml
             record['last_creation_command'] = row.last_creation_command

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -645,6 +645,9 @@ def _wait_for_pods_to_schedule(namespace, context, new_nodes, timeout: int,
                 rich_utils.force_update_status(
                     ux_utils.spinner_message(f'Launching ({msg})',
                                              cluster_name=cluster_name))
+                # The cluster row is written by add_or_update_cluster
+                # earlier in the launch flow, so the hash lookup inside
+                # add_cluster_event is guaranteed to succeed here.
                 # TODO(kev): mirror this emit on AWS / GCP / Slurm autoscaler
                 # paths.
                 global_user_state.add_cluster_event(

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -645,6 +645,16 @@ def _wait_for_pods_to_schedule(namespace, context, new_nodes, timeout: int,
                 rich_utils.force_update_status(
                     ux_utils.spinner_message(f'Launching ({msg})',
                                              cluster_name=cluster_name))
+                # TODO(kev): mirror this emit on AWS / GCP / Slurm autoscaler
+                # paths.
+                global_user_state.add_cluster_event(
+                    cluster_name,
+                    new_status=None,
+                    reason=f'Launching ({msg})',
+                    event_type=global_user_state.ClusterEventType
+                    .LAUNCH_PROGRESS,
+                    nop_if_duplicate=True,
+                )
         if not is_autoscaling:
             _update_spinner_message(iteration=iteration,
                                     pods=pods,

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -839,6 +839,22 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
                                                   cluster_name=cluster_name)
         if new_status_msg != last_status_msg:
             rich_utils.force_update_status(new_status_msg)
+            if pending_reasons_count:
+                # Skip the bare 'Launching' status_text — it duplicates
+                # the badge label and would produce a useless tooltip.
+                # The cluster row is written by add_or_update_cluster
+                # earlier in the launch flow, so the hash lookup inside
+                # add_cluster_event is guaranteed to succeed here.
+                # TODO(kev): mirror this emit on AWS / GCP / Slurm
+                # wait-for-instance loops.
+                global_user_state.add_cluster_event(
+                    cluster_name,
+                    new_status=None,
+                    reason=status_text,
+                    event_type=global_user_state.ClusterEventType
+                    .LAUNCH_PROGRESS,
+                    nop_if_duplicate=True,
+                )
             last_status_msg = new_status_msg
         time.sleep(1)
 

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -651,8 +651,8 @@ def _wait_for_pods_to_schedule(namespace, context, new_nodes, timeout: int,
                     cluster_name,
                     new_status=None,
                     reason=f'Launching ({msg})',
-                    event_type=global_user_state.ClusterEventType
-                    .LAUNCH_PROGRESS,
+                    event_type=global_user_state.ClusterEventType.
+                    LAUNCH_PROGRESS,
                     nop_if_duplicate=True,
                 )
         if not is_autoscaling:
@@ -851,8 +851,8 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
                     cluster_name,
                     new_status=None,
                     reason=status_text,
-                    event_type=global_user_state.ClusterEventType
-                    .LAUNCH_PROGRESS,
+                    event_type=global_user_state.ClusterEventType.
+                    LAUNCH_PROGRESS,
                     nop_if_duplicate=True,
                 )
             last_status_msg = new_status_msg

--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -119,10 +119,11 @@ class StatusResponse(ResponseBaseModel):
     last_creation_command: Optional[str] = None
     is_managed: bool
     last_event: Optional[str] = None
+    # Latest LAUNCH_PROGRESS event reason for clusters in INIT status
+    # (rendered as LAUNCHING on the dashboard). None for all other
+    # statuses and for clusters that have not yet emitted a
+    # launch-progress event.
     launch_status_reason: Optional[str] = None
-    """Latest LAUNCH_PROGRESS event reason for clusters in INIT status
-    (rendered as LAUNCHING on the dashboard). None for all other statuses
-    and for clusters that have not yet emitted a launch-progress event."""
     resources_str: Optional[str] = None
     resources_str_full: Optional[str] = None
     # credentials is a JSON, so we use Any here.

--- a/sky/schemas/api/responses.py
+++ b/sky/schemas/api/responses.py
@@ -119,6 +119,10 @@ class StatusResponse(ResponseBaseModel):
     last_creation_command: Optional[str] = None
     is_managed: bool
     last_event: Optional[str] = None
+    launch_status_reason: Optional[str] = None
+    """Latest LAUNCH_PROGRESS event reason for clusters in INIT status
+    (rendered as LAUNCHING on the dashboard). None for all other statuses
+    and for clusters that have not yet emitted a launch-progress event."""
     resources_str: Optional[str] = None
     resources_str_full: Optional[str] = None
     # credentials is a JSON, so we use Any here.

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -1587,8 +1587,8 @@ class TestWaitForPodsToScheduleAutoscaleTimeout:
         # The autoscaler branch latches once — exactly one LAUNCH_PROGRESS emit.
         launch_progress_calls = [
             call for call in add_event.call_args_list
-            if call.kwargs.get('event_type')
-            is instance.global_user_state.ClusterEventType.LAUNCH_PROGRESS
+            if call.kwargs.get('event_type') is
+            instance.global_user_state.ClusterEventType.LAUNCH_PROGRESS
         ]
         assert len(launch_progress_calls) == 1
         kwargs = launch_progress_calls[0].kwargs
@@ -2025,9 +2025,8 @@ class TestWaitForPodsToRunLaunchProgressEmit:
         )
 
         lp_calls = [
-            c for c in add_event.call_args_list
-            if c.kwargs.get('event_type')
-            is instance.global_user_state.ClusterEventType.LAUNCH_PROGRESS
+            c for c in add_event.call_args_list if c.kwargs.get('event_type') is
+            instance.global_user_state.ClusterEventType.LAUNCH_PROGRESS
         ]
         assert len(lp_calls) == 1
         assert lp_calls[0].kwargs['reason'] == (
@@ -2051,8 +2050,7 @@ class TestWaitForPodsToRunLaunchProgressEmit:
         )
 
         lp_calls = [
-            c for c in add_event.call_args_list
-            if c.kwargs.get('event_type')
-            is instance.global_user_state.ClusterEventType.LAUNCH_PROGRESS
+            c for c in add_event.call_args_list if c.kwargs.get('event_type') is
+            instance.global_user_state.ClusterEventType.LAUNCH_PROGRESS
         ]
         assert lp_calls == []

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -1959,3 +1959,100 @@ class TestFullPipeline:
         assert 'nvcr.io/nvidia/pytorch:bad-tag' in blocks
         assert 'Hint:' in blocks
         assert 'image' in blocks.lower() or 'registry' in blocks.lower()
+
+
+class TestWaitForPodsToRunLaunchProgressEmit:
+    """Tests for the LAUNCH_PROGRESS emit added to _wait_for_pods_to_run."""
+
+    @staticmethod
+    def _make_pod(name: str, cluster_name_on_cloud: str):
+        from sky.provision import constants as prov_constants
+        pod = mock.MagicMock()
+        pod.metadata.name = name
+        pod.metadata.labels = {
+            prov_constants.TAG_SKYPILOT_CLUSTER_NAME: cluster_name_on_cloud,
+        }
+        # status_text branch in the production code only checks
+        # phase / container_statuses via _inspect_pod_status, which we
+        # mock below — so attribute values here can be loose.
+        pod.status.phase = 'Pending'
+        pod.status.container_statuses = None
+        return pod
+
+    def _setup(self, monkeypatch, inspect_results_per_iter):
+        """Drive the loop with a scripted sequence of _inspect_pod_status
+        return values. Each entry of inspect_results_per_iter is the list
+        the parallel-map returns for that iteration (one tuple per pod)."""
+        cluster_name_on_cloud = 'my-cluster'
+        pod = self._make_pod('pod-0', cluster_name_on_cloud)
+        pods_list = mock.MagicMock()
+        pods_list.items = [pod]
+        core_api = mock.MagicMock()
+        core_api.list_namespaced_pod.return_value = pods_list
+        monkeypatch.setattr('sky.adaptors.kubernetes.core_api',
+                            lambda *a, **kw: core_api)
+
+        results_iter = iter(inspect_results_per_iter)
+        monkeypatch.setattr(
+            'sky.utils.subprocess_utils.run_in_parallel',
+            lambda fn, items, n: next(results_iter),
+        )
+
+        monkeypatch.setattr('sky.utils.rich_utils.force_update_status',
+                            lambda *a, **kw: None)
+        monkeypatch.setattr(instance.time, 'sleep', lambda *a, **kw: None)
+
+        add_event = mock.MagicMock()
+        monkeypatch.setattr(instance.global_user_state, 'add_cluster_event',
+                            add_event)
+        return pod, add_event
+
+    def test_emit_on_stage_change_dedup_on_no_change(self, monkeypatch):
+        """First iteration: pulling → emit. Second iteration: still pulling
+        → no emit (same status_text). Third iteration: all running → loop
+        exits."""
+        pod, add_event = self._setup(monkeypatch, [
+            [(False, 'Pulling')],
+            [(False, 'Pulling')],
+            [(True, None)],
+        ])
+
+        instance._wait_for_pods_to_run(
+            namespace='ns',
+            context='ctx',
+            cluster_name='cn',
+            new_pods=[pod],
+        )
+
+        lp_calls = [
+            c for c in add_event.call_args_list
+            if c.kwargs.get('event_type')
+            is instance.global_user_state.ClusterEventType.LAUNCH_PROGRESS
+        ]
+        assert len(lp_calls) == 1
+        assert lp_calls[0].kwargs['reason'] == (
+            'Launching (1 pod(s) pending due to Pulling)')
+        assert lp_calls[0].kwargs['nop_if_duplicate'] is True
+
+    def test_no_emit_when_pending_reasons_empty(self, monkeypatch):
+        """When _inspect_pod_status returns no pending reason but is_running
+        is False, status_text is the bare 'Launching' — useless tooltip.
+        No emit must happen for that iteration."""
+        pod, add_event = self._setup(monkeypatch, [
+            [(False, None)],
+            [(True, None)],
+        ])
+
+        instance._wait_for_pods_to_run(
+            namespace='ns',
+            context='ctx',
+            cluster_name='cn',
+            new_pods=[pod],
+        )
+
+        lp_calls = [
+            c for c in add_event.call_args_list
+            if c.kwargs.get('event_type')
+            is instance.global_user_state.ClusterEventType.LAUNCH_PROGRESS
+        ]
+        assert lp_calls == []

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -1558,6 +1558,43 @@ class TestWaitForPodsToScheduleAutoscaleTimeout:
             f'No autoscaler configured → short user timeout must not be '
             f'bumped, but loop ran for {clock.now}s.')
 
+    def test_emits_launch_progress_on_autoscale_detection(self, monkeypatch):
+        """When the autoscaler is detected, exactly one LAUNCH_PROGRESS event
+        must be emitted with the spinner's status text."""
+        _, raise_errors, cluster_name_on_cloud = self._setup(
+            monkeypatch,
+            autoscaler_type='gke',
+            autoscale_detected=True,
+        )
+
+        add_event = mock.MagicMock()
+        monkeypatch.setattr(instance.global_user_state, 'add_cluster_event',
+                            add_event)
+
+        node = self._make_node('pod-0', cluster_name_on_cloud)
+        import datetime  # pylint: disable=import-outside-toplevel
+
+        with pytest.raises(config_lib.KubernetesError,
+                           match='simulated-timeout'):
+            instance._wait_for_pods_to_schedule(
+                namespace='ns',
+                context='test-context',
+                new_nodes=[node],
+                timeout=5,
+                cluster_name='cn',
+                create_pods_start=datetime.datetime.now(datetime.timezone.utc))
+
+        # The autoscaler branch latches once — exactly one LAUNCH_PROGRESS emit.
+        launch_progress_calls = [
+            call for call in add_event.call_args_list
+            if call.kwargs.get('event_type')
+            is instance.global_user_state.ClusterEventType.LAUNCH_PROGRESS
+        ]
+        assert len(launch_progress_calls) == 1
+        kwargs = launch_progress_calls[0].kwargs
+        assert kwargs['reason'].startswith('Launching (')
+        assert kwargs['nop_if_duplicate'] is True
+
 
 # ---------------------------------------------------------------------------
 # Helpers and tests for _condensed_pod_reason()

--- a/tests/unit_tests/test_sky/test_global_user_state_cluster_events.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_cluster_events.py
@@ -101,3 +101,45 @@ def test_launch_progress_retention_cleans_old_rows(tmp_path, monkeypatch):
         event_type=global_user_state.ClusterEventType.LAUNCH_PROGRESS,
     )
     assert remaining == 'recent-launch-step'
+
+
+def test_get_last_event_of_type_multiple(tmp_path, monkeypatch):
+    _fresh_db(tmp_path, monkeypatch)
+    h1 = _add_cluster('a')
+    h2 = _add_cluster('b')
+
+    global_user_state.add_cluster_event(
+        'a',
+        new_status=None,
+        reason='a-old',
+        event_type=global_user_state.ClusterEventType.LAUNCH_PROGRESS,
+        transitioned_at=1,
+    )
+    global_user_state.add_cluster_event(
+        'a',
+        new_status=None,
+        reason='a-new',
+        event_type=global_user_state.ClusterEventType.LAUNCH_PROGRESS,
+        transitioned_at=2,
+    )
+    global_user_state.add_cluster_event(
+        'b',
+        new_status=None,
+        reason='b-only',
+        event_type=global_user_state.ClusterEventType.LAUNCH_PROGRESS,
+        transitioned_at=5,
+    )
+    # Wrong-type row for 'b' to verify the filter:
+    global_user_state.add_cluster_event(
+        'b',
+        new_status=None,
+        reason='b-status-change',
+        event_type=global_user_state.ClusterEventType.STATUS_CHANGE,
+        transitioned_at=10,
+    )
+
+    result = global_user_state._get_last_cluster_event_of_type_multiple(
+        {h1, h2},
+        event_type=global_user_state.ClusterEventType.LAUNCH_PROGRESS,
+    )
+    assert result == {h1: 'a-new', h2: 'b-only'}

--- a/tests/unit_tests/test_sky/test_global_user_state_cluster_events.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_cluster_events.py
@@ -66,3 +66,38 @@ def test_launch_progress_excluded_from_last_event_helper(
     # The helper must skip the LAUNCH_PROGRESS row and return the
     # STATUS_CHANGE reason.
     assert result == {cluster_hash: 'status-change-reason'}
+
+
+def test_launch_progress_retention_cleans_old_rows(tmp_path, monkeypatch):
+    _fresh_db(tmp_path, monkeypatch)
+    _add_cluster('c2')
+
+    # Insert one ancient event and one recent one.
+    now = int(time.time())
+    global_user_state.add_cluster_event(
+        'c2',
+        new_status=None,
+        reason='old-launch-step',
+        event_type=global_user_state.ClusterEventType.LAUNCH_PROGRESS,
+        transitioned_at=now - 24 * 3600,  # 24h ago
+    )
+    global_user_state.add_cluster_event(
+        'c2',
+        new_status=None,
+        reason='recent-launch-step',
+        event_type=global_user_state.ClusterEventType.LAUNCH_PROGRESS,
+        transitioned_at=now,
+    )
+
+    # Retention = 1h → old row should be deleted, recent row should remain.
+    global_user_state.cleanup_cluster_events_with_retention(
+        retention_hours=1,
+        event_type=global_user_state.ClusterEventType.LAUNCH_PROGRESS,
+    )
+
+    cluster_hash = global_user_state._get_hash_for_existing_cluster('c2')
+    remaining = global_user_state.get_last_cluster_event(
+        cluster_hash,
+        event_type=global_user_state.ClusterEventType.LAUNCH_PROGRESS,
+    )
+    assert remaining == 'recent-launch-step'

--- a/tests/unit_tests/test_sky/test_global_user_state_cluster_events.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_cluster_events.py
@@ -1,0 +1,68 @@
+"""Unit tests for cluster_event accessors in global_user_state."""
+import time
+
+from sky import global_user_state
+from sky.skylet import constants
+from sky.utils.db import db_utils
+
+
+def _fresh_db(tmp_path, monkeypatch):
+    """Point the global state DB at a tmp sqlite file (mirrors the helper in
+    test_global_user_state_check_results.py)."""
+    monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY, str(tmp_path))
+    monkeypatch.setattr(
+        global_user_state,
+        '_db_manager',
+        db_utils.DatabaseManager(
+            'state',
+            global_user_state.create_table,
+            post_init_fn=lambda _: global_user_state._sqlite_supports_returning(
+            ),
+        ),
+    )
+
+
+def _add_cluster(name: str) -> str:
+    """Create a minimal cluster row so add_cluster_event can find a hash.
+
+    Returns the cluster_hash.
+    """
+    global_user_state.add_or_update_cluster(
+        cluster_name=name,
+        cluster_handle=None,
+        requested_resources=set(),
+        ready=False,
+    )
+    return global_user_state._get_hash_for_existing_cluster(name)
+
+
+def test_launch_progress_excluded_from_last_event_helper(
+        tmp_path, monkeypatch):
+    """Adding a LAUNCH_PROGRESS event must not change the value returned by
+    _get_last_or_terminal_cluster_event_multiple, which feeds the existing
+    last_event field."""
+    _fresh_db(tmp_path, monkeypatch)
+    cluster_hash = _add_cluster('c1')
+
+    # 1. Write a STATUS_CHANGE event first (older).
+    global_user_state.add_cluster_event(
+        'c1',
+        new_status=None,
+        reason='status-change-reason',
+        event_type=global_user_state.ClusterEventType.STATUS_CHANGE,
+        transitioned_at=1,
+    )
+    # 2. Then a newer LAUNCH_PROGRESS event.
+    global_user_state.add_cluster_event(
+        'c1',
+        new_status=None,
+        reason='launch-progress-reason',
+        event_type=global_user_state.ClusterEventType.LAUNCH_PROGRESS,
+        transitioned_at=2,
+    )
+
+    result = global_user_state._get_last_or_terminal_cluster_event_multiple(
+        {cluster_hash})
+    # The helper must skip the LAUNCH_PROGRESS row and return the
+    # STATUS_CHANGE reason.
+    assert result == {cluster_hash: 'status-change-reason'}

--- a/tests/unit_tests/test_sky/test_global_user_state_cluster_events.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_cluster_events.py
@@ -42,8 +42,7 @@ def _add_cluster(name: str) -> str:
     return global_user_state._get_hash_for_existing_cluster(name)
 
 
-def test_launch_progress_excluded_from_last_event_helper(
-        tmp_path, monkeypatch):
+def test_launch_progress_excluded_from_last_event_helper(tmp_path, monkeypatch):
     """Adding a LAUNCH_PROGRESS event must not change the value returned by
     _get_last_or_terminal_cluster_event_multiple, which feeds the existing
     last_event field."""
@@ -174,8 +173,7 @@ def test_get_clusters_populates_launch_status_reason_for_init(
             'Launching (1 pod(s) pending due to Pulling)')
 
 
-def test_get_clusters_no_launch_status_reason_for_up(
-        tmp_path, monkeypatch):
+def test_get_clusters_no_launch_status_reason_for_up(tmp_path, monkeypatch):
     _fresh_db(tmp_path, monkeypatch)
     _add_cluster('up-cluster')
     # Bring the cluster to UP.

--- a/tests/unit_tests/test_sky/test_global_user_state_cluster_events.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_cluster_events.py
@@ -143,7 +143,7 @@ def test_get_last_event_of_type_multiple(tmp_path, monkeypatch):
         transitioned_at=10,
     )
 
-    result = global_user_state._get_last_cluster_event_of_type_multiple(
+    result = global_user_state.get_last_cluster_event_of_type_multiple(
         {h1, h2},
         event_type=global_user_state.ClusterEventType.LAUNCH_PROGRESS,
     )

--- a/tests/unit_tests/test_sky/test_global_user_state_cluster_events.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_cluster_events.py
@@ -3,6 +3,7 @@ import time
 
 from sky import global_user_state
 from sky.skylet import constants
+from sky.utils import status_lib
 from sky.utils.db import db_utils
 
 
@@ -22,6 +23,11 @@ def _fresh_db(tmp_path, monkeypatch):
     )
 
 
+class _MinimalHandle:
+    """Minimal handle that satisfies get_clusters' attribute access."""
+    launched_resources = None
+
+
 def _add_cluster(name: str) -> str:
     """Create a minimal cluster row so add_cluster_event can find a hash.
 
@@ -29,7 +35,7 @@ def _add_cluster(name: str) -> str:
     """
     global_user_state.add_or_update_cluster(
         cluster_name=name,
-        cluster_handle=None,
+        cluster_handle=_MinimalHandle(),
         requested_resources=set(),
         ready=False,
     )
@@ -143,3 +149,53 @@ def test_get_last_event_of_type_multiple(tmp_path, monkeypatch):
         event_type=global_user_state.ClusterEventType.LAUNCH_PROGRESS,
     )
     assert result == {h1: 'a-new', h2: 'b-only'}
+
+
+def test_get_clusters_populates_launch_status_reason_for_init(
+        tmp_path, monkeypatch):
+    _fresh_db(tmp_path, monkeypatch)
+    _add_cluster('init-cluster')
+    # add_or_update_cluster default leaves the row in INIT.
+    global_user_state.add_cluster_event(
+        'init-cluster',
+        new_status=None,
+        reason='Launching (1 pod(s) pending due to Pulling)',
+        event_type=global_user_state.ClusterEventType.LAUNCH_PROGRESS,
+        transitioned_at=int(time.time()),
+    )
+
+    # Both summary and full responses must carry the field.
+    for summary in (True, False):
+        records = global_user_state.get_clusters(summary_response=summary)
+        match = [r for r in records if r['name'] == 'init-cluster']
+        assert len(match) == 1
+        assert match[0]['status'] is status_lib.ClusterStatus.INIT
+        assert match[0]['launch_status_reason'] == (
+            'Launching (1 pod(s) pending due to Pulling)')
+
+
+def test_get_clusters_no_launch_status_reason_for_up(
+        tmp_path, monkeypatch):
+    _fresh_db(tmp_path, monkeypatch)
+    _add_cluster('up-cluster')
+    # Bring the cluster to UP.
+    global_user_state.add_or_update_cluster(
+        cluster_name='up-cluster',
+        cluster_handle=_MinimalHandle(),
+        requested_resources=set(),
+        ready=True,
+    )
+    # Even with a LAUNCH_PROGRESS event present, an UP cluster's field
+    # must be None.
+    global_user_state.add_cluster_event(
+        'up-cluster',
+        new_status=None,
+        reason='stale-launch-step',
+        event_type=global_user_state.ClusterEventType.LAUNCH_PROGRESS,
+        transitioned_at=int(time.time()),
+    )
+    records = global_user_state.get_clusters(summary_response=False)
+    match = [r for r in records if r['name'] == 'up-cluster']
+    assert len(match) == 1
+    assert match[0]['status'] is status_lib.ClusterStatus.UP
+    assert match[0].get('launch_status_reason') is None


### PR DESCRIPTION
## Summary

Show the current launch step (e.g. "Pulling image", "Waiting for cluster autoscaler") in the LAUNCHING status badge tooltip on the dashboard cluster list and detail pages. Reuses the existing CLI spinner string via a new `LAUNCH_PROGRESS` event type in `cluster_events` — same source the `sky launch` spinner already builds.

<img width="428" height="265" alt="list-launching-tooltip" src="https://github.com/user-attachments/assets/84150e03-55bd-45ee-a42a-3c9e167fa658" />

Today users have to dig through provision logs to see why a launch is stuck; this surfaces the same hint on the dashboard.

Scope is Kubernetes-only (covers both regular clusters and devspaces, since they share the `_wait_for_pods_to_schedule` / `_wait_for_pods_to_run` path). AWS / GCP / Slurm emits and failure-state surfacing are explicit follow-ups marked with `TODO(kev)` in the code.

### How it works

1. New `ClusterEventType.LAUNCH_PROGRESS` enum value.
2. The Kubernetes provisioner emits one event per stage transition from two existing wait-loops:
   - `_wait_for_pods_to_schedule` — when the autoscaler is first detected.
   - `_wait_for_pods_to_run` — on each distinct pending-reasons aggregate (skipping the bare "Launching" case).
3. `get_clusters()` reads the latest `LAUNCH_PROGRESS` event per cluster (batched), populates a new optional `launch_status_reason` field on `StatusResponse` for clusters in `INIT` status.
4. Dashboard connector maps it onto `cluster.statusTooltip` (with an `INIT`-only guard so a stale value never leaks to a non-launching badge). `StatusBadge` already supports `statusTooltip`.

### Regression guard

The existing `_get_last_or_terminal_cluster_event_multiple` helper feeds the shipped `last_event` field. Its filter is extended from `!= DEBUG` to `notin_([DEBUG, LAUNCH_PROGRESS])` so the new event type doesn't silently change `last_event` behavior. There's a regression test pinning this.

### Retention

`LAUNCH_PROGRESS` events piggyback on the existing `cluster_debug_event_retention_hours` cleanup — short-lived observability info, no separate config knob.

## Test plan

- [x] `pytest tests/unit_tests/test_sky/test_global_user_state_cluster_events.py` — 5 new tests pass
- [x] `pytest tests/unit_tests/kubernetes/test_provision.py` — 67 tests pass, including 3 new
- [x] Manual e2e: launch a Kubernetes cluster, hover the LAUNCHING badge on the dashboard list and detail pages, confirm the tooltip matches the CLI spinner text. Confirm the tooltip is empty (just status name) on RUNNING.