### PR TITLE
[Vast] Add live price overlay for the Vast catalog to improve vast offering so user see a competitive data.

### DIFF
--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -152,6 +152,15 @@ class LazyDataFrame:
                     raise e
         return self._df
 
+    def get_dataframe(self) -> 'pd.DataFrame':
+        """Force-load (refreshing if stale) and return the underlying df."""
+        return self._load_df()
+
+    @property
+    def filename(self) -> str:
+        """Path to the on-disk CSV that backs this lazy df."""
+        return self._filename
+
     def __getattr__(self, name: str):
         return getattr(self._load_df(), name)
 

--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -153,7 +153,12 @@ class LazyDataFrame:
         return self._df
 
     def get_dataframe(self) -> 'pd.DataFrame':
-        """Force-load (refreshing if stale) and return the underlying df."""
+        """Return the underlying df, loading it on first use per request.
+
+        Backed by `_load_df`, which is request-scoped LRU-cached: the first
+        call in a request checks staleness and reads the CSV; subsequent
+        calls in the same request reuse the cached frame.
+        """
         return self._load_df()
 
     @property

--- a/sky/catalog/data_fetchers/fetch_vast.py
+++ b/sky/catalog/data_fetchers/fetch_vast.py
@@ -1,159 +1,30 @@
 """A script that generates the Vast Cloud catalog. """
-
-#
-# Due to the design of the sdk, pylint has a false
-# positive for the functions.
-#
 # pylint: disable=assignment-from-no-return
-import collections
 import csv
-import json
-import math
 import os
-import re
-from typing import Any, Dict, List
 
 from sky.adaptors import vast
+from sky.catalog.vast import _offer_processing as proc
 
-_map = {
-    'TeslaV100': 'V100',
-    'TeslaT4': 'T4',
-    'TeslaP100': 'P100',
-    'QRTX6000': 'RTX6000',
-    'QRTX8000': 'RTX8000'
-}
-
-
-def create_instance_type(obj: Dict[str, Any]) -> str:
-    stubify = lambda x: re.sub(r'\s', '_', x)
-    return '{}x-{}-{}-{}'.format(obj['num_gpus'], stubify(obj['gpu_name']),
-                                 obj['cpu_cores'], obj['cpu_ram'])
-
-
-def dot_get(d: dict, key: str) -> Any:
-    for k in key.split('.'):
-        d = d[k]
-    return d
-
+# Vast has a wide variety of machines, some of which will have less diskspace
+# and network bandwidth than others. The flags here mirror the historical
+# behavior of this fetcher:
+#   * georegion consolidates geographic areas
+#   * chunked rounds down specifications (e.g. 1025GB to 1024GB disk) so
+#     machine specifications look consistent
+#   * inet_down keeps machines with reasonable downlink speed
+#   * disk_space sets a lower bound to filter tiny disk pools
+_QUERY = ('georegion = true chunked = true '
+          'inet_down >= 100 disk_space >= 80')
 
 if __name__ == '__main__':
-    seen = set()
-    # InstanceList is the buffered list to emit to
-    # the CSV
-    csvList = []
+    offer_list = vast.vast().search_offers(query=_QUERY, limit=10000)
 
-    # InstanceType and gpuInfo are basically just stubs
-    # so that the dictwriter is happy without weird
-    # code.
-    mapped_keys = (('gpu_name', 'InstanceType'), ('gpu_name',
-                                                  'AcceleratorName'),
-                   ('num_gpus', 'AcceleratorCount'), ('cpu_cores', 'vCPUs'),
-                   ('cpu_ram', 'MemoryGiB'), ('gpu_name', 'GpuInfo'),
-                   ('search.totalHour', 'Price'), ('min_bid', 'SpotPrice'),
-                   ('geolocation', 'Region'), ('hosting_type', 'HostingType'))
-
-    # Vast has a wide variety of machines, some of
-    # which will have less diskspace and network
-    # bandwidth than others.
-    #
-    # The machine normally have high specificity
-    # in the vast catalog - this is fairly unique
-    # to Vast and can make bucketing them into
-    # instance types difficult.
-    #
-    # The flags
-    #
-    #   * georegion consolidates geographic areas
-    #
-    #   * chunked rounds down specifications (such
-    #     as 1025GB to 1024GB disk) in order to
-    #     make machine specifications look more
-    #     consistent
-    #
-    #   * inet_down makes sure that only machines
-    #     with "reasonable" downlink speed are
-    #     considered
-    #
-    #   * disk_space sets a lower limit of how
-    #     much space is availble to be allocated
-    #     in order to ensure that machines with
-    #     small disk pools aren't listed
-    #
-    offerList = vast.vast().search_offers(
-        query=('georegion = true chunked = true '
-               'inet_down >= 100 disk_space >= 80'),
-        limit=10000)
-
-    priceMap: Dict[str, List] = collections.defaultdict(list)
-    for offer in offerList:
-        entry = {}
-        for ours, theirs in mapped_keys:
-            field = dot_get(offer, ours)
-            entry[theirs] = field
-
-        instance_type = create_instance_type(offer)
-        entry['InstanceType'] = instance_type
-
-        # the documentation says
-        # "{'gpus': [{
-        #   'name': 'v100',
-        #   'manufacturer': 'nvidia',
-        #   'count': 8.0,
-        #   'memoryinfo': {'sizeinmib': 16384}
-        #   }],
-        #   'totalgpumemoryinmib': 16384}",
-        # we can do that.
-        entry['MemoryGiB'] /= 1024
-
-        gpu = re.sub('Ada', '-Ada', re.sub(r'\s', '', offer['gpu_name']))
-        gpu = re.sub(r'(Ti|PCIE|SXM4|SXM|NVL)$', '', gpu)
-        gpu = re.sub(r'(RTX\d0\d0)(S|D)$', r'\1', gpu)
-
-        if gpu in _map:
-            gpu = _map[gpu]
-
-        entry['AcceleratorName'] = gpu
-        entry['GpuInfo'] = json.dumps({
-            'Gpus': [{
-                'Name': gpu,
-                'Count': offer['num_gpus'],
-                'MemoryInfo': {
-                    'SizeInMiB': offer['gpu_total_ram']
-                }
-            }],
-            'TotalGpuMemoryInMiB': offer['gpu_total_ram']
-        }).replace('"', '\'')
-
-        priceMap[instance_type].append(entry)
-
-    for instanceList in priceMap.values():
-        priceList = sorted([x['Price'] for x in instanceList])
-        index = math.ceil(0.5 * len(priceList)) - 1
-        priceTarget = priceList[index]
-        toList: List = []
-        for instance in instanceList:
-            if instance['Price'] <= priceTarget:
-                instance['Price'] = '{:.2f}'.format(priceTarget)
-                toList.append(instance)
-
-        maxBid = max([x.get('SpotPrice') for x in toList])
-        for instance in toList:
-            hosting_type = instance.get('HostingType', 0)
-            stub = (f'{instance["InstanceType"]} '
-                    f'{instance["Region"][-2:]} {hosting_type}')
-            if stub in seen:
-                printstub = f'{stub}#print'
-                if printstub not in seen:
-                    instance['SpotPrice'] = f'{maxBid:.2f}'
-                    csvList.append(instance)
-                    seen.add(printstub)
-            else:
-                seen.add(stub)
+    rows = proc.build_csv_rows(offer_list)
 
     os.makedirs('vast', exist_ok=True)
     with open('vast/vms.csv', 'w', newline='', encoding='utf-8') as csvfile:
-        writer = csv.DictWriter(csvfile, fieldnames=[x[1] for x in mapped_keys])
+        writer = csv.DictWriter(csvfile, fieldnames=proc.CSV_FIELDNAMES)
         writer.writeheader()
-
-        for instance in csvList:
-            writer.writerow(instance)
+        for row in rows:
+            writer.writerow(row)

--- a/sky/catalog/vast/__init__.py
+++ b/sky/catalog/vast/__init__.py
@@ -1,0 +1,1 @@
+"""Vast catalog support modules (live overlay, shared offer processing)."""

--- a/sky/catalog/vast/_offer_processing.py
+++ b/sky/catalog/vast/_offer_processing.py
@@ -1,0 +1,176 @@
+"""Shared row-builder for Vast offers.
+
+This module is the single source of truth for turning a Vast `/bundles/`
+search response into SkyPilot-catalog-shaped rows. Both the offline catalog
+fetcher (`sky/catalog/data_fetchers/fetch_vast.py`) and the runtime live
+overlay (`sky/catalog/vast/live_overlay.py`) call into here so the
+`InstanceType` merge key never drifts between them.
+"""
+import collections
+import json
+import math
+import re
+from typing import Any, Dict, Iterable, List, Tuple
+
+# Same column order/semantics as historical fetch_vast.py.
+_MAPPED_KEYS: Tuple[Tuple[str, str], ...] = (
+    ('gpu_name', 'InstanceType'),
+    ('gpu_name', 'AcceleratorName'),
+    ('num_gpus', 'AcceleratorCount'),
+    ('cpu_cores', 'vCPUs'),
+    ('cpu_ram', 'MemoryGiB'),
+    ('gpu_name', 'GpuInfo'),
+    ('search.totalHour', 'Price'),
+    ('min_bid', 'SpotPrice'),
+    ('geolocation', 'Region'),
+    ('hosting_type', 'HostingType'),
+)
+
+CSV_FIELDNAMES: List[str] = [theirs for _, theirs in _MAPPED_KEYS]
+
+_GPU_RENAME: Dict[str, str] = {
+    'TeslaV100': 'V100',
+    'TeslaT4': 'T4',
+    'TeslaP100': 'P100',
+    'QRTX6000': 'RTX6000',
+    'QRTX8000': 'RTX8000',
+}
+
+
+def _stubify(name: str) -> str:
+    return re.sub(r'\s', '_', name)
+
+
+def make_instance_type(num_gpus: int, gpu_name: str, cpu_cores: int,
+                       cpu_ram_mib: int) -> str:
+    """SkyPilot's invented Vast InstanceType id.
+
+    Format matches `fetch_vast.create_instance_type` exactly:
+        '{num_gpus}x-{stubify(gpu_name)}-{cpu_cores}-{cpu_ram_mib}'
+    """
+    return '{}x-{}-{}-{}'.format(num_gpus, _stubify(gpu_name), cpu_cores,
+                                 cpu_ram_mib)
+
+
+def normalize_gpu_name(raw: str) -> str:
+    """Same gpu-name normalization the offline fetcher applies."""
+    gpu = re.sub('Ada', '-Ada', re.sub(r'\s', '', raw))
+    gpu = re.sub(r'(Ti|PCIE|SXM4|SXM|NVL)$', '', gpu)
+    gpu = re.sub(r'(RTX\d0\d0)(S|D)$', r'\1', gpu)
+    return _GPU_RENAME.get(gpu, gpu)
+
+
+def _dot_get(d: Dict[str, Any], key: str) -> Any:
+    cursor: Any = d
+    for k in key.split('.'):
+        cursor = cursor[k]
+    return cursor
+
+
+def _build_entry(offer: Dict[str, Any]) -> Dict[str, Any]:
+    """One row, pre-bucketing. Mirrors the per-offer block of fetch_vast.py."""
+    entry: Dict[str, Any] = {}
+    for ours, theirs in _MAPPED_KEYS:
+        entry[theirs] = _dot_get(offer, ours)
+
+    entry['InstanceType'] = make_instance_type(offer['num_gpus'],
+                                               offer['gpu_name'],
+                                               offer['cpu_cores'],
+                                               offer['cpu_ram'])
+
+    # MemoryGiB: bundle returns MiB.
+    entry['MemoryGiB'] = entry['MemoryGiB'] / 1024
+
+    gpu = normalize_gpu_name(offer['gpu_name'])
+    entry['AcceleratorName'] = gpu
+    entry['GpuInfo'] = json.dumps({
+        'Gpus': [{
+            'Name': gpu,
+            'Count': offer['num_gpus'],
+            'MemoryInfo': {
+                'SizeInMiB': offer['gpu_total_ram']
+            }
+        }],
+        'TotalGpuMemoryInMiB': offer['gpu_total_ram']
+    }).replace('"', '\'')
+
+    return entry
+
+
+def _bucket_and_dedup(entries: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Median-price bucketing + 'seen' dedup, mirroring fetch_vast.py.
+
+    Returns rows ready for CSV (Price/SpotPrice formatted as 2-decimal
+    strings, same as today's vms.csv).
+    """
+    price_map: Dict[str, List[Dict[str, Any]]] = collections.defaultdict(list)
+    for entry in entries:
+        price_map[entry['InstanceType']].append(entry)
+
+    seen: set = set()
+    out: List[Dict[str, Any]] = []
+    for instance_list in price_map.values():
+        prices = sorted([row['Price'] for row in instance_list])
+        if not prices:
+            continue
+        index = math.ceil(0.5 * len(prices)) - 1
+        target = prices[index]
+        bucket: List[Dict[str, Any]] = []
+        for instance in instance_list:
+            if instance['Price'] <= target:
+                instance['Price'] = '{:.2f}'.format(target)
+                bucket.append(instance)
+        if not bucket:
+            continue
+        max_bid = max(row.get('SpotPrice') or 0.0 for row in bucket)
+        for instance in bucket:
+            hosting_type = instance.get('HostingType', 0)
+            stub = (f'{instance["InstanceType"]} '
+                    f'{instance["Region"][-2:]} {hosting_type}')
+            if stub in seen:
+                printstub = f'{stub}#print'
+                if printstub not in seen:
+                    instance['SpotPrice'] = f'{max_bid:.2f}'
+                    out.append(instance)
+                    seen.add(printstub)
+            else:
+                seen.add(stub)
+    return out
+
+
+def build_csv_rows(offers: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Turn raw bundle offers into CSV-ready rows.
+
+    Output order, columns and string-formatted Price/SpotPrice match what
+    today's `fetch_vast.py` writes to `vast/vms.csv`.
+    """
+    raw: List[Dict[str, Any]] = []
+    for offer in offers:
+        try:
+            raw.append(_build_entry(offer))
+        except (KeyError, TypeError, ValueError):
+            # Fail-open: skip malformed offers instead of aborting the build.
+            continue
+    return _bucket_and_dedup(raw)
+
+
+def offers_to_dataframe(offers: Iterable[Dict[str, Any]]):
+    """Same data as `build_csv_rows` but typed for runtime use.
+
+    Price/SpotPrice are floats (not strings), and the result is a pandas
+    DataFrame with `CSV_FIELDNAMES` columns. Heavy imports are deferred so
+    this module stays cheap to import.
+    """
+    # pylint: disable=import-outside-toplevel
+    import pandas as pd
+    rows = build_csv_rows(offers)
+    df = pd.DataFrame(rows, columns=CSV_FIELDNAMES)
+    if df.empty:
+        return df
+    df['Price'] = df['Price'].astype(float)
+    df['SpotPrice'] = df['SpotPrice'].astype(float)
+    df['AcceleratorCount'] = df['AcceleratorCount'].astype(float)
+    df['vCPUs'] = df['vCPUs'].astype(float)
+    df['MemoryGiB'] = df['MemoryGiB'].astype(float)
+    df['HostingType'] = df['HostingType'].astype(int)
+    return df

--- a/sky/catalog/vast/live_overlay.py
+++ b/sky/catalog/vast/live_overlay.py
@@ -127,6 +127,25 @@ def _search_offers_safely() -> Optional[List[Dict[str, Any]]]:
 # ---------------------------------------------------------------------------
 # Disk cache I/O.
 # ---------------------------------------------------------------------------
+def _write_meta_atomically(meta: Dict[str, Any]) -> None:
+    _ensure_cache_dir()
+    with tempfile.NamedTemporaryFile(mode='w',
+                                     dir=_CACHE_DIR,
+                                     delete=False,
+                                     encoding='utf-8') as tmp:
+        json.dump(meta, tmp)
+        tmp_path = tmp.name
+    os.rename(tmp_path, _META_PATH)
+
+
+def _read_meta() -> Optional[Dict[str, Any]]:
+    try:
+        with open(_META_PATH, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
 def _write_cache_atomically(df: 'pd.DataFrame', offer_count: int) -> None:
     _ensure_cache_dir()
     with tempfile.NamedTemporaryFile(mode='w',
@@ -137,14 +156,12 @@ def _write_cache_atomically(df: 'pd.DataFrame', offer_count: int) -> None:
         df.to_csv(tmp, index=False)
         tmp_path = tmp.name
     os.rename(tmp_path, _CACHE_PATH)
-    meta = {
+    _write_meta_atomically({
         'ts': time.time(),
         'status': 'ok',
         'offer_count': offer_count,
         'row_count': int(df.shape[0]),
-    }
-    with open(_META_PATH, 'w', encoding='utf-8') as f:
-        json.dump(meta, f)
+    })
 
 
 def _read_cached_df() -> Optional['pd.DataFrame']:
@@ -177,14 +194,22 @@ def _refresh_locked() -> None:
     if age is not None and age < _TTL_SEC:
         # Another process won the race.
         return
+    # Back off if a recent fetch failed — otherwise a Vast outage causes
+    # every catalog read to re-fire the SDK once the inflight watchdog
+    # window elapses.
+    meta = _read_meta()
+    if (meta is not None and meta.get('status') == 'fetch_failed' and
+            time.time() - meta.get('ts', 0) < _TTL_SEC):
+        return
     offers = _search_offers_safely()
     if offers is None:
-        # Touch the meta file so we don't hammer the SDK after a transient
-        # failure; the existing CSV is left untouched.
-        _ensure_cache_dir()
+        # Mark the failure so subsequent refreshes back off; the existing
+        # CSV is left untouched.
         try:
-            with open(_META_PATH, 'w', encoding='utf-8') as f:
-                json.dump({'ts': time.time(), 'status': 'fetch_failed'}, f)
+            _write_meta_atomically({
+                'ts': time.time(),
+                'status': 'fetch_failed',
+            })
         except OSError:
             pass
         return
@@ -314,11 +339,14 @@ def merge_with_base(base_df: 'pd.DataFrame',
 
     # both: take min over real (>0) prices.
     if both.any():
-        # vectorize via apply for clarity; size is small.
-        merged.loc[both, 'Price'] = merged.loc[both].apply(
-            lambda r: _min_or_other(r['Price'], r['_live_price']), axis=1)
-        merged.loc[both, 'SpotPrice'] = merged.loc[both].apply(
-            lambda r: _min_or_other(r['SpotPrice'], r['_live_spot']), axis=1)
+        for col, live_col in (('Price', '_live_price'), ('SpotPrice',
+                                                         '_live_spot')):
+            p_csv = pd.to_numeric(merged.loc[both, col],
+                                  errors='coerce').replace(0, float('nan'))
+            p_live = pd.to_numeric(merged.loc[both, live_col],
+                                   errors='coerce').replace(0, float('nan'))
+            merged.loc[both, col] = pd.concat([p_csv, p_live],
+                                              axis=1).min(axis=1).fillna(0.0)
 
     # csv-only: nothing to do; CSV columns are already present.
     del csv_only  # kept for readability

--- a/sky/catalog/vast/live_overlay.py
+++ b/sky/catalog/vast/live_overlay.py
@@ -28,6 +28,7 @@ import filelock
 from sky import sky_logging
 from sky.adaptors import common as adaptors_common
 from sky.catalog.vast import _offer_processing as proc
+from sky.utils import annotations
 
 if typing.TYPE_CHECKING:
     import pandas as pd
@@ -36,12 +37,29 @@ else:
 
 logger = sky_logging.init_logger(__name__)
 
+
 # ---------------------------------------------------------------------------
 # Tunables (env vars, read at import time).
 # ---------------------------------------------------------------------------
-_TTL_SEC = int(os.environ.get('SKYPILOT_VAST_LIVE_TTL_SEC', '600'))
-_FETCH_TIMEOUT_SEC = int(
-    os.environ.get('SKYPILOT_VAST_LIVE_FETCH_TIMEOUT_SEC', '8'))
+def _env_int(name: str, default: int) -> int:
+    """Parse an int env var; on bad input, log and fall back to the default.
+
+    The overlay is fail-open; a malformed env var must not break catalog
+    loading.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(f'vast live overlay: ignoring invalid {name}={raw!r}; '
+                       f'using default {default}.')
+        return default
+
+
+_TTL_SEC = _env_int('SKYPILOT_VAST_LIVE_TTL_SEC', 600)
+_FETCH_TIMEOUT_SEC = _env_int('SKYPILOT_VAST_LIVE_FETCH_TIMEOUT_SEC', 8)
 _DISABLED_BY_ENV = os.environ.get('SKYPILOT_VAST_DISABLE_LIVE_OVERLAY',
                                   '0') == '1'
 
@@ -197,9 +215,7 @@ def _refresh_locked() -> None:
     # Back off if a recent fetch failed — otherwise a Vast outage causes
     # every catalog read to re-fire the SDK once the inflight watchdog
     # window elapses.
-    meta = _read_meta()
-    if (meta is not None and meta.get('status') == 'fetch_failed' and
-            time.time() - meta.get('ts', 0) < _TTL_SEC):
+    if _recent_fetch_failed():
         return
     offers = _search_offers_safely()
     if offers is None:
@@ -235,14 +251,29 @@ def _refresh_safely() -> None:
             _REFRESH_INFLIGHT = False
 
 
+def _recent_fetch_failed() -> bool:
+    """True if the last refresh wrote status=fetch_failed within the TTL.
+
+    Used to back off so a Vast outage doesn't cause every catalog read to
+    spawn a thread that immediately bails inside the file lock.
+    """
+    meta = _read_meta()
+    if meta is None or meta.get('status') != 'fetch_failed':
+        return False
+    return time.time() - meta.get('ts', 0) < _TTL_SEC
+
+
 def _maybe_spawn_refresh() -> None:
     """Spawn a single background refresh if none is in flight.
 
     Includes a watchdog so a hung SDK call doesn't permanently disable
-    refreshes for the life of the process.
+    refreshes for the life of the process. Backs off when the previous
+    fetch failed recently.
     """
     global _REFRESH_INFLIGHT, _REFRESH_SPAWN_TS
     if _TEST_REFRESH_DISABLED:
+        return
+    if _recent_fetch_failed():
         return
     with _REFRESH_LOCK:
         now = time.time()
@@ -277,30 +308,27 @@ def get_overlay_dataframe() -> Optional['pd.DataFrame']:
     return _read_cached_df()
 
 
-def _coerce_price(value: Any) -> float:
-    """Treat 0 and NaN as 'no price'; return a float for valid prices."""
-    if value is None:
-        return float('nan')
-    try:
-        v = float(value)
-    except (TypeError, ValueError):
-        return float('nan')
-    if v <= 0.0:
-        return float('nan')
-    return v
+def _dedupe_overlay(df: 'pd.DataFrame', keys: List[str]) -> 'pd.DataFrame':
+    """Collapse overlay rows sharing `keys`.
 
-
-def _min_or_other(a: Any, b: Any) -> float:
-    """Min of two prices, treating 0/NaN as missing on either side."""
-    fa = _coerce_price(a)
-    fb = _coerce_price(b)
-    if fa != fa and fb != fb:  # both NaN
-        return 0.0
-    if fa != fa:
-        return fb
-    if fb != fb:
-        return fa
-    return min(fa, fb)
+    Multiple Vast offers can normalize to the same (InstanceType, Region,
+    HostingType) tuple. Left untouched, the outer merge in `merge_with_base`
+    multiply-matches base rows and silently inflates the catalog. We take
+    the min real (>0) Price/SpotPrice and the first value for other columns.
+    """
+    if not df.duplicated(subset=keys).any():
+        return df
+    df = df.copy()
+    for col in ('Price', 'SpotPrice'):
+        df[col] = pd.to_numeric(df[col],
+                                errors='coerce').replace(0, float('nan'))
+    agg: Dict[str, str] = {c: 'first' for c in df.columns if c not in keys}
+    agg['Price'] = 'min'
+    agg['SpotPrice'] = 'min'
+    df = df.groupby(keys, as_index=False).agg(agg)
+    df['Price'] = df['Price'].fillna(0.0)
+    df['SpotPrice'] = df['SpotPrice'].fillna(0.0)
+    return df
 
 
 def merge_with_base(base_df: 'pd.DataFrame',
@@ -325,6 +353,7 @@ def merge_with_base(base_df: 'pd.DataFrame',
         return base_df
 
     keys = ['InstanceType', 'Region', 'HostingType']
+    overlay_df = _dedupe_overlay(overlay_df, keys)
     overlay_keep = overlay_df[keys + ['Price', 'SpotPrice']].copy()
     overlay_keep = overlay_keep.rename(columns={
         'Price': '_live_price',
@@ -425,6 +454,12 @@ class OverlayDataFrame:
     def __init__(self, base_lazy):
         self._base = base_lazy
 
+    # Snapshot the merged dataframe once per request. This makes patterns
+    # like `df[df['HostingType'] >= 1]` safe: the boolean mask produced by
+    # the first call is indexed against the same frame the second call
+    # operates on, even if the background refresh writes a new overlay
+    # between them.
+    @annotations.lru_cache(scope='request')
     def _df(self) -> 'pd.DataFrame':
         return get_merged_dataframe(self._base)
 

--- a/sky/catalog/vast/live_overlay.py
+++ b/sky/catalog/vast/live_overlay.py
@@ -1,0 +1,415 @@
+"""Vast live-price overlay for the SkyPilot catalog.
+
+The cached `vast/vms.csv` published by the SkyPilot catalog repo is the
+source of truth for vast inventory in the SDK; however it can be hours stale,
+which means users may not see the cheapest vast price/inventory at the time
+they query. This module fetches recent offers from Vast's `/bundles/`
+endpoint, normalizes them into the same shape as `vms.csv`, and merges them
+into the catalog dataframe at read time.
+
+Design notes:
+- Stale-while-revalidate disk cache. Reads never block on the network.
+- Fail-open: any error path returns the unmodified base catalog.
+- Schema-identical with `vms.csv` so all advanced filters (`datacenter_only`,
+  `max_hourly_cost`, region/cpu/memory filters) keep working unchanged.
+- SDK-version-agnostic: any `TypeError`/`AttributeError` from a future
+  `vastai_sdk` signature drift latches the overlay off for the process.
+"""
+import json
+import os
+import tempfile
+import threading
+import time
+import typing
+from typing import Any, Dict, List, Optional, Tuple
+
+import filelock
+
+from sky import sky_logging
+from sky.adaptors import common as adaptors_common
+from sky.catalog.vast import _offer_processing as proc
+
+if typing.TYPE_CHECKING:
+    import pandas as pd
+else:
+    pd = adaptors_common.LazyImport('pandas')
+
+logger = sky_logging.init_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Tunables (env vars, read at import time).
+# ---------------------------------------------------------------------------
+_TTL_SEC = int(os.environ.get('SKYPILOT_VAST_LIVE_TTL_SEC', '600'))
+_FETCH_TIMEOUT_SEC = int(
+    os.environ.get('SKYPILOT_VAST_LIVE_FETCH_TIMEOUT_SEC', '8'))
+_DISABLED_BY_ENV = os.environ.get('SKYPILOT_VAST_DISABLE_LIVE_OVERLAY',
+                                  '0') == '1'
+
+_CACHE_DIR = os.path.expanduser('~/.sky/cache/vast')
+_CACHE_PATH = os.path.join(_CACHE_DIR, 'live_offers.csv')
+_META_PATH = os.path.join(_CACHE_DIR, 'live_offers.meta')
+_LOCK_PATH = _META_PATH + '.lock'
+
+_QUERY = ('georegion = true chunked = true '
+          'inet_down >= 100 disk_space >= 80')
+
+# ---------------------------------------------------------------------------
+# Process-local state.
+# ---------------------------------------------------------------------------
+_REFRESH_LOCK = threading.Lock()
+_REFRESH_INFLIGHT = False
+_REFRESH_SPAWN_TS = 0.0
+_OVERLAY_DISABLED = False  # latched on hard SDK incompatibility
+_TEST_REFRESH_DISABLED = False  # set by unit-test fixture; never spawn threads
+
+# Single-entry memo: keyed on (base_mtime, overlay_mtime), replaced on change.
+_MEMO: Dict[Tuple[float, float], 'pd.DataFrame'] = {}
+
+
+def _ensure_cache_dir() -> None:
+    os.makedirs(_CACHE_DIR, exist_ok=True)
+
+
+def _is_overlay_active() -> bool:
+    return not (_DISABLED_BY_ENV or _OVERLAY_DISABLED)
+
+
+# ---------------------------------------------------------------------------
+# SDK call (defensive).
+# ---------------------------------------------------------------------------
+def _search_offers_safely() -> Optional[List[Dict[str, Any]]]:
+    """Call `vastai_sdk.search_offers` with a wall-clock cap. Never raises.
+
+    Returns None on any failure path (no SDK, signature drift, network
+    error, server error, non-list payload).
+    """
+    global _OVERLAY_DISABLED
+    try:
+        # pylint: disable=import-outside-toplevel
+        from sky.adaptors import vast as vast_adaptor
+        sdk = vast_adaptor.vast()
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'vast live overlay: SDK unavailable: {e}')
+        return None
+
+    result_box: List[Any] = [None]
+    err_box: List[Optional[BaseException]] = [None]
+
+    def _do_call() -> None:
+        try:
+            result_box[0] = sdk.search_offers(query=_QUERY, limit=10000)
+        except BaseException as exc:  # pylint: disable=broad-except
+            err_box[0] = exc
+
+    worker = threading.Thread(target=_do_call, daemon=True)
+    worker.start()
+    worker.join(_FETCH_TIMEOUT_SEC)
+    if worker.is_alive():
+        logger.debug('vast live overlay: search_offers timed out')
+        return None
+
+    err = err_box[0]
+    if isinstance(err, (TypeError, AttributeError)):
+        _OVERLAY_DISABLED = True
+        logger.warning(f'vast live overlay disabled: SDK incompatible: {err}')
+        return None
+    if err is not None:
+        logger.debug(f'vast live overlay: search_offers failed: {err}')
+        return None
+
+    result = result_box[0]
+    if not isinstance(result, list):
+        # The SDK returns int on some error paths (see provision/vast/utils.py).
+        return None
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Disk cache I/O.
+# ---------------------------------------------------------------------------
+def _write_cache_atomically(df: 'pd.DataFrame', offer_count: int) -> None:
+    _ensure_cache_dir()
+    with tempfile.NamedTemporaryFile(mode='w',
+                                     dir=_CACHE_DIR,
+                                     delete=False,
+                                     newline='',
+                                     encoding='utf-8') as tmp:
+        df.to_csv(tmp, index=False)
+        tmp_path = tmp.name
+    os.rename(tmp_path, _CACHE_PATH)
+    meta = {
+        'ts': time.time(),
+        'status': 'ok',
+        'offer_count': offer_count,
+        'row_count': int(df.shape[0]),
+    }
+    with open(_META_PATH, 'w', encoding='utf-8') as f:
+        json.dump(meta, f)
+
+
+def _read_cached_df() -> Optional['pd.DataFrame']:
+    if not os.path.exists(_CACHE_PATH):
+        return None
+    try:
+        df = pd.read_csv(_CACHE_PATH)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'vast live overlay: cache read failed: {e}')
+        return None
+    if df.empty:
+        return None
+    return df
+
+
+def _cache_age_sec() -> Optional[float]:
+    try:
+        mtime = os.path.getmtime(_CACHE_PATH)
+    except OSError:
+        return None
+    return time.time() - mtime
+
+
+# ---------------------------------------------------------------------------
+# Background refresh.
+# ---------------------------------------------------------------------------
+def _refresh_locked() -> None:
+    """Write a fresh overlay CSV. Caller holds the cross-process file lock."""
+    age = _cache_age_sec()
+    if age is not None and age < _TTL_SEC:
+        # Another process won the race.
+        return
+    offers = _search_offers_safely()
+    if offers is None:
+        # Touch the meta file so we don't hammer the SDK after a transient
+        # failure; the existing CSV is left untouched.
+        _ensure_cache_dir()
+        try:
+            with open(_META_PATH, 'w', encoding='utf-8') as f:
+                json.dump({'ts': time.time(), 'status': 'fetch_failed'}, f)
+        except OSError:
+            pass
+        return
+    df = proc.offers_to_dataframe(offers)
+    if df.empty:
+        return
+    _write_cache_atomically(df, offer_count=len(offers))
+
+
+def _refresh_safely() -> None:
+    global _REFRESH_INFLIGHT
+    try:
+        _ensure_cache_dir()
+        with filelock.FileLock(_LOCK_PATH, timeout=0.1):
+            _refresh_locked()
+    except filelock.Timeout:
+        # Another process is refreshing; that's fine.
+        pass
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'vast live overlay: refresh raised: {e}')
+    finally:
+        with _REFRESH_LOCK:
+            _REFRESH_INFLIGHT = False
+
+
+def _maybe_spawn_refresh() -> None:
+    """Spawn a single background refresh if none is in flight.
+
+    Includes a watchdog so a hung SDK call doesn't permanently disable
+    refreshes for the life of the process.
+    """
+    global _REFRESH_INFLIGHT, _REFRESH_SPAWN_TS
+    if _TEST_REFRESH_DISABLED:
+        return
+    with _REFRESH_LOCK:
+        now = time.time()
+        if _REFRESH_INFLIGHT:
+            if now - _REFRESH_SPAWN_TS < 2 * _FETCH_TIMEOUT_SEC:
+                return
+            # Watchdog: assume the prior thread is wedged; allow respawn.
+            logger.debug('vast live overlay: refresh watchdog tripped')
+        _REFRESH_INFLIGHT = True
+        _REFRESH_SPAWN_TS = now
+    threading.Thread(target=_refresh_safely, daemon=True).start()
+
+
+# ---------------------------------------------------------------------------
+# Public surface.
+# ---------------------------------------------------------------------------
+def get_overlay_dataframe() -> Optional['pd.DataFrame']:
+    """Return the latest disk-cached overlay df, or None.
+
+    Spawns a background refresh when the cache is stale or missing. Never
+    raises.
+    """
+    if not _is_overlay_active():
+        return None
+    age = _cache_age_sec()
+    if age is None:
+        # Cold start: skip overlay this call; warm the cache for next time.
+        _maybe_spawn_refresh()
+        return None
+    if age > _TTL_SEC:
+        _maybe_spawn_refresh()
+    return _read_cached_df()
+
+
+def _coerce_price(value: Any) -> float:
+    """Treat 0 and NaN as 'no price'; return a float for valid prices."""
+    if value is None:
+        return float('nan')
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return float('nan')
+    if v <= 0.0:
+        return float('nan')
+    return v
+
+
+def _min_or_other(a: Any, b: Any) -> float:
+    """Min of two prices, treating 0/NaN as missing on either side."""
+    fa = _coerce_price(a)
+    fb = _coerce_price(b)
+    if fa != fa and fb != fb:  # both NaN
+        return 0.0
+    if fa != fa:
+        return fb
+    if fb != fb:
+        return fa
+    return min(fa, fb)
+
+
+def merge_with_base(base_df: 'pd.DataFrame',
+                    overlay_df: Optional['pd.DataFrame']) -> 'pd.DataFrame':
+    """Min-price merge of overlay into base on (InstanceType, Region,
+    HostingType).
+
+    - both: Price = min over real (>0) values; SpotPrice same.
+    - csv-only: keep CSV row.
+    - live-only: append (so new GPU types surface immediately).
+
+    Pure function. Returns base_df unchanged on any schema mismatch.
+    """
+    if overlay_df is None or overlay_df.empty:
+        return base_df
+
+    csv_cols: List[str] = list(base_df.columns)
+    required = {'InstanceType', 'Region', 'HostingType', 'Price', 'SpotPrice'}
+    if not required.issubset(set(overlay_df.columns)):
+        return base_df
+    if not required.issubset(set(csv_cols)):
+        return base_df
+
+    keys = ['InstanceType', 'Region', 'HostingType']
+    overlay_keep = overlay_df[keys + ['Price', 'SpotPrice']].copy()
+    overlay_keep = overlay_keep.rename(columns={
+        'Price': '_live_price',
+        'SpotPrice': '_live_spot',
+    })
+
+    merged = base_df.merge(overlay_keep, on=keys, how='outer', indicator=True)
+
+    csv_only = merged['_merge'] == 'left_only'
+    both = merged['_merge'] == 'both'
+    live_only_mask = merged['_merge'] == 'right_only'
+
+    # both: take min over real (>0) prices.
+    if both.any():
+        # vectorize via apply for clarity; size is small.
+        merged.loc[both, 'Price'] = merged.loc[both].apply(
+            lambda r: _min_or_other(r['Price'], r['_live_price']), axis=1)
+        merged.loc[both, 'SpotPrice'] = merged.loc[both].apply(
+            lambda r: _min_or_other(r['SpotPrice'], r['_live_spot']), axis=1)
+
+    # csv-only: nothing to do; CSV columns are already present.
+    del csv_only  # kept for readability
+
+    # live-only: pull full rows from overlay_df. Columns absent from overlay
+    # (e.g. AvailabilityZone) are filled with NaN in the concat.
+    if live_only_mask.any():
+        live_only_keys = merged.loc[live_only_mask, keys]
+        live_rows = overlay_df.merge(live_only_keys, on=keys, how='inner')
+        # Align columns to base_df's order; missing columns default to NaN.
+        for col in csv_cols:
+            if col not in live_rows.columns:
+                live_rows[col] = float('nan')
+        live_rows = live_rows[csv_cols]
+    else:
+        live_rows = None
+
+    keep_mask = merged['_merge'] != 'right_only'
+    base_keep = merged.loc[keep_mask, csv_cols]
+
+    if live_rows is None or live_rows.empty:
+        return base_keep.reset_index(drop=True)
+    return pd.concat([base_keep, live_rows],
+                     ignore_index=True).reset_index(drop=True)
+
+
+def get_merged_dataframe(base_lazy) -> 'pd.DataFrame':
+    """Return a (cached) merge of the base catalog with the live overlay.
+
+    `base_lazy` is a `sky.catalog.common.LazyDataFrame`. We delegate the
+    base load through its public `get_dataframe()` so its own staleness
+    handling stays intact.
+    """
+    base_df = base_lazy.get_dataframe()
+    if not _is_overlay_active():
+        return base_df
+
+    overlay_df = get_overlay_dataframe()
+    base_path = base_lazy.filename
+    try:
+        base_mtime = os.path.getmtime(base_path)
+    except OSError:
+        base_mtime = 0.0
+    try:
+        overlay_mtime = os.path.getmtime(_CACHE_PATH)
+    except OSError:
+        overlay_mtime = 0.0
+
+    key = (base_mtime, overlay_mtime)
+    cached = _MEMO.get(key)
+    if cached is not None:
+        return cached
+
+    try:
+        merged = merge_with_base(base_df, overlay_df)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'vast live overlay: merge failed: {e}')
+        return base_df
+    # Single-entry memo: replaced whenever either mtime changes.
+    _MEMO.clear()
+    _MEMO[key] = merged
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# DataFrame wrapper used by vast_catalog.py.
+# ---------------------------------------------------------------------------
+class OverlayDataFrame:
+    """Drop-in replacement for `LazyDataFrame` that splices live prices.
+
+    Exposes the same `__getattr__` / `__getitem__` / `__setitem__` surface
+    that callers in `sky/catalog/common.py` use, so this is invisible to
+    every consumer of `vast_catalog._df`.
+    """
+
+    def __init__(self, base_lazy):
+        self._base = base_lazy
+
+    def _df(self) -> 'pd.DataFrame':
+        return get_merged_dataframe(self._base)
+
+    def __getattr__(self, name: str):
+        # Avoid infinite recursion on internal attrs during init.
+        if name.startswith('_'):
+            raise AttributeError(name)
+        return getattr(self._df(), name)
+
+    def __getitem__(self, key):
+        return self._df()[key]
+
+    def __setitem__(self, key, value):
+        # The catalog read path does `df = df.copy()` before mutating, so
+        # this mostly exists for API parity with LazyDataFrame.
+        self._df()[key] = value

--- a/sky/catalog/vast_catalog.py
+++ b/sky/catalog/vast_catalog.py
@@ -10,13 +10,19 @@ from typing import Dict, List, Optional, Tuple, Union
 import pandas as pd
 
 from sky.catalog import common
+from sky.catalog.vast import live_overlay as _live_overlay
 from sky.utils import resources_utils
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
     from sky.clouds import cloud
 
-_df = common.read_catalog('vast/vms.csv')
+_base_df = common.read_catalog('vast/vms.csv')
+# OverlayDataFrame transparently splices fresh prices from Vast's bundle
+# endpoint into the cached CSV catalog at read time. It is fail-open: any
+# failure path returns the unmodified base catalog, so disabling network or
+# uninstalling vastai_sdk leaves behavior identical to the CSV-only path.
+_df = _live_overlay.OverlayDataFrame(_base_df)
 
 
 def _apply_datacenter_filter(df: pd.DataFrame,

--- a/tests/unit_tests/test_vast_live_overlay.py
+++ b/tests/unit_tests/test_vast_live_overlay.py
@@ -1,0 +1,376 @@
+"""Unit tests for the Vast live-price overlay."""
+# pylint: disable=protected-access
+import math
+from unittest import mock
+
+import pandas as pd
+import pytest
+
+from sky.catalog.vast import _offer_processing as proc
+from sky.catalog.vast import live_overlay
+
+
+@pytest.fixture(autouse=True)
+def _disable_background_refresh(monkeypatch):
+    """Never spawn refresh threads from unit tests."""
+    monkeypatch.setattr(live_overlay, '_TEST_REFRESH_DISABLED', True)
+    # Reset latched state between tests.
+    monkeypatch.setattr(live_overlay, '_OVERLAY_DISABLED', False)
+    monkeypatch.setattr(live_overlay, '_DISABLED_BY_ENV', False)
+    live_overlay._MEMO.clear()
+    yield
+    live_overlay._MEMO.clear()
+
+
+# ---------------------------------------------------------------------------
+# _offer_processing
+# ---------------------------------------------------------------------------
+def _fake_offer(num_gpus=1,
+                gpu_name='RTX 5090',
+                cpu_cores=32,
+                cpu_ram=65536,
+                price=0.50,
+                spot=0.10,
+                region='Spain, ES, EU',
+                hosting_type=0,
+                gpu_total_ram=32607):
+    return {
+        'num_gpus': num_gpus,
+        'gpu_name': gpu_name,
+        'cpu_cores': cpu_cores,
+        'cpu_ram': cpu_ram,
+        'gpu_total_ram': gpu_total_ram,
+        'search': {
+            'totalHour': price
+        },
+        'min_bid': spot,
+        'geolocation': region,
+        'hosting_type': hosting_type,
+    }
+
+
+def test_make_instance_type_matches_legacy_format():
+    # The legacy format from fetch_vast.create_instance_type was:
+    #   '{num_gpus}x-{stubify(gpu_name)}-{cpu_cores}-{cpu_ram}'
+    assert proc.make_instance_type(2, 'A100 SXM4', 64, 524288) == \
+        '2x-A100_SXM4-64-524288'
+
+
+def test_normalize_gpu_name_known_renames():
+    assert proc.normalize_gpu_name('TeslaV100') == 'V100'
+    assert proc.normalize_gpu_name('TeslaT4') == 'T4'
+    # Drops trailing PCIE/SXM/Ti/NVL.
+    assert proc.normalize_gpu_name('A100 SXM4') == 'A100'
+    # 'Ada' gets a hyphen prefix.
+    assert proc.normalize_gpu_name('RTX 6000Ada') == 'RTX6000-Ada'
+
+
+def test_offers_to_dataframe_typed_columns():
+    # The median-price + 'seen' dedup pipeline (mirrors fetch_vast.py)
+    # emits one row per unique (InstanceType, country, hosting_type) tuple
+    # only when at least two offers tie at the median price. Provide two
+    # at identical prices to land in the bucket.
+    offers = [_fake_offer(price=0.50), _fake_offer(price=0.50)]
+    df = proc.offers_to_dataframe(offers)
+    assert df.shape[0] == 1
+    assert 'InstanceType' in df.columns
+    assert df['Price'].dtype.kind == 'f'
+    assert df['SpotPrice'].dtype.kind == 'f'
+    assert df['HostingType'].iloc[0] == 0
+    # GpuInfo is single-quoted so list_accelerators_impl can ast.literal_eval.
+    assert df['GpuInfo'].iloc[0].startswith('{\'Gpus\':')
+
+
+def test_offers_to_dataframe_drops_malformed_offers():
+    bad = {'gpu_name': 'X'}  # missing num_gpus etc.
+    good_a = _fake_offer(price=0.50)
+    good_b = _fake_offer(price=0.50)
+    df = proc.offers_to_dataframe([bad, good_a, good_b])
+    assert df.shape[0] == 1
+    assert df['AcceleratorName'].iloc[0] == 'RTX5090'
+
+
+# ---------------------------------------------------------------------------
+# merge_with_base
+# ---------------------------------------------------------------------------
+def _csv_row(it='1x-H100-32-65536',
+             region='Spain, ES, EU',
+             hosting_type=0,
+             price=2.50,
+             spot=0.00,
+             accel='H100',
+             accel_count=1,
+             vcpus=32,
+             memory=64.0,
+             gpu_info=('{\'Gpus\': [{\'Name\': \'H100\', \'Count\': 1, '
+                       '\'MemoryInfo\': {\'SizeInMiB\': 81920}}]}')):
+    return {
+        'InstanceType': it,
+        'AcceleratorName': accel,
+        'AcceleratorCount': accel_count,
+        'vCPUs': vcpus,
+        'MemoryGiB': memory,
+        'GpuInfo': gpu_info,
+        'Price': price,
+        'SpotPrice': spot,
+        'Region': region,
+        'HostingType': hosting_type,
+    }
+
+
+_KW_TO_COL = {
+    'it': 'InstanceType',
+    'region': 'Region',
+    'hosting_type': 'HostingType',
+    'price': 'Price',
+    'spot': 'SpotPrice',
+    'accel': 'AcceleratorName',
+    'accel_count': 'AcceleratorCount',
+    'vcpus': 'vCPUs',
+    'memory': 'MemoryGiB',
+    'gpu_info': 'GpuInfo',
+}
+
+
+def _live_row(**overrides):
+    base = _csv_row()
+    for k, v in overrides.items():
+        base[_KW_TO_COL.get(k, k)] = v
+    return base
+
+
+def test_merge_both_sides_takes_min_price():
+    base = pd.DataFrame([_csv_row(price=2.50)])
+    overlay = pd.DataFrame([_live_row(price=1.99)])
+    out = live_overlay.merge_with_base(base, overlay)
+    assert out.shape[0] == 1
+    assert math.isclose(out.iloc[0]['Price'], 1.99)
+
+
+def test_merge_treats_zero_spot_as_missing():
+    base = pd.DataFrame([_csv_row(price=2.50, spot=0.00)])
+    overlay = pd.DataFrame([_live_row(price=2.50, spot=0.30)])
+    out = live_overlay.merge_with_base(base, overlay)
+    # 0 from CSV must be ignored; live's 0.30 wins.
+    assert math.isclose(out.iloc[0]['SpotPrice'], 0.30)
+
+
+def test_merge_appends_live_only_rows():
+    base = pd.DataFrame([_csv_row(it='1x-H100-32-65536')])
+    overlay = pd.DataFrame(
+        [_live_row(it='2x-RTX5090-64-131072', accel='RTX5090', accel_count=2)])
+    out = live_overlay.merge_with_base(base, overlay)
+    assert set(
+        out['InstanceType']) == {'1x-H100-32-65536', '2x-RTX5090-64-131072'}
+
+
+def test_merge_keeps_csv_only_rows():
+    base = pd.DataFrame([
+        _csv_row(it='1x-H100-32-65536'),
+        _csv_row(it='1x-T4-32-65536', accel='T4'),
+    ])
+    overlay = pd.DataFrame([_live_row(it='1x-H100-32-65536', price=1.50)])
+    out = live_overlay.merge_with_base(base, overlay)
+    types = sorted(out['InstanceType'].tolist())
+    assert types == ['1x-H100-32-65536', '1x-T4-32-65536']
+
+
+def test_merge_returns_base_when_overlay_missing_columns():
+    base = pd.DataFrame([_csv_row()])
+    overlay = pd.DataFrame([{'InstanceType': 'X'}])  # missing keys
+    out = live_overlay.merge_with_base(base, overlay)
+    pd.testing.assert_frame_equal(out, base)
+
+
+def test_merge_returns_base_when_overlay_none_or_empty():
+    base = pd.DataFrame([_csv_row()])
+    pd.testing.assert_frame_equal(live_overlay.merge_with_base(base, None),
+                                  base)
+    pd.testing.assert_frame_equal(
+        live_overlay.merge_with_base(base, pd.DataFrame()), base)
+
+
+# ---------------------------------------------------------------------------
+# _search_offers_safely
+# ---------------------------------------------------------------------------
+def test_search_offers_safely_handles_int_payload(monkeypatch):
+    fake_sdk = mock.Mock()
+    fake_sdk.search_offers.return_value = 1  # SDK error sentinel
+    monkeypatch.setattr('sky.adaptors.vast.vast', lambda: fake_sdk)
+    assert live_overlay._search_offers_safely() is None
+
+
+def test_search_offers_safely_latches_disabled_on_signature_drift(monkeypatch):
+    fake_sdk = mock.Mock()
+    fake_sdk.search_offers.side_effect = TypeError('unexpected kwarg')
+    monkeypatch.setattr('sky.adaptors.vast.vast', lambda: fake_sdk)
+    assert live_overlay._search_offers_safely() is None
+    assert live_overlay._OVERLAY_DISABLED is True
+
+
+def test_search_offers_safely_swallows_runtime_errors(monkeypatch):
+    fake_sdk = mock.Mock()
+    fake_sdk.search_offers.side_effect = RuntimeError('timeout')
+    monkeypatch.setattr('sky.adaptors.vast.vast', lambda: fake_sdk)
+    assert live_overlay._search_offers_safely() is None
+    # RuntimeError must NOT latch the overlay off.
+    assert live_overlay._OVERLAY_DISABLED is False
+
+
+def test_search_offers_safely_handles_missing_sdk(monkeypatch):
+
+    def _raise():
+        raise ImportError('no vastai_sdk')
+
+    monkeypatch.setattr('sky.adaptors.vast.vast', _raise)
+    assert live_overlay._search_offers_safely() is None
+
+
+# ---------------------------------------------------------------------------
+# OverlayDataFrame end-to-end
+# ---------------------------------------------------------------------------
+def test_overlay_dataframe_returns_base_when_overlay_disabled(monkeypatch):
+    base_df = pd.DataFrame([_csv_row(price=2.50)])
+    fake_lazy = mock.Mock()
+    fake_lazy.get_dataframe.return_value = base_df
+    fake_lazy.filename = '/tmp/does-not-exist.csv'
+
+    monkeypatch.setattr(live_overlay, '_DISABLED_BY_ENV', True)
+    odf = live_overlay.OverlayDataFrame(fake_lazy)
+    pd.testing.assert_frame_equal(odf._df(), base_df)
+
+
+def test_overlay_dataframe_splices_live_prices(monkeypatch):
+    base_df = pd.DataFrame([_csv_row(price=2.50)])
+    overlay_df = pd.DataFrame([_live_row(price=1.20)])
+
+    fake_lazy = mock.Mock()
+    fake_lazy.get_dataframe.return_value = base_df
+    fake_lazy.filename = '/tmp/does-not-exist.csv'
+
+    monkeypatch.setattr(live_overlay, 'get_overlay_dataframe',
+                        lambda: overlay_df)
+
+    odf = live_overlay.OverlayDataFrame(fake_lazy)
+    out = odf._df()
+    assert math.isclose(out.iloc[0]['Price'], 1.20)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: a populated overlay cache must surface through vast_catalog.
+# ---------------------------------------------------------------------------
+def test_end_to_end_overlay_surfaces_lower_price_and_new_inventory(
+        monkeypatch, tmp_path):
+    # pylint: disable=import-outside-toplevel
+    from sky.catalog import vast_catalog
+
+    # Build a base df with one known instance type and one HostingType=1 row.
+    base = pd.DataFrame([
+        _csv_row(it='1x-RTX_5090-32-65536',
+                 accel='RTX5090',
+                 region='Spain, ES, EU',
+                 hosting_type=0,
+                 price=2.50,
+                 spot=0.00),
+        _csv_row(it='1x-A100-32-65536',
+                 accel='A100',
+                 region='Virginia, US, NA',
+                 hosting_type=1,
+                 price=3.00,
+                 spot=0.00),
+    ])
+
+    # Live overlay: cheaper price for the existing row + a brand-new IT.
+    overlay = pd.DataFrame([
+        _live_row(it='1x-RTX_5090-32-65536',
+                  accel='RTX5090',
+                  region='Spain, ES, EU',
+                  hosting_type=0,
+                  price=1.20,
+                  spot=0.00),
+        _live_row(it='99x-FAKEGPU-32-65536',
+                  accel='FAKEGPU',
+                  accel_count=99,
+                  region='Mars, MR, ZZ',
+                  hosting_type=1,
+                  price=42.00,
+                  spot=0.00),
+    ])
+
+    # Wire both into the live overlay machinery without touching disk.
+    fake_lazy = mock.Mock()
+    fake_lazy.get_dataframe.return_value = base
+    fake_lazy.filename = str(tmp_path / 'fake_base.csv')
+    (tmp_path / 'fake_base.csv').write_text('placeholder')
+
+    monkeypatch.setattr(live_overlay, 'get_overlay_dataframe', lambda: overlay)
+    monkeypatch.setattr(vast_catalog, '_df',
+                        live_overlay.OverlayDataFrame(fake_lazy))
+    live_overlay._MEMO.clear()
+
+    # 1. Cheaper live price wins through get_hourly_cost.
+    price = vast_catalog.get_hourly_cost('1x-RTX_5090-32-65536', use_spot=False)
+    assert math.isclose(price, 1.20)
+
+    # 2. Live-only inventory is reachable via get_instance_type_for_accelerator.
+    inst, _ = vast_catalog.get_instance_type_for_accelerator('FAKEGPU', 99)
+    assert inst == ['99x-FAKEGPU-32-65536']
+
+    # 3. Boolean indexing through OverlayDataFrame for the datacenter filter.
+    dc_only = vast_catalog._apply_datacenter_filter(vast_catalog._df,
+                                                    datacenter_only=True)
+    instance_types = sorted(set(dc_only['InstanceType'].tolist()))
+    assert '1x-A100-32-65536' in instance_types
+    assert '99x-FAKEGPU-32-65536' in instance_types
+    # The HostingType=0 row must be filtered out.
+    assert '1x-RTX_5090-32-65536' not in instance_types
+
+
+# ---------------------------------------------------------------------------
+# Legacy-equivalence: the refactored row builder must produce a row that
+# matches what the historical fetch_vast logic produced for the same offer.
+# This locks down the (InstanceType, Region, HostingType) merge key.
+# ---------------------------------------------------------------------------
+def test_build_csv_rows_legacy_equivalence():
+    # Two duplicate offers at the same price guarantee one emitted row,
+    # mirroring how the live catalog has many machines per (IT, country,
+    # hosting) tuple.
+    offers = [
+        _fake_offer(num_gpus=1,
+                    gpu_name='RTX 5090',
+                    cpu_cores=32,
+                    cpu_ram=65536,
+                    price=0.47,
+                    spot=0.00,
+                    region='Spain, ES, EU',
+                    hosting_type=0,
+                    gpu_total_ram=32607),
+        _fake_offer(num_gpus=1,
+                    gpu_name='RTX 5090',
+                    cpu_cores=32,
+                    cpu_ram=65536,
+                    price=0.47,
+                    spot=0.00,
+                    region='Spain, ES, EU',
+                    hosting_type=0,
+                    gpu_total_ram=32607),
+    ]
+    rows = proc.build_csv_rows(offers)
+    assert len(rows) == 1
+    row = rows[0]
+    # Merge-key columns (these are what live_overlay.merge_with_base joins on)
+    assert row['InstanceType'] == '1x-RTX_5090-32-65536'
+    assert row['Region'] == 'Spain, ES, EU'
+    assert row['HostingType'] == 0
+    # Other catalog columns expected by downstream readers.
+    assert row['AcceleratorName'] == 'RTX5090'
+    assert row['AcceleratorCount'] == 1
+    assert row['vCPUs'] == 32
+    # cpu_ram in MiB -> GiB
+    assert row['MemoryGiB'] == 64.0
+    # Single-quoted dict so list_accelerators_impl can ast.literal_eval it.
+    assert row['GpuInfo'].startswith('{\'Gpus\':')
+    assert '\'Name\': \'RTX5090\'' in row['GpuInfo']
+    # Median price formatted as 2-decimal string (CSV format).
+    assert row['Price'] == '0.47'
+    assert row['SpotPrice'] == '0.00'

--- a/tests/unit_tests/test_vast_live_overlay.py
+++ b/tests/unit_tests/test_vast_live_overlay.py
@@ -190,6 +190,50 @@ def test_merge_returns_base_when_overlay_none_or_empty():
         live_overlay.merge_with_base(base, pd.DataFrame()), base)
 
 
+def test_env_int_falls_back_on_garbage(monkeypatch):
+    monkeypatch.setenv('SKYPILOT_VAST_LIVE_TTL_SEC', 'not-an-int')
+    assert live_overlay._env_int('SKYPILOT_VAST_LIVE_TTL_SEC', 600) == 600
+
+
+def test_env_int_uses_default_when_unset(monkeypatch):
+    monkeypatch.delenv('SKYPILOT_VAST_LIVE_TTL_SEC', raising=False)
+    assert live_overlay._env_int('SKYPILOT_VAST_LIVE_TTL_SEC', 600) == 600
+
+
+def test_maybe_spawn_refresh_skips_during_recent_failure(monkeypatch):
+    monkeypatch.setattr(live_overlay, '_TEST_REFRESH_DISABLED', False)
+    monkeypatch.setattr(
+        live_overlay, '_read_meta', lambda: {
+            'status': 'fetch_failed',
+            'ts': live_overlay.time.time(),
+        })
+    spawned: list = []
+
+    class _FakeThread:
+
+        def __init__(self, *args, **kwargs):
+            spawned.append((args, kwargs))
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(live_overlay.threading, 'Thread', _FakeThread)
+    live_overlay._maybe_spawn_refresh()
+    assert not spawned
+
+
+def test_merge_dedupes_overlay_and_takes_min_price():
+    base = pd.DataFrame([_csv_row(price=2.50, spot=0.40)])
+    overlay = pd.DataFrame([
+        _live_row(price=1.99, spot=0.00),
+        _live_row(price=1.50, spot=0.30),
+    ])
+    out = live_overlay.merge_with_base(base, overlay)
+    assert out.shape[0] == 1
+    assert math.isclose(out.iloc[0]['Price'], 1.50)
+    assert math.isclose(out.iloc[0]['SpotPrice'], 0.30)
+
+
 # ---------------------------------------------------------------------------
 # _search_offers_safely
 # ---------------------------------------------------------------------------
@@ -254,6 +298,51 @@ def test_overlay_dataframe_splices_live_prices(monkeypatch):
     odf = live_overlay.OverlayDataFrame(fake_lazy)
     out = odf._df()
     assert math.isclose(out.iloc[0]['Price'], 1.20)
+
+
+def test_overlay_dataframe_caches_snapshot_per_request(monkeypatch):
+    # The @lru_cache(scope='request') on _df() must bind on self so that
+    # repeated calls within a request reuse the same DataFrame object.
+    # Two odf._df() invocations are `is`-identical, and the underlying
+    # merge runs only once.
+    live_overlay.OverlayDataFrame._df.cache_clear()
+    call_count = {'n': 0}
+
+    def _fake_merged(_):
+        call_count['n'] += 1
+        return pd.DataFrame([_csv_row(price=2.50)])
+
+    monkeypatch.setattr(live_overlay, 'get_merged_dataframe', _fake_merged)
+    odf = live_overlay.OverlayDataFrame(mock.Mock())
+    first = odf._df()
+    second = odf._df()
+    assert first is second
+    assert call_count['n'] == 1
+    live_overlay.OverlayDataFrame._df.cache_clear()
+
+
+def test_overlay_dataframe_boolean_mask_survives_overlay_refresh(monkeypatch):
+    live_overlay.OverlayDataFrame._df.cache_clear()
+    frame_a = pd.DataFrame(
+        [_csv_row(hosting_type=0),
+         _csv_row(hosting_type=1)],
+        index=[10, 11],
+    )
+    frame_b = pd.DataFrame(
+        [_csv_row(hosting_type=1)],
+        index=[200],
+    )
+    frames = iter([frame_a, frame_b])
+
+    monkeypatch.setattr(live_overlay, 'get_merged_dataframe',
+                        lambda _: next(frames))
+    odf = live_overlay.OverlayDataFrame(mock.Mock())
+
+    mask = odf['HostingType'] >= 1
+    filtered = odf[mask]  # would raise without the request-scoped cache.
+    assert filtered.shape[0] == 1
+    assert filtered.iloc[0]['HostingType'] == 1
+    live_overlay.OverlayDataFrame._df.cache_clear()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
[Vast] Add live price overlay for the Vast catalog

## Summary                                                                    
  - New `sky/catalog/vast/live_overlay.py` adds a stale-while-revalidate overlay
   on top of the cached `vast/vms.csv`. The base catalog is published on a      
  schedule and can lag Vast's live bundle prices by hours since price can sometimes change. the overlay closes
  that gap without blocking the read path.                                      

                                                                                
  ## Test plan                                                    
  - `pytest tests/unit_tests/test_vast_live_overlay.py` — 18/18 pass (covers
  offer normalization, cache I/O, TTL refresh, merge semantics, SDK-error       
  latching, and the catalog wrapper).
  - Manual catalog smoke against the live Vast API:                             
    - `sky gpus list --infra vast --all` exposes overlay-only GPUs the cached
  CSV doesn't have: RTX 5060 Ti 1x/2x/4x ($0.17/$0.24/$0.39), A100_PCIE 2x      
  ($1.31), RTX 6000 Ada 2x.
    - Overlay wins on price for existing SKUs the catalog already had: V100 2x  
  $0.36 → $0.28, RTX PRO 6000 S 1x $1.33 → $1.14, 4x $5.33 → $4.54.             
    - Cold call returns base catalog and spawns refresh; cache file appears in 
  ~2s; subsequent calls return merged data.                                     
  - `sky check vast` — Vast remains enabled with the modified catalog path.
  - `bash format.sh` — black/yapf/isort/mypy clean, pylint 10.00/10.    
<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->