### PR TITLE
[Serve] Fix HA controller routing, atomic cleanup, and cross-pod log streaming

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -72,6 +72,12 @@ spec:
         resources:
           {{- toYaml .Values.apiService.resources | nindent 10 }}
         env:
+        {{- /* Detect whether POD_IP is already declared in extraEnvs (e.g. */ -}}
+        {{- /* injected by a downstream chart) so we don't emit duplicates. */ -}}
+        {{- $podIpInExtraEnvs := false }}
+        {{- range concat (default (list) $.Values.global.extraEnvs) (default (list) .Values.apiService.extraEnvs) }}
+        {{- if eq .name "POD_IP" }}{{- $podIpInExtraEnvs = true }}{{- end }}
+        {{- end }}
         {{- with $.Values.global.extraEnvs }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -168,6 +174,12 @@ spec:
             resourceFieldRef:
               containerName: skypilot-api
               resource: requests.memory
+        {{- if not $podIpInExtraEnvs }}
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        {{- end }}
         # Use tini as the init process
         command: ["tini", "--"]
         # Start API server in foreground (if supported) to:

--- a/charts/skypilot/tests/deployment_test.yaml
+++ b/charts/skypilot/tests/deployment_test.yaml
@@ -1173,3 +1173,56 @@ tests:
           path: spec.template.spec.containers[0].livenessProbe
       - notExists:
           path: spec.template.spec.containers[0].readinessProbe
+
+  - it: should inject POD_IP env from downward API
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+
+  - it: should not duplicate POD_IP env when apiService.extraEnvs already provides it
+    set:
+      apiService.extraEnvs:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SOME_OTHER_ENV
+          value: "x"
+    asserts:
+      # User-supplied POD_IP from extraEnvs should still be present.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+      # And the user's other extraEnv should be preserved.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOME_OTHER_ENV
+            value: "x"
+      # Total env count = baseline (9, with chart's POD_IP suppressed: 8) + 2
+      # user-provided = 10. A duplicate would push it to 11.
+      - lengthEqual:
+          path: spec.template.spec.containers[0].env
+          count: 10
+
+  - it: should not duplicate POD_IP env when global.extraEnvs already provides it
+    set:
+      global.extraEnvs:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+    asserts:
+      # Baseline (9) - chart's POD_IP suppressed (8) + user's POD_IP (1) = 9.
+      - lengthEqual:
+          path: spec.template.spec.containers[0].env
+          count: 9

--- a/sky/schemas/db/serve_state/003_controller_ip.py
+++ b/sky/schemas/db/serve_state/003_controller_ip.py
@@ -1,0 +1,33 @@
+"""Add controller_ip column to services.
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-05-08
+
+"""
+# pylint: disable=invalid-name
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from sky.utils.db import db_utils
+
+# revision identifiers, used by Alembic.
+revision: str = '003'
+down_revision: Union[str, Sequence[str], None] = '002'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    """Add controller_ip column for HA leader-aware routing."""
+    with op.get_context().autocommit_block():
+        db_utils.add_column_to_table_alembic('services',
+                                             'controller_ip',
+                                             sa.Text(),
+                                             server_default=None)
+
+
+def downgrade():
+    pass

--- a/sky/serve/constants.py
+++ b/sky/serve/constants.py
@@ -4,13 +4,25 @@ CONTROLLER_TEMPLATE = 'sky-serve-controller.yaml.j2'
 
 SKYSERVE_METADATA_DIR = '~/.sky/serve'
 
-# The filelock for selecting service ports on controller VM when starting a
-# service. We need to have a filelock to avoid port collision when starting
-# multiple services at the same time.
-PORT_SELECTION_FILE_LOCK_PATH = f'{SKYSERVE_METADATA_DIR}/port_selection.lock'
+# The filelock for selecting service ports when starting a service. Two
+# requirements:
+#  (1) Same-pod sky.serve.service subprocesses must serialize so they don't
+#      both pick the same just-freed port between their respective
+#      `find_free_port` and the controller subprocess actually `bind()`-ing.
+#  (2) The lock must NOT live on a network filesystem. fcntl/flock over NFS
+#      requires a working NLM server (rpc.statd/lockd); many K8s NFS PVC
+#      setups mount with `local_lock=none` and the server has no lockd, so
+#      flock silently becomes a no-op — multiple processes "acquire" the
+#      lock simultaneously and race anyway.
+PORT_SELECTION_FILE_LOCK_PATH = '~/.sky/skyserve_port_selection.lock'
 
 # Signal file path for controller to handle signals.
-SIGNAL_FILE_PATH = '/tmp/sky_serve_controller_signal_{}'
+SIGNAL_FILE_PATH = '~/.sky/signals/sky_serve_controller_signal_{}'
+
+# PG advisory lock IDs ensuring only one pod runs the pool/serve HA recovery
+# at a time.
+POOL_CONSOLIDATION_MODE_LOCK_ID = '~/.sky/pool_consolidation_mode_lock'
+SERVE_CONSOLIDATION_MODE_LOCK_ID = '~/.sky/serve_consolidation_mode_lock'
 
 # Time to wait in seconds for controller to setup, this involves the time to run
 # cloud dependencies installation.

--- a/sky/serve/constants.py
+++ b/sky/serve/constants.py
@@ -19,8 +19,9 @@ PORT_SELECTION_FILE_LOCK_PATH = '~/.sky/skyserve_port_selection.lock'
 # Signal file path for controller to handle signals.
 SIGNAL_FILE_PATH = '~/.sky/signals/sky_serve_controller_signal_{}'
 
-# PG advisory lock IDs ensuring only one pod runs the pool/serve HA recovery
-# at a time.
+# The consolidation mode lock ensures that if multiple API servers are running
+# at the same time (e.g. during a rolling update), recovery can only happen once
+# the previous API server has exited.
 POOL_CONSOLIDATION_MODE_LOCK_ID = '~/.sky/pool_consolidation_mode_lock'
 SERVE_CONSOLIDATION_MODE_LOCK_ID = '~/.sky/serve_consolidation_mode_lock'
 

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -65,6 +65,9 @@ services_table = sqlalchemy.Table(
                       server_default=None),
     sqlalchemy.Column('hash', sqlalchemy.Text, server_default=None),
     sqlalchemy.Column('entrypoint', sqlalchemy.Text, server_default=None),
+    # Pod IP where the controller process is running.
+    # Written by the sky.serve.service process at startup.
+    sqlalchemy.Column('controller_ip', sqlalchemy.Text, server_default=None),
 )
 
 replicas_table = sqlalchemy.Table(
@@ -252,7 +255,12 @@ class ServiceStatus(enum.Enum):
         return [cls.CONTROLLER_FAILED, cls.FAILED_CLEANUP]
 
     @classmethod
-    def refuse_to_terminate_statuses(cls) -> List['ServiceStatus']:
+    def terminal_statuses(cls) -> List['ServiceStatus']:
+        """States in which the service is either dying or already broken
+        and cannot accept new operations like update/apply. SHUTTING_DOWN
+        is included because it's a transient state that the service may
+        never leave on its own (the previous cleanup may have died
+        mid-flight, leaving a zombie row — see _cleanup)."""
         return [cls.CONTROLLER_FAILED, cls.FAILED_CLEANUP, cls.SHUTTING_DOWN]
 
     def colored_str(self) -> str:
@@ -287,10 +295,17 @@ _SERVICE_STATUS_TO_COLOR = {
 }
 
 
-def add_service(name: str, controller_job_id: int, policy: str,
-                requested_resources_str: str, load_balancing_policy: str,
-                status: ServiceStatus, tls_encrypted: bool, pool: bool,
-                controller_pid: int, entrypoint: str) -> bool:
+def add_service(name: str,
+                controller_job_id: int,
+                policy: str,
+                requested_resources_str: str,
+                load_balancing_policy: str,
+                status: ServiceStatus,
+                tls_encrypted: bool,
+                pool: bool,
+                controller_pid: int,
+                entrypoint: str,
+                controller_ip: Optional[str] = None) -> bool:
     """Add a service in the database.
 
     Returns:
@@ -318,6 +333,7 @@ def add_service(name: str, controller_job_id: int, policy: str,
                 tls_encrypted=int(tls_encrypted),
                 pool=int(pool),
                 controller_pid=controller_pid,
+                controller_ip=controller_ip,
                 hash=str(uuid.uuid4()),
                 entrypoint=entrypoint)
             session.execute(insert_stmt)
@@ -345,6 +361,44 @@ def update_service_controller_pid(service_name: str,
         session.commit()
 
 
+def update_service_controller_pid_ip_and_port(service_name: str,
+                                              controller_pid: int,
+                                              controller_ip: Optional[str],
+                                              controller_port: int) -> None:
+    """Atomically updates controller pid + IP + port for a service.
+
+    Used during HA recovery: the controller subprocess on the new pod must be
+    listening on the chosen port before we flip PG to point requests at it.
+    By updating all three fields in one statement, clients never see a
+    half-flipped row (e.g. new pid + old ip, or new ip + stale port that
+    points at a different service's listener on the new pod).
+
+    Recovery picks the port locally (find_free_port on the recovery pod) —
+    it must NOT reuse the previous pod's port — so the port change has to
+    propagate to DB together with the pid/ip flip.
+    """
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        session.query(services_table).filter(
+            services_table.c.name == service_name).update({
+                services_table.c.controller_pid: controller_pid,
+                services_table.c.controller_ip: controller_ip,
+                services_table.c.controller_port: controller_port,
+            })
+        session.commit()
+
+
+def set_service_controller_ip(service_name: str,
+                              controller_ip: Optional[str]) -> None:
+    """Sets the controller IP of a service."""
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        session.query(services_table).filter(
+            services_table.c.name == service_name).update(
+                {services_table.c.controller_ip: controller_ip})
+        session.commit()
+
+
 def remove_service(service_name: str) -> None:
     """Removes a service from the database."""
     engine = _db_manager.get_engine()
@@ -352,6 +406,34 @@ def remove_service(service_name: str) -> None:
         session.execute(
             sqlalchemy.delete(services_table).where(
                 services_table.c.name == service_name))
+        session.commit()
+
+
+def remove_service_completely(service_name: str) -> None:
+    """Atomically remove the service-level DB state for a service.
+
+    Deletes from `services`, `version_specs`, and
+    `serve_ha_recovery_script` in a single transaction. These were the
+    three tables whose sequential teardown left orphan rows when a
+    subprocess died mid-cleanup.
+
+    Replicas are intentionally NOT touched here. Both callers
+    (`_cleanup` success path in `_start`, and `_terminate_failed_services`
+    on the `--purge` path) iterate replicas one-by-one before this call
+    so they can run per-replica logic (cluster-existence probes for
+    leak reporting, terminate-thread join, failure marking).
+    """
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        session.execute(
+            sqlalchemy.delete(services_table).where(
+                services_table.c.name == service_name))
+        session.execute(
+            sqlalchemy.delete(version_specs_table).where(
+                version_specs_table.c.service_name == service_name))
+        session.execute(
+            sqlalchemy.delete(serve_ha_recovery_script_table).where(
+                serve_ha_recovery_script_table.c.service_name == service_name))
         session.commit()
 
 
@@ -429,6 +511,7 @@ def _get_service_from_row(r: 'row.RowMapping') -> Dict[str, Any]:
         'tls_encrypted': bool(r['tls_encrypted']),
         'pool': bool(r['pool']),
         'controller_pid': r['controller_pid'],
+        'controller_ip': r['controller_ip'],
         'hash': r['hash'],
         'entrypoint': r['entrypoint'],
         'yaml_content': r.get('yaml_content'),

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -368,7 +368,7 @@ def update_service_controller_pid_ip_and_port(service_name: str,
     """Atomically updates controller pid + IP + port for a service.
 
     Used during HA recovery: the controller subprocess on the new pod must be
-    listening on the chosen port before we flip PG to point requests at it.
+    listening on the chosen port before we flip DB to point requests at it.
     By updating all three fields in one statement, clients never see a
     half-flipped row (e.g. new pid + old ip, or new ip + stale port that
     points at a different service's listener on the new pod).

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -57,7 +57,88 @@ else:
 
 logger = sky_logging.init_logger(__name__)
 
-_CONTROLLER_URL = 'http://localhost:{CONTROLLER_PORT}'
+# Retry settings for cross-pod controller HTTP calls. The DB row update of
+# `controller_ip` is atomic w.r.t. controller readiness (sky.serve.service
+# only flips DB after _wait_for_controller_ready), so the only failure modes
+# left are: (1) DB read replica lag right after a recovery; (2) brief network
+# blips between pods. Both resolve in <1s — a small bounded retry covers them.
+# Intermediate retries log at DEBUG to avoid spamming WARN every refresh tick
+# while the controller is intentionally absent (CONTROLLER_INIT /
+# SHUTTING_DOWN / FAILED_CLEANUP); the final-attempt failure logs once at
+# WARN.
+_CONTROLLER_HTTP_RETRY_ATTEMPTS = 3
+_CONTROLLER_HTTP_RETRY_BACKOFF_SECONDS = 0.5
+# (connect_timeout, read_timeout). Connect timeout matters most: when the
+# controller pod is dead/unreachable, kernel ECONNREFUSED is instant on
+# loopback but cross-pod TCP can hang for 30s+ if the remote pod silently
+# drops SYN (e.g. NetworkPolicy, pod terminating mid-flight). Without an
+# explicit timeout, `requests` waits forever and `sky jobs pool status`
+# appears to hang. Read timeout is generous because /autoscaler/info on a
+# busy controller can take a moment.
+_CONTROLLER_HTTP_TIMEOUT_SECONDS = (2.0, 10.0)
+
+
+def _get_controller_url(service_name: str, controller_port: int) -> str:
+    """Resolve the controller HTTP URL.
+
+    In single-pod (or daemon == controller pod) deployments the IP read from
+    DB either matches our own POD_IP or is None — in both cases we fall back
+    to localhost. In HA where the request handler runs on a different pod
+    than the controller process, we route via the controller's pod IP from DB.
+    """
+    self_ip = os.environ.get('POD_IP')
+    record = serve_state.get_service_from_name(service_name)
+    controller_ip = record.get('controller_ip') if record else None
+    if controller_ip is None or controller_ip == self_ip:
+        url = f'http://localhost:{controller_port}'
+    else:
+        url = f'http://{controller_ip}:{controller_port}'
+    logger.debug(f'_get_controller_url for {service_name}: url={url} '
+                 f'self_ip={self_ip} controller_ip={controller_ip}')
+    return url
+
+
+def _request_to_controller_with_retry(method: str, service_name: str,
+                                      controller_port: int, path: str,
+                                      **kwargs):
+    """HTTP `method` to the controller with bounded retry on ConnectionError.
+    """
+    request_fn = getattr(requests, method)
+    # Force a bounded timeout.
+    if 'timeout' not in kwargs:
+        kwargs['timeout'] = _CONTROLLER_HTTP_TIMEOUT_SECONDS
+    for attempt in range(_CONTROLLER_HTTP_RETRY_ATTEMPTS):
+        url = _get_controller_url(service_name, controller_port) + path
+        try:
+            return request_fn(url, **kwargs)
+        except (requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout):
+            if attempt < _CONTROLLER_HTTP_RETRY_ATTEMPTS - 1:
+                logger.debug(
+                    f'Connection to controller {url} failed '
+                    f'(attempt {attempt + 1}/'
+                    f'{_CONTROLLER_HTTP_RETRY_ATTEMPTS}); retrying after '
+                    f'{_CONTROLLER_HTTP_RETRY_BACKOFF_SECONDS}s.')
+                time.sleep(_CONTROLLER_HTTP_RETRY_BACKOFF_SECONDS)
+                continue
+            logger.warning(
+                f'Connection to controller {url} failed after '
+                f'{_CONTROLLER_HTTP_RETRY_ATTEMPTS} attempts. '
+                'Controller may be down, restarting, or mid-HA-flip.')
+            raise
+
+
+def _post_to_controller_with_retry(service_name: str, controller_port: int,
+                                   path: str, **kwargs):
+    return _request_to_controller_with_retry('post', service_name,
+                                             controller_port, path, **kwargs)
+
+
+def _get_to_controller_with_retry(service_name: str, controller_port: int,
+                                  path: str, **kwargs):
+    return _request_to_controller_with_retry('get', service_name,
+                                             controller_port, path, **kwargs)
+
 
 # NOTE(dev): We assume log are print with the hint 'sky api logs -l'. Be careful
 # when changing UX as this assumption is used to expand some log files while
@@ -297,18 +378,30 @@ def ha_recovery_for_consolidation_mode(pool: bool):
             if svc is None:
                 continue
             controller_pid = svc['controller_pid']
+            controller_ip = svc.get('controller_ip')
+            status_dbg = svc.get('status')
+            f.write(f'ha_recovery candidate {service_name}: '
+                    f'pid={controller_pid} ip={controller_ip} '
+                    f'status={status_dbg}')
             if controller_pid is not None:
                 try:
-                    if _controller_process_alive(controller_pid, service_name):
-                        f.write(f'Controller pid {controller_pid} for '
-                                f'{noun} {service_name} is still running. '
-                                'Skipping recovery.\n')
-                        continue
-                except Exception:  # pylint: disable=broad-except
-                    # _controller_process_alive may raise if psutil fails; we
-                    # should not crash the recovery logic because of this.
-                    f.write('Error checking controller pid '
-                            f'{controller_pid} for {noun} {service_name}\n')
+                    alive = _controller_process_alive(controller_pid,
+                                                      service_name)
+                except Exception as e:  # pylint: disable=broad-except
+                    # _controller_process_alive may raise if psutil fails
+                    # (transient AccessDenied / cmdline read race / etc).
+                    # Treating "raised" as "dead" would replace a possibly-
+                    # alive controller every iteration that hits the
+                    # exception, churning pid/ip/port and disrupting
+                    # in-flight requests. Be conservative: skip this round.
+                    f.write(f'Error checking controller pid {controller_pid}'
+                            f' for {noun} {service_name}: {e}\n')
+                    continue
+                if alive:
+                    f.write(f'Controller pid {controller_pid} for '
+                            f'{noun} {service_name} is still running. '
+                            'Skipping recovery.\n')
+                    continue
 
             script = serve_state.get_ha_recovery_script(service_name)
             if script is None:
@@ -604,13 +697,13 @@ def update_service_encoded(service_name: str, version: int, mode: str,
         with ux_utils.print_exception_no_traceback():
             raise ValueError(f'{capnoun} {service_name!r} does not exist.')
     controller_port = service_status['controller_port']
-    resp = requests.post(
-        _CONTROLLER_URL.format(CONTROLLER_PORT=controller_port) +
-        '/controller/update_service',
-        json={
-            'version': version,
-            'mode': mode,
-        })
+    resp = _post_to_controller_with_retry(service_name,
+                                          controller_port,
+                                          '/controller/update_service',
+                                          json={
+                                              'version': version,
+                                              'mode': mode,
+                                          })
     if resp.status_code == 404:
         with ux_utils.print_exception_no_traceback():
             # This only happens for services since pool is added after the
@@ -649,13 +742,13 @@ def terminate_replica(service_name: str, replica_id: int, purge: bool) -> str:
                 'exist.')
 
     controller_port = service_status['controller_port']
-    resp = requests.post(
-        _CONTROLLER_URL.format(CONTROLLER_PORT=controller_port) +
-        '/controller/terminate_replica',
-        json={
-            'replica_id': replica_id,
-            'purge': purge,
-        })
+    resp = _post_to_controller_with_retry(service_name,
+                                          controller_port,
+                                          '/controller/terminate_replica',
+                                          json={
+                                              'replica_id': replica_id,
+                                              'purge': purge,
+                                          })
 
     message: str = resp.json()['message']
     if resp.status_code != 200:
@@ -727,9 +820,8 @@ def _get_service_status(
     record['target_num_replicas'] = 0
     try:
         controller_port = record['controller_port']
-        resp = requests.get(
-            _CONTROLLER_URL.format(CONTROLLER_PORT=controller_port) +
-            '/autoscaler/info')
+        resp = _get_to_controller_with_retry(service_name, controller_port,
+                                             '/autoscaler/info')
         record['target_num_replicas'] = resp.json()['target_num_replicas']
     except requests.exceptions.RequestException:
         record['target_num_replicas'] = None
@@ -1115,10 +1207,16 @@ def _terminate_failed_services(
 
     service_dir = os.path.expanduser(
         generate_remote_service_dir_name(service_name))
-    shutil.rmtree(service_dir)
-    serve_state.remove_service(service_name)
-    serve_state.delete_all_versions(service_name)
-    serve_state.remove_ha_recovery_script(service_name)
+    # Same atomicity argument as the success path in `_start`: remove all
+    # DB state in one transaction so an interrupted purge doesn't leave
+    # stragglers.
+    serve_state.remove_service_completely(service_name)
+    try:
+        shutil.rmtree(service_dir)
+    except FileNotFoundError:
+        # The service_dir may already be gone (e.g. the controller's own
+        # success path raced with a purge).
+        pass
 
     if not remaining_replica_clusters:
         return None
@@ -1145,7 +1243,23 @@ def terminate_services(service_names: Optional[List[str]], purge: bool,
             continue
         if (service_status is not None and service_status['status']
                 == serve_state.ServiceStatus.SHUTTING_DOWN):
-            # Already scheduled to be terminated.
+            if purge:
+                # Force-clean a zombie SHUTTING_DOWN row. This happens when
+                # the controller subprocess died mid-`_cleanup` (pod
+                # restart / OOM / SIGKILL) before it could remove the
+                # services row. The row is then unrecoverable: HA recovery
+                # can't relaunch (ha_recovery_script was deleted in
+                # cleanup's first step before the move to success-path),
+                # plain `down` skips it ("already scheduled"), and `apply`
+                # tries to update a dead controller. With --purge the user
+                # explicitly accepts a possible cluster-resource leak in
+                # exchange for clearing the row.
+                message = _terminate_failed_services(
+                    service_name, serve_state.ServiceStatus.SHUTTING_DOWN)
+                if message is not None:
+                    messages.append(message)
+                terminated_service_names.append(service_name)
+            # Without --purge, treat as already scheduled to terminate.
             continue
         if pool:
             nonterminal_job_ids = (
@@ -1192,7 +1306,9 @@ def terminate_services(service_names: Optional[List[str]], purge: bool,
         else:
             # Send the terminate signal to controller.
             signal_file = pathlib.Path(
-                constants.SIGNAL_FILE_PATH.format(service_name))
+                constants.SIGNAL_FILE_PATH.format(service_name)).expanduser()
+            # Make sure parent directory exists.
+            signal_file.parent.mkdir(parents=True, exist_ok=True)
             # Filelock is needed to prevent race condition between signal
             # check/removal and signal writing.
             with filelock.FileLock(str(signal_file) + '.lock'):
@@ -1499,7 +1615,17 @@ def stream_replica_logs(service_name: str, replica_id: int, follow: bool,
     print(f'{colorama.Fore.YELLOW}Start streaming logs for launching process '
           f'of {repnoun} {replica_id}.{colorama.Style.RESET_ALL}')
     log_file_name = generate_replica_log_file_name(service_name, replica_id)
-    if os.path.exists(log_file_name):
+    # The replica_<id>.log file is the post-mortem archive: it's only
+    # populated on the teardown path (terminate_cluster's redirect_log,
+    # or _download_and_stream_logs writing launch_log + ssh'd job logs
+    # into it). A 0-byte file on disk is a teardown-race remnant — e.g.
+    # `terminate_cluster` was invoked on a replica that never came up, so
+    # `ctx.redirect_log` created the file but no log lines were written;
+    # or `_download_and_stream_logs` opened with mode='w' and crashed
+    # before writing. If we trust `os.path.exists` alone, we commit to
+    # the (empty) main log and silently drop the launch log fallback,
+    # making `sky jobs pool logs` return empty for an alive replica.
+    if (os.path.exists(log_file_name) and os.path.getsize(log_file_name) > 0):
         if tail is not None:
             lines = common_utils.read_last_n_lines(log_file_name, tail)
             for line in lines:

--- a/sky/serve/server/impl.py
+++ b/sky/serve/server/impl.py
@@ -710,9 +710,12 @@ def apply(
                 # Refuse update for terminal-state rows (CONTROLLER_FAILED /
                 # FAILED_CLEANUP / SHUTTING_DOWN). The controller HTTP
                 # listener may already be gone, so update would just hit
-                # ECONNREFUSED with a confusing error. Also, SHUTTING_DOWN
-                # zombies (interrupted cleanup) are recoverable only via
-                # --purge; ask the user to do that explicitly.
+                # ECONNREFUSED with a confusing error. SHUTTING_DOWN is the
+                # ambiguous case: it can be a normal in-progress shutdown
+                # (will self-resolve in seconds) or a zombie (cleanup died
+                # mid-flight; recoverable only via --purge). We give it a
+                # friendlier message so a user who just ran `sky serve down`
+                # and immediately re-applies isn't pushed to --purge.
                 svc_status = service_record['status']
                 if svc_status in (
                         serve_state.ServiceStatus.terminal_statuses()):
@@ -720,12 +723,20 @@ def apply(
                     purge_cmd = (f'sky jobs pool down {service_name} --purge'
                                  if pool else
                                  f'sky serve down {service_name} --purge')
+                    if svc_status == serve_state.ServiceStatus.SHUTTING_DOWN:
+                        msg = (f'{noun.capitalize()} {service_name!r} is '
+                               f'shutting down. Wait for shutdown to '
+                               f'complete, then re-apply. If it stays in '
+                               f'this state for a long time, the cleanup '
+                               f'may be stuck; run `{purge_cmd}` to '
+                               f'force-clean.')
+                    else:
+                        msg = (f'{noun.capitalize()} {service_name!r} is '
+                               f'in {svc_status.value} state and cannot '
+                               f'be updated. Run `{purge_cmd}` to clean '
+                               f'it up and retry.')
                     with ux_utils.print_exception_no_traceback():
-                        raise RuntimeError(
-                            f'{noun.capitalize()} {service_name!r} is in '
-                            f'{svc_status.value} state and cannot be '
-                            f'updated. Run `{purge_cmd}` to clean it up '
-                            f'and retry.')
+                        raise RuntimeError(msg)
                 return update(task, service_name, mode, pool, workers)
         except exceptions.ClusterNotUpError:
             pass

--- a/sky/serve/server/impl.py
+++ b/sky/serve/server/impl.py
@@ -1,4 +1,5 @@
 """Implementation of the SkyServe core APIs."""
+import os
 import pathlib
 import re
 import shlex
@@ -319,6 +320,9 @@ def up(
             run_script = '\n'.join(env_cmds + [run_script])
             # Dump script for high availability recovery.
             serve_state.set_ha_recovery_script(service_name, run_script)
+            self_pod_ip_dbg = os.environ.get('POD_IP', '<unset>')
+            logger.debug(f'Serve up() run_on_head: spawning controller '
+                         f'subprocess locally on {self_pod_ip_dbg}')
             backend.run_on_head(controller_handle, run_script)
 
         style = colorama.Style
@@ -703,6 +707,25 @@ def apply(
             service_record = _get_service_record(service_name, pool, handle,
                                                  backend)
             if service_record is not None:
+                # Refuse update for terminal-state rows (CONTROLLER_FAILED /
+                # FAILED_CLEANUP / SHUTTING_DOWN). The controller HTTP
+                # listener may already be gone, so update would just hit
+                # ECONNREFUSED with a confusing error. Also, SHUTTING_DOWN
+                # zombies (interrupted cleanup) are recoverable only via
+                # --purge; ask the user to do that explicitly.
+                svc_status = service_record['status']
+                if svc_status in (
+                        serve_state.ServiceStatus.terminal_statuses()):
+                    noun = 'pool' if pool else 'service'
+                    purge_cmd = (f'sky jobs pool down {service_name} --purge'
+                                 if pool else
+                                 f'sky serve down {service_name} --purge')
+                    with ux_utils.print_exception_no_traceback():
+                        raise RuntimeError(
+                            f'{noun.capitalize()} {service_name!r} is in '
+                            f'{svc_status.value} state and cannot be '
+                            f'updated. Run `{purge_cmd}` to clean it up '
+                            f'and retry.')
                 return update(task, service_name, mode, pool, workers)
         except exceptions.ClusterNotUpError:
             pass

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -239,7 +239,7 @@ def _cleanup(service_name: str, pool: bool) -> bool:
     # makes the `services` row invisible to `get_service_from_name` (it
     # uses an INNER JOIN with `version_specs`), so `sky ... status` /
     # `sky ... down --purge` can no longer locate the FAILED_CLEANUP row,
-    # and the only way out is to manually delete the PG row.
+    # and the only way out is to manually delete the DB row.
     return failed
 
 
@@ -261,10 +261,9 @@ def _cleanup_task_run_script(job_id: int) -> None:
 def _wait_for_controller_ready(host: str, port: int, timeout: int = 30) -> None:
     """Block until the controller HTTP server is accepting connections.
 
-    Used by HA recovery in consolidation mode: we must not flip DB
-    `controller_pid`/`controller_ip` until the new subprocess is actually
-    listening, otherwise clients routed by PG hit the new pod's IP before
-    its uvicorn binds and get ECONNREFUSED.
+    We must not flip DB `controller_pid`/`controller_ip` until the new
+    subprocess is actually listening, otherwise clients routed by DB hit
+    the new pod's IP before its uvicorn binds and get ECONNREFUSED.
     """
     # When binding 0.0.0.0, probe via loopback.
     probe_host = '127.0.0.1' if host == '0.0.0.0' else host
@@ -406,7 +405,7 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
                 os.path.expanduser(constants.PORT_SELECTION_FILE_LOCK_PATH)):
             # Start the controller.
             # NOTE: also pick a fresh free port on recovery — do NOT reuse
-            # the port from PG. The port in PG was chosen on the previous
+            # the port from DB. The port in DB was chosen on the previous
             # controller's pod (e.g. Pod A); on a different recovery pod
             # (Pod B), that port may be in use by another service's
             # controller, in which case our subprocess would fail to bind
@@ -482,7 +481,7 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
                     controller_port=controller_port)
             else:
                 # Fresh up: add_service already wrote pid/ip with the row.
-                # Only the port needs to land in PG now (after bind).
+                # Only the port needs to land in DB now (after bind).
                 serve_state.set_service_controller_port(service_name,
                                                         controller_port)
 

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -7,9 +7,10 @@ import multiprocessing
 import os
 import pathlib
 import shutil
+import socket
 import time
 import traceback
-from typing import Dict
+from typing import Any, Dict, Optional
 
 import filelock
 
@@ -42,7 +43,8 @@ logger = sky_logging.init_logger('sky.serve.service')
 
 def _handle_signal(service_name: str) -> None:
     """Handles the signal user sent to controller."""
-    signal_file = pathlib.Path(constants.SIGNAL_FILE_PATH.format(service_name))
+    signal_file = pathlib.Path(
+        constants.SIGNAL_FILE_PATH.format(service_name)).expanduser()
     user_signal = None
     if signal_file.exists():
         # Filelock is needed to prevent race condition with concurrent
@@ -76,6 +78,7 @@ def cleanup_storage(yaml_content: str) -> bool:
         True if the storage is cleaned up successfully, False otherwise.
     """
     failed = False
+    task = None
 
     try:
         task = task_lib.Task.from_yaml_str(yaml_content)
@@ -84,8 +87,24 @@ def cleanup_storage(yaml_content: str) -> bool:
         # because when SkyPilot API server machine sends the yaml config to the
         # controller machine, only storage metadata is sent, not the storage
         # object itself.
-        for storage in task.storage_mounts.values():
-            storage.construct()
+        # Construct storages individually so a stale reference (bucket
+        # already deleted by a prior cleanup pass) doesn't abort cleanup of
+        # the rest. StorageBucketGetError on construct here means the bucket
+        # is already gone — which IS the cleanup target state, not a failure.
+        # Without this, FAILED_CLEANUP becomes self-perpetuating: the loop
+        # crashes on a stale storage entry, the service goes to
+        # FAILED_CLEANUP, ha_recovery_for_consolidation_mode respawns the
+        # controller, the controller re-reads the same yaml and crashes on
+        # the same stale entry — forever.
+        for storage_name in list(task.storage_mounts.keys()):
+            storage = task.storage_mounts[storage_name]
+            try:
+                storage.construct()
+            except exceptions.StorageBucketGetError as e:
+                logger.debug(f'cleanup_storage: bucket for storage '
+                             f'{storage_name!r} already gone, treating as '
+                             f'already cleaned: {e}')
+                del task.storage_mounts[storage_name]
         backend.teardown_ephemeral_storage(task)
     except Exception as e:  # pylint: disable=broad-except
         logger.error('Failed to clean up storage: '
@@ -95,8 +114,10 @@ def cleanup_storage(yaml_content: str) -> bool:
         failed = True
 
     # Clean up any files mounted from the local disk, such as two-hop file
-    # mounts.
-    for file_mount in (task.file_mounts or {}).values():
+    # mounts. Guard against `task` being unbound if from_yaml_str raised above.
+    file_mount_values = (list(
+        (task.file_mounts or {}).values()) if task else [])
+    for file_mount in file_mount_values:
         try:
             if not data_utils.is_cloud_store_url(file_mount):
                 path = os.path.expanduser(file_mount)
@@ -213,10 +234,12 @@ def _cleanup(service_name: str, pool: bool) -> bool:
     if not all(map(cleanup_version_storage, versions)):
         failed = True
 
-    # Cleanup version metadata after all storages are cleaned up, otherwise
-    # the get_yaml_content will return None as all versions are deleted.
-    serve_state.delete_all_versions(service_name)
-
+    # NOTE: do not delete version_specs here. The success path in `_start`
+    # deletes them along with `remove_service`. Deleting them on failure
+    # makes the `services` row invisible to `get_service_from_name` (it
+    # uses an INNER JOIN with `version_specs`), so `sky ... status` /
+    # `sky ... down --purge` can no longer locate the FAILED_CLEANUP row,
+    # and the only way out is to manually delete the PG row.
     return failed
 
 
@@ -233,6 +256,61 @@ def _cleanup_task_run_script(job_id: int) -> None:
             logger.info(f'Task run script {this_task_run_script} removed')
         else:
             logger.warning(f'Task run script {this_task_run_script} not found')
+
+
+def _wait_for_controller_ready(host: str, port: int, timeout: int = 30) -> None:
+    """Block until the controller HTTP server is accepting connections.
+
+    Used by HA recovery in consolidation mode: we must not flip DB
+    `controller_pid`/`controller_ip` until the new subprocess is actually
+    listening, otherwise clients routed by PG hit the new pod's IP before
+    its uvicorn binds and get ECONNREFUSED.
+    """
+    # When binding 0.0.0.0, probe via loopback.
+    probe_host = '127.0.0.1' if host == '0.0.0.0' else host
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            with socket.create_connection((probe_host, port), timeout=0.5):
+                return
+        except (ConnectionRefusedError, OSError):
+            time.sleep(0.2)
+    raise RuntimeError(f'Controller did not become ready on '
+                       f'{probe_host}:{port} within {timeout}s')
+
+
+def _orphan_exit(
+        controller_process: Optional[multiprocessing.Process],
+        load_balancer_process: Optional[multiprocessing.Process]) -> None:
+    """Quick exit path for an orphan sky.serve.service.
+
+    Triggered when our self-check sees DB `controller_pid` no longer matches
+    our own pid (a newer instance on another pod has taken over) or when the
+    services row has been removed (down completed). DB state is now owned by
+    that new instance — we must NOT call _cleanup, which would teardown
+    replicas and delete versions, racing with the new owner.
+
+    Just kill our own forked subprocesses and exit immediately.
+    """
+    logger.info(
+        f'_orphan_exit invoked: own_pid={os.getpid()} '
+        f'controller_process_pid='
+        f'{controller_process.pid if controller_process else None} '
+        f'load_balancer_process_pid='
+        f'{load_balancer_process.pid if load_balancer_process else None}')
+    process_to_kill = [
+        proc for proc in [load_balancer_process, controller_process]
+        if proc is not None
+    ]
+    if process_to_kill:
+        try:
+            subprocess_utils.kill_children_processes(
+                parent_pids=[p.pid for p in process_to_kill], force=True)
+        except Exception:  # pylint: disable=broad-except
+            logger.warning('Failed to kill children during orphan exit; '
+                           'proceeding with os._exit anyway')
+    # os._exit() bypasses the try/finally which would call _cleanup.
+    os._exit(0)  # pylint: disable=protected-access
 
 
 def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
@@ -271,6 +349,9 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
     service_dir = os.path.expanduser(
         serve_utils.generate_remote_service_dir_name(service_name))
 
+    # Pod IP for HA leader-aware routing.
+    pod_ip: Optional[str] = os.environ.get('POD_IP')
+
     if not is_recovery:
         with filelock.FileLock(controller_utils.get_resources_lock_path()):
             if not controller_utils.can_start_new_process(task.service.pool):
@@ -290,6 +371,7 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
                 tls_encrypted=service_spec.tls_credential is not None,
                 pool=service_spec.pool,
                 controller_pid=os.getpid(),
+                controller_ip=pod_ip,
                 entrypoint=entrypoint)
         # Directly throw an error here. See sky/serve/api.py::up
         # for more details.
@@ -310,7 +392,12 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
         if latest_version is None:
             raise ValueError(f'No version found for service {service_name}')
         version = latest_version
-        serve_state.update_service_controller_pid(service_name, os.getpid())
+        # NOTE: do NOT update controller_pid/controller_ip yet. We must wait
+        # until our subprocess is actually listening on the port (see the
+        # update_service_controller_pid_ip_and_port call after
+        # _wait_for_controller_ready below). Otherwise clients in other pods
+        # would route to our pod IP before uvicorn binds and get
+        # ECONNREFUSED for the duration of the boot.
 
     controller_process = None
     load_balancer_process = None
@@ -318,10 +405,17 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
         with filelock.FileLock(
                 os.path.expanduser(constants.PORT_SELECTION_FILE_LOCK_PATH)):
             # Start the controller.
-            controller_port = (
-                common_utils.find_free_port(constants.CONTROLLER_PORT_START)
-                if not is_recovery else
-                serve_state.get_service_controller_port(service_name))
+            # NOTE: also pick a fresh free port on recovery — do NOT reuse
+            # the port from PG. The port in PG was chosen on the previous
+            # controller's pod (e.g. Pod A); on a different recovery pod
+            # (Pod B), that port may be in use by another service's
+            # controller, in which case our subprocess would fail to bind
+            # → _wait_for_controller_ready times out → daemon retries
+            # forever. Picking locally guarantees the port is free *on this
+            # pod*, and the post-bind atomic flip writes the new port to
+            # DB together with pid/ip so clients route correctly.
+            controller_port = common_utils.find_free_port(
+                constants.CONTROLLER_PORT_START)
 
             def _get_controller_host():
                 """Get the controller host address.
@@ -344,8 +438,51 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
                 args=(service_name, service_spec, version, controller_host,
                       controller_port))
             controller_process.start()
+            logger.debug(f'_start() spawned controller_process pid='
+                         f'{controller_process.pid} host={controller_host} '
+                         f'port={controller_port}')
 
-            if not is_recovery:
+            # NOTE: do NOT write controller_port to DB before the subprocess
+            # actually binds. If the spawn races with another service for
+            # the same port and our subprocess fails to bind, we don't want
+            # DB to advertise an unbound port to clients. Move the DB write
+            # to after `_wait_for_controller_ready` succeeds (below).
+
+            # Wait for the uvicorn server inside the controller subprocess to
+            # be listening before we (potentially) flip DB to point at us.
+            # This makes the recovery's DB update atomic from the client's
+            # perspective: DB either still points at the previous controller
+            # (which is alive) or it points at us (which is now ready).
+            try:
+                _wait_for_controller_ready(
+                    controller_host,
+                    controller_port,
+                    timeout=constants.SERVICE_REGISTER_TIMEOUT_SECONDS)
+            except RuntimeError:
+                # Controller subprocess failed to start. Bail; the daemon's
+                # next ha_recovery iteration will retry.
+                logger.error('Controller subprocess failed to start within '
+                             f'{constants.SERVICE_REGISTER_TIMEOUT_SECONDS}s; '
+                             'aborting _start. DB state untouched so the '
+                             'previous controller (if any) keeps serving.')
+                raise
+
+            # Now we know the subprocess is bound on `controller_port`. Write
+            # DB.
+            if is_recovery:
+                # Atomic flip: DB now points at us; clients route here. We're
+                # ready to serve.
+                logger.debug(f'is_recovery: flipping DB controller_pid '
+                             f'-> {os.getpid()}, controller_ip -> {pod_ip}, '
+                             f'controller_port -> {controller_port}')
+                serve_state.update_service_controller_pid_ip_and_port(
+                    service_name,
+                    controller_pid=os.getpid(),
+                    controller_ip=pod_ip,
+                    controller_port=controller_port)
+            else:
+                # Fresh up: add_service already wrote pid/ip with the row.
+                # Only the port needs to land in PG now (after bind).
                 serve_state.set_service_controller_port(service_name,
                                                         controller_port)
 
@@ -380,10 +517,47 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
                 serve_state.set_service_load_balancer_port(
                     service_name, load_balancer_port)
 
+        # Self-check cadence (seconds): how often we re-read DB to confirm
+        # we're still the authoritative controller. Ghost detection only
+        # matters in HA deployments and is checked once per
+        # interval to avoid DB load.
+        orphan_check_interval_seconds = 30
+        own_pid = os.getpid()
+        loop_count = 0
         while True:
             _handle_signal(service_name)
+            loop_count += 1
+            # Periodically check whether we still own the row in DB. If
+            # another instance on a different pod has taken over (HA recovery
+            # raced us to the row), or if down has removed the row entirely,
+            # exit immediately without running cleanup — that work belongs to
+            # the new owner / has already happened.
+            if loop_count % orphan_check_interval_seconds == 0:
+                db_read_failed = False
+                record: Optional[Dict[str, Any]] = None
+                try:
+                    record = serve_state.get_service_from_name(service_name)
+                except Exception:  # pylint: disable=broad-except
+                    # DB transient failure — keep running, retry next tick.
+                    db_read_failed = True
+                if not db_read_failed and record is None:
+                    logger.warning(
+                        f'Service {service_name} row no longer present in '
+                        'DB. Exiting as orphan without running cleanup.')
+                    _orphan_exit(controller_process, load_balancer_process)
+                elif (record is not None and
+                      record.get('controller_pid') is not None and
+                      record.get('controller_pid') != own_pid):
+                    logger.warning(
+                        f'Service {service_name} controller_pid in DB is '
+                        f'{record.get("controller_pid")} but our pid is '
+                        f'{own_pid}; another instance has taken over. '
+                        'Exiting as orphan without running cleanup.')
+                    _orphan_exit(controller_process, load_balancer_process)
             time.sleep(1)
     except exceptions.ServeUserTerminatedError:
+        logger.debug(f'Caught ServeUserTerminatedError for '
+                     f'{service_name}; setting status=SHUTTING_DOWN')
         serve_state.set_service_status_and_active_versions(
             service_name, serve_state.ServiceStatus.SHUTTING_DOWN)
     finally:
@@ -417,9 +591,13 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
                 service_name, serve_state.ServiceStatus.FAILED_CLEANUP)
             logger.error(f'Service {service_name} failed to clean up.')
         else:
-            shutil.rmtree(service_dir)
-            serve_state.remove_service(service_name)
-            serve_state.delete_all_versions(service_name)
+            serve_state.remove_service_completely(service_name)
+            try:
+                shutil.rmtree(service_dir)
+            except FileNotFoundError:
+                # The service_dir may already be gone (e.g. the controller's own
+                # success path raced with a purge).
+                pass
             logger.info(f'Service {service_name} terminated successfully.')
 
         _cleanup_task_run_script(job_id)

--- a/sky/server/daemons.py
+++ b/sky/server/daemons.py
@@ -210,7 +210,7 @@ def _release_managed_job_consolidation_mode_lock() -> None:
         _managed_job_consolidation_mode_lock = None
 
 
-def _release_serve_consolidation_mode_locks() -> None:
+def _release_serve_and_pool_consolidation_mode_locks() -> None:
     global _pool_consolidation_mode_lock, _serve_consolidation_mode_lock
     if _pool_consolidation_mode_lock is not None:
         _pool_consolidation_mode_lock.release()
@@ -221,7 +221,7 @@ def _release_serve_consolidation_mode_locks() -> None:
 
 
 atexit.register(_release_managed_job_consolidation_mode_lock)
-atexit.register(_release_serve_consolidation_mode_locks)
+atexit.register(_release_serve_and_pool_consolidation_mode_locks)
 
 
 def managed_job_status_refresh_event():

--- a/sky/server/daemons.py
+++ b/sky/server/daemons.py
@@ -197,6 +197,8 @@ def refresh_volume_status_event():
 
 
 _managed_job_consolidation_mode_lock = None
+_pool_consolidation_mode_lock = None
+_serve_consolidation_mode_lock = None
 
 
 # Attempt to gracefully release the lock when the process exits.
@@ -208,7 +210,18 @@ def _release_managed_job_consolidation_mode_lock() -> None:
         _managed_job_consolidation_mode_lock = None
 
 
+def _release_serve_consolidation_mode_locks() -> None:
+    global _pool_consolidation_mode_lock, _serve_consolidation_mode_lock
+    if _pool_consolidation_mode_lock is not None:
+        _pool_consolidation_mode_lock.release()
+        _pool_consolidation_mode_lock = None
+    if _serve_consolidation_mode_lock is not None:
+        _serve_consolidation_mode_lock.release()
+        _serve_consolidation_mode_lock = None
+
+
 atexit.register(_release_managed_job_consolidation_mode_lock)
+atexit.register(_release_serve_consolidation_mode_locks)
 
 
 def managed_job_status_refresh_event():
@@ -278,7 +291,29 @@ def should_skip_managed_job_status_refresh():
 def _serve_status_refresh_event(pool: bool):
     """Refresh the sky serve status for controller consolidation mode."""
     # pylint: disable=import-outside-toplevel
+    from sky.serve import constants as serve_constants
     from sky.serve import serve_utils
+
+    # Acquire an advisory lock so that only one pod runs the recovery /
+    # controller-startup path at a time.
+    global _pool_consolidation_mode_lock, _serve_consolidation_mode_lock
+    if pool:
+        if _pool_consolidation_mode_lock is None:
+            _pool_consolidation_mode_lock = locks.get_lock(
+                serve_constants.POOL_CONSOLIDATION_MODE_LOCK_ID)
+        lock = _pool_consolidation_mode_lock
+        lock_label = 'pool consolidation mode lock'
+    else:
+        if _serve_consolidation_mode_lock is None:
+            _serve_consolidation_mode_lock = locks.get_lock(
+                serve_constants.SERVE_CONSOLIDATION_MODE_LOCK_ID)
+        lock = _serve_consolidation_mode_lock
+        lock_label = 'serve consolidation mode lock'
+
+    if not lock.is_locked():
+        logger.info(f'Acquiring the {lock_label}: {lock}')
+        lock.acquire()
+        logger.info(f'{lock_label} acquired')
 
     # We run the recovery logic before starting the event loop as those two are
     # conflicting. Check PERSISTENT_RUN_RESTARTING_SIGNAL_FILE for details.

--- a/sky/server/stream_utils.py
+++ b/sky/server/stream_utils.py
@@ -433,8 +433,13 @@ def stream_response(
         # https://fastapi.tiangolo.com/tutorial/background-tasks/
         background_tasks.add_task(on_disconnect)
 
+    # Route through LogProvider.
+    # pylint: disable=import-outside-toplevel
+    from sky.server.requests import log_provider as lp
     return fastapi.responses.StreamingResponse(
-        log_streamer(request_id, logs_path, polling_interval=polling_interval),
+        lp.get_log_provider().log_stream(request_id=request_id,
+                                         log_path=logs_path,
+                                         polling_interval=polling_interval),
         media_type='text/plain',
         headers={
             'Cache-Control': 'no-cache, no-transform',

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -576,8 +576,15 @@ def shared_controller_vars_to_fill(
         constants.USING_REMOTE_API_SERVER_ENV_VAR: str(
             common_utils.get_using_remote_api_server()),
     })
-    if skypilot_config.loaded():
-        # Only set the SKYPILOT_CONFIG env var if the user has a config file.
+    # Only set the SKYPILOT_CONFIG env var when we actually file_mount a
+    # config to the controller (i.e. local_user_config was non-empty so
+    # local_user_config_path is a real tempfile that gets rsynced/SSH'd to
+    # remote_user_config_path on the controller). Previously this gated on
+    # `skypilot_config.loaded()` (API server's own config), which can be True
+    # even when local_user_config is empty — pointing the controller's
+    # SKYPILOT_CONFIG env to a file that was never created and crashing it
+    # with FileNotFoundError on startup.
+    if local_user_config_path is not None:
         env_vars[
             skypilot_config.ENV_VAR_SKYPILOT_CONFIG] = remote_user_config_path
     vars_to_fill['controller_envs'].update(env_vars)

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -38,7 +38,7 @@ SPOT_JOBS_VERSION = '019'  # add file_mounts_blob_id column to job_info
 SPOT_JOBS_LOCK_PATH = f'~/.sky/locks/.{SPOT_JOBS_DB_NAME}.lock'
 
 SERVE_DB_NAME = 'serve_db'
-SERVE_VERSION = '002'  # add yaml_content column to version_specs
+SERVE_VERSION = '003'  # add controller_ip column to services
 SERVE_LOCK_PATH = f'~/.sky/locks/.{SERVE_DB_NAME}.lock'
 
 SKYPILOT_CONFIG_DB_NAME = 'sky_config_db'

--- a/tests/unit_tests/test_controller_utils.py
+++ b/tests/unit_tests/test_controller_utils.py
@@ -700,6 +700,81 @@ def test_shared_controller_vars_to_fill(controller_type: str, monkeypatch):
     os.unlink(local_config_path)
 
 
+# ---------------------------------------------------------------------------
+# Tests for the SKYPILOT_CONFIG env / file_mount consistency fix (change A1
+# from plans/jobs-pool-consolidation-ha-architecture.md).
+#
+# Bug: previously, the SKYPILOT_CONFIG env var on the controller was set
+# whenever `skypilot_config.loaded()` was True (i.e. the API server itself
+# had any config). But the file that env var pointed to was only file_mount'd
+# when `local_user_config` was non-empty. If admin_policy returned an empty
+# dict (or no admin_policy was set and the API server's config happened to
+# load from an empty file), the env var would point to a path that was
+# never created — controller process would FileNotFoundError on startup.
+#
+# Fix: gate the env var on the same condition that gates the file_mount —
+# `local_user_config_path is not None`. These tests pin that contract.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('controller_type', ['jobs', 'serve'])
+def test_skypilot_config_env_set_when_local_config_present(
+        controller_type: str, monkeypatch):
+    from sky import skypilot_config
+
+    monkeypatch.setattr(
+        'sky.utils.controller_utils._get_cloud_dependencies_installation_commands',
+        lambda controller: [])
+
+    controller = controller_utils.Controllers.from_type(controller_type)
+    user_config = {'jobs': {'controller': {'resources': {'cpus': '8+'}}}}
+
+    result = controller_utils.shared_controller_vars_to_fill(
+        controller, '/remote/path/config.yaml', user_config.copy())
+
+    # local_user_config non-empty → tempfile written, file_mount populated.
+    assert result['local_user_config_path'] is not None
+    # And SKYPILOT_CONFIG env points to the file_mount target on the
+    # controller side.
+    env_vars = result['controller_envs']
+    assert env_vars[skypilot_config.ENV_VAR_SKYPILOT_CONFIG] == (
+        '/remote/path/config.yaml')
+
+    os.unlink(result['local_user_config_path'])
+
+
+@pytest.mark.parametrize('controller_type', ['jobs', 'serve'])
+def test_skypilot_config_env_NOT_set_when_local_config_empty(
+        controller_type: str, monkeypatch):
+    """Regression test: even if the API server's own config is loaded
+    (skypilot_config.loaded() is True), if the config we're passing to the
+    controller is empty, we MUST NOT set SKYPILOT_CONFIG — otherwise the
+    controller process tries to read a non-existent file and crashes
+    (this is the exact build #403 failure mode for controllers running
+    outside of the original recovery context)."""
+    from sky import skypilot_config
+
+    monkeypatch.setattr(
+        'sky.utils.controller_utils._get_cloud_dependencies_installation_commands',
+        lambda controller: [])
+    # Force the API server's own skypilot_config to look "loaded" — this
+    # used to be the gating condition and would incorrectly set the env
+    # even when the controller-side config is empty.
+    monkeypatch.setattr('sky.skypilot_config.loaded', lambda: True)
+
+    controller = controller_utils.Controllers.from_type(controller_type)
+
+    result = controller_utils.shared_controller_vars_to_fill(
+        controller, '/remote/path/config.yaml', {})
+
+    # Empty local_user_config → no tempfile, no file_mount.
+    assert result['local_user_config_path'] is None
+    # And critically: no SKYPILOT_CONFIG env on the controller (which would
+    # otherwise point at a path that file_mounts won't materialize).
+    env_vars = result['controller_envs']
+    assert skypilot_config.ENV_VAR_SKYPILOT_CONFIG not in env_vars
+
+
 def _run_controller_cluster_name_refresh_test(controller_type: str):
     """Helper function to run in subprocess to avoid module pollution."""
     import importlib

--- a/tests/unit_tests/test_controller_utils.py
+++ b/tests/unit_tests/test_controller_utils.py
@@ -701,8 +701,7 @@ def test_shared_controller_vars_to_fill(controller_type: str, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Tests for the SKYPILOT_CONFIG env / file_mount consistency fix (change A1
-# from plans/jobs-pool-consolidation-ha-architecture.md).
+# Tests for the SKYPILOT_CONFIG env / file_mount consistency fix.
 #
 # Bug: previously, the SKYPILOT_CONFIG env var on the controller was set
 # whenever `skypilot_config.loaded()` was True (i.e. the API server itself
@@ -749,9 +748,7 @@ def test_skypilot_config_env_NOT_set_when_local_config_empty(
     """Regression test: even if the API server's own config is loaded
     (skypilot_config.loaded() is True), if the config we're passing to the
     controller is empty, we MUST NOT set SKYPILOT_CONFIG — otherwise the
-    controller process tries to read a non-existent file and crashes
-    (this is the exact build #403 failure mode for controllers running
-    outside of the original recovery context)."""
+    controller process tries to read a non-existent file and crashes."""
     from sky import skypilot_config
 
     monkeypatch.setattr(

--- a/tests/unit_tests/test_serve_impl.py
+++ b/tests/unit_tests/test_serve_impl.py
@@ -24,8 +24,7 @@ class TestApplyRefusesTerminalStates:
     """`apply` should refuse to update a row that's in a terminal state.
     The previous behavior was to call `update()` regardless, which would
     POST to the (likely-dead) controller HTTP listener and surface a
-    confusing ECONNREFUSED to the user. We saw 12 SHUTTING_DOWN zombies
-    on the test cluster that all hit this path."""
+    confusing ECONNREFUSED to the user."""
 
     def _service_record(self, status):
         return {

--- a/tests/unit_tests/test_serve_impl.py
+++ b/tests/unit_tests/test_serve_impl.py
@@ -1,0 +1,143 @@
+"""Tests for sky/serve/server/impl.py.
+
+Focused on `apply()` rejecting terminal-state rows so callers don't blindly
+hit a dead controller HTTP listener and get an opaque ECONNREFUSED. This
+also makes the user-visible failure mode "go run --purge" instead of "look
+at the connection-refused traceback and figure it out."
+"""
+# pylint: disable=invalid-name,protected-access
+from unittest import mock
+
+import pytest
+
+from sky import backends
+from sky.serve import serve_state
+from sky.serve.server import impl
+
+
+def _backend_mock():
+    """A mock that passes `isinstance(_, backends.CloudVmRayBackend)`."""
+    return mock.MagicMock(spec=backends.CloudVmRayBackend)
+
+
+class TestApplyRefusesTerminalStates:
+    """`apply` should refuse to update a row that's in a terminal state.
+    The previous behavior was to call `update()` regardless, which would
+    POST to the (likely-dead) controller HTTP listener and surface a
+    confusing ECONNREFUSED to the user. We saw 12 SHUTTING_DOWN zombies
+    on the test cluster that all hit this path."""
+
+    def _service_record(self, status):
+        return {
+            'name': 'svc',
+            'status': status,
+            'controller_pid': 1234,
+            'controller_port': 20001,
+            'controller_ip': None,
+            'pool': True,
+        }
+
+    def _common_patches(self, status):
+        # Pretend the controller cluster is accessible (consolidation mode
+        # is_controller_accessible is essentially a no-op anyway).
+        return [
+            mock.patch(
+                'sky.serve.server.impl.serve_utils.get_service_filelock_path',
+                return_value='/tmp/test_apply_lock'),
+            mock.patch('sky.serve.server.impl.controller_utils.'
+                       'get_controller_for_pool'),
+            mock.patch(
+                'sky.serve.server.impl.backend_utils.'
+                'is_controller_accessible',
+                return_value=mock.Mock()),
+            mock.patch(
+                'sky.serve.server.impl.backend_utils.'
+                'get_backend_from_handle',
+                return_value=_backend_mock()),
+            mock.patch('sky.serve.server.impl._get_service_record',
+                       return_value=self._service_record(status)),
+        ]
+
+    def _run_apply_with_status(self, status, pool):
+        patches = self._common_patches(status)
+        with mock.patch('sky.serve.server.impl.update') as mock_update, \
+             mock.patch('sky.serve.server.impl.up') as mock_up:
+            for p in patches:
+                p.start()
+            try:
+                impl.apply(task=mock.Mock(),
+                           workers=None,
+                           service_name='svc',
+                           pool=pool)
+            finally:
+                for p in patches:
+                    p.stop()
+            return mock_update, mock_up
+
+    def test_refuses_shutting_down(self):
+        with pytest.raises(RuntimeError, match='SHUTTING_DOWN'):
+            self._run_apply_with_status(serve_state.ServiceStatus.SHUTTING_DOWN,
+                                        pool=True)
+
+    def test_refuses_failed_cleanup(self):
+        with pytest.raises(RuntimeError, match='FAILED_CLEANUP'):
+            self._run_apply_with_status(
+                serve_state.ServiceStatus.FAILED_CLEANUP, pool=True)
+
+    def test_refuses_controller_failed(self):
+        with pytest.raises(RuntimeError, match='CONTROLLER_FAILED'):
+            self._run_apply_with_status(
+                serve_state.ServiceStatus.CONTROLLER_FAILED, pool=False)
+
+    def test_error_message_includes_purge_hint_for_pool(self):
+        with pytest.raises(RuntimeError,
+                           match='sky jobs pool down svc --purge'):
+            self._run_apply_with_status(serve_state.ServiceStatus.SHUTTING_DOWN,
+                                        pool=True)
+
+    def test_error_message_includes_purge_hint_for_serve(self):
+        with pytest.raises(RuntimeError, match='sky serve down svc --purge'):
+            self._run_apply_with_status(serve_state.ServiceStatus.SHUTTING_DOWN,
+                                        pool=False)
+
+    def test_ready_does_not_raise_and_calls_update(self):
+        """Sanity check: healthy READY rows still go through to update()."""
+        mock_update, mock_up = self._run_apply_with_status(
+            serve_state.ServiceStatus.READY, pool=True)
+        mock_update.assert_called_once()
+        mock_up.assert_not_called()
+
+    def test_no_existing_record_calls_up(self):
+        """When no row exists, apply should fall through to up() (create new),
+        not raise."""
+        patches = [
+            mock.patch(
+                'sky.serve.server.impl.serve_utils.get_service_filelock_path',
+                return_value='/tmp/test_apply_lock'),
+            mock.patch('sky.serve.server.impl.controller_utils.'
+                       'get_controller_for_pool'),
+            mock.patch(
+                'sky.serve.server.impl.backend_utils.'
+                'is_controller_accessible',
+                return_value=mock.Mock()),
+            mock.patch(
+                'sky.serve.server.impl.backend_utils.'
+                'get_backend_from_handle',
+                return_value=_backend_mock()),
+            mock.patch('sky.serve.server.impl._get_service_record',
+                       return_value=None),
+        ]
+        with mock.patch('sky.serve.server.impl.update') as mock_update, \
+             mock.patch('sky.serve.server.impl.up') as mock_up:
+            for p in patches:
+                p.start()
+            try:
+                impl.apply(task=mock.Mock(),
+                           workers=None,
+                           service_name='svc',
+                           pool=True)
+            finally:
+                for p in patches:
+                    p.stop()
+        mock_up.assert_called_once()
+        mock_update.assert_not_called()

--- a/tests/unit_tests/test_serve_impl.py
+++ b/tests/unit_tests/test_serve_impl.py
@@ -74,7 +74,11 @@ class TestApplyRefusesTerminalStates:
             return mock_update, mock_up
 
     def test_refuses_shutting_down(self):
-        with pytest.raises(RuntimeError, match='SHUTTING_DOWN'):
+        # SHUTTING_DOWN gets a friendlier "wait for shutdown" message that
+        # still mentions --purge as a fallback for stuck cleanups, so users
+        # who just ran `down` and re-applied aren't pushed straight to purge.
+        with pytest.raises(RuntimeError,
+                           match='shutting down.*Wait for shutdown.*--purge'):
             self._run_apply_with_status(serve_state.ServiceStatus.SHUTTING_DOWN,
                                         pool=True)
 

--- a/tests/unit_tests/test_serve_service.py
+++ b/tests/unit_tests/test_serve_service.py
@@ -1,0 +1,341 @@
+"""Tests for sky/serve/service.py.
+
+Focused on the helpers added for HA leader-aware routing (changes C.2 / C.3
+from plans/jobs-pool-consolidation-ha-architecture.md):
+
+- _wait_for_controller_ready: must block until the uvicorn subprocess is
+  actually accepting connections. Used to gate the PG flip in the recovery
+  path so that clients never route to a pod whose listener isn't bound yet.
+- _orphan_exit: must NOT call _cleanup. The whole point of this exit path
+  is that another instance has already taken over the row, so any cleanup
+  here would race with the new owner's replica state writes.
+- _cleanup: must NOT delete version_specs. Deleting them on failure leaves
+  the `services` row invisible to JOIN-based queries and breaks
+  status / down --purge.
+"""
+import socket
+import threading
+import time
+from unittest import mock
+
+import pytest
+
+from sky.serve import service
+
+
+def _bind_socket_async(host, port, delay):
+    """Helper: bind to host:port after `delay` seconds, then keep the socket
+    open until the test thread sets a stop event."""
+    stop_event = threading.Event()
+
+    def run():
+        time.sleep(delay)
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            s.bind((host, port))
+            s.listen(1)
+            stop_event.wait()
+        finally:
+            s.close()
+
+    t = threading.Thread(target=run, daemon=True)
+    t.start()
+    return t, stop_event
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(('127.0.0.1', 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+class TestWaitForControllerReady:
+
+    def test_returns_when_listener_already_up(self):
+        """Listener is up before we even start polling — fast path."""
+        port = _free_port()
+        thread, stop = _bind_socket_async('127.0.0.1', port, delay=0)
+        try:
+            time.sleep(0.1)  # let bind complete
+            start = time.time()
+            service._wait_for_controller_ready('127.0.0.1', port, timeout=5)
+            assert time.time() - start < 1.0
+        finally:
+            stop.set()
+            thread.join(timeout=2)
+
+    def test_polls_until_listener_comes_up(self):
+        """Listener comes up partway through — verifies polling actually
+        retries instead of returning the first ECONNREFUSED."""
+        port = _free_port()
+        # Bind 0.5s after we start waiting — well within timeout.
+        thread, stop = _bind_socket_async('127.0.0.1', port, delay=0.5)
+        try:
+            start = time.time()
+            service._wait_for_controller_ready('127.0.0.1', port, timeout=5)
+            elapsed = time.time() - start
+            # Should take at least the bind delay, but well under the timeout.
+            assert 0.4 < elapsed < 4.0
+        finally:
+            stop.set()
+            thread.join(timeout=2)
+
+    def test_raises_on_timeout(self):
+        """Listener never comes up — must raise RuntimeError, not block
+        forever (would otherwise leave the daemon stuck with the old PG row
+        intact, blocking subsequent recoveries)."""
+        port = _free_port()
+        # Don't bind anything.
+        with pytest.raises(RuntimeError, match='did not become ready'):
+            service._wait_for_controller_ready('127.0.0.1', port, timeout=1)
+
+    def test_treats_zero_zero_as_loopback(self):
+        """Controller may be configured to bind 0.0.0.0 (k8s mode); we must
+        probe via 127.0.0.1, not literally connect to 0.0.0.0 (which is not
+        always a valid connect target on macOS)."""
+        port = _free_port()
+        thread, stop = _bind_socket_async('127.0.0.1', port, delay=0)
+        try:
+            time.sleep(0.1)
+            service._wait_for_controller_ready('0.0.0.0', port, timeout=5)
+        finally:
+            stop.set()
+            thread.join(timeout=2)
+
+
+class TestOrphanExit:
+    """Critical contract: _orphan_exit must NOT touch any PG state. It only
+    kills our forked subprocesses and calls os._exit(0). This is what
+    distinguishes orphan exit from normal cleanup — the new owner is now
+    responsible for replica state, version cleanup, services row deletion,
+    etc."""
+
+    def test_calls_os_exit_zero(self):
+        with mock.patch('os._exit') as mock_exit, \
+             mock.patch('sky.serve.service.subprocess_utils.'
+                        'kill_children_processes'):
+            # Pass two mock processes so the function has something to kill.
+            ctrl = mock.Mock(pid=11111)
+            lb = mock.Mock(pid=22222)
+            service._orphan_exit(ctrl, lb)
+            mock_exit.assert_called_once_with(0)
+
+    def test_does_not_call_cleanup(self):
+        """Regression guard: a previous version of the plan had _orphan_exit
+        going through _cleanup with an `orphan` flag; sub-agent review caught
+        that _cleanup writes replica state and would race the new owner.
+        Verify we don't call into _cleanup at all."""
+        with mock.patch('os._exit'), \
+             mock.patch('sky.serve.service.subprocess_utils.'
+                        'kill_children_processes'), \
+             mock.patch('sky.serve.service._cleanup') as mock_cleanup, \
+             mock.patch('sky.serve.service.serve_state.'
+                        'remove_service') as mock_remove, \
+             mock.patch('sky.serve.service.serve_state.'
+                        'remove_replica') as mock_remove_replica:
+            ctrl = mock.Mock(pid=11111)
+            service._orphan_exit(ctrl, None)
+            mock_cleanup.assert_not_called()
+            mock_remove.assert_not_called()
+            mock_remove_replica.assert_not_called()
+
+    def test_kills_only_provided_subprocesses(self):
+        with mock.patch('os._exit'), \
+             mock.patch('sky.serve.service.subprocess_utils.'
+                        'kill_children_processes') as mock_kill:
+            ctrl = mock.Mock(pid=11111)
+            lb = mock.Mock(pid=22222)
+            service._orphan_exit(ctrl, lb)
+            _, kwargs = mock_kill.call_args
+            # Both pids included.
+            assert sorted(kwargs['parent_pids']) == [11111, 22222]
+            assert kwargs['force'] is True
+
+    def test_handles_none_subprocesses(self):
+        """Both subprocesses may be None if we crashed before spawning."""
+        with mock.patch('os._exit') as mock_exit, \
+             mock.patch('sky.serve.service.subprocess_utils.'
+                        'kill_children_processes') as mock_kill:
+            service._orphan_exit(None, None)
+            mock_kill.assert_not_called()
+            mock_exit.assert_called_once_with(0)
+
+    def test_swallows_kill_failure(self):
+        """If kill_children_processes raises (e.g. pid already gone), we
+        still must os._exit. Otherwise an exception leaves the orphan loop
+        running."""
+        with mock.patch('os._exit') as mock_exit, \
+             mock.patch('sky.serve.service.subprocess_utils.'
+                        'kill_children_processes',
+                        side_effect=OSError('no such process')):
+            ctrl = mock.Mock(pid=11111)
+            service._orphan_exit(ctrl, None)
+            mock_exit.assert_called_once_with(0)
+
+
+class TestCleanupBlocksHaRecoveryButKeepsVersionSpecs:
+    """`_cleanup` must:
+
+    1. Delete `serve_ha_recovery_script` up front. Once the user has issued
+       `pool down`, HA recovery must NOT respawn the controller — the SIGNAL
+       file is unlinked on first read in `_handle_signal`, so a recovered
+       controller can't "resume cleanup", it just silently brings the pool
+       back to life and starts replacing replicas. Deleting the recovery
+       script is the only thing that stops the daemon from reviving a
+       service the user explicitly downed.
+
+    2. Keep `version_specs` intact. `get_service_from_name` uses an INNER
+       JOIN with `version_specs`, so deleting the version rows during a
+       _cleanup that may still fail makes the resulting FAILED_CLEANUP row
+       invisible to status queries AND to `--purge` — the only escape would
+       be raw SQL DELETE. The success path in `_start` removes both
+       atomically via `remove_service_completely`; failure leaves the row
+       findable so the user can recover with `--purge`.
+    """
+
+    def _patch_common(self):
+        # Replicas: empty → skip the terminate-thread loop.
+        return [
+            mock.patch('sky.serve.service.serve_state.get_replica_infos',
+                       return_value=[]),
+            mock.patch(
+                'sky.serve.service.global_user_state.'
+                'get_cluster_names_start_with',
+                return_value=[]),
+            mock.patch('sky.serve.service.serve_state.get_service_versions',
+                       return_value=[1, 2]),
+            mock.patch('sky.serve.service.serve_state.get_yaml_content',
+                       return_value='dummy: yaml'),
+        ]
+
+    def test_recovery_script_removed_on_storage_success(self):
+        patches = self._patch_common()
+        with mock.patch('sky.serve.service.cleanup_storage',
+                        return_value=True), \
+             mock.patch(
+                 'sky.serve.service.serve_state.delete_all_versions'
+             ) as mock_delete_versions, \
+             mock.patch(
+                 'sky.serve.service.serve_state.remove_ha_recovery_script'
+             ) as mock_remove_recovery:
+            for p in patches:
+                p.start()
+            try:
+                failed = service._cleanup('svc', pool=False)
+            finally:
+                for p in patches:
+                    p.stop()
+            assert failed is False
+            # version_specs must NOT be touched by _cleanup (success path
+            # in _start handles it via remove_service_completely).
+            mock_delete_versions.assert_not_called()
+            # recovery_script MUST be removed up front to block HA daemon.
+            mock_remove_recovery.assert_called_once_with('svc')
+
+    def test_recovery_script_removed_even_when_cleanup_fails(self):
+        """Even when storage cleanup fails (we'll end up in FAILED_CLEANUP),
+        the recovery script must already be gone — otherwise HA daemon
+        respawns the controller into normal-pool mode (signal file is
+        already unlinked) and the pool comes back to life."""
+        patches = self._patch_common()
+        with mock.patch('sky.serve.service.cleanup_storage',
+                        return_value=False), \
+             mock.patch(
+                 'sky.serve.service.serve_state.delete_all_versions'
+             ) as mock_delete_versions, \
+             mock.patch(
+                 'sky.serve.service.serve_state.remove_ha_recovery_script'
+             ) as mock_remove_recovery:
+            for p in patches:
+                p.start()
+            try:
+                failed = service._cleanup('svc', pool=False)
+            finally:
+                for p in patches:
+                    p.stop()
+            assert failed is True
+            # version_specs preserved → row still findable via JOIN, --purge
+            # can clear it.
+            mock_delete_versions.assert_not_called()
+            # recovery_script gone → HA daemon won't respawn.
+            mock_remove_recovery.assert_called_once_with('svc')
+
+
+class TestCleanupStorageStaleBucket:
+    """When a storage's bucket has already been deleted (e.g. by an earlier
+    cleanup pass that succeeded for the bucket but crashed before remove_
+    service committed), re-running `cleanup_storage` must NOT mark the
+    cleanup as failed — the bucket already being gone IS the cleanup target
+    state.
+
+    Without this, FAILED_CLEANUP becomes a self-perpetuating loop:
+    `ha_recovery_for_consolidation_mode` respawns the controller, which
+    re-reads the same yaml and crashes on the same stale storage entry,
+    re-entering FAILED_CLEANUP forever (observed live as a pool flipping
+    between FAILED_CLEANUP and NO_REPLICA every time the recovery daemon
+    ticked).
+    """
+
+    def test_returns_success_when_bucket_already_gone(self):
+        from sky import exceptions as sky_exc
+
+        stale_storage = mock.MagicMock()
+        stale_storage.construct.side_effect = sky_exc.StorageBucketGetError(
+            'Attempted to use a non-existent bucket as a source: s3://gone')
+
+        live_storage = mock.MagicMock()
+        # construct() returns normally → storage stays in storage_mounts.
+
+        mock_task = mock.MagicMock()
+        mock_task.storage_mounts = {
+            '/stale': stale_storage,
+            '/live': live_storage,
+        }
+        mock_task.file_mounts = None
+
+        mock_backend = mock.MagicMock()
+
+        with mock.patch('sky.serve.service.task_lib.Task.from_yaml_str',
+                        return_value=mock_task), \
+             mock.patch(
+                 'sky.serve.service.cloud_vm_ray_backend.CloudVmRayBackend',
+                 return_value=mock_backend):
+            result = service.cleanup_storage('dummy: yaml')
+
+        assert result is True, (
+            'a bucket that is already gone is the cleanup target state, '
+            'must not be reported as failure')
+        # Stale entry dropped before teardown so backend doesn't retry it.
+        assert '/stale' not in mock_task.storage_mounts
+        assert '/live' in mock_task.storage_mounts
+        mock_backend.teardown_ephemeral_storage.assert_called_once_with(
+            mock_task)
+        live_storage.construct.assert_called_once()
+
+    def test_returns_failure_for_other_construct_errors(self):
+        """Non-bucket-missing construct errors still fail cleanup — we
+        don't want to silently swallow real bugs like expired creds."""
+        broken_storage = mock.MagicMock()
+        broken_storage.construct.side_effect = RuntimeError(
+            'credential expired')
+
+        mock_task = mock.MagicMock()
+        mock_task.storage_mounts = {'/x': broken_storage}
+        mock_task.file_mounts = None
+
+        mock_backend = mock.MagicMock()
+
+        with mock.patch('sky.serve.service.task_lib.Task.from_yaml_str',
+                        return_value=mock_task), \
+             mock.patch(
+                 'sky.serve.service.cloud_vm_ray_backend.CloudVmRayBackend',
+                 return_value=mock_backend):
+            result = service.cleanup_storage('dummy: yaml')
+
+        assert result is False, (
+            'unexpected construct errors must propagate as cleanup failure')
+        # The broader except block aborted before reaching teardown.
+        mock_backend.teardown_ephemeral_storage.assert_not_called()

--- a/tests/unit_tests/test_serve_service.py
+++ b/tests/unit_tests/test_serve_service.py
@@ -1,10 +1,9 @@
 """Tests for sky/serve/service.py.
 
-Focused on the helpers added for HA leader-aware routing (changes C.2 / C.3
-from plans/jobs-pool-consolidation-ha-architecture.md):
+Focused on the helpers added for HA leader-aware routing:
 
 - _wait_for_controller_ready: must block until the uvicorn subprocess is
-  actually accepting connections. Used to gate the PG flip in the recovery
+  actually accepting connections. Used to gate the DB flip in the recovery
   path so that clients never route to a pod whose listener isn't bound yet.
 - _orphan_exit: must NOT call _cleanup. The whole point of this exit path
   is that another instance has already taken over the row, so any cleanup
@@ -85,7 +84,7 @@ class TestWaitForControllerReady:
 
     def test_raises_on_timeout(self):
         """Listener never comes up — must raise RuntimeError, not block
-        forever (would otherwise leave the daemon stuck with the old PG row
+        forever (would otherwise leave the daemon stuck with the old DB row
         intact, blocking subsequent recoveries)."""
         port = _free_port()
         # Don't bind anything.
@@ -107,7 +106,7 @@ class TestWaitForControllerReady:
 
 
 class TestOrphanExit:
-    """Critical contract: _orphan_exit must NOT touch any PG state. It only
+    """Critical contract: _orphan_exit must NOT touch any DB state. It only
     kills our forked subprocesses and calls os._exit(0). This is what
     distinguishes orphan exit from normal cleanup — the new owner is now
     responsible for replica state, version cleanup, services row deletion,
@@ -124,10 +123,6 @@ class TestOrphanExit:
             mock_exit.assert_called_once_with(0)
 
     def test_does_not_call_cleanup(self):
-        """Regression guard: a previous version of the plan had _orphan_exit
-        going through _cleanup with an `orphan` flag; sub-agent review caught
-        that _cleanup writes replica state and would race the new owner.
-        Verify we don't call into _cleanup at all."""
         with mock.patch('os._exit'), \
              mock.patch('sky.serve.service.subprocess_utils.'
                         'kill_children_processes'), \

--- a/tests/unit_tests/test_serve_state.py
+++ b/tests/unit_tests/test_serve_state.py
@@ -1,0 +1,352 @@
+"""Tests for serve_state.
+
+Focused on the new controller_ip column + atomic update introduced for HA
+multi-replica leader-aware routing (changes C.1 from
+plans/jobs-pool-consolidation-ha-architecture.md).
+"""
+# Pytest fixture name collides with pylint's "private name" rule (leading
+# underscore is the standard convention for fixtures injected for side
+# effects). Disable for the file.
+# pylint: disable=invalid-name,protected-access
+import pytest
+import sqlalchemy
+from sqlalchemy import create_engine
+from sqlalchemy import orm
+
+from sky.serve import serve_state
+
+
+def _read_row(engine, name):
+    """Read raw services row directly (bypassing get_service_from_name which
+    does an INNER JOIN with version_specs and would skip rows without a
+    version registered)."""
+    with orm.Session(engine) as session:
+        result = session.execute(
+            sqlalchemy.select(serve_state.services_table).where(
+                serve_state.services_table.c.name == name)).fetchone()
+    return None if result is None else dict(result._mapping)  # pylint: disable=protected-access
+
+
+@pytest.fixture
+def _mock_serve_db(tmp_path, monkeypatch):
+    """Point serve_state at a fresh sqlite DB for the duration of one test."""
+    db_path = tmp_path / 'serve_state_testing.db'
+    engine = create_engine(f'sqlite:///{db_path}')
+
+    monkeypatch.setattr(serve_state._db_manager, '_engine', engine)
+    # `metadata.create_all` only creates tables that don't already exist; this
+    # is enough since we're starting from a brand-new DB and the alembic
+    # upgrade step in `create_table` would otherwise need a full env.
+    serve_state.Base.metadata.create_all(engine)
+    yield engine
+
+
+def _add_minimal_service(name: str, controller_ip=None):
+    """Add a service row with all-required-args defaults so individual tests
+    only need to specify what they care about."""
+    return serve_state.add_service(
+        name=name,
+        controller_job_id=1,
+        policy='policy',
+        requested_resources_str='1x[CPU:1+]',
+        load_balancing_policy='round_robin',
+        status=serve_state.ServiceStatus.CONTROLLER_INIT,
+        tls_encrypted=False,
+        pool=False,
+        controller_pid=12345,
+        entrypoint='entry',
+        controller_ip=controller_ip,
+    )
+
+
+class TestAddServiceWritesControllerIp:
+    """`add_service` should persist the new controller_ip column when caller
+    provides POD_IP. Older callers that don't pass it must still work
+    (column defaults to NULL)."""
+
+    def test_with_controller_ip(self, _mock_serve_db):
+        success = _add_minimal_service('svc1', controller_ip='10.0.0.7')
+        assert success is True
+        record = _read_row(_mock_serve_db, 'svc1')
+        assert record is not None
+        assert record['controller_ip'] == '10.0.0.7'
+
+    def test_without_controller_ip(self, _mock_serve_db):
+        # No controller_ip arg → column stays NULL (used by single-pod /
+        # non-K8s deployments where the routing layer falls back to localhost).
+        success = _add_minimal_service('svc2')
+        assert success is True
+        record = _read_row(_mock_serve_db, 'svc2')
+        assert record is not None
+        assert record['controller_ip'] is None
+
+    def test_returns_false_on_duplicate(self, _mock_serve_db):
+        assert _add_minimal_service('svc3', controller_ip='10.0.0.7') is True
+        # Adding the same service again must not corrupt — uniqueness violation
+        # is converted to False so up() can short-circuit.
+        assert _add_minimal_service('svc3', controller_ip='10.0.0.8') is False
+        # And the row is unchanged.
+        record = _read_row(_mock_serve_db, 'svc3')
+        assert record['controller_ip'] == '10.0.0.7'
+
+
+class TestGetServiceFromNameReturnsControllerIp:
+    """Regression guard: `_get_service_from_row` originally constructed the
+    record dict without `controller_ip`. Even though PG had the column and
+    `add_service` wrote to it, every reader that came through
+    `get_service_from_name` saw `record.get('controller_ip') == None`.
+
+    This silently broke HA cross-pod routing in `_get_controller_url`:
+    callers always fell through to `http://localhost:<port>` even when the
+    controller was on a different pod, so any non-controller pod handling
+    a status / down / update request hit ECONNREFUSED.
+
+    These tests assert that `get_service_from_name` returns the field and
+    that the value round-trips. If a future schema change adds another
+    column without updating `_get_service_from_row`, the same class of bug
+    can resurface; the assertion list below is the canary.
+    """
+
+    def _add_with_version(self, service_name, controller_ip):
+        # Reading via get_service_from_name requires a version_specs row
+        # (it's an INNER JOIN). Use the lightweight `add_version` helper,
+        # which inserts with spec=pickle.dumps(None) and yaml_content=NULL —
+        # enough for the JOIN to fire, no SkyServiceSpec wrangling needed.
+        _add_minimal_service(service_name, controller_ip=controller_ip)
+        serve_state.add_version(service_name)
+
+    def test_round_trips_controller_ip(self, _mock_serve_db):
+        self._add_with_version('svc-rt', controller_ip='10.4.10.8')
+        record = serve_state.get_service_from_name('svc-rt')
+        assert record is not None
+        # The whole point: the dict KEY must exist with the persisted value.
+        assert 'controller_ip' in record, (
+            'controller_ip key missing from get_service_from_name() record — '
+            'callers will silently fall back to localhost routing')
+        assert record['controller_ip'] == '10.4.10.8'
+
+    def test_round_trips_none_controller_ip(self, _mock_serve_db):
+        # Even when the row was written without controller_ip (single-pod
+        # mode), the dict must contain the key with value None — otherwise
+        # `record.get('controller_ip')` and `record['controller_ip']` give
+        # inconsistent answers.
+        self._add_with_version('svc-rt-none', controller_ip=None)
+        record = serve_state.get_service_from_name('svc-rt-none')
+        assert record is not None
+        assert 'controller_ip' in record
+        assert record['controller_ip'] is None
+
+    def test_record_includes_all_persisted_columns(self, _mock_serve_db):
+        """Belt and braces: snapshot the keys we expect from the read path.
+        If a future PR adds a column to services_table but forgets to update
+        `_get_service_from_row`, this test fails loudly."""
+        self._add_with_version('svc-rt-keys', controller_ip='10.0.0.1')
+        record = serve_state.get_service_from_name('svc-rt-keys')
+        assert record is not None
+        for key in (
+                'name',
+                'status',
+                'controller_pid',
+                'controller_ip',
+                'controller_port',
+                'pool',
+        ):
+            assert key in record, f'missing key: {key}'
+
+
+class TestUpdateServiceControllerPidIpAndPort:
+    """The atomic update is the core of the HA-recovery PG flip — it must
+    write pid, ip, AND port in a single transaction so clients never
+    observe a half-flipped row (e.g. new pid + old ip + stale port that
+    points at a different service's listener on the new pod).
+
+    Recovery picks port locally (find_free_port on the recovery pod);
+    that new port has to land in PG together with pid/ip, otherwise
+    a `_get_controller_url` consumer reading PG between writes could
+    route to the new pod with the old port and hit the wrong listener.
+    """
+
+    def test_updates_all_three_fields(self, _mock_serve_db):
+        _add_minimal_service('svc', controller_ip='10.0.0.7')
+        serve_state.set_service_controller_port('svc', 20001)
+
+        serve_state.update_service_controller_pid_ip_and_port(
+            'svc',
+            controller_pid=99999,
+            controller_ip='10.0.0.8',
+            controller_port=20007)
+
+        record = _read_row(_mock_serve_db, 'svc')
+        assert record['controller_pid'] == 99999
+        assert record['controller_ip'] == '10.0.0.8'
+        assert record['controller_port'] == 20007
+
+    def test_can_clear_controller_ip(self, _mock_serve_db):
+        # If we ever need to write None (e.g. controller is on a non-K8s pod
+        # in a hybrid deploy), the column must accept NULL. Port is still
+        # required (it's an int column, no NULL).
+        _add_minimal_service('svc', controller_ip='10.0.0.7')
+        serve_state.update_service_controller_pid_ip_and_port(
+            'svc',
+            controller_pid=99999,
+            controller_ip=None,
+            controller_port=20007)
+        record = _read_row(_mock_serve_db, 'svc')
+        assert record['controller_pid'] == 99999
+        assert record['controller_ip'] is None
+        assert record['controller_port'] == 20007
+
+    def test_no_op_when_service_missing(self, _mock_serve_db):
+        # Should not raise if the row was deleted between read and write
+        # (e.g. a `down` raced our recovery).
+        serve_state.update_service_controller_pid_ip_and_port(
+            'never-existed',
+            controller_pid=1,
+            controller_ip='10.0.0.7',
+            controller_port=20001)
+        assert _read_row(_mock_serve_db, 'never-existed') is None
+
+    def test_does_not_touch_other_fields(self, _mock_serve_db):
+        # The atomic update must only touch the three specified columns —
+        # don't want to clobber e.g. status, load_balancer_port from a
+        # concurrent writer.
+        _add_minimal_service('svc', controller_ip='10.0.0.7')
+        serve_state.set_service_controller_port('svc', 20001)
+        serve_state.set_service_load_balancer_port('svc', 30000)
+
+        serve_state.update_service_controller_pid_ip_and_port(
+            'svc',
+            controller_pid=99999,
+            controller_ip='10.0.0.8',
+            controller_port=20007)
+
+        record = _read_row(_mock_serve_db, 'svc')
+        assert record['controller_pid'] == 99999
+        assert record['controller_ip'] == '10.0.0.8'
+        assert record['controller_port'] == 20007
+        assert record['load_balancer_port'] == 30000  # untouched
+
+
+class TestSetServiceControllerIp:
+    """Standalone IP setter is rarely called (the atomic version is preferred
+    for recovery), but kept for symmetry with set_service_controller_port."""
+
+    def test_basic(self, _mock_serve_db):
+        _add_minimal_service('svc', controller_ip=None)
+        serve_state.set_service_controller_ip('svc', '10.0.0.9')
+        record = _read_row(_mock_serve_db, 'svc')
+        assert record['controller_ip'] == '10.0.0.9'
+        # pid unchanged
+        assert record['controller_pid'] == 12345
+
+
+class TestRemoveServiceCompletely:
+    """`remove_service_completely` deletes services / version_specs /
+    serve_ha_recovery_script in one transaction. Sequential deletes had
+    a real-world failure mode where the last call
+    (`remove_ha_recovery_script`) was the one most likely to be skipped
+    when the subprocess died mid-cleanup, leaving the row orphaned across
+    many test runs while the other tables stayed clean. This guarantees
+    all-or-nothing teardown for service metadata.
+
+    Replicas are NOT touched: both callers (`_cleanup` success path,
+    `_terminate_failed_services` on `--purge`) iterate replicas with
+    per-replica logic (cluster-existence probes, terminate-thread join,
+    failure marking) and clear the rows themselves before reaching this
+    function. The tests below explicitly assert that pre-existing
+    replica rows survive.
+    """
+
+    def _populate(self, engine, name):
+        # Seed all three service-metadata tables plus a replica row so we
+        # can assert metadata is removed atomically while the replica row
+        # survives.
+        _add_minimal_service(name, controller_ip='10.0.0.1')
+        serve_state.add_version(name)
+        serve_state.set_ha_recovery_script(name, 'dummy script')
+        # replicas: a minimal pickled ReplicaInfo proxy is hard to
+        # construct here, so just write a row directly to the table.
+        with orm.Session(engine) as session:
+            session.execute(serve_state.replicas_table.insert().values(
+                service_name=name, replica_id=1, replica_info=b'fake-pickle'))
+            session.commit()
+
+    def test_removes_service_metadata_tables(self, _mock_serve_db):
+        self._populate(_mock_serve_db, 'svc-rsc')
+        # Sanity: rows are present.
+        with orm.Session(_mock_serve_db) as session:
+            assert session.execute(
+                sqlalchemy.select(serve_state.services_table.c.name).where(
+                    serve_state.services_table.c.name ==
+                    'svc-rsc')).first() is not None
+            assert session.execute(
+                sqlalchemy.select(
+                    serve_state.serve_ha_recovery_script_table.c.service_name).
+                where(serve_state.serve_ha_recovery_script_table.c.service_name
+                      == 'svc-rsc')).first() is not None
+            assert session.execute(
+                sqlalchemy.select(
+                    serve_state.replicas_table.c.service_name).where(
+                        serve_state.replicas_table.c.service_name ==
+                        'svc-rsc')).first() is not None
+            assert session.execute(
+                sqlalchemy.select(
+                    serve_state.version_specs_table.c.service_name).where(
+                        serve_state.version_specs_table.c.service_name ==
+                        'svc-rsc')).first() is not None
+
+        serve_state.remove_service_completely('svc-rsc')
+
+        # The three metadata tables must be gone.
+        with orm.Session(_mock_serve_db) as session:
+            assert session.execute(
+                sqlalchemy.select(serve_state.services_table.c.name).where(
+                    serve_state.services_table.c.name ==
+                    'svc-rsc')).first() is None
+            assert session.execute(
+                sqlalchemy.select(
+                    serve_state.serve_ha_recovery_script_table.c.service_name).
+                where(serve_state.serve_ha_recovery_script_table.c.service_name
+                      == 'svc-rsc')).first() is None
+            assert session.execute(
+                sqlalchemy.select(
+                    serve_state.version_specs_table.c.service_name).where(
+                        serve_state.version_specs_table.c.service_name ==
+                        'svc-rsc')).first() is None
+            # The replicas row must SURVIVE — replicas are the caller's
+            # responsibility, not this function's. Deleting them here
+            # would fold over the per-replica leak-detection and
+            # failure-marking logic in the two real callers.
+            assert session.execute(
+                sqlalchemy.select(
+                    serve_state.replicas_table.c.service_name).where(
+                        serve_state.replicas_table.c.service_name ==
+                        'svc-rsc')).first() is not None
+
+    def test_does_not_touch_other_services(self, _mock_serve_db):
+        """Make sure deletion is scoped to the named service."""
+        self._populate(_mock_serve_db, 'svc-keep')
+        self._populate(_mock_serve_db, 'svc-drop')
+
+        serve_state.remove_service_completely('svc-drop')
+
+        # svc-keep's rows must all survive.
+        with orm.Session(_mock_serve_db) as session:
+            for tbl_name, tbl, col_name in [
+                ('services', serve_state.services_table, 'name'),
+                ('version_specs', serve_state.version_specs_table,
+                 'service_name'),
+                ('serve_ha_recovery_script',
+                 serve_state.serve_ha_recovery_script_table, 'service_name'),
+                ('replicas', serve_state.replicas_table, 'service_name'),
+            ]:
+                col = getattr(tbl.c, col_name)
+                assert session.execute(
+                    sqlalchemy.select(col).where(
+                        col == 'svc-keep')).first() is not None, (
+                            f'svc-keep was wrongly removed from {tbl_name}')
+
+    def test_no_op_when_nothing_to_delete(self, _mock_serve_db):
+        # Should be a silent no-op when no rows exist.
+        serve_state.remove_service_completely('never-existed')
+        # No assertion needed beyond "didn't raise".

--- a/tests/unit_tests/test_serve_state.py
+++ b/tests/unit_tests/test_serve_state.py
@@ -1,8 +1,7 @@
 """Tests for serve_state.
 
 Focused on the new controller_ip column + atomic update introduced for HA
-multi-replica leader-aware routing (changes C.1 from
-plans/jobs-pool-consolidation-ha-architecture.md).
+leader-aware routing.
 """
 # Pytest fixture name collides with pylint's "private name" rule (leading
 # underscore is the standard convention for fixtures injected for side
@@ -25,20 +24,6 @@ def _read_row(engine, name):
             sqlalchemy.select(serve_state.services_table).where(
                 serve_state.services_table.c.name == name)).fetchone()
     return None if result is None else dict(result._mapping)  # pylint: disable=protected-access
-
-
-@pytest.fixture
-def _mock_serve_db(tmp_path, monkeypatch):
-    """Point serve_state at a fresh sqlite DB for the duration of one test."""
-    db_path = tmp_path / 'serve_state_testing.db'
-    engine = create_engine(f'sqlite:///{db_path}')
-
-    monkeypatch.setattr(serve_state._db_manager, '_engine', engine)
-    # `metadata.create_all` only creates tables that don't already exist; this
-    # is enough since we're starting from a brand-new DB and the alembic
-    # upgrade step in `create_table` would otherwise need a full env.
-    serve_state.Base.metadata.create_all(engine)
-    yield engine
 
 
 def _add_minimal_service(name: str, controller_ip=None):
@@ -91,21 +76,6 @@ class TestAddServiceWritesControllerIp:
 
 
 class TestGetServiceFromNameReturnsControllerIp:
-    """Regression guard: `_get_service_from_row` originally constructed the
-    record dict without `controller_ip`. Even though PG had the column and
-    `add_service` wrote to it, every reader that came through
-    `get_service_from_name` saw `record.get('controller_ip') == None`.
-
-    This silently broke HA cross-pod routing in `_get_controller_url`:
-    callers always fell through to `http://localhost:<port>` even when the
-    controller was on a different pod, so any non-controller pod handling
-    a status / down / update request hit ECONNREFUSED.
-
-    These tests assert that `get_service_from_name` returns the field and
-    that the value round-trips. If a future schema change adds another
-    column without updating `_get_service_from_row`, the same class of bug
-    can resurface; the assertion list below is the canary.
-    """
 
     def _add_with_version(self, service_name, controller_ip):
         # Reading via get_service_from_name requires a version_specs row
@@ -155,14 +125,14 @@ class TestGetServiceFromNameReturnsControllerIp:
 
 
 class TestUpdateServiceControllerPidIpAndPort:
-    """The atomic update is the core of the HA-recovery PG flip — it must
+    """The atomic update is the core of the HA-recovery DB flip — it must
     write pid, ip, AND port in a single transaction so clients never
     observe a half-flipped row (e.g. new pid + old ip + stale port that
     points at a different service's listener on the new pod).
 
     Recovery picks port locally (find_free_port on the recovery pod);
-    that new port has to land in PG together with pid/ip, otherwise
-    a `_get_controller_url` consumer reading PG between writes could
+    that new port has to land in DB together with pid/ip, otherwise
+    a `_get_controller_url` consumer reading DB between writes could
     route to the new pod with the old port and hit the wrong listener.
     """
 
@@ -244,17 +214,10 @@ class TestRemoveServiceCompletely:
     """`remove_service_completely` deletes services / version_specs /
     serve_ha_recovery_script in one transaction. Sequential deletes had
     a real-world failure mode where the last call
-    (`remove_ha_recovery_script`) was the one most likely to be skipped
+    was the one most likely to be skipped
     when the subprocess died mid-cleanup, leaving the row orphaned across
     many test runs while the other tables stayed clean. This guarantees
     all-or-nothing teardown for service metadata.
-
-    Replicas are NOT touched: both callers (`_cleanup` success path,
-    `_terminate_failed_services` on `--purge`) iterate replicas with
-    per-replica logic (cluster-existence probes, terminate-thread join,
-    failure marking) and clear the rows themselves before reaching this
-    function. The tests below explicitly assert that pre-existing
-    replica rows survive.
     """
 
     def _populate(self, engine, name):

--- a/tests/unit_tests/test_serve_state.py
+++ b/tests/unit_tests/test_serve_state.py
@@ -26,6 +26,20 @@ def _read_row(engine, name):
     return None if result is None else dict(result._mapping)  # pylint: disable=protected-access
 
 
+@pytest.fixture
+def _mock_serve_db(tmp_path, monkeypatch):
+    """Point serve_state at a fresh sqlite DB for the duration of one test."""
+    db_path = tmp_path / 'serve_state_testing.db'
+    engine = create_engine(f'sqlite:///{db_path}')
+
+    monkeypatch.setattr(serve_state._db_manager, '_engine', engine)
+    # `metadata.create_all` only creates tables that don't already exist; this
+    # is enough since we're starting from a brand-new DB and the alembic
+    # upgrade step in `create_table` would otherwise need a full env.
+    serve_state.Base.metadata.create_all(engine)
+    yield engine
+
+
 def _add_minimal_service(name: str, controller_ip=None):
     """Add a service row with all-required-args defaults so individual tests
     only need to specify what they care about."""

--- a/tests/unit_tests/test_serve_utils.py
+++ b/tests/unit_tests/test_serve_utils.py
@@ -153,19 +153,19 @@ class TestIsConsolidationMode:
 
 
 # ---------------------------------------------------------------------------
-# Tests for HA leader-aware controller URL routing (changes A.2 / C.4 / D)
+# Tests for HA leader-aware controller URL routing
 # ---------------------------------------------------------------------------
 # pylint: disable=protected-access
 
 
 class TestGetControllerUrl:
     """`_get_controller_url` should:
-    - fall back to localhost when no controller_ip is recorded (single-pod /
-      pre-migration), so existing single-replica deployments are unaffected;
+    - fall back to localhost when no controller_ip is recorded (
+      pre-migration), so existing deployments are unaffected;
     - fall back to localhost when controller_ip equals our own POD_IP, so the
       pod that owns the controller doesn't pay for an extra cross-pod hop;
     - return http://<controller_ip>:<port> only when running on a different
-      pod than the one hosting the controller (multi-replica HA case).
+      pod than the one hosting the controller.
     """
 
     def _patch_record(self, controller_ip):
@@ -180,7 +180,7 @@ class TestGetControllerUrl:
             })
 
     def test_no_record_returns_localhost(self):
-        """Service row missing → fall back to localhost (no PG to route by)."""
+        """Service row missing → fall back to localhost."""
         with mock.patch(
                 'sky.serve.serve_utils.serve_state.'
                 'get_service_from_name',
@@ -222,15 +222,6 @@ class TestGetControllerUrl:
 
 
 class TestControllerHttpRetry:
-    """The retry wrappers cover the only realistic failure mode after change
-    C: a brief window when a follower pod races a recovery — the controller
-    process on the new owner may already be listening but PG may still point
-    at the old owner (or the old pod is mid-shutdown). 3 attempts × 0.5s
-    backoff (~1s total) is enough for the PG-flip race and bounded enough
-    not to hang the user. Intermediate attempts log at DEBUG; only the
-    final-attempt failure logs at WARN, so each refresh tick produces at
-    most one WARN line even when the controller is intentionally absent
-    (CONTROLLER_INIT / SHUTTING_DOWN / FAILED_CLEANUP)."""
 
     def _patch_record(self, controller_ip):
         return mock.patch(
@@ -288,11 +279,11 @@ class TestControllerHttpRetry:
                 assert m.call_count == 1
 
     def test_get_retries_url_is_re_resolved_each_attempt(self):
-        """Between retries we re-call _get_controller_url so that if PG
+        """Between retries we re-call _get_controller_url so that if DB
         finished flipping during the backoff, we route to the new owner on
         the next try."""
 
-        # Simulate PG flip mid-retry: first lookup says 10.0.0.7, second
+        # Simulate DB flip mid-retry: first lookup says 10.0.0.7, second
         # lookup says 10.0.0.8.
         records = [
             {
@@ -328,12 +319,6 @@ class TestControllerHttpRetry:
         assert urls_called[1] == 'http://10.0.0.8:20001/autoscaler/info'
 
     def test_log_levels_one_warn_per_cycle(self):
-        """Each refresh tick during SHUTTING_DOWN spams retries into the
-        daemon log; we want at most one WARN line per cycle (final attempt)
-        with intermediate attempts at DEBUG. Catches the regression where
-        every retry was a WARN. We patch logger directly (caplog doesn't
-        capture sky_logging-initialized loggers because they
-        `propagate=False`)."""
         with self._patch_record(None), \
              mock.patch('sky.serve.serve_utils.time.sleep'), \
              mock.patch(

--- a/tests/unit_tests/test_serve_utils.py
+++ b/tests/unit_tests/test_serve_utils.py
@@ -3,6 +3,7 @@ import tempfile
 from unittest import mock
 
 import pytest
+import requests.exceptions as requests_exceptions
 
 from sky import clouds
 from sky.resources import Resources
@@ -149,3 +150,474 @@ class TestIsConsolidationMode:
         short-circuit tested in controller_utils."""
         with mock.patch('sky.serve.serve_utils.skypilot_config'):
             assert serve_utils.is_consolidation_mode(pool=False) is True
+
+
+# ---------------------------------------------------------------------------
+# Tests for HA leader-aware controller URL routing (changes A.2 / C.4 / D)
+# ---------------------------------------------------------------------------
+# pylint: disable=protected-access
+
+
+class TestGetControllerUrl:
+    """`_get_controller_url` should:
+    - fall back to localhost when no controller_ip is recorded (single-pod /
+      pre-migration), so existing single-replica deployments are unaffected;
+    - fall back to localhost when controller_ip equals our own POD_IP, so the
+      pod that owns the controller doesn't pay for an extra cross-pod hop;
+    - return http://<controller_ip>:<port> only when running on a different
+      pod than the one hosting the controller (multi-replica HA case).
+    """
+
+    def _patch_record(self, controller_ip):
+        return mock.patch(
+            'sky.serve.serve_utils.serve_state.'
+            'get_service_from_name',
+            return_value={
+                'name': 'svc',
+                'controller_pid': 1234,
+                'controller_port': 20001,
+                'controller_ip': controller_ip,
+            })
+
+    def test_no_record_returns_localhost(self):
+        """Service row missing → fall back to localhost (no PG to route by)."""
+        with mock.patch(
+                'sky.serve.serve_utils.serve_state.'
+                'get_service_from_name',
+                return_value=None):
+            assert serve_utils._get_controller_url(
+                'svc', 20001) == 'http://localhost:20001'
+
+    def test_controller_ip_none_returns_localhost(self):
+        """Row exists but controller_ip not yet written (e.g. older row from
+        before the migration) → localhost."""
+        with self._patch_record(None):
+            assert serve_utils._get_controller_url(
+                'svc', 20001) == 'http://localhost:20001'
+
+    def test_controller_ip_equals_self_returns_localhost(self, monkeypatch):
+        """We are the controller's host pod → loopback is correct + faster."""
+        monkeypatch.setenv('POD_IP', '10.0.0.5')
+        with self._patch_record('10.0.0.5'):
+            assert serve_utils._get_controller_url(
+                'svc', 20001) == 'http://localhost:20001'
+
+    def test_controller_ip_differs_returns_pod_ip(self, monkeypatch):
+        """We are on a follower pod → route to controller pod's IP."""
+        monkeypatch.setenv('POD_IP', '10.0.0.5')
+        with self._patch_record('10.0.0.7'):
+            assert serve_utils._get_controller_url(
+                'svc', 20001) == 'http://10.0.0.7:20001'
+
+    def test_no_pod_ip_env_routes_via_recorded_ip(self, monkeypatch):
+        """No POD_IP env (non-K8s deploy) but a controller_ip is recorded.
+        We can't decide we're the controller pod — route to recorded IP. This
+        case shouldn't happen in practice (a pod recording controller_ip
+        implies POD_IP env was injected when it started the controller), but
+        the routing must remain deterministic."""
+        monkeypatch.delenv('POD_IP', raising=False)
+        with self._patch_record('10.0.0.7'):
+            assert serve_utils._get_controller_url(
+                'svc', 20001) == 'http://10.0.0.7:20001'
+
+
+class TestControllerHttpRetry:
+    """The retry wrappers cover the only realistic failure mode after change
+    C: a brief window when a follower pod races a recovery — the controller
+    process on the new owner may already be listening but PG may still point
+    at the old owner (or the old pod is mid-shutdown). 3 attempts × 0.5s
+    backoff (~1s total) is enough for the PG-flip race and bounded enough
+    not to hang the user. Intermediate attempts log at DEBUG; only the
+    final-attempt failure logs at WARN, so each refresh tick produces at
+    most one WARN line even when the controller is intentionally absent
+    (CONTROLLER_INIT / SHUTTING_DOWN / FAILED_CLEANUP)."""
+
+    def _patch_record(self, controller_ip):
+        return mock.patch(
+            'sky.serve.serve_utils.serve_state.'
+            'get_service_from_name',
+            return_value={
+                'name': 'svc',
+                'controller_pid': 1234,
+                'controller_port': 20001,
+                'controller_ip': controller_ip,
+            })
+
+    def test_post_succeeds_first_try(self):
+        with self._patch_record(None):
+            with mock.patch('sky.serve.serve_utils.requests.post',
+                            return_value=mock.Mock(status_code=200)) as m:
+                resp = serve_utils._post_to_controller_with_retry(
+                    'svc', 20001, '/controller/update_service', json={})
+                assert resp.status_code == 200
+                assert m.call_count == 1
+
+    def test_post_retries_then_succeeds(self):
+        # First 2 calls raise, 3rd succeeds.
+        side = [
+            requests_exceptions.ConnectionError('refused'),
+            requests_exceptions.ConnectionError('refused'),
+            mock.Mock(status_code=200)
+        ]
+        with self._patch_record(None), \
+             mock.patch('sky.serve.serve_utils.time.sleep'), \
+             mock.patch('sky.serve.serve_utils.requests.post',
+                        side_effect=side) as m:
+            resp = serve_utils._post_to_controller_with_retry(
+                'svc', 20001, '/controller/update_service', json={})
+            assert resp.status_code == 200
+            assert m.call_count == 3
+
+    def test_post_exhausts_retries_and_raises(self):
+        with self._patch_record(None), \
+             mock.patch('sky.serve.serve_utils.time.sleep'), \
+             mock.patch('sky.serve.serve_utils.requests.post',
+                        side_effect=requests_exceptions.ConnectionError('refused')) as m:
+            with pytest.raises(requests_exceptions.ConnectionError):
+                serve_utils._post_to_controller_with_retry(
+                    'svc', 20001, '/controller/update_service', json={})
+            assert m.call_count == serve_utils._CONTROLLER_HTTP_RETRY_ATTEMPTS
+
+    def test_get_succeeds_first_try(self):
+        with self._patch_record(None):
+            with mock.patch('sky.serve.serve_utils.requests.get',
+                            return_value=mock.Mock(status_code=200)) as m:
+                resp = serve_utils._get_to_controller_with_retry(
+                    'svc', 20001, '/autoscaler/info')
+                assert resp.status_code == 200
+                assert m.call_count == 1
+
+    def test_get_retries_url_is_re_resolved_each_attempt(self):
+        """Between retries we re-call _get_controller_url so that if PG
+        finished flipping during the backoff, we route to the new owner on
+        the next try."""
+
+        # Simulate PG flip mid-retry: first lookup says 10.0.0.7, second
+        # lookup says 10.0.0.8.
+        records = [
+            {
+                'name': 'svc',
+                'controller_pid': 1,
+                'controller_port': 20001,
+                'controller_ip': '10.0.0.7'
+            },
+            {
+                'name': 'svc',
+                'controller_pid': 2,
+                'controller_port': 20001,
+                'controller_ip': '10.0.0.8'
+            },
+        ]
+        urls_called = []
+
+        def capture_get(url, **kwargs):  # pylint: disable=unused-argument
+            urls_called.append(url)
+            if len(urls_called) == 1:
+                raise requests_exceptions.ConnectionError('refused')
+            return mock.Mock(status_code=200)
+
+        with mock.patch('sky.serve.serve_utils.serve_state.'
+                        'get_service_from_name',
+                        side_effect=records), \
+             mock.patch('sky.serve.serve_utils.time.sleep'), \
+             mock.patch('sky.serve.serve_utils.requests.get',
+                        side_effect=capture_get):
+            serve_utils._get_to_controller_with_retry('svc', 20001,
+                                                      '/autoscaler/info')
+        assert urls_called[0] == 'http://10.0.0.7:20001/autoscaler/info'
+        assert urls_called[1] == 'http://10.0.0.8:20001/autoscaler/info'
+
+    def test_log_levels_one_warn_per_cycle(self):
+        """Each refresh tick during SHUTTING_DOWN spams retries into the
+        daemon log; we want at most one WARN line per cycle (final attempt)
+        with intermediate attempts at DEBUG. Catches the regression where
+        every retry was a WARN. We patch logger directly (caplog doesn't
+        capture sky_logging-initialized loggers because they
+        `propagate=False`)."""
+        with self._patch_record(None), \
+             mock.patch('sky.serve.serve_utils.time.sleep'), \
+             mock.patch(
+                 'sky.serve.serve_utils.requests.get',
+                 side_effect=requests_exceptions.ConnectionError('refused')), \
+             mock.patch.object(serve_utils.logger, 'warning') as warn, \
+             mock.patch.object(serve_utils.logger, 'debug') as debug:
+            with pytest.raises(requests_exceptions.ConnectionError):
+                serve_utils._get_to_controller_with_retry(
+                    'svc', 20001, '/autoscaler/info')
+        # Final-attempt failure → exactly one WARN.
+        assert warn.call_count == 1, (
+            f'expected exactly 1 WARN call, got {warn.call_count}: '
+            f'{warn.call_args_list}')
+        # Intermediate retry attempts log at DEBUG (N-1 of them). Filter
+        # by message content so the assertion stays robust to other
+        # DEBUG lines emitted on the same path (e.g. `_get_controller_url`
+        # also emits one DEBUG per URL resolution — those are routing
+        # diagnostics, not retry signals).
+        retry_debug_calls = [
+            c for c in debug.call_args_list
+            if 'Connection to controller' in (c.args[0] if c.args else '')
+        ]
+        assert len(retry_debug_calls) == (
+            serve_utils._CONTROLLER_HTTP_RETRY_ATTEMPTS -
+            1), (f'expected {serve_utils._CONTROLLER_HTTP_RETRY_ATTEMPTS - 1} '
+                 f'retry DEBUG calls, got {len(retry_debug_calls)}: '
+                 f'{retry_debug_calls}')
+
+    def test_default_timeout_is_passed_to_requests(self):
+        """Without an explicit timeout, `requests` blocks forever. Cross-pod
+        TCP connect to a dead remote pod can hang for tens of seconds, which
+        is why `sky jobs pool status` was hanging. Verify we always inject
+        the default timeout if caller didn't provide one."""
+        captured = {}
+
+        def capture(url, **kwargs):
+            captured.update(kwargs)
+            return mock.Mock(status_code=200)
+
+        with self._patch_record(None), \
+             mock.patch('sky.serve.serve_utils.requests.get',
+                        side_effect=capture):
+            serve_utils._get_to_controller_with_retry('svc', 20001,
+                                                      '/autoscaler/info')
+        assert 'timeout' in captured
+        assert captured['timeout'] == (
+            serve_utils._CONTROLLER_HTTP_TIMEOUT_SECONDS)
+
+    def test_caller_supplied_timeout_wins(self):
+        """If a call site explicitly passes timeout, don't override it."""
+        captured = {}
+
+        def capture(url, **kwargs):
+            captured.update(kwargs)
+            return mock.Mock(status_code=200)
+
+        with self._patch_record(None), \
+             mock.patch('sky.serve.serve_utils.requests.get',
+                        side_effect=capture):
+            serve_utils._get_to_controller_with_retry('svc',
+                                                      20001,
+                                                      '/autoscaler/info',
+                                                      timeout=42)
+        assert captured['timeout'] == 42
+
+    def test_timeout_exception_triggers_retry(self):
+        """`requests.exceptions.Timeout` (raised on connect/read timeout)
+        must go through the same retry path as ConnectionError. Otherwise
+        the first slow connect would propagate immediately and the user
+        would see a hang from the timeout itself rather than a fast
+        retry-and-fail."""
+        side = [
+            requests_exceptions.Timeout('connect timed out'),
+            requests_exceptions.Timeout('connect timed out'),
+            mock.Mock(status_code=200),
+        ]
+        with self._patch_record(None), \
+             mock.patch('sky.serve.serve_utils.time.sleep'), \
+             mock.patch('sky.serve.serve_utils.requests.get',
+                        side_effect=side) as m:
+            resp = serve_utils._get_to_controller_with_retry(
+                'svc', 20001, '/autoscaler/info')
+            assert resp.status_code == 200
+            assert m.call_count == 3
+
+
+class TestTerminateShuttingDownPurge:
+    """SHUTTING_DOWN zombies (e.g. controller subprocess SIGKILL'd between
+    `_cleanup`'s first step and the row removal) must be reachable via
+    `--purge`. Plain `down` keeps its previous skip-already-scheduled
+    behavior."""
+
+    def _service_record(self, status):
+        return {
+            'name': 'svc',
+            'status': status,
+            'controller_pid': 1234,
+            'controller_port': 20001,
+            'controller_ip': None,
+            'pool': True,
+        }
+
+    def test_purge_calls_terminate_failed_services_for_shutting_down(self):
+        # pylint: disable=import-outside-toplevel
+        from sky.serve import serve_state
+        with mock.patch('sky.serve.serve_utils.serve_state.'
+                        'get_glob_service_names',
+                        return_value=['svc']), \
+             mock.patch('sky.serve.serve_utils._get_service_status',
+                        return_value=self._service_record(
+                            serve_state.ServiceStatus.SHUTTING_DOWN)), \
+             mock.patch(
+                 'sky.serve.serve_utils.managed_job_state.'
+                 'get_nonterminal_job_ids_by_pool',
+                 return_value=[]), \
+             mock.patch('sky.serve.serve_utils._terminate_failed_services',
+                        return_value=None) as mock_purge:
+            serve_utils.terminate_services(['svc'], purge=True, pool=True)
+            mock_purge.assert_called_once()
+            args = mock_purge.call_args[0]
+            assert args[0] == 'svc'
+            assert args[1] == serve_state.ServiceStatus.SHUTTING_DOWN
+
+    def test_no_purge_skips_shutting_down_unchanged(self):
+        # pylint: disable=import-outside-toplevel
+        from sky.serve import serve_state
+        with mock.patch('sky.serve.serve_utils.serve_state.'
+                        'get_glob_service_names',
+                        return_value=['svc']), \
+             mock.patch('sky.serve.serve_utils._get_service_status',
+                        return_value=self._service_record(
+                            serve_state.ServiceStatus.SHUTTING_DOWN)), \
+             mock.patch(
+                 'sky.serve.serve_utils.managed_job_state.'
+                 'get_nonterminal_job_ids_by_pool',
+                 return_value=[]), \
+             mock.patch('sky.serve.serve_utils._terminate_failed_services'
+                       ) as mock_purge:
+            serve_utils.terminate_services(['svc'], purge=False, pool=True)
+            mock_purge.assert_not_called()
+
+
+class TestTerminalStatuses:
+    """`terminal_statuses` includes SHUTTING_DOWN so that callers like
+    apply() can refuse to update a row that's either dying or already
+    broken (CONTROLLER_FAILED / FAILED_CLEANUP / SHUTTING_DOWN)."""
+
+    def test_includes_shutting_down(self):
+        # pylint: disable=import-outside-toplevel
+        from sky.serve import serve_state
+        statuses = serve_state.ServiceStatus.terminal_statuses()
+        assert serve_state.ServiceStatus.SHUTTING_DOWN in statuses
+        assert serve_state.ServiceStatus.FAILED_CLEANUP in statuses
+        assert serve_state.ServiceStatus.CONTROLLER_FAILED in statuses
+        # Healthy states must NOT be in here, otherwise apply() would refuse
+        # to update healthy pools.
+        assert serve_state.ServiceStatus.READY not in statuses
+        assert serve_state.ServiceStatus.CONTROLLER_INIT not in statuses
+
+
+class TestStreamReplicaLogsZeroByteFallback:
+    """`replica_<id>.log` is the teardown archive (only written by
+    terminate_cluster's redirect_log or _download_and_stream_logs). Once
+    the teardown path runs and crashes mid-flight (or terminate_cluster is
+    invoked on a replica that never provisioned a cluster), a 0-byte
+    `replica_<id>.log` is left on disk.
+
+    Before the fix, `stream_replica_logs` checked `os.path.exists`
+    only — so it would commit to the (empty) main log, print "", and
+    return without ever consulting the launch log. Result: `sky jobs
+    pool logs` returns blank for a perfectly alive replica whose real
+    output is in `replica_<id>_launch.log`.
+
+    Fix: also gate on `os.path.getsize > 0`. These tests pin that
+    invariant.
+    """
+
+    def _patch_healthy(self):
+        # _check_service_status_healthy returns None → continue past gate.
+        return mock.patch('sky.serve.serve_utils._check_service_status_healthy',
+                          return_value=None)
+
+    def test_zero_byte_main_log_falls_through_to_launch_log(
+            self, tmp_path, capsys):
+        # Set up: 0-byte replica_1.log + 100-byte replica_1_launch.log
+        # under a fake service dir. Patch the path generators to return
+        # them. The function should print the launch log content, not "".
+        main_log = tmp_path / 'replica_1.log'
+        launch_log = tmp_path / 'replica_1_launch.log'
+        main_log.touch()
+        launch_log.write_text('LAUNCH-CONTENT\n')
+        with self._patch_healthy(), \
+             mock.patch(
+                 'sky.serve.serve_utils.generate_replica_log_file_name',
+                 return_value=str(main_log)), \
+             mock.patch(
+                 'sky.serve.serve_utils.generate_replica_launch_log_file_name',
+                 return_value=str(launch_log)), \
+             mock.patch(
+                 'sky.serve.serve_utils.serve_state.get_replica_infos',
+                 return_value=[mock.Mock(replica_id=1, status='READY')]), \
+             mock.patch(
+                 'sky.serve.serve_utils._follow_logs_with_provision_expanding',
+                 return_value=iter(['LAUNCH-CONTENT\n'])), \
+             mock.patch(
+                 'sky.serve.serve_utils._get_service_status',
+                 return_value={'status': 'READY'}):
+            serve_utils.stream_replica_logs('svc',
+                                            replica_id=1,
+                                            follow=False,
+                                            tail=None,
+                                            pool=True)
+        captured = capsys.readouterr()
+        # The launch log content must have been emitted.
+        assert 'LAUNCH-CONTENT' in captured.out, (
+            f'launch log fallback failed; captured stdout: {captured.out!r}')
+
+    def test_nonempty_main_log_still_used(self, tmp_path, capsys):
+        """Sanity: when main log has content, we still use it (no
+        regression to the original happy path)."""
+        main_log = tmp_path / 'replica_1.log'
+        launch_log = tmp_path / 'replica_1_launch.log'
+        main_log.write_text('MAIN-CONTENT\n')
+        # Launch log should NOT be touched in this case.
+        launch_log.write_text('SHOULD-NOT-APPEAR\n')
+        with self._patch_healthy(), \
+             mock.patch(
+                 'sky.serve.serve_utils.generate_replica_log_file_name',
+                 return_value=str(main_log)), \
+             mock.patch(
+                 'sky.serve.serve_utils.generate_replica_launch_log_file_name',
+                 return_value=str(launch_log)):
+            serve_utils.stream_replica_logs('svc',
+                                            replica_id=1,
+                                            follow=False,
+                                            tail=None,
+                                            pool=True)
+        captured = capsys.readouterr()
+        assert 'MAIN-CONTENT' in captured.out
+        assert 'SHOULD-NOT-APPEAR' not in captured.out
+
+
+class TestHaRecoveryDefensiveOnAliveCheckException:
+    """`ha_recovery_for_consolidation_mode` calls `_controller_process_alive`
+    to decide whether to respawn the controller. If that call raises a
+    transient psutil exception (AccessDenied / cmdline read race / etc.),
+    the previous code FELL THROUGH to running the recovery script —
+    effectively replacing a possibly-alive controller every iteration that
+    hit the exception. The fix is to skip recovery for that round and
+    revisit next iteration.
+    """
+
+    def test_skip_when_alive_check_raises(self, tmp_path, monkeypatch):
+        # pylint: disable=import-outside-toplevel
+        import psutil
+
+        # Pretend pool 'svc' has a controller_pid recorded; alive check
+        # raises AccessDenied (transient). Recovery script must NOT run.
+        monkeypatch.setenv('POD_IP', '10.4.0.1')
+        with mock.patch(
+                'sky.serve.serve_utils.serve_state.get_glob_service_names',
+                return_value=['svc']), \
+             mock.patch(
+                 'sky.serve.serve_utils._get_service_status',
+                 return_value={'controller_pid': 1234,
+                               'controller_ip': '10.4.0.1',
+                               'status': 'READY'}), \
+             mock.patch(
+                 'sky.serve.serve_utils._controller_process_alive',
+                 side_effect=psutil.AccessDenied(1234)) as mock_alive, \
+             mock.patch(
+                 'sky.serve.serve_utils.serve_state.get_ha_recovery_script',
+                 return_value='dummy script') as mock_script, \
+             mock.patch(
+                 'sky.serve.serve_utils.command_runner.'
+                 'LocalProcessCommandRunner') as mock_runner_cls, \
+             mock.patch(
+                 'sky.serve.serve_utils.skylet_constants.'
+                 'HA_PERSISTENT_RECOVERY_LOG_PATH',
+                 str(tmp_path / 'recovery_log_{}.log')):
+            serve_utils.ha_recovery_for_consolidation_mode(pool=True)
+            # alive was probed
+            assert mock_alive.called
+            # recovery script lookup or run must NOT happen — we skipped early
+            mock_script.assert_not_called()
+            mock_runner_cls.return_value.run.assert_not_called()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
## Summary

A batch of correctness and robustness fixes for SkyPilot's HA pool subsystem.

### Cross-pod controller routing

- **`_get_controller_url`** reads DB `controller_ip` and returns `http://localhost:<port>` when same-pod, else the remote pod URL. Added a DEBUG-level diag line for post-mortem of routing failures.
- **`_request_to_controller_with_retry`** wraps controller HTTP calls with 3-attempt bounded retry and a `(2.0, 10.0)` connect/read timeout. Replaces bare `requests.post/get` that hung 30s+ on dead cross-pod TCP. Intermediate retries log DEBUG, final-attempt failure logs once at WARN.
- **`update_service_controller_pid_ip_and_port`** atomically flips all three fields in a single SQL UPDATE. Prevents clients from reading `(new_pid, new_ip, old_port)` mid-recovery.
- **Migration `003_controller_ip.py`** adds the new column (idempotent).

### Port allocation under HA

- Recovery branch in `service.py` now allocates a fresh port via `find_free_port` instead of reusing the cached DB port. Atomically commits all three columns only after `_wait_for_controller_ready` confirms the socket is bound.
- `PORT_SELECTION_FILE_LOCK_PATH` moved from `~/.sky/serve/` (with PVC NFS, where `flock` silently becomes a no-op with `local_lock=none`) to pod-local `~/.sky/`.

### Cleanup correctness & HA blocking

- **`serve_state.remove_service_completely`**: atomic single-transaction delete across `services` + `version_specs` + `serve_ha_recovery_script`. Replicas are intentionally NOT touched here — both callers (`_cleanup` success path, `_terminate_failed_services` for `--purge`) iterate replicas with per-replica logic (leak detection, terminate-thread join) and clear those rows themselves before reaching this function.
- **`cleanup_storage` is idempotent on missing buckets**: `storage.construct()` raising `StorageBucketGetError` for an already-deleted bucket is now treated as "already cleaned" — the entry is dropped from `task.storage_mounts` and the loop continues. Without this, FAILED_CLEANUP self-perpetuated with the HA daemon respawning a controller that crashed on the same stale storage entry.
- Success path reordered: `remove_service_completely` first (DB atomic), then `shutil.rmtree(service_dir)` last (try/except, non-fatal).

### HA recovery daemon defenses

- `ha_recovery_for_consolidation_mode` now skips the round when `_controller_process_alive` raises (transient psutil AccessDenied / cmdline race). Previously, "raised" was treated as "dead," replacing a possibly-alive controller every iteration that hit the exception and churning pid/ip/port.

### Long-request streaming HA-awareness

- **`stream_response` now routes through `log_provider.get_log_provider().log_stream(...)`** instead of calling `log_streamer` directly.

### `pool logs` correctness

- `stream_replica_logs` now checks `os.path.getsize > 0` before committing to `replica_<id>.log` (post-mortem archive). A 0-byte file from a teardown-race remnant (`terminate_cluster`'s `ctx.redirect_log` created the file but no lines were written) used to make `pool logs` return empty for an alive replica.

### `--purge` UX

- `terminate_services` routes both `FAILED_CLEANUP` and `SHUTTING_DOWN` + `--purge` through `_terminate_failed_services`. Previously only FAILED_CLEANUP got the direct `remove_service_completely` path; SHUTTING_DOWN zombies needed manual SQL.
- `impl.apply()` rejects requests on services in `terminal_statuses()` with a `--purge` hint.

## Test plan

- New / updated unit tests (all pass locally, 63/63):
  - `tests/unit_tests/test_serve_state.py` — `TestAddServiceWritesControllerIp`, `TestGetServiceFromNameReturnsControllerIp`, `TestUpdateServiceControllerPidIpAndPort`, `TestRemoveServiceCompletely`
  - `tests/unit_tests/test_serve_utils.py` — `TestGetControllerUrl`, `TestControllerHttpRetry`, `TestTerminateShuttingDownPurge`, `TestStreamReplicaLogsZeroByteFallback`, `TestHaRecoveryDefensiveOnAliveCheckException`
  - `tests/unit_tests/test_serve_service.py` — `TestWaitForControllerReady`, `TestOrphanExit`, `TestCleanupBlocksHaRecoveryButKeepsVersionSpecs`, `TestCleanupStorageStaleBucket`
  - `tests/unit_tests/test_serve_impl.py` — `TestApplyRefusesTerminalStates`
- Manual verification:
  - Reproduced and fixed `test_pool_secrets_preserved_on_worker_update` failure
  - Reproduced and fixed `FAILED_CLEANUP ↔ NO_REPLICA` self-perpetuating loop (locally + build): `cleanup_storage` was crashing on stale `s3://...` bucket references, HA daemon kept respawning the controller, which re-read the same yaml and crashed again. Now idempotent.
  - Cross-pod routing verified end-to-end.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
