### PR TITLE
[Client] Give /launch and /exec room for slow remote API server reads

### DIFF
--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -864,7 +864,16 @@ def _launch(
         extra_launch_context=_extra_launch_context or {},
     )
     response = server_common.make_authenticated_request(
-        'POST', '/launch', json=json.loads(body.model_dump_json()), timeout=5)
+        'POST',
+        '/launch',
+        json=json.loads(body.model_dump_json()),
+        # /launch should return a request_id quickly, but under burst load
+        # against a remote API server the read can take more than the bare
+        # 5s the literal used to allow. Keep the short connect timeout so
+        # we still fail fast against a wedged server, but give the read
+        # leg room.
+        timeout=(client_common.API_SERVER_REQUEST_CONNECTION_TIMEOUT_SECONDS,
+                 30))
     return server_common.get_request_id(response)
 
 
@@ -947,7 +956,12 @@ def exec(  # pylint: disable=redefined-builtin
     )
 
     response = server_common.make_authenticated_request(
-        'POST', '/exec', json=json.loads(body.model_dump_json()), timeout=5)
+        'POST',
+        '/exec',
+        json=json.loads(body.model_dump_json()),
+        # See /launch above for rationale.
+        timeout=(client_common.API_SERVER_REQUEST_CONNECTION_TIMEOUT_SECONDS,
+                 30))
     return server_common.get_request_id(response)
 
 


### PR DESCRIPTION
## Summary

`sky.client.sdk._launch` and `sky.client.sdk.exec` pass `timeout=5` to `make_authenticated_request`, which `requests` treats as both connect and read timeout. The connect side is fine — a wedged server should still fail fast — but 5s for read is too tight when the API server is on a higher-latency link or briefly under burst load.

In practice this fires as `urllib3.exceptions.ReadTimeoutError` on the client side when many short requests arrive in quick succession (e.g. submitting dozens of `sky exec` jobs in a tight loop against a remote endpoint). The request itself usually completes on the server, but the client gives up before reading the response and the user sees a spurious failure.

This PR splits the timeout: keeps the existing `API_SERVER_REQUEST_CONNECTION_TIMEOUT_SECONDS` (5s) for connect, raises read to 30s. Both endpoints just return a `request_id` for asynchronous work, so 30s is generous headroom for a server that hasn't genuinely hung.

## Why

Other endpoints in `sdk.py` that submit async work and return a `request_id` (e.g. `/logs`) already use a `(connect, read)` tuple. The bare `timeout=5` literal on `/launch` and `/exec` predates that pattern.

## Tested

- [x] Format check via `bash format.sh` on the modified file
- [ ] `/smoke-test -k test_large_job_queue --kubernetes --remote-server` (the test where this matters)
- [ ] Regression: `/smoke-test -k test_launch_fast_with_autostop` to confirm no behavior change on the happy path