### PR TITLE
[GCP] Pin gcloud SDK version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,22 @@
 # Stage 1: Install Google Cloud SDK using APT
 FROM python:3.10.19-slim AS gcloud-apt-install
 
+# Keep in sync with _GCLOUD_VERSION in sky/clouds/gcp.py. Pinned so the apt
+# install layer doesn't bake in a stale version via buildx registry caching
+# (the RUN command's hash is the cache key, so without a version specifier
+# the layer is reused indefinitely from whatever apt resolved at first build).
+# 567.0.0 ships gsutil 5.37, which replaced OpenSSL.crypto.sign with the
+# cryptography library — required after pyopenssl 24.3 dropped that API (#8070).
+ARG GCLOUD_VERSION=567.0.0-0
+
 RUN apt-get update && \
     apt-get install -y curl gnupg lsb-release && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     apt-get update && \
     apt-get install --no-install-recommends -y \
-        google-cloud-cli \
-        google-cloud-cli-gke-gcloud-auth-plugin && \
+        google-cloud-cli=${GCLOUD_VERSION} \
+        google-cloud-cli-gke-gcloud-auth-plugin=${GCLOUD_VERSION} && \
     apt-get clean && rm -rf /usr/lib/google-cloud-sdk/platform/bundledpythonunix \
     /var/lib/apt/lists/*
 


### PR DESCRIPTION
[#9535](https://github.com/skypilot-org/skypilot/pull/9535) bumped `_GCLOUD_VERSION` in `sky/clouds/gcp.py` to 567.0.0 so the wget-installed gcloud on remote VMs picks up `gsutil 5.37` — which replaced `OpenSSL.crypto.sign` with the `cryptography` library, fixing the breakage from [#8070](https://github.com/skypilot-org/skypilot/pull/8070) (drop `pyopenssl < 24.3` cap, needed for the [GHSA-79v4-65xg-pq4g](https://github.com/advisories/GHSA-79v4-65xg-pq4g) `cryptography >= 44` upgrade).

The Dockerfile's apt-install path was left unpinned, which left a subtle hole. With no version specifier on `apt-get install google-cloud-cli`, the `RUN` command's content hash is stable, so any buildx `--cache-from` (e.g. a registry-backed `:buildcache`) reuses the first layer it ever populated — even after Google publishes a newer `google-cloud-cli`. In practice this means downstream consumers of `berkeleyskypilot/skypilot{,-nightly}` (and forks that build from this Dockerfile, including enterprise builds that layer plugins on top) are pinned to whichever gcloud apt happened to have on the day their cache layer was first built. For caches populated before May 5 2026, that's gcloud 564.0.0 / gsutil 5.36, which still calls `OpenSSL.crypto.sign` and crashes on every server-side GCS code path under modern pyopenssl.

Pin both `google-cloud-cli` and `google-cloud-cli-gke-gcloud-auth-plugin` to `567.0.0-0` via a top-of-stage `ARG`, with a comment cross-referencing `_GCLOUD_VERSION` so future bumps move both in lockstep.

Exact-pin (not a floor) because apt's CLI doesn't natively support `>=` and exact pins buy reproducibility across all consumers — and survive registry cache deletion, since the pin lives in source.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or \`bash format.sh\` — no formatter affects Dockerfile.
- [x] Any manual or new tests for this PR (please specify below)
  - \`docker build -f Dockerfile --target gcloud-apt-install -t test .\` succeeds.
  - \`docker run --rm test gcloud version\` → \`Google Cloud SDK 567.0.0\`.
  - \`docker run --rm test gsutil version\` → \`gsutil version: 5.37\`.
- [ ] All smoke tests: \`/smoke-test\` (CI) or \`pytest tests/test_smoke.py\` (local)
- [ ] Relevant individual tests: \`/smoke-test -k test_name\` (CI) or \`pytest tests/test_smoke.py::test_name\` (local)
- [ ] Backward compatibility: \`/quicktest-core\` (CI) or \`pytest tests/smoke_tests/test_backward_compat.py\` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->