### PR TITLE
[Jobs] Add daemon to sweep expired managed-job API access tokens

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -3021,6 +3021,40 @@ def remove_cluster_yaml(cluster_name: str):
 
 
 @metrics_lib.time_me
+def get_expired_service_account_tokens_by_name_prefix(
+        name_prefix: str, now: int) -> List[Dict[str, Any]]:
+    """Return service-account tokens that have expired and match a name prefix.
+
+    Tokens with no expiration are excluded. The LIKE pattern is built with
+    SQLAlchemy parameterization so the prefix cannot inject SQL.
+    """
+    engine = _db_manager.get_engine()
+    # Escape the LIKE metacharacters in the prefix so callers can pass an
+    # arbitrary string without it being treated as a pattern.
+    escaped_prefix = name_prefix.replace('\\', '\\\\').replace('%',
+                                                               '\\%').replace(
+                                                                   '_', '\\_')
+    like_pattern = f'{escaped_prefix}%'
+    with orm.Session(engine) as session:
+        rows = session.query(service_account_token_table).filter(
+            service_account_token_table.c.token_name.like(like_pattern,
+                                                          escape='\\'),
+            service_account_token_table.c.expires_at.isnot(None),
+            service_account_token_table.c.expires_at < now,
+        ).all()
+    return [{
+        'token_id': row.token_id,
+        'token_name': row.token_name,
+        'token_hash': row.token_hash,
+        'created_at': row.created_at,
+        'last_used_at': row.last_used_at,
+        'expires_at': row.expires_at,
+        'creator_user_hash': row.creator_user_hash,
+        'service_account_user_id': row.service_account_user_id,
+    } for row in rows]
+
+
+@metrics_lib.time_me
 def get_all_service_account_tokens() -> List[Dict[str, Any]]:
     """Get all service account tokens across all users (for admin access)."""
     engine = _db_manager.get_engine()

--- a/sky/jobs/constants.py
+++ b/sky/jobs/constants.py
@@ -73,3 +73,10 @@ JOBS_CLUSTER_NAME_PREFIX_LENGTH = 25
 # WARNING: If you update this due to a codegen change, make sure to make the
 # corresponding change in the ManagedJobsService AND bump the SKYLET_VERSION.
 MANAGED_JOBS_VERSION = 21  # add tail_offset to stream_logs
+
+# Prefix used for service-account tokens issued to managed jobs that opt in
+# to api_server_access. The expired-token-cleanup daemon uses this prefix to
+# identify managed-job tokens that should be swept once their TTL passes.
+# Keep this in sync with the token name format in
+# sky/jobs/server/core.py::_create_job_api_token.
+MANAGED_JOB_TOKEN_NAME_PREFIX = 'managed-job-'

--- a/sky/jobs/constants.py
+++ b/sky/jobs/constants.py
@@ -80,3 +80,8 @@ MANAGED_JOBS_VERSION = 21  # add tail_offset to stream_logs
 # Keep this in sync with the token name format in
 # sky/jobs/server/core.py::_create_job_api_token.
 MANAGED_JOB_TOKEN_NAME_PREFIX = 'managed-job-'
+
+# TTL for service-account tokens issued to managed jobs with
+# api_server_access. Kept short so any tokens that leak past the controller
+# cleanup are reaped quickly by the expired-token-cleanup daemon.
+MANAGED_JOB_TOKEN_TTL_DAYS = 3

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -627,7 +627,7 @@ def _create_job_api_token(creator_user_id: str, job_name: Optional[str],
         creator_user_id=creator_user_id,
         service_account_user_id=creator_user_id,
         token_name=token_name,
-        expires_in_days=3)
+        expires_in_days=managed_job_constants.MANAGED_JOB_TOKEN_TTL_DAYS)
 
     global_user_state.add_service_account_token(
         token_id=token_data['token_id'],

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -620,13 +620,14 @@ def _create_job_api_token(creator_user_id: str, job_name: Optional[str],
     # pylint: disable=import-outside-toplevel
     from sky.users.token_service import token_service
 
-    token_name = f'managed-job-{job_name or "unnamed"}-{dag_uuid[:8]}'
+    token_name = (f'{managed_job_constants.MANAGED_JOB_TOKEN_NAME_PREFIX}'
+                  f'{job_name or "unnamed"}-{dag_uuid[:8]}')
 
     token_data = token_service.create_token(
         creator_user_id=creator_user_id,
         service_account_user_id=creator_user_id,
         token_name=token_name,
-        expires_in_days=7)
+        expires_in_days=3)
 
     global_user_state.add_service_account_token(
         token_id=token_data['token_id'],

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -262,6 +262,59 @@ def is_consolidation_mode() -> bool:
     return controller_utils.is_jobs_consolidation_mode()
 
 
+_MANAGED_JOB_TOKEN_NAME_RE = re.compile(
+    f'^{re.escape(managed_job_constants.MANAGED_JOB_TOKEN_NAME_PREFIX)}'
+    r'.+-[0-9a-f]{8}$')
+
+
+def cleanup_expired_api_access_tokens() -> int:
+    """Delete expired managed-job API access tokens.
+
+    Scans the service_account_tokens table for any token whose name starts
+    with the managed-job prefix and whose expires_at is in the past, then
+    requires the name to also end with the 8-hex-char dag_uuid suffix
+    produced by _create_job_api_token. Matching tokens are deleted.
+
+    Driving the sweep off the name shape means tokens that leaked due to
+    a controller crash mid-cleanup, or that were issued by older code
+    paths, are still reaped once their TTL passes.
+
+    Limitation: a user could in principle create a custom service-account
+    token whose name happens to match `managed-job-<anything>-<8 hex>` and
+    let it expire. The daemon would treat such a token as a leaked
+    managed-job token and remove it once expired. The prefix + 8-hex-char
+    suffix combination makes accidental collisions unlikely in practice,
+    but custom token names should avoid this shape if expired tokens are
+    meant to be retained for audit.
+
+    Returns the number of tokens removed.
+    """
+    now = int(time.time())
+    prefix = managed_job_constants.MANAGED_JOB_TOKEN_NAME_PREFIX
+    expired = (
+        global_user_state.get_expired_service_account_tokens_by_name_prefix(
+            prefix, now))
+    removed = 0
+    for token in expired:
+        token_name = token.get('token_name') or ''
+        if not _MANAGED_JOB_TOKEN_NAME_RE.match(token_name):
+            # Prefix matched but the suffix does not look like a managed-job
+            # dag_uuid; leave it alone to avoid touching user-created tokens
+            # that happen to share the prefix.
+            continue
+        token_id = token['token_id']
+        try:
+            global_user_state.delete_service_account_token(token_id)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(
+                f'Failed to delete expired managed-job token {token_id}: {e}')
+            continue
+        removed += 1
+        logger.info(f'Cleaned up expired managed-job API access token '
+                    f'{token_id} ({token_name})')
+    return removed
+
+
 def ha_recovery_for_consolidation_mode() -> None:
     """Recovery logic for consolidation mode.
 

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -130,3 +130,10 @@ DEFAULT_DAEMON_LOG_MAX_BYTES = 128 * 1024 * 1024  # 128 MB
 # Interval for the server-side heartbeat daemon that sends plugin metrics
 # to Loki (e.g., GPU inventory from billing plugin).
 SERVER_HEARTBEAT_INTERVAL_SECONDS = 600  # 10 minutes
+
+# Interval for the daemon that sweeps expired managed-job API access tokens
+# from the service_account_tokens table. These tokens are normally revoked
+# by the jobs controller on completion, but the daemon ensures any tokens
+# that leak (e.g., due to controller crash mid-cleanup) are eventually
+# removed once their TTL has passed.
+EXPIRED_TOKEN_CLEANUP_DAEMON_INTERVAL_SECONDS = 3600  # 1 hour

--- a/sky/server/daemons.py
+++ b/sky/server/daemons.py
@@ -324,6 +324,20 @@ def should_skip_server_heartbeat():
     return False
 
 
+def expired_token_cleanup_event():
+    """Periodically remove expired managed-job API access tokens."""
+    # pylint: disable=import-outside-toplevel
+    from sky.jobs import utils as managed_job_utils
+
+    logger.info('=== Cleaning up expired managed-job API access tokens ===')
+    removed = managed_job_utils.cleanup_expired_api_access_tokens()
+    logger.info(
+        f'Expired token cleanup removed {removed} token(s). Sleeping '
+        f'{server_constants.EXPIRED_TOKEN_CLEANUP_DAEMON_INTERVAL_SECONDS} '
+        'seconds for the next sweep...\n')
+    time.sleep(server_constants.EXPIRED_TOKEN_CLEANUP_DAEMON_INTERVAL_SECONDS)
+
+
 def server_heartbeat_event():
     """Periodically send server-side plugin metrics to Loki."""
     # pylint: disable=import-outside-toplevel
@@ -387,6 +401,10 @@ INTERNAL_REQUEST_DAEMONS = [
         name=request_names.RequestName.REQUEST_DAEMON_SERVER_HEARTBEAT,
         event_fn=server_heartbeat_event,
         should_skip=should_skip_server_heartbeat),
+    InternalRequestDaemon(
+        id='expired-token-cleanup-daemon',
+        name=request_names.RequestName.REQUEST_DAEMON_EXPIRED_TOKEN_CLEANUP,
+        event_fn=expired_token_cleanup_event),
 ]
 
 HIDDEN_REQUEST_NAMES = [

--- a/sky/server/daemons.py
+++ b/sky/server/daemons.py
@@ -331,11 +331,14 @@ def expired_token_cleanup_event():
 
     logger.info('=== Cleaning up expired managed-job API access tokens ===')
     removed = managed_job_utils.cleanup_expired_api_access_tokens()
-    logger.info(
-        f'Expired token cleanup removed {removed} token(s). Sleeping '
-        f'{server_constants.EXPIRED_TOKEN_CLEANUP_DAEMON_INTERVAL_SECONDS} '
-        'seconds for the next sweep...\n')
-    time.sleep(server_constants.EXPIRED_TOKEN_CLEANUP_DAEMON_INTERVAL_SECONDS)
+    # Read the interval from config on every iteration so operators can
+    # lower it (e.g., for testing) without restarting the API server.
+    interval = skypilot_config.get_nested(
+        ('daemons', 'expired-token-cleanup-daemon', 'interval_seconds'),
+        server_constants.EXPIRED_TOKEN_CLEANUP_DAEMON_INTERVAL_SECONDS)
+    logger.info(f'Expired token cleanup removed {removed} token(s). '
+                f'Sleeping {interval} seconds for the next sweep...\n')
+    time.sleep(interval)
 
 
 def server_heartbeat_event():

--- a/sky/server/requests/request_names.py
+++ b/sky/server/requests/request_names.py
@@ -96,6 +96,7 @@ class RequestName(str, enum.Enum):
     REQUEST_DAEMON_SKY_SERVE_STATUS_REFRESH = 'sky-serve-status-refresh'
     REQUEST_DAEMON_POOL_STATUS_REFRESH = 'pool-status-refresh'
     REQUEST_DAEMON_SERVER_HEARTBEAT = 'server-heartbeat'
+    REQUEST_DAEMON_EXPIRED_TOKEN_CLEANUP = 'expired-token-cleanup'
 
     def __repr__(self):
         return self.value

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -132,6 +132,7 @@ _REQUEST_BODY_ALLOWLIST: Dict[str, Tuple[str, ...]] = {
     'sky.sky-serve-status-refresh': (),
     'sky.pool-status-refresh': (),
     'sky.server-heartbeat': (),
+    'sky.expired-token-cleanup': (),
     # Category 2: redact task/dag YAML fields before including
     'sky.launch': ('task',),
     'sky.exec': ('task',),

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -2174,6 +2174,12 @@ def get_config_schema():
                 'type': 'string',
                 'case_insensitive_enum': ['DEBUG', 'INFO', 'WARNING'],
             },
+            # Only honored by daemons that opt in to reading this; see the
+            # per-daemon event functions in sky/server/daemons.py for support.
+            'interval_seconds': {
+                'type': 'integer',
+                'minimum': 1,
+            },
         }
     }
 

--- a/tests/unit_tests/test_jobs_utils.py
+++ b/tests/unit_tests/test_jobs_utils.py
@@ -791,3 +791,61 @@ class TestCollectDebugDumpManifestParallel:
             if p['relative_path'].endswith('/job_info.json')
         ]
         assert len(job_info_items) == len(ok_jobs)
+
+
+class TestCleanupExpiredApiAccessTokens:
+    """Unit tests for the expired managed-job token sweep."""
+
+    @staticmethod
+    def _token(token_id: str, name: str, expires_at):
+        return {
+            'token_id': token_id,
+            'token_name': name,
+            'expires_at': expires_at,
+        }
+
+    @mock.patch('sky.global_user_state.delete_service_account_token')
+    @mock.patch('sky.global_user_state.'
+                'get_expired_service_account_tokens_by_name_prefix')
+    def test_deletes_only_managed_job_shaped_names(self, mock_get_expired,
+                                                   mock_delete_token):
+        now = int(time.time())
+        mock_get_expired.return_value = [
+            # Looks like a real managed-job token: prefix + 8 hex suffix.
+            self._token('tok-a', 'managed-job-myjob-abcdef01', now - 60),
+            # Multi-segment job name, still ends in 8 hex chars.
+            self._token('tok-b', 'managed-job-bench-burst-0028-fea61234',
+                        now - 60),
+            # Prefix matches but the suffix isn't 8 hex chars: skip.
+            self._token('tok-c', 'managed-job-user-named-something', now - 60),
+            # Suffix is 8 chars but contains non-hex letters: skip.
+            self._token('tok-d', 'managed-job-foo-zzzzzzzz', now - 60),
+        ]
+
+        removed = utils.cleanup_expired_api_access_tokens()
+
+        assert removed == 2
+        deleted_tokens = sorted(
+            c.args[0] for c in mock_delete_token.call_args_list)
+        assert deleted_tokens == ['tok-a', 'tok-b']
+
+    @mock.patch('sky.global_user_state.delete_service_account_token')
+    @mock.patch('sky.global_user_state.'
+                'get_expired_service_account_tokens_by_name_prefix')
+    def test_token_delete_failure_is_skipped(self, mock_get_expired,
+                                             mock_delete_token):
+        now = int(time.time())
+        mock_get_expired.return_value = [
+            self._token('tok-a', 'managed-job-myjob-abcdef01', now - 60),
+        ]
+        mock_delete_token.side_effect = RuntimeError('db down')
+
+        # Token revocation failed: report zero so the next sweep can retry.
+        removed = utils.cleanup_expired_api_access_tokens()
+        assert removed == 0
+
+    @mock.patch('sky.global_user_state.'
+                'get_expired_service_account_tokens_by_name_prefix')
+    def test_no_expired_tokens_is_noop(self, mock_get_expired):
+        mock_get_expired.return_value = []
+        assert utils.cleanup_expired_api_access_tokens() == 0

--- a/tests/unit_tests/test_sky/server/test_config.py
+++ b/tests/unit_tests/test_sky/server/test_config.py
@@ -73,7 +73,7 @@ def test_compute_server_config_low_resources(cpu_count, mem_size_gb):
     assert c.num_server_workers == 1
     assert c.long_worker_config.garanteed_parallelism == 1
     assert c.long_worker_config.burstable_parallelism == 0
-    assert c.short_worker_config.garanteed_parallelism == 4
+    assert c.short_worker_config.garanteed_parallelism == 5
     assert c.short_worker_config.burstable_parallelism == 0
     assert c.queue_backend == config.QueueBackend.MULTIPROCESSING
 
@@ -125,7 +125,7 @@ def test_parallel_size_short():
     # Test with insufficient memory
     blocking_size = 1
     mem_size_gb = 2
-    expected = 4
+    expected = 5
     assert config._max_short_worker_parallism(mem_size_gb,
                                               blocking_size) == expected
 
@@ -139,7 +139,7 @@ def test_parallel_size_short():
     # Test with limited memory
     blocking_size = 1
     mem_size_gb = 3
-    expected = 4
+    expected = 5
     assert config._max_short_worker_parallism(mem_size_gb,
                                               blocking_size) == expected
 

--- a/tests/unit_tests/test_sky/test_global_user_state_service_accounts.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_service_accounts.py
@@ -6,6 +6,8 @@ from unittest import mock
 import pytest
 
 from sky import global_user_state
+from sky.skylet import constants
+from sky.utils.db import db_utils
 
 
 class TestServiceAccountDatabaseOperations:
@@ -265,3 +267,97 @@ class TestServiceAccountDatabaseOperations:
             assert hasattr(
                 func,
                 '__module__'), f"Function {func} has no __module__ attribute"
+
+
+def _fresh_db(tmp_path, monkeypatch):
+    """Spin up a fresh sqlite-backed global state DB for integration tests."""
+    monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY, str(tmp_path))
+    monkeypatch.setattr(
+        global_user_state,
+        '_db_manager',
+        db_utils.DatabaseManager(
+            'state',
+            global_user_state.create_table,
+            post_init_fn=lambda _: global_user_state._sqlite_supports_returning(
+            ),
+        ),
+    )
+
+
+class TestGetExpiredServiceAccountTokensByNamePrefix:
+    """Real-DB tests for the prefix+expiry query used by the cleanup daemon."""
+
+    def test_filters_by_prefix_and_expiry(self, tmp_path, monkeypatch):
+        _fresh_db(tmp_path, monkeypatch)
+        now = int(time.time())
+        # Two managed-job tokens (one expired, one fresh) + one unrelated
+        # token + one without expiry. Only the expired managed-job token
+        # should be returned.
+        global_user_state.add_service_account_token(
+            token_id='expired-mj',
+            token_name='managed-job-foo-abcdef01',
+            token_hash='h1',
+            creator_user_hash='u1',
+            service_account_user_id='u1',
+            expires_at=now - 60)
+        global_user_state.add_service_account_token(
+            token_id='fresh-mj',
+            token_name='managed-job-bar-12345678',
+            token_hash='h2',
+            creator_user_hash='u1',
+            service_account_user_id='u1',
+            expires_at=now + 3600)
+        global_user_state.add_service_account_token(
+            token_id='other',
+            token_name='user-token-baz',
+            token_hash='h3',
+            creator_user_hash='u1',
+            service_account_user_id='u1',
+            expires_at=now - 60)
+        global_user_state.add_service_account_token(
+            token_id='no-expiry-mj',
+            token_name='managed-job-eternal-deadbeef',
+            token_hash='h4',
+            creator_user_hash='u1',
+            service_account_user_id='u1',
+            expires_at=None)
+
+        results = (
+            global_user_state.get_expired_service_account_tokens_by_name_prefix(
+                'managed-job-', now))
+
+        assert {r['token_id'] for r in results} == {'expired-mj'}
+
+    def test_empty_when_no_matches(self, tmp_path, monkeypatch):
+        _fresh_db(tmp_path, monkeypatch)
+        assert (
+            global_user_state.get_expired_service_account_tokens_by_name_prefix(
+                'managed-job-', int(time.time())) == [])
+
+    def test_like_metacharacters_in_prefix_are_escaped(self, tmp_path,
+                                                       monkeypatch):
+        # A prefix containing % or _ should be treated as literal text. We
+        # add tokens that would match a naive LIKE pattern but should NOT
+        # match the escaped one.
+        _fresh_db(tmp_path, monkeypatch)
+        now = int(time.time())
+        global_user_state.add_service_account_token(
+            token_id='naive-match',
+            token_name='prefix-anything-abcdef01',
+            token_hash='h1',
+            creator_user_hash='u1',
+            service_account_user_id='u1',
+            expires_at=now - 60)
+        global_user_state.add_service_account_token(
+            token_id='literal-match',
+            token_name='prefix%foo',
+            token_hash='h2',
+            creator_user_hash='u1',
+            service_account_user_id='u1',
+            expires_at=now - 60)
+
+        results = (
+            global_user_state.get_expired_service_account_tokens_by_name_prefix(
+                'prefix%', now))
+
+        assert {r['token_id'] for r in results} == {'literal-match'}


### PR DESCRIPTION
## Summary
- Add an internal server daemon (`expired-token-cleanup-daemon`) that scans `service_account_tokens` once an hour for tokens whose name matches the managed-job shape (`managed-job-<...>-<8 hex>`) and whose `expires_at` is in the past, then deletes them.
- The jobs controller already revokes API access tokens on job completion (PR #8900), but tokens can leak when the controller crashes mid-cleanup or when older code paths skipped the controller-side revoke. Without a sweep these expired tokens accumulate forever (issue surfaced as a wall of \"Expired\" tokens in the Service Accounts UI).
- Driving the sweep off the token name shape (prefix + dag_uuid suffix) instead of the `api_access_tokens` mapping table means leaked tokens with no mapping row are still reaped.
- Reduce the managed-job token TTL from 7 days to 3 days so any leaks are shorter-lived.

### Limitation
A user-created service-account token whose name happens to match `managed-job-<anything>-<8 hex>` would be removed by this daemon once it expires. The prefix + 8-hex-char dag_uuid suffix combination makes accidental collisions unlikely, but custom token names that need to be retained for audit should avoid that shape.

## Test plan
- [x] `pytest tests/unit_tests/test_jobs_utils.py::TestCleanupExpiredApiAccessTokens` (name-shape filtering, delete-failure retry, no-op path)
- [x] `pytest tests/unit_tests/test_sky/test_global_user_state_service_accounts.py::TestGetExpiredServiceAccountTokensByNamePrefix` (real-DB prefix + expiry query, LIKE metacharacter escaping)
- [ ] Manually verify on a deployment that already has leaked expired managed-job tokens: tail the daemon log (`~/.sky/api_server/request_logs/expired-token-cleanup-daemon.log`), confirm tokens are removed from the Service Accounts dashboard after the next sweep, confirm fresh managed-job tokens are NOT touched.
- [ ] Launch a managed job with `api_server_access: true`, confirm the issued token now has a 3-day TTL.