### PR TITLE
[Dashboard] Add server-side pagination hook for service account tokens

### DIFF
--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -2456,8 +2456,13 @@ function ServiceAccountTokensView({
   const [tokensWithCounts, setTokensWithCounts] = useState([]);
 
   // Server-side pagination state (used only when the pagination plugin
-  // exposes window.__skyServiceAccountTokensPaginationFetch).
-  const serverPaginated = isServiceAccountTokensPaginationAvailable();
+  // exposes window.__skyServiceAccountTokensPaginationFetch). Defer the
+  // window check to a mount effect so that the statically-exported
+  // initial render and the post-hydration render agree.
+  const [serverPaginated, setServerPaginated] = useState(false);
+  useEffect(() => {
+    setServerPaginated(isServiceAccountTokensPaginationAvailable());
+  }, []);
   const [page, setPage] = useState(1);
   const [limit, setLimit] = useState(20);
   const [total, setTotal] = useState(0);
@@ -2478,124 +2483,135 @@ function ServiceAccountTokensView({
   }, [debouncedSearch, serverPaginated]);
 
   // Fetch tokens and related data
-  const fetchTokensAndCounts = async (forceRefresh = false) => {
-    try {
-      setLoading(true);
+  const fetchTokensAndCounts = useCallback(
+    async (forceRefresh = false) => {
+      try {
+        setLoading(true);
 
-      if (serverPaginated) {
-        // Server-paginated path: skip client-side cluster/job count fan-out.
-        // Counts are deliberately omitted here because computing them
-        // requires loading all clusters + jobs across all SAs, which is the
-        // bottleneck this pagination flow exists to avoid. Counts will be
-        // surfaced per-row via dedicated drill-ins later.
-        const resp = await getServiceAccountTokensPaginated({
-          page,
-          limit,
-          search: debouncedSearch,
-          sortBy: 'created_at',
-          sortOrder: 'desc',
-        });
-        const items = resp.items || [];
-        setTokens(items);
-        setTotal(resp.total ?? items.length);
-        setTotalPages(resp.total_pages ?? resp.totalPages ?? 1);
-        setHasNext(resp.has_next ?? resp.hasNext ?? false);
-        setHasPrev(resp.has_prev ?? resp.hasPrev ?? false);
-        const enhanced = items.map((token) => ({
-          ...token,
-          clusterCount: undefined,
-          jobCount: undefined,
-          gpuCount: undefined,
-          primaryRole:
-            token.service_account_roles &&
-            token.service_account_roles.length > 0
-              ? token.service_account_roles[0]
-              : 'user',
-        }));
-        setTokensWithCounts(enhanced);
-        return;
-      }
+        if (serverPaginated) {
+          // Server-paginated path: skip client-side cluster/job count
+          // fan-out. Counts are deliberately omitted here because
+          // computing them requires loading all clusters + jobs across
+          // all SAs, which is the bottleneck this pagination flow
+          // exists to avoid. Counts will be surfaced per-row via
+          // dedicated drill-ins later.
+          if (forceRefresh) {
+            dashboardCache.invalidate(getServiceAccountTokensPaginated);
+          }
+          const resp = await dashboardCache.get(
+            getServiceAccountTokensPaginated,
+            [
+              {
+                page,
+                limit,
+                search: debouncedSearch,
+                sortBy: 'created_at',
+                sortOrder: 'desc',
+              },
+            ]
+          );
+          const items = resp.items || [];
+          setTokens(items);
+          setTotal(resp.total ?? items.length);
+          setTotalPages(resp.total_pages ?? resp.totalPages ?? 1);
+          setHasNext(resp.has_next ?? resp.hasNext ?? false);
+          setHasPrev(resp.has_prev ?? resp.hasPrev ?? false);
+          const enhanced = items.map((token) => ({
+            ...token,
+            clusterCount: undefined,
+            jobCount: undefined,
+            gpuCount: undefined,
+            primaryRole:
+              token.service_account_roles &&
+              token.service_account_roles.length > 0
+                ? token.service_account_roles[0]
+                : 'user',
+          }));
+          setTokensWithCounts(enhanced);
+          return;
+        }
 
-      // Invalidate cache if force refresh requested (after mutations)
-      if (forceRefresh) {
-        dashboardCache.invalidate(getServiceAccountTokens);
-      }
+        // Invalidate cache if force refresh requested (after mutations)
+        if (forceRefresh) {
+          dashboardCache.invalidate(getServiceAccountTokens);
+        }
 
-      // Step 1: Fetch service account tokens (using cache)
-      const tokensData = await dashboardCache.get(getServiceAccountTokens);
-      setTokens(tokensData || []);
+        // Step 1: Fetch service account tokens (using cache)
+        const tokensData = await dashboardCache.get(getServiceAccountTokens);
+        setTokens(tokensData || []);
 
-      // Step 2: Fetch clusters and jobs data in parallel
-      const { clustersData, jobsResponse } = await fetchClustersAndJobs();
-      const jobsData = jobsResponse?.jobs || [];
+        // Step 2: Fetch clusters and jobs data in parallel
+        const { clustersData, jobsResponse } = await fetchClustersAndJobs();
+        const jobsData = jobsResponse?.jobs || [];
 
-      // Step 3: Calculate counts for each service account
-      const enhancedTokens = (tokensData || []).map((token) => {
-        const serviceAccountId = token.service_account_user_id;
-        let clusterCount = 0;
-        let clusterGPUCount = 0;
-        let jobCount = 0;
-        let jobGPUCount = 0;
+        // Step 3: Calculate counts for each service account
+        const enhancedTokens = (tokensData || []).map((token) => {
+          const serviceAccountId = token.service_account_user_id;
+          let clusterCount = 0;
+          let clusterGPUCount = 0;
+          let jobCount = 0;
+          let jobGPUCount = 0;
 
-        // Count clusters and sum GPUs in one pass (exclude STOPPED and TERMINATED clusters from GPU count)
-        for (const cluster of clustersData) {
-          if (cluster.user_hash === serviceAccountId) {
-            clusterCount++;
-            // Only count GPUs from active clusters (exclude STOPPED and TERMINATED)
+          // Count clusters and sum GPUs in one pass (exclude STOPPED and TERMINATED clusters from GPU count)
+          for (const cluster of clustersData) {
+            if (cluster.user_hash === serviceAccountId) {
+              clusterCount++;
+              // Only count GPUs from active clusters (exclude STOPPED and TERMINATED)
+              if (
+                cluster.status !== 'STOPPED' &&
+                cluster.status !== 'TERMINATED'
+              ) {
+                clusterGPUCount += getGPUCount(
+                  cluster.gpus,
+                  `Cluster ${cluster.cluster}`
+                );
+              }
+            }
+          }
+
+          // Count active jobs and sum GPUs in one pass
+          for (const job of jobsData) {
             if (
-              cluster.status !== 'STOPPED' &&
-              cluster.status !== 'TERMINATED'
+              job.user_hash === serviceAccountId &&
+              ACTIVE_JOB_STATUSES.has(job.status)
             ) {
-              clusterGPUCount += getGPUCount(
-                cluster.gpus,
-                `Cluster ${cluster.cluster}`
+              jobCount++;
+              jobGPUCount += getGPUCount(
+                job.accelerators,
+                `Job ${job.job_name || job.job_id}`
               );
             }
           }
-        }
 
-        // Count active jobs and sum GPUs in one pass
-        for (const job of jobsData) {
-          if (
-            job.user_hash === serviceAccountId &&
-            ACTIVE_JOB_STATUSES.has(job.status)
-          ) {
-            jobCount++;
-            jobGPUCount += getGPUCount(
-              job.accelerators,
-              `Job ${job.job_name || job.job_id}`
-            );
-          }
-        }
+          return {
+            ...token,
+            clusterCount,
+            jobCount,
+            gpuCount: clusterGPUCount + jobGPUCount,
+            // Extract primary role
+            primaryRole:
+              token.service_account_roles &&
+              token.service_account_roles.length > 0
+                ? token.service_account_roles[0]
+                : 'user',
+          };
+        });
 
-        return {
-          ...token,
-          clusterCount,
-          jobCount,
-          gpuCount: clusterGPUCount + jobGPUCount,
-          // Extract primary role
-          primaryRole:
-            token.service_account_roles &&
-            token.service_account_roles.length > 0
-              ? token.service_account_roles[0]
-              : 'user',
-        };
-      });
-
-      setTokensWithCounts(enhancedTokens);
-    } catch (error) {
-      console.error('Error fetching tokens and counts:', error);
-      setTokens([]);
-      setTokensWithCounts([]);
-    } finally {
-      setLoading(false);
-    }
-  };
+        setTokensWithCounts(enhancedTokens);
+      } catch (error) {
+        console.error('Error fetching tokens and counts:', error);
+        setTokens([]);
+        setTokensWithCounts([]);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [page, limit, debouncedSearch, serverPaginated]
+  );
 
   useEffect(() => {
     fetchTokensAndCounts();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [page, limit, debouncedSearch, serverPaginated]);
+  }, [fetchTokensAndCounts]);
 
   // Role editing functions
   const handleEditClick = async (tokenId, currentRole) => {

--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -2459,7 +2459,7 @@ function ServiceAccountTokensView({
   // exposes window.__skyServiceAccountTokensPaginationFetch).
   const serverPaginated = isServiceAccountTokensPaginationAvailable();
   const [page, setPage] = useState(1);
-  const [limit, setLimit] = useState(50);
+  const [limit, setLimit] = useState(20);
   const [total, setTotal] = useState(0);
   const [totalPages, setTotalPages] = useState(1);
   const [hasNext, setHasNext] = useState(false);
@@ -3057,7 +3057,7 @@ function ServiceAccountTokensView({
                   className="h-7 px-2 border border-gray-300 rounded text-sm"
                   disabled={loading}
                 >
-                  {[25, 50, 100, 200].map((opt) => (
+                  {[10, 20, 50, 100, 200].map((opt) => (
                     <option key={opt} value={opt}>
                       {opt} / page
                     </option>

--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -20,7 +20,12 @@ import {
   TableBody,
   TableCell,
 } from '@/components/ui/table';
-import { getUsers, getServiceAccountTokens } from '@/data/connectors/users';
+import {
+  getUsers,
+  getServiceAccountTokens,
+  getServiceAccountTokensPaginated,
+  isServiceAccountTokensPaginationAvailable,
+} from '@/data/connectors/users';
 import { getClusters } from '@/data/connectors/clusters';
 import { getManagedJobs } from '@/data/connectors/jobs';
 import dashboardCache from '@/lib/cache';
@@ -2450,10 +2455,66 @@ function ServiceAccountTokensView({
   // Enhanced tokens with cluster/job counts
   const [tokensWithCounts, setTokensWithCounts] = useState([]);
 
+  // Server-side pagination state (used only when the pagination plugin
+  // exposes window.__skyServiceAccountTokensPaginationFetch).
+  const serverPaginated = isServiceAccountTokensPaginationAvailable();
+  const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(50);
+  const [total, setTotal] = useState(0);
+  const [totalPages, setTotalPages] = useState(1);
+  const [hasNext, setHasNext] = useState(false);
+  const [hasPrev, setHasPrev] = useState(false);
+  // Debounce search input to avoid hammering the server on every keystroke.
+  const [debouncedSearch, setDebouncedSearch] = useState(searchQuery || '');
+  useEffect(() => {
+    if (!serverPaginated) return undefined;
+    const t = setTimeout(() => setDebouncedSearch(searchQuery || ''), 250);
+    return () => clearTimeout(t);
+  }, [searchQuery, serverPaginated]);
+  // Reset to first page whenever the active search changes.
+  useEffect(() => {
+    if (!serverPaginated) return;
+    setPage(1);
+  }, [debouncedSearch, serverPaginated]);
+
   // Fetch tokens and related data
   const fetchTokensAndCounts = async (forceRefresh = false) => {
     try {
       setLoading(true);
+
+      if (serverPaginated) {
+        // Server-paginated path: skip client-side cluster/job count fan-out.
+        // Counts are deliberately omitted here because computing them
+        // requires loading all clusters + jobs across all SAs, which is the
+        // bottleneck this pagination flow exists to avoid. Counts will be
+        // surfaced per-row via dedicated drill-ins later.
+        const resp = await getServiceAccountTokensPaginated({
+          page,
+          limit,
+          search: debouncedSearch,
+          sortBy: 'created_at',
+          sortOrder: 'desc',
+        });
+        const items = resp.items || [];
+        setTokens(items);
+        setTotal(resp.total ?? items.length);
+        setTotalPages(resp.total_pages ?? resp.totalPages ?? 1);
+        setHasNext(resp.has_next ?? resp.hasNext ?? false);
+        setHasPrev(resp.has_prev ?? resp.hasPrev ?? false);
+        const enhanced = items.map((token) => ({
+          ...token,
+          clusterCount: undefined,
+          jobCount: undefined,
+          gpuCount: undefined,
+          primaryRole:
+            token.service_account_roles &&
+            token.service_account_roles.length > 0
+              ? token.service_account_roles[0]
+              : 'user',
+        }));
+        setTokensWithCounts(enhanced);
+        return;
+      }
 
       // Invalidate cache if force refresh requested (after mutations)
       if (forceRefresh) {
@@ -2533,7 +2594,8 @@ function ServiceAccountTokensView({
 
   useEffect(() => {
     fetchTokensAndCounts();
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, limit, debouncedSearch, serverPaginated]);
 
   // Role editing functions
   const handleEditClick = async (tokenId, currentRole) => {
@@ -2697,18 +2759,23 @@ function ServiceAccountTokensView({
     }
   };
 
-  // Filter tokens based on search query
-  const filteredTokens = tokensWithCounts.filter((token) => {
-    if (!searchQuery?.trim()) return true;
+  // Filter tokens based on search query.
+  // Server-paginated mode pushes search to the backend, so the client list
+  // is already filtered — do not double-filter, which would hide rows that
+  // matched on backend-only fields (e.g. service_account_user_id).
+  const filteredTokens = serverPaginated
+    ? tokensWithCounts
+    : tokensWithCounts.filter((token) => {
+        if (!searchQuery?.trim()) return true;
 
-    const query = searchQuery.toLowerCase();
-    return (
-      token.token_name?.toLowerCase().includes(query) ||
-      token.creator_name?.toLowerCase().includes(query) ||
-      token.service_account_name?.toLowerCase().includes(query) ||
-      token.primaryRole?.toLowerCase().includes(query)
-    );
-  });
+        const query = searchQuery.toLowerCase();
+        return (
+          token.token_name?.toLowerCase().includes(query) ||
+          token.creator_name?.toLowerCase().includes(query) ||
+          token.service_account_name?.toLowerCase().includes(query) ||
+          token.primaryRole?.toLowerCase().includes(query)
+        );
+      });
 
   if (loading && tokensWithCounts.length === 0) {
     return (
@@ -2826,42 +2893,69 @@ function ServiceAccountTokensView({
                       </div>
                     </TableCell>
                     <TableCell>
-                      <Link
-                        href={`/clusters?property=user&operator=%3A&value=${encodeURIComponent(token.service_account_name)}`}
-                        className={`px-2 py-0.5 rounded text-xs font-medium transition-colors duration-200 cursor-pointer inline-block ${
-                          token.clusterCount > 0
-                            ? 'bg-blue-100 text-blue-600 hover:bg-blue-200 hover:text-blue-700'
-                            : 'bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-700'
-                        }`}
-                        title={`View ${token.clusterCount} cluster${token.clusterCount !== 1 ? 's' : ''} for ${token.token_name}`}
-                      >
-                        {token.clusterCount}
-                      </Link>
+                      {token.clusterCount === undefined ? (
+                        <span
+                          className="px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-400"
+                          title="Counts hidden in server-paginated view"
+                        >
+                          —
+                        </span>
+                      ) : (
+                        <Link
+                          href={`/clusters?property=user&operator=%3A&value=${encodeURIComponent(token.service_account_name)}`}
+                          className={`px-2 py-0.5 rounded text-xs font-medium transition-colors duration-200 cursor-pointer inline-block ${
+                            token.clusterCount > 0
+                              ? 'bg-blue-100 text-blue-600 hover:bg-blue-200 hover:text-blue-700'
+                              : 'bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-700'
+                          }`}
+                          title={`View ${token.clusterCount} cluster${token.clusterCount !== 1 ? 's' : ''} for ${token.token_name}`}
+                        >
+                          {token.clusterCount}
+                        </Link>
+                      )}
                     </TableCell>
                     <TableCell>
-                      <Link
-                        href={`/jobs?property=user&operator=%3A&value=${encodeURIComponent(token.service_account_name)}`}
-                        className={`px-2 py-0.5 rounded text-xs font-medium transition-colors duration-200 cursor-pointer inline-block ${
-                          token.jobCount > 0
-                            ? 'bg-green-100 text-green-600 hover:bg-green-200 hover:text-green-700'
-                            : 'bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-700'
-                        }`}
-                        title={`View ${token.jobCount} active job${token.jobCount !== 1 ? 's' : ''} for ${token.token_name}`}
-                      >
-                        {token.jobCount}
-                      </Link>
+                      {token.jobCount === undefined ? (
+                        <span
+                          className="px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-400"
+                          title="Counts hidden in server-paginated view"
+                        >
+                          —
+                        </span>
+                      ) : (
+                        <Link
+                          href={`/jobs?property=user&operator=%3A&value=${encodeURIComponent(token.service_account_name)}`}
+                          className={`px-2 py-0.5 rounded text-xs font-medium transition-colors duration-200 cursor-pointer inline-block ${
+                            token.jobCount > 0
+                              ? 'bg-green-100 text-green-600 hover:bg-green-200 hover:text-green-700'
+                              : 'bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-700'
+                          }`}
+                          title={`View ${token.jobCount} active job${token.jobCount !== 1 ? 's' : ''} for ${token.token_name}`}
+                        >
+                          {token.jobCount}
+                        </Link>
+                      )}
                     </TableCell>
                     <TableCell>
-                      <span
-                        className={`px-2 py-0.5 rounded text-xs font-medium ${
-                          token.gpuCount > 0
-                            ? 'bg-purple-100 text-purple-600'
-                            : 'bg-gray-100 text-gray-500'
-                        }`}
-                        title={`Total GPUs: ${token.gpuCount}`}
-                      >
-                        {token.gpuCount}
-                      </span>
+                      {token.gpuCount === undefined ? (
+                        <span
+                          className="px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-400"
+                          title="Counts hidden in server-paginated view"
+                        >
+                          —
+                        </span>
+                      ) : (
+                        <span
+                          className={`px-2 py-0.5 rounded text-xs font-medium ${
+                            token.gpuCount > 0
+                              ? 'bg-purple-100 text-purple-600'
+                              : 'bg-gray-100 text-gray-500'
+                          }`}
+                          title={`Total GPUs: ${token.gpuCount}`}
+                        >
+                          {token.gpuCount}
+                        </span>
+                      )}
                     </TableCell>
                     <TableCell className="truncate">
                       {token.created_at ? (
@@ -2947,6 +3041,48 @@ function ServiceAccountTokensView({
               </TableBody>
             </Table>
           </Card>
+          {serverPaginated && (
+            <div className="flex items-center justify-between mt-3 text-sm text-gray-600">
+              <div>
+                Showing {(page - 1) * limit + 1}-{Math.min(page * limit, total)}{' '}
+                of {total}
+              </div>
+              <div className="flex items-center gap-2">
+                <select
+                  value={limit}
+                  onChange={(e) => {
+                    setLimit(Number(e.target.value));
+                    setPage(1);
+                  }}
+                  className="h-7 px-2 border border-gray-300 rounded text-sm"
+                  disabled={loading}
+                >
+                  {[25, 50, 100, 200].map((opt) => (
+                    <option key={opt} value={opt}>
+                      {opt} / page
+                    </option>
+                  ))}
+                </select>
+                <button
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={!hasPrev || loading}
+                  className="h-7 px-3 border border-gray-300 rounded text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Previous
+                </button>
+                <span>
+                  Page {page} of {totalPages}
+                </span>
+                <button
+                  onClick={() => setPage((p) => p + 1)}
+                  disabled={!hasNext || loading}
+                  className="h-7 px-3 border border-gray-300 rounded text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          )}
         </>
       )}
 

--- a/sky/dashboard/src/data/connectors/users.js
+++ b/sky/dashboard/src/data/connectors/users.js
@@ -1,5 +1,38 @@
 import { apiClient } from '@/data/connectors/client';
 
+/**
+ * Whether a server-side pagination plugin is available for SA tokens.
+ * The pagination plugin sets this on window when its bundle is loaded.
+ */
+export function isServiceAccountTokensPaginationAvailable() {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.__skyServiceAccountTokensPaginationFetch === 'function'
+  );
+}
+
+/**
+ * Server-paginated SA tokens fetch. Returns { items, total, page, limit,
+ * total_pages, has_next, has_prev }. Throws if the pagination plugin is
+ * not installed — callers should gate on
+ * isServiceAccountTokensPaginationAvailable().
+ */
+export async function getServiceAccountTokensPaginated({
+  page = 1,
+  limit = 50,
+  search = '',
+  sortBy = 'created_at',
+  sortOrder = 'desc',
+} = {}) {
+  const fetcher =
+    typeof window !== 'undefined' &&
+    window.__skyServiceAccountTokensPaginationFetch;
+  if (typeof fetcher !== 'function') {
+    throw new Error('Service account tokens pagination plugin not available');
+  }
+  return fetcher({ page, limit, search, sortBy, sortOrder });
+}
+
 export async function getServiceAccountTokens() {
   try {
     const response = await apiClient.get('/users/service-account-tokens');


### PR DESCRIPTION
## Summary

Add a window-hook contract so a server-paginating provider can swap in for the existing service-account-tokens fetch path, mirroring how clusters / managed jobs already opt in via `window.__skyPaginationFetch` / `window.__skyJobsPaginationFetch`.
