### PR TITLE
[Kubernetes] Update base image for k8s

### DIFF
--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -1,18 +1,25 @@
-FROM continuumio/miniconda3:23.3.1-0
+# Ubuntu 22.04 to match the GPU image's base (nvidia/cuda:*-ubuntu22.04 is
+# layered on top of ubuntu:22.04). Keeping the OS/glibc aligned makes
+# debugging across CPU controller pods and GPU worker pods consistent.
+FROM ubuntu:22.04
 
-# TODO(romilb): Investigate if this image can be consolidated with the skypilot
-#  client image (`Dockerfile`)
-
-ARG DEBIAN_FRONTEND=noninteractive
 # Detect architecture
 ARG TARGETARCH
+ARG DEBIAN_FRONTEND=noninteractive
 
-# Initialize conda for root user, install ssh and other local dependencies
-RUN apt update -y && \
-    apt install git gcc rsync sudo patch openssh-server pciutils nano fuse socat netcat-openbsd curl autossh jq -y && \
-    rm -rf /var/lib/apt/lists/* && \
-    apt remove -y python3 && \
-    conda init
+# Install ssh and other local dependencies.
+# FUSE setup mirrors sky/templates/kubernetes-ray.yml.j2:825-832 — install
+# fuse (FUSE 2) in the main batch, then fuse3 in a separate apt-get call.
+# fuse and fuse3 cannot be installed together (fuse3 Breaks: fuse — both ship
+# /usr/bin/fusermount), but in two steps apt resolves the conflict by removing
+# the `fuse` package while leaving `libfuse2`. Final state: libfuse.so.2 +
+# libfuse3.so.3 both in ldconfig (covers hf-mount + legacy FUSE 2 clients).
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        git gcc rsync sudo patch openssh-server \
+        pciutils nano fuse unzip socat netcat-openbsd curl autossh jq && \
+    apt-get install -y --no-install-recommends fuse3 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Setup SSH and generate hostkeys
 RUN mkdir -p /var/run/sshd && \
@@ -21,14 +28,12 @@ RUN mkdir -p /var/run/sshd && \
     cd /etc/ssh/ && \
     ssh-keygen -A
 
-# Setup new user named sky and add to sudoers. Also add /opt/conda/bin to sudo path.
+# Setup new user named sky and add to sudoers. secure_path is hardcoded
+# (sudoers cannot expand $HOME) with /home/sky/miniconda3/bin so that
+# `sudo conda ...` resolves — conda lives in $HOME/miniconda3 in this image.
 RUN useradd -m -s /bin/bash sky && \
     echo "sky ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-    echo 'Defaults        secure_path="/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"' > /etc/sudoers.d/sky
-
-# give sky group write permission to /opt/conda
-RUN chown -R :sky /opt/conda && \
-    chmod -R g+w /opt/conda
+    echo 'Defaults        secure_path="/home/sky/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"' > /etc/sudoers.d/sky
 
 # Switch to sky user
 USER sky
@@ -41,19 +46,33 @@ WORKDIR /home/sky
 
 SHELL ["/bin/bash", "-c"]
 
-# Install skypilot dependencies
-RUN conda init && \
-    export PIP_DISABLE_PIP_VERSION_CHECK=1 && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    $HOME/.local/bin/uv venv ~/skypilot-runtime --seed --python=3.10 && \
-    source ~/skypilot-runtime/bin/activate && \
-    $HOME/.local/bin/uv pip install 'skypilot-nightly[remote,kubernetes]' 'ray[default]==2.9.3' 'pycryptodome==3.12.0' && \
-    $HOME/.local/bin/uv pip uninstall skypilot-nightly && \
-    ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
+# Install conda, uv, and skypilot runtime dependencies.
+# Keep the conda and Ray versions below in sync with the ones in skylet.constants
+# and with the GPU image (Dockerfile_k8s_gpu).
+RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
         "x86_64") echo "amd64" ;; \
         "aarch64") echo "arm64" ;; \
         *) echo "$(uname -m)" ;; \
     esac)} && \
+    if [ "$ARCH" = "arm64" ]; then \
+        curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-py311_23.11.0-2-Linux-aarch64.sh -o miniconda.sh; \
+    else \
+        curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-py311_23.11.0-2-Linux-x86_64.sh -o miniconda.sh; \
+    fi && \
+    bash miniconda.sh -b -p $HOME/miniconda3 && \
+    rm miniconda.sh && \
+    eval "$($HOME/miniconda3/bin/conda shell.bash hook)" && \
+    conda init && \
+    conda config --set auto_activate_base true && \
+    export PIP_DISABLE_PIP_VERSION_CHECK=1 && \
+    curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    $HOME/.local/bin/uv venv ~/skypilot-runtime --seed --python=3.10 && \
+    source ~/skypilot-runtime/bin/activate && \
+    # See Dockerfile_k8s_gpu for rationale on the setuptools / click pins.
+    $HOME/.local/bin/uv pip install 'skypilot-nightly[remote,kubernetes]' \
+        'ray[default]==2.9.3' 'pycryptodome==3.12.0' \
+        'setuptools<70' 'click<8.3.0' && \
+    $HOME/.local/bin/uv pip uninstall skypilot-nightly && \
     curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/$ARCH/kubectl" && \
     chmod +x kubectl && \
     mkdir -p $HOME/.local/bin && \

--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -16,6 +16,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # libfuse3.so.3 both in ldconfig (covers hf-mount + legacy FUSE 2 clients).
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
+        ca-certificates \
         git gcc rsync sudo patch openssh-server \
         pciutils nano fuse unzip socat netcat-openbsd curl autossh jq && \
     apt-get install -y --no-install-recommends fuse3 && \

--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -15,6 +15,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # the `fuse` package while leaving `libfuse2`. Final state: libfuse.so.2 +
 # libfuse3.so.3 both in ldconfig (covers hf-mount + legacy FUSE 2 clients).
 RUN apt-get update -y && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         git gcc rsync sudo patch openssh-server \

--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -75,7 +75,7 @@ RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
         'ray[default]==2.9.3' 'pycryptodome==3.12.0' \
         'setuptools<70' 'click<8.3.0' && \
     $HOME/.local/bin/uv pip uninstall skypilot-nightly && \
-    curl -LO "https://dl.k8s.io/release/v1.33.7/bin/linux/$ARCH/kubectl" && \
+    curl -LO "https://dl.k8s.io/release/v1.33.11/bin/linux/$ARCH/kubectl" && \
     chmod +x kubectl && \
     mkdir -p $HOME/.local/bin && \
     mv kubectl $HOME/.local/bin/ && \

--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -55,9 +55,9 @@ RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
         *) echo "$(uname -m)" ;; \
     esac)} && \
     if [ "$ARCH" = "arm64" ]; then \
-        curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-py311_23.11.0-2-Linux-aarch64.sh -o miniconda.sh; \
+        curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Linux-aarch64.sh -o miniconda.sh; \
     else \
-        curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-py311_23.11.0-2-Linux-x86_64.sh -o miniconda.sh; \
+        curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Linux-x86_64.sh -o miniconda.sh; \
     fi && \
     bash miniconda.sh -b -p $HOME/miniconda3 && \
     rm miniconda.sh && \

--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -49,8 +49,6 @@ WORKDIR /home/sky
 SHELL ["/bin/bash", "-c"]
 
 # Install conda, uv, and skypilot runtime dependencies.
-# Keep the conda and Ray versions below in sync with the ones in skylet.constants
-# and with the GPU image (Dockerfile_k8s_gpu).
 RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
         "x86_64") echo "amd64" ;; \
         "aarch64") echo "arm64" ;; \
@@ -70,15 +68,9 @@ RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
     curl -LsSf https://astral.sh/uv/install.sh | sh && \
     $HOME/.local/bin/uv venv ~/skypilot-runtime --seed --python=3.10 && \
     source ~/skypilot-runtime/bin/activate && \
-    # See Dockerfile_k8s_gpu for rationale on the setuptools / click pins.
     $HOME/.local/bin/uv pip install 'skypilot-nightly[remote,kubernetes]' \
-        'ray[default]==2.9.3' 'pycryptodome==3.12.0' \
-        'setuptools<70' 'click<8.3.0' && \
+        'ray[default]==2.9.3' 'pycryptodome==3.12.0' && \
     $HOME/.local/bin/uv pip uninstall skypilot-nightly && \
-    curl -LO "https://dl.k8s.io/release/v1.33.11/bin/linux/$ARCH/kubectl" && \
-    chmod +x kubectl && \
-    mkdir -p $HOME/.local/bin && \
-    mv kubectl $HOME/.local/bin/ && \
     echo 'export PATH="$PATH:$HOME/.local/bin"' >> ~/.bashrc
 
 # Set PYTHONUNBUFFERED=1 to have Python print to stdout/stderr immediately

--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -19,7 +19,7 @@ RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         git gcc rsync sudo patch openssh-server \
-        pciutils nano fuse unzip socat netcat-openbsd curl autossh jq && \
+        pciutils nano fuse unzip socat netcat-openbsd curl wget autossh jq && \
     apt-get install -y --no-install-recommends fuse3 && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -1,9 +1,8 @@
 # Ubuntu 22.04 to match the GPU image's base (nvidia/cuda:*-ubuntu22.04 is
-# layered on top of ubuntu:22.04). Keeping the OS/glibc aligned makes
-# debugging across CPU controller pods and GPU worker pods consistent.
+# layered on top of ubuntu:22.04).
 FROM ubuntu:22.04
 
-# Detect architecture
+# Detect architecture using ARG with default value
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -48,7 +47,9 @@ WORKDIR /home/sky
 
 SHELL ["/bin/bash", "-c"]
 
-# Install conda, uv, and skypilot runtime dependencies.
+# Install conda and other dependencies based on architecture
+# Keep the conda and Ray versions below in sync with the ones in skylet.constants
+# Keep this section in sync with the custom image optimization recommendations in our docs (kubernetes-getting-started.rst)
 RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
         "x86_64") echo "amd64" ;; \
         "aarch64") echo "arm64" ;; \
@@ -71,6 +72,12 @@ RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
     $HOME/.local/bin/uv pip install 'skypilot-nightly[remote,kubernetes]' \
         'ray[default]==2.9.3' 'pycryptodome==3.12.0' && \
     $HOME/.local/bin/uv pip uninstall skypilot-nightly && \
+    curl -LO "https://dl.k8s.io/release/v1.33.12/bin/linux/$ARCH/kubectl" && \
+    # Install kubectl to user's local bin instead of system path to avoid
+    # sudo-related issues during cross-architecture builds, especially on ARM
+    chmod +x kubectl && \
+    mkdir -p $HOME/.local/bin && \
+    mv kubectl $HOME/.local/bin/ && \
     echo 'export PATH="$PATH:$HOME/.local/bin"' >> ~/.bashrc
 
 # Set PYTHONUNBUFFERED=1 to have Python print to stdout/stderr immediately

--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -18,7 +18,7 @@ RUN apt-get update -y && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
-        git gcc rsync sudo patch openssh-server \
+        git build-essential rsync sudo patch openssh-server \
         pciutils nano fuse unzip socat netcat-openbsd curl wget autossh jq && \
     apt-get install -y --no-install-recommends fuse3 && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -75,7 +75,7 @@ RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
         'ray[default]==2.9.3' 'pycryptodome==3.12.0' \
         'setuptools<70' 'click<8.3.0' && \
     $HOME/.local/bin/uv pip uninstall skypilot-nightly && \
-    curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/$ARCH/kubectl" && \
+    curl -LO "https://dl.k8s.io/release/v1.33.7/bin/linux/$ARCH/kubectl" && \
     chmod +x kubectl && \
     mkdir -p $HOME/.local/bin && \
     mv kubectl $HOME/.local/bin/ && \

--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -1,5 +1,5 @@
 # We use the cuda runtime image instead of devel image to reduce size (1.3GB vs 3.6GB)
-FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04
+FROM nvidia/cuda:12.1.1-runtime-ubuntu22.04
 
 # Detect architecture using ARG with default value
 ARG TARGETARCH
@@ -18,7 +18,7 @@ RUN rm -rf /etc/apt/sources.list.d/cuda* && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
-        git gcc rsync sudo patch openssh-server \
+        git build-essential rsync sudo patch openssh-server \
         pciutils nano fuse unzip socat netcat-openbsd curl wget autossh jq \
         rdma-core ibverbs-providers libibverbs1 libibverbs-dev \
         librdmacm1 ibverbs-utils infiniband-diags \

--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -27,18 +27,18 @@ RUN rm -rf /etc/apt/sources.list.d/cuda* && \
     rm -rf /var/lib/apt/lists/*
 
 # Setup SSH and generate hostkeys
-RUN sudo mkdir -p /var/run/sshd && \
-    sudo sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
-    sudo sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd && \
+RUN mkdir -p /var/run/sshd && \
+    sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
+    sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd && \
     cd /etc/ssh/ && \
-    sudo ssh-keygen -A
+    ssh-keygen -A
 
 # Setup new user named sky and add to sudoers. secure_path is hardcoded
 # (sudoers cannot expand $HOME) with /home/sky/miniconda3/bin so that
 # `sudo conda ...` resolves — conda lives in $HOME/miniconda3 in this image.
-RUN sudo useradd -m -s /bin/bash sky && \
-    sudo /bin/bash -c 'echo "sky ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers' && \
-    sudo /bin/bash -c "echo 'Defaults        secure_path=\"/home/sky/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"' > /etc/sudoers.d/sky"
+RUN useradd -m -s /bin/bash sky && \
+    echo "sky ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
+    echo 'Defaults        secure_path="/home/sky/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"' > /etc/sudoers.d/sky
 
 # Switch to sky user
 USER sky
@@ -76,6 +76,12 @@ RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
     $HOME/.local/bin/uv pip install 'skypilot-nightly[remote,kubernetes]' \
         'ray[default]==2.9.3' 'pycryptodome==3.12.0' && \
     $HOME/.local/bin/uv pip uninstall skypilot-nightly && \
+    curl -LO "https://dl.k8s.io/release/v1.33.12/bin/linux/$ARCH/kubectl" && \
+    # Install kubectl to user's local bin instead of system path to avoid
+    # sudo-related issues during cross-architecture builds, especially on ARM
+    chmod +x kubectl && \
+    mkdir -p $HOME/.local/bin && \
+    mv kubectl $HOME/.local/bin/ && \
     echo 'export PATH="$PATH:$HOME/.local/bin"' >> ~/.bashrc
 
 # Set PYTHONUNBUFFERED=1 to have Python print to stdout/stderr immediately

--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -19,7 +19,7 @@ RUN rm -rf /etc/apt/sources.list.d/cuda* && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         git gcc rsync sudo patch openssh-server \
-        pciutils nano fuse unzip socat netcat-openbsd curl autossh jq \
+        pciutils nano fuse unzip socat netcat-openbsd curl wget autossh jq \
         rdma-core ibverbs-providers libibverbs1 libibverbs-dev \
         librdmacm1 ibverbs-utils infiniband-diags \
         numactl iputils-ping && \

--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -73,22 +73,9 @@ RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
     curl -LsSf https://astral.sh/uv/install.sh | sh && \
     $HOME/.local/bin/uv venv ~/skypilot-runtime --seed --python=3.10 && \
     source ~/skypilot-runtime/bin/activate && \
-    # Pre-install setuptools<70 and click<8.3.0 here so that the per-launch
-    # pins in RAY_INSTALLATION_COMMANDS hit "already satisfied" and skip the
-    # network round-trip. setuptools<70 avoids pkg_resources packaging import
-    # break; click<8.3.0 avoids Ray CLI deepcopy break (ray-project/ray#56747).
-    # uv pip uninstall skypilot-nightly leaves all transitive deps in place,
-    # so subsequent `sky launch` only installs the matching skypilot wheel.
     $HOME/.local/bin/uv pip install 'skypilot-nightly[remote,kubernetes]' \
-        'ray[default]==2.9.3' 'pycryptodome==3.12.0' \
-        'setuptools<70' 'click<8.3.0' && \
+        'ray[default]==2.9.3' 'pycryptodome==3.12.0' && \
     $HOME/.local/bin/uv pip uninstall skypilot-nightly && \
-    curl -LO "https://dl.k8s.io/release/v1.33.11/bin/linux/$ARCH/kubectl" && \
-    # Install kubectl to user's local bin instead of system path to avoid
-    # sudo-related issues during cross-architecture builds, especially on ARM
-    chmod +x kubectl && \
-    mkdir -p $HOME/.local/bin && \
-    mv kubectl $HOME/.local/bin/ && \
     echo 'export PATH="$PATH:$HOME/.local/bin"' >> ~/.bashrc
 
 # Set PYTHONUNBUFFERED=1 to have Python print to stdout/stderr immediately

--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -83,7 +83,7 @@ RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
         'ray[default]==2.9.3' 'pycryptodome==3.12.0' \
         'setuptools<70' 'click<8.3.0' && \
     $HOME/.local/bin/uv pip uninstall skypilot-nightly && \
-    curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/$ARCH/kubectl" && \
+    curl -LO "https://dl.k8s.io/release/v1.33.7/bin/linux/$ARCH/kubectl" && \
     # Install kubectl to user's local bin instead of system path to avoid
     # sudo-related issues during cross-architecture builds, especially on ARM
     chmod +x kubectl && \

--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -1,15 +1,27 @@
 # We use the cuda runtime image instead of devel image to reduce size (1.3GB vs 3.6GB)
-FROM nvidia/cuda:12.1.1-runtime-ubuntu20.04
+FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04
 
 # Detect architecture using ARG with default value
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Install ssh and other local dependencies
-# We remove cuda lists to avoid conflicts with the cuda version installed by ray
+# Install ssh, InfiniBand userspace, and other local dependencies.
+# We remove cuda lists to avoid conflicts with the cuda version installed by ray.
+# FUSE setup mirrors sky/templates/kubernetes-ray.yml.j2:825-832 — install
+# fuse (FUSE 2) in the main batch, then fuse3 in a separate apt-get call.
+# fuse and fuse3 cannot be installed together (fuse3 Breaks: fuse — both ship
+# /usr/bin/fusermount), but in two steps apt resolves the conflict by removing
+# the `fuse` package while leaving `libfuse2`. Final state: libfuse.so.2 +
+# libfuse3.so.3 both in ldconfig (covers hf-mount + legacy FUSE 2 clients).
 RUN rm -rf /etc/apt/sources.list.d/cuda* && \
-    apt update -y && \
-    apt install git gcc rsync sudo patch openssh-server pciutils nano fuse unzip socat netcat-openbsd curl jq -y && \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        git gcc rsync sudo patch openssh-server \
+        pciutils nano fuse unzip socat netcat-openbsd curl autossh jq \
+        rdma-core ibverbs-providers libibverbs1 libibverbs-dev \
+        librdmacm1 ibverbs-utils infiniband-diags \
+        numactl iputils-ping && \
+    apt-get install -y --no-install-recommends fuse3 && \
     rm -rf /var/lib/apt/lists/*
 
 # Setup SSH and generate hostkeys
@@ -19,11 +31,12 @@ RUN sudo mkdir -p /var/run/sshd && \
     cd /etc/ssh/ && \
     sudo ssh-keygen -A
 
-# Setup new user named sky and add to sudoers. \
-# Also add /opt/conda/bin to sudo path and give sky user permission to run sudo without password
+# Setup new user named sky and add to sudoers. secure_path is hardcoded
+# (sudoers cannot expand $HOME) with /home/sky/miniconda3/bin so that
+# `sudo conda ...` resolves — conda lives in $HOME/miniconda3 in this image.
 RUN sudo useradd -m -s /bin/bash sky && \
     sudo /bin/bash -c 'echo "sky ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers' && \
-    sudo /bin/bash -c "echo 'Defaults        secure_path=\"/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"' > /etc/sudoers.d/sky"
+    sudo /bin/bash -c "echo 'Defaults        secure_path=\"/home/sky/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"' > /etc/sudoers.d/sky"
 
 # Switch to sky user
 USER sky
@@ -45,9 +58,9 @@ RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
         *) echo "$(uname -m)" ;; \
     esac)} && \
     if [ "$ARCH" = "arm64" ]; then \
-        curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Linux-aarch64.sh -o miniconda.sh; \
+        curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-py311_23.11.0-2-Linux-aarch64.sh -o miniconda.sh; \
     else \
-        curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Linux-x86_64.sh -o miniconda.sh; \
+        curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-py311_23.11.0-2-Linux-x86_64.sh -o miniconda.sh; \
     fi && \
     bash miniconda.sh -b -p $HOME/miniconda3 && \
     rm miniconda.sh && \
@@ -58,7 +71,15 @@ RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
     curl -LsSf https://astral.sh/uv/install.sh | sh && \
     $HOME/.local/bin/uv venv ~/skypilot-runtime --seed --python=3.10 && \
     source ~/skypilot-runtime/bin/activate && \
-    $HOME/.local/bin/uv pip install 'skypilot-nightly[remote,kubernetes]' 'ray[default]==2.9.3' 'pycryptodome==3.12.0' && \
+    # Pre-install setuptools<70 and click<8.3.0 here so that the per-launch
+    # pins in RAY_INSTALLATION_COMMANDS hit "already satisfied" and skip the
+    # network round-trip. setuptools<70 avoids pkg_resources packaging import
+    # break; click<8.3.0 avoids Ray CLI deepcopy break (ray-project/ray#56747).
+    # uv pip uninstall skypilot-nightly leaves all transitive deps in place,
+    # so subsequent `sky launch` only installs the matching skypilot wheel.
+    $HOME/.local/bin/uv pip install 'skypilot-nightly[remote,kubernetes]' \
+        'ray[default]==2.9.3' 'pycryptodome==3.12.0' \
+        'setuptools<70' 'click<8.3.0' && \
     $HOME/.local/bin/uv pip uninstall skypilot-nightly && \
     curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/$ARCH/kubectl" && \
     # Install kubectl to user's local bin instead of system path to avoid

--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -83,7 +83,7 @@ RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
         'ray[default]==2.9.3' 'pycryptodome==3.12.0' \
         'setuptools<70' 'click<8.3.0' && \
     $HOME/.local/bin/uv pip uninstall skypilot-nightly && \
-    curl -LO "https://dl.k8s.io/release/v1.33.7/bin/linux/$ARCH/kubectl" && \
+    curl -LO "https://dl.k8s.io/release/v1.33.11/bin/linux/$ARCH/kubectl" && \
     # Install kubectl to user's local bin instead of system path to avoid
     # sudo-related issues during cross-architecture builds, especially on ARM
     chmod +x kubectl && \

--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -16,6 +16,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN rm -rf /etc/apt/sources.list.d/cuda* && \
     apt-get update -y && \
     apt-get install -y --no-install-recommends \
+        ca-certificates \
         git gcc rsync sudo patch openssh-server \
         pciutils nano fuse unzip socat netcat-openbsd curl autossh jq \
         rdma-core ibverbs-providers libibverbs1 libibverbs-dev \

--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -15,6 +15,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # libfuse3.so.3 both in ldconfig (covers hf-mount + legacy FUSE 2 clients).
 RUN rm -rf /etc/apt/sources.list.d/cuda* && \
     apt-get update -y && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         git gcc rsync sudo patch openssh-server \

--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -60,9 +60,9 @@ RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
         *) echo "$(uname -m)" ;; \
     esac)} && \
     if [ "$ARCH" = "arm64" ]; then \
-        curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-py311_23.11.0-2-Linux-aarch64.sh -o miniconda.sh; \
+        curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Linux-aarch64.sh -o miniconda.sh; \
     else \
-        curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-py311_23.11.0-2-Linux-x86_64.sh -o miniconda.sh; \
+        curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Linux-x86_64.sh -o miniconda.sh; \
     fi && \
     bash miniconda.sh -b -p $HOME/miniconda3 && \
     rm miniconda.sh && \

--- a/examples/huggingface_glue_imdb_app.yaml
+++ b/examples/huggingface_glue_imdb_app.yaml
@@ -8,13 +8,12 @@ resources:
 # The setup command.  Will be run under the working directory.
 setup: |
   git clone https://github.com/huggingface/transformers/
-  # checkout to the correct version
   cd transformers
-  git checkout v4.25.1
+  git checkout v4.46.3
   pip3 install .
   cd examples/pytorch/text-classification
-  # SkyPilot's default image on AWS/GCP has CUDA 11.6 (Azure 11.5).
-  pip3 install -r requirements.txt tensorboard torch==1.12.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113
+  # Pin cu121 PyTorch wheels for broad host driver compatibility.
+  pip3 install -r requirements.txt tensorboard torch --extra-index-url https://download.pytorch.org/whl/cu121
 
 # The command to run.  Will be run under the working directory.
 run: |

--- a/examples/huggingface_glue_imdb_app.yaml
+++ b/examples/huggingface_glue_imdb_app.yaml
@@ -7,13 +7,14 @@ resources:
 
 # The setup command.  Will be run under the working directory.
 setup: |
+  pip3 install torch==2.5.1+cu121 --extra-index-url https://download.pytorch.org/whl/cu121
+
   git clone https://github.com/huggingface/transformers/
   cd transformers
   git checkout v4.46.3
   pip3 install .
   cd examples/pytorch/text-classification
-  # Pin cu121 PyTorch wheels for broad host driver compatibility.
-  pip3 install -r requirements.txt tensorboard torch --extra-index-url https://download.pytorch.org/whl/cu121
+  pip3 install -r requirements.txt tensorboard
 
 # The command to run.  Will be run under the working directory.
 run: |

--- a/sky/catalog/images/skypilot-k8s-image.sh
+++ b/sky/catalog/images/skypilot-k8s-image.sh
@@ -9,7 +9,7 @@
 # Usage: ./skypilot-k8s-image.sh [-p] [-g] [-l] [-r region]
 # -p: Push the image to the registry
 # -g: Builds the GPU image in Dockerfile_k8s_gpu. GPU image is built only for amd64
-# -l: Use latest tag instead of the date tag. Date tag is of the form YYYYMMDDHHMMSS
+# -l: Use latest tag instead of the date tag. Date tag is of the form YYYYMMDDHHMM
 # -r: Specify the region to be us, europe or asia
 region=us
 push=false
@@ -55,7 +55,7 @@ TAG=$region-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot
 if [[ $latest == "true" ]]; then
   VERSION_TAG=latest
 else
-  VERSION_TAG=$(date +%Y%m%d%H%M%S)
+  VERSION_TAG=$(date +%Y%m%d%H%M)
 fi
 
 # Add -gpu to the tag if the GPU image is being built

--- a/sky/catalog/images/skypilot-k8s-image.sh
+++ b/sky/catalog/images/skypilot-k8s-image.sh
@@ -9,7 +9,7 @@
 # Usage: ./skypilot-k8s-image.sh [-p] [-g] [-l] [-r region]
 # -p: Push the image to the registry
 # -g: Builds the GPU image in Dockerfile_k8s_gpu. GPU image is built only for amd64
-# -l: Use latest tag instead of the date tag. Date tag is of the form YYYYMMDD
+# -l: Use latest tag instead of the date tag. Date tag is of the form YYYYMMDDHHMMSS
 # -r: Specify the region to be us, europe or asia
 region=us
 push=false
@@ -55,7 +55,7 @@ TAG=$region-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot
 if [[ $latest == "true" ]]; then
   VERSION_TAG=latest
 else
-  VERSION_TAG=$(date +%Y%m%d)
+  VERSION_TAG=$(date +%Y%m%d%H%M%S)
 fi
 
 # Add -gpu to the tag if the GPU image is being built

--- a/sky/catalog/images/skypilot-k8s-image.sh
+++ b/sky/catalog/images/skypilot-k8s-image.sh
@@ -102,7 +102,7 @@ else
   fi
 
   echo "Tagging image."
-  if [[ $gpu ]]; then
+  if [[ "$gpu" == "true" ]]; then
     docker tag $TAG skypilot-gpu:latest
   else
     docker tag $TAG skypilot:latest

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -578,7 +578,7 @@ class Kubernetes(clouds.Cloud):
                 # Get the container image ID from the service catalog.
                 image_id = catalog.get_image_id_from_tag(image_id,
                                                          clouds='kubernetes')
-                image_id = 'us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202605140114' if acc_count > 0 else 'us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202605140114'  # pylint: disable=line-too-long
+                image_id = 'us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202605140618' if acc_count > 0 else 'us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202605140114'  # pylint: disable=line-too-long
             return image_id
 
         image_id = _get_image_id(resources)

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -578,7 +578,7 @@ class Kubernetes(clouds.Cloud):
                 # Get the container image ID from the service catalog.
                 image_id = catalog.get_image_id_from_tag(image_id,
                                                          clouds='kubernetes')
-                image_id = 'us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:20260513023216' if acc_count > 0 else 'us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:20260513023230'  # pylint: disable=line-too-long
+                image_id = 'us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202605140114' if acc_count > 0 else 'us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202605140114'  # pylint: disable=line-too-long
             return image_id
 
         image_id = _get_image_id(resources)

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -578,7 +578,7 @@ class Kubernetes(clouds.Cloud):
                 # Get the container image ID from the service catalog.
                 image_id = catalog.get_image_id_from_tag(image_id,
                                                          clouds='kubernetes')
-                image_id = 'us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202605140919' if acc_count > 0 else 'us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202605140919'  # pylint: disable=line-too-long
+                image_id = 'us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202605150216' if acc_count > 0 else 'us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202605150216'  # pylint: disable=line-too-long
             return image_id
 
         image_id = _get_image_id(resources)

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -578,7 +578,6 @@ class Kubernetes(clouds.Cloud):
                 # Get the container image ID from the service catalog.
                 image_id = catalog.get_image_id_from_tag(image_id,
                                                          clouds='kubernetes')
-                image_id = 'us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202605150216' if acc_count > 0 else 'us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202605150216'  # pylint: disable=line-too-long
             return image_id
 
         image_id = _get_image_id(resources)

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -578,6 +578,7 @@ class Kubernetes(clouds.Cloud):
                 # Get the container image ID from the service catalog.
                 image_id = catalog.get_image_id_from_tag(image_id,
                                                          clouds='kubernetes')
+                image_id = 'us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:20260513023216' if acc_count > 0 else 'us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:20260513023230'  # pylint: disable=line-too-long
             return image_id
 
         image_id = _get_image_id(resources)

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -578,7 +578,7 @@ class Kubernetes(clouds.Cloud):
                 # Get the container image ID from the service catalog.
                 image_id = catalog.get_image_id_from_tag(image_id,
                                                          clouds='kubernetes')
-                image_id = 'us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202605140618' if acc_count > 0 else 'us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202605140114'  # pylint: disable=line-too-long
+                image_id = 'us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:202605140919' if acc_count > 0 else 'us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:202605140919'  # pylint: disable=line-too-long
             return image_id
 
         image_id = _get_image_id(resources)

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -822,14 +822,16 @@ available_node_types:
                     echo "/tmp/apt-update.log not found" >&2
                   fi
                 }
-                # Install both fuse2 and fuse3 for compatibility for all possible fuse adapters in advance,
-                # so that both fusemount and fusermount3 can be masked before enabling SSH access.
-                PACKAGES="rsync curl wget netcat gcc patch pciutils fuse fuse3 openssh-server";
+                # FUSE compatibility: we want libfuse2 (FUSE 2 ABI for legacy
+                # clients like older s3fs/sshfs) AND fuse3 (binary + libfuse3-3
+                # for hf-mount, rclone, blobfuse2, etc.). On Ubuntu 22.04+
+                # `fuse3 Breaks: fuse` (both ship /usr/bin/fusermount), so the
+                # two packages cannot coexist. FUSE is handled out-of-band below.
+                PACKAGES="rsync curl wget netcat gcc patch pciutils openssh-server";
 
                 # Separate packages into two groups: packages that are installed first
                 # so that curl, rsync, ssh and wget are available sooner to unblock the following
                 # conda installation and rsync.
-                # Also, we install fuse first to avoid confliction with fuse3.
                 set -e
                 INSTALL_FIRST="";
                 MISSING_PACKAGES="";
@@ -839,13 +841,34 @@ available_node_types:
                       INSTALL_FIRST="$INSTALL_FIRST netcat-openbsd";
                     fi
                   elif ! dpkg -l | grep -q "^ii  $pkg "; then
-                    if [ "$pkg" == "curl" ] || [ "$pkg" == "rsync" ] || [ "$pkg" == "fuse" ] || [ "$pkg" == "wget" ]; then
+                    if [ "$pkg" == "curl" ] || [ "$pkg" == "rsync" ] || [ "$pkg" == "wget" ]; then
                       INSTALL_FIRST="$INSTALL_FIRST $pkg";
                     else
                       MISSING_PACKAGES="$MISSING_PACKAGES $pkg";
                     fi
                   fi
                 done;
+
+                # FUSE handling — four cases for (fuse_installed, fuse3_installed):
+                #   (0, 0): install fuse first then fuse3. apt's Breaks
+                #           resolution removes the `fuse` package while leaving
+                #           libfuse2 → final state: libfuse2 (FUSE 2 ABI) +
+                #           fuse3 (binary + libfuse3-3 for FUSE 3 ABI).
+                #   (1, 0): only fuse3 missing. Queue it in MISSING_PACKAGES;
+                #           apt removes `fuse` package but libfuse2 survives.
+                #   (0, 1): already the desired state (SkyPilot default images).
+                #           User-supplied images may lack libfuse2, need to handle
+                #           this.
+                #   (1, 1): impossible on Ubuntu 22.04+ (Breaks declaration);
+                #           treated as no-op for forward-compat.
+                HAS_FUSE=0; dpkg -l 2>/dev/null | grep -q "^ii  fuse " && HAS_FUSE=1
+                HAS_FUSE3=0; dpkg -l 2>/dev/null | grep -q "^ii  fuse3 " && HAS_FUSE3=1
+                if [ "$HAS_FUSE" = "0" ] && [ "$HAS_FUSE3" = "0" ]; then
+                  INSTALL_FIRST="$INSTALL_FIRST fuse"
+                  MISSING_PACKAGES="$MISSING_PACKAGES fuse3"
+                elif [ "$HAS_FUSE" = "1" ] && [ "$HAS_FUSE3" = "0" ]; then
+                  MISSING_PACKAGES="$MISSING_PACKAGES fuse3"
+                fi
 
                 # Detect distro for mirror fallback
                 APT_OS="unknown"
@@ -880,6 +903,9 @@ available_node_types:
                 fi
                 {% endif %}
 
+                # Wrap the candidate-mirror loop in a function so we can
+                # short-circuit when nothing needs installing.
+                run_apt_install_with_fallback() {
                 INSTALL_SUCCESS=false
                 backup_source
                 for candidate in "" $MIRROR_CANDIDATES; do
@@ -932,6 +958,15 @@ available_node_types:
                   break
                 done
                 restore_source
+                }
+
+                INSTALL_SUCCESS=false
+                if [ -z "$INSTALL_FIRST" ] && [ -z "$MISSING_PACKAGES" ]; then
+                  echo "All required packages already installed; skipping apt-update/install." >> /tmp/apt-update.log
+                  INSTALL_SUCCESS=true
+                else
+                  run_apt_install_with_fallback
+                fi
 
                 if [ "$INSTALL_SUCCESS" = "false" ] && [ ! -z "$INSTALL_FIRST" ]; then
                   echo "Error: core package installation failed across all sources." >> /tmp/apt-update.log


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Update the CPU and GPU images for k8s:
- Align up the Dockerfiles for the CPU and GPU
- Upgrade to Ubuntu 22.04 for both images
- Update Dockerfiles and `sky/templates/kubernetes-ray.yml.j2` to make sure no packages are required to be installed by default
- Fix conda sudo path setting
- Remove kubectl installation since it's limited usage but introducing critical/high security issues
- Update the image build script


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
