### PR TITLE
[Jobs] Remove unused cleanup() hook from ManagedJobRuntime Protocol

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -312,10 +312,6 @@ class JobController:
         if cluster_name is None:
             return
         if self._pool is None:
-            tmp_handle = await asyncio.to_thread(
-                global_user_state.get_handle_from_cluster_name, cluster_name)
-            if tmp_handle is not None and managed_job_runtime.is_registered():
-                await asyncio.to_thread(managed_job_runtime.cleanup, tmp_handle)
             await asyncio.to_thread(managed_job_utils.terminate_cluster,
                                     cluster_name)
 

--- a/sky/jobs/runtime.py
+++ b/sky/jobs/runtime.py
@@ -80,13 +80,6 @@ class ManagedJobRuntime(Protocol):
         """Download logs to a local file. Returns the path or None."""
         ...
 
-    def cleanup(
-        self,
-        handle: 'cloud_vm_ray_backend.CloudVmRayResourceHandle',
-    ) -> Optional[bool]:
-        """Clean up runtime-specific resources. Returns True / None."""
-        ...
-
     def tail_logs(
         self,
         handle: 'cloud_vm_ray_backend.CloudVmRayResourceHandle',
@@ -203,13 +196,6 @@ def download_logs(
     if _current is None:
         return None
     return _current.download_logs(handle, job_id, task_id)
-
-
-def cleanup(
-    handle: 'cloud_vm_ray_backend.CloudVmRayResourceHandle',) -> Optional[bool]:
-    if _current is None:
-        return None
-    return _current.cleanup(handle)
 
 
 def tail_logs(


### PR DESCRIPTION
## Summary

- The `cleanup()` hook on the `ManagedJobRuntime` Protocol overlaps with what `terminate_cluster` already does via `provision.terminate_instances` — for runtimes whose cluster-equivalent resources are the same objects the provisioner tears down, this leads to redundant teardown calls back-to-back.
- Drop the hook from the Protocol, drop its module-level dispatcher, and remove the call site in `JobController._cleanup_cluster`. Managed-job teardown now runs exclusively via `terminate_cluster`.
- If a future runtime needs a pre-teardown hook with semantics distinct from instance termination (e.g. log flushing, runtime-side state cleanup that must run *before* the instance dies), it can be reintroduced with a clearer contract.

## Test plan

- [ ] `pytest tests/unit_tests/` passes
- [ ] Smoke: launch and tear down a managed job; verify cluster terminates cleanly via the `terminate_cluster` path (no orphaned resources, no errors in controller logs)
- [ ] Smoke: launch and cancel a managed job mid-run; verify cleanup still runs to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)