### PR TITLE
[Test] Catch #9294-class sync-down regressions cross-version

### DIFF
--- a/tests/smoke_tests/backward_compat/sdk_backward_compat_utils.py
+++ b/tests/smoke_tests/backward_compat/sdk_backward_compat_utils.py
@@ -86,21 +86,6 @@ def managed_job_logs(job_name: str) -> None:
 
 
 @cli.command()
-@click.option("--job-name", type=str, help="The name of the job")
-def managed_job_sync_down_legacy(job_name: str) -> None:
-    # Bypass the CLI's streaming-first wrapper and call the legacy
-    # /jobs/download_logs path directly. This is the path that broke
-    # cross-version sync-down in #9294 (revert) and was fixed in #9310;
-    # tracks #9315.
-    result = jobs_sdk.download_logs(name=job_name,
-                                    job_id=None,
-                                    refresh=False,
-                                    controller=False)
-    for jid, path in result.items():
-        print(f'Job {jid} logs: {path}')
-
-
-@cli.command()
 def managed_job_queue() -> None:
     request_id = jobs_sdk.queue(refresh=True)
     records = sdk.stream_and_get(request_id)

--- a/tests/smoke_tests/backward_compat/sdk_backward_compat_utils.py
+++ b/tests/smoke_tests/backward_compat/sdk_backward_compat_utils.py
@@ -86,6 +86,21 @@ def managed_job_logs(job_name: str) -> None:
 
 
 @cli.command()
+@click.option("--job-name", type=str, help="The name of the job")
+def managed_job_sync_down_legacy(job_name: str) -> None:
+    # Bypass the CLI's streaming-first wrapper and call the legacy
+    # /jobs/download_logs path directly. This is the path that broke
+    # cross-version sync-down in #9294 (revert) and was fixed in #9310;
+    # tracks #9315.
+    result = jobs_sdk.download_logs(name=job_name,
+                                    job_id=None,
+                                    refresh=False,
+                                    controller=False)
+    for jid, path in result.items():
+        print(f'Job {jid} logs: {path}')
+
+
+@cli.command()
 def managed_job_queue() -> None:
     request_id = jobs_sdk.queue(refresh=True)
     records = sdk.stream_and_get(request_id)

--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -623,8 +623,6 @@ class TestBackwardCompatibility:
             )
         cluster_name = smoke_tests_utils.get_cluster_name()
         job_name = f"{cluster_name}-job"
-        sdk_utils_file = os.path.join(os.path.dirname(__file__),
-                                      'sdk_backward_compat_utils.py')
         commands = [
             # Check API version compatibility
             f'{self.ACTIVATE_BASE} && {smoke_tests_utils.SKY_API_RESTART} && '
@@ -647,18 +645,8 @@ class TestBackwardCompatibility:
             # writes downloaded logs under the path the client expects to
             # rewrite (api_server_user_logs_dir_prefix); regression check
             # for https://github.com/skypilot-org/skypilot/issues/9315.
-            #
-            # Two cells: the CLI cell exercises the streaming fast path
-            # (PR #9464) with legacy fallback; the SDK cell forces the
-            # legacy /jobs/download_logs path that #9294 broke. Without
-            # the SDK cell, a server-side regression in download_logs
-            # would be masked whenever streaming succeeds.
             f'{self.ACTIVATE_CURRENT} && '
             f's="$(SKYPILOT_DEBUG=0 sky jobs logs --sync-down -n {job_name} 2>&1)" && '
-            f'echo "$s" && echo "$s" | grep -E "Job .* logs: "',
-            f'{self.ACTIVATE_CURRENT} && '
-            f's="$(SKYPILOT_DEBUG=0 python {sdk_utils_file} '
-            f'managed-job-sync-down-legacy --job-name {job_name} 2>&1)" && '
             f'echo "$s" && echo "$s" | grep -E "Job .* logs: "',
             # cluster launch/exec test
             f'{self.ACTIVATE_BASE} && {smoke_tests_utils.SKY_API_RESTART}',
@@ -726,8 +714,6 @@ class TestBackwardCompatibility:
             )
         cluster_name = smoke_tests_utils.get_cluster_name()
         job_name = f"{cluster_name}-job"
-        sdk_utils_file = os.path.join(os.path.dirname(__file__),
-                                      'sdk_backward_compat_utils.py')
         commands = [
             # Check API version compatibility
             f'{self.ACTIVATE_CURRENT} && {smoke_tests_utils.SKY_API_RESTART} && '
@@ -750,18 +736,8 @@ class TestBackwardCompatibility:
             # still writes downloaded logs under the path the legacy
             # client rewrites (api_server_user_logs_dir_prefix); regression
             # check for https://github.com/skypilot-org/skypilot/issues/9315.
-            #
-            # The CLI cell covers the path the old client actually uses;
-            # the SDK cell pins coverage on the legacy /jobs/download_logs
-            # endpoint specifically (the one that #9294 broke and #9310
-            # fixed) so any future regression in that endpoint surfaces
-            # here even if the BASE CLI later grows a streaming wrapper.
             f'{self.ACTIVATE_BASE} && '
             f's="$(SKYPILOT_DEBUG=0 sky jobs logs --sync-down -n {job_name} 2>&1)" && '
-            f'echo "$s" && echo "$s" | grep -E "Job .* logs: "',
-            f'{self.ACTIVATE_BASE} && '
-            f's="$(SKYPILOT_DEBUG=0 python {sdk_utils_file} '
-            f'managed-job-sync-down-legacy --job-name {job_name} 2>&1)" && '
             f'echo "$s" && echo "$s" | grep -E "Job .* logs: "',
             # cluster launch/exec test
             f'{self.ACTIVATE_CURRENT} && {smoke_tests_utils.SKY_API_RESTART}',

--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -655,6 +655,14 @@ class TestBackwardCompatibility:
             f'{self.ACTIVATE_CURRENT} && result="$(sky queue {cluster_name})"; echo "$result"',
             f'{self.ACTIVATE_CURRENT} && result="$(sky logs {cluster_name} 1 --status)"; echo "$result"',
             f'{self.ACTIVATE_CURRENT} && result="$(sky logs {cluster_name} 1)"; echo "$result"; echo "$result" | grep "hello world"',
+            # sync-down: new client, old server, against the cluster CLI.
+            # Goes straight to /download_logs (no streaming wrapper), so
+            # the server's download_tmp_dir() path-generation contract is
+            # exercised directly — this is the path #9294 broke and #9310
+            # fixed; tracks #9315.
+            f'{self.ACTIVATE_CURRENT} && '
+            f's="$(SKYPILOT_DEBUG=0 sky logs {cluster_name} 1 --sync-down 2>&1)" && '
+            f'echo "$s" && echo "$s" | grep -E "Job 1 logs: "',
             f'{self.ACTIVATE_BASE} && sky exec {cluster_name} "echo from base"',
             f'{self.ACTIVATE_CURRENT} && result="$(sky logs {cluster_name} 2)"; echo "$result"; echo "$result" | grep "from base"',
             f'{self.ACTIVATE_CURRENT} && result="$(sky status)"; echo "$result"; echo "$result" | grep "{cluster_name}"',
@@ -746,6 +754,14 @@ class TestBackwardCompatibility:
             f'{self.ACTIVATE_BASE} && result="$(sky queue {cluster_name})"; echo "$result"',
             f'{self.ACTIVATE_BASE} && result="$(sky logs {cluster_name} 1 --status)"; echo "$result"',
             f'{self.ACTIVATE_BASE} && result="$(sky logs {cluster_name} 1)"; echo "$result"; echo "$result" | grep "hello world"',
+            # sync-down: old client, new server, against the cluster CLI.
+            # Goes straight to /download_logs (no streaming wrapper), so
+            # the server's download_tmp_dir() path-generation contract is
+            # exercised directly — this is the path #9294 broke and #9310
+            # fixed; tracks #9315.
+            f'{self.ACTIVATE_BASE} && '
+            f's="$(SKYPILOT_DEBUG=0 sky logs {cluster_name} 1 --sync-down 2>&1)" && '
+            f'echo "$s" && echo "$s" | grep -E "Job 1 logs: "',
             f'{self.ACTIVATE_CURRENT} && sky exec {cluster_name} "echo from current"',
             f'{self.ACTIVATE_BASE} && result="$(sky logs {cluster_name} 2)"; echo "$result"; echo "$result" | grep "from current"',
             f'{self.ACTIVATE_BASE} && result="$(sky status)"; echo "$result"; echo "$result" | grep "{cluster_name}"',

--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -641,6 +641,13 @@ class TestBackwardCompatibility:
             f'{self.ACTIVATE_CURRENT} && result="$(sky jobs logs --no-follow -n {job_name})"; echo "$result"; echo "$result" | grep "hello world"',
             f'{self.ACTIVATE_CURRENT} && {self._wait_for_managed_job_status(job_name, [sky.ManagedJobStatus.SUCCEEDED])}',
             f'{self.ACTIVATE_CURRENT} && result="$(sky jobs queue)"; echo "$result"; echo "$result" | grep {job_name} | grep SUCCEEDED',
+            # sync-down: new client, old server. Verifies the server still
+            # writes downloaded logs under the path the client expects to
+            # rewrite (api_server_user_logs_dir_prefix); regression check
+            # for https://github.com/skypilot-org/skypilot/issues/9315.
+            f'{self.ACTIVATE_CURRENT} && '
+            f's="$(SKYPILOT_DEBUG=0 sky jobs logs --sync-down -n {job_name} 2>&1)" && '
+            f'echo "$s" && echo "$s" | grep -E "Job .* logs: "',
             # cluster launch/exec test
             f'{self.ACTIVATE_BASE} && {smoke_tests_utils.SKY_API_RESTART}',
             # No restart on switch to current, cli in current, server in base
@@ -725,6 +732,13 @@ class TestBackwardCompatibility:
             f'{self.ACTIVATE_BASE} && result="$(sky jobs logs --no-follow -n {job_name})"; echo "$result"; echo "$result" | grep "hello world"',
             f'{self.ACTIVATE_BASE} && {self._wait_for_managed_job_status(job_name, [sky.ManagedJobStatus.SUCCEEDED])}',
             f'{self.ACTIVATE_BASE} && result="$(sky jobs queue)"; echo "$result"; echo "$result" | grep {job_name} | grep SUCCEEDED',
+            # sync-down: old client, new server. Verifies the new server
+            # still writes downloaded logs under the path the legacy
+            # client rewrites (api_server_user_logs_dir_prefix); regression
+            # check for https://github.com/skypilot-org/skypilot/issues/9315.
+            f'{self.ACTIVATE_BASE} && '
+            f's="$(SKYPILOT_DEBUG=0 sky jobs logs --sync-down -n {job_name} 2>&1)" && '
+            f'echo "$s" && echo "$s" | grep -E "Job .* logs: "',
             # cluster launch/exec test
             f'{self.ACTIVATE_CURRENT} && {smoke_tests_utils.SKY_API_RESTART}',
             # No restart on switch to base, cli in base, server in current

--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -623,6 +623,8 @@ class TestBackwardCompatibility:
             )
         cluster_name = smoke_tests_utils.get_cluster_name()
         job_name = f"{cluster_name}-job"
+        sdk_utils_file = os.path.join(os.path.dirname(__file__),
+                                      'sdk_backward_compat_utils.py')
         commands = [
             # Check API version compatibility
             f'{self.ACTIVATE_BASE} && {smoke_tests_utils.SKY_API_RESTART} && '
@@ -645,8 +647,18 @@ class TestBackwardCompatibility:
             # writes downloaded logs under the path the client expects to
             # rewrite (api_server_user_logs_dir_prefix); regression check
             # for https://github.com/skypilot-org/skypilot/issues/9315.
+            #
+            # Two cells: the CLI cell exercises the streaming fast path
+            # (PR #9464) with legacy fallback; the SDK cell forces the
+            # legacy /jobs/download_logs path that #9294 broke. Without
+            # the SDK cell, a server-side regression in download_logs
+            # would be masked whenever streaming succeeds.
             f'{self.ACTIVATE_CURRENT} && '
             f's="$(SKYPILOT_DEBUG=0 sky jobs logs --sync-down -n {job_name} 2>&1)" && '
+            f'echo "$s" && echo "$s" | grep -E "Job .* logs: "',
+            f'{self.ACTIVATE_CURRENT} && '
+            f's="$(SKYPILOT_DEBUG=0 python {sdk_utils_file} '
+            f'managed-job-sync-down-legacy --job-name {job_name} 2>&1)" && '
             f'echo "$s" && echo "$s" | grep -E "Job .* logs: "',
             # cluster launch/exec test
             f'{self.ACTIVATE_BASE} && {smoke_tests_utils.SKY_API_RESTART}',
@@ -714,6 +726,8 @@ class TestBackwardCompatibility:
             )
         cluster_name = smoke_tests_utils.get_cluster_name()
         job_name = f"{cluster_name}-job"
+        sdk_utils_file = os.path.join(os.path.dirname(__file__),
+                                      'sdk_backward_compat_utils.py')
         commands = [
             # Check API version compatibility
             f'{self.ACTIVATE_CURRENT} && {smoke_tests_utils.SKY_API_RESTART} && '
@@ -736,8 +750,18 @@ class TestBackwardCompatibility:
             # still writes downloaded logs under the path the legacy
             # client rewrites (api_server_user_logs_dir_prefix); regression
             # check for https://github.com/skypilot-org/skypilot/issues/9315.
+            #
+            # The CLI cell covers the path the old client actually uses;
+            # the SDK cell pins coverage on the legacy /jobs/download_logs
+            # endpoint specifically (the one that #9294 broke and #9310
+            # fixed) so any future regression in that endpoint surfaces
+            # here even if the BASE CLI later grows a streaming wrapper.
             f'{self.ACTIVATE_BASE} && '
             f's="$(SKYPILOT_DEBUG=0 sky jobs logs --sync-down -n {job_name} 2>&1)" && '
+            f'echo "$s" && echo "$s" | grep -E "Job .* logs: "',
+            f'{self.ACTIVATE_BASE} && '
+            f's="$(SKYPILOT_DEBUG=0 python {sdk_utils_file} '
+            f'managed-job-sync-down-legacy --job-name {job_name} 2>&1)" && '
             f'echo "$s" && echo "$s" | grep -E "Job .* logs: "',
             # cluster launch/exec test
             f'{self.ACTIVATE_CURRENT} && {smoke_tests_utils.SKY_API_RESTART}',


### PR DESCRIPTION
## Summary

- Closes #9315 — follow-up to @zpoint's review comment on https://github.com/skypilot-org/skypilot/pull/9310#discussion_r3069031247.
- Adds two sync-down assertions to both `test_client_server_compatibility_old_server` (new CLI → old server) and `test_client_server_compatibility_new_server` (old CLI → new server) in `tests/smoke_tests/backward_compat/test_backward_compat.py`:
  1. **Managed-job CLI cell** — `sky jobs logs --sync-down -n {job}` — covers the streaming code path (`/jobs/logs` + `/api/stream`).
  2. **Cluster CLI cell** — `sky logs {cluster} 1 --sync-down` — covers the legacy code path (`/download_logs` + `/download`). **This is the path that #9294 broke and #9310 fixed.**

## Why two assertions, not one

The managed-job CLI tries `download_logs_streaming` first (added in #9464) and only falls through to `/jobs/download_logs` if streaming fails. On any server that has the controller-cached log (i.e. every modern server, including 9294), streaming succeeds and the legacy endpoint is never called — so a #9294-style server-side regression in `download_tmp_dir()` is silently masked by the streaming wrapper.

The cluster CLI (`sky logs <cluster> <id> --sync-down`) has **no streaming wrapper** — it calls `sdk.download_logs(cluster, [id])` directly, which goes straight to the cluster `/download_logs` endpoint. Both server endpoints share the same `bs.get_blob_storage().download_tmp_dir(user_hash)` contract, so the cluster cell exercises the exact path #9294 broke.

## End-to-end verification (real AWS, twice)

| Run | BASE = | Managed-job CLI cell (streaming) | Cluster CLI cell (legacy) |
|---|---|---|---|
| 1 | `edd856ee1` (buggy #9294) | ✅ pass (streaming masks bug) | ❌ **fail** — `Error creating zip file: No such file or directory: ~/.sky/api_server/clients/{hash}/sky_logs/folder_XXX.zip` |
| 2 | `12259b8c4` (#9310 fix) | ✅ pass | ✅ **pass** — `Job 1 logs: ~/sky_logs/<cluster>/1-sky-cmd` |

The cluster cell is bug-specific (fails on the buggy base, passes on the fixed base) and reaches the assertion via real AWS managed-job + cluster launch + version switch — not a unit test stub.

## Test plan

- [x] AWS e2e against the reverted commit (`--base-branch edd856ee1f0679dfd22ef15999666282f3342b7b`): cluster sync-down cell fails with the path-mismatch error.
- [x] AWS e2e against the reapply commit (`--base-branch 12259b8c4c22056d946a974ccdf33a91bc7702e0`): cluster sync-down cell passes.
- [ ] CI: `/quicktest-core`
- [ ] CI: `pytest tests/smoke_tests/backward_compat/test_backward_compat.py::TestBackwardCompatibility::test_client_server_compatibility_old_server --base-branch pypi/skypilot==0.11.0 --generic-cloud aws`
- [ ] CI: `pytest tests/smoke_tests/backward_compat/test_backward_compat.py::TestBackwardCompatibility::test_client_server_compatibility_new_server --base-branch pypi/skypilot==0.11.0 --generic-cloud aws`

🤖 Generated with [Claude Code](https://claude.com/claude-code)