### PR TITLE
[Kubernetes] Extend PodInfoSource with namespace/label filters and use it in query_instances

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -2490,6 +2490,30 @@ def query_instances(
     # below, which dominates this function's wall time at scale. We pass
     # the same namespace+label scope so the cache returns the exact same
     # pod set the direct query would.
+    #
+    # Three possible cache outcomes:
+    #   1. Non-empty list  — trust it; matches direct-K8s semantics.
+    #   2. ``None``        — no provider registered, or the provider
+    #                        couldn't answer (e.g. context unknown to
+    #                        the cache, transient backend error). Fall
+    #                        through to direct ``list_namespaced_pod``.
+    #   3. Empty list (``[]``) — *ambiguous*. Either there genuinely are
+    #      no pods for this cluster, or the cache hasn't observed an
+    #      ADD event yet (informer-style caches are eventually
+    #      consistent and can lag the API server by ~100ms–seconds
+    #      depending on watch health). For ``retry_if_missing=True``,
+    #      the existing retry loop below covers this by re-querying
+    #      ``list_namespaced_pod`` directly. For ``retry_if_missing=
+    #      False`` we must NOT trust the cache's empty answer, because
+    #      callers that pass ``False`` are typically about to act on
+    #      "cluster has no instances" as a terminal decision (e.g.
+    #      ``_update_cluster_status``'s ``_LAUNCH_DOUBLE_CHECK_DELAY``
+    #      recheck that marks the cluster TERMINATED on empty result,
+    #      or ``post_teardown_cleanup``'s sanity check). Pre-cache
+    #      these callers got a single ground-truth read from
+    #      ``list_namespaced_pod``; we preserve that contract by
+    #      falling back to a direct read when cache says empty and
+    #      ``retry_if_missing`` is False.
     pods = None
     if plugin_extensions.PodInfoSource.is_registered() and context is not None:
         pods = plugin_extensions.PodInfoSource.get(
@@ -2503,7 +2527,14 @@ def query_instances(
                 f'provider ({len(pods)} pods)')
 
     attempts = 0
-    if pods is None:
+    # Fall back to direct ``list_namespaced_pod`` when:
+    #   - the cache is unavailable (``pods is None``); OR
+    #   - the cache returned empty AND the caller will not retry on its
+    #     own (``not retry_if_missing``). The ``retry_if_missing=True``
+    #     empty-result case is handled by the retry loop just below,
+    #     which already invokes ``list_namespaced_pod`` directly and
+    #     would duplicate work if we fell back here too.
+    if pods is None or (not pods and not retry_if_missing):
         pods = list_namespaced_pod(context, namespace, cluster_name_on_cloud,
                                    is_ssh, identity, label_selector)
     # When we see no pods returned from the k8s api, we assume the pods have

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -2485,9 +2485,27 @@ def query_instances(
     label_selector = (f'{constants.TAG_SKYPILOT_CLUSTER_NAME}='
                       f'{cluster_name_on_cloud}')
 
+    # Try the registered ``PodInfoSource`` first — a plugin can serve this
+    # from a local cache and avoid the direct ``list_namespaced_pod`` call
+    # below, which dominates this function's wall time at scale. We pass
+    # the same namespace+label scope so the cache returns the exact same
+    # pod set the direct query would.
+    pods = None
+    if plugin_extensions.PodInfoSource.is_registered() and context is not None:
+        pods = plugin_extensions.PodInfoSource.get(
+            context,
+            namespace=namespace,
+            labels={constants.TAG_SKYPILOT_CLUSTER_NAME: cluster_name_on_cloud},
+        )
+        if pods is not None:
+            logger.debug(
+                f'Got pod info for {cluster_name_on_cloud} from external '
+                f'provider ({len(pods)} pods)')
+
     attempts = 0
-    pods = list_namespaced_pod(context, namespace, cluster_name_on_cloud,
-                               is_ssh, identity, label_selector)
+    if pods is None:
+        pods = list_namespaced_pod(context, namespace, cluster_name_on_cloud,
+                                   is_ssh, identity, label_selector)
     # When we see no pods returned from the k8s api, we assume the pods have
     # been terminated by the user directly and mark the cluster as terminated
     # in the global user state.

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -4187,10 +4187,19 @@ def get_skypilot_pods(context: Optional[str] = None) -> List[Any]:
     if context is None:
         context = get_current_kube_config_context_name()
 
-    # Try external pod info source first (e.g., node-info-service cache).
+    # Try the registered ``PodInfoSource`` first — a plugin can serve this
+    # from a local cache and avoid the direct ``list_pod_for_all_namespaces``
+    # round-trip below.
     if plugin_extensions.PodInfoSource.is_registered():
         if context is not None:
-            result = plugin_extensions.PodInfoSource.get(context)
+            # Match the direct-K8s ``label_selector`` semantics below —
+            # all skypilot pods cluster-wide, identified by the presence
+            # of ``TAG_SKYPILOT_CLUSTER_NAME``.
+            result = plugin_extensions.PodInfoSource.get(
+                context,
+                namespace=None,
+                labels={provision_constants.TAG_SKYPILOT_CLUSTER_NAME: None},
+            )
             if result is not None:
                 logger.debug(f'Got pod info from external provider for '
                              f'{context}')

--- a/sky/utils/plugin_extensions/pod_info_source.py
+++ b/sky/utils/plugin_extensions/pod_info_source.py
@@ -2,8 +2,9 @@
 
 This module provides an extension point that allows plugins to provide
 cached Kubernetes pod information. By default, no-op implementations
-are used. Plugins can register their own implementations to provide
-cached pod info (e.g., from a node-info-service sidecar).
+are used. Plugins can register their own implementations to serve pod
+info from an external cache (e.g. an in-cluster informer cache) instead
+of paying a direct Kubernetes API round-trip on every read.
 
 Example usage in a plugin:
     from sky.utils.plugin_extensions import PodInfoSource
@@ -16,28 +17,44 @@ Example usage in core SkyPilot:
 
     # Get cached pod info (returns None if not registered or unavailable)
     pods = PodInfoSource.get(context='my-k8s-context')
+
+    # Or scoped to a specific namespace / label selector — useful for
+    # per-cluster queries like ``query_instances``:
+    pods = PodInfoSource.get(
+        context='my-k8s-context',
+        namespace='default',
+        labels={'skypilot-cluster-name': 'sky-cmd-1'},
+    )
 """
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from sky import sky_logging
 
 logger = sky_logging.init_logger(__name__)
 
-# Type alias for the pod info provider function
-# Function signature: (context: str) -> Optional[List[Any]]
-# Returns a list of V1Pod-compatible objects if available, None otherwise.
-# Returning None means "no cached data, fall through to direct API".
-# Returning [] means "checked cache, no SkyPilot pods found" (valid result).
-PodInfoProviderFunc = Callable[[str], Optional[List[Any]]]
+# Type alias for the pod info provider function.
+#
+# Function signature: (context, namespace, labels) -> Optional[List[Any]]
+# - context: K8s context name (required).
+# - namespace: optional namespace filter; ``None`` means all namespaces.
+# - labels: optional label filter. Keys with ``None`` values mean
+#   "label exists" (existence check); keys with string values mean
+#   "label exists and equals this value" (exact match).
+# Returns a list of V1Pod-compatible objects if available, ``None`` otherwise.
+# Returning ``None`` means "no cached data, fall through to direct API".
+# Returning ``[]`` means "checked cache, no SkyPilot pods found" (valid result).
+PodInfoProviderFunc = Callable[
+    [str, Optional[str], Optional[Dict[str,
+                                       Optional[str]]]], Optional[List[Any]],]
 
 
 class PodInfoSource:
     """Singleton class for external Kubernetes pod info source.
 
     This class provides an extension point for plugins to register their own
-    pod info providers (e.g., a node-info-service that caches Kubernetes
-    pod information). By default, no provider is registered and get()
-    returns None.
+    pod info providers (e.g. a process backed by an in-cluster informer
+    cache). By default, no provider is registered and ``get()`` returns
+    ``None``.
 
     Plugins can register their provider during their install() phase,
     and core SkyPilot code can use the get() method to attempt to retrieve
@@ -54,10 +71,12 @@ class PodInfoSource:
         Only one provider can be registered at a time.
 
         Args:
-            provider: Function to get pod info for a context.
-                Signature: (context: str) -> Optional[List[Any]]
+            provider: Function to get pod info for a context, optionally
+                filtered by namespace and labels.
+                Signature:
+                  ``(context, namespace, labels) -> Optional[List[Any]]``
                 Returns a list of V1Pod-compatible objects if available,
-                None otherwise.
+                ``None`` otherwise.
         """
         cls._provider_func = provider
         logger.debug('Registered external pod info provider')
@@ -68,11 +87,23 @@ class PodInfoSource:
         return cls._provider_func is not None
 
     @classmethod
-    def get(cls, context: str) -> Optional[List[Any]]:
+    def get(
+        cls,
+        context: str,
+        namespace: Optional[str] = None,
+        labels: Optional[Dict[str, Optional[str]]] = None,
+    ) -> Optional[List[Any]]:
         """Get pod info from the registered provider.
 
         Args:
             context: Kubernetes context name to get pod info for.
+            namespace: Optional namespace filter. ``None`` means
+                "all namespaces" (matching the cluster-wide
+                ``list_pod_for_all_namespaces`` semantics).
+            labels: Optional label filter. Each entry restricts the result
+                set: a ``None`` value means "label exists" (existence
+                check); a string value means "label exists and equals this
+                value" (exact match). ``None`` means "no label filter".
 
         Returns:
             List of V1Pod-compatible objects if provider returns data,
@@ -84,7 +115,7 @@ class PodInfoSource:
             return None
         try:
             # pylint: disable=not-callable
-            return cls._provider_func(context)
+            return cls._provider_func(context, namespace, labels)
         except Exception as e:  # pylint: disable=broad-except
             logger.debug(f'External pod info provider failed: {e}')
             return None


### PR DESCRIPTION
## Summary

- Plumb optional `namespace` and `labels` parameters through `PodInfoSource.get(...)` so a registered provider can serve scoped queries (single-namespace, single-cluster) — not just the cluster-wide `list_pod_for_all_namespaces` semantics that `get_skypilot_pods` needs today.
- Route `query_instances` through the same extension point. Today every call falls through to a direct `list_namespaced_pod` API round-trip; a provider backed by an in-cluster informer cache can answer the same scoped query in single-digit milliseconds.
- `get_skypilot_pods` keeps its existing semantics by passing `namespace=None` plus a label-existence filter (`{TAG_SKYPILOT_CLUSTER_NAME: None}`).

## Why

`PodInfoSource` already exists as an extension point but only exposes a cluster-wide, all-namespaces query. The two highest-traffic SkyPilot read paths against the K8s API that *could* benefit from caching are:

- `get_skypilot_pods()` — cluster-wide, already wired into `PodInfoSource`.
- `query_instances()` — per-cluster, scoped to a single `cluster_name_on_cloud` label + a single namespace. Never goes through the extension point today.

Without this change, a plugin that wants to cache pod state has no way to answer the per-cluster query — the existing `get(context)` signature returns every SkyPilot pod cluster-wide, and forcing each `query_instances` caller to fetch-all-then-filter would defeat the purpose of caching at scale.

## Compatibility

- Two keyword-only parameters added with default `None`; existing call sites pass nothing and behaviour is unchanged.
- `PodInfoProviderFunc` signature is widened from `(context) -> ...` to `(context, namespace, labels) -> ...`. No in-tree provider exists today, so no in-tree caller is affected.
- `query_instances` only *consults* the provider — `None` (no provider / cache miss) falls through to the existing `list_namespaced_pod` path, and an empty list still triggers the existing `retry_if_missing` slow-path retry against the K8s API.

## Labels filter shape

`labels` is a `Dict[str, Optional[str]]`:

- `{'skypilot-cluster-name': 'sky-cmd-1'}` — label exists *and equals this value* (exact match).
- `{'skypilot-cluster-name': None}` — label exists (existence check, any value). This matches the K8s label-selector existence syntax (`key` without `=value`).

Letting providers express both shapes keeps `get_skypilot_pods` (existence) and `query_instances` (exact match) on the same API.

## Test plan

- [x] `format.sh` passes (yapf + isort + mypy + pylint, dashboard lint).
- [x] AST-parse clean.
- [x] Manual: with a locally-registered provider backed by an in-cluster informer cache, `query_instances` on a 100-pod cluster drops from ~2.3s (direct `list_namespaced_pod`) to ~30ms.
- [x] Manual: with no provider registered, `query_instances` and `get_skypilot_pods` behave identically to before (fall through to the existing direct-K8s path).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->