### PR TITLE
[Test] Raise sky-status SLA in scale test from 18s to 25s

### DIFF
--- a/tests/load_tests/db_scale_tests/test_large_production_performance.sh
+++ b/tests/load_tests/db_scale_tests/test_large_production_performance.sh
@@ -218,8 +218,23 @@ fi
 python "$INJECT_SCRIPT" "${INJECT_ARGS[@]}"
 
 # Step 5: Test sky status performance
+#
+# SLA: sky status with 12,501 in-progress managed jobs must finish in
+# SKY_STATUS_SLA_SECONDS. Survey of the last 30 same-config nightly builds
+# (10177..10560) measured the distribution as:
+#   min 12s | median 18s | max 22s
+# 52% of runs landed at or above the previous 18s ceiling, with the median
+# *exactly* at the threshold, so the SLA was effectively a coin flip rather
+# than a regression detector. After #9592 made the inject script populate
+# `full_resources` (previously silently NULL because of an asyncpg/sslmode
+# bug), sky status does strictly more JSON work per row and the median is
+# expected to shift slightly higher. 25s covers 100% of observed durations
+# with ~15% headroom, and is still tight enough to catch the real ~38s
+# regression seen during PR #9592 debugging when the controller was
+# accidentally reconciling every cloned row.
+SKY_STATUS_SLA_SECONDS=25
 echo "Step 5: Testing sky status performance..."
-echo "Expected: Show 12501 managed jobs in progress and finish within 18 seconds"
+echo "Expected: Show 12501 managed jobs in progress and finish within ${SKY_STATUS_SLA_SECONDS} seconds"
 time_start=$(date +%s)
 STATUS_OUTPUT=$(timeout 60 sky status 2>&1 || true)
 time_end=$(date +%s)
@@ -243,8 +258,8 @@ if ! echo "$STRIPPED_STATUS" | grep -qE "12501.*(RUNNING|STARTING|PENDING|manage
     exit 1
 fi
 
-if [ $duration -gt 18 ]; then
-    echo "ERROR: sky status took ${duration}s, expected <= 18s"
+if [ $duration -gt $SKY_STATUS_SLA_SECONDS ]; then
+    echo "ERROR: sky status took ${duration}s, expected <= ${SKY_STATUS_SLA_SECONDS}s"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

`test_large_production_performance` Step 5 (`sky status` ≤ 18s) has been a borderline flake for **4+ weeks** — and got worse over the last 2 weeks. Tightening more is impossible; the rest of the test passes cleanly. This PR raises the threshold to 25s with full survey data so the bump is defensible, not arbitrary.

## Evidence — dated 4-week timeline of same-config nightlies

Survey covers every build with message exactly `nightly-build-pypi --kubernetes --no-resource-heavy` from 2026-04-15 → 2026-05-14, taking the FINAL (post-auto-retry) sky-status duration per build:

| Week (Wed → Tue) | N builds | sky-status durations (sorted, seconds) | min / **median** / max | over-18s |
|---|---|---|---|---|
| 04-15 → 04-21 | 12 | 12, 16, 16, 17, 17, 17, 17, 18, 18, 18, 18, **19** | 12 / **17** / 19 | 8 % |
| 04-22 → 04-28 | 8  | 14, 15, 17, 17, 17, 18, 18, **20** | 14 / **17** / 20 | 12 % |
| 04-29 → 05-05 | 15 | 12, 13, 15, 16, 16, 16, 16, 17, 17, 18, 18, 18, 18, 18, **21** | 12 / **17** / 21 | 7 % |
| 05-06 → 05-12 | 13 | 13, 16, 17, 17, 17, 18, 18, 18, 18, 18, **21, 21, 22** | 13 / **18** / 22 | **23 %** |
| 05-13 → 05-14 | 4  | 18, 18, **19, 19** | 18 / **18.5** / 19 | **50 %** |

Sources for the durations: literal `✓ sky status test passed (Ns)` / `ERROR: sky status took Ns` lines in each build's job log.

### Three things this data establishes

1. **Chronic, not a single-commit regression.** The 18s threshold has been crossed in **every one of the last 4 weeks** — week 1 already had 19s (build 9944 at fed79208 family), week 2 had 20s. There is no clean step-change from any single commit.
2. **Variance dominates.** Same commit `a9be1292` (5/4 17:21 PT) within 24h: build 10276 = **21s fail**, build 10288 = **12s pass**. Identical code, ~9s spread, on the same Buildkite kind infra. That's noise, not regression.
3. **Drift exists but is small.** Medians moved 17 → 17 → 17 → 18 → 18.5. About a 1s drift over 4 weeks, plausibly attributable to gradual data-scale increase (e.g., `[Core] Bump default cluster event retention to 30 days` #9462 indirectly affects state.db row counts) but not enough to call a single-commit revert. A separate perf investigation can chase the +1s drift — it doesn't need to block unblocking nightlies.

### Why 25s

- Covers 100 % of observed historical durations (max = 22s) with a small margin for VM variance.
- Still catches the real regressions: during PR #9592 debugging on parallel-VM-contended runs, sky status spiked to 38s. That would still fail under a 25s ceiling.
- Encoded as a named constant `SKY_STATUS_SLA_SECONDS` with a multi-line comment explaining the rationale, so future readers can re-evaluate from real data, not guesswork.

### Untouched

- `sky jobs queue` (10s SLA, observed max 10s, has never failed): unchanged.
- `sky jobs queue --all` (30s SLA, observed max 24s, has never failed): unchanged.

## Test plan

- [x] `bash -n tests/load_tests/db_scale_tests/test_large_production_performance.sh` syntax check.
- [x] Rebased on current master to clear out an unrelated stale-catalog-data CI failure (Verda accelerator listing test) that hit on the prior commit.
- [ ] `/smoke-test --kubernetes -k test_large_production_performance` triggered on this PR — expect sky status to print `Expected: Show 12501 managed jobs in progress and finish within 25 seconds` and the test to pass at whatever the run's observed duration is (≤ 25s).
- [ ] Future regressions that take sky-status above 25s will still fail this test with `ERROR: sky status took Ns, expected <= 25s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)