### PR TITLE
[Jobs] Add TODO for managed-job token renewal during long-running jobs

### DIFF
--- a/sky/jobs/constants.py
+++ b/sky/jobs/constants.py
@@ -84,4 +84,8 @@ MANAGED_JOB_TOKEN_NAME_PREFIX = 'managed-job-'
 # TTL for service-account tokens issued to managed jobs with
 # api_server_access. Kept short so any tokens that leak past the controller
 # cleanup are reaped quickly by the expired-token-cleanup daemon.
+# TODO(lloyd-brown): The controller does not renew this token while the job is
+# still running, so long-running jobs (e.g. multi-day training) can have their
+# api_server_access token expire mid-run. Add token renewal so the TTL only
+# bounds leaked-token lifetime, not in-use token lifetime.
 MANAGED_JOB_TOKEN_TTL_DAYS = 3


### PR DESCRIPTION
## Summary
- Follow-up to #9588. The controller does not renew the `api_server_access` service-account token while a managed job is running, so long-running jobs (multi-day training) can have their token expire mid-run after the 3-day TTL introduced in that PR.
- Adds a TODO next to `MANAGED_JOB_TOKEN_TTL_DAYS` so the limitation is discoverable next to the constant that causes it.
- Addresses review comment https://github.com/skypilot-org/skypilot/pull/9588#discussion_r3224131141.

## Test plan
- [x] `bash format.sh --files sky/jobs/constants.py` — 10.00/10
- No behavior change; comment-only.