### PR TITLE
[Kubernetes] Probe Ray ports when pod has hostNetwork: true

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -768,20 +768,10 @@ class Kubernetes(clouds.Cloud):
 
         namespace = kubernetes_utils.get_kube_config_context_namespace(context)
 
-        # Detect hostNetwork: true in the user's pod_config. When set,
-        # the pod shares the host's network namespace and Ray's default
-        # ports would collide with any sibling SkyPilot pod scheduled to
-        # the same node. We auto-enable the host-network probe path:
-        # the head pod picks free ports and publishes them via a
-        # ConfigMap; workers read it back. See
-        # sky/provision/kubernetes/host_network_probe.py and
-        # sky/provision/instance_setup._host_network_probe_cmd.
-        # We re-derive the merged pod_config here (rather than reading
-        # the already-merged spec back from the rendered template) so
-        # the bootstrap env vars are wired into deploy_vars before the
-        # template is rendered. combine_pod_config_fields() merges the
-        # same sources again at template-merge time — both calls land
-        # on the same final pod_config.
+        # Detect hostNetwork to wire the probe env vars into deploy_vars
+        # before the template is rendered. The same merge happens again
+        # later in combine_pod_config_fields when the user's pod_config
+        # is folded into the rendered YAML.
         merged_pod_config = skypilot_config.get_effective_region_config(
             cloud=cloud_config_str,
             region=context,

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -27,6 +27,7 @@ from sky.provision.kubernetes.utils import normalize_tpu_accelerator_name
 from sky.skylet import constants
 from sky.utils import annotations
 from sky.utils import common_utils
+from sky.utils import config_utils
 from sky.utils import env_options
 from sky.utils import kubernetes_enums
 from sky.utils import registry
@@ -529,7 +530,7 @@ class Kubernetes(clouds.Cloud):
         dryrun: bool = False,
         volume_mounts: Optional[List['volume_lib.VolumeMount']] = None,
     ) -> Dict[str, Optional[str]]:
-        del cluster_name, zones  # Unused.
+        del zones  # Unused.
         if region is None:
             context = kubernetes_utils.get_current_kube_config_context_name()
         else:
@@ -767,6 +768,41 @@ class Kubernetes(clouds.Cloud):
 
         namespace = kubernetes_utils.get_kube_config_context_namespace(context)
 
+        # Detect hostNetwork: true in the user's pod_config. When set,
+        # the pod shares the host's network namespace and Ray's default
+        # ports would collide with any sibling SkyPilot pod scheduled to
+        # the same node. We auto-enable the host-network probe path:
+        # the head pod picks free ports and publishes them via a
+        # ConfigMap; workers read it back. See
+        # sky/provision/kubernetes/host_network_probe.py and
+        # sky/provision/instance_setup._host_network_probe_cmd.
+        # We re-derive the merged pod_config here (rather than reading
+        # the already-merged spec back from the rendered template) so
+        # the bootstrap env vars are wired into deploy_vars before the
+        # template is rendered. combine_pod_config_fields() merges the
+        # same sources again at template-merge time — both calls land
+        # on the same final pod_config.
+        merged_pod_config = skypilot_config.get_effective_region_config(
+            cloud=cloud_config_str,
+            region=context,
+            keys=('pod_config',),
+            default_value={})
+        override_pod_config = config_utils.get_cloud_config_value_from_dict(
+            dict_config=resources.cluster_config_overrides,
+            cloud=cloud_config_str,
+            region=context,
+            keys=('pod_config',),
+            default_value={})
+        config_utils.merge_k8s_configs(merged_pod_config, override_pod_config)
+        k8s_host_network = bool(
+            merged_pod_config.get('spec', {}).get('hostNetwork', False))
+        if k8s_host_network:
+            cluster_name_on_cloud = cluster_name.name_on_cloud
+            k8s_env_vars['SKYPILOT_HOST_NETWORK'] = '1'
+            k8s_env_vars['SKYPILOT_RAY_PORTS_CONFIGMAP_NAME'] = (
+                f'{cluster_name_on_cloud}-ray-ports')
+            k8s_env_vars['SKYPILOT_RAY_PORTS_CONFIGMAP_NAMESPACE'] = namespace
+
         deploy_vars = {
             'instance_type': resources.instance_type,
             'custom_resources': custom_resources,
@@ -825,6 +861,7 @@ class Kubernetes(clouds.Cloud):
             'k8s_network_type': network_type.value,
             'k8s_context': context,
             'k8s_namespace': namespace,
+            'k8s_host_network': k8s_host_network,
         }
 
         # Add ephemeral storage to deploy vars if specified.

--- a/sky/provision/common.py
+++ b/sky/provision/common.py
@@ -192,6 +192,12 @@ class ClusterInfo:
     # Override the ssh_user from the cluster config.
     ssh_user: Optional[str] = None
     custom_ray_options: Optional[Dict[str, Any]] = None
+    # True for Kubernetes clusters launched with pod_config.spec.hostNetwork.
+    # Used by the SSH-over-websocket proxy: for hostNetwork the pod's sshd
+    # is on a probed port (held in InstanceInfo.ssh_port); otherwise the
+    # pod's sshd is always on the container-internal port 22 even if the
+    # external SSH port is a NodePort.
+    host_network: bool = False
 
     @property
     def num_instances(self) -> int:

--- a/sky/provision/common.py
+++ b/sky/provision/common.py
@@ -192,12 +192,6 @@ class ClusterInfo:
     # Override the ssh_user from the cluster config.
     ssh_user: Optional[str] = None
     custom_ray_options: Optional[Dict[str, Any]] = None
-    # True for Kubernetes clusters launched with pod_config.spec.hostNetwork.
-    # Used by the SSH-over-websocket proxy: for hostNetwork the pod's sshd
-    # is on a probed port (held in InstanceInfo.ssh_port); otherwise the
-    # pod's sshd is always on the container-internal port 22 even if the
-    # external SSH port is a NodePort.
-    host_network: bool = False
 
     @property
     def num_instances(self) -> int:

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -49,63 +49,36 @@ DUMP_RAY_PORTS = (f'{constants.SKY_PYTHON_CMD} -c \'import json, os; '
                   f'"{constants.SKY_REMOTE_RAY_PORT_FILE}"), "w", '
                   'encoding="utf-8"))\';')
 
-# Path the probe writes; the bash snippet sources it to pull the chosen
-# ports into the env so ray start picks them up via ${VAR:-default}
-# substitution below.
 _HOST_NETWORK_ENV_FILE = '/tmp/sky_host_network_ports.env'
-
-# Where the inlined probe script is written on the pod each time
-# ray_head_start_command / ray_worker_start_command runs. Reusing a
-# fixed path is fine — the content is identical across invocations and
-# the redirect (`cat >`) truncates on each write.
 _HOST_NETWORK_PROBE_TARGET = '/tmp/sky_host_network_probe.py'
 
 
 def _read_host_network_probe_b64() -> str:
-    # Load the probe source once at module import and base64-encode it.
-    # __file__ resolves to whichever sky.provision.instance_setup is
-    # running (the local checkout for an editable install, the wheel's
-    # copy otherwise); the probe file ships alongside in
-    # sky/provision/kubernetes/.
     path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                         'kubernetes', 'host_network_probe.py')
     with open(path, 'rb') as f:
-        body = f.read()
-    return base64.b64encode(body).decode('ascii')
+        return base64.b64encode(f.read()).decode('ascii')
 
 
-# Base64 keeps the embedded content on a single YAML-safe line —
-# heredoc-inlining the raw script content puts column-0 lines inside a
-# block-scalar where they parse as new keys ("could not find expected
-# ':'"). Using b64 + a one-line `echo … | base64 -d > …` sidesteps
-# YAML indentation concerns entirely and stays well within bash's
-# command-line length limit (~19 KB for the current probe).
 _HOST_NETWORK_PROBE_B64 = _read_host_network_probe_b64()
 
 
 def _host_network_probe_cmd(mode: str) -> str:
     """Bash snippet that probes free Ray ports when running with hostNetwork.
 
-    Grabs a free port set on the pod's host network namespace and writes
-    them to a sourceable env file. For the head, the probe also
-    publishes the chosen ports to a ConfigMap so worker pods (which
-    share the host net namespace on different nodes but still need to
-    dial the head's GCS) can discover them.
+    Returns a runtime-gated snippet: a no-op shell branch unless
+    SKYPILOT_HOST_NETWORK=1 and SKYPILOT_RAY_PORTS_CONFIGMAP_NAME are
+    set in the pod env. Non-hostNetwork bootstraps see no change — env
+    vars stay unset and ``${VAR:-default}`` in the ray flags falls back
+    to the constants.
 
-    Gated entirely on runtime env vars: returns a no-op-ish snippet when
-    SKYPILOT_HOST_NETWORK is unset or SKYPILOT_RAY_PORTS_CONFIGMAP_NAME
-    is empty. Non-K8s callers and K8s callers without hostNetwork: true
-    therefore see no behavior change — the env vars stay unset and
-    ``${VAR:-default}`` in the ray flags falls back to the constants.
-
-    Ships the probe content base64-encoded inside the bash command,
-    decoding it to /tmp on the pod at run time. The K8s bootstrap
-    installs stable skypilot from PyPI before ray_head_start_command
-    runs in the pod (the dev wheel ships later via
-    kubernetes-ray.yml.j2's skypilot_wheel_installation_commands at
-    line ~1635), so the probe file from the dev wheel isn't yet on
-    disk in site-packages at probe time. Inlining the bytes makes the
-    bash command self-shipping regardless of what's installed.
+    The probe is shipped base64-inline rather than invoked as a module
+    because the K8s template installs stable skypilot from PyPI before
+    ray_head_start_command runs (the dev wheel ships later), so neither
+    `python -m sky.provision.kubernetes.host_network_probe` nor a
+    site-packages file lookup is reliable at probe time. The b64 form
+    also keeps the payload on a single line, which is required to stay
+    inside the rendered YAML's block-scalar indentation.
     """
     assert mode in ('head', 'worker'), mode
     return ('if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ] && '
@@ -122,17 +95,10 @@ def _host_network_probe_cmd(mode: str) -> str:
             'fi; ')
 
 
-# Python expression to read the chosen Ray port from ~/.sky/ray_port.json.
-# Stdlib only — deliberately does not import `sky`, so this survives a
-# half-baked sky package install. The K8s bootstrap re-runs `uv pip install
-# skypilot[kubernetes,remote]` right after the local dev wheel, which (without
-# --prerelease=allow) downgrades to the latest stable on PyPI; the resulting
-# install can leave `sky/__init__.py` in a state where `from sky.X import Y`
-# raises ImportError mid-import. The previous reader used `from sky.skylet
-# import job_lib` and silently fell back to `echo 6379` on error, sending the
-# health-check poll to the wrong port and forcing a 90s timeout. Falling back
-# to SKY_REMOTE_RAY_PORT (SkyPilot's default 6380) instead of legacy 6379 is
-# strictly more correct — any cluster launched after #1790 is on 6380.
+# Stdlib only — deliberately doesn't import `sky` so the read still
+# works during the K8s bootstrap's brief stable→dev skypilot reinstall
+# window. Falls back to SKY_REMOTE_RAY_PORT (not legacy 6379) so the
+# health-check poll lands on something Ray could plausibly be on.
 _READ_RAY_PORT_PY = (
     'import json, os; '
     'd = os.path.expanduser(os.environ.get('
@@ -152,10 +118,8 @@ RAY_STATUS_WITH_SKY_RAY_PORT_COMMAND = (
 
 # Command that waits for the ray status to be initialized. Otherwise, a later
 # `sky status -r` may fail due to the ray cluster not being ready.
-# constants.RAY_STATUS pins RAY_ADDRESS to the SkyPilot default port. The
-# hostNetwork probe binds Ray to a dynamic free port, so use SKYPILOT_RAY_PORT
-# (exported by the probe just above this loop) when present, falling back to
-# the constant so non-hostNetwork bootstraps behave the same as before.
+# Reads SKYPILOT_RAY_PORT (exported by the hostNetwork probe) rather than
+# the constants.RAY_STATUS literal — the probe picks a dynamic port.
 RAY_HEAD_WAIT_INITIALIZED_COMMAND = (
     'while `RAY_ADDRESS=127.0.0.1:${SKYPILOT_RAY_PORT:-'
     f'{constants.SKY_REMOTE_RAY_PORT}}} '
@@ -388,16 +352,10 @@ def _ray_gpu_options(custom_resource: str) -> str:
 def ray_head_start_command(custom_resource: Optional[str],
                            custom_ray_options: Optional[Dict[str, Any]]) -> str:
     """Returns the command to start Ray on the head node."""
-    # Port flags use ${VAR:-default} substitution so that:
-    # * When SKYPILOT_HOST_NETWORK is unset (the common case), the env
-    #   vars are unset and the flags expand to their original constants
-    #   — bit-identical to the pre-hostNetwork behavior.
-    # * When the probe ran (hostNetwork: true K8s pod), the env file is
-    #   sourced first and the flags expand to the probed port numbers.
-    # New flags (node-manager-port, ray-client-server-port, dashboard
-    # agent / runtime-env agent / metrics export) use ${VAR:+--flag=...}
-    # so they are *omitted entirely* when unset, preserving Ray's own
-    # default-port behavior for non-hostNetwork clusters.
+    # Existing port flags use ${VAR:-default} (probed value when the
+    # hostNetwork probe ran, original constant otherwise). New flags
+    # use ${VAR:+--flag=...} so they vanish when unset, deferring to
+    # Ray's own defaults for non-hostNetwork bootstraps.
     ray_options = (
         # --disable-usage-stats in `ray start` saves 10 seconds of idle wait.
         f'--disable-usage-stats '
@@ -454,14 +412,9 @@ def ray_worker_start_command(custom_resource: Optional[str],
                              custom_ray_options: Optional[Dict[str, Any]],
                              no_restart: bool) -> str:
     """Returns the command to start Ray on the worker node."""
-    # SKYPILOT_RAY_PORT carries the head's GCS port. In the non-hostNetwork
-    # path the K8s template (or the SSH-fallback caller) exports it from a
-    # build-time constant; in the hostNetwork path the worker-side probe
-    # pulls it from the head's ConfigMap and writes it to the env file
-    # sourced just above. Local-bind ports (node-manager, object-manager,
-    # etc.) come from the worker's own probe via ${VAR:+...} substitution
-    # so they are omitted entirely (preserving Ray's default behavior)
-    # when the probe didn't run.
+    # SKYPILOT_RAY_PORT is the head's GCS port — exported as a constant
+    # by the K8s template's worker bootstrap, or as the probed value
+    # (read from the head's ConfigMap) by the hostNetwork worker probe.
     ray_options = (
         '--address=${SKYPILOT_RAY_HEAD_IP}:${SKYPILOT_RAY_PORT} '
         '--object-manager-port=${SKYPILOT_RAY_OBJECT_MANAGER_PORT:-8076} '

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -64,13 +64,18 @@ _HOST_NETWORK_PROBE_B64 = _read_host_network_probe_b64()
 
 
 def _host_network_probe_cmd(mode: str) -> str:
-    """Bash snippet that probes free Ray ports when running with hostNetwork.
+    """Bash snippet that probes Ray + sshd ports when running with hostNetwork.
 
     Returns a runtime-gated snippet: a no-op shell branch unless
     SKYPILOT_HOST_NETWORK=1 and SKYPILOT_RAY_PORTS_CONFIGMAP_NAME are
     set in the pod env. Non-hostNetwork bootstraps see no change — env
     vars stay unset and ``${VAR:-default}`` in the ray flags falls back
     to the constants.
+
+    Also rebinds the pod's sshd to the probed SKYPILOT_SSHD_PORT. Under
+    hostNetwork the node's own sshd already owns host:22 so the pod's
+    sshd silently failed to bind in apt-ssh-setup; rewriting Port in
+    sshd_config and restarting picks up the probed port instead.
 
     The probe is shipped base64-inline rather than invoked as a module
     because the K8s template installs stable skypilot from PyPI before
@@ -81,18 +86,29 @@ def _host_network_probe_cmd(mode: str) -> str:
     inside the rendered YAML's block-scalar indentation.
     """
     assert mode in ('head', 'worker'), mode
-    return ('if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ] && '
-            '[ -n "${SKYPILOT_RAY_PORTS_CONFIGMAP_NAME:-}" ]; then '
-            f'echo \'{_HOST_NETWORK_PROBE_B64}\' | base64 -d > '
-            f'{_HOST_NETWORK_PROBE_TARGET}; '
-            f'{constants.SKY_PYTHON_CMD} {_HOST_NETWORK_PROBE_TARGET} '
-            f'--mode {mode} '
-            f'--env-file {_HOST_NETWORK_ENV_FILE} '
-            '--configmap-name "$SKYPILOT_RAY_PORTS_CONFIGMAP_NAME" '
-            '--configmap-namespace '
-            '"$SKYPILOT_RAY_PORTS_CONFIGMAP_NAMESPACE" || exit 1; '
-            f'set -a; . {_HOST_NETWORK_ENV_FILE}; set +a; '
-            'fi; ')
+    return (
+        'if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ] && '
+        '[ -n "${SKYPILOT_RAY_PORTS_CONFIGMAP_NAME:-}" ]; then '
+        f'echo \'{_HOST_NETWORK_PROBE_B64}\' | base64 -d > '
+        f'{_HOST_NETWORK_PROBE_TARGET}; '
+        f'{constants.SKY_PYTHON_CMD} {_HOST_NETWORK_PROBE_TARGET} '
+        f'--mode {mode} '
+        f'--env-file {_HOST_NETWORK_ENV_FILE} '
+        '--configmap-name "$SKYPILOT_RAY_PORTS_CONFIGMAP_NAME" '
+        '--configmap-namespace '
+        '"$SKYPILOT_RAY_PORTS_CONFIGMAP_NAMESPACE" || exit 1; '
+        f'set -a; . {_HOST_NETWORK_ENV_FILE}; set +a; '
+        'if [ -n "${SKYPILOT_SSHD_PORT:-}" ]; then '
+        # Delete any existing Port directive (commented or not) then
+        # append ours. Replace-in-place fails closed if sshd_config
+        # lacks any Port line, so this delete+append is more robust.
+        'sudo sed -i -E "/^[[:space:]]*#?[[:space:]]*Port[[:space:]]+/d" '
+        '/etc/ssh/sshd_config; '
+        'echo "Port ${SKYPILOT_SSHD_PORT}" | '
+        'sudo tee -a /etc/ssh/sshd_config > /dev/null; '
+        'sudo service ssh restart; '
+        'fi; '
+        'fi; ')
 
 
 # Stdlib only — deliberately doesn't import `sky` so the read still

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -69,12 +69,25 @@ def _host_network_probe_cmd(mode: str) -> str:
     is empty. Non-K8s callers and K8s callers without hostNetwork: true
     therefore see no behavior change — the env vars stay unset and
     ``${VAR:-default}`` in the ray flags falls back to the constants.
+
+    Invokes the probe by its filesystem path rather than ``python -m
+    sky.provision.kubernetes.host_network_probe`` because the K8s
+    bootstrap template re-installs skypilot from PyPI right after
+    installing the dev wheel (kubernetes-ray.yml.j2 line ~1067) — that
+    pinless install excludes pre-releases and downgrades the dev wheel,
+    leaving sky/__init__.py in a state where ``-m sky.X`` triggers an
+    ImportError. The probe module is stdlib-only, so loading it by path
+    sidesteps the broken package init entirely. sysconfig.get_paths()
+    is used to locate site-packages without importing ``sky`` itself.
     """
     assert mode in ('head', 'worker'), mode
+    probe_path_cmd = (f'{constants.SKY_PYTHON_CMD} -c "import sysconfig, os; '
+                      'print(os.path.join(sysconfig.get_paths()[\'purelib\'], '
+                      '\'sky/provision/kubernetes/host_network_probe.py\'))"')
     return ('if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ] && '
             '[ -n "${SKYPILOT_RAY_PORTS_CONFIGMAP_NAME:-}" ]; then '
-            f'{constants.SKY_PYTHON_CMD} -m '
-            'sky.provision.kubernetes.host_network_probe '
+            f'SKY_HOST_NETWORK_PROBE_PATH=$({probe_path_cmd}); '
+            f'{constants.SKY_PYTHON_CMD} "$SKY_HOST_NETWORK_PROBE_PATH" '
             f'--mode {mode} '
             f'--env-file {_HOST_NETWORK_ENV_FILE} '
             '--configmap-name "$SKYPILOT_RAY_PORTS_CONFIGMAP_NAME" '

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -48,6 +48,42 @@ DUMP_RAY_PORTS = (f'{constants.SKY_PYTHON_CMD} -c \'import json, os; '
                   f'"{constants.SKY_REMOTE_RAY_PORT_FILE}"), "w", '
                   'encoding="utf-8"))\';')
 
+# Path the probe writes; the bash snippet sources it to pull the chosen
+# ports into the env so ray start picks them up via ${VAR:-default}
+# substitution below.
+_HOST_NETWORK_ENV_FILE = '/tmp/sky_host_network_ports.env'
+
+
+def _host_network_probe_cmd(mode: str) -> str:
+    """Bash snippet that probes free Ray ports when running with hostNetwork.
+
+    Runs sky.provision.kubernetes.host_network_probe to grab a free port
+    set on the pod's host network namespace and write them to a
+    sourceable env file. For the head, the probe also publishes the
+    chosen ports to a ConfigMap so worker pods (which share the host net
+    namespace on different nodes but still need to dial the head's GCS)
+    can discover them.
+
+    Gated entirely on runtime env vars: returns a no-op-ish snippet when
+    SKYPILOT_HOST_NETWORK is unset or SKYPILOT_RAY_PORTS_CONFIGMAP_NAME
+    is empty. Non-K8s callers and K8s callers without hostNetwork: true
+    therefore see no behavior change — the env vars stay unset and
+    ``${VAR:-default}`` in the ray flags falls back to the constants.
+    """
+    assert mode in ('head', 'worker'), mode
+    return ('if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ] && '
+            '[ -n "${SKYPILOT_RAY_PORTS_CONFIGMAP_NAME:-}" ]; then '
+            f'{constants.SKY_PYTHON_CMD} -m '
+            'sky.provision.kubernetes.host_network_probe '
+            f'--mode {mode} '
+            f'--env-file {_HOST_NETWORK_ENV_FILE} '
+            '--configmap-name "$SKYPILOT_RAY_PORTS_CONFIGMAP_NAME" '
+            '--configmap-namespace '
+            '"$SKYPILOT_RAY_PORTS_CONFIGMAP_NAMESPACE" || exit 1; '
+            f'set -a; . {_HOST_NETWORK_ENV_FILE}; set +a; '
+            'fi; ')
+
+
 _RAY_PORT_COMMAND = (
     f'RAY_PORT=$({constants.SKY_PYTHON_CMD} -c '
     '"from sky import sky_logging\n'
@@ -294,13 +330,35 @@ def _ray_gpu_options(custom_resource: str) -> str:
 def ray_head_start_command(custom_resource: Optional[str],
                            custom_ray_options: Optional[Dict[str, Any]]) -> str:
     """Returns the command to start Ray on the head node."""
+    # Port flags use ${VAR:-default} substitution so that:
+    # * When SKYPILOT_HOST_NETWORK is unset (the common case), the env
+    #   vars are unset and the flags expand to their original constants
+    #   — bit-identical to the pre-hostNetwork behavior.
+    # * When the probe ran (hostNetwork: true K8s pod), the env file is
+    #   sourced first and the flags expand to the probed port numbers.
+    # New flags (node-manager-port, ray-client-server-port, dashboard
+    # agent / runtime-env agent / metrics export) use ${VAR:+--flag=...}
+    # so they are *omitted entirely* when unset, preserving Ray's own
+    # default-port behavior for non-hostNetwork clusters.
     ray_options = (
         # --disable-usage-stats in `ray start` saves 10 seconds of idle wait.
         f'--disable-usage-stats '
-        f'--port={constants.SKY_REMOTE_RAY_PORT} '
-        f'--dashboard-port={constants.SKY_REMOTE_RAY_DASHBOARD_PORT} '
+        f'--port=${{SKYPILOT_RAY_PORT:-{constants.SKY_REMOTE_RAY_PORT}}} '
+        f'--dashboard-port=${{SKYPILOT_RAY_DASHBOARD_PORT:-'
+        f'{constants.SKY_REMOTE_RAY_DASHBOARD_PORT}}} '
         f'--min-worker-port 11002 '
-        f'--object-manager-port=8076 '
+        f'--object-manager-port=${{SKYPILOT_RAY_OBJECT_MANAGER_PORT:-8076}} '
+        '${SKYPILOT_RAY_NODE_MANAGER_PORT:+'
+        '--node-manager-port=$SKYPILOT_RAY_NODE_MANAGER_PORT} '
+        '${SKYPILOT_RAY_CLIENT_SERVER_PORT:+'
+        '--ray-client-server-port=$SKYPILOT_RAY_CLIENT_SERVER_PORT} '
+        '${SKYPILOT_RAY_DASHBOARD_AGENT_LISTEN_PORT:+'
+        '--dashboard-agent-listen-port='
+        '$SKYPILOT_RAY_DASHBOARD_AGENT_LISTEN_PORT} '
+        '${SKYPILOT_RAY_RUNTIME_ENV_AGENT_PORT:+'
+        '--runtime-env-agent-port=$SKYPILOT_RAY_RUNTIME_ENV_AGENT_PORT} '
+        '${SKYPILOT_RAY_METRICS_EXPORT_PORT:+'
+        '--metrics-export-port=$SKYPILOT_RAY_METRICS_EXPORT_PORT} '
         f'--temp-dir={constants.SKY_REMOTE_RAY_TEMPDIR}')
     if custom_resource:
         ray_options += f' --resources=\'{custom_resource}\''
@@ -312,7 +370,7 @@ def ray_head_start_command(custom_resource: Optional[str],
             ray_options += f' --{key}={value}'
 
     cmd = (
-        f'{constants.SKY_RAY_CMD} stop; '
+        _host_network_probe_cmd('head') + f'{constants.SKY_RAY_CMD} stop; '
         'RAY_SCHEDULER_EVENTS=0 RAY_DEDUP_LOGS=0 '
         # worker_maximum_startup_concurrency controls the maximum number of
         # workers that can be started concurrently. However, it also controls
@@ -338,10 +396,26 @@ def ray_worker_start_command(custom_resource: Optional[str],
                              custom_ray_options: Optional[Dict[str, Any]],
                              no_restart: bool) -> str:
     """Returns the command to start Ray on the worker node."""
-    # We need to use the ray port in the env variable, because the head node
-    # determines the port to be used for the worker node.
-    ray_options = ('--address=${SKYPILOT_RAY_HEAD_IP}:${SKYPILOT_RAY_PORT} '
-                   '--object-manager-port=8076')
+    # SKYPILOT_RAY_PORT carries the head's GCS port. In the non-hostNetwork
+    # path the K8s template (or the SSH-fallback caller) exports it from a
+    # build-time constant; in the hostNetwork path the worker-side probe
+    # pulls it from the head's ConfigMap and writes it to the env file
+    # sourced just above. Local-bind ports (node-manager, object-manager,
+    # etc.) come from the worker's own probe via ${VAR:+...} substitution
+    # so they are omitted entirely (preserving Ray's default behavior)
+    # when the probe didn't run.
+    ray_options = (
+        '--address=${SKYPILOT_RAY_HEAD_IP}:${SKYPILOT_RAY_PORT} '
+        '--object-manager-port=${SKYPILOT_RAY_OBJECT_MANAGER_PORT:-8076} '
+        '${SKYPILOT_RAY_NODE_MANAGER_PORT:+'
+        '--node-manager-port=$SKYPILOT_RAY_NODE_MANAGER_PORT} '
+        '${SKYPILOT_RAY_DASHBOARD_AGENT_LISTEN_PORT:+'
+        '--dashboard-agent-listen-port='
+        '$SKYPILOT_RAY_DASHBOARD_AGENT_LISTEN_PORT} '
+        '${SKYPILOT_RAY_RUNTIME_ENV_AGENT_PORT:+'
+        '--runtime-env-agent-port=$SKYPILOT_RAY_RUNTIME_ENV_AGENT_PORT} '
+        '${SKYPILOT_RAY_METRICS_EXPORT_PORT:+'
+        '--metrics-export-port=$SKYPILOT_RAY_METRICS_EXPORT_PORT}')
 
     if custom_resource:
         ray_options += f' --resources=\'{custom_resource}\''
@@ -367,7 +441,7 @@ def ray_worker_start_command(custom_resource: Optional[str],
             f'|| {{ {cmd} }}')
     else:
         cmd = f'{constants.SKY_RAY_CMD} stop; ' + cmd
-    return cmd
+    return _host_network_probe_cmd('worker') + cmd
 
 
 @common.log_function_start_end

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -2,6 +2,7 @@
 import base64
 from concurrent import futures
 import functools
+import gzip
 import hashlib
 import json
 import os
@@ -26,6 +27,7 @@ from sky.utils import command_runner
 from sky.utils import common_utils
 from sky.utils import env_options
 from sky.utils import resources_utils
+from sky.utils import source_utils
 from sky.utils import subprocess_utils
 from sky.utils import timeline
 from sky.utils import ux_utils
@@ -56,8 +58,13 @@ _HOST_NETWORK_PROBE_TARGET = '/tmp/sky_host_network_probe.py'
 def _read_host_network_probe_b64() -> str:
     path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                         'kubernetes', 'host_network_probe.py')
-    with open(path, 'rb') as f:
-        return base64.b64encode(f.read()).decode('ascii')
+    with open(path, 'r', encoding='utf-8') as f:
+        source = f.read()
+    minified = source_utils.minify_python_source(source)
+    # Sanity-check: minified source must still parse.
+    compile(minified, path, 'exec')
+    compressed = gzip.compress(minified.encode('utf-8'))
+    return base64.b64encode(compressed).decode('ascii')
 
 
 _HOST_NETWORK_PROBE_B64 = _read_host_network_probe_b64()
@@ -77,19 +84,20 @@ def _host_network_probe_cmd(mode: str) -> str:
     sshd silently failed to bind in apt-ssh-setup; rewriting Port in
     sshd_config and restarting picks up the probed port instead.
 
-    The probe is shipped base64-inline rather than invoked as a module
-    because the K8s template installs stable skypilot from PyPI before
-    ray_head_start_command runs (the dev wheel ships later), so neither
-    `python -m sky.provision.kubernetes.host_network_probe` nor a
-    site-packages file lookup is reliable at probe time. The b64 form
+    The probe is shipped gzip+base64-inline rather than invoked as a
+    module because the K8s template installs stable skypilot from PyPI
+    before ray_head_start_command runs (the dev wheel ships later), so
+    neither `python -m sky.provision.kubernetes.host_network_probe` nor
+    a site-packages file lookup is reliable at probe time. The b64 form
     also keeps the payload on a single line, which is required to stay
-    inside the rendered YAML's block-scalar indentation.
+    inside the rendered YAML's block-scalar indentation. Gzip cuts the
+    payload by ~4x; the source on disk stays readable.
     """
     assert mode in ('head', 'worker'), mode
     return (
         'if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ] && '
         '[ -n "${SKYPILOT_RAY_PORTS_CONFIGMAP_NAME:-}" ]; then '
-        f'echo \'{_HOST_NETWORK_PROBE_B64}\' | base64 -d > '
+        f'echo \'{_HOST_NETWORK_PROBE_B64}\' | base64 -d | gunzip > '
         f'{_HOST_NETWORK_PROBE_TARGET}; '
         f'{constants.SKY_PYTHON_CMD} {_HOST_NETWORK_PROBE_TARGET} '
         f'--mode {mode} '

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -98,15 +98,15 @@ def _host_network_probe_cmd(mode: str) -> str:
         '--configmap-namespace '
         '"$SKYPILOT_RAY_PORTS_CONFIGMAP_NAMESPACE" || exit 1; '
         f'set -a; . {_HOST_NETWORK_ENV_FILE}; set +a; '
+        # Delete-then-append rather than sed-in-place: sshd_config files
+        # without an existing Port directive would otherwise keep the
+        # default 22 (where the K8s node's own sshd already listens).
         'if [ -n "${SKYPILOT_SSHD_PORT:-}" ]; then '
-        # Delete any existing Port directive (commented or not) then
-        # append ours. Replace-in-place fails closed if sshd_config
-        # lacks any Port line, so this delete+append is more robust.
-        'sudo sed -i -E "/^[[:space:]]*#?[[:space:]]*Port[[:space:]]+/d" '
-        '/etc/ssh/sshd_config; '
-        'echo "Port ${SKYPILOT_SSHD_PORT}" | '
-        'sudo tee -a /etc/ssh/sshd_config > /dev/null; '
-        'sudo service ssh restart; '
+        'sudo sh -c "'
+        'sed -i -E \'/^[[:space:]]*#?[[:space:]]*Port[[:space:]]+/d\' '
+        '/etc/ssh/sshd_config && '
+        'echo Port ${SKYPILOT_SSHD_PORT} >> /etc/ssh/sshd_config && '
+        'service ssh restart"; '
         'fi; '
         'fi; ')
 

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -100,8 +100,14 @@ RAY_STATUS_WITH_SKY_RAY_PORT_COMMAND = (
 
 # Command that waits for the ray status to be initialized. Otherwise, a later
 # `sky status -r` may fail due to the ray cluster not being ready.
+# constants.RAY_STATUS pins RAY_ADDRESS to the SkyPilot default port. The
+# hostNetwork probe binds Ray to a dynamic free port, so use SKYPILOT_RAY_PORT
+# (exported by the probe just above this loop) when present, falling back to
+# the constant so non-hostNetwork bootstraps behave the same as before.
 RAY_HEAD_WAIT_INITIALIZED_COMMAND = (
-    f'while `{constants.RAY_STATUS} | grep -q "No cluster status."`; do '
+    'while `RAY_ADDRESS=127.0.0.1:${SKYPILOT_RAY_PORT:-'
+    f'{constants.SKY_REMOTE_RAY_PORT}}} '
+    f'{constants.SKY_RAY_CMD} status | grep -q "No cluster status."`; do '
     'sleep 0.5; '
     'echo "Waiting ray cluster to be initialized"; '
     'done;')

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -1,4 +1,5 @@
 """Setup dependencies & services for instances."""
+import base64
 from concurrent import futures
 import functools
 import hashlib
@@ -60,22 +61,26 @@ _HOST_NETWORK_ENV_FILE = '/tmp/sky_host_network_ports.env'
 _HOST_NETWORK_PROBE_TARGET = '/tmp/sky_host_network_probe.py'
 
 
-def _read_host_network_probe_script() -> str:
-    # Load the probe source once at module import. __file__ resolves to
-    # whichever sky.provision.instance_setup is running (the local
-    # checkout for an editable install, the wheel's copy otherwise);
-    # the probe file ships alongside in sky/provision/kubernetes/.
+def _read_host_network_probe_b64() -> str:
+    # Load the probe source once at module import and base64-encode it.
+    # __file__ resolves to whichever sky.provision.instance_setup is
+    # running (the local checkout for an editable install, the wheel's
+    # copy otherwise); the probe file ships alongside in
+    # sky/provision/kubernetes/.
     path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                         'kubernetes', 'host_network_probe.py')
-    with open(path, encoding='utf-8') as f:
+    with open(path, 'rb') as f:
         body = f.read()
-    # Heredoc requires the terminator on its own line; guarantee a
-    # trailing newline so the closing _SKY_PROBE_EOF_ isn't smushed
-    # onto the script's last code line.
-    return body if body.endswith('\n') else body + '\n'
+    return base64.b64encode(body).decode('ascii')
 
 
-_HOST_NETWORK_PROBE_SCRIPT = _read_host_network_probe_script()
+# Base64 keeps the embedded content on a single YAML-safe line —
+# heredoc-inlining the raw script content puts column-0 lines inside a
+# block-scalar where they parse as new keys ("could not find expected
+# ':'"). Using b64 + a one-line `echo … | base64 -d > …` sidesteps
+# YAML indentation concerns entirely and stays well within bash's
+# command-line length limit (~19 KB for the current probe).
+_HOST_NETWORK_PROBE_B64 = _read_host_network_probe_b64()
 
 
 def _host_network_probe_cmd(mode: str) -> str:
@@ -93,24 +98,20 @@ def _host_network_probe_cmd(mode: str) -> str:
     therefore see no behavior change — the env vars stay unset and
     ``${VAR:-default}`` in the ray flags falls back to the constants.
 
-    Inlines the probe content via a single-quoted heredoc rather than
-    invoking the installed sky.provision.kubernetes.host_network_probe
-    module. The K8s bootstrap installs stable skypilot from PyPI before
-    ray_head_start_command runs in the pod (the dev wheel ships later
-    via kubernetes-ray.yml.j2's skypilot_wheel_installation_commands at
-    line ~1635) — so the probe file from the dev wheel isn't yet on
-    disk in site-packages at probe time. Heredoc-embedding makes the
-    bash command self-shipping: the script lands in /tmp from the
-    string we built on the SkyPilot host, regardless of what's
-    installed in the pod's site-packages.
+    Ships the probe content base64-encoded inside the bash command,
+    decoding it to /tmp on the pod at run time. The K8s bootstrap
+    installs stable skypilot from PyPI before ray_head_start_command
+    runs in the pod (the dev wheel ships later via
+    kubernetes-ray.yml.j2's skypilot_wheel_installation_commands at
+    line ~1635), so the probe file from the dev wheel isn't yet on
+    disk in site-packages at probe time. Inlining the bytes makes the
+    bash command self-shipping regardless of what's installed.
     """
     assert mode in ('head', 'worker'), mode
-    # The probe content contains Python dict literals with `{` and `}`,
-    # so it cannot live inside an f-string — concatenate it raw.
     return ('if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ] && '
             '[ -n "${SKYPILOT_RAY_PORTS_CONFIGMAP_NAME:-}" ]; then '
-            f'cat > {_HOST_NETWORK_PROBE_TARGET} <<\'_SKY_PROBE_EOF_\'\n' +
-            _HOST_NETWORK_PROBE_SCRIPT + '_SKY_PROBE_EOF_\n'
+            f'echo \'{_HOST_NETWORK_PROBE_B64}\' | base64 -d > '
+            f'{_HOST_NETWORK_PROBE_TARGET}; '
             f'{constants.SKY_PYTHON_CMD} {_HOST_NETWORK_PROBE_TARGET} '
             f'--mode {mode} '
             f'--env-file {_HOST_NETWORK_ENV_FILE} '

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -97,12 +97,26 @@ def _host_network_probe_cmd(mode: str) -> str:
             'fi; ')
 
 
+# Python expression to read the chosen Ray port from ~/.sky/ray_port.json.
+# Stdlib only — deliberately does not import `sky`, so this survives a
+# half-baked sky package install. The K8s bootstrap re-runs `uv pip install
+# skypilot[kubernetes,remote]` right after the local dev wheel, which (without
+# --prerelease=allow) downgrades to the latest stable on PyPI; the resulting
+# install can leave `sky/__init__.py` in a state where `from sky.X import Y`
+# raises ImportError mid-import. The previous reader used `from sky.skylet
+# import job_lib` and silently fell back to `echo 6379` on error, sending the
+# health-check poll to the wrong port and forcing a 90s timeout. Falling back
+# to SKY_REMOTE_RAY_PORT (SkyPilot's default 6380) instead of legacy 6379 is
+# strictly more correct — any cluster launched after #1790 is on 6380.
+_READ_RAY_PORT_PY = (
+    'import json, os; '
+    'd = os.path.expanduser(os.environ.get('
+    f'\'{constants.SKY_RUNTIME_DIR_ENV_VAR_KEY}\', \'~\')); '
+    'print(json.load(open(os.path.join(d, '
+    f'\'{constants.SKY_REMOTE_RAY_PORT_FILE}\')))[\'ray_port\'])')
 _RAY_PORT_COMMAND = (
-    f'RAY_PORT=$({constants.SKY_PYTHON_CMD} -c '
-    '"from sky import sky_logging\n'
-    'with sky_logging.silent(): '
-    'from sky.skylet import job_lib; print(job_lib.get_ray_port())" '
-    '2> /dev/null || echo 6379);'
+    f'RAY_PORT=$({constants.SKY_PYTHON_CMD} -c "{_READ_RAY_PORT_PY}" '
+    f'2> /dev/null || echo {constants.SKY_REMOTE_RAY_PORT});'
     f'{constants.SKY_PYTHON_CMD} -c "from sky.utils import message_utils; '
     'print(message_utils.encode_payload({\'ray_port\': $RAY_PORT}))"')
 

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -53,16 +53,39 @@ DUMP_RAY_PORTS = (f'{constants.SKY_PYTHON_CMD} -c \'import json, os; '
 # substitution below.
 _HOST_NETWORK_ENV_FILE = '/tmp/sky_host_network_ports.env'
 
+# Where the inlined probe script is written on the pod each time
+# ray_head_start_command / ray_worker_start_command runs. Reusing a
+# fixed path is fine — the content is identical across invocations and
+# the redirect (`cat >`) truncates on each write.
+_HOST_NETWORK_PROBE_TARGET = '/tmp/sky_host_network_probe.py'
+
+
+def _read_host_network_probe_script() -> str:
+    # Load the probe source once at module import. __file__ resolves to
+    # whichever sky.provision.instance_setup is running (the local
+    # checkout for an editable install, the wheel's copy otherwise);
+    # the probe file ships alongside in sky/provision/kubernetes/.
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                        'kubernetes', 'host_network_probe.py')
+    with open(path, encoding='utf-8') as f:
+        body = f.read()
+    # Heredoc requires the terminator on its own line; guarantee a
+    # trailing newline so the closing _SKY_PROBE_EOF_ isn't smushed
+    # onto the script's last code line.
+    return body if body.endswith('\n') else body + '\n'
+
+
+_HOST_NETWORK_PROBE_SCRIPT = _read_host_network_probe_script()
+
 
 def _host_network_probe_cmd(mode: str) -> str:
     """Bash snippet that probes free Ray ports when running with hostNetwork.
 
-    Runs sky.provision.kubernetes.host_network_probe to grab a free port
-    set on the pod's host network namespace and write them to a
-    sourceable env file. For the head, the probe also publishes the
-    chosen ports to a ConfigMap so worker pods (which share the host net
-    namespace on different nodes but still need to dial the head's GCS)
-    can discover them.
+    Grabs a free port set on the pod's host network namespace and writes
+    them to a sourceable env file. For the head, the probe also
+    publishes the chosen ports to a ConfigMap so worker pods (which
+    share the host net namespace on different nodes but still need to
+    dial the head's GCS) can discover them.
 
     Gated entirely on runtime env vars: returns a no-op-ish snippet when
     SKYPILOT_HOST_NETWORK is unset or SKYPILOT_RAY_PORTS_CONFIGMAP_NAME
@@ -70,24 +93,25 @@ def _host_network_probe_cmd(mode: str) -> str:
     therefore see no behavior change — the env vars stay unset and
     ``${VAR:-default}`` in the ray flags falls back to the constants.
 
-    Invokes the probe by its filesystem path rather than ``python -m
-    sky.provision.kubernetes.host_network_probe`` because the K8s
-    bootstrap template re-installs skypilot from PyPI right after
-    installing the dev wheel (kubernetes-ray.yml.j2 line ~1067) — that
-    pinless install excludes pre-releases and downgrades the dev wheel,
-    leaving sky/__init__.py in a state where ``-m sky.X`` triggers an
-    ImportError. The probe module is stdlib-only, so loading it by path
-    sidesteps the broken package init entirely. sysconfig.get_paths()
-    is used to locate site-packages without importing ``sky`` itself.
+    Inlines the probe content via a single-quoted heredoc rather than
+    invoking the installed sky.provision.kubernetes.host_network_probe
+    module. The K8s bootstrap installs stable skypilot from PyPI before
+    ray_head_start_command runs in the pod (the dev wheel ships later
+    via kubernetes-ray.yml.j2's skypilot_wheel_installation_commands at
+    line ~1635) — so the probe file from the dev wheel isn't yet on
+    disk in site-packages at probe time. Heredoc-embedding makes the
+    bash command self-shipping: the script lands in /tmp from the
+    string we built on the SkyPilot host, regardless of what's
+    installed in the pod's site-packages.
     """
     assert mode in ('head', 'worker'), mode
-    probe_path_cmd = (f'{constants.SKY_PYTHON_CMD} -c "import sysconfig, os; '
-                      'print(os.path.join(sysconfig.get_paths()[\'purelib\'], '
-                      '\'sky/provision/kubernetes/host_network_probe.py\'))"')
+    # The probe content contains Python dict literals with `{` and `}`,
+    # so it cannot live inside an f-string — concatenate it raw.
     return ('if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ] && '
             '[ -n "${SKYPILOT_RAY_PORTS_CONFIGMAP_NAME:-}" ]; then '
-            f'SKY_HOST_NETWORK_PROBE_PATH=$({probe_path_cmd}); '
-            f'{constants.SKY_PYTHON_CMD} "$SKY_HOST_NETWORK_PROBE_PATH" '
+            f'cat > {_HOST_NETWORK_PROBE_TARGET} <<\'_SKY_PROBE_EOF_\'\n' +
+            _HOST_NETWORK_PROBE_SCRIPT + '_SKY_PROBE_EOF_\n'
+            f'{constants.SKY_PYTHON_CMD} {_HOST_NETWORK_PROBE_TARGET} '
             f'--mode {mode} '
             f'--env-file {_HOST_NETWORK_ENV_FILE} '
             '--configmap-name "$SKYPILOT_RAY_PORTS_CONFIGMAP_NAME" '

--- a/sky/provision/kubernetes/host_network_probe.py
+++ b/sky/provision/kubernetes/host_network_probe.py
@@ -154,18 +154,6 @@ def _k8s_api_request(
         return e.code, e.read()
 
 
-def _get_pod_uid(pod_name: str, namespace: str) -> str:
-    """Look up the head pod's UID for the ConfigMap's ownerReference."""
-    status, resp = _k8s_api_request(
-        'GET', f'/api/v1/namespaces/{namespace}/pods/{pod_name}')
-    if status >= 300:
-        raise RuntimeError(
-            f'Failed to GET pod {namespace}/{pod_name} to derive the '
-            f'ConfigMap ownerReference: status={status} '
-            f'body={resp.decode("utf-8", "replace")}')
-    return json.loads(resp)['metadata']['uid']
-
-
 def _build_configmap_body(name: str, namespace: str, ports: Dict[str, int],
                           owner_pod_name: str,
                           owner_pod_uid: str) -> Dict[str, Any]:
@@ -209,10 +197,12 @@ def _publish_configmap(name: str, namespace: str, ports: Dict[str,
     fired yet), we refresh its ownerReference to the current head pod so
     cleanup catches it.
     """
-    # K8s exports the pod name as HOSTNAME by default. Required because
-    # this script runs inside the pod the OwnerReference will point at.
-    owner_pod_name = os.environ['HOSTNAME']
-    owner_pod_uid = _get_pod_uid(owner_pod_name, namespace)
+    # SKYPILOT_POD_NAME / SKYPILOT_POD_UID are injected by the K8s
+    # downward API in kubernetes-ray.yml.j2. We can't use $HOSTNAME here
+    # because under hostNetwork: true the container inherits the host
+    # node's hostname (e.g. gke-*-pool-*), not the pod's name.
+    owner_pod_name = os.environ['SKYPILOT_POD_NAME']
+    owner_pod_uid = os.environ['SKYPILOT_POD_UID']
     body = _build_configmap_body(name, namespace, ports, owner_pod_name,
                                  owner_pod_uid)
     base = f'/api/v1/namespaces/{namespace}/configmaps'

--- a/sky/provision/kubernetes/host_network_probe.py
+++ b/sky/provision/kubernetes/host_network_probe.py
@@ -1,30 +1,12 @@
 """Free-port probe and ConfigMap publish/discover for hostNetwork pods.
 
-When a Kubernetes pod is launched with ``hostNetwork: true`` (required for
-RoCE / RDMA performance on some accelerator setups), the pod shares the
-host's network namespace. Ray's default port set (GCS, dashboard,
-object/node manager, dashboard agent, runtime env agent, metrics export,
-ray client server) then binds directly on the host. A second SkyPilot
-pod scheduled to the same node would collide on those ports.
-
-This module:
-
-* Picks a free port for each Ray role by binding ephemeral sockets on
-  ``0.0.0.0`` and reading back what the kernel assigned. Sockets are held
-  until the process exits, then released right before ``ray start`` binds
-  them — a millisecond race window that is acceptable for v0.
-* Writes the chosen ports to a sourceable env file consumed by Ray's
-  bootstrap commands in :mod:`sky.provision.instance_setup`.
-* For the head pod: publishes the chosen ports to a Kubernetes ConfigMap
-  named ``<cluster>-ray-ports`` so worker pods can discover the head's
-  GCS port (head IP is already discoverable via the headless Service DNS).
-* For worker pods: polls that ConfigMap to learn the head's GCS port,
-  then probes its own host for local-bind ports independently.
-
-The script is invoked via ``python -m
-sky.provision.kubernetes.host_network_probe`` from the K8s pod
-entrypoint. It depends only on the Python standard library so it can run
-before the skypilot wheel has finished installing.
+When a K8s pod has ``hostNetwork: true`` it shares the host's network
+namespace, so a sibling SkyPilot pod scheduled to the same node would
+collide on Ray's default ports. This script binds ephemeral sockets to
+pick a free port set for the local Ray daemon, then either publishes
+them (head) to a ``<cluster>-ray-ports`` ConfigMap or reads the head's
+port from that ConfigMap (worker). Stdlib-only so it can run during the
+window when the pod's skypilot install is in flux.
 """
 import argparse
 import json
@@ -37,12 +19,9 @@ from typing import Any, Dict, List, Optional, Tuple
 import urllib.error
 import urllib.request
 
-# Maps internal port names (also used as ConfigMap keys) to the env vars
-# that ray_head_start_command / ray_worker_start_command read via
-# ${VAR:-default} substitution. SKYPILOT_RAY_PORT is the head's GCS port
-# — it predates this feature (the worker bootstrap template already uses
-# this name to dial the head) so we reuse it instead of inventing a
-# parallel SKYPILOT_RAY_GCS_PORT.
+# SKYPILOT_RAY_PORT is the head's GCS port; the worker template already
+# uses that name to dial the head, so we reuse it rather than introduce
+# a parallel SKYPILOT_RAY_GCS_PORT.
 _ENV_VAR_FOR_PORT: Dict[str, str] = {
     'gcs': 'SKYPILOT_RAY_PORT',
     'dashboard': 'SKYPILOT_RAY_DASHBOARD_PORT',
@@ -54,20 +33,9 @@ _ENV_VAR_FOR_PORT: Dict[str, str] = {
     'metrics_export': 'SKYPILOT_RAY_METRICS_EXPORT_PORT',
 }
 
-# Ports the head needs.
-_HEAD_PORT_NAMES: List[str] = [
-    'gcs',
-    'dashboard',
-    'node_manager',
-    'object_manager',
-    'ray_client_server',
-    'dashboard_agent_listen',
-    'runtime_env_agent',
-    'metrics_export',
-]
+_HEAD_PORT_NAMES: List[str] = list(_ENV_VAR_FOR_PORT)
 
-# Ports a worker needs. Worker doesn't run GCS/dashboard/ray-client server
-# — it only binds local raylet ports.
+# Workers don't run GCS/dashboard/ray-client-server.
 _WORKER_PORT_NAMES: List[str] = [
     'node_manager',
     'object_manager',
@@ -79,16 +47,11 @@ _WORKER_PORT_NAMES: List[str] = [
 _SA_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
 _SA_CA_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
 
-# ConfigMap poll: how long workers wait for the head to publish its ports
-# before giving up. Bootstraps that exceed this likely indicate the head
-# pod is wedged; fail loudly rather than hang the worker forever.
 _CONFIGMAP_POLL_TIMEOUT_S = 600
 _CONFIGMAP_POLL_INTERVAL_S = 2
 
-# Worker TCP wait: the ConfigMap is published just before the head's
-# probe exits (and ray binds), so the worker can read the GCS port a
-# beat before ray is actually accepting connections. Wait until the
-# port answers before handing off to `ray start --address`.
+# Bridges the gap between the head publishing its ConfigMap (just before
+# ray binds) and ray actually accepting connections.
 _HEAD_GCS_TCP_WAIT_TIMEOUT_S = 600
 _HEAD_GCS_TCP_WAIT_INTERVAL_S = 1
 
@@ -101,12 +64,8 @@ def _bind_ephemeral_port() -> Tuple[socket.socket, int]:
 
 def _probe_ports(
         names: List[str]) -> Tuple[List[socket.socket], Dict[str, int]]:
-    """Bind one ephemeral socket per name and return (held_sockets, ports).
-
-    Sockets must be kept alive until just before ``ray start`` runs, then
-    closed. The caller does this by exiting the process after writing the
-    env file.
-    """
+    """Bind one ephemeral socket per name; caller must keep them alive
+    until just before ``ray start`` rebinds the ports."""
     held: List[socket.socket] = []
     ports: Dict[str, int] = {}
     for name in names:
@@ -169,11 +128,8 @@ def _build_configmap_body(name: str, namespace: str, ports: Dict[str, int],
                 'parent': 'skypilot',
                 'skypilot-ray-ports': 'true',
             },
-            # When the head pod is deleted (sky down deletes pods), the
-            # K8s garbage collector cascades and removes this ConfigMap.
-            # controller=false because we're not actually controlling
-            # the pod; blockOwnerDeletion=false so deleting the pod
-            # doesn't wait on our cleanup.
+            # ownerReference ties the ConfigMap's lifetime to the head
+            # pod so it's GC'd on sky down without explicit teardown.
             'ownerReferences': [{
                 'apiVersion': 'v1',
                 'kind': 'Pod',
@@ -191,16 +147,12 @@ def _publish_configmap(name: str, namespace: str, ports: Dict[str,
                                                               int]) -> None:
     """Create or update a ConfigMap with the head's chosen ports.
 
-    Idempotent: if the ConfigMap exists (head pod restarted with the same
-    UID), PUT replaces its data. If a stale ConfigMap exists from a prior
-    head pod (different UID — owner already gone but the GC sweep hasn't
-    fired yet), we refresh its ownerReference to the current head pod so
-    cleanup catches it.
+    Idempotent: on 409 we GET, lift the resourceVersion, and PUT — which
+    also re-points the ownerReference at the current head pod (relevant
+    on head-pod restart, where a stale ConfigMap may still be around).
     """
-    # SKYPILOT_POD_NAME / SKYPILOT_POD_UID are injected by the K8s
-    # downward API in kubernetes-ray.yml.j2. We can't use $HOSTNAME here
-    # because under hostNetwork: true the container inherits the host
-    # node's hostname (e.g. gke-*-pool-*), not the pod's name.
+    # SKYPILOT_POD_NAME / SKYPILOT_POD_UID come from the K8s downward
+    # API — $HOSTNAME is the host node's name under hostNetwork.
     owner_pod_name = os.environ['SKYPILOT_POD_NAME']
     owner_pod_uid = os.environ['SKYPILOT_POD_UID']
     body = _build_configmap_body(name, namespace, ports, owner_pod_name,
@@ -227,10 +179,8 @@ def _publish_configmap(name: str, namespace: str, ports: Dict[str,
 def _read_configmap_with_retry(name: str, namespace: str) -> Dict[str, str]:
     """Poll a ConfigMap until it exists, returning its ``data`` field.
 
-    Workers call this before invoking ``ray start --address`` — the
-    polling doubles as the "head is up" sync barrier, replacing the
-    constant-port-only ``nc -z`` loop that the template uses without
-    hostNetwork.
+    Doubles as the "head is up" sync barrier for workers — the same
+    role ``nc -z`` plays for non-hostNetwork bootstraps.
     """
     base = f'/api/v1/namespaces/{namespace}/configmaps/{name}'
     deadline = time.monotonic() + _CONFIGMAP_POLL_TIMEOUT_S
@@ -249,29 +199,10 @@ def _read_configmap_with_retry(name: str, namespace: str) -> Dict[str, str]:
         f'{_CONFIGMAP_POLL_TIMEOUT_S}s — is the head pod healthy?')
 
 
-def _run_head(env_file: str, configmap_name: str,
-              configmap_namespace: str) -> None:
-    held, ports = _probe_ports(_HEAD_PORT_NAMES)
-    _publish_configmap(configmap_name, configmap_namespace, ports)
-    # Write env file after ConfigMap publish so that if publish fails,
-    # ray start doesn't run with ports that workers will never learn
-    # about.
-    _write_env_file(ports, env_file)
-    # Hand off: held sockets close on process exit.
-    del held
-
-
 def _wait_head_gcs_tcp(host: str, port: int) -> None:
-    """Block until the head's GCS port answers on TCP.
-
-    Without this the worker can dial through the configured DNS to the
-    head and find that Ray hasn't quite finished binding yet —
-    ``ray start --address`` would then fail. The non-hostNetwork path
-    uses ``nc -z`` in the K8s template for the same purpose, against a
-    constant port.
-    """
+    """Block until the head's GCS port answers on TCP."""
     deadline = time.monotonic() + _HEAD_GCS_TCP_WAIT_TIMEOUT_S
-    last_err: Exception = None  # type: ignore[assignment]
+    last_err: Optional[Exception] = None
     while time.monotonic() < deadline:
         try:
             with socket.create_connection((host, port), timeout=2):
@@ -284,6 +215,16 @@ def _wait_head_gcs_tcp(host: str, port: int) -> None:
         f'{_HEAD_GCS_TCP_WAIT_TIMEOUT_S}s (last error: {last_err}).')
 
 
+def _run_head(env_file: str, configmap_name: str,
+              configmap_namespace: str) -> None:
+    held, ports = _probe_ports(_HEAD_PORT_NAMES)
+    # Publish before writing the env file so a failed publish prevents
+    # ray start from binding ports the workers will never discover.
+    _publish_configmap(configmap_name, configmap_namespace, ports)
+    _write_env_file(ports, env_file)
+    del held  # release the held sockets just before this process exits
+
+
 def _run_worker(env_file: str, configmap_name: str,
                 configmap_namespace: str) -> None:
     head_data = _read_configmap_with_retry(configmap_name, configmap_namespace)
@@ -292,16 +233,12 @@ def _run_worker(env_file: str, configmap_name: str,
         raise RuntimeError(
             f'ConfigMap {configmap_namespace}/{configmap_name} is missing '
             f'the "gcs" key. Data: {head_data}')
-    # SKYPILOT_RAY_PORT (the env var for 'gcs') carries the head's GCS
-    # port — the address this worker's raylet will connect to. Worker's
-    # own local-bind ports are probed below.
     held, ports = _probe_ports(_WORKER_PORT_NAMES)
     ports['gcs'] = int(head_gcs)
     _write_env_file(ports, env_file)
     del held
     # SKYPILOT_RAY_HEAD_IP is exported by the K8s template before this
-    # script runs; if absent (e.g. under SSH-fallback re-provisioning)
-    # we skip the wait — ray start's own retries take over.
+    # script runs; if absent we skip the wait and let ray start retry.
     head_ip = os.environ.get('SKYPILOT_RAY_HEAD_IP')
     if head_ip:
         _wait_head_gcs_tcp(head_ip, int(head_gcs))

--- a/sky/provision/kubernetes/host_network_probe.py
+++ b/sky/provision/kubernetes/host_network_probe.py
@@ -9,6 +9,7 @@ port from that ConfigMap (worker). Stdlib-only so it can run during the
 window when the pod's skypilot install is in flux.
 """
 import argparse
+import functools
 import json
 import os
 import socket
@@ -67,6 +68,21 @@ _HEAD_GCS_TCP_WAIT_INTERVAL_S = 1
 # (409 Conflict from stale resourceVersion).
 _MERGE_RETRY_LIMIT = 5
 
+# Per-request budget for K8s API calls. Without this, urlopen would
+# block forever on a hung API server and freeze the pod bootstrap.
+_K8S_API_TIMEOUT_S = 10
+
+
+@functools.lru_cache(maxsize=None)
+def _api_auth_token() -> str:
+    with open(_SA_TOKEN_PATH, encoding='utf-8') as f:
+        return f.read().strip()
+
+
+@functools.lru_cache(maxsize=None)
+def _api_ssl_context() -> ssl.SSLContext:
+    return ssl.create_default_context(cafile=_SA_CA_PATH)
+
 
 def _bind_ephemeral_port() -> Tuple[socket.socket, int]:
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -102,10 +118,8 @@ def _k8s_api_request(
         body: Optional[Dict[str, Any]] = None) -> Tuple[int, bytes]:
     api_host = os.environ['KUBERNETES_SERVICE_HOST']
     api_port = os.environ['KUBERNETES_SERVICE_PORT']
-    with open(_SA_TOKEN_PATH, encoding='utf-8') as f:
-        token = f.read().strip()
     headers = {
-        'Authorization': f'Bearer {token}',
+        'Authorization': f'Bearer {_api_auth_token()}',
         'Accept': 'application/json',
     }
     data: bytes = b''
@@ -113,13 +127,14 @@ def _k8s_api_request(
         data = json.dumps(body).encode('utf-8')
         headers['Content-Type'] = 'application/json'
     url = f'https://{api_host}:{api_port}{path}'
-    ctx = ssl.create_default_context(cafile=_SA_CA_PATH)
     req = urllib.request.Request(url,
                                  data=data if data else None,
                                  headers=headers,
                                  method=method)
     try:
-        with urllib.request.urlopen(req, context=ctx) as resp:  # noqa: S310
+        with urllib.request.urlopen(
+                req, context=_api_ssl_context(),
+                timeout=_K8S_API_TIMEOUT_S) as resp:  # noqa: S310
             return resp.status, resp.read()
     except urllib.error.HTTPError as e:
         return e.code, e.read()

--- a/sky/provision/kubernetes/host_network_probe.py
+++ b/sky/provision/kubernetes/host_network_probe.py
@@ -48,10 +48,9 @@ _WORKER_PORT_NAMES: List[str] = [
     'sshd',
 ]
 
-# ConfigMap key prefix for per-pod sshd ports. Each pod publishes
-# ``{_SSHD_KEY_PREFIX}{podname}: <port>`` so the SkyPilot client can
-# discover the right port when generating the SSH config.
-_SSHD_KEY_PREFIX = 'sshd_'
+# Public so the SkyPilot client (sky/provision/kubernetes/instance.py)
+# can read the same key when assembling InstanceInfo.ssh_port.
+SSHD_KEY_PREFIX = 'sshd_'
 
 _SA_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
 _SA_CA_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
@@ -63,6 +62,10 @@ _CONFIGMAP_POLL_INTERVAL_S = 2
 # ray binds) and ray actually accepting connections.
 _HEAD_GCS_TCP_WAIT_TIMEOUT_S = 600
 _HEAD_GCS_TCP_WAIT_INTERVAL_S = 1
+
+# Bound on retries when a worker's ConfigMap merge races another worker
+# (409 Conflict from stale resourceVersion).
+_MERGE_RETRY_LIMIT = 5
 
 
 def _bind_ephemeral_port() -> Tuple[socket.socket, int]:
@@ -133,7 +136,7 @@ def _configmap_data_for_ports(podname: str, ports: Dict[str,
     """
     out: Dict[str, str] = {}
     for name, port in ports.items():
-        key = f'{_SSHD_KEY_PREFIX}{podname}' if name == 'sshd' else name
+        key = f'{SSHD_KEY_PREFIX}{podname}' if name == 'sshd' else name
         out[key] = str(port)
     return out
 
@@ -168,6 +171,23 @@ def _build_configmap_body(name: str, namespace: str, ports: Dict[str, int],
     }
 
 
+def _format_api_error(action: str, name: str, namespace: str, status: int,
+                      resp: bytes) -> str:
+    body = resp.decode('utf-8', 'replace')
+    return (f'Failed to {action} ConfigMap {namespace}/{name}: '
+            f'status={status} body={body}')
+
+
+def _get_configmap(name: str, namespace: str) -> Dict[str, Any]:
+    """GET a ConfigMap, returning its parsed body. Raises on non-200."""
+    base = f'/api/v1/namespaces/{namespace}/configmaps/{name}'
+    status, resp = _k8s_api_request('GET', base)
+    if status >= 300:
+        raise RuntimeError(
+            _format_api_error('GET', name, namespace, status, resp))
+    return json.loads(resp)
+
+
 def _publish_configmap(name: str, namespace: str, ports: Dict[str,
                                                               int]) -> None:
     """Create or update a ConfigMap with the head's chosen ports.
@@ -185,23 +205,13 @@ def _publish_configmap(name: str, namespace: str, ports: Dict[str,
     base = f'/api/v1/namespaces/{namespace}/configmaps'
     status, resp = _k8s_api_request('POST', base, body)
     if status == 409:
-        # Already exists; fetch resourceVersion and PUT to update.
-        status, resp = _k8s_api_request('GET', f'{base}/{name}')
-        if status >= 300:
-            raise RuntimeError(
-                f'Failed to GET ConfigMap {namespace}/{name} for update: '
-                f'status={status} body={resp.decode("utf-8", "replace")}')
-        existing = json.loads(resp)
+        existing = _get_configmap(name, namespace)
         body['metadata']['resourceVersion'] = (
             existing['metadata']['resourceVersion'])
         status, resp = _k8s_api_request('PUT', f'{base}/{name}', body)
     if status >= 300:
         raise RuntimeError(
-            f'Failed to publish ConfigMap {namespace}/{name}: '
-            f'status={status} body={resp.decode("utf-8", "replace")}')
-
-
-_MERGE_RETRY_LIMIT = 5
+            _format_api_error('publish', name, namespace, status, resp))
 
 
 def _merge_sshd_port(name: str, namespace: str, podname: str,
@@ -210,27 +220,21 @@ def _merge_sshd_port(name: str, namespace: str, podname: str,
 
     Workers call this after the head has published the ConfigMap so the
     SkyPilot client can read every pod's sshd port from one place.
-    Retries on 409 (lost optimistic-concurrency race against another
-    worker) up to a small bound.
+    Retries on 409 (resourceVersion went stale — typically another
+    worker won the merge race) up to a small bound.
     """
     base = f'/api/v1/namespaces/{namespace}/configmaps/{name}'
-    key = f'{_SSHD_KEY_PREFIX}{podname}'
+    key = f'{SSHD_KEY_PREFIX}{podname}'
     last_err: Optional[str] = None
     for _ in range(_MERGE_RETRY_LIMIT):
-        status, resp = _k8s_api_request('GET', base)
-        if status >= 300:
-            raise RuntimeError(
-                f'Failed to GET ConfigMap {namespace}/{name} for merge: '
-                f'status={status} body={resp.decode("utf-8", "replace")}')
-        existing = json.loads(resp)
+        existing = _get_configmap(name, namespace)
         data = dict(existing.get('data') or {})
         data[key] = str(port)
         existing['data'] = data
         status, resp = _k8s_api_request('PUT', base, existing)
         if status < 300:
             return
-        # 409: resourceVersion went stale — re-GET and try again.
-        last_err = f'status={status} body={resp.decode("utf-8", "replace")}'
+        last_err = _format_api_error('PUT', name, namespace, status, resp)
         if status != 409:
             break
     raise RuntimeError(
@@ -296,10 +300,8 @@ def _run_worker(env_file: str, configmap_name: str,
             f'ConfigMap {configmap_namespace}/{configmap_name} is missing '
             f'the "gcs" key. Data: {head_data}')
     held, ports = _probe_ports(_WORKER_PORT_NAMES)
-    # Publish this worker's sshd port back into the ConfigMap so the
-    # SkyPilot client can write the right Port directive for it. Done
-    # before releasing the held sockets so a failed publish aborts the
-    # bootstrap before sshd binds to a port nothing can discover.
+    # Publish before releasing the held sockets so a failed merge
+    # aborts the bootstrap before sshd binds a port nothing can find.
     podname = os.environ['SKYPILOT_POD_NAME']
     _merge_sshd_port(configmap_name, configmap_namespace, podname,
                      ports['sshd'])

--- a/sky/provision/kubernetes/host_network_probe.py
+++ b/sky/provision/kubernetes/host_network_probe.py
@@ -331,7 +331,9 @@ def _run_worker(env_file: str, configmap_name: str,
 
 
 def main(argv: Optional[List[str]] = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    # No description: __doc__ is stripped by source_utils.minify_python_source
+    # before the script is inlined into the pod bootstrap.
+    parser = argparse.ArgumentParser()
     parser.add_argument('--mode', choices=['head', 'worker'], required=True)
     parser.add_argument('--env-file',
                         required=True,

--- a/sky/provision/kubernetes/host_network_probe.py
+++ b/sky/provision/kubernetes/host_network_probe.py
@@ -31,18 +31,27 @@ _ENV_VAR_FOR_PORT: Dict[str, str] = {
     'dashboard_agent_listen': 'SKYPILOT_RAY_DASHBOARD_AGENT_LISTEN_PORT',
     'runtime_env_agent': 'SKYPILOT_RAY_RUNTIME_ENV_AGENT_PORT',
     'metrics_export': 'SKYPILOT_RAY_METRICS_EXPORT_PORT',
+    # Pod sshd port. host:22 is owned by the K8s node's own sshd under
+    # hostNetwork, so the pod must bind sshd to a probed port instead.
+    'sshd': 'SKYPILOT_SSHD_PORT',
 }
 
 _HEAD_PORT_NAMES: List[str] = list(_ENV_VAR_FOR_PORT)
 
-# Workers don't run GCS/dashboard/ray-client-server.
+# Workers don't run GCS/dashboard/ray-client-server, but they DO run sshd.
 _WORKER_PORT_NAMES: List[str] = [
     'node_manager',
     'object_manager',
     'dashboard_agent_listen',
     'runtime_env_agent',
     'metrics_export',
+    'sshd',
 ]
+
+# ConfigMap key prefix for per-pod sshd ports. Each pod publishes
+# ``{_SSHD_KEY_PREFIX}{podname}: <port>`` so the SkyPilot client can
+# discover the right port when generating the SSH config.
+_SSHD_KEY_PREFIX = 'sshd_'
 
 _SA_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
 _SA_CA_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
@@ -113,6 +122,22 @@ def _k8s_api_request(
         return e.code, e.read()
 
 
+def _configmap_data_for_ports(podname: str, ports: Dict[str,
+                                                        int]) -> Dict[str, str]:
+    """Translate probe port names into ConfigMap data keys.
+
+    The 'sshd' port is rewritten to ``sshd_<podname>`` because every pod
+    (head + each worker) publishes its own sshd port into the same
+    ConfigMap. Other keys are head-owned Ray ports and stay flat so the
+    worker probe can look up the head's GCS by the bare key 'gcs'.
+    """
+    out: Dict[str, str] = {}
+    for name, port in ports.items():
+        key = f'{_SSHD_KEY_PREFIX}{podname}' if name == 'sshd' else name
+        out[key] = str(port)
+    return out
+
+
 def _build_configmap_body(name: str, namespace: str, ports: Dict[str, int],
                           owner_pod_name: str,
                           owner_pod_uid: str) -> Dict[str, Any]:
@@ -139,7 +164,7 @@ def _build_configmap_body(name: str, namespace: str, ports: Dict[str, int],
                 'blockOwnerDeletion': False,
             }],
         },
-        'data': {k: str(v) for k, v in ports.items()},
+        'data': _configmap_data_for_ports(owner_pod_name, ports),
     }
 
 
@@ -174,6 +199,43 @@ def _publish_configmap(name: str, namespace: str, ports: Dict[str,
         raise RuntimeError(
             f'Failed to publish ConfigMap {namespace}/{name}: '
             f'status={status} body={resp.decode("utf-8", "replace")}')
+
+
+_MERGE_RETRY_LIMIT = 5
+
+
+def _merge_sshd_port(name: str, namespace: str, podname: str,
+                     port: int) -> None:
+    """Merge ``sshd_<podname>: <port>`` into an existing ConfigMap.
+
+    Workers call this after the head has published the ConfigMap so the
+    SkyPilot client can read every pod's sshd port from one place.
+    Retries on 409 (lost optimistic-concurrency race against another
+    worker) up to a small bound.
+    """
+    base = f'/api/v1/namespaces/{namespace}/configmaps/{name}'
+    key = f'{_SSHD_KEY_PREFIX}{podname}'
+    last_err: Optional[str] = None
+    for _ in range(_MERGE_RETRY_LIMIT):
+        status, resp = _k8s_api_request('GET', base)
+        if status >= 300:
+            raise RuntimeError(
+                f'Failed to GET ConfigMap {namespace}/{name} for merge: '
+                f'status={status} body={resp.decode("utf-8", "replace")}')
+        existing = json.loads(resp)
+        data = dict(existing.get('data') or {})
+        data[key] = str(port)
+        existing['data'] = data
+        status, resp = _k8s_api_request('PUT', base, existing)
+        if status < 300:
+            return
+        # 409: resourceVersion went stale — re-GET and try again.
+        last_err = f'status={status} body={resp.decode("utf-8", "replace")}'
+        if status != 409:
+            break
+    raise RuntimeError(
+        f'Failed to merge {key} into ConfigMap {namespace}/{name} after '
+        f'{_MERGE_RETRY_LIMIT} attempts: {last_err}')
 
 
 def _read_configmap_with_retry(name: str, namespace: str) -> Dict[str, str]:
@@ -234,6 +296,13 @@ def _run_worker(env_file: str, configmap_name: str,
             f'ConfigMap {configmap_namespace}/{configmap_name} is missing '
             f'the "gcs" key. Data: {head_data}')
     held, ports = _probe_ports(_WORKER_PORT_NAMES)
+    # Publish this worker's sshd port back into the ConfigMap so the
+    # SkyPilot client can write the right Port directive for it. Done
+    # before releasing the held sockets so a failed publish aborts the
+    # bootstrap before sshd binds to a port nothing can discover.
+    podname = os.environ['SKYPILOT_POD_NAME']
+    _merge_sshd_port(configmap_name, configmap_namespace, podname,
+                     ports['sshd'])
     ports['gcs'] = int(head_gcs)
     _write_env_file(ports, env_file)
     del held

--- a/sky/provision/kubernetes/host_network_probe.py
+++ b/sky/provision/kubernetes/host_network_probe.py
@@ -99,7 +99,8 @@ def _bind_ephemeral_port() -> Tuple[socket.socket, int]:
     return s, s.getsockname()[1]
 
 
-def _probe_ports(names: List[str]) -> Tuple[List[socket.socket], Dict[str, int]]:
+def _probe_ports(
+        names: List[str]) -> Tuple[List[socket.socket], Dict[str, int]]:
     """Bind one ephemeral socket per name and return (held_sockets, ports).
 
     Sockets must be kept alive until just before ``ray start`` runs, then
@@ -153,28 +154,67 @@ def _k8s_api_request(
         return e.code, e.read()
 
 
-def _publish_configmap(name: str, namespace: str,
-                       ports: Dict[str, int]) -> None:
-    """Create or update a ConfigMap with the head's chosen ports.
+def _get_pod_uid(pod_name: str, namespace: str) -> str:
+    """Look up the head pod's UID for the ConfigMap's ownerReference."""
+    status, resp = _k8s_api_request(
+        'GET', f'/api/v1/namespaces/{namespace}/pods/{pod_name}')
+    if status >= 300:
+        raise RuntimeError(
+            f'Failed to GET pod {namespace}/{pod_name} to derive the '
+            f'ConfigMap ownerReference: status={status} '
+            f'body={resp.decode("utf-8", "replace")}')
+    return json.loads(resp)['metadata']['uid']
 
-    Idempotent: if the ConfigMap exists (head pod restarted), PUT replaces
-    its data with the new probe results so workers see fresh ports.
-    """
-    data = {k: str(v) for k, v in ports.items()}
-    metadata: Dict[str, Any] = {
-        'name': name,
-        'namespace': namespace,
-        'labels': {
-            'parent': 'skypilot',
-            'skypilot-ray-ports': 'true',
-        },
-    }
-    body: Dict[str, Any] = {
+
+def _build_configmap_body(name: str, namespace: str, ports: Dict[str, int],
+                          owner_pod_name: str,
+                          owner_pod_uid: str) -> Dict[str, Any]:
+    """Build the ConfigMap body, including the ownerReference that ties its
+    lifetime to the head pod so K8s garbage-collects it on `sky down`."""
+    return {
         'apiVersion': 'v1',
         'kind': 'ConfigMap',
-        'metadata': metadata,
-        'data': data,
+        'metadata': {
+            'name': name,
+            'namespace': namespace,
+            'labels': {
+                'parent': 'skypilot',
+                'skypilot-ray-ports': 'true',
+            },
+            # When the head pod is deleted (sky down deletes pods), the
+            # K8s garbage collector cascades and removes this ConfigMap.
+            # controller=false because we're not actually controlling
+            # the pod; blockOwnerDeletion=false so deleting the pod
+            # doesn't wait on our cleanup.
+            'ownerReferences': [{
+                'apiVersion': 'v1',
+                'kind': 'Pod',
+                'name': owner_pod_name,
+                'uid': owner_pod_uid,
+                'controller': False,
+                'blockOwnerDeletion': False,
+            }],
+        },
+        'data': {k: str(v) for k, v in ports.items()},
     }
+
+
+def _publish_configmap(name: str, namespace: str, ports: Dict[str,
+                                                              int]) -> None:
+    """Create or update a ConfigMap with the head's chosen ports.
+
+    Idempotent: if the ConfigMap exists (head pod restarted with the same
+    UID), PUT replaces its data. If a stale ConfigMap exists from a prior
+    head pod (different UID — owner already gone but the GC sweep hasn't
+    fired yet), we refresh its ownerReference to the current head pod so
+    cleanup catches it.
+    """
+    # K8s exports the pod name as HOSTNAME by default. Required because
+    # this script runs inside the pod the OwnerReference will point at.
+    owner_pod_name = os.environ['HOSTNAME']
+    owner_pod_uid = _get_pod_uid(owner_pod_name, namespace)
+    body = _build_configmap_body(name, namespace, ports, owner_pod_name,
+                                 owner_pod_uid)
     base = f'/api/v1/namespaces/{namespace}/configmaps'
     status, resp = _k8s_api_request('POST', base, body)
     if status == 409:
@@ -185,7 +225,7 @@ def _publish_configmap(name: str, namespace: str,
                 f'Failed to GET ConfigMap {namespace}/{name} for update: '
                 f'status={status} body={resp.decode("utf-8", "replace")}')
         existing = json.loads(resp)
-        metadata['resourceVersion'] = (
+        body['metadata']['resourceVersion'] = (
             existing['metadata']['resourceVersion'])
         status, resp = _k8s_api_request('PUT', f'{base}/{name}', body)
     if status >= 300:
@@ -256,8 +296,7 @@ def _wait_head_gcs_tcp(host: str, port: int) -> None:
 
 def _run_worker(env_file: str, configmap_name: str,
                 configmap_namespace: str) -> None:
-    head_data = _read_configmap_with_retry(configmap_name,
-                                           configmap_namespace)
+    head_data = _read_configmap_with_retry(configmap_name, configmap_namespace)
     head_gcs = head_data.get('gcs')
     if head_gcs is None:
         raise RuntimeError(
@@ -281,14 +320,14 @@ def _run_worker(env_file: str, configmap_name: str,
 def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument('--mode', choices=['head', 'worker'], required=True)
-    parser.add_argument('--env-file', required=True,
+    parser.add_argument('--env-file',
+                        required=True,
                         help='Path to write `export VAR=value` lines to.')
     parser.add_argument('--configmap-name', required=True)
     parser.add_argument('--configmap-namespace', required=True)
     args = parser.parse_args(argv)
     if args.mode == 'head':
-        _run_head(args.env_file, args.configmap_name,
-                  args.configmap_namespace)
+        _run_head(args.env_file, args.configmap_name, args.configmap_namespace)
     else:
         _run_worker(args.env_file, args.configmap_name,
                     args.configmap_namespace)

--- a/sky/provision/kubernetes/host_network_probe.py
+++ b/sky/provision/kubernetes/host_network_probe.py
@@ -1,0 +1,299 @@
+"""Free-port probe and ConfigMap publish/discover for hostNetwork pods.
+
+When a Kubernetes pod is launched with ``hostNetwork: true`` (required for
+RoCE / RDMA performance on some accelerator setups), the pod shares the
+host's network namespace. Ray's default port set (GCS, dashboard,
+object/node manager, dashboard agent, runtime env agent, metrics export,
+ray client server) then binds directly on the host. A second SkyPilot
+pod scheduled to the same node would collide on those ports.
+
+This module:
+
+* Picks a free port for each Ray role by binding ephemeral sockets on
+  ``0.0.0.0`` and reading back what the kernel assigned. Sockets are held
+  until the process exits, then released right before ``ray start`` binds
+  them — a millisecond race window that is acceptable for v0.
+* Writes the chosen ports to a sourceable env file consumed by Ray's
+  bootstrap commands in :mod:`sky.provision.instance_setup`.
+* For the head pod: publishes the chosen ports to a Kubernetes ConfigMap
+  named ``<cluster>-ray-ports`` so worker pods can discover the head's
+  GCS port (head IP is already discoverable via the headless Service DNS).
+* For worker pods: polls that ConfigMap to learn the head's GCS port,
+  then probes its own host for local-bind ports independently.
+
+The script is invoked via ``python -m
+sky.provision.kubernetes.host_network_probe`` from the K8s pod
+entrypoint. It depends only on the Python standard library so it can run
+before the skypilot wheel has finished installing.
+"""
+import argparse
+import json
+import os
+import socket
+import ssl
+import sys
+import time
+from typing import Any, Dict, List, Optional, Tuple
+import urllib.error
+import urllib.request
+
+# Maps internal port names (also used as ConfigMap keys) to the env vars
+# that ray_head_start_command / ray_worker_start_command read via
+# ${VAR:-default} substitution. SKYPILOT_RAY_PORT is the head's GCS port
+# — it predates this feature (the worker bootstrap template already uses
+# this name to dial the head) so we reuse it instead of inventing a
+# parallel SKYPILOT_RAY_GCS_PORT.
+_ENV_VAR_FOR_PORT: Dict[str, str] = {
+    'gcs': 'SKYPILOT_RAY_PORT',
+    'dashboard': 'SKYPILOT_RAY_DASHBOARD_PORT',
+    'node_manager': 'SKYPILOT_RAY_NODE_MANAGER_PORT',
+    'object_manager': 'SKYPILOT_RAY_OBJECT_MANAGER_PORT',
+    'ray_client_server': 'SKYPILOT_RAY_CLIENT_SERVER_PORT',
+    'dashboard_agent_listen': 'SKYPILOT_RAY_DASHBOARD_AGENT_LISTEN_PORT',
+    'runtime_env_agent': 'SKYPILOT_RAY_RUNTIME_ENV_AGENT_PORT',
+    'metrics_export': 'SKYPILOT_RAY_METRICS_EXPORT_PORT',
+}
+
+# Ports the head needs.
+_HEAD_PORT_NAMES: List[str] = [
+    'gcs',
+    'dashboard',
+    'node_manager',
+    'object_manager',
+    'ray_client_server',
+    'dashboard_agent_listen',
+    'runtime_env_agent',
+    'metrics_export',
+]
+
+# Ports a worker needs. Worker doesn't run GCS/dashboard/ray-client server
+# — it only binds local raylet ports.
+_WORKER_PORT_NAMES: List[str] = [
+    'node_manager',
+    'object_manager',
+    'dashboard_agent_listen',
+    'runtime_env_agent',
+    'metrics_export',
+]
+
+_SA_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
+_SA_CA_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+
+# ConfigMap poll: how long workers wait for the head to publish its ports
+# before giving up. Bootstraps that exceed this likely indicate the head
+# pod is wedged; fail loudly rather than hang the worker forever.
+_CONFIGMAP_POLL_TIMEOUT_S = 600
+_CONFIGMAP_POLL_INTERVAL_S = 2
+
+# Worker TCP wait: the ConfigMap is published just before the head's
+# probe exits (and ray binds), so the worker can read the GCS port a
+# beat before ray is actually accepting connections. Wait until the
+# port answers before handing off to `ray start --address`.
+_HEAD_GCS_TCP_WAIT_TIMEOUT_S = 600
+_HEAD_GCS_TCP_WAIT_INTERVAL_S = 1
+
+
+def _bind_ephemeral_port() -> Tuple[socket.socket, int]:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(('0.0.0.0', 0))
+    return s, s.getsockname()[1]
+
+
+def _probe_ports(names: List[str]) -> Tuple[List[socket.socket], Dict[str, int]]:
+    """Bind one ephemeral socket per name and return (held_sockets, ports).
+
+    Sockets must be kept alive until just before ``ray start`` runs, then
+    closed. The caller does this by exiting the process after writing the
+    env file.
+    """
+    held: List[socket.socket] = []
+    ports: Dict[str, int] = {}
+    for name in names:
+        sock, port = _bind_ephemeral_port()
+        held.append(sock)
+        ports[name] = port
+    return held, ports
+
+
+def _write_env_file(ports: Dict[str, int], path: str) -> None:
+    lines = [
+        f'export {_ENV_VAR_FOR_PORT[name]}={port}'
+        for name, port in ports.items()
+    ]
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write('\n'.join(lines) + '\n')
+
+
+def _k8s_api_request(
+        method: str,
+        path: str,
+        body: Optional[Dict[str, Any]] = None) -> Tuple[int, bytes]:
+    api_host = os.environ['KUBERNETES_SERVICE_HOST']
+    api_port = os.environ['KUBERNETES_SERVICE_PORT']
+    with open(_SA_TOKEN_PATH, encoding='utf-8') as f:
+        token = f.read().strip()
+    headers = {
+        'Authorization': f'Bearer {token}',
+        'Accept': 'application/json',
+    }
+    data: bytes = b''
+    if body is not None:
+        data = json.dumps(body).encode('utf-8')
+        headers['Content-Type'] = 'application/json'
+    url = f'https://{api_host}:{api_port}{path}'
+    ctx = ssl.create_default_context(cafile=_SA_CA_PATH)
+    req = urllib.request.Request(url,
+                                 data=data if data else None,
+                                 headers=headers,
+                                 method=method)
+    try:
+        with urllib.request.urlopen(req, context=ctx) as resp:  # noqa: S310
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+
+
+def _publish_configmap(name: str, namespace: str,
+                       ports: Dict[str, int]) -> None:
+    """Create or update a ConfigMap with the head's chosen ports.
+
+    Idempotent: if the ConfigMap exists (head pod restarted), PUT replaces
+    its data with the new probe results so workers see fresh ports.
+    """
+    data = {k: str(v) for k, v in ports.items()}
+    metadata: Dict[str, Any] = {
+        'name': name,
+        'namespace': namespace,
+        'labels': {
+            'parent': 'skypilot',
+            'skypilot-ray-ports': 'true',
+        },
+    }
+    body: Dict[str, Any] = {
+        'apiVersion': 'v1',
+        'kind': 'ConfigMap',
+        'metadata': metadata,
+        'data': data,
+    }
+    base = f'/api/v1/namespaces/{namespace}/configmaps'
+    status, resp = _k8s_api_request('POST', base, body)
+    if status == 409:
+        # Already exists; fetch resourceVersion and PUT to update.
+        status, resp = _k8s_api_request('GET', f'{base}/{name}')
+        if status >= 300:
+            raise RuntimeError(
+                f'Failed to GET ConfigMap {namespace}/{name} for update: '
+                f'status={status} body={resp.decode("utf-8", "replace")}')
+        existing = json.loads(resp)
+        metadata['resourceVersion'] = (
+            existing['metadata']['resourceVersion'])
+        status, resp = _k8s_api_request('PUT', f'{base}/{name}', body)
+    if status >= 300:
+        raise RuntimeError(
+            f'Failed to publish ConfigMap {namespace}/{name}: '
+            f'status={status} body={resp.decode("utf-8", "replace")}')
+
+
+def _read_configmap_with_retry(name: str, namespace: str) -> Dict[str, str]:
+    """Poll a ConfigMap until it exists, returning its ``data`` field.
+
+    Workers call this before invoking ``ray start --address`` — the
+    polling doubles as the "head is up" sync barrier, replacing the
+    constant-port-only ``nc -z`` loop that the template uses without
+    hostNetwork.
+    """
+    base = f'/api/v1/namespaces/{namespace}/configmaps/{name}'
+    deadline = time.monotonic() + _CONFIGMAP_POLL_TIMEOUT_S
+    while time.monotonic() < deadline:
+        status, resp = _k8s_api_request('GET', base)
+        if status == 200:
+            body = json.loads(resp)
+            return body.get('data', {})
+        if status != 404:
+            raise RuntimeError(
+                f'Unexpected status {status} reading ConfigMap '
+                f'{namespace}/{name}: {resp.decode("utf-8", "replace")}')
+        time.sleep(_CONFIGMAP_POLL_INTERVAL_S)
+    raise TimeoutError(
+        f'ConfigMap {namespace}/{name} did not appear within '
+        f'{_CONFIGMAP_POLL_TIMEOUT_S}s — is the head pod healthy?')
+
+
+def _run_head(env_file: str, configmap_name: str,
+              configmap_namespace: str) -> None:
+    held, ports = _probe_ports(_HEAD_PORT_NAMES)
+    _publish_configmap(configmap_name, configmap_namespace, ports)
+    # Write env file after ConfigMap publish so that if publish fails,
+    # ray start doesn't run with ports that workers will never learn
+    # about.
+    _write_env_file(ports, env_file)
+    # Hand off: held sockets close on process exit.
+    del held
+
+
+def _wait_head_gcs_tcp(host: str, port: int) -> None:
+    """Block until the head's GCS port answers on TCP.
+
+    Without this the worker can dial through the configured DNS to the
+    head and find that Ray hasn't quite finished binding yet —
+    ``ray start --address`` would then fail. The non-hostNetwork path
+    uses ``nc -z`` in the K8s template for the same purpose, against a
+    constant port.
+    """
+    deadline = time.monotonic() + _HEAD_GCS_TCP_WAIT_TIMEOUT_S
+    last_err: Exception = None  # type: ignore[assignment]
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=2):
+                return
+        except OSError as e:
+            last_err = e
+            time.sleep(_HEAD_GCS_TCP_WAIT_INTERVAL_S)
+    raise TimeoutError(
+        f'Head GCS {host}:{port} did not accept connections within '
+        f'{_HEAD_GCS_TCP_WAIT_TIMEOUT_S}s (last error: {last_err}).')
+
+
+def _run_worker(env_file: str, configmap_name: str,
+                configmap_namespace: str) -> None:
+    head_data = _read_configmap_with_retry(configmap_name,
+                                           configmap_namespace)
+    head_gcs = head_data.get('gcs')
+    if head_gcs is None:
+        raise RuntimeError(
+            f'ConfigMap {configmap_namespace}/{configmap_name} is missing '
+            f'the "gcs" key. Data: {head_data}')
+    # SKYPILOT_RAY_PORT (the env var for 'gcs') carries the head's GCS
+    # port — the address this worker's raylet will connect to. Worker's
+    # own local-bind ports are probed below.
+    held, ports = _probe_ports(_WORKER_PORT_NAMES)
+    ports['gcs'] = int(head_gcs)
+    _write_env_file(ports, env_file)
+    del held
+    # SKYPILOT_RAY_HEAD_IP is exported by the K8s template before this
+    # script runs; if absent (e.g. under SSH-fallback re-provisioning)
+    # we skip the wait — ray start's own retries take over.
+    head_ip = os.environ.get('SKYPILOT_RAY_HEAD_IP')
+    if head_ip:
+        _wait_head_gcs_tcp(head_ip, int(head_gcs))
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument('--mode', choices=['head', 'worker'], required=True)
+    parser.add_argument('--env-file', required=True,
+                        help='Path to write `export VAR=value` lines to.')
+    parser.add_argument('--configmap-name', required=True)
+    parser.add_argument('--configmap-namespace', required=True)
+    args = parser.parse_args(argv)
+    if args.mode == 'head':
+        _run_head(args.env_file, args.configmap_name,
+                  args.configmap_namespace)
+    else:
+        _run_worker(args.env_file, args.configmap_name,
+                    args.configmap_namespace)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1923,7 +1923,8 @@ def get_cluster_info(
             'num-cpus': str_cpus,
         },
         provider_name='kubernetes',
-        provider_config=provider_config)
+        provider_config=provider_config,
+        host_network=bool(host_network_pods))
 
 
 class NodeHealthInfo:

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1746,16 +1746,12 @@ def cleanup_cluster_resources(
     _delete_cluster_services(cluster_name_on_cloud, namespace, context)
 
 
-# Short best-effort budget. get_cluster_info is on the `sky status` read
-# path; blocking it for tens of seconds during a pod-restart window would
-# be a worse regression than briefly falling back to port 22 (the
-# K8s node's sshd, which doesn't have SkyPilot keys). A freshly launched
-# cluster always reaches `get_cluster_info` after `ray start` has run on
-# every pod (provisioner.py calls it post-provision), so the probe has
-# already published by then and the first attempt succeeds. Pod
-# restarts top up on the next refresh.
-_HOST_NETWORK_SSHD_WAIT_TIMEOUT_S = 5
-_HOST_NETWORK_SSHD_WAIT_INTERVAL_S = 1
+# The probe runs as soon as ray-installation finishes in step 2 of the
+# pod bootstrap, typically within tens of seconds of the pod going
+# Running. 60s gives the common case plenty of slack without pinning
+# every status refresh during a pod restart to a multi-minute hang.
+_HOST_NETWORK_SSHD_WAIT_TIMEOUT_S = 60
+_HOST_NETWORK_SSHD_WAIT_INTERVAL_S = 2
 
 
 def _read_host_network_sshd_ports(cluster_name_on_cloud: str, namespace: str,
@@ -1763,11 +1759,9 @@ def _read_host_network_sshd_ports(cluster_name_on_cloud: str, namespace: str,
                                   expected_pods: List[str]) -> Dict[str, int]:
     """Read each pod's probed sshd port from the hostNetwork ConfigMap.
 
-    Best-effort: tries up to ``_HOST_NETWORK_SSHD_WAIT_TIMEOUT_S`` for
-    every ``expected_pods`` entry to appear, but returns whatever is
-    present once the budget is exhausted. Missing pods fall back to
-    port 22 in the InstanceInfo and will be picked up on the next
-    refresh.
+    Polls until every entry in ``expected_pods`` is present (or the
+    timeout elapses); returning partial state would freeze every
+    subsequent SSH at port 22 until the next refresh.
     """
     if not expected_pods:
         return {}
@@ -1800,12 +1794,12 @@ def _read_host_network_sshd_ports(cluster_name_on_cloud: str, namespace: str,
             return out
         if time.monotonic() >= deadline:
             missing = sorted(expected - out.keys())
-            logger.debug(
-                f'hostNetwork sshd ports for {missing} not yet in '
-                f'ConfigMap {namespace}/{name} after '
-                f'{_HOST_NETWORK_SSHD_WAIT_TIMEOUT_S}s; falling back to '
-                f'port 22 for those pods. They will be picked up on the '
-                f'next refresh once the probe republishes.')
+            logger.warning(
+                f'hostNetwork sshd ports for {missing} did not appear '
+                f'in ConfigMap {namespace}/{name} within '
+                f'{_HOST_NETWORK_SSHD_WAIT_TIMEOUT_S}s — `ssh <cluster>` '
+                f'to those pods will fail until the next '
+                f'`sky status -r`.')
             return out
         time.sleep(_HOST_NETWORK_SSHD_WAIT_INTERVAL_S)
 

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1746,12 +1746,16 @@ def cleanup_cluster_resources(
     _delete_cluster_services(cluster_name_on_cloud, namespace, context)
 
 
-# The probe runs as soon as ray-installation finishes in step 2 of the
-# pod bootstrap, typically within tens of seconds of the pod going
-# Running. 60s gives the common case plenty of slack without pinning
-# every status refresh during a pod restart to a multi-minute hang.
-_HOST_NETWORK_SSHD_WAIT_TIMEOUT_S = 60
-_HOST_NETWORK_SSHD_WAIT_INTERVAL_S = 2
+# Short best-effort budget. get_cluster_info is on the `sky status` read
+# path; blocking it for tens of seconds during a pod-restart window would
+# be a worse regression than briefly falling back to port 22 (the
+# K8s node's sshd, which doesn't have SkyPilot keys). A freshly launched
+# cluster always reaches `get_cluster_info` after `ray start` has run on
+# every pod (provisioner.py calls it post-provision), so the probe has
+# already published by then and the first attempt succeeds. Pod
+# restarts top up on the next refresh.
+_HOST_NETWORK_SSHD_WAIT_TIMEOUT_S = 5
+_HOST_NETWORK_SSHD_WAIT_INTERVAL_S = 1
 
 
 def _read_host_network_sshd_ports(cluster_name_on_cloud: str, namespace: str,
@@ -1759,9 +1763,11 @@ def _read_host_network_sshd_ports(cluster_name_on_cloud: str, namespace: str,
                                   expected_pods: List[str]) -> Dict[str, int]:
     """Read each pod's probed sshd port from the hostNetwork ConfigMap.
 
-    Polls until every entry in ``expected_pods`` is present (or the
-    timeout elapses); returning partial state would freeze every
-    subsequent SSH at port 22 until the next refresh.
+    Best-effort: tries up to ``_HOST_NETWORK_SSHD_WAIT_TIMEOUT_S`` for
+    every ``expected_pods`` entry to appear, but returns whatever is
+    present once the budget is exhausted. Missing pods fall back to
+    port 22 in the InstanceInfo and will be picked up on the next
+    refresh.
     """
     if not expected_pods:
         return {}
@@ -1794,12 +1800,12 @@ def _read_host_network_sshd_ports(cluster_name_on_cloud: str, namespace: str,
             return out
         if time.monotonic() >= deadline:
             missing = sorted(expected - out.keys())
-            logger.warning(
-                f'hostNetwork sshd ports for {missing} did not appear '
-                f'in ConfigMap {namespace}/{name} within '
-                f'{_HOST_NETWORK_SSHD_WAIT_TIMEOUT_S}s — `ssh <cluster>` '
-                f'to those pods will fail until the next '
-                f'`sky status -r`.')
+            logger.debug(
+                f'hostNetwork sshd ports for {missing} not yet in '
+                f'ConfigMap {namespace}/{name} after '
+                f'{_HOST_NETWORK_SSHD_WAIT_TIMEOUT_S}s; falling back to '
+                f'port 22 for those pods. They will be picked up on the '
+                f'next refresh once the probe republishes.')
             return out
         time.sleep(_HOST_NETWORK_SSHD_WAIT_INTERVAL_S)
 

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1923,8 +1923,7 @@ def get_cluster_info(
             'num-cpus': str_cpus,
         },
         provider_name='kubernetes',
-        provider_config=provider_config,
-        host_network=bool(host_network_pods))
+        provider_config=provider_config)
 
 
 class NodeHealthInfo:

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1745,6 +1745,66 @@ def cleanup_cluster_resources(
     _delete_cluster_services(cluster_name_on_cloud, namespace, context)
 
 
+_HOST_NETWORK_SSHD_WAIT_TIMEOUT_S = 180
+_HOST_NETWORK_SSHD_WAIT_INTERVAL_S = 2
+
+
+def _read_host_network_sshd_ports(
+        cluster_name_on_cloud: str,
+        namespace: str,
+        context: Optional[str],
+        expected_pods: Optional[List[str]] = None) -> Dict[str, int]:
+    """Read each pod's probed sshd port from the hostNetwork ConfigMap.
+
+    Returns ``{podname: port}`` for every ``sshd_<podname>`` entry the
+    pods published. Returns ``{}`` when the ConfigMap doesn't exist
+    (cluster isn't running under hostNetwork).
+
+    When ``expected_pods`` is given, polls the ConfigMap until every
+    listed pod has an entry (or the timeout elapses). The probe runs
+    inside each pod's bootstrap and may not have populated the
+    ConfigMap by the time the post-provision flow reaches us;
+    surfacing partial state would freeze every subsequent SSH at
+    port 22 until the next refresh.
+    """
+    name = f'{cluster_name_on_cloud}-ray-ports'
+    prefix = 'sshd_'
+    expected = set(expected_pods or [])
+    deadline = time.monotonic() + (_HOST_NETWORK_SSHD_WAIT_TIMEOUT_S
+                                   if expected else 0)
+    while True:
+        out: Dict[str, int] = {}
+        try:
+            cm = kubernetes.core_api(context).read_namespaced_config_map(
+                name=name, namespace=namespace)
+        except kubernetes.api_exception() as e:
+            if getattr(e, 'status', None) != 404:
+                raise
+            cm = None
+        data = (cm.data or {}) if cm is not None else {}
+        for key, value in data.items():
+            if not key.startswith(prefix):
+                continue
+            try:
+                out[key[len(prefix):]] = int(value)
+            except ValueError:
+                logger.warning(
+                    f'ConfigMap {namespace}/{name} has non-integer value '
+                    f'for {key!r}: {value!r}. Falling back to default '
+                    f'SSH port.')
+        if not expected or expected.issubset(out.keys()):
+            return out
+        if time.monotonic() >= deadline:
+            missing = sorted(expected - out.keys())
+            logger.warning(
+                f'hostNetwork sshd ports for {missing} did not appear in '
+                f'ConfigMap {namespace}/{name} within '
+                f'{_HOST_NETWORK_SSHD_WAIT_TIMEOUT_S}s; falling back to '
+                f'default SSH port for those pods.')
+            return out
+        time.sleep(_HOST_NETWORK_SSHD_WAIT_INTERVAL_S)
+
+
 def get_cluster_info(
         region: str,
         cluster_name_on_cloud: str,
@@ -1766,6 +1826,21 @@ def get_cluster_info(
         port = kubernetes_utils.get_head_ssh_port(cluster_name_on_cloud,
                                                   namespace, context)
 
+    # Per-pod sshd ports under hostNetwork. host:22 belongs to the K8s
+    # node's own sshd, so each pod's sshd binds a probed port instead;
+    # the SSH config writer needs that port per-pod. Wait for entries
+    # from the hostNetwork pods so the cached SSH config doesn't lock
+    # in 22 (= node's sshd, not the pod's).
+    host_network_pods = [
+        name for name, pod in running_pods.items()
+        if getattr(pod.spec, 'host_network', False)
+    ]
+    pod_sshd_ports = _read_host_network_sshd_ports(
+        cluster_name_on_cloud,
+        namespace,
+        context,
+        expected_pods=host_network_pods)
+
     head_pod_name = None
     cpu_request = None
     for pod_name, pod in running_pods.items():
@@ -1777,7 +1852,7 @@ def get_cluster_info(
                 instance_id=pod_name,
                 internal_ip=internal_ip,
                 external_ip=None,
-                ssh_port=port,
+                ssh_port=pod_sshd_ports.get(pod_name, port),
                 tags=pod.metadata.labels,
                 # TODO(hailong): `cluster.local` may need to be configurable
                 # Service name is same as the pod name for now.

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -18,6 +18,7 @@ from sky.provision import constants
 from sky.provision import docker_utils
 from sky.provision.kubernetes import config as config_lib
 from sky.provision.kubernetes import constants as k8s_constants
+from sky.provision.kubernetes import host_network_probe
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.provision.kubernetes import volume
 from sky.utils import command_runner
@@ -1745,62 +1746,60 @@ def cleanup_cluster_resources(
     _delete_cluster_services(cluster_name_on_cloud, namespace, context)
 
 
-_HOST_NETWORK_SSHD_WAIT_TIMEOUT_S = 180
+# The probe runs as soon as ray-installation finishes in step 2 of the
+# pod bootstrap, typically within tens of seconds of the pod going
+# Running. 60s gives the common case plenty of slack without pinning
+# every status refresh during a pod restart to a multi-minute hang.
+_HOST_NETWORK_SSHD_WAIT_TIMEOUT_S = 60
 _HOST_NETWORK_SSHD_WAIT_INTERVAL_S = 2
 
 
-def _read_host_network_sshd_ports(
-        cluster_name_on_cloud: str,
-        namespace: str,
-        context: Optional[str],
-        expected_pods: Optional[List[str]] = None) -> Dict[str, int]:
+def _read_host_network_sshd_ports(cluster_name_on_cloud: str, namespace: str,
+                                  context: Optional[str],
+                                  expected_pods: List[str]) -> Dict[str, int]:
     """Read each pod's probed sshd port from the hostNetwork ConfigMap.
 
-    Returns ``{podname: port}`` for every ``sshd_<podname>`` entry the
-    pods published. Returns ``{}`` when the ConfigMap doesn't exist
-    (cluster isn't running under hostNetwork).
-
-    When ``expected_pods`` is given, polls the ConfigMap until every
-    listed pod has an entry (or the timeout elapses). The probe runs
-    inside each pod's bootstrap and may not have populated the
-    ConfigMap by the time the post-provision flow reaches us;
-    surfacing partial state would freeze every subsequent SSH at
-    port 22 until the next refresh.
+    Polls until every entry in ``expected_pods`` is present (or the
+    timeout elapses); returning partial state would freeze every
+    subsequent SSH at port 22 until the next refresh.
     """
+    if not expected_pods:
+        return {}
     name = f'{cluster_name_on_cloud}-ray-ports'
-    prefix = 'sshd_'
-    expected = set(expected_pods or [])
-    deadline = time.monotonic() + (_HOST_NETWORK_SSHD_WAIT_TIMEOUT_S
-                                   if expected else 0)
+    expected = set(expected_pods)
+    deadline = time.monotonic() + _HOST_NETWORK_SSHD_WAIT_TIMEOUT_S
     while True:
         out: Dict[str, int] = {}
         try:
             cm = kubernetes.core_api(context).read_namespaced_config_map(
                 name=name, namespace=namespace)
         except kubernetes.api_exception() as e:
-            if getattr(e, 'status', None) != 404:
+            if e.status != 404:
                 raise
             cm = None
         data = (cm.data or {}) if cm is not None else {}
         for key, value in data.items():
-            if not key.startswith(prefix):
+            if not key.startswith(host_network_probe.SSHD_KEY_PREFIX):
                 continue
+            podname = common_utils.removeprefix(
+                key, host_network_probe.SSHD_KEY_PREFIX)
             try:
-                out[key[len(prefix):]] = int(value)
+                out[podname] = int(value)
             except ValueError:
                 logger.warning(
                     f'ConfigMap {namespace}/{name} has non-integer value '
-                    f'for {key!r}: {value!r}. Falling back to default '
-                    f'SSH port.')
-        if not expected or expected.issubset(out.keys()):
+                    f'for {key!r}: {value!r}. SSH to {podname!r} will '
+                    f'fall back to port 22 and hit the K8s node\'s sshd.')
+        if expected.issubset(out.keys()):
             return out
         if time.monotonic() >= deadline:
             missing = sorted(expected - out.keys())
             logger.warning(
-                f'hostNetwork sshd ports for {missing} did not appear in '
-                f'ConfigMap {namespace}/{name} within '
-                f'{_HOST_NETWORK_SSHD_WAIT_TIMEOUT_S}s; falling back to '
-                f'default SSH port for those pods.')
+                f'hostNetwork sshd ports for {missing} did not appear '
+                f'in ConfigMap {namespace}/{name} within '
+                f'{_HOST_NETWORK_SSHD_WAIT_TIMEOUT_S}s — `ssh <cluster>` '
+                f'to those pods will fail until the next '
+                f'`sky status -r`.')
             return out
         time.sleep(_HOST_NETWORK_SSHD_WAIT_INTERVAL_S)
 
@@ -1826,20 +1825,16 @@ def get_cluster_info(
         port = kubernetes_utils.get_head_ssh_port(cluster_name_on_cloud,
                                                   namespace, context)
 
-    # Per-pod sshd ports under hostNetwork. host:22 belongs to the K8s
-    # node's own sshd, so each pod's sshd binds a probed port instead;
-    # the SSH config writer needs that port per-pod. Wait for entries
-    # from the hostNetwork pods so the cached SSH config doesn't lock
-    # in 22 (= node's sshd, not the pod's).
+    # Each hostNetwork pod's sshd binds a probed port (host:22 is the
+    # K8s node's own sshd). The SSH config writer needs that port per
+    # pod, so wait for every hostNetwork pod's entry to land in the
+    # ConfigMap before caching the result.
     host_network_pods = [
-        name for name, pod in running_pods.items()
-        if getattr(pod.spec, 'host_network', False)
+        name for name, pod in running_pods.items() if pod.spec.host_network
     ]
-    pod_sshd_ports = _read_host_network_sshd_ports(
-        cluster_name_on_cloud,
-        namespace,
-        context,
-        expected_pods=host_network_pods)
+    pod_sshd_ports = _read_host_network_sshd_ports(cluster_name_on_cloud,
+                                                   namespace, context,
+                                                   host_network_pods)
 
     head_pod_name = None
     cpu_request = None

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -209,7 +209,7 @@ KIND_CONTEXT_NAME = 'kind-skypilot'  # Context name used by sky local up
 PORT_FORWARD_PROXY_CMD_TEMPLATE = 'kubernetes-port-forward-proxy-command.sh'
 # We add a version suffix to the port-forward proxy command to ensure backward
 # compatibility and avoid overwriting the older version.
-PORT_FORWARD_PROXY_CMD_VERSION = 2
+PORT_FORWARD_PROXY_CMD_VERSION = 3
 PORT_FORWARD_PROXY_CMD_PATH = ('~/.sky/kubernetes-port-forward-proxy-command-'
                                f'v{PORT_FORWARD_PROXY_CMD_VERSION}.sh')
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2771,8 +2771,16 @@ async def kubernetes_pod_ssh_proxy(websocket: fastapi.WebSocket,
 
     handle = await _get_cluster_and_validate(cluster_name, clouds.Kubernetes)
 
+    # Use the head pod's recorded SSH port — under hostNetwork the pod's
+    # sshd binds a probed port (not 22, which is owned by the K8s node's
+    # own sshd). cached_external_ssh_ports is filled from InstanceInfo
+    # when the cluster info is refreshed and falls back to 22.
+    head_ssh_port = 22
+    ssh_ports = getattr(handle, 'cached_external_ssh_ports', None) or []
+    if ssh_ports:
+        head_ssh_port = ssh_ports[0]
     kubectl_cmd = handle.get_command_runners()[0].port_forward_command(
-        port_forward=[(None, 22)])
+        port_forward=[(None, head_ssh_port)])
     # Under uvloop, `asyncio.create_subprocess_exec` goes through libuv's
     # `uv_spawn`, which on Linux always uses fork().
     # The forked child runs `PyOS_AfterFork_Child` which tears down inherited

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2771,12 +2771,18 @@ async def kubernetes_pod_ssh_proxy(websocket: fastapi.WebSocket,
 
     handle = await _get_cluster_and_validate(cluster_name, clouds.Kubernetes)
 
-    # Under hostNetwork the pod's sshd binds a probed port (not 22,
-    # which is owned by the K8s node's own sshd). head_ssh_port flows
-    # from InstanceInfo.ssh_port through cached_external_ssh_ports.
-    head_ssh_port = handle.head_ssh_port or 22
+    # kubectl port-forward needs the pod-internal sshd port. Always 22
+    # except under hostNetwork, where the K8s node's own sshd owns
+    # host:22 and the probe puts our sshd on a free port (carried in
+    # head_ssh_port via InstanceInfo.ssh_port). For NodePort networking
+    # without hostNetwork, head_ssh_port holds the external NodePort,
+    # which would forward to a non-listening port here.
+    cluster_info = handle.cached_cluster_info
+    is_host_network = bool(cluster_info) and getattr(cluster_info,
+                                                     'host_network', False)
+    pod_ssh_port = (handle.head_ssh_port or 22) if is_host_network else 22
     kubectl_cmd = handle.get_command_runners()[0].port_forward_command(
-        port_forward=[(None, head_ssh_port)])
+        port_forward=[(None, pod_ssh_port)])
     # Under uvloop, `asyncio.create_subprocess_exec` goes through libuv's
     # `uv_spawn`, which on Linux always uses fork().
     # The forked child runs `PyOS_AfterFork_Child` which tears down inherited

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2771,18 +2771,12 @@ async def kubernetes_pod_ssh_proxy(websocket: fastapi.WebSocket,
 
     handle = await _get_cluster_and_validate(cluster_name, clouds.Kubernetes)
 
-    # kubectl port-forward needs the pod-internal sshd port. Always 22
-    # except under hostNetwork, where the K8s node's own sshd owns
-    # host:22 and the probe puts our sshd on a free port (carried in
-    # head_ssh_port via InstanceInfo.ssh_port). For NodePort networking
-    # without hostNetwork, head_ssh_port holds the external NodePort,
-    # which would forward to a non-listening port here.
-    cluster_info = handle.cached_cluster_info
-    is_host_network = bool(cluster_info) and getattr(cluster_info,
-                                                     'host_network', False)
-    pod_ssh_port = (handle.head_ssh_port or 22) if is_host_network else 22
+    # Under hostNetwork the pod's sshd binds a probed port (not 22,
+    # which is owned by the K8s node's own sshd). head_ssh_port flows
+    # from InstanceInfo.ssh_port through cached_external_ssh_ports.
+    head_ssh_port = handle.head_ssh_port or 22
     kubectl_cmd = handle.get_command_runners()[0].port_forward_command(
-        port_forward=[(None, pod_ssh_port)])
+        port_forward=[(None, head_ssh_port)])
     # Under uvloop, `asyncio.create_subprocess_exec` goes through libuv's
     # `uv_spawn`, which on Linux always uses fork().
     # The forked child runs `PyOS_AfterFork_Child` which tears down inherited

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2771,14 +2771,10 @@ async def kubernetes_pod_ssh_proxy(websocket: fastapi.WebSocket,
 
     handle = await _get_cluster_and_validate(cluster_name, clouds.Kubernetes)
 
-    # Use the head pod's recorded SSH port — under hostNetwork the pod's
-    # sshd binds a probed port (not 22, which is owned by the K8s node's
-    # own sshd). cached_external_ssh_ports is filled from InstanceInfo
-    # when the cluster info is refreshed and falls back to 22.
-    head_ssh_port = 22
-    ssh_ports = getattr(handle, 'cached_external_ssh_ports', None) or []
-    if ssh_ports:
-        head_ssh_port = ssh_ports[0]
+    # Under hostNetwork the pod's sshd binds a probed port (not 22,
+    # which is owned by the K8s node's own sshd). head_ssh_port flows
+    # from InstanceInfo.ssh_port through cached_external_ssh_ports.
+    head_ssh_port = handle.head_ssh_port or 22
     kubectl_cmd = handle.get_command_runners()[0].port_forward_command(
         port_forward=[(None, head_ssh_port)])
     # Under uvloop, `asyncio.create_subprocess_exec` goes through libuv's

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -38,9 +38,17 @@ SKY_REMOTE_RAY_PORT = 6380
 SKY_REMOTE_RAY_DASHBOARD_PORT = 8266
 # Note we can not use json.dumps which will add a space between ":" and its
 # value which causes the yaml parser to fail.
+# Reads SKYPILOT_RAY_PORT / SKYPILOT_RAY_DASHBOARD_PORT from the env (set by
+# sky.provision.kubernetes.host_network_probe in the hostNetwork: true K8s
+# path), falling back to the SkyPilot defaults so non-hostNetwork clusters
+# write the same ports to ~/.sky/ray_port.json as before.
 SKY_REMOTE_RAY_PORT_DICT_STR = (
-    f'{{"ray_port":{SKY_REMOTE_RAY_PORT}, '
-    f'"ray_dashboard_port":{SKY_REMOTE_RAY_DASHBOARD_PORT}}}')
+    '{'
+    f'"ray_port":int(os.environ.get("SKYPILOT_RAY_PORT",'
+    f'{SKY_REMOTE_RAY_PORT})), '
+    f'"ray_dashboard_port":int(os.environ.get('
+    f'"SKYPILOT_RAY_DASHBOARD_PORT",{SKY_REMOTE_RAY_DASHBOARD_PORT}))'
+    '}')
 # The file contains the ports of the Ray cluster that SkyPilot launched,
 # i.e. the PORT_DICT_STR above.
 SKY_REMOTE_RAY_PORT_FILE = '.sky/ray_port.json'

--- a/sky/templates/kubernetes-port-forward-proxy-command.sh
+++ b/sky/templates/kubernetes-port-forward-proxy-command.sh
@@ -67,7 +67,28 @@ if [ -n "$KUBE_NAMESPACE" ]; then
   KUBECTL_ARGS+=("--namespace=$KUBE_NAMESPACE")
 fi
 
-kubectl "${KUBECTL_ARGS[@]}" port-forward pod/"${POD_NAME}" :22 > "${KUBECTL_OUTPUT}" 2>&1 &
+# Under hostNetwork the pod shares the K8s node's net namespace, so its
+# sshd cannot bind to port 22 (the node's own sshd is there on managed
+# K8s; even on kind there's no SkyPilot-owned listener on 22 once the
+# probe rebinds). The host_network_probe writes the probed sshd port
+# to the cluster's <cluster>-ray-ports ConfigMap under sshd_<pod>;
+# discover it here so port-forward routes to the right pod-internal
+# port. Falls back to 22 for non-hostNetwork pods (the common case).
+POD_PORT=22
+HOST_NETWORK=$(kubectl "${KUBECTL_ARGS[@]}" get pod "${POD_NAME}" \
+    -o jsonpath='{.spec.hostNetwork}' 2>/dev/null)
+if [ "${HOST_NETWORK}" = "true" ]; then
+    # SkyPilot pod names are <cluster>-head or <cluster>-worker<N>.
+    CLUSTER_NAME=$(echo "${POD_NAME}" | sed -E 's/-head$//; s/-worker[0-9]+$//')
+    PROBED_PORT=$(kubectl "${KUBECTL_ARGS[@]}" get configmap \
+        "${CLUSTER_NAME}-ray-ports" \
+        -o jsonpath="{.data.sshd_${POD_NAME}}" 2>/dev/null)
+    if [ -n "${PROBED_PORT}" ]; then
+        POD_PORT="${PROBED_PORT}"
+    fi
+fi
+
+kubectl "${KUBECTL_ARGS[@]}" port-forward pod/"${POD_NAME}" ":${POD_PORT}" > "${KUBECTL_OUTPUT}" 2>&1 &
 
 # Capture the PID for the backgrounded kubectl command
 K8S_PORT_FWD_PID=$!

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -413,8 +413,10 @@ available_node_types:
             cloud.google.com/gke-flex-start: "true"
             {% endif %}
         {% endif %}
-        {% if (k8s_acc_label_key is not none and k8s_acc_label_values is not none) or (avoid_label_keys is not none) %}
+        {% set _affinity_node = (k8s_acc_label_key is not none and k8s_acc_label_values is not none) or (avoid_label_keys is not none) %}
+        {% if _affinity_node or k8s_host_network %}
         affinity:
+          {% if _affinity_node %}
           nodeAffinity:
             {% if k8s_acc_label_key is not none and k8s_acc_label_values is not none %}
             requiredDuringSchedulingIgnoredDuringExecution:
@@ -449,6 +451,27 @@ available_node_types:
                         values:
                           - "gpu"
                   topologyKey: kubernetes.io/hostname
+          {% endif %}
+          {% endif %}
+          {% if k8s_host_network %}
+          # Mode b: one cluster pod per K8s node. Under hostNetwork a pod
+          # shares the node's net namespace, so two pods of the SAME SkyPilot
+          # cluster on one node would (a) collide on host ports and (b)
+          # register both raylets under the same host IP -- Ray's client-side
+          # resolver then collapses the two NodeIDs onto one gRPC endpoint and
+          # hangs pg.ready(). Forcing one pod per node makes every pod's host
+          # IP unique and routable, which is also exactly what lets a
+          # hostNetwork cluster span multiple K8s nodes. requiredDuring (not
+          # preferred): the guarantee must be hard -- a multi-pod hostNetwork
+          # cluster that cannot get a node per pod fails to schedule loudly
+          # rather than silently racing. The selector is per-cluster
+          # (skypilot-cluster), so unrelated clusters can still co-locate.
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  skypilot-cluster: {{cluster_name_on_cloud}}
+              topologyKey: kubernetes.io/hostname
           {% endif %}
         {% endif %}
         {% if k8s_spot_label_key is not none %}

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -388,6 +388,12 @@ available_node_types:
         serviceAccountName: {{k8s_service_account_name}}
         automountServiceAccountToken: {{k8s_automount_sa_token}}
         restartPolicy: {{ "Always" if high_availability else "Never" }}
+        {% if k8s_host_network %}
+        # Under hostNetwork the default dnsPolicy silently falls back to
+        # the host's resolv.conf — Service DNS like ${head}.svc.cluster.local
+        # won't resolve, and the worker probe gets stuck dialing the head.
+        dnsPolicy: ClusterFirstWithHostNet
+        {% endif %}
         {% if volume_mounts %}
         securityContext:
           fsGroup: 1000

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -559,7 +559,10 @@ available_node_types:
               value: "0"
             {% for key, value in k8s_env_vars.items() if k8s_env_vars is not none %}
             - name: {{ key }}
-              value: {{ value }}
+              # tojson quotes the value so YAML parses it as a string —
+              # K8s rejects pods whose env.value is anything but a string
+              # (e.g. when value is "1", a bare emit yields YAML int 1).
+              value: {{ value | tojson }}
             {% endfor %}
             {% if k8s_enable_docker_all %}
             - name: DOCKER_HOST

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -545,8 +545,11 @@ available_node_types:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['ray-node-type']
+            {% if k8s_host_network %}
             # Downward API rather than $HOSTNAME — hostNetwork pods
-            # inherit the host node's hostname.
+            # inherit the host node's hostname. Used by
+            # host_network_probe to key per-pod ConfigMap entries and
+            # set ownerReferences for GC.
             - name: SKYPILOT_POD_NAME
               valueFrom:
                 fieldRef:
@@ -555,6 +558,7 @@ available_node_types:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.uid
+            {% endif %}
             - name: SKYPILOT_POD_CPU_CORE_LIMIT
               valueFrom:
                 resourceFieldRef:

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -1086,6 +1086,18 @@ available_node_types:
                   # Start ray worker on the worker pod.
                   # Wait until the head pod is available with an IP address
                   export SKYPILOT_RAY_HEAD_IP="{{cluster_name_on_cloud}}-head.{{k8s_namespace}}.svc.cluster.local"
+{% if k8s_host_network %}
+                  # hostNetwork: the head's GCS port is dynamic (picked
+                  # by sky.provision.kubernetes.host_network_probe to
+                  # avoid collisions on the shared host network
+                  # namespace). The worker probe inside
+                  # ray_worker_start_command below polls the
+                  # <cluster>-ray-ports ConfigMap for the head's port,
+                  # exports SKYPILOT_RAY_PORT, and TCP-waits for the
+                  # head's GCS to accept — covering the same role as the
+                  # constant-port `nc -z` check used in the non-host-
+                  # network path.
+{% else %}
                   export SKYPILOT_RAY_PORT={{skypilot_ray_port}}
                   # Wait until the ray cluster is started on the head pod
                   until dpkg -l | grep -q "^ii  \(netcat\|netcat-openbsd\|netcat-traditional\) "; do
@@ -1095,6 +1107,7 @@ available_node_types:
                   until nc -z -w 1 ${SKYPILOT_RAY_HEAD_IP} ${SKYPILOT_RAY_PORT}; do
                     sleep 0.1
                   done
+{% endif %}
 
                   set +e
                   {{ ray_worker_start_command }}

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -539,11 +539,8 @@ available_node_types:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['ray-node-type']
-            # metadata.name / metadata.uid via downward API rather than
-            # $HOSTNAME — under hostNetwork: true the container inherits
-            # the host node's hostname, so HOSTNAME points at the wrong
-            # thing for any pod self-identification (see
-            # sky.provision.kubernetes.host_network_probe).
+            # Downward API rather than $HOSTNAME — hostNetwork pods
+            # inherit the host node's hostname.
             - name: SKYPILOT_POD_NAME
               valueFrom:
                 fieldRef:
@@ -572,9 +569,7 @@ available_node_types:
               value: "0"
             {% for key, value in k8s_env_vars.items() if k8s_env_vars is not none %}
             - name: {{ key }}
-              # tojson quotes the value so YAML parses it as a string —
-              # K8s rejects pods whose env.value is anything but a string
-              # (e.g. when value is "1", a bare emit yields YAML int 1).
+              # tojson forces a quoted string; K8s rejects non-string env values.
               value: {{ value | tojson }}
             {% endfor %}
             {% if k8s_enable_docker_all %}
@@ -1103,16 +1098,8 @@ available_node_types:
                   # Wait until the head pod is available with an IP address
                   export SKYPILOT_RAY_HEAD_IP="{{cluster_name_on_cloud}}-head.{{k8s_namespace}}.svc.cluster.local"
 {% if k8s_host_network %}
-                  # hostNetwork: the head's GCS port is dynamic (picked
-                  # by sky.provision.kubernetes.host_network_probe to
-                  # avoid collisions on the shared host network
-                  # namespace). The worker probe inside
-                  # ray_worker_start_command below polls the
-                  # <cluster>-ray-ports ConfigMap for the head's port,
-                  # exports SKYPILOT_RAY_PORT, and TCP-waits for the
-                  # head's GCS to accept — covering the same role as the
-                  # constant-port `nc -z` check used in the non-host-
-                  # network path.
+                  # SKYPILOT_RAY_PORT and the head-up wait are handled
+                  # by the worker probe inside ray_worker_start_command.
 {% else %}
                   export SKYPILOT_RAY_PORT={{skypilot_ray_port}}
                   # Wait until the ray cluster is started on the head pod
@@ -1310,15 +1297,9 @@ available_node_types:
               while true; do sleep infinity & wait $!; done
 
           {% if not k8s_host_network %}
-          # Under hostNetwork: true the K8s scheduler treats containerPort
-          # entries as hostPort reservations, blocking a second pod on
-          # the same node with the same declarations (event "Predicate
-          # NodePorts failed: node(s) didn't have free ports for the
-          # requested pod ports"). The Ray ports here are also stale
-          # under hostNetwork because the probe picks them dynamically,
-          # so omit the block entirely in that mode. containerPort is
-          # informational only when hostNetwork is off — Services dial
-          # via targetPort, which still works.
+          # Omitted under hostNetwork: the scheduler's NodePorts predicate
+          # treats containerPort as hostPort and blocks sibling pods even
+          # though the probe assigns Ray's ports dynamically.
           ports:
           - containerPort: 22  # Used for SSH
           - containerPort: {{ray_port}}  # Redis port

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -1309,12 +1309,23 @@ available_node_types:
               log_tail &
               while true; do sleep infinity & wait $!; done
 
+          {% if not k8s_host_network %}
+          # Under hostNetwork: true the K8s scheduler treats containerPort
+          # entries as hostPort reservations, blocking a second pod on
+          # the same node with the same declarations (event "Predicate
+          # NodePorts failed: node(s) didn't have free ports for the
+          # requested pod ports"). The Ray ports here are also stale
+          # under hostNetwork because the probe picks them dynamically,
+          # so omit the block entirely in that mode. containerPort is
+          # informational only when hostNetwork is off — Services dial
+          # via targetPort, which still works.
           ports:
           - containerPort: 22  # Used for SSH
           - containerPort: {{ray_port}}  # Redis port
           - containerPort: 10001  # Used by Ray Client
           - containerPort: {{ray_dashboard_port}}  # Used by Ray Dashboard
           - containerPort: 46590  # Used by Skylet gRPC
+          {% endif %}
 
           # This volume allocates shared memory for Ray to use for its plasma
           # object store. If you do not provide this, Ray will fall back to

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -539,6 +539,19 @@ available_node_types:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['ray-node-type']
+            # metadata.name / metadata.uid via downward API rather than
+            # $HOSTNAME — under hostNetwork: true the container inherits
+            # the host node's hostname, so HOSTNAME points at the wrong
+            # thing for any pod self-identification (see
+            # sky.provision.kubernetes.host_network_probe).
+            - name: SKYPILOT_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: SKYPILOT_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: SKYPILOT_POD_CPU_CORE_LIMIT
               valueFrom:
                 resourceFieldRef:

--- a/sky/utils/source_utils.py
+++ b/sky/utils/source_utils.py
@@ -1,0 +1,44 @@
+"""Helpers for handling Python source text.
+
+Useful when shipping a script inline through a transport that has a
+size budget — e.g. base64'd into a Pod spec or a cloud user-data
+field. Pair with ``gzip`` + ``base64`` at the call site.
+"""
+import io
+import token
+import tokenize
+from typing import List
+
+
+def minify_python_source(source: str) -> str:
+    """Strip comments and module/class/function docstrings.
+
+    Stdlib-only. The result must still parse and execute identically;
+    only comment tokens and docstring-position string literals are
+    dropped. Identifiers, non-docstring string literals, and control
+    flow are untouched.
+    """
+    out: List[str] = []
+    prev_toktype = token.INDENT
+    last_lineno = -1
+    last_col = 0
+    readline = io.StringIO(source).readline
+    for tok in tokenize.generate_tokens(readline):
+        toktype, tokstr, (sline, scol), (eline, ecol), _ = tok
+        if sline > last_lineno:
+            last_col = 0
+        if scol > last_col and toktype != tokenize.COMMENT:
+            out.append(' ' * (scol - last_col))
+        if toktype == tokenize.COMMENT:
+            pass
+        elif toktype == token.STRING and prev_toktype in (token.INDENT,
+                                                          token.NEWLINE):
+            # String that is its own statement at module/class/function
+            # top — that's a docstring. Drop it.
+            pass
+        else:
+            out.append(tokstr)
+        prev_toktype = toktype
+        last_col = ecol
+        last_lineno = eline
+    return ''.join(out)

--- a/tests/smoke_tests/test_kubernetes_host_network.py
+++ b/tests/smoke_tests/test_kubernetes_host_network.py
@@ -14,8 +14,11 @@ so a single cluster's pods never share a node -- which both removes
 the same-node raylet-identity collapse and lets a hostNetwork
 cluster span multiple K8s nodes. ``coexistence`` covers two
 *different* clusters sharing a node (still allowed -- the
-anti-affinity is per-cluster); ``multi_node`` covers one cluster
-spread across nodes.
+anti-affinity is per-cluster); ``multi_node`` asserts the
+fail-loud guarantee: on a single-node K8s cluster a 2-node
+hostNetwork cluster must fail to schedule (the required
+anti-affinity refuses to pack the worker onto the head's node)
+rather than silently racing on the shared host.
 """
 import uuid
 
@@ -131,39 +134,37 @@ def test_kubernetes_host_network_coexistence():
 @pytest.mark.kubernetes
 @pytest.mark.no_dependency
 def test_kubernetes_host_network_multi_node():
-    """A 2-node hostNetwork SkyPilot cluster spread across two K8s nodes.
+    """A 2-node hostNetwork cluster correctly *fails* on single-node K8s.
 
-    With mode b (the required, per-cluster ``podAntiAffinity`` SkyPilot
-    injects for every hostNetwork pod) the head and worker of one
-    cluster *cannot* land on the same K8s node, so this exercises
-    cross-K8s-node hostNetwork end to end with no anchor / podAffinity
-    needed — the injected rule does the spreading.
+    This asserts mode b's fail-loud guarantee on the infra the smoke
+    suite actually runs against (single-node K8s clusters). The required,
+    per-cluster ``podAntiAffinity`` SkyPilot injects for every hostNetwork
+    pod forbids the head and worker of one cluster from sharing a node;
+    with only one node available the worker cannot be scheduled, so the
+    launch must fail with the scheduler's pod-anti-affinity error rather
+    than silently packing both pods onto one host (which is exactly the
+    raylet-collapse / port-collision race mode b exists to prevent).
 
-    Requires the test K8s cluster to have >=2 schedulable nodes (that
-    is the scenario under test; on a single-node cluster the required
-    anti-affinity correctly leaves the worker Pending and the launch
-    fails loudly rather than silently racing on the shared host).
+    On a >=2-node K8s cluster this same config would instead succeed and
+    spread one pod per node (the cross-node capability mode b unlocks);
+    that path is not exercised here because the smoke clusters are
+    single-node.
 
     Verifies:
 
-    1. The 2-node launch succeeds — under the required per-cluster
-       anti-affinity, success means the two pods are on *different* K8s
-       nodes (a same-node placement would leave the worker Pending and
-       fail this step).
-    2. Ray works across nodes: ``sky exec`` runs on the cluster, which
-       implies the worker (on a different K8s node) joined the head's
-       Ray cluster over the head's routable host IP + probed GCS port.
-    3. SSH to the head works (per-pod sshd port rebind + SkyPilot SSH
-       config writer using the probed port).
-    4. SSH to the worker works — its separately probed sshd port, on a
-       different K8s node from the head.
+    1. ``sky launch --num-nodes 2`` returns non-zero (it must not
+       succeed by co-locating the pods).
+    2. The failure is specifically the pod-anti-affinity scheduling
+       rejection (SkyPilot surfaces the verbatim kube-scheduler
+       ``FailedScheduling`` message, which contains "anti-affinity"),
+       not some unrelated error.
     """
     name = smoke_tests_utils.get_cluster_name()
     cfg = f'/tmp/sky-hostnet-multinode-{uuid.uuid4().hex[:12]}.yaml'
 
-    # hostNetwork only — no podAffinity / anchor. SkyPilot's injected
-    # per-cluster podAntiAffinity (mode b) spreads the head and worker
-    # onto separate K8s nodes by itself.
+    # hostNetwork only. SkyPilot injects the per-cluster podAntiAffinity
+    # (mode b); on a single-node cluster that leaves the 2nd pod
+    # unschedulable.
     write_cfg = (f'cat > {cfg} <<EOF\n'
                  f'kubernetes:\n'
                  f'  pod_config:\n'
@@ -171,38 +172,36 @@ def test_kubernetes_host_network_multi_node():
                  f'      hostNetwork: true\n'
                  f'EOF')
 
+    # One self-contained command: capture the launch, assert it failed,
+    # and assert it failed *for the anti-affinity reason* (so an
+    # unrelated failure — image pull, quota — doesn't spuriously pass).
+    # grep -iE "anti-?affinity" matches the kube-scheduler phrasings
+    # ("...didn't match pod anti-affinity rules", "antiaffinity").
+    expect_fail = (
+        f'set +e; '
+        f'OUT=$(sky launch -y -c {name} --infra kubernetes '
+        f'--config {cfg} --num-nodes 2 --cpus 1 --memory 2 2>&1); '
+        f'RC=$?; set -e; '
+        f'echo "$OUT"; '
+        f'if [ $RC -eq 0 ]; then '
+        f'echo "FAIL: 2-node hostNetwork launch unexpectedly SUCCEEDED on '
+        f'single-node K8s; mode-b anti-affinity should have blocked it"; '
+        f'exit 1; fi; '
+        f'echo "$OUT" | grep -qiE "anti-?affinity" || {{ '
+        f'echo "FAIL: launch failed but NOT via the pod anti-affinity '
+        f'scheduling rule (unexpected failure reason)"; exit 1; }}; '
+        f'echo "OK: mode-b anti-affinity correctly rejected the 2-node '
+        f'hostNetwork cluster on single-node K8s"')
+
     test = smoke_tests_utils.Test(
         'kubernetes_host_network_multi_node',
         [
             write_cfg,
-
-            # 1. 2-node launch. Under the required per-cluster
-            # anti-affinity a successful launch *is* the proof the two
-            # pods are on different K8s nodes (a same-node placement
-            # would leave the worker Pending and fail this step). 1 CPU
-            # / 2 GB per pod keeps Ray's first job submission off the
-            # FAILED_DRIVER edge.
-            f'sky launch -y -c {name} --infra kubernetes '
-            f'--config {cfg} --num-nodes 2 --cpus 1 --memory 2',
-
-            # 2. Ray must work across the two nodes. `sky exec` runs the
-            # task through Ray on the head, which means the worker (on a
-            # different K8s node) joined the head over its routable host
-            # IP + probed GCS port.
-            f'sky exec {name} -- echo "job_ok"',
-            f'sky logs {name} 1 --status',
-
-            # 3. SSH to head — per-pod sshd port rebind + SkyPilot SSH
-            # config using the probed port.
-            f's=$(ssh -o StrictHostKeyChecking=no {name} '
-            f'"echo ssh_head_ok" 2>&1) && echo "$s" | grep ssh_head_ok',
-
-            # 4. SSH to the worker — its separately probed sshd port, on
-            # a different K8s node from the head.
-            f's=$(ssh -o StrictHostKeyChecking=no {name}-worker1 '
-            f'"echo ssh_worker_ok" 2>&1) && echo "$s" | grep ssh_worker_ok',
+            expect_fail,
         ],
+        # Best-effort cleanup: a failed launch still leaves a cluster
+        # record (and the head pod that did schedule).
         teardown=f'sky down -y {name}; rm -f {cfg}',
-        timeout=5 * 60,
+        timeout=10 * 60,
     )
     smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_kubernetes_host_network.py
+++ b/tests/smoke_tests/test_kubernetes_host_network.py
@@ -8,101 +8,86 @@ SkyPilot's host_network_probe picks a free Ray port set per pod
 and rebinds the pod's sshd to a probed port; these tests prove
 both work end-to-end.
 """
-import subprocess
+import uuid
 
 import pytest
 from smoke_tests import smoke_tests_utils
 
 
-def _pick_worker_node() -> str:
-    """Return the name of one worker node (non control-plane).
-
-    Smoke tests run against the user's current kubeconfig; we want a
-    node that the scheduler will actually place workloads on.
-    """
-    result = subprocess.run([
-        'kubectl', 'get', 'nodes', '-o',
-        'jsonpath={range .items[?(@.metadata.labels.node-role\\.'
-        'kubernetes\\.io/control-plane!="")]}{.metadata.name}'
-        '{"\\n"}{end}'
-        '{range .items[?(@.metadata.labels.node-role\\.'
-        'kubernetes\\.io/control-plane=="")]}{.metadata.name}'
-        '{"\\n"}{end}'
-    ],
-                            capture_output=True,
-                            text=True,
-                            check=False)
-    if result.returncode != 0:
-        pytest.skip(f'kubectl get nodes failed: {result.stderr}')
-    # Worker nodes appear after the control-plane block. Fall back to
-    # any node if the cluster has no nodes labeled control-plane (kind,
-    # minikube, etc.).
-    names = [n for n in result.stdout.splitlines() if n]
-    if not names:
-        pytest.skip('No nodes returned by kubectl')
-    # Prefer the last node — on managed clusters control-plane nodes
-    # are listed first; on single-node clusters this still works.
-    return names[-1]
-
-
 @pytest.mark.kubernetes
-@pytest.mark.resource_heavy
 @pytest.mark.no_dependency
 def test_kubernetes_host_network_coexistence():
     """Two hostNetwork SkyPilot clusters on the same K8s node coexist.
 
-    Forces both clusters' pods onto the same K8s node via
-    ``nodeSelector: kubernetes.io/hostname=<node>`` and turns on
-    ``hostNetwork: true``. Verifies:
+    Co-location is enforced via Kubernetes ``podAffinity`` (cluster B
+    requires the same node as cluster A's anchor pod) rather than a
+    kubectl-queried nodeSelector — so the test runs against both
+    local and remote API servers, and on any K8s cluster regardless
+    of node count. Verifies:
 
-    1. Both launches succeed (head_network_probe picked free ports).
-    2. Both pods landed on the target node (the actual repro setup).
-    3. ``ssh <cluster>`` works against both heads (sshd_<podname>
-       propagation to InstanceInfo.ssh_port and the per-pod sshd Port
-       rewrite both worked).
-    4. The two clusters' head GCS ports are distinct (probe didn't
-       hand out the same number twice).
+    1. Both launches succeed (probe avoided port collision).
+    2. SSH to both heads works (per-pod sshd port rebind worked).
+    3. The two heads' probed GCS ports are distinct.
     """
-    if smoke_tests_utils.is_non_docker_remote_api_server():
-        pytest.skip('Skipping test because the Kubernetes configs and '
-                    'credentials are located on the remote API server '
-                    'and not the machine where the test is running')
-
-    target_node = _pick_worker_node()
+    # Unique anchor so concurrent test runs don't co-locate onto each
+    # other. The label is placed on cluster A's pod; cluster B's
+    # podAffinity binds to it.
+    anchor_key = 'skypilot-coexist-anchor'
+    anchor_val = uuid.uuid4().hex[:12]
 
     base = smoke_tests_utils.get_cluster_name()
     name_a = f'{base}-a'
     name_b = f'{base}-b'
 
-    # Extract a pod's node name by the skypilot-cluster-name annotation
-    # (the label is hash-suffixed; the annotation is the exact name).
-    # Not an f-string, so braces here are literal (no doubling needed).
-    get_pod_node = ('kubectl get pods --all-namespaces -o jsonpath=\''
-                    '{range .items[*]}'
-                    '{.metadata.annotations.skypilot-cluster-name} '
-                    '{.spec.nodeName}{"\\n"}{end}\'')
+    cfg_a = f'/tmp/sky-coexist-{anchor_val}-a.yaml'
+    cfg_b = f'/tmp/sky-coexist-{anchor_val}-b.yaml'
+
+    # Cluster A: hostNetwork + a unique label. No affinity (it's the
+    # anchor, and K8s podAffinity required-during-scheduling cannot be
+    # self-satisfied — the matching pod must already be running).
+    write_cfg_a = (f'cat > {cfg_a} <<EOF\n'
+                   f'kubernetes:\n'
+                   f'  pod_config:\n'
+                   f'    metadata:\n'
+                   f'      labels:\n'
+                   f'        {anchor_key}: "{anchor_val}"\n'
+                   f'    spec:\n'
+                   f'      hostNetwork: true\n'
+                   f'EOF')
+
+    # Cluster B: hostNetwork + podAffinity onto cluster A's pod.
+    write_cfg_b = (
+        f'cat > {cfg_b} <<EOF\n'
+        f'kubernetes:\n'
+        f'  pod_config:\n'
+        f'    spec:\n'
+        f'      hostNetwork: true\n'
+        f'      affinity:\n'
+        f'        podAffinity:\n'
+        f'          requiredDuringSchedulingIgnoredDuringExecution:\n'
+        f'          - labelSelector:\n'
+        f'              matchLabels:\n'
+        f'                {anchor_key}: "{anchor_val}"\n'
+        f'            topologyKey: kubernetes.io/hostname\n'
+        f'EOF')
 
     test = smoke_tests_utils.Test(
         'kubernetes_host_network_coexistence',
         [
-            # 1. Launch both clusters onto the same node with hostNetwork.
+            write_cfg_a,
+            write_cfg_b,
+
+            # 1. Launch A first (anchor), then B (forced onto A's node).
             f'sky launch -y -c {name_a} --infra kubernetes '
+            f'--config {cfg_a} '
             f'--cpus 0.5 --memory 1 -- echo "hello from A"',
             f'sky logs {name_a} 1 --status',
             f'sky launch -y -c {name_b} --infra kubernetes '
+            f'--config {cfg_b} '
             f'--cpus 0.5 --memory 1 -- echo "hello from B"',
             f'sky logs {name_b} 1 --status',
 
-            # 2. Both pods must be on the target node.
-            f'A_NODE=$({get_pod_node} | grep "^{name_a} " '
-            f'| awk \'{{print $2}}\') && '
-            f'B_NODE=$({get_pod_node} | grep "^{name_b} " '
-            f'| awk \'{{print $2}}\') && '
-            f'echo "A_NODE=$A_NODE B_NODE=$B_NODE" && '
-            f'[ "$A_NODE" = "{target_node}" ] && '
-            f'[ "$B_NODE" = "{target_node}" ]',
-
-            # 3. SSH must work against both heads. This exercises:
+            # 2. SSH to both heads. Exercises:
             #    - sshd_<podname> ConfigMap entry -> InstanceInfo.ssh_port
             #    - /etc/ssh/sshd_config Port rewrite by the probe
             #    - SkyPilot SSH config writer using the probed port
@@ -111,7 +96,7 @@ def test_kubernetes_host_network_coexistence():
             f's=$(ssh -o StrictHostKeyChecking=no {name_b} '
             f'"echo ssh_works_B" 2>&1) && echo "$s" | grep ssh_works_B',
 
-            # 4. The probe must have assigned distinct GCS ports to the
+            # 3. The probe must have assigned distinct GCS ports to the
             #    two heads. The env file written by the probe is the
             #    authoritative source on each pod.
             f'A_GCS=$(ssh {name_a} '
@@ -124,19 +109,8 @@ def test_kubernetes_host_network_coexistence():
             f'[ -n "$A_GCS" ] && [ -n "$B_GCS" ] && '
             f'[ "$A_GCS" != "$B_GCS" ]',
         ],
-        teardown=f'sky down -y {name_a}; sky down -y {name_b}',
+        teardown=(f'sky down -y {name_a}; sky down -y {name_b}; '
+                  f'rm -f {cfg_a} {cfg_b}'),
         timeout=smoke_tests_utils.get_timeout('kubernetes'),
-        config_dict={
-            'kubernetes': {
-                'pod_config': {
-                    'spec': {
-                        'hostNetwork': True,
-                        'nodeSelector': {
-                            'kubernetes.io/hostname': target_node,
-                        },
-                    },
-                },
-            },
-        },
     )
     smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_kubernetes_host_network.py
+++ b/tests/smoke_tests/test_kubernetes_host_network.py
@@ -114,3 +114,110 @@ def test_kubernetes_host_network_coexistence():
         timeout=smoke_tests_utils.get_timeout('kubernetes'),
     )
     smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.kubernetes
+@pytest.mark.no_dependency
+def test_kubernetes_host_network_multi_node():
+    """A 2-node SkyPilot cluster, both pods on one K8s node, hostNetwork on.
+
+    Head and worker pods are created in parallel by SkyPilot's K8s
+    provisioner, so a self-referential podAffinity would deadlock
+    (neither pod can satisfy the other's required-during-scheduling
+    constraint until one is running). To force co-location anyway, an
+    anchor SkyPilot cluster is launched first with a unique label;
+    the 2-node target cluster's pod_config then sets podAffinity onto
+    that label, which both pods can independently satisfy.
+
+    Verifies:
+
+    1. Both target pods land on the anchor's K8s node (otherwise the
+       second pod would Pending forever, failing the launch step).
+    2. Ray cluster works: ``sky exec`` runs on the cluster (which
+       implies head + worker have joined the Ray cluster — the worker
+       reading the head's probed GCS port from the ConfigMap).
+    3. SSH to the head works.
+    4. SSH to the worker works — exercises the per-pod sshd port
+       rebind on the worker pod and the SkyPilot SSH config writer's
+       use of ``pod_sshd_ports[worker_pod_name]``.
+    """
+    anchor_key = 'skypilot-multinode-anchor'
+    anchor_val = uuid.uuid4().hex[:12]
+
+    base = smoke_tests_utils.get_cluster_name()
+    name_anchor = f'{base}-anchor'
+    name_multi = f'{base}-multi'
+
+    cfg_anchor = f'/tmp/sky-multinode-{anchor_val}-anchor.yaml'
+    cfg_multi = f'/tmp/sky-multinode-{anchor_val}-multi.yaml'
+
+    # Anchor: hostNetwork + unique label, no affinity.
+    write_cfg_anchor = (f'cat > {cfg_anchor} <<EOF\n'
+                        f'kubernetes:\n'
+                        f'  pod_config:\n'
+                        f'    metadata:\n'
+                        f'      labels:\n'
+                        f'        {anchor_key}: "{anchor_val}"\n'
+                        f'    spec:\n'
+                        f'      hostNetwork: true\n'
+                        f'EOF')
+
+    # 2-node target: hostNetwork + podAffinity onto anchor's node.
+    # Both head and worker pods inherit this pod_config and so each
+    # can independently match against the anchor pod.
+    write_cfg_multi = (
+        f'cat > {cfg_multi} <<EOF\n'
+        f'kubernetes:\n'
+        f'  pod_config:\n'
+        f'    spec:\n'
+        f'      hostNetwork: true\n'
+        f'      affinity:\n'
+        f'        podAffinity:\n'
+        f'          requiredDuringSchedulingIgnoredDuringExecution:\n'
+        f'          - labelSelector:\n'
+        f'              matchLabels:\n'
+        f'                {anchor_key}: "{anchor_val}"\n'
+        f'            topologyKey: kubernetes.io/hostname\n'
+        f'EOF')
+
+    test = smoke_tests_utils.Test(
+        'kubernetes_host_network_multi_node',
+        [
+            write_cfg_anchor,
+            write_cfg_multi,
+
+            # 1. Launch anchor (1 pod), then the 2-node target. If the
+            # target launch returns success, both pods scheduled — i.e.
+            # both landed on the anchor's node.
+            f'sky launch -y -c {name_anchor} --infra kubernetes '
+            f'--config {cfg_anchor} '
+            f'--cpus 0.5 --memory 1 -- echo "anchor up"',
+            f'sky logs {name_anchor} 1 --status',
+            f'sky launch -y -c {name_multi} --infra kubernetes '
+            f'--config {cfg_multi} --num-nodes 2 '
+            f'--cpus 0.5 --memory 1 -- echo "multi up"',
+            f'sky logs {name_multi} 1 --status',
+
+            # 2. Ray cluster must work end-to-end. `sky exec` runs the
+            # task through Ray on the head, which means the head <->
+            # worker join happened (worker read head's probed GCS port
+            # from the ConfigMap).
+            f'sky exec {name_multi} -- echo "job_ok"',
+            f'sky logs {name_multi} 2 --status',
+
+            # 3. SSH to head — exercises per-pod sshd port rebind on
+            # the head + SkyPilot SSH config using the probed port.
+            f's=$(ssh -o StrictHostKeyChecking=no {name_multi} '
+            f'"echo ssh_head_ok" 2>&1) && echo "$s" | grep ssh_head_ok',
+
+            # 4. SSH to worker — same path as the head but uses the
+            # worker pod's separately probed sshd port (read from the
+            # ConfigMap's sshd_<podname> entry into InstanceInfo.ssh_port).
+            f's=$(ssh -o StrictHostKeyChecking=no {name_multi}-worker1 '
+            f'"echo ssh_worker_ok" 2>&1) && echo "$s" | grep ssh_worker_ok',
+        ],
+        teardown=(f'sky down -y {name_anchor}; sky down -y {name_multi}; '
+                  f'rm -f {cfg_anchor} {cfg_multi}'),
+        timeout=smoke_tests_utils.get_timeout('kubernetes'),
+    )
+    smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_kubernetes_host_network.py
+++ b/tests/smoke_tests/test_kubernetes_host_network.py
@@ -7,6 +7,15 @@ landing on the same node would collide on Ray's default ports
 SkyPilot's host_network_probe picks a free Ray port set per pod
 and rebinds the pod's sshd to a probed port; these tests prove
 both work end-to-end.
+
+SkyPilot also injects a required, per-cluster ``podAntiAffinity``
+for every hostNetwork pod (mode b: one cluster pod per K8s node),
+so a single cluster's pods never share a node -- which both removes
+the same-node raylet-identity collapse and lets a hostNetwork
+cluster span multiple K8s nodes. ``coexistence`` covers two
+*different* clusters sharing a node (still allowed -- the
+anti-affinity is per-cluster); ``multi_node`` covers one cluster
+spread across nodes.
 """
 import uuid
 
@@ -122,104 +131,78 @@ def test_kubernetes_host_network_coexistence():
 @pytest.mark.kubernetes
 @pytest.mark.no_dependency
 def test_kubernetes_host_network_multi_node():
-    """A 2-node SkyPilot cluster, both pods on one K8s node, hostNetwork on.
+    """A 2-node hostNetwork SkyPilot cluster spread across two K8s nodes.
 
-    Head and worker pods are created in parallel by SkyPilot's K8s
-    provisioner, so a self-referential podAffinity would deadlock
-    (neither pod can satisfy the other's required-during-scheduling
-    constraint until one is running). To force co-location anyway, an
-    anchor SkyPilot cluster is launched first with a unique label;
-    the 2-node target cluster's pod_config then sets podAffinity onto
-    that label, which both pods can independently satisfy.
+    With mode b (the required, per-cluster ``podAntiAffinity`` SkyPilot
+    injects for every hostNetwork pod) the head and worker of one
+    cluster *cannot* land on the same K8s node, so this exercises
+    cross-K8s-node hostNetwork end to end with no anchor / podAffinity
+    needed — the injected rule does the spreading.
+
+    Requires the test K8s cluster to have >=2 schedulable nodes (that
+    is the scenario under test; on a single-node cluster the required
+    anti-affinity correctly leaves the worker Pending and the launch
+    fails loudly rather than silently racing on the shared host).
 
     Verifies:
 
-    1. Both target pods land on the anchor's K8s node (otherwise the
-       second pod would Pending forever, failing the launch step).
-    2. Ray cluster works: ``sky exec`` runs on the cluster (which
-       implies head + worker have joined the Ray cluster — the worker
-       reading the head's probed GCS port from the ConfigMap).
-    3. SSH to the head works.
-    4. SSH to the worker works — exercises the per-pod sshd port
-       rebind on the worker pod and the SkyPilot SSH config writer's
-       use of ``pod_sshd_ports[worker_pod_name]``.
+    1. The 2-node launch succeeds — under the required per-cluster
+       anti-affinity, success means the two pods are on *different* K8s
+       nodes (a same-node placement would leave the worker Pending and
+       fail this step).
+    2. Ray works across nodes: ``sky exec`` runs on the cluster, which
+       implies the worker (on a different K8s node) joined the head's
+       Ray cluster over the head's routable host IP + probed GCS port.
+    3. SSH to the head works (per-pod sshd port rebind + SkyPilot SSH
+       config writer using the probed port).
+    4. SSH to the worker works — its separately probed sshd port, on a
+       different K8s node from the head.
     """
-    anchor_key = 'skypilot-multinode-anchor'
-    anchor_val = uuid.uuid4().hex[:12]
+    name = smoke_tests_utils.get_cluster_name()
+    cfg = f'/tmp/sky-hostnet-multinode-{uuid.uuid4().hex[:12]}.yaml'
 
-    base = smoke_tests_utils.get_cluster_name()
-    name_anchor = f'{base}-anchor'
-    name_multi = f'{base}-multi'
-
-    cfg_anchor = f'/tmp/sky-multinode-{anchor_val}-anchor.yaml'
-    cfg_multi = f'/tmp/sky-multinode-{anchor_val}-multi.yaml'
-
-    # Anchor: hostNetwork + unique label, no affinity.
-    write_cfg_anchor = (f'cat > {cfg_anchor} <<EOF\n'
-                        f'kubernetes:\n'
-                        f'  pod_config:\n'
-                        f'    metadata:\n'
-                        f'      labels:\n'
-                        f'        {anchor_key}: "{anchor_val}"\n'
-                        f'    spec:\n'
-                        f'      hostNetwork: true\n'
-                        f'EOF')
-
-    # 2-node target: hostNetwork + podAffinity onto anchor's node.
-    # Both head and worker pods inherit this pod_config and so each
-    # can independently match against the anchor pod.
-    write_cfg_multi = (
-        f'cat > {cfg_multi} <<EOF\n'
-        f'kubernetes:\n'
-        f'  pod_config:\n'
-        f'    spec:\n'
-        f'      hostNetwork: true\n'
-        f'      affinity:\n'
-        f'        podAffinity:\n'
-        f'          requiredDuringSchedulingIgnoredDuringExecution:\n'
-        f'          - labelSelector:\n'
-        f'              matchLabels:\n'
-        f'                {anchor_key}: "{anchor_val}"\n'
-        f'            topologyKey: kubernetes.io/hostname\n'
-        f'EOF')
+    # hostNetwork only — no podAffinity / anchor. SkyPilot's injected
+    # per-cluster podAntiAffinity (mode b) spreads the head and worker
+    # onto separate K8s nodes by itself.
+    write_cfg = (f'cat > {cfg} <<EOF\n'
+                 f'kubernetes:\n'
+                 f'  pod_config:\n'
+                 f'    spec:\n'
+                 f'      hostNetwork: true\n'
+                 f'EOF')
 
     test = smoke_tests_utils.Test(
         'kubernetes_host_network_multi_node',
         [
-            write_cfg_anchor,
-            write_cfg_multi,
+            write_cfg,
 
-            # 1. Launch anchor (1 pod), then the 2-node target. If the
-            # target launch returns success, both pods scheduled — i.e.
-            # both landed on the anchor's node. 1 CPU / 2 GB per pod
-            # leaves Ray driver enough headroom (under tighter CPU
-            # the first job submission flakes with FAILED_DRIVER) and
-            # still fits 3 pods on a 4-CPU/8-GB node.
-            f'sky launch -y -c {name_anchor} --infra kubernetes '
-            f'--config {cfg_anchor} --cpus 1 --memory 2',
-            f'sky launch -y -c {name_multi} --infra kubernetes '
-            f'--config {cfg_multi} --num-nodes 2 --cpus 1 --memory 2',
+            # 1. 2-node launch. Under the required per-cluster
+            # anti-affinity a successful launch *is* the proof the two
+            # pods are on different K8s nodes (a same-node placement
+            # would leave the worker Pending and fail this step). 1 CPU
+            # / 2 GB per pod keeps Ray's first job submission off the
+            # FAILED_DRIVER edge.
+            f'sky launch -y -c {name} --infra kubernetes '
+            f'--config {cfg} --num-nodes 2 --cpus 1 --memory 2',
 
-            # 2. Ray cluster must work end-to-end. `sky exec` runs the
-            # task through Ray on the head, which means the head <->
-            # worker join happened (worker read head's probed GCS port
-            # from the ConfigMap).
-            f'sky exec {name_multi} -- echo "job_ok"',
-            f'sky logs {name_multi} 1 --status',
+            # 2. Ray must work across the two nodes. `sky exec` runs the
+            # task through Ray on the head, which means the worker (on a
+            # different K8s node) joined the head over its routable host
+            # IP + probed GCS port.
+            f'sky exec {name} -- echo "job_ok"',
+            f'sky logs {name} 1 --status',
 
-            # 3. SSH to head — exercises per-pod sshd port rebind on
-            # the head + SkyPilot SSH config using the probed port.
-            f's=$(ssh -o StrictHostKeyChecking=no {name_multi} '
+            # 3. SSH to head — per-pod sshd port rebind + SkyPilot SSH
+            # config using the probed port.
+            f's=$(ssh -o StrictHostKeyChecking=no {name} '
             f'"echo ssh_head_ok" 2>&1) && echo "$s" | grep ssh_head_ok',
 
-            # 4. SSH to worker — same path as the head but uses the
-            # worker pod's separately probed sshd port (read from the
-            # ConfigMap's sshd_<podname> entry into InstanceInfo.ssh_port).
-            f's=$(ssh -o StrictHostKeyChecking=no {name_multi}-worker1 '
+            # 4. SSH to the worker — its separately probed sshd port, on
+            # a different K8s node from the head.
+            f's=$(ssh -o StrictHostKeyChecking=no {name}-worker1 '
             f'"echo ssh_worker_ok" 2>&1) && echo "$s" | grep ssh_worker_ok',
         ],
-        teardown=(f'sky down -y {name_anchor}; sky down -y {name_multi}; '
-                  f'rm -f {cfg_anchor} {cfg_multi}'),
+        teardown=f'sky down -y {name}; rm -f {cfg}',
         timeout=5 * 60,
     )
     smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_kubernetes_host_network.py
+++ b/tests/smoke_tests/test_kubernetes_host_network.py
@@ -1,0 +1,142 @@
+"""Smoke tests for the Kubernetes hostNetwork codepath.
+
+Under ``kubernetes.pod_config.spec.hostNetwork = true`` the pod
+shares the K8s node's net namespace, so a second SkyPilot pod
+landing on the same node would collide on Ray's default ports
+(6380, 8266, 8076, ...) and on the node's own sshd (host:22).
+SkyPilot's host_network_probe picks a free Ray port set per pod
+and rebinds the pod's sshd to a probed port; these tests prove
+both work end-to-end.
+"""
+import subprocess
+
+import pytest
+from smoke_tests import smoke_tests_utils
+
+
+def _pick_worker_node() -> str:
+    """Return the name of one worker node (non control-plane).
+
+    Smoke tests run against the user's current kubeconfig; we want a
+    node that the scheduler will actually place workloads on.
+    """
+    result = subprocess.run([
+        'kubectl', 'get', 'nodes', '-o',
+        'jsonpath={range .items[?(@.metadata.labels.node-role\\.'
+        'kubernetes\\.io/control-plane!="")]}{.metadata.name}'
+        '{"\\n"}{end}'
+        '{range .items[?(@.metadata.labels.node-role\\.'
+        'kubernetes\\.io/control-plane=="")]}{.metadata.name}'
+        '{"\\n"}{end}'
+    ],
+                            capture_output=True,
+                            text=True,
+                            check=False)
+    if result.returncode != 0:
+        pytest.skip(f'kubectl get nodes failed: {result.stderr}')
+    # Worker nodes appear after the control-plane block. Fall back to
+    # any node if the cluster has no nodes labeled control-plane (kind,
+    # minikube, etc.).
+    names = [n for n in result.stdout.splitlines() if n]
+    if not names:
+        pytest.skip('No nodes returned by kubectl')
+    # Prefer the last node — on managed clusters control-plane nodes
+    # are listed first; on single-node clusters this still works.
+    return names[-1]
+
+
+@pytest.mark.kubernetes
+@pytest.mark.resource_heavy
+@pytest.mark.no_dependency
+def test_kubernetes_host_network_coexistence():
+    """Two hostNetwork SkyPilot clusters on the same K8s node coexist.
+
+    Forces both clusters' pods onto the same K8s node via
+    ``nodeSelector: kubernetes.io/hostname=<node>`` and turns on
+    ``hostNetwork: true``. Verifies:
+
+    1. Both launches succeed (head_network_probe picked free ports).
+    2. Both pods landed on the target node (the actual repro setup).
+    3. ``ssh <cluster>`` works against both heads (sshd_<podname>
+       propagation to InstanceInfo.ssh_port and the per-pod sshd Port
+       rewrite both worked).
+    4. The two clusters' head GCS ports are distinct (probe didn't
+       hand out the same number twice).
+    """
+    if smoke_tests_utils.is_non_docker_remote_api_server():
+        pytest.skip('Skipping test because the Kubernetes configs and '
+                    'credentials are located on the remote API server '
+                    'and not the machine where the test is running')
+
+    target_node = _pick_worker_node()
+
+    base = smoke_tests_utils.get_cluster_name()
+    name_a = f'{base}-a'
+    name_b = f'{base}-b'
+
+    # Extract a pod's node name by the skypilot-cluster-name annotation
+    # (the label is hash-suffixed; the annotation is the exact name).
+    # Not an f-string, so braces here are literal (no doubling needed).
+    get_pod_node = ('kubectl get pods --all-namespaces -o jsonpath=\''
+                    '{range .items[*]}'
+                    '{.metadata.annotations.skypilot-cluster-name} '
+                    '{.spec.nodeName}{"\\n"}{end}\'')
+
+    test = smoke_tests_utils.Test(
+        'kubernetes_host_network_coexistence',
+        [
+            # 1. Launch both clusters onto the same node with hostNetwork.
+            f'sky launch -y -c {name_a} --infra kubernetes '
+            f'--cpus 0.5 --memory 1 -- echo "hello from A"',
+            f'sky logs {name_a} 1 --status',
+            f'sky launch -y -c {name_b} --infra kubernetes '
+            f'--cpus 0.5 --memory 1 -- echo "hello from B"',
+            f'sky logs {name_b} 1 --status',
+
+            # 2. Both pods must be on the target node.
+            f'A_NODE=$({get_pod_node} | grep "^{name_a} " '
+            f'| awk \'{{print $2}}\') && '
+            f'B_NODE=$({get_pod_node} | grep "^{name_b} " '
+            f'| awk \'{{print $2}}\') && '
+            f'echo "A_NODE=$A_NODE B_NODE=$B_NODE" && '
+            f'[ "$A_NODE" = "{target_node}" ] && '
+            f'[ "$B_NODE" = "{target_node}" ]',
+
+            # 3. SSH must work against both heads. This exercises:
+            #    - sshd_<podname> ConfigMap entry -> InstanceInfo.ssh_port
+            #    - /etc/ssh/sshd_config Port rewrite by the probe
+            #    - SkyPilot SSH config writer using the probed port
+            f's=$(ssh -o StrictHostKeyChecking=no {name_a} '
+            f'"echo ssh_works_A" 2>&1) && echo "$s" | grep ssh_works_A',
+            f's=$(ssh -o StrictHostKeyChecking=no {name_b} '
+            f'"echo ssh_works_B" 2>&1) && echo "$s" | grep ssh_works_B',
+
+            # 4. The probe must have assigned distinct GCS ports to the
+            #    two heads. The env file written by the probe is the
+            #    authoritative source on each pod.
+            f'A_GCS=$(ssh {name_a} '
+            f'". /tmp/sky_host_network_ports.env && '
+            f'echo $SKYPILOT_RAY_PORT") && '
+            f'B_GCS=$(ssh {name_b} '
+            f'". /tmp/sky_host_network_ports.env && '
+            f'echo $SKYPILOT_RAY_PORT") && '
+            f'echo "A_GCS=$A_GCS B_GCS=$B_GCS" && '
+            f'[ -n "$A_GCS" ] && [ -n "$B_GCS" ] && '
+            f'[ "$A_GCS" != "$B_GCS" ]',
+        ],
+        teardown=f'sky down -y {name_a}; sky down -y {name_b}',
+        timeout=smoke_tests_utils.get_timeout('kubernetes'),
+        config_dict={
+            'kubernetes': {
+                'pod_config': {
+                    'spec': {
+                        'hostNetwork': True,
+                        'nodeSelector': {
+                            'kubernetes.io/hostname': target_node,
+                        },
+                    },
+                },
+            },
+        },
+    )
+    smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_kubernetes_host_network.py
+++ b/tests/smoke_tests/test_kubernetes_host_network.py
@@ -78,14 +78,15 @@ def test_kubernetes_host_network_coexistence():
             write_cfg_b,
 
             # 1. Launch A first (anchor), then B (forced onto A's node).
+            # 1 CPU / 2 GB per pod: enough headroom for Ray driver +
+            # raylet + GCS + dashboard (under tight CPU Ray's first-job
+            # submission flakes with FAILED_DRIVER); still fits two
+            # pods on a 4-CPU/8-GB node. No inline task — the SSH/port
+            # checks below are what we're asserting on.
             f'sky launch -y -c {name_a} --infra kubernetes '
-            f'--config {cfg_a} '
-            f'--cpus 0.5 --memory 1 -- echo "hello from A"',
-            f'sky logs {name_a} 1 --status',
+            f'--config {cfg_a} --cpus 1 --memory 2',
             f'sky launch -y -c {name_b} --infra kubernetes '
-            f'--config {cfg_b} '
-            f'--cpus 0.5 --memory 1 -- echo "hello from B"',
-            f'sky logs {name_b} 1 --status',
+            f'--config {cfg_b} --cpus 1 --memory 2',
 
             # 2. SSH to both heads. Exercises:
             #    - sshd_<podname> ConfigMap entry -> InstanceInfo.ssh_port
@@ -190,22 +191,21 @@ def test_kubernetes_host_network_multi_node():
 
             # 1. Launch anchor (1 pod), then the 2-node target. If the
             # target launch returns success, both pods scheduled — i.e.
-            # both landed on the anchor's node.
+            # both landed on the anchor's node. 1 CPU / 2 GB per pod
+            # leaves Ray driver enough headroom (under tighter CPU
+            # the first job submission flakes with FAILED_DRIVER) and
+            # still fits 3 pods on a 4-CPU/8-GB node.
             f'sky launch -y -c {name_anchor} --infra kubernetes '
-            f'--config {cfg_anchor} '
-            f'--cpus 0.5 --memory 1 -- echo "anchor up"',
-            f'sky logs {name_anchor} 1 --status',
+            f'--config {cfg_anchor} --cpus 1 --memory 2',
             f'sky launch -y -c {name_multi} --infra kubernetes '
-            f'--config {cfg_multi} --num-nodes 2 '
-            f'--cpus 0.5 --memory 1 -- echo "multi up"',
-            f'sky logs {name_multi} 1 --status',
+            f'--config {cfg_multi} --num-nodes 2 --cpus 1 --memory 2',
 
             # 2. Ray cluster must work end-to-end. `sky exec` runs the
             # task through Ray on the head, which means the head <->
             # worker join happened (worker read head's probed GCS port
             # from the ConfigMap).
             f'sky exec {name_multi} -- echo "job_ok"',
-            f'sky logs {name_multi} 2 --status',
+            f'sky logs {name_multi} 1 --status',
 
             # 3. SSH to head — exercises per-pod sshd port rebind on
             # the head + SkyPilot SSH config using the probed port.

--- a/tests/smoke_tests/test_kubernetes_host_network.py
+++ b/tests/smoke_tests/test_kubernetes_host_network.py
@@ -220,6 +220,6 @@ def test_kubernetes_host_network_multi_node():
         ],
         teardown=(f'sky down -y {name_anchor}; sky down -y {name_multi}; '
                   f'rm -f {cfg_anchor} {cfg_multi}'),
-        timeout=smoke_tests_utils.get_timeout('kubernetes'),
+        timeout=5 * 60,
     )
     smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_kubernetes_host_network.py
+++ b/tests/smoke_tests/test_kubernetes_host_network.py
@@ -98,13 +98,15 @@ def test_kubernetes_host_network_coexistence():
 
             # 3. The probe must have assigned distinct GCS ports to the
             #    two heads. The env file written by the probe is the
-            #    authoritative source on each pod.
+            #    authoritative source on each pod. Single-quote the
+            #    ssh remote command so $SKYPILOT_RAY_PORT expands on
+            #    the pod, not on the local test runner.
             f'A_GCS=$(ssh {name_a} '
-            f'". /tmp/sky_host_network_ports.env && '
-            f'echo $SKYPILOT_RAY_PORT") && '
+            f'\'. /tmp/sky_host_network_ports.env && '
+            f'echo $SKYPILOT_RAY_PORT\') && '
             f'B_GCS=$(ssh {name_b} '
-            f'". /tmp/sky_host_network_ports.env && '
-            f'echo $SKYPILOT_RAY_PORT") && '
+            f'\'. /tmp/sky_host_network_ports.env && '
+            f'echo $SKYPILOT_RAY_PORT\') && '
             f'echo "A_GCS=$A_GCS B_GCS=$B_GCS" && '
             f'[ -n "$A_GCS" ] && [ -n "$B_GCS" ] && '
             f'[ "$A_GCS" != "$B_GCS" ]',

--- a/tests/unit_tests/test_sky/provision/test_host_network_probe.py
+++ b/tests/unit_tests/test_sky/provision/test_host_network_probe.py
@@ -10,7 +10,7 @@ Covers:
 The probe module's ConfigMap publish/poll paths require a live K8s API
 and are exercised by smoke tests instead.
 """
-import os
+import base64
 import re
 import socket
 
@@ -87,14 +87,11 @@ class TestRayStartCommands:
     def test_head_prepended_probe_is_runtime_gated(self):
         cmd = instance_setup.ray_head_start_command(custom_resource=None,
                                                     custom_ray_options=None)
-        # The probe runs only when both env vars are set on the pod;
-        # missing either makes it a no-op shell branch.
+        # No-op shell branch unless both env vars are set on the pod.
         assert 'if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ]' in cmd
         assert '[ -n "${SKYPILOT_RAY_PORTS_CONFIGMAP_NAME:-}" ]' in cmd
-        # Probe content is base64-shipped on a single line (not loaded
-        # from site-packages, not multiline-heredoc'd into the YAML);
-        # see _host_network_probe_cmd docstring.
-        assert '| base64 -d > /tmp/sky_host_network_probe.py' in cmd
+        assert (f'| base64 -d > {instance_setup._HOST_NETWORK_PROBE_TARGET}'
+                in cmd)
         assert '--mode head' in cmd
 
     def test_worker_prepended_probe_uses_worker_mode(self):
@@ -102,35 +99,27 @@ class TestRayStartCommands:
                                                       custom_ray_options=None,
                                                       no_restart=False)
         assert 'if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ]' in cmd
-        assert '| base64 -d > /tmp/sky_host_network_probe.py' in cmd
+        assert (f'| base64 -d > {instance_setup._HOST_NETWORK_PROBE_TARGET}'
+                in cmd)
         assert '--mode worker' in cmd
 
     def test_probe_command_has_no_unencoded_newlines(self):
-        # Multi-line content in the bash command lands at column 0 of
-        # the rendered cluster YAML and breaks the block-scalar parse.
-        # Base64 encoding keeps the shipped content on one line; the
-        # only newlines should come from the bash structure itself, not
-        # from the embedded script.
+        # Newlines in the bash command land at column 0 of the rendered
+        # cluster YAML and break block-scalar parsing — the b64 payload
+        # must stay on one line.
         cmd = instance_setup.ray_head_start_command(custom_resource=None,
                                                     custom_ray_options=None)
-        # The base64 payload is one long token between `echo '` and `'`.
-        # Inspect it directly.
-        import re
         m = re.search(r"echo '([A-Za-z0-9+/=]+)' \| base64 -d", cmd)
         assert m is not None, ('expected base64 payload not found '
                                'in probe command')
         assert '\n' not in m.group(1)
 
     def test_probe_script_round_trips_through_base64(self):
-        # Verify the b64 payload decodes back to the actual probe
-        # source — guards against accidental truncation/corruption.
-        import base64 as _b64
-        import re
         cmd = instance_setup.ray_head_start_command(custom_resource=None,
                                                     custom_ray_options=None)
         m = re.search(r"echo '([A-Za-z0-9+/=]+)' \| base64 -d", cmd)
         assert m is not None
-        decoded = _b64.b64decode(m.group(1)).decode('utf-8')
+        decoded = base64.b64decode(m.group(1)).decode('utf-8')
         assert 'def _run_head' in decoded
         assert 'def _run_worker' in decoded
 
@@ -138,9 +127,6 @@ class TestRayStartCommands:
         cmd = instance_setup.ray_worker_start_command(custom_resource=None,
                                                       custom_ray_options=None,
                                                       no_restart=False)
-        # Worker's object-manager-port default of 8076 is preserved when
-        # the probe didn't run — same constant the old hardcoded form
-        # used, so non-hostNetwork worker pods see no change.
         assert ('--object-manager-port=${SKYPILOT_RAY_OBJECT_MANAGER_PORT:-'
                 '8076}') in cmd
 

--- a/tests/unit_tests/test_sky/provision/test_host_network_probe.py
+++ b/tests/unit_tests/test_sky/provision/test_host_network_probe.py
@@ -1,0 +1,153 @@
+"""Unit tests for hostNetwork-aware Ray port handling.
+
+Covers:
+* sky.provision.kubernetes.host_network_probe — the port probe + env
+  file emission used inside hostNetwork: true K8s pods.
+* sky.provision.instance_setup — the env-var-substituted port flags and
+  the probe-gating snippet in ray_head_start_command /
+  ray_worker_start_command.
+
+The probe module's ConfigMap publish/poll paths require a live K8s API
+and are exercised by smoke tests instead.
+"""
+import os
+import re
+import socket
+
+from sky.provision import instance_setup
+from sky.provision.kubernetes import host_network_probe
+from sky.skylet import constants
+
+
+class TestProbePorts:
+    """The bind-and-hold port probe should produce N distinct usable ports."""
+
+    def test_probe_head_returns_unique_ports(self):
+        held, ports = host_network_probe._probe_ports(
+            host_network_probe._HEAD_PORT_NAMES)
+        try:
+            assert set(ports.keys()) == set(
+                host_network_probe._HEAD_PORT_NAMES)
+            assert len(set(ports.values())) == len(ports)
+            for port in ports.values():
+                assert 1024 <= port <= 65535
+        finally:
+            for sock in held:
+                sock.close()
+
+    def test_probe_worker_subset_of_head_names(self):
+        # Workers don't run GCS/dashboard/ray-client-server.
+        for name in host_network_probe._WORKER_PORT_NAMES:
+            assert name in host_network_probe._HEAD_PORT_NAMES
+
+    def test_write_env_file_uses_skypilot_ray_env_var_names(self, tmp_path):
+        path = tmp_path / 'env.sh'
+        host_network_probe._write_env_file(
+            {
+                'gcs': 6380,
+                'dashboard': 8266,
+                'node_manager': 50001,
+            }, str(path))
+        body = path.read_text()
+        # SKYPILOT_RAY_PORT (not _GCS_PORT) is the existing public name
+        # for the head's GCS port; the worker template already exports
+        # it under that name when hostNetwork is off.
+        assert 'export SKYPILOT_RAY_PORT=6380' in body
+        assert 'export SKYPILOT_RAY_DASHBOARD_PORT=8266' in body
+        assert 'export SKYPILOT_RAY_NODE_MANAGER_PORT=50001' in body
+
+
+class TestRayStartCommands:
+    """ray_head_start_command / ray_worker_start_command behavior."""
+
+    def test_head_uses_default_ports_when_env_vars_unset(self):
+        cmd = instance_setup.ray_head_start_command(custom_resource=None,
+                                                    custom_ray_options=None)
+        # The substitution ${VAR:-default} expands to the constant when
+        # SKYPILOT_HOST_NETWORK is unset; we check the literal expansion
+        # text is present in the emitted shell command.
+        assert (f'--port=${{SKYPILOT_RAY_PORT:-'
+                f'{constants.SKY_REMOTE_RAY_PORT}}}') in cmd
+        assert (f'--dashboard-port=${{SKYPILOT_RAY_DASHBOARD_PORT:-'
+                f'{constants.SKY_REMOTE_RAY_DASHBOARD_PORT}}}') in cmd
+        assert '--object-manager-port=${SKYPILOT_RAY_OBJECT_MANAGER_PORT:-8076}' in cmd
+
+    def test_head_omits_new_port_flags_when_env_vars_unset(self):
+        cmd = instance_setup.ray_head_start_command(custom_resource=None,
+                                                    custom_ray_options=None)
+        # ${VAR:+--flag=$VAR} expands to nothing when VAR is unset, so
+        # Ray sees its own default behavior for these. We verify the
+        # substitution form is in place (i.e., we didn't accidentally
+        # hardcode a value).
+        assert ('${SKYPILOT_RAY_NODE_MANAGER_PORT:+'
+                '--node-manager-port=$SKYPILOT_RAY_NODE_MANAGER_PORT}') in cmd
+        assert ('${SKYPILOT_RAY_CLIENT_SERVER_PORT:+'
+                '--ray-client-server-port=$SKYPILOT_RAY_CLIENT_SERVER_PORT}'
+               ) in cmd
+
+    def test_head_prepended_probe_is_runtime_gated(self):
+        cmd = instance_setup.ray_head_start_command(custom_resource=None,
+                                                    custom_ray_options=None)
+        # The probe runs only when both env vars are set on the pod;
+        # missing either makes it a no-op shell branch.
+        assert 'if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ]' in cmd
+        assert '[ -n "${SKYPILOT_RAY_PORTS_CONFIGMAP_NAME:-}" ]' in cmd
+        assert ('sky.provision.kubernetes.host_network_probe '
+                '--mode head') in cmd
+
+    def test_worker_prepended_probe_uses_worker_mode(self):
+        cmd = instance_setup.ray_worker_start_command(custom_resource=None,
+                                                      custom_ray_options=None,
+                                                      no_restart=False)
+        assert 'if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ]' in cmd
+        assert ('sky.provision.kubernetes.host_network_probe '
+                '--mode worker') in cmd
+
+    def test_worker_keeps_existing_object_manager_default(self):
+        cmd = instance_setup.ray_worker_start_command(custom_resource=None,
+                                                      custom_ray_options=None,
+                                                      no_restart=False)
+        # Worker's object-manager-port default of 8076 is preserved when
+        # the probe didn't run — same constant the old hardcoded form
+        # used, so non-hostNetwork worker pods see no change.
+        assert ('--object-manager-port=${SKYPILOT_RAY_OBJECT_MANAGER_PORT:-'
+                '8076}') in cmd
+
+    def test_custom_ray_options_user_overrides_appended_last(self):
+        # The for-loop over custom_ray_options runs after the templated
+        # flag string is built, so a user-supplied --port=7000 lands
+        # after the ${SKYPILOT_RAY_PORT:-...} expansion. Ray honors the
+        # last --port on the command line, so user overrides win.
+        cmd = instance_setup.ray_head_start_command(
+            custom_resource=None, custom_ray_options={'port': 7000})
+        port_positions = [
+            m.start() for m in re.finditer(r'--port=', cmd)
+        ]
+        assert len(port_positions) == 2
+        # User value comes after the env-var substitution.
+        assert cmd.index('--port=7000') > cmd.index('--port=${SKYPILOT_RAY_PORT')
+
+    def test_dump_ray_ports_reads_env_vars(self):
+        # The runtime-resolved dict expression in
+        # SKY_REMOTE_RAY_PORT_DICT_STR must look up env vars so the
+        # probed port set lands in ~/.sky/ray_port.json (and the file
+        # falls back to the SkyPilot defaults when env vars are unset).
+        assert 'os.environ.get("SKYPILOT_RAY_PORT"' in (
+            constants.SKY_REMOTE_RAY_PORT_DICT_STR)
+        assert 'os.environ.get("SKYPILOT_RAY_DASHBOARD_PORT"' in (
+            constants.SKY_REMOTE_RAY_PORT_DICT_STR)
+
+
+class TestWaitHeadGcsTcp:
+    """The worker probe's TCP wait should accept once the head port is up."""
+
+    def test_returns_when_port_is_listening(self):
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.bind(('127.0.0.1', 0))
+        listener.listen(1)
+        try:
+            _, port = listener.getsockname()
+            # Should return promptly without raising.
+            host_network_probe._wait_head_gcs_tcp('127.0.0.1', port)
+        finally:
+            listener.close()

--- a/tests/unit_tests/test_sky/provision/test_host_network_probe.py
+++ b/tests/unit_tests/test_sky/provision/test_host_network_probe.py
@@ -11,6 +11,7 @@ The probe module's ConfigMap publish/poll paths require a live K8s API
 and are exercised by smoke tests instead.
 """
 import base64
+import gzip
 import re
 import socket
 
@@ -90,8 +91,8 @@ class TestRayStartCommands:
         # No-op shell branch unless both env vars are set on the pod.
         assert 'if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ]' in cmd
         assert '[ -n "${SKYPILOT_RAY_PORTS_CONFIGMAP_NAME:-}" ]' in cmd
-        assert (f'| base64 -d > {instance_setup._HOST_NETWORK_PROBE_TARGET}'
-                in cmd)
+        assert (f'| base64 -d | gunzip > '
+                f'{instance_setup._HOST_NETWORK_PROBE_TARGET}') in cmd
         assert '--mode head' in cmd
 
     def test_worker_prepended_probe_uses_worker_mode(self):
@@ -99,8 +100,8 @@ class TestRayStartCommands:
                                                       custom_ray_options=None,
                                                       no_restart=False)
         assert 'if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ]' in cmd
-        assert (f'| base64 -d > {instance_setup._HOST_NETWORK_PROBE_TARGET}'
-                in cmd)
+        assert (f'| base64 -d | gunzip > '
+                f'{instance_setup._HOST_NETWORK_PROBE_TARGET}') in cmd
         assert '--mode worker' in cmd
 
     def test_probe_command_has_no_unencoded_newlines(self):
@@ -119,9 +120,16 @@ class TestRayStartCommands:
                                                     custom_ray_options=None)
         m = re.search(r"echo '([A-Za-z0-9+/=]+)' \| base64 -d", cmd)
         assert m is not None
-        decoded = base64.b64decode(m.group(1)).decode('utf-8')
+        # The payload is minified + gzipped before b64'ing to keep the
+        # rendered cluster YAML small. The bash counterpart pipes
+        # `base64 -d | gunzip`.
+        decoded = gzip.decompress(base64.b64decode(m.group(1))).decode('utf-8')
+        # Minification must preserve identifiers and module structure
+        # — the probe still needs --mode head and --mode worker entry
+        # points and a parseable AST.
         assert 'def _run_head' in decoded
         assert 'def _run_worker' in decoded
+        compile(decoded, '<probe>', 'exec')
 
     def test_worker_keeps_existing_object_manager_default(self):
         cmd = instance_setup.ray_worker_start_command(custom_resource=None,

--- a/tests/unit_tests/test_sky/provision/test_host_network_probe.py
+++ b/tests/unit_tests/test_sky/provision/test_host_network_probe.py
@@ -196,6 +196,55 @@ class TestConfigMapBody:
         # ConfigMap data values must be strings.
         assert body['data'] == {'gcs': '6380', 'dashboard': '8266'}
 
+    def test_sshd_port_is_keyed_by_pod_name(self):
+        body = host_network_probe._build_configmap_body(
+            name='c-ray-ports',
+            namespace='ns',
+            ports={
+                'gcs': 6380,
+                'sshd': 33445
+            },
+            owner_pod_name='c-head-xx',
+            owner_pod_uid='uid-1',
+        )
+        # 'sshd' is rewritten to 'sshd_<podname>' so multiple pods (head
+        # + each worker) can publish into the same ConfigMap without
+        # clobbering each other. 'gcs' stays flat (head-owned).
+        assert body['data'] == {'gcs': '6380', 'sshd_c-head-xx': '33445'}
+
+
+class TestSshdPortPropagation:
+    """sshd is probed by both head and worker; bootstrap snippet rebinds."""
+
+    def test_sshd_is_in_both_head_and_worker_port_sets(self):
+        # Each pod's sshd is in its own filesystem but shares the host
+        # net namespace under hostNetwork, so each pod needs its own
+        # probed port.
+        assert 'sshd' in host_network_probe._HEAD_PORT_NAMES
+        assert 'sshd' in host_network_probe._WORKER_PORT_NAMES
+
+    def test_env_file_emits_skypilot_sshd_port(self, tmp_path):
+        path = tmp_path / 'env.sh'
+        host_network_probe._write_env_file({'sshd': 33445}, str(path))
+        # The bootstrap snippet reads SKYPILOT_SSHD_PORT to rewrite
+        # /etc/ssh/sshd_config's Port directive before restart.
+        assert 'export SKYPILOT_SSHD_PORT=33445' in path.read_text()
+
+    def test_probe_cmd_rebinds_sshd_after_sourcing_env(self):
+        cmd = instance_setup.ray_head_start_command(custom_resource=None,
+                                                    custom_ray_options=None)
+        # The Port-directive rewrite is gated on SKYPILOT_SSHD_PORT
+        # being set (the probe just sourced the env file). Non-host-
+        # Network bootstraps leave it unset and skip the rewrite.
+        assert 'if [ -n "${SKYPILOT_SSHD_PORT:-}" ]' in cmd
+        # We delete-then-append rather than substituting in place, so
+        # sshd_config files without an explicit Port directive still
+        # end up with one.
+        assert ('sed -i -E "/^[[:space:]]*#?[[:space:]]*Port'
+                '[[:space:]]+/d"') in cmd
+        assert 'echo "Port ${SKYPILOT_SSHD_PORT}"' in cmd
+        assert 'sudo service ssh restart' in cmd
+
 
 class TestWaitHeadGcsTcp:
     """The worker probe's TCP wait should accept once the head port is up."""

--- a/tests/unit_tests/test_sky/provision/test_host_network_probe.py
+++ b/tests/unit_tests/test_sky/provision/test_host_network_probe.py
@@ -91,10 +91,12 @@ class TestRayStartCommands:
         # missing either makes it a no-op shell branch.
         assert 'if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ]' in cmd
         assert '[ -n "${SKYPILOT_RAY_PORTS_CONFIGMAP_NAME:-}" ]' in cmd
-        # Probe is invoked by file path (not `-m sky.X`) so the broken
-        # sky/__init__.py left by the bootstrap's PyPI downgrade can't
-        # take the probe down — see _host_network_probe_cmd docstring.
-        assert 'sky/provision/kubernetes/host_network_probe.py' in cmd
+        # Probe content is heredoc-shipped (not loaded from
+        # site-packages) so the pod's stable-skypilot install can't
+        # take it down — see _host_network_probe_cmd docstring.
+        assert "<<'_SKY_PROBE_EOF_'" in cmd
+        assert '_SKY_PROBE_EOF_\n' in cmd
+        assert '/tmp/sky_host_network_probe.py' in cmd
         assert '--mode head' in cmd
 
     def test_worker_prepended_probe_uses_worker_mode(self):
@@ -102,8 +104,16 @@ class TestRayStartCommands:
                                                       custom_ray_options=None,
                                                       no_restart=False)
         assert 'if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ]' in cmd
-        assert 'sky/provision/kubernetes/host_network_probe.py' in cmd
+        assert '/tmp/sky_host_network_probe.py' in cmd
         assert '--mode worker' in cmd
+
+    def test_probe_script_is_embedded_in_command(self):
+        cmd = instance_setup.ray_head_start_command(custom_resource=None,
+                                                    custom_ray_options=None)
+        # A sentinel from the probe module — confirms the actual probe
+        # source is heredoc-shipped, not just a reference to it.
+        assert 'def _run_head' in cmd
+        assert 'def _run_worker' in cmd
 
     def test_worker_keeps_existing_object_manager_default(self):
         cmd = instance_setup.ray_worker_start_command(custom_resource=None,

--- a/tests/unit_tests/test_sky/provision/test_host_network_probe.py
+++ b/tests/unit_tests/test_sky/provision/test_host_network_probe.py
@@ -91,16 +91,19 @@ class TestRayStartCommands:
         # missing either makes it a no-op shell branch.
         assert 'if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ]' in cmd
         assert '[ -n "${SKYPILOT_RAY_PORTS_CONFIGMAP_NAME:-}" ]' in cmd
-        assert ('sky.provision.kubernetes.host_network_probe '
-                '--mode head') in cmd
+        # Probe is invoked by file path (not `-m sky.X`) so the broken
+        # sky/__init__.py left by the bootstrap's PyPI downgrade can't
+        # take the probe down — see _host_network_probe_cmd docstring.
+        assert 'sky/provision/kubernetes/host_network_probe.py' in cmd
+        assert '--mode head' in cmd
 
     def test_worker_prepended_probe_uses_worker_mode(self):
         cmd = instance_setup.ray_worker_start_command(custom_resource=None,
                                                       custom_ray_options=None,
                                                       no_restart=False)
         assert 'if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ]' in cmd
-        assert ('sky.provision.kubernetes.host_network_probe '
-                '--mode worker') in cmd
+        assert 'sky/provision/kubernetes/host_network_probe.py' in cmd
+        assert '--mode worker' in cmd
 
     def test_worker_keeps_existing_object_manager_default(self):
         cmd = instance_setup.ray_worker_start_command(custom_resource=None,

--- a/tests/unit_tests/test_sky/provision/test_host_network_probe.py
+++ b/tests/unit_tests/test_sky/provision/test_host_network_probe.py
@@ -237,13 +237,13 @@ class TestSshdPortPropagation:
         # being set (the probe just sourced the env file). Non-host-
         # Network bootstraps leave it unset and skip the rewrite.
         assert 'if [ -n "${SKYPILOT_SSHD_PORT:-}" ]' in cmd
-        # We delete-then-append rather than substituting in place, so
-        # sshd_config files without an explicit Port directive still
-        # end up with one.
-        assert ('sed -i -E "/^[[:space:]]*#?[[:space:]]*Port'
-                '[[:space:]]+/d"') in cmd
-        assert 'echo "Port ${SKYPILOT_SSHD_PORT}"' in cmd
-        assert 'sudo service ssh restart' in cmd
+        # Delete-then-append, all under one sudo, so the redirect
+        # happens as root and we don't pay three sudo costs in a row.
+        assert 'sudo sh -c "' in cmd
+        assert ("sed -i -E '/^[[:space:]]*#?[[:space:]]*Port"
+                "[[:space:]]+/d'") in cmd
+        assert 'echo Port ${SKYPILOT_SSHD_PORT} >> /etc/ssh/sshd_config' in cmd
+        assert 'service ssh restart' in cmd
 
 
 class TestWaitHeadGcsTcp:

--- a/tests/unit_tests/test_sky/provision/test_host_network_probe.py
+++ b/tests/unit_tests/test_sky/provision/test_host_network_probe.py
@@ -91,12 +91,10 @@ class TestRayStartCommands:
         # missing either makes it a no-op shell branch.
         assert 'if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ]' in cmd
         assert '[ -n "${SKYPILOT_RAY_PORTS_CONFIGMAP_NAME:-}" ]' in cmd
-        # Probe content is heredoc-shipped (not loaded from
-        # site-packages) so the pod's stable-skypilot install can't
-        # take it down — see _host_network_probe_cmd docstring.
-        assert "<<'_SKY_PROBE_EOF_'" in cmd
-        assert '_SKY_PROBE_EOF_\n' in cmd
-        assert '/tmp/sky_host_network_probe.py' in cmd
+        # Probe content is base64-shipped on a single line (not loaded
+        # from site-packages, not multiline-heredoc'd into the YAML);
+        # see _host_network_probe_cmd docstring.
+        assert '| base64 -d > /tmp/sky_host_network_probe.py' in cmd
         assert '--mode head' in cmd
 
     def test_worker_prepended_probe_uses_worker_mode(self):
@@ -104,16 +102,37 @@ class TestRayStartCommands:
                                                       custom_ray_options=None,
                                                       no_restart=False)
         assert 'if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ]' in cmd
-        assert '/tmp/sky_host_network_probe.py' in cmd
+        assert '| base64 -d > /tmp/sky_host_network_probe.py' in cmd
         assert '--mode worker' in cmd
 
-    def test_probe_script_is_embedded_in_command(self):
+    def test_probe_command_has_no_unencoded_newlines(self):
+        # Multi-line content in the bash command lands at column 0 of
+        # the rendered cluster YAML and breaks the block-scalar parse.
+        # Base64 encoding keeps the shipped content on one line; the
+        # only newlines should come from the bash structure itself, not
+        # from the embedded script.
         cmd = instance_setup.ray_head_start_command(custom_resource=None,
                                                     custom_ray_options=None)
-        # A sentinel from the probe module — confirms the actual probe
-        # source is heredoc-shipped, not just a reference to it.
-        assert 'def _run_head' in cmd
-        assert 'def _run_worker' in cmd
+        # The base64 payload is one long token between `echo '` and `'`.
+        # Inspect it directly.
+        import re
+        m = re.search(r"echo '([A-Za-z0-9+/=]+)' \| base64 -d", cmd)
+        assert m is not None, ('expected base64 payload not found '
+                               'in probe command')
+        assert '\n' not in m.group(1)
+
+    def test_probe_script_round_trips_through_base64(self):
+        # Verify the b64 payload decodes back to the actual probe
+        # source — guards against accidental truncation/corruption.
+        import base64 as _b64
+        import re
+        cmd = instance_setup.ray_head_start_command(custom_resource=None,
+                                                    custom_ray_options=None)
+        m = re.search(r"echo '([A-Za-z0-9+/=]+)' \| base64 -d", cmd)
+        assert m is not None
+        decoded = _b64.b64decode(m.group(1)).decode('utf-8')
+        assert 'def _run_head' in decoded
+        assert 'def _run_worker' in decoded
 
     def test_worker_keeps_existing_object_manager_default(self):
         cmd = instance_setup.ray_worker_start_command(custom_resource=None,

--- a/tests/unit_tests/test_sky/provision/test_host_network_probe.py
+++ b/tests/unit_tests/test_sky/provision/test_host_network_probe.py
@@ -26,8 +26,7 @@ class TestProbePorts:
         held, ports = host_network_probe._probe_ports(
             host_network_probe._HEAD_PORT_NAMES)
         try:
-            assert set(ports.keys()) == set(
-                host_network_probe._HEAD_PORT_NAMES)
+            assert set(ports.keys()) == set(host_network_probe._HEAD_PORT_NAMES)
             assert len(set(ports.values())) == len(ports)
             for port in ports.values():
                 assert 1024 <= port <= 65535
@@ -81,9 +80,9 @@ class TestRayStartCommands:
         # hardcode a value).
         assert ('${SKYPILOT_RAY_NODE_MANAGER_PORT:+'
                 '--node-manager-port=$SKYPILOT_RAY_NODE_MANAGER_PORT}') in cmd
-        assert ('${SKYPILOT_RAY_CLIENT_SERVER_PORT:+'
-                '--ray-client-server-port=$SKYPILOT_RAY_CLIENT_SERVER_PORT}'
-               ) in cmd
+        assert (
+            '${SKYPILOT_RAY_CLIENT_SERVER_PORT:+'
+            '--ray-client-server-port=$SKYPILOT_RAY_CLIENT_SERVER_PORT}') in cmd
 
     def test_head_prepended_probe_is_runtime_gated(self):
         cmd = instance_setup.ray_head_start_command(custom_resource=None,
@@ -120,12 +119,11 @@ class TestRayStartCommands:
         # last --port on the command line, so user overrides win.
         cmd = instance_setup.ray_head_start_command(
             custom_resource=None, custom_ray_options={'port': 7000})
-        port_positions = [
-            m.start() for m in re.finditer(r'--port=', cmd)
-        ]
+        port_positions = [m.start() for m in re.finditer(r'--port=', cmd)]
         assert len(port_positions) == 2
         # User value comes after the env-var substitution.
-        assert cmd.index('--port=7000') > cmd.index('--port=${SKYPILOT_RAY_PORT')
+        assert cmd.index('--port=7000') > cmd.index(
+            '--port=${SKYPILOT_RAY_PORT')
 
     def test_dump_ray_ports_reads_env_vars(self):
         # The runtime-resolved dict expression in
@@ -136,6 +134,49 @@ class TestRayStartCommands:
             constants.SKY_REMOTE_RAY_PORT_DICT_STR)
         assert 'os.environ.get("SKYPILOT_RAY_DASHBOARD_PORT"' in (
             constants.SKY_REMOTE_RAY_PORT_DICT_STR)
+
+
+class TestConfigMapBody:
+    """ConfigMap should carry an ownerReference so it is GC'd with the pod."""
+
+    def test_body_pins_lifetime_to_head_pod(self):
+        body = host_network_probe._build_configmap_body(
+            name='cluster-xyz-ray-ports',
+            namespace='my-ns',
+            ports={
+                'gcs': 6380,
+                'dashboard': 8266
+            },
+            owner_pod_name='cluster-xyz-head-abc',
+            owner_pod_uid='11111111-2222-3333-4444-555555555555',
+        )
+        # K8s deletes ConfigMaps whose owner Pod has been deleted, so on
+        # `sky down` (which deletes the head pod) the ConfigMap is GC'd
+        # without any extra teardown logic in SkyPilot.
+        owner_refs = body['metadata']['ownerReferences']
+        assert len(owner_refs) == 1
+        assert owner_refs[0]['kind'] == 'Pod'
+        assert owner_refs[0]['name'] == 'cluster-xyz-head-abc'
+        assert owner_refs[0]['uid'] == ('11111111-2222-3333-4444-555555555555')
+        # blockOwnerDeletion=false: deleting the head pod doesn't wait
+        # for the ConfigMap. controller=false: we're not the pod's
+        # controller, just a dependent.
+        assert owner_refs[0]['controller'] is False
+        assert owner_refs[0]['blockOwnerDeletion'] is False
+
+    def test_body_carries_port_data_as_strings(self):
+        body = host_network_probe._build_configmap_body(
+            name='c-ray-ports',
+            namespace='ns',
+            ports={
+                'gcs': 6380,
+                'dashboard': 8266
+            },
+            owner_pod_name='c-head-xx',
+            owner_pod_uid='uid-1',
+        )
+        # ConfigMap data values must be strings.
+        assert body['data'] == {'gcs': '6380', 'dashboard': '8266'}
 
 
 class TestWaitHeadGcsTcp:

--- a/tests/unit_tests/test_sky/utils/test_source_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_source_utils.py
@@ -1,0 +1,57 @@
+"""Unit tests for sky.utils.source_utils."""
+from sky.utils import source_utils
+
+
+class TestMinifyPythonSource:
+    """Strips docstrings/comments but preserves code."""
+
+    def test_strips_module_and_function_docstrings(self):
+        source = ('"""module doc"""\n'
+                  'def foo():\n'
+                  '    """fn doc"""\n'
+                  '    return 1\n')
+        out = source_utils.minify_python_source(source)
+        assert 'module doc' not in out
+        assert 'fn doc' not in out
+        assert 'def foo' in out
+        assert 'return 1' in out
+
+    def test_strips_comments(self):
+        source = 'x = 1  # trailing\n# leading\ny = 2\n'
+        out = source_utils.minify_python_source(source)
+        assert 'trailing' not in out
+        assert 'leading' not in out
+        assert 'x = 1' in out
+        assert 'y = 2' in out
+
+    def test_preserves_string_literals_that_are_not_docstrings(self):
+        # Strings used as RHS or argument must survive — only "string
+        # is its own statement at top of module/class/func" gets cut.
+        source = 'def f():\n    msg = "hello"\n    return msg\n'
+        out = source_utils.minify_python_source(source)
+        assert '"hello"' in out
+
+    def test_strips_class_docstring(self):
+        source = 'class C:\n    """class doc"""\n    x = 1\n'
+        out = source_utils.minify_python_source(source)
+        assert 'class doc' not in out
+        assert 'class C' in out
+        assert 'x = 1' in out
+
+    def test_output_round_trips_compile(self):
+        # End-to-end on a non-trivial input: docstrings + comments +
+        # multiple defs + non-docstring strings. The minified output
+        # must still parse.
+        source = ('"""mod"""\n'
+                  'import os  # noqa\n'
+                  '\n'
+                  'def a():\n'
+                  '    """a"""\n'
+                  '    return "literal"\n'
+                  '\n'
+                  'class K:\n'
+                  '    """k"""\n'
+                  '    def m(self):\n'
+                  '        return os.environ.get("X", "y")\n')
+        out = source_utils.minify_python_source(source)
+        compile(out, '<test>', 'exec')


### PR DESCRIPTION
## Summary

- Auto-detect `hostNetwork: true` in `kubernetes.pod_config` and pick a free Ray port set at pod startup so SkyPilot pods can run with `hostNetwork` (RoCE/RDMA workloads, fractional-GPU jobs) without colliding on Ray's default ports.
- Head pod publishes its chosen GCS/dashboard/etc. ports to a `<cluster>-ray-ports` ConfigMap; workers poll it to learn the head's GCS port (head IP is discovered via the existing headless Service DNS).
- Each pod (head + workers) also probes a free sshd port and publishes it under `sshd_<podname>` in the same ConfigMap; the SSH config writer reads them per pod. Required because under `hostNetwork` the K8s node's own sshd owns `host:22`.
- **Mode b — one cluster pod per K8s node.** SkyPilot injects a required, per-cluster `podAntiAffinity` for every `hostNetwork` pod. Every pod of a cluster then gets its own node, so each pod's host IP is unique and routable. This (a) removes the co-located-raylet failure mode by construction (two raylets can no longer register under the same host IP and get collapsed onto one gRPC endpoint in Ray's client cache), and (b) makes `hostNetwork` clusters work **across multiple K8s nodes**. Unrelated clusters can still co-locate (the selector is per-cluster); the free-port probe resolves their cross-cluster port collisions.
- Non-hostNetwork clusters: port flags use `${VAR:-default}` / `${VAR:+--flag=$VAR}` substitution so missing env vars fall back to the SkyPilot constants; the affinity block is byte-identical when `hostNetwork` is off. Full audit below. No API version bump.

## Why

`hostNetwork: true` is required to get RoCE/RDMA throughput on Oracle and other non-EFA/non-InfiniBand/non-GPUDirect setups. The first SkyPilot pod on a node grabs Ray's default ports (6380, 8266, 8076, 11002…) directly on the host; a second pod fails to admit with `EADDRINUSE`. The probe + ConfigMap discovery channel decouples the head's port choice from a hardcoded constant while keeping the existing DNS-based head-identity flow intact.

A separate failure mode otherwise appears when two pods of the same cluster land on one K8s node: both raylets register in GCS with `node_manager_address = <K8s host IP>`. Ray's client-side resolver can collapse the two NodeIDs onto a single endpoint in its gRPC channel cache, routing every lease request to one raylet and hanging `pg.ready()`. Rather than disambiguate co-located raylets after the fact (an earlier iteration bound each raylet to a per-pod `127.x.y.<rank>` loopback IP — reverted; see *Superseded*), **mode b prevents same-cluster co-location entirely**. With one pod per node every host IP is distinct, so the collapse cannot occur — and the same property makes the head reachable from workers on other K8s nodes (over its routable host IP + probed GCS port via the headless Service DNS), which is what unlocks cross-node `hostNetwork`.

## Design notes

- **Trigger**: `kubernetes.pod_config.spec.hostNetwork = true` (read from `skypilot_config` and `cluster_config_overrides`, merged the same way `combine_pod_config_fields` does). No new config knob.
- **Mode b anti-affinity**: a `requiredDuringSchedulingIgnoredDuringExecution` `podAntiAffinity`, `labelSelector` `skypilot-cluster=<cluster_name_on_cloud>`, `topologyKey: kubernetes.io/hostname`, rendered into the pod spec only when `k8s_host_network`. `required` (not `preferred`) so the guarantee is hard: a multi-pod `hostNetwork` cluster that cannot get a node per pod fails to schedule loudly rather than silently racing on a shared host. The `affinity:` block is restructured to emit for the pre-existing `nodeAffinity` conditions **or** `hostNetwork`; the non-hostNetwork path renders no affinity block (byte-identical to before).
- **Probe**: `sky/provision/kubernetes/host_network_probe.py` — stdlib-only (runs before the SkyPilot wheel finishes installing). Binds ephemeral sockets, writes a sourceable env file, then exits. Still needed under mode b: it resolves collisions against *other* clusters co-located on a node (allowed — anti-affinity is per-cluster) and against the node's own services.
- **Discovery channel**: a Kubernetes ConfigMap written by the head via the in-cluster service account; workers poll it then TCP-wait for the head's GCS to accept before `ray start --address`. `ownerReference` → head pod so K8s GCs it on `sky down`.
- **sshd rebind**: each pod's bootstrap rewrites `Port` in `/etc/ssh/sshd_config` to its probed port and restarts sshd. `kubernetes_pod_ssh_proxy` forwards to that probed port via `handle.head_ssh_port`.
- **Superseded — per-pod loopback IP.** An earlier iteration bound each raylet to `127.<H1>.<H2>.<rank>` via `--node-ip-address` to disambiguate raylets sharing a host IP. Mode b makes that unnecessary (same-cluster pods never share a host) and the loopback was itself the reason cross-node was impossible (a worker's `127.x.y.0` dial-back to the head is only routable in a shared netns). Those commits stay reverted and are not in this diff.
- **Backward compat**: `${VAR:-default}` for ports SkyPilot already pins; `${VAR:+--flag=$VAR}` for new flags so they vanish when the probe didn't run. `~/.sky/ray_port.json` schema unchanged.
- **User overrides**: `custom_ray_options` still wins.
- **Status path**: `get_cluster_info` makes one extra `read_namespaced_config_map` for hostNetwork clusters (5 s best-effort budget); non-hostNetwork clusters make zero additional calls.

## Scope notes / limitations

- **Cross-K8s-node hostNetwork is now supported** — the headline behavioral change vs. earlier revisions. A multi-pod `hostNetwork` cluster spreads one pod per node; workers reach the head over its routable host IP + probed GCS port via the headless Service DNS.
- **Same-cluster, same-node packing is no longer supported (by design).** The required per-cluster anti-affinity forbids two pods of one cluster on one node — intentionally trading the earlier "stack multiple same-cluster pods on one node" capability for correctness (no raylet collapse) and cross-node support. *Different* clusters may still co-locate.
- **Requires one schedulable node per pod.** On a single-node K8s (kind, `sky local up`, one box) a multi-pod `hostNetwork` cluster will not schedule — the worker stays `Pending` and the launch fails loudly with the kube-scheduler pod-anti-affinity rejection. Intended (fail loud, don't race), but a change in single-node ergonomics; the `multi_node` smoke test asserts exactly this failure (the smoke clusters are single-node, so the cross-node-spread path is not exercised in CI). A future opt-out knob could relax this (see *Open follow-ups*).
- **User-supplied affinity**: SkyPilot merges user `pod_config` over the rendered YAML. A user who sets their own `affinity.podAntiAffinity` interacts with the injected rule via `merge_k8s_configs` list semantics — effectively the escape hatch for the single-node case. Worth an explicit test (see *Open follow-ups*).

## Non-hostNetwork impact audit

### Strictly hostNetwork-only (no codepath change when off)

- `sky/provision/kubernetes/host_network_probe.py` — new; only invoked by the gated probe snippet.
- `sky/utils/source_utils.py` — called once at import time on the client to encode the inlined probe payload.
- `sky/templates/kubernetes-ray.yml.j2` — every edit is inside `{% if k8s_host_network %}` / `{% if not k8s_host_network %}` (dnsPolicy, pod-identity env vars, alternative head-up-wait, `containerPort` list, **and the mode-b `podAntiAffinity`**). With `hostNetwork` off the affinity block is byte-identical to before (no affinity block unless GPU/avoid labels, exactly as today).
- `sky/clouds/kubernetes.py` — hostNetwork-detection block gated behind `if k8s_host_network:`.
- `sky/provision/kubernetes/instance.py` — `_read_host_network_sshd_ports` short-circuits for non-hostNetwork clusters (`pod_sshd_ports.get(pod_name, port)` returns the existing `port`).

### Touches non-hostNetwork codepath but preserves resolved behavior

| File | Change | Non-hostNetwork resolved behavior |
|---|---|---|
| `instance_setup.py` (head/worker `ray start` flags) | Hardcoded ports replaced with `${SKYPILOT_RAY_PORT:-6380}` etc.; new flags use `${VAR:+--flag=$VAR}`. | Env unset → original SkyPilot defaults; `${VAR:+…}` expands empty. Identical resolved command. |
| `instance_setup.py` (command prefix) | `_host_network_probe_cmd(mode)` prepended. | Wrapped in `if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ] && [ -n "${...CONFIGMAP_NAME:-}" ]; then …; fi;` — no-op when env unset. |
| `instance_setup.py` (`_RAY_PORT_COMMAND`) | `job_lib.get_ray_port()` → stdlib `~/.sky/ray_port.json` read. | Same file contents; no longer needs `sky` importable mid-bootstrap. |
| `instance_setup.py` (`RAY_HEAD_WAIT_INITIALIZED_COMMAND`) | `constants.RAY_STATUS` → `RAY_ADDRESS=127.0.0.1:${SKYPILOT_RAY_PORT:-6380} ray status`. | Same resolved command when `SKYPILOT_RAY_PORT` unset. |
| `skylet/constants.py` (`SKY_REMOTE_RAY_PORT_DICT_STR`) | Literal dict → expression reading `os.environ.get("SKYPILOT_RAY_PORT", 6380)`. | Env unset → same `{"ray_port":6380,"ray_dashboard_port":8266}`. |

## Files

- `sky/provision/kubernetes/host_network_probe.py` (new) — probe + ConfigMap publish/poll
- `sky/utils/source_utils.py` (new) — `minify_python_source()` for inlining the probe via b64
- `sky/provision/instance_setup.py` — probe snippet, env-var-substituted port flags, sshd rebind
- `sky/skylet/constants.py` — `SKY_REMOTE_RAY_PORT_DICT_STR` reads env at runtime
- `sky/clouds/kubernetes.py` — hostNetwork detection + env var injection
- `sky/templates/kubernetes-ray.yml.j2` — gated dnsPolicy, pod-identity env vars, alternative worker head-up-wait, containerPort list, **and the mode-b per-cluster `podAntiAffinity`**
- `sky/provision/kubernetes/instance.py` — best-effort short read of per-pod sshd ports in `get_cluster_info`
- `tests/unit_tests/test_sky/provision/test_host_network_probe.py` (new), `tests/unit_tests/test_sky/utils/test_source_utils.py` (new)
- `tests/smoke_tests/test_kubernetes_host_network.py` (new) — `multi_node` **rewritten to assert the single-node fail-loud path** (a 2-node hostNetwork launch must fail with the pod-anti-affinity scheduling error, since the smoke clusters are single-node); `coexistence` (two different clusters on one node) unchanged

## Test plan

- [x] Unit tests: `pytest tests/unit_tests/test_sky/provision/test_host_network_probe.py tests/unit_tests/test_sky/utils/test_source_utils.py` — passing
- [x] `bash format.sh` — yapf, isort, mypy, pylint green
- [x] Jinja: template parses with balanced tags; affinity block rendered + YAML-validated for hostNetwork × {none, GPU, avoid} — `podAntiAffinity` emitted iff hostNetwork, coexists with `nodeAffinity`, no affinity block when off
- [x] Verify `ray_{head,worker}_start_command()` produce the original default ports when env vars are unset (regression-proof for existing clusters)
- [ ] `/smoke-test --kubernetes` (single-node clusters): `test_kubernetes_host_network_multi_node` — a 2-node hostNetwork launch correctly **fails** with the pod-anti-affinity scheduling rejection (asserts both the non-zero exit and that the failure is the anti-affinity reason). The cross-node-spread success path needs a ≥2-node K8s cluster and is only verified manually off-CI.
- [ ] Manual: two hostNetwork clusters forced onto one node — both launch + SSH (probe avoided the cross-cluster collision) — `test_kubernetes_host_network_coexistence`

## Open follow-ups

- Optional config knob to relax the required anti-affinity to `preferred` (or opt out) for single-K8s-node users who accept the same-node race.
- Explicit test for the user-`pod_config`-affinity ⊕ injected-anti-affinity merge path (`merge_k8s_configs` list semantics).
- `cached_external_ssh_ports` is set at provisioning time and not refreshed on pod restart — if a hostNetwork pod restarts and the probe picks a different sshd port, `ssh <cluster>` uses the stale port until the next `sky status -r`.
- TOCTOU: the probe releases held sockets just before `ray start` / sshd bind; a racing process on the same node could grab the freed port. Narrowed by mode b — only the cross-cluster case, on a deliberately co-located node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

