### PR TITLE
[Catalog] Move catalog dir to SKY_RUNTIME_DIR; remove import-time FS side effects

### DIFF
--- a/sky/catalog/aws_catalog.py
+++ b/sky/catalog/aws_catalog.py
@@ -105,6 +105,10 @@ def _get_az_mappings(aws_user_hash: str) -> Optional['pd.DataFrame']:
                 az_mappings = fetch_aws.fetch_availability_zone_mappings()
         else:
             return None
+        # get_catalog_path() is now a pure path getter; create the
+        # parent dirs explicitly before writing.
+        os.makedirs(os.path.dirname(az_mapping_path), exist_ok=True)
+        os.makedirs(os.path.dirname(az_mapping_md5_path), exist_ok=True)
         az_mappings.to_csv(az_mapping_path, index=False)
         # Write md5 of the az_mapping file to a file so we can check it for
         # any changes when uploading to the controller

--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -14,6 +14,7 @@ from sky import sky_logging
 from sky.adaptors import common as adaptors_common
 from sky.clouds import cloud as cloud_lib
 from sky.skylet import constants
+from sky.skylet import runtime_utils
 from sky.utils import annotations
 from sky.utils import common_utils
 from sky.utils import registry
@@ -30,9 +31,25 @@ else:
 
 logger = sky_logging.init_logger(__name__)
 
-_ABSOLUTE_VERSIONED_CATALOG_DIR = os.path.join(
-    os.path.expanduser(constants.CATALOG_DIR), constants.CATALOG_SCHEMA_VERSION)
-os.makedirs(_ABSOLUTE_VERSIONED_CATALOG_DIR, exist_ok=True)
+# Catalogs are a regeneratable cache, downloaded from the hosted catalog
+# mirror on first read. Route them through SKY_RUNTIME_DIR (per the
+# pattern documented at sky/skylet/constants.py:9-22) so they live on
+# the SKY_RUNTIME_DIR-rooted location rather than the user's $HOME. On
+# environments where $HOME is a shared NFS mount (e.g. Slurm), this
+# avoids both the SQLite-on-NFS class of issue and cross-user
+# collisions on the catalogs directory itself.
+#
+# Note: constants.CATALOG_DIR is kept at '~/.sky/catalogs' for the
+# remote_path used by get_modified_catalog_file_mounts() below, where
+# the '~' is expanded by the receiving controller pod's shell.
+_ABSOLUTE_VERSIONED_CATALOG_DIR = runtime_utils.get_runtime_dir_path(
+    os.path.join('.sky/catalogs', constants.CATALOG_SCHEMA_VERSION))
+# The catalog dir is created lazily at the call sites that actually
+# write a file (e.g. _update_catalog below, _get_az_mappings,
+# initialize_vsphere_data). Creating it eagerly at module load is
+# unnecessary FS contact, and on shared-NFS $HOME setups it used to
+# crash `import sky` outright if the dir existed but was owned by a
+# different user.
 
 
 class InstanceTypeInfo(NamedTuple):
@@ -63,9 +80,11 @@ class InstanceTypeInfo(NamedTuple):
 
 
 def get_catalog_path(filename: str) -> str:
-    catalog_path = os.path.join(_ABSOLUTE_VERSIONED_CATALOG_DIR, filename)
-    os.makedirs(os.path.dirname(catalog_path), exist_ok=True)
-    return catalog_path
+    # Pure path getter, no side effects. Callers that intend to write
+    # to the returned path must create the parent dir themselves. This
+    # keeps `import sky` (and read-only commands) from touching the
+    # filesystem when ~/.sky/catalogs is not writable by the caller.
+    return os.path.join(_ABSOLUTE_VERSIONED_CATALOG_DIR, filename)
 
 
 def is_catalog_modified(filename: str) -> bool:
@@ -115,10 +134,17 @@ def get_modified_catalog_file_mounts() -> Dict[str, str]:
     modified_catalog_list = _get_modified_catalogs()
     modified_catalog_path_map = {}  # Map of remote: local catalog paths
     for catalog in modified_catalog_list:
-        # Use relative paths for remote to handle varying usernames on the cloud
+        # remote_path stays as '~/.sky/catalogs/<version>/<catalog>' so the
+        # file_mounts upload lands at the controller pod's $HOME (controllers
+        # don't set SKY_RUNTIME_DIR, so its catalog lookup also resolves to
+        # $HOME via the default in runtime_utils.get_runtime_dir_path).
         remote_path = os.path.join(constants.CATALOG_DIR,
                                    constants.CATALOG_SCHEMA_VERSION, catalog)
-        local_path = os.path.expanduser(remote_path)
+        # local_path comes from the same SKY_RUNTIME_DIR-aware resolution
+        # used to populate _ABSOLUTE_VERSIONED_CATALOG_DIR above, so that
+        # locally-modified catalogs are picked up from wherever they
+        # actually live (which may be SKY_RUNTIME_DIR-rooted, not $HOME).
+        local_path = os.path.join(_ABSOLUTE_VERSIONED_CATALOG_DIR, catalog)
         modified_catalog_path_map[remote_path] = local_path
     return modified_catalog_path_map
 
@@ -184,7 +210,9 @@ def read_catalog(filename: str,
         cloud = str(registry.CLOUD_REGISTRY.from_str(cloud))
 
     meta_path = os.path.join(_ABSOLUTE_VERSIONED_CATALOG_DIR, '.meta', filename)
-    os.makedirs(os.path.dirname(meta_path), exist_ok=True)
+
+    # The meta dir is created lazily inside _update_catalog before the
+    # filelock is acquired; see comment on _ABSOLUTE_VERSIONED_CATALOG_DIR.
 
     def _need_update() -> bool:
         if not os.path.exists(catalog_path):
@@ -204,6 +232,10 @@ def read_catalog(filename: str,
         if not _need_update():
             return False
 
+        # The meta dir must exist before the filelock + md5 file write
+        # below. Create it lazily here so module-level read_catalog()
+        # calls remain side-effect-free on the filesystem.
+        os.makedirs(os.path.dirname(meta_path), exist_ok=True)
         # Atomic check, to avoid conflicts with other processes.
         with filelock.FileLock(meta_path + '.lock'):
             # Double check after acquiring the lock.

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -1328,6 +1328,9 @@ class AWS(clouds.Cloud):
                 pass
 
         result = cls._sts_get_caller_identity()
+        # get_catalog_path() is now a pure path getter; create the
+        # parent dir explicitly before writing.
+        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
         with open(cache_path, 'w', encoding='utf-8') as f:
             f.write(json.dumps(result))
         return result


### PR DESCRIPTION
## Summary

This PR makes `~/.sky/catalogs` robust on shared-NFS-home setups via two complementary changes:

1. **Route the local catalog dir through `SKY_RUNTIME_DIR`**, matching the convention at `sky/skylet/constants.py:9-22` for other runtime artifacts (SQLite DBs, the skypilot-runtime venv, `miniconda3`, `python_path`, `ray_path`). When `SKY_RUNTIME_DIR` is set, catalogs live at `$SKY_RUNTIME_DIR/.sky/catalogs/<version>/` (typically a per-runtime writable location). When it isn't set, behavior is unchanged: catalogs default to `$HOME/.sky/catalogs/<version>/`.
2. **Remove all filesystem side effects at `import sky`**. `import sky` no longer does any `os.makedirs`, even transitively. The catalog dir is created lazily by `_update_catalog` only when something actually needs to write.

Together: (1) eliminates the bad-perm scenario for environments with `SKY_RUNTIME_DIR` set; (2) makes `import sky` and read-only commands robust on environments without `SKY_RUNTIME_DIR` where `~/.sky/catalogs` may exist with bad perms.

## Motivation

`catalog/common.py:35` ran `os.makedirs(~/.sky/catalogs/<version>)` at module load. `get_catalog_path()` and `read_catalog()` additionally fired eager `os.makedirs` calls, and module-level `read_catalog()` calls in the per-cloud catalog files (aws_catalog, gcp_catalog, etc.) amplified those into multiple eager filesystem writes per `import sky`.

On environments where `~/.sky/catalogs` exists but is owned by a different user (or is otherwise not writable), `import sky` crashes:

```
PermissionError: [Errno 13] Permission denied: '/home/sky/.sky/catalogs/v8'
  File ".../sky/catalog/common.py", line 35, in <module>
    os.makedirs(_ABSOLUTE_VERSIONED_CATALOG_DIR, exist_ok=True)
```

Even commands that don't need to write a catalog (`sky status`, `sky api status`, etc.) fail. The classic offender is shared NFS home directories (Slurm setups in particular, which the existing comment at `constants.py:9-22` explicitly calls out as the motivation for `SKY_RUNTIME_DIR` in the first place; catalogs were just a missed migration).

## Changes

- `sky/catalog/common.py`:
  - `_ABSOLUTE_VERSIONED_CATALOG_DIR` now resolves via `runtime_utils.get_runtime_dir_path('.sky/catalogs/<version>')`.
  - Drop the module-level `os.makedirs` call.
  - `get_catalog_path()` becomes a pure path joiner (no side effects). Documented in a comment.
  - Move the eager meta-dir `os.makedirs` out of `read_catalog()` and into `_update_catalog`, right before the filelock + md5 file write. The eager call was firing on every `read_catalog()` invocation, including module-level ones.
  - `get_modified_catalog_file_mounts()` computes `local_path` from the SKY_RUNTIME_DIR-aware `_ABSOLUTE_VERSIONED_CATALOG_DIR`. `remote_path` stays `~/.sky/catalogs/<version>/<catalog>` so the file_mounts upload lands at the controller pod's `$HOME` (controllers that don't set `SKY_RUNTIME_DIR` also resolve to `$HOME` via the same `runtime_utils` default).
- `sky/catalog/aws_catalog.py`: `_get_az_mappings()` used to rely on `get_catalog_path()`'s mkdir side effect. With the pure-getter change, added explicit `os.makedirs` for both the catalog path and the meta path before the writes.
- `sky/clouds/aws.py`: `get_user_identities()` had the same implicit dependency for the AWS user-identity cache write. Added explicit `os.makedirs` for the cache parent dir before the open-for-write.

Other write callers (`_update_catalog` itself, `initialize_vsphere_data` in `provision/vsphere/vsphere_utils.py`, fetchers in `catalog/data_fetchers/`) already mkdir explicitly, so no changes needed there.

`constants.CATALOG_DIR` (`'~/.sky/catalogs'`) is intentionally unchanged. It is used only by `get_modified_catalog_file_mounts()`'s `remote_path`, where the `~` is expanded by the receiving controller pod's shell.

## Backwards compatibility

`runtime_utils.get_runtime_dir_path()` defaults to `~` when `SKY_RUNTIME_DIR` is unset. So on laptops or any environment that doesn't set the env var, catalogs continue to live at `$HOME/.sky/catalogs/<version>/` exactly as before. Existing local catalog caches are picked up without re-download.

## Test plan

- [x] **`import sky` with bad-perm `$HOME/.sky/catalogs` and no `SKY_RUNTIME_DIR`**: `mkdir -p /tmp/fake-home/.sky/catalogs && chmod 555 /tmp/fake-home/.sky/catalogs && HOME=/tmp/fake-home python -c 'import sky'`. On master this crashed with `PermissionError`; with this PR it succeeds.
- [x] **`import sky` with bad-perm `$HOME/.sky/catalogs` AND `SKY_RUNTIME_DIR` set**: same setup plus `SKY_RUNTIME_DIR=/tmp/runtime`. Succeeds. `_ABSOLUTE_VERSIONED_CATALOG_DIR` resolves to `/tmp/runtime/.sky/catalogs/v8`.
- [x] **Default env**: `python -c "import sky.catalog.common as cc; print(cc._ABSOLUTE_VERSIONED_CATALOG_DIR)"` returns `$HOME/.sky/catalogs/v8`. Matches prior behavior.
- [x] **`get_modified_catalog_file_mounts()` plumbing**: created a fake locally-modified catalog at `/tmp/runtime/.sky/catalogs/v8/aws/vms.csv` with `SKY_RUNTIME_DIR` set. Function returns `{'~/.sky/catalogs/v8/aws/vms.csv': '/tmp/runtime/.sky/catalogs/v8/aws/vms.csv'}`. Remote stays `~`-prefixed for controller-side `$HOME` expansion; local correctly comes from the SKY_RUNTIME_DIR-resolved location.
- [x] **End-to-end on a SkyPilot pod** with `SKY_RUNTIME_DIR` set to a writable location and `$HOME` on shared NFS, with `~/.sky/catalogs/` deliberately set up owned by an unrelated user mode `755` (to simulate the bug scenario):
  - `sky check` for a Kubernetes context: succeeds.
  - `sky show-gpus`: succeeds, returns live GPU inventory.
  - `sky launch` optimizer step ("Considered resources" output): succeeds.
  - Catalog files land at `$SKY_RUNTIME_DIR/.sky/catalogs/v8/` (full subdirs for aws/azure/gcp/kubernetes/etc).
  - `$HOME/.sky/catalogs/` on the shared volume: not touched.
- [x] `format.sh`: 10.00/10. mypy passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)