### PR TITLE
[Token] Fix service account token revocation and expiration enforcement

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -261,7 +261,9 @@ service_account_token_table = sqlalchemy.Table(
     Base.metadata,
     sqlalchemy.Column('token_id', sqlalchemy.Text, primary_key=True),
     sqlalchemy.Column('token_name', sqlalchemy.Text),
-    sqlalchemy.Column('token_hash', sqlalchemy.Text),
+    # Indexed + unique: the auth middleware looks up rows by hash on every
+    # request to enforce revocation/rotation/expiration.
+    sqlalchemy.Column('token_hash', sqlalchemy.Text, index=True, unique=True),
     sqlalchemy.Column('created_at', sqlalchemy.Integer),
     sqlalchemy.Column('last_used_at', sqlalchemy.Integer, server_default=None),
     sqlalchemy.Column('expires_at', sqlalchemy.Integer, server_default=None),
@@ -2802,6 +2804,34 @@ def get_service_account_token(token_id: str) -> Optional[Dict[str, Any]]:
     with orm.Session(engine) as session:
         row = session.query(service_account_token_table).filter_by(
             token_id=token_id).first()
+    if row is None:
+        return None
+    return {
+        'token_id': row.token_id,
+        'token_name': row.token_name,
+        'token_hash': row.token_hash,
+        'created_at': row.created_at,
+        'last_used_at': row.last_used_at,
+        'expires_at': row.expires_at,
+        'creator_user_hash': row.creator_user_hash,
+        'service_account_user_id': row.service_account_user_id,
+    }
+
+
+@metrics_lib.time_me
+def get_service_account_token_by_hash(
+        token_hash: str) -> Optional[Dict[str, Any]]:
+    """Get a service account token by its sha256 hash.
+
+    Used by the request-auth middleware: hashing the incoming bearer token
+    and matching against this column is what makes revocation and rotation
+    take effect (the DB row's hash is updated on rotation, so old JWTs
+    stop matching). Relies on the unique index on token_hash.
+    """
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        row = session.query(service_account_token_table).filter_by(
+            token_hash=token_hash).first()
     if row is None:
         return None
     return {

--- a/sky/schemas/db/global_user_state/017_service_account_token_hash_index.py
+++ b/sky/schemas/db/global_user_state/017_service_account_token_hash_index.py
@@ -1,0 +1,47 @@
+"""Add unique index on service_account_tokens.token_hash.
+
+Revision ID: 017
+Revises: 016
+Create Date: 2026-05-14
+
+The auth middleware looks up service account token rows by their sha256
+hash on every authenticated request. Without an index this is a full
+table scan; the unique constraint also defends against any future
+duplicate-hash insertion bugs.
+
+"""
+# pylint: disable=invalid-name
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '017'
+down_revision: Union[str, Sequence[str], None] = '016'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_INDEX_NAME = 'ix_service_account_tokens_token_hash'
+_TABLE_NAME = 'service_account_tokens'
+
+
+def upgrade():
+    """Add unique index on token_hash for fast hash-based authentication.
+
+    Idempotent: skips creation if an index with the same name already
+    exists (e.g. created manually out-of-band or by a prior partial run).
+    """
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing = {ix['name'] for ix in inspector.get_indexes(_TABLE_NAME)}
+    if _INDEX_NAME in existing:
+        return
+
+    with op.get_context().autocommit_block():
+        op.create_index(_INDEX_NAME, _TABLE_NAME, ['token_hash'], unique=True)
+
+
+def downgrade():
+    """No-op for backward compatibility."""
+    pass

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -473,6 +473,29 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                 return _bearer_auth_401_response(
                     {'detail': 'Invalid token payload'})
 
+            # Look up the token row by its sha256 hash. This is what makes
+            # revocation (row deleted) and rotation (row's hash replaced)
+            # take effect at request time -- the JWT alone cannot be revoked.
+            # We match on hash rather than token_id because rotation updates
+            # the row's hash but keeps the original token_id, while the new
+            # JWT carries a freshly-generated token_id; only the hash is
+            # consistent between the live JWT and the live DB row.
+            incoming_hash = hashlib.sha256(sa_token.encode()).hexdigest()
+            token_row = global_user_state.get_service_account_token_by_hash(
+                incoming_hash)
+            if token_row is None:
+                logger.warning(
+                    f'Service account token {token_id} not found in DB '
+                    '(revoked or rotated)')
+                return _bearer_auth_401_response(
+                    {'detail': 'Service account token revoked or rotated'})
+
+            if (token_row['expires_at'] is not None and
+                    token_row['expires_at'] < int(time.time())):
+                logger.warning(f'Service account token {token_id} has expired')
+                return _bearer_auth_401_response(
+                    {'detail': 'Service account token has expired'})
+
             # Verify user still exists in database
             user_info = global_user_state.get_user(user_id)
             if user_info is None:
@@ -481,10 +504,12 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                 return _bearer_auth_401_response(
                     {'detail': 'Service account user no longer exists'})
 
-            # Update last used timestamp for token tracking
+            # Update last used timestamp for token tracking. Use the
+            # DB row's token_id (not the JWT's): after rotation the JWT
+            # carries a different token_id than the DB row.
             try:
                 global_user_state.update_service_account_token_last_used(
-                    token_id)
+                    token_row['token_id'])
             except Exception as e:  # pylint: disable=broad-except
                 logger.debug(f'Failed to update token last used time: {e}')
 

--- a/sky/users/token_service.py
+++ b/sky/users/token_service.py
@@ -6,6 +6,7 @@ import hashlib
 import os
 import secrets
 import threading
+import time
 from typing import Any, Dict, Generator, Optional
 
 import filelock
@@ -126,13 +127,19 @@ class TokenService:
             'y': 'sa',  # Type: service account (shortened from 'type')
         }
 
-        # Add expiration if specified
+        # Add expiration if specified. Write both 'e' (legacy short name)
+        # and the RFC 7519 standard 'exp' so PyJWT's automatic
+        # ExpiredSignatureError path enforces it without our manual check.
+        # The manual 'e' check in verify_token stays for backward compat
+        # with tokens issued before this change; once those have expired
+        # the manual check can be deleted.
         expires_at = None
         if expires_in_days:
             exp_time = now + datetime.timedelta(days=expires_in_days)
-            payload['e'] = int(
-                exp_time.timestamp())  # Expiration (shortened from 'exp')
-            expires_at = int(exp_time.timestamp())
+            exp_ts = int(exp_time.timestamp())
+            payload['e'] = exp_ts
+            payload['exp'] = exp_ts
+            expires_at = exp_ts
 
         # Generate JWT
         jwt_token = jwt.encode(payload,
@@ -177,6 +184,17 @@ class TokenService:
             payload = jwt.decode(jwt_token,
                                  self.secret_key,
                                  algorithms=[JWT_ALGORITHM])
+
+            # Manually verify expiration for tokens issued before we
+            # started writing the standard 'exp' claim alongside 'e'.
+            # New tokens carry both, and PyJWT's jwt.decode above will
+            # have already raised ExpiredSignatureError on 'exp'. This
+            # branch only matters for legacy tokens with 'e' only; it
+            # can be removed once those have all expired.
+            exp = payload.get('e')
+            if exp is not None and exp < int(time.time()):
+                logger.warning('Token has expired')
+                return None
 
             # Manually verify issuer using our shortened field name
             token_issuer = payload.get('i')

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -30,7 +30,7 @@ DB_INIT_LOCK_TIMEOUT_SECONDS = 10
 _alembic_thread_lock = threading.Lock()
 
 GLOBAL_USER_STATE_DB_NAME = 'state_db'
-GLOBAL_USER_STATE_VERSION = '016'  # add volume creation_yaml column
+GLOBAL_USER_STATE_VERSION = '017'  # add index to token_hash column
 GLOBAL_USER_STATE_LOCK_PATH = f'~/.sky/locks/.{GLOBAL_USER_STATE_DB_NAME}.lock'
 
 SPOT_JOBS_DB_NAME = 'spot_jobs_db'

--- a/tests/unit_tests/test_sky/server/test_bearer_token_middleware.py
+++ b/tests/unit_tests/test_sky/server/test_bearer_token_middleware.py
@@ -36,6 +36,28 @@ class TestBearerTokenMiddleware:
 
         return call_next
 
+    @pytest.fixture
+    def mock_token_row(self):
+        """A live, unexpired service-account-token DB row.
+
+        Uses a token_id that DIFFERS from the JWT payload's token_id used
+        throughout these tests ('token_123'). This mirrors production state
+        after a rotation: the JWT carries a freshly-generated token_id
+        while the DB row keeps the original. update_last_used must be
+        called with the DB row's token_id, not the JWT's -- if it used the
+        JWT's, rotated tokens would silently fail to update last_used_at.
+        """
+        return {
+            'token_id': 'token_db_id_456',
+            'token_name': 'test-token',
+            'token_hash': 'hash_xyz',
+            'created_at': 1700000000,
+            'last_used_at': None,
+            'expires_at': None,
+            'creator_user_hash': 'user-creator',
+            'service_account_user_id': 'sa-123456',
+        }
+
     @pytest.mark.asyncio
     async def test_no_authorization_header_bypass(self, middleware,
                                                   base_mock_request,
@@ -121,9 +143,85 @@ class TestBearerTokenMiddleware:
             )
 
     @pytest.mark.asyncio
+    async def test_token_revoked_or_rotated(self, middleware, base_mock_request,
+                                            mock_call_next):
+        """JWT signature is valid but the DB row is gone (deleted) or its
+        hash no longer matches (the token was rotated and the caller is
+        presenting the OLD JWT). In both cases the hash lookup returns
+        None and the middleware must 401.
+        """
+        base_mock_request.headers = {'authorization': 'Bearer sky_valid_token'}
+
+        mock_payload = {
+            'sub': 'sa-123456',
+            'name': 'test-service-account',
+            'token_id': 'token_123'
+        }
+
+        with mock.patch.dict(
+                os.environ,
+            {constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS: 'true'}), \
+                mock.patch('sky.users.token_service.token_service') as mock_token_service, \
+                mock.patch('sky.global_user_state.get_service_account_token_by_hash') as mock_get_by_hash:
+
+            mock_token_service.verify_token.return_value = mock_payload
+            mock_get_by_hash.return_value = None  # row absent or hash mismatch
+
+            response = await middleware.dispatch(base_mock_request,
+                                                 mock_call_next)
+
+            assert response.status_code == 401
+            assert ('Service account token revoked or rotated'
+                    in response.body.decode())
+
+    @pytest.mark.asyncio
+    async def test_token_expired_per_db(self, middleware, base_mock_request,
+                                        mock_call_next):
+        """The DB row exists and the hash matches, but expires_at is in
+        the past. This catches tokens whose JWT 'e' claim was issued
+        with a wrong/missing value, and tokens whose expires_at was
+        modified administratively after issuance.
+        """
+        base_mock_request.headers = {'authorization': 'Bearer sky_valid_token'}
+
+        mock_payload = {
+            'sub': 'sa-123456',
+            'name': 'test-service-account',
+            'token_id': 'token_123'
+        }
+
+        expired_row = {
+            'token_id': 'token_db_id_456',
+            'token_name': 'test-token',
+            'token_hash': 'hash_xyz',
+            'created_at': 1700000000,
+            'last_used_at': None,
+            'expires_at': 1700000001,  # epoch, definitely in the past
+            'creator_user_hash': 'user-creator',
+            'service_account_user_id': 'sa-123456',
+        }
+
+        with mock.patch.dict(
+                os.environ,
+            {constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS: 'true'}), \
+                mock.patch('sky.users.token_service.token_service') as mock_token_service, \
+                mock.patch('sky.global_user_state.get_service_account_token_by_hash') as mock_get_by_hash:
+
+            mock_token_service.verify_token.return_value = mock_payload
+            mock_get_by_hash.return_value = expired_row
+
+            response = await middleware.dispatch(base_mock_request,
+                                                 mock_call_next)
+
+            assert response.status_code == 401
+            assert ('Service account token has expired'
+                    in response.body.decode())
+
+    @pytest.mark.asyncio
     async def test_valid_service_account_token_success(self, middleware,
                                                        base_mock_request,
-                                                       mock_call_next):
+                                                       mock_call_next,
+                                                       mock_token_row):
         """Test middleware with valid service account token."""
         base_mock_request.headers = {'authorization': 'Bearer sky_valid_token'}
 
@@ -140,10 +238,12 @@ class TestBearerTokenMiddleware:
                 os.environ,
             {constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS: 'true'}), \
                 mock.patch('sky.users.token_service.token_service') as mock_token_service, \
+                mock.patch('sky.global_user_state.get_service_account_token_by_hash') as mock_get_by_hash, \
                 mock.patch('sky.global_user_state.get_user') as mock_get_user, \
                 mock.patch('sky.global_user_state.update_service_account_token_last_used') as mock_update_last_used:
 
             mock_token_service.verify_token.return_value = mock_payload
+            mock_get_by_hash.return_value = mock_token_row
             mock_get_user.return_value = mock_user_info
 
             response = await middleware.dispatch(base_mock_request,
@@ -153,8 +253,9 @@ class TestBearerTokenMiddleware:
             # Verify user was set in request state
             assert base_mock_request.state.auth_user.id == 'sa-123456'
             assert base_mock_request.state.auth_user.name == 'test-service-account'
-            # Verify token last used was updated
-            mock_update_last_used.assert_called_once_with('token_123')
+            # last_used must be updated with the DB row's token_id, not
+            # the JWT's.
+            mock_update_last_used.assert_called_once_with('token_db_id_456')
 
     @pytest.mark.asyncio
     async def test_missing_user_id_in_token(self, middleware, base_mock_request,
@@ -212,7 +313,7 @@ class TestBearerTokenMiddleware:
 
     @pytest.mark.asyncio
     async def test_user_no_longer_exists(self, middleware, base_mock_request,
-                                         mock_call_next):
+                                         mock_call_next, mock_token_row):
         """Test middleware when service account user no longer exists."""
         base_mock_request.headers = {'authorization': 'Bearer sky_valid_token'}
 
@@ -226,9 +327,11 @@ class TestBearerTokenMiddleware:
                 os.environ,
             {constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS: 'true'}), \
                 mock.patch('sky.users.token_service.token_service') as mock_token_service, \
+                mock.patch('sky.global_user_state.get_service_account_token_by_hash') as mock_get_by_hash, \
                 mock.patch('sky.global_user_state.get_user') as mock_get_user:
 
             mock_token_service.verify_token.return_value = mock_payload
+            mock_get_by_hash.return_value = mock_token_row
             mock_get_user.return_value = None  # User no longer exists
 
             response = await middleware.dispatch(base_mock_request,
@@ -241,7 +344,8 @@ class TestBearerTokenMiddleware:
     @pytest.mark.asyncio
     async def test_update_last_used_failure_not_fatal(self, middleware,
                                                       base_mock_request,
-                                                      mock_call_next):
+                                                      mock_call_next,
+                                                      mock_token_row):
         """Test that failure to update last used timestamp doesn't fail authentication."""
         base_mock_request.headers = {'authorization': 'Bearer sky_valid_token'}
 
@@ -258,10 +362,12 @@ class TestBearerTokenMiddleware:
                 os.environ,
             {constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS: 'true'}), \
                 mock.patch('sky.users.token_service.token_service') as mock_token_service, \
+                mock.patch('sky.global_user_state.get_service_account_token_by_hash') as mock_get_by_hash, \
                 mock.patch('sky.global_user_state.get_user') as mock_get_user, \
                 mock.patch('sky.global_user_state.update_service_account_token_last_used') as mock_update_last_used:
 
             mock_token_service.verify_token.return_value = mock_payload
+            mock_get_by_hash.return_value = mock_token_row
             mock_get_user.return_value = mock_user_info
             mock_update_last_used.side_effect = Exception("Database error")
 
@@ -299,7 +405,8 @@ class TestBearerTokenMiddleware:
     @pytest.mark.asyncio
     async def test_case_insensitive_bearer_check(self, middleware,
                                                  base_mock_request,
-                                                 mock_call_next):
+                                                 mock_call_next,
+                                                 mock_token_row):
         """Test that Bearer token check is case insensitive."""
         base_mock_request.headers = {
             'authorization': 'bearer sky_test_token'
@@ -318,10 +425,12 @@ class TestBearerTokenMiddleware:
                 os.environ,
             {constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS: 'true'}), \
                 mock.patch('sky.users.token_service.token_service') as mock_token_service, \
+                mock.patch('sky.global_user_state.get_service_account_token_by_hash') as mock_get_by_hash, \
                 mock.patch('sky.global_user_state.get_user') as mock_get_user, \
                 mock.patch('sky.global_user_state.update_service_account_token_last_used'):
 
             mock_token_service.verify_token.return_value = mock_payload
+            mock_get_by_hash.return_value = mock_token_row
             mock_get_user.return_value = mock_user_info
 
             response = await middleware.dispatch(base_mock_request,
@@ -367,7 +476,8 @@ class TestBearerTokenMiddleware:
 
     @pytest.mark.asyncio
     async def test_bearer_auth_then_basic_auth_middleware(
-            self, middleware, base_mock_request, mock_call_next):
+            self, middleware, base_mock_request, mock_call_next,
+            mock_token_row):
         """Test that BasicAuthMiddleware respects user authenticated by BearerTokenMiddleware.
 
         This test simulates the middleware chain: BearerTokenMiddleware -> BasicAuthMiddleware.
@@ -402,11 +512,13 @@ class TestBearerTokenMiddleware:
                 os.environ,
             {constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS: 'true'}), \
                 mock.patch('sky.users.token_service.token_service') as mock_token_service, \
+                mock.patch('sky.global_user_state.get_service_account_token_by_hash') as mock_get_by_hash, \
                 mock.patch('sky.global_user_state.get_user') as mock_get_user, \
                 mock.patch('sky.global_user_state.update_service_account_token_last_used'), \
                 mock.patch('sky.jobs.utils.is_consolidation_mode', return_value=False):
 
             mock_token_service.verify_token.return_value = mock_payload
+            mock_get_by_hash.return_value = mock_token_row
             mock_get_user.return_value = mock_user_info
 
             # First BearerTokenMiddleware authenticates

--- a/tests/unit_tests/test_sky/test_global_user_state_service_accounts.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_service_accounts.py
@@ -129,6 +129,50 @@ class TestServiceAccountDatabaseOperations:
 
         assert result is None
 
+    def test_get_service_account_token_by_hash_found(self, mock_engine,
+                                                     mock_session):
+        """Hash lookup returns the row dict when a matching row exists."""
+        mock_row = mock.Mock()
+        mock_row.token_id = 'token123'
+        mock_row.token_name = 'test-token'
+        mock_row.token_hash = 'hash123'
+        mock_row.created_at = 1234567890
+        mock_row.last_used_at = 1234567900
+        mock_row.expires_at = 1234567890 + 2592000
+        mock_row.creator_user_hash = 'user456'
+        mock_row.service_account_user_id = 'sa789'
+
+        mock_filter = mock_session.query.return_value.filter_by
+        mock_filter.return_value.first.return_value = mock_row
+
+        result = global_user_state.get_service_account_token_by_hash('hash123')
+
+        assert result == {
+            'token_id': 'token123',
+            'token_name': 'test-token',
+            'token_hash': 'hash123',
+            'created_at': 1234567890,
+            'last_used_at': 1234567900,
+            'expires_at': 1234567890 + 2592000,
+            'creator_user_hash': 'user456',
+            'service_account_user_id': 'sa789'
+        }
+        # The query must filter by token_hash, not token_id. This is what
+        # makes rotation work: after rotation the DB row keeps the original
+        # token_id but its hash is replaced, so looking up by token_id would
+        # incorrectly accept the old JWT.
+        mock_filter.assert_called_once_with(token_hash='hash123')
+
+    def test_get_service_account_token_by_hash_not_found(
+            self, mock_engine, mock_session):
+        """Hash lookup returns None when no matching row exists."""
+        mock_session.query.return_value.filter_by.return_value.first.return_value = None
+
+        result = global_user_state.get_service_account_token_by_hash(
+            'unknown_hash')
+
+        assert result is None
+
     def test_get_all_service_account_tokens(self, mock_engine, mock_session):
         """Test getting all service account tokens."""
         mock_row1 = mock.Mock()

--- a/tests/unit_tests/test_sky/users/test_token_service.py
+++ b/tests/unit_tests/test_sky/users/test_token_service.py
@@ -2,6 +2,7 @@
 
 import datetime
 import secrets
+import time
 from unittest import mock
 
 import pytest
@@ -79,6 +80,81 @@ class TestTokenService:
             assert result['expires_at'] < now + (31 * 24 * 3600
                                                 )  # Less than 31 days
 
+    def test_create_token_writes_both_e_and_exp(self):
+        """New tokens must carry both the legacy 'e' claim and the
+        standard 'exp' claim with the same value.
+
+        'exp' is what makes PyJWT enforce expiration automatically; 'e'
+        is kept so that the verify_token backward-compat branch still
+        catches tokens issued before this change.
+        """
+        import jwt as pyjwt
+        with mock.patch('sky.users.token_service.global_user_state'
+                       ) as mock_global_state:
+            mock_global_state.get_system_config.return_value = 'test_secret_key'
+
+            service = token_service.TokenService()
+            result = service.create_token(creator_user_id='creator123',
+                                          service_account_user_id='sa123',
+                                          token_name='test-token',
+                                          expires_in_days=30)
+
+            raw = pyjwt.decode(result['token'][4:],
+                               'test_secret_key',
+                               algorithms=['HS256'])
+            assert 'e' in raw and 'exp' in raw
+            assert raw['e'] == raw['exp'] == result['expires_at']
+
+    def test_create_token_without_expiration_has_no_exp(self):
+        """No expiration → neither 'e' nor 'exp' should be present."""
+        import jwt as pyjwt
+        with mock.patch('sky.users.token_service.global_user_state'
+                       ) as mock_global_state:
+            mock_global_state.get_system_config.return_value = 'test_secret_key'
+
+            service = token_service.TokenService()
+            result = service.create_token(creator_user_id='creator123',
+                                          service_account_user_id='sa123',
+                                          token_name='test-token')
+
+            raw = pyjwt.decode(result['token'][4:],
+                               'test_secret_key',
+                               algorithms=['HS256'])
+            assert 'e' not in raw
+            assert 'exp' not in raw
+            assert result['expires_at'] is None
+
+    def test_verify_expired_token_via_pyjwt_only(self):
+        """For tokens that carry the standard 'exp' claim, PyJWT raises
+        ExpiredSignatureError on its own -- the manual 'e' check in
+        verify_token is not needed for new tokens.
+
+        This documents the deprecation path: once all legacy 'e'-only
+        tokens have expired, the manual check can be removed and this
+        test still passes (it doesn't depend on the manual check).
+        """
+        import jwt as pyjwt
+        with mock.patch('sky.users.token_service.global_user_state'
+                       ) as mock_global_state:
+            mock_global_state.get_system_config.return_value = 'test_secret_key'
+
+            # Hand-craft a JWT that has only 'exp' (no 'e'), expired.
+            past = int((datetime.datetime.now(datetime.timezone.utc) -
+                        datetime.timedelta(days=1)).timestamp())
+            payload = {
+                'i': 'sky',
+                't': past,
+                'u': 'sa123',
+                'k': 'tok',
+                'y': 'sa',
+                'exp': past,  # standard claim only
+            }
+            jwt_token = 'sky_' + pyjwt.encode(
+                payload, 'test_secret_key', algorithm='HS256')
+
+            service = token_service.TokenService()
+            assert service.verify_token(jwt_token) is None
+
     def test_verify_valid_token(self):
         """Test verifying a valid token."""
         with mock.patch('sky.users.token_service.global_user_state'
@@ -117,7 +193,14 @@ class TestTokenService:
             assert payload is None
 
     def test_verify_expired_token(self):
-        """Test verifying an expired token."""
+        """Test verifying an expired token returns None.
+
+        The JWT payload uses the non-standard claim name 'e' for the
+        expiration timestamp. PyJWT only auto-validates the standard 'exp'
+        claim, so verify_token must perform the expiration check manually.
+        Without that manual check, this test would pass with a non-None
+        payload (the historical bug).
+        """
         with mock.patch('sky.users.token_service.global_user_state'
                        ) as mock_global_state:
             mock_global_state.get_system_config.return_value = 'test_secret_key'
@@ -139,20 +222,8 @@ class TestTokenService:
                     expires_in_days=0.5  # Half day, so it's expired
                 )
 
-            # Verify the expired token
             payload = service.verify_token(token_data['token'])
-            # Note: JWT expiration might not be immediately enforced in test environment
-            # The test expects None but we'll accept either None or an expired payload
-            if payload is not None:
-                # If payload is returned, check that the expiration time has passed
-                import time
-                current_time = int(time.time())
-                exp_time = payload.get('exp')
-                # The token should be expired (current time > expiration time)
-                assert exp_time is None or current_time > exp_time, f"Token should be expired: current={current_time}, exp={exp_time}"
-            else:
-                # This is the expected behavior - expired tokens should return None
-                assert payload is None
+            assert payload is None
 
     def test_verify_token_wrong_secret(self):
         """Test verifying a token with wrong secret key."""
@@ -195,16 +266,19 @@ class TestTokenService:
                 assert payload is None
 
     def test_verify_token_wrong_type(self):
-        """Test verifying a token with wrong type."""
+        """Test verifying a token with wrong type.
+
+        Uses the correct issuer ('sky') so the issuer branch passes;
+        otherwise the wrong-type branch is never reached.
+        """
         with mock.patch('sky.users.token_service.global_user_state'
                        ) as mock_global_state:
             mock_global_state.get_system_config.return_value = 'test_secret_key'
 
-            # Mock JWT to return payload with wrong type
             with mock.patch('sky.users.token_service.jwt') as mock_jwt:
                 mock_jwt.encode.return_value = 'mocked_jwt'
                 mock_jwt.decode.return_value = {
-                    'i': 'skypilot.api',
+                    'i': token_service.JWT_ISSUER,  # correct issuer
                     't': 1234567890,
                     'u': 'sa123',
                     'k': 'token123',
@@ -215,6 +289,43 @@ class TestTokenService:
                 payload = service.verify_token('sky_mocked_jwt')
 
                 assert payload is None
+
+    def test_verify_legacy_token_with_only_e_claim_expired(self):
+        """Cover the manual 'e' expiration check for legacy tokens that
+        predate the 'exp' claim. Hand-crafts a JWT that carries only
+        the shortened 'e' claim (no standard 'exp'), expired one day
+        ago.
+
+        PyJWT does NOT auto-validate the non-standard 'e' claim, so
+        without the manual check verify_token would return a payload
+        instead of None.
+        """
+        import jwt as pyjwt
+        with mock.patch('sky.users.token_service.global_user_state'
+                       ) as mock_global_state:
+            mock_global_state.get_system_config.return_value = 'test_secret_key'
+
+            past = int(time.time()) - 24 * 3600  # one day ago
+            payload = {
+                'i': token_service.JWT_ISSUER,
+                't': past,
+                'u': 'sa123',
+                'k': 'tok',
+                'y': 'sa',
+                'e': past,  # legacy short-name claim only, no 'exp'
+            }
+            jwt_token = 'sky_' + pyjwt.encode(
+                payload, 'test_secret_key', algorithm='HS256')
+
+            # Sanity: confirm the test setup truly is "legacy only".
+            raw = pyjwt.decode(jwt_token[4:],
+                               'test_secret_key',
+                               algorithms=['HS256'])
+            assert 'exp' not in raw
+            assert raw['e'] == past
+
+            service = token_service.TokenService()
+            assert service.verify_token(jwt_token) is None
 
     def test_token_service_singleton(self):
         """Test that token_service is properly initialized as singleton."""


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fix the following issues with service account token:
- Expired tokens were accepted
- Revoked tokens were accepted
- Rotation did not invalidate old tokens
<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
