### PR TITLE
[Chart] Add devMode flag for in-cluster api-server iteration

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -66,20 +66,16 @@ spec:
         image: {{ include "common.image" (dict "root" . "image" .Values.apiService.image) }}
         imagePullPolicy: {{ .Values.apiService.imagePullPolicy }}
         {{- if .Values.apiService.devMode.enabled }}
-        # Dev mode: fully open securityContext. Runs as root with all
-        # capabilities so the developer can attach py-spy / strace, edit
-        # site-packages, and restart the server, regardless of what the
-        # tenant configured. NEVER enable in production.
+        # Dev mode: fully open securityContext. Runs as root and
+        # `privileged: true` implicitly grants all capabilities (including
+        # SYS_PTRACE for py-spy/strace) and allowPrivilegeEscalation, so the
+        # developer can edit site-packages and restart the server regardless
+        # of what the tenant configured. NEVER enable in production.
         securityContext:
           privileged: true
           runAsUser: 0
           runAsGroup: 0
           readOnlyRootFilesystem: false
-          allowPrivilegeEscalation: true
-          capabilities:
-            add:
-            - SYS_PTRACE
-            - SYS_ADMIN
         {{- else }}
         {{- with .Values.securityContext }}
         securityContext:

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -65,9 +65,26 @@ spec:
       - name: skypilot-api
         image: {{ include "common.image" (dict "root" . "image" .Values.apiService.image) }}
         imagePullPolicy: {{ .Values.apiService.imagePullPolicy }}
+        {{- if .Values.apiService.devMode.enabled }}
+        # Dev mode: fully open securityContext. Runs as root with all
+        # capabilities so the developer can attach py-spy / strace, edit
+        # site-packages, and restart the server, regardless of what the
+        # tenant configured. NEVER enable in production.
+        securityContext:
+          privileged: true
+          runAsUser: 0
+          runAsGroup: 0
+          readOnlyRootFilesystem: false
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - SYS_PTRACE
+            - SYS_ADMIN
+        {{- else }}
         {{- with .Values.securityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}
+        {{- end }}
         {{- end }}
         resources:
           {{- toYaml .Values.apiService.resources | nindent 10 }}
@@ -252,6 +269,11 @@ spec:
           done
           {{- end }}
 
+          {{- if .Values.apiService.devMode.enabled }}
+          # Dev mode: hold the container without starting the API server so a
+          # developer can drive `sky api start` / `sky api stop` via kubectl exec.
+          exec tail -f /dev/null
+          {{- else }}
           {{- if .Values.apiService.serveServerLog }}
           mkdir -p /root/.sky/api_server
           # Use a FIFO instead of a pipe so that exec replaces the shell,
@@ -262,8 +284,10 @@ spec:
           {{- else }}
           exec sky api start {{ include "skypilot.apiArgs" . }} --foreground
           {{- end }}
+          {{- end }}
         ports:
         - containerPort: 46580
+        {{- if not .Values.apiService.devMode.enabled }}
         {{- with .Values.apiService.livenessProbe }}
         livenessProbe:
           {{- toYaml . | nindent 10 }}
@@ -284,6 +308,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- toYaml . | nindent 10 }}
+        {{- end }}
         {{- end }}
         volumeMounts:
         {{- if and .Values.storage.enabled (eq .Values.apiService.upgradeStrategy "RollingUpdate") }}

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -217,6 +217,14 @@
                 "terminationGracePeriodSeconds": {
                     "type": "integer"
                 },
+                "devMode": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
                 "tolerations": {
                     "type": "array"
                 },

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -38,6 +38,14 @@
                         "null"
                     ]
                 },
+                "devMode": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
                 "enableServiceAccounts": {
                     "type": "boolean"
                 },
@@ -216,14 +224,6 @@
                 },
                 "terminationGracePeriodSeconds": {
                     "type": "integer"
-                },
-                "devMode": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        }
-                    }
                 },
                 "tolerations": {
                     "type": "array"

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -69,6 +69,10 @@ apiService:
   # The default value is 60 seconds.
   terminationGracePeriodSeconds: 60
 
+  # Dev mode: do not start and probe the server automatically
+  devMode:
+    enabled: false
+
   # Liveness and readiness probe configuration for the API server container.
   # @schema type: [object, null]
   livenessProbe:


### PR DESCRIPTION
Adds an `apiService.devMode` flag to the api-server chart. When `apiService.devMode.enabled=true`:

- The api container's args are replaced with `exec tail -f /dev/null`, so the pod stays Running without auto-starting `sky api`.
- Liveness/readiness probes are removed from the api container.
- A permissive `securityContext` is forced on the api container (`privileged: true`, `runAsUser: 0`, `runAsGroup: 0`, `readOnlyRootFilesystem: false`, `SYS_PTRACE`/`SYS_ADMIN` capabilities) so a developer can edit `site-packages` in place, attach `py-spy`, etc.

```
kubectl exec ... -- sky api stop
kubectl exec ... -- bash -lc 'nohup sky api start --deploy --foreground > /tmp/sky-api.log 2>&1 &'
```

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

Manual tests:
- `helm template charts/skypilot --show-only templates/api-deployment.yaml` vs origin/master: zero diff (default off).
- `helm template ... --set apiService.devMode.enabled=true`: api container shows `exec tail -f /dev/null`, no probes, privileged securityContext.
- `helm lint charts/skypilot` passes with the flag on and off.