### PR TITLE
[Catalog] Move ~/.sky/catalogs to SKY_RUNTIME_DIR

### DIFF
--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -14,6 +14,7 @@ from sky import sky_logging
 from sky.adaptors import common as adaptors_common
 from sky.clouds import cloud as cloud_lib
 from sky.skylet import constants
+from sky.skylet import runtime_utils
 from sky.utils import annotations
 from sky.utils import common_utils
 from sky.utils import registry
@@ -30,8 +31,20 @@ else:
 
 logger = sky_logging.init_logger(__name__)
 
-_ABSOLUTE_VERSIONED_CATALOG_DIR = os.path.join(
-    os.path.expanduser(constants.CATALOG_DIR), constants.CATALOG_SCHEMA_VERSION)
+# Catalogs are a regeneratable cache (downloaded CSVs from the hosted
+# catalog mirror on first read). Route them through SKY_RUNTIME_DIR,
+# matching the pattern documented at sky/skylet/constants.py:9-22 for
+# other runtime artifacts (SQLite DBs, the skypilot-runtime venv,
+# miniconda, etc.). When SKY_RUNTIME_DIR is set, catalogs land off
+# the user's $HOME (the same reason the SQLite DBs migrated, to
+# avoid shared-NFS-home pitfalls); when it isn't,
+# runtime_utils.get_runtime_dir_path() falls back to '~', so
+# behavior is unchanged.
+#
+# constants.CATALOG_DIR ('~/.sky/catalogs') is intentionally kept for
+# the remote_path computed by get_modified_catalog_file_mounts() below.
+_ABSOLUTE_VERSIONED_CATALOG_DIR = runtime_utils.get_runtime_dir_path(
+    os.path.join('.sky/catalogs', constants.CATALOG_SCHEMA_VERSION))
 os.makedirs(_ABSOLUTE_VERSIONED_CATALOG_DIR, exist_ok=True)
 
 
@@ -115,10 +128,18 @@ def get_modified_catalog_file_mounts() -> Dict[str, str]:
     modified_catalog_list = _get_modified_catalogs()
     modified_catalog_path_map = {}  # Map of remote: local catalog paths
     for catalog in modified_catalog_list:
-        # Use relative paths for remote to handle varying usernames on the cloud
+        # remote_path stays as '~/.sky/catalogs/<version>/<catalog>' so the
+        # file_mounts upload lands at the controller pod's $HOME (controllers
+        # don't set SKY_RUNTIME_DIR, so the controller-side catalog lookup
+        # also resolves to $HOME via the default in
+        # runtime_utils.get_runtime_dir_path()).
         remote_path = os.path.join(constants.CATALOG_DIR,
                                    constants.CATALOG_SCHEMA_VERSION, catalog)
-        local_path = os.path.expanduser(remote_path)
+        # local_path comes from the SKY_RUNTIME_DIR-aware
+        # _ABSOLUTE_VERSIONED_CATALOG_DIR above, not expanduser(remote_path),
+        # so that locally-modified catalogs are picked up from wherever they
+        # actually live (which may be SKY_RUNTIME_DIR-rooted, not $HOME).
+        local_path = os.path.join(_ABSOLUTE_VERSIONED_CATALOG_DIR, catalog)
         modified_catalog_path_map[remote_path] = local_path
     return modified_catalog_path_map
 


### PR DESCRIPTION
## Summary

- Route the local catalog directory through `SKY_RUNTIME_DIR`, matching the existing convention for SQLite DBs, the skypilot-runtime venv, `miniconda3`, `python_path`, and `ray_path` (see the comment at `sky/skylet/constants.py:9-22`).
- Backwards compatible: when `SKY_RUNTIME_DIR` is unset, catalogs continue to live under `$HOME/.sky/catalogs/` exactly as today.
- Single-file change: `sky/catalog/common.py` only.

## Motivation

Catalogs are downloaded CSVs from the hosted catalog mirror, pure regeneratable cache. The existing comment at `sky/skylet/constants.py:9-22` documents `SKY_RUNTIME_DIR` as the home for all SkyPilot runtime artifacts, specifically because `$HOME` is often a shared NFS mount that misbehaves for this kind of state (the SQLite case it explicitly calls out). Catalogs were a missed migration. Leaving them on `$HOME` causes two related problems on shared-NFS-home setups:

1. `import sky` crashes at module load if `~/.sky/catalogs/` already exists but is owned by a different user, because `sky/catalog/common.py:35` does an eager `os.makedirs`:

   ```
   File ".../sky/catalog/common.py", line 35, in <module>
       os.makedirs(_ABSOLUTE_VERSIONED_CATALOG_DIR, exist_ok=True)
   PermissionError: [Errno 13] Permission denied: '/home/sky/.sky/catalogs/v8'
   ```

2. Subsequent catalog writes (catalog downloads, AZ mapping cache, user-identity cache) hit the same bad-perm parent and fail.

Routing through `SKY_RUNTIME_DIR` puts catalogs on whatever the runtime dir resolves to, typically local disk on deployed SkyPilot envs, where the running user owns the parent. The bad-perm dir on the shared `$HOME` volume becomes irrelevant.

## Changes

Just `sky/catalog/common.py`:

- `_ABSOLUTE_VERSIONED_CATALOG_DIR` now resolves via `runtime_utils.get_runtime_dir_path('.sky/catalogs/<version>')`.
- `get_modified_catalog_file_mounts()` computes `local_path` from `_ABSOLUTE_VERSIONED_CATALOG_DIR` (the SKY_RUNTIME_DIR-aware location), not `os.path.expanduser(remote_path)`. `remote_path` stays `~/.sky/catalogs/<version>/<catalog>` so the file_mounts upload lands at the controller pod's `$HOME`. Controllers don't set `SKY_RUNTIME_DIR`, so the controller-side catalog lookup also resolves to `$HOME` via the same `runtime_utils` default, and paths match end to end.

`constants.CATALOG_DIR` is intentionally unchanged. It is now used only by `get_modified_catalog_file_mounts()`'s `remote_path` computation, where the `~` is expanded by the receiving controller pod's shell.

## Backwards compatibility

`runtime_utils.get_runtime_dir_path()` defaults to `~` when `SKY_RUNTIME_DIR` is unset (see `sky/skylet/runtime_utils.py`). So on laptops or any environment that doesn't set the env var, catalogs continue to live at `$HOME/.sky/catalogs/<version>/` exactly as before. Existing local catalog caches are picked up without re-download.

## Test plan

- [x] **Default env, no `SKY_RUNTIME_DIR`**: `python -c "import sky.catalog.common as cc; print(cc._ABSOLUTE_VERSIONED_CATALOG_DIR)"` returns `$HOME/.sky/catalogs/v8`. Matches prior behavior.
- [x] **`SKY_RUNTIME_DIR=/tmp/runtime-test`**: same probe returns `/tmp/runtime-test/.sky/catalogs/v8`.
- [x] **`get_modified_catalog_file_mounts()` plumbing**: created a fake locally-modified catalog at `/tmp/runtime-test/.sky/catalogs/v8/aws/vms.csv` with `SKY_RUNTIME_DIR` set. Function returns `{'~/.sky/catalogs/v8/aws/vms.csv': '/tmp/runtime-test/.sky/catalogs/v8/aws/vms.csv'}`. Remote stays `~`-prefixed for controller-side `$HOME` expansion; local correctly comes from the `SKY_RUNTIME_DIR`-resolved location.
- [x] **End-to-end on a SkyPilot pod** where `SKY_RUNTIME_DIR` is set to a local-disk path and `$HOME` is on shared NFS, with a deliberately permission-corrupted `~/.sky/catalogs/` owned by an unrelated user mode `755` (to simulate the bug scenario):
  - `sky check` for a Kubernetes context: succeeds.
  - `sky show-gpus`: succeeds, returns live GPU inventory.
  - `sky launch` optimizer step ("Considered resources" output): succeeds.
  - All catalog files land at `$SKY_RUNTIME_DIR/.sky/catalogs/v8/`.
  - `$HOME/.sky/catalogs/` on the shared volume: not touched.
- [x] `format.sh`: 10.00/10. mypy passes.

## Alternative considered

An earlier draft (#9605) took a different approach: keep catalogs at `$HOME/.sky/catalogs/` but make `import sky` and read-only commands robust to a non-writable catalog dir (drop the module-level `os.makedirs`, make `get_catalog_path()` a pure path-getter, add explicit `os.makedirs` at write call sites). That approach fixed the import-time crash but left subsequent catalog writes (downloads, AZ mapping cache, identity cache) still failing on the same bad-perm parent. This PR is the architectural fix: catalogs route around the bad-perm dir entirely by living somewhere the running user owns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)