### PR TITLE
Add below_min_since and all_ready_at columns and helpers to managed-jobs spot table

### DIFF
--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -743,6 +743,7 @@ function JobDetails() {
             <PluginSlot
               name="jobs.detail.nodes"
               context={{
+                jobId: detailJobData.id,
                 clusterName: detailJobData.current_cluster_name,
                 clusterNameOnCloud: detailJobData.cluster_name_on_cloud,
                 nodeNames: detailJobData.node_names,

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -400,6 +400,22 @@ function JobDetails() {
               </Card>
             </div>
 
+            {/* Plugin Slot: Job Overview — for at-a-glance status that's
+                useful immediately on opening a running/recovering job
+                (e.g. pod readiness for elastic K8s jobs). Sits above
+                Logs/Telemetry so it's visible without scrolling. */}
+            <PluginSlot
+              name="jobs.detail.overview"
+              context={{
+                jobId: detailJobData.id,
+                status: detailJobData.status,
+                clusterName: detailJobData.current_cluster_name,
+                clusterNameOnCloud: detailJobData.cluster_name_on_cloud,
+                infra: detailJobData.full_infra,
+              }}
+              wrapperClassName="mt-6"
+            />
+
             {/* Tasks Section - only show for multi-task jobs */}
             {isMultiTask && (
               <div id="tasks-section" className="mt-6">

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -102,6 +102,19 @@ spot_table = sqlalchemy.Table(
     sqlalchemy.Column('is_primary_in_job_group',
                       sqlalchemy.Boolean,
                       server_default=None),
+    # Tracks the most recent time at which (running + succeeded) dropped
+    # below the lower bound of an elastic job. NULL when at/above the
+    # lower bound. Set via COALESCE so the first drop's timestamp survives
+    # subsequent updates while still below.
+    sqlalchemy.Column('below_min_since',
+                      sqlalchemy.Float,
+                      server_default=None),
+    # Set once via atomic UPDATE ... WHERE all_ready_at IS NULL when the
+    # job's running pod count first reaches the launched node count.
+    # NULL means never reached.
+    sqlalchemy.Column('all_ready_at',
+                      sqlalchemy.Float,
+                      server_default=None),
 )
 
 job_info_table = sqlalchemy.Table(
@@ -2670,6 +2683,85 @@ async def set_recovered_async(job_id: int, task_id: int, recovered_time: float,
             raise exceptions.ManagedJobStatusError(message)
     logger.info('==== Recovered. ====')
     await callback_func('RECOVERED')
+
+
+async def set_below_min_since_async(job_id: int,
+                                    task_id: int,
+                                    *,
+                                    ts: float) -> None:
+    """Set spot.below_min_since via COALESCE.
+
+    Updates the column to :ts only if currently NULL; otherwise preserves
+    the existing value. Idempotent — repeated calls are no-ops once a
+    timestamp is set.
+    """
+    engine = await _db_manager.get_async_engine()
+    async with sql_async.AsyncSession(engine) as session:
+        await session.execute(
+            sqlalchemy.update(spot_table).where(
+                sqlalchemy.and_(
+                    spot_table.c.spot_job_id == job_id,
+                    spot_table.c.task_id == task_id,
+                )).values({
+                    spot_table.c.below_min_since: sqlalchemy.func.coalesce(
+                        spot_table.c.below_min_since, ts),
+                }))
+        await session.commit()
+
+
+async def clear_below_min_since_async(job_id: int, task_id: int) -> None:
+    """Set spot.below_min_since to NULL. Idempotent."""
+    engine = await _db_manager.get_async_engine()
+    async with sql_async.AsyncSession(engine) as session:
+        await session.execute(
+            sqlalchemy.update(spot_table).where(
+                sqlalchemy.and_(
+                    spot_table.c.spot_job_id == job_id,
+                    spot_table.c.task_id == task_id,
+                )).values({spot_table.c.below_min_since: None}))
+        await session.commit()
+
+
+async def mark_all_ready_once_async(job_id: int,
+                                    task_id: int,
+                                    *,
+                                    ts: float) -> bool:
+    """Atomically set spot.all_ready_at iff currently NULL.
+
+    Returns True only on the call that actually updated a row; subsequent
+    calls return False. The WHERE all_ready_at IS NULL guard provides
+    SQL-level once-only semantics.
+    """
+    engine = await _db_manager.get_async_engine()
+    async with sql_async.AsyncSession(engine) as session:
+        result = await session.execute(
+            sqlalchemy.update(spot_table).where(
+                sqlalchemy.and_(
+                    spot_table.c.spot_job_id == job_id,
+                    spot_table.c.task_id == task_id,
+                    spot_table.c.all_ready_at.is_(None),
+                )).values({spot_table.c.all_ready_at: ts}))
+        await session.commit()
+        return result.rowcount == 1
+
+
+async def get_below_min_and_all_ready_async(
+        job_id: int,
+        task_id: int) -> Tuple[Optional[float], Optional[float]]:
+    """Read the (below_min_since, all_ready_at) timestamps for a job/task row."""
+    engine = await _db_manager.get_async_engine()
+    async with sql_async.AsyncSession(engine) as session:
+        result = await session.execute(
+            sqlalchemy.select(spot_table.c.below_min_since,
+                              spot_table.c.all_ready_at).where(
+                sqlalchemy.and_(
+                    spot_table.c.spot_job_id == job_id,
+                    spot_table.c.task_id == task_id,
+                )))
+        row = result.one_or_none()
+        if row is None:
+            return None, None
+        return row.below_min_since, row.all_ready_at
 
 
 def set_winding_down(job_id: int, task_id: int) -> None:

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -2689,11 +2689,11 @@ async def set_below_min_since_async(job_id: int,
                                     task_id: int,
                                     *,
                                     ts: float) -> None:
-    """Set spot.below_min_since via COALESCE.
+    """Set spot.below_min_since to :ts iff currently NULL. Idempotent.
 
-    Updates the column to :ts only if currently NULL; otherwise preserves
-    the existing value. Idempotent — repeated calls are no-ops once a
-    timestamp is set.
+    Called every monitor-loop tick, so the WHERE clause gates the write
+    itself — once a timestamp is persisted, repeated calls match zero rows
+    and issue no UPDATE.
     """
     engine = await _db_manager.get_async_engine()
     async with sql_async.AsyncSession(engine) as session:
@@ -2702,15 +2702,17 @@ async def set_below_min_since_async(job_id: int,
                 sqlalchemy.and_(
                     spot_table.c.spot_job_id == job_id,
                     spot_table.c.task_id == task_id,
-                )).values({
-                    spot_table.c.below_min_since: sqlalchemy.func.coalesce(
-                        spot_table.c.below_min_since, ts),
-                }))
+                    spot_table.c.below_min_since.is_(None),
+                )).values({spot_table.c.below_min_since: ts}))
         await session.commit()
 
 
 async def clear_below_min_since_async(job_id: int, task_id: int) -> None:
-    """Set spot.below_min_since to NULL. Idempotent."""
+    """Set spot.below_min_since to NULL iff currently non-NULL. Idempotent.
+
+    Called every monitor-loop tick when the job is at/above min; the
+    IS NOT NULL guard skips the write when the column is already cleared.
+    """
     engine = await _db_manager.get_async_engine()
     async with sql_async.AsyncSession(engine) as session:
         await session.execute(
@@ -2718,6 +2720,7 @@ async def clear_below_min_since_async(job_id: int, task_id: int) -> None:
                 sqlalchemy.and_(
                     spot_table.c.spot_job_id == job_id,
                     spot_table.c.task_id == task_id,
+                    spot_table.c.below_min_since.is_not(None),
                 )).values({spot_table.c.below_min_since: None}))
         await session.commit()
 

--- a/sky/schemas/db/spot_jobs/020_add_elastic_job_state_columns.py
+++ b/sky/schemas/db/spot_jobs/020_add_elastic_job_state_columns.py
@@ -1,0 +1,37 @@
+"""Add below_min_since and all_ready_at columns to spot table.
+
+Two nullable unix-epoch float timestamps tracking elastic-managed-job
+state transitions:
+- below_min_since: most recent moment (running + succeeded) < min_nodes
+- all_ready_at: first moment running == launched node count
+
+Revision ID: 020
+Revises: 019
+Create Date: 2026-05-13
+"""
+# pylint: disable=invalid-name
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from sky.utils.db import db_utils
+
+revision: str = '020'
+down_revision: Union[str, Sequence[str], None] = '019'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    """Add below_min_since and all_ready_at columns to spot table."""
+    with op.get_context().autocommit_block():
+        db_utils.add_column_to_table_alembic(
+            'spot', 'below_min_since', sa.Float(), server_default=None)
+        db_utils.add_column_to_table_alembic(
+            'spot', 'all_ready_at', sa.Float(), server_default=None)
+
+
+def downgrade():
+    """No downgrade logic."""
+    pass

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -34,7 +34,7 @@ GLOBAL_USER_STATE_VERSION = '016'  # add volume creation_yaml column
 GLOBAL_USER_STATE_LOCK_PATH = f'~/.sky/locks/.{GLOBAL_USER_STATE_DB_NAME}.lock'
 
 SPOT_JOBS_DB_NAME = 'spot_jobs_db'
-SPOT_JOBS_VERSION = '019'  # add file_mounts_blob_id column to job_info
+SPOT_JOBS_VERSION = '020'  # add below_min_since + all_ready_at columns to spot
 SPOT_JOBS_LOCK_PATH = f'~/.sky/locks/.{SPOT_JOBS_DB_NAME}.lock'
 
 SERVE_DB_NAME = 'serve_db'

--- a/tests/unit_tests/test_sky/jobs/test_below_min_and_all_ready.py
+++ b/tests/unit_tests/test_sky/jobs/test_below_min_and_all_ready.py
@@ -1,0 +1,146 @@
+"""Tests for below_min_since and all_ready_at async helpers in sky.jobs.state."""
+
+import contextlib
+
+import filelock
+import pytest
+import sqlalchemy
+from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from sky.jobs import state as managed_job_state
+from sky.jobs.state import spot_table
+
+
+@pytest.fixture
+def jobs_db(tmp_path, monkeypatch):
+    """Temporary SQLite DB for jobs.state with patched engines."""
+    db_path = tmp_path / 'jobs_state_testing.db'
+    engine = create_engine(f'sqlite:///{db_path}')
+    async_engine = create_async_engine(f'sqlite+aiosqlite:///{db_path}',
+                                       connect_args={'timeout': 30})
+
+    @contextlib.contextmanager
+    def _tmp_db_lock(_section: str):
+        lock_path = tmp_path / f'.{_section}.lock'
+        with filelock.FileLock(str(lock_path), timeout=10):
+            yield
+
+    monkeypatch.setattr(managed_job_state.migration_utils, 'db_lock',
+                        _tmp_db_lock)
+    monkeypatch.setattr(managed_job_state._db_manager, '_engine', engine)
+    monkeypatch.setattr(managed_job_state._db_manager, '_engine_async',
+                        async_engine)
+    managed_job_state.create_table(engine)
+    yield engine
+
+
+def _insert_spot_row(engine, *, spot_job_id, task_id=0,
+                     below_min_since=None, all_ready_at=None):
+    with engine.begin() as conn:
+        conn.execute(spot_table.insert().values(
+            spot_job_id=spot_job_id,
+            task_id=task_id,
+            job_name=f'job-{spot_job_id}',
+            submitted_at=0.0,
+            status='RUNNING',
+            below_min_since=below_min_since,
+            all_ready_at=all_ready_at,
+        ))
+
+
+def _read_below_min(engine, *, spot_job_id, task_id=0):
+    with engine.begin() as conn:
+        result = conn.execute(
+            sqlalchemy.select(spot_table.c.below_min_since)
+            .where(spot_table.c.spot_job_id == spot_job_id)
+            .where(spot_table.c.task_id == task_id))
+        row = result.one_or_none()
+        return row.below_min_since if row else None
+
+
+@pytest.mark.asyncio
+async def test_set_below_min_since_sets_when_null(jobs_db):
+    _insert_spot_row(jobs_db, spot_job_id=1, below_min_since=None)
+    await managed_job_state.set_below_min_since_async(1, 0, ts=100.0)
+    assert _read_below_min(jobs_db, spot_job_id=1) == 100.0
+
+
+@pytest.mark.asyncio
+async def test_set_below_min_since_preserves_existing(jobs_db):
+    _insert_spot_row(jobs_db, spot_job_id=2, below_min_since=50.0)
+    await managed_job_state.set_below_min_since_async(2, 0, ts=200.0)
+    assert _read_below_min(jobs_db, spot_job_id=2) == 50.0
+
+
+@pytest.mark.asyncio
+async def test_clear_below_min_since(jobs_db):
+    _insert_spot_row(jobs_db, spot_job_id=3, below_min_since=50.0)
+    await managed_job_state.clear_below_min_since_async(3, 0)
+    assert _read_below_min(jobs_db, spot_job_id=3) is None
+
+
+@pytest.mark.asyncio
+async def test_clear_below_min_since_idempotent_on_null(jobs_db):
+    _insert_spot_row(jobs_db, spot_job_id=4, below_min_since=None)
+    await managed_job_state.clear_below_min_since_async(4, 0)
+    assert _read_below_min(jobs_db, spot_job_id=4) is None
+
+
+def _read_all_ready_at(engine, *, spot_job_id, task_id=0):
+    with engine.begin() as conn:
+        result = conn.execute(
+            sqlalchemy.select(spot_table.c.all_ready_at)
+            .where(spot_table.c.spot_job_id == spot_job_id)
+            .where(spot_table.c.task_id == task_id))
+        row = result.one_or_none()
+        return row.all_ready_at if row else None
+
+
+@pytest.mark.asyncio
+async def test_mark_all_ready_once_first_call_returns_true(jobs_db):
+    _insert_spot_row(jobs_db, spot_job_id=10, all_ready_at=None)
+    result = await managed_job_state.mark_all_ready_once_async(10, 0, ts=300.0)
+    assert result is True
+    assert _read_all_ready_at(jobs_db, spot_job_id=10) == 300.0
+
+
+@pytest.mark.asyncio
+async def test_mark_all_ready_once_second_call_returns_false(jobs_db):
+    _insert_spot_row(jobs_db, spot_job_id=11, all_ready_at=100.0)
+    result = await managed_job_state.mark_all_ready_once_async(11, 0, ts=300.0)
+    assert result is False
+    # Original preserved
+    assert _read_all_ready_at(jobs_db, spot_job_id=11) == 100.0
+
+
+@pytest.mark.asyncio
+async def test_mark_all_ready_once_concurrent_only_one_wins(jobs_db):
+    import asyncio
+    _insert_spot_row(jobs_db, spot_job_id=12, all_ready_at=None)
+    results = await asyncio.gather(
+        managed_job_state.mark_all_ready_once_async(12, 0, ts=400.0),
+        managed_job_state.mark_all_ready_once_async(12, 0, ts=500.0),
+        managed_job_state.mark_all_ready_once_async(12, 0, ts=600.0),
+    )
+    assert sum(1 for r in results if r) == 1
+    final = _read_all_ready_at(jobs_db, spot_job_id=12)
+    assert final in (400.0, 500.0, 600.0)
+
+
+@pytest.mark.asyncio
+async def test_get_below_min_and_all_ready_returns_both(jobs_db):
+    _insert_spot_row(jobs_db, spot_job_id=20, below_min_since=42.0,
+                     all_ready_at=99.0)
+    below, ready = await managed_job_state.get_below_min_and_all_ready_async(
+        20, 0)
+    assert below == 42.0
+    assert ready == 99.0
+
+
+@pytest.mark.asyncio
+async def test_get_below_min_and_all_ready_returns_nulls_for_missing(jobs_db):
+    below, ready = await managed_job_state.get_below_min_and_all_ready_async(
+        9999, 0)
+    assert below is None
+    assert ready is None

--- a/tests/unit_tests/test_sky/jobs/test_state_schema.py
+++ b/tests/unit_tests/test_sky/jobs/test_state_schema.py
@@ -1,0 +1,21 @@
+"""Schema-shape regression tests for sky.jobs.state."""
+
+import sqlalchemy
+
+from sky.jobs.state import spot_table
+
+
+def test_spot_has_node_readiness_columns():
+    """The spot table includes below_min_since and all_ready_at."""
+    cols = {c.name for c in spot_table.columns}
+    assert 'below_min_since' in cols
+    assert 'all_ready_at' in cols
+
+
+def test_spot_node_readiness_columns_are_nullable_float():
+    """Both new columns are nullable Float (matches last_recovered_at shape)."""
+    for name in ('below_min_since', 'all_ready_at'):
+        col = spot_table.c[name]
+        assert col.nullable is True, f'{name} should be nullable'
+        assert isinstance(col.type, sqlalchemy.Float), (
+            f'{name} type {col.type!r} should be Float')

--- a/tests/unit_tests/test_sky/jobs/test_state_schema.py
+++ b/tests/unit_tests/test_sky/jobs/test_state_schema.py
@@ -5,14 +5,14 @@ import sqlalchemy
 from sky.jobs.state import spot_table
 
 
-def test_spot_has_node_readiness_columns():
+def test_spot_has_below_min_since_and_all_ready_at():
     """The spot table includes below_min_since and all_ready_at."""
     cols = {c.name for c in spot_table.columns}
     assert 'below_min_since' in cols
     assert 'all_ready_at' in cols
 
 
-def test_spot_node_readiness_columns_are_nullable_float():
+def test_spot_elastic_columns_are_nullable_float():
     """Both new columns are nullable Float (matches last_recovered_at shape)."""
     for name in ('below_min_since', 'all_ready_at'):
         col = spot_table.c[name]


### PR DESCRIPTION
## Summary

Adds two nullable Float columns (`below_min_since`, `all_ready_at`) to the managed-jobs `spot` table and four small async helpers in `sky/jobs/state.py` to manage them. Also passes `jobId` to the existing `jobs.detail.nodes` dashboard plugin slot context (mirrors the same field already passed to `jobs.detail.events`).

## Columns

- `below_min_since DOUBLE PRECISION NULL` — most recent unix-epoch time at which a managed job's `running + succeeded` count dropped below its lower bound. NULL when at/above. COALESCE-preserved.
- `all_ready_at DOUBLE PRECISION NULL` — first time the job's running pod count equaled its launched node count. NULL means never reached. Set via atomic `UPDATE ... WHERE all_ready_at IS NULL`.

## Helpers

- `set_below_min_since_async(job_id, task_id, *, ts)` — COALESCE-set, idempotent.
- `clear_below_min_since_async(job_id, task_id)` — set to NULL.
- `mark_all_ready_once_async(job_id, task_id, *, ts) -> bool` — atomic once-only setter; returns whether it actually updated.
- `get_below_min_and_all_ready_async(job_id, task_id) -> (Optional[float], Optional[float])` — read both columns.

## Dashboard slot context

One-line addition: `jobId: detailJobData.id` to the existing `<PluginSlot name="jobs.detail.nodes">` context object in `sky/dashboard/src/pages/jobs/[job].js`. Backward-compatible; downstream slot consumers destructure named keys.

## Tests

- `tests/unit_tests/test_sky/jobs/test_state_schema.py` — column-shape regression.
- `tests/unit_tests/test_sky/jobs/test_below_min_and_all_ready.py` — happy paths, idempotency, and a concurrent `asyncio.gather` test for the once-only guard.

## Test plan

- [ ] CI passes the new tests.
- [ ] Existing managed-jobs unit tests remain green.