### PR TITLE
[Dashboard] add PluginPageSlot for page-level slot replacement

### DIFF
--- a/sky/dashboard/src/__tests__/pages-infra.test.jsx
+++ b/sky/dashboard/src/__tests__/pages-infra.test.jsx
@@ -35,7 +35,7 @@ jest.mock('@/components/infra', () => ({
 let infraPage;
 beforeAll(async () => {
   // Defer require until after window mock setup
-  infraPage = (await import('../infra')).default;
+  infraPage = (await import('../pages/infra')).default;
 });
 
 beforeEach(() => {

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -76,6 +76,7 @@ import { REFRESH_INTERVALS, UI_CONFIG } from '@/lib/config';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { PluginSlot } from '@/plugins/PluginSlot';
+import { PluginPageSlot } from '@/plugins/PluginPageSlot';
 import { PluginWrapperSlot } from '@/plugins/PluginWrapperSlot';
 import {
   useAllDataProviders,
@@ -3336,118 +3337,131 @@ export function GPUs() {
           onResult={recordExtraInfraResult}
         />
       ))}
-      {selectedContext && (
-        // Detail-view header: small back button on its own line, then a
-        // larger h1 row below (rendered further down). This matches the
-        // dashboard's other detail pages and gives the leaf identifier
-        // proper visual weight.
-        <div className="mb-2">
-          <Link
-            href="/infra"
-            className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 cursor-pointer"
-          >
-            ← Infrastructure
-          </Link>
-        </div>
-      )}
-      {/* List-view top bar: title link + workspace selector + Refresh +
-          plugin header actions. Skipped entirely on a detail page —
-          the back link above already serves as the leaf navigation,
-          and the page-level Refresh / Add Infra controls don't apply
-          when viewing one infra. Hiding the whole row also closes the
-          ~36px gap (h-5 + mb-4) between the back link and the h1. */}
-      {!selectedContext && (
-        <div className="flex items-center justify-between mb-4 h-5">
-          <div className="text-base flex items-center">
-            <Link href="/infra" className="text-sky-blue cursor-default">
-              Infrastructure
+      {selectedContext ? (
+        // Detail view — back link, attention banner, h1 with header actions,
+        // then the per-context tab content. Unchanged from the original layout.
+        <>
+          {/* Detail-view header: small back button on its own line, then a
+              larger h1 row below (rendered further down). This matches the
+              dashboard's other detail pages and gives the leaf identifier
+              proper visual weight. */}
+          <div className="mb-2">
+            <Link
+              href="/infra"
+              className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 cursor-pointer"
+            >
+              ← Infrastructure
             </Link>
           </div>
-          <div className="flex items-center">
-            {/* Workspace Selector */}
-            {availableWorkspaces.length > 0 && (
-              <div className="flex items-center mr-4">
-                <label className="text-sm font-medium text-gray-700 mr-2">
-                  Workspace:
-                </label>
-                <Select
-                  value={selectedWorkspace}
-                  onValueChange={setSelectedWorkspace}
-                >
-                  <SelectTrigger className="w-40 h-8 text-sm">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All Workspaces</SelectItem>
-                    {availableWorkspaces.map((workspace) => (
-                      <SelectItem key={workspace} value={workspace}>
-                        {workspace}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            )}
-
-            {isAnyLoading && (
-              <div className="flex items-center mr-2">
-                <CircularProgress size={15} className="mt-0" />
-                <span className="ml-2 text-gray-500">Loading...</span>
-              </div>
-            )}
-            {!isAnyLoading && lastFetchedTime && (
-              <LastUpdatedTimestamp
-                timestamp={lastFetchedTime}
-                className="mr-2"
-              />
-            )}
-            <button
-              onClick={handleRefresh}
-              disabled={isAnyLoading}
-              className="text-sky-blue hover:text-sky-blue-bright flex items-center"
+          <PluginSlot name="infra.attentionBanner" />
+          {/* Large h1 title + plugin-injected header actions (e.g. Remove)
+              on a single row. */}
+          <div className="flex items-center justify-between gap-3 mb-5">
+            <h1
+              className={`text-2xl font-semibold text-gray-900 leading-tight tracking-tight ${
+                selectedContext.startsWith('ssh-') ||
+                slurmClusters.includes(selectedContext)
+                  ? ''
+                  : 'font-mono'
+              }`}
             >
-              <RotateCwIcon className="h-4 w-4 mr-1.5" />
-              {!isMobile && 'Refresh'}
-            </button>
-            <PluginSlot name="infra.headerActions" wrapperClassName="ml-3" />
-          </div>
-        </div>
-      )}
-
-      <PluginSlot name="infra.attentionBanner" />
-
-      {selectedContext && (
-        // Large h1 title + plugin-injected header actions (e.g. Remove)
-        // on a single row.
-        <div className="flex items-center justify-between gap-3 mb-5">
-          <h1
-            className={`text-2xl font-semibold text-gray-900 leading-tight tracking-tight ${
-              selectedContext.startsWith('ssh-') ||
-              slurmClusters.includes(selectedContext)
-                ? ''
-                : 'font-mono'
-            }`}
-          >
-            {selectedContext.startsWith('ssh-')
-              ? selectedContext.replace(/^ssh-/, '')
-              : selectedContext}
-          </h1>
-          <PluginSlot
-            name="infra.contextDetail.headerActions"
-            context={{
-              contextName: selectedContext.startsWith('ssh-')
+              {selectedContext.startsWith('ssh-')
                 ? selectedContext.replace(/^ssh-/, '')
-                : selectedContext,
-              isSlurm: slurmClusters.includes(selectedContext),
-              isSsh: selectedContext.startsWith('ssh-'),
-            }}
-            wrapperClassName="flex items-center gap-2"
-          />
-        </div>
-      )}
+                : selectedContext}
+            </h1>
+            <PluginSlot
+              name="infra.contextDetail.headerActions"
+              context={{
+                contextName: selectedContext.startsWith('ssh-')
+                  ? selectedContext.replace(/^ssh-/, '')
+                  : selectedContext,
+                isSlurm: slurmClusters.includes(selectedContext),
+                isSsh: selectedContext.startsWith('ssh-'),
+              }}
+              wrapperClassName="flex items-center gap-2"
+            />
+          </div>
+          {/* Each section handles its own loading state */}
+          {renderKubernetesTab()}
+        </>
+      ) : (
+        // List view — owned by a plugin when one registers `infra.page`;
+        // else the OSS fallback is rendered.
+        <PluginPageSlot
+          name="infra.page"
+          fallback={
+            <>
+              {/* List-view top bar: title link + workspace selector + Refresh +
+                  plugin header actions. Skipped entirely on a detail page —
+                  the back link above already serves as the leaf navigation,
+                  and the page-level Refresh / Add Infra controls don't apply
+                  when viewing one infra. Hiding the whole row also closes the
+                  ~36px gap (h-5 + mb-4) between the back link and the h1. */}
+              <div className="flex items-center justify-between mb-4 h-5">
+                <div className="text-base flex items-center">
+                  <Link href="/infra" className="text-sky-blue cursor-default">
+                    Infrastructure
+                  </Link>
+                </div>
+                <div className="flex items-center">
+                  {/* Workspace Selector */}
+                  {availableWorkspaces.length > 0 && (
+                    <div className="flex items-center mr-4">
+                      <label className="text-sm font-medium text-gray-700 mr-2">
+                        Workspace:
+                      </label>
+                      <Select
+                        value={selectedWorkspace}
+                        onValueChange={setSelectedWorkspace}
+                      >
+                        <SelectTrigger className="w-40 h-8 text-sm">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="all">All Workspaces</SelectItem>
+                          {availableWorkspaces.map((workspace) => (
+                            <SelectItem key={workspace} value={workspace}>
+                              {workspace}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  )}
 
-      {/* Each section handles its own loading state */}
-      {renderKubernetesTab()}
+                  {isAnyLoading && (
+                    <div className="flex items-center mr-2">
+                      <CircularProgress size={15} className="mt-0" />
+                      <span className="ml-2 text-gray-500">Loading...</span>
+                    </div>
+                  )}
+                  {!isAnyLoading && lastFetchedTime && (
+                    <LastUpdatedTimestamp
+                      timestamp={lastFetchedTime}
+                      className="mr-2"
+                    />
+                  )}
+                  <button
+                    onClick={handleRefresh}
+                    disabled={isAnyLoading}
+                    className="text-sky-blue hover:text-sky-blue-bright flex items-center"
+                  >
+                    <RotateCwIcon className="h-4 w-4 mr-1.5" />
+                    {!isMobile && 'Refresh'}
+                  </button>
+                  <PluginSlot
+                    name="infra.headerActions"
+                    wrapperClassName="ml-3"
+                  />
+                </div>
+              </div>
+              <PluginSlot name="infra.attentionBanner" />
+              {/* Each section handles its own loading state */}
+              {renderKubernetesTab()}
+            </>
+          }
+        />
+      )}
 
       {/* SSH Node Pool Modal - Always available */}
       <SSHNodePoolModal

--- a/sky/dashboard/src/pages/__tests__/infra.test.jsx
+++ b/sky/dashboard/src/pages/__tests__/infra.test.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+
+// Make next/dynamic a pass-through in tests: resolve the loader synchronously
+// via a require()-based trick so the wrapped component renders immediately.
+jest.mock('next/dynamic', () => (loader) => {
+  // Capture the resolved module synchronously by abusing the fact that Jest
+  // module mocks are evaluated in a synchronous context and the loader's
+  // import() will resolve to the already-mocked module.
+  let Resolved = null;
+  // We can't await here, but the mock for @/components/infra is synchronous,
+  // so we store the promise and return a wrapper that reads it.
+  const promise = loader().then((mod) => {
+    Resolved = mod;
+  });
+  const Dynamic = (props) => {
+    const [Comp, setComp] = React.useState(() => Resolved);
+    React.useEffect(() => {
+      if (!Comp) {
+        promise.then(() => setComp(() => Resolved));
+      }
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    if (!Comp) return null;
+    return React.createElement(Comp, props);
+  };
+  Dynamic.displayName = 'DynamicComponent';
+  return Dynamic;
+});
+
+// Mock the heavy GPUs component
+jest.mock('@/components/infra', () => ({
+  GPUs: () => <div data-testid="gpus-component">GPUs</div>,
+}));
+
+let infraPage;
+beforeAll(async () => {
+  // Defer require until after window mock setup
+  infraPage = (await import('../infra')).default;
+});
+
+beforeEach(() => {
+  delete window.__skyDashboardPluginsLoaded;
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('InfraPage plugin-loaded gate', () => {
+  it('renders GPUs immediately when plugins already loaded', async () => {
+    window.__skyDashboardPluginsLoaded = true;
+    const { findByTestId } = render(React.createElement(infraPage));
+    expect(await findByTestId('gpus-component')).toBeInTheDocument();
+  });
+
+  it('shows loading spinner until the plugins-loaded event fires', () => {
+    render(React.createElement(infraPage));
+    expect(screen.queryByTestId('gpus-component')).not.toBeInTheDocument();
+    act(() => {
+      window.dispatchEvent(new Event('skydashboard:plugins-loaded'));
+    });
+    expect(screen.getByTestId('gpus-component')).toBeInTheDocument();
+  });
+
+  it('falls through after 2s if the plugins-loaded event never fires', () => {
+    render(React.createElement(infraPage));
+    expect(screen.queryByTestId('gpus-component')).not.toBeInTheDocument();
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(screen.getByTestId('gpus-component')).toBeInTheDocument();
+  });
+});

--- a/sky/dashboard/src/pages/infra.js
+++ b/sky/dashboard/src/pages/infra.js
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Head from 'next/head';
 import dynamic from 'next/dynamic';
+import { CircularProgress } from '@mui/material';
+import { EVENT_PLUGINS_LOADED } from '@/data/connectors/constants';
 
 const GPUs = dynamic(
   () => import('@/components/infra').then((mod) => mod.GPUs),
@@ -8,12 +10,46 @@ const GPUs = dynamic(
 );
 
 export default function InfraPage() {
+  // Don't render GPUs until plugins have finished loading, so the list view
+  // body doesn't briefly flash through the OSS fallback before the plugin's
+  // `registerComponent('infra.page', …)` call lands. Mirror the same pattern
+  // used by `pages/infra/[...context].js`.
+  const [pluginsLoaded, setPluginsLoaded] = useState(
+    () =>
+      typeof window !== 'undefined' &&
+      window.__skyDashboardPluginsLoaded === true
+  );
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    if (window.__skyDashboardPluginsLoaded === true) {
+      setPluginsLoaded(true);
+      return undefined;
+    }
+    const handler = () => setPluginsLoaded(true);
+    window.addEventListener(EVENT_PLUGINS_LOADED, handler);
+    // Safety net: if the event never fires (no plugins configured, bundle
+    // failed to load, network blocked), fall through after 2 seconds so the
+    // page is not wedged.
+    const timer = window.setTimeout(handler, 2000);
+    return () => {
+      window.removeEventListener(EVENT_PLUGINS_LOADED, handler);
+      window.clearTimeout(timer);
+    };
+  }, []);
+
   return (
     <>
       <Head>
         <title>Infra | SkyPilot Dashboard</title>
       </Head>
-      <GPUs />
+      {pluginsLoaded ? (
+        <GPUs />
+      ) : (
+        <div className="flex justify-center items-center h-64">
+          <CircularProgress size={20} />
+          <span className="ml-2 text-gray-500">Loading…</span>
+        </div>
+      )}
     </>
   );
 }

--- a/sky/dashboard/src/plugins/PluginPageSlot.jsx
+++ b/sky/dashboard/src/plugins/PluginPageSlot.jsx
@@ -1,0 +1,38 @@
+'use client';
+
+import React from 'react';
+import { usePluginComponents } from './PluginProvider';
+
+/**
+ * PluginPageSlot renders the **first** plugin component registered for `name`
+ * instead of the fallback. If no plugin is registered, renders `fallback`.
+ *
+ * Unlike PluginSlot (which wraps results in a <div> and renders all registered
+ * components), this helper has page-replacement semantics: exactly one of
+ * (plugin component | fallback) renders, with no wrapper element. The first
+ * registration wins; we log a dev warning when more than one plugin tries to
+ * own the same page slot.
+ *
+ * @param {string} name - The slot name (e.g., 'infra.page')
+ * @param {React.ReactNode} fallback - Rendered when no plugin is registered
+ */
+export function PluginPageSlot({ name, fallback = null }) {
+  const components = usePluginComponents(name);
+
+  if (components.length === 0) {
+    return fallback;
+  }
+
+  if (components.length > 1 && process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[PluginPageSlot] Multiple plugins registered for slot "${name}"; rendering the first one and ignoring the rest:`,
+      components.map((c) => c.id)
+    );
+  }
+
+  const Component = components[0].component;
+  return <Component />;
+}
+
+export default PluginPageSlot;

--- a/sky/dashboard/src/plugins/PluginPageSlot.jsx
+++ b/sky/dashboard/src/plugins/PluginPageSlot.jsx
@@ -23,6 +23,7 @@ export function PluginPageSlot({ name, fallback = null }) {
     return fallback;
   }
 
+  // Dev-only: the slot already deterministically picks the first registration, so surfacing this in production would just spam the console without changing behavior.
   if (components.length > 1 && process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line no-console
     console.warn(

--- a/sky/dashboard/src/plugins/__tests__/PluginPageSlot.test.jsx
+++ b/sky/dashboard/src/plugins/__tests__/PluginPageSlot.test.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { PluginPageSlot } from '../PluginPageSlot';
+
+// Mock usePluginComponents — controlled per test via the variable below.
+let mockRegistered = [];
+jest.mock('../PluginProvider', () => ({
+  usePluginComponents: () => mockRegistered,
+}));
+
+afterEach(() => {
+  mockRegistered = [];
+  jest.clearAllMocks();
+});
+
+describe('PluginPageSlot', () => {
+  it('renders fallback when no plugins are registered', () => {
+    mockRegistered = [];
+    render(
+      <PluginPageSlot name="infra.page" fallback={<div>Fallback content</div>} />
+    );
+    expect(screen.getByText('Fallback content')).toBeInTheDocument();
+  });
+
+  it('renders the registered plugin component instead of fallback', () => {
+    const PluginPage = () => <div>Plugin content</div>;
+    mockRegistered = [{ id: 'plugin-a', component: PluginPage }];
+    render(
+      <PluginPageSlot name="infra.page" fallback={<div>Fallback content</div>} />
+    );
+    expect(screen.getByText('Plugin content')).toBeInTheDocument();
+    expect(screen.queryByText('Fallback content')).not.toBeInTheDocument();
+  });
+
+  it('renders only the first registered component and warns when more than one is registered', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const First = () => <div>First plugin</div>;
+    const Second = () => <div>Second plugin</div>;
+    mockRegistered = [
+      { id: 'plugin-a', component: First },
+      { id: 'plugin-b', component: Second },
+    ];
+    render(<PluginPageSlot name="infra.page" fallback={<div>Fallback</div>} />);
+    expect(screen.getByText('First plugin')).toBeInTheDocument();
+    expect(screen.queryByText('Second plugin')).not.toBeInTheDocument();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('infra.page'),
+      expect.anything()
+    );
+    warn.mockRestore();
+  });
+});

--- a/sky/dashboard/src/plugins/__tests__/PluginPageSlot.test.jsx
+++ b/sky/dashboard/src/plugins/__tests__/PluginPageSlot.test.jsx
@@ -15,7 +15,6 @@ afterEach(() => {
 
 describe('PluginPageSlot', () => {
   it('renders fallback when no plugins are registered', () => {
-    mockRegistered = [];
     render(
       <PluginPageSlot name="infra.page" fallback={<div>Fallback content</div>} />
     );
@@ -48,5 +47,25 @@ describe('PluginPageSlot', () => {
       expect.anything()
     );
     warn.mockRestore();
+  });
+
+  it('does not warn in production mode when more than one is registered', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const prevEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    try {
+      const First = () => <div>First plugin</div>;
+      const Second = () => <div>Second plugin</div>;
+      mockRegistered = [
+        { id: 'plugin-a', component: First },
+        { id: 'plugin-b', component: Second },
+      ];
+      render(<PluginPageSlot name="infra.page" fallback={<div>Fallback</div>} />);
+      expect(screen.getByText('First plugin')).toBeInTheDocument();
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = prevEnv;
+      warn.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Adds a new `PluginPageSlot` slot helper for page-level component replacement (vs. the existing `PluginSlot` which renders multiple components inside a wrapper `<div>`). When a plugin registers a component for a `PluginPageSlot` slot, the helper renders that component instead of the `fallback`; with no registrations, it renders `fallback` as-is. The first registration wins; a dev-only `console.warn` fires if more than one plugin tries to own the same page slot.
- Uses the new slot inside `GPUs()` in `components/infra.jsx` so the entire `/infra` list-view body can be replaced by a plugin via `registerComponent({ slot: 'infra.page', component: … })`. The OSS-only render path (the slot's `fallback`) is byte-identical to today's list view; detail-view rendering is untouched.
- Gates `pages/infra.js` on the existing `skydashboard:plugins-loaded` event (with a 2s safety-net timeout) so the OSS list view doesn't briefly flash before plugins have a chance to register \`infra.page\`. Mirrors the pattern already used by `pages/infra/[...context].js:43-63`.

## Tested
- New Jest tests for \`PluginPageSlot\`: renders fallback when no plugins are registered; renders the first registered component (no wrapper); production-mode silences the dev warning; dev mode emits the warning when >1 plugin registers.
- New Jest tests for the \`pages/infra.js\` gate: renders \`<GPUs />\` immediately when \`window.__skyDashboardPluginsLoaded\` is already true; waits for the \`skydashboard:plugins-loaded\` event; falls through after 2s if the event never fires.
- \`npm test\` and \`npm run build\` pass locally for the dashboard. Six pre-existing failures in \`version-display.test.jsx\` are unrelated to this change and reproduce against master.
- Manual: \`npm run dev\` and visit \`/infra\` — page renders identically to before with no plugin registered.