### PR TITLE
[Core] Add register_config_update_hook for post-update cache invalidation

### DIFF
--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -847,7 +847,8 @@ def register_config_update_hook(fn: Callable[[], None]) -> None:
     persisted and reloaded; exceptions are caught and logged so a misbehaving
     hook cannot fail the config update.
     """
-    _CONFIG_UPDATE_HOOKS.append(fn)
+    if fn not in _CONFIG_UPDATE_HOOKS:
+        _CONFIG_UPDATE_HOOKS.append(fn)
 
 
 def get_effective_queue_name(
@@ -1059,8 +1060,8 @@ def update_api_server_config_no_lock(config: config_utils.Config) -> None:
                 config, global_config_path)
 
     reload_config()
-    for hook in _CONFIG_UPDATE_HOOKS:
+    for hook in list(_CONFIG_UPDATE_HOOKS):
         try:
             hook()
         except Exception as e:  # pylint: disable=broad-except
-            logger.warning(f'Config-update hook {hook!r} raised: {e}')
+            logger.warning(f'Config-update hook {hook!r} raised: {e}', exc_info=True)

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -1064,4 +1064,5 @@ def update_api_server_config_no_lock(config: config_utils.Config) -> None:
         try:
             hook()
         except Exception as e:  # pylint: disable=broad-except
-            logger.warning(f'Config-update hook {hook!r} raised: {e}', exc_info=True)
+            logger.warning(f'Config-update hook {hook!r} raised: {e}',
+                           exc_info=True)

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -56,7 +56,7 @@ import pathlib
 import tempfile
 import threading
 import typing
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 import filelock
 import sqlalchemy
@@ -831,6 +831,24 @@ _QUEUE_NAME_KEYS: List[Tuple[str, ...]] = [
     ('kueue', 'local_queue_name'),
 ]
 
+# Hooks invoked at the end of `update_api_server_config_no_lock`, after the
+# new config has been persisted and reloaded in-process. Plugins use this to
+# invalidate caches that were derived from the config (e.g. a request that
+# memoized the result of `get_nested(...)` for a TTL). Registered at server
+# startup during single-threaded plugin loading, so no lock is needed.
+_CONFIG_UPDATE_HOOKS: List[Callable[[], None]] = []
+
+
+def register_config_update_hook(fn: Callable[[], None]) -> None:
+    """Register a callback to be invoked when the API server config is updated.
+
+    Called at server startup during plugin loading (single-threaded), so no
+    lock is needed. The callback runs after the new config has been
+    persisted and reloaded; exceptions are caught and logged so a misbehaving
+    hook cannot fail the config update.
+    """
+    _CONFIG_UPDATE_HOOKS.append(fn)
+
 
 def get_effective_queue_name(
         cloud: str,
@@ -1041,3 +1059,8 @@ def update_api_server_config_no_lock(config: config_utils.Config) -> None:
                 config, global_config_path)
 
     reload_config()
+    for hook in _CONFIG_UPDATE_HOOKS:
+        try:
+            hook()
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Config-update hook {hook!r} raised: {e}')


### PR DESCRIPTION
## Summary

Adds a small hook mechanism so plugins (and other server code) can react when the API server config is updated.

**Motivation:** Plugins that memoize state derived from the loaded config (e.g. a TTL-cached query whose result depends on \`get_nested(...)\`) currently have no way to react when the config changes through a path they don't control — for example, the dashboard's settings page, which goes through \`workspaces.update_config\`. The result is stale plugin-side caches until the TTL expires.

**Mechanism:**
- New \`register_config_update_hook(fn)\` — a callable registry populated at single-threaded server startup during plugin loading.
- At the end of \`update_api_server_config_no_lock\`, after the new config has been persisted and \`reload_config()\` has refreshed in-process state, each registered hook is invoked once.
- Hook exceptions are caught and logged at WARNING so a misbehaving hook cannot fail the config update itself.

\`update_api_server_config_no_lock\` is the natural choke point — every API-server-side config write funnels through it, so a single hook registration covers all current and future write paths.

## Test plan

- [ ] Register a no-op hook at startup, edit the config via the dashboard's settings page, and confirm the hook fires exactly once after the config is reloaded.
- [ ] Replace the hook with one that raises; confirm the config update still completes and the exception is logged at WARNING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)