### PR TITLE
[Core] Cancel in-flight Skylet gRPC calls on SkyPilotContext cancel

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -4387,10 +4387,14 @@ def _raise_if_ctx_canceled() -> None:
             'SkyPilotContext cancelled during Skylet retry')
 
 
-def invoke_grpc_unary(method: Any,
-                      request: Any,
-                      timeout: Optional[float] = None) -> Any:
-    """Call a gRPC unary method; cancel it when the SkyPilotContext is cancelled.
+def _cancelled_via_ctx(ctx: 'context_lib.SkyPilotContext',
+                       err: 'grpc.RpcError') -> bool:
+    """Did this RpcError come from ctx.cancel() firing our call.cancel()?"""
+    return ctx.is_canceled() and err.code() == grpc.StatusCode.CANCELLED
+
+
+def invoke_grpc_unary(method: Any, *args: Any, **kwargs: Any) -> Any:
+    """Call a gRPC unary method; cancel it on SkyPilotContext cancel.
 
     Without this wrapper, ``method(request, timeout=...)`` blocks the worker
     thread inside ``threading.Condition.wait()`` until the gRPC deadline
@@ -4402,22 +4406,33 @@ def invoke_grpc_unary(method: Any,
     active SkyPilotContext so it fires on client disconnect, request
     cancellation, or any other code path that calls ``ctx.cancel()``.
 
-    If there is no active context, falls through to the plain blocking call.
+    When the surrounding ctx cancels the call, the gRPC ``CANCELLED``
+    ``RpcError`` is re-raised as ``asyncio.CancelledError`` so the request
+    executor classifies the request as CANCELLED rather than FAILED.
+
+    With no active context, this falls through to the plain blocking call.
+    ``*args`` / ``**kwargs`` are forwarded verbatim so callers can pass
+    ``metadata``, ``credentials``, ``wait_for_ready`` and other gRPC
+    options unchanged.
     """
     ctx = context_lib.get()
     if ctx is None:
-        return method(request, timeout=timeout)
-    call = method.future(request, timeout=timeout)
+        return method(*args, **kwargs)
+    call = method.future(*args, **kwargs)
     ctx.register_cancel_callback(call.cancel)
     try:
         return call.result()
+    except grpc.RpcError as e:
+        if _cancelled_via_ctx(ctx, e):
+            raise asyncio.CancelledError(
+                'Skylet gRPC call cancelled via SkyPilotContext') from e
+        raise
     finally:
         ctx.unregister_cancel_callback(call.cancel)
 
 
-def invoke_grpc_streaming(method: Any,
-                          request: Any,
-                          timeout: Optional[float] = None) -> Iterator[Any]:
+def invoke_grpc_streaming(method: Any, *args: Any,
+                          **kwargs: Any) -> Iterator[Any]:
     """Call a gRPC unary-stream method; cancel it on SkyPilotContext cancel.
 
     The streaming iterator returned by gRPC is a ``_MultiThreadedRendezvous``
@@ -4426,18 +4441,28 @@ def invoke_grpc_streaming(method: Any,
     client disconnect tears the stream down instead of leaking a worker
     thread until the (often absent) deadline.
 
-    The returned generator unregisters the callback on completion or error,
-    so successful streams that outlive the cancel scope don't leak the
-    iterator's ``.cancel`` reference.
+    When the surrounding ctx cancels the stream, the gRPC ``CANCELLED``
+    ``RpcError`` is re-raised as ``asyncio.CancelledError`` (same
+    rationale as ``invoke_grpc_unary``).
+
+    The returned generator unregisters the callback on completion or
+    error, so successful streams that outlive the cancel scope don't leak
+    the iterator's ``.cancel`` reference. ``*args`` / ``**kwargs`` are
+    forwarded verbatim.
     """
     ctx = context_lib.get()
-    call = method(request, timeout=timeout)
+    call = method(*args, **kwargs)
     if ctx is None:
         yield from call
         return
     ctx.register_cancel_callback(call.cancel)
     try:
         yield from call
+    except grpc.RpcError as e:
+        if _cancelled_via_ctx(ctx, e):
+            raise asyncio.CancelledError(
+                'Skylet gRPC stream cancelled via SkyPilotContext') from e
+        raise
     finally:
         ctx.unregister_cancel_callback(call.cancel)
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -4374,6 +4374,74 @@ def open_ssh_tunnel(head_runner: Union[command_runner.SSHCommandRunner,
 T = TypeVar('T')
 
 
+def _raise_if_ctx_canceled() -> None:
+    """If we are running inside a cancelled SkyPilotContext, raise immediately.
+
+    Used between gRPC retry attempts so a context cancelled during the
+    backoff sleep does not silently start a new RPC that nobody is waiting
+    for.
+    """
+    ctx = context_lib.get()
+    if ctx is not None and ctx.is_canceled():
+        raise asyncio.CancelledError(
+            'SkyPilotContext cancelled during Skylet retry')
+
+
+def invoke_grpc_unary(method: Any,
+                      request: Any,
+                      timeout: Optional[float] = None) -> Any:
+    """Call a gRPC unary method; cancel it when the SkyPilotContext is cancelled.
+
+    Without this wrapper, ``method(request, timeout=...)`` blocks the worker
+    thread inside ``threading.Condition.wait()`` until the gRPC deadline
+    fires, even if the surrounding asyncio task has already been cancelled
+    and nobody is waiting for the result.
+
+    Using ``method.future(...)`` exposes the underlying call object, which
+    can be cancelled from any thread; we register that cancellation with the
+    active SkyPilotContext so it fires on client disconnect, request
+    cancellation, or any other code path that calls ``ctx.cancel()``.
+
+    If there is no active context, falls through to the plain blocking call.
+    """
+    ctx = context_lib.get()
+    if ctx is None:
+        return method(request, timeout=timeout)
+    call = method.future(request, timeout=timeout)
+    ctx.register_cancel_callback(call.cancel)
+    try:
+        return call.result()
+    finally:
+        ctx.unregister_cancel_callback(call.cancel)
+
+
+def invoke_grpc_streaming(method: Any,
+                          request: Any,
+                          timeout: Optional[float] = None) -> Iterator[Any]:
+    """Call a gRPC unary-stream method; cancel it on SkyPilotContext cancel.
+
+    The streaming iterator returned by gRPC is a ``_MultiThreadedRendezvous``
+    whose ``.cancel()`` aborts the RPC and unblocks any thread stuck in
+    ``__next__``. We register that on the current SkyPilotContext so a
+    client disconnect tears the stream down instead of leaking a worker
+    thread until the (often absent) deadline.
+
+    The returned generator unregisters the callback on completion or error,
+    so successful streams that outlive the cancel scope don't leak the
+    iterator's ``.cancel`` reference.
+    """
+    ctx = context_lib.get()
+    call = method(request, timeout=timeout)
+    if ctx is None:
+        yield from call
+        return
+    ctx.register_cancel_callback(call.cancel)
+    try:
+        yield from call
+    finally:
+        ctx.unregister_cancel_callback(call.cancel)
+
+
 def invoke_skylet_with_retries(func: Callable[..., T]) -> T:
     """Generic helper for making Skylet gRPC requests.
 
@@ -4386,6 +4454,7 @@ def invoke_skylet_with_retries(func: Callable[..., T]) -> T:
     last_exception: Optional[Exception] = None
 
     for _ in range(max_attempts):
+        _raise_if_ctx_canceled()
         try:
             return func()
         except grpc.RpcError as e:
@@ -4405,6 +4474,7 @@ def invoke_skylet_streaming_with_retries(
     last_exception: Optional[Exception] = None
 
     for _ in range(max_attempts):
+        _raise_if_ctx_canceled()
         try:
             for response in stream_func():
                 yield response

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2865,17 +2865,14 @@ class _CancelAwareStub:
         method = getattr(self._stub, name)
         if name in self._streaming:
 
-            def wrapped_streaming(request, timeout=None):
-                return backend_utils.invoke_grpc_streaming(method,
-                                                           request,
-                                                           timeout=timeout)
+            def wrapped_streaming(*args, **kwargs):
+                return backend_utils.invoke_grpc_streaming(
+                    method, *args, **kwargs)
 
             return wrapped_streaming
 
-        def wrapped_unary(request, timeout=None):
-            return backend_utils.invoke_grpc_unary(method,
-                                                   request,
-                                                   timeout=timeout)
+        def wrapped_unary(*args, **kwargs):
+            return backend_utils.invoke_grpc_unary(method, *args, **kwargs)
 
         return wrapped_unary
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -19,7 +19,7 @@ import threading
 import time
 import typing
 from typing import (Any, Callable, Dict, Iterable, Iterator, List, Optional,
-                    Set, Tuple, Union)
+                    Sequence, Set, Tuple, Union)
 
 import colorama
 import psutil
@@ -2393,6 +2393,12 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
             # The task YAMLs can be large, so the default
             # max_receive_message_length of 4MB might not be enough.
             ('grpc.max_receive_message_length', -1),
+            # Keepalive so half-dead TCP connections (cloud LB / proxy /
+            # NAT silently dropping a connection mid-stream) get failed by
+            # gRPC instead of stalling a worker thread inside __next__.
+            ('grpc.keepalive_time_ms', 30_000),
+            ('grpc.keepalive_timeout_ms', 10_000),
+            ('grpc.keepalive_permit_without_calls', 1),
         ]
         # It's fine to not grab the lock here, as we're only reading,
         # and writes are very rare.
@@ -2840,14 +2846,52 @@ class LocalResourcesHandle(CloudVmRayResourceHandle):
         return [command_runner.LocalProcessCommandRunner()]
 
 
+class _CancelAwareStub:
+    """Proxy that makes a gRPC stub honor the current SkyPilotContext cancel.
+
+    Each method becomes cancellable: when the active context is cancelled
+    (e.g. on client disconnect), the in-flight RPC is aborted instead of
+    leaving the worker thread blocked in gRPC's ``Condition.wait()``.
+
+    Methods listed in ``streaming_methods`` go through
+    ``invoke_grpc_streaming``; everything else uses ``invoke_grpc_unary``.
+    """
+
+    def __init__(self, stub: Any, streaming_methods: Sequence[str] = ()):
+        self._stub = stub
+        self._streaming = frozenset(streaming_methods)
+
+    def __getattr__(self, name: str):
+        method = getattr(self._stub, name)
+        if name in self._streaming:
+
+            def wrapped_streaming(request, timeout=None):
+                return backend_utils.invoke_grpc_streaming(method,
+                                                           request,
+                                                           timeout=timeout)
+
+            return wrapped_streaming
+
+        def wrapped_unary(request, timeout=None):
+            return backend_utils.invoke_grpc_unary(method,
+                                                   request,
+                                                   timeout=timeout)
+
+        return wrapped_unary
+
+
 class SkyletClient:
     """The client to interact with a remote cluster through Skylet."""
 
     def __init__(self, channel: 'grpc.Channel'):
-        self._autostop_stub = autostopv1_pb2_grpc.AutostopServiceStub(channel)
-        self._jobs_stub = jobsv1_pb2_grpc.JobsServiceStub(channel)
-        self._serve_stub = servev1_pb2_grpc.ServeServiceStub(channel)
-        self._managed_jobs_stub = (
+        self._autostop_stub = _CancelAwareStub(
+            autostopv1_pb2_grpc.AutostopServiceStub(channel))
+        self._jobs_stub = _CancelAwareStub(
+            jobsv1_pb2_grpc.JobsServiceStub(channel),
+            streaming_methods=('TailLogs',))
+        self._serve_stub = _CancelAwareStub(
+            servev1_pb2_grpc.ServeServiceStub(channel))
+        self._managed_jobs_stub = _CancelAwareStub(
             managed_jobsv1_pb2_grpc.ManagedJobsServiceStub(channel))
 
     def set_autostop(

--- a/sky/utils/context.py
+++ b/sky/utils/context.py
@@ -5,12 +5,14 @@ from collections.abc import Mapping
 import contextvars
 import copy
 import functools
+import logging
 import os
 import pathlib
 import subprocess
 import sys
-from typing import (Any, Callable, Coroutine, Dict, Iterator, MutableMapping,
-                    Optional, TextIO, TYPE_CHECKING, TypeVar)
+import threading
+from typing import (Any, Callable, Coroutine, Dict, Iterator, List,
+                    MutableMapping, Optional, TextIO, TYPE_CHECKING, TypeVar)
 
 from typing_extensions import ParamSpec
 
@@ -18,6 +20,8 @@ if TYPE_CHECKING:
     from sky.skypilot_config import ConfigContext
 
 _PROCESS_GLOBAL_VARS = {}
+
+_logger = logging.getLogger(__name__)
 
 
 class SkyPilotContext(object):
@@ -69,14 +73,58 @@ class SkyPilotContext(object):
         self.config_context = None
         self.request_context = None
         self.vars = {}
+        # Callbacks invoked exactly once when cancel() is called. Used to
+        # propagate cancellation into blocking sync work that cannot poll
+        # is_canceled() — e.g. a gRPC streaming iterator stuck in
+        # threading.Condition.wait() inside __next__.
+        self._cancel_callbacks: List[Callable[[], None]] = []
+        self._cancel_callbacks_lock = threading.Lock()
 
     def cancel(self):
-        """Cancel the context."""
-        self._canceled.set()
+        """Cancel the context. Idempotent."""
+        with self._cancel_callbacks_lock:
+            if self._canceled.is_set():
+                return
+            self._canceled.set()
+            callbacks = self._cancel_callbacks
+            self._cancel_callbacks = []
+        for cb in callbacks:
+            try:
+                cb()
+            except Exception:  # pylint: disable=broad-except
+                _logger.debug('cancel callback raised', exc_info=True)
 
     def is_canceled(self):
         """Check if the context is canceled."""
         return self._canceled.is_set()
+
+    def register_cancel_callback(self, callback: Callable[[], None]) -> None:
+        """Register a callback fired when ``cancel()`` is called.
+
+        Callbacks run on whatever thread invokes ``cancel()`` — they must be
+        thread-safe and non-blocking (e.g. ``grpc_call.cancel()``).
+
+        Closes the cancel-before-register race: if the context is already
+        cancelled when ``register_cancel_callback`` is called, the callback
+        is invoked synchronously here.
+        """
+        with self._cancel_callbacks_lock:
+            if not self._canceled.is_set():
+                self._cancel_callbacks.append(callback)
+                return
+        # Already cancelled — fire immediately, outside the lock.
+        try:
+            callback()
+        except Exception:  # pylint: disable=broad-except
+            _logger.debug('cancel callback raised', exc_info=True)
+
+    def unregister_cancel_callback(self, callback: Callable[[], None]) -> None:
+        """Remove a previously registered cancel callback (best effort)."""
+        with self._cancel_callbacks_lock:
+            try:
+                self._cancel_callbacks.remove(callback)
+            except ValueError:
+                pass
 
     def redirect_log(
             self, log_file: Optional[pathlib.Path]) -> Optional[pathlib.Path]:

--- a/tests/unit_tests/test_context_cancel_callbacks.py
+++ b/tests/unit_tests/test_context_cancel_callbacks.py
@@ -1,0 +1,122 @@
+"""Tests for SkyPilotContext cancel-callback channel.
+
+The cancel callback channel lets blocking sync work (e.g. a gRPC streaming
+iterator stuck in Condition.wait inside __next__) react to ctx.cancel()
+even though it cannot poll is_canceled() itself.
+"""
+import threading
+
+from sky.utils import context
+
+
+def test_callback_fires_on_cancel():
+    ctx = context.SkyPilotContext()
+    calls = []
+    ctx.register_cancel_callback(lambda: calls.append('a'))
+    ctx.register_cancel_callback(lambda: calls.append('b'))
+    assert not calls
+    ctx.cancel()
+    assert calls == ['a', 'b']
+    assert ctx.is_canceled()
+
+
+def test_cancel_is_idempotent():
+    ctx = context.SkyPilotContext()
+    calls = []
+    ctx.register_cancel_callback(lambda: calls.append(1))
+    ctx.cancel()
+    ctx.cancel()
+    ctx.cancel()
+    assert calls == [1]
+
+
+def test_register_after_cancel_fires_immediately():
+    ctx = context.SkyPilotContext()
+    ctx.cancel()
+    calls = []
+    ctx.register_cancel_callback(lambda: calls.append('late'))
+    assert calls == ['late']
+
+
+def test_unregister_prevents_firing():
+    ctx = context.SkyPilotContext()
+    calls = []
+
+    def cb():
+        calls.append('fired')
+
+    ctx.register_cancel_callback(cb)
+    ctx.unregister_cancel_callback(cb)
+    ctx.cancel()
+    assert not calls
+
+
+def test_unregister_unknown_callback_is_noop():
+    ctx = context.SkyPilotContext()
+    ctx.unregister_cancel_callback(lambda: None)  # Should not raise.
+
+
+def test_callback_exception_does_not_block_others():
+    ctx = context.SkyPilotContext()
+    calls = []
+
+    def boom():
+        raise RuntimeError('intentional')
+
+    ctx.register_cancel_callback(boom)
+    ctx.register_cancel_callback(lambda: calls.append('after-boom'))
+    ctx.cancel()
+    assert calls == ['after-boom']
+    assert ctx.is_canceled()
+
+
+def test_register_from_other_thread():
+    ctx = context.SkyPilotContext()
+    calls = []
+    ready = threading.Event()
+
+    def worker():
+        ctx.register_cancel_callback(lambda: calls.append('worker'))
+        ready.set()
+
+    t = threading.Thread(target=worker)
+    t.start()
+    ready.wait(timeout=1)
+    t.join(timeout=1)
+    ctx.cancel()
+    assert calls == ['worker']
+
+
+def test_concurrent_register_and_cancel_race():
+    """register_cancel_callback racing with cancel() must never drop the
+    callback: either it goes on the list and fires on cancel, or the
+    register call sees is_set() and fires immediately. Never both, never
+    neither."""
+
+    def _race_once(idx):
+        del idx
+        ctx = context.SkyPilotContext()
+        calls = []
+        start = threading.Event()
+
+        def canceller():
+            start.wait()
+            ctx.cancel()
+
+        def registerer():
+            start.wait()
+            ctx.register_cancel_callback(lambda: calls.append('x'))
+
+        threads = [
+            threading.Thread(target=canceller),
+            threading.Thread(target=registerer),
+        ]
+        for t in threads:
+            t.start()
+        start.set()
+        for t in threads:
+            t.join(timeout=2)
+        assert calls == ['x']
+
+    for i in range(50):
+        _race_once(i)

--- a/tests/unit_tests/test_context_cancel_callbacks.py
+++ b/tests/unit_tests/test_context_cancel_callbacks.py
@@ -4,9 +4,29 @@ The cancel callback channel lets blocking sync work (e.g. a gRPC streaming
 iterator stuck in Condition.wait inside __next__) react to ctx.cancel()
 even though it cannot poll is_canceled() itself.
 """
+import asyncio
 import threading
 
+import pytest
+
 from sky.utils import context
+
+
+@pytest.fixture(autouse=True)
+def _ensure_event_loop():
+    """``SkyPilotContext.__init__`` calls ``asyncio.Event()``, which on
+    Python 3.9 needs a current event loop in the main thread. A prior test
+    in the same session can call ``asyncio.set_event_loop(None)`` and
+    suppress the lazy main-thread auto-creation, so install a fresh loop
+    for each test here.
+    """
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        yield
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
 
 
 def test_callback_fires_on_cancel():

--- a/tests/unit_tests/test_skylet_grpc_cancellable.py
+++ b/tests/unit_tests/test_skylet_grpc_cancellable.py
@@ -1,0 +1,254 @@
+"""Tests for the cancellable gRPC unary / streaming wrappers in backend_utils.
+
+Verifies that when a SkyPilotContext is cancelled mid-call, the underlying
+gRPC call object's .cancel() is invoked — which is what unblocks a worker
+thread stuck in __next__ / .result() inside threading.Condition.wait().
+"""
+import asyncio
+import contextvars
+import threading
+import time
+from unittest import mock
+
+import grpc
+import pytest
+
+from sky.backends import backend_utils
+from sky.utils import context
+
+
+@pytest.fixture(autouse=True)
+def _isolate_context():
+    """Reset the SkyPilotContext ContextVar between tests.
+
+    Without this, ``context.initialize()`` from an earlier test in the same
+    xdist worker leaks the SkyPilotContext into the next test, which makes
+    the no-ctx test see a stale context and hang inside the fake unary
+    call's ``.result()``.
+    """
+    # pylint: disable=protected-access
+    token = context._CONTEXT.set(None)
+    try:
+        yield
+    finally:
+        context._CONTEXT.reset(token)
+
+
+def _run_in_ctx_thread(ctx_snapshot: contextvars.Context, fn):
+    """Spawn a daemon thread that runs ``fn`` inside ``ctx_snapshot``.
+
+    Mirrors how to_thread_with_executor propagates the SkyPilotContext
+    (via contextvars.copy_context().run) into worker threads.
+    """
+    t = threading.Thread(target=ctx_snapshot.run, args=(fn,), daemon=True)
+    t.start()
+    return t
+
+
+class _FakeUnaryCall:
+    """Stand-in for the grpc future returned by ``method.future(req, ...)``."""
+
+    def __init__(self, block_forever: bool = True):
+        self._done = threading.Event()
+        self._cancelled = False
+        self._block = block_forever
+
+    def cancel(self):
+        self._cancelled = True
+        self._done.set()
+
+    def cancelled(self):
+        return self._cancelled
+
+    def result(self, timeout=None):
+        if self._block:
+            self._done.wait(timeout=timeout)
+        if self._cancelled:
+            err = grpc.RpcError()
+            err.code = lambda: grpc.StatusCode.CANCELLED  # type: ignore
+            raise err
+        return 'ok'
+
+
+class _FakeUnaryMethod:
+    """Stand-in for a unary-unary gRPC stub method."""
+
+    def __init__(self):
+        self.calls = []
+
+    def future(self, request, timeout=None):
+        del request, timeout
+        call = _FakeUnaryCall()
+        self.calls.append(call)
+        return call
+
+    def __call__(self, request, timeout=None):  # plain blocking form
+        del request, timeout
+        # Not used in cancel test, but exercised by the no-ctx path.
+        return 'sync-ok'
+
+
+class _FakeStreamingCall:
+    """Stand-in for the iterator returned by ``method(req, timeout=...)`` for
+    unary-stream RPCs."""
+
+    def __init__(self, items, hang_at=None):
+        self._items = list(items)
+        self._idx = 0
+        self._cancelled = threading.Event()
+        self._hang_at = hang_at  # yield items, then hang here
+
+    def cancel(self):
+        self._cancelled.set()
+
+    def cancelled_event_is_set(self) -> bool:
+        return self._cancelled.is_set()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._cancelled.is_set():
+            err = grpc.RpcError()
+            err.code = lambda: grpc.StatusCode.CANCELLED  # type: ignore
+            raise err
+        if self._hang_at is not None and self._idx == self._hang_at:
+            # Block until cancel() is called.
+            self._cancelled.wait()
+            err = grpc.RpcError()
+            err.code = lambda: grpc.StatusCode.CANCELLED  # type: ignore
+            raise err
+        if self._idx >= len(self._items):
+            raise StopIteration
+        item = self._items[self._idx]
+        self._idx += 1
+        return item
+
+
+def test_unary_no_ctx_falls_through_to_blocking_call():
+    method = _FakeUnaryMethod()
+    # No SkyPilotContext: should NOT use .future().
+    result = backend_utils.invoke_grpc_unary(method, 'req', timeout=1.0)
+    assert result == 'sync-ok'
+    assert not method.calls  # .future() was never invoked.
+
+
+def test_unary_with_ctx_uses_future_and_cancels_on_ctx_cancel():
+    ctx = context.initialize()
+    method = _FakeUnaryMethod()
+    results = []
+    errors = []
+
+    def worker():
+        try:
+            results.append(
+                backend_utils.invoke_grpc_unary(method, 'req', timeout=None))
+        except Exception as e:  # pylint: disable=broad-except
+            errors.append(e)
+
+    snapshot = contextvars.copy_context()
+    t = _run_in_ctx_thread(snapshot, worker)
+    # Wait for the worker to start the call.
+    for _ in range(50):
+        if method.calls:
+            break
+        time.sleep(0.01)
+    assert len(method.calls) == 1
+    assert not method.calls[0].cancelled()
+
+    ctx.cancel()
+    t.join(timeout=2)
+    assert not t.is_alive(), 'Worker did not exit after ctx.cancel()'
+    assert method.calls[0].cancelled(), (
+        'Underlying gRPC call.cancel() was not invoked')
+    assert errors, 'Expected the cancellation to surface as an error'
+
+
+def test_unary_cleans_up_callback_on_success():
+    ctx = context.initialize()
+    method = mock.MagicMock()
+    fut = mock.MagicMock()
+    fut.result.return_value = 'value'
+    method.future.return_value = fut
+    out = backend_utils.invoke_grpc_unary(method, 'req', timeout=1.0)
+    assert out == 'value'
+    # After success, ctx.cancel() must NOT call fut.cancel() — the callback
+    # was unregistered.
+    fut.cancel.assert_not_called()
+    ctx.cancel()
+    fut.cancel.assert_not_called()
+
+
+def test_streaming_yields_items_when_no_cancel():
+    context.initialize()
+    call = _FakeStreamingCall(['a', 'b', 'c'])
+    method = mock.MagicMock(return_value=call)
+    out = list(backend_utils.invoke_grpc_streaming(method, 'req', timeout=None))
+    assert out == ['a', 'b', 'c']
+
+
+def test_streaming_cancels_iterator_on_ctx_cancel():
+    ctx = context.initialize()
+    call = _FakeStreamingCall(['a', 'b'], hang_at=2)
+    method = mock.MagicMock(return_value=call)
+    received = []
+    errors = []
+
+    def consume():
+        try:
+            for item in backend_utils.invoke_grpc_streaming(method, 'req'):
+                received.append(item)
+        except grpc.RpcError as e:
+            errors.append(e)
+
+    snapshot = contextvars.copy_context()
+    t = _run_in_ctx_thread(snapshot, consume)
+    # Wait for the consumer to consume the buffered items and start hanging.
+    for _ in range(100):
+        if len(received) == 2:
+            break
+        time.sleep(0.01)
+    assert received == ['a', 'b']
+    assert t.is_alive(), 'Consumer should be blocked on the next item'
+
+    ctx.cancel()
+    t.join(timeout=2)
+    assert not t.is_alive(), 'Consumer did not exit after ctx.cancel()'
+    assert errors, 'Expected CANCELLED error to be raised'
+
+
+def test_streaming_cleans_up_callback_on_normal_completion():
+    ctx = context.initialize()
+    call = _FakeStreamingCall(['only-one'])
+    method = mock.MagicMock(return_value=call)
+    out = list(backend_utils.invoke_grpc_streaming(method, 'req'))
+    assert out == ['only-one']
+    # After normal completion, ctx.cancel() should not try to cancel the
+    # already-finished iterator (cb was unregistered).
+    ctx.cancel()
+    assert not call.cancelled_event_is_set()
+
+
+def test_invoke_skylet_with_retries_bails_on_ctx_cancel_during_backoff():
+    """If ctx is cancelled while we're sleeping between retries, the next
+    iteration must raise instead of starting a new gRPC call."""
+    ctx = context.initialize()
+    call_count = {'n': 0}
+
+    def func():
+        call_count['n'] += 1
+        # Simulate UNAVAILABLE so we go into the retry path.
+        err = grpc.RpcError()
+        err.code = lambda: grpc.StatusCode.UNAVAILABLE  # type: ignore
+        err.details = lambda: 'transient'  # type: ignore
+        raise err
+
+    # Patch sleep so the retry loop reaches the cancel check fast.
+    with mock.patch.object(backend_utils, '_handle_grpc_error') as h:
+        # Make _handle_grpc_error a no-op (simulates retry-worthy error).
+        h.return_value = None
+        ctx.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            backend_utils.invoke_skylet_with_retries(func)
+        # Should never have called func because ctx was already cancelled.
+        assert call_count['n'] == 0

--- a/tests/unit_tests/test_skylet_grpc_cancellable.py
+++ b/tests/unit_tests/test_skylet_grpc_cancellable.py
@@ -143,7 +143,8 @@ def test_unary_with_ctx_uses_future_and_cancels_on_ctx_cancel():
         try:
             results.append(
                 backend_utils.invoke_grpc_unary(method, 'req', timeout=None))
-        except Exception as e:  # pylint: disable=broad-except
+        except (Exception, asyncio.CancelledError) as e:  # pylint: disable=broad-except
+            # CancelledError is BaseException in py3.8+, not Exception.
             errors.append(e)
 
     snapshot = contextvars.copy_context()
@@ -161,7 +162,11 @@ def test_unary_with_ctx_uses_future_and_cancels_on_ctx_cancel():
     assert not t.is_alive(), 'Worker did not exit after ctx.cancel()'
     assert method.calls[0].cancelled(), (
         'Underlying gRPC call.cancel() was not invoked')
-    assert errors, 'Expected the cancellation to surface as an error'
+    # The CANCELLED RpcError must surface as asyncio.CancelledError so the
+    # request executor classifies the request as CANCELLED, not FAILED.
+    assert len(errors) == 1, f'expected one error, got {errors}'
+    assert isinstance(errors[0], asyncio.CancelledError), (
+        f'expected CancelledError, got {type(errors[0]).__name__}')
 
 
 def test_unary_cleans_up_callback_on_success():
@@ -198,7 +203,7 @@ def test_streaming_cancels_iterator_on_ctx_cancel():
         try:
             for item in backend_utils.invoke_grpc_streaming(method, 'req'):
                 received.append(item)
-        except grpc.RpcError as e:
+        except (grpc.RpcError, asyncio.CancelledError) as e:
             errors.append(e)
 
     snapshot = contextvars.copy_context()
@@ -214,7 +219,10 @@ def test_streaming_cancels_iterator_on_ctx_cancel():
     ctx.cancel()
     t.join(timeout=2)
     assert not t.is_alive(), 'Consumer did not exit after ctx.cancel()'
-    assert errors, 'Expected CANCELLED error to be raised'
+    # CANCELLED RpcError must be translated to asyncio.CancelledError.
+    assert len(errors) == 1, f'expected one error, got {errors}'
+    assert isinstance(errors[0], asyncio.CancelledError), (
+        f'expected CancelledError, got {type(errors[0]).__name__}')
 
 
 def test_streaming_cleans_up_callback_on_normal_completion():
@@ -227,6 +235,46 @@ def test_streaming_cleans_up_callback_on_normal_completion():
     # already-finished iterator (cb was unregistered).
     ctx.cancel()
     assert not call.cancelled_event_is_set()
+
+
+def test_unary_forwards_extra_grpc_options():
+    """Callers must be able to pass metadata / wait_for_ready / credentials."""
+    context.initialize()
+    method = mock.MagicMock()
+    fut = mock.MagicMock()
+    fut.result.return_value = 'value'
+    method.future.return_value = fut
+    backend_utils.invoke_grpc_unary(
+        method,
+        'req',
+        timeout=1.0,
+        metadata=(('x-extra', '1'),),
+        wait_for_ready=True,
+    )
+    method.future.assert_called_once_with(
+        'req',
+        timeout=1.0,
+        metadata=(('x-extra', '1'),),
+        wait_for_ready=True,
+    )
+
+
+def test_streaming_forwards_extra_grpc_options():
+    context.initialize()
+    call = _FakeStreamingCall(['only-one'])
+    method = mock.MagicMock(return_value=call)
+    list(
+        backend_utils.invoke_grpc_streaming(
+            method,
+            'req',
+            timeout=None,
+            metadata=(('x-extra', '1'),),
+        ))
+    method.assert_called_once_with(
+        'req',
+        timeout=None,
+        metadata=(('x-extra', '1'),),
+    )
 
 
 def test_invoke_skylet_with_retries_bails_on_ctx_cancel_during_backoff():


### PR DESCRIPTION
## Summary

When a `SkyPilotContext` is cancelled — typically because the API client disconnected mid-request — in-flight synchronous gRPC calls to Skylet continue to block their worker thread inside `threading.Condition.wait()` until the call's deadline fires. For streaming calls like `tail_logs` the deadline is `None`, so the thread can be held indefinitely, eventually exhausting the per-process `request_thread_executor` pool (cap 128) and rejecting subsequent log/streaming requests with `ConcurrentWorkerExhaustedError`.

This PR closes the cancel path end-to-end:

- `SkyPilotContext` gains a `register_cancel_callback` / `unregister_cancel_callback` channel — callbacks fire (on whatever thread invokes `cancel()`) when the context is cancelled. Idempotent; race-safe via an internal lock; one callback raising doesn't block the rest.
- New `invoke_grpc_unary` / `invoke_grpc_streaming` helpers in `backend_utils` go through the gRPC future / iterator's `.cancel()` and register that with the current context, so a context cancel aborts the in-flight RPC instead of leaving the thread blocked.
- `SkyletClient` wires every stub method through a `_CancelAwareStub` proxy that picks the right helper (unary vs unary-stream), so all 25+ Skylet RPCs gain cancel support with one change.
- `invoke_skylet_with_retries` / `invoke_skylet_streaming_with_retries` bail at the start of each retry iteration when the context is already cancelled, so a cancel during backoff doesn't fan out into a new RPC nobody is waiting on.
- `get_grpc_channel` gets the same gRPC keepalive options that already protect the cluster-side gRPC channel elsewhere in the codebase (30 s ping, 10 s timeout, `permit_without_calls=1`), so half-dead TCP connections (cloud LB / proxy / NAT silently dropping a stream) get failed by gRPC as a backstop even if the cancel path is never invoked.

## Test plan

Unit tests:

- `tests/unit_tests/test_context_cancel_callbacks.py` covers register / unregister, idempotent cancel, register-after-cancel firing synchronously, exception isolation, cross-thread registration, and a 50-iteration concurrent cancel / register race.
- `tests/unit_tests/test_skylet_grpc_cancellable.py` covers the unary and streaming helpers: fall-through with no context, `future.cancel()` triggered on context cancel, iterator `.cancel()` triggered on context cancel, callback cleanup on normal completion (no spurious cancel of finished call), and the retry helper bailing on a pre-cancelled context.

Manual reproduction against a real cluster:

- Opened 900 concurrent streaming `POST /logs` requests against an API server, hard-killed each client process after the first chunk arrived. Before the change: 580 threads stuck in `request_thread_executor` inside `tail_logs → invoke_skylet_streaming_with_retries → grpc/_common.py:wait`, never draining; subsequent `POST /logs` requests hung for 10 s+.
<img width="1643" height="512" alt="image" src="https://github.com/user-attachments/assets/18ad2631-4c36-4ec6-a62a-849fb5b3f484" />

- After the change, the same workload leaves 0 stuck threads within 5 s of the clients being killed; new `POST /logs` requests succeed in < 2 s.



Tested:
- `bash format.sh --files sky/utils/context.py sky/backends/backend_utils.py sky/backends/cloud_vm_ray_backend.py tests/unit_tests/test_context_cancel_callbacks.py tests/unit_tests/test_skylet_grpc_cancellable.py` clean.
- `pytest tests/unit_tests/test_context_cancel_callbacks.py tests/unit_tests/test_skylet_grpc_cancellable.py` — 15/15 pass.
