### PR TITLE
[Docs] Job Groups: new architecture diagrams

### DIFF
--- a/docs/source/examples/job-groups.rst
+++ b/docs/source/examples/job-groups.rst
@@ -203,7 +203,7 @@ Parallel train-eval with shared storage
 This example runs training and evaluation in parallel, sharing checkpoints via
 a Kubernetes PVC volume:
 
-.. figure:: ../images/job-groups-train-eval-architecture.png
+.. figure:: ../images/job-groups-train-eval-architecture.svg
    :width: 80%
    :align: center
    :alt: Parallel Train-Eval Architecture with Job Groups
@@ -237,6 +237,13 @@ See the full example at ``llm/train-eval-jobgroup/`` in the SkyPilot repository.
 
 RL post-training architecture
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. figure:: ../images/job-groups-rl-architecture.svg
+   :width: 95%
+   :align: center
+   :alt: RL post-training Job Group: rollout-server and ppo-trainer on GPU; data-server, reward-server, and replay-buffer on CPU. Samples flow rollout → reward → buffer → trainer; policy weights loop back to rollout.
+
+   Five tasks run side-by-side in one Job Group: samples flow rollout → reward → buffer → trainer; new policy weights loop back from the trainer to the rollout server every step.
 
 This example demonstrates a distributed RL post-training architecture with 5 tasks:
 

--- a/docs/source/examples/job-groups.rst
+++ b/docs/source/examples/job-groups.rst
@@ -280,6 +280,14 @@ This example demonstrates a distributed RL post-training architecture with 5 tas
         --rollout-server rollout-server-0.${SKYPILOT_JOBGROUP_NAME}:8001 \
         --reward-server reward-server-0.${SKYPILOT_JOBGROUP_NAME}:8002
 
+.. figure:: ../images/job-groups-dashboard.png
+   :width: 100%
+   :align: center
+   :alt: Job Groups in SkyPilot Dashboard
+
+   The same Job Group running in production, viewed from the SkyPilot dashboard.
+   Each task has independent resources and can be monitored separately.
+
 See the full RL post-training example at ``llm/rl-post-training-jobgroup/`` in the SkyPilot repository.
 
 Primary and auxiliary tasks

--- a/docs/source/examples/job-groups.rst
+++ b/docs/source/examples/job-groups.rst
@@ -11,14 +11,12 @@ Job Groups allow you to run multiple related tasks in parallel as a single manag
 Unlike :ref:`managed jobs <managed-jobs>` which run tasks sequentially (pipelines),
 Job Groups launch all tasks simultaneously, enabling complex distributed architectures.
 
-.. figure:: ../images/job-groups-dashboard.png
+.. figure:: ../images/job-groups-rl-architecture.svg
    :width: 100%
    :align: center
-   :alt: Job Groups in SkyPilot Dashboard
+   :alt: SkyPilot Job Group: five tasks running in parallel for RL post-training — rollout-server and ppo-trainer on GPU; data-server, reward-server, and replay-buffer on CPU. Samples flow rollout → reward → buffer → trainer; policy weights loop back to rollout every step.
 
-   A Job Group with 4 tasks (data-server, rollout-server, reward-server, ppo-trainer)
-   running in parallel on Kubernetes. Each task has different resource requirements
-   and can be monitored independently through the dashboard.
+   A **SkyPilot Job Group** for RL post-training. Five heterogeneous tasks run side by side: samples flow rollout → reward → buffer → trainer, and new policy weights loop back to the rollout server every step.
 
 Overview
 --------
@@ -238,14 +236,7 @@ See the full example at ``llm/train-eval-jobgroup/`` in the SkyPilot repository.
 RL post-training architecture
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. figure:: ../images/job-groups-rl-architecture.svg
-   :width: 95%
-   :align: center
-   :alt: RL post-training Job Group: rollout-server and ppo-trainer on GPU; data-server, reward-server, and replay-buffer on CPU. Samples flow rollout → reward → buffer → trainer; policy weights loop back to rollout.
-
-   Five tasks run side-by-side in one Job Group: samples flow rollout → reward → buffer → trainer; new policy weights loop back from the trainer to the rollout server every step.
-
-This example demonstrates a distributed RL post-training architecture with 5 tasks:
+This example demonstrates a distributed RL post-training architecture with 5 tasks (see the hero diagram at the top of the page):
 
 .. code-block:: yaml
 

--- a/docs/source/examples/job-groups.rst
+++ b/docs/source/examples/job-groups.rst
@@ -3,10 +3,6 @@
 Job Groups for RL
 =================
 
-.. warning::
-
-  **This is an experimental feature.** The interface may change in future versions.
-
 Job Groups allow you to run multiple related tasks in parallel as a single managed unit.
 Unlike :ref:`managed jobs <managed-jobs>` which run tasks sequentially (pipelines),
 Job Groups launch all tasks simultaneously, enabling complex distributed architectures.

--- a/docs/source/images/job-groups-rl-architecture.svg
+++ b/docs/source/images/job-groups-rl-architecture.svg
@@ -12,7 +12,7 @@
     @keyframes flow-dash { from { stroke-dashoffset: 0; } to { stroke-dashoffset: -22; } }
     .diag .flow { animation: flow-dash 1.8s linear infinite; }
 ]]></style>
-  <g><rect x="40" y="32" width="1200" height="470" rx="20" fill="none" stroke="#C8C6C7" stroke-width="1.25" stroke-dasharray="2 5"/><g transform="translate(66 32)"><rect x="-10" y="-14" width="220" height="28" rx="14" fill="#FFFFFF"/><text x="0" y="5" font-family="BerkeleyMono, monospace" font-size="13" letter-spacing="0.18em" font-weight="700" fill="#243142">JOB&#160;GROUP<tspan fill="#5d6a7a" font-weight="400">&#160;·&#160;rlhf-experiment</tspan></text></g></g>
+  <g><rect x="40" y="32" width="1200" height="470" rx="20" fill="none" stroke="#0A55EE" stroke-width="1.5" stroke-dasharray="2 5"/><g transform="translate(66 32)"><rect x="-12" y="-16" width="340" height="32" rx="16" fill="#FFFFFF" stroke="#0A55EE" stroke-width="1.25"/><text x="0" y="6" font-family="BerkeleyMono, monospace" font-size="14" letter-spacing="0.18em" font-weight="700" fill="#0A55EE">SKYPILOT&#160;JOB&#160;GROUP<tspan fill="#5d6a7a" font-weight="400">&#160;·&#160;rlhf-experiment</tspan></text></g></g>
   <g transform="translate(300 110)">
       <rect x="0" y="0" width="250" height="124" rx="12" fill="#FBEEEB" stroke="#C7402E" stroke-width="1.5"/>
       <text x="16" y="24" class="role">sample generation</text>

--- a/docs/source/images/job-groups-rl-architecture.svg
+++ b/docs/source/images/job-groups-rl-architecture.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 1280 620" width="100%" height="auto" class="diag" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="RL post-training Job Group: rollout-server and ppo-trainer on GPU; data-server, reward-server, and replay-buffer on CPU. Samples flow rollout → reward → buffer → trainer; policy weights loop back to rollout.">
+  <style><![CDATA[
+    .diag { font-family: 'Waldenburg', system-ui, -apple-system, sans-serif; color: #04070B; letter-spacing: -0.01em; }
+    .diag .mono { font-family: 'BerkeleyMono', ui-monospace, Menlo, monospace; font-feature-settings: "zero" 1; letter-spacing: 0.02em; }
+    .diag .eyebrow { font-family: 'BerkeleyMono', monospace; font-size: 12px; letter-spacing: 0.18em; text-transform: uppercase; fill: #5d6a7a; font-feature-settings: "zero" 1; }
+    .diag .role { font-family: 'BerkeleyMono', monospace; font-size: 11.5px; letter-spacing: 0.14em; text-transform: uppercase; fill: #5d6a7a; }
+    .diag .task-name { font-family: 'Waldenburg', sans-serif; font-size: 22px; font-weight: 500; letter-spacing: -0.015em; fill: #04070B; }
+    .diag .annot { font-family: 'Waldenburg', sans-serif; font-size: 15px; font-weight: 400; fill: #5d6a7a; }
+    .diag .flow-label { font-family: 'BerkeleyMono', monospace; font-size: 13px; letter-spacing: 0.04em; font-weight: 600; fill: #0A55EE; paint-order: stroke; stroke: #FFFFFF; stroke-width: 6; stroke-linejoin: round; }
+    .diag .flow-label.hot { fill: #C7402E; }
+    @keyframes flow-dash { from { stroke-dashoffset: 0; } to { stroke-dashoffset: -22; } }
+    .diag .flow { animation: flow-dash 1.8s linear infinite; }
+]]></style>
+  <g><rect x="40" y="32" width="1200" height="470" rx="20" fill="none" stroke="#C8C6C7" stroke-width="1.25" stroke-dasharray="2 5"/><g transform="translate(66 32)"><rect x="-10" y="-14" width="220" height="28" rx="14" fill="#FFFFFF"/><text x="0" y="5" font-family="BerkeleyMono, monospace" font-size="13" letter-spacing="0.18em" font-weight="700" fill="#243142">JOB&#160;GROUP<tspan fill="#5d6a7a" font-weight="400">&#160;·&#160;rlhf-experiment</tspan></text></g></g>
+  <g transform="translate(300 110)">
+      <rect x="0" y="0" width="250" height="124" rx="12" fill="#FBEEEB" stroke="#C7402E" stroke-width="1.5"/>
+      <text x="16" y="24" class="role">sample generation</text>
+      <text x="16" y="52" class="task-name">rollout-server</text>
+      <g transform="translate(0 62)">
+      <g transform="translate(14 0)"><rect x="0" y="0" width="64.40" height="22" rx="11" fill="#FBEEEB" stroke="#C7402E" stroke-width="1.2"/><text x="10" y="15.5" fill="#C7402E" font-family="BerkeleyMono, monospace" font-size="12" font-weight="600" letter-spacing="0.04em">A100×2</text></g>
+      <g transform="translate(86.4 0)"><rect x="0" y="0" width="71.80" height="22" rx="11" fill="#FFFFFF" stroke="#C8C6C7" stroke-width="1.2"/><text x="10" y="15.5" fill="#243142" font-family="BerkeleyMono, monospace" font-size="12" font-weight="600" letter-spacing="0.04em">2 nodes</text></g>
+      </g>
+      </g>
+      <g transform="translate(790 110)">
+      <rect x="0" y="0" width="250" height="124" rx="12" fill="#ECF2FD" stroke="#0A55EE" stroke-width="1.5"/>
+      <text x="16" y="24" class="role">policy update</text>
+      <text x="16" y="52" class="task-name">ppo-trainer</text>
+      <g transform="translate(0 62)">
+      <g transform="translate(14 0)"><rect x="0" y="0" width="64.40" height="22" rx="11" fill="#FBEEEB" stroke="#C7402E" stroke-width="1.2"/><text x="10" y="15.5" fill="#C7402E" font-family="BerkeleyMono, monospace" font-size="12" font-weight="600" letter-spacing="0.04em">A100×2</text></g>
+      <g transform="translate(86.4 0)"><rect x="0" y="0" width="71.80" height="22" rx="11" fill="#FFFFFF" stroke="#C8C6C7" stroke-width="1.2"/><text x="10" y="15.5" fill="#243142" font-family="BerkeleyMono, monospace" font-size="12" font-weight="600" letter-spacing="0.04em">2 nodes</text></g>
+      </g>
+      </g>
+      <g transform="translate(120 360)">
+      <rect x="0" y="0" width="230" height="106" rx="12" fill="#FFFFFF" stroke="#C8C6C7" stroke-width="1"/>
+      <text x="16" y="24" class="role">prompts</text>
+      <text x="16" y="52" class="task-name">data-server</text>
+      <g transform="translate(0 62)">
+      <g transform="translate(14 0)"><rect x="0" y="0" width="64.40" height="22" rx="11" fill="#FFFFFF" stroke="#C8C6C7" stroke-width="1.2"/><text x="10" y="15.5" fill="#243142" font-family="BerkeleyMono, monospace" font-size="12" font-weight="600" letter-spacing="0.04em">CPU:4+</text></g>
+      </g>
+      </g>
+      <g transform="translate(525 360)">
+      <rect x="0" y="0" width="230" height="106" rx="12" fill="#FFFFFF" stroke="#C8C6C7" stroke-width="1"/>
+      <text x="16" y="24" class="role">reward scoring</text>
+      <text x="16" y="52" class="task-name">reward-server</text>
+      <g transform="translate(0 62)">
+      <g transform="translate(14 0)"><rect x="0" y="0" width="64.40" height="22" rx="11" fill="#FFFFFF" stroke="#C8C6C7" stroke-width="1.2"/><text x="10" y="15.5" fill="#243142" font-family="BerkeleyMono, monospace" font-size="12" font-weight="600" letter-spacing="0.04em">CPU:8+</text></g>
+      </g>
+      </g>
+      <g transform="translate(930 360)">
+      <rect x="0" y="0" width="230" height="106" rx="12" fill="#FFFFFF" stroke="#C8C6C7" stroke-width="1"/>
+      <text x="16" y="24" class="role">experience</text>
+      <text x="16" y="52" class="task-name">replay-buffer</text>
+      <g transform="translate(0 62)">
+      <g transform="translate(14 0)"><rect x="0" y="0" width="64.40" height="22" rx="11" fill="#FFFFFF" stroke="#C8C6C7" stroke-width="1.2"/><text x="10" y="15.5" fill="#243142" font-family="BerkeleyMono, monospace" font-size="12" font-weight="600" letter-spacing="0.04em">CPU:4+</text></g>
+      <g transform="translate(86.4 0)"><rect x="0" y="0" width="42.20" height="22" rx="11" fill="#FFFFFF" stroke="#C8C6C7" stroke-width="1.2"/><text x="10" y="15.5" fill="#243142" font-family="BerkeleyMono, monospace" font-size="12" font-weight="600" letter-spacing="0.04em">32G</text></g>
+      </g>
+      </g>
+    <g>
+      <path d="M 255.0 360 Q 293.67 285.48 360 234" fill="none" stroke="#0A55EE" stroke-width="1.5" stroke-linecap="round" stroke-dasharray="8 4" class="flow"/>
+      <polyline points="355.30,245.88 360,234 347.32,235.61" fill="none" stroke="#0A55EE" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="bevel"/>
+      <text x="293.67" y="275.48" text-anchor="middle" class="flow-label">prompts</text>
+      </g>
+  <g>
+      <path d="M 480 234 Q 517.14 309.80 585 360" fill="none" stroke="#0A55EE" stroke-width="1.5" stroke-linecap="round" stroke-dasharray="8 4" class="flow"/>
+      <polyline points="572.29,358.68 585,360 580.02,348.23" fill="none" stroke="#0A55EE" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="bevel"/>
+      <text x="517.14" y="299.80" text-anchor="middle" class="flow-label">samples</text>
+      </g>
+  <g>
+      <path d="M 755 413.0 Q 842.50 413.00 930 413.0" fill="none" stroke="#0A55EE" stroke-width="1.5" stroke-linecap="round" stroke-dasharray="8 4" class="flow"/>
+      <polyline points="919.00,419.50 930,413.0 919.00,406.50" fill="none" stroke="#0A55EE" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="bevel"/>
+      <text x="842.50" y="402.00" text-anchor="middle" class="flow-label">scored</text>
+      </g>
+  <g>
+      <path d="M 1025.0 360 Q 1015.83 289.00 970 234" fill="none" stroke="#0A55EE" stroke-width="1.5" stroke-linecap="round" stroke-dasharray="8 4" class="flow"/>
+      <polyline points="982.04,238.29 970,234 972.05,246.61" fill="none" stroke="#0A55EE" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="bevel"/>
+      <text x="1015.83" y="279.00" text-anchor="middle" class="flow-label">batches</text>
+      </g>
+  <g>
+      <path d="M 870 110 Q 670.00 54.00 470 110" fill="none" stroke="#C7402E" stroke-width="1.5" stroke-linecap="round" stroke-dasharray="6 5" class="flow"/>
+      <polyline points="478.84,100.77 470,110 482.35,113.29" fill="none" stroke="#C7402E" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="bevel"/>
+      <text x="670.00" y="74.00" text-anchor="middle" class="flow-label hot">policy weights ↺</text>
+      </g>
+  <g transform="translate(40 564)"><text x="0" y="0" class="eyebrow">SERVICE&#160;DISCOVERY</text><text x="0" y="26" class="mono" font-size="14" fill="#243142">{task}-0.${SKYPILOT_JOBGROUP_NAME}<tspan fill="#5d6a7a">&#160;·&#160;e.g.&#160;</tspan><tspan fill="#0A55EE">rollout-server-0.rlhf-experiment:8001</tspan></text></g>
+  <g transform="translate(880 576)"><g><line x1="0" y1="6" x2="32" y2="6" stroke="#0A55EE" stroke-width="1.5" stroke-dasharray="8 4"/><polyline points="21.00,12.50 32,6 21.00,-0.50" fill="none" stroke="#0A55EE" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="bevel"/><text x="42" y="11" class="annot" font-size="14" fill="#243142">data flow</text></g><g transform="translate(170 0)"><line x1="0" y1="6" x2="32" y2="6" stroke="#C7402E" stroke-width="1.5" stroke-dasharray="6 5"/><polyline points="21.00,12.50 32,6 21.00,-0.50" fill="none" stroke="#C7402E" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="bevel"/><text x="42" y="11" class="annot" font-size="14" fill="#243142">control / weights</text></g></g>
+</svg>

--- a/docs/source/images/job-groups-rl-architecture.svg
+++ b/docs/source/images/job-groups-rl-architecture.svg
@@ -12,7 +12,7 @@
     @keyframes flow-dash { from { stroke-dashoffset: 0; } to { stroke-dashoffset: -22; } }
     .diag .flow { animation: flow-dash 1.8s linear infinite; }
 ]]></style>
-  <g><rect x="40" y="32" width="1200" height="470" rx="20" fill="none" stroke="#0A55EE" stroke-width="1.5" stroke-dasharray="2 5"/><g transform="translate(66 32)"><rect x="-12" y="-16" width="340" height="32" rx="16" fill="#FFFFFF" stroke="#0A55EE" stroke-width="1.25"/><text x="0" y="6" font-family="BerkeleyMono, monospace" font-size="14" letter-spacing="0.18em" font-weight="700" fill="#0A55EE">SKYPILOT&#160;JOB&#160;GROUP<tspan fill="#5d6a7a" font-weight="400">&#160;·&#160;rlhf-experiment</tspan></text></g></g>
+  <g><rect x="40" y="32" width="1200" height="470" rx="20" fill="none" stroke="#0A55EE" stroke-width="1.5" stroke-dasharray="2 5"/><g transform="translate(66 32)"><rect x="-12" y="-16" width="260" height="32" rx="16" fill="#FFFFFF" stroke="#0A55EE" stroke-width="1.25"/><text x="0" y="6" font-family="BerkeleyMono, monospace" font-size="14" letter-spacing="0.18em" font-weight="700" fill="#0A55EE">SKYPILOT&#160;JOB&#160;GROUP</text></g></g>
   <g transform="translate(300 110)">
       <rect x="0" y="0" width="250" height="124" rx="12" fill="#FBEEEB" stroke="#C7402E" stroke-width="1.5"/>
       <text x="16" y="24" class="role">sample generation</text>

--- a/docs/source/images/job-groups-train-eval-architecture.svg
+++ b/docs/source/images/job-groups-train-eval-architecture.svg
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 1100 460" width="100%" height="auto" class="diag" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Parallel train-eval Job Group: trainer writes checkpoints to a shared PVC; evaluator reads them concurrently.">
+  <style><![CDATA[
+    .diag { font-family: 'Waldenburg', system-ui, -apple-system, sans-serif; color: #04070B; letter-spacing: -0.01em; }
+    .diag .mono { font-family: 'BerkeleyMono', ui-monospace, Menlo, monospace; font-feature-settings: "zero" 1; letter-spacing: 0.02em; }
+    .diag .eyebrow { font-family: 'BerkeleyMono', monospace; font-size: 12px; letter-spacing: 0.18em; text-transform: uppercase; fill: #5d6a7a; font-feature-settings: "zero" 1; }
+    .diag .role { font-family: 'BerkeleyMono', monospace; font-size: 11.5px; letter-spacing: 0.14em; text-transform: uppercase; fill: #5d6a7a; }
+    .diag .task-name { font-family: 'Waldenburg', sans-serif; font-size: 22px; font-weight: 500; letter-spacing: -0.015em; fill: #04070B; }
+    .diag .annot { font-family: 'Waldenburg', sans-serif; font-size: 15px; font-weight: 400; fill: #5d6a7a; }
+    .diag .flow-label { font-family: 'BerkeleyMono', monospace; font-size: 13px; letter-spacing: 0.04em; font-weight: 600; fill: #0A55EE; paint-order: stroke; stroke: #FFFFFF; stroke-width: 6; stroke-linejoin: round; }
+    .diag .flow-label.hot { fill: #C7402E; }
+    @keyframes flow-dash { from { stroke-dashoffset: 0; } to { stroke-dashoffset: -22; } }
+    .diag .flow { animation: flow-dash 1.8s linear infinite; }
+]]></style>
+  <g><path d="M 730.0 80 L 730.0 390 A 120.0 24 0 0 0 970.0 390 L 970.0 80 A 120.0 24 0 0 1 730.0 80 Z" fill="#E4F2FB" stroke="#0A55EE" stroke-width="1.5"/><ellipse cx="850" cy="80" rx="120.0" ry="24" fill="#ECF2FD" stroke="#0A55EE" stroke-width="1.5"/><text x="850" y="223.0" text-anchor="middle" font-family="BerkeleyMono, monospace" font-size="22" font-weight="700" fill="#062152">/checkpoints</text><text x="850" y="251.0" text-anchor="middle" class="annot" fill="#243142">Kubernetes PVC · shared volume</text><text x="850" y="277.0" text-anchor="middle" class="mono" font-size="13" fill="#5d6a7a">my-checkpoint-volume</text></g>
+  <g transform="translate(90 80)"><rect x="0" y="0" width="340" height="140" rx="14" fill="#FFFFFF" stroke="#C7402E" stroke-width="1.5"/><text x="22" y="32" class="role">TASK&#160;01</text><text x="22" y="72" font-family="Waldenburg, sans-serif" font-size="28" font-weight="500" fill="#04070B" letter-spacing="-0.015em">trainer</text><text x="22" y="100" class="annot">writes a checkpoint every N steps</text></g>
+  <g transform="translate(90 250)"><rect x="0" y="0" width="340" height="140" rx="14" fill="#FFFFFF" stroke="#0A55EE" stroke-width="1.5"/><text x="22" y="32" class="role">TASK&#160;02</text><text x="22" y="72" font-family="Waldenburg, sans-serif" font-size="28" font-weight="500" fill="#04070B" letter-spacing="-0.015em">evaluator</text><text x="22" y="100" class="annot">polls the volume for new checkpoints</text></g>
+  <g>
+      <path d="M 438 150.0 Q 582.00 150.00 726.0 150.0" fill="none" stroke="#C7402E" stroke-width="1.5" stroke-linecap="round" stroke-dasharray="8 4" class="flow"/>
+      <polyline points="715.00,156.50 726.0,150.0 715.00,143.50" fill="none" stroke="#C7402E" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="bevel"/>
+      <text x="582.00" y="136.00" text-anchor="middle" class="flow-label hot">write</text>
+      </g>
+  <g>
+      <path d="M 726.0 320.0 Q 582.00 320.00 438 320.0" fill="none" stroke="#0A55EE" stroke-width="1.5" stroke-linecap="round" stroke-dasharray="6 5" class="flow"/>
+      <polyline points="449.00,313.50 438,320.0 449.00,326.50" fill="none" stroke="#0A55EE" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="bevel"/>
+      <text x="582.00" y="306.00" text-anchor="middle" class="flow-label">read</text>
+      </g>
+  <g transform="translate(90 26)"><rect x="0" y="0" width="188" height="26" rx="13" fill="none" stroke="#C8C6C7" stroke-width="1"/><text x="94" y="17" text-anchor="middle" font-family="BerkeleyMono, monospace" font-size="12" letter-spacing="0.16em" fill="#243142">EXECUTION:&#160;PARALLEL</text></g>
+</svg>

--- a/docs/source/images/job-groups-train-eval-architecture.svg
+++ b/docs/source/images/job-groups-train-eval-architecture.svg
@@ -12,6 +12,7 @@
     @keyframes flow-dash { from { stroke-dashoffset: 0; } to { stroke-dashoffset: -22; } }
     .diag .flow { animation: flow-dash 1.8s linear infinite; }
 ]]></style>
+  <g><rect x="70" y="60" width="380" height="350" rx="20" fill="none" stroke="#0A55EE" stroke-width="1.5" stroke-dasharray="2 5"/><g transform="translate(96 60)"><rect x="-12" y="-16" width="260" height="32" rx="16" fill="#FFFFFF" stroke="#0A55EE" stroke-width="1.25"/><text x="0" y="6" font-family="BerkeleyMono, monospace" font-size="14" letter-spacing="0.18em" font-weight="700" fill="#0A55EE">SKYPILOT&#160;JOB&#160;GROUP</text></g></g>
   <g><path d="M 730.0 80 L 730.0 390 A 120.0 24 0 0 0 970.0 390 L 970.0 80 A 120.0 24 0 0 1 730.0 80 Z" fill="#E4F2FB" stroke="#0A55EE" stroke-width="1.5"/><ellipse cx="850" cy="80" rx="120.0" ry="24" fill="#ECF2FD" stroke="#0A55EE" stroke-width="1.5"/><text x="850" y="223.0" text-anchor="middle" font-family="BerkeleyMono, monospace" font-size="22" font-weight="700" fill="#062152">/checkpoints</text><text x="850" y="251.0" text-anchor="middle" class="annot" fill="#243142">Kubernetes PVC · shared volume</text><text x="850" y="277.0" text-anchor="middle" class="mono" font-size="13" fill="#5d6a7a">my-checkpoint-volume</text></g>
   <g transform="translate(90 80)"><rect x="0" y="0" width="340" height="140" rx="14" fill="#FFFFFF" stroke="#C7402E" stroke-width="1.5"/><text x="22" y="32" class="role">TASK&#160;01</text><text x="22" y="72" font-family="Waldenburg, sans-serif" font-size="28" font-weight="500" fill="#04070B" letter-spacing="-0.015em">trainer</text><text x="22" y="100" class="annot">writes a checkpoint every N steps</text></g>
   <g transform="translate(90 250)"><rect x="0" y="0" width="340" height="140" rx="14" fill="#FFFFFF" stroke="#0A55EE" stroke-width="1.5"/><text x="22" y="32" class="role">TASK&#160;02</text><text x="22" y="72" font-family="Waldenburg, sans-serif" font-size="28" font-weight="500" fill="#04070B" letter-spacing="-0.015em">evaluator</text><text x="22" y="100" class="annot">polls the volume for new checkpoints</text></g>
@@ -25,5 +26,4 @@
       <polyline points="449.00,313.50 438,320.0 449.00,326.50" fill="none" stroke="#0A55EE" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="bevel"/>
       <text x="582.00" y="306.00" text-anchor="middle" class="flow-label">read</text>
       </g>
-  <g transform="translate(90 26)"><rect x="0" y="0" width="188" height="26" rx="13" fill="none" stroke="#C8C6C7" stroke-width="1"/><text x="94" y="17" text-anchor="middle" font-family="BerkeleyMono, monospace" font-size="12" letter-spacing="0.16em" fill="#243142">EXECUTION:&#160;PARALLEL</text></g>
 </svg>

--- a/llm/rl-post-training-jobgroup/README.md
+++ b/llm/rl-post-training-jobgroup/README.md
@@ -7,7 +7,7 @@ This example demonstrates a distributed RL post-training architecture using SkyP
 The example consists of 5 task types that communicate over HTTP, with built-in load balancing for scaling inference:
 
 <p align="center">
-  <img src="../../docs/source/images/job-groups-rl-architecture.jpg" width="80%">
+  <img src="../../docs/source/images/job-groups-rl-architecture.svg" width="80%">
 </p>
 
 ### Components

--- a/llm/train-eval-jobgroup/README.md
+++ b/llm/train-eval-jobgroup/README.md
@@ -5,7 +5,7 @@ This example demonstrates SkyPilot job groups with parallel training and evaluat
 ## Architecture
 
 <p align="center">
-  <img src="../../docs/source/images/job-groups-train-eval-architecture.png" width="80%">
+  <img src="../../docs/source/images/job-groups-train-eval-architecture.svg" width="80%">
 </p>
 
 ### Components


### PR DESCRIPTION
## Summary

Refresh the Job Groups docs page with new diagrams, front-load the RL architecture as a hero, and tighten the page.

- **New brand-styled SVGs** (`docs/source/images/job-groups-rl-architecture.svg`, `job-groups-train-eval-architecture.svg`) rendered from the design bundle's JSX source. Self-contained (inline `<style>`), animated dashed flows, Berkeley Mono + Waldenburg typography matching the SkyPilot brand.
- **RL architecture is now the page hero** — promoted to the top of `docs/source/examples/job-groups.rst`, replacing the dashboard screenshot as the lead visual. The dashboard PNG is repositioned to the RL example section as "the same Job Group running in production".
- **Both diagrams now have a "SKYPILOT JOB GROUP" boundary** — dashed sky-blue box around the tasks with a corner pill, so the SkyPilot identity reads at a glance.
- **Train-eval diagram**: the trainer + evaluator are wrapped in the Job Group box; the shared PVC sits outside (it's a K8s resource, not part of the Job Group). The redundant `EXECUTION: PARALLEL` pill was removed.
- **Page tightening**: removed the experimental warning banner; dropped the duplicate RL figure that used to live under "RL post-training architecture" (the hero covers it).
- **READMEs in the two example folders** (`llm/rl-post-training-jobgroup/`, `llm/train-eval-jobgroup/`) updated to reference the new SVGs.

## Test plan

- Local `./build.sh --watch --port 8000` — page renders, both SVGs animate (dashed flows), Job Group boundary labels read cleanly with no text overflow.
- Verified inline CSS in both SVGs renders standalone (without the host HTML's stylesheet).
