### PR TITLE
[Kubernetes] Deterministic Ray/sshd ports for hostNetwork pods (alt to #9604)

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -19,6 +19,7 @@ from sky.adaptors import kubernetes
 from sky.clouds.utils import gcp_utils
 from sky.provision import instance_setup
 from sky.provision.gcp import constants as gcp_constants
+from sky.provision.kubernetes import host_network
 from sky.provision.kubernetes import network_utils
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.provision.kubernetes.utils import is_tpu_on_gke
@@ -27,6 +28,7 @@ from sky.provision.kubernetes.utils import normalize_tpu_accelerator_name
 from sky.skylet import constants
 from sky.utils import annotations
 from sky.utils import common_utils
+from sky.utils import config_utils
 from sky.utils import env_options
 from sky.utils import kubernetes_enums
 from sky.utils import registry
@@ -529,7 +531,7 @@ class Kubernetes(clouds.Cloud):
         dryrun: bool = False,
         volume_mounts: Optional[List['volume_lib.VolumeMount']] = None,
     ) -> Dict[str, Optional[str]]:
-        del cluster_name, zones  # Unused.
+        del zones  # Unused.
         if region is None:
             context = kubernetes_utils.get_current_kube_config_context_name()
         else:
@@ -767,6 +769,44 @@ class Kubernetes(clouds.Cloud):
 
         namespace = kubernetes_utils.get_kube_config_context_namespace(context)
 
+        # Detect `hostNetwork: true` up front so the deterministic Ray/sshd
+        # ports and per-pod loopback IPs (see sky.provision.kubernetes.
+        # host_network) can be baked into the rendered cluster YAML at
+        # provision time — no startup probe, no ConfigMap, no RBAC. The same
+        # pod_config merge happens again later in combine_pod_config_fields
+        # when the user's pod_config is folded into the rendered YAML.
+        cluster_name_on_cloud = cluster_name.name_on_cloud
+        merged_pod_config = skypilot_config.get_effective_region_config(
+            cloud=cloud_config_str,
+            region=context,
+            keys=('pod_config',),
+            default_value={})
+        override_pod_config = config_utils.get_cloud_config_value_from_dict(
+            dict_config=resources.cluster_config_overrides,
+            cloud=cloud_config_str,
+            region=context,
+            keys=('pod_config',),
+            default_value={})
+        config_utils.merge_k8s_configs(merged_pod_config, override_pod_config)
+        k8s_host_network = host_network.is_host_network(merged_pod_config)
+        # Passed to ray_{head,worker}_start_command so they emit deterministic
+        # port flags; None keeps the non-hostNetwork command byte-identical.
+        host_network_params = (
+            host_network.HostNetworkRayParams.build(cluster_name_on_cloud)
+            if k8s_host_network else None)
+        k8s_host_network_head_ip = (host_network_params.head_node_ip
+                                    if host_network_params else None)
+        k8s_host_network_head_gcs_port = (host_network_params.head_ports.gcs
+                                          if host_network_params else None)
+        # Bash that sets $SKYPILOT_NODE_RANK + the deterministic sshd port
+        # expression; the template uses them to rebind every pod's sshd off
+        # host:22 (owned by the K8s node's own sshd under hostNetwork).
+        k8s_host_network_rank_shell = (host_network_params.rank_shell
+                                       if host_network_params else None)
+        k8s_host_network_sshd_port_expr = (
+            host_network_params.worker_port_exprs['sshd']
+            if host_network_params else None)
+
         deploy_vars = {
             'instance_type': resources.instance_type,
             'custom_resources': custom_resources,
@@ -796,10 +836,15 @@ class Kubernetes(clouds.Cloud):
             'image_id': image_id,
             'ray_installation_commands': constants.RAY_INSTALLATION_COMMANDS,
             'ray_head_start_command': instance_setup.ray_head_start_command(
-                custom_resources, custom_ray_options),
+                custom_resources,
+                custom_ray_options,
+                host_network_params=host_network_params),
             'skypilot_ray_port': constants.SKY_REMOTE_RAY_PORT,
             'ray_worker_start_command': instance_setup.ray_worker_start_command(
-                custom_resources, custom_ray_options, no_restart=False),
+                custom_resources,
+                custom_ray_options,
+                no_restart=False,
+                host_network_params=host_network_params),
             'k8s_high_availability_deployment_volume_mount_name':
                 (kubernetes_utils.HIGH_AVAILABILITY_DEPLOYMENT_VOLUME_MOUNT_NAME
                 ),
@@ -825,6 +870,14 @@ class Kubernetes(clouds.Cloud):
             'k8s_network_type': network_type.value,
             'k8s_context': context,
             'k8s_namespace': namespace,
+            'k8s_host_network': k8s_host_network,
+            # Head's deterministic loopback IP + GCS port. Workers export
+            # these (template) so `ray start --address` dials the head over
+            # the shared host netns instead of the (host-IP) Service DNS.
+            'k8s_host_network_head_ip': k8s_host_network_head_ip,
+            'k8s_host_network_head_gcs_port': k8s_host_network_head_gcs_port,
+            'k8s_host_network_rank_shell': k8s_host_network_rank_shell,
+            'k8s_host_network_sshd_port_expr': k8s_host_network_sshd_port_expr,
         }
 
         # Add ephemeral storage to deploy vars if specified.

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -6,6 +6,7 @@ import json
 import os
 import shlex
 import time
+import typing
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from sky import exceptions
@@ -29,6 +30,9 @@ from sky.utils import subprocess_utils
 from sky.utils import timeline
 from sky.utils import ux_utils
 
+if typing.TYPE_CHECKING:
+    from sky.provision.kubernetes import host_network
+
 logger = sky_logging.init_logger(__name__)
 
 _MAX_RETRY = 6
@@ -40,13 +44,22 @@ _RAY_PRLIMIT = (
     'which prlimit && for id in $(pgrep -f raylet/raylet); '
     'do sudo prlimit --nofile=1048576:1048576 --pid=$id || true; done;')
 
-DUMP_RAY_PORTS = (f'{constants.SKY_PYTHON_CMD} -c \'import json, os; '
-                  f'runtime_dir = os.path.expanduser(os.environ.get('
-                  f'"{constants.SKY_RUNTIME_DIR_ENV_VAR_KEY}", "~")); '
-                  f'json.dump({constants.SKY_REMOTE_RAY_PORT_DICT_STR}, '
-                  f'open(os.path.join(runtime_dir, '
-                  f'"{constants.SKY_REMOTE_RAY_PORT_FILE}"), "w", '
-                  'encoding="utf-8"))\';')
+
+def _dump_ray_ports_cmd(
+        port_dict_str: str = constants.SKY_REMOTE_RAY_PORT_DICT_STR) -> str:
+    """Shell that writes the Ray port file. ``port_dict_str`` is a Python dict
+    literal; hostNetwork bakes the deterministic ports in here so
+    ``job_lib.get_ray_port()`` (and thus ``ray status``, skylet) is correct."""
+    return (f'{constants.SKY_PYTHON_CMD} -c \'import json, os; '
+            f'runtime_dir = os.path.expanduser(os.environ.get('
+            f'"{constants.SKY_RUNTIME_DIR_ENV_VAR_KEY}", "~")); '
+            f'json.dump({port_dict_str}, '
+            f'open(os.path.join(runtime_dir, '
+            f'"{constants.SKY_REMOTE_RAY_PORT_FILE}"), "w", '
+            'encoding="utf-8"))\';')
+
+
+DUMP_RAY_PORTS = _dump_ray_ports_cmd()
 
 _RAY_PORT_COMMAND = (
     f'RAY_PORT=$({constants.SKY_PYTHON_CMD} -c '
@@ -291,17 +304,57 @@ def _ray_gpu_options(custom_resource: str) -> str:
     return f' --num-gpus={acc_count}'
 
 
-def ray_head_start_command(custom_resource: Optional[str],
-                           custom_ray_options: Optional[Dict[str, Any]]) -> str:
-    """Returns the command to start Ray on the head node."""
-    ray_options = (
-        # --disable-usage-stats in `ray start` saves 10 seconds of idle wait.
-        f'--disable-usage-stats '
-        f'--port={constants.SKY_REMOTE_RAY_PORT} '
-        f'--dashboard-port={constants.SKY_REMOTE_RAY_DASHBOARD_PORT} '
-        f'--min-worker-port 11002 '
-        f'--object-manager-port=8076 '
-        f'--temp-dir={constants.SKY_REMOTE_RAY_TEMPDIR}')
+def ray_head_start_command(
+    custom_resource: Optional[str],
+    custom_ray_options: Optional[Dict[str, Any]],
+    host_network_params: Optional['host_network.HostNetworkRayParams'] = None,
+) -> str:
+    """Returns the command to start Ray on the head node.
+
+    When ``host_network_params`` is given (Kubernetes ``hostNetwork: true``)
+    every Ray port is the cluster's deterministic rank-0 value and all Ray
+    daemons are pinned to the head's per-pod loopback IP, so a sibling
+    SkyPilot pod sharing the K8s node's net namespace can't collide on ports
+    and Ray's client-side NodeID->endpoint cache can't collapse two raylets
+    onto one address. ``None`` keeps the command byte-identical to before.
+    """
+    if host_network_params is None:
+        ray_options = (
+            # --disable-usage-stats saves 10 seconds of idle wait.
+            f'--disable-usage-stats '
+            f'--port={constants.SKY_REMOTE_RAY_PORT} '
+            f'--dashboard-port={constants.SKY_REMOTE_RAY_DASHBOARD_PORT} '
+            f'--min-worker-port 11002 '
+            f'--object-manager-port=8076 '
+            f'--temp-dir={constants.SKY_REMOTE_RAY_TEMPDIR}')
+        dump_ray_ports = DUMP_RAY_PORTS
+        wait_initialized = RAY_HEAD_WAIT_INITIALIZED_COMMAND
+    else:
+        p = host_network_params.head_ports
+        node_ip = host_network_params.head_node_ip
+        ray_options = (
+            f'--disable-usage-stats '
+            f'--port={p.gcs} '
+            f'--dashboard-port={p.dashboard} '
+            f'--min-worker-port 11002 '
+            f'--object-manager-port={p.object_manager} '
+            f'--node-manager-port={p.node_manager} '
+            f'--ray-client-server-port={p.ray_client_server} '
+            f'--dashboard-agent-listen-port={p.dashboard_agent_listen} '
+            f'--runtime-env-agent-port={p.runtime_env_agent} '
+            f'--metrics-export-port={p.metrics_export} '
+            f'--node-ip-address={node_ip} '
+            f'--temp-dir={constants.SKY_REMOTE_RAY_TEMPDIR}')
+        # Bake the real ports into the port file so job_lib.get_ray_port()
+        # (hence `ray status`, skylet) reports the deterministic GCS port.
+        dump_ray_ports = _dump_ray_ports_cmd(
+            f'{{"ray_port":{p.gcs},"ray_dashboard_port":{p.dashboard}}}')
+        # GCS binds the loopback IP, not 127.0.0.1:6380 — poll the right addr.
+        wait_initialized = (
+            f'while `RAY_ADDRESS={node_ip}:{p.gcs} '
+            f'{constants.SKY_RAY_CMD} status | '
+            'grep -q "No cluster status."`; do sleep 0.5; '
+            'echo "Waiting ray cluster to be initialized"; done;')
     if custom_resource:
         ray_options += f' --resources=\'{custom_resource}\''
         ray_options += _ray_gpu_options(custom_resource)
@@ -330,18 +383,43 @@ def ray_head_start_command(custom_resource: Optional[str],
         # the warning when the worker count is >12x CPUs.
         'RAY_worker_maximum_startup_concurrency=$(( 3 * $(nproc --all) )) '
         f'{constants.SKY_RAY_CMD} start --head {ray_options} || exit 1;' +
-        _RAY_PRLIMIT + DUMP_RAY_PORTS + RAY_HEAD_WAIT_INITIALIZED_COMMAND)
+        _RAY_PRLIMIT + dump_ray_ports + wait_initialized)
     return cmd
 
 
-def ray_worker_start_command(custom_resource: Optional[str],
-                             custom_ray_options: Optional[Dict[str, Any]],
-                             no_restart: bool) -> str:
-    """Returns the command to start Ray on the worker node."""
+def ray_worker_start_command(
+    custom_resource: Optional[str],
+    custom_ray_options: Optional[Dict[str, Any]],
+    no_restart: bool,
+    host_network_params: Optional['host_network.HostNetworkRayParams'] = None,
+) -> str:
+    """Returns the command to start Ray on the worker node.
+
+    When ``host_network_params`` is given (Kubernetes ``hostNetwork: true``)
+    the worker's Ray ports are its deterministic per-rank slot and
+    ``--node-ip-address`` pins this pod's raylet to a distinct loopback IP, so
+    it neither collides on ports with nor gets cache-collapsed against the
+    head (or another pod) sharing the K8s node's net namespace. The rank is
+    resolved in-pod (``rank_shell``) since one rendered worker command serves
+    every worker. ``None`` keeps the command byte-identical to before.
+    """
     # We need to use the ray port in the env variable, because the head node
     # determines the port to be used for the worker node.
     ray_options = ('--address=${SKYPILOT_RAY_HEAD_IP}:${SKYPILOT_RAY_PORT} '
                    '--object-manager-port=8076')
+    if host_network_params is not None:
+        # SKYPILOT_RAY_HEAD_IP/PORT are exported (template) to the head's
+        # deterministic loopback IP + GCS port. $SKYPILOT_NODE_RANK is set by
+        # rank_shell (prepended below) before this command runs.
+        e = host_network_params.worker_port_exprs
+        ray_options = (
+            '--address=${SKYPILOT_RAY_HEAD_IP}:${SKYPILOT_RAY_PORT} '
+            f'--object-manager-port={e["object_manager"]} '
+            f'--node-manager-port={e["node_manager"]} '
+            f'--dashboard-agent-listen-port={e["dashboard_agent_listen"]} '
+            f'--runtime-env-agent-port={e["runtime_env_agent"]} '
+            f'--metrics-export-port={e["metrics_export"]} '
+            f'--node-ip-address={host_network_params.worker_node_ip_expr}')
 
     if custom_resource:
         ray_options += f' --resources=\'{custom_resource}\''
@@ -367,6 +445,10 @@ def ray_worker_start_command(custom_resource: Optional[str],
             f'|| {{ {cmd} }}')
     else:
         cmd = f'{constants.SKY_RAY_CMD} stop; ' + cmd
+    if host_network_params is not None:
+        # Define $SKYPILOT_NODE_RANK before anything references it (the
+        # ray-options arithmetic and node-ip expression both use it).
+        cmd = f'{host_network_params.rank_shell}; ' + cmd
     return cmd
 
 

--- a/sky/provision/kubernetes/host_network.py
+++ b/sky/provision/kubernetes/host_network.py
@@ -1,0 +1,230 @@
+"""Deterministic Ray + sshd ports and loopback IPs for hostNetwork pods.
+
+When a Kubernetes pod runs with ``hostNetwork: true`` it shares the host's
+network namespace, so a second SkyPilot pod scheduled to the same node would
+collide on Ray's default ports (6380, 8266, 8076, ...) and on the node's own
+sshd (host:22).
+
+Rather than probing for free ports at pod startup and shipping the head's
+choice to the workers through a ConfigMap (which needs an in-cluster service
+account with namespace-wide RBAC), every pod independently derives an
+*identical* port set and a per-pod loopback IP from
+``sha256(cluster_name_on_cloud)`` and its rank. Because the head is always rank
+0, every worker can compute the head's GCS port and loopback IP locally — no
+ConfigMap, no RBAC, no head->worker handoff, no in-cluster API calls.
+
+The derived numbers are baked into the rendered cluster YAML at provision time
+(see ``sky/provision/instance_setup.py`` and ``kubernetes-ray.yml.j2``); only a
+worker's own rank is resolved at runtime, since a single worker pod spec serves
+every worker.
+
+Scheme::
+
+    h         = sha256(cluster_name_on_cloud)
+    port_base = 20000 + (h[:2] as uint16 % 120) * 100   # 20000..31900
+    port      = port_base + rank * 10 + offset           # offset table below
+    node_ip   = 127.<h[0] | 0x80>.<h[1]>.<rank>
+
+Trade-offs (accepted, same failure mode as a probe's TOCTOU — fails loudly with
+``EADDRINUSE``, never silently mis-routes):
+
+- Birthday-paradox bucket collision between two *unrelated* SkyPilot clusters on
+  one node: with 120 buckets the chance of any collision reaches ~50% at ~13
+  co-located clusters. A non-issue for RDMA/RoCE hosts (one or two clusters per
+  node).
+- More than 10 pods of the *same* cluster co-located on one node would overflow
+  the 100-port window into the neighbouring bucket. Also a non-issue for the
+  typical one-pod-per-node RDMA layout.
+- Cross-K8s-node hostNetwork is unchanged and still unsupported: a worker's
+  ``127.x.y.0`` dial-back to the head's loopback is only routable when head and
+  worker share the host's netns (same node).
+
+Stdlib-only so it stays importable on both the client and the API server
+without pulling in heavy dependencies.
+"""
+import dataclasses
+import hashlib
+import re
+from typing import Any, Dict, Optional, Tuple
+
+# The deterministic port band. Chosen to sit clear of Ray's defaults (6380,
+# 8266, 8076), the skylet gRPC port (46590), and the Linux ephemeral range
+# (typically 32768+), while leaving Ray's own ``--min-worker-port 11002``
+# untouched.
+_PORT_RANGE_START = 20000
+_NUM_BUCKETS = 120
+_PORTS_PER_BUCKET = 100
+_PORTS_PER_RANK = 10
+
+# Largest rank that still fits inside a cluster's 100-port window
+# (rank * 10 + max_offset must stay < _PORTS_PER_BUCKET).
+MAX_RANK = _PORTS_PER_BUCKET // _PORTS_PER_RANK - 1
+
+# Offset of each port within a pod's per-rank 10-port slot. ``sshd`` is parked
+# at the top of the slot so the contiguous low offsets stay available for Ray.
+# Offset 8 is intentionally reserved for a future Ray port.
+PORT_OFFSETS: Dict[str, int] = {
+    'gcs': 0,
+    'dashboard': 1,
+    'node_manager': 2,
+    'object_manager': 3,
+    'runtime_env_agent': 4,
+    'dashboard_agent_listen': 5,
+    'metrics_export': 6,
+    'ray_client_server': 7,
+    'sshd': 9,
+}
+
+_WORKER_POD_RE = re.compile(r'-worker(\d+)$')
+
+# Env var a worker pod's bootstrap sets to its own rank (see
+# ``worker_rank_shell``), used to index the deterministic per-rank port slot
+# at runtime. A worker's rank is the one value not known at provision time —
+# a single rendered worker pod spec serves every worker — so it is the only
+# part of the scheme resolved in-pod rather than baked into the YAML.
+WORKER_RANK_ENV = 'SKYPILOT_NODE_RANK'
+
+
+@dataclasses.dataclass(frozen=True)
+class HostNetworkPorts:
+    """The deterministic port set for a single hostNetwork pod (one rank)."""
+    gcs: int
+    dashboard: int
+    node_manager: int
+    object_manager: int
+    runtime_env_agent: int
+    dashboard_agent_listen: int
+    metrics_export: int
+    ray_client_server: int
+    sshd: int
+
+
+def is_host_network(pod_config: Optional[Dict[str, Any]]) -> bool:
+    """Returns True if the merged pod_config requests ``hostNetwork: true``."""
+    if not pod_config:
+        return False
+    spec = pod_config.get('spec') or {}
+    return bool(spec.get('hostNetwork', False))
+
+
+def _cluster_digest(cluster_name_on_cloud: str) -> bytes:
+    return hashlib.sha256(cluster_name_on_cloud.encode('utf-8')).digest()
+
+
+def port_base(cluster_name_on_cloud: str) -> int:
+    """The start of the cluster's 100-port window (rank 0, offset 0)."""
+    h = _cluster_digest(cluster_name_on_cloud)
+    bucket = int.from_bytes(h[:2], 'big') % _NUM_BUCKETS
+    return _PORT_RANGE_START + bucket * _PORTS_PER_BUCKET
+
+
+def derive_ports(cluster_name_on_cloud: str, rank: int) -> HostNetworkPorts:
+    """Deterministic port set for the pod at ``rank`` (head=0, worker i=i)."""
+    if rank < 0:
+        raise ValueError(f'rank must be non-negative, got {rank}')
+    base = port_base(cluster_name_on_cloud) + rank * _PORTS_PER_RANK
+    return HostNetworkPorts(
+        **{name: base + off for name, off in PORT_OFFSETS.items()})
+
+
+def node_ip_prefix(cluster_name_on_cloud: str) -> str:
+    """The ``127.<b1>.<b2>.`` prefix; append a rank to get a pod's loopback.
+
+    Lets the (single) worker pod spec compute ``<prefix><rank>`` at runtime,
+    since one rendered worker command serves every worker.
+    """
+    h = _cluster_digest(cluster_name_on_cloud)
+    return f'127.{h[0] | 0x80}.{h[1]}.'
+
+
+def derive_node_ip(cluster_name_on_cloud: str, rank: int) -> str:
+    """Per-pod loopback IP ``127.<b1>.<b2>.<rank>``.
+
+    The whole of ``127.0.0.0/8`` is routed to ``lo`` by the Linux kernel, so no
+    ``CAP_NET_ADMIN`` is needed and every pod sharing the host netns can dial
+    every other pod's loopback. ``b1`` has its high bit set so the address
+    never lands in ``127.0.0.x`` (where the kernel's own ``127.0.0.1`` lives).
+    """
+    if rank < 0:
+        raise ValueError(f'rank must be non-negative, got {rank}')
+    return f'{node_ip_prefix(cluster_name_on_cloud)}{rank}'
+
+
+def worker_rank_shell() -> str:
+    """Bash that sets ``$SKYPILOT_NODE_RANK`` from the pod's downward-API name.
+
+    ``${SKYPILOT_POD_NAME##*-worker}`` strips up to and including the last
+    ``-worker`` (``cl-worker3`` -> ``3``); the ``case`` guard keeps any
+    non-worker name at rank 0. Kept to one line for the YAML block scalar.
+    """
+    return (f'{WORKER_RANK_ENV}=0; '
+            f'case "$SKYPILOT_POD_NAME" in '
+            f'*-worker*[0-9]) '
+            f'{WORKER_RANK_ENV}="${{SKYPILOT_POD_NAME##*-worker}}";; '
+            f'esac')
+
+
+@dataclasses.dataclass(frozen=True)
+class HostNetworkRayParams:
+    """Deterministic values spliced into the rendered Ray start commands.
+
+    Built once at provision time (sky/clouds/kubernetes.py). The head's values
+    are fully resolved literals (its rank is known: 0). The worker's are bash
+    expressions evaluated in-pod against ``$SKYPILOT_NODE_RANK`` because one
+    rendered worker command serves every worker.
+    """
+    head_ports: HostNetworkPorts
+    head_node_ip: str
+    # Ray-port-role -> bash arithmetic expression, e.g.
+    # ``$(( 20500 + SKYPILOT_NODE_RANK * 10 + 2 ))``.
+    worker_port_exprs: Dict[str, str]
+    # ``127.<b1>.<b2>.$SKYPILOT_NODE_RANK``.
+    worker_node_ip_expr: str
+    # Bash that defines ``$SKYPILOT_NODE_RANK`` (prepended to the worker cmd).
+    rank_shell: str
+
+    @classmethod
+    def build(cls, cluster_name_on_cloud: str) -> 'HostNetworkRayParams':
+        base = port_base(cluster_name_on_cloud)
+        prefix = node_ip_prefix(cluster_name_on_cloud)
+        worker_port_exprs = {
+            role: f'$(( {base} + {WORKER_RANK_ENV} * '
+            f'{_PORTS_PER_RANK} + {off} ))'
+            for role, off in PORT_OFFSETS.items()
+        }
+        return cls(
+            head_ports=derive_ports(cluster_name_on_cloud, rank=0),
+            head_node_ip=derive_node_ip(cluster_name_on_cloud, rank=0),
+            worker_port_exprs=worker_port_exprs,
+            worker_node_ip_expr=f'{prefix}${WORKER_RANK_ENV}',
+            rank_shell=worker_rank_shell(),
+        )
+
+
+def rank_from_pod_name(pod_name: str) -> int:
+    """Rank from a SkyPilot K8s pod name: ``-head`` -> 0, ``-worker<i>`` -> i.
+
+    Anchored at the end so a cluster name that itself contains ``-worker`` or
+    ``-head`` doesn't confuse the parse. Unrecognized names default to rank 0
+    (treated as the head's slot) rather than raising — a wrong-but-deterministic
+    rank still beats crashing a status refresh.
+    """
+    m = _WORKER_POD_RE.search(pod_name)
+    if m is not None:
+        return int(m.group(1))
+    return 0
+
+
+def cluster_and_rank_from_pod_name(pod_name: str) -> Tuple[str, int]:
+    """Split a SkyPilot K8s pod name into (cluster_name_on_cloud, rank).
+
+    ``<cluster>-head`` -> ``(<cluster>, 0)``; ``<cluster>-worker<i>`` ->
+    ``(<cluster>, i)``. Lets a caller that only has the pod name (e.g. the SSH
+    proxy) recompute the same deterministic ports the pod itself derived.
+    """
+    m = _WORKER_POD_RE.search(pod_name)
+    if m is not None:
+        return pod_name[:m.start()], int(m.group(1))
+    if pod_name.endswith('-head'):
+        return pod_name[:-len('-head')], 0
+    return pod_name, 0

--- a/sky/provision/kubernetes/host_network.py
+++ b/sky/provision/kubernetes/host_network.py
@@ -43,6 +43,7 @@ Stdlib-only so it stays importable on both the client and the API server
 without pulling in heavy dependencies.
 """
 import dataclasses
+import functools
 import hashlib
 import re
 from typing import Any, Dict, Optional, Tuple
@@ -107,6 +108,12 @@ def is_host_network(pod_config: Optional[Dict[str, Any]]) -> bool:
     return bool(spec.get('hostNetwork', False))
 
 
+# Cached: the digest is a pure function of the name, and the derivation
+# helpers each recompute it (port_base, node_ip_prefix, derive_ports,
+# derive_node_ip), so a single build() or a get_cluster_info() loop over N
+# pods would otherwise rehash the same name 4N times. Bounded so a long-lived
+# API server process can't grow it without limit.
+@functools.lru_cache(maxsize=1024)
 def _cluster_digest(cluster_name_on_cloud: str) -> bytes:
     return hashlib.sha256(cluster_name_on_cloud.encode('utf-8')).digest()
 

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -18,6 +18,7 @@ from sky.provision import constants
 from sky.provision import docker_utils
 from sky.provision.kubernetes import config as config_lib
 from sky.provision.kubernetes import constants as k8s_constants
+from sky.provision.kubernetes import host_network
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.provision.kubernetes import volume
 from sky.utils import command_runner
@@ -1799,6 +1800,22 @@ def get_cluster_info(
     cpu_request = None
     for pod_name, pod in running_pods.items():
         internal_ip = pod.status.pod_ip
+        ssh_port = port
+        # Under hostNetwork the pod shares the host's net namespace: its sshd
+        # can't own host:22 (the K8s node's own sshd does), and its pod_ip is
+        # the host IP. Both the sshd port and the per-pod loopback IP are
+        # deterministic functions of the cluster name + rank (see
+        # host_network), so recompute them here — no ConfigMap, no probe, no
+        # extra API call. Mirroring internal_ip to the loopback keeps
+        # RayCodeGen's cluster_ips_to_node_id aligned with what
+        # ray.util.get_node_ip_address() (the pod's --node-ip-address)
+        # reports inside the pod.
+        if getattr(pod.spec, 'host_network', False):
+            rank = host_network.rank_from_pod_name(pod_name)
+            internal_ip = host_network.derive_node_ip(cluster_name_on_cloud,
+                                                      rank)
+            ssh_port = host_network.derive_ports(cluster_name_on_cloud,
+                                                 rank).sshd
         # Get the k8s node name the pod is running on (for dashboard display)
         k8s_node_name = getattr(pod.spec, 'node_name', None)
         pods[pod_name] = [
@@ -1806,7 +1823,7 @@ def get_cluster_info(
                 instance_id=pod_name,
                 internal_ip=internal_ip,
                 external_ip=None,
-                ssh_port=port,
+                ssh_port=ssh_port,
                 tags=pod.metadata.labels,
                 # TODO(hailong): `cluster.local` may need to be configurable
                 # Service name is same as the pod name for now.

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -30,6 +30,7 @@ from sky.adaptors import gcp
 from sky.adaptors import kubernetes
 from sky.provision import constants as provision_constants
 from sky.provision.kubernetes import constants as kubernetes_constants
+from sky.provision.kubernetes import host_network
 from sky.provision.kubernetes import network_utils
 from sky.skylet import constants
 from sky.utils import annotations
@@ -209,7 +210,7 @@ KIND_CONTEXT_NAME = 'kind-skypilot'  # Context name used by sky local up
 PORT_FORWARD_PROXY_CMD_TEMPLATE = 'kubernetes-port-forward-proxy-command.sh'
 # We add a version suffix to the port-forward proxy command to ensure backward
 # compatibility and avoid overwriting the older version.
-PORT_FORWARD_PROXY_CMD_VERSION = 2
+PORT_FORWARD_PROXY_CMD_VERSION = 3
 PORT_FORWARD_PROXY_CMD_PATH = ('~/.sky/kubernetes-port-forward-proxy-command-'
                                f'v{PORT_FORWARD_PROXY_CMD_VERSION}.sh')
 
@@ -2990,6 +2991,7 @@ def construct_ssh_jump_command(
         ssh_jump_user: str = 'sky',
         proxy_cmd_path: Optional[str] = None,
         proxy_cmd_target_pod: Optional[str] = None,
+        proxy_cmd_pod_port: Optional[int] = None,
         current_kube_context: Optional[str] = None,
         current_kube_namespace: Optional[str] = None) -> str:
     ssh_jump_proxy_command = (f'ssh -tt -i {private_key_path} '
@@ -3008,9 +3010,15 @@ def construct_ssh_jump_command(
             current_kube_context is not None) else ''
         kube_namespace_flag = f'-n {current_kube_namespace} ' if (
             current_kube_namespace is not None) else ''
+        # The pod's deterministic sshd port under hostNetwork (host:22 is
+        # owned by the K8s node's own sshd). The script only honours it for
+        # pods that are actually hostNetwork; harmless to pass otherwise.
+        pod_port_flag = (f'-p {proxy_cmd_pod_port} '
+                         if proxy_cmd_pod_port is not None else '')
         ssh_jump_proxy_command += (f' -o ProxyCommand=\'{proxy_cmd_path} '
                                    f'{kube_context_flag}'
                                    f'{kube_namespace_flag}'
+                                   f'{pod_port_flag}'
                                    f'{proxy_cmd_target_pod}\'')
     return ssh_jump_proxy_command
 
@@ -3055,12 +3063,19 @@ def get_ssh_proxy_command(
     ssh_jump_ip = '127.0.0.1'  # Local end of the port-forward tunnel
     assert private_key_path is not None, 'Private key path must be provided'
     ssh_jump_proxy_command_path = create_proxy_command_script()
+    # Deterministic sshd port for this pod (cluster hash + rank); the proxy
+    # script only port-forwards to it for pods that are actually hostNetwork,
+    # so this is a no-op for the common (non-hostNetwork) case.
+    cluster_name_on_cloud, rank = (
+        host_network.cluster_and_rank_from_pod_name(pod_name))
+    pod_sshd_port = host_network.derive_ports(cluster_name_on_cloud, rank).sshd
     ssh_jump_proxy_command = construct_ssh_jump_command(
         private_key_path,
         ssh_jump_ip,
         ssh_jump_user=constants.SKY_SSH_USER_PLACEHOLDER,
         proxy_cmd_path=ssh_jump_proxy_command_path,
         proxy_cmd_target_pod=pod_name,
+        proxy_cmd_pod_port=pod_sshd_port,
         # We embed both the current context and namespace to the SSH proxy
         # command to make sure SSH still works when the current
         # context/namespace is changed by the user.

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2796,8 +2796,13 @@ async def kubernetes_pod_ssh_proxy(websocket: fastapi.WebSocket,
 
     handle = await _get_cluster_and_validate(cluster_name, clouds.Kubernetes)
 
+    # Under hostNetwork the head pod's sshd binds a deterministic port (not
+    # 22, which the K8s node's own sshd owns). head_ssh_port flows from
+    # InstanceInfo.ssh_port (set in get_cluster_info) through
+    # cached_external_ssh_ports; falls back to 22 for the common case.
+    head_ssh_port = handle.head_ssh_port or 22
     kubectl_cmd = handle.get_command_runners()[0].port_forward_command(
-        port_forward=[(None, 22)])
+        port_forward=[(None, head_ssh_port)])
     # Under uvloop, `asyncio.create_subprocess_exec` goes through libuv's
     # `uv_spawn`, which on Linux always uses fork().
     # The forked child runs `PyOS_AfterFork_Child` which tears down inherited

--- a/sky/templates/kubernetes-port-forward-proxy-command.sh
+++ b/sky/templates/kubernetes-port-forward-proxy-command.sh
@@ -3,9 +3,13 @@ set -uo pipefail
 
 KUBE_CONTEXT=""
 KUBE_NAMESPACE=""
+# Deterministic in-pod sshd port (cluster hash + rank), passed by SkyPilot.
+# Only used for pods that are actually hostNetwork (host:22 is owned by the
+# K8s node's own sshd there); non-hostNetwork pods keep the default 22.
+POD_SSHD_PORT=""
 
 # Parse flags
-while getopts ":c:n:" opt; do
+while getopts ":c:n:p:" opt; do
   case ${opt} in
     c)
       KUBE_CONTEXT="$OPTARG"
@@ -13,9 +17,12 @@ while getopts ":c:n:" opt; do
     n)
       KUBE_NAMESPACE="$OPTARG"
       ;;
+    p)
+      POD_SSHD_PORT="$OPTARG"
+      ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
-      echo "Usage: $0 <pod_name> [-c kube_context] [-n kube_namespace]" >&2
+      echo "Usage: $0 <pod_name> [-c kube_context] [-n kube_namespace] [-p pod_sshd_port]" >&2
       exit 1
       ;;
     :)
@@ -30,7 +37,7 @@ shift $((OPTIND -1))
 
 # Check if pod name is passed as an argument
 if [ $# -lt 1 ]; then
-  echo "Usage: $0 <pod_name> [-c kube_context] [-n kube_namespace]" >&2
+  echo "Usage: $0 <pod_name> [-c kube_context] [-n kube_namespace] [-p pod_sshd_port]" >&2
   exit 1
 fi
 
@@ -67,7 +74,20 @@ if [ -n "$KUBE_NAMESPACE" ]; then
   KUBECTL_ARGS+=("--namespace=$KUBE_NAMESPACE")
 fi
 
-kubectl "${KUBECTL_ARGS[@]}" port-forward pod/"${POD_NAME}" :22 > "${KUBECTL_OUTPUT}" 2>&1 &
+# Under hostNetwork the pod's sshd can't bind host:22 (the K8s node's own
+# sshd owns it), so SkyPilot rebinds it to a deterministic port and passes
+# that here via -p. Only honour it when the pod is actually hostNetwork; a
+# single read-only `kubectl get pod` (no ConfigMap, no extra RBAC) decides.
+POD_PORT=22
+if [ -n "${POD_SSHD_PORT}" ]; then
+  HOST_NETWORK=$(kubectl "${KUBECTL_ARGS[@]}" get pod "${POD_NAME}" \
+      -o jsonpath='{.spec.hostNetwork}' 2>/dev/null)
+  if [ "${HOST_NETWORK}" = "true" ]; then
+    POD_PORT="${POD_SSHD_PORT}"
+  fi
+fi
+
+kubectl "${KUBECTL_ARGS[@]}" port-forward pod/"${POD_NAME}" ":${POD_PORT}" > "${KUBECTL_OUTPUT}" 2>&1 &
 
 # Capture the PID for the backgrounded kubectl command
 K8S_PORT_FWD_PID=$!

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -388,6 +388,13 @@ available_node_types:
         serviceAccountName: {{k8s_service_account_name}}
         automountServiceAccountToken: {{k8s_automount_sa_token}}
         restartPolicy: {{ "Always" if high_availability else "Never" }}
+        {% if k8s_host_network %}
+        # Under hostNetwork the default dnsPolicy silently falls back to the
+        # host's resolv.conf, so Service DNS (e.g. *.svc.cluster.local) won't
+        # resolve. SkyPilot itself dials the head over its deterministic
+        # loopback IP, but in-cluster DNS is still needed for other lookups.
+        dnsPolicy: ClusterFirstWithHostNet
+        {% endif %}
         {% if volume_mounts %}
         securityContext:
           fsGroup: 1000
@@ -539,6 +546,16 @@ available_node_types:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['ray-node-type']
+            {% if k8s_host_network %}
+            # Downward API rather than $HOSTNAME: hostNetwork pods inherit the
+            # host node's hostname. ray_worker_start_command derives the
+            # worker's rank ($SKYPILOT_NODE_RANK) from this to index its
+            # deterministic per-rank port slot.
+            - name: SKYPILOT_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            {% endif %}
             - name: SKYPILOT_POD_CPU_CORE_LIMIT
               valueFrom:
                 resourceFieldRef:
@@ -1052,6 +1069,17 @@ available_node_types:
               skypilot:ssh_public_key_content
               SKYPILOT_SSH_KEY_EOF
                 $(prefix_cmd) chmod 644 ~/.ssh/authorized_keys;
+                {% if k8s_host_network %}
+                # Under hostNetwork the K8s node's own sshd owns host:22, so
+                # the pod's sshd silently fails to bind there. Rebind it to
+                # this pod's deterministic sshd port (cluster hash + rank).
+                # Delete-then-append so a config with no Port line (which
+                # would default to 22) is fixed too. The restart below picks
+                # the new port up.
+                {{ k8s_host_network_rank_shell }};
+                $(prefix_cmd) sed -i -E '/^[[:space:]]*#?[[:space:]]*Port[[:space:]]+/d' /etc/ssh/sshd_config;
+                echo "Port {{ k8s_host_network_sshd_port_expr }}" | $(prefix_cmd) tee -a /etc/ssh/sshd_config > /dev/null;
+                {% endif %}
                 $(prefix_cmd) service ssh restart;
                 $(prefix_cmd) sed -i "s/mesg n/tty -s \&\& mesg n/" ~/.profile;
 
@@ -1120,8 +1148,18 @@ available_node_types:
                 else
                   # Start ray worker on the worker pod.
                   # Wait until the head pod is available with an IP address
+                  {% if k8s_host_network %}
+                  # Under hostNetwork the head's GCS binds the head's
+                  # deterministic loopback IP (not the host IP that the
+                  # *.svc.cluster.local Service resolves to), so dial that
+                  # directly. Reachable because the worker shares the K8s
+                  # node's net namespace (same-node hostNetwork).
+                  export SKYPILOT_RAY_HEAD_IP="{{k8s_host_network_head_ip}}"
+                  export SKYPILOT_RAY_PORT={{k8s_host_network_head_gcs_port}}
+                  {% else %}
                   export SKYPILOT_RAY_HEAD_IP="{{cluster_name_on_cloud}}-head.{{k8s_namespace}}.svc.cluster.local"
                   export SKYPILOT_RAY_PORT={{skypilot_ray_port}}
+                  {% endif %}
                   # Wait until the ray cluster is started on the head pod
                   until dpkg -l | grep -q "^ii  \(netcat\|netcat-openbsd\|netcat-traditional\) "; do
                     sleep 0.1
@@ -1315,12 +1353,18 @@ available_node_types:
               log_tail &
               while true; do sleep infinity & wait $!; done
 
+          {% if not k8s_host_network %}
+          # Omitted under hostNetwork: the scheduler's NodePorts predicate
+          # treats containerPort as a host port and would block a sibling
+          # SkyPilot pod from the node, even though every Ray/sshd port here
+          # is reassigned to a deterministic per-pod value at provision time.
           ports:
           - containerPort: 22  # Used for SSH
           - containerPort: {{ray_port}}  # Redis port
           - containerPort: 10001  # Used by Ray Client
           - containerPort: {{ray_dashboard_port}}  # Used by Ray Dashboard
           - containerPort: 46590  # Used by Skylet gRPC
+          {% endif %}
 
           # This volume allocates shared memory for Ray to use for its plasma
           # object store. If you do not provide this, Ray will fall back to

--- a/tests/smoke_tests/test_kubernetes_host_network.py
+++ b/tests/smoke_tests/test_kubernetes_host_network.py
@@ -20,6 +20,50 @@ import pytest
 from smoke_tests import smoke_tests_utils
 
 
+def _write_anchor_cfg(path: str, label_key: str, label_val: str) -> str:
+    """Shell that writes a hostNetwork pod_config carrying a unique label.
+
+    The anchor must be its own (label-less affinity) cluster because a
+    podAffinity required-during-scheduling rule cannot be self-satisfied —
+    the matching pod has to already be running.
+    """
+    return (f'cat > {path} <<EOF\n'
+            f'kubernetes:\n'
+            f'  pod_config:\n'
+            f'    metadata:\n'
+            f'      labels:\n'
+            f'        {label_key}: "{label_val}"\n'
+            f'    spec:\n'
+            f'      hostNetwork: true\n'
+            f'EOF')
+
+
+def _write_colocated_cfg(path: str, label_key: str, label_val: str) -> str:
+    """Shell that writes a hostNetwork pod_config pinned (podAffinity) onto
+    the anchor's node. Inherited by both head and worker pods, so each can
+    independently satisfy the affinity against the running anchor."""
+    return (f'cat > {path} <<EOF\n'
+            f'kubernetes:\n'
+            f'  pod_config:\n'
+            f'    spec:\n'
+            f'      hostNetwork: true\n'
+            f'      affinity:\n'
+            f'        podAffinity:\n'
+            f'          requiredDuringSchedulingIgnoredDuringExecution:\n'
+            f'          - labelSelector:\n'
+            f'              matchLabels:\n'
+            f'                {label_key}: "{label_val}"\n'
+            f'            topologyKey: kubernetes.io/hostname\n'
+            f'EOF')
+
+
+def _ssh_echo_check(target: str, token: str) -> str:
+    """Shell that SSHes to ``target`` and asserts it echoes ``token`` back —
+    exercises the deterministic sshd-port rebind + proxy ``-p`` routing."""
+    return (f's=$(ssh -o StrictHostKeyChecking=no {target} '
+            f'"echo {token}" 2>&1) && echo "$s" | grep {token}')
+
+
 @pytest.mark.kubernetes
 @pytest.mark.no_dependency
 def test_kubernetes_host_network_coexistence():
@@ -41,38 +85,11 @@ def test_kubernetes_host_network_coexistence():
     cfg_a = f'/tmp/sky-coexist-{anchor_val}-a.yaml'
     cfg_b = f'/tmp/sky-coexist-{anchor_val}-b.yaml'
 
-    # Cluster A is the anchor (a podAffinity required-during-scheduling rule
-    # cannot be self-satisfied — the matching pod must already be running).
-    write_cfg_a = (f'cat > {cfg_a} <<EOF\n'
-                   f'kubernetes:\n'
-                   f'  pod_config:\n'
-                   f'    metadata:\n'
-                   f'      labels:\n'
-                   f'        {anchor_key}: "{anchor_val}"\n'
-                   f'    spec:\n'
-                   f'      hostNetwork: true\n'
-                   f'EOF')
-
-    write_cfg_b = (
-        f'cat > {cfg_b} <<EOF\n'
-        f'kubernetes:\n'
-        f'  pod_config:\n'
-        f'    spec:\n'
-        f'      hostNetwork: true\n'
-        f'      affinity:\n'
-        f'        podAffinity:\n'
-        f'          requiredDuringSchedulingIgnoredDuringExecution:\n'
-        f'          - labelSelector:\n'
-        f'              matchLabels:\n'
-        f'                {anchor_key}: "{anchor_val}"\n'
-        f'            topologyKey: kubernetes.io/hostname\n'
-        f'EOF')
-
     test = smoke_tests_utils.Test(
         'kubernetes_host_network_coexistence',
         [
-            write_cfg_a,
-            write_cfg_b,
+            _write_anchor_cfg(cfg_a, anchor_key, anchor_val),
+            _write_colocated_cfg(cfg_b, anchor_key, anchor_val),
 
             # 1. Launch A (anchor), then B (forced onto A's node). 1 CPU /
             # 2 GB per pod gives Ray's driver headroom (under tighter CPU the
@@ -83,12 +100,9 @@ def test_kubernetes_host_network_coexistence():
             f'sky launch -y -c {name_b} --infra kubernetes '
             f'--config {cfg_b} --cpus 1 --memory 2',
 
-            # 2. SSH to both heads. Exercises the deterministic sshd port
-            # rebind + the port-forward proxy `-p` routing.
-            f's=$(ssh -o StrictHostKeyChecking=no {name_a} '
-            f'"echo ssh_works_A" 2>&1) && echo "$s" | grep ssh_works_A',
-            f's=$(ssh -o StrictHostKeyChecking=no {name_b} '
-            f'"echo ssh_works_B" 2>&1) && echo "$s" | grep ssh_works_B',
+            # 2. SSH to both heads.
+            _ssh_echo_check(name_a, 'ssh_works_A'),
+            _ssh_echo_check(name_b, 'ssh_works_B'),
 
             # 3. Ray on both heads is healthy (ports didn't collide).
             f'sky exec {name_a} -- echo ray_ok_a',
@@ -128,48 +142,19 @@ def test_kubernetes_host_network_multi_node():
     cfg_anchor = f'/tmp/sky-multinode-{anchor_val}-anchor.yaml'
     cfg_multi = f'/tmp/sky-multinode-{anchor_val}-multi.yaml'
 
-    write_cfg_anchor = (f'cat > {cfg_anchor} <<EOF\n'
-                        f'kubernetes:\n'
-                        f'  pod_config:\n'
-                        f'    metadata:\n'
-                        f'      labels:\n'
-                        f'        {anchor_key}: "{anchor_val}"\n'
-                        f'    spec:\n'
-                        f'      hostNetwork: true\n'
-                        f'EOF')
-
-    # Both head and worker pods inherit this pod_config, so each can
-    # independently satisfy the affinity against the already-running anchor.
-    write_cfg_multi = (
-        f'cat > {cfg_multi} <<EOF\n'
-        f'kubernetes:\n'
-        f'  pod_config:\n'
-        f'    spec:\n'
-        f'      hostNetwork: true\n'
-        f'      affinity:\n'
-        f'        podAffinity:\n'
-        f'          requiredDuringSchedulingIgnoredDuringExecution:\n'
-        f'          - labelSelector:\n'
-        f'              matchLabels:\n'
-        f'                {anchor_key}: "{anchor_val}"\n'
-        f'            topologyKey: kubernetes.io/hostname\n'
-        f'EOF')
-
     test = smoke_tests_utils.Test(
         'kubernetes_host_network_multi_node',
         [
-            write_cfg_anchor,
-            write_cfg_multi,
+            _write_anchor_cfg(cfg_anchor, anchor_key, anchor_val),
+            _write_colocated_cfg(cfg_multi, anchor_key, anchor_val),
             f'sky launch -y -c {name_anchor} --infra kubernetes '
             f'--config {cfg_anchor} --cpus 1 --memory 2',
             f'sky launch -y -c {name_multi} --infra kubernetes '
             f'--config {cfg_multi} --num-nodes 2 --cpus 1 --memory 2',
             f'sky exec {name_multi} -- echo "job_ok"',
             f'sky logs {name_multi} 1 --status',
-            f's=$(ssh -o StrictHostKeyChecking=no {name_multi} '
-            f'"echo ssh_head_ok" 2>&1) && echo "$s" | grep ssh_head_ok',
-            f's=$(ssh -o StrictHostKeyChecking=no {name_multi}-worker1 '
-            f'"echo ssh_worker_ok" 2>&1) && echo "$s" | grep ssh_worker_ok',
+            _ssh_echo_check(name_multi, 'ssh_head_ok'),
+            _ssh_echo_check(f'{name_multi}-worker1', 'ssh_worker_ok'),
         ],
         teardown=(f'sky down -y {name_anchor}; sky down -y {name_multi}; '
                   f'rm -f {cfg_anchor} {cfg_multi}'),

--- a/tests/smoke_tests/test_kubernetes_host_network.py
+++ b/tests/smoke_tests/test_kubernetes_host_network.py
@@ -1,0 +1,178 @@
+"""Smoke tests for the Kubernetes hostNetwork codepath.
+
+Under ``kubernetes.pod_config.spec.hostNetwork = true`` the pod shares the K8s
+node's net namespace, so a second SkyPilot pod landing on the same node would
+collide on Ray's default ports (6380, 8266, 8076, ...) and on the node's own
+sshd (host:22). SkyPilot derives a deterministic, collision-resistant port set
+and per-pod loopback IP from the cluster name + rank (no startup probe, no
+ConfigMap) and rebinds each pod's sshd to a deterministic port. These tests
+prove both work end-to-end.
+
+Co-location is forced via Kubernetes ``podAffinity`` onto a pre-launched
+anchor pod (rather than a kubectl-queried nodeSelector) so the tests run
+against both local and remote API servers and on any K8s cluster regardless
+of node count. A self-referential podAffinity would deadlock SkyPilot's
+parallel head+worker creation, so an anchor cluster carries the unique label.
+"""
+import uuid
+
+import pytest
+from smoke_tests import smoke_tests_utils
+
+
+@pytest.mark.kubernetes
+@pytest.mark.no_dependency
+def test_kubernetes_host_network_coexistence():
+    """Two hostNetwork SkyPilot clusters on the same K8s node coexist.
+
+    Both launches succeeding is itself the proof that the deterministic
+    per-cluster port windows didn't collide: a collision would leave the
+    second cluster's Ray daemons unable to bind, failing its launch step.
+    SSH to both heads additionally exercises the per-pod sshd rebind + the
+    port-forward proxy ``-p`` routing.
+    """
+    anchor_key = 'skypilot-coexist-anchor'
+    anchor_val = uuid.uuid4().hex[:12]
+
+    base = smoke_tests_utils.get_cluster_name()
+    name_a = f'{base}-a'
+    name_b = f'{base}-b'
+
+    cfg_a = f'/tmp/sky-coexist-{anchor_val}-a.yaml'
+    cfg_b = f'/tmp/sky-coexist-{anchor_val}-b.yaml'
+
+    # Cluster A is the anchor (a podAffinity required-during-scheduling rule
+    # cannot be self-satisfied — the matching pod must already be running).
+    write_cfg_a = (f'cat > {cfg_a} <<EOF\n'
+                   f'kubernetes:\n'
+                   f'  pod_config:\n'
+                   f'    metadata:\n'
+                   f'      labels:\n'
+                   f'        {anchor_key}: "{anchor_val}"\n'
+                   f'    spec:\n'
+                   f'      hostNetwork: true\n'
+                   f'EOF')
+
+    write_cfg_b = (
+        f'cat > {cfg_b} <<EOF\n'
+        f'kubernetes:\n'
+        f'  pod_config:\n'
+        f'    spec:\n'
+        f'      hostNetwork: true\n'
+        f'      affinity:\n'
+        f'        podAffinity:\n'
+        f'          requiredDuringSchedulingIgnoredDuringExecution:\n'
+        f'          - labelSelector:\n'
+        f'              matchLabels:\n'
+        f'                {anchor_key}: "{anchor_val}"\n'
+        f'            topologyKey: kubernetes.io/hostname\n'
+        f'EOF')
+
+    test = smoke_tests_utils.Test(
+        'kubernetes_host_network_coexistence',
+        [
+            write_cfg_a,
+            write_cfg_b,
+
+            # 1. Launch A (anchor), then B (forced onto A's node). 1 CPU /
+            # 2 GB per pod gives Ray's driver headroom (under tighter CPU the
+            # first job submission flakes with FAILED_DRIVER) and still fits
+            # two pods on a 4-CPU / 8-GB node.
+            f'sky launch -y -c {name_a} --infra kubernetes '
+            f'--config {cfg_a} --cpus 1 --memory 2',
+            f'sky launch -y -c {name_b} --infra kubernetes '
+            f'--config {cfg_b} --cpus 1 --memory 2',
+
+            # 2. SSH to both heads. Exercises the deterministic sshd port
+            # rebind + the port-forward proxy `-p` routing.
+            f's=$(ssh -o StrictHostKeyChecking=no {name_a} '
+            f'"echo ssh_works_A" 2>&1) && echo "$s" | grep ssh_works_A',
+            f's=$(ssh -o StrictHostKeyChecking=no {name_b} '
+            f'"echo ssh_works_B" 2>&1) && echo "$s" | grep ssh_works_B',
+
+            # 3. Ray on both heads is healthy (ports didn't collide).
+            f'sky exec {name_a} -- echo ray_ok_a',
+            f'sky logs {name_a} 1 --status',
+            f'sky exec {name_b} -- echo ray_ok_b',
+            f'sky logs {name_b} 1 --status',
+        ],
+        teardown=(f'sky down -y {name_a}; sky down -y {name_b}; '
+                  f'rm -f {cfg_a} {cfg_b}'),
+        timeout=smoke_tests_utils.get_timeout('kubernetes'),
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.kubernetes
+@pytest.mark.no_dependency
+def test_kubernetes_host_network_multi_node():
+    """A 2-node SkyPilot cluster, both pods on one K8s node, hostNetwork on.
+
+    Verifies:
+    1. Both target pods land on the anchor's K8s node (otherwise the second
+       pod Pending forever, failing the launch step).
+    2. Ray works: ``sky exec`` runs on the cluster — implying head + worker
+       joined Ray, with the worker dialing the head's *deterministic* GCS
+       port + loopback IP it computed locally (no ConfigMap handoff).
+    3. SSH to the head works.
+    4. SSH to the worker works — exercises the worker pod's own
+       deterministic sshd port (rank-derived) end-to-end.
+    """
+    anchor_key = 'skypilot-multinode-anchor'
+    anchor_val = uuid.uuid4().hex[:12]
+
+    base = smoke_tests_utils.get_cluster_name()
+    name_anchor = f'{base}-anchor'
+    name_multi = f'{base}-multi'
+
+    cfg_anchor = f'/tmp/sky-multinode-{anchor_val}-anchor.yaml'
+    cfg_multi = f'/tmp/sky-multinode-{anchor_val}-multi.yaml'
+
+    write_cfg_anchor = (f'cat > {cfg_anchor} <<EOF\n'
+                        f'kubernetes:\n'
+                        f'  pod_config:\n'
+                        f'    metadata:\n'
+                        f'      labels:\n'
+                        f'        {anchor_key}: "{anchor_val}"\n'
+                        f'    spec:\n'
+                        f'      hostNetwork: true\n'
+                        f'EOF')
+
+    # Both head and worker pods inherit this pod_config, so each can
+    # independently satisfy the affinity against the already-running anchor.
+    write_cfg_multi = (
+        f'cat > {cfg_multi} <<EOF\n'
+        f'kubernetes:\n'
+        f'  pod_config:\n'
+        f'    spec:\n'
+        f'      hostNetwork: true\n'
+        f'      affinity:\n'
+        f'        podAffinity:\n'
+        f'          requiredDuringSchedulingIgnoredDuringExecution:\n'
+        f'          - labelSelector:\n'
+        f'              matchLabels:\n'
+        f'                {anchor_key}: "{anchor_val}"\n'
+        f'            topologyKey: kubernetes.io/hostname\n'
+        f'EOF')
+
+    test = smoke_tests_utils.Test(
+        'kubernetes_host_network_multi_node',
+        [
+            write_cfg_anchor,
+            write_cfg_multi,
+            f'sky launch -y -c {name_anchor} --infra kubernetes '
+            f'--config {cfg_anchor} --cpus 1 --memory 2',
+            f'sky launch -y -c {name_multi} --infra kubernetes '
+            f'--config {cfg_multi} --num-nodes 2 --cpus 1 --memory 2',
+            f'sky exec {name_multi} -- echo "job_ok"',
+            f'sky logs {name_multi} 1 --status',
+            f's=$(ssh -o StrictHostKeyChecking=no {name_multi} '
+            f'"echo ssh_head_ok" 2>&1) && echo "$s" | grep ssh_head_ok',
+            f's=$(ssh -o StrictHostKeyChecking=no {name_multi}-worker1 '
+            f'"echo ssh_worker_ok" 2>&1) && echo "$s" | grep ssh_worker_ok',
+        ],
+        teardown=(f'sky down -y {name_anchor}; sky down -y {name_multi}; '
+                  f'rm -f {cfg_anchor} {cfg_multi}'),
+        timeout=5 * 60,
+    )
+    smoke_tests_utils.run_one_test(test)

--- a/tests/unit_tests/test_sky/provision/test_host_network.py
+++ b/tests/unit_tests/test_sky/provision/test_host_network.py
@@ -1,0 +1,210 @@
+"""Unit tests for deterministic hostNetwork port/IP derivation.
+
+These cover the scheme that replaces PR #9604's runtime probe + ConfigMap
+discovery: every pod independently derives an identical port set and per-pod
+loopback IP from sha256(cluster_name) + rank, so there is no head->worker
+handoff to test end-to-end here — only the math and the rendered commands.
+"""
+import hashlib
+import subprocess
+
+import pytest
+
+from sky.provision import instance_setup
+from sky.provision.kubernetes import host_network
+
+
+def test_port_base_range_and_alignment():
+    for name in ['a', 'sky-cluster', 'x' * 200, 'cluster-with-üñïçødé']:
+        pb = host_network.port_base(name)
+        assert 20000 <= pb <= 31900, (name, pb)
+        assert pb % 100 == 0, (name, pb)
+
+
+def test_port_base_matches_documented_formula():
+    name = 'my-cluster-on-cloud'
+    h = hashlib.sha256(name.encode()).digest()
+    expected = 20000 + (int.from_bytes(h[:2], 'big') % 120) * 100
+    assert host_network.port_base(name) == expected
+
+
+def test_derivation_is_deterministic():
+    name = 'deterministic-check'
+    assert host_network.derive_ports(name,
+                                     0) == host_network.derive_ports(name, 0)
+    assert host_network.derive_ports(name,
+                                     5) == host_network.derive_ports(name, 5)
+    assert host_network.derive_node_ip(name, 2) == host_network.derive_node_ip(
+        name, 2)
+
+
+def test_port_offsets_within_rank_slot():
+    name = 'offset-cluster'
+    pb = host_network.port_base(name)
+    p = host_network.derive_ports(name, 0)
+    assert p.gcs == pb
+    assert p.dashboard == pb + 1
+    assert p.node_manager == pb + 2
+    assert p.object_manager == pb + 3
+    assert p.runtime_env_agent == pb + 4
+    assert p.dashboard_agent_listen == pb + 5
+    assert p.metrics_export == pb + 6
+    assert p.ray_client_server == pb + 7
+    assert p.sshd == pb + 9  # 8 is reserved
+
+
+def test_head_and_worker_ports_are_disjoint():
+    name = 'disjoint-cluster'
+    head = set(vars(host_network.derive_ports(name, 0)).values())
+    for rank in range(1, host_network.MAX_RANK + 1):
+        worker = set(vars(host_network.derive_ports(name, rank)).values())
+        assert head.isdisjoint(worker), rank
+    # And every pod's slot stays inside the cluster's 100-port window.
+    pb = host_network.port_base(name)
+    top = max(
+        vars(host_network.derive_ports(name, host_network.MAX_RANK)).values())
+    assert top < pb + 100
+
+
+def test_unrelated_clusters_usually_get_different_windows():
+    # Not a guarantee (birthday-paradox bucket collisions are accepted), but
+    # two arbitrary names should not systematically collide.
+    a = host_network.port_base('cluster-alpha-xyz')
+    b = host_network.port_base('cluster-beta-xyz')
+    assert a != b
+
+
+def test_node_ip_scheme():
+    name = 'ip-cluster'
+    h = hashlib.sha256(name.encode()).digest()
+    for rank in (0, 1, 9):
+        ip = host_network.derive_node_ip(name, rank)
+        octets = ip.split('.')
+        assert octets[0] == '127'
+        assert int(octets[1]) == (h[0] | 0x80)
+        assert int(octets[1]) >= 128  # never lands in 127.0.0.x
+        assert int(octets[2]) == h[1]
+        assert int(octets[3]) == rank
+    assert host_network.derive_node_ip(name, 0) != host_network.derive_node_ip(
+        name, 1)
+
+
+def test_node_ip_prefix_consistent_with_derive_node_ip():
+    name = 'prefix-cluster'
+    prefix = host_network.node_ip_prefix(name)
+    assert host_network.derive_node_ip(name, 4) == f'{prefix}4'
+
+
+@pytest.mark.parametrize('pod_name,expected', [
+    ('mycluster-head', ('mycluster', 0)),
+    ('mycluster-worker1', ('mycluster', 1)),
+    ('mycluster-worker42', ('mycluster', 42)),
+    ('a-b-c-worker3', ('a-b-c', 3)),
+    ('weird-worker-in-name-head', ('weird-worker-in-name', 0)),
+])
+def test_cluster_and_rank_from_pod_name(pod_name, expected):
+    assert host_network.cluster_and_rank_from_pod_name(pod_name) == expected
+    assert host_network.rank_from_pod_name(pod_name) == expected[1]
+
+
+def test_negative_rank_rejected():
+    with pytest.raises(ValueError):
+        host_network.derive_ports('c', -1)
+    with pytest.raises(ValueError):
+        host_network.derive_node_ip('c', -1)
+
+
+@pytest.mark.parametrize('pod_config,expected', [
+    (None, False),
+    ({}, False),
+    ({
+        'spec': {}
+    }, False),
+    ({
+        'spec': {
+            'hostNetwork': False
+        }
+    }, False),
+    ({
+        'spec': {
+            'hostNetwork': True
+        }
+    }, True),
+])
+def test_is_host_network(pod_config, expected):
+    assert host_network.is_host_network(pod_config) is expected
+
+
+def test_worker_rank_shell_keeps_head_at_zero():
+    # Smoke check the bash: head pod name -> rank 0, worker -> its index.
+    shell = host_network.worker_rank_shell()
+    for pod, want in [('cl-head', '0'), ('cl-worker0', '0'),
+                      ('cl-worker7', '7'), ('cl-worker13', '13')]:
+        out = subprocess.run([
+            'bash', '-c', f'SKYPILOT_POD_NAME={pod}; {shell}; '
+            f'echo ${host_network.WORKER_RANK_ENV}'
+        ],
+                             capture_output=True,
+                             text=True,
+                             check=True)
+        assert out.stdout.strip() == want, (pod, out.stdout)
+
+
+# --- Regression: the non-hostNetwork command must not change at all. -------
+
+
+def test_ray_commands_byte_identical_without_host_network():
+    """ray_{head,worker}_start_command(...) with host_network_params=None must
+    be byte-identical to the legacy call (no regression for VM / non-host
+    -network K8s clusters, which is the overwhelmingly common path)."""
+    cr = '{"A100":1}'
+    cro = {'object-store-memory': 500000000, 'num-cpus': '4'}
+    # Default (None) param must equal the call without the param at all.
+    assert (instance_setup.ray_head_start_command(
+        cr, dict(cro)) == instance_setup.ray_head_start_command(
+            cr, dict(cro), host_network_params=None))
+    for nr in (True, False):
+        assert (instance_setup.ray_worker_start_command(
+            cr, dict(cro),
+            no_restart=nr) == instance_setup.ray_worker_start_command(
+                cr, dict(cro), no_restart=nr, host_network_params=None))
+    # And the legacy default ports are still present literally.
+    h = instance_setup.ray_head_start_command(None, None)
+    assert '--port=6380 ' in h
+    assert '--dashboard-port=8266 ' in h
+    assert '--object-manager-port=8076 ' in h
+    assert '--node-ip-address' not in h
+
+
+def test_host_network_head_command_bakes_literal_ports():
+    params = host_network.HostNetworkRayParams.build('clusterX')
+    p = params.head_ports
+    cmd = instance_setup.ray_head_start_command(None,
+                                                None,
+                                                host_network_params=params)
+    assert f'--port={p.gcs} ' in cmd
+    assert f'--dashboard-port={p.dashboard} ' in cmd
+    assert f'--object-manager-port={p.object_manager} ' in cmd
+    assert f'--node-manager-port={p.node_manager} ' in cmd
+    assert f'--ray-client-server-port={p.ray_client_server} ' in cmd
+    assert f'--node-ip-address={params.head_node_ip} ' in cmd
+    # Port file + ray-status wait must use the derived port, not 6380.
+    assert f'"ray_port":{p.gcs}' in cmd
+    assert f'RAY_ADDRESS={params.head_node_ip}:{p.gcs} ' in cmd
+    assert '6380' not in cmd
+
+
+def test_host_network_worker_command_uses_runtime_rank():
+    params = host_network.HostNetworkRayParams.build('clusterX')
+    cmd = instance_setup.ray_worker_start_command(None,
+                                                  None,
+                                                  no_restart=False,
+                                                  host_network_params=params)
+    # rank_shell defines the rank var before anything references it.
+    assert cmd.startswith(params.rank_shell + '; ')
+    assert host_network.WORKER_RANK_ENV in cmd
+    # Worker ports are per-rank bash arithmetic, not literals.
+    assert params.worker_port_exprs['node_manager'] in cmd
+    assert params.worker_node_ip_expr in cmd
+    # Worker still dials the head via the env exported by the template.
+    assert '--address=${SKYPILOT_RAY_HEAD_IP}:${SKYPILOT_RAY_PORT}' in cmd


### PR DESCRIPTION
## Summary

Alternative to #9604. Replaces the runtime free-port **probe + ConfigMap discovery channel** with **deterministic** port + loopback-IP derivation: every pod independently computes an identical port set and per-pod loopback IP from `sha256(cluster_name_on_cloud)` + rank. The head is always rank 0, so every worker computes the head's GCS port and loopback IP **locally** — no ConfigMap, no RBAC, no head→worker handoff, no in-cluster API calls. The numbers are baked into the rendered cluster YAML at provision time; only a worker's own rank is resolved in-pod (one rendered worker spec serves every worker).

```
h         = sha256(cluster_name_on_cloud)
port_base = 20000 + (h[:2] as u16 % 120) * 100   # 20000..31900, 100-port window/cluster
port      = port_base + rank*10 + offset          # gcs=+0 dashboard=+1 node_mgr=+2
                                                  # obj_mgr=+3 rea=+4 da=+5 metrics=+6
                                                  # ray_client=+7 (8 reserved) sshd=+9
node_ip   = 127.<h[0]|0x80>.<h[1]>.<rank>
```

## Why

`hostNetwork: true` is required for RoCE/RDMA throughput on Oracle and other non-EFA/non-IB setups. The first SkyPilot pod on a node grabs Ray's default ports (6380/8266/8076/…) directly on the host; a second pod fails to admit with `EADDRINUSE`. Separately, when head + worker land on one K8s node both raylets register with `node_manager_address = <host IP>`, and Ray's client-side resolver can collapse the two NodeIDs onto one gRPC endpoint and hang `pg.ready()`. The per-pod loopback IP (`--node-ip-address`) makes each raylet a distinct endpoint.

Both problems are solved without any discovery channel: the derivation is a pure function of the cluster name, which the head and every worker already know.

### Deleted vs #9604
- `host_network_probe.py` (the probe) and `source_utils.py` (the b64/gzip minifier)
- ConfigMap publish/poll + GC/ownerReference + the namespace-wide RBAC dependency
- The `${VAR:-default}` / `${VAR:+--flag=$VAR}` substitution audit
- The `_RAY_PORT_COMMAND` rewrite (port now lives in the rendered YAML, not env)
- The TOCTOU / probe-race / probe-shipping follow-up items

### Kept
- Per-pod loopback IP override (`--node-ip-address`). **Note:** this is described in #9604's body but lives in its *Reverts* section and is absent from that PR's diff; it is implemented here because it is the actual fix for the raylet gRPC-cache collapse.
- The sshd rebind step — now to a deterministic port (host:22 is owned by the K8s node's own sshd under hostNetwork).
- The `hostNetwork` detection block in `clouds/kubernetes.py`.

### Non-hostNetwork impact
`ray_head_start_command` / `ray_worker_start_command` take an optional `host_network_params`; when `None` the output is **byte-identical** to before (regression-tested). VM clusters and ordinary (non-hostNetwork) Kubernetes clusters are unaffected, and `get_cluster_info` makes **zero** extra API calls for them.

## Trade-offs (documented in code; fail loudly via `EADDRINUSE`, never silently mis-route)

- Birthday-paradox bucket collision between two *unrelated* clusters on one node: ~50% chance of any collision at ~13 co-located clusters. A non-issue for RDMA hosts (1–2 clusters/node).
- >10 pods of the *same* cluster co-located on one node overflow the 100-port window into the neighbouring bucket.
- Cross-K8s-node hostNetwork is unchanged and still unsupported (the loopback dial-back needs a shared netns) — same scope as #9604.

## Files

- `sky/provision/kubernetes/host_network.py` (new) — stdlib-only deterministic derivation + `HostNetworkRayParams`
- `sky/clouds/kubernetes.py` — hostNetwork detection, builds the params, wires Jinja vars
- `sky/provision/instance_setup.py` — literal head port flags / per-rank worker exprs + `--node-ip-address`; `_dump_ray_ports_cmd` writes the derived ports
- `sky/templates/kubernetes-ray.yml.j2` — gated `dnsPolicy`, `SKYPILOT_POD_NAME` (downward API), dropped `containerPort` list, worker dials head loopback, deterministic sshd rebind
- `sky/provision/kubernetes/instance.py` — deterministic `ssh_port` + loopback `internal_ip` for hostNetwork pods
- `sky/server/server.py` — `head_ssh_port or 22` for the pod-ssh-proxy
- `sky/provision/kubernetes/utils.py` + `kubernetes-port-forward-proxy-command.sh` — pass the deterministic sshd port via `-p` (no ConfigMap query); `PORT_FORWARD_PROXY_CMD_VERSION` 2→3
- `tests/unit_tests/test_sky/provision/test_host_network.py` (new), `tests/smoke_tests/test_kubernetes_host_network.py` (new)

## Test plan

- [x] `pytest tests/unit_tests/test_sky/provision/test_host_network.py` — 23 cases: scheme determinism / range / head-worker disjointness / IP scheme / rank parsing; **byte-identical** non-hostNetwork ray commands; host-network command shape
- [x] `bash format.sh` — yapf, isort, mypy (560 files), pylint 10.00/10 all green
- [x] Verified `ray_{head,worker}_start_command(..., host_network_params=None)` is byte-identical to `master` (regression-proof for existing VM / non-hostNetwork K8s clusters)
- [x] Jinja template parses for both `k8s_host_network` true/false; proxy script `bash -n` clean
- [ ] Manual (needs a real K8s cluster): two hostNetwork clusters co-located on one node via `podAffinity` both launch + SSH + `sky exec`; 2-node hostNetwork cluster, both pods on one node, `sky exec` + SSH to head & worker — covered by the new smoke tests (`/smoke-test --kubernetes`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
