### PR TITLE
[Kubernetes] Clean up Failed/Succeeded pods before creating new ones

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1291,6 +1291,21 @@ def _create_pods(region: str, cluster_name: str, cluster_name_on_cloud: str,
                 _request_timeout=config_lib.DELETION_TIMEOUT,
                 grace_period_seconds=0)
 
+    # Clean up pods in Failed/Succeeded phase from previous runs.
+    # These are invisible to the Pending/Running filter below but still
+    # block pod creation with the same name (409 AlreadyExists).
+    stale_pods = kubernetes_utils.filter_pods(namespace, context, tags,
+                                              ['Failed', 'Succeeded'])
+    if stale_pods:
+        logger.info(f'Found {len(stale_pods)} pods in Failed/Succeeded '
+                    f'phase: {list(stale_pods.keys())}. Deleting them.')
+        for pod_name in stale_pods:
+            kubernetes.core_api(context).delete_namespaced_pod(
+                pod_name,
+                namespace,
+                _request_timeout=config_lib.DELETION_TIMEOUT,
+                grace_period_seconds=0)
+
     running_pods = kubernetes_utils.filter_pods(namespace, context, tags,
                                                 ['Pending', 'Running'])
     head_pod_name = _get_head_pod_name(running_pods)

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1300,11 +1300,16 @@ def _create_pods(region: str, cluster_name: str, cluster_name_on_cloud: str,
         logger.info(f'Found {len(stale_pods)} pods in Failed/Succeeded '
                     f'phase: {list(stale_pods.keys())}. Deleting them.')
         for pod_name in stale_pods:
-            kubernetes.core_api(context).delete_namespaced_pod(
-                pod_name,
-                namespace,
-                _request_timeout=config_lib.DELETION_TIMEOUT,
-                grace_period_seconds=0)
+            # pylint: disable=cell-var-from-loop
+            kubernetes_utils.delete_k8s_resource_with_retry(
+                delete_func=lambda name=pod_name: kubernetes.core_api(
+                    context).delete_namespaced_pod(name,
+                                                   namespace,
+                                                   _request_timeout=config_lib.
+                                                   DELETION_TIMEOUT,
+                                                   grace_period_seconds=0),
+                resource_type='pod',
+                resource_name=pod_name)
 
     running_pods = kubernetes_utils.filter_pods(namespace, context, tags,
                                                 ['Pending', 'Running'])

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -3028,6 +3028,8 @@ def test_kubernetes_stale_pod_cleanup():
             f'if [ "$phase" = "Failed" ]; then break; fi; '
             f'sleep 2; done && '
             f'test "$phase" = "Failed"',
+            # Refresh state so the API server records the cluster as INIT.
+            f'sky status {name} -r',
             # sky start should clean up the Failed pod and succeed.
             f'sky start -y {name}',
         ],

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2998,6 +2998,46 @@ def test_kubernetes_recovery():
 
 
 @pytest.mark.kubernetes
+def test_kubernetes_stale_pod_cleanup():
+    """Test that sky start cleans up Failed pods before re-creating them.
+
+    When a pod OOMKills, it enters the Failed phase but remains in the K8s
+    API server. A subsequent sky start must delete the stale pod before
+    creating a new one, otherwise it hits a 409 AlreadyExists error.
+
+    Regression test for #9627.
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    name_on_cloud = common_utils.make_cluster_name_on_cloud(
+        name, sky.Kubernetes.max_cluster_name_length())
+    head_pod = f'{name_on_cloud}-head'
+    test = smoke_tests_utils.Test(
+        'kubernetes_stale_pod_cleanup',
+        [
+            # Launch a cluster with memory limits (2GB is enough to boot
+            # but tight enough to OOM on a large allocation).
+            f'sky launch -y -c {name} --infra kubernetes --cpus 1 --memory 2 '
+            f'--config kubernetes.set_pod_resource_limits=true -- echo ready',
+            # OOM the pod by writing 4GB to tmpfs, exceeding the 2GB limit.
+            f'sky exec {name} -- dd if=/dev/zero of=/dev/shm/oom bs=1M count=4096 || true',
+            # Wait for the pod to enter Failed phase.
+            f'for i in $(seq 1 30); do '
+            f'phase=$(kubectl get pod {head_pod} '
+            f'-o jsonpath=\'{{.status.phase}}\'); '
+            f'echo "attempt $i: phase=$phase"; '
+            f'if [ "$phase" = "Failed" ]; then break; fi; '
+            f'sleep 2; done && '
+            f'test "$phase" = "Failed"',
+            # sky start should clean up the Failed pod and succeed.
+            f'sky start -y {name}',
+        ],
+        f'sky down -y {name}',
+        timeout=10 * 60,
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.kubernetes
 def test_kubernetes_sigterm_keepalive():
     """Test that worker pods survive SIGTERM (node drain) via keep-alive fix."""
     name = smoke_tests_utils.get_cluster_name()

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -3017,7 +3017,7 @@ def test_kubernetes_stale_pod_cleanup():
             # Launch a cluster with memory limits (2GB is enough to boot
             # but tight enough to OOM on a large allocation).
             f'sky launch -y -c {name} --infra kubernetes --cpus 1 --memory 2 '
-            f'--config kubernetes.set_pod_resource_limits=true -- echo ready',
+            f'--config kubernetes.set_pod_resource_limits=true',
             # OOM the pod by writing 4GB to tmpfs, exceeding the 2GB limit.
             f'sky exec {name} -- dd if=/dev/zero of=/dev/shm/oom bs=1M count=4096 || true',
             # Wait for the pod to enter Failed phase.

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -3028,8 +3028,8 @@ def test_kubernetes_stale_pod_cleanup():
             f'if [ "$phase" = "Failed" ]; then break; fi; '
             f'sleep 2; done && '
             f'test "$phase" = "Failed"',
-            # Refresh state so the API server records the cluster as INIT.
-            f'sky status {name} -r',
+            # Refresh state and assert INIT before restart.
+            f'sky status {name} -r | grep INIT',
             # sky start should clean up the Failed pod and succeed.
             f'sky start -y {name}',
         ],


### PR DESCRIPTION
## Summary
- When a K8s pod OOMKills or otherwise enters Failed/Succeeded phase, it remains in the API server but is invisible to the `Pending`/`Running` filter in `_create_pods`. A subsequent `sky start` tries to create a pod with the same name and hits a 409 AlreadyExists error, which then triggers a `StopFailoverError` that leaves the cluster stuck.
- Fix by explicitly cleaning up stale `Failed`/`Succeeded` pods before attempting pod creation, using retry-safe deletion handling.
- Make the smoke repro deterministic by refreshing cluster state (`sky status <name> -r | grep INIT`) before `sky start`, so the API server observes `INIT` and exercises the stale-pod restart path.

## Test plan
- [x] Reproduce by OOMKilling a pod, then running `sky start` on the cluster
- [x] Update smoke test to refresh state (`sky status -r | grep INIT`) before `sky start`
- [ ] Verify Failed pods are cleaned up and the start succeeds
- [ ] Verify normal launch path (no stale pods) still works

### Repro steps (before fix)
1. Launch a Kubernetes cluster with tight memory limits:
   ```bash
   sky launch -y -c pr9627-oomtiny --infra k8s/kev-dev-sa \
     --config kubernetes.set_pod_resource_limits=true \
     --cpus 1 --memory 2 -- echo ready
   ```
2. OOM the head pod workload and wait for pod phase `Failed`:
   ```bash
   sky exec pr9627-oomtiny -- dd if=/dev/zero of=/dev/shm/oom bs=1M count=4096 || true
   kubectl get pod pr9627-oomtiny-<hash>-head -o jsonpath='{.status.phase}'
   ```
3. Refresh API server state for the cluster and assert `INIT`:
   ```bash
   sky status pr9627-oomtiny -r | grep INIT
   ```
4. Attempt to restart:
   ```bash
   sky start -y pr9627-oomtiny
   ```
5. Observe the failure:
   - `ApiException: (409) Reason: Conflict`
   - `pods "pr9627-oomtiny-<hash>-head" already exists`

This demonstrates that stale `Failed` pods can block restart due to name collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
