### PR TITLE
fix(azure): pass class name as string in _get_azure_sdk_function error

### DIFF
--- a/sky/provision/azure/instance.py
+++ b/sky/provision/azure/instance.py
@@ -149,7 +149,7 @@ def _get_azure_sdk_function(client: Any, function_name: str) -> Callable:
     if func is None:
         raise AttributeError(
             '"{obj}" object has no {func} or begin_{func} attribute'.format(
-                obj={client.__name__}, func=function_name))
+                obj=client.__name__, func=function_name))
     return func
 
 


### PR DESCRIPTION
## Bug

In \`_get_azure_sdk_function\` (\`sky/provision/azure/instance.py\`), when neither the old-style nor the \`begin_\`-prefixed SDK method exists on the client, the raised \`AttributeError\` does not contain the client class name. Instead it reads:

\`\"{'NetworkManagementClient'}\" object has no <func> or begin_<func> attribute\`

— the class name is rendered as a one-element set, with quotes and braces, which makes the message harder to read and impossible to grep for.

## Root cause

\`\`\`python
'\"{obj}\" object has no {func} or begin_{func} attribute'.format(
    obj={client.__name__}, func=function_name)
\`\`\`

The \`obj={client.__name__}\` expression is a set literal containing the class name string, not the string itself. \`str.format\` then renders the set via \`repr\`.

## Fix

Remove the curly braces so \`obj\` is the string \`client.__name__\`. One-character change; no other behavior is affected.