### PR TITLE
[CI] Add concurrency limit for --env-file smoke tests

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -331,7 +331,9 @@ def _generate_pipeline(test_file: str, args: str) -> Dict[str, Any]:
     steps = []
     generated_steps_set = set()
     default_clouds_to_run, k_value, extra_args, concurrency = _parse_args(args)
-    function_cloud_map = _extract_marked_tests(test_file, args,
+    # Strip --concurrency from args before passing to pytest --collect-only
+    pytest_args = re.sub(r'--concurrency\s+\d+', '', args).strip()
+    function_cloud_map = _extract_marked_tests(test_file, pytest_args,
                                                default_clouds_to_run, k_value,
                                                extra_args)
     if '--env-file' in args:

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -207,7 +207,8 @@ def _parse_args(args: Optional[str] = None):
         space = ' ' if parsed_args.dependency else ''
         extra_args.append(f'--dependency{space}{parsed_args.dependency}')
 
-    return default_clouds_to_run, parsed_args.k, extra_args, parsed_args.concurrency
+    return (default_clouds_to_run, parsed_args.k, extra_args,
+            parsed_args.concurrency, parsed_args.env_file is not None)
 
 
 def _extract_marked_tests(
@@ -330,17 +331,17 @@ def _generate_pipeline(test_file: str, args: str) -> Dict[str, Any]:
     """Generate a Buildkite pipeline from test files."""
     steps = []
     generated_steps_set = set()
-    default_clouds_to_run, k_value, extra_args, concurrency = _parse_args(args)
-    # Strip --concurrency from args before passing to pytest --collect-only
-    pytest_args = re.sub(r'--concurrency\s+\d+', '', args).strip()
-    function_cloud_map = _extract_marked_tests(test_file, pytest_args,
+    (default_clouds_to_run, k_value, extra_args, concurrency,
+     has_env_file) = _parse_args(args)
+    function_cloud_map = _extract_marked_tests(test_file, args,
                                                default_clouds_to_run, k_value,
                                                extra_args)
-    if '--env-file' in args:
+    concurrency_limit = None
+    build_id = None
+    if has_env_file:
         concurrency_limit = (concurrency if concurrency is not None else
                              DEFAULT_ENV_FILE_CONCURRENCY_LIMIT)
-    else:
-        concurrency_limit = None
+        build_id = os.environ.get('BUILDKITE_BUILD_ID', 'local')
     for test_function, clouds_queues_param in function_cloud_map.items():
         for cloud, queue, param, extra_args, no_auto_retry in zip(
                 *clouds_queues_param):
@@ -368,9 +369,8 @@ def _generate_pipeline(test_file: str, args: str) -> Dict[str, Any]:
                 }
             }
             if concurrency_limit is not None:
-                build_id = os.environ.get('BUILDKITE_BUILD_ID', 'local')
                 step['concurrency'] = concurrency_limit
-                step['concurrency_group'] = (f'env-file-smoke-test-{build_id}')
+                step['concurrency_group'] = f'env-file-smoke-test-{build_id}'
             if no_auto_retry:
                 # Disable automatic retries but allow manual retries.
                 step['retry'] = {

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -51,6 +51,9 @@ QUEUE_BENCHMARK = 'single_container'
 # Kubernetes has low concurrency on a single VM originally,
 # so remote-server won't drain VM resources, we can reuse the same queue.
 QUEUE_GENERIC_CLOUD_REMOTE_SERVER = 'generic_cloud_remote_server'
+# Default concurrency limit when --env-file is used (shared remote API
+# server). Override per-build with --concurrency N.
+DEFAULT_ENV_FILE_CONCURRENCY_LIMIT = 10
 # We use KUBE_BACKEND to specify the queue for kubernetes tests mark as
 # resource_heavy. It can be either EKS or GKE.
 QUEUE_KUBE_BACKEND = os.getenv('KUBE_BACKEND', QUEUE_EKS).lower()
@@ -149,6 +152,7 @@ def _parse_args(args: Optional[str] = None):
     parser.add_argument('--plugin-yaml')
     parser.add_argument('--submodule-base-branch')
     parser.add_argument('--dependency', nargs='?', const='', default='all')
+    parser.add_argument('--concurrency', type=int)
 
     parsed_args, _ = parser.parse_known_args(args_list)
 
@@ -203,11 +207,12 @@ def _parse_args(args: Optional[str] = None):
         space = ' ' if parsed_args.dependency else ''
         extra_args.append(f'--dependency{space}{parsed_args.dependency}')
 
-    return default_clouds_to_run, parsed_args.k, extra_args
+    return default_clouds_to_run, parsed_args.k, extra_args, parsed_args.concurrency
 
 
 def _extract_marked_tests(
-    file_path: str, args: str
+    file_path: str, args: str, default_clouds_to_run: List[str],
+    k_value: Optional[str], extra_args: List[str]
 ) -> Dict[str, Tuple[List[str], List[str], List[Optional[str]], List[str],
                      List[bool]]]:
     """Extract test functions and filter clouds using pytest.mark
@@ -232,7 +237,6 @@ def _extract_marked_tests(
     output = subprocess.run(cmd, shell=True, capture_output=True, text=True)
     matches = re.findall('Collected .+?\.py::(.+?) with marks: \[(.*?)\]',
                          output.stdout)
-    default_clouds_to_run, k_value, extra_args = _parse_args(args)
 
     function_name_marks_map = collections.defaultdict(set)
     function_name_param_map = collections.defaultdict(list)
@@ -326,7 +330,15 @@ def _generate_pipeline(test_file: str, args: str) -> Dict[str, Any]:
     """Generate a Buildkite pipeline from test files."""
     steps = []
     generated_steps_set = set()
-    function_cloud_map = _extract_marked_tests(test_file, args)
+    default_clouds_to_run, k_value, extra_args, concurrency = _parse_args(args)
+    function_cloud_map = _extract_marked_tests(test_file, args,
+                                               default_clouds_to_run, k_value,
+                                               extra_args)
+    if '--env-file' in args:
+        concurrency_limit = (concurrency if concurrency is not None else
+                             DEFAULT_ENV_FILE_CONCURRENCY_LIMIT)
+    else:
+        concurrency_limit = None
     for test_function, clouds_queues_param in function_cloud_map.items():
         for cloud, queue, param, extra_args, no_auto_retry in zip(
                 *clouds_queues_param):
@@ -353,6 +365,10 @@ def _generate_pipeline(test_file: str, args: str) -> Dict[str, Any]:
                     'queue': queue
                 }
             }
+            if concurrency_limit is not None:
+                build_id = os.environ.get('BUILDKITE_BUILD_ID', 'local')
+                step['concurrency'] = concurrency_limit
+                step['concurrency_group'] = (f'env-file-smoke-test-{build_id}')
             if no_auto_retry:
                 # Disable automatic retries but allow manual retries.
                 step['retry'] = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -285,6 +285,13 @@ def pytest_addoption(parser):
         'Use existing cluster for backend integration tests instead of creating a new one',
     )
     parser.addoption(
+        '--concurrency',
+        type=int,
+        default=None,
+        help=('Buildkite concurrency limit per build (configured in pipeline '
+              'generator; has no effect when running locally)'),
+    )
+    parser.addoption(
         '--dependency',
         type=str,
         nargs='?',


### PR DESCRIPTION
## Summary
- When running smoke tests with `--env-file` (shared remote API server), all test steps fan out in parallel and can overwhelm the server.
- Add Buildkite `concurrency` / `concurrency_group` to each generated step, capping parallel tests per build.
- Defaults to 10 concurrent tests; override with `--concurrency N` (e.g., `/smoke-test --env-file s3://... --concurrency 5`).
- Also registers `--concurrency` with pytest via `conftest.py` so it doesn't break `pytest --collect-only` during pipeline generation.

## Test plan
- [x] Trigger a build with `--env-file --concurrency 8` and verify Buildkite applies the limit: 8 jobs `running`, 145 jobs in `limited` state (blocked by concurrency group), confirming the cap is enforced.

<img width="362" height="144" alt="Screenshot 2026-05-16 at 8 06 04 PM" src="https://github.com/user-attachments/assets/ee74d812-b737-41c9-9f82-7280dfbc3290" />


- [x] Trigger without `--env-file` and verify no concurrency fields are added (steps run with default parallelism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)