### PR TITLE
[Kubernetes] Skip external network check when running inside K8s pods

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2033,6 +2033,13 @@ def get_node_ips(cluster_yaml: str,
 
 
 def check_network_connection():
+    # When running inside a Kubernetes pod, public internet may not be
+    # available (e.g. air-gapped clusters or TLS handshake failures from
+    # within the container). SkyPilot operations in K8s only need
+    # cluster-internal connectivity, so skip the external network check.
+    if 'KUBERNETES_SERVICE_HOST' in os.environ:
+        return
+
     # Tolerate 3 retries as it is observed that connections can fail.
     http = requests.Session()
     http.mount('https://', adapters.HTTPAdapter())
@@ -2064,6 +2071,13 @@ async def async_check_network_connection():
     Tolerates 3 retries as it is observed that connections can fail.
     Uses aiohttp for async HTTP requests.
     """
+    # When running inside a Kubernetes pod, public internet may not be
+    # available (e.g. air-gapped clusters or TLS handshake failures from
+    # within the container). SkyPilot operations in K8s only need
+    # cluster-internal connectivity, so skip the external network check.
+    if 'KUBERNETES_SERVICE_HOST' in os.environ:
+        return
+
     # Create a session with retry logic
     timeout = ClientTimeout(total=15)
     connector = TCPConnector(limit=1)  # Limit to 1 connection at a time


### PR DESCRIPTION
**Bug:** `sky.serve.status()` (and all `sky.serve.*` operations) fail with `RuntimeError: Failed to refresh services status due to network error` when the SkyPilot API Server runs inside a Kubernetes pod.

**Root cause:** `check_network_connection()` in `sky/backends/backend_utils.py` probes external HTTPS endpoints (8.8.8.8, 1.1.1.1) to verify network connectivity. In Kubernetes pods:
1. **TLS handshake failure** — the container's OpenSSL cannot complete TLS handshake with external HTTPS endpoints (SSLV3_ALERT_HANDSHAKE_FAILURE), even when TCP connectivity works. `requests.head()` raises `SSLError`, caught as `ConnectionError`.
2. **Air-gapped clusters** — many production K8s clusters have no public internet egress by policy.

Meanwhile, SkyPilot serve operations only need **cluster-internal connectivity** (API Server → Controller pod → Replica pods), which works perfectly fine.

**Fix:** Add an early return when `KUBERNETES_SERVICE_HOST` is detected in the environment (a standard env var injected by Kubernetes into every pod). This pattern is already used elsewhere in the codebase (`sky/adaptors/kubernetes.py`, `sky/serve/service.py`).

The fix is applied to both `check_network_connection()` and `async_check_network_connection()` for consistency.

Fixes #8865

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9630" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->