### PR TITLE
[Vast] Make account-level SSH key registration best-effort

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -29,6 +29,7 @@ import uuid
 
 import colorama
 import filelock
+import requests
 
 from sky import clouds
 from sky import exceptions
@@ -348,10 +349,19 @@ def setup_vast_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
     _, public_key_path = auth_utils.get_or_generate_keys()
     with open(public_key_path, 'r', encoding='UTF-8') as pub_key_file:
         public_key = pub_key_file.read().strip()
-        current_key_list = vast.vast().show_ssh_keys()  # pylint: disable=assignment-from-no-return
-        # Only add an ssh key if it hasn't already been added
-        if not any(x['public_key'] == public_key for x in current_key_list):
-            vast.vast().create_ssh_key(ssh_key=public_key)
+        try:
+            current_key_list = vast.vast().show_ssh_keys()  # pylint: disable=assignment-from-no-return
+            # Only add an ssh key if it hasn't already been added
+            if not any(x['public_key'] == public_key for x in current_key_list):
+                vast.vast().create_ssh_key(ssh_key=public_key)
+        except requests.HTTPError as e:
+            # Team-scoped Vast keys can't register account SSH keys;
+            # onstart_cmd injection in vast/utils.py handles SSH access.
+            body = e.response.text if e.response is not None else ''
+            if 'team_ssh_keys_not_supported' not in body:
+                raise
+            logger.debug('Skipping Vast account SSH key registration: '
+                         'team API key context.')
 
     config['auth']['ssh_public_key'] = public_key_path
     return configure_ssh_info(config)


### PR DESCRIPTION
## Summary

- Vast.ai now rejects `POST /api/v0/ssh/` (account-level SSH key registration) when called with a team-scoped API key, returning HTTP 400 with `team_ssh_keys_not_supported`. This previously aborted `setup_vast_authentication`, breaking `sky launch` on Vast for any user whose SkyPilot public key wasn't already on the account *and* was using a team API key for authentication.
- SSH access does not actually depend on this step: SkyPilot already injects the public key into each Vast instance's `~/.ssh/authorized_keys` at launch via `onstart_cmd` (see `sky/provision/vast/utils.py:207-219`, plumbed from `instance.py:142`). The account-level registration is a UX nicety (key appears under SSH keys in the Vast UI), not a functional requirement.
- This change wraps the `show_ssh_keys` + `create_ssh_key` calls in a try/except. If the response body contains `team_ssh_keys_not_supported`, the registration is skipped with a debug log and provisioning continues. Any other `HTTPError` still propagates.

## Test plan

- [x] On a Vast team API key, reproduce the 400: `POST /ssh/` returns `{"success":false,"error":"team_ssh_keys_not_supported", ...}`.
- [x] `sky launch -c <name> <yaml>` on Vast: with the fix, `setup_vast_authentication` no longer aborts; provisioning proceeds past the auth step.
- [ ] (For reviewers) Run `sky launch` with a **personal** Vast API key whose account does not yet have the SkyPilot public key registered, and confirm the existing behavior — the key is registered via `create_ssh_key` and listed by `show_ssh_keys` afterwards — is unchanged.
- [ ] (For reviewers) Run `sky launch` with a **team** Vast API key whose account does not yet have the SkyPilot public key registered, and confirm (a) current `master` fails with something like `sky.exceptions.CloudError: requests error (HTTPError): 400 Client Error: Bad Request for url: https://console.vast.ai/api/v0/ssh/?api_key=<redacted>`. With this branch, an instance should successfully launch instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)