### PR TITLE
[Vast] Wire docker_login_config through the ray template

### DIFF
--- a/sky/provision/vast/instance.py
+++ b/sky/provision/vast/instance.py
@@ -72,7 +72,7 @@ def run_instances(region: str, cluster_name: str, cluster_name_on_cloud: str,
             logger.warning(f'Failed to read SSH public key from '
                            f'{ssh_public_key_path}: {e}')
 
-    docker_login_config = config.docker_config.get('docker_login_config')
+    docker_login_config = config.provider_config.get('docker_login_config')
     login_args = None
     image_name = config.node_config['ImageId']
     if docker_login_config:

--- a/sky/templates/vast-ray.yml.j2
+++ b/sky/templates/vast-ray.yml.j2
@@ -14,6 +14,15 @@ provider:
   {%- if create_instance_kwargs %}
   create_instance_kwargs: {{create_instance_kwargs | tojson}}
   {%- endif %}
+  {%- if docker_login_config is not none %}
+  docker_login_config:
+    username: |-
+      {{docker_login_config.username}}
+    password: |-
+      {{docker_login_config.password | indent(6) }}
+    server: |-
+      {{docker_login_config.server}}
+  {%- endif %}
 
 auth:
   ssh_user: root


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Currently, the Vast backend does not properly handle authentication for private docker repositories. This PR makes sure that the `SKYPILOT_DOCKER_*` env vars, if present in a yaml, are plumbed correctly. 

<!-- Describe the tests ran -->

Testing:

- Ran with current upstream master, and a private docker image. The launch will succeed, but looking at the Vast.ai web-UI, there will be an error message like `Error response from daemon: Head "<image repository url>": unauthorized`
- Ran with this fix. The private image was successfully pulled, and launch completed without instance.

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
