### PR TITLE
[Slurm] Let users override --time and fall back to DefaultTime when MaxTime is UNLIMITED

### DIFF
--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -47,7 +47,7 @@ class SlurmPartition(NamedTuple):
     # The raw Slurm time string the partition assigns when --time is omitted
     # (e.g. '01:00:00', '2-00:00:00'). None if the partition has no
     # DefaultTime configured (NONE/UNLIMITED).
-    default_time: Optional[str] = None
+    default_time: Optional[str]
 
 
 # TODO(kevin): Add more API types for other client functions.

--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -25,6 +25,10 @@ _PARTITION_NAME_REGEX = re.compile(r'PartitionName=(.+?)(?:\s+\w+=|$)')
 # Matches MaxTime=<time> and captures the time
 _MAXTIME_REGEX = re.compile(r'MaxTime=((?:\d+-)?\d{1,2}:\d{2}:\d{2}|UNLIMITED)')
 
+# Regex pattern to extract DefaultTime from scontrol output
+# Matches DefaultTime=<value> and captures until the next whitespace
+_DEFAULT_TIME_REGEX = re.compile(r'DefaultTime=(\S+)')
+
 _IMPORT_ERROR_MESSAGE = ('Failed to import dependencies for Slurm. '
                          'Try running: pip install "skypilot[slurm]"')
 hostlist = common.LazyImport('hostlist',
@@ -40,6 +44,10 @@ class SlurmPartition(NamedTuple):
     # The maximum time a job can run in seconds.
     # None if the maximum time is unlimited.
     maxtime: Optional[int]
+    # The raw Slurm time string the partition assigns when --time is omitted
+    # (e.g. '01:00:00', '2-00:00:00'). None if the partition has no
+    # DefaultTime configured (NONE/UNLIMITED).
+    default_time: Optional[str] = None
 
 
 # TODO(kevin): Add more API types for other client functions.
@@ -74,6 +82,22 @@ def _parse_maxtime(line: str) -> Optional[int]:
 
     h, m, s = map(int, time_part.split(':'))
     return days * 86400 + h * 3600 + m * 60 + s
+
+
+def _parse_default_time(line: str) -> Optional[str]:
+    """Parse the DefaultTime a partition uses from the scontrol output.
+
+    Returns the raw Slurm time string (e.g. '01:00:00', '2-00:00:00') so it
+    can be passed straight through to ``--time``. Returns None when the
+    partition has no DefaultTime configured (``NONE``/``UNLIMITED``).
+    """
+    match = _DEFAULT_TIME_REGEX.search(line)
+    if not match:
+        return None
+    raw = match.group(1)
+    if raw in ('NONE', 'UNLIMITED'):
+        return None
+    return raw
 
 
 class SlurmClient:
@@ -595,13 +619,15 @@ class SlurmClient:
             if 'Default=YES' in line:
                 is_default = True
             maxtime = _parse_maxtime(line)
+            default_time = _parse_default_time(line)
             if match:
                 partition = match.group(1).strip()
                 if partition:
                     partitions.append(
                         SlurmPartition(name=partition,
                                        is_default=is_default,
-                                       maxtime=maxtime))
+                                       maxtime=maxtime,
+                                       default_time=default_time))
         return partitions
 
     def get_default_partition(self) -> Optional[str]:

--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -26,8 +26,9 @@ _PARTITION_NAME_REGEX = re.compile(r'PartitionName=(.+?)(?:\s+\w+=|$)')
 _MAXTIME_REGEX = re.compile(r'MaxTime=((?:\d+-)?\d{1,2}:\d{2}:\d{2}|UNLIMITED)')
 
 # Regex pattern to extract DefaultTime from scontrol output
-# Matches DefaultTime=<value> and captures until the next whitespace
-_DEFAULT_TIME_REGEX = re.compile(r'DefaultTime=(\S+)')
+# Matches DefaultTime=<time>, DefaultTime=UNLIMITED, or DefaultTime=NONE.
+_DEFAULT_TIME_REGEX = re.compile(
+    r'DefaultTime=((?:\d+-)?\d{1,2}:\d{2}:\d{2}|UNLIMITED|NONE)')
 
 _IMPORT_ERROR_MESSAGE = ('Failed to import dependencies for Slurm. '
                          'Try running: pip install "skypilot[slurm]"')

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -114,34 +114,43 @@ def _compute_time_directive(sbatch_options: Dict[str, Any],
                             partition: str) -> str:
     """Compute the auto-generated ``#SBATCH --time=...`` directive.
 
-    Priority: user-supplied > partition DefaultTime > partition MaxTime >
-    none (with warning). Omitting ``--time`` when DefaultTime is set lets
-    Slurm apply the partition default, which matches what an admin who
-    configured DefaultTime intended. Capping at MaxTime preserves today's
-    behavior for clusters without DefaultTime. When neither is set we warn
-    instead of silently picking a value, because a fixed default would
-    silently kill long-running jobs.
+    Priority: user-supplied > partition MaxTime > partition DefaultTime >
+    warn-and-omit. The MaxTime-before-DefaultTime ordering preserves
+    longstanding behavior (pre-existing code always emitted
+    ``--time={MaxTime}`` and ignored ``DefaultTime``). DefaultTime is
+    only consulted when MaxTime is UNLIMITED — emitting
+    ``--time=UNLIMITED`` is the #9370 footgun (backfill scheduler
+    refuses to schedule ahead of maintenance reservations).
 
-    Returns the directive ending with a newline (so it can be inserted
-    into the sbatch script f-string), or the empty string when no
-    auto-generated directive should be emitted. The user-supplied case
-    returns empty because ``_build_custom_sbatch_directives`` emits the
-    user's ``--time`` from sbatch_options instead.
+    TODO(dev): consider preferring DefaultTime over MaxTime. Arguments:
+    (1) matches Slurm's own default-resolution order; (2) DefaultTime
+    is the more intentional admin signal — MaxTime is usually the
+    ceiling, DefaultTime is "what a typical job should get";
+    (3) friendlier to the backfill scheduler; (4) less surprising for
+    admins who explicitly configured DefaultTime.
+
+    Returns the directive ending with a newline, or empty string when
+    no auto-generated directive should be emitted (user supplied their
+    own, or DefaultTime path, or warn path).
     """
     user_supplied_time = (sbatch_options.get('time') is not None or
                           sbatch_options.get('t') is not None)
     if user_supplied_time:
         return ''
-    if partition_info.default_time is not None:
-        return ''
+    # MaxTime first: preserve pre-existing behavior for partitions where
+    # MaxTime is set.
     if partition_info.maxtime is not None:
         max_time = slurm_utils.format_slurm_duration(partition_info.maxtime)
         return f'#SBATCH --time={max_time}\n'
+    # MaxTime is UNLIMITED / NONE. Fall back to DefaultTime (the #9370
+    # fix path) so Slurm doesn't see --time=UNLIMITED.
+    if partition_info.default_time is not None:
+        return ''
     logger.warning(
         f'Partition {partition!r} has no MaxTime or DefaultTime configured. '
         'Submitting without --time may cause the job to hang behind '
         'maintenance reservations. Set slurm.sbatch_options.time in your '
-        "task YAML or in ~/.sky/config.yaml.")
+        'task YAML or in ~/.sky/config.yaml.')
     return ''
 
 

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -129,9 +129,9 @@ def _compute_time_directive(sbatch_options: Dict[str, Any],
     (3) friendlier to the backfill scheduler; (4) less surprising for
     admins who explicitly configured DefaultTime.
 
-    Returns the directive ending with a newline, or empty string when
-    no auto-generated directive should be emitted (user supplied their
-    own, or DefaultTime path, or warn path).
+    Returns the directive line (no trailing newline), or empty string
+    when no auto-generated directive should be emitted (user supplied
+    their own, or DefaultTime path, or warn path).
     """
     user_supplied_time = (sbatch_options.get('time') is not None or
                           sbatch_options.get('t') is not None)
@@ -141,7 +141,7 @@ def _compute_time_directive(sbatch_options: Dict[str, Any],
     # MaxTime is set.
     if partition_info.maxtime is not None:
         max_time = slurm_utils.format_slurm_duration(partition_info.maxtime)
-        return f'#SBATCH --time={max_time}\n'
+        return f'#SBATCH --time={max_time}'
     # MaxTime is UNLIMITED / NONE. Fall back to DefaultTime (the #9370
     # fix path) so Slurm doesn't see --time=UNLIMITED.
     if partition_info.default_time is not None:
@@ -152,6 +152,24 @@ def _compute_time_directive(sbatch_options: Dict[str, Any],
         'maintenance reservations. Set slurm.sbatch_options.time in your '
         'task YAML or in ~/.sky/config.yaml.')
     return ''
+
+
+def _build_sbatch_directives(sbatch_options: Dict[str, Any],
+                             partition_info: 'slurm.SlurmPartition',
+                             partition: str) -> str:
+    """Combine auto-generated and user-supplied ``#SBATCH`` directives.
+
+    Returns a string with a leading newline so it slots into the sbatch
+    script f-string after the pre-existing directives, or empty string
+    when nothing to emit.
+    """
+    user_block = _build_custom_sbatch_directives(sbatch_options)
+    auto_time = _compute_time_directive(sbatch_options, partition_info,
+                                        partition)
+    if not auto_time:
+        return user_block
+    # user_block is either '' or '\n#SBATCH ...' (leading \n, no trailing).
+    return '\n' + auto_time + user_block
 
 
 def _wait_for_job_nodes(
@@ -494,11 +512,12 @@ def _create_virtual_instance(
                     container_image = f'{maybe_domain}#{maybe_path}'
     container_name = slurm_utils.pyxis_container_name(cluster_name_on_cloud)
 
-    # Build custom sbatch directives from user config.
+    # Build the appended sbatch directive block (auto-generated --time
+    # + user-supplied options from sbatch_options).
     sbatch_options = resources.get('sbatch_options', {}) or {}
-    custom_sbatch_directives = _build_custom_sbatch_directives(sbatch_options)
-    time_directive = _compute_time_directive(sbatch_options, partition_info,
-                                             partition)
+    extra_sbatch_directives = _build_sbatch_directives(sbatch_options,
+                                                       partition_info,
+                                                       partition)
 
     # Build the sbatch script
     gpu_directive = ''
@@ -610,11 +629,11 @@ echo "[container-init] Packages installed in $((SECONDS - INIT_START))s"
 #SBATCH --output={_sbatch_log_path(sbatch_log_base_dir, '%j')}
 #SBATCH --error={_sbatch_log_path(sbatch_log_base_dir, '%j')}
 #SBATCH --nodes={num_nodes}
-{time_directive}#SBATCH --wait-all-nodes=1
+#SBATCH --wait-all-nodes=1
 # Let the job be terminated rather than requeued implicitly.
 #SBATCH --no-requeue
 #SBATCH --cpus-per-task={int(resources["cpus"])}
-{mem_directive}{gpu_directive}{custom_sbatch_directives}
+{mem_directive}{gpu_directive}{extra_sbatch_directives}
 
 # Cleanup function to remove cluster dirs on job termination.
 cleanup() {{

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -47,7 +47,6 @@ _SBATCH_PROTECTED_OPTIONS = frozenset({
     'output',
     'error',
     'nodes',
-    'time',
     'wait-all-nodes',
     'no-requeue',
     'cpus-per-task',
@@ -97,6 +96,8 @@ def _build_custom_sbatch_directives(sbatch_options: Dict[str, Any]) -> str:
             raise ValueError(
                 f'Newline characters are not allowed in sbatch options: '
                 f'{key!r}={str_value!r}')
+        if key in ('time', 't'):
+            slurm_utils.validate_sbatch_time(str_value)
         if value is True:
             lines.append(f'#SBATCH --{key}')
         else:
@@ -106,6 +107,42 @@ def _build_custom_sbatch_directives(sbatch_options: Dict[str, Any]) -> str:
     # Prefix with newline so it slots in after other directives
     # in the provision script f-string.
     return '\n' + '\n'.join(lines)
+
+
+def _compute_time_directive(sbatch_options: Dict[str, Any],
+                            partition_info: 'slurm.SlurmPartition',
+                            partition: str) -> str:
+    """Compute the auto-generated ``#SBATCH --time=...`` directive.
+
+    Priority: user-supplied > partition DefaultTime > partition MaxTime >
+    none (with warning). Omitting ``--time`` when DefaultTime is set lets
+    Slurm apply the partition default, which matches what an admin who
+    configured DefaultTime intended. Capping at MaxTime preserves today's
+    behavior for clusters without DefaultTime. When neither is set we warn
+    instead of silently picking a value, because a fixed default would
+    silently kill long-running jobs.
+
+    Returns the directive ending with a newline (so it can be inserted
+    into the sbatch script f-string), or the empty string when no
+    auto-generated directive should be emitted. The user-supplied case
+    returns empty because ``_build_custom_sbatch_directives`` emits the
+    user's ``--time`` from sbatch_options instead.
+    """
+    user_supplied_time = (sbatch_options.get('time') is not None or
+                          sbatch_options.get('t') is not None)
+    if user_supplied_time:
+        return ''
+    if partition_info.default_time is not None:
+        return ''
+    if partition_info.maxtime is not None:
+        max_time = slurm_utils.format_slurm_duration(partition_info.maxtime)
+        return f'#SBATCH --time={max_time}\n'
+    logger.warning(
+        f'Partition {partition!r} has no MaxTime or DefaultTime configured. '
+        'Submitting without --time may cause the job to hang behind '
+        'maintenance reservations. Set slurm.sbatch_options.time in your '
+        "task YAML or in ~/.sky/config.yaml.")
+    return ''
 
 
 def _wait_for_job_nodes(
@@ -273,7 +310,6 @@ def _create_virtual_instance(
     if partition_info is None:
         raise ValueError(f'Partition info for {partition} not found '
                          f'for SLURM cluster {slurm_cluster}')
-    max_time = slurm_utils.format_slurm_duration(partition_info.maxtime)
 
     # COMPLETING state occurs when a job is being terminated - during this
     # phase, slurmd sends SIGTERM to tasks, waits for KillWait period, sends
@@ -450,8 +486,10 @@ def _create_virtual_instance(
     container_name = slurm_utils.pyxis_container_name(cluster_name_on_cloud)
 
     # Build custom sbatch directives from user config.
-    custom_sbatch_directives = _build_custom_sbatch_directives(
-        resources.get('sbatch_options', {}))
+    sbatch_options = resources.get('sbatch_options', {}) or {}
+    custom_sbatch_directives = _build_custom_sbatch_directives(sbatch_options)
+    time_directive = _compute_time_directive(sbatch_options, partition_info,
+                                             partition)
 
     # Build the sbatch script
     gpu_directive = ''
@@ -563,8 +601,7 @@ echo "[container-init] Packages installed in $((SECONDS - INIT_START))s"
 #SBATCH --output={_sbatch_log_path(sbatch_log_base_dir, '%j')}
 #SBATCH --error={_sbatch_log_path(sbatch_log_base_dir, '%j')}
 #SBATCH --nodes={num_nodes}
-#SBATCH --time={max_time}
-#SBATCH --wait-all-nodes=1
+{time_directive}#SBATCH --wait-all-nodes=1
 # Let the job be terminated rather than requeued implicitly.
 #SBATCH --no-requeue
 #SBATCH --cpus-per-task={int(resources["cpus"])}

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -122,7 +122,7 @@ def _compute_time_directive(sbatch_options: Dict[str, Any],
     ``--time=UNLIMITED`` is the #9370 footgun (backfill scheduler
     refuses to schedule ahead of maintenance reservations).
 
-    TODO(dev): consider preferring DefaultTime over MaxTime. Arguments:
+    TODO(kevin): consider preferring DefaultTime over MaxTime. Arguments:
     (1) matches Slurm's own default-resolution order; (2) DefaultTime
     is the more intentional admin signal — MaxTime is usually the
     ceiling, DefaultTime is "what a typical job should get";

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -133,8 +133,13 @@ def _compute_time_directive(sbatch_options: Dict[str, Any],
     when no auto-generated directive should be emitted (user supplied
     their own, or DefaultTime path, or warn path).
     """
-    user_supplied_time = (sbatch_options.get('time') is not None or
-                          sbatch_options.get('t') is not None)
+    # Match _build_custom_sbatch_directives' emit criteria: None and False
+    # are skipped there (the convention for boolean-shaped options like
+    # `exclusive: false`), so we treat them the same way here. Otherwise
+    # `time: false` would suppress both the user's directive AND the auto
+    # fallback, silently bypassing the safety net.
+    user_supplied_time = any(
+        sbatch_options.get(k) not in (None, False) for k in ('time', 't'))
     if user_supplied_time:
         return ''
     # MaxTime first: preserve pre-existing behavior for partitions where

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -1156,6 +1156,32 @@ def format_slurm_duration(duration_seconds: Optional[int]) -> str:
     return f'{days}-{hours:02}:{minutes:02}:{seconds:02}'
 
 
+# Accepted sbatch --time formats:
+#   m, m:s, h:m:s, d-h, d-h:m, d-h:m:s
+# See: https://slurm.schedmd.com/sbatch.html#OPT_time
+_TIME_FORMAT_RE = re.compile(
+    r'\d+|\d+:\d+|\d+:\d+:\d+|\d+-\d+|\d+-\d+:\d+|\d+-\d+:\d+:\d+')
+
+
+def validate_sbatch_time(value: str) -> None:
+    """Validate that a user-supplied sbatch --time value is well-formed.
+
+    Reject malformed values up front (at config-load / directive-build time)
+    rather than letting `sbatch` reject the directive at submit time, which
+    yields a less actionable error.
+
+    Raises:
+        ValueError: If the value does not match a Slurm-accepted time format.
+    """
+    # Use fullmatch (not match) so trailing whitespace or newlines are
+    # rejected — `$` would match before a final newline due to Python's
+    # MULTILINE default and let `'5\n'` slip through.
+    if not _TIME_FORMAT_RE.fullmatch(value):
+        raise ValueError(
+            f'Invalid slurm.sbatch_options.time {value!r}. '
+            'Accepted formats: m, m:s, h:m:s, d-h, d-h:m, d-h:m:s.')
+
+
 def srun_sshd_command(
     job_id: str,
     target_node: str,

--- a/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
+++ b/tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py
@@ -452,6 +452,69 @@ class TestParseMaxtime:
         assert result is None
 
 
+class TestParseDefaultTime:
+    """Test _parse_default_time()."""
+
+    def test_parse_default_time_none(self):
+        """DefaultTime=NONE returns None."""
+        line = 'PartitionName=dev DefaultTime=NONE MaxTime=UNLIMITED'
+        result = slurm._parse_default_time(line)
+        assert result is None
+
+    def test_parse_default_time_unlimited(self):
+        """DefaultTime=UNLIMITED returns None (no useful default)."""
+        line = 'PartitionName=dev DefaultTime=UNLIMITED MaxTime=UNLIMITED'
+        result = slurm._parse_default_time(line)
+        assert result is None
+
+    def test_parse_default_time_hms(self):
+        """Returns the raw hh:mm:ss string verbatim."""
+        line = 'PartitionName=dev DefaultTime=01:00:00 MaxTime=12:00:00'
+        result = slurm._parse_default_time(line)
+        assert result == '01:00:00'
+
+    def test_parse_default_time_with_days(self):
+        line = 'PartitionName=dev DefaultTime=2-00:00:00 MaxTime=7-00:00:00'
+        result = slurm._parse_default_time(line)
+        assert result == '2-00:00:00'
+
+    def test_parse_default_time_no_match(self):
+        line = 'PartitionName=dev MaxTime=12:00:00'
+        result = slurm._parse_default_time(line)
+        assert result is None
+
+
+class TestGetPartitionsInfoDefaultTime:
+    """Verify get_partitions_info() populates the default_time field."""
+
+    def test_populates_default_time(self):
+        client = slurm.SlurmClient(
+            ssh_host='localhost',
+            ssh_port=22,
+            ssh_user='root',
+            ssh_key=None,
+        )
+
+        mock_output = ('PartitionName=cpu Default=YES DefaultTime=01:00:00 '
+                       'MaxTime=UNLIMITED\n'
+                       'PartitionName=gpu Default=NO DefaultTime=NONE '
+                       'MaxTime=02:00:00')
+
+        with mock.patch.object(client._runner, 'run') as mock_run:
+            mock_run.return_value = (0, mock_output, '')
+            result = client.get_partitions_info()
+
+        assert len(result) == 2
+        assert result[0].name == 'cpu'
+        assert result[0].is_default is True
+        assert result[0].maxtime is None  # UNLIMITED
+        assert result[0].default_time == '01:00:00'
+        assert result[1].name == 'gpu'
+        assert result[1].is_default is False
+        assert result[1].maxtime == 7200
+        assert result[1].default_time is None
+
+
 class TestGetProctrackType:
     """Test SlurmClient.get_proctrack_type()."""
 

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -892,7 +892,8 @@ class TestProvisionTimeoutPassthrough:
         mock_get_partition_info.return_value = SlurmPartition(name='gpu',
                                                               is_default=False,
                                                               maxtime=7 * 24 *
-                                                              60 * 60)
+                                                              60 * 60,
+                                                              default_time=None)
         mock_get_proctrack_type.return_value = 'cgroup'
 
         mock_client = mock.MagicMock()
@@ -960,7 +961,8 @@ class TestProvisionTimeoutPassthrough:
         mock_get_partition_info.return_value = SlurmPartition(name='gpu',
                                                               is_default=False,
                                                               maxtime=7 * 24 *
-                                                              60 * 60)
+                                                              60 * 60,
+                                                              default_time=None)
         mock_get_proctrack_type.return_value = 'cgroup'
 
         mock_client = mock.MagicMock()
@@ -1022,7 +1024,10 @@ class TestCreateVirtualInstance:
         from sky.adaptors.slurm import SlurmPartition
 
         mock_get_partition_info.return_value = SlurmPartition(
-            name=partition_name, is_default=False, maxtime=7 * 24 * 60 * 60)
+            name=partition_name,
+            is_default=False,
+            maxtime=7 * 24 * 60 * 60,
+            default_time=None)
 
         mock_client = mock.MagicMock()
         mock_client.query_jobs.return_value = []

--- a/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/basic.sh
+++ b/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/basic.sh
@@ -3,13 +3,13 @@
 #SBATCH --output=/home/testuser/.sky_provision/slurm-%j.out
 #SBATCH --error=/home/testuser/.sky_provision/slurm-%j.out
 #SBATCH --nodes=1
-#SBATCH --time=7-00:00:00
 #SBATCH --wait-all-nodes=1
 # Let the job be terminated rather than requeued implicitly.
 #SBATCH --no-requeue
 #SBATCH --cpus-per-task=2
 #SBATCH --mem=8192M
 
+#SBATCH --time=7-00:00:00
 
 # Cleanup function to remove cluster dirs on job termination.
 cleanup() {

--- a/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/containers.sh
+++ b/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/containers.sh
@@ -3,13 +3,13 @@
 #SBATCH --output=/home/testuser/.sky_provision/slurm-%j.out
 #SBATCH --error=/home/testuser/.sky_provision/slurm-%j.out
 #SBATCH --nodes=1
-#SBATCH --time=7-00:00:00
 #SBATCH --wait-all-nodes=1
 # Let the job be terminated rather than requeued implicitly.
 #SBATCH --no-requeue
 #SBATCH --cpus-per-task=4
 #SBATCH --mem=16384M
 #SBATCH --gres=gpu:A100:2
+#SBATCH --time=7-00:00:00
 
 # Cleanup function to remove cluster dirs on job termination.
 cleanup() {

--- a/tests/unit_tests/test_sky/provision/slurm/test_sbatch_config.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_sbatch_config.py
@@ -1,11 +1,15 @@
 """Unit tests for sbatch_options support in Slurm provisioner."""
 
 import subprocess
+import unittest.mock as mock
 
 import jsonschema
 import pytest
 
+from sky.adaptors import slurm as slurm_adaptor
+from sky.provision.slurm import instance as slurm_instance
 from sky.provision.slurm.instance import _build_custom_sbatch_directives
+from sky.provision.slurm.instance import _compute_time_directive
 from sky.provision.slurm.instance import _SBATCH_PROTECTED_OPTIONS
 from sky.utils.schemas import get_config_schema
 
@@ -142,6 +146,103 @@ class TestBuildCustomSbatchDirectives:
         result = _build_custom_sbatch_directives(allowed_options)
         for key, value in allowed_options.items():
             assert f'#SBATCH --{key}={value}' in result
+
+    def test_time_no_longer_protected(self):
+        """`time` is now user-overridable (issue #9370)."""
+        assert 'time' not in _SBATCH_PROTECTED_OPTIONS
+        result = _build_custom_sbatch_directives({'time': '2:00:00'})
+        assert result == '\n#SBATCH --time=2:00:00'
+
+    def test_time_short_form_allowed(self):
+        result = _build_custom_sbatch_directives({'t': '5'})
+        assert result == '\n#SBATCH --t=5'
+
+    @pytest.mark.parametrize('value', [
+        '5',
+        '2:30',
+        '4:00:00',
+        '1-12',
+        '1-12:30',
+        '2-23:59:59',
+    ])
+    def test_time_accepted_formats(self, value):
+        result = _build_custom_sbatch_directives({'time': value})
+        assert result == f'\n#SBATCH --time={value}'
+
+    @pytest.mark.parametrize('value', [
+        'garbage',
+        '1h',
+        '1:2:3:4',
+        '1.5',
+        '-1',
+        '1-2-3',
+        '',
+    ])
+    def test_time_invalid_format_raises(self, value):
+        with pytest.raises(ValueError, match='Invalid slurm.sbatch_options'):
+            _build_custom_sbatch_directives({'time': value})
+
+    def test_time_short_form_invalid_raises(self):
+        with pytest.raises(ValueError, match='Invalid slurm.sbatch_options'):
+            _build_custom_sbatch_directives({'t': 'bogus'})
+
+
+class TestComputeTimeDirective:
+    """Test _compute_time_directive() fallback dispatch."""
+
+    @staticmethod
+    def _partition(maxtime=None, default_time=None):
+        return slurm_adaptor.SlurmPartition(
+            name='cpu',
+            is_default=True,
+            maxtime=maxtime,
+            default_time=default_time,
+        )
+
+    def test_user_supplied_time_skips_auto_directive(self):
+        """User-supplied --time wins; auto-generated directive omitted."""
+        partition = self._partition(maxtime=3600, default_time='01:00:00')
+        result = _compute_time_directive({'time': '4:00:00'}, partition, 'cpu')
+        assert result == ''
+
+    def test_user_supplied_short_form_skips_auto_directive(self):
+        partition = self._partition(maxtime=3600, default_time='01:00:00')
+        result = _compute_time_directive({'t': '5'}, partition, 'cpu')
+        assert result == ''
+
+    def test_default_time_skips_auto_directive(self):
+        """Partition has DefaultTime; omit --time so Slurm applies it."""
+        # MaxTime=UNLIMITED, DefaultTime=01:00:00 — the bug scenario in #9370.
+        partition = self._partition(maxtime=None, default_time='01:00:00')
+        result = _compute_time_directive({}, partition, 'cpu')
+        assert result == ''
+
+    def test_falls_back_to_maxtime(self):
+        """No DefaultTime, MaxTime set — emit --time=MaxTime (today's behavior)."""
+        partition = self._partition(maxtime=7200)
+        result = _compute_time_directive({}, partition, 'cpu')
+        assert result == '#SBATCH --time=0-02:00:00\n'
+
+    def test_no_maxtime_no_default_warns_and_emits_nothing(self, monkeypatch):
+        """No MaxTime and no DefaultTime — warn and emit nothing."""
+        partition = self._partition()
+        # The `sky` logger has propagate=False, so caplog cannot observe
+        # it. Mock the module logger's `warning` directly.
+        warning_mock = mock.MagicMock()
+        monkeypatch.setattr(slurm_instance.logger, 'warning', warning_mock)
+        result = _compute_time_directive({}, partition, 'gpu')
+        assert result == ''
+        warning_mock.assert_called_once()
+        msg = warning_mock.call_args.args[0]
+        assert 'no MaxTime or DefaultTime' in msg
+        assert 'gpu' in msg
+
+    def test_explicit_null_time_treated_as_unset(self):
+        """sbatch_options.time=null behaves the same as not setting it."""
+        partition = self._partition(maxtime=3600)
+        result = _compute_time_directive({'time': None}, partition, 'cpu')
+        # MaxTime fallback kicks in because user did not actually supply time.
+        assert result == '#SBATCH --time=0-01:00:00\n'
 
 
 class TestSbatchConfigSchema:

--- a/tests/unit_tests/test_sky/provision/slurm/test_sbatch_config.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_sbatch_config.py
@@ -210,12 +210,27 @@ class TestComputeTimeDirective:
         result = _compute_time_directive({'t': '5'}, partition, 'cpu')
         assert result == ''
 
-    def test_default_time_skips_auto_directive(self):
-        """Partition has DefaultTime; omit --time so Slurm applies it."""
-        # MaxTime=UNLIMITED, DefaultTime=01:00:00 — the bug scenario in #9370.
+    def test_default_time_used_only_when_maxtime_unset(self):
+        """Partition has DefaultTime but no MaxTime; omit --time so Slurm applies it.
+
+        This is the #9370 fix: pre-existing code would emit
+        --time=UNLIMITED here, which the backfill scheduler refuses to
+        schedule ahead of maintenance reservations.
+        """
         partition = self._partition(maxtime=None, default_time='01:00:00')
         result = _compute_time_directive({}, partition, 'cpu')
         assert result == ''
+
+    def test_maxtime_wins_when_both_set(self):
+        """When both MaxTime and DefaultTime are set, MaxTime wins.
+
+        Preserves SkyPilot's longstanding behavior of always emitting
+        --time=MaxTime (Hyrum's law - some users rely on this).
+        """
+        partition = self._partition(maxtime=3600, default_time='00:15:00')
+        result = _compute_time_directive({}, partition, 'cpu')
+        # MaxTime (1h), not DefaultTime (15min).
+        assert result == '#SBATCH --time=0-01:00:00\n'
 
     def test_falls_back_to_maxtime(self):
         """No DefaultTime, MaxTime set — emit --time=MaxTime (today's behavior)."""

--- a/tests/unit_tests/test_sky/provision/slurm/test_sbatch_config.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_sbatch_config.py
@@ -9,6 +9,7 @@ import pytest
 from sky.adaptors import slurm as slurm_adaptor
 from sky.provision.slurm import instance as slurm_instance
 from sky.provision.slurm.instance import _build_custom_sbatch_directives
+from sky.provision.slurm.instance import _build_sbatch_directives
 from sky.provision.slurm.instance import _compute_time_directive
 from sky.provision.slurm.instance import _SBATCH_PROTECTED_OPTIONS
 from sky.utils.schemas import get_config_schema
@@ -221,7 +222,7 @@ class TestComputeTimeDirective:
         partition = self._partition(maxtime=3600, default_time='00:15:00')
         result = _compute_time_directive({}, partition, 'cpu')
         # MaxTime (1h), not DefaultTime (15min).
-        assert result == '#SBATCH --time=0-01:00:00\n'
+        assert result == '#SBATCH --time=0-01:00:00'
 
     def test_no_maxtime_no_default_warns_and_emits_nothing(self, monkeypatch):
         """No MaxTime and no DefaultTime — warn and emit nothing."""
@@ -242,7 +243,42 @@ class TestComputeTimeDirective:
         partition = self._partition(maxtime=3600)
         result = _compute_time_directive({'time': None}, partition, 'cpu')
         # MaxTime fallback kicks in because user did not actually supply time.
-        assert result == '#SBATCH --time=0-01:00:00\n'
+        assert result == '#SBATCH --time=0-01:00:00'
+
+
+class TestBuildSbatchDirectives:
+    """Test _build_sbatch_directives() combines auto --time + user options."""
+
+    @staticmethod
+    def _partition(maxtime=None, default_time=None):
+        return slurm_adaptor.SlurmPartition(name='cpu',
+                                            is_default=True,
+                                            maxtime=maxtime,
+                                            default_time=default_time)
+
+    def test_only_auto_time(self):
+        """Partition has MaxTime, user has no options."""
+        result = _build_sbatch_directives({}, self._partition(maxtime=3600),
+                                          'cpu')
+        assert result == '\n#SBATCH --time=0-01:00:00'
+
+    def test_only_user_options(self):
+        """No auto --time, user supplies other options."""
+        result = _build_sbatch_directives(
+            {'qos': 'high'}, self._partition(default_time='01:00:00'), 'cpu')
+        assert result == '\n#SBATCH --qos=high'
+
+    def test_both_auto_time_and_user_options(self):
+        """Auto --time and user options both present, no double newline."""
+        result = _build_sbatch_directives({'qos': 'high'},
+                                          self._partition(maxtime=3600), 'cpu')
+        assert result == '\n#SBATCH --time=0-01:00:00\n#SBATCH --qos=high'
+
+    def test_user_time_replaces_auto_time(self):
+        """User-supplied time wins; only the user's --time appears."""
+        result = _build_sbatch_directives({'time': '2:00:00'},
+                                          self._partition(maxtime=3600), 'cpu')
+        assert result == '\n#SBATCH --time=2:00:00'
 
 
 class TestSbatchConfigSchema:

--- a/tests/unit_tests/test_sky/provision/slurm/test_sbatch_config.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_sbatch_config.py
@@ -245,6 +245,17 @@ class TestComputeTimeDirective:
         # MaxTime fallback kicks in because user did not actually supply time.
         assert result == '#SBATCH --time=0-01:00:00'
 
+    def test_false_time_falls_through_to_auto(self):
+        """sbatch_options.time=False is equivalent to not setting the key.
+
+        Mirrors _build_custom_sbatch_directives, which skips None/False
+        values. Without this alignment, `time: false` would silently
+        bypass both the user directive and the auto fallback.
+        """
+        partition = self._partition(maxtime=3600)
+        result = _compute_time_directive({'time': False}, partition, 'cpu')
+        assert result == '#SBATCH --time=0-01:00:00'
+
 
 class TestBuildSbatchDirectives:
     """Test _build_sbatch_directives() combines auto --time + user options."""

--- a/tests/unit_tests/test_sky/provision/slurm/test_sbatch_config.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_sbatch_config.py
@@ -157,32 +157,22 @@ class TestBuildCustomSbatchDirectives:
         result = _build_custom_sbatch_directives({'t': '5'})
         assert result == '\n#SBATCH --t=5'
 
-    @pytest.mark.parametrize('value', [
-        '5',
-        '2:30',
-        '4:00:00',
-        '1-12',
-        '1-12:30',
-        '2-23:59:59',
-    ])
-    def test_time_accepted_formats(self, value):
-        result = _build_custom_sbatch_directives({'time': value})
-        assert result == f'\n#SBATCH --time={value}'
+    def test_time_validator_wired(self):
+        """Smoke test that validate_sbatch_time runs when key is 'time'.
 
-    @pytest.mark.parametrize('value', [
-        'garbage',
-        '1h',
-        '1:2:3:4',
-        '1.5',
-        '-1',
-        '1-2-3',
-        '',
-    ])
-    def test_time_invalid_format_raises(self, value):
+        Exhaustive accepted/rejected format coverage lives in
+        TestValidateSbatchTime (test_slurm_utils.py); this test only
+        verifies the validator is called from the build path.
+        """
+        # Accepted format passes through.
+        result = _build_custom_sbatch_directives({'time': '4:00:00'})
+        assert result == '\n#SBATCH --time=4:00:00'
+        # Rejected format raises with our error message.
         with pytest.raises(ValueError, match='Invalid slurm.sbatch_options'):
-            _build_custom_sbatch_directives({'time': value})
+            _build_custom_sbatch_directives({'time': 'garbage'})
 
     def test_time_short_form_invalid_raises(self):
+        """Validator is also wired for the short form 't'."""
         with pytest.raises(ValueError, match='Invalid slurm.sbatch_options'):
             _build_custom_sbatch_directives({'t': 'bogus'})
 
@@ -225,18 +215,13 @@ class TestComputeTimeDirective:
         """When both MaxTime and DefaultTime are set, MaxTime wins.
 
         Preserves SkyPilot's longstanding behavior of always emitting
-        --time=MaxTime (Hyrum's law - some users rely on this).
+        --time=MaxTime. See `TODO(kevin)` in `_compute_time_directive`
+        for arguments to reconsider this priority later.
         """
         partition = self._partition(maxtime=3600, default_time='00:15:00')
         result = _compute_time_directive({}, partition, 'cpu')
         # MaxTime (1h), not DefaultTime (15min).
         assert result == '#SBATCH --time=0-01:00:00\n'
-
-    def test_falls_back_to_maxtime(self):
-        """No DefaultTime, MaxTime set — emit --time=MaxTime (today's behavior)."""
-        partition = self._partition(maxtime=7200)
-        result = _compute_time_directive({}, partition, 'cpu')
-        assert result == '#SBATCH --time=0-02:00:00\n'
 
     def test_no_maxtime_no_default_warns_and_emits_nothing(self, monkeypatch):
         """No MaxTime and no DefaultTime — warn and emit nothing."""

--- a/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
@@ -24,21 +24,16 @@ class TestValidateSbatchTime:
     """Test validate_sbatch_time()."""
 
     @pytest.mark.parametrize('value', [
-        '0',
-        '5',
-        '60',
-        '1:30',
-        '12:30',
-        '0:00:00',
-        '4:00:00',
-        '23:59:59',
-        '1-0',
-        '1-12',
-        '2-23:59',
-        '7-00:00:00',
+        '5',           # m (bare minutes)
+        '1:30',        # m:s
+        '4:00:00',     # h:m:s
+        '1-0',         # d-h
+        '1-12',        # d-h (multi-digit hour)
+        '2-23:59',     # d-h:m
+        '7-00:00:00',  # d-h:m:s
     ])
     def test_accepted_formats(self, value):
-        # Should not raise.
+        # Should not raise. One sample per grammatical form.
         utils.validate_sbatch_time(value)
 
     @pytest.mark.parametrize('value', [

--- a/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
@@ -20,6 +20,47 @@ class TestFormatSlurmDuration:
         assert result == expected
 
 
+class TestValidateSbatchTime:
+    """Test validate_sbatch_time()."""
+
+    @pytest.mark.parametrize('value', [
+        '0',
+        '5',
+        '60',
+        '1:30',
+        '12:30',
+        '0:00:00',
+        '4:00:00',
+        '23:59:59',
+        '1-0',
+        '1-12',
+        '2-23:59',
+        '7-00:00:00',
+    ])
+    def test_accepted_formats(self, value):
+        # Should not raise.
+        utils.validate_sbatch_time(value)
+
+    @pytest.mark.parametrize('value', [
+        '',
+        'garbage',
+        '1h',
+        '1m30s',
+        '1:2:3:4',
+        '1.5',
+        '-1',
+        '1-2-3',
+        ':30',
+        '1:',
+        ' 5',
+        '5 ',
+        '5\n',
+    ])
+    def test_invalid_formats_raise(self, value):
+        with pytest.raises(ValueError, match='Invalid slurm.sbatch_options'):
+            utils.validate_sbatch_time(value)
+
+
 class TestGetIdentityFile:
     """Test get_identity_file() helper function."""
 

--- a/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_slurm_utils.py
@@ -23,15 +23,17 @@ class TestFormatSlurmDuration:
 class TestValidateSbatchTime:
     """Test validate_sbatch_time()."""
 
-    @pytest.mark.parametrize('value', [
-        '5',           # m (bare minutes)
-        '1:30',        # m:s
-        '4:00:00',     # h:m:s
-        '1-0',         # d-h
-        '1-12',        # d-h (multi-digit hour)
-        '2-23:59',     # d-h:m
-        '7-00:00:00',  # d-h:m:s
-    ])
+    @pytest.mark.parametrize(
+        'value',
+        [
+            '5',  # m (bare minutes)
+            '1:30',  # m:s
+            '4:00:00',  # h:m:s
+            '1-0',  # d-h
+            '1-12',  # d-h (multi-digit hour)
+            '2-23:59',  # d-h:m
+            '7-00:00:00',  # d-h:m:s
+        ])
     def test_accepted_formats(self, value):
         # Should not raise. One sample per grammatical form.
         utils.validate_sbatch_time(value)


### PR DESCRIPTION
## Summary

The SLURM provisioner hard-codes `#SBATCH --time={partition_MaxTime}`. On partitions with `MaxTime=UNLIMITED` this becomes `--time=UNLIMITED`, which the backfill scheduler refuses to schedule ahead of a maintenance reservation — the job hangs with `ReqNodeNotAvail, Reserved for maintenance` (reported in #9370). Users also could not override `--time` via `sbatch_options` because `time` was in `_SBATCH_PROTECTED_OPTIONS`.

## Changes

- Remove `'time'` from `_SBATCH_PROTECTED_OPTIONS` so users can set `slurm.sbatch_options.time` in their task YAML or `~/.sky/config.yaml`.
- New `_compute_time_directive()` with priority: **user-supplied > partition `MaxTime` > partition `DefaultTime` > warn-and-omit**. The MaxTime-before-DefaultTime ordering preserves SkyPilot's longstanding behavior — pre-existing code always emitted `--time={MaxTime}` and ignored `DefaultTime` entirely. `DefaultTime` is consulted only when `MaxTime` is `UNLIMITED`, which is exactly the #9370 footgun: pre-existing code would emit `--time=UNLIMITED` in that case, and the backfill scheduler refuses to schedule that ahead of any maintenance reservation. The warn-and-omit terminal case avoids silently picking a fixed value that would kill long-running jobs. A `TODO(kevin)` records the case for a future flip (it would match Slurm's own default-resolution order, be friendlier to the backfill scheduler, and better match admin intent), but flipping now would be a silent regression for users who depend on the current MaxTime behavior.
- Plumb `DefaultTime` through `SlurmPartition` + adaptor parser (new `_parse_default_time`).
- Validate user-supplied `--time` format up front (`m`, `m:s`, `h:m:s`, `d-h`, `d-h:m`, `d-h:m:s`) so bad values fail at directive-build time with a clear error, not at sbatch submit time.

Fixes #9370.

## Test plan

- [x] **Unit tests (38 new):** `pytest tests/unit_tests/test_sky/provision/slurm tests/unit_tests/test_sky/adaptors/test_slurm_adaptor.py` — covers format validation, dispatch priority, and `DefaultTime` parsing.
- [x] **E2E on a real SLURM cluster.** Created 4 test partitions covering every combination of `MaxTime` and `DefaultTime` ∈ {set, NONE}, then for each `(partition × user sbatch_options.time)` submitted a job and verified `scontrol show job` reports the expected `TimeLimit`:

| Partition | User `time` | Expected `TimeLimit` | Observed |
| --- | --- | --- | --- |
| `MaxTime=UNLIM, DefaultTime=NONE` | — | unlimited (+ warning) | `365-00:00:00` ✓ |
| `MaxTime=UNLIM, DefaultTime=NONE` | `5` | `00:05:00` | `00:05:00` ✓ |
| `MaxTime=UNLIM, DefaultTime=10m` | — | `00:10:00` (DefaultTime applied by Slurm) | `00:10:00` ✓ |
| `MaxTime=UNLIM, DefaultTime=10m` | `5` | `00:05:00` (user wins) | `00:05:00` ✓ |
| `MaxTime=30m, DefaultTime=NONE` | — | `00:30:00` (MaxTime) | `00:30:00` ✓ |
| `MaxTime=30m, DefaultTime=NONE` | `5` | `00:05:00` | `00:05:00` ✓ |
| `MaxTime=1h, DefaultTime=15m` | — | `01:00:00` (MaxTime wins, preserves legacy) | `01:00:00` ✓ |
| `MaxTime=1h, DefaultTime=15m` | `5` | `00:05:00` | `00:05:00` ✓ |

- [x] **Lifetime actually enforced.** Submitted with `time=1` (1 minute) + `sleep infinity`; SLURM killed it at 1 min mark (`JobState=TIMEOUT`, `Reason=TimeLimit`). Proves the user's `--time` is respected and not held open by SkyPilot's `sleep infinity`.
- [x] **SLURM rejects out-of-range.** On `MaxTime=30m` partition, `time=60` → `JobState=PENDING`, `Reason=PartitionTimeLimit` (surfaced via sky's `on_pending` callback).
- [x] **Actual #9370 repro.** Created a maintenance reservation 15 min out; pre-fix-style submission (`--time=UNLIMITED`) → `PENDING / ReqNodeNotAvail,_Reserved_for_maintenance` (the user's exact symptom). Post-fix path (no `--time`, partition `DefaultTime=10m`) → `RUNNING` with `TimeLimit=00:10:00`, scheduled cleanly. Also verified via real `sky launch`.
- [x] **Input validation.** Smoke-tested 15 inputs to `_build_custom_sbatch_directives` — accepted (`5`, `5:00`, `4:00:00`, `1-12`, `1-12:30`, `1-12:30:45`, yaml int, short form `t`), rejected (`garbage`, `1h`, `1.5`, `-1`, `5 `, empty, `1:2:3:4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)