### PR TITLE
[GCP] Add RTX PRO 6000 Blackwell (G4) support

### DIFF
--- a/sky/catalog/__init__.py
+++ b/sky/catalog/__init__.py
@@ -350,6 +350,7 @@ def get_common_gpus() -> List[str]:
         'L4',
         'L40S',
         'RTX5090',
+        'RTXPRO6000',
         'T4',
         'V100',
         'V100-32GB',

--- a/sky/catalog/data_fetchers/fetch_gcp.py
+++ b/sky/catalog/data_fetchers/fetch_gcp.py
@@ -182,9 +182,9 @@ TPU_V4_HOST_DF = pd.read_csv(
 SERIES_TO_DESCRIPTION = {
     'a2': 'A2 Instance',
     'a3': 'A3 Instance',
-    # NOTE: GCP does not provide separate CPU/RAM pricing for A4 instances.
-    # The B200 GPU pricing includes the full VM cost. See special handling in
-    # get_vm_price() which sets A4 VM price to 0.
+    # NOTE: GCP does not provide separate CPU/RAM pricing for A4
+    # instances. The B200 GPU SKU includes the full VM cost. See special
+    # handling in get_vm_price() which sets A4 VM price to 0.
     'a4': 'A4 Instance',
     'c2': 'Compute optimized',
     'c2d': 'C2D AMD Instance',
@@ -410,9 +410,9 @@ def get_vm_df(skus: List[Dict[str, Any]], region_prefix: str) -> 'pd.DataFrame':
             memory_price = 0.0
 
         # Special case for A4 instances.
-        # GCP does not provide separate CPU/RAM pricing for A4 instances in the
-        # SKUs API. The GPU pricing (B200) includes the full VM cost.
-        # We set the VM price to 0 so the entry is not dropped, and the GPU
+        # GCP does not provide separate CPU/RAM pricing for A4 instances in
+        # the SKUs API. The B200 GPU SKU includes the full VM cost. We set
+        # the VM price to 0 so the entry is not dropped, and the GPU
         # pricing will provide the total cost.
         if series == 'a4':
             cpu_price = 0.0
@@ -461,6 +461,13 @@ def _get_gpus_for_zone(zone: str) -> 'pd.DataFrame':
             gpu_name = gpu_name.replace('nvidia-', '')
             gpu_name = gpu_name.replace('tesla-', '')
             gpu_name = gpu_name.upper()
+            # Skip Virtual Workstation (vGPU) variants, e.g. `nvidia-l4-vws`,
+            # `nvidia-rtx-pro-6000-vws`. This must run before the renaming
+            # below: the `RTX-PRO-6000` substring match would otherwise
+            # rewrite `RTX-PRO-6000-VWS` to `RTXPRO6000` and strip the `VWS`
+            # token, letting the workstation SKU escape this filter.
+            if 'VWS' in gpu_name:
+                continue
             if 'H100-80GB' in gpu_name:
                 gpu_name = 'H100'
 
@@ -476,8 +483,10 @@ def _get_gpus_for_zone(zone: str) -> 'pd.DataFrame':
                 gpu_name = 'B200'
                 if count != 8:
                     continue
-            if 'VWS' in gpu_name:
-                continue
+            elif 'RTX-PRO-6000' in gpu_name:
+                # GCP accelerator name is `nvidia-rtx-pro-6000`; normalize to
+                # SkyPilot's hyphen-less convention (matches AWS / RunPod).
+                gpu_name = 'RTXPRO6000'
             if gpu_name.startswith('TPU-'):
                 continue
             gpu_info = _gpu_info_from_name(gpu_name)
@@ -507,6 +516,7 @@ def _gpu_info_from_name(name: str) -> Optional[Dict[str, List[Dict[str, Any]]]]:
         'H100-MEGA': 80 * 1024,
         'H200': 141 * 1024,
         'B200': 180 * 1024,
+        'RTXPRO6000': 96 * 1024,
         'P4': 8 * 1024,
         'T4': 16 * 1024,
         'V100': 16 * 1024,
@@ -569,6 +579,13 @@ def get_gpu_df(skus: List[Dict[str, Any]],
             if not spot and row_gpu_name == 'B200' and is_spot_description:
                 continue
 
+            # Skip Dynamic Workload Scheduler "Defined Duration" SKUs. GCP
+            # publishes them alongside the regular OnDemand SKU for some
+            # accelerators (notably G4's RTX 6000), but they represent a
+            # separate reservation product, not the standard hourly rate.
+            if 'dws defined duration' in description.lower():
+                continue
+
             gpu_names = [f'{row_gpu_name} GPU']
             if row_gpu_name == 'A100-80GB':
                 gpu_names = ['A100 80GB GPU']
@@ -585,6 +602,10 @@ def get_gpu_df(skus: List[Dict[str, Any]],
                 gpu_names = ['H200 141GB GPU']
             elif row_gpu_name == 'B200':
                 gpu_names = ['Nvidia B200 (1 gpu slice)']
+            elif row_gpu_name == 'RTXPRO6000':
+                # GCP's billing description for the G4 GPU SKU is
+                # "RTX 6000 96GB" (e.g. "RTX 6000 96GB running in Iowa").
+                gpu_names = ['RTX 6000 96GB']
             if not any(
                     gpu_name in sku['description'] for gpu_name in gpu_names):
                 continue

--- a/sky/catalog/gcp_catalog.py
+++ b/sky/catalog/gcp_catalog.py
@@ -128,6 +128,12 @@ _ACC_INSTANCE_TYPE_DICTS = {
     'B200': {
         8: ['a4-highgpu-8g'],
     },
+    'RTXPRO6000': {
+        1: ['g4-standard-48'],
+        2: ['g4-standard-96'],
+        4: ['g4-standard-192'],
+        8: ['g4-standard-384'],
+    },
 }
 # Enable GPU type inference from instance types
 _INSTANCE_TYPE_TO_ACC = {

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -606,8 +606,14 @@ class GCP(clouds.Cloud):
                 # Convert to GCP names:
                 # https://cloud.google.com/compute/docs/gpus
                 if acc in ('A100-80GB', 'L4', 'B200'):
-                    # A100-80GB and L4 have a different name pattern.
+                    # A100-80GB, L4, and B200 use the `nvidia-<acc>` form
+                    # rather than `nvidia-tesla-<acc>`.
                     resources_vars['gpu'] = f'nvidia-{acc.lower()}'
+                elif acc == 'RTXPRO6000':
+                    # GCP's accelerator type is `nvidia-rtx-pro-6000`; the
+                    # `nvidia-{acc.lower()}` shortcut would produce the wrong
+                    # `nvidia-rtxpro6000`.
+                    resources_vars['gpu'] = 'nvidia-rtx-pro-6000'
                 elif acc in ('H100', 'H100-MEGA'):
                     resources_vars['gpu'] = f'nvidia-{acc.lower()}-80gb'
                 elif acc in ('H200',):
@@ -1236,8 +1242,10 @@ class GCP(clouds.Cloud):
             # These series don't support pd-standard, use pd-balanced for LOW.
             _propagate_disk_type(
                 lowest=tier2name[resources_utils.DiskTier.MEDIUM])
-        if instance_type.startswith('a3-ultragpu') or series in ('n4', 'a4'):
-            # a3-ultragpu, n4, and a4 instances only support hyperdisk-balanced.
+        if instance_type.startswith('a3-ultragpu') or series in ('n4', 'a4',
+                                                                 'g4'):
+            # a3-ultragpu, n4, a4, and g4 instances only support
+            # hyperdisk-balanced.
             _propagate_disk_type(all='hyperdisk-balanced')
 
         # Series specific handling

--- a/sky/provision/gcp/volume_utils.py
+++ b/sky/provision/gcp/volume_utils.py
@@ -85,7 +85,7 @@ def get_data_disk_tier_mapping(
         num_cpus = int(instance_type.split('-')[2])  # type: ignore
         if num_cpus < 88:
             tier2name[resources_utils.DiskTier.ULTRA] = 'hyperdisk-balanced'
-    elif series in ['n4']:
+    elif series in ['n4', 'g4']:
         tier2name[resources_utils.DiskTier.ULTRA] = 'hyperdisk-balanced'
         tier2name[resources_utils.DiskTier.HIGH] = 'hyperdisk-balanced'
         tier2name[resources_utils.DiskTier.MEDIUM] = 'hyperdisk-balanced'

--- a/tests/unit_tests/test_catalog.py
+++ b/tests/unit_tests/test_catalog.py
@@ -8,8 +8,16 @@ import orjson
 import pandas as pd
 import pytest
 
+from sky import catalog
 from sky.catalog import common as catalog_common
 from sky.utils import annotations
+
+
+def test_rtxpro6000_in_common_gpus():
+    # RTXPRO6000 (NVIDIA RTX PRO 6000 Blackwell) must appear in the common GPU
+    # list so that `sky show-gpus` surfaces it across clouds. Naming matches
+    # the AWS and RunPod catalogs (no hyphens), not GCP's `nvidia-rtx-pro-6000`.
+    assert 'RTXPRO6000' in catalog.get_common_gpus()
 
 
 @mock.patch('sky.catalog.common.requests.get')

--- a/tests/unit_tests/test_gcp.py
+++ b/tests/unit_tests/test_gcp.py
@@ -8,6 +8,7 @@ from sky import logs
 from sky import resources
 from sky import skypilot_config
 from sky.backends import backend_utils
+from sky.catalog import gcp_catalog
 from sky.clouds import Region
 from sky.clouds import Zone
 from sky.clouds.gcp import GCP
@@ -15,8 +16,44 @@ from sky.clouds.utils import gcp_utils
 from sky.provision import common
 from sky.provision.gcp import config as gcp_config
 from sky.provision.gcp import constants as gcp_constants
+from sky.provision.gcp import volume_utils as gcp_volume_utils
 from sky.utils import common_utils
 from sky.utils import config_utils
+from sky.utils import resources_utils
+
+
+def test_gcp_rtxpro6000_instance_type_mapping():
+    # RTXPRO6000 (GCP G4) maps to g4-standard-{48,96,192,384} for 1/2/4/8 GPUs.
+    assert gcp_catalog._ACC_INSTANCE_TYPE_DICTS['RTXPRO6000'] == {
+        1: ['g4-standard-48'],
+        2: ['g4-standard-96'],
+        4: ['g4-standard-192'],
+        8: ['g4-standard-384'],
+    }
+    expected = {
+        'g4-standard-48': 1,
+        'g4-standard-96': 2,
+        'g4-standard-192': 4,
+        'g4-standard-384': 8,
+    }
+    for instance_type, count in expected.items():
+        assert gcp_catalog._INSTANCE_TYPE_TO_ACC[instance_type] == {
+            'RTXPRO6000': count,
+        }
+
+
+@pytest.mark.parametrize(
+    'instance_type',
+    ['g4-standard-48', 'g4-standard-96', 'g4-standard-192', 'g4-standard-384'])
+def test_gcp_g4_uses_hyperdisk_balanced(instance_type):
+    # G4 only supports hyperdisk-balanced (no pd-* support), like n4/a4.
+    tier2name = gcp_volume_utils.get_data_disk_tier_mapping(instance_type)
+    for tier in resources_utils.DiskTier:
+        if tier == resources_utils.DiskTier.BEST:
+            continue
+        assert tier2name[tier] == 'hyperdisk-balanced', (
+            f'{instance_type} tier {tier.value} should be hyperdisk-balanced, '
+            f'got {tier2name[tier]}')
 
 
 @pytest.mark.parametrize((


### PR DESCRIPTION
## Summary

Add support for NVIDIA RTX PRO 6000 Blackwell (96 GB) on GCP's G4 family (`g4-standard-{48,96,192,384}`) for 1/2/4/8 GPUs. The GPU is registered as `RTXPRO6000` — matching the existing AWS and RunPod catalog naming (hyphen-less) for consistency across clouds.

Unlike A4/B200, GCP bills G4 with separate CPU/RAM/GPU SKUs (the standard pattern, same as L4/H100), so no special-case is needed in `get_vm_price()`. See "Tested" below for the verification against the GCP Cloud Billing Catalog API.

**Companion PR: #9639** ([GCP] Bump GPU image to NVIDIA 580 open + CUDA 13 for Blackwell). This PR adds the catalog/launch-path metadata only; #9639 updates `cuda.sh` so the rebuilt image actually supports Blackwell drivers. The two are independent and can be reviewed / merged in either order — full end-to-end RTX PRO 6000 support requires both, plus a maintainer-driven Packer rebuild and catalog image bump.

**Catalog fetcher** (`sky/catalog/data_fetchers/fetch_gcp.py`):
- Add `g4` to `SERIES_TO_DESCRIPTION` so VM rows are kept.
- Normalize the GCP accelerator name `nvidia-rtx-pro-6000` to SkyPilot's `RTXPRO6000` and register 96 GiB of GPU memory.
- Match GCP's billing description `RTX 6000 96GB`, and skip `DWS Defined Duration` SKUs — Dynamic Workload Scheduler is a separate reservation product, not the standard hourly rate.

**Launch path** (`sky/clouds/gcp.py`, `sky/catalog/gcp_catalog.py`, `sky/provision/gcp/volume_utils.py`):
- Register `RTXPRO6000` in `get_common_gpus()` and add the count → `g4-standard-*` mapping in `_ACC_INSTANCE_TYPE_DICTS`. Without the latter the optimizer falls back to n1 for unknown GPUs.
- Map `RTXPRO6000` explicitly to the GCP accelerator type `nvidia-rtx-pro-6000` (the `nvidia-{acc.lower()}` shortcut used for A100-80GB/L4/B200 would produce the wrong `nvidia-rtxpro6000`).
- Add `g4` to the n4/a4 hyperdisk-balanced-only set; G4 does not support pd-* disks.

**Unit tests** (`tests/unit_tests/test_catalog.py`, `tests/unit_tests/test_gcp.py`):
- `RTXPRO6000` is in `catalog.get_common_gpus()`.
- `gcp_catalog._ACC_INSTANCE_TYPE_DICTS['RTXPRO6000']` maps 1/2/4/8 GPUs to `g4-standard-{48,96,192,384}` and the reverse `_INSTANCE_TYPE_TO_ACC` is consistent.
- `volume_utils.get_data_disk_tier_mapping` returns hyperdisk-balanced for all four `g4-standard-*` shapes.

Tested:

- [x] Code formatting: `bash format.sh` clean (yapf / isort / mypy / pylint 10.00/10).
- [x] New unit tests:
  ```
  pytest tests/unit_tests/test_catalog.py::test_rtxpro6000_in_common_gpus \
         tests/unit_tests/test_gcp.py::test_gcp_rtxpro6000_instance_type_mapping \
         tests/unit_tests/test_gcp.py::test_gcp_g4_uses_hyperdisk_balanced
  ```
  → 6 items pass.
- [x] Cross-checked the fetcher output against GCP's Cloud Billing Catalog API for europe-west4 (OnDemand):
  | Component | GCP SKU | Hourly rate |
  |---|---|---|
  | CPU | `G4 Instance Core running in Netherlands` | $0.053801/vCPU |
  | RAM | `G4 Instance Ram running in Netherlands` | $0.006457/GiB |
  | GPU | `RTX 6000 96GB running in Netherlands` | $1.205215/GPU |

  Computed total for `g4-standard-384` (8 GPU): 384×$0.0538 + 1440×$0.00646 + 8×$1.205 = **$39.60/hr** — matches the deployed SkyPilot catalog to the cent.
- [x] Launch-path UX (deployed catalog built from this branch):
  - `sky gpus list RTXPRO6000 --infra gcp/europe-west4` lists 1/2/4/8 GPU rows at $4.95 / $9.90 / $19.80 / $39.60 per hour.
  - `sky launch --infra gcp/europe-west4 --gpus RTXPRO6000:1 --dryrun` picks `g4-standard-48` at $4.95/hr.
- [x] Smoke tests — could a maintainer please trigger `/quicktest-core` and `/smoke-test --gcp`? I don't have permission to run CI.
