### PR TITLE
[Jobs] Speed up pool dashboard with batched query and indexes

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1374,15 +1374,24 @@ def get_handle_from_cluster_name(
 def get_handles_from_cluster_names(
         cluster_names: Set[str]
 ) -> Dict[str, Optional['backends.ResourceHandle']]:
+    # Chunk the IN list to stay under SQLite's SQLITE_MAX_VARIABLE_NUMBER
+    # (default 999 on sqlite < 3.32) and avoid huge IN-clause planning on
+    # PostgreSQL. See _CLUSTER_IN_QUERY_CHUNK_SIZE for the rationale.
+    result: Dict[str, Optional['backends.ResourceHandle']] = {}
+    if not cluster_names:
+        return result
     engine = _db_manager.get_engine()
+    names_list = list(cluster_names)
     with orm.Session(engine) as session:
-        rows = session.query(cluster_table.c.name,
-                             cluster_table.c.handle).filter(
-                                 cluster_table.c.name.in_(cluster_names)).all()
-        return {
-            row.name: pickle.loads(row.handle) if row is not None else None
-            for row in rows
-        }
+        for offset in range(0, len(names_list), _CLUSTER_IN_QUERY_CHUNK_SIZE):
+            batch = names_list[offset:offset + _CLUSTER_IN_QUERY_CHUNK_SIZE]
+            rows = session.query(cluster_table.c.name,
+                                 cluster_table.c.handle).filter(
+                                     cluster_table.c.name.in_(batch)).all()
+            for row in rows:
+                result[row.name] = (pickle.loads(row.handle)
+                                    if row is not None else None)
+    return result
 
 
 @metrics_lib.time_me
@@ -1889,6 +1898,106 @@ def get_cluster_from_name(
         record['user_name'] = user_name
 
     return record
+
+
+# Bound the IN list per query so we stay under SQLite's
+# SQLITE_MAX_VARIABLE_NUMBER (default 999 on sqlite < 3.32, 32766+ on newer
+# builds) and avoid pathological IN-clause planning on PostgreSQL. 500 is
+# comfortably under both ceilings.
+# Module-level so tests can monkeypatch.
+_CLUSTER_IN_QUERY_CHUNK_SIZE = 500
+
+
+@metrics_lib.time_me
+def get_clusters_from_names(
+    cluster_names: List[str],
+    *,
+    include_user_info: bool = False,
+    summary_response: bool = True,
+) -> Dict[str, Optional[Dict[str, Any]]]:
+    """Batched ``get_cluster_from_name`` for many cluster names at once.
+
+    Args:
+        cluster_names: List of cluster names to look up.
+        include_user_info: If True, per-row resolve user_hash → user. This
+            re-introduces a per-row DB lookup, so it's off by default.
+        summary_response: If True, skip the last_creation_yaml /
+            last_creation_command / last_event fields. Matches the existing
+            ``get_cluster_from_name(summary_response=True)`` defaults used by
+            ``to_info_dict``.
+
+    Returns:
+        Dict mapping ``cluster_name`` to its record (same shape as
+        ``get_cluster_from_name`` returns), or to ``None`` for names that
+        don't exist in the cluster table.
+    """
+    result: Dict[str,
+                 Optional[Dict[str,
+                               Any]]] = {name: None for name in cluster_names}
+    if not cluster_names:
+        return result
+    engine = _db_manager.get_engine()
+    query_fields = [
+        cluster_table.c.name,
+        cluster_table.c.launched_at,
+        cluster_table.c.handle,
+        cluster_table.c.last_use,
+        cluster_table.c.status,
+        cluster_table.c.autostop,
+        cluster_table.c.to_down,
+        cluster_table.c.owner,
+        cluster_table.c.metadata,
+        cluster_table.c.cluster_hash,
+        cluster_table.c.cluster_ever_up,
+        cluster_table.c.status_updated_at,
+        cluster_table.c.user_hash,
+        cluster_table.c.config_hash,
+        cluster_table.c.workspace,
+        cluster_table.c.is_managed,
+    ]
+    if not summary_response:
+        query_fields.extend([
+            cluster_table.c.last_creation_yaml,
+            cluster_table.c.last_creation_command,
+        ])
+    with orm.Session(engine) as session:
+        for offset in range(0, len(cluster_names),
+                            _CLUSTER_IN_QUERY_CHUNK_SIZE):
+            batch = cluster_names[offset:offset + _CLUSTER_IN_QUERY_CHUNK_SIZE]
+            rows = session.query(*query_fields).filter(
+                cluster_table.c.name.in_(batch)).all()
+            for row in rows:
+                record: Dict[str, Any] = {
+                    'name': row.name,
+                    'launched_at': row.launched_at,
+                    'handle': pickle.loads(row.handle),
+                    'last_use': row.last_use,
+                    'status': status_lib.ClusterStatus[row.status],
+                    'autostop': row.autostop,
+                    'to_down': bool(row.to_down),
+                    'owner': _load_owner(row.owner),
+                    'metadata': json.loads(row.metadata),
+                    'cluster_hash': row.cluster_hash,
+                    'cluster_ever_up': bool(row.cluster_ever_up),
+                    'status_updated_at': row.status_updated_at,
+                    'workspace': row.workspace,
+                    'is_managed': bool(row.is_managed),
+                    'config_hash': row.config_hash,
+                }
+                if not summary_response:
+                    record['last_creation_yaml'] = row.last_creation_yaml
+                    record['last_creation_command'] = row.last_creation_command
+                    # last_event would be per-row DB work; not supported in
+                    # the batched path. Callers needing it should use
+                    # get_cluster_from_name.
+                if include_user_info:
+                    user_hash = _get_user_hash_or_current_user(row.user_hash)
+                    user = get_user(user_hash)
+                    record['user_hash'] = user_hash
+                    record['user_name'] = (user.name
+                                           if user is not None else None)
+                result[row.name] = record
+    return result
 
 
 @metrics_lib.time_me

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1913,23 +1913,24 @@ def get_clusters_from_names(
     cluster_names: List[str],
     *,
     include_user_info: bool = False,
-    summary_response: bool = True,
 ) -> Dict[str, Optional[Dict[str, Any]]]:
     """Batched ``get_cluster_from_name`` for many cluster names at once.
+
+    Returns records in the same shape as
+    ``get_cluster_from_name(summary_response=True)``. The verbose
+    ``summary_response=False`` mode is intentionally not exposed here: it
+    would also require batching ``get_terminal_or_last_status_change_event``
+    (another per-row DB call), which is out of scope for the callers that
+    motivated this helper. Use ``get_cluster_from_name`` for those fields.
 
     Args:
         cluster_names: List of cluster names to look up.
         include_user_info: If True, per-row resolve user_hash → user. This
             re-introduces a per-row DB lookup, so it's off by default.
-        summary_response: If True, skip the last_creation_yaml /
-            last_creation_command / last_event fields. Matches the existing
-            ``get_cluster_from_name(summary_response=True)`` defaults used by
-            ``to_info_dict``.
 
     Returns:
-        Dict mapping ``cluster_name`` to its record (same shape as
-        ``get_cluster_from_name`` returns), or to ``None`` for names that
-        don't exist in the cluster table.
+        Dict mapping ``cluster_name`` to its record, or to ``None`` for
+        names that don't exist in the cluster table.
     """
     result: Dict[str,
                  Optional[Dict[str,
@@ -1955,11 +1956,6 @@ def get_clusters_from_names(
         cluster_table.c.workspace,
         cluster_table.c.is_managed,
     ]
-    if not summary_response:
-        query_fields.extend([
-            cluster_table.c.last_creation_yaml,
-            cluster_table.c.last_creation_command,
-        ])
     with orm.Session(engine) as session:
         for offset in range(0, len(cluster_names),
                             _CLUSTER_IN_QUERY_CHUNK_SIZE):
@@ -1984,12 +1980,6 @@ def get_clusters_from_names(
                     'is_managed': bool(row.is_managed),
                     'config_hash': row.config_hash,
                 }
-                if not summary_response:
-                    record['last_creation_yaml'] = row.last_creation_yaml
-                    record['last_creation_command'] = row.last_creation_command
-                    # last_event would be per-row DB work; not supported in
-                    # the batched path. Callers needing it should use
-                    # get_cluster_from_name.
                 if include_user_info:
                     user_hash = _get_user_hash_or_current_user(row.user_hash)
                     user = get_user(user_hash)

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -77,7 +77,11 @@ spot_table = sqlalchemy.Table(
     sqlalchemy.Column('job_name', sqlalchemy.Text),
     sqlalchemy.Column('resources', sqlalchemy.Text),
     sqlalchemy.Column('submitted_at', sqlalchemy.Float),
-    sqlalchemy.Column('status', sqlalchemy.Text),
+    # Indexed because non-terminal-status filtering on this column is on the
+    # hot path for the pool dashboard (per-pool job listing) and skip_finished
+    # queries; without it the filter is a full table scan over all (including
+    # finished) tasks.
+    sqlalchemy.Column('status', sqlalchemy.Text, index=True),
     sqlalchemy.Column('run_timestamp', sqlalchemy.Text),
     sqlalchemy.Column('start_at', sqlalchemy.Float, server_default=None),
     sqlalchemy.Column('end_at', sqlalchemy.Float, server_default=None),
@@ -138,10 +142,17 @@ job_info_table = sqlalchemy.Table(
     sqlalchemy.Column('original_user_yaml_content',
                       sqlalchemy.Text,
                       server_default=None),
-    sqlalchemy.Column('pool', sqlalchemy.Text, server_default=None),
+    # Indexed: every per-pool dashboard query and pool_status request filters
+    # by this column. Without an index a job_info table with tens of thousands
+    # of (mostly finished) rows turns each pool lookup into a full scan.
+    sqlalchemy.Column('pool', sqlalchemy.Text, server_default=None, index=True),
+    # Indexed: pool_status fetches per-replica used_by lists by filtering on
+    # current_cluster_name; the index keeps that fast when many jobs share
+    # the same pool.
     sqlalchemy.Column('current_cluster_name',
                       sqlalchemy.Text,
-                      server_default=None),
+                      server_default=None,
+                      index=True),
     sqlalchemy.Column('job_id_on_pool_cluster',
                       sqlalchemy.Integer,
                       server_default=None),
@@ -2249,6 +2260,46 @@ def get_nonterminal_job_ids_by_pool(pool: str,
         rows = session.execute(query).fetchall()
         job_ids = [row[0] for row in rows if row[0] is not None]
         return job_ids
+
+
+def get_nonterminal_job_ids_by_pool_grouped(
+        pool: str) -> Dict[Optional[str], List[int]]:
+    """Get nonterminal job ids in a pool, grouped by current_cluster_name.
+
+    Equivalent to calling get_nonterminal_job_ids_by_pool once per replica
+    (plus once for the pool as a whole), but executed in a single query so
+    callers like pool_status avoid the N+1 round-trips that dominate
+    dashboard latency when there are many finished jobs.
+
+    Returns:
+        A dict mapping current_cluster_name to the list of nonterminal
+        spot_job_ids assigned to that cluster. Jobs not yet bound to a
+        specific cluster (current_cluster_name IS NULL) are grouped under
+        the ``None`` key. Each list is sorted by spot_job_id ascending.
+    """
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        query = sqlalchemy.select(
+            job_info_table.c.current_cluster_name,
+            spot_table.c.spot_job_id,
+        ).distinct().select_from(
+            spot_table.outerjoin(
+                job_info_table, spot_table.c.spot_job_id ==
+                job_info_table.c.spot_job_id)).where(
+                    sqlalchemy.and_(
+                        ~spot_table.c.status.in_([
+                            status.value
+                            for status in ManagedJobStatus.terminal_statuses()
+                        ]),
+                        job_info_table.c.pool == pool,
+                    )).order_by(spot_table.c.spot_job_id.asc())
+        rows = session.execute(query).fetchall()
+        result: Dict[Optional[str], List[int]] = {}
+        for cluster_name, job_id in rows:
+            if job_id is None:
+                continue
+            result.setdefault(cluster_name, []).append(job_id)
+        return result
 
 
 def _is_any_of_or_ordered(resource_config: Dict[str, Any]) -> bool:

--- a/sky/schemas/db/spot_jobs/020_add_pool_indexes.py
+++ b/sky/schemas/db/spot_jobs/020_add_pool_indexes.py
@@ -1,0 +1,64 @@
+"""Add indexes for pool dashboard queries.
+
+The pool dashboard executes per-pool job lookups (via
+`get_nonterminal_job_ids_by_pool` in `sky/jobs/state.py`) and `skip_finished`
+queue scans on every refresh. Without these indexes both code paths fall back
+to full scans of the `spot` and `job_info` tables, which becomes >1min on
+deployments with tens of thousands of finished jobs and only a handful of
+pools.
+
+Indexes added:
+  - job_info.pool: every per-pool query filters on this column.
+  - job_info.current_cluster_name: per-replica `used_by` lookups filter on
+    this column.
+  - spot.status: non-terminal filtering (NOT IN (terminal_statuses)) is on
+    the hot path for both pool_status and the dashboard's skip_finished
+    managed-jobs fetch.
+
+Revision ID: 020
+Revises: 019
+Create Date: 2026-05-18
+
+"""
+# pylint: disable=invalid-name
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '020'
+down_revision: Union[str, Sequence[str], None] = '019'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_INDEXES = (
+    ('ix_job_info_pool', 'job_info', ['pool']),
+    ('ix_job_info_current_cluster_name', 'job_info', ['current_cluster_name']),
+    ('ix_spot_status', 'spot', ['status']),
+)
+
+
+def _existing_indexes(table_name: str) -> set:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return {ix['name'] for ix in inspector.get_indexes(table_name)}
+
+
+def upgrade():
+    """Create pool-dashboard indexes if they don't already exist.
+
+    Idempotent: skips any index that already exists. Each index is created
+    inside its own autocommit block so PostgreSQL is happy with implicit
+    transactional DDL and SQLite can run the statements directly.
+    """
+    for index_name, table_name, columns in _INDEXES:
+        if index_name in _existing_indexes(table_name):
+            continue
+        with op.get_context().autocommit_block():
+            op.create_index(index_name, table_name, columns)
+
+
+def downgrade():
+    """No-op for backward compatibility."""
+    pass

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -52,6 +52,13 @@ _RETRY_INIT_GAP_SECONDS = 60
 _DEFAULT_DRAIN_SECONDS = 120
 _WAIT_LAUNCH_THREAD_TIMEOUT_SECONDS = 15
 
+# Sentinel for to_info_dict's pre-fetched cluster_record
+# parameters. We can't use None because None is a legitimate value (it means
+# "no cluster row" / "no handle"). The sentinel lets callers opt in to the
+# batched fetch path while preserving the existing self-fetch behavior for
+# back-compat callers like ReplicaInfo.__repr__.
+_NOT_PROVIDED: Any = object()
+
 # TODO(tian): Backward compatibility. Remove this after 3 minor release, i.e.
 # 0.13.0. We move the ProcessStatus to common_utils.ProcessStatus in #6666, but
 # old ReplicaInfo in database will still tries to unpickle using ProcessStatus
@@ -527,9 +534,28 @@ class ReplicaInfo:
 
     def to_info_dict(self,
                      with_handle: bool,
-                     with_url: bool = True) -> Dict[str, Any]:
-        cluster_record = global_user_state.get_cluster_from_name(
-            self.cluster_name, include_user_info=False, summary_response=True)
+                     with_url: bool = True,
+                     cluster_record: Any = _NOT_PROVIDED) -> Dict[str, Any]:
+        """Build the dashboard/CLI view dict for this replica.
+
+        Args:
+            with_handle: include the (pickled) ResourceHandle and derived
+                cloud/region/resources_str fields.
+            with_url: resolve the replica endpoint via ``self.url`` (does a
+                cluster lookup itself). Off for pool views.
+            cluster_record: optional pre-fetched record from
+                ``global_user_state.get_cluster_from_name`` /
+                ``get_clusters_from_names``. Pass to avoid the per-replica
+                DB round-trip when iterating many replicas. Use
+                ``_NOT_PROVIDED`` (the default) to fall back to the
+                self-fetch path for backward compatibility (e.g. ``__repr__``
+                still works without changes).
+        """
+        if cluster_record is _NOT_PROVIDED:
+            cluster_record = global_user_state.get_cluster_from_name(
+                self.cluster_name,
+                include_user_info=False,
+                summary_response=True)
         info_dict = {
             'replica_id': self.replica_id,
             'name': self.cluster_name,
@@ -542,7 +568,14 @@ class ReplicaInfo:
                             if cluster_record is not None else None),
         }
         if with_handle:
-            handle = self.handle(cluster_record)
+            # When the cluster row is missing, the handle is also missing
+            # (they live in the same row). ``self.handle(None)`` would issue
+            # another DB lookup against the same row and return None
+            # anyway, so short-circuit instead.
+            if cluster_record is None:
+                handle = None
+            else:
+                handle = self.handle(cluster_record)
             info_dict['handle'] = handle
             if handle is not None:
                 info_dict['cloud'] = repr(handle.launched_resources.cloud)

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -836,14 +836,25 @@ def _get_service_status(
             for info in serve_state.get_replica_infos(service_name)
         ]
         if pool:
-            # Get pool-level jobs (e.g. batch coordinators) that use
-            # all workers — they have pool set but no cluster_name.
-            pool_level_job_ids = (
-                managed_job_state.get_nonterminal_job_ids_by_pool(
-                    service_name, cluster_name=None))
+            # Fetch all nonterminal job ids in the pool in a single query,
+            # grouped by current_cluster_name. Avoids the N+1 pattern of
+            # (1 + len(replicas)) per-pool queries against a job_info table
+            # that may contain tens of thousands of finished rows.
+            jobs_by_cluster = (
+                managed_job_state.get_nonterminal_job_ids_by_pool_grouped(
+                    service_name))
+            # Pool-level jobs (e.g. batch coordinators) span every worker.
+            # They have pool set but no cluster_name, so they live under the
+            # None bucket of the grouped result. Note: the prior per-call
+            # implementation passed cluster_name=None to a function that
+            # treated None as "no filter" rather than "IS NULL", so it
+            # accidentally returned every nonterminal job in the pool and
+            # surfaced unrelated replicas' jobs as `used_by` on each READY
+            # worker. The grouped query lets us implement the intended
+            # semantic exactly.
+            pool_level_job_ids = list(jobs_by_cluster.get(None, []))
             for replica_info in record['replica_info']:
-                job_ids = managed_job_state.get_nonterminal_job_ids_by_pool(
-                    service_name, replica_info['name'])
+                job_ids = list(jobs_by_cluster.get(replica_info['name'], []))
                 # Show pool-level jobs on READY workers only.
                 if (replica_info.get('status') ==
                         serve_state.ReplicaStatus.READY):

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -837,10 +837,7 @@ def _get_service_status(
         # history this was an N+1.
         cluster_names = [info.cluster_name for info in replica_infos]
         cluster_records = global_user_state.get_clusters_from_names(
-            cluster_names,
-            include_user_info=False,
-            summary_response=True,
-        )
+            cluster_names)
         record['replica_info'] = [
             info.to_info_dict(
                 with_handle=True,

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -831,9 +831,22 @@ def _get_service_status(
                      f'Traceback: {traceback.format_exc()}')
 
     if with_replica_info:
+        replica_infos = serve_state.get_replica_infos(service_name)
+        # Pre-fetch cluster records in one batched DB query instead of
+        # letting each to_info_dict() do its own. With a long failure
+        # history this was an N+1.
+        cluster_names = [info.cluster_name for info in replica_infos]
+        cluster_records = global_user_state.get_clusters_from_names(
+            cluster_names,
+            include_user_info=False,
+            summary_response=True,
+        )
         record['replica_info'] = [
-            info.to_info_dict(with_handle=True, with_url=not pool)
-            for info in serve_state.get_replica_infos(service_name)
+            info.to_info_dict(
+                with_handle=True,
+                with_url=not pool,
+                cluster_record=cluster_records[info.cluster_name],
+            ) for info in replica_infos
         ]
         if pool:
             # Fetch all nonterminal job ids in the pool in a single query,

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -34,7 +34,7 @@ GLOBAL_USER_STATE_VERSION = '018'  # add cluster links column
 GLOBAL_USER_STATE_LOCK_PATH = f'~/.sky/locks/.{GLOBAL_USER_STATE_DB_NAME}.lock'
 
 SPOT_JOBS_DB_NAME = 'spot_jobs_db'
-SPOT_JOBS_VERSION = '019'  # add file_mounts_blob_id column to job_info
+SPOT_JOBS_VERSION = '020'  # add indexes for pool dashboard queries
 SPOT_JOBS_LOCK_PATH = f'~/.sky/locks/.{SPOT_JOBS_DB_NAME}.lock'
 
 SERVE_DB_NAME = 'serve_db'

--- a/tests/unit_tests/test_serve_utils.py
+++ b/tests/unit_tests/test_serve_utils.py
@@ -473,6 +473,10 @@ class TestPoolStatusBatchedQuery:
         # pylint: disable=import-outside-toplevel
         from sky.serve import serve_state
         info = mock.Mock()
+        # cluster_name is what _get_service_status reads when building the
+        # batched names list. Setting it as a real attribute prevents
+        # MagicMock from returning a separate Mock per access.
+        info.cluster_name = name
         info.to_info_dict.return_value = {
             'name': name,
             'status': (status if isinstance(status, serve_state.ReplicaStatus)
@@ -480,7 +484,7 @@ class TestPoolStatusBatchedQuery:
         }
         return info
 
-    def _patch_environment(self, replicas, grouped_jobs):
+    def _patch_environment(self, replicas, grouped_jobs, cluster_records=None):
         # pylint: disable=import-outside-toplevel
         from sky.serve import serve_state
 
@@ -490,6 +494,16 @@ class TestPoolStatusBatchedQuery:
             'version': 1,
             'controller_port': 20001,
         }
+        # Default: every replica's cluster row exists. Tests that want to
+        # simulate "dead" replicas can override by passing cluster_records
+        # with explicit None values.
+        if cluster_records is None:
+            cluster_records = {
+                r.cluster_name: {
+                    'launched_at': 0,
+                    'handle': None,
+                } for r in replicas
+            }
         return (
             mock.patch(
                 'sky.serve.serve_utils.serve_state.get_service_from_name',
@@ -506,6 +520,10 @@ class TestPoolStatusBatchedQuery:
                 return_value=grouped_jobs),
             mock.patch('sky.serve.serve_utils.managed_job_state.'
                        'get_nonterminal_job_ids_by_pool'),
+            mock.patch(
+                'sky.serve.serve_utils.global_user_state.'
+                'get_clusters_from_names',
+                return_value=cluster_records),
             serve_state,  # returned for callers to use as needed
         )
 
@@ -528,9 +546,11 @@ class TestPoolStatusBatchedQuery:
             'replica-2': [30],
         }
         (svc_patch, replica_patch, ctrl_patch, yaml_patch, grouped_patch,
-         legacy_patch, _) = self._patch_environment(replicas, grouped_jobs)
+         legacy_patch, clusters_patch,
+         _) = self._patch_environment(replicas, grouped_jobs)
         with svc_patch, replica_patch, ctrl_patch, yaml_patch, \
-             grouped_patch as mock_grouped, legacy_patch as mock_legacy:
+             grouped_patch as mock_grouped, legacy_patch as mock_legacy, \
+             clusters_patch:
             record = serve_utils._get_service_status('pool-a', pool=True)
 
         assert record is not None
@@ -564,14 +584,112 @@ class TestPoolStatusBatchedQuery:
             'replica-other': [4],
         }
         (svc_patch, replica_patch, ctrl_patch, yaml_patch, grouped_patch,
-         legacy_patch, _) = self._patch_environment(replicas, grouped_jobs)
+         legacy_patch, clusters_patch,
+         _) = self._patch_environment(replicas, grouped_jobs)
         with svc_patch, replica_patch, ctrl_patch, yaml_patch, \
-             grouped_patch, legacy_patch:
+             grouped_patch, legacy_patch, clusters_patch:
             record = serve_utils._get_service_status('pool-a', pool=True)
 
         assert record is not None
         used_by = {r['name']: r['used_by'] for r in record['replica_info']}
         assert used_by['replica-init'] == [2, 3]
+
+    def test_pool_status_uses_batched_cluster_lookups(self):
+        """The per-replica `get_cluster_from_name` call inside to_info_dict
+        used to dominate pool_status latency on pools with long failure
+        history. `_get_service_status` now pre-fetches all records in one
+        batched call and passes them through to to_info_dict.
+
+        There is no separate handle-fallback round-trip: handle is just a
+        column on the same cluster_table row, so when ``cluster_record`` is
+        None the handle is also None and we skip ``self.handle()`` entirely.
+        """
+        # pylint: disable=import-outside-toplevel
+        from sky.serve import serve_state
+
+        replicas = [
+            self._replica(f'r-{i}', serve_state.ReplicaStatus.READY)
+            for i in range(5)
+        ]
+        # First three "alive" (cluster row exists), last two "dead" (cluster
+        # row gone). The dead ones must not trigger any extra DB lookups.
+        cluster_records = {
+            'r-0': {
+                'launched_at': 1,
+                'handle': None
+            },
+            'r-1': {
+                'launched_at': 2,
+                'handle': None
+            },
+            'r-2': {
+                'launched_at': 3,
+                'handle': None
+            },
+            'r-3': None,
+            'r-4': None,
+        }
+        (svc_patch, replica_patch, ctrl_patch, yaml_patch, grouped_patch,
+         legacy_patch, clusters_patch,
+         _) = self._patch_environment(replicas, {None: []},
+                                      cluster_records=cluster_records)
+        # No mock for get_handles_from_cluster_names — the test fails if
+        # _get_service_status reintroduces a redundant call to it.
+        with mock.patch('sky.serve.serve_utils.global_user_state.'
+                        'get_handles_from_cluster_names') as mock_handles:
+            with svc_patch, replica_patch, ctrl_patch, yaml_patch, \
+                 grouped_patch, legacy_patch, \
+                 clusters_patch as mock_clusters:
+                record = serve_utils._get_service_status('pool-a', pool=True)
+
+        assert record is not None
+        # Batched cluster lookup happens exactly once and gets every name.
+        mock_clusters.assert_called_once()
+        passed_names = mock_clusters.call_args.args[0]
+        assert sorted(passed_names) == [f'r-{i}' for i in range(5)]
+        # Handle lookup must not be reintroduced: missing cluster_record
+        # implies missing handle, so the second batched call would be a
+        # guaranteed-empty waste.
+        mock_handles.assert_not_called()
+        # to_info_dict was called per replica with the pre-fetched record
+        # supplied, so it must not re-fetch on its own.
+        for replica_mock in replicas:
+            replica_mock.to_info_dict.assert_called_once()
+            kwargs = replica_mock.to_info_dict.call_args.kwargs
+            assert 'cluster_record' in kwargs
+
+    def test_pool_status_no_handles_lookup_call(self):
+        """All replicas alive: there should never be a fallback handle
+        batched query (deleted by design)."""
+        # pylint: disable=import-outside-toplevel
+        from sky.serve import serve_state
+
+        replicas = [
+            self._replica('r-0', serve_state.ReplicaStatus.READY),
+            self._replica('r-1', serve_state.ReplicaStatus.READY),
+        ]
+        cluster_records = {
+            'r-0': {
+                'launched_at': 1,
+                'handle': None
+            },
+            'r-1': {
+                'launched_at': 2,
+                'handle': None
+            },
+        }
+        (svc_patch, replica_patch, ctrl_patch, yaml_patch, grouped_patch,
+         legacy_patch, clusters_patch,
+         _) = self._patch_environment(replicas, {None: []},
+                                      cluster_records=cluster_records)
+        with mock.patch('sky.serve.serve_utils.global_user_state.'
+                        'get_handles_from_cluster_names') as mock_handles:
+            with svc_patch, replica_patch, ctrl_patch, yaml_patch, \
+                 grouped_patch, legacy_patch, clusters_patch:
+                serve_utils._get_service_status('pool-a', pool=True)
+
+        # The handle-fallback batched query was removed entirely.
+        mock_handles.assert_not_called()
 
 
 class TestTerminalStatuses:

--- a/tests/unit_tests/test_serve_utils.py
+++ b/tests/unit_tests/test_serve_utils.py
@@ -462,6 +462,118 @@ class TestTerminateShuttingDownPurge:
             mock_purge.assert_not_called()
 
 
+class TestPoolStatusBatchedQuery:
+    """`_get_service_status(pool=True)` must batch its per-replica job lookups
+    into a single grouped query. The previous per-replica fan-out scaled with
+    pool replica count and ran a full scan over the job_info table
+    each iteration.
+    """
+
+    def _replica(self, name, status):
+        # pylint: disable=import-outside-toplevel
+        from sky.serve import serve_state
+        info = mock.Mock()
+        info.to_info_dict.return_value = {
+            'name': name,
+            'status': (status if isinstance(status, serve_state.ReplicaStatus)
+                       else serve_state.ReplicaStatus[status]),
+        }
+        return info
+
+    def _patch_environment(self, replicas, grouped_jobs):
+        # pylint: disable=import-outside-toplevel
+        from sky.serve import serve_state
+
+        record = {
+            'name': 'pool-a',
+            'pool': True,
+            'version': 1,
+            'controller_port': 20001,
+        }
+        return (
+            mock.patch(
+                'sky.serve.serve_utils.serve_state.get_service_from_name',
+                return_value=record),
+            mock.patch('sky.serve.serve_utils.serve_state.get_replica_infos',
+                       return_value=replicas),
+            mock.patch('sky.serve.serve_utils._get_to_controller_with_retry',
+                       side_effect=requests_exceptions.RequestException()),
+            mock.patch('sky.serve.serve_utils.get_yaml_content',
+                       side_effect=Exception('skip yaml')),
+            mock.patch(
+                'sky.serve.serve_utils.managed_job_state.'
+                'get_nonterminal_job_ids_by_pool_grouped',
+                return_value=grouped_jobs),
+            mock.patch('sky.serve.serve_utils.managed_job_state.'
+                       'get_nonterminal_job_ids_by_pool'),
+            serve_state,  # returned for callers to use as needed
+        )
+
+    def test_pool_status_uses_grouped_query_once(self):
+        # pylint: disable=import-outside-toplevel
+        from sky.serve import serve_state
+
+        replicas = [
+            self._replica('replica-1', serve_state.ReplicaStatus.READY),
+            self._replica('replica-2', serve_state.ReplicaStatus.READY),
+            self._replica('replica-3', serve_state.ReplicaStatus.PROVISIONING),
+        ]
+        # job 10: batch coordinator (no cluster_name) — should appear on all
+        # READY replicas.
+        # jobs 20, 21: bound to replica-1 — must not leak to replica-2.
+        # job 30: bound to replica-2 — must not leak to replica-1.
+        grouped_jobs = {
+            None: [10],
+            'replica-1': [20, 21],
+            'replica-2': [30],
+        }
+        (svc_patch, replica_patch, ctrl_patch, yaml_patch, grouped_patch,
+         legacy_patch, _) = self._patch_environment(replicas, grouped_jobs)
+        with svc_patch, replica_patch, ctrl_patch, yaml_patch, \
+             grouped_patch as mock_grouped, legacy_patch as mock_legacy:
+            record = serve_utils._get_service_status('pool-a', pool=True)
+
+        assert record is not None
+        # Exactly one DB round-trip — no N+1.
+        mock_grouped.assert_called_once_with('pool-a')
+        mock_legacy.assert_not_called()
+
+        used_by = {r['name']: r['used_by'] for r in record['replica_info']}
+        # READY workers see (pool-level coordinator jobs) + (their own slice).
+        # They must NOT see jobs bound to other replicas: that was a latent
+        # bug in master where every READY worker reported every nonterminal
+        # job in the pool.
+        assert used_by['replica-1'] == [10, 20, 21]
+        assert used_by['replica-2'] == [10, 30]
+        # Non-READY workers only see jobs assigned to them; replica-3 has none.
+        assert used_by['replica-3'] == []
+
+    def test_pool_status_non_ready_only_sees_own_jobs(self):
+        """A non-READY replica with assigned jobs sees only those, not the
+        rest of the pool."""
+        # pylint: disable=import-outside-toplevel
+        from sky.serve import serve_state
+
+        replicas = [
+            self._replica('replica-init',
+                          serve_state.ReplicaStatus.PROVISIONING),
+        ]
+        grouped_jobs = {
+            None: [1],
+            'replica-init': [2, 3],
+            'replica-other': [4],
+        }
+        (svc_patch, replica_patch, ctrl_patch, yaml_patch, grouped_patch,
+         legacy_patch, _) = self._patch_environment(replicas, grouped_jobs)
+        with svc_patch, replica_patch, ctrl_patch, yaml_patch, \
+             grouped_patch, legacy_patch:
+            record = serve_utils._get_service_status('pool-a', pool=True)
+
+        assert record is not None
+        used_by = {r['name']: r['used_by'] for r in record['replica_info']}
+        assert used_by['replica-init'] == [2, 3]
+
+
 class TestTerminalStatuses:
     """`terminal_statuses` includes SHUTTING_DOWN so that callers like
     apply() can refuse to update a row that's either dying or already

--- a/tests/unit_tests/test_sky/jobs/test_state.py
+++ b/tests/unit_tests/test_sky/jobs/test_state.py
@@ -413,3 +413,89 @@ def test_get_active_file_mounts_blob_ids(_mock_managed_jobs_db_conn):
 
     blob_ids = state.get_active_file_mounts_blob_ids()
     assert blob_ids == {'blob-active', 'blob-queued', 'blob-recovering'}
+
+
+def _new_pool_job(engine,
+                  *,
+                  pool: str,
+                  status: ManagedJobStatus,
+                  cluster_name=None) -> int:
+    """Create a managed job in `pool` with optional `current_cluster_name`."""
+    job_id = state.set_job_info_without_job_id(
+        name=f'job-{pool}',
+        workspace='ws',
+        entrypoint='entry',
+        pool=pool,
+        pool_hash=None,
+        user_hash='u',
+    )
+    _insert_task(engine, job_id, 0, status=status)
+    if cluster_name is not None:
+        state.set_current_cluster_name(job_id, cluster_name)
+    return job_id
+
+
+def test_get_nonterminal_job_ids_by_pool_grouped(_mock_managed_jobs_db_conn):
+    """Verify the batched grouped query matches the per-call helper."""
+    engine = state._db_manager.get_engine()
+
+    # Pool A: unassigned job, two replicas with one nonterminal job each,
+    # one job on a replica that is already SUCCEEDED (should be excluded).
+    unassigned_a = _new_pool_job(engine,
+                                 pool='pool-a',
+                                 status=ManagedJobStatus.PENDING)
+    r1_running_a = _new_pool_job(engine,
+                                 pool='pool-a',
+                                 status=ManagedJobStatus.RUNNING,
+                                 cluster_name='replica-1')
+    r1_recovering_a = _new_pool_job(engine,
+                                    pool='pool-a',
+                                    status=ManagedJobStatus.RECOVERING,
+                                    cluster_name='replica-1')
+    r2_running_a = _new_pool_job(engine,
+                                 pool='pool-a',
+                                 status=ManagedJobStatus.RUNNING,
+                                 cluster_name='replica-2')
+    _new_pool_job(engine,
+                  pool='pool-a',
+                  status=ManagedJobStatus.SUCCEEDED,
+                  cluster_name='replica-1')  # terminal -> filtered
+
+    # Pool B: separate pool to ensure the filter is scoped correctly.
+    _new_pool_job(engine, pool='pool-b', status=ManagedJobStatus.RUNNING)
+
+    grouped = state.get_nonterminal_job_ids_by_pool_grouped('pool-a')
+
+    assert set(grouped.keys()) == {None, 'replica-1', 'replica-2'}
+    assert grouped[None] == [unassigned_a]
+    assert grouped['replica-1'] == sorted([r1_running_a, r1_recovering_a])
+    assert grouped['replica-2'] == [r2_running_a]
+
+    # Grouped result must agree with the legacy per-call helper.
+    assert sorted(grouped['replica-1']) == sorted(
+        state.get_nonterminal_job_ids_by_pool('pool-a',
+                                              cluster_name='replica-1'))
+    assert sorted(grouped['replica-2']) == sorted(
+        state.get_nonterminal_job_ids_by_pool('pool-a',
+                                              cluster_name='replica-2'))
+    all_jobs_a = sorted(state.get_nonterminal_job_ids_by_pool('pool-a'))
+    flattened = sorted(j for ids in grouped.values() for j in ids)
+    assert flattened == all_jobs_a
+
+
+def test_get_nonterminal_job_ids_by_pool_grouped_empty(
+        _mock_managed_jobs_db_conn):
+    """No jobs in pool -> empty dict (not raise)."""
+    assert not state.get_nonterminal_job_ids_by_pool_grouped('nope')
+
+
+def test_get_nonterminal_job_ids_by_pool_grouped_all_terminal(
+        _mock_managed_jobs_db_conn):
+    """Pool with only finished jobs should also yield an empty grouping."""
+    engine = state._db_manager.get_engine()
+    _new_pool_job(engine,
+                  pool='pool-done',
+                  status=ManagedJobStatus.SUCCEEDED,
+                  cluster_name='replica-x')
+    _new_pool_job(engine, pool='pool-done', status=ManagedJobStatus.FAILED)
+    assert not state.get_nonterminal_job_ids_by_pool_grouped('pool-done')

--- a/tests/unit_tests/test_sky/test_global_user_state_batched_clusters.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_batched_clusters.py
@@ -60,9 +60,11 @@ def test_get_clusters_from_names_returns_record_per_name(tmp_path, monkeypatch):
     assert result['alive-2'] is not None
     assert result['alive-1']['name'] == 'alive-1'
     assert result['alive-2']['name'] == 'alive-2'
-    # summary_response defaults to True, so these extra fields are absent.
+    # The batched helper intentionally only supports the summary shape, so
+    # the verbose-only fields are never present.
     assert 'last_creation_yaml' not in result['alive-1']
     assert 'last_creation_command' not in result['alive-1']
+    assert 'last_event' not in result['alive-1']
 
 
 def test_get_clusters_from_names_missing_names_become_none(
@@ -79,20 +81,6 @@ def test_get_clusters_from_names_missing_names_become_none(
     assert result['alive-1'] is not None
     assert result['gone-1'] is None
     assert result['gone-2'] is None
-
-
-def test_get_clusters_from_names_summary_false_includes_extras(
-        tmp_path, monkeypatch):
-    """summary_response=False mirrors the single-name path and surfaces
-    the extra last_creation_* columns."""
-    _fresh_db(tmp_path, monkeypatch)
-    _add_cluster('alive-1')
-
-    result = global_user_state.get_clusters_from_names(['alive-1'],
-                                                       summary_response=False)
-
-    assert 'last_creation_yaml' in result['alive-1']
-    assert 'last_creation_command' in result['alive-1']
 
 
 def test_get_handles_from_cluster_names_chunks_large_input(
@@ -140,13 +128,13 @@ def test_get_clusters_from_names_chunks_large_input(tmp_path, monkeypatch):
 
 def test_get_clusters_from_names_matches_single_helper(tmp_path, monkeypatch):
     """Batched record for an existing cluster must match the single-name
-    helper field-for-field (modulo summary_response/include_user_info-only
-    keys), so callers can swap one for the other without subtle diffs."""
+    helper field-for-field in summary mode, so callers can swap one for the
+    other without subtle diffs."""
     _fresh_db(tmp_path, monkeypatch)
     _add_cluster('alive-1')
 
     batched = global_user_state.get_clusters_from_names(
-        ['alive-1'], include_user_info=False, summary_response=True)['alive-1']
+        ['alive-1'], include_user_info=False)['alive-1']
     single = global_user_state.get_cluster_from_name('alive-1',
                                                      include_user_info=False,
                                                      summary_response=True)

--- a/tests/unit_tests/test_sky/test_global_user_state_batched_clusters.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_batched_clusters.py
@@ -1,0 +1,163 @@
+"""Unit tests for the batched cluster-lookup helpers in global_user_state.
+
+These helpers exist so pool dashboard (and any future caller iterating many
+replicas) can avoid the per-name DB round-trip that would otherwise show up
+as a double N+1 inside ReplicaInfo.to_info_dict.
+"""
+from sky import global_user_state
+from sky.skylet import constants
+from sky.utils.db import db_utils
+
+
+def _fresh_db(tmp_path, monkeypatch):
+    """Point the global state DB at a tmp sqlite file (mirrors the helper in
+    test_global_user_state_cluster_events.py)."""
+    monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY, str(tmp_path))
+    monkeypatch.setattr(
+        global_user_state,
+        '_db_manager',
+        db_utils.DatabaseManager(
+            'state',
+            global_user_state.create_table,
+            post_init_fn=lambda _: global_user_state._sqlite_supports_returning(
+            ),
+        ),
+    )
+
+
+class _MinimalHandle:
+    """Just enough for global_user_state.add_or_update_cluster to pickle."""
+    launched_resources = None
+
+
+def _add_cluster(name: str) -> None:
+    global_user_state.add_or_update_cluster(
+        cluster_name=name,
+        cluster_handle=_MinimalHandle(),
+        requested_resources=set(),
+        ready=False,
+    )
+
+
+def test_get_clusters_from_names_empty_input_returns_empty(
+        tmp_path, monkeypatch):
+    """Empty input must NOT hit the DB and must return {} so callers can
+    safely pass empty lists from comprehensions."""
+    _fresh_db(tmp_path, monkeypatch)
+    # No mocks needed — the function returns before touching the engine.
+    assert not global_user_state.get_clusters_from_names([])
+
+
+def test_get_clusters_from_names_returns_record_per_name(tmp_path, monkeypatch):
+    _fresh_db(tmp_path, monkeypatch)
+    _add_cluster('alive-1')
+    _add_cluster('alive-2')
+
+    result = global_user_state.get_clusters_from_names(['alive-1', 'alive-2'])
+
+    assert set(result.keys()) == {'alive-1', 'alive-2'}
+    assert result['alive-1'] is not None
+    assert result['alive-2'] is not None
+    assert result['alive-1']['name'] == 'alive-1'
+    assert result['alive-2']['name'] == 'alive-2'
+    # summary_response defaults to True, so these extra fields are absent.
+    assert 'last_creation_yaml' not in result['alive-1']
+    assert 'last_creation_command' not in result['alive-1']
+
+
+def test_get_clusters_from_names_missing_names_become_none(
+        tmp_path, monkeypatch):
+    """Names that don't exist in the cluster table must appear in the result
+    mapped to None — callers (e.g. _get_service_status) rely on this to know
+    which replicas need a handle fallback lookup."""
+    _fresh_db(tmp_path, monkeypatch)
+    _add_cluster('alive-1')
+
+    result = global_user_state.get_clusters_from_names(
+        ['alive-1', 'gone-1', 'gone-2'])
+
+    assert result['alive-1'] is not None
+    assert result['gone-1'] is None
+    assert result['gone-2'] is None
+
+
+def test_get_clusters_from_names_summary_false_includes_extras(
+        tmp_path, monkeypatch):
+    """summary_response=False mirrors the single-name path and surfaces
+    the extra last_creation_* columns."""
+    _fresh_db(tmp_path, monkeypatch)
+    _add_cluster('alive-1')
+
+    result = global_user_state.get_clusters_from_names(['alive-1'],
+                                                       summary_response=False)
+
+    assert 'last_creation_yaml' in result['alive-1']
+    assert 'last_creation_command' in result['alive-1']
+
+
+def test_get_handles_from_cluster_names_chunks_large_input(
+        tmp_path, monkeypatch):
+    """`get_handles_from_cluster_names` shares the IN-chunking knob with
+    `get_clusters_from_names`. Same setup: shrink chunk size to 2, insert 5
+    clusters, verify all five names resolve through the loop."""
+    _fresh_db(tmp_path, monkeypatch)
+    monkeypatch.setattr(global_user_state, '_CLUSTER_IN_QUERY_CHUNK_SIZE', 2)
+    names = [f'c-{i}' for i in range(5)]
+    for name in names:
+        _add_cluster(name)
+    # Missing names just don't appear in the result (this helper doesn't
+    # None-fill, matching its existing contract).
+    result = global_user_state.get_handles_from_cluster_names(
+        set(names) | {'missing'})
+
+    assert set(result.keys()) == set(names)
+    for name in names:
+        # Each handle round-trips through pickle.loads, so we only assert it
+        # came back as the right type rather than identity.
+        assert isinstance(result[name], _MinimalHandle), name
+
+
+def test_get_clusters_from_names_chunks_large_input(tmp_path, monkeypatch):
+    """Names beyond a single batch must still be resolved. Shrink the chunk
+    size to 2 so we exercise the loop with only 5 clusters."""
+    _fresh_db(tmp_path, monkeypatch)
+    monkeypatch.setattr(global_user_state, '_CLUSTER_IN_QUERY_CHUNK_SIZE', 2)
+    names = [f'c-{i}' for i in range(5)]
+    for name in names:
+        _add_cluster(name)
+    # Also include a missing name to confirm the None-fill behavior survives
+    # chunking.
+    queried = names + ['missing']
+
+    result = global_user_state.get_clusters_from_names(queried)
+
+    assert set(result.keys()) == set(queried)
+    for name in names:
+        assert result[name] is not None, name
+        assert result[name]['name'] == name
+    assert result['missing'] is None
+
+
+def test_get_clusters_from_names_matches_single_helper(tmp_path, monkeypatch):
+    """Batched record for an existing cluster must match the single-name
+    helper field-for-field (modulo summary_response/include_user_info-only
+    keys), so callers can swap one for the other without subtle diffs."""
+    _fresh_db(tmp_path, monkeypatch)
+    _add_cluster('alive-1')
+
+    batched = global_user_state.get_clusters_from_names(
+        ['alive-1'], include_user_info=False, summary_response=True)['alive-1']
+    single = global_user_state.get_cluster_from_name('alive-1',
+                                                     include_user_info=False,
+                                                     summary_response=True)
+
+    # handle is a freshly unpickled instance each call (no __eq__ defined on
+    # _MinimalHandle), so identity comparison fails. Verify the rest match
+    # field-for-field, and the handle type is at least the same.
+    assert batched is not None and single is not None
+    assert set(batched.keys()) == set(single.keys())
+    for key in batched:
+        if key == 'handle':
+            assert type(batched[key]) is type(single[key])  # noqa: E721
+        else:
+            assert batched[key] == single[key], f'mismatch on {key}'


### PR DESCRIPTION
## Summary

- Collapse the per-replica `used_by` lookups in `serve_utils._get_service_status` into a single grouped query (`get_nonterminal_job_ids_by_pool_grouped`), eliminating the `(1 + len(replicas))` per-pool N+1 against `job_info`.
- Add alembic `020` to create `ix_job_info_pool`, `ix_job_info_current_cluster_name`, and `ix_spot_status` so the per-pool / `skip_finished` filters stop falling back to full scans of a 60K-row table. The migration is idempotent and runs inside an `autocommit_block` for both SQLite and PostgreSQL.
- Fix a long-standing semantic bug: \"pool-level\" jobs were meant to be batch coordinators with `current_cluster_name IS NULL`, but the helper treated `cluster_name=None` as \"no filter\" and surfaced every other replica's jobs on every READY worker. The grouped query lets us read `jobs_by_cluster.get(None)` directly, matching the original intent.

## Test plan

- [x] `pytest tests/unit_tests/test_sky/jobs/test_state.py tests/unit_tests/test_serve_utils.py` — 39 passed locally, including new coverage of `get_nonterminal_job_ids_by_pool_grouped` and a regression test that pins \"jobs from other replicas don't leak into a READY worker's `used_by`\".
- [x] `bash format.sh --files <changed files>` — yapf / isort / mypy clean.
- [x] Manual verification against a remote PG deployment with ~60K finished jobs: confirm `ix_job_info_pool` / `ix_job_info_current_cluster_name` / `ix_spot_status` are created on upgrade, and that `POST /jobs/pool_status` round-trip improves on a multi-pool, multi-replica setup. 
- [x] After deploy: confirm `used_by` only shows the jobs actually bound to each replica (not the whole pool).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->