### PR TITLE
[Kubernetes] Allow excluding in-cluster context from `allowed_contexts: all`

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -72,6 +72,7 @@ Below is the configuration syntax and some example values. See detailed explanat
     :ref:`allowed_contexts <config-yaml-kubernetes-allowed-contexts>`:
       - context1
       - context2
+    :ref:`all_includes_in_cluster <config-yaml-kubernetes-all-includes-in-cluster>`: true
     :ref:`allowed_nodes <config-yaml-kubernetes-allowed-nodes>`:
       names:
         - gpu-node-01
@@ -1610,6 +1611,35 @@ If you want all available contexts to be allowed, set it to 'all' like this:
 
 You can also set ``SKYPILOT_ALLOW_ALL_KUBERNETES_CONTEXTS`` environment variable to ``"true"``
 for the same effect. Configuration option overrides the environment variable if set.
+
+.. _config-yaml-kubernetes-all-includes-in-cluster:
+
+``kubernetes.all_includes_in_cluster``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Whether ``allowed_contexts: all`` (or the ``SKYPILOT_ALLOW_ALL_KUBERNETES_CONTEXTS``
+env var) should include the API server's own in-cluster context (optional, default ``true``).
+
+When the SkyPilot API server runs inside Kubernetes, the pod's own host cluster is
+discoverable as an ``in-cluster`` context. By default it is included in the
+``allowed_contexts: all`` expansion (backward compatible). Set this to ``false`` to
+exclude it — useful on deployments where the API server's host cluster
+should not be a user-facing compute target. Explicitly listing ``in-cluster`` in
+``allowed_contexts`` always keeps it, regardless of this flag.
+
+.. code-block:: yaml
+
+  kubernetes:
+    allowed_contexts: all
+    all_includes_in_cluster: false
+
+You can also set the ``SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER``
+environment variable on the API server pod. The env var takes precedence over
+the config field — useful for operators of the deployments to enforce a
+value that admins editing SkyPilot config cannot override.
+
+Resolution order (highest first): env var, workspace config, global config,
+default ``true``.
 
 .. _config-yaml-kubernetes-allowed-nodes:
 

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -199,13 +199,8 @@ class Kubernetes(clouds.Cloud):
                    ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER.get_optional())
         if env_val is not None:
             return env_val
-        workspace_val = skypilot_config.get_workspace_cloud('kubernetes').get(
-            'all_includes_in_cluster', None)
-        if workspace_val is not None:
-            return workspace_val
-        return skypilot_config.get_effective_region_config(
+        return skypilot_config.get_effective_workspace_region_config(
             cloud='kubernetes',
-            region=None,
             keys=('all_includes_in_cluster',),
             default_value=True)
 

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -173,17 +173,6 @@ class Kubernetes(clouds.Cloud):
                 'Ignoring these contexts.')
 
     @classmethod
-    @annotations.lru_cache(scope='global', maxsize=1)
-    def _log_in_cluster_excluded_from_all_once(cls,
-                                               in_cluster_name: str) -> None:
-        """Log once when in-cluster is excluded from the 'all' expansion."""
-        logger.debug(
-            f'Excluding Kubernetes in-cluster context {in_cluster_name!r} '
-            'from `allowed_contexts: all` because `all_includes_in_cluster` '
-            'is set to false (config or '
-            'SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER env).')
-
-    @classmethod
     def _resolve_all_includes_in_cluster(cls) -> bool:
         """Resolve whether 'all' should include the in-cluster context.
 
@@ -247,8 +236,6 @@ class Kubernetes(clouds.Cloud):
                 allowed_contexts = [
                     c for c in all_contexts if c != in_cluster_name
                 ]
-                if not silent and in_cluster_name in all_contexts:
-                    cls._log_in_cluster_excluded_from_all_once(in_cluster_name)
 
         if allowed_contexts is None:
             # Try kubeconfig if present

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -173,6 +173,43 @@ class Kubernetes(clouds.Cloud):
                 'Ignoring these contexts.')
 
     @classmethod
+    @annotations.lru_cache(scope='global', maxsize=1)
+    def _log_in_cluster_excluded_from_all_once(cls,
+                                               in_cluster_name: str) -> None:
+        """Log once when in-cluster is excluded from the 'all' expansion."""
+        logger.info(
+            f'Excluding Kubernetes in-cluster context {in_cluster_name!r} '
+            'from `allowed_contexts: all` because `all_includes_in_cluster` '
+            'is set to false (config or '
+            'SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER env).')
+
+    @classmethod
+    def _resolve_all_includes_in_cluster(cls) -> bool:
+        """Resolve whether 'all' should include the in-cluster context.
+
+        Precedence (highest first):
+          1. SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER env var
+             (operator-level, set on the API server pod;
+             not overridable by admin via config).
+          2. `kubernetes.all_includes_in_cluster` config field (workspace
+             beats global).
+          3. Default: True (backward compatible).
+        """
+        env_val = (env_options.Options.
+                   ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER.get_optional())
+        if env_val is not None:
+            return env_val
+        workspace_val = skypilot_config.get_workspace_cloud('kubernetes').get(
+            'all_includes_in_cluster', None)
+        if workspace_val is not None:
+            return workspace_val
+        return skypilot_config.get_effective_region_config(
+            cloud='kubernetes',
+            region=None,
+            keys=('all_includes_in_cluster',),
+            default_value=True)
+
+    @classmethod
     def existing_allowed_contexts(cls, silent: bool = False) -> List[str]:
         """Get existing allowed contexts.
 
@@ -207,7 +244,16 @@ class Kubernetes(clouds.Cloud):
             allowed_contexts is None and
             env_options.Options.ALLOW_ALL_KUBERNETES_CONTEXTS.get())
         if allow_all_contexts:
-            allowed_contexts = all_contexts
+            all_includes_in_cluster = cls._resolve_all_includes_in_cluster()
+            if all_includes_in_cluster:
+                allowed_contexts = all_contexts
+            else:
+                in_cluster_name = kubernetes.in_cluster_context_name()
+                allowed_contexts = [
+                    c for c in all_contexts if c != in_cluster_name
+                ]
+                if not silent and in_cluster_name in all_contexts:
+                    cls._log_in_cluster_excluded_from_all_once(in_cluster_name)
 
         if allowed_contexts is None:
             # Try kubeconfig if present

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -177,7 +177,7 @@ class Kubernetes(clouds.Cloud):
     def _log_in_cluster_excluded_from_all_once(cls,
                                                in_cluster_name: str) -> None:
         """Log once when in-cluster is excluded from the 'all' expansion."""
-        logger.info(
+        logger.debug(
             f'Excluding Kubernetes in-cluster context {in_cluster_name!r} '
             'from `allowed_contexts: all` because `all_includes_in_cluster` '
             'is set to false (config or '

--- a/sky/utils/env_options.py
+++ b/sky/utils/env_options.py
@@ -1,7 +1,7 @@
 """Global environment options for sky."""
 import enum
 import os
-from typing import Dict
+from typing import Dict, Optional
 
 
 class Options(enum.Enum):
@@ -31,6 +31,14 @@ class Options(enum.Enum):
     # config.
     ALLOW_ALL_KUBERNETES_CONTEXTS = ('SKYPILOT_ALLOW_ALL_KUBERNETES_CONTEXTS',
                                      False)
+    # Operator-level override for whether `allowed_contexts: 'all'` (or the
+    # env-var-triggered allow-all path) should include the API server's own
+    # in-cluster context. Unset by default; falls through to the config field
+    # `kubernetes.all_includes_in_cluster`.
+    # Read via `get_optional()` since "unset" is
+    # semantically distinct from "false".
+    ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER = (
+        'SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER', False)
 
     def __init__(self, env_var: str, default: bool) -> None:
         super().__init__()
@@ -44,6 +52,17 @@ class Options(enum.Enum):
         """Check if an environment variable is set to True."""
         return os.getenv(self.env_var,
                          str(self.default)).lower() in ('true', '1')
+
+    def get_optional(self) -> Optional[bool]:
+        """Parse the env var as a bool, or return None if unset.
+
+        Use when "unset" is semantically distinct from "false" (e.g. for
+        layered resolution where a config field provides the default).
+        """
+        val = os.environ.get(self.env_var)
+        if val is None:
+            return None
+        return val.lower() in ('true', '1')
 
     @property
     def env_key(self) -> str:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1885,6 +1885,9 @@ def get_config_schema():
                         'pattern': '^all$'
                     }]
                 },
+                'all_includes_in_cluster': {
+                    'type': 'boolean',
+                },
                 'context_configs': {
                     'type': 'object',
                     'required': [],
@@ -2345,6 +2348,9 @@ def get_config_schema():
                                 'type': 'string',
                                 'pattern': '^all$'
                             }]
+                        },
+                        'all_includes_in_cluster': {
+                            'type': 'boolean',
                         },
                         'disabled': {
                             'type': 'boolean'

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes.py
@@ -376,8 +376,6 @@ class TestKubernetesAllIncludesInCluster(unittest.TestCase):
 
     def setUp(self):
         kubernetes.Kubernetes._log_skipped_contexts_once.cache_clear()
-        kubernetes.Kubernetes._log_in_cluster_excluded_from_all_once \
-            .cache_clear()
         # Ensure env var leaks from other tests don't influence assertions.
         self._original_env = os.environ.pop(self.ENV_VAR, None)
 

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes.py
@@ -85,16 +85,24 @@ class TestKubernetesExistingAllowedContexts(unittest.TestCase):
         """Test using global allowed_contexts=all in config when workspace config is None."""
         mock_get_all_contexts.return_value = ['ctx1', 'ctx2', 'ctx3']
         mock_get_workspace_cloud.return_value.get.return_value = None
-        mock_get_cloud_config_value.return_value = 'all'
+
+        # get_effective_region_config is called for both 'allowed_contexts'
+        # and 'all_includes_in_cluster'. Drive the two via side_effect.
+        def _get_eff(*args, **kwargs):
+            keys = kwargs.get('keys') or args[2]
+            if keys == ('allowed_contexts',):
+                return 'all'
+            return kwargs.get('default_value')
+
+        mock_get_cloud_config_value.side_effect = _get_eff
 
         result = kubernetes.Kubernetes.existing_allowed_contexts()
 
         self.assertEqual(set(result), {'ctx1', 'ctx2', 'ctx3'})
-        mock_get_cloud_config_value.assert_called_once_with(
-            cloud='kubernetes',
-            keys=('allowed_contexts',),
-            region=None,
-            default_value=None)
+        mock_get_cloud_config_value.assert_any_call(cloud='kubernetes',
+                                                    keys=('allowed_contexts',),
+                                                    region=None,
+                                                    default_value=None)
 
     @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
     @patch('sky.skypilot_config.get_workspace_cloud')
@@ -358,6 +366,226 @@ class TestKubernetesExistingAllowedContexts(unittest.TestCase):
                              ['prod-cluster', 'staging-cluster'])
             # Should log the nonexistent context (SSH contexts are skipped)
             mock_log.assert_called_once_with(('nonexistent-cluster',))
+
+
+class TestKubernetesAllIncludesInCluster(unittest.TestCase):
+    """Tests for `kubernetes.all_includes_in_cluster` and its env var."""
+
+    ENV_VAR = 'SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER'
+
+    def setUp(self):
+        kubernetes.Kubernetes._log_skipped_contexts_once.cache_clear()
+        kubernetes.Kubernetes._log_in_cluster_excluded_from_all_once \
+            .cache_clear()
+        # Ensure env var leaks from other tests don't influence assertions.
+        self._original_env = os.environ.pop(self.ENV_VAR, None)
+
+    def tearDown(self):
+        if self._original_env is not None:
+            os.environ[self.ENV_VAR] = self._original_env
+        else:
+            os.environ.pop(self.ENV_VAR, None)
+
+    @staticmethod
+    def _mk_region_config_side_effect(allowed_contexts_value,
+                                      all_includes_value):
+
+        def _side_effect(*args, **kwargs):
+            keys = kwargs.get('keys') or args[2]
+            if keys == ('allowed_contexts',):
+                return allowed_contexts_value
+            if keys == ('all_includes_in_cluster',):
+                return all_includes_value
+            return kwargs.get('default_value')
+
+        return _side_effect
+
+    @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
+    @patch('sky.skypilot_config.get_workspace_cloud')
+    @patch('sky.skypilot_config.get_effective_region_config')
+    def test_default_all_includes_in_cluster(self, mock_get_region,
+                                             mock_get_workspace,
+                                             mock_get_all_contexts):
+        """Default behavior: 'all' includes in-cluster (backward compat)."""
+        mock_get_all_contexts.return_value = ['ctx-a', 'ctx-b', 'in-cluster']
+        mock_get_workspace.return_value.get.return_value = None
+        # 'all' for allowed_contexts; flag unset (returns default_value=True).
+        mock_get_region.side_effect = self._mk_region_config_side_effect(
+            'all', True)
+
+        result = kubernetes.Kubernetes.existing_allowed_contexts()
+
+        self.assertEqual(set(result), {'ctx-a', 'ctx-b', 'in-cluster'})
+
+    @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
+    @patch('sky.skypilot_config.get_workspace_cloud')
+    @patch('sky.skypilot_config.get_effective_region_config')
+    def test_all_excludes_in_cluster_via_config(self, mock_get_region,
+                                                mock_get_workspace,
+                                                mock_get_all_contexts):
+        """`all_includes_in_cluster: false` in config -> in-cluster excluded."""
+        mock_get_all_contexts.return_value = ['ctx-a', 'ctx-b', 'in-cluster']
+        mock_get_workspace.return_value.get.return_value = None
+        mock_get_region.side_effect = self._mk_region_config_side_effect(
+            'all', False)
+
+        result = kubernetes.Kubernetes.existing_allowed_contexts()
+
+        self.assertEqual(set(result), {'ctx-a', 'ctx-b'})
+
+    @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
+    @patch('sky.skypilot_config.get_workspace_cloud')
+    @patch('sky.skypilot_config.get_effective_region_config')
+    def test_env_overrides_config_true(self, mock_get_region,
+                                       mock_get_workspace,
+                                       mock_get_all_contexts):
+        """Env var true overrides config false."""
+        mock_get_all_contexts.return_value = ['ctx-a', 'in-cluster']
+        mock_get_workspace.return_value.get.return_value = None
+        mock_get_region.side_effect = self._mk_region_config_side_effect(
+            'all', False)
+
+        with patch.dict(os.environ, {self.ENV_VAR: 'true'}, clear=False):
+            result = kubernetes.Kubernetes.existing_allowed_contexts()
+
+        self.assertEqual(set(result), {'ctx-a', 'in-cluster'})
+
+    @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
+    @patch('sky.skypilot_config.get_workspace_cloud')
+    @patch('sky.skypilot_config.get_effective_region_config')
+    def test_env_overrides_config_false(self, mock_get_region,
+                                        mock_get_workspace,
+                                        mock_get_all_contexts):
+        """Env var false overrides config true. The hosted-product use case."""
+        mock_get_all_contexts.return_value = ['ctx-a', 'in-cluster']
+        mock_get_workspace.return_value.get.return_value = None
+        mock_get_region.side_effect = self._mk_region_config_side_effect(
+            'all', True)
+
+        with patch.dict(os.environ, {self.ENV_VAR: 'false'}, clear=False):
+            result = kubernetes.Kubernetes.existing_allowed_contexts()
+
+        self.assertEqual(set(result), {'ctx-a'})
+
+    @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
+    @patch('sky.skypilot_config.get_workspace_cloud')
+    @patch('sky.skypilot_config.get_effective_region_config')
+    def test_workspace_overrides_global(self, mock_get_region,
+                                        mock_get_workspace,
+                                        mock_get_all_contexts):
+        """Workspace-level all_includes_in_cluster beats global."""
+        mock_get_all_contexts.return_value = ['ctx-a', 'in-cluster']
+
+        # Workspace returns 'all' for allowed_contexts and False for the flag.
+        def _workspace_get(key, default=None):
+            if key == 'allowed_contexts':
+                return 'all'
+            if key == 'all_includes_in_cluster':
+                return False
+            return default
+
+        mock_get_workspace.return_value.get.side_effect = _workspace_get
+        # Global flag is True; should be ignored because workspace set False.
+        mock_get_region.side_effect = self._mk_region_config_side_effect(
+            None, True)
+
+        result = kubernetes.Kubernetes.existing_allowed_contexts()
+
+        self.assertEqual(set(result), {'ctx-a'})
+
+    @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
+    @patch('sky.skypilot_config.get_workspace_cloud')
+    @patch('sky.skypilot_config.get_effective_region_config')
+    def test_env_var_path_also_filters(self, mock_get_region,
+                                       mock_get_workspace,
+                                       mock_get_all_contexts):
+        """`SKYPILOT_ALLOW_ALL_KUBERNETES_CONTEXTS=true` path is symmetric.
+
+        When neither workspace nor global allowed_contexts is set, the env
+        var triggers the same allow-all branch; `all_includes_in_cluster`
+        should still filter in-cluster out.
+        """
+        mock_get_all_contexts.return_value = ['ctx-a', 'in-cluster']
+        mock_get_workspace.return_value.get.return_value = None
+        mock_get_region.side_effect = self._mk_region_config_side_effect(
+            None, False)
+
+        with patch.dict(os.environ, {
+                'SKYPILOT_ALLOW_ALL_KUBERNETES_CONTEXTS': 'true',
+        },
+                        clear=False):
+            result = kubernetes.Kubernetes.existing_allowed_contexts()
+
+        self.assertEqual(set(result), {'ctx-a'})
+
+    @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
+    @patch('sky.skypilot_config.get_workspace_cloud')
+    def test_explicit_in_cluster_in_list_is_kept(self, mock_get_workspace,
+                                                 mock_get_all_contexts):
+        """Explicit allowed_contexts list ignores the all_includes flag."""
+        mock_get_all_contexts.return_value = ['ctx-a', 'in-cluster']
+
+        def _workspace_get(key, default=None):
+            if key == 'allowed_contexts':
+                return ['ctx-a', 'in-cluster']
+            if key == 'all_includes_in_cluster':
+                return False
+            return default
+
+        mock_get_workspace.return_value.get.side_effect = _workspace_get
+
+        with patch.dict(os.environ, {self.ENV_VAR: 'false'}, clear=False):
+            result = kubernetes.Kubernetes.existing_allowed_contexts()
+
+        self.assertEqual(set(result), {'ctx-a', 'in-cluster'})
+
+    @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
+    @patch('sky.skypilot_config.get_workspace_cloud')
+    @patch('sky.skypilot_config.get_nested')
+    @patch('sky.provision.kubernetes.utils.'
+           'get_current_kube_config_context_name')
+    @patch('sky.provision.kubernetes.utils.is_incluster_config_available')
+    @patch('sky.adaptors.kubernetes.in_cluster_context_name')
+    def test_no_kubeconfig_fallback_unaffected_by_flag(
+            self, mock_in_cluster_name, mock_is_incluster, mock_current,
+            mock_get_nested, mock_get_workspace, mock_get_all_contexts):
+        """The "no kubeconfig -> in-cluster" fallback ignores the flag."""
+        mock_get_all_contexts.return_value = ['in-cluster']
+        mock_get_workspace.return_value.get.return_value = None
+        mock_get_nested.return_value = None
+        mock_current.return_value = None
+        mock_is_incluster.return_value = True
+        mock_in_cluster_name.return_value = 'in-cluster'
+
+        with patch.dict(os.environ, {self.ENV_VAR: 'false'}, clear=False):
+            result = kubernetes.Kubernetes.existing_allowed_contexts()
+
+        self.assertEqual(result, ['in-cluster'])
+
+    @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
+    @patch('sky.skypilot_config.get_workspace_cloud')
+    @patch('sky.skypilot_config.get_effective_region_config')
+    @patch('sky.adaptors.kubernetes.in_cluster_context_name')
+    def test_custom_in_cluster_name_is_filtered(self, mock_in_cluster_name,
+                                                mock_get_region,
+                                                mock_get_workspace,
+                                                mock_get_all_contexts):
+        """Custom in-cluster name (via env) is what gets filtered, not the
+        literal 'in-cluster'."""
+        mock_in_cluster_name.return_value = 'my-host-cluster'
+        mock_get_all_contexts.return_value = [
+            'ctx-a', 'my-host-cluster', 'in-cluster'
+        ]
+        mock_get_workspace.return_value.get.return_value = None
+        mock_get_region.side_effect = self._mk_region_config_side_effect(
+            'all', False)
+
+        result = kubernetes.Kubernetes.existing_allowed_contexts()
+
+        # 'my-host-cluster' (the custom in-cluster name) is excluded; the
+        # literal string 'in-cluster' happens to be a regular kubeconfig
+        # context here and is kept.
+        self.assertEqual(set(result), {'ctx-a', 'in-cluster'})
 
 
 class TestKubernetesSecurityContextMerging(unittest.TestCase):

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes.py
@@ -389,13 +389,7 @@ class TestKubernetesAllIncludesInCluster(unittest.TestCase):
 
     @staticmethod
     def _mk_allowed_contexts_side_effect(allowed_contexts_value):
-        """Side effect for `get_effective_region_config`.
-
-        After moving `all_includes_in_cluster` to
-        `get_effective_workspace_region_config`, the only key resolved via
-        `get_effective_region_config` in the existing_allowed_contexts path
-        is `allowed_contexts`.
-        """
+        """Side effect for `get_effective_region_config`."""
 
         def _side_effect(*args, **kwargs):
             keys = kwargs.get('keys') or (args[1] if len(args) > 1 else None)

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes.py
@@ -86,10 +86,11 @@ class TestKubernetesExistingAllowedContexts(unittest.TestCase):
         mock_get_all_contexts.return_value = ['ctx1', 'ctx2', 'ctx3']
         mock_get_workspace_cloud.return_value.get.return_value = None
 
-        # get_effective_region_config is called for both 'allowed_contexts'
-        # and 'all_includes_in_cluster'. Drive the two via side_effect.
+        # get_effective_region_config is called for 'allowed_contexts';
+        # 'all_includes_in_cluster' is read via
+        # get_effective_workspace_region_config and patched separately.
         def _get_eff(*args, **kwargs):
-            keys = kwargs.get('keys') or args[2]
+            keys = kwargs.get('keys') or (args[1] if len(args) > 1 else None)
             if keys == ('allowed_contexts',):
                 return 'all'
             return kwargs.get('default_value')
@@ -387,15 +388,19 @@ class TestKubernetesAllIncludesInCluster(unittest.TestCase):
             os.environ.pop(self.ENV_VAR, None)
 
     @staticmethod
-    def _mk_region_config_side_effect(allowed_contexts_value,
-                                      all_includes_value):
+    def _mk_allowed_contexts_side_effect(allowed_contexts_value):
+        """Side effect for `get_effective_region_config`.
+
+        After moving `all_includes_in_cluster` to
+        `get_effective_workspace_region_config`, the only key resolved via
+        `get_effective_region_config` in the existing_allowed_contexts path
+        is `allowed_contexts`.
+        """
 
         def _side_effect(*args, **kwargs):
-            keys = kwargs.get('keys') or args[2]
+            keys = kwargs.get('keys') or (args[1] if len(args) > 1 else None)
             if keys == ('allowed_contexts',):
                 return allowed_contexts_value
-            if keys == ('all_includes_in_cluster',):
-                return all_includes_value
             return kwargs.get('default_value')
 
         return _side_effect
@@ -403,15 +408,18 @@ class TestKubernetesAllIncludesInCluster(unittest.TestCase):
     @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
     @patch('sky.skypilot_config.get_workspace_cloud')
     @patch('sky.skypilot_config.get_effective_region_config')
-    def test_default_all_includes_in_cluster(self, mock_get_region,
+    @patch('sky.skypilot_config.get_effective_workspace_region_config')
+    def test_default_all_includes_in_cluster(self, mock_get_ws_region,
+                                             mock_get_region,
                                              mock_get_workspace,
                                              mock_get_all_contexts):
         """Default behavior: 'all' includes in-cluster (backward compat)."""
         mock_get_all_contexts.return_value = ['ctx-a', 'ctx-b', 'in-cluster']
         mock_get_workspace.return_value.get.return_value = None
-        # 'all' for allowed_contexts; flag unset (returns default_value=True).
-        mock_get_region.side_effect = self._mk_region_config_side_effect(
-            'all', True)
+        mock_get_region.side_effect = self._mk_allowed_contexts_side_effect(
+            'all')
+        # Flag unset -> default_value=True wins.
+        mock_get_ws_region.return_value = True
 
         result = kubernetes.Kubernetes.existing_allowed_contexts()
 
@@ -420,14 +428,17 @@ class TestKubernetesAllIncludesInCluster(unittest.TestCase):
     @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
     @patch('sky.skypilot_config.get_workspace_cloud')
     @patch('sky.skypilot_config.get_effective_region_config')
-    def test_all_excludes_in_cluster_via_config(self, mock_get_region,
+    @patch('sky.skypilot_config.get_effective_workspace_region_config')
+    def test_all_excludes_in_cluster_via_config(self, mock_get_ws_region,
+                                                mock_get_region,
                                                 mock_get_workspace,
                                                 mock_get_all_contexts):
         """`all_includes_in_cluster: false` in config -> in-cluster excluded."""
         mock_get_all_contexts.return_value = ['ctx-a', 'ctx-b', 'in-cluster']
         mock_get_workspace.return_value.get.return_value = None
-        mock_get_region.side_effect = self._mk_region_config_side_effect(
-            'all', False)
+        mock_get_region.side_effect = self._mk_allowed_contexts_side_effect(
+            'all')
+        mock_get_ws_region.return_value = False
 
         result = kubernetes.Kubernetes.existing_allowed_contexts()
 
@@ -436,68 +447,83 @@ class TestKubernetesAllIncludesInCluster(unittest.TestCase):
     @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
     @patch('sky.skypilot_config.get_workspace_cloud')
     @patch('sky.skypilot_config.get_effective_region_config')
-    def test_env_overrides_config_true(self, mock_get_region,
-                                       mock_get_workspace,
+    @patch('sky.skypilot_config.get_effective_workspace_region_config')
+    def test_env_overrides_config_true(self, mock_get_ws_region,
+                                       mock_get_region, mock_get_workspace,
                                        mock_get_all_contexts):
         """Env var true overrides config false."""
         mock_get_all_contexts.return_value = ['ctx-a', 'in-cluster']
         mock_get_workspace.return_value.get.return_value = None
-        mock_get_region.side_effect = self._mk_region_config_side_effect(
-            'all', False)
+        mock_get_region.side_effect = self._mk_allowed_contexts_side_effect(
+            'all')
+        mock_get_ws_region.return_value = False  # ignored: env wins
 
         with patch.dict(os.environ, {self.ENV_VAR: 'true'}, clear=False):
             result = kubernetes.Kubernetes.existing_allowed_contexts()
 
         self.assertEqual(set(result), {'ctx-a', 'in-cluster'})
+        # Resolution should short-circuit on env var; config flag not read.
+        mock_get_ws_region.assert_not_called()
 
     @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
     @patch('sky.skypilot_config.get_workspace_cloud')
     @patch('sky.skypilot_config.get_effective_region_config')
-    def test_env_overrides_config_false(self, mock_get_region,
-                                        mock_get_workspace,
+    @patch('sky.skypilot_config.get_effective_workspace_region_config')
+    def test_env_overrides_config_false(self, mock_get_ws_region,
+                                        mock_get_region, mock_get_workspace,
                                         mock_get_all_contexts):
         """Env var false overrides config true. The hosted-product use case."""
         mock_get_all_contexts.return_value = ['ctx-a', 'in-cluster']
         mock_get_workspace.return_value.get.return_value = None
-        mock_get_region.side_effect = self._mk_region_config_side_effect(
-            'all', True)
+        mock_get_region.side_effect = self._mk_allowed_contexts_side_effect(
+            'all')
+        mock_get_ws_region.return_value = True  # ignored: env wins
 
         with patch.dict(os.environ, {self.ENV_VAR: 'false'}, clear=False):
             result = kubernetes.Kubernetes.existing_allowed_contexts()
 
         self.assertEqual(set(result), {'ctx-a'})
+        mock_get_ws_region.assert_not_called()
 
     @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
     @patch('sky.skypilot_config.get_workspace_cloud')
     @patch('sky.skypilot_config.get_effective_region_config')
-    def test_workspace_overrides_global(self, mock_get_region,
-                                        mock_get_workspace,
+    @patch('sky.skypilot_config.get_effective_workspace_region_config')
+    def test_workspace_overrides_global(self, mock_get_ws_region,
+                                        mock_get_region, mock_get_workspace,
                                         mock_get_all_contexts):
-        """Workspace-level all_includes_in_cluster beats global."""
+        """Workspace-level all_includes_in_cluster beats global.
+
+        get_effective_workspace_region_config performs the workspace > global
+        resolution internally — we mock its return to be the resolved value.
+        """
         mock_get_all_contexts.return_value = ['ctx-a', 'in-cluster']
 
-        # Workspace returns 'all' for allowed_contexts and False for the flag.
         def _workspace_get(key, default=None):
             if key == 'allowed_contexts':
                 return 'all'
-            if key == 'all_includes_in_cluster':
-                return False
             return default
 
         mock_get_workspace.return_value.get.side_effect = _workspace_get
-        # Global flag is True; should be ignored because workspace set False.
-        mock_get_region.side_effect = self._mk_region_config_side_effect(
-            None, True)
+        mock_get_region.side_effect = self._mk_allowed_contexts_side_effect(
+            None)
+        # Workspace says False (which is what the helper would return).
+        mock_get_ws_region.return_value = False
 
         result = kubernetes.Kubernetes.existing_allowed_contexts()
 
         self.assertEqual(set(result), {'ctx-a'})
+        mock_get_ws_region.assert_called_once_with(
+            cloud='kubernetes',
+            keys=('all_includes_in_cluster',),
+            default_value=True)
 
     @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
     @patch('sky.skypilot_config.get_workspace_cloud')
     @patch('sky.skypilot_config.get_effective_region_config')
-    def test_env_var_path_also_filters(self, mock_get_region,
-                                       mock_get_workspace,
+    @patch('sky.skypilot_config.get_effective_workspace_region_config')
+    def test_env_var_path_also_filters(self, mock_get_ws_region,
+                                       mock_get_region, mock_get_workspace,
                                        mock_get_all_contexts):
         """`SKYPILOT_ALLOW_ALL_KUBERNETES_CONTEXTS=true` path is symmetric.
 
@@ -507,8 +533,9 @@ class TestKubernetesAllIncludesInCluster(unittest.TestCase):
         """
         mock_get_all_contexts.return_value = ['ctx-a', 'in-cluster']
         mock_get_workspace.return_value.get.return_value = None
-        mock_get_region.side_effect = self._mk_region_config_side_effect(
-            None, False)
+        mock_get_region.side_effect = self._mk_allowed_contexts_side_effect(
+            None)
+        mock_get_ws_region.return_value = False
 
         with patch.dict(os.environ, {
                 'SKYPILOT_ALLOW_ALL_KUBERNETES_CONTEXTS': 'true',
@@ -565,8 +592,10 @@ class TestKubernetesAllIncludesInCluster(unittest.TestCase):
     @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
     @patch('sky.skypilot_config.get_workspace_cloud')
     @patch('sky.skypilot_config.get_effective_region_config')
+    @patch('sky.skypilot_config.get_effective_workspace_region_config')
     @patch('sky.adaptors.kubernetes.in_cluster_context_name')
     def test_custom_in_cluster_name_is_filtered(self, mock_in_cluster_name,
+                                                mock_get_ws_region,
                                                 mock_get_region,
                                                 mock_get_workspace,
                                                 mock_get_all_contexts):
@@ -577,8 +606,9 @@ class TestKubernetesAllIncludesInCluster(unittest.TestCase):
             'ctx-a', 'my-host-cluster', 'in-cluster'
         ]
         mock_get_workspace.return_value.get.return_value = None
-        mock_get_region.side_effect = self._mk_region_config_side_effect(
-            'all', False)
+        mock_get_region.side_effect = self._mk_allowed_contexts_side_effect(
+            'all')
+        mock_get_ws_region.return_value = False
 
         result = kubernetes.Kubernetes.existing_allowed_contexts()
 


### PR DESCRIPTION
## Summary

When the SkyPilot API server runs inside Kubernetes, the pod's own host cluster is discoverable as an `in-cluster` context. With `allowed_contexts: all` (or `SKYPILOT_ALLOW_ALL_KUBERNETES_CONTEXTS=true`), that context is silently included alongside uploaded kubeconfig contexts — surprising in deployments where the API server's own cluster shouldn't be a user-facing compute target.

This PR adds an opt-in flag to exclude `in-cluster` from the `'all'` expansion. **Default is unchanged** (in-cluster included) for backward compatibility.

Two layers, in resolution order (highest first):

1. **env var `SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER`** — operator-level, set on the API server pod. Tenant admins editing config can't override it.
2. **config field `kubernetes.all_includes_in_cluster`** (bool, workspace + global, default `true`) — admin-level switch.

Explicit listings (e.g. `allowed_contexts: ['in-cluster', 'ctx-a']`) always honor the listing regardless of this flag. The `allowed_contexts: None` → in-cluster fallback (no kubeconfig present, in-cluster auth available) is also unaffected.

## Behavior matrix

| Config | resolved flag | in-cluster included? |
|---|---|---|
| `allowed_contexts: 'all'` | `true` (default) | Yes (unchanged) |
| `allowed_contexts: 'all'` | `false` | **No** |
| `SKYPILOT_ALLOW_ALL_KUBERNETES_CONTEXTS=true`, no config | `true` (default) | Yes (unchanged) |
| `SKYPILOT_ALLOW_ALL_KUBERNETES_CONTEXTS=true`, no config | `false` | No (symmetric with config `'all'`) |
| `allowed_contexts: ['in-cluster']` | any | Yes |
| `allowed_contexts: ['ctx-a', 'in-cluster']` | any | Yes |
| `allowed_contexts: ['ctx-a']` | any | No |
| `allowed_contexts` unset, no kubeconfig, in-cluster available | any | Yes (fallback path) |

## Test plan

- [x] Added `TestKubernetesAllIncludesInCluster` with 9 cases covering:
  - Default backward-compat (in-cluster included)
  - Config `false` excludes in-cluster
  - Env var overrides config in both directions
  - Workspace-level flag beats global
  - Env-var allow-all path symmetric with config `'all'`
  - Explicit list with `in-cluster` ignores the flag
  - No-kubeconfig fallback unaffected
  - Custom in-cluster name via `SKYPILOT_IN_CLUSTER_CONTEXT_NAME` is what gets filtered (not literal `'in-cluster'`)
- [x] \`pytest tests/unit_tests/test_sky/clouds/test_kubernetes.py\` — full file passes locally.
- [x] \`bash format.sh\` on touched files — yapf/isort/mypy clean; pre-commit hook also passes.
- [x] Manual verification on a remote API server: set `SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER=false` on the API server pod, set `allowed_contexts: all`, confirm `sky check` does not list `in-cluster`. Then list `['in-cluster']` explicitly and confirm it appears.

## Docs

Added a new section `kubernetes.all_includes_in_cluster` in `docs/source/reference/config.rst` documenting the field, the env var, precedence, and when to set `false`.