### PR TITLE
[Kubernetes] Per-workspace namespace via `context_configs`

### DIFF
--- a/docs/source/admin/workspaces.rst
+++ b/docs/source/admin/workspaces.rst
@@ -80,6 +80,11 @@ The above is achieved by configuring the following section in the config file:
              allowed_contexts:
                - node-pool-1
                - node-pool-2
+             # Per-workspace per-context overrides (optional). Lets a single
+             # shared context target a different namespace per workspace.
+             context_configs:
+               node-pool-1:
+                 namespace: team-a-namespace
 
            gcp:
              disabled: false

--- a/docs/source/admin/workspaces.rst
+++ b/docs/source/admin/workspaces.rst
@@ -80,11 +80,16 @@ The above is achieved by configuring the following section in the config file:
              allowed_contexts:
                - node-pool-1
                - node-pool-2
+             # Workspace-level default namespace (optional). Applies to every
+             # context in `allowed_contexts` that does not set its own
+             # `context_configs.<ctx>.namespace` below.
+             namespace: team-a-namespace
              # Per-workspace per-context overrides (optional). Lets a single
-             # shared context target a different namespace per workspace.
+             # shared context target a different namespace per workspace and
+             # takes precedence over the workspace-level `namespace` above.
              context_configs:
                node-pool-1:
-                 namespace: team-a-namespace
+                 namespace: team-a-node-pool-1-namespace
 
            gcp:
              disabled: false

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -72,6 +72,7 @@ Below is the configuration syntax and some example values. See detailed explanat
     :ref:`allowed_contexts <config-yaml-kubernetes-allowed-contexts>`:
       - context1
       - context2
+    :ref:`namespace <config-yaml-kubernetes-namespace>`: my-namespace
     :ref:`allowed_nodes <config-yaml-kubernetes-allowed-nodes>`:
       names:
         - gpu-node-01
@@ -1610,6 +1611,41 @@ If you want all available contexts to be allowed, set it to 'all' like this:
 
 You can also set ``SKYPILOT_ALLOW_ALL_KUBERNETES_CONTEXTS`` environment variable to ``"true"``
 for the same effect. Configuration option overrides the environment variable if set.
+
+.. _config-yaml-kubernetes-namespace:
+
+``kubernetes.namespace``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Kubernetes namespace SkyPilot pods are launched into (optional).
+
+If unset, SkyPilot uses the namespace from the active kubeconfig context (or
+``default``), preserving the historical behavior. Setting this value lets you
+target a specific namespace without modifying your kubeconfig.
+
+.. code-block:: yaml
+
+  kubernetes:
+    namespace: my-namespace
+
+You can also set this per-context using ``context_configs``:
+
+.. code-block:: yaml
+
+  kubernetes:
+    context_configs:
+      prod-cluster:
+        namespace: prod-workloads
+      dev-cluster:
+        namespace: dev-workloads
+
+When set, the namespace is used for both pod creation and resource discovery
+(e.g., listing pods to count used resources), so quotas and visibility line up
+with the chosen namespace.
+
+For per-workspace overrides — e.g. sharing a single cluster context across
+teams, with each team scoped to its own namespace — see
+:ref:`Workspaces <workspaces>`.
 
 .. _config-yaml-kubernetes-allowed-nodes:
 

--- a/docs/source/reference/kubernetes/multi-kubernetes.rst
+++ b/docs/source/reference/kubernetes/multi-kubernetes.rst
@@ -181,6 +181,7 @@ You can specify per-context configurations for any Kubernetes config field, incl
 * ``remote_identity``: Service account to use for the context
 * ``provision_timeout``: Timeout for provisioning pods if autoscaler is used
 * ``pricing``: Per-vCPU, per-GB, and per-accelerator hourly rates for cost estimation (see :ref:`config-yaml-kubernetes-pricing`)
+* ``namespace``: Kubernetes namespace pods are launched into (see :ref:`config-yaml-kubernetes-namespace`)
 
 See :ref:`Kubernetes config<config-yaml-kubernetes>` for the list of all fields supported.
 

--- a/sky/catalog/kubernetes_catalog.py
+++ b/sky/catalog/kubernetes_catalog.py
@@ -151,7 +151,7 @@ def _list_accelerators(
         return {}, {}, {}
 
     # Verify that the credentials are still valid.
-    if not kubernetes_utils.check_credentials(context)[0]:
+    if not kubernetes_utils.check_credentials(context, cloud='kubernetes')[0]:
         return {}, {}, {}
 
     has_gpu = kubernetes_utils.detect_accelerator_resource(context)

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -1240,7 +1240,7 @@ class Kubernetes(clouds.Cloud):
 
         try:
             check_result = kubernetes_utils.check_credentials(
-                context, run_optional_checks=True)
+                context, run_optional_checks=True, cloud=cls._REPR.lower())
             if check_result[0]:
                 if check_result[1] is not None:
                     return True, (_bright_green_color('enabled.') +

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -921,6 +921,7 @@ class Kubernetes(clouds.Cloud):
         namespace = kubernetes_utils.get_namespace(
             context=context,
             override_configs=resources.cluster_config_overrides,
+            cloud=cloud_config_str,
         )
 
         # Detect hostNetwork before the template is rendered so the probe

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -918,7 +918,10 @@ class Kubernetes(clouds.Cloud):
             default_value=timeout,
             override_configs=resources.cluster_config_overrides)
 
-        namespace = kubernetes_utils.get_kube_config_context_namespace(context)
+        namespace = kubernetes_utils.get_namespace(
+            context=context,
+            override_configs=resources.cluster_config_overrides,
+        )
 
         # Detect hostNetwork before the template is rendered so the probe
         # env vars can be wired into deploy_vars. Two independent paths put

--- a/sky/jobs/job_group_networking.py
+++ b/sky/jobs/job_group_networking.py
@@ -69,8 +69,8 @@ def _get_k8s_namespace_from_handle(
         try:
             # pylint: disable=import-outside-toplevel
             from sky.provision.kubernetes import utils as k8s_utils
-            return k8s_utils.get_kube_config_context_namespace(
-                handle.launched_resources.region)
+            return k8s_utils.get_namespace(
+                context=handle.launched_resources.region)
         except Exception as e:  # pylint: disable=broad-except
             logger.debug(f'Failed to get K8s namespace from handle, '
                          f'falling back to default: {e}')

--- a/sky/jobs/job_group_networking.py
+++ b/sky/jobs/job_group_networking.py
@@ -55,31 +55,20 @@ def _is_kubernetes(
 
 def _get_k8s_namespace_from_handle(
         handle: 'cloud_vm_ray_backend.CloudVmRayResourceHandle') -> str:
-    """Get Kubernetes namespace from a resource handle.
+    """Resolve the Kubernetes namespace the handle's pods live in.
 
-    Reads ``provider.namespace`` from the cluster YAML — the value set
-    at launch by ``make_deploy_resources_variables`` — rather than
-    re-resolving via the active config. Reading off the handle's YAML
-    avoids races with the active workspace (the handle does not carry
-    its launch-time workspace, so resolving via ``get_namespace``
-    here could return a different namespace than the pods actually
-    live in when the active workspace at query time differs from the
-    cluster's launch-time workspace).
+    Reads ``provider.namespace`` from the cluster YAML (set at launch
+    time and workspace-invariant). Resolving via ``get_namespace`` here
+    would depend on the active workspace at query time, which is not
+    guaranteed to match the workspace the cluster was launched under.
 
-    Mirrors the pattern in
-    ``CloudVmRayResourceHandle._use_internal_ips`` for the same
-    reason.
-
-    Returns:
-        Namespace string, defaults to ``'default'`` if neither the
-        YAML nor the kubeconfig lookup yields a value.
+    Falls back to the kubeconfig context default for legacy clusters
+    whose YAML pre-dates ``provider.namespace``; returns ``'default'``
+    if both lookups fail.
     """
     if handle is None:
         return 'default'
 
-    # Source of truth: provider.namespace persisted in the cluster
-    # YAML at launch. Set by make_deploy_resources_variables for every
-    # cluster provisioned by PR #9640 and earlier.
     if handle.cluster_yaml:
         try:
             # pylint: disable=import-outside-toplevel
@@ -93,10 +82,6 @@ def _get_k8s_namespace_from_handle(
             logger.debug(f'Failed to read namespace from cluster YAML, '
                          f'falling back: {e}')
 
-    # Legacy-cluster fallback: provider.namespace missing or YAML
-    # unreadable. Use the kubeconfig context default rather than
-    # `get_namespace`, since the latter is workspace-aware and we have
-    # no record of the launch-time workspace on the handle.
     if handle.launched_resources and handle.launched_resources.region:
         try:
             # pylint: disable=import-outside-toplevel

--- a/sky/jobs/job_group_networking.py
+++ b/sky/jobs/job_group_networking.py
@@ -57,25 +57,56 @@ def _get_k8s_namespace_from_handle(
         handle: 'cloud_vm_ray_backend.CloudVmRayResourceHandle') -> str:
     """Get Kubernetes namespace from a resource handle.
 
+    Reads ``provider.namespace`` from the cluster YAML — the value set
+    at launch by ``make_deploy_resources_variables`` — rather than
+    re-resolving via the active config. Reading off the handle's YAML
+    avoids races with the active workspace (the handle does not carry
+    its launch-time workspace, so resolving via ``get_namespace``
+    here could return a different namespace than the pods actually
+    live in when the active workspace at query time differs from the
+    cluster's launch-time workspace).
+
+    Mirrors the pattern in
+    ``CloudVmRayResourceHandle._use_internal_ips`` for the same
+    reason.
+
     Returns:
-        Namespace string, defaults to 'default' if not available.
+        Namespace string, defaults to ``'default'`` if neither the
+        YAML nor the kubeconfig lookup yields a value.
     """
     if handle is None:
         return 'default'
 
-    # Try to get namespace from launched_resources
+    # Source of truth: provider.namespace persisted in the cluster
+    # YAML at launch. Set by make_deploy_resources_variables for every
+    # cluster provisioned by PR #9640 and earlier.
+    if handle.cluster_yaml:
+        try:
+            # pylint: disable=import-outside-toplevel
+            from sky import global_user_state
+            cluster_yaml_dict = global_user_state.get_cluster_yaml_dict(
+                handle.cluster_yaml)
+            namespace = cluster_yaml_dict.get('provider', {}).get('namespace')
+            if namespace:
+                return namespace
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Failed to read namespace from cluster YAML, '
+                         f'falling back: {e}')
+
+    # Legacy-cluster fallback: provider.namespace missing or YAML
+    # unreadable. Use the kubeconfig context default rather than
+    # `get_namespace`, since the latter is workspace-aware and we have
+    # no record of the launch-time workspace on the handle.
     if handle.launched_resources and handle.launched_resources.region:
-        # In K8s, region is the context name
         try:
             # pylint: disable=import-outside-toplevel
             from sky.provision.kubernetes import utils as k8s_utils
-            return k8s_utils.get_namespace(
-                context=handle.launched_resources.region)
+            return k8s_utils.get_kube_config_context_namespace(
+                handle.launched_resources.region)
         except Exception as e:  # pylint: disable=broad-except
             logger.debug(f'Failed to get K8s namespace from handle, '
                          f'falling back to default: {e}')
 
-    # Fallback to default namespace
     return 'default'
 
 

--- a/sky/provision/kubernetes/network.py
+++ b/sky/provision/kubernetes/network.py
@@ -90,11 +90,8 @@ def _open_ports_using_ingress(
             'https://github.com/kubernetes/ingress-nginx/blob/main/docs/deploy/index.md.'  # pylint: disable=line-too-long
         )
 
-    # Prepare service names, ports, for template rendering. Use the same
-    # `namespace` resolved above (from `provider_config`) so the ingress URL
-    # path matches where the Service is actually created — required for
-    # workspace/per-context namespace overrides where the kubeconfig context's
-    # default namespace and the cluster's chosen namespace can differ.
+    # URL path namespace must match the Service's namespace (resolved above
+    # from `provider_config`); per-workspace overrides can make these differ.
     service_details = [
         (f'{cluster_name_on_cloud}--skypilot-svc--{port}', port,
          _PATH_PREFIX.format(cluster_name_on_cloud=cluster_name_on_cloud,

--- a/sky/provision/kubernetes/network.py
+++ b/sky/provision/kubernetes/network.py
@@ -90,14 +90,17 @@ def _open_ports_using_ingress(
             'https://github.com/kubernetes/ingress-nginx/blob/main/docs/deploy/index.md.'  # pylint: disable=line-too-long
         )
 
-    # Prepare service names, ports, for template rendering
+    # Prepare service names, ports, for template rendering. Use the same
+    # `namespace` resolved above (from `provider_config`) so the ingress URL
+    # path matches where the Service is actually created — required for
+    # workspace/per-context namespace overrides where the kubeconfig context's
+    # default namespace and the cluster's chosen namespace can differ.
     service_details = [
         (f'{cluster_name_on_cloud}--skypilot-svc--{port}', port,
-         _PATH_PREFIX.format(
-             cluster_name_on_cloud=cluster_name_on_cloud,
-             port=port,
-             namespace=kubernetes_utils.get_kube_config_context_namespace(
-                 context)).rstrip('/').lstrip('/')) for port in ports
+         _PATH_PREFIX.format(cluster_name_on_cloud=cluster_name_on_cloud,
+                             port=port,
+                             namespace=namespace).rstrip('/').lstrip('/'))
+        for port in ports
     ]
 
     # Generate ingress and services specs

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2892,6 +2892,29 @@ def get_kube_config_context_namespace(
         return DEFAULT_NAMESPACE
 
 
+def get_namespace(context: Optional[str] = None,
+                  workspace: Optional[str] = None,
+                  override_configs: Optional[Dict[str, Any]] = None) -> str:
+    """Resolve the Kubernetes namespace for ``context``, with fallback.
+
+    Calls ``skypilot_config.get_effective_namespace`` to resolve the
+    namespace from config; on miss, falls back to
+    ``get_kube_config_context_namespace(context)`` (then ``"default"``).
+
+    Drop-in replacement for ``get_kube_config_context_namespace`` at
+    sites that have a workspace in scope.
+    """
+    config_namespace = skypilot_config.get_effective_namespace(
+        cloud='kubernetes',
+        region=context,
+        workspace=workspace,
+        override_configs=override_configs,
+    )
+    if config_namespace is not None:
+        return config_namespace
+    return get_kube_config_context_namespace(context)
+
+
 def parse_cpu_or_gpu_resource_to_float(resource_str: str) -> float:
     if not resource_str:
         return 0.0

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2894,7 +2894,8 @@ def get_kube_config_context_namespace(
 
 def get_namespace(context: Optional[str] = None,
                   workspace: Optional[str] = None,
-                  override_configs: Optional[Dict[str, Any]] = None) -> str:
+                  override_configs: Optional[Dict[str, Any]] = None,
+                  cloud: str = 'kubernetes') -> str:
     """Resolve the Kubernetes namespace for ``context``, with fallback.
 
     Calls ``skypilot_config.get_effective_namespace`` to resolve the
@@ -2903,9 +2904,12 @@ def get_namespace(context: Optional[str] = None,
 
     Drop-in replacement for ``get_kube_config_context_namespace`` at
     sites that have a workspace in scope.
+
+    ``cloud`` selects the top-level config key the resolver consults
+    (e.g. ``'kubernetes'`` vs ``'ssh'``).
     """
     config_namespace = skypilot_config.get_effective_namespace(
-        cloud='kubernetes',
+        cloud=cloud,
         region=context,
         workspace=workspace,
         override_configs=override_configs,

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2373,21 +2373,31 @@ def get_port(svc_name: str, namespace: str, context: Optional[str]) -> int:
 
 def check_credentials(context: Optional[str],
                       timeout: int = kubernetes.API_TIMEOUT,
-                      run_optional_checks: bool = False) -> \
+                      run_optional_checks: bool = False,
+                      cloud: str = 'kubernetes') -> \
         Tuple[bool, Optional[str]]:
     """Check if the credentials in kubeconfig file are valid
+
+    The RBAC probe ``list_namespaced_pod`` is issued against the
+    workspace-resolved namespace (via ``get_namespace``) rather than the
+    raw kubeconfig context default, so a user who only has access to
+    their workspace's configured namespace is not reported as broken.
 
     Args:
         context (Optional[str]): The Kubernetes context to use. If none, uses
             in-cluster auth to check credentials, if available.
         timeout (int): Timeout in seconds for the test API call
+        run_optional_checks (bool): Whether to run additional soft checks
+            (exec-based auth, GPU labels) after the credential probe.
+        cloud (str): Top-level config key the namespace resolver consults
+            (e.g. ``'kubernetes'`` vs ``'ssh'``).
 
     Returns:
         bool: True if credentials are valid, False otherwise
         str: Error message if credentials are invalid, None otherwise
     """
     try:
-        namespace = get_kube_config_context_namespace(context)
+        namespace = get_namespace(context=context, cloud=cloud)
         kubernetes.core_api(context).list_namespaced_pod(
             namespace, limit=1, _request_timeout=timeout)
         # This call is "free" because this function is a cached call,

--- a/sky/provision/kubernetes/volume.py
+++ b/sky/provision/kubernetes/volume.py
@@ -40,7 +40,7 @@ def _get_context_namespace(config: models.VolumeConfig) -> Tuple[str, str]:
         context = config.region
     namespace = config.config.get('namespace')
     if namespace is None:
-        namespace = kubernetes_utils.get_kube_config_context_namespace(context)
+        namespace = kubernetes_utils.get_namespace(context=context)
         config.config['namespace'] = namespace
     return context, namespace
 

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -857,6 +857,8 @@ _QUEUE_NAME_KEYS: List[Tuple[str, ...]] = [
     ('kueue', 'local_queue_name'),
 ]
 
+_NAMESPACE_KEYS: List[Tuple[str, ...]] = [('namespace',)]
+
 # Hooks invoked at the end of `update_api_server_config_no_lock`, after the
 # new config has been persisted and reloaded in-process. Plugins use this to
 # invalidate caches that were derived from the config (e.g. a request that
@@ -877,17 +879,27 @@ def register_config_update_hook(fn: Callable[[], None]) -> None:
         _CONFIG_UPDATE_HOOKS.append(fn)
 
 
-def get_effective_queue_name(
+def _get_effective_k8s_config_value(
         cloud: str,
+        property_keys: List[Tuple[str, ...]],
         region: Optional[str] = None,
         workspace: Optional[str] = None,
         override_configs: Optional[Dict[str, Any]] = None) -> Optional[str]:
-    """Returns the effective Kueue local queue name from config.
+    """Generic Kubernetes config-value resolver.
 
-    Supports two equivalent spellings, ``kueue.local_queue_name`` and
-    ``quota.queue``. Scope precedence (workspace > global; context > cloud)
-    takes priority over spelling; within the same scope, ``quota.queue``
-    wins over ``kueue.local_queue_name`` when both are set.
+    Resolution precedence (most specific first):
+
+    1. ``workspaces.<workspace>.<cloud>.context_configs.<region>.<property>``
+    2. ``workspaces.<workspace>.<cloud>.<property>``
+    3. ``<cloud>.context_configs.<region>.<property>``
+    4. ``<cloud>.<property>``
+    5. ``None`` — caller is responsible for any default.
+
+    Within a scope, ``property_keys`` are tried in order; the first non-None
+    hit wins. For single-spelling fields pass ``[('namespace',)]``; for
+    multi-spelling fields pass e.g. ``[('quota', 'queue'),
+    ('kueue', 'local_queue_name')]`` to express "quota.queue wins over
+    kueue.local_queue_name when both are set at the same scope".
     """
     if workspace is None:
         workspace = get_active_workspace()
@@ -912,18 +924,37 @@ def get_effective_queue_name(
                                         default_value={},
                                         override_configs=override_configs))
         if region is not None:
-            for queue_keys in _QUEUE_NAME_KEYS:
+            for property_key in property_keys:
                 value = scope_config.get_nested(
-                    keys=(cloud, 'context_configs', region) + queue_keys,
+                    keys=(cloud, 'context_configs', region) + property_key,
                     default_value=None)
                 if value is not None:
                     return value
-        for queue_keys in _QUEUE_NAME_KEYS:
-            value = scope_config.get_nested(keys=(cloud,) + queue_keys,
+        for property_key in property_keys:
+            value = scope_config.get_nested(keys=(cloud,) + property_key,
                                             default_value=None)
             if value is not None:
                 return value
     return None
+
+
+def get_effective_queue_name(
+        cloud: str,
+        region: Optional[str] = None,
+        workspace: Optional[str] = None,
+        override_configs: Optional[Dict[str, Any]] = None) -> Optional[str]:
+    """Returns the effective Kueue local queue name from config.
+
+    Supports two equivalent spellings, ``kueue.local_queue_name`` and
+    ``quota.queue``. Scope precedence (workspace > global; context > cloud)
+    takes priority over spelling; within the same scope, ``quota.queue``
+    wins over ``kueue.local_queue_name`` when both are set.
+    """
+    return _get_effective_k8s_config_value(cloud=cloud,
+                                           property_keys=_QUEUE_NAME_KEYS,
+                                           region=region,
+                                           workspace=workspace,
+                                           override_configs=override_configs)
 
 
 def get_effective_namespace(
@@ -941,36 +972,11 @@ def get_effective_namespace(
     4. ``<cloud>.namespace``
     5. ``None`` — caller is responsible for the kubeconfig-default fallback.
     """
-    if workspace is None:
-        workspace = get_active_workspace()
-
-    def _lookup(scope: Dict[str, Any]) -> Optional[str]:
-        # Within a scope: per-context wins over cloud-level.
-        cfg = config_utils.Config(scope)
-        if override_configs is not None:
-            cfg = config_utils.Config(
-                cfg.get_nested(keys=(),
-                               default_value={},
-                               override_configs=override_configs))
-        if region is not None:
-            value = cfg.get_nested(keys=(cloud, 'context_configs', region,
-                                         'namespace'),
-                                   default_value=None)
-            if value is not None:
-                return value
-        return cfg.get_nested(keys=(cloud, 'namespace'), default_value=None)
-
-    # Workspace scope wins over global.
-    if workspace is not None:
-        ws_config = get_nested(keys=('workspaces', workspace),
-                               default_value=None)
-        if ws_config is not None:
-            value = _lookup(ws_config)
-            if value is not None:
-                return value
-
-    # Fall back to global scope.
-    return _lookup(_get_loaded_config())
+    return _get_effective_k8s_config_value(cloud=cloud,
+                                           property_keys=_NAMESPACE_KEYS,
+                                           region=region,
+                                           workspace=workspace,
+                                           override_configs=override_configs)
 
 
 def register_queue_name_key(key: Tuple[str, ...]) -> None:

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -926,6 +926,53 @@ def get_effective_queue_name(
     return None
 
 
+def get_effective_namespace(
+        cloud: str,
+        region: Optional[str] = None,
+        workspace: Optional[str] = None,
+        override_configs: Optional[Dict[str, Any]] = None) -> Optional[str]:
+    """Returns the effective Kubernetes namespace from config.
+
+    Resolution precedence, most specific first:
+
+    1. ``workspaces.<workspace>.<cloud>.context_configs.<region>.namespace``
+    2. ``workspaces.<workspace>.<cloud>.namespace``
+    3. ``<cloud>.context_configs.<region>.namespace``
+    4. ``<cloud>.namespace``
+    5. ``None`` — caller is responsible for the kubeconfig-default fallback.
+    """
+    if workspace is None:
+        workspace = get_active_workspace()
+
+    def _lookup(scope: Dict[str, Any]) -> Optional[str]:
+        # Within a scope: per-context wins over cloud-level.
+        cfg = config_utils.Config(scope)
+        if override_configs is not None:
+            cfg = config_utils.Config(
+                cfg.get_nested(keys=(),
+                               default_value={},
+                               override_configs=override_configs))
+        if region is not None:
+            value = cfg.get_nested(keys=(cloud, 'context_configs', region,
+                                         'namespace'),
+                                   default_value=None)
+            if value is not None:
+                return value
+        return cfg.get_nested(keys=(cloud, 'namespace'), default_value=None)
+
+    # Workspace scope wins over global.
+    if workspace is not None:
+        ws_config = get_nested(keys=('workspaces', workspace),
+                               default_value=None)
+        if ws_config is not None:
+            value = _lookup(ws_config)
+            if value is not None:
+                return value
+
+    # Fall back to global scope.
+    return _lookup(_get_loaded_config())
+
+
 def register_queue_name_key(key: Tuple[str, ...]) -> None:
     """Register a new queue name key to be removed from the config.
 

--- a/sky/utils/kubernetes/gpu_labeler.py
+++ b/sky/utils/kubernetes/gpu_labeler.py
@@ -316,7 +316,8 @@ def label_gpus_server(context: Optional[str] = None,
         Dict with 'success' boolean and 'message' string.
     """
     # Check prerequisites
-    prereq_ok, reason = kubernetes_utils.check_credentials(context=context)
+    prereq_ok, reason = kubernetes_utils.check_credentials(context=context,
+                                                           cloud='kubernetes')
     if not prereq_ok:
         print(reason, flush=True)  # Will be streamed to client
         return {'success': False, 'message': reason}
@@ -374,7 +375,8 @@ def main():
         context = args.context
 
     # Check if kubectl is installed and kubeconfig is set up
-    prereq_ok, reason = kubernetes_utils.check_credentials(context=context)
+    prereq_ok, reason = kubernetes_utils.check_credentials(context=context,
+                                                           cloud='kubernetes')
     if not prereq_ok:
         print(reason)
         sys.exit(1)

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1557,6 +1557,9 @@ _CONTEXT_CONFIG_SCHEMA_KUBERNETES = {
         ],
     },
     **_CONTEXT_CONFIG_SCHEMA_MINIMAL,
+    'namespace': {
+        'type': 'string',
+    },
     'autoscaler': {
         'type': 'string',
         'case_insensitive_enum': [
@@ -2475,6 +2478,9 @@ def get_config_schema():
                                 'additionalProperties':
                                     _allow_additional_properties(),
                                 'properties': {
+                                    'namespace': {
+                                        'type': 'string',
+                                    },
                                     'kueue': {
                                         'type': 'object',
                                         'required': [],

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -2438,6 +2438,9 @@ def get_config_schema():
                         'disabled': {
                             'type': 'boolean'
                         },
+                        'namespace': {
+                            'type': 'string',
+                        },
                         'kueue': {
                             'type': 'object',
                             'required': [],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1411,7 +1411,7 @@ def test_get_effective_queue_name_workspace_override(monkeypatch,
 
 
 def test_get_effective_namespace(monkeypatch, tmp_path) -> None:
-    """Full precedence matrix: workspace per-context > global per-context > global cloud > None."""
+    """Full precedence matrix across all four resolver layers."""
     with open(tmp_path / 'namespace.yaml', 'w', encoding='utf-8') as f:
         f.write("""\
         kubernetes:
@@ -1435,12 +1435,16 @@ def test_get_effective_namespace(monkeypatch, tmp_path) -> None:
                 kubernetes:
                     # Workspace declared but sets no namespace overrides.
                     allowed_contexts: ['contextA']
+            workspaceC:
+                kubernetes:
+                    # Workspace-level shorthand; no per-context override.
+                    namespace: workspaceC-shorthand-namespace
         """)
     monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH',
                         tmp_path / 'namespace.yaml')
     skypilot_config.reload_config()
 
-    # Layer 1: workspace per-context wins.
+    # Layer 1: workspace per-context wins over every lower layer.
     assert skypilot_config.get_effective_namespace(
         cloud='kubernetes', region='contextA',
         workspace='workspaceA') == 'workspaceA-contextA-namespace'
@@ -1448,7 +1452,17 @@ def test_get_effective_namespace(monkeypatch, tmp_path) -> None:
         cloud='kubernetes', region='contextB',
         workspace='workspaceA') == 'workspaceA-contextB-namespace'
 
-    # Layer 2: global per-context wins when workspace has no override.
+    # Layer 2: workspace cloud-level shorthand wins over the global
+    # per-context (layer 3) and global cloud-level (layer 4) layers, and
+    # applies regardless of which context the launch targets.
+    assert skypilot_config.get_effective_namespace(
+        cloud='kubernetes', region='contextA',
+        workspace='workspaceC') == 'workspaceC-shorthand-namespace'
+    assert skypilot_config.get_effective_namespace(
+        cloud='kubernetes', region='contextB',
+        workspace='workspaceC') == 'workspaceC-shorthand-namespace'
+
+    # Layer 3: global per-context wins when no workspace layer matches.
     assert skypilot_config.get_effective_namespace(
         cloud='kubernetes', region='contextA',
         workspace='workspaceB') == 'contextA-global-namespace'
@@ -1456,14 +1470,14 @@ def test_get_effective_namespace(monkeypatch, tmp_path) -> None:
         cloud='kubernetes', region='contextA',
         workspace='default') == 'contextA-global-namespace'
 
-    # Layer 3: global cloud-level when no per-context override exists.
+    # Layer 4: global cloud-level when no per-context override exists.
     assert skypilot_config.get_effective_namespace(
         cloud='kubernetes', region='contextB',
         workspace='workspaceB') == 'global-default-namespace'
     assert skypilot_config.get_effective_namespace(
         cloud='kubernetes', workspace='default') == 'global-default-namespace'
 
-    # Layer 4: None when no layer matches (aws has no config in this fixture).
+    # No layer matches: returns None (aws has no config in this fixture).
     assert skypilot_config.get_effective_namespace(
         cloud='aws', workspace='workspaceA') is None
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1529,6 +1529,180 @@ def test_get_effective_namespace_override_configs(monkeypatch,
         override_configs=cloud_level_override) == 'override-namespace'
 
 
+def test_get_effective_k8s_config_value_returns_none_when_unset(
+        monkeypatch, tmp_path) -> None:
+    """No matching key at any scope -> None."""
+    with open(tmp_path / 'empty.yaml', 'w', encoding='utf-8') as f:
+        f.write('kubernetes:\n  context_configs:\n    contextA: {}\n')
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH',
+                        tmp_path / 'empty.yaml')
+    skypilot_config.reload_config()
+
+    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+        cloud='kubernetes',
+        property_keys=[('namespace',)],
+        region='contextA',
+        workspace='default') is None
+
+
+def test_get_effective_k8s_config_value_property_key_priority(
+        monkeypatch, tmp_path) -> None:
+    """Within a scope, ``property_keys`` order is priority (first hit wins).
+
+    Drives the queue-name semantics: ``quota.queue`` wins over
+    ``kueue.local_queue_name`` because it appears first in the list.
+    Generalised here so the contract is exercised independently of any
+    wrapper.
+    """
+    with open(tmp_path / 'priority.yaml', 'w', encoding='utf-8') as f:
+        f.write("""\
+        kubernetes:
+            primary: from-primary
+            secondary: from-secondary
+            context_configs:
+                contextA:
+                    secondary: contextA-from-secondary
+                contextB:
+                    primary: contextB-from-primary
+                    secondary: contextB-from-secondary
+        """)
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH',
+                        tmp_path / 'priority.yaml')
+    skypilot_config.reload_config()
+
+    keys = [('primary',), ('secondary',)]
+
+    # Cloud-level: both set, `primary` wins.
+    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+        cloud='kubernetes',
+        property_keys=keys,
+        workspace='default') == 'from-primary'
+    # Per-context where only `secondary` is set: falls through to it.
+    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+        cloud='kubernetes',
+        property_keys=keys,
+        region='contextA',
+        workspace='default') == 'contextA-from-secondary'
+    # Per-context where both are set: `primary` wins.
+    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+        cloud='kubernetes',
+        property_keys=keys,
+        region='contextB',
+        workspace='default') == 'contextB-from-primary'
+    # Reversed order changes the winner.
+    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+        cloud='kubernetes',
+        property_keys=[('secondary',), ('primary',)],
+        region='contextB',
+        workspace='default') == 'contextB-from-secondary'
+
+
+def test_get_effective_k8s_config_value_full_precedence_matrix(
+        monkeypatch, tmp_path) -> None:
+    """Full precedence: ws per-context > ws cloud > global per-context > global cloud.
+
+    Uses a custom property name to verify the precedence machinery lives in
+    the shared helper, not in the namespace/queue wrappers.
+    """
+    with open(tmp_path / 'matrix.yaml', 'w', encoding='utf-8') as f:
+        f.write("""\
+        kubernetes:
+            myfield: global-cloud
+            context_configs:
+                contextA:
+                    myfield: global-context
+                contextB: {}
+        workspaces:
+            workspaceA:
+                kubernetes:
+                    myfield: ws-cloud
+                    context_configs:
+                        contextA:
+                            myfield: ws-context
+            workspaceB:
+                kubernetes:
+                    myfield: wsB-cloud
+            workspaceC: {}
+        """)
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH',
+                        tmp_path / 'matrix.yaml')
+    skypilot_config.reload_config()
+
+    keys = [('myfield',)]
+
+    # Layer 1: ws per-context wins everything.
+    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+        cloud='kubernetes',
+        property_keys=keys,
+        region='contextA',
+        workspace='workspaceA') == 'ws-context'
+    # Layer 2: ws cloud wins when ws has no per-context override.
+    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+        cloud='kubernetes',
+        property_keys=keys,
+        region='contextB',
+        workspace='workspaceA') == 'ws-cloud'
+    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+        cloud='kubernetes',
+        property_keys=keys,
+        workspace='workspaceB') == 'wsB-cloud'
+    # Layer 3: global per-context when ws has no override at any layer.
+    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+        cloud='kubernetes',
+        property_keys=keys,
+        region='contextA',
+        workspace='workspaceC') == 'global-context'
+    # Layer 4: global cloud as final fallback.
+    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+        cloud='kubernetes',
+        property_keys=keys,
+        region='contextB',
+        workspace='workspaceC') == 'global-cloud'
+
+
+def test_get_effective_k8s_config_value_override_configs_at_workspace_scope(
+        monkeypatch, tmp_path) -> None:
+    """Cloud-level ``override_configs`` apply inside the workspace scope.
+
+    Mirrors ``test_get_effective_queue_name_workspace_override`` but on the
+    shared helper directly: the override has no ``workspaces`` section, so
+    it must be merged at the *workspace* depth (replacing the workspace's
+    cloud-level value), not at config-root.
+    """
+    with open(tmp_path / 'override.yaml', 'w', encoding='utf-8') as f:
+        f.write("""\
+        kubernetes:
+            myfield: global-cloud
+        workspaces:
+            workspaceA:
+                kubernetes:
+                    myfield: ws-cloud
+                    context_configs:
+                        contextA:
+                            myfield: ws-context
+        """)
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH',
+                        tmp_path / 'override.yaml')
+    skypilot_config.reload_config()
+
+    keys = [('myfield',)]
+    cloud_override = {'kubernetes': {'myfield': 'override-value'}}
+
+    # Cloud-level override replaces the workspace's cloud-level value.
+    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+        cloud='kubernetes',
+        property_keys=keys,
+        workspace='workspaceA',
+        override_configs=cloud_override) == 'override-value'
+    # Per-context value at the workspace scope still wins (more specific).
+    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+        cloud='kubernetes',
+        property_keys=keys,
+        region='contextA',
+        workspace='workspaceA',
+        override_configs=cloud_override) == 'ws-context'
+
+
 def _make_config(d: dict) -> config_utils.Config:
     """Helper to build a Config from a plain dict."""
     cfg = config_utils.Config()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1410,6 +1410,125 @@ def test_get_effective_queue_name_workspace_override(monkeypatch,
         override_configs=cloud_level_override) == 'override-queue'
 
 
+def test_get_effective_namespace(monkeypatch, tmp_path) -> None:
+    """Full precedence matrix: workspace per-context > global per-context > global cloud > None."""
+    with open(tmp_path / 'namespace.yaml', 'w', encoding='utf-8') as f:
+        f.write("""\
+        kubernetes:
+            namespace: global-default-namespace
+            context_configs:
+                contextA:
+                    namespace: contextA-global-namespace
+                contextB:
+                    # No namespace set; falls through to `kubernetes.namespace`.
+                    kueue:
+                        local_queue_name: contextB-queue
+        workspaces:
+            workspaceA:
+                kubernetes:
+                    context_configs:
+                        contextA:
+                            namespace: workspaceA-contextA-namespace
+                        contextB:
+                            namespace: workspaceA-contextB-namespace
+            workspaceB:
+                kubernetes:
+                    # Workspace declared but sets no namespace overrides.
+                    allowed_contexts: ['contextA']
+        """)
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH',
+                        tmp_path / 'namespace.yaml')
+    skypilot_config.reload_config()
+
+    # Layer 1: workspace per-context wins.
+    assert skypilot_config.get_effective_namespace(
+        cloud='kubernetes', region='contextA',
+        workspace='workspaceA') == 'workspaceA-contextA-namespace'
+    assert skypilot_config.get_effective_namespace(
+        cloud='kubernetes', region='contextB',
+        workspace='workspaceA') == 'workspaceA-contextB-namespace'
+
+    # Layer 2: global per-context wins when workspace has no override.
+    assert skypilot_config.get_effective_namespace(
+        cloud='kubernetes', region='contextA',
+        workspace='workspaceB') == 'contextA-global-namespace'
+    assert skypilot_config.get_effective_namespace(
+        cloud='kubernetes', region='contextA',
+        workspace='default') == 'contextA-global-namespace'
+
+    # Layer 3: global cloud-level when no per-context override exists.
+    assert skypilot_config.get_effective_namespace(
+        cloud='kubernetes', region='contextB',
+        workspace='workspaceB') == 'global-default-namespace'
+    assert skypilot_config.get_effective_namespace(
+        cloud='kubernetes', workspace='default') == 'global-default-namespace'
+
+    # Layer 4: None when no layer matches (aws has no config in this fixture).
+    assert skypilot_config.get_effective_namespace(
+        cloud='aws', workspace='workspaceA') is None
+
+
+def test_get_effective_namespace_no_config(monkeypatch, tmp_path) -> None:
+    """Returns None when `namespace` is unset at every layer."""
+    with open(tmp_path / 'empty.yaml', 'w', encoding='utf-8') as f:
+        f.write("""\
+        kubernetes:
+            allowed_contexts: ['contextA']
+        """)
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH',
+                        tmp_path / 'empty.yaml')
+    skypilot_config.reload_config()
+
+    assert skypilot_config.get_effective_namespace(
+        cloud='kubernetes', region='contextA', workspace='default') is None
+    assert skypilot_config.get_effective_namespace(cloud='kubernetes',
+                                                   workspace='default') is None
+
+
+def test_get_effective_namespace_override_configs(monkeypatch,
+                                                  tmp_path) -> None:
+    """Cloud-level `override_configs` apply inside workspace scope.
+
+    Regression mirror of `test_get_effective_queue_name_workspace_override`.
+    """
+    with open(tmp_path / 'override.yaml', 'w', encoding='utf-8') as f:
+        f.write("""\
+        kubernetes:
+            namespace: global-namespace
+        workspaces:
+            workspaceA:
+                kubernetes:
+                    context_configs:
+                        contextA:
+                            namespace: workspaceA-contextA-namespace
+        """)
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH',
+                        tmp_path / 'override.yaml')
+    skypilot_config.reload_config()
+
+    cloud_level_override = {'kubernetes': {'namespace': 'override-namespace',}}
+
+    # Override replaces the global namespace when no per-context value exists.
+    assert skypilot_config.get_effective_namespace(
+        cloud='kubernetes',
+        workspace='default',
+        override_configs=cloud_level_override) == 'override-namespace'
+
+    # Per-context value wins over a cloud-level override (more specific).
+    assert skypilot_config.get_effective_namespace(
+        cloud='kubernetes',
+        region='contextA',
+        workspace='workspaceA',
+        override_configs=cloud_level_override
+    ) == 'workspaceA-contextA-namespace'
+
+    # Override applies for an unknown workspace (falls through to global).
+    assert skypilot_config.get_effective_namespace(
+        cloud='kubernetes',
+        workspace='nonexistent-ws',
+        override_configs=cloud_level_override) == 'override-namespace'
+
+
 def _make_config(d: dict) -> config_utils.Config:
     """Helper to build a Config from a plain dict."""
     cfg = config_utils.Config()

--- a/tests/test_job_groups/test_job_group.py
+++ b/tests/test_job_groups/test_job_group.py
@@ -434,19 +434,21 @@ class TestJobGroupNetworking:
             'SKYPILOT_JOBGROUP_NAME')
 
     def test_get_k8s_namespace_logs_on_exception(self):
-        """Test that _get_k8s_namespace_from_handle logs debug message on error.
+        """`_get_k8s_namespace_from_handle` logs at debug when fallback errors.
 
-        This test verifies the fix for silent exception handling - exceptions
-        should be logged at debug level instead of silently passed.
+        Pins the silent-exception fix: when the kubeconfig fallback raises
+        we log a debug message and return 'default' rather than letting the
+        exception propagate. `cluster_yaml` is set to None so the new
+        YAML-read path is skipped and the kubeconfig path is tested in
+        isolation.
         """
         from sky.jobs import job_group_networking
 
-        # Create a mock handle that will cause an exception
         mock_handle = mock.MagicMock()
+        mock_handle.cluster_yaml = None  # skip YAML read; test fallback
         mock_handle.launched_resources = mock.MagicMock()
         mock_handle.launched_resources.region = 'test-context'
 
-        # Mock the k8s_utils to raise an exception and patch the logger
         with mock.patch(
                 'sky.provision.kubernetes.utils.'
                 'get_kube_config_context_namespace') as mock_get_ns, \
@@ -457,21 +459,115 @@ class TestJobGroupNetworking:
             result = job_group_networking._get_k8s_namespace_from_handle(
                 mock_handle)
 
-            # Should fall back to default
             assert result == 'default'
-
-            # Should have logged the exception at debug level
             mock_logger.debug.assert_called_once()
             log_message = mock_logger.debug.call_args[0][0]
             assert 'Failed to get K8s namespace from handle' in log_message
             assert 'Test K8s error' in log_message
 
     def test_get_k8s_namespace_returns_default_for_none_handle(self):
-        """Test _get_k8s_namespace_from_handle returns 'default' for None."""
+        """`_get_k8s_namespace_from_handle` returns 'default' for None."""
         from sky.jobs import job_group_networking
 
         result = job_group_networking._get_k8s_namespace_from_handle(None)
         assert result == 'default'
+
+    def test_get_k8s_namespace_reads_provider_namespace_from_yaml(self):
+        """The namespace must come from the cluster YAML's provider.namespace.
+
+        Source-of-truth check: `make_deploy_resources_variables` persists
+        the resolved namespace under `provider.namespace` in the cluster
+        YAML at launch time. The JobGroup DNS path must read it from
+        there, independent of whatever the active workspace is at query
+        time — otherwise a multi-workspace JobGroup or a controller
+        running under a different workspace would construct DNS for the
+        wrong namespace.
+        """
+        from sky.jobs import job_group_networking
+
+        mock_handle = mock.MagicMock()
+        mock_handle.cluster_yaml = '~/.sky/generated/cluster.yaml'
+        mock_handle.launched_resources = mock.MagicMock()
+        mock_handle.launched_resources.region = 'in-cluster'
+
+        with mock.patch(
+                'sky.global_user_state.get_cluster_yaml_dict'
+        ) as mock_get_yaml, \
+                mock.patch(
+                'sky.provision.kubernetes.utils.'
+                'get_kube_config_context_namespace') as mock_kubeconfig:
+            mock_get_yaml.return_value = {
+                'provider': {
+                    'namespace': 'team-a-ns'
+                }
+            }
+
+            result = job_group_networking._get_k8s_namespace_from_handle(
+                mock_handle)
+
+            assert result == 'team-a-ns'
+            mock_get_yaml.assert_called_once_with(mock_handle.cluster_yaml)
+            mock_kubeconfig.assert_not_called()
+
+    def test_get_k8s_namespace_falls_back_when_yaml_missing_namespace(self):
+        """Legacy clusters without provider.namespace fall back to kubeconfig.
+
+        Clusters provisioned before the per-workspace namespace feature
+        existed won't have `provider.namespace` set in their YAML. The
+        fallback uses `get_kube_config_context_namespace` (deterministic,
+        workspace-invariant) rather than `get_namespace` (workspace-aware,
+        which would re-introduce the race the YAML read is meant to avoid).
+        """
+        from sky.jobs import job_group_networking
+
+        mock_handle = mock.MagicMock()
+        mock_handle.cluster_yaml = '~/.sky/generated/cluster.yaml'
+        mock_handle.launched_resources = mock.MagicMock()
+        mock_handle.launched_resources.region = 'in-cluster'
+
+        with mock.patch(
+                'sky.global_user_state.get_cluster_yaml_dict'
+        ) as mock_get_yaml, \
+                mock.patch(
+                'sky.provision.kubernetes.utils.'
+                'get_kube_config_context_namespace') as mock_kubeconfig:
+            # Legacy YAML: provider exists but has no `namespace` key.
+            mock_get_yaml.return_value = {'provider': {'type': 'kubernetes'}}
+            mock_kubeconfig.return_value = 'kubeconfig-default'
+
+            result = job_group_networking._get_k8s_namespace_from_handle(
+                mock_handle)
+
+            assert result == 'kubeconfig-default'
+            mock_kubeconfig.assert_called_once_with('in-cluster')
+
+    def test_get_k8s_namespace_skips_yaml_when_cluster_yaml_is_none(self):
+        """When the handle has no `cluster_yaml`, the YAML read is skipped.
+
+        Covers unpickled handles for older clusters where `cluster_yaml`
+        may be None.
+        """
+        from sky.jobs import job_group_networking
+
+        mock_handle = mock.MagicMock()
+        mock_handle.cluster_yaml = None
+        mock_handle.launched_resources = mock.MagicMock()
+        mock_handle.launched_resources.region = 'in-cluster'
+
+        with mock.patch(
+                'sky.global_user_state.get_cluster_yaml_dict'
+        ) as mock_get_yaml, \
+                mock.patch(
+                'sky.provision.kubernetes.utils.'
+                'get_kube_config_context_namespace') as mock_kubeconfig:
+            mock_kubeconfig.return_value = 'kubeconfig-default'
+
+            result = job_group_networking._get_k8s_namespace_from_handle(
+                mock_handle)
+
+            assert result == 'kubeconfig-default'
+            mock_get_yaml.assert_not_called()
+            mock_kubeconfig.assert_called_once_with('in-cluster')
 
     def test_generate_wait_for_networking_script_with_hostnames(self):
         """Test wait script generation with multiple job names."""

--- a/tests/test_job_groups/test_job_group.py
+++ b/tests/test_job_groups/test_job_group.py
@@ -434,13 +434,10 @@ class TestJobGroupNetworking:
             'SKYPILOT_JOBGROUP_NAME')
 
     def test_get_k8s_namespace_logs_on_exception(self):
-        """`_get_k8s_namespace_from_handle` logs at debug when fallback errors.
+        """Kubeconfig-fallback exceptions are caught, logged, and return 'default'.
 
-        Pins the silent-exception fix: when the kubeconfig fallback raises
-        we log a debug message and return 'default' rather than letting the
-        exception propagate. `cluster_yaml` is set to None so the new
-        YAML-read path is skipped and the kubeconfig path is tested in
-        isolation.
+        ``cluster_yaml=None`` skips the YAML read so the kubeconfig path
+        is exercised in isolation.
         """
         from sky.jobs import job_group_networking
 
@@ -473,15 +470,10 @@ class TestJobGroupNetworking:
         assert result == 'default'
 
     def test_get_k8s_namespace_reads_provider_namespace_from_yaml(self):
-        """The namespace must come from the cluster YAML's provider.namespace.
+        """Namespace comes from the cluster YAML's ``provider.namespace``.
 
-        Source-of-truth check: `make_deploy_resources_variables` persists
-        the resolved namespace under `provider.namespace` in the cluster
-        YAML at launch time. The JobGroup DNS path must read it from
-        there, independent of whatever the active workspace is at query
-        time — otherwise a multi-workspace JobGroup or a controller
-        running under a different workspace would construct DNS for the
-        wrong namespace.
+        Reading the launch-time value off the handle keeps DNS resolution
+        independent of the active workspace at query time.
         """
         from sky.jobs import job_group_networking
 
@@ -510,13 +502,10 @@ class TestJobGroupNetworking:
             mock_kubeconfig.assert_not_called()
 
     def test_get_k8s_namespace_falls_back_when_yaml_missing_namespace(self):
-        """Legacy clusters without provider.namespace fall back to kubeconfig.
+        """YAML without ``provider.namespace`` falls back to kubeconfig default.
 
-        Clusters provisioned before the per-workspace namespace feature
-        existed won't have `provider.namespace` set in their YAML. The
-        fallback uses `get_kube_config_context_namespace` (deterministic,
-        workspace-invariant) rather than `get_namespace` (workspace-aware,
-        which would re-introduce the race the YAML read is meant to avoid).
+        The fallback uses the workspace-invariant kubeconfig lookup so
+        legacy clusters keep their pre-feature behaviour.
         """
         from sky.jobs import job_group_networking
 
@@ -542,11 +531,7 @@ class TestJobGroupNetworking:
             mock_kubeconfig.assert_called_once_with('in-cluster')
 
     def test_get_k8s_namespace_skips_yaml_when_cluster_yaml_is_none(self):
-        """When the handle has no `cluster_yaml`, the YAML read is skipped.
-
-        Covers unpickled handles for older clusters where `cluster_yaml`
-        may be None.
-        """
+        """``cluster_yaml=None`` skips the YAML read (e.g. legacy handles)."""
         from sky.jobs import job_group_networking
 
         mock_handle = mock.MagicMock()

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -4251,3 +4251,69 @@ class TestAdjustResourcesToAllocatable:
         ]
         result = utils.adjust_resources_to_allocatable(4.0, 16.0, 'ctx')
         assert result == (4.0, 16.0)
+
+
+class TestGetNamespace:
+    """Tests for `get_namespace`: config resolution + kubeconfig fallback."""
+
+    @patch('sky.provision.kubernetes.utils.get_kube_config_context_namespace')
+    @patch('sky.provision.kubernetes.utils.skypilot_config'
+           '.get_effective_namespace')
+    def test_returns_config_value_when_set(self, mock_effective,
+                                           mock_kubeconfig):
+        """When config has a value, kubeconfig fallback is not consulted."""
+        mock_effective.return_value = 'team-a'
+        result = utils.get_namespace(context='shared-ctx',
+                                     workspace='workspaceA')
+        assert result == 'team-a'
+        mock_effective.assert_called_once_with(
+            cloud='kubernetes',
+            region='shared-ctx',
+            workspace='workspaceA',
+            override_configs=None,
+        )
+        mock_kubeconfig.assert_not_called()
+
+    @patch('sky.provision.kubernetes.utils.get_kube_config_context_namespace')
+    @patch('sky.provision.kubernetes.utils.skypilot_config'
+           '.get_effective_namespace')
+    def test_falls_back_to_kubeconfig_when_unset(self, mock_effective,
+                                                 mock_kubeconfig):
+        """No config value → kubeconfig context's default namespace."""
+        mock_effective.return_value = None
+        mock_kubeconfig.return_value = 'kubeconfig-default-ns'
+        result = utils.get_namespace(context='shared-ctx')
+        assert result == 'kubeconfig-default-ns'
+        mock_kubeconfig.assert_called_once_with('shared-ctx')
+
+    @patch('sky.provision.kubernetes.utils.get_kube_config_context_namespace')
+    @patch('sky.provision.kubernetes.utils.skypilot_config'
+           '.get_effective_namespace')
+    def test_passes_override_configs_through(self, mock_effective,
+                                             mock_kubeconfig):
+        """`override_configs` are forwarded to the resolver verbatim."""
+        mock_effective.return_value = 'override-ns'
+        overrides = {'kubernetes': {'namespace': 'override-ns'}}
+        result = utils.get_namespace(context='shared-ctx',
+                                     workspace='workspaceA',
+                                     override_configs=overrides)
+        assert result == 'override-ns'
+        mock_effective.assert_called_once_with(
+            cloud='kubernetes',
+            region='shared-ctx',
+            workspace='workspaceA',
+            override_configs=overrides,
+        )
+        mock_kubeconfig.assert_not_called()
+
+    @patch('sky.provision.kubernetes.utils.get_kube_config_context_namespace')
+    @patch('sky.provision.kubernetes.utils.skypilot_config'
+           '.get_effective_namespace')
+    def test_context_none_propagates_to_kubeconfig_fallback(
+            self, mock_effective, mock_kubeconfig):
+        """`context=None` propagates to the kubeconfig current-context fallback."""
+        mock_effective.return_value = None
+        mock_kubeconfig.return_value = 'current-ctx-default'
+        result = utils.get_namespace()
+        assert result == 'current-ctx-default'
+        mock_kubeconfig.assert_called_once_with(None)

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -4338,3 +4338,99 @@ class TestGetNamespace:
             workspace=None,
             override_configs=None,
         )
+
+
+class TestCheckCredentials:
+    """Tests for `check_credentials`: probe namespace resolution.
+
+    The probe ``list_namespaced_pod`` was historically issued against
+    the raw kubeconfig context default. With workspace- and cloud-level
+    namespace overrides supported, the probe must use the resolved
+    namespace so users with RBAC only on their workspace's namespace
+    are not falsely reported as broken by ``sky check``.
+    """
+
+    def _patch_common(self):
+        """Patch the side-effects `check_credentials` triggers besides the probe.
+
+        Returns the active-context patches so individual tests can
+        configure them; everything else is short-circuited.
+        """
+        patches = [
+            patch('sky.provision.kubernetes.utils.kubernetes.core_api'),
+            patch('sky.provision.kubernetes.utils.get_kubernetes_nodes'),
+            patch('sky.provision.kubernetes.utils.get_kubeconfig_paths',
+                  return_value=['~/.kube/config']),
+        ]
+        return [p.start() for p in patches], patches
+
+    def _stop(self, patches):
+        for p in patches:
+            p.stop()
+
+    @patch('sky.provision.kubernetes.utils.get_namespace')
+    def test_probes_workspace_resolved_namespace(self, mock_get_namespace):
+        """Probe uses the workspace/cloud-resolved namespace, not kubeconfig.
+
+        With ``kubernetes.namespace: team-a`` configured, the
+        ``list_namespaced_pod`` call must target ``team-a`` so users
+        without RBAC on the kubeconfig default are not falsely reported
+        as broken by ``sky check``.
+        """
+        mocks, patches = self._patch_common()
+        mock_core_api = mocks[0]
+        try:
+            mock_get_namespace.return_value = 'team-a'
+
+            ok, reason = utils.check_credentials(context='shared-ctx')
+
+            assert ok is True
+            assert reason is None
+            mock_get_namespace.assert_called_once_with(context='shared-ctx',
+                                                       cloud='kubernetes')
+            mock_core_api.return_value.list_namespaced_pod.assert_called_once()
+            args, _ = (mock_core_api.return_value.list_namespaced_pod.call_args)
+            assert args[0] == 'team-a'
+        finally:
+            self._stop(patches)
+
+    @patch('sky.provision.kubernetes.utils.get_namespace')
+    def test_falls_back_to_kubeconfig_default_when_unconfigured(
+            self, mock_get_namespace):
+        """When no namespace override is set the kubeconfig default is used.
+
+        Pinned to preserve pre-feature behaviour: a user without any
+        workspace or global ``kubernetes.namespace`` should see the
+        same probe target as before.
+        """
+        mocks, patches = self._patch_common()
+        mock_core_api = mocks[0]
+        try:
+            mock_get_namespace.return_value = 'kubeconfig-default'
+
+            ok, _ = utils.check_credentials(context='shared-ctx')
+
+            assert ok is True
+            args, _ = (mock_core_api.return_value.list_namespaced_pod.call_args)
+            assert args[0] == 'kubeconfig-default'
+        finally:
+            self._stop(patches)
+
+    @patch('sky.provision.kubernetes.utils.get_namespace')
+    def test_forwards_explicit_cloud(self, mock_get_namespace):
+        """`cloud` arg is forwarded to `get_namespace`.
+
+        Required so that the SSH path's credential check resolves
+        under ``ssh.*`` and a global ``kubernetes.namespace`` setting
+        does not bleed into SSH ``sky check`` results.
+        """
+        mocks, patches = self._patch_common()
+        try:
+            mock_get_namespace.return_value = 'kubeconfig-default'
+
+            utils.check_credentials(context='ssh-cluster', cloud='ssh')
+
+            mock_get_namespace.assert_called_once_with(context='ssh-cluster',
+                                                       cloud='ssh')
+        finally:
+            self._stop(patches)

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -4317,3 +4317,24 @@ class TestGetNamespace:
         result = utils.get_namespace()
         assert result == 'current-ctx-default'
         mock_kubeconfig.assert_called_once_with(None)
+
+    @patch('sky.provision.kubernetes.utils.get_kube_config_context_namespace')
+    @patch('sky.provision.kubernetes.utils.skypilot_config'
+           '.get_effective_namespace')
+    def test_forwards_explicit_cloud(self, mock_effective, mock_kubeconfig):
+        """Explicit `cloud` arg is forwarded to the resolver.
+
+        Callers reused across cloud classes (e.g. Kubernetes and SSH node
+        pools) need to scope namespace lookups to their own cloud key so
+        configuration set under one cloud does not bleed into another.
+        """
+        mock_effective.return_value = None
+        mock_kubeconfig.return_value = 'kubeconfig-default'
+        result = utils.get_namespace(context='ssh-cluster', cloud='ssh')
+        assert result == 'kubeconfig-default'
+        mock_effective.assert_called_once_with(
+            cloud='ssh',
+            region='ssh-cluster',
+            workspace=None,
+            override_configs=None,
+        )

--- a/tests/unit_tests/kubernetes/test_network.py
+++ b/tests/unit_tests/kubernetes/test_network.py
@@ -1,0 +1,122 @@
+"""Tests for `sky/provision/kubernetes/network.py`."""
+
+from unittest.mock import patch
+
+from sky.provision.kubernetes import network
+
+
+class TestOpenPortsUsingIngress:
+    """Tests for `_open_ports_using_ingress`."""
+
+    @patch('sky.provision.kubernetes.network.kubernetes_utils'
+           '.merge_custom_metadata')
+    @patch('sky.provision.kubernetes.network.network_utils'
+           '.create_or_replace_namespaced_ingress')
+    @patch('sky.provision.kubernetes.network.network_utils'
+           '.create_or_replace_namespaced_service')
+    @patch('sky.provision.kubernetes.network.network_utils'
+           '.fill_ingress_template')
+    @patch('sky.provision.kubernetes.network.network_utils'
+           '.ingress_controller_exists')
+    @patch('sky.provision.kubernetes.network.kubernetes_utils'
+           '.get_kube_config_context_namespace')
+    @patch('sky.provision.kubernetes.network.kubernetes_utils'
+           '.get_namespace_from_config')
+    @patch('sky.provision.kubernetes.network.kubernetes_utils'
+           '.get_context_from_config')
+    def test_url_path_uses_provider_namespace_not_kubeconfig_default(
+            self, mock_get_context, mock_get_ns_from_config, mock_kubeconfig_ns,
+            mock_ingress_exists, mock_fill_template, mock_create_service,
+            mock_create_ingress, mock_merge_metadata):
+        """The Ingress URL path must reference the same namespace as the Service.
+
+        Regression: when a workspace/per-context override sets
+        `provider_config['namespace']` to something other than the kubeconfig
+        context's default namespace, the URL path embedded in the Ingress rule
+        must match the Service's actual namespace, otherwise nginx routes to a
+        non-existent service. Both must agree by construction (same variable).
+        """
+        provider_config = {
+            'context': 'shared-ctx',
+            'namespace': 'team-a',
+        }
+        mock_get_context.return_value = 'shared-ctx'
+        mock_get_ns_from_config.return_value = 'team-a'
+        mock_kubeconfig_ns.return_value = 'kubeconfig-default'
+        mock_ingress_exists.return_value = True
+        mock_fill_template.return_value = {
+            'services_spec': {},
+            'ingress_spec': {
+                'metadata': {}
+            },
+        }
+
+        network._open_ports_using_ingress(  # pylint: disable=protected-access
+            cluster_name_on_cloud='cluster0',
+            ports=[8080],
+            provider_config=provider_config,
+        )
+
+        mock_fill_template.assert_called_once()
+        call_kwargs = mock_fill_template.call_args.kwargs
+        assert call_kwargs['namespace'] == 'team-a', (
+            'Service is created with the provider_config namespace.')
+        service_details = call_kwargs['service_details']
+        assert len(service_details) == 1
+        _, _, url_path = service_details[0]
+        assert 'team-a' in url_path, (
+            f'URL path must reference the provider_config namespace, '
+            f'got: {url_path!r}')
+        assert 'kubeconfig-default' not in url_path, (
+            f'URL path must not fall back to the kubeconfig context default '
+            f'when provider_config has an explicit namespace, '
+            f'got: {url_path!r}')
+        mock_kubeconfig_ns.assert_not_called()
+
+    @patch('sky.provision.kubernetes.network.kubernetes_utils'
+           '.merge_custom_metadata')
+    @patch('sky.provision.kubernetes.network.network_utils'
+           '.create_or_replace_namespaced_ingress')
+    @patch('sky.provision.kubernetes.network.network_utils'
+           '.create_or_replace_namespaced_service')
+    @patch('sky.provision.kubernetes.network.network_utils'
+           '.fill_ingress_template')
+    @patch('sky.provision.kubernetes.network.network_utils'
+           '.ingress_controller_exists')
+    @patch('sky.provision.kubernetes.network.kubernetes_utils'
+           '.get_kube_config_context_namespace')
+    @patch('sky.provision.kubernetes.network.kubernetes_utils'
+           '.get_namespace_from_config')
+    @patch('sky.provision.kubernetes.network.kubernetes_utils'
+           '.get_context_from_config')
+    def test_url_path_namespace_matches_service_namespace_for_all_ports(
+            self, mock_get_context, mock_get_ns_from_config, mock_kubeconfig_ns,
+            mock_ingress_exists, mock_fill_template, mock_create_service,
+            mock_create_ingress, mock_merge_metadata):
+        """Multiple ports all share the same namespace in their URL paths."""
+        provider_config = {
+            'context': 'shared-ctx',
+            'namespace': 'team-b',
+        }
+        mock_get_context.return_value = 'shared-ctx'
+        mock_get_ns_from_config.return_value = 'team-b'
+        mock_kubeconfig_ns.return_value = 'kubeconfig-default'
+        mock_ingress_exists.return_value = True
+        mock_fill_template.return_value = {
+            'services_spec': {},
+            'ingress_spec': {
+                'metadata': {}
+            },
+        }
+
+        network._open_ports_using_ingress(  # pylint: disable=protected-access
+            cluster_name_on_cloud='cluster0',
+            ports=[8080, 8081, 8082],
+            provider_config=provider_config,
+        )
+
+        call_kwargs = mock_fill_template.call_args.kwargs
+        for _, _, url_path in call_kwargs['service_details']:
+            assert 'team-b' in url_path, (
+                f'Every port URL path must use the resolved namespace, '
+                f'got: {url_path!r}')

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes.py
@@ -4084,5 +4084,22 @@ class TestKubernetesDetectNetworkType(unittest.TestCase):
              None))
 
 
+class TestKubernetesCheckSingleContextForwardsCloud(unittest.TestCase):
+    """`_check_single_context` forwards the cloud key to `check_credentials`.
+
+    Ensures `sky check` resolves the credential-probe namespace under
+    the calling cloud's config key (``kubernetes`` vs ``ssh``) instead
+    of always querying the kubeconfig context default.
+    """
+
+    @patch('sky.provision.kubernetes.utils.check_credentials')
+    def test_forwards_kubernetes_cloud_key(self, mock_check_credentials):
+        mock_check_credentials.return_value = (True, None)
+        kubernetes.Kubernetes._check_single_context('some-ctx')
+        mock_check_credentials.assert_called_once_with('some-ctx',
+                                                       run_optional_checks=True,
+                                                       cloud='kubernetes')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit_tests/test_sky/clouds/test_ssh.py
+++ b/tests/unit_tests/test_sky/clouds/test_ssh.py
@@ -615,5 +615,22 @@ class TestSSHMakeDeployResourcesVariables(unittest.TestCase):
             self.assertEqual(call.kwargs.get('cloud'), 'ssh')
 
 
+class TestSSHCheckSingleContextForwardsCloud(unittest.TestCase):
+    """SSH `_check_single_context` must forward `cloud='ssh'`.
+
+    Without this forwarding, a global ``kubernetes.namespace`` would
+    leak into the SSH `sky check` probe and could falsely fail/pass
+    against a namespace the user does not actually target.
+    """
+
+    @patch('sky.provision.kubernetes.utils.check_credentials')
+    def test_forwards_ssh_cloud_key(self, mock_check_credentials):
+        mock_check_credentials.return_value = (True, None)
+        ssh.SSH._check_single_context('ssh-some-ctx')
+        mock_check_credentials.assert_called_once_with('ssh-some-ctx',
+                                                       run_optional_checks=True,
+                                                       cloud='ssh')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit_tests/test_sky/clouds/test_ssh.py
+++ b/tests/unit_tests/test_sky/clouds/test_ssh.py
@@ -514,6 +514,106 @@ class TestSSHMakeDeployResourcesVariables(unittest.TestCase):
         self.assertIn('timeout', deploy_vars)
         self.assertEqual(deploy_vars['timeout'], '9000')
 
+    @patch('sky.provision.kubernetes.utils.get_kubernetes_nodes')
+    @patch('sky.provision.kubernetes.utils.get_current_kube_config_context_name'
+          )
+    @patch('sky.provision.kubernetes.utils.get_kube_config_context_namespace')
+    @patch('sky.provision.kubernetes.utils.get_accelerator_label_keys')
+    @patch('sky.provision.kubernetes.utils.is_kubeconfig_exec_auth')
+    @patch('sky.skypilot_config.get_effective_namespace')
+    @patch('sky.skypilot_config.get_effective_region_config')
+    @patch('sky.skypilot_config.get_workspace_cloud')
+    @patch('sky.provision.kubernetes.network_utils.get_port_mode')
+    @patch('sky.catalog.get_image_id_from_tag')
+    @patch('sky.clouds.kubernetes.Kubernetes._detect_network_type')
+    def test_ssh_cloud_does_not_leak_global_kubernetes_namespace(
+            self, mock_detect_network_type, mock_get_image, mock_get_port_mode,
+            mock_get_workspace_cloud, mock_get_cloud_config_value,
+            mock_get_effective_namespace, mock_is_exec_auth,
+            mock_get_accelerator_label_keys, mock_get_kubeconfig_namespace,
+            mock_get_current_context, mock_get_k8s_nodes):
+        """Global ``kubernetes.namespace`` must not leak into SSH launches.
+
+        SSH pools resolve namespaces under the ``ssh.*`` config key, so a
+        ``kubernetes.namespace`` set at the top level must not influence
+        where an SSH pod lands. When the SSH path has nothing configured,
+        the namespace must fall back to the kubeconfig context default.
+        """
+
+        from sky.provision.kubernetes.utils import (
+            KubernetesHighPerformanceNetworkType)
+        mock_detect_network_type.return_value = (
+            KubernetesHighPerformanceNetworkType.NONE, '')
+
+        mock_get_current_context.return_value = 'ssh-my-cluster'
+        mock_get_kubeconfig_namespace.return_value = 'kubeconfig-default'
+        mock_get_accelerator_label_keys.return_value = []
+        mock_get_workspace_cloud.return_value.get.return_value = None
+        mock_is_exec_auth.return_value = (False, None)
+
+        # Simulate `kubernetes.namespace: prod-ns` set globally, with no
+        # `ssh.namespace` configured (the SSH schema does not carry one).
+        def effective_namespace_side_effect(cloud,
+                                            region=None,
+                                            workspace=None,
+                                            override_configs=None):
+            if cloud == 'kubernetes':
+                return 'prod-ns'
+            return None
+
+        mock_get_effective_namespace.side_effect = (
+            effective_namespace_side_effect)
+
+        def config_side_effect(cloud,
+                               keys,
+                               region,
+                               default_value=None,
+                               override_configs=None):
+            if keys == ('remote_identity',):
+                return 'SERVICE_ACCOUNT'
+            if keys == ('high_availability', 'storage_class_name'):
+                return None
+            return default_value
+
+        mock_get_cloud_config_value.side_effect = config_side_effect
+
+        mock_port_mode = mock.MagicMock()
+        mock_port_mode.value = 'portforward'
+        mock_get_port_mode.return_value = mock_port_mode
+
+        mock_get_image.return_value = 'test-image:latest'
+
+        ssh_cloud = ssh.SSH()
+        self.assertEqual(ssh_cloud._REPR, 'SSH')
+
+        deploy_vars = ssh_cloud.make_deploy_resources_variables(
+            resources=self.resources,
+            cluster_name=resources_utils.ClusterName(
+                display_name=self.cluster_name,
+                name_on_cloud=self.cluster_name),
+            region=self.region,
+            zones=None,
+            num_nodes=1,
+            dryrun=False)
+
+        # SSH launch must land in the kubeconfig default, NOT `prod-ns`.
+        self.assertIn('k8s_namespace', deploy_vars)
+        self.assertEqual(deploy_vars['k8s_namespace'], 'kubeconfig-default')
+        self.assertNotEqual(deploy_vars['k8s_namespace'], 'prod-ns')
+
+        # The resolver must be consulted with cloud='ssh', so the global
+        # `kubernetes.namespace` entry can't apply.
+        namespace_calls = [
+            call for call in mock_get_effective_namespace.call_args_list
+            if call.kwargs.get('region') == 'ssh-my-cluster'
+        ]
+        self.assertTrue(
+            namespace_calls,
+            'get_effective_namespace was not consulted for SSH '
+            'launch')
+        for call in namespace_calls:
+            self.assertEqual(call.kwargs.get('cloud'), 'ssh')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit_tests/test_sky/test_check.py
+++ b/tests/unit_tests/test_sky/test_check.py
@@ -233,8 +233,10 @@ def _mock_k8s_env(monkeypatch,
         lambda: False)
 
     # Mock per-context credential checks as enabled
-    def mock_check_credentials(context, run_optional_checks=True):
-        del run_optional_checks
+    def mock_check_credentials(context,
+                               run_optional_checks=True,
+                               cloud='kubernetes'):
+        del run_optional_checks, cloud
         return True, check_note
 
     monkeypatch.setattr('sky.provision.kubernetes.utils.check_credentials',

--- a/tests/unit_tests/test_sky/utils/test_schemas.py
+++ b/tests/unit_tests/test_sky/utils/test_schemas.py
@@ -473,26 +473,74 @@ class TestWorkspaceSchema(unittest.TestCase):
         jsonschema.validate(instance=valid_config,
                             schema=self.workspaces_schema)
 
-    def test_workspace_kubernetes_namespace_shorthand_rejected(self):
-        """`workspaces.<ws>.kubernetes.namespace` (no context) is rejected.
+    def test_workspace_kubernetes_namespace_shorthand_accepted(self):
+        """`workspaces.<ws>.kubernetes.namespace` (no context) validates.
 
-        Design choice: only the per-context spelling is supported.
+        Mirrors the `kueue`/`quota` shorthand already accepted at the
+        workspace cloud level, and matches layer 2 of the resolver
+        precedence in `get_effective_namespace`.
         """
-        invalid_config = {
+        valid_config = {
             'my-workspace': {
                 'kubernetes': {
                     'namespace': 'team-a',
                 },
             },
         }
-        with self.assertRaises(jsonschema.exceptions.ValidationError):
-            jsonschema.validate(instance=invalid_config,
-                                schema=self.workspaces_schema)
+        jsonschema.validate(instance=valid_config,
+                            schema=self.workspaces_schema)
 
-    def test_workspace_kubernetes_context_configs_namespace_must_be_string(
-            self):
-        """Non-string `namespace` is rejected at the workspace level too."""
+    def test_workspace_kubernetes_namespace_shorthand_coexists(self):
+        """Shorthand `namespace` validates alongside other workspace fields.
+
+        Pins that adding the shorthand does not regress the existing
+        per-context, `allowed_contexts`, `kueue`, or `quota` spellings
+        when they are set in the same workspace block.
+        """
+        valid_config = {
+            'my-workspace': {
+                'kubernetes': {
+                    'namespace': 'team-a',
+                    'allowed_contexts': ['shared-context'],
+                    'kueue': {
+                        'local_queue_name': 'team-a-queue',
+                    },
+                    'quota': {
+                        'queue': 'team-a-quota',
+                    },
+                    'context_configs': {
+                        'shared-context': {
+                            'namespace': 'team-a-shared',
+                        },
+                    },
+                },
+            },
+        }
+        jsonschema.validate(instance=valid_config,
+                            schema=self.workspaces_schema)
+
+    def test_workspace_kubernetes_namespace_must_be_string(self):
+        """Non-string `namespace` is rejected at every workspace spelling.
+
+        Covers both the shorthand (`workspaces.<ws>.kubernetes.namespace`)
+        and the per-context spelling
+        (`workspaces.<ws>.kubernetes.context_configs.<ctx>.namespace`).
+        """
         invalid_configs = [
+            {
+                'my-workspace': {
+                    'kubernetes': {
+                        'namespace': 123,
+                    },
+                },
+            },
+            {
+                'my-workspace': {
+                    'kubernetes': {
+                        'namespace': ['team-a'],
+                    },
+                },
+            },
             {
                 'my-workspace': {
                     'kubernetes': {

--- a/tests/unit_tests/test_sky/utils/test_schemas.py
+++ b/tests/unit_tests/test_sky/utils/test_schemas.py
@@ -435,6 +435,95 @@ class TestWorkspaceSchema(unittest.TestCase):
                 jsonschema.validate(instance=config,
                                     schema=self.workspaces_schema)
 
+    def test_workspace_kubernetes_context_configs_allows_namespace(self):
+        """`workspaces.<ws>.kubernetes.context_configs.<ctx>.namespace` validates."""
+        valid_config = {
+            'my-workspace': {
+                'kubernetes': {
+                    'context_configs': {
+                        'shared-context': {
+                            'namespace': 'team-a',
+                        },
+                    },
+                },
+            },
+        }
+        jsonschema.validate(instance=valid_config,
+                            schema=self.workspaces_schema)
+
+    def test_workspace_kubernetes_context_configs_preserves_kueue_quota(self):
+        """Backward-compat: `kueue` and `quota` still validate alongside `namespace`."""
+        valid_config = {
+            'my-workspace': {
+                'kubernetes': {
+                    'context_configs': {
+                        'shared-context': {
+                            'namespace': 'team-a',
+                            'kueue': {
+                                'local_queue_name': 'team-a-queue',
+                            },
+                            'quota': {
+                                'queue': 'team-a-quota',
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        jsonschema.validate(instance=valid_config,
+                            schema=self.workspaces_schema)
+
+    def test_workspace_kubernetes_namespace_shorthand_rejected(self):
+        """`workspaces.<ws>.kubernetes.namespace` (no context) is rejected.
+
+        Design choice: only the per-context spelling is supported.
+        """
+        invalid_config = {
+            'my-workspace': {
+                'kubernetes': {
+                    'namespace': 'team-a',
+                },
+            },
+        }
+        with self.assertRaises(jsonschema.exceptions.ValidationError):
+            jsonschema.validate(instance=invalid_config,
+                                schema=self.workspaces_schema)
+
+    def test_workspace_kubernetes_context_configs_namespace_must_be_string(
+            self):
+        """Non-string `namespace` is rejected at the workspace level too."""
+        invalid_configs = [
+            {
+                'my-workspace': {
+                    'kubernetes': {
+                        'context_configs': {
+                            'shared-context': {
+                                'namespace': 123,
+                            },
+                        },
+                    },
+                },
+            },
+            {
+                'my-workspace': {
+                    'kubernetes': {
+                        'context_configs': {
+                            'shared-context': {
+                                'namespace': ['team-a'],
+                            },
+                        },
+                    },
+                },
+            },
+        ]
+        for config in invalid_configs:
+            with self.assertRaises(
+                    jsonschema.exceptions.ValidationError,
+                    msg=f'Invalid workspace namespace {config!r} should be '
+                    'rejected'):
+                jsonschema.validate(instance=config,
+                                    schema=self.workspaces_schema)
+
 
 class TestKubernetesSchema(unittest.TestCase):
     """Tests for the kubernetes schema in schemas.py."""
@@ -453,6 +542,64 @@ class TestKubernetesSchema(unittest.TestCase):
             }
         }
         jsonschema.validate(instance=valid_config, schema=self.k8s_schema)
+
+    def test_global_namespace_field(self):
+        """`kubernetes.namespace` validates as a string."""
+        jsonschema.validate(instance={'namespace': 'team-a'},
+                            schema=self.k8s_schema)
+
+    def test_context_configs_allows_namespace(self):
+        """`kubernetes.context_configs.<ctx>.namespace` validates."""
+        jsonschema.validate(
+            instance={
+                'context_configs': {
+                    'my-context': {
+                        'namespace': 'team-a'
+                    }
+                }
+            },
+            schema=self.k8s_schema,
+        )
+
+    def test_namespace_must_be_string(self):
+        """Non-string `namespace` values are rejected."""
+        invalid_instances = [
+            {
+                'namespace': 123
+            },
+            {
+                'namespace': ['team-a']
+            },
+            {
+                'namespace': True
+            },
+            {
+                'context_configs': {
+                    'my-context': {
+                        'namespace': 123
+                    }
+                }
+            },
+        ]
+        for instance in invalid_instances:
+            with self.assertRaises(
+                    jsonschema.exceptions.ValidationError,
+                    msg=f'Invalid namespace {instance!r} should be rejected'):
+                jsonschema.validate(instance=instance, schema=self.k8s_schema)
+
+    def test_global_namespace_coexists_with_context_override(self):
+        """Global `namespace` plus a per-context override both validate."""
+        jsonschema.validate(
+            instance={
+                'namespace': 'default-team',
+                'context_configs': {
+                    'override-context': {
+                        'namespace': 'override-team',
+                    },
+                },
+            },
+            schema=self.k8s_schema,
+        )
 
 
 class TestSSHSchema(unittest.TestCase):


### PR DESCRIPTION
## Summary

Add a `namespace` field to SkyPilot's Kubernetes config so workspaces sharing a single physical Kubernetes cluster can target different namespaces, without synthesizing one kubeconfig context per namespace.

Resolution layers, most-specific wins:

1. `workspaces.<ws>.kubernetes.context_configs.<ctx>.namespace`
2. `workspaces.<ws>.kubernetes.namespace`
3. `kubernetes.context_configs.<ctx>.namespace`
4. `kubernetes.namespace`
5. `None` — caller falls back to the kubeconfig context default.

Net result: one real cluster context can be shared by N workspaces, each in its own namespace; the synthetic-context-per-namespace workaround can be dropped.

## Motivation

Operators today synthesize one kubeconfig context per namespace and select between them via per-workspace `allowed_contexts`. This has two visible costs:

- **API server load.** SkyPilot opens one informer per allowed context; N synthetic contexts on the same cluster mean N independent watch streams against the same kube-apiserver.
- **Resource double-counting.** Cluster-level resources (nodes, GPUs) appear once per allowed context, inflating dashboard totals.

A per-workspace namespace override removes both.

## Changes

### Schema (`sky/utils/schemas.py`)

Adds `namespace: { type: string }` at four spellings:

| Layer | Where |
|---|---|
| Global cloud-level | `kubernetes.namespace` (via `_CONTEXT_CONFIG_SCHEMA_KUBERNETES`) |
| Global per-context | `kubernetes.context_configs.<ctx>.namespace` (same dict) |
| Workspace cloud-level | `workspaces.<ws>.kubernetes.namespace` (next to `kueue`/`quota`) |
| Workspace per-context | `workspaces.<ws>.kubernetes.context_configs.<ctx>.namespace` |

### Resolver (`sky/skypilot_config.py`)

`get_effective_namespace(cloud, region, workspace, override_configs) -> Optional[str]` walks the four layers above. Shared body with `get_effective_queue_name` lives in `_get_effective_k8s_config_value(cloud, property_keys, ...)`; the public helpers are thin delegates.

### Namespace helper (`sky/provision/kubernetes/utils.py`)

`get_namespace(context, workspace=None, override_configs=None, cloud='kubernetes') -> str` calls the resolver; on miss falls back to `get_kube_config_context_namespace(context)`. The `cloud` parameter keeps callers shared between Kubernetes and SSH from leaking `kubernetes.*` config into SSH lookups.

### Call sites

Switched to `get_namespace`:

| File | Function | Cloud passed |
|---|---|---|
| `sky/clouds/kubernetes.py` | `make_deploy_resources_variables` | `self._REPR.lower()` (Kubernetes or SSH) |
| `sky/provision/kubernetes/volume.py` | `_get_context_namespace` | default (`kubernetes`) |
| `sky/jobs/job_group_networking.py` | `_get_k8s_namespace_from_handle` | default |
| `sky/provision/kubernetes/utils.py` | `check_credentials` (RBAC probe) | forwarded by `_check_single_context` |

Intentionally left on `provider_config['namespace']` + kubeconfig fallback (legacy-cluster path): `get_namespace_from_config` and three sites in `sky/provision/kubernetes/network.py` (`_query_ports_for_loadbalancer`, `_query_ports_for_ingress`, `_query_ports_for_podip`). Switching the fallback would break clusters provisioned before this PR if the user later sets the new config.

### Ingress URL parity (`sky/provision/kubernetes/network.py`)

`_open_ports_using_ingress` now sources the URL-path namespace from the same `provider_config['namespace']` it uses for the Service, eliminating the pre-existing divergence that this PR would have made user-visible.

## Backward compatibility

A config that sets no `namespace` at any layer resolves to the kubeconfig context default — identical to today. Existing per-workspace configs with only `allowed_contexts` / `disabled` / `kueue` / `quota` continue to validate unchanged. Legacy clusters keep their existing kubeconfig fallback path.

## Testing

| Component | Tests |
|---|---|
| Schema (global + per-context, workspace + shorthand, non-string rejection, kueue/quota coexistence) | `tests/unit_tests/test_sky/utils/test_schemas.py::TestKubernetesSchema`, `::TestWorkspaceSchema` |
| Resolver (4-layer precedence, no-config, override_configs, shared helper) | `tests/test_config.py::test_get_effective_namespace*` |
| `get_namespace` helper (config wins, kubeconfig fallback, override forwarding, explicit cloud) | `tests/unit_tests/kubernetes/test_kubernetes_utils.py::TestGetNamespace` |
| `check_credentials` probes resolved namespace, forwards cloud | `tests/unit_tests/kubernetes/test_kubernetes_utils.py::TestCheckCredentials`, `test_kubernetes.py::TestKubernetesCheckSingleContextForwardsCloud`, `test_ssh.py::TestSSHCheckSingleContextForwardsCloud` |
| SSH path is not affected by global `kubernetes.namespace` | `test_ssh.py::TestSSHMakeDeployResourcesVariables::test_ssh_cloud_does_not_leak_global_kubernetes_namespace` |
| Ingress URL/Service namespace parity | `tests/unit_tests/kubernetes/test_network.py::TestOpenPortsUsingIngress` |
| Backward compat (queue-name resolution unchanged) | `tests/test_config.py::test_get_effective_queue_name*` |

## Open questions for reviewers

1. **Validation strictness** at config-load time: validate the namespace string matches RFC 1123 label syntax, or accept any string and surface the Kubernetes error at first use? This PR matches `kueue.local_queue_name` (`{type: string}`, no pattern).
2. **`workspaces.<ws>.ssh.context_configs.<ctx>.namespace`?** SSH workspaces use `_CONTEXT_CONFIG_SCHEMA_MINIMAL`, which doesn't include `namespace`. Out of scope here; happy to expand if there's interest.

## Related work

- #9635 — `kueue.local_queue_name` added to `_CONTEXT_CONFIG_SCHEMA_KUBERNETES`. Two-layer precedent (global + global-per-context) for the field-addition pattern.