### PR TITLE
[Kubernetes] Use IfNotPresent image pull policy for ray-node pods

### DIFF
--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -532,7 +532,7 @@ available_node_types:
         {% endif %}
         containers:
         - name: ray-node
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           image: {{image_id}}
           env:
             - name: SKYPILOT_POD_NODE_TYPE


### PR DESCRIPTION
## Changes

Change `imagePullPolicy` for the `ray-node` container in `kubernetes-ray.yml.j2` from `Always` to `IfNotPresent`.

## Why

`Always` forces Kubernetes to re-pull the SkyPilot image on every `sky launch`, even when the image is already present on the node. For GPU images (which are typically 2GB+), this means:

- Pod startup is delayed by 13+ minutes on a cold node instead of < 30 seconds
- The extra pull time can cascade into rsync/setup timeouts, causing launch failures that look unrelated to image pulling

SkyPilot always uses pinned image tags, so there is no correctness risk from `IfNotPresent` — the image on the node will always match what was requested.

> **Note:** The default Ubuntu 22.04 catalog images currently resolve to `:latest` tags. With `IfNotPresent`, these will not be re-pulled after the first launch on a node. We should move the catalog to dated/versioned tags (as already done for the Ubuntu 20.04 images, e.g. `:20250909`) so that image updates are picked up automatically on version bumps.

## Future Work
After this PR lands we will not be able to update images simply by pushing to latest. The next time we do an image update we should switch to tagging versions by date and remove latest as a tag.

Closes #9617