### PR TITLE
[Slurm] Fix autostop config not visible to skylet on container clusters

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -5689,7 +5689,11 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     idle_minutes_to_autostop, self.NAME, wait_for, down, hook,
                     hook_timeout)
                 returncode, _, stderr = self.run_on_head(
-                    handle, code, require_outputs=True, stream_logs=stream_logs)
+                    handle,
+                    code,
+                    require_outputs=True,
+                    stream_logs=stream_logs,
+                    target_skylet_env=True)
                 subprocess_utils.handle_returncode(returncode,
                                                    code,
                                                    'Failed to set autostop',
@@ -5739,7 +5743,11 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         else:
             code = autostop_lib.AutostopCodeGen.is_autostopping()
             returncode, stdout, stderr = self.run_on_head(
-                handle, code, require_outputs=True, stream_logs=stream_logs)
+                handle,
+                code,
+                require_outputs=True,
+                stream_logs=stream_logs,
+                target_skylet_env=True)
             if returncode == 0:
                 is_autostopping = message_utils.decode_payload(stdout)
             else:
@@ -5769,6 +5777,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         separate_stderr: bool = False,
         process_stream: bool = True,
         source_bashrc: bool = False,
+        target_skylet_env: bool = False,
         **kwargs,
     ) -> Union[int, Tuple[int, str, str]]:
         """Runs 'cmd' on the cluster's head node.
@@ -5797,6 +5806,14 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             source_bashrc: Whether to source bashrc when running on the command
                 on the VM. If it is a user-related commands, it would always be
                 good to source bashrc to make sure the env vars are set.
+            target_skylet_env: Whether the command should run in the same
+                environment as the skylet (e.g., inside the container on Slurm
+                container clusters). When False (default), uses the driver
+                environment which on Slurm runs on the host so that commands
+                spawning srun do not hit srun-in-srun limits. Set True for
+                commands that manipulate skylet-local state (e.g., the
+                ``skylet_config.db`` written by ``set_autostop``), which must
+                reach the same path the skylet reads.
 
         Returns:
             returncode
@@ -5814,7 +5831,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         if under_remote_workdir:
             cmd = f'cd {SKY_REMOTE_WORKDIR} && {cmd}'
 
-        return head_runner.run_driver(
+        runner_method = (head_runner.run
+                         if target_skylet_env else head_runner.run_driver)
+        return runner_method(
             cmd,
             port_forward=port_forward,
             log_path=log_path,


### PR DESCRIPTION
## Summary

- On Slurm container clusters (Pyxis/Enroot), `sky autostop` / `sky launch -i N --down` reported success but never actually triggered autostop. The skylet runs inside the container and reads `~/.sky/skylet_config.db` (resolved against in-container `HOME=/root`), but `set_autostop` codegen went through `backend.run_on_head → head_runner.run_driver`, which on Slurm hard-codes `in_container=False` and writes to the host's `/tmp/<cluster>/.sky/skylet_config.db` — a different file the skylet never reads.
- Add a `target_skylet_env` flag to `CloudVmRayBackend.run_on_head`. When `True`, dispatch to `head_runner.run` (which on Slurm honors `container_args` and routes into the container). Pass `target_skylet_env=True` from `set_autostop` and `is_autostopping`. Ray-driver and other srun-launching callers keep the default `run_driver` path and continue to run on the host. For non-Slurm runners `run_driver` already delegates to `run`, so behavior is unchanged.
- Fixes SKY-4985.

## Test plan

Manual repro on the `aws-hyperpod` SLURM cluster with a container image:

1. Create `task.yaml`:
   ```yaml
   resources:
     infra: slurm/aws-hyperpod
     cpus: 1
     image_id: docker:ubuntu:22.04
   run: |
     echo hello; sleep 10
   ```
2. `sky launch -c sky4985-repro --infra slurm/aws-hyperpod -i 5 --down -y task.yaml`
3. Verify `autostop_config` is written to the **container** DB the skylet reads:
   ```
   ssh sky4985-repro '/root/skypilot-runtime/bin/python -c \
     "import sqlite3; print(list(sqlite3.connect(\"/root/.sky/skylet_config.db\").execute(\"SELECT key FROM config\")))"'
   ```
   Expected: contains `('autostop_config',)`.
   Before the fix: only `('autostop_last_active_time',)`.
4. After ~5 minutes idle, observe `sky status -r` reports `STATUS=AUTOSTOPPING` and the launch CLI prints `Cluster '...' is autodowning.`

Verified ✅ on this branch. Without the fix, the same launch leaves the cluster up indefinitely.

### Backwards compatibility / scope

- Non-Slurm backends: `CommandRunner.run_driver` defaults to `self.run`, so `target_skylet_env=True` is a no-op.
- Slurm without container image: `SlurmCommandRunner.run` picks `in_container = container_args is not None` → `False`, matching `run_driver`'s host path. No behavior change.
- Slurm with container image: `run` routes into the container, fixing the bug.
- Other `run_on_head` call sites are untouched and keep the existing `run_driver` path (the Ray-driver/srun-launching commands that intentionally must stay on the host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)