### PR TITLE
[Kubernetes] Probe Ray ports when pod has hostNetwork: true

### DIFF
--- a/docs/source/reference/kubernetes/kubernetes-setup.rst
+++ b/docs/source/reference/kubernetes/kubernetes-setup.rst
@@ -258,6 +258,7 @@ The following setup steps are optional and can be performed based on your specif
 * :ref:`kubernetes-setup-ports`
 * :ref:`kubernetes-setup-fuse`
 * :ref:`kubernetes-setup-proxy`
+* :ref:`kubernetes-setup-hostnetwork`
 
 .. _kubernetes-setup-volumes:
 
@@ -382,6 +383,27 @@ To resolve this, you can configure proxy settings for SkyPilot pods by adding en
 Replace ``proxy-host:3128`` with your actual proxy server address and port.
 
 Both uppercase and lowercase versions of the proxy environment variables are included for maximum compatibility across different tools and libraries.
+
+.. _kubernetes-setup-hostnetwork:
+
+Set up host networking
+^^^^^^^^^^^^^^^^^^^^^^
+
+For workloads that need the node's network stack directly — for example, RDMA/InfiniBand for multi-node training, or to avoid CNI overhead for latency-sensitive jobs — you can run SkyPilot pods with host networking by setting ``hostNetwork: true`` in the pod spec:
+
+.. code-block:: yaml
+
+    # ~/.sky/config.yaml
+    kubernetes:
+      pod_config:
+        spec:
+          hostNetwork: true
+
+With ``hostNetwork: true``, a pod shares the node's network namespace instead of getting its own. Normally this would cause two SkyPilot pods scheduled to the same node to collide on Ray's default ports and on the node's SSH port. SkyPilot handles this automatically: before Ray starts, each pod probes a free port set on the node, the head publishes its chosen ports to a ``<cluster>-ray-ports`` ConfigMap for workers to discover, and each pod's in-container SSH server is rebound to a probed port. **No additional configuration beyond** ``hostNetwork: true`` **is required**, and multiple SkyPilot clusters can safely share a node.
+
+.. note::
+
+    The ConfigMap is created in the same namespace as the SkyPilot pods and is owned by the head pod, so it is garbage-collected by Kubernetes on ``sky down``. The SkyPilot service account must be able to create, get, and update ConfigMaps in that namespace (already covered by the :ref:`minimal permissions <cloud-permissions-kubernetes>`).
 
 .. _kubernetes-observability:
 

--- a/docs/source/reference/kubernetes/kubernetes-setup.rst
+++ b/docs/source/reference/kubernetes/kubernetes-setup.rst
@@ -411,6 +411,10 @@ For a multi-node cluster, SkyPilot additionally enforces that **every pod of the
 
     The ConfigMap is created in the same namespace as the SkyPilot pods and is owned by the head pod, so it is garbage-collected by Kubernetes on ``sky down``. The SkyPilot service account must be able to create, get, and update ConfigMaps in that namespace (already covered by the :ref:`minimal permissions <cloud-permissions-kubernetes>`).
 
+.. note::
+
+    OCI OKE RoCE clusters (launched with ``network_tier: best`` on OCI bare-metal GPU shapes) require host networking to reach the RDMA fabric, so SkyPilot enables it for them automatically — you do **not** set ``hostNetwork: true`` yourself. The same probe and one-pod-per-node behavior described above (including the multi-node node-count requirement in the warning) applies to those clusters.
+
 .. _kubernetes-observability:
 
 Observability for administrators

--- a/docs/source/reference/kubernetes/kubernetes-setup.rst
+++ b/docs/source/reference/kubernetes/kubernetes-setup.rst
@@ -401,6 +401,12 @@ For workloads that need the node's network stack directly — for example, RDMA/
 
 With ``hostNetwork: true``, a pod shares the node's network namespace instead of getting its own. Normally this would cause two SkyPilot pods scheduled to the same node to collide on Ray's default ports and on the node's SSH port. SkyPilot handles this automatically: before Ray starts, each pod probes a free port set on the node, the head publishes its chosen ports to a ``<cluster>-ray-ports`` ConfigMap for workers to discover, and each pod's in-container SSH server is rebound to a probed port. **No additional configuration beyond** ``hostNetwork: true`` **is required**, and multiple SkyPilot clusters can safely share a node.
 
+For a multi-node cluster, SkyPilot additionally enforces that **every pod of the same cluster is placed on a distinct Kubernetes node**. This is implemented as a required pod anti-affinity (per-cluster label selector, topology key ``kubernetes.io/hostname``) injected into every ``hostNetwork`` pod. One pod per node guarantees each pod has a unique, routable host IP — which is also exactly what lets a ``hostNetwork`` cluster span multiple Kubernetes nodes. The selector is scoped per cluster, so pods of *different* clusters can still co-locate on a node (their cross-cluster port collisions are resolved by the free-port probe described above).
+
+.. warning::
+
+    Because this anti-affinity is a *hard* scheduling constraint (``requiredDuringSchedulingIgnoredDuringExecution``), a multi-node ``hostNetwork`` cluster needs at least as many schedulable Kubernetes nodes as it has pods. If enough distinct nodes are not available, the cluster fails to schedule with a clear error rather than silently co-locating pods of the same cluster and racing on the shared host network.
+
 .. note::
 
     The ConfigMap is created in the same namespace as the SkyPilot pods and is owned by the head pod, so it is garbage-collected by Kubernetes on ``sky down``. The SkyPilot service account must be able to create, get, and update ConfigMaps in that namespace (already covered by the :ref:`minimal permissions <cloud-permissions-kubernetes>`).

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -315,11 +315,22 @@ def setup_kubernetes_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
     #   This optimization can reduce SSH time from ~0.35s to ~0.25s, tested
     #   on GKE.
     pod_name = config['cluster_name'] + '-head'
+    # combine_pod_config_fields_and_metadata() has already folded the
+    # user's kubernetes.pod_config (incl. spec.hostNetwork) into
+    # node_config by the time auth runs, so this is the resolved value.
+    # Pass it as a flag to the proxy script so the common path makes no
+    # extra `kubectl get pod` call per connection.
+    head_node_config = config.get('available_node_types',
+                                  {}).get('ray_head_default',
+                                          {}).get('node_config', {})
+    host_network = bool(
+        head_node_config.get('spec', {}).get('hostNetwork', False))
     ssh_proxy_cmd = kubernetes_utils.get_ssh_proxy_command(
         pod_name,
         private_key_path=private_key_path,
         context=context,
-        namespace=namespace)
+        namespace=namespace,
+        host_network=host_network)
     config['auth']['ssh_proxy_command'] = ssh_proxy_cmd
     config['auth']['ssh_private_key'] = private_key_path
 

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -797,12 +797,23 @@ class Kubernetes(clouds.Cloud):
         namespace = kubernetes_utils.get_kube_config_context_namespace(context)
 
         # Detect hostNetwork before the template is rendered so the probe
-        # env vars can be wired into deploy_vars. Resolved through the same
-        # helper combine_pod_config_fields() uses, so this agrees with the
-        # pod_config that is actually folded into the rendered YAML.
+        # env vars can be wired into deploy_vars. Two independent paths put
+        # a pod on the host network namespace, and both need the probe:
+        #   1. The user sets spec.hostNetwork in pod_config. Resolved through
+        #      the same helper combine_pod_config_fields() uses, so this
+        #      agrees with the pod_config folded into the rendered YAML.
+        #   2. OCI OKE RoCE: the template forces `hostNetwork: true` from
+        #      k8s_enable_oci_roce (the user never sets it in pod_config, so
+        #      path 1 wouldn't catch it). Without the probe, the OCI RoCE
+        #      pod's sshd can't bind host:22 (the K8s node's own sshd owns
+        #      it) and inter-node Ray ports collide — so OCI RoCE is treated
+        #      as host-networked here too. Keep this in sync with the
+        #      `hostNetwork: true` gate in kubernetes-ray.yml.j2.
+        oci_roce_enabled = (
+            network_type == KubernetesHighPerformanceNetworkType.OCI_ROCE)
         merged_pod_config = kubernetes_utils.resolve_effective_pod_config(
             resources.cluster_config_overrides, self, context)
-        k8s_host_network = bool(
+        k8s_host_network = oci_roce_enabled or bool(
             merged_pod_config.get('spec', {}).get('hostNetwork', False))
         if k8s_host_network:
             cluster_name_on_cloud = cluster_name.name_on_cloud
@@ -923,9 +934,10 @@ class Kubernetes(clouds.Cloud):
             network_type.requires_ipc_lock_capability())
 
         # OCI OKE RoCE: requires hostNetwork, privileged containers, and a
-        # hostPath mount of /dev/infiniband (no device plugin on OCI).
-        deploy_vars['k8s_enable_oci_roce'] = (
-            network_type == KubernetesHighPerformanceNetworkType.OCI_ROCE)
+        # hostPath mount of /dev/infiniband (no device plugin on OCI). The
+        # hostNetwork part also feeds k8s_host_network above (see comment
+        # there), which is what activates the Ray-port probe machinery.
+        deploy_vars['k8s_enable_oci_roce'] = oci_roce_enabled
 
         # User-specified APT mirror candidates for pod package installs.
         # None means unset (template uses built-in defaults); an empty list

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -19,6 +19,7 @@ from sky.adaptors import kubernetes
 from sky.clouds.utils import gcp_utils
 from sky.provision import instance_setup
 from sky.provision.gcp import constants as gcp_constants
+from sky.provision.kubernetes import host_network_probe
 from sky.provision.kubernetes import network_utils
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.provision.kubernetes.utils import is_tpu_on_gke
@@ -27,7 +28,6 @@ from sky.provision.kubernetes.utils import normalize_tpu_accelerator_name
 from sky.skylet import constants
 from sky.utils import annotations
 from sky.utils import common_utils
-from sky.utils import config_utils
 from sky.utils import env_options
 from sky.utils import kubernetes_enums
 from sky.utils import registry
@@ -796,29 +796,20 @@ class Kubernetes(clouds.Cloud):
 
         namespace = kubernetes_utils.get_kube_config_context_namespace(context)
 
-        # Detect hostNetwork to wire the probe env vars into deploy_vars
-        # before the template is rendered. The same merge happens again
-        # later in combine_pod_config_fields when the user's pod_config
-        # is folded into the rendered YAML.
-        merged_pod_config = skypilot_config.get_effective_region_config(
-            cloud=cloud_config_str,
-            region=context,
-            keys=('pod_config',),
-            default_value={})
-        override_pod_config = config_utils.get_cloud_config_value_from_dict(
-            dict_config=resources.cluster_config_overrides,
-            cloud=cloud_config_str,
-            region=context,
-            keys=('pod_config',),
-            default_value={})
-        config_utils.merge_k8s_configs(merged_pod_config, override_pod_config)
+        # Detect hostNetwork before the template is rendered so the probe
+        # env vars can be wired into deploy_vars. Resolved through the same
+        # helper combine_pod_config_fields() uses, so this agrees with the
+        # pod_config that is actually folded into the rendered YAML.
+        merged_pod_config = kubernetes_utils.resolve_effective_pod_config(
+            resources.cluster_config_overrides, self, context)
         k8s_host_network = bool(
             merged_pod_config.get('spec', {}).get('hostNetwork', False))
         if k8s_host_network:
             cluster_name_on_cloud = cluster_name.name_on_cloud
             k8s_env_vars['SKYPILOT_HOST_NETWORK'] = '1'
             k8s_env_vars['SKYPILOT_RAY_PORTS_CONFIGMAP_NAME'] = (
-                f'{cluster_name_on_cloud}-ray-ports')
+                host_network_probe.ray_ports_configmap_name(
+                    cluster_name_on_cloud))
             k8s_env_vars['SKYPILOT_RAY_PORTS_CONFIGMAP_NAMESPACE'] = namespace
 
         deploy_vars = {

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -27,6 +27,7 @@ from sky.provision.kubernetes.utils import normalize_tpu_accelerator_name
 from sky.skylet import constants
 from sky.utils import annotations
 from sky.utils import common_utils
+from sky.utils import config_utils
 from sky.utils import env_options
 from sky.utils import kubernetes_enums
 from sky.utils import registry
@@ -557,7 +558,7 @@ class Kubernetes(clouds.Cloud):
         dryrun: bool = False,
         volume_mounts: Optional[List['volume_lib.VolumeMount']] = None,
     ) -> Dict[str, Optional[str]]:
-        del cluster_name, zones  # Unused.
+        del zones  # Unused.
         if region is None:
             context = kubernetes_utils.get_current_kube_config_context_name()
         else:
@@ -795,6 +796,31 @@ class Kubernetes(clouds.Cloud):
 
         namespace = kubernetes_utils.get_kube_config_context_namespace(context)
 
+        # Detect hostNetwork to wire the probe env vars into deploy_vars
+        # before the template is rendered. The same merge happens again
+        # later in combine_pod_config_fields when the user's pod_config
+        # is folded into the rendered YAML.
+        merged_pod_config = skypilot_config.get_effective_region_config(
+            cloud=cloud_config_str,
+            region=context,
+            keys=('pod_config',),
+            default_value={})
+        override_pod_config = config_utils.get_cloud_config_value_from_dict(
+            dict_config=resources.cluster_config_overrides,
+            cloud=cloud_config_str,
+            region=context,
+            keys=('pod_config',),
+            default_value={})
+        config_utils.merge_k8s_configs(merged_pod_config, override_pod_config)
+        k8s_host_network = bool(
+            merged_pod_config.get('spec', {}).get('hostNetwork', False))
+        if k8s_host_network:
+            cluster_name_on_cloud = cluster_name.name_on_cloud
+            k8s_env_vars['SKYPILOT_HOST_NETWORK'] = '1'
+            k8s_env_vars['SKYPILOT_RAY_PORTS_CONFIGMAP_NAME'] = (
+                f'{cluster_name_on_cloud}-ray-ports')
+            k8s_env_vars['SKYPILOT_RAY_PORTS_CONFIGMAP_NAMESPACE'] = namespace
+
         deploy_vars = {
             'instance_type': resources.instance_type,
             'custom_resources': custom_resources,
@@ -853,6 +879,7 @@ class Kubernetes(clouds.Cloud):
             'k8s_network_type': network_type.value,
             'k8s_context': context,
             'k8s_namespace': namespace,
+            'k8s_host_network': k8s_host_network,
         }
 
         # Add ephemeral storage to deploy vars if specified.

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -55,7 +55,11 @@ _HOST_NETWORK_ENV_FILE = '/tmp/sky_host_network_ports.env'
 _HOST_NETWORK_PROBE_TARGET = '/tmp/sky_host_network_probe.py'
 
 
-def _read_host_network_probe_b64() -> str:
+@functools.lru_cache(maxsize=1)
+def _host_network_probe_b64() -> str:
+    # Cached, not module-level: instance_setup is imported on every `import
+    # sky`, but the probe payload is only needed when actually building a
+    # launch command, so the read/minify/gzip cost stays off the CLI path.
     path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                         'kubernetes', 'host_network_probe.py')
     with open(path, 'r', encoding='utf-8') as f:
@@ -65,9 +69,6 @@ def _read_host_network_probe_b64() -> str:
     compile(minified, path, 'exec')
     compressed = gzip.compress(minified.encode('utf-8'))
     return base64.b64encode(compressed).decode('ascii')
-
-
-_HOST_NETWORK_PROBE_B64 = _read_host_network_probe_b64()
 
 
 def _host_network_probe_cmd(mode: str) -> str:
@@ -97,7 +98,7 @@ def _host_network_probe_cmd(mode: str) -> str:
     return (
         'if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ] && '
         '[ -n "${SKYPILOT_RAY_PORTS_CONFIGMAP_NAME:-}" ]; then '
-        f'echo \'{_HOST_NETWORK_PROBE_B64}\' | base64 -d | gunzip > '
+        f'echo \'{_host_network_probe_b64()}\' | base64 -d | gunzip > '
         f'{_HOST_NETWORK_PROBE_TARGET}; '
         f'{constants.SKY_PYTHON_CMD} {_HOST_NETWORK_PROBE_TARGET} '
         f'--mode {mode} '
@@ -373,13 +374,27 @@ def _ray_gpu_options(custom_resource: str) -> str:
     return f' --num-gpus={acc_count}'
 
 
+# Ray port flags shared by the head and worker start commands. The
+# ${VAR:-default} forms take the probed value when the hostNetwork probe
+# ran and the original constant otherwise; the ${VAR:+--flag=...} forms
+# vanish when unset, so non-hostNetwork bootstraps defer to Ray's own
+# defaults. Kept in one place so the head/worker flag sets can't drift.
+_SHARED_RAY_PORT_FLAGS = (
+    '--object-manager-port=${SKYPILOT_RAY_OBJECT_MANAGER_PORT:-8076} '
+    '${SKYPILOT_RAY_NODE_MANAGER_PORT:+'
+    '--node-manager-port=$SKYPILOT_RAY_NODE_MANAGER_PORT} '
+    '${SKYPILOT_RAY_DASHBOARD_AGENT_LISTEN_PORT:+'
+    '--dashboard-agent-listen-port='
+    '$SKYPILOT_RAY_DASHBOARD_AGENT_LISTEN_PORT} '
+    '${SKYPILOT_RAY_RUNTIME_ENV_AGENT_PORT:+'
+    '--runtime-env-agent-port=$SKYPILOT_RAY_RUNTIME_ENV_AGENT_PORT} '
+    '${SKYPILOT_RAY_METRICS_EXPORT_PORT:+'
+    '--metrics-export-port=$SKYPILOT_RAY_METRICS_EXPORT_PORT}')
+
+
 def ray_head_start_command(custom_resource: Optional[str],
                            custom_ray_options: Optional[Dict[str, Any]]) -> str:
     """Returns the command to start Ray on the head node."""
-    # Existing port flags use ${VAR:-default} (probed value when the
-    # hostNetwork probe ran, original constant otherwise). New flags
-    # use ${VAR:+--flag=...} so they vanish when unset, deferring to
-    # Ray's own defaults for non-hostNetwork bootstraps.
     ray_options = (
         # --disable-usage-stats in `ray start` saves 10 seconds of idle wait.
         f'--disable-usage-stats '
@@ -387,18 +402,10 @@ def ray_head_start_command(custom_resource: Optional[str],
         f'--dashboard-port=${{SKYPILOT_RAY_DASHBOARD_PORT:-'
         f'{constants.SKY_REMOTE_RAY_DASHBOARD_PORT}}} '
         f'--min-worker-port 11002 '
-        f'--object-manager-port=${{SKYPILOT_RAY_OBJECT_MANAGER_PORT:-8076}} '
-        '${SKYPILOT_RAY_NODE_MANAGER_PORT:+'
-        '--node-manager-port=$SKYPILOT_RAY_NODE_MANAGER_PORT} '
+        f'{_SHARED_RAY_PORT_FLAGS} '
+        # Head-only: workers don't run the Ray Client server.
         '${SKYPILOT_RAY_CLIENT_SERVER_PORT:+'
         '--ray-client-server-port=$SKYPILOT_RAY_CLIENT_SERVER_PORT} '
-        '${SKYPILOT_RAY_DASHBOARD_AGENT_LISTEN_PORT:+'
-        '--dashboard-agent-listen-port='
-        '$SKYPILOT_RAY_DASHBOARD_AGENT_LISTEN_PORT} '
-        '${SKYPILOT_RAY_RUNTIME_ENV_AGENT_PORT:+'
-        '--runtime-env-agent-port=$SKYPILOT_RAY_RUNTIME_ENV_AGENT_PORT} '
-        '${SKYPILOT_RAY_METRICS_EXPORT_PORT:+'
-        '--metrics-export-port=$SKYPILOT_RAY_METRICS_EXPORT_PORT} '
         f'--temp-dir={constants.SKY_REMOTE_RAY_TEMPDIR}')
     if custom_resource:
         ray_options += f' --resources=\'{custom_resource}\''
@@ -439,18 +446,8 @@ def ray_worker_start_command(custom_resource: Optional[str],
     # SKYPILOT_RAY_PORT is the head's GCS port — exported as a constant
     # by the K8s template's worker bootstrap, or as the probed value
     # (read from the head's ConfigMap) by the hostNetwork worker probe.
-    ray_options = (
-        '--address=${SKYPILOT_RAY_HEAD_IP}:${SKYPILOT_RAY_PORT} '
-        '--object-manager-port=${SKYPILOT_RAY_OBJECT_MANAGER_PORT:-8076} '
-        '${SKYPILOT_RAY_NODE_MANAGER_PORT:+'
-        '--node-manager-port=$SKYPILOT_RAY_NODE_MANAGER_PORT} '
-        '${SKYPILOT_RAY_DASHBOARD_AGENT_LISTEN_PORT:+'
-        '--dashboard-agent-listen-port='
-        '$SKYPILOT_RAY_DASHBOARD_AGENT_LISTEN_PORT} '
-        '${SKYPILOT_RAY_RUNTIME_ENV_AGENT_PORT:+'
-        '--runtime-env-agent-port=$SKYPILOT_RAY_RUNTIME_ENV_AGENT_PORT} '
-        '${SKYPILOT_RAY_METRICS_EXPORT_PORT:+'
-        '--metrics-export-port=$SKYPILOT_RAY_METRICS_EXPORT_PORT}')
+    ray_options = ('--address=${SKYPILOT_RAY_HEAD_IP}:${SKYPILOT_RAY_PORT} '
+                   f'{_SHARED_RAY_PORT_FLAGS}')
 
     if custom_resource:
         ray_options += f' --resources=\'{custom_resource}\''

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -399,10 +399,6 @@ def ray_head_start_command(custom_resource: Optional[str],
         '--runtime-env-agent-port=$SKYPILOT_RAY_RUNTIME_ENV_AGENT_PORT} '
         '${SKYPILOT_RAY_METRICS_EXPORT_PORT:+'
         '--metrics-export-port=$SKYPILOT_RAY_METRICS_EXPORT_PORT} '
-        # Distinct per-pod loopback IP under hostNetwork; absent unless
-        # the probe ran. Disambiguates (NodeID -> endpoint) routing in
-        # Ray's client cache when two raylets share the host's IP.
-        '${SKYPILOT_RAY_NODE_IP:+--node-ip-address=$SKYPILOT_RAY_NODE_IP} '
         f'--temp-dir={constants.SKY_REMOTE_RAY_TEMPDIR}')
     if custom_resource:
         ray_options += f' --resources=\'{custom_resource}\''
@@ -454,9 +450,7 @@ def ray_worker_start_command(custom_resource: Optional[str],
         '${SKYPILOT_RAY_RUNTIME_ENV_AGENT_PORT:+'
         '--runtime-env-agent-port=$SKYPILOT_RAY_RUNTIME_ENV_AGENT_PORT} '
         '${SKYPILOT_RAY_METRICS_EXPORT_PORT:+'
-        '--metrics-export-port=$SKYPILOT_RAY_METRICS_EXPORT_PORT} '
-        # See ray_head_start_command for the rationale on --node-ip-address.
-        '${SKYPILOT_RAY_NODE_IP:+--node-ip-address=$SKYPILOT_RAY_NODE_IP}')
+        '--metrics-export-port=$SKYPILOT_RAY_METRICS_EXPORT_PORT}')
 
     if custom_resource:
         ray_options += f' --resources=\'{custom_resource}\''

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -1,6 +1,8 @@
 """Setup dependencies & services for instances."""
+import base64
 from concurrent import futures
 import functools
+import gzip
 import hashlib
 import json
 import os
@@ -25,6 +27,7 @@ from sky.utils import command_runner
 from sky.utils import common_utils
 from sky.utils import env_options
 from sky.utils import resources_utils
+from sky.utils import source_utils
 from sky.utils import subprocess_utils
 from sky.utils import timeline
 from sky.utils import ux_utils
@@ -48,12 +51,87 @@ DUMP_RAY_PORTS = (f'{constants.SKY_PYTHON_CMD} -c \'import json, os; '
                   f'"{constants.SKY_REMOTE_RAY_PORT_FILE}"), "w", '
                   'encoding="utf-8"))\';')
 
+_HOST_NETWORK_ENV_FILE = '/tmp/sky_host_network_ports.env'
+_HOST_NETWORK_PROBE_TARGET = '/tmp/sky_host_network_probe.py'
+
+
+def _read_host_network_probe_b64() -> str:
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                        'kubernetes', 'host_network_probe.py')
+    with open(path, 'r', encoding='utf-8') as f:
+        source = f.read()
+    minified = source_utils.minify_python_source(source)
+    # Sanity-check: minified source must still parse.
+    compile(minified, path, 'exec')
+    compressed = gzip.compress(minified.encode('utf-8'))
+    return base64.b64encode(compressed).decode('ascii')
+
+
+_HOST_NETWORK_PROBE_B64 = _read_host_network_probe_b64()
+
+
+def _host_network_probe_cmd(mode: str) -> str:
+    """Bash snippet that probes Ray + sshd ports when running with hostNetwork.
+
+    Returns a runtime-gated snippet: a no-op shell branch unless
+    SKYPILOT_HOST_NETWORK=1 and SKYPILOT_RAY_PORTS_CONFIGMAP_NAME are
+    set in the pod env. Non-hostNetwork bootstraps see no change — env
+    vars stay unset and ``${VAR:-default}`` in the ray flags falls back
+    to the constants.
+
+    Also rebinds the pod's sshd to the probed SKYPILOT_SSHD_PORT. Under
+    hostNetwork the node's own sshd already owns host:22 so the pod's
+    sshd silently failed to bind in apt-ssh-setup; rewriting Port in
+    sshd_config and restarting picks up the probed port instead.
+
+    The probe is shipped gzip+base64-inline rather than invoked as a
+    module because the K8s template installs stable skypilot from PyPI
+    before ray_head_start_command runs (the dev wheel ships later), so
+    neither `python -m sky.provision.kubernetes.host_network_probe` nor
+    a site-packages file lookup is reliable at probe time. The b64 form
+    also keeps the payload on a single line, which is required to stay
+    inside the rendered YAML's block-scalar indentation. Gzip cuts the
+    payload by ~4x; the source on disk stays readable.
+    """
+    assert mode in ('head', 'worker'), mode
+    return (
+        'if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ] && '
+        '[ -n "${SKYPILOT_RAY_PORTS_CONFIGMAP_NAME:-}" ]; then '
+        f'echo \'{_HOST_NETWORK_PROBE_B64}\' | base64 -d | gunzip > '
+        f'{_HOST_NETWORK_PROBE_TARGET}; '
+        f'{constants.SKY_PYTHON_CMD} {_HOST_NETWORK_PROBE_TARGET} '
+        f'--mode {mode} '
+        f'--env-file {_HOST_NETWORK_ENV_FILE} '
+        '--configmap-name "$SKYPILOT_RAY_PORTS_CONFIGMAP_NAME" '
+        '--configmap-namespace '
+        '"$SKYPILOT_RAY_PORTS_CONFIGMAP_NAMESPACE" || exit 1; '
+        f'set -a; . {_HOST_NETWORK_ENV_FILE}; set +a; '
+        # Delete-then-append rather than sed-in-place: sshd_config files
+        # without an existing Port directive would otherwise keep the
+        # default 22 (where the K8s node's own sshd already listens).
+        'if [ -n "${SKYPILOT_SSHD_PORT:-}" ]; then '
+        'sudo sh -c "'
+        'sed -i -E \'/^[[:space:]]*#?[[:space:]]*Port[[:space:]]+/d\' '
+        '/etc/ssh/sshd_config && '
+        'echo Port ${SKYPILOT_SSHD_PORT} >> /etc/ssh/sshd_config && '
+        'service ssh restart"; '
+        'fi; '
+        'fi; ')
+
+
+# Stdlib only — deliberately doesn't import `sky` so the read still
+# works during the K8s bootstrap's brief stable→dev skypilot reinstall
+# window. Falls back to SKY_REMOTE_RAY_PORT (not legacy 6379) so the
+# health-check poll lands on something Ray could plausibly be on.
+_READ_RAY_PORT_PY = (
+    'import json, os; '
+    'd = os.path.expanduser(os.environ.get('
+    f'\'{constants.SKY_RUNTIME_DIR_ENV_VAR_KEY}\', \'~\')); '
+    'print(json.load(open(os.path.join(d, '
+    f'\'{constants.SKY_REMOTE_RAY_PORT_FILE}\')))[\'ray_port\'])')
 _RAY_PORT_COMMAND = (
-    f'RAY_PORT=$({constants.SKY_PYTHON_CMD} -c '
-    '"from sky import sky_logging\n'
-    'with sky_logging.silent(): '
-    'from sky.skylet import job_lib; print(job_lib.get_ray_port())" '
-    '2> /dev/null || echo 6379);'
+    f'RAY_PORT=$({constants.SKY_PYTHON_CMD} -c "{_READ_RAY_PORT_PY}" '
+    f'2> /dev/null || echo {constants.SKY_REMOTE_RAY_PORT});'
     f'{constants.SKY_PYTHON_CMD} -c "from sky.utils import message_utils; '
     'print(message_utils.encode_payload({\'ray_port\': $RAY_PORT}))"')
 
@@ -64,8 +142,12 @@ RAY_STATUS_WITH_SKY_RAY_PORT_COMMAND = (
 
 # Command that waits for the ray status to be initialized. Otherwise, a later
 # `sky status -r` may fail due to the ray cluster not being ready.
+# Reads SKYPILOT_RAY_PORT (exported by the hostNetwork probe) rather than
+# the constants.RAY_STATUS literal — the probe picks a dynamic port.
 RAY_HEAD_WAIT_INITIALIZED_COMMAND = (
-    f'while `{constants.RAY_STATUS} | grep -q "No cluster status."`; do '
+    'while `RAY_ADDRESS=127.0.0.1:${SKYPILOT_RAY_PORT:-'
+    f'{constants.SKY_REMOTE_RAY_PORT}}} '
+    f'{constants.SKY_RAY_CMD} status | grep -q "No cluster status."`; do '
     'sleep 0.5; '
     'echo "Waiting ray cluster to be initialized"; '
     'done;')
@@ -294,13 +376,33 @@ def _ray_gpu_options(custom_resource: str) -> str:
 def ray_head_start_command(custom_resource: Optional[str],
                            custom_ray_options: Optional[Dict[str, Any]]) -> str:
     """Returns the command to start Ray on the head node."""
+    # Existing port flags use ${VAR:-default} (probed value when the
+    # hostNetwork probe ran, original constant otherwise). New flags
+    # use ${VAR:+--flag=...} so they vanish when unset, deferring to
+    # Ray's own defaults for non-hostNetwork bootstraps.
     ray_options = (
         # --disable-usage-stats in `ray start` saves 10 seconds of idle wait.
         f'--disable-usage-stats '
-        f'--port={constants.SKY_REMOTE_RAY_PORT} '
-        f'--dashboard-port={constants.SKY_REMOTE_RAY_DASHBOARD_PORT} '
+        f'--port=${{SKYPILOT_RAY_PORT:-{constants.SKY_REMOTE_RAY_PORT}}} '
+        f'--dashboard-port=${{SKYPILOT_RAY_DASHBOARD_PORT:-'
+        f'{constants.SKY_REMOTE_RAY_DASHBOARD_PORT}}} '
         f'--min-worker-port 11002 '
-        f'--object-manager-port=8076 '
+        f'--object-manager-port=${{SKYPILOT_RAY_OBJECT_MANAGER_PORT:-8076}} '
+        '${SKYPILOT_RAY_NODE_MANAGER_PORT:+'
+        '--node-manager-port=$SKYPILOT_RAY_NODE_MANAGER_PORT} '
+        '${SKYPILOT_RAY_CLIENT_SERVER_PORT:+'
+        '--ray-client-server-port=$SKYPILOT_RAY_CLIENT_SERVER_PORT} '
+        '${SKYPILOT_RAY_DASHBOARD_AGENT_LISTEN_PORT:+'
+        '--dashboard-agent-listen-port='
+        '$SKYPILOT_RAY_DASHBOARD_AGENT_LISTEN_PORT} '
+        '${SKYPILOT_RAY_RUNTIME_ENV_AGENT_PORT:+'
+        '--runtime-env-agent-port=$SKYPILOT_RAY_RUNTIME_ENV_AGENT_PORT} '
+        '${SKYPILOT_RAY_METRICS_EXPORT_PORT:+'
+        '--metrics-export-port=$SKYPILOT_RAY_METRICS_EXPORT_PORT} '
+        # Distinct per-pod loopback IP under hostNetwork; absent unless
+        # the probe ran. Disambiguates (NodeID -> endpoint) routing in
+        # Ray's client cache when two raylets share the host's IP.
+        '${SKYPILOT_RAY_NODE_IP:+--node-ip-address=$SKYPILOT_RAY_NODE_IP} '
         f'--temp-dir={constants.SKY_REMOTE_RAY_TEMPDIR}')
     if custom_resource:
         ray_options += f' --resources=\'{custom_resource}\''
@@ -312,7 +414,7 @@ def ray_head_start_command(custom_resource: Optional[str],
             ray_options += f' --{key}={value}'
 
     cmd = (
-        f'{constants.SKY_RAY_CMD} stop; '
+        _host_network_probe_cmd('head') + f'{constants.SKY_RAY_CMD} stop; '
         'RAY_SCHEDULER_EVENTS=0 RAY_DEDUP_LOGS=0 '
         # worker_maximum_startup_concurrency controls the maximum number of
         # workers that can be started concurrently. However, it also controls
@@ -338,10 +440,23 @@ def ray_worker_start_command(custom_resource: Optional[str],
                              custom_ray_options: Optional[Dict[str, Any]],
                              no_restart: bool) -> str:
     """Returns the command to start Ray on the worker node."""
-    # We need to use the ray port in the env variable, because the head node
-    # determines the port to be used for the worker node.
-    ray_options = ('--address=${SKYPILOT_RAY_HEAD_IP}:${SKYPILOT_RAY_PORT} '
-                   '--object-manager-port=8076')
+    # SKYPILOT_RAY_PORT is the head's GCS port — exported as a constant
+    # by the K8s template's worker bootstrap, or as the probed value
+    # (read from the head's ConfigMap) by the hostNetwork worker probe.
+    ray_options = (
+        '--address=${SKYPILOT_RAY_HEAD_IP}:${SKYPILOT_RAY_PORT} '
+        '--object-manager-port=${SKYPILOT_RAY_OBJECT_MANAGER_PORT:-8076} '
+        '${SKYPILOT_RAY_NODE_MANAGER_PORT:+'
+        '--node-manager-port=$SKYPILOT_RAY_NODE_MANAGER_PORT} '
+        '${SKYPILOT_RAY_DASHBOARD_AGENT_LISTEN_PORT:+'
+        '--dashboard-agent-listen-port='
+        '$SKYPILOT_RAY_DASHBOARD_AGENT_LISTEN_PORT} '
+        '${SKYPILOT_RAY_RUNTIME_ENV_AGENT_PORT:+'
+        '--runtime-env-agent-port=$SKYPILOT_RAY_RUNTIME_ENV_AGENT_PORT} '
+        '${SKYPILOT_RAY_METRICS_EXPORT_PORT:+'
+        '--metrics-export-port=$SKYPILOT_RAY_METRICS_EXPORT_PORT} '
+        # See ray_head_start_command for the rationale on --node-ip-address.
+        '${SKYPILOT_RAY_NODE_IP:+--node-ip-address=$SKYPILOT_RAY_NODE_IP}')
 
     if custom_resource:
         ray_options += f' --resources=\'{custom_resource}\''
@@ -367,7 +482,7 @@ def ray_worker_start_command(custom_resource: Optional[str],
             f'|| {{ {cmd} }}')
     else:
         cmd = f'{constants.SKY_RAY_CMD} stop; ' + cmd
-    return cmd
+    return _host_network_probe_cmd('worker') + cmd
 
 
 @common.log_function_start_end

--- a/sky/provision/kubernetes/host_network_probe.py
+++ b/sky/provision/kubernetes/host_network_probe.py
@@ -116,7 +116,8 @@ def _probe_ports(
     return held, ports
 
 
-def _write_env_file(ports: Dict[str, int], path: str,
+def _write_env_file(ports: Dict[str, int],
+                    path: str,
                     extra: Optional[Dict[str, str]] = None) -> None:
     lines = [
         f'export {_ENV_VAR_FOR_PORT[name]}={port}'
@@ -268,8 +269,8 @@ def _publish_configmap(name: str, namespace: str, ports: Dict[str, int],
     # API — $HOSTNAME is the host node's name under hostNetwork.
     owner_pod_name = os.environ['SKYPILOT_POD_NAME']
     owner_pod_uid = os.environ['SKYPILOT_POD_UID']
-    body = _build_configmap_body(name, namespace, ports, extra,
-                                 owner_pod_name, owner_pod_uid)
+    body = _build_configmap_body(name, namespace, ports, extra, owner_pod_name,
+                                 owner_pod_uid)
     base = f'/api/v1/namespaces/{namespace}/configmaps'
     status, resp = _k8s_api_request('POST', base, body)
     if status == 409:
@@ -355,7 +356,9 @@ def _run_head(env_file: str, configmap_name: str,
     node_ip = loopback_ip_for_pod(os.environ['SKYPILOT_POD_NAME'])
     # Publish before writing the env file so a failed publish prevents
     # ray start from binding ports the workers will never discover.
-    _publish_configmap(configmap_name, configmap_namespace, ports,
+    _publish_configmap(configmap_name,
+                       configmap_namespace,
+                       ports,
                        extra={HEAD_NODE_IP_KEY: node_ip})
     _write_env_file(ports, env_file, extra={'SKYPILOT_RAY_NODE_IP': node_ip})
     del held  # release the held sockets just before this process exits

--- a/sky/provision/kubernetes/host_network_probe.py
+++ b/sky/provision/kubernetes/host_network_probe.py
@@ -60,6 +60,12 @@ _WORKER_PORT_NAMES: List[str] = [
 # can read the same key when assembling InstanceInfo.ssh_port.
 SSHD_KEY_PREFIX = 'sshd_'
 
+
+def ray_ports_configmap_name(cluster_name_on_cloud: str) -> str:
+    """Name of the per-cluster ConfigMap the head publishes Ray ports to."""
+    return f'{cluster_name_on_cloud}-ray-ports'
+
+
 _SA_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
 _SA_CA_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
 

--- a/sky/provision/kubernetes/host_network_probe.py
+++ b/sky/provision/kubernetes/host_network_probe.py
@@ -1,0 +1,417 @@
+"""Free-port probe and ConfigMap publish/discover for hostNetwork pods.
+
+When a K8s pod has ``hostNetwork: true`` it shares the host's network
+namespace, so a sibling SkyPilot pod scheduled to the same node would
+collide on Ray's default ports. This script binds ephemeral sockets to
+pick a free port set for the local Ray daemon, then either publishes
+them (head) to a ``<cluster>-ray-ports`` ConfigMap or reads the head's
+port from that ConfigMap (worker). Stdlib-only so it can run during the
+window when the pod's skypilot install is in flux.
+
+It also assigns each pod a deterministic 127.X.Y.Z loopback IP derived
+from its pod name and exports it as ``SKYPILOT_RAY_NODE_IP``. Ray binds
+its raylet on that IP, which disambiguates the (NodeID -> endpoint)
+lookup when two raylets are otherwise co-located on the same host IP.
+Without this, Ray's gRPC client cache can collapse both NodeIDs onto a
+single endpoint and route every lease request to the wrong raylet.
+"""
+import argparse
+import functools
+import hashlib
+import json
+import os
+import re
+import socket
+import ssl
+import sys
+import time
+from typing import Any, Dict, List, Optional, Tuple
+import urllib.error
+import urllib.request
+
+# SKYPILOT_RAY_PORT is the head's GCS port; the worker template already
+# uses that name to dial the head, so we reuse it rather than introduce
+# a parallel SKYPILOT_RAY_GCS_PORT.
+_ENV_VAR_FOR_PORT: Dict[str, str] = {
+    'gcs': 'SKYPILOT_RAY_PORT',
+    'dashboard': 'SKYPILOT_RAY_DASHBOARD_PORT',
+    'node_manager': 'SKYPILOT_RAY_NODE_MANAGER_PORT',
+    'object_manager': 'SKYPILOT_RAY_OBJECT_MANAGER_PORT',
+    'ray_client_server': 'SKYPILOT_RAY_CLIENT_SERVER_PORT',
+    'dashboard_agent_listen': 'SKYPILOT_RAY_DASHBOARD_AGENT_LISTEN_PORT',
+    'runtime_env_agent': 'SKYPILOT_RAY_RUNTIME_ENV_AGENT_PORT',
+    'metrics_export': 'SKYPILOT_RAY_METRICS_EXPORT_PORT',
+    # Pod sshd port. host:22 is owned by the K8s node's own sshd under
+    # hostNetwork, so the pod must bind sshd to a probed port instead.
+    'sshd': 'SKYPILOT_SSHD_PORT',
+}
+
+_HEAD_PORT_NAMES: List[str] = list(_ENV_VAR_FOR_PORT)
+
+# Workers don't run GCS/dashboard/ray-client-server, but they DO run sshd.
+_WORKER_PORT_NAMES: List[str] = [
+    'node_manager',
+    'object_manager',
+    'dashboard_agent_listen',
+    'runtime_env_agent',
+    'metrics_export',
+    'sshd',
+]
+
+# Public so the SkyPilot client (sky/provision/kubernetes/instance.py)
+# can read the same key when assembling InstanceInfo.ssh_port.
+SSHD_KEY_PREFIX = 'sshd_'
+
+# ConfigMap key carrying the head pod's loopback IP. Workers read it to
+# dial the head's GCS over the shared loopback (same K8s node only).
+HEAD_NODE_IP_KEY = 'head_node_ip'
+
+_SA_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
+_SA_CA_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+
+_CONFIGMAP_POLL_TIMEOUT_S = 600
+_CONFIGMAP_POLL_INTERVAL_S = 2
+
+# Bridges the gap between the head publishing its ConfigMap (just before
+# ray binds) and ray actually accepting connections.
+_HEAD_GCS_TCP_WAIT_TIMEOUT_S = 600
+_HEAD_GCS_TCP_WAIT_INTERVAL_S = 1
+
+# Bound on retries when a worker's ConfigMap merge races another worker
+# (409 Conflict from stale resourceVersion).
+_MERGE_RETRY_LIMIT = 5
+
+# Per-request budget for K8s API calls. Without this, urlopen would
+# block forever on a hung API server and freeze the pod bootstrap.
+_K8S_API_TIMEOUT_S = 10
+
+
+@functools.lru_cache(maxsize=None)
+def _api_auth_token() -> str:
+    with open(_SA_TOKEN_PATH, encoding='utf-8') as f:
+        return f.read().strip()
+
+
+@functools.lru_cache(maxsize=None)
+def _api_ssl_context() -> ssl.SSLContext:
+    return ssl.create_default_context(cafile=_SA_CA_PATH)
+
+
+def _bind_ephemeral_port() -> Tuple[socket.socket, int]:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(('0.0.0.0', 0))
+    return s, s.getsockname()[1]
+
+
+def _probe_ports(
+        names: List[str]) -> Tuple[List[socket.socket], Dict[str, int]]:
+    """Bind one ephemeral socket per name; caller must keep them alive
+    until just before ``ray start`` rebinds the ports."""
+    held: List[socket.socket] = []
+    ports: Dict[str, int] = {}
+    for name in names:
+        sock, port = _bind_ephemeral_port()
+        held.append(sock)
+        ports[name] = port
+    return held, ports
+
+
+def _write_env_file(ports: Dict[str, int], path: str,
+                    extra: Optional[Dict[str, str]] = None) -> None:
+    lines = [
+        f'export {_ENV_VAR_FOR_PORT[name]}={port}'
+        for name, port in ports.items()
+    ]
+    for key, value in (extra or {}).items():
+        lines.append(f'export {key}={value}')
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write('\n'.join(lines) + '\n')
+
+
+_POD_NAME_RANK_RE = re.compile(r'^(.*)-(head|worker(\d+))$')
+
+
+def loopback_ip_for_pod(pod_name: str) -> str:
+    """Deterministic 127.X.Y.Z address per pod for ``--node-ip-address``.
+
+    127.0.0.0/8 is wholly routed to ``lo`` by the Linux kernel, so the
+    address is bindable with no CAP_NET_ADMIN and reachable from any
+    process sharing the netns (i.e. any other pod on the same K8s node
+    under hostNetwork).
+
+    Layout: ``127.<H1>.<H2>.<rank>`` where (H1, H2) come from a SHA-256
+    of the cluster prefix (pod name minus the ``-head`` / ``-workerN``
+    suffix) and ``rank`` is 0 for the head, N for ``-workerN``. Putting
+    rank in the last byte makes IPs immediately readable in debug
+    output ('head is .0, worker1 is .1'); the cluster-id bytes keep
+    two concurrent SkyPilot clusters on the same K8s node from
+    colliding. H1 is OR'd with 0x80 to stay out of the conventionally
+    special 127.0.x.x range (in particular 127.0.0.1).
+    """
+    match = _POD_NAME_RANK_RE.match(pod_name)
+    if match:
+        cluster = match.group(1)
+        rank = 0 if match.group(2) == 'head' else int(match.group(3))
+    else:
+        # Pod-name shape we don't recognize: hash the whole name as a
+        # fallback. Better to stay deterministically distinct than to
+        # fail provisioning.
+        cluster = pod_name
+        rank = 0
+    digest = hashlib.sha256(cluster.encode('utf-8')).digest()
+    return f'127.{digest[0] | 0x80}.{digest[1]}.{rank % 256}'
+
+
+def _k8s_api_request(
+        method: str,
+        path: str,
+        body: Optional[Dict[str, Any]] = None) -> Tuple[int, bytes]:
+    api_host = os.environ['KUBERNETES_SERVICE_HOST']
+    api_port = os.environ['KUBERNETES_SERVICE_PORT']
+    headers = {
+        'Authorization': f'Bearer {_api_auth_token()}',
+        'Accept': 'application/json',
+    }
+    data: bytes = b''
+    if body is not None:
+        data = json.dumps(body).encode('utf-8')
+        headers['Content-Type'] = 'application/json'
+    url = f'https://{api_host}:{api_port}{path}'
+    req = urllib.request.Request(url,
+                                 data=data if data else None,
+                                 headers=headers,
+                                 method=method)
+    try:
+        with urllib.request.urlopen(
+                req, context=_api_ssl_context(),
+                timeout=_K8S_API_TIMEOUT_S) as resp:  # noqa: S310
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+
+
+def _configmap_data_for_ports(podname: str, ports: Dict[str, int],
+                              extra: Dict[str, str]) -> Dict[str, str]:
+    """Translate probe port names into ConfigMap data keys.
+
+    The 'sshd' port is rewritten to ``sshd_<podname>`` because every pod
+    (head + each worker) publishes its own sshd port into the same
+    ConfigMap. Other keys are head-owned Ray ports and stay flat so the
+    worker probe can look up the head's GCS by the bare key 'gcs'.
+    Non-port head-owned values (e.g. the head's loopback IP) are passed
+    in via ``extra`` and written through as-is.
+    """
+    out: Dict[str, str] = {}
+    for name, port in ports.items():
+        key = f'{SSHD_KEY_PREFIX}{podname}' if name == 'sshd' else name
+        out[key] = str(port)
+    out.update(extra)
+    return out
+
+
+def _build_configmap_body(name: str, namespace: str, ports: Dict[str, int],
+                          extra: Dict[str, str], owner_pod_name: str,
+                          owner_pod_uid: str) -> Dict[str, Any]:
+    """Build the ConfigMap body, including the ownerReference that ties its
+    lifetime to the head pod so K8s garbage-collects it on `sky down`."""
+    return {
+        'apiVersion': 'v1',
+        'kind': 'ConfigMap',
+        'metadata': {
+            'name': name,
+            'namespace': namespace,
+            'labels': {
+                'parent': 'skypilot',
+                'skypilot-ray-ports': 'true',
+            },
+            # ownerReference ties the ConfigMap's lifetime to the head
+            # pod so it's GC'd on sky down without explicit teardown.
+            'ownerReferences': [{
+                'apiVersion': 'v1',
+                'kind': 'Pod',
+                'name': owner_pod_name,
+                'uid': owner_pod_uid,
+                'controller': False,
+                'blockOwnerDeletion': False,
+            }],
+        },
+        'data': _configmap_data_for_ports(owner_pod_name, ports, extra),
+    }
+
+
+def _format_api_error(action: str, name: str, namespace: str, status: int,
+                      resp: bytes) -> str:
+    body = resp.decode('utf-8', 'replace')
+    return (f'Failed to {action} ConfigMap {namespace}/{name}: '
+            f'status={status} body={body}')
+
+
+def _get_configmap(name: str, namespace: str) -> Dict[str, Any]:
+    """GET a ConfigMap, returning its parsed body. Raises on non-200."""
+    base = f'/api/v1/namespaces/{namespace}/configmaps/{name}'
+    status, resp = _k8s_api_request('GET', base)
+    if status >= 300:
+        raise RuntimeError(
+            _format_api_error('GET', name, namespace, status, resp))
+    return json.loads(resp)
+
+
+def _publish_configmap(name: str, namespace: str, ports: Dict[str, int],
+                       extra: Dict[str, str]) -> None:
+    """Create or update a ConfigMap with the head's chosen ports.
+
+    Idempotent: on 409 we GET, lift the resourceVersion, and PUT — which
+    also re-points the ownerReference at the current head pod (relevant
+    on head-pod restart, where a stale ConfigMap may still be around).
+    """
+    # SKYPILOT_POD_NAME / SKYPILOT_POD_UID come from the K8s downward
+    # API — $HOSTNAME is the host node's name under hostNetwork.
+    owner_pod_name = os.environ['SKYPILOT_POD_NAME']
+    owner_pod_uid = os.environ['SKYPILOT_POD_UID']
+    body = _build_configmap_body(name, namespace, ports, extra,
+                                 owner_pod_name, owner_pod_uid)
+    base = f'/api/v1/namespaces/{namespace}/configmaps'
+    status, resp = _k8s_api_request('POST', base, body)
+    if status == 409:
+        existing = _get_configmap(name, namespace)
+        body['metadata']['resourceVersion'] = (
+            existing['metadata']['resourceVersion'])
+        status, resp = _k8s_api_request('PUT', f'{base}/{name}', body)
+    if status >= 300:
+        raise RuntimeError(
+            _format_api_error('publish', name, namespace, status, resp))
+
+
+def _merge_sshd_port(name: str, namespace: str, podname: str,
+                     port: int) -> None:
+    """Merge ``sshd_<podname>: <port>`` into an existing ConfigMap.
+
+    Workers call this after the head has published the ConfigMap so the
+    SkyPilot client can read every pod's sshd port from one place.
+    Retries on 409 (resourceVersion went stale — typically another
+    worker won the merge race) up to a small bound.
+    """
+    base = f'/api/v1/namespaces/{namespace}/configmaps/{name}'
+    key = f'{SSHD_KEY_PREFIX}{podname}'
+    last_err: Optional[str] = None
+    for _ in range(_MERGE_RETRY_LIMIT):
+        existing = _get_configmap(name, namespace)
+        data = dict(existing.get('data') or {})
+        data[key] = str(port)
+        existing['data'] = data
+        status, resp = _k8s_api_request('PUT', base, existing)
+        if status < 300:
+            return
+        last_err = _format_api_error('PUT', name, namespace, status, resp)
+        if status != 409:
+            break
+    raise RuntimeError(
+        f'Failed to merge {key} into ConfigMap {namespace}/{name} after '
+        f'{_MERGE_RETRY_LIMIT} attempts: {last_err}')
+
+
+def _read_configmap_with_retry(name: str, namespace: str) -> Dict[str, str]:
+    """Poll a ConfigMap until it exists, returning its ``data`` field.
+
+    Doubles as the "head is up" sync barrier for workers — the same
+    role ``nc -z`` plays for non-hostNetwork bootstraps.
+    """
+    base = f'/api/v1/namespaces/{namespace}/configmaps/{name}'
+    deadline = time.monotonic() + _CONFIGMAP_POLL_TIMEOUT_S
+    while time.monotonic() < deadline:
+        status, resp = _k8s_api_request('GET', base)
+        if status == 200:
+            body = json.loads(resp)
+            return body.get('data', {})
+        if status != 404:
+            raise RuntimeError(
+                f'Unexpected status {status} reading ConfigMap '
+                f'{namespace}/{name}: {resp.decode("utf-8", "replace")}')
+        time.sleep(_CONFIGMAP_POLL_INTERVAL_S)
+    raise TimeoutError(
+        f'ConfigMap {namespace}/{name} did not appear within '
+        f'{_CONFIGMAP_POLL_TIMEOUT_S}s — is the head pod healthy?')
+
+
+def _wait_head_gcs_tcp(host: str, port: int) -> None:
+    """Block until the head's GCS port answers on TCP."""
+    deadline = time.monotonic() + _HEAD_GCS_TCP_WAIT_TIMEOUT_S
+    last_err: Optional[Exception] = None
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=2):
+                return
+        except OSError as e:
+            last_err = e
+            time.sleep(_HEAD_GCS_TCP_WAIT_INTERVAL_S)
+    raise TimeoutError(
+        f'Head GCS {host}:{port} did not accept connections within '
+        f'{_HEAD_GCS_TCP_WAIT_TIMEOUT_S}s (last error: {last_err}).')
+
+
+def _run_head(env_file: str, configmap_name: str,
+              configmap_namespace: str) -> None:
+    held, ports = _probe_ports(_HEAD_PORT_NAMES)
+    node_ip = loopback_ip_for_pod(os.environ['SKYPILOT_POD_NAME'])
+    # Publish before writing the env file so a failed publish prevents
+    # ray start from binding ports the workers will never discover.
+    _publish_configmap(configmap_name, configmap_namespace, ports,
+                       extra={HEAD_NODE_IP_KEY: node_ip})
+    _write_env_file(ports, env_file, extra={'SKYPILOT_RAY_NODE_IP': node_ip})
+    del held  # release the held sockets just before this process exits
+
+
+def _run_worker(env_file: str, configmap_name: str,
+                configmap_namespace: str) -> None:
+    head_data = _read_configmap_with_retry(configmap_name, configmap_namespace)
+    head_gcs = head_data.get('gcs')
+    if head_gcs is None:
+        raise RuntimeError(
+            f'ConfigMap {configmap_namespace}/{configmap_name} is missing '
+            f'the "gcs" key. Data: {head_data}')
+    held, ports = _probe_ports(_WORKER_PORT_NAMES)
+    # Publish before releasing the held sockets so a failed merge
+    # aborts the bootstrap before sshd binds a port nothing can find.
+    podname = os.environ['SKYPILOT_POD_NAME']
+    _merge_sshd_port(configmap_name, configmap_namespace, podname,
+                     ports['sshd'])
+    ports['gcs'] = int(head_gcs)
+    extra = {'SKYPILOT_RAY_NODE_IP': loopback_ip_for_pod(podname)}
+    # Override SKYPILOT_RAY_HEAD_IP to the head's loopback so the worker
+    # raylet's --address dials the head over 127.16.X.Y. Requires the
+    # worker to be on the same K8s node as the head (the only case where
+    # the IP-collision bug bites; cross-node hostNetwork pods have
+    # naturally distinct host IPs).
+    head_node_ip = head_data.get(HEAD_NODE_IP_KEY)
+    if head_node_ip:
+        extra['SKYPILOT_RAY_HEAD_IP'] = head_node_ip
+    _write_env_file(ports, env_file, extra=extra)
+    del held
+    # Prefer the loopback IP we just decided to dial; fall back to
+    # whatever SKYPILOT_RAY_HEAD_IP was set to before the probe ran.
+    head_ip = head_node_ip or os.environ.get('SKYPILOT_RAY_HEAD_IP')
+    if head_ip:
+        _wait_head_gcs_tcp(head_ip, int(head_gcs))
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    # No description: __doc__ is stripped by source_utils.minify_python_source
+    # before the script is inlined into the pod bootstrap.
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--mode', choices=['head', 'worker'], required=True)
+    parser.add_argument('--env-file',
+                        required=True,
+                        help='Path to write `export VAR=value` lines to.')
+    parser.add_argument('--configmap-name', required=True)
+    parser.add_argument('--configmap-namespace', required=True)
+    args = parser.parse_args(argv)
+    if args.mode == 'head':
+        _run_head(args.env_file, args.configmap_name, args.configmap_namespace)
+    else:
+        _run_worker(args.env_file, args.configmap_name,
+                    args.configmap_namespace)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/sky/provision/kubernetes/host_network_probe.py
+++ b/sky/provision/kubernetes/host_network_probe.py
@@ -8,19 +8,17 @@ them (head) to a ``<cluster>-ray-ports`` ConfigMap or reads the head's
 port from that ConfigMap (worker). Stdlib-only so it can run during the
 window when the pod's skypilot install is in flux.
 
-It also assigns each pod a deterministic 127.X.Y.Z loopback IP derived
-from its pod name and exports it as ``SKYPILOT_RAY_NODE_IP``. Ray binds
-its raylet on that IP, which disambiguates the (NodeID -> endpoint)
-lookup when two raylets are otherwise co-located on the same host IP.
-Without this, Ray's gRPC client cache can collapse both NodeIDs onto a
-single endpoint and route every lease request to the wrong raylet.
+Same-cluster pods never share a K8s node (SkyPilot injects a required
+per-cluster ``podAntiAffinity`` for hostNetwork clusters), so each
+pod's host IP is unique and routable. The worker dials the head over
+the headless Service DNS (``SKYPILOT_RAY_HEAD_IP``, set by the pod
+template) plus the head's probed GCS port from the ConfigMap — no
+loopback-IP disambiguation is needed.
 """
 import argparse
 import functools
-import hashlib
 import json
 import os
-import re
 import socket
 import ssl
 import sys
@@ -61,10 +59,6 @@ _WORKER_PORT_NAMES: List[str] = [
 # Public so the SkyPilot client (sky/provision/kubernetes/instance.py)
 # can read the same key when assembling InstanceInfo.ssh_port.
 SSHD_KEY_PREFIX = 'sshd_'
-
-# ConfigMap key carrying the head pod's loopback IP. Workers read it to
-# dial the head's GCS over the shared loopback (same K8s node only).
-HEAD_NODE_IP_KEY = 'head_node_ip'
 
 _SA_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
 _SA_CA_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
@@ -116,51 +110,13 @@ def _probe_ports(
     return held, ports
 
 
-def _write_env_file(ports: Dict[str, int],
-                    path: str,
-                    extra: Optional[Dict[str, str]] = None) -> None:
+def _write_env_file(ports: Dict[str, int], path: str) -> None:
     lines = [
         f'export {_ENV_VAR_FOR_PORT[name]}={port}'
         for name, port in ports.items()
     ]
-    for key, value in (extra or {}).items():
-        lines.append(f'export {key}={value}')
     with open(path, 'w', encoding='utf-8') as f:
         f.write('\n'.join(lines) + '\n')
-
-
-_POD_NAME_RANK_RE = re.compile(r'^(.*)-(head|worker(\d+))$')
-
-
-def loopback_ip_for_pod(pod_name: str) -> str:
-    """Deterministic 127.X.Y.Z address per pod for ``--node-ip-address``.
-
-    127.0.0.0/8 is wholly routed to ``lo`` by the Linux kernel, so the
-    address is bindable with no CAP_NET_ADMIN and reachable from any
-    process sharing the netns (i.e. any other pod on the same K8s node
-    under hostNetwork).
-
-    Layout: ``127.<H1>.<H2>.<rank>`` where (H1, H2) come from a SHA-256
-    of the cluster prefix (pod name minus the ``-head`` / ``-workerN``
-    suffix) and ``rank`` is 0 for the head, N for ``-workerN``. Putting
-    rank in the last byte makes IPs immediately readable in debug
-    output ('head is .0, worker1 is .1'); the cluster-id bytes keep
-    two concurrent SkyPilot clusters on the same K8s node from
-    colliding. H1 is OR'd with 0x80 to stay out of the conventionally
-    special 127.0.x.x range (in particular 127.0.0.1).
-    """
-    match = _POD_NAME_RANK_RE.match(pod_name)
-    if match:
-        cluster = match.group(1)
-        rank = 0 if match.group(2) == 'head' else int(match.group(3))
-    else:
-        # Pod-name shape we don't recognize: hash the whole name as a
-        # fallback. Better to stay deterministically distinct than to
-        # fail provisioning.
-        cluster = pod_name
-        rank = 0
-    digest = hashlib.sha256(cluster.encode('utf-8')).digest()
-    return f'127.{digest[0] | 0x80}.{digest[1]}.{rank % 256}'
 
 
 def _k8s_api_request(
@@ -191,27 +147,24 @@ def _k8s_api_request(
         return e.code, e.read()
 
 
-def _configmap_data_for_ports(podname: str, ports: Dict[str, int],
-                              extra: Dict[str, str]) -> Dict[str, str]:
+def _configmap_data_for_ports(podname: str,
+                              ports: Dict[str, int]) -> Dict[str, str]:
     """Translate probe port names into ConfigMap data keys.
 
     The 'sshd' port is rewritten to ``sshd_<podname>`` because every pod
     (head + each worker) publishes its own sshd port into the same
     ConfigMap. Other keys are head-owned Ray ports and stay flat so the
     worker probe can look up the head's GCS by the bare key 'gcs'.
-    Non-port head-owned values (e.g. the head's loopback IP) are passed
-    in via ``extra`` and written through as-is.
     """
     out: Dict[str, str] = {}
     for name, port in ports.items():
         key = f'{SSHD_KEY_PREFIX}{podname}' if name == 'sshd' else name
         out[key] = str(port)
-    out.update(extra)
     return out
 
 
 def _build_configmap_body(name: str, namespace: str, ports: Dict[str, int],
-                          extra: Dict[str, str], owner_pod_name: str,
+                          owner_pod_name: str,
                           owner_pod_uid: str) -> Dict[str, Any]:
     """Build the ConfigMap body, including the ownerReference that ties its
     lifetime to the head pod so K8s garbage-collects it on `sky down`."""
@@ -236,7 +189,7 @@ def _build_configmap_body(name: str, namespace: str, ports: Dict[str, int],
                 'blockOwnerDeletion': False,
             }],
         },
-        'data': _configmap_data_for_ports(owner_pod_name, ports, extra),
+        'data': _configmap_data_for_ports(owner_pod_name, ports),
     }
 
 
@@ -257,8 +210,8 @@ def _get_configmap(name: str, namespace: str) -> Dict[str, Any]:
     return json.loads(resp)
 
 
-def _publish_configmap(name: str, namespace: str, ports: Dict[str, int],
-                       extra: Dict[str, str]) -> None:
+def _publish_configmap(name: str, namespace: str,
+                       ports: Dict[str, int]) -> None:
     """Create or update a ConfigMap with the head's chosen ports.
 
     Idempotent: on 409 we GET, lift the resourceVersion, and PUT — which
@@ -269,7 +222,7 @@ def _publish_configmap(name: str, namespace: str, ports: Dict[str, int],
     # API — $HOSTNAME is the host node's name under hostNetwork.
     owner_pod_name = os.environ['SKYPILOT_POD_NAME']
     owner_pod_uid = os.environ['SKYPILOT_POD_UID']
-    body = _build_configmap_body(name, namespace, ports, extra, owner_pod_name,
+    body = _build_configmap_body(name, namespace, ports, owner_pod_name,
                                  owner_pod_uid)
     base = f'/api/v1/namespaces/{namespace}/configmaps'
     status, resp = _k8s_api_request('POST', base, body)
@@ -353,14 +306,10 @@ def _wait_head_gcs_tcp(host: str, port: int) -> None:
 def _run_head(env_file: str, configmap_name: str,
               configmap_namespace: str) -> None:
     held, ports = _probe_ports(_HEAD_PORT_NAMES)
-    node_ip = loopback_ip_for_pod(os.environ['SKYPILOT_POD_NAME'])
     # Publish before writing the env file so a failed publish prevents
     # ray start from binding ports the workers will never discover.
-    _publish_configmap(configmap_name,
-                       configmap_namespace,
-                       ports,
-                       extra={HEAD_NODE_IP_KEY: node_ip})
-    _write_env_file(ports, env_file, extra={'SKYPILOT_RAY_NODE_IP': node_ip})
+    _publish_configmap(configmap_name, configmap_namespace, ports)
+    _write_env_file(ports, env_file)
     del held  # release the held sockets just before this process exits
 
 
@@ -379,20 +328,12 @@ def _run_worker(env_file: str, configmap_name: str,
     _merge_sshd_port(configmap_name, configmap_namespace, podname,
                      ports['sshd'])
     ports['gcs'] = int(head_gcs)
-    extra = {'SKYPILOT_RAY_NODE_IP': loopback_ip_for_pod(podname)}
-    # Override SKYPILOT_RAY_HEAD_IP to the head's loopback so the worker
-    # raylet's --address dials the head over 127.16.X.Y. Requires the
-    # worker to be on the same K8s node as the head (the only case where
-    # the IP-collision bug bites; cross-node hostNetwork pods have
-    # naturally distinct host IPs).
-    head_node_ip = head_data.get(HEAD_NODE_IP_KEY)
-    if head_node_ip:
-        extra['SKYPILOT_RAY_HEAD_IP'] = head_node_ip
-    _write_env_file(ports, env_file, extra=extra)
+    _write_env_file(ports, env_file)
     del held
-    # Prefer the loopback IP we just decided to dial; fall back to
-    # whatever SKYPILOT_RAY_HEAD_IP was set to before the probe ran.
-    head_ip = head_node_ip or os.environ.get('SKYPILOT_RAY_HEAD_IP')
+    # The pod template points SKYPILOT_RAY_HEAD_IP at the head's headless
+    # Service DNS. Same-cluster pods never share a K8s node (per-cluster
+    # podAntiAffinity), so that resolves to the head's routable host IP.
+    head_ip = os.environ.get('SKYPILOT_RAY_HEAD_IP')
     if head_ip:
         _wait_head_gcs_tcp(head_ip, int(head_gcs))
 

--- a/sky/provision/kubernetes/host_network_probe.py
+++ b/sky/provision/kubernetes/host_network_probe.py
@@ -147,8 +147,8 @@ def _k8s_api_request(
         return e.code, e.read()
 
 
-def _configmap_data_for_ports(podname: str,
-                              ports: Dict[str, int]) -> Dict[str, str]:
+def _configmap_data_for_ports(podname: str, ports: Dict[str,
+                                                        int]) -> Dict[str, str]:
     """Translate probe port names into ConfigMap data keys.
 
     The 'sshd' port is rewritten to ``sshd_<podname>`` because every pod
@@ -210,8 +210,8 @@ def _get_configmap(name: str, namespace: str) -> Dict[str, Any]:
     return json.loads(resp)
 
 
-def _publish_configmap(name: str, namespace: str,
-                       ports: Dict[str, int]) -> None:
+def _publish_configmap(name: str, namespace: str, ports: Dict[str,
+                                                              int]) -> None:
     """Create or update a ConfigMap with the head's chosen ports.
 
     Idempotent: on 409 we GET, lift the resourceVersion, and PUT — which

--- a/sky/provision/kubernetes/host_network_probe.py
+++ b/sky/provision/kubernetes/host_network_probe.py
@@ -19,6 +19,7 @@ import argparse
 import functools
 import json
 import os
+import random
 import socket
 import ssl
 import sys
@@ -78,21 +79,30 @@ _HEAD_GCS_TCP_WAIT_TIMEOUT_S = 600
 _HEAD_GCS_TCP_WAIT_INTERVAL_S = 1
 
 # Bound on retries when a worker's ConfigMap merge races another worker
-# (409 Conflict from stale resourceVersion).
-_MERGE_RETRY_LIMIT = 5
+# (409 Conflict from stale resourceVersion). On a many-node cluster
+# every worker contends for the one ConfigMap, so the loser of a race
+# can be bounced several times before it lands — keep this generous.
+_MERGE_RETRY_LIMIT = 8
+# Full-jitter exponential backoff between 409 retries. Without it, N
+# workers retrying in lockstep are a thundering herd that keeps losing
+# to each other; spreading them out lets a large cluster converge.
+_MERGE_RETRY_BASE_DELAY_S = 0.2
+_MERGE_RETRY_MAX_DELAY_S = 5
 
 # Per-request budget for K8s API calls. Without this, urlopen would
 # block forever on a hung API server and freeze the pod bootstrap.
 _K8S_API_TIMEOUT_S = 10
 
 
-@functools.lru_cache(maxsize=None)
+# maxsize=1: both take no arguments, so a single slot caches the only
+# possible call. (Memoizing a constant read/parse, not a keyed cache.)
+@functools.lru_cache(maxsize=1)
 def _api_auth_token() -> str:
     with open(_SA_TOKEN_PATH, encoding='utf-8') as f:
         return f.read().strip()
 
 
-@functools.lru_cache(maxsize=None)
+@functools.lru_cache(maxsize=1)
 def _api_ssl_context() -> ssl.SSLContext:
     return ssl.create_default_context(cafile=_SA_CA_PATH)
 
@@ -169,6 +179,27 @@ def _configmap_data_for_ports(podname: str, ports: Dict[str,
     return out
 
 
+def _head_ports_from_configmap_data(data: Dict[str, str],
+                                    podname: str) -> Optional[Dict[str, int]]:
+    """Reconstruct the head's probed ports from a ConfigMap's data.
+
+    Inverse of _configmap_data_for_ports for the head's own keys. Returns
+    None if any expected head port is missing or non-integer, so the
+    caller falls back to a fresh probe rather than reusing a partial set.
+    """
+    ports: Dict[str, int] = {}
+    for name in _HEAD_PORT_NAMES:
+        key = f'{SSHD_KEY_PREFIX}{podname}' if name == 'sshd' else name
+        raw = data.get(key)
+        if raw is None:
+            return None
+        try:
+            ports[name] = int(raw)
+        except ValueError:
+            return None
+    return ports
+
+
 def _build_configmap_body(name: str, namespace: str, ports: Dict[str, int],
                           owner_pod_name: str,
                           owner_pod_uid: str) -> Dict[str, Any]:
@@ -216,13 +247,25 @@ def _get_configmap(name: str, namespace: str) -> Dict[str, Any]:
     return json.loads(resp)
 
 
+def _try_get_configmap(name: str, namespace: str) -> Optional[Dict[str, Any]]:
+    """GET a ConfigMap, returning None if it doesn't exist (404)."""
+    base = f'/api/v1/namespaces/{namespace}/configmaps/{name}'
+    status, resp = _k8s_api_request('GET', base)
+    if status == 404:
+        return None
+    if status >= 300:
+        raise RuntimeError(
+            _format_api_error('GET', name, namespace, status, resp))
+    return json.loads(resp)
+
+
 def _publish_configmap(name: str, namespace: str, ports: Dict[str,
                                                               int]) -> None:
     """Create or update a ConfigMap with the head's chosen ports.
 
     Idempotent: on 409 we GET, lift the resourceVersion, and PUT — which
-    also re-points the ownerReference at the current head pod (relevant
-    on head-pod restart, where a stale ConfigMap may still be around).
+    also re-points the ownerReference at the current head pod (so a
+    ConfigMap left by a prior, GC-lagging head gets re-adopted).
     """
     # SKYPILOT_POD_NAME / SKYPILOT_POD_UID come from the K8s downward
     # API — $HOSTNAME is the host node's name under hostNetwork.
@@ -254,7 +297,7 @@ def _merge_sshd_port(name: str, namespace: str, podname: str,
     base = f'/api/v1/namespaces/{namespace}/configmaps/{name}'
     key = f'{SSHD_KEY_PREFIX}{podname}'
     last_err: Optional[str] = None
-    for _ in range(_MERGE_RETRY_LIMIT):
+    for attempt in range(_MERGE_RETRY_LIMIT):
         existing = _get_configmap(name, namespace)
         data = dict(existing.get('data') or {})
         data[key] = str(port)
@@ -265,6 +308,13 @@ def _merge_sshd_port(name: str, namespace: str, podname: str,
         last_err = _format_api_error('PUT', name, namespace, status, resp)
         if status != 409:
             break
+        # Lost the resourceVersion race (typically to another worker).
+        # Back off with full jitter before re-reading so a many-node
+        # cluster's workers don't keep colliding in lockstep.
+        if attempt < _MERGE_RETRY_LIMIT - 1:
+            ceiling = min(_MERGE_RETRY_MAX_DELAY_S,
+                          _MERGE_RETRY_BASE_DELAY_S * 2**attempt)
+            time.sleep(random.uniform(0, ceiling))
     raise RuntimeError(
         f'Failed to merge {key} into ConfigMap {namespace}/{name} after '
         f'{_MERGE_RETRY_LIMIT} attempts: {last_err}')
@@ -309,11 +359,50 @@ def _wait_head_gcs_tcp(host: str, port: int) -> None:
         f'{_HEAD_GCS_TCP_WAIT_TIMEOUT_S}s (last error: {last_err}).')
 
 
+def _existing_head_ports_to_reuse(name: str,
+                                  namespace: str) -> Optional[Dict[str, int]]:
+    """Ports to reuse if this head pod's ConfigMap already exists.
+
+    A *container* restart (crash, OOM, ``ray stop``-then-up) keeps the
+    Pod object — and its UID — so the ownerReference'd ConfigMap is NOT
+    garbage-collected; only deleting the Pod object triggers GC. After a
+    container restart the head must reuse the already-published ports:
+    workers and the SkyPilot SSH client are still dialing the old
+    GCS/sshd ports, so re-probing would strand them on a port nothing
+    rebinds.
+
+    Reuse only when the ConfigMap is owned by *this* pod UID. A
+    different UID means a stale ConfigMap from a prior, now-deleted head
+    whose GC simply hasn't caught up yet; its ports may already be taken
+    on this fresh node, so probe afresh (the subsequent publish, via its
+    409 PUT, re-points the ownerReference at the live pod).
+    """
+    existing = _try_get_configmap(name, namespace)
+    if existing is None:
+        return None
+    owner_uid = os.environ['SKYPILOT_POD_UID']
+    owners = existing.get('metadata', {}).get('ownerReferences') or []
+    if not any(o.get('uid') == owner_uid for o in owners):
+        return None
+    podname = os.environ['SKYPILOT_POD_NAME']
+    return _head_ports_from_configmap_data(existing.get('data') or {}, podname)
+
+
 def _run_head(env_file: str, configmap_name: str,
               configmap_namespace: str) -> None:
-    held, ports = _probe_ports(_HEAD_PORT_NAMES)
+    reused = _existing_head_ports_to_reuse(configmap_name, configmap_namespace)
+    if reused is not None:
+        # This head pod's container restarted; keep the published ports
+        # so in-flight workers / SSH stay valid. Nothing to hold — ray
+        # rebinds the same ports the dead process vacated.
+        held: List[socket.socket] = []
+        ports = reused
+    else:
+        held, ports = _probe_ports(_HEAD_PORT_NAMES)
     # Publish before writing the env file so a failed publish prevents
-    # ray start from binding ports the workers will never discover.
+    # ray start from binding ports the workers will never discover. The
+    # publish is idempotent (409 → PUT), so it harmlessly re-points the
+    # ownerReference at the current pod on the reuse path too.
     _publish_configmap(configmap_name, configmap_namespace, ports)
     _write_env_file(ports, env_file)
     del held  # release the held sockets just before this process exits

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1818,7 +1818,7 @@ def _read_host_network_sshd_ports(cluster_name_on_cloud: str, namespace: str,
     """
     if not expected_pods:
         return {}
-    name = f'{cluster_name_on_cloud}-ray-ports'
+    name = host_network_probe.ray_ports_configmap_name(cluster_name_on_cloud)
     expected = set(expected_pods)
     deadline = time.monotonic() + _HOST_NETWORK_SSHD_WAIT_TIMEOUT_S
     while True:

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -18,6 +18,7 @@ from sky.provision import constants
 from sky.provision import docker_utils
 from sky.provision.kubernetes import config as config_lib
 from sky.provision.kubernetes import constants as k8s_constants
+from sky.provision.kubernetes import host_network_probe
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.provision.kubernetes import volume
 from sky.utils import command_runner
@@ -1798,6 +1799,64 @@ def cleanup_cluster_resources(
     _delete_cluster_services(cluster_name_on_cloud, namespace, context)
 
 
+# The probe runs as soon as ray-installation finishes in step 2 of the
+# pod bootstrap, typically within tens of seconds of the pod going
+# Running. 60s gives the common case plenty of slack without pinning
+# every status refresh during a pod restart to a multi-minute hang.
+_HOST_NETWORK_SSHD_WAIT_TIMEOUT_S = 60
+_HOST_NETWORK_SSHD_WAIT_INTERVAL_S = 2
+
+
+def _read_host_network_sshd_ports(cluster_name_on_cloud: str, namespace: str,
+                                  context: Optional[str],
+                                  expected_pods: List[str]) -> Dict[str, int]:
+    """Read each pod's probed sshd port from the hostNetwork ConfigMap.
+
+    Polls until every entry in ``expected_pods`` is present (or the
+    timeout elapses); returning partial state would freeze every
+    subsequent SSH at port 22 until the next refresh.
+    """
+    if not expected_pods:
+        return {}
+    name = f'{cluster_name_on_cloud}-ray-ports'
+    expected = set(expected_pods)
+    deadline = time.monotonic() + _HOST_NETWORK_SSHD_WAIT_TIMEOUT_S
+    while True:
+        out: Dict[str, int] = {}
+        try:
+            cm = kubernetes.core_api(context).read_namespaced_config_map(
+                name=name, namespace=namespace)
+        except kubernetes.api_exception() as e:
+            if e.status != 404:
+                raise
+            cm = None
+        data = (cm.data or {}) if cm is not None else {}
+        for key, value in data.items():
+            if not key.startswith(host_network_probe.SSHD_KEY_PREFIX):
+                continue
+            podname = common_utils.removeprefix(
+                key, host_network_probe.SSHD_KEY_PREFIX)
+            try:
+                out[podname] = int(value)
+            except ValueError:
+                logger.warning(
+                    f'ConfigMap {namespace}/{name} has non-integer value '
+                    f'for {key!r}: {value!r}. SSH to {podname!r} will '
+                    f'fall back to port 22 and hit the K8s node\'s sshd.')
+        if expected.issubset(out.keys()):
+            return out
+        if time.monotonic() >= deadline:
+            missing = sorted(expected - out.keys())
+            logger.warning(
+                f'hostNetwork sshd ports for {missing} did not appear '
+                f'in ConfigMap {namespace}/{name} within '
+                f'{_HOST_NETWORK_SSHD_WAIT_TIMEOUT_S}s — `ssh <cluster>` '
+                f'to those pods will fail until the next '
+                f'`sky status -r`.')
+            return out
+        time.sleep(_HOST_NETWORK_SSHD_WAIT_INTERVAL_S)
+
+
 def get_cluster_info(
         region: str,
         cluster_name_on_cloud: str,
@@ -1819,10 +1878,31 @@ def get_cluster_info(
         port = kubernetes_utils.get_head_ssh_port(cluster_name_on_cloud,
                                                   namespace, context)
 
+    # Each hostNetwork pod's sshd binds a probed port (host:22 is the
+    # K8s node's own sshd). The SSH config writer needs that port per
+    # pod, so wait for every hostNetwork pod's entry to land in the
+    # ConfigMap before caching the result.
+    host_network_pods = [
+        name for name, pod in running_pods.items() if pod.spec.host_network
+    ]
+    pod_sshd_ports = _read_host_network_sshd_ports(cluster_name_on_cloud,
+                                                   namespace, context,
+                                                   host_network_pods)
+
     head_pod_name = None
     cpu_request = None
     for pod_name, pod in running_pods.items():
-        internal_ip = pod.status.pod_ip
+        # Under hostNetwork the pod's network namespace is the host's, so
+        # every pod on a given K8s node shares one pod_ip (the host IP).
+        # That collapses cluster_ips_to_node_id in task_codegen and makes
+        # Ray's get_node_ip_address() (which returns the raylet's
+        # --node-ip-address, our per-pod loopback) disagree with the
+        # SkyPilot-side IP list. Use the same loopback derivation here so
+        # both views line up. Same mapping as in host_network_probe.
+        if pod.spec.host_network:
+            internal_ip = host_network_probe.loopback_ip_for_pod(pod_name)
+        else:
+            internal_ip = pod.status.pod_ip
         # Get the k8s node name the pod is running on (for dashboard display)
         k8s_node_name = getattr(pod.spec, 'node_name', None)
         pods[pod_name] = [
@@ -1830,7 +1910,7 @@ def get_cluster_info(
                 instance_id=pod_name,
                 internal_ip=internal_ip,
                 external_ip=None,
-                ssh_port=port,
+                ssh_port=pod_sshd_ports.get(pod_name, port),
                 tags=pod.metadata.labels,
                 # TODO(hailong): `cluster.local` may need to be configurable
                 # Service name is same as the pod name for now.

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1893,16 +1893,11 @@ def get_cluster_info(
     cpu_request = None
     for pod_name, pod in running_pods.items():
         # Under hostNetwork the pod's network namespace is the host's, so
-        # every pod on a given K8s node shares one pod_ip (the host IP).
-        # That collapses cluster_ips_to_node_id in task_codegen and makes
-        # Ray's get_node_ip_address() (which returns the raylet's
-        # --node-ip-address, our per-pod loopback) disagree with the
-        # SkyPilot-side IP list. Use the same loopback derivation here so
-        # both views line up. Same mapping as in host_network_probe.
-        if pod.spec.host_network:
-            internal_ip = host_network_probe.loopback_ip_for_pod(pod_name)
-        else:
-            internal_ip = pod.status.pod_ip
+        # pod_ip is the K8s node's host IP. SkyPilot injects a required
+        # per-cluster podAntiAffinity for hostNetwork clusters, so every
+        # pod of a cluster is on its own node and thus has a distinct,
+        # routable host IP — no per-pod loopback disambiguation needed.
+        internal_ip = pod.status.pod_ip
         # Get the k8s node name the pod is running on (for dashboard display)
         k8s_node_name = getattr(pod.spec, 'node_name', None)
         pods[pod_name] = [

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -3397,6 +3397,40 @@ def inject_docker_cache_volume(
                 })
 
 
+def resolve_effective_pod_config(
+    cluster_config_overrides: Dict[str, Any],
+    cloud: Optional[clouds.Cloud] = None,
+    context: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Resolves the effective ``kubernetes.pod_config`` (global + overrides).
+
+    This is the same pod_config that combine_pod_config_fields() folds into
+    the rendered cluster YAML. make_deploy_resources_variables() needs it
+    before the template is rendered (to detect ``hostNetwork``), so both
+    resolve it here to stay in agreement on the SSH cloud/context handling.
+    """
+    # We don't use override_configs in `get_effective_region_config`, as
+    # merging the pod config requires special handling.
+    cloud_str = 'ssh' if isinstance(cloud, clouds.SSH) else 'kubernetes'
+    context_str = context
+    if isinstance(cloud, clouds.SSH) and context is not None:
+        assert context.startswith('ssh-'), 'SSH context must start with "ssh-"'
+        context_str = context[len('ssh-'):]
+    kubernetes_config = skypilot_config.get_effective_region_config(
+        cloud=cloud_str,
+        region=context_str,
+        keys=('pod_config',),
+        default_value={})
+    override_pod_config = config_utils.get_cloud_config_value_from_dict(
+        dict_config=cluster_config_overrides,
+        cloud=cloud_str,
+        region=context_str,
+        keys=('pod_config',),
+        default_value={})
+    config_utils.merge_k8s_configs(kubernetes_config, override_pod_config)
+    return kubernetes_config
+
+
 def combine_pod_config_fields(
     cluster_yaml_obj: Dict[str, Any],
     cluster_config_overrides: Dict[str, Any],
@@ -3442,25 +3476,8 @@ def combine_pod_config_fields(
         ```
     """
     merged_cluster_yaml_obj = copy.deepcopy(cluster_yaml_obj)
-    # We don't use override_configs in `get_effective_region_config`, as merging
-    # the pod config requires special handling.
-    cloud_str = 'ssh' if isinstance(cloud, clouds.SSH) else 'kubernetes'
-    context_str = context
-    if isinstance(cloud, clouds.SSH) and context is not None:
-        assert context.startswith('ssh-'), 'SSH context must start with "ssh-"'
-        context_str = context[len('ssh-'):]
-    kubernetes_config = skypilot_config.get_effective_region_config(
-        cloud=cloud_str,
-        region=context_str,
-        keys=('pod_config',),
-        default_value={})
-    override_pod_config = config_utils.get_cloud_config_value_from_dict(
-        dict_config=cluster_config_overrides,
-        cloud=cloud_str,
-        region=context_str,
-        keys=('pod_config',),
-        default_value={})
-    config_utils.merge_k8s_configs(kubernetes_config, override_pod_config)
+    kubernetes_config = resolve_effective_pod_config(cluster_config_overrides,
+                                                     cloud, context)
 
     # Merge the kubernetes config into the YAML for both head and worker nodes.
     config_utils.merge_k8s_configs(

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -3008,15 +3008,15 @@ class KubernetesInstanceType:
         return self.name
 
 
-def construct_ssh_jump_command(
-        private_key_path: str,
-        ssh_jump_ip: str,
-        ssh_jump_port: Optional[int] = None,
-        ssh_jump_user: str = 'sky',
-        proxy_cmd_path: Optional[str] = None,
-        proxy_cmd_target_pod: Optional[str] = None,
-        current_kube_context: Optional[str] = None,
-        current_kube_namespace: Optional[str] = None) -> str:
+def construct_ssh_jump_command(private_key_path: str,
+                               ssh_jump_ip: str,
+                               ssh_jump_port: Optional[int] = None,
+                               ssh_jump_user: str = 'sky',
+                               proxy_cmd_path: Optional[str] = None,
+                               proxy_cmd_target_pod: Optional[str] = None,
+                               current_kube_context: Optional[str] = None,
+                               current_kube_namespace: Optional[str] = None,
+                               host_network: bool = False) -> str:
     ssh_jump_proxy_command = (f'ssh -tt -i {private_key_path} '
                               '-o StrictHostKeyChecking=no '
                               '-o UserKnownHostsFile=/dev/null '
@@ -3033,9 +3033,14 @@ def construct_ssh_jump_command(
             current_kube_context is not None) else ''
         kube_namespace_flag = f'-n {current_kube_namespace} ' if (
             current_kube_namespace is not None) else ''
+        # Pass hostNetwork as a flag: it's known statically here, so the
+        # proxy script avoids a per-connection `kubectl get pod` probe
+        # (zero extra kubectl calls on the common non-hostNetwork path).
+        host_network_flag = '-N ' if host_network else ''
         ssh_jump_proxy_command += (f' -o ProxyCommand=\'{proxy_cmd_path} '
                                    f'{kube_context_flag}'
                                    f'{kube_namespace_flag}'
+                                   f'{host_network_flag}'
                                    f'{proxy_cmd_target_pod}\'')
     return ssh_jump_proxy_command
 
@@ -3045,6 +3050,7 @@ def get_ssh_proxy_command(
     private_key_path: str,
     context: Optional[str],
     namespace: str,
+    host_network: bool = False,
 ) -> str:
     """Generates the SSH proxy command to connect to the pod.
 
@@ -3076,6 +3082,12 @@ def get_ssh_proxy_command(
         private_key_path: str; Path to the private key to use for SSH.
             This key must be authorized to access the SSH jump pod.
         namespace: Kubernetes namespace to use.
+        host_network: bool; Whether the target pod runs with
+            ``hostNetwork: true``. When True the proxy script discovers
+            the pod's probed sshd port from the cluster's ConfigMap;
+            when False it skips that lookup and uses port 22. Passed as
+            a flag so the script needs no per-connection `kubectl get
+            pod` probe to determine this.
     """
     ssh_jump_ip = '127.0.0.1'  # Local end of the port-forward tunnel
     assert private_key_path is not None, 'Private key path must be provided'
@@ -3090,7 +3102,8 @@ def get_ssh_proxy_command(
         # command to make sure SSH still works when the current
         # context/namespace is changed by the user.
         current_kube_context=context,
-        current_kube_namespace=namespace)
+        current_kube_namespace=namespace,
+        host_network=host_network)
     return ssh_jump_proxy_command
 
 

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -234,7 +234,7 @@ KIND_CONTEXT_NAME = 'kind-skypilot'  # Context name used by sky local up
 PORT_FORWARD_PROXY_CMD_TEMPLATE = 'kubernetes-port-forward-proxy-command.sh'
 # We add a version suffix to the port-forward proxy command to ensure backward
 # compatibility and avoid overwriting the older version.
-PORT_FORWARD_PROXY_CMD_VERSION = 2
+PORT_FORWARD_PROXY_CMD_VERSION = 3
 PORT_FORWARD_PROXY_CMD_PATH = ('~/.sky/kubernetes-port-forward-proxy-command-'
                                f'v{PORT_FORWARD_PROXY_CMD_VERSION}.sh')
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2819,8 +2819,12 @@ async def kubernetes_pod_ssh_proxy(websocket: fastapi.WebSocket,
 
     handle = await _get_cluster_and_validate(cluster_name, clouds.Kubernetes)
 
+    # Under hostNetwork the pod's sshd binds a probed port (not 22,
+    # which is owned by the K8s node's own sshd). head_ssh_port flows
+    # from InstanceInfo.ssh_port through cached_external_ssh_ports.
+    head_ssh_port = handle.head_ssh_port or 22
     kubectl_cmd = handle.get_command_runners()[0].port_forward_command(
-        port_forward=[(None, 22)])
+        port_forward=[(None, head_ssh_port)])
     # Under uvloop, `asyncio.create_subprocess_exec` goes through libuv's
     # `uv_spawn`, which on Linux always uses fork().
     # The forked child runs `PyOS_AfterFork_Child` which tears down inherited

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -38,10 +38,10 @@ SKY_REMOTE_RAY_PORT = 6380
 SKY_REMOTE_RAY_DASHBOARD_PORT = 8266
 # Note we can not use json.dumps which will add a space between ":" and its
 # value which causes the yaml parser to fail.
-# Reads SKYPILOT_RAY_PORT / SKYPILOT_RAY_DASHBOARD_PORT from the env (set by
-# sky.provision.kubernetes.host_network_probe in the hostNetwork: true K8s
-# path), falling back to the SkyPilot defaults so non-hostNetwork clusters
-# write the same ports to ~/.sky/ray_port.json as before.
+# The os.environ.get(...) calls stay unevaluated here on purpose: this
+# string is executed remotely on the pod, where the hostNetwork probe
+# (sky.provision.kubernetes.host_network_probe) may have set the port env
+# vars. It falls back to the SkyPilot defaults otherwise.
 SKY_REMOTE_RAY_PORT_DICT_STR = (
     '{'
     f'"ray_port":int(os.environ.get("SKYPILOT_RAY_PORT",'

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -38,9 +38,17 @@ SKY_REMOTE_RAY_PORT = 6380
 SKY_REMOTE_RAY_DASHBOARD_PORT = 8266
 # Note we can not use json.dumps which will add a space between ":" and its
 # value which causes the yaml parser to fail.
+# Reads SKYPILOT_RAY_PORT / SKYPILOT_RAY_DASHBOARD_PORT from the env (set by
+# sky.provision.kubernetes.host_network_probe in the hostNetwork: true K8s
+# path), falling back to the SkyPilot defaults so non-hostNetwork clusters
+# write the same ports to ~/.sky/ray_port.json as before.
 SKY_REMOTE_RAY_PORT_DICT_STR = (
-    f'{{"ray_port":{SKY_REMOTE_RAY_PORT}, '
-    f'"ray_dashboard_port":{SKY_REMOTE_RAY_DASHBOARD_PORT}}}')
+    '{'
+    f'"ray_port":int(os.environ.get("SKYPILOT_RAY_PORT",'
+    f'{SKY_REMOTE_RAY_PORT})), '
+    f'"ray_dashboard_port":int(os.environ.get('
+    f'"SKYPILOT_RAY_DASHBOARD_PORT",{SKY_REMOTE_RAY_DASHBOARD_PORT}))'
+    '}')
 # The file contains the ports of the Ray cluster that SkyPilot launched,
 # i.e. the PORT_DICT_STR above.
 SKY_REMOTE_RAY_PORT_FILE = '.sky/ray_port.json'

--- a/sky/templates/kubernetes-port-forward-proxy-command.sh
+++ b/sky/templates/kubernetes-port-forward-proxy-command.sh
@@ -3,9 +3,14 @@ set -uo pipefail
 
 KUBE_CONTEXT=""
 KUBE_NAMESPACE=""
+# Whether the target pod runs with hostNetwork: true. Passed as a flag
+# by the SkyPilot client (it is known statically at proxy-command
+# construction time) so the common non-hostNetwork path makes zero
+# extra kubectl calls — no per-connection `kubectl get pod` probe.
+HOST_NETWORK=false
 
 # Parse flags
-while getopts ":c:n:" opt; do
+while getopts ":c:n:N" opt; do
   case ${opt} in
     c)
       KUBE_CONTEXT="$OPTARG"
@@ -13,9 +18,12 @@ while getopts ":c:n:" opt; do
     n)
       KUBE_NAMESPACE="$OPTARG"
       ;;
+    N)
+      HOST_NETWORK=true
+      ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
-      echo "Usage: $0 <pod_name> [-c kube_context] [-n kube_namespace]" >&2
+      echo "Usage: $0 <pod_name> [-c kube_context] [-n kube_namespace] [-N]" >&2
       exit 1
       ;;
     :)
@@ -30,7 +38,7 @@ shift $((OPTIND -1))
 
 # Check if pod name is passed as an argument
 if [ $# -lt 1 ]; then
-  echo "Usage: $0 <pod_name> [-c kube_context] [-n kube_namespace]" >&2
+  echo "Usage: $0 <pod_name> [-c kube_context] [-n kube_namespace] [-N]" >&2
   exit 1
 fi
 
@@ -73,10 +81,11 @@ fi
 # probe rebinds). The host_network_probe writes the probed sshd port
 # to the cluster's <cluster>-ray-ports ConfigMap under sshd_<pod>;
 # discover it here so port-forward routes to the right pod-internal
-# port. Falls back to 22 for non-hostNetwork pods (the common case).
+# port. Falls back to 22 for non-hostNetwork pods (the common case),
+# which take this branch's `false` and make no kubectl calls at all.
+# The ConfigMap is still read live (not passed as a flag) because the
+# probed port can change across a pod restart.
 POD_PORT=22
-HOST_NETWORK=$(kubectl "${KUBECTL_ARGS[@]}" get pod "${POD_NAME}" \
-    -o jsonpath='{.spec.hostNetwork}' 2>/dev/null)
 if [ "${HOST_NETWORK}" = "true" ]; then
     # SkyPilot pod names are <cluster>-head or <cluster>-worker<N>.
     CLUSTER_NAME=$(echo "${POD_NAME}" | sed -E 's/-head$//; s/-worker[0-9]+$//')

--- a/sky/templates/kubernetes-port-forward-proxy-command.sh
+++ b/sky/templates/kubernetes-port-forward-proxy-command.sh
@@ -67,7 +67,28 @@ if [ -n "$KUBE_NAMESPACE" ]; then
   KUBECTL_ARGS+=("--namespace=$KUBE_NAMESPACE")
 fi
 
-kubectl "${KUBECTL_ARGS[@]}" port-forward pod/"${POD_NAME}" :22 > "${KUBECTL_OUTPUT}" 2>&1 &
+# Under hostNetwork the pod shares the K8s node's net namespace, so its
+# sshd cannot bind to port 22 (the node's own sshd is there on managed
+# K8s; even on kind there's no SkyPilot-owned listener on 22 once the
+# probe rebinds). The host_network_probe writes the probed sshd port
+# to the cluster's <cluster>-ray-ports ConfigMap under sshd_<pod>;
+# discover it here so port-forward routes to the right pod-internal
+# port. Falls back to 22 for non-hostNetwork pods (the common case).
+POD_PORT=22
+HOST_NETWORK=$(kubectl "${KUBECTL_ARGS[@]}" get pod "${POD_NAME}" \
+    -o jsonpath='{.spec.hostNetwork}' 2>/dev/null)
+if [ "${HOST_NETWORK}" = "true" ]; then
+    # SkyPilot pod names are <cluster>-head or <cluster>-worker<N>.
+    CLUSTER_NAME=$(echo "${POD_NAME}" | sed -E 's/-head$//; s/-worker[0-9]+$//')
+    PROBED_PORT=$(kubectl "${KUBECTL_ARGS[@]}" get configmap \
+        "${CLUSTER_NAME}-ray-ports" \
+        -o jsonpath="{.data.sshd_${POD_NAME}}" 2>/dev/null)
+    if [ -n "${PROBED_PORT}" ]; then
+        POD_PORT="${PROBED_PORT}"
+    fi
+fi
+
+kubectl "${KUBECTL_ARGS[@]}" port-forward pod/"${POD_NAME}" ":${POD_PORT}" > "${KUBECTL_OUTPUT}" 2>&1 &
 
 # Capture the PID for the backgrounded kubectl command
 K8S_PORT_FWD_PID=$!

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -395,6 +395,11 @@ available_node_types:
         # lookups to CoreDNS so inter-node Ray comms work.
         # Refer to https://github.com/oracle-quickstart/oci-hpc-oke/blob/main/docs/running-pytorch-jobs-on-oke-using-hostnetwork-with-rdma.md for more details.
         hostNetwork: true
+        {% endif %}
+        {% if k8s_enable_oci_roce or k8s_host_network %}
+        # Under hostNetwork the default dnsPolicy silently falls back to
+        # the host's resolv.conf — Service DNS like ${head}.svc.cluster.local
+        # won't resolve, and the worker probe gets stuck dialing the head.
         dnsPolicy: ClusterFirstWithHostNet
         {% endif %}
         {% if volume_mounts %}
@@ -554,6 +559,20 @@ available_node_types:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['ray-node-type']
+            {% if k8s_host_network %}
+            # Downward API rather than $HOSTNAME — hostNetwork pods
+            # inherit the host node's hostname. Used by
+            # host_network_probe to key per-pod ConfigMap entries and
+            # set ownerReferences for GC.
+            - name: SKYPILOT_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: SKYPILOT_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            {% endif %}
             - name: SKYPILOT_POD_CPU_CORE_LIMIT
               valueFrom:
                 resourceFieldRef:
@@ -574,7 +593,8 @@ available_node_types:
               value: "0"
             {% for key, value in k8s_env_vars.items() if k8s_env_vars is not none %}
             - name: {{ key }}
-              value: {{ value }}
+              # tojson forces a quoted string; K8s rejects non-string env values.
+              value: {{ value | tojson }}
             {% endfor %}
             {% if k8s_enable_docker_all %}
             - name: DOCKER_HOST
@@ -1136,6 +1156,10 @@ available_node_types:
                   # Start ray worker on the worker pod.
                   # Wait until the head pod is available with an IP address
                   export SKYPILOT_RAY_HEAD_IP="{{cluster_name_on_cloud}}-head.{{k8s_namespace}}.svc.cluster.local"
+{% if k8s_host_network %}
+                  # SKYPILOT_RAY_PORT and the head-up wait are handled
+                  # by the worker probe inside ray_worker_start_command.
+{% else %}
                   export SKYPILOT_RAY_PORT={{skypilot_ray_port}}
                   # Wait until the ray cluster is started on the head pod
                   until dpkg -l | grep -q "^ii  \(netcat\|netcat-openbsd\|netcat-traditional\) "; do
@@ -1145,6 +1169,7 @@ available_node_types:
                   until nc -z -w 1 ${SKYPILOT_RAY_HEAD_IP} ${SKYPILOT_RAY_PORT}; do
                     sleep 0.1
                   done
+{% endif %}
 
                   set +e
                   {{ ray_worker_start_command }}
@@ -1330,12 +1355,17 @@ available_node_types:
               log_tail &
               while true; do sleep infinity & wait $!; done
 
+          {% if not k8s_host_network %}
+          # Omitted under hostNetwork: the scheduler's NodePorts predicate
+          # treats containerPort as hostPort and blocks sibling pods even
+          # though the probe assigns Ray's ports dynamically.
           ports:
           - containerPort: 22  # Used for SSH
           - containerPort: {{ray_port}}  # Redis port
           - containerPort: 10001  # Used by Ray Client
           - containerPort: {{ray_dashboard_port}}  # Used by Ray Dashboard
           - containerPort: 46590  # Used by Skylet gRPC
+          {% endif %}
 
           # This volume allocates shared memory for Ray to use for its plasma
           # object store. If you do not provide this, Ray will fall back to

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -421,8 +421,10 @@ available_node_types:
             cloud.google.com/gke-flex-start: "true"
             {% endif %}
         {% endif %}
-        {% if (k8s_acc_label_key is not none and k8s_acc_label_values is not none) or (avoid_label_keys is not none) %}
+        {% set _affinity_node = (k8s_acc_label_key is not none and k8s_acc_label_values is not none) or (avoid_label_keys is not none) %}
+        {% if _affinity_node or k8s_host_network %}
         affinity:
+          {% if _affinity_node %}
           nodeAffinity:
             {% if k8s_acc_label_key is not none and k8s_acc_label_values is not none %}
             requiredDuringSchedulingIgnoredDuringExecution:
@@ -457,6 +459,27 @@ available_node_types:
                         values:
                           - "gpu"
                   topologyKey: kubernetes.io/hostname
+          {% endif %}
+          {% endif %}
+          {% if k8s_host_network %}
+          # Mode b: one cluster pod per K8s node. Under hostNetwork a pod
+          # shares the node's net namespace, so two pods of the SAME SkyPilot
+          # cluster on one node would (a) collide on host ports and (b)
+          # register both raylets under the same host IP -- Ray's client-side
+          # resolver then collapses the two NodeIDs onto one gRPC endpoint and
+          # hangs pg.ready(). Forcing one pod per node makes every pod's host
+          # IP unique and routable, which is also exactly what lets a
+          # hostNetwork cluster span multiple K8s nodes. requiredDuring (not
+          # preferred): the guarantee must be hard -- a multi-pod hostNetwork
+          # cluster that cannot get a node per pod fails to schedule loudly
+          # rather than silently racing. The selector is per-cluster
+          # (skypilot-cluster), so unrelated clusters can still co-locate.
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  skypilot-cluster: {{cluster_name_on_cloud}}
+              topologyKey: kubernetes.io/hostname
           {% endif %}
         {% endif %}
         {% if k8s_spot_label_key is not none %}

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -391,15 +391,21 @@ available_node_types:
         {% if k8s_enable_oci_roce %}
         # OCI OKE bare-metal GPU shapes expose RoCE NICs only on the host
         # network namespace; pods must share host networking to reach the
-        # RDMA fabric. ClusterFirstWithHostNet still routes .svc.cluster.local
-        # lookups to CoreDNS so inter-node Ray comms work.
+        # RDMA fabric. This is the only path that sets hostNetwork from the
+        # template — the pod_config path injects it via
+        # combine_pod_config_fields(). k8s_enable_oci_roce also implies
+        # k8s_host_network on the Python side, so the dnsPolicy below and the
+        # Ray-port probe machinery apply here too.
         # Refer to https://github.com/oracle-quickstart/oci-hpc-oke/blob/main/docs/running-pytorch-jobs-on-oke-using-hostnetwork-with-rdma.md for more details.
         hostNetwork: true
         {% endif %}
-        {% if k8s_enable_oci_roce or k8s_host_network %}
+        {% if k8s_host_network %}
         # Under hostNetwork the default dnsPolicy silently falls back to
         # the host's resolv.conf — Service DNS like ${head}.svc.cluster.local
         # won't resolve, and the worker probe gets stuck dialing the head.
+        # k8s_host_network is the single source of truth for "this pod runs
+        # on the host network" (set for both the pod_config and OCI RoCE
+        # paths), so this covers OCI RoCE too.
         dnsPolicy: ClusterFirstWithHostNet
         {% endif %}
         {% if volume_mounts %}

--- a/sky/utils/source_utils.py
+++ b/sky/utils/source_utils.py
@@ -1,0 +1,44 @@
+"""Helpers for handling Python source text.
+
+Useful when shipping a script inline through a transport that has a
+size budget — e.g. base64'd into a Pod spec or a cloud user-data
+field. Pair with ``gzip`` + ``base64`` at the call site.
+"""
+import io
+import token
+import tokenize
+from typing import List
+
+
+def minify_python_source(source: str) -> str:
+    """Strip comments and module/class/function docstrings.
+
+    Stdlib-only. The result must still parse and execute identically;
+    only comment tokens and docstring-position string literals are
+    dropped. Identifiers, non-docstring string literals, and control
+    flow are untouched.
+    """
+    out: List[str] = []
+    prev_toktype = token.INDENT
+    last_lineno = -1
+    last_col = 0
+    readline = io.StringIO(source).readline
+    for tok in tokenize.generate_tokens(readline):
+        toktype, tokstr, (sline, scol), (eline, ecol), _ = tok
+        if sline > last_lineno:
+            last_col = 0
+        if scol > last_col and toktype != tokenize.COMMENT:
+            out.append(' ' * (scol - last_col))
+        if toktype == tokenize.COMMENT:
+            pass
+        elif toktype == token.STRING and prev_toktype in (token.INDENT,
+                                                          token.NEWLINE):
+            # String that is its own statement at module/class/function
+            # top — that's a docstring. Drop it.
+            pass
+        else:
+            out.append(tokstr)
+        prev_toktype = toktype
+        last_col = ecol
+        last_lineno = eline
+    return ''.join(out)

--- a/tests/smoke_tests/test_kubernetes_host_network.py
+++ b/tests/smoke_tests/test_kubernetes_host_network.py
@@ -121,7 +121,7 @@ def test_kubernetes_host_network_coexistence():
 
 @pytest.mark.kubernetes
 @pytest.mark.no_dependency
-def test_kubernetes_host_network_multi_node():
+def test_kubernetes_host_network_multi_node_same_node():
     """A 2-node SkyPilot cluster, both pods on one K8s node, hostNetwork on.
 
     Head and worker pods are created in parallel by SkyPilot's K8s
@@ -184,7 +184,7 @@ def test_kubernetes_host_network_multi_node():
         f'EOF')
 
     test = smoke_tests_utils.Test(
-        'kubernetes_host_network_multi_node',
+        'kubernetes_host_network_multi_node_same_node',
         [
             write_cfg_anchor,
             write_cfg_multi,

--- a/tests/smoke_tests/test_kubernetes_host_network.py
+++ b/tests/smoke_tests/test_kubernetes_host_network.py
@@ -7,6 +7,15 @@ landing on the same node would collide on Ray's default ports
 SkyPilot's host_network_probe picks a free Ray port set per pod
 and rebinds the pod's sshd to a probed port; these tests prove
 both work end-to-end.
+
+SkyPilot also injects a required, per-cluster ``podAntiAffinity``
+for every hostNetwork pod (mode b: one cluster pod per K8s node),
+so a single cluster's pods never share a node -- which both removes
+the same-node raylet-identity collapse and lets a hostNetwork
+cluster span multiple K8s nodes. ``coexistence`` covers two
+*different* clusters sharing a node (still allowed -- the
+anti-affinity is per-cluster); ``multi_node`` covers one cluster
+spread across nodes.
 """
 import uuid
 
@@ -122,104 +131,78 @@ def test_kubernetes_host_network_coexistence():
 @pytest.mark.kubernetes
 @pytest.mark.no_dependency
 def test_kubernetes_host_network_multi_node_same_node():
-    """A 2-node SkyPilot cluster, both pods on one K8s node, hostNetwork on.
+    """A 2-node SkyPilot cluster, spread across two K8s nodes, hostNetwork on.
 
-    Head and worker pods are created in parallel by SkyPilot's K8s
-    provisioner, so a self-referential podAffinity would deadlock
-    (neither pod can satisfy the other's required-during-scheduling
-    constraint until one is running). To force co-location anyway, an
-    anchor SkyPilot cluster is launched first with a unique label;
-    the 2-node target cluster's pod_config then sets podAffinity onto
-    that label, which both pods can independently satisfy.
+    With mode b (the required, per-cluster ``podAntiAffinity`` SkyPilot
+    injects for every hostNetwork pod) the head and worker of one
+    cluster *cannot* land on the same K8s node, so this exercises
+    cross-K8s-node hostNetwork end to end with no anchor / podAffinity
+    needed — the injected rule does the spreading.
+
+    Requires the test K8s cluster to have >=2 schedulable nodes (that
+    is the scenario under test; on a single-node cluster the required
+    anti-affinity correctly leaves the worker Pending and the launch
+    fails loudly rather than silently racing on the shared host).
 
     Verifies:
 
-    1. Both target pods land on the anchor's K8s node (otherwise the
-       second pod would Pending forever, failing the launch step).
-    2. Ray cluster works: ``sky exec`` runs on the cluster (which
-       implies head + worker have joined the Ray cluster — the worker
-       reading the head's probed GCS port from the ConfigMap).
-    3. SSH to the head works.
-    4. SSH to the worker works — exercises the per-pod sshd port
-       rebind on the worker pod and the SkyPilot SSH config writer's
-       use of ``pod_sshd_ports[worker_pod_name]``.
+    1. The 2-node launch succeeds — under the required per-cluster
+       anti-affinity, success means the two pods are on *different* K8s
+       nodes (a same-node placement would leave the worker Pending and
+       fail this step).
+    2. Ray works across nodes: ``sky exec`` runs on the cluster, which
+       implies the worker (on a different K8s node) joined the head's
+       Ray cluster over the head's routable host IP + probed GCS port.
+    3. SSH to the head works (per-pod sshd port rebind + SkyPilot SSH
+       config writer using the probed port).
+    4. SSH to the worker works — its separately probed sshd port, on a
+       different K8s node from the head.
     """
-    anchor_key = 'skypilot-multinode-anchor'
-    anchor_val = uuid.uuid4().hex[:12]
+    name = smoke_tests_utils.get_cluster_name()
+    cfg = f'/tmp/sky-hostnet-multinode-{uuid.uuid4().hex[:12]}.yaml'
 
-    base = smoke_tests_utils.get_cluster_name()
-    name_anchor = f'{base}-anchor'
-    name_multi = f'{base}-multi'
-
-    cfg_anchor = f'/tmp/sky-multinode-{anchor_val}-anchor.yaml'
-    cfg_multi = f'/tmp/sky-multinode-{anchor_val}-multi.yaml'
-
-    # Anchor: hostNetwork + unique label, no affinity.
-    write_cfg_anchor = (f'cat > {cfg_anchor} <<EOF\n'
-                        f'kubernetes:\n'
-                        f'  pod_config:\n'
-                        f'    metadata:\n'
-                        f'      labels:\n'
-                        f'        {anchor_key}: "{anchor_val}"\n'
-                        f'    spec:\n'
-                        f'      hostNetwork: true\n'
-                        f'EOF')
-
-    # 2-node target: hostNetwork + podAffinity onto anchor's node.
-    # Both head and worker pods inherit this pod_config and so each
-    # can independently match against the anchor pod.
-    write_cfg_multi = (
-        f'cat > {cfg_multi} <<EOF\n'
-        f'kubernetes:\n'
-        f'  pod_config:\n'
-        f'    spec:\n'
-        f'      hostNetwork: true\n'
-        f'      affinity:\n'
-        f'        podAffinity:\n'
-        f'          requiredDuringSchedulingIgnoredDuringExecution:\n'
-        f'          - labelSelector:\n'
-        f'              matchLabels:\n'
-        f'                {anchor_key}: "{anchor_val}"\n'
-        f'            topologyKey: kubernetes.io/hostname\n'
-        f'EOF')
+    # hostNetwork only — no podAffinity / anchor. SkyPilot's injected
+    # per-cluster podAntiAffinity (mode b) spreads the head and worker
+    # onto separate K8s nodes by itself.
+    write_cfg = (f'cat > {cfg} <<EOF\n'
+                 f'kubernetes:\n'
+                 f'  pod_config:\n'
+                 f'    spec:\n'
+                 f'      hostNetwork: true\n'
+                 f'EOF')
 
     test = smoke_tests_utils.Test(
         'kubernetes_host_network_multi_node_same_node',
         [
-            write_cfg_anchor,
-            write_cfg_multi,
+            write_cfg,
 
-            # 1. Launch anchor (1 pod), then the 2-node target. If the
-            # target launch returns success, both pods scheduled — i.e.
-            # both landed on the anchor's node. 1 CPU / 2 GB per pod
-            # leaves Ray driver enough headroom (under tighter CPU
-            # the first job submission flakes with FAILED_DRIVER) and
-            # still fits 3 pods on a 4-CPU/8-GB node.
-            f'sky launch -y -c {name_anchor} --infra kubernetes '
-            f'--config {cfg_anchor} --cpus 1 --memory 2',
-            f'sky launch -y -c {name_multi} --infra kubernetes '
-            f'--config {cfg_multi} --num-nodes 2 --cpus 1 --memory 2',
+            # 1. 2-node launch. Under the required per-cluster
+            # anti-affinity a successful launch *is* the proof the two
+            # pods are on different K8s nodes (a same-node placement
+            # would leave the worker Pending and fail this step). 1 CPU
+            # / 2 GB per pod keeps Ray's first job submission off the
+            # FAILED_DRIVER edge.
+            f'sky launch -y -c {name} --infra kubernetes '
+            f'--config {cfg} --num-nodes 2 --cpus 1 --memory 2',
 
-            # 2. Ray cluster must work end-to-end. `sky exec` runs the
-            # task through Ray on the head, which means the head <->
-            # worker join happened (worker read head's probed GCS port
-            # from the ConfigMap).
-            f'sky exec {name_multi} -- echo "job_ok"',
-            f'sky logs {name_multi} 1 --status',
+            # 2. Ray must work across the two nodes. `sky exec` runs the
+            # task through Ray on the head, which means the worker (on a
+            # different K8s node) joined the head over its routable host
+            # IP + probed GCS port.
+            f'sky exec {name} -- echo "job_ok"',
+            f'sky logs {name} 1 --status',
 
-            # 3. SSH to head — exercises per-pod sshd port rebind on
-            # the head + SkyPilot SSH config using the probed port.
-            f's=$(ssh -o StrictHostKeyChecking=no {name_multi} '
+            # 3. SSH to head — per-pod sshd port rebind + SkyPilot SSH
+            # config using the probed port.
+            f's=$(ssh -o StrictHostKeyChecking=no {name} '
             f'"echo ssh_head_ok" 2>&1) && echo "$s" | grep ssh_head_ok',
 
-            # 4. SSH to worker — same path as the head but uses the
-            # worker pod's separately probed sshd port (read from the
-            # ConfigMap's sshd_<podname> entry into InstanceInfo.ssh_port).
-            f's=$(ssh -o StrictHostKeyChecking=no {name_multi}-worker1 '
+            # 4. SSH to the worker — its separately probed sshd port, on
+            # a different K8s node from the head.
+            f's=$(ssh -o StrictHostKeyChecking=no {name}-worker1 '
             f'"echo ssh_worker_ok" 2>&1) && echo "$s" | grep ssh_worker_ok',
         ],
-        teardown=(f'sky down -y {name_anchor}; sky down -y {name_multi}; '
-                  f'rm -f {cfg_anchor} {cfg_multi}'),
+        teardown=f'sky down -y {name}; rm -f {cfg}',
         timeout=5 * 60,
     )
     smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_kubernetes_host_network.py
+++ b/tests/smoke_tests/test_kubernetes_host_network.py
@@ -1,0 +1,225 @@
+"""Smoke tests for the Kubernetes hostNetwork codepath.
+
+Under ``kubernetes.pod_config.spec.hostNetwork = true`` the pod
+shares the K8s node's net namespace, so a second SkyPilot pod
+landing on the same node would collide on Ray's default ports
+(6380, 8266, 8076, ...) and on the node's own sshd (host:22).
+SkyPilot's host_network_probe picks a free Ray port set per pod
+and rebinds the pod's sshd to a probed port; these tests prove
+both work end-to-end.
+"""
+import uuid
+
+import pytest
+from smoke_tests import smoke_tests_utils
+
+
+@pytest.mark.kubernetes
+@pytest.mark.no_dependency
+def test_kubernetes_host_network_coexistence():
+    """Two hostNetwork SkyPilot clusters on the same K8s node coexist.
+
+    Co-location is enforced via Kubernetes ``podAffinity`` (cluster B
+    requires the same node as cluster A's anchor pod) rather than a
+    kubectl-queried nodeSelector — so the test runs against both
+    local and remote API servers, and on any K8s cluster regardless
+    of node count. Verifies:
+
+    1. Both launches succeed (probe avoided port collision).
+    2. SSH to both heads works (per-pod sshd port rebind worked).
+    3. The two heads' probed GCS ports are distinct.
+    """
+    # Unique anchor so concurrent test runs don't co-locate onto each
+    # other. The label is placed on cluster A's pod; cluster B's
+    # podAffinity binds to it.
+    anchor_key = 'skypilot-coexist-anchor'
+    anchor_val = uuid.uuid4().hex[:12]
+
+    base = smoke_tests_utils.get_cluster_name()
+    name_a = f'{base}-a'
+    name_b = f'{base}-b'
+
+    cfg_a = f'/tmp/sky-coexist-{anchor_val}-a.yaml'
+    cfg_b = f'/tmp/sky-coexist-{anchor_val}-b.yaml'
+
+    # Cluster A: hostNetwork + a unique label. No affinity (it's the
+    # anchor, and K8s podAffinity required-during-scheduling cannot be
+    # self-satisfied — the matching pod must already be running).
+    write_cfg_a = (f'cat > {cfg_a} <<EOF\n'
+                   f'kubernetes:\n'
+                   f'  pod_config:\n'
+                   f'    metadata:\n'
+                   f'      labels:\n'
+                   f'        {anchor_key}: "{anchor_val}"\n'
+                   f'    spec:\n'
+                   f'      hostNetwork: true\n'
+                   f'EOF')
+
+    # Cluster B: hostNetwork + podAffinity onto cluster A's pod.
+    write_cfg_b = (
+        f'cat > {cfg_b} <<EOF\n'
+        f'kubernetes:\n'
+        f'  pod_config:\n'
+        f'    spec:\n'
+        f'      hostNetwork: true\n'
+        f'      affinity:\n'
+        f'        podAffinity:\n'
+        f'          requiredDuringSchedulingIgnoredDuringExecution:\n'
+        f'          - labelSelector:\n'
+        f'              matchLabels:\n'
+        f'                {anchor_key}: "{anchor_val}"\n'
+        f'            topologyKey: kubernetes.io/hostname\n'
+        f'EOF')
+
+    test = smoke_tests_utils.Test(
+        'kubernetes_host_network_coexistence',
+        [
+            write_cfg_a,
+            write_cfg_b,
+
+            # 1. Launch A first (anchor), then B (forced onto A's node).
+            # 1 CPU / 2 GB per pod: enough headroom for Ray driver +
+            # raylet + GCS + dashboard (under tight CPU Ray's first-job
+            # submission flakes with FAILED_DRIVER); still fits two
+            # pods on a 4-CPU/8-GB node. No inline task — the SSH/port
+            # checks below are what we're asserting on.
+            f'sky launch -y -c {name_a} --infra kubernetes '
+            f'--config {cfg_a} --cpus 1 --memory 2',
+            f'sky launch -y -c {name_b} --infra kubernetes '
+            f'--config {cfg_b} --cpus 1 --memory 2',
+
+            # 2. SSH to both heads. Exercises:
+            #    - sshd_<podname> ConfigMap entry -> InstanceInfo.ssh_port
+            #    - /etc/ssh/sshd_config Port rewrite by the probe
+            #    - SkyPilot SSH config writer using the probed port
+            f's=$(ssh -o StrictHostKeyChecking=no {name_a} '
+            f'"echo ssh_works_A" 2>&1) && echo "$s" | grep ssh_works_A',
+            f's=$(ssh -o StrictHostKeyChecking=no {name_b} '
+            f'"echo ssh_works_B" 2>&1) && echo "$s" | grep ssh_works_B',
+
+            # 3. The probe must have assigned distinct GCS ports to the
+            #    two heads. The env file written by the probe is the
+            #    authoritative source on each pod. Single-quote the
+            #    ssh remote command so $SKYPILOT_RAY_PORT expands on
+            #    the pod, not on the local test runner.
+            f'A_GCS=$(ssh {name_a} '
+            f'\'. /tmp/sky_host_network_ports.env && '
+            f'echo $SKYPILOT_RAY_PORT\') && '
+            f'B_GCS=$(ssh {name_b} '
+            f'\'. /tmp/sky_host_network_ports.env && '
+            f'echo $SKYPILOT_RAY_PORT\') && '
+            f'echo "A_GCS=$A_GCS B_GCS=$B_GCS" && '
+            f'[ -n "$A_GCS" ] && [ -n "$B_GCS" ] && '
+            f'[ "$A_GCS" != "$B_GCS" ]',
+        ],
+        teardown=(f'sky down -y {name_a}; sky down -y {name_b}; '
+                  f'rm -f {cfg_a} {cfg_b}'),
+        timeout=smoke_tests_utils.get_timeout('kubernetes'),
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.kubernetes
+@pytest.mark.no_dependency
+def test_kubernetes_host_network_multi_node():
+    """A 2-node SkyPilot cluster, both pods on one K8s node, hostNetwork on.
+
+    Head and worker pods are created in parallel by SkyPilot's K8s
+    provisioner, so a self-referential podAffinity would deadlock
+    (neither pod can satisfy the other's required-during-scheduling
+    constraint until one is running). To force co-location anyway, an
+    anchor SkyPilot cluster is launched first with a unique label;
+    the 2-node target cluster's pod_config then sets podAffinity onto
+    that label, which both pods can independently satisfy.
+
+    Verifies:
+
+    1. Both target pods land on the anchor's K8s node (otherwise the
+       second pod would Pending forever, failing the launch step).
+    2. Ray cluster works: ``sky exec`` runs on the cluster (which
+       implies head + worker have joined the Ray cluster — the worker
+       reading the head's probed GCS port from the ConfigMap).
+    3. SSH to the head works.
+    4. SSH to the worker works — exercises the per-pod sshd port
+       rebind on the worker pod and the SkyPilot SSH config writer's
+       use of ``pod_sshd_ports[worker_pod_name]``.
+    """
+    anchor_key = 'skypilot-multinode-anchor'
+    anchor_val = uuid.uuid4().hex[:12]
+
+    base = smoke_tests_utils.get_cluster_name()
+    name_anchor = f'{base}-anchor'
+    name_multi = f'{base}-multi'
+
+    cfg_anchor = f'/tmp/sky-multinode-{anchor_val}-anchor.yaml'
+    cfg_multi = f'/tmp/sky-multinode-{anchor_val}-multi.yaml'
+
+    # Anchor: hostNetwork + unique label, no affinity.
+    write_cfg_anchor = (f'cat > {cfg_anchor} <<EOF\n'
+                        f'kubernetes:\n'
+                        f'  pod_config:\n'
+                        f'    metadata:\n'
+                        f'      labels:\n'
+                        f'        {anchor_key}: "{anchor_val}"\n'
+                        f'    spec:\n'
+                        f'      hostNetwork: true\n'
+                        f'EOF')
+
+    # 2-node target: hostNetwork + podAffinity onto anchor's node.
+    # Both head and worker pods inherit this pod_config and so each
+    # can independently match against the anchor pod.
+    write_cfg_multi = (
+        f'cat > {cfg_multi} <<EOF\n'
+        f'kubernetes:\n'
+        f'  pod_config:\n'
+        f'    spec:\n'
+        f'      hostNetwork: true\n'
+        f'      affinity:\n'
+        f'        podAffinity:\n'
+        f'          requiredDuringSchedulingIgnoredDuringExecution:\n'
+        f'          - labelSelector:\n'
+        f'              matchLabels:\n'
+        f'                {anchor_key}: "{anchor_val}"\n'
+        f'            topologyKey: kubernetes.io/hostname\n'
+        f'EOF')
+
+    test = smoke_tests_utils.Test(
+        'kubernetes_host_network_multi_node',
+        [
+            write_cfg_anchor,
+            write_cfg_multi,
+
+            # 1. Launch anchor (1 pod), then the 2-node target. If the
+            # target launch returns success, both pods scheduled — i.e.
+            # both landed on the anchor's node. 1 CPU / 2 GB per pod
+            # leaves Ray driver enough headroom (under tighter CPU
+            # the first job submission flakes with FAILED_DRIVER) and
+            # still fits 3 pods on a 4-CPU/8-GB node.
+            f'sky launch -y -c {name_anchor} --infra kubernetes '
+            f'--config {cfg_anchor} --cpus 1 --memory 2',
+            f'sky launch -y -c {name_multi} --infra kubernetes '
+            f'--config {cfg_multi} --num-nodes 2 --cpus 1 --memory 2',
+
+            # 2. Ray cluster must work end-to-end. `sky exec` runs the
+            # task through Ray on the head, which means the head <->
+            # worker join happened (worker read head's probed GCS port
+            # from the ConfigMap).
+            f'sky exec {name_multi} -- echo "job_ok"',
+            f'sky logs {name_multi} 1 --status',
+
+            # 3. SSH to head — exercises per-pod sshd port rebind on
+            # the head + SkyPilot SSH config using the probed port.
+            f's=$(ssh -o StrictHostKeyChecking=no {name_multi} '
+            f'"echo ssh_head_ok" 2>&1) && echo "$s" | grep ssh_head_ok',
+
+            # 4. SSH to worker — same path as the head but uses the
+            # worker pod's separately probed sshd port (read from the
+            # ConfigMap's sshd_<podname> entry into InstanceInfo.ssh_port).
+            f's=$(ssh -o StrictHostKeyChecking=no {name_multi}-worker1 '
+            f'"echo ssh_worker_ok" 2>&1) && echo "$s" | grep ssh_worker_ok',
+        ],
+        teardown=(f'sky down -y {name_anchor}; sky down -y {name_multi}; '
+                  f'rm -f {cfg_anchor} {cfg_multi}'),
+        timeout=5 * 60,
+    )
+    smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_kubernetes_host_network.py
+++ b/tests/smoke_tests/test_kubernetes_host_network.py
@@ -14,8 +14,11 @@ so a single cluster's pods never share a node -- which both removes
 the same-node raylet-identity collapse and lets a hostNetwork
 cluster span multiple K8s nodes. ``coexistence`` covers two
 *different* clusters sharing a node (still allowed -- the
-anti-affinity is per-cluster); ``multi_node`` covers one cluster
-spread across nodes.
+anti-affinity is per-cluster); ``multi_node`` asserts the
+fail-loud guarantee: on a single-node K8s cluster a 2-node
+hostNetwork cluster must fail to schedule (the required
+anti-affinity refuses to pack the worker onto the head's node)
+rather than silently racing on the shared host.
 """
 import uuid
 
@@ -133,37 +136,35 @@ def test_kubernetes_host_network_coexistence():
 def test_kubernetes_host_network_multi_node_same_node():
     """A 2-node SkyPilot cluster, spread across two K8s nodes, hostNetwork on.
 
-    With mode b (the required, per-cluster ``podAntiAffinity`` SkyPilot
-    injects for every hostNetwork pod) the head and worker of one
-    cluster *cannot* land on the same K8s node, so this exercises
-    cross-K8s-node hostNetwork end to end with no anchor / podAffinity
-    needed — the injected rule does the spreading.
+    This asserts fail-loud guarantee on the infra the smoke
+    suite actually runs against (single-node K8s clusters). The required,
+    per-cluster ``podAntiAffinity`` SkyPilot injects for every hostNetwork
+    pod forbids the head and worker of one cluster from sharing a node;
+    with only one node available the worker cannot be scheduled, so the
+    launch must fail with the scheduler's pod-anti-affinity error rather
+    than silently packing both pods onto one host (which is exactly the
+    raylet-collapse / port-collision race mode b exists to prevent).
 
-    Requires the test K8s cluster to have >=2 schedulable nodes (that
-    is the scenario under test; on a single-node cluster the required
-    anti-affinity correctly leaves the worker Pending and the launch
-    fails loudly rather than silently racing on the shared host).
+    On a >=2-node K8s cluster this same config would instead succeed and
+    spread one pod per node (the cross-node capability mode b unlocks);
+    that path is not exercised here because the smoke clusters are
+    single-node.
 
     Verifies:
 
-    1. The 2-node launch succeeds — under the required per-cluster
-       anti-affinity, success means the two pods are on *different* K8s
-       nodes (a same-node placement would leave the worker Pending and
-       fail this step).
-    2. Ray works across nodes: ``sky exec`` runs on the cluster, which
-       implies the worker (on a different K8s node) joined the head's
-       Ray cluster over the head's routable host IP + probed GCS port.
-    3. SSH to the head works (per-pod sshd port rebind + SkyPilot SSH
-       config writer using the probed port).
-    4. SSH to the worker works — its separately probed sshd port, on a
-       different K8s node from the head.
+    1. ``sky launch --num-nodes 2`` returns non-zero (it must not
+       succeed by co-locating the pods).
+    2. The failure is specifically the pod-anti-affinity scheduling
+       rejection (SkyPilot surfaces the verbatim kube-scheduler
+       ``FailedScheduling`` message, which contains "anti-affinity"),
+       not some unrelated error.
     """
     name = smoke_tests_utils.get_cluster_name()
     cfg = f'/tmp/sky-hostnet-multinode-{uuid.uuid4().hex[:12]}.yaml'
 
-    # hostNetwork only — no podAffinity / anchor. SkyPilot's injected
-    # per-cluster podAntiAffinity (mode b) spreads the head and worker
-    # onto separate K8s nodes by itself.
+    # hostNetwork only. SkyPilot injects the per-cluster podAntiAffinity
+    # (mode b); on a single-node cluster that leaves the 2nd pod
+    # unschedulable.
     write_cfg = (f'cat > {cfg} <<EOF\n'
                  f'kubernetes:\n'
                  f'  pod_config:\n'
@@ -171,38 +172,36 @@ def test_kubernetes_host_network_multi_node_same_node():
                  f'      hostNetwork: true\n'
                  f'EOF')
 
+    # One self-contained command: capture the launch, assert it failed,
+    # and assert it failed *for the anti-affinity reason* (so an
+    # unrelated failure — image pull, quota — doesn't spuriously pass).
+    # grep -iE "anti-?affinity" matches the kube-scheduler phrasings
+    # ("...didn't match pod anti-affinity rules", "antiaffinity").
+    expect_fail = (
+        f'set +e; '
+        f'OUT=$(sky launch -y -c {name} --infra kubernetes '
+        f'--config {cfg} --num-nodes 2 --cpus 1 --memory 2 2>&1); '
+        f'RC=$?; set -e; '
+        f'echo "$OUT"; '
+        f'if [ $RC -eq 0 ]; then '
+        f'echo "FAIL: 2-node hostNetwork launch unexpectedly SUCCEEDED on '
+        f'single-node K8s; mode-b anti-affinity should have blocked it"; '
+        f'exit 1; fi; '
+        f'echo "$OUT" | grep -qiE "anti-?affinity" || {{ '
+        f'echo "FAIL: launch failed but NOT via the pod anti-affinity '
+        f'scheduling rule (unexpected failure reason)"; exit 1; }}; '
+        f'echo "OK: mode-b anti-affinity correctly rejected the 2-node '
+        f'hostNetwork cluster on single-node K8s"')
+
     test = smoke_tests_utils.Test(
         'kubernetes_host_network_multi_node_same_node',
         [
             write_cfg,
-
-            # 1. 2-node launch. Under the required per-cluster
-            # anti-affinity a successful launch *is* the proof the two
-            # pods are on different K8s nodes (a same-node placement
-            # would leave the worker Pending and fail this step). 1 CPU
-            # / 2 GB per pod keeps Ray's first job submission off the
-            # FAILED_DRIVER edge.
-            f'sky launch -y -c {name} --infra kubernetes '
-            f'--config {cfg} --num-nodes 2 --cpus 1 --memory 2',
-
-            # 2. Ray must work across the two nodes. `sky exec` runs the
-            # task through Ray on the head, which means the worker (on a
-            # different K8s node) joined the head over its routable host
-            # IP + probed GCS port.
-            f'sky exec {name} -- echo "job_ok"',
-            f'sky logs {name} 1 --status',
-
-            # 3. SSH to head — per-pod sshd port rebind + SkyPilot SSH
-            # config using the probed port.
-            f's=$(ssh -o StrictHostKeyChecking=no {name} '
-            f'"echo ssh_head_ok" 2>&1) && echo "$s" | grep ssh_head_ok',
-
-            # 4. SSH to the worker — its separately probed sshd port, on
-            # a different K8s node from the head.
-            f's=$(ssh -o StrictHostKeyChecking=no {name}-worker1 '
-            f'"echo ssh_worker_ok" 2>&1) && echo "$s" | grep ssh_worker_ok',
+            expect_fail,
         ],
+        # Best-effort cleanup: a failed launch still leaves a cluster
+        # record (and the head pod that did schedule).
         teardown=f'sky down -y {name}; rm -f {cfg}',
-        timeout=5 * 60,
+        timeout=10 * 60,
     )
     smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_kubernetes_host_network.py
+++ b/tests/smoke_tests/test_kubernetes_host_network.py
@@ -205,3 +205,106 @@ def test_kubernetes_host_network_multi_node_same_node():
         timeout=10 * 60,
     )
     smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.kubernetes
+@pytest.mark.no_dependency
+def test_kubernetes_host_network_head_restart_reuses_ports():
+    """A head *container* restart must reuse the published port set.
+
+    The probe's ``<cluster>-ray-ports`` ConfigMap carries an
+    ``ownerReference`` to the *head Pod object*. A container restart
+    (crash / OOM / ``ray stop``-then-up) keeps the Pod object — and its
+    UID — so the ConfigMap is **not** garbage-collected (only deleting
+    the Pod object triggers GC). When the head bootstrap re-runs after
+    such a restart it must therefore reuse the already-published
+    GCS/dashboard/sshd ports rather than probe a fresh ephemeral set:
+    workers and the SkyPilot SSH client are still dialing the old ports.
+
+    The smoke clusters use ``restartPolicy: Never`` (non-HA), so we
+    cannot make kubelet truly restart the container. Instead we re-run
+    the inlined probe (``/tmp/sky_host_network_probe.py --mode head``)
+    against the surviving ConfigMap, in the *same* pod-identity env the
+    real bootstrap uses (pulled from PID 1's environ via the Downward
+    API vars), which is exactly what the head bootstrap re-executes on
+    restart. Verifies:
+
+    1. The ConfigMap survived (the reuse path requires it to exist and
+       to be owned by this pod's UID — both encoded in the assertion).
+    2. The re-run reuses the *identical* published port set
+       (``/tmp/sky_host_network_ports.env`` unchanged). Pre-fix this
+       step re-probed and the port set would differ.
+    3. SSH still works afterward — the re-publish preserved the head's
+       ``sshd_<pod>`` ConfigMap entry the SSH config writer relies on.
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    cfg = f'/tmp/sky-hostnet-restart-{uuid.uuid4().hex[:12]}.yaml'
+
+    write_cfg = (f'cat > {cfg} <<EOF\n'
+                 f'kubernetes:\n'
+                 f'  pod_config:\n'
+                 f'    spec:\n'
+                 f'      hostNetwork: true\n'
+                 f'EOF')
+
+    # Runs on the head pod. Re-invokes the head probe exactly as the
+    # bootstrap would after a container restart: same pod-identity env
+    # (Downward API vars + in-cluster API host), same ConfigMap. The
+    # probe's _existing_head_ports_to_reuse() only reuses when the
+    # ConfigMap exists AND is owned by this pod UID, so an unchanged
+    # port set proves both (and that the reuse codepath fired); a
+    # deleted ConfigMap or a regressed re-probe makes BEFORE != AFTER.
+    # Raw string: \0 / \n must reach `tr` literally. Only double quotes
+    # inside so the whole script can be single-quoted to ssh (no local
+    # $VAR expansion). No {} so it is f-string/heredoc safe.
+    remote = (
+        r'set -e; '
+        r'PROBE=/tmp/sky_host_network_probe.py; '
+        r'ENVF=/tmp/sky_host_network_ports.env; '
+        r'test -s "$ENVF"; test -s "$PROBE"; '
+        r'eval "$(sudo cat /proc/1/environ | tr "\0" "\n" | '
+        r'grep -E "^(KUBERNETES_SERVICE_HOST|KUBERNETES_SERVICE_PORT|'
+        r'SKYPILOT_POD_NAME|SKYPILOT_POD_UID|'
+        r'SKYPILOT_RAY_PORTS_CONFIGMAP_NAME|'
+        r'SKYPILOT_RAY_PORTS_CONFIGMAP_NAMESPACE)=" | '
+        r'sed "s/^/export /")"; '
+        r'test -n "$SKYPILOT_RAY_PORTS_CONFIGMAP_NAME"; '
+        r'test -n "$SKYPILOT_POD_UID"; '
+        r'BEFORE=$(sort "$ENVF"); '
+        r'python3 "$PROBE" --mode head '
+        r'--env-file /tmp/sky_restart_check.env '
+        r'--configmap-name "$SKYPILOT_RAY_PORTS_CONFIGMAP_NAME" '
+        r'--configmap-namespace "$SKYPILOT_RAY_PORTS_CONFIGMAP_NAMESPACE"; '
+        r'AFTER=$(sort /tmp/sky_restart_check.env); '
+        r'echo "BEFORE=[$BEFORE]"; echo "AFTER=[$AFTER]"; '
+        r'if [ -z "$BEFORE" ]; then echo "FAIL: empty env file"; exit 1; fi; '
+        r'if [ "$BEFORE" != "$AFTER" ]; then '
+        r'echo "FAIL: head re-run did NOT reuse the published ports '
+        r'(ConfigMap deleted or re-probed instead of reused)"; exit 1; fi; '
+        r'echo HEAD_RESTART_REUSED_PORTS')
+
+    test = smoke_tests_utils.Test(
+        'kubernetes_host_network_head_restart_reuses_ports',
+        [
+            write_cfg,
+
+            # 1 CPU / 2 GB: same headroom rationale as coexistence.
+            f'sky launch -y -c {name} --infra kubernetes '
+            f'--config {cfg} --cpus 1 --memory 2',
+
+            # Re-run the head probe against the surviving ConfigMap and
+            # assert the published port set is reused verbatim.
+            f's=$(ssh -o StrictHostKeyChecking=no {name} \'{remote}\' '
+            f'2>&1); echo "$s"; '
+            f'echo "$s" | grep -q HEAD_RESTART_REUSED_PORTS',
+
+            # SSH must still work after the re-publish (the head's
+            # sshd_<pod> ConfigMap entry — read by the SkyPilot SSH
+            # config writer — was preserved on the reuse path).
+            f's=$(ssh -o StrictHostKeyChecking=no {name} '
+            f'"echo head_ssh_ok" 2>&1) && echo "$s" | grep head_ssh_ok',
+        ],
+        teardown=f'sky down -y {name}; rm -f {cfg}',
+        timeout=smoke_tests_utils.get_timeout('kubernetes'),
+    )
+    smoke_tests_utils.run_one_test(test)

--- a/tests/smoke_tests/test_kubernetes_host_network.py
+++ b/tests/smoke_tests/test_kubernetes_host_network.py
@@ -225,9 +225,18 @@ def test_kubernetes_host_network_head_restart_reuses_ports():
     cannot make kubelet truly restart the container. Instead we re-run
     the inlined probe (``/tmp/sky_host_network_probe.py --mode head``)
     against the surviving ConfigMap, in the *same* pod-identity env the
-    real bootstrap uses (pulled from PID 1's environ via the Downward
-    API vars), which is exactly what the head bootstrap re-executes on
-    restart. Verifies:
+    real bootstrap uses. An SSH session does **not** inherit the pod
+    container's Downward-API env, and a Kubernetes container cannot
+    read ``/proc/1/environ`` even via ``sudo`` (no ``CAP_SYS_PTRACE``
+    in the default capability set, and the node's
+    ``yama.ptrace_scope`` blocks reading an ancestor's environ). So
+    rather than scraping PID 1, we recover the pod identity from the
+    pod's own *bound* ServiceAccount-token JWT (its
+    ``kubernetes.io.{namespace,pod.name,pod.uid}`` claims) and locate
+    the ``<cluster>-ray-ports`` ConfigMap by its ``ownerReference`` to
+    that UID. On a real container restart the Pod object is unchanged,
+    so its name/UID are exactly what the Downward API would re-inject
+    — these claims are equivalent. Verifies:
 
     1. The ConfigMap survived (the reuse path requires it to exist and
        to be owned by this pod's UID — both encoded in the assertion).
@@ -247,41 +256,88 @@ def test_kubernetes_host_network_head_restart_reuses_ports():
                  f'      hostNetwork: true\n'
                  f'EOF')
 
-    # Runs on the head pod. Re-invokes the head probe exactly as the
-    # bootstrap would after a container restart: same pod-identity env
-    # (Downward API vars + in-cluster API host), same ConfigMap. The
-    # probe's _existing_head_ports_to_reuse() only reuses when the
-    # ConfigMap exists AND is owned by this pod UID, so an unchanged
-    # port set proves both (and that the reuse codepath fired); a
-    # deleted ConfigMap or a regressed re-probe makes BEFORE != AFTER.
-    # Raw string: \0 / \n must reach `tr` literally. Only double quotes
-    # inside so the whole script can be single-quoted to ssh (no local
-    # $VAR expansion). No {} so it is f-string/heredoc safe.
+    # Discovery script run *on the head pod*. An SSH session has
+    # neither the pod container's Downward-API env nor a readable
+    # /proc/1/environ (see the docstring), so we reconstruct the
+    # pod-identity env the head probe needs from authoritative on-pod
+    # sources: the bound ServiceAccount-token JWT (this pod's
+    # name/uid/namespace claims) and the surviving ray-ports ConfigMap
+    # selected by ownerReference == our pod UID. Selecting by our UID
+    # (not just the skypilot-ray-ports label) keeps this correct when
+    # other concurrent hostNetwork tests share the namespace. Stdlib
+    # only; no single quotes (the whole script is single-quoted to
+    # ssh) and no f-string/{} so it is heredoc/format safe.
+    discover = (
+        'import base64, json, ssl, sys, urllib.request\n'
+        'b = "/var/run/secrets/kubernetes.io/serviceaccount/"\n'
+        'tok = open(b + "token").read().strip()\n'
+        'ctx = ssl.create_default_context(cafile=b + "ca.crt")\n'
+        'seg = tok.split(".")[1]\n'
+        'seg += "=" * (-len(seg) % 4)\n'
+        'kio = json.loads(base64.urlsafe_b64decode(seg))["kubernetes.io"]\n'
+        'ns = kio["namespace"]\n'
+        'uid = kio["pod"]["uid"]\n'
+        'pname = kio["pod"]["name"]\n'
+        'u = ("https://kubernetes.default.svc:443/api/v1/namespaces/"\n'
+        '     + ns + "/configmaps"\n'
+        '     "?labelSelector=skypilot-ray-ports%3Dtrue")\n'
+        'r = urllib.request.Request(u)\n'
+        'r.add_header("Authorization", "Bearer " + tok)\n'
+        'data = urllib.request.urlopen(r, context=ctx, timeout=10).read()\n'
+        'items = json.loads(data)["items"]\n'
+        'mine = [c for c in items\n'
+        '        if any(o.get("uid") == uid\n'
+        '               for o in (c["metadata"].get("ownerReferences")\n'
+        '                          or []))]\n'
+        'if len(mine) != 1:\n'
+        '    sys.exit("want exactly 1 ray-ports ConfigMap owned by pod "\n'
+        '             + uid + ", got " + str(len(mine)) + " of "\n'
+        '             + str(len(items)) + " labeled")\n'
+        'm = mine[0]["metadata"]\n'
+        'print("export SKYPILOT_RAY_PORTS_CONFIGMAP_NAME=" + m["name"])\n'
+        'print("export SKYPILOT_RAY_PORTS_CONFIGMAP_NAMESPACE=" + ns)\n'
+        'print("export SKYPILOT_POD_NAME=" + pname)\n'
+        'print("export SKYPILOT_POD_UID=" + uid)\n')
+
+    # The probe is run under ``sudo`` (production parity: the bootstrap
+    # runs it as root, and root reliably reads the SA token regardless
+    # of its file mode), with the recovered identity passed explicitly
+    # via ``env``. ``<<\PYEOF`` is a literal heredoc so the shell does
+    # not touch the embedded Python. ``set -e``: any failed step (an
+    # unreadable token, a deleted ConfigMap, a regressed re-probe)
+    # fails the test loudly. BEFORE != AFTER means the head re-probed
+    # instead of reusing the published ports.
     remote = (
-        r'set -e; '
-        r'PROBE=/tmp/sky_host_network_probe.py; '
-        r'ENVF=/tmp/sky_host_network_ports.env; '
-        r'test -s "$ENVF"; test -s "$PROBE"; '
-        r'eval "$(sudo cat /proc/1/environ | tr "\0" "\n" | '
-        r'grep -E "^(KUBERNETES_SERVICE_HOST|KUBERNETES_SERVICE_PORT|'
-        r'SKYPILOT_POD_NAME|SKYPILOT_POD_UID|'
-        r'SKYPILOT_RAY_PORTS_CONFIGMAP_NAME|'
-        r'SKYPILOT_RAY_PORTS_CONFIGMAP_NAMESPACE)=" | '
-        r'sed "s/^/export /")"; '
-        r'test -n "$SKYPILOT_RAY_PORTS_CONFIGMAP_NAME"; '
-        r'test -n "$SKYPILOT_POD_UID"; '
-        r'BEFORE=$(sort "$ENVF"); '
-        r'python3 "$PROBE" --mode head '
-        r'--env-file /tmp/sky_restart_check.env '
-        r'--configmap-name "$SKYPILOT_RAY_PORTS_CONFIGMAP_NAME" '
-        r'--configmap-namespace "$SKYPILOT_RAY_PORTS_CONFIGMAP_NAMESPACE"; '
-        r'AFTER=$(sort /tmp/sky_restart_check.env); '
-        r'echo "BEFORE=[$BEFORE]"; echo "AFTER=[$AFTER]"; '
-        r'if [ -z "$BEFORE" ]; then echo "FAIL: empty env file"; exit 1; fi; '
-        r'if [ "$BEFORE" != "$AFTER" ]; then '
-        r'echo "FAIL: head re-run did NOT reuse the published ports '
-        r'(ConfigMap deleted or re-probed instead of reused)"; exit 1; fi; '
-        r'echo HEAD_RESTART_REUSED_PORTS')
+        'set -e; '
+        'PROBE=/tmp/sky_host_network_probe.py; '
+        'ENVF=/tmp/sky_host_network_ports.env; '
+        'test -s "$ENVF"; test -s "$PROBE"; '
+        'cat > /tmp/sky_cm_discover.py <<\\PYEOF\n' + discover + 'PYEOF\n'
+        'if ! OUT="$(sudo python3 /tmp/sky_cm_discover.py '
+        '2>/tmp/sky_cm_discover.err)"; then '
+        'echo "FAIL: ray-ports ConfigMap discovery failed:"; '
+        'cat /tmp/sky_cm_discover.err; exit 1; fi; '
+        'eval "$OUT"; '
+        'export KUBERNETES_SERVICE_HOST=kubernetes.default.svc; '
+        'export KUBERNETES_SERVICE_PORT=443; '
+        'test -n "$SKYPILOT_RAY_PORTS_CONFIGMAP_NAME"; '
+        'test -n "$SKYPILOT_POD_UID"; '
+        'BEFORE=$(sort "$ENVF"); '
+        'sudo env KUBERNETES_SERVICE_HOST="$KUBERNETES_SERVICE_HOST" '
+        'KUBERNETES_SERVICE_PORT="$KUBERNETES_SERVICE_PORT" '
+        'SKYPILOT_POD_NAME="$SKYPILOT_POD_NAME" '
+        'SKYPILOT_POD_UID="$SKYPILOT_POD_UID" '
+        'python3 "$PROBE" --mode head '
+        '--env-file /tmp/sky_restart_check.env '
+        '--configmap-name "$SKYPILOT_RAY_PORTS_CONFIGMAP_NAME" '
+        '--configmap-namespace "$SKYPILOT_RAY_PORTS_CONFIGMAP_NAMESPACE"; '
+        'AFTER=$(sort /tmp/sky_restart_check.env); '
+        'echo "BEFORE=[$BEFORE]"; echo "AFTER=[$AFTER]"; '
+        'if [ -z "$BEFORE" ]; then echo "FAIL: empty env file"; exit 1; fi; '
+        'if [ "$BEFORE" != "$AFTER" ]; then '
+        'echo "FAIL: head re-run did NOT reuse the published ports '
+        '(ConfigMap deleted or re-probed instead of reused)"; exit 1; fi; '
+        'echo HEAD_RESTART_REUSED_PORTS')
 
     test = smoke_tests_utils.Test(
         'kubernetes_host_network_head_restart_reuses_ports',

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes.py
@@ -1018,6 +1018,11 @@ class TestKubernetesSecurityContextMerging(unittest.TestCase):
 
         # OCI RoCE requires hostNetwork, privileged, and /dev/infiniband.
         self.assertTrue(deploy_vars['k8s_enable_oci_roce'])
+        # OCI RoCE forces hostNetwork via the template, so k8s_host_network
+        # must also be True — otherwise the Ray-port/sshd probe machinery is
+        # skipped and inter-node Ray + `ssh <cluster>` break under
+        # hostNetwork (the pod's sshd can't bind host:22).
+        self.assertTrue(deploy_vars['k8s_host_network'])
         # IPC_LOCK is shared with other high-perf types and stays True.
         self.assertTrue(deploy_vars['k8s_ipc_lock_capability'])
         # Sanity: GPUDirect flags are False for OCI.
@@ -1026,6 +1031,14 @@ class TestKubernetesSecurityContextMerging(unittest.TestCase):
         self.assertFalse(deploy_vars['k8s_enable_gpudirect_rdma'])
 
         k8s_env_vars = deploy_vars['k8s_env_vars']
+        # The probe is runtime-gated on these env vars (see
+        # instance_setup._host_network_probe_cmd); they must be wired for
+        # OCI RoCE so the probe actually runs.
+        self.assertEqual(k8s_env_vars['SKYPILOT_HOST_NETWORK'], '1')
+        self.assertEqual(k8s_env_vars['SKYPILOT_RAY_PORTS_CONFIGMAP_NAME'],
+                         'test-oci-cluster-ray-ports')
+        self.assertEqual(k8s_env_vars['SKYPILOT_RAY_PORTS_CONFIGMAP_NAMESPACE'],
+                         'default')
         self.assertEqual(k8s_env_vars['NCCL_IB_HCA'], 'mlx5')
         self.assertEqual(k8s_env_vars['NCCL_IB_GID_INDEX'], '3')
         self.assertEqual(k8s_env_vars['NCCL_IB_TC'], '41')
@@ -1107,6 +1120,12 @@ class TestKubernetesSecurityContextMerging(unittest.TestCase):
 
         self.assertFalse(deploy_vars['k8s_enable_oci_roce'])
         self.assertFalse(deploy_vars['k8s_ipc_lock_capability'])
+        # No OCI RoCE and no pod_config hostNetwork override -> the pod is
+        # not host-networked, so the probe machinery stays off.
+        self.assertFalse(deploy_vars['k8s_host_network'])
+        self.assertNotIn('SKYPILOT_HOST_NETWORK', deploy_vars['k8s_env_vars'])
+        self.assertNotIn('SKYPILOT_RAY_PORTS_CONFIGMAP_NAME',
+                         deploy_vars['k8s_env_vars'])
         self.assertNotIn('NCCL_IB_GID_INDEX', deploy_vars['k8s_env_vars'])
 
 

--- a/tests/unit_tests/test_sky/provision/test_host_network_probe.py
+++ b/tests/unit_tests/test_sky/provision/test_host_network_probe.py
@@ -1,0 +1,269 @@
+"""Unit tests for hostNetwork-aware Ray port handling.
+
+Covers:
+* sky.provision.kubernetes.host_network_probe — the port probe + env
+  file emission used inside hostNetwork: true K8s pods.
+* sky.provision.instance_setup — the env-var-substituted port flags and
+  the probe-gating snippet in ray_head_start_command /
+  ray_worker_start_command.
+
+The probe module's ConfigMap publish/poll paths require a live K8s API
+and are exercised by smoke tests instead.
+"""
+import base64
+import gzip
+import re
+import socket
+
+from sky.provision import instance_setup
+from sky.provision.kubernetes import host_network_probe
+from sky.skylet import constants
+
+
+class TestProbePorts:
+    """The bind-and-hold port probe should produce N distinct usable ports."""
+
+    def test_probe_head_returns_unique_ports(self):
+        held, ports = host_network_probe._probe_ports(
+            host_network_probe._HEAD_PORT_NAMES)
+        try:
+            assert set(ports.keys()) == set(host_network_probe._HEAD_PORT_NAMES)
+            assert len(set(ports.values())) == len(ports)
+            for port in ports.values():
+                assert 1024 <= port <= 65535
+        finally:
+            for sock in held:
+                sock.close()
+
+    def test_probe_worker_subset_of_head_names(self):
+        # Workers don't run GCS/dashboard/ray-client-server.
+        for name in host_network_probe._WORKER_PORT_NAMES:
+            assert name in host_network_probe._HEAD_PORT_NAMES
+
+    def test_write_env_file_uses_skypilot_ray_env_var_names(self, tmp_path):
+        path = tmp_path / 'env.sh'
+        host_network_probe._write_env_file(
+            {
+                'gcs': 6380,
+                'dashboard': 8266,
+                'node_manager': 50001,
+            }, str(path))
+        body = path.read_text()
+        # SKYPILOT_RAY_PORT (not _GCS_PORT) is the existing public name
+        # for the head's GCS port; the worker template already exports
+        # it under that name when hostNetwork is off.
+        assert 'export SKYPILOT_RAY_PORT=6380' in body
+        assert 'export SKYPILOT_RAY_DASHBOARD_PORT=8266' in body
+        assert 'export SKYPILOT_RAY_NODE_MANAGER_PORT=50001' in body
+
+
+class TestRayStartCommands:
+    """ray_head_start_command / ray_worker_start_command behavior."""
+
+    def test_head_uses_default_ports_when_env_vars_unset(self):
+        cmd = instance_setup.ray_head_start_command(custom_resource=None,
+                                                    custom_ray_options=None)
+        # The substitution ${VAR:-default} expands to the constant when
+        # SKYPILOT_HOST_NETWORK is unset; we check the literal expansion
+        # text is present in the emitted shell command.
+        assert (f'--port=${{SKYPILOT_RAY_PORT:-'
+                f'{constants.SKY_REMOTE_RAY_PORT}}}') in cmd
+        assert (f'--dashboard-port=${{SKYPILOT_RAY_DASHBOARD_PORT:-'
+                f'{constants.SKY_REMOTE_RAY_DASHBOARD_PORT}}}') in cmd
+        assert '--object-manager-port=${SKYPILOT_RAY_OBJECT_MANAGER_PORT:-8076}' in cmd
+
+    def test_head_omits_new_port_flags_when_env_vars_unset(self):
+        cmd = instance_setup.ray_head_start_command(custom_resource=None,
+                                                    custom_ray_options=None)
+        # ${VAR:+--flag=$VAR} expands to nothing when VAR is unset, so
+        # Ray sees its own default behavior for these. We verify the
+        # substitution form is in place (i.e., we didn't accidentally
+        # hardcode a value).
+        assert ('${SKYPILOT_RAY_NODE_MANAGER_PORT:+'
+                '--node-manager-port=$SKYPILOT_RAY_NODE_MANAGER_PORT}') in cmd
+        assert (
+            '${SKYPILOT_RAY_CLIENT_SERVER_PORT:+'
+            '--ray-client-server-port=$SKYPILOT_RAY_CLIENT_SERVER_PORT}') in cmd
+
+    def test_head_prepended_probe_is_runtime_gated(self):
+        cmd = instance_setup.ray_head_start_command(custom_resource=None,
+                                                    custom_ray_options=None)
+        # No-op shell branch unless both env vars are set on the pod.
+        assert 'if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ]' in cmd
+        assert '[ -n "${SKYPILOT_RAY_PORTS_CONFIGMAP_NAME:-}" ]' in cmd
+        assert (f'| base64 -d | gunzip > '
+                f'{instance_setup._HOST_NETWORK_PROBE_TARGET}') in cmd
+        assert '--mode head' in cmd
+
+    def test_worker_prepended_probe_uses_worker_mode(self):
+        cmd = instance_setup.ray_worker_start_command(custom_resource=None,
+                                                      custom_ray_options=None,
+                                                      no_restart=False)
+        assert 'if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ]' in cmd
+        assert (f'| base64 -d | gunzip > '
+                f'{instance_setup._HOST_NETWORK_PROBE_TARGET}') in cmd
+        assert '--mode worker' in cmd
+
+    def test_probe_command_has_no_unencoded_newlines(self):
+        # Newlines in the bash command land at column 0 of the rendered
+        # cluster YAML and break block-scalar parsing — the b64 payload
+        # must stay on one line.
+        cmd = instance_setup.ray_head_start_command(custom_resource=None,
+                                                    custom_ray_options=None)
+        m = re.search(r"echo '([A-Za-z0-9+/=]+)' \| base64 -d", cmd)
+        assert m is not None, ('expected base64 payload not found '
+                               'in probe command')
+        assert '\n' not in m.group(1)
+
+    def test_probe_script_round_trips_through_base64(self):
+        cmd = instance_setup.ray_head_start_command(custom_resource=None,
+                                                    custom_ray_options=None)
+        m = re.search(r"echo '([A-Za-z0-9+/=]+)' \| base64 -d", cmd)
+        assert m is not None
+        # The payload is minified + gzipped before b64'ing to keep the
+        # rendered cluster YAML small. The bash counterpart pipes
+        # `base64 -d | gunzip`.
+        decoded = gzip.decompress(base64.b64decode(m.group(1))).decode('utf-8')
+        # Minification must preserve identifiers and module structure
+        # — the probe still needs --mode head and --mode worker entry
+        # points and a parseable AST.
+        assert 'def _run_head' in decoded
+        assert 'def _run_worker' in decoded
+        compile(decoded, '<probe>', 'exec')
+
+    def test_worker_keeps_existing_object_manager_default(self):
+        cmd = instance_setup.ray_worker_start_command(custom_resource=None,
+                                                      custom_ray_options=None,
+                                                      no_restart=False)
+        assert ('--object-manager-port=${SKYPILOT_RAY_OBJECT_MANAGER_PORT:-'
+                '8076}') in cmd
+
+    def test_custom_ray_options_user_overrides_appended_last(self):
+        # The for-loop over custom_ray_options runs after the templated
+        # flag string is built, so a user-supplied --port=7000 lands
+        # after the ${SKYPILOT_RAY_PORT:-...} expansion. Ray honors the
+        # last --port on the command line, so user overrides win.
+        cmd = instance_setup.ray_head_start_command(
+            custom_resource=None, custom_ray_options={'port': 7000})
+        port_positions = [m.start() for m in re.finditer(r'--port=', cmd)]
+        assert len(port_positions) == 2
+        # User value comes after the env-var substitution.
+        assert cmd.index('--port=7000') > cmd.index(
+            '--port=${SKYPILOT_RAY_PORT')
+
+    def test_dump_ray_ports_reads_env_vars(self):
+        # The runtime-resolved dict expression in
+        # SKY_REMOTE_RAY_PORT_DICT_STR must look up env vars so the
+        # probed port set lands in ~/.sky/ray_port.json (and the file
+        # falls back to the SkyPilot defaults when env vars are unset).
+        assert 'os.environ.get("SKYPILOT_RAY_PORT"' in (
+            constants.SKY_REMOTE_RAY_PORT_DICT_STR)
+        assert 'os.environ.get("SKYPILOT_RAY_DASHBOARD_PORT"' in (
+            constants.SKY_REMOTE_RAY_PORT_DICT_STR)
+
+
+class TestConfigMapBody:
+    """ConfigMap should carry an ownerReference so it is GC'd with the pod."""
+
+    def test_body_pins_lifetime_to_head_pod(self):
+        body = host_network_probe._build_configmap_body(
+            name='cluster-xyz-ray-ports',
+            namespace='my-ns',
+            ports={
+                'gcs': 6380,
+                'dashboard': 8266
+            },
+            owner_pod_name='cluster-xyz-head-abc',
+            owner_pod_uid='11111111-2222-3333-4444-555555555555',
+        )
+        # K8s deletes ConfigMaps whose owner Pod has been deleted, so on
+        # `sky down` (which deletes the head pod) the ConfigMap is GC'd
+        # without any extra teardown logic in SkyPilot.
+        owner_refs = body['metadata']['ownerReferences']
+        assert len(owner_refs) == 1
+        assert owner_refs[0]['kind'] == 'Pod'
+        assert owner_refs[0]['name'] == 'cluster-xyz-head-abc'
+        assert owner_refs[0]['uid'] == ('11111111-2222-3333-4444-555555555555')
+        # blockOwnerDeletion=false: deleting the head pod doesn't wait
+        # for the ConfigMap. controller=false: we're not the pod's
+        # controller, just a dependent.
+        assert owner_refs[0]['controller'] is False
+        assert owner_refs[0]['blockOwnerDeletion'] is False
+
+    def test_body_carries_port_data_as_strings(self):
+        body = host_network_probe._build_configmap_body(
+            name='c-ray-ports',
+            namespace='ns',
+            ports={
+                'gcs': 6380,
+                'dashboard': 8266
+            },
+            owner_pod_name='c-head-xx',
+            owner_pod_uid='uid-1',
+        )
+        # ConfigMap data values must be strings.
+        assert body['data'] == {'gcs': '6380', 'dashboard': '8266'}
+
+    def test_sshd_port_is_keyed_by_pod_name(self):
+        body = host_network_probe._build_configmap_body(
+            name='c-ray-ports',
+            namespace='ns',
+            ports={
+                'gcs': 6380,
+                'sshd': 33445
+            },
+            owner_pod_name='c-head-xx',
+            owner_pod_uid='uid-1',
+        )
+        # 'sshd' is rewritten to 'sshd_<podname>' so multiple pods (head
+        # + each worker) can publish into the same ConfigMap without
+        # clobbering each other. 'gcs' stays flat (head-owned).
+        assert body['data'] == {'gcs': '6380', 'sshd_c-head-xx': '33445'}
+
+
+class TestSshdPortPropagation:
+    """sshd is probed by both head and worker; bootstrap snippet rebinds."""
+
+    def test_sshd_is_in_both_head_and_worker_port_sets(self):
+        # Each pod's sshd is in its own filesystem but shares the host
+        # net namespace under hostNetwork, so each pod needs its own
+        # probed port.
+        assert 'sshd' in host_network_probe._HEAD_PORT_NAMES
+        assert 'sshd' in host_network_probe._WORKER_PORT_NAMES
+
+    def test_env_file_emits_skypilot_sshd_port(self, tmp_path):
+        path = tmp_path / 'env.sh'
+        host_network_probe._write_env_file({'sshd': 33445}, str(path))
+        # The bootstrap snippet reads SKYPILOT_SSHD_PORT to rewrite
+        # /etc/ssh/sshd_config's Port directive before restart.
+        assert 'export SKYPILOT_SSHD_PORT=33445' in path.read_text()
+
+    def test_probe_cmd_rebinds_sshd_after_sourcing_env(self):
+        cmd = instance_setup.ray_head_start_command(custom_resource=None,
+                                                    custom_ray_options=None)
+        # The Port-directive rewrite is gated on SKYPILOT_SSHD_PORT
+        # being set (the probe just sourced the env file). Non-host-
+        # Network bootstraps leave it unset and skip the rewrite.
+        assert 'if [ -n "${SKYPILOT_SSHD_PORT:-}" ]' in cmd
+        # Delete-then-append, all under one sudo, so the redirect
+        # happens as root and we don't pay three sudo costs in a row.
+        assert 'sudo sh -c "' in cmd
+        assert ("sed -i -E '/^[[:space:]]*#?[[:space:]]*Port"
+                "[[:space:]]+/d'") in cmd
+        assert 'echo Port ${SKYPILOT_SSHD_PORT} >> /etc/ssh/sshd_config' in cmd
+        assert 'service ssh restart' in cmd
+
+
+class TestWaitHeadGcsTcp:
+    """The worker probe's TCP wait should accept once the head port is up."""
+
+    def test_returns_when_port_is_listening(self):
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.bind(('127.0.0.1', 0))
+        listener.listen(1)
+        try:
+            _, port = listener.getsockname()
+            # Should return promptly without raising.
+            host_network_probe._wait_head_gcs_tcp('127.0.0.1', port)
+        finally:
+            listener.close()

--- a/tests/unit_tests/test_sky/provision/test_host_network_probe.py
+++ b/tests/unit_tests/test_sky/provision/test_host_network_probe.py
@@ -15,6 +15,8 @@ import gzip
 import re
 import socket
 
+import pytest
+
 from sky.provision import instance_setup
 from sky.provision.kubernetes import host_network_probe
 from sky.skylet import constants
@@ -267,3 +269,125 @@ class TestWaitHeadGcsTcp:
             host_network_probe._wait_head_gcs_tcp('127.0.0.1', port)
         finally:
             listener.close()
+
+
+class TestHeadPortReuse:
+    """On a head *container* restart the ownerReference'd ConfigMap
+    survives (the Pod object/UID is unchanged), so the head must reuse
+    the already-published ports rather than re-probe and strand workers.
+    """
+
+    def _full_head_data(self, podname):
+        ports = {
+            n: 30000 + i
+            for i, n in enumerate(host_network_probe._HEAD_PORT_NAMES)
+        }
+        return ports, host_network_probe._configmap_data_for_ports(
+            podname, ports)
+
+    def test_round_trips_configmap_data(self):
+        ports, data = self._full_head_data('c-head-abc')
+        got = host_network_probe._head_ports_from_configmap_data(
+            data, 'c-head-abc')
+        assert got == ports
+
+    def test_partial_data_returns_none(self):
+        _, data = self._full_head_data('c-head-abc')
+        data.pop('gcs')
+        assert host_network_probe._head_ports_from_configmap_data(
+            data, 'c-head-abc') is None
+
+    def test_non_integer_value_returns_none(self):
+        _, data = self._full_head_data('c-head-abc')
+        data['gcs'] = 'not-a-port'
+        assert host_network_probe._head_ports_from_configmap_data(
+            data, 'c-head-abc') is None
+
+    def test_reuse_requires_owner_uid_match(self, monkeypatch):
+        monkeypatch.setenv('SKYPILOT_POD_NAME', 'c-head-abc')
+        monkeypatch.setenv('SKYPILOT_POD_UID', 'live-uid')
+        ports, data = self._full_head_data('c-head-abc')
+
+        def fake_get(owner_uid):
+            return {
+                'metadata': {
+                    'ownerReferences': [{
+                        'uid': owner_uid
+                    }]
+                },
+                'data': data,
+            }
+
+        # Owned by this pod (genuine container restart) -> reuse.
+        monkeypatch.setattr(host_network_probe, '_try_get_configmap',
+                            lambda *_a: fake_get('live-uid'))
+        assert host_network_probe._existing_head_ports_to_reuse('cm',
+                                                                'ns') == ports
+
+        # Owned by a different (now-deleted, GC-lagging) pod -> probe
+        # fresh; its ports may already be taken on this fresh node.
+        monkeypatch.setattr(host_network_probe, '_try_get_configmap',
+                            lambda *_a: fake_get('stale-uid'))
+        assert host_network_probe._existing_head_ports_to_reuse('cm',
+                                                                'ns') is None
+
+    def test_reuse_none_when_configmap_absent(self, monkeypatch):
+        monkeypatch.setenv('SKYPILOT_POD_NAME', 'c-head-abc')
+        monkeypatch.setenv('SKYPILOT_POD_UID', 'live-uid')
+        monkeypatch.setattr(host_network_probe, '_try_get_configmap',
+                            lambda n, ns: None)
+        assert host_network_probe._existing_head_ports_to_reuse('cm',
+                                                                'ns') is None
+
+
+class TestMergeSshdPortBackoff:
+    """Workers merge their sshd port into the one shared ConfigMap; on a
+    large cluster the 409 losers must back off with jitter so they don't
+    thunder on the API server in lockstep.
+    """
+
+    def _patch(self, monkeypatch, statuses):
+        # _get_configmap returns a minimal mergeable body.
+        monkeypatch.setattr(
+            host_network_probe, '_get_configmap', lambda n, ns: {
+                'data': {},
+                'metadata': {
+                    'resourceVersion': '1'
+                }
+            })
+        calls = iter(statuses)
+        monkeypatch.setattr(host_network_probe, '_k8s_api_request',
+                            lambda *a, **k: (next(calls), b''))
+        sleeps = []
+        monkeypatch.setattr(host_network_probe.time, 'sleep', sleeps.append)
+        # Collapse jitter to its upper bound so the ceiling is asserted
+        # deterministically.
+        monkeypatch.setattr(host_network_probe.random, 'uniform',
+                            lambda lo, hi: hi)
+        return sleeps
+
+    def test_backoff_is_exponential_and_capped(self, monkeypatch):
+        # Always 409 -> exhaust retries and raise.
+        sleeps = self._patch(monkeypatch,
+                             [409] * host_network_probe._MERGE_RETRY_LIMIT)
+        with pytest.raises(RuntimeError, match='after'):
+            host_network_probe._merge_sshd_port('cm', 'ns', 'w1', 12345)
+        # One backoff between each pair of attempts (not after the last).
+        assert len(sleeps) == host_network_probe._MERGE_RETRY_LIMIT - 1
+        # Strictly increasing until the cap, never exceeding the cap.
+        assert sleeps[0] == host_network_probe._MERGE_RETRY_BASE_DELAY_S
+        assert max(sleeps) <= host_network_probe._MERGE_RETRY_MAX_DELAY_S
+        assert sleeps == sorted(sleeps)
+
+    def test_succeeds_after_transient_conflicts(self, monkeypatch):
+        sleeps = self._patch(monkeypatch, [409, 409, 200])
+        # Returns without raising; only backed off between the conflicts.
+        host_network_probe._merge_sshd_port('cm', 'ns', 'w1', 12345)
+        assert len(sleeps) == 2
+
+    def test_non_conflict_error_does_not_retry(self, monkeypatch):
+        sleeps = self._patch(monkeypatch, [500])
+        with pytest.raises(RuntimeError):
+            host_network_probe._merge_sshd_port('cm', 'ns', 'w1', 12345)
+        # 500 is not retriable -> bail immediately, no backoff.
+        assert not sleeps

--- a/tests/unit_tests/test_sky/provision/test_host_network_probe.py
+++ b/tests/unit_tests/test_sky/provision/test_host_network_probe.py
@@ -173,6 +173,7 @@ class TestConfigMapBody:
                 'gcs': 6380,
                 'dashboard': 8266
             },
+            extra={},
             owner_pod_name='cluster-xyz-head-abc',
             owner_pod_uid='11111111-2222-3333-4444-555555555555',
         )
@@ -198,6 +199,7 @@ class TestConfigMapBody:
                 'gcs': 6380,
                 'dashboard': 8266
             },
+            extra={},
             owner_pod_name='c-head-xx',
             owner_pod_uid='uid-1',
         )
@@ -212,6 +214,7 @@ class TestConfigMapBody:
                 'gcs': 6380,
                 'sshd': 33445
             },
+            extra={},
             owner_pod_name='c-head-xx',
             owner_pod_uid='uid-1',
         )

--- a/tests/unit_tests/test_sky/provision/test_host_network_probe.py
+++ b/tests/unit_tests/test_sky/provision/test_host_network_probe.py
@@ -173,7 +173,6 @@ class TestConfigMapBody:
                 'gcs': 6380,
                 'dashboard': 8266
             },
-            extra={},
             owner_pod_name='cluster-xyz-head-abc',
             owner_pod_uid='11111111-2222-3333-4444-555555555555',
         )
@@ -199,7 +198,6 @@ class TestConfigMapBody:
                 'gcs': 6380,
                 'dashboard': 8266
             },
-            extra={},
             owner_pod_name='c-head-xx',
             owner_pod_uid='uid-1',
         )
@@ -214,7 +212,6 @@ class TestConfigMapBody:
                 'gcs': 6380,
                 'sshd': 33445
             },
-            extra={},
             owner_pod_name='c-head-xx',
             owner_pod_uid='uid-1',
         )

--- a/tests/unit_tests/test_sky/utils/test_source_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_source_utils.py
@@ -1,0 +1,57 @@
+"""Unit tests for sky.utils.source_utils."""
+from sky.utils import source_utils
+
+
+class TestMinifyPythonSource:
+    """Strips docstrings/comments but preserves code."""
+
+    def test_strips_module_and_function_docstrings(self):
+        source = ('"""module doc"""\n'
+                  'def foo():\n'
+                  '    """fn doc"""\n'
+                  '    return 1\n')
+        out = source_utils.minify_python_source(source)
+        assert 'module doc' not in out
+        assert 'fn doc' not in out
+        assert 'def foo' in out
+        assert 'return 1' in out
+
+    def test_strips_comments(self):
+        source = 'x = 1  # trailing\n# leading\ny = 2\n'
+        out = source_utils.minify_python_source(source)
+        assert 'trailing' not in out
+        assert 'leading' not in out
+        assert 'x = 1' in out
+        assert 'y = 2' in out
+
+    def test_preserves_string_literals_that_are_not_docstrings(self):
+        # Strings used as RHS or argument must survive — only "string
+        # is its own statement at top of module/class/func" gets cut.
+        source = 'def f():\n    msg = "hello"\n    return msg\n'
+        out = source_utils.minify_python_source(source)
+        assert '"hello"' in out
+
+    def test_strips_class_docstring(self):
+        source = 'class C:\n    """class doc"""\n    x = 1\n'
+        out = source_utils.minify_python_source(source)
+        assert 'class doc' not in out
+        assert 'class C' in out
+        assert 'x = 1' in out
+
+    def test_output_round_trips_compile(self):
+        # End-to-end on a non-trivial input: docstrings + comments +
+        # multiple defs + non-docstring strings. The minified output
+        # must still parse.
+        source = ('"""mod"""\n'
+                  'import os  # noqa\n'
+                  '\n'
+                  'def a():\n'
+                  '    """a"""\n'
+                  '    return "literal"\n'
+                  '\n'
+                  'class K:\n'
+                  '    """k"""\n'
+                  '    def m(self):\n'
+                  '        return os.environ.get("X", "y")\n')
+        out = source_utils.minify_python_source(source)
+        compile(out, '<test>', 'exec')


### PR DESCRIPTION
## Summary

- Auto-detect `hostNetwork: true` in `kubernetes.pod_config` and pick a free Ray port set at pod startup so SkyPilot pods can run with `hostNetwork` (RoCE/RDMA workloads, fractional-GPU jobs) without colliding on Ray's default ports.
- Head pod publishes its chosen GCS/dashboard/etc. ports to a `<cluster>-ray-ports` ConfigMap; workers poll it to learn the head's GCS port (head IP is discovered via the existing headless Service DNS).
- Each pod (head + workers) also probes a free sshd port and publishes it under `sshd_<podname>` in the same ConfigMap; the SSH config writer reads them per pod. Required because under `hostNetwork` the K8s node's own sshd owns `host:22`.
- **Mode b — one cluster pod per K8s node.** SkyPilot injects a required, per-cluster `podAntiAffinity` for every `hostNetwork` pod. Every pod of a cluster then gets its own node, so each pod's host IP is unique and routable. This (a) removes the co-located-raylet failure mode by construction (two raylets can no longer register under the same host IP and get collapsed onto one gRPC endpoint in Ray's client cache), and (b) makes `hostNetwork` clusters work **across multiple K8s nodes**. Unrelated clusters can still co-locate (the selector is per-cluster); the free-port probe resolves their cross-cluster port collisions.
- Non-hostNetwork clusters: port flags use `${VAR:-default}` / `${VAR:+--flag=$VAR}` substitution so missing env vars fall back to the SkyPilot constants; the affinity block is byte-identical when `hostNetwork` is off. Full audit below. No API version bump.

## Why

`hostNetwork: true` is required to get RoCE/RDMA throughput on Oracle and other non-EFA/non-InfiniBand/non-GPUDirect setups. The first SkyPilot pod on a node grabs Ray's default ports (6380, 8266, 8076, 11002…) directly on the host; a second pod fails to admit with `EADDRINUSE`. The probe + ConfigMap discovery channel decouples the head's port choice from a hardcoded constant while keeping the existing DNS-based head-identity flow intact.

A separate failure mode otherwise appears when two pods of the same cluster land on one K8s node: both raylets register in GCS with `node_manager_address = <K8s host IP>`. Ray's client-side resolver can collapse the two NodeIDs onto a single endpoint in its gRPC channel cache, routing every lease request to one raylet and hanging `pg.ready()`. Rather than disambiguate co-located raylets after the fact (an earlier iteration bound each raylet to a per-pod `127.x.y.<rank>` loopback IP — reverted; see *Superseded*), **mode b prevents same-cluster co-location entirely**. With one pod per node every host IP is distinct, so the collapse cannot occur — and the same property makes the head reachable from workers on other K8s nodes (over its routable host IP + probed GCS port via the headless Service DNS), which is what unlocks cross-node `hostNetwork`.

## Design notes

- **Trigger**: `kubernetes.pod_config.spec.hostNetwork = true` (read from `skypilot_config` and `cluster_config_overrides`, merged the same way `combine_pod_config_fields` does). No new config knob.
- **Mode b anti-affinity**: a `requiredDuringSchedulingIgnoredDuringExecution` `podAntiAffinity`, `labelSelector` `skypilot-cluster=<cluster_name_on_cloud>`, `topologyKey: kubernetes.io/hostname`, rendered into the pod spec only when `k8s_host_network`. `required` (not `preferred`) so the guarantee is hard: a multi-pod `hostNetwork` cluster that cannot get a node per pod fails to schedule loudly rather than silently racing on a shared host. The `affinity:` block is restructured to emit for the pre-existing `nodeAffinity` conditions **or** `hostNetwork`; the non-hostNetwork path renders no affinity block (byte-identical to before).
- **Probe**: `sky/provision/kubernetes/host_network_probe.py` — stdlib-only (runs before the SkyPilot wheel finishes installing). Binds ephemeral sockets, writes a sourceable env file, then exits. Still needed under mode b: it resolves collisions against *other* clusters co-located on a node (allowed — anti-affinity is per-cluster) and against the node's own services.
- **Discovery channel**: a Kubernetes ConfigMap written by the head via the in-cluster service account; workers poll it then TCP-wait for the head's GCS to accept before `ray start --address`. `ownerReference` → head pod so K8s GCs it on `sky down`.
- **sshd rebind**: each pod's bootstrap rewrites `Port` in `/etc/ssh/sshd_config` to its probed port and restarts sshd. `kubernetes_pod_ssh_proxy` forwards to that probed port via `handle.head_ssh_port`.
- **Superseded — per-pod loopback IP.** An earlier iteration bound each raylet to `127.<H1>.<H2>.<rank>` via `--node-ip-address` to disambiguate raylets sharing a host IP. Mode b makes that unnecessary (same-cluster pods never share a host) and the loopback was itself the reason cross-node was impossible (a worker's `127.x.y.0` dial-back to the head is only routable in a shared netns). Those commits stay reverted and are not in this diff.
- **Backward compat**: `${VAR:-default}` for ports SkyPilot already pins; `${VAR:+--flag=$VAR}` for new flags so they vanish when the probe didn't run. `~/.sky/ray_port.json` schema unchanged.
- **User overrides**: `custom_ray_options` still wins.
- **Status path**: `get_cluster_info` makes one extra `read_namespaced_config_map` for hostNetwork clusters (5 s best-effort budget); non-hostNetwork clusters make zero additional calls.

## Scope notes / limitations

- **Cross-K8s-node hostNetwork is now supported** — the headline behavioral change vs. earlier revisions. A multi-pod `hostNetwork` cluster spreads one pod per node; workers reach the head over its routable host IP + probed GCS port via the headless Service DNS.
- **Same-cluster, same-node packing is no longer supported (by design).** The required per-cluster anti-affinity forbids two pods of one cluster on one node — intentionally trading the earlier "stack multiple same-cluster pods on one node" capability for correctness (no raylet collapse) and cross-node support. *Different* clusters may still co-locate.
- **Requires one schedulable node per pod.** On a single-node K8s (kind, `sky local up`, one box) a multi-pod `hostNetwork` cluster will not schedule — the worker stays `Pending` and the launch fails loudly with the kube-scheduler pod-anti-affinity rejection. Intended (fail loud, don't race), but a change in single-node ergonomics; the `multi_node` smoke test asserts exactly this failure (the smoke clusters are single-node, so the cross-node-spread path is not exercised in CI). A future opt-out knob could relax this (see *Open follow-ups*).
- **User-supplied affinity**: SkyPilot merges user `pod_config` over the rendered YAML. A user who sets their own `affinity.podAntiAffinity` interacts with the injected rule via `merge_k8s_configs` list semantics — effectively the escape hatch for the single-node case. Worth an explicit test (see *Open follow-ups*).

## Non-hostNetwork impact audit

### Strictly hostNetwork-only (no codepath change when off)

- `sky/provision/kubernetes/host_network_probe.py` — new; only invoked by the gated probe snippet.
- `sky/utils/source_utils.py` — called once at import time on the client to encode the inlined probe payload.
- `sky/templates/kubernetes-ray.yml.j2` — every edit is inside `{% if k8s_host_network %}` / `{% if not k8s_host_network %}` (dnsPolicy, pod-identity env vars, alternative head-up-wait, `containerPort` list, **and the mode-b `podAntiAffinity`**). With `hostNetwork` off the affinity block is byte-identical to before (no affinity block unless GPU/avoid labels, exactly as today).
- `sky/clouds/kubernetes.py` — hostNetwork-detection block gated behind `if k8s_host_network:`.
- `sky/provision/kubernetes/instance.py` — `_read_host_network_sshd_ports` short-circuits for non-hostNetwork clusters (`pod_sshd_ports.get(pod_name, port)` returns the existing `port`).

### Touches non-hostNetwork codepath but preserves resolved behavior

| File | Change | Non-hostNetwork resolved behavior |
|---|---|---|
| `instance_setup.py` (head/worker `ray start` flags) | Hardcoded ports replaced with `${SKYPILOT_RAY_PORT:-6380}` etc.; new flags use `${VAR:+--flag=$VAR}`. | Env unset → original SkyPilot defaults; `${VAR:+…}` expands empty. Identical resolved command. |
| `instance_setup.py` (command prefix) | `_host_network_probe_cmd(mode)` prepended. | Wrapped in `if [ "${SKYPILOT_HOST_NETWORK:-0}" = "1" ] && [ -n "${...CONFIGMAP_NAME:-}" ]; then …; fi;` — no-op when env unset. |
| `instance_setup.py` (`_RAY_PORT_COMMAND`) | `job_lib.get_ray_port()` → stdlib `~/.sky/ray_port.json` read. | Same file contents; no longer needs `sky` importable mid-bootstrap. |
| `instance_setup.py` (`RAY_HEAD_WAIT_INITIALIZED_COMMAND`) | `constants.RAY_STATUS` → `RAY_ADDRESS=127.0.0.1:${SKYPILOT_RAY_PORT:-6380} ray status`. | Same resolved command when `SKYPILOT_RAY_PORT` unset. |
| `skylet/constants.py` (`SKY_REMOTE_RAY_PORT_DICT_STR`) | Literal dict → expression reading `os.environ.get("SKYPILOT_RAY_PORT", 6380)`. | Env unset → same `{"ray_port":6380,"ray_dashboard_port":8266}`. |

## Files

- `sky/provision/kubernetes/host_network_probe.py` (new) — probe + ConfigMap publish/poll
- `sky/utils/source_utils.py` (new) — `minify_python_source()` for inlining the probe via b64
- `sky/provision/instance_setup.py` — probe snippet, env-var-substituted port flags, sshd rebind
- `sky/skylet/constants.py` — `SKY_REMOTE_RAY_PORT_DICT_STR` reads env at runtime
- `sky/clouds/kubernetes.py` — hostNetwork detection + env var injection
- `sky/templates/kubernetes-ray.yml.j2` — gated dnsPolicy, pod-identity env vars, alternative worker head-up-wait, containerPort list, **and the mode-b per-cluster `podAntiAffinity`**
- `sky/provision/kubernetes/instance.py` — best-effort short read of per-pod sshd ports in `get_cluster_info`
- `tests/unit_tests/test_sky/provision/test_host_network_probe.py` (new), `tests/unit_tests/test_sky/utils/test_source_utils.py` (new)
- `tests/smoke_tests/test_kubernetes_host_network.py` (new) — `multi_node` **rewritten to assert the single-node fail-loud path** (a 2-node hostNetwork launch must fail with the pod-anti-affinity scheduling error, since the smoke clusters are single-node); `coexistence` (two different clusters on one node) unchanged

## Test plan

- [x] Unit tests: `pytest tests/unit_tests/test_sky/provision/test_host_network_probe.py tests/unit_tests/test_sky/utils/test_source_utils.py` — passing
- [x] `bash format.sh` — yapf, isort, mypy, pylint green
- [x] Jinja: template parses with balanced tags; affinity block rendered + YAML-validated for hostNetwork × {none, GPU, avoid} — `podAntiAffinity` emitted iff hostNetwork, coexists with `nodeAffinity`, no affinity block when off
- [x] Verify `ray_{head,worker}_start_command()` produce the original default ports when env vars are unset (regression-proof for existing clusters)
- [ ] `/smoke-test --kubernetes` (single-node clusters): `test_kubernetes_host_network_multi_node` — a 2-node hostNetwork launch correctly **fails** with the pod-anti-affinity scheduling rejection (asserts both the non-zero exit and that the failure is the anti-affinity reason). The cross-node-spread success path needs a ≥2-node K8s cluster and is only verified manually off-CI.
- [ ] Manual: two hostNetwork clusters forced onto one node — both launch + SSH (probe avoided the cross-cluster collision) — `test_kubernetes_host_network_coexistence`

## Open follow-ups

- Optional config knob to relax the required anti-affinity to `preferred` (or opt out) for single-K8s-node users who accept the same-node race.
- Explicit test for the user-`pod_config`-affinity ⊕ injected-anti-affinity merge path (`merge_k8s_configs` list semantics).
- `cached_external_ssh_ports` is set at provisioning time and not refreshed on pod restart — if a hostNetwork pod restarts and the probe picks a different sshd port, `ssh <cluster>` uses the stale port until the next `sky status -r`.
- TOCTOU: the probe releases held sockets just before `ray start` / sshd bind; a racing process on the same node could grab the freed port. Narrowed by mode b — only the cross-cluster case, on a deliberately co-located node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->