### PR TITLE
[Dashboard] Don't block managed-jobs table on /status when controller is up

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -614,7 +614,16 @@ export function ManagedJobsTable({
             setTotalCount(response.total || 0);
             setTotalNoFilter(response.totalNoFilter || response.total || 0);
             setStatusCounts(response.statusCounts || {});
+            // Controller is reachable: clear any stale banner state from a
+            // previous fetch and skip the cluster-status lookup below.
+            setControllerStopped(false);
+            setControllerLaunching(false);
           }
+
+          // Render the table as soon as the queue data is in. Any optional
+          // controller-status banner is resolved below without blocking the
+          // table.
+          setIsInitialLoad(false);
 
           // Prefetch next page in background
           if (response.hasNext) {
@@ -622,8 +631,16 @@ export function ManagedJobsTable({
           }
         }
 
-        // Check controller status from clusters
-        if (includeStatus) {
+        // Check controller status from clusters — only needed when the
+        // queue response indicated the controller wasn't reachable. The
+        // queue endpoint catches ClusterNotUpError and returns
+        // controllerStopped=true for both STOPPED and INIT-without-head_ip
+        // (i.e. LAUNCHING). We then call /status to disambiguate so the
+        // right banner is shown. When the controller is reachable
+        // (controllerStopped === false) there is no banner to show, so we
+        // skip /status entirely — saving ~hundreds of ms on every page
+        // load and on every 5-second periodic refresh.
+        if (includeStatus && response.controllerStopped) {
           try {
             const clustersData = await dashboardCache.get(getClusters);
 
@@ -637,11 +654,7 @@ export function ManagedJobsTable({
               const jobControllerClusterStatus = jobControllerCluster
                 ? jobControllerCluster.status
                 : 'NOT_FOUND';
-              // Check both cluster status and API response
-              if (
-                jobControllerClusterStatus === 'STOPPED' &&
-                response.controllerStopped
-              ) {
+              if (jobControllerClusterStatus === 'STOPPED') {
                 isControllerStopped = true;
               }
               if (jobControllerClusterStatus === 'LAUNCHING') {
@@ -656,10 +669,6 @@ export function ManagedJobsTable({
           } catch (error) {
             console.error('Error fetching clusters:', error);
           }
-        }
-
-        if (version === requestSeqRef.current) {
-          setIsInitialLoad(false);
         }
       } catch (err) {
         console.error('Error fetching data:', err);


### PR DESCRIPTION
## Summary

The managed-jobs page calls `getClusters` (`POST /status`) after every `pagination/jobs` fetch to decide whether to show a "controller stopped" or "controller launching" banner. The `await` is sequential: the table `tbody` stays in its `Loading...` state until `/status` returns, even though the row data is already in component state.

The pagination/jobs endpoint already catches `ClusterNotUpError` and returns `controller_stopped=true` for both `STOPPED` and `INIT`-without-head_ip (LAUNCHING) cases. `/status` is only used to disambiguate which banner to show; when `controller_stopped` is `false` the controller is reachable, so there is no banner to show and `/status` can be skipped.

This PR:
- Renders the table as soon as `pagination/jobs` returns (moves `setIsInitialLoad(false)` before the cluster check).
- Calls `getClusters` only when `response.controllerStopped === true`.
- Clears stale banner state on the happy path so a STOPPED→UP transition doesn't leave a stale banner.

Trade-off: the rare "controller is `INIT`-with-head_ip and queue succeeded" transient no longer shows a LAUNCHING banner. The state resolves on the next periodic refresh once the controller fully transitions, and this state lasts only seconds in practice.

## Measurements

Dev stack on PostgreSQL with 50,000 synthetic managed jobs in `spot`/`job_info`. Playwright timeline, time-to-row-visible:

- **Before**: 2.68 s (consistent across 3 runs)
- **After**: 1.51 s (consistent across 3 runs)

The cache preloader fires `/status` in parallel before `pagination/jobs` returns (see `cache-preloader.js:80`), so the actual network request happens whether or not `fetchData` calls `dashboardCache.get(getClusters)`. The win is removing the sequential `await` that was blocking the tbody render after data already landed.

## Test plan

Coverage matrix (mode × controller state), all four cases verified end-to-end with a real running controller cluster on Kubernetes:

| Mode | State | Possible? | Tested |
|---|---|---|---|
| Consolidation | up | ✅ | ✅ real playwright (2.68 s → 1.51 s) |
| Consolidation | stopped | ❌ impossible — `LocalResourcesHandle` is always "accessible" | n/a |
| Non-consolidation | up | ✅ | ✅ real playwright, real provisioned controller: `controllerStopped=False`, no `/status` call fires after `pagination/jobs` returned |
| Non-consolidation | stopped | ✅ | ✅ real playwright, real provisioned-then-stopped controller: `controllerStopped=True`, "controller has been stopped" banner renders correctly with "Restart Controller" CTA |

Additional checks:

- [x] Playwright with `route.fulfill` mocking `controllerStopped=true`: confirmed `dashboardCache.get(getClusters)` is invoked from the conditional branch.
- [x] `npm test -- --testPathPattern=cache.test` — passes. (Unrelated `version-display.test.jsx` failures pre-exist on master — verified by re-running on stashed branch.)
- [x] `npx prettier --check src/components/jobs.jsx` — clean.

-Claude
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->