### PR TITLE
[Jobs] Propagate scheduler subprocess exit code in consolidation mode

### DIFF
--- a/sky/jobs/scheduler.py
+++ b/sky/jobs/scheduler.py
@@ -323,7 +323,29 @@ def submit_jobs(job_ids: List[int],
     state.scheduler_set_waiting(job_ids, dag_yaml_content,
                                 original_user_yaml_content, env_file_content,
                                 config_file_content, priority, priority_class)
-    maybe_start_controllers(from_scheduler=True)
+    # `maybe_start_controllers` is an eager optimization; the periodic
+    # managed-job-status-refresh-daemon also calls it. If it raises here
+    # — after `scheduler_set_waiting` has already committed — the row is
+    # WAITING and the next recovery pass will spawn the controller and
+    # run the job anyway. Letting this exception propagate would make
+    # the caller (`_consolidated_launch`) mark the user's request FAILED
+    # while the job will still run, prompting the user to retry and
+    # double-launch. Swallow the error so the script's exit code tracks
+    # whether the job was successfully queued (= `scheduler_set_waiting`
+    # committed), not whether the eager controller spawn succeeded.
+    try:
+        maybe_start_controllers(from_scheduler=True)
+    except Exception as e:  # pylint: disable=broad-except
+        # Loud — this should not normally happen; if it does, a real bug
+        # is likely lurking in maybe_start_controllers. Log with full
+        # traceback at ERROR so it shows up in any reasonable log
+        # configuration. The job itself is not lost (recovery will retry).
+        logger.error(
+            f'maybe_start_controllers raised after scheduler_set_waiting '
+            f'committed for jobs {job_ids}; swallowing so the script '
+            f'exit code stays 0 (the row is WAITING and the next recovery '
+            f'pass will retry the controller spawn). Error: {e}',
+            exc_info=True)
 
 
 @contextlib.asynccontextmanager

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -387,7 +387,24 @@ def _consolidated_launch(
     os.makedirs(log_dir, exist_ok=True)
     job_ids_str = _job_ids_to_str(job_ids)
     log_path = os.path.join(log_dir, f'submit-job-{job_ids_str}.log')
-    backend.run_on_head(local_handle, run_script, log_path=log_path)
+    # Surface the script's exit code so that a failure here marks the
+    # `jobs.launch` request as FAILED. Without this, a non-zero exit from the
+    # scheduler script (e.g. unreachable controller DB, interpreter mismatch,
+    # OOM mid-`scheduler_set_waiting`) is silently dropped — leaving a
+    # PENDING+INACTIVE job row while the user is told the launch succeeded.
+    returncode = backend.run_on_head(local_handle,
+                                     run_script,
+                                     log_path=log_path)
+    if returncode != 0:
+        raise exceptions.CommandError(
+            returncode=returncode,
+            command=f'sky.jobs.scheduler[job_ids={job_ids_str}]',
+            error_msg=(
+                f'Managed job submission script failed '
+                f'(returncode={returncode}). The job row is in an incomplete '
+                f'state; cancel it with `sky jobs cancel {job_ids_str}` '
+                f'before retrying. Script log: {log_path}'),
+            detailed_reason=None)
     ux_utils.starting_message(f'Job submitted, ID: {job_ids_str}')
     return job_ids, local_handle
 

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -404,7 +404,7 @@ def _consolidated_launch(
                 f'(returncode={returncode}). The job row is in an incomplete '
                 f'state; cancel it with `sky jobs cancel {job_ids_str}` '
                 f'before retrying. Script log: {log_path}'),
-            detailed_reason=None)
+            detailed_reason='')
     ux_utils.starting_message(f'Job submitted, ID: {job_ids_str}')
     return job_ids, local_handle
 

--- a/tests/unit_tests/test_sky/jobs/test_consolidated_launch_returncode.py
+++ b/tests/unit_tests/test_sky/jobs/test_consolidated_launch_returncode.py
@@ -81,8 +81,8 @@ def test_zero_returncode_succeeds(monkeypatch):
     task = _make_controller_task()
 
     job_ids, handle = jobs_core._consolidated_launch(controller,
-                                                    task,
-                                                    job_ids=[7])
+                                                     task,
+                                                     job_ids=[7])
     assert job_ids == [7]
     assert handle is not None
 

--- a/tests/unit_tests/test_sky/jobs/test_consolidated_launch_returncode.py
+++ b/tests/unit_tests/test_sky/jobs/test_consolidated_launch_returncode.py
@@ -1,0 +1,101 @@
+"""Regression test for `_consolidated_launch` returncode propagation.
+
+`_consolidated_launch` historically discarded the return code of the
+controller subprocess. A non-zero exit (e.g. interpreter mismatch, DB
+unreachable, OOM during scheduler_set_waiting) was silently swallowed,
+leaving a PENDING+INACTIVE job row in the DB while the API returned
+SUCCEEDED to the user. This test pins the new behavior: non-zero
+returncode must raise so the request is marked FAILED.
+"""
+
+from unittest import mock
+
+import pytest
+
+from sky import exceptions
+from sky.jobs.server import core as jobs_core
+
+
+def _make_mock_backend(returncode: int) -> mock.MagicMock:
+    """A CloudVmRayBackend stub that returns the given returncode."""
+    backend = mock.MagicMock()
+    backend.run_on_head.return_value = returncode
+    # sync_file_mounts is a no-op for our purposes.
+    backend.sync_file_mounts = mock.MagicMock()
+    return backend
+
+
+def _patch_consolidated_launch_deps(monkeypatch, returncode: int) -> None:
+    """Wire up the minimum surface needed for `_consolidated_launch` to run.
+
+    We mock everything `_consolidated_launch` reaches for *before* the
+    `run_on_head` call so the function gets to the returncode check with
+    a controlled value.
+    """
+    fake_handle = mock.MagicMock()
+    monkeypatch.setattr(
+        'sky.backends.backend_utils.is_controller_accessible',
+        lambda **kwargs: fake_handle,
+    )
+    backend = _make_mock_backend(returncode)
+    monkeypatch.setattr(
+        'sky.backends.backend_utils.get_backend_from_handle',
+        lambda _h: backend,
+    )
+    # _consolidated_launch asserts the backend is a CloudVmRayBackend; the
+    # asserted type comes from `sky.backends`. Make isinstance() happy.
+    import sky.backends as sky_backends
+    monkeypatch.setattr(sky_backends, 'CloudVmRayBackend', mock.MagicMock)
+
+
+def _make_controller_task() -> mock.MagicMock:
+    task = mock.MagicMock()
+    task.run = 'echo "test run script"'
+    task.envs = {}
+    task.file_mounts = None
+    task.storage_mounts = None
+    return task
+
+
+def test_nonzero_returncode_raises_command_error(monkeypatch):
+    """A non-zero exit from the controller subprocess must raise so the
+    user's `jobs.launch` request is marked FAILED."""
+    _patch_consolidated_launch_deps(monkeypatch, returncode=42)
+
+    controller = mock.MagicMock()
+    task = _make_controller_task()
+
+    with pytest.raises(exceptions.CommandError) as excinfo:
+        jobs_core._consolidated_launch(controller, task, job_ids=[7])
+    # Surface the returncode and a hint to cancel-and-retry.
+    assert excinfo.value.returncode == 42
+    assert 'sky jobs cancel 7' in excinfo.value.error_msg
+    assert 'returncode=42' in excinfo.value.error_msg
+
+
+def test_zero_returncode_succeeds(monkeypatch):
+    """Happy path: returncode 0 should return job_ids without raising."""
+    _patch_consolidated_launch_deps(monkeypatch, returncode=0)
+
+    controller = mock.MagicMock()
+    task = _make_controller_task()
+
+    job_ids, handle = jobs_core._consolidated_launch(controller,
+                                                    task,
+                                                    job_ids=[7])
+    assert job_ids == [7]
+    assert handle is not None
+
+
+def test_multiple_job_ids_in_error_message(monkeypatch):
+    """The cancel hint must list all job ids in the same compact form
+    that `_job_ids_to_str` emits."""
+    _patch_consolidated_launch_deps(monkeypatch, returncode=1)
+
+    controller = mock.MagicMock()
+    task = _make_controller_task()
+
+    with pytest.raises(exceptions.CommandError) as excinfo:
+        jobs_core._consolidated_launch(controller, task, job_ids=[10, 11, 12])
+    # _job_ids_to_str collapses contiguous ranges.
+    assert 'sky jobs cancel 10-12' in excinfo.value.error_msg

--- a/tests/unit_tests/test_sky/jobs/test_scheduler_submit_jobs.py
+++ b/tests/unit_tests/test_sky/jobs/test_scheduler_submit_jobs.py
@@ -1,0 +1,132 @@
+"""Coverage for `sky.jobs.scheduler.submit_jobs` exit-code semantics.
+
+`submit_jobs` does two things in sequence:
+
+1. `scheduler_set_waiting` — DB write that transitions the row to WAITING
+   and stamps the dag/env/config content. If this succeeds, the
+   periodic managed-job-status-refresh-daemon will see the WAITING row
+   and spawn a controller within ~one event cycle.
+2. `maybe_start_controllers(from_scheduler=True)` — eager optimization
+   that spawns controllers in the same process so the new job picks up
+   quickly instead of waiting for the next recovery pass.
+
+A failure in step 2 is recoverable: the next recovery pass will retry
+the spawn for any WAITING+no-controller_pid row. Therefore step 2
+failures must NOT propagate up to the caller (`_consolidated_launch`),
+which now uses the script's exit code to decide whether the user's
+`jobs.launch` request is SUCCEEDED or FAILED. Letting the step-2 error
+propagate would tell the user the launch failed while the job goes on
+to run anyway — leading to user-visible "FAILED request, job runs"
+inversion and prompting a retry that double-launches.
+"""
+
+from unittest import mock
+
+import pytest
+
+from sky.jobs import scheduler
+
+
+@pytest.fixture
+def _mock_submit_jobs_io(tmp_path, monkeypatch):
+    """Stub out filesystem reads + DB writes that `submit_jobs` does
+    before reaching `maybe_start_controllers`."""
+    dag_yaml = tmp_path / 'dag.yaml'
+    user_yaml = tmp_path / 'user.yaml'
+    env_file = tmp_path / 'env'
+    for p in (dag_yaml, user_yaml, env_file):
+        p.write_text(f'# stub content for {p.name}')
+
+    # No controller process running for any job — submit_jobs's
+    # pre-filter at the top should be a no-op.
+    monkeypatch.setattr(
+        'sky.jobs.state.get_job_controller_process',
+        lambda _job_id: None,
+    )
+
+    scheduler_set_waiting_mock = mock.MagicMock()
+    monkeypatch.setattr(
+        'sky.jobs.state.scheduler_set_waiting',
+        scheduler_set_waiting_mock,
+    )
+
+    return {
+        'dag_yaml': str(dag_yaml),
+        'user_yaml': str(user_yaml),
+        'env_file': str(env_file),
+        'scheduler_set_waiting': scheduler_set_waiting_mock,
+    }
+
+
+def test_maybe_start_controllers_failure_is_swallowed(monkeypatch,
+                                                     _mock_submit_jobs_io):
+    """If `maybe_start_controllers` raises AFTER `scheduler_set_waiting`
+    has committed, `submit_jobs` must NOT propagate the exception. The
+    row is already WAITING in the DB and the periodic recovery daemon
+    will retry the controller spawn."""
+    monkeypatch.setattr(
+        'sky.jobs.scheduler.maybe_start_controllers',
+        mock.MagicMock(side_effect=RuntimeError('simulated spawn failure')),
+    )
+
+    # Must not raise. The script will exit 0, the user's `jobs.launch`
+    # request will be marked SUCCEEDED, and the job will run via the
+    # recovery-driven retry.
+    scheduler.submit_jobs(
+        job_ids=[42],
+        dag_yaml_path=_mock_submit_jobs_io['dag_yaml'],
+        original_user_yaml_path=_mock_submit_jobs_io['user_yaml'],
+        env_file_path=_mock_submit_jobs_io['env_file'],
+        priority=500,
+        priority_class=None,
+    )
+
+    # scheduler_set_waiting was called exactly once (with the job_id).
+    _mock_submit_jobs_io['scheduler_set_waiting'].assert_called_once()
+    call_job_ids = _mock_submit_jobs_io['scheduler_set_waiting'].call_args[0][0]
+    assert call_job_ids == [42]
+
+
+def test_maybe_start_controllers_success_returns_normally(
+        monkeypatch, _mock_submit_jobs_io):
+    """Happy path: both calls succeed, submit_jobs returns without raising."""
+    msc_mock = mock.MagicMock()
+    monkeypatch.setattr('sky.jobs.scheduler.maybe_start_controllers', msc_mock)
+
+    scheduler.submit_jobs(
+        job_ids=[1],
+        dag_yaml_path=_mock_submit_jobs_io['dag_yaml'],
+        original_user_yaml_path=_mock_submit_jobs_io['user_yaml'],
+        env_file_path=_mock_submit_jobs_io['env_file'],
+        priority=500,
+        priority_class=None,
+    )
+
+    msc_mock.assert_called_once_with(from_scheduler=True)
+    _mock_submit_jobs_io['scheduler_set_waiting'].assert_called_once()
+
+
+def test_scheduler_set_waiting_failure_does_propagate(monkeypatch,
+                                                     _mock_submit_jobs_io):
+    """`scheduler_set_waiting` failures *must* propagate. If the DB
+    write fails, the row was never transitioned to WAITING — recovery
+    cannot resurrect this job, so the user must be told the launch
+    failed."""
+    _mock_submit_jobs_io['scheduler_set_waiting'].side_effect = RuntimeError(
+        'simulated DB write failure')
+
+    # maybe_start_controllers shouldn't even be reached.
+    msc_mock = mock.MagicMock()
+    monkeypatch.setattr('sky.jobs.scheduler.maybe_start_controllers', msc_mock)
+
+    with pytest.raises(RuntimeError, match='simulated DB write failure'):
+        scheduler.submit_jobs(
+            job_ids=[1],
+            dag_yaml_path=_mock_submit_jobs_io['dag_yaml'],
+            original_user_yaml_path=_mock_submit_jobs_io['user_yaml'],
+            env_file_path=_mock_submit_jobs_io['env_file'],
+            priority=500,
+            priority_class=None,
+        )
+
+    msc_mock.assert_not_called()


### PR DESCRIPTION
## Summary

Two related fixes to bring the managed-job consolidation-mode launch path in line with the contract:

> If a `jobs.launch` request returns SUCCEEDED, the managed job will eventually run.

Today, two paths violate this contract in consolidation mode. This PR fixes both.

### Fix 1: Propagate the controller-subprocess exit code (`_consolidated_launch`)

`_consolidated_launch` in `sky/jobs/server/core.py` was discarding the return code of `backend.run_on_head`. When the controller script (`python -m sky.jobs.scheduler ...`) exited non-zero — e.g. the script's interpreter is missing a dependency, a database write fails, or the process is OOM-killed mid-flight — the failure was invisible to the API server. The user's request was marked SUCCEEDED while the managed job row remained `(status=PENDING, schedule_state=INACTIVE)` forever; both `ha_recovery_for_consolidation_mode` and `update_managed_jobs_statuses` skip INACTIVE rows by design.

```python
# Before
backend.run_on_head(local_handle, run_script, log_path=log_path)
# returncode dropped — request reported SUCCEEDED even on subprocess failure
```
```python
# After
returncode = backend.run_on_head(local_handle, run_script, log_path=log_path)
if returncode != 0:
    raise exceptions.CommandError(...)
```

### Fix 2: Don't fail the request when the eager `maybe_start_controllers` raises (`scheduler.submit_jobs`)

`scheduler.submit_jobs` does:
1. `scheduler_set_waiting` — commits `schedule_state=WAITING` + yaml/env/config content. Once committed, the periodic `managed-job-status-refresh-daemon` will find the row and spawn a controller within one event cycle.
2. `maybe_start_controllers(from_scheduler=True)` — eager optimization to spawn the controller in-process for low latency.

If step 2 raises after step 1 commits, Fix 1 above would mark the user's request as FAILED — but the row is already WAITING and recovery WILL spawn a controller. So the user sees FAILED, retries, and ends up with a duplicate of their own job.

Swallow exceptions from `maybe_start_controllers` after `scheduler_set_waiting` has committed. Errors are logged at ERROR with full traceback so any genuine bug stays loud; the script's exit code now tracks whether the job was queued (= the DB commit landed), not whether the eager spawn succeeded.

## Why only consolidation mode

Non-consolidation paths already propagate subprocess failures:
- gRPC `queue_job` (`sky/skylet/services.py:185`) aborts INTERNAL on any controller-side error.
- SSH-fallback (`sky/backends/cloud_vm_ray_backend.py:4244`) uses `subprocess_utils.handle_returncode`.

Only `_consolidated_launch` swallowed the returncode. Both fixes are scoped to the consolidation-mode launch path.

## Known remaining gap (out of scope)

If the API server worker process **dies** before reaching the returncode check (e.g. k8s SIGKILL during rolling update, OOM, or any abrupt termination), neither Fix 1 nor Fix 2 helps:

- The worker never gets to raise or to call `set_request_succeeded`.
- Independently: if the script subprocess had already committed `scheduler_set_waiting` before being killed, recovery will spawn a controller for the orphaned WAITING row → job runs.
- The graceful-shutdown path will mark the request CANCELLED (with `should_retry=True`); a less-graceful exit leaves it as RUNNING and a fail-orphan path will eventually transition it to a terminal state.
- Net: request not SUCCEEDED, but the job runs anyway. If the user retries, they get a duplicate.

Closing this remaining gap requires linking the request to the managed-jobs it created and cancel-cascading on request termination (a `request_id` column on `job_info` plus a hook in `interrupt_request_for_retry`). That's a deeper change with broader implications; tracked as a follow-up.

## Test plan

### Unit

- `tests/unit_tests/test_sky/jobs/test_consolidated_launch_returncode.py` covers Fix 1:
  - non-zero returncode raises `CommandError` with the cancel hint
  - returncode 0 returns `(job_ids, handle)` unchanged
  - multi-job-id cancel hint uses the compact range form (`sky jobs cancel 10-12`)
- `tests/unit_tests/test_sky/jobs/test_scheduler_submit_jobs.py` covers Fix 2:
  - `maybe_start_controllers` raising is swallowed; `submit_jobs` returns normally
  - happy path: both calls succeed
  - `scheduler_set_waiting` failures still propagate (we mustn't mark SUCCEEDED if the DB commit didn't land)

### End-to-end (consolidation mode, local Kubernetes)

| Scenario | Before | After |
|---|---|---|
| Happy path: normal launch | SUCCEEDED, job runs | SUCCEEDED, job runs |
| Subprocess fails (`exit 99` injected into controller script `run`) | request marked **SUCCEEDED**; orphan PENDING+INACTIVE row in queue | request marked **FAILED** with `sky jobs cancel <id>` hint; orphan exists but is flagged |
| `maybe_start_controllers` raises (injected `RuntimeError` in `submit_jobs`) | (would-be) request marked **FAILED**; controller spawned by next recovery cycle | request marked **SUCCEEDED**; error logged at ERROR; controller spawned by recovery; job runs without double-launch |
| API server killed mid-script | request returns nothing useful; orphan PENDING+INACTIVE row stays forever | request status not SUCCEEDED (cleared on restart or marked terminal by HA); orphan remains (out of scope per contract) |

Reproducer for the silent-failure case:

```bash
# Enable consolidation mode
echo 'jobs:
  controller:
    consolidation_mode: true' > ~/.sky/config.yaml
sky api stop && sky api start --deploy

# Force the controller script to fail by patching the template:
# sky/templates/jobs-controller.yaml.j2, in the `run:` block, add at the top:
#   echo "injected failure" >&2; exit 99

# Restart API server, then launch a managed job
sky jobs launch some-job.yaml -n test -y --async
# Without this PR: request status SUCCEEDED, job stuck PENDING forever
# With this PR:    request status FAILED with a clear error
```

### CI

- `format.sh` clean (yapf, isort, mypy, pylint 10.00/10)
- Local pytest on `tests/unit_tests/test_sky/jobs/`: 223 passed (after deselecting one pre-existing flake unrelated to this change)