### PR TITLE
[GPU Metrics] Raise per-context timeout to 20s for large GPU fleets

### DIFF
--- a/examples/metrics/prometheus-values.yaml
+++ b/examples/metrics/prometheus-values.yaml
@@ -4,6 +4,12 @@ server:
     size: 50Gi
   retention: "1000d"
   retentionSize: "43GB"
+  # scrape_timeout must be longer than the SkyPilot API server's
+  # _PER_CONTEXT_TIMEOUT_SECONDS (20s in sky/server/metrics.py),
+  # otherwise this Prometheus will time out scraping /gpu-metrics on
+  # large clusters and mark the api-server target as down.
+  global:
+    scrape_timeout: 30s
 kube-state-metrics:
   enabled: true
   metricLabelsAllowlist:

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -209,12 +209,18 @@ def metrics() -> fastapi.Response:
 
 
 # Per-context timeout for metrics collection. Must be shorter than the
-# Prometheus scrape_timeout (default 10s in our Helm chart) so that the
-# endpoint responds promptly even when one remote cluster is unreachable.
-# Without this, a single hanging port-forward (e.g. 30s httpx timeout)
-# blocks the entire /gpu-metrics response, causing Prometheus to mark the
-# scrape target as down.
-_PER_CONTEXT_TIMEOUT_SECONDS = 8
+# Prometheus scrape_timeout configured on the upstream Prometheus that
+# scrapes this endpoint so the response arrives before that scrape times
+# out and marks the target down. Operators federating from a Prometheus
+# with a non-default scrape_timeout should adjust both together; see
+# docs/source/reference/api-server/examples/api-server-gpu-metrics-setup.rst.
+#
+# Without a per-context timeout, a single hanging port-forward (e.g. 30s
+# httpx timeout) would block the entire /gpu-metrics response.
+#
+# 20s accommodates large compute clusters where federate latency plus
+# port-forward setup can run 5-10s warm and longer cold.
+_PER_CONTEXT_TIMEOUT_SECONDS = 20
 
 _CREDENTIAL_MANAGER_KUBECONFIG_PATH = (
     '/var/skypilot/credentials/kubeconfig/kubeconfig')


### PR DESCRIPTION
## Summary

The `/gpu-metrics` endpoint port-forwards to `skypilot-prometheus-server` in each remote Kubernetes context and runs a `/federate` query. On large clusters, the federate response can exceed 100k samples and the end-to-end query — including port-forward setup — takes 5–10s warm, longer cold. The previous 8s per-context budget intermittently drops those clusters with an empty `asyncio.TimeoutError` and they disappear from `/gpu-metrics` output.

## Changes

- `sky/server/metrics.py`: `_PER_CONTEXT_TIMEOUT_SECONDS` 8 → 20.
- `examples/metrics/prometheus-values.yaml`: add `server.global.scrape_timeout: 30s` so the upstream Prometheus that scrapes `/gpu-metrics` doesn't itself time out before the endpoint can answer.
- Comment update: clarifies that the constraint is against whatever `scrape_timeout` the operator's Prometheus uses, not against a hardcoded 10s. The two values need to be kept in sync, and the example values file now matches.

## Why not smaller?

Federate latency scales with sample count, and clusters with hundreds of GPUs (each emitting many DCGM_FI_DEV_* series) naturally produce 50–150k samples. 20s gives meaningful headroom over the observed worst case while still bounding the response on a truly stuck context.

## Test plan

- [ ] Existing /gpu-metrics tests pass
- [ ] Verify on a cluster with high federate latency that all contexts report