### PR TITLE
[Dashboard] Encode managed jobs tab and status filter, workspaces search, and infra workspace selector in URL

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -4,6 +4,7 @@
  * Documentation: https://v0.dev/docs#integrating-generated-code-into-your-nextjs-app
  */
 import React, { useState, useEffect, useCallback } from 'react';
+import { useUrlState } from '@/hooks/useUrlState';
 import { CircularProgress } from '@mui/material';
 import { Layout } from '@/components/elements/layout';
 import {
@@ -2020,7 +2021,11 @@ export function GPUs() {
 
   // Workspace-aware infrastructure state
   const [workspaceInfrastructure, setWorkspaceInfrastructure] = useState({});
-  const [selectedWorkspace, setSelectedWorkspace] = useState('all');
+  // `?workspace=` makes the selector shareable. Default 'all' stays out of URL.
+  const [selectedWorkspace, setSelectedWorkspace] = useUrlState(
+    'workspace',
+    'all'
+  );
   const [availableWorkspaces, setAvailableWorkspaces] = useState([]);
 
   // SSH Node Pool state

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -72,6 +72,7 @@ import {
   buildFilterUrl,
   evaluateCondition,
 } from '@/components/shared/FilterSystem';
+import { useUrlState, parseEnum, parseStringList } from '@/hooks/useUrlState';
 import { trackJobAction, trackFilterUsed } from '@/lib/analytics';
 
 // Define status groups for active and finished jobs
@@ -462,13 +463,21 @@ export function ManagedJobsTable({
   const [expandedRowId, setExpandedRowId] = useState(null);
   const expandedRowRef = useRef(null);
   const [expandedJobGroups, setExpandedJobGroups] = useState(new Set());
-  const [selectedStatuses, setSelectedStatuses] = useState([]);
+  const [selectedStatuses, setSelectedStatuses] = useUrlState('status', [], {
+    parse: parseStringList([...statusGroups.active, ...statusGroups.finished]),
+  });
   const [statusCounts, setStatusCounts] = useState({});
   const [controllerStopped, setControllerStopped] = useState(false);
   const [controllerLaunching, setControllerLaunching] = useState(false);
   const [isRestarting, setIsRestarting] = useState(false);
-  const [activeTab, setActiveTab] = useState('all');
-  const [showAllMode, setShowAllMode] = useState(true);
+  const [activeTab, setActiveTab] = useUrlState('jobTab', 'all', {
+    parse: parseEnum(['all', 'active', 'finished'], 'all'),
+  });
+  // "Show all" means no specific status pills are selected and the user is
+  // viewing every job in the current tab. Derived from selectedStatuses so
+  // that URL-hydrated selections stay consistent with the highlight state
+  // without an extra reconciling effect.
+  const showAllMode = selectedStatuses.length === 0;
   const [confirmationModal, setConfirmationModal] = useState({
     isOpen: false,
     title: '',
@@ -804,12 +813,6 @@ export function ManagedJobsTable({
     setCurrentPage(1);
   }, [sortConfig]);
 
-  // Reset status filter when activeTab changes
-  useEffect(() => {
-    setSelectedStatuses([]);
-    setShowAllMode(true); // Default to show all mode when changing tabs
-  }, [activeTab]);
-
   // Populate valueList for filter dropdown
   useEffect(() => {
     if (!setValueList) {
@@ -1075,26 +1078,12 @@ export function ManagedJobsTable({
 
   // Handle status selection
   const handleStatusClick = (status) => {
-    // Toggle the clicked status without affecting others
+    // Toggle the clicked status without affecting others. showAllMode is
+    // derived from selectedStatuses.length so no separate update is needed.
     if (selectedStatuses.includes(status)) {
-      // If the status is already selected, unselect it
-      const newSelectedStatuses = selectedStatuses.filter((s) => s !== status);
-
-      if (newSelectedStatuses.length === 0) {
-        // When deselecting the last selected status, go back to "show all" mode
-        // for the current active tab (active/finished)
-        setShowAllMode(true);
-        setSelectedStatuses([]);
-      } else {
-        setSelectedStatuses(newSelectedStatuses);
-        // We're not in "show all" mode if there are specific statuses selected
-        setShowAllMode(false);
-      }
+      setSelectedStatuses(selectedStatuses.filter((s) => s !== status));
     } else {
-      // Add the clicked status to the selected statuses
       setSelectedStatuses([...selectedStatuses, status]);
-      // We're not in "show all" mode if there are specific statuses selected
-      setShowAllMode(false);
     }
 
     // Reset to first page when changing status filters
@@ -1751,12 +1740,11 @@ export function ManagedJobsTable({
                   <span className="text-gray-500">(</span>
                   <button
                     onClick={() => {
-                      // When showing all jobs, clear all selected statuses
-                      // Use React.startTransition to batch state updates
+                      // When showing all jobs, clear all selected statuses.
+                      // showAllMode is derived from selectedStatuses.length.
                       React.startTransition(() => {
                         setActiveTab('all');
                         setSelectedStatuses([]);
-                        setShowAllMode(true);
                         setCurrentPage(1);
                       });
                     }}
@@ -1771,12 +1759,11 @@ export function ManagedJobsTable({
                   <span className="text-gray-500 mx-1">|</span>
                   <button
                     onClick={() => {
-                      // When showing all active jobs, clear all selected statuses
-                      // Use React.startTransition to batch state updates
+                      // When showing all active jobs, clear all selected
+                      // statuses. showAllMode is derived.
                       React.startTransition(() => {
                         setActiveTab('active');
                         setSelectedStatuses([]);
-                        setShowAllMode(true);
                         setCurrentPage(1);
                       });
                     }}
@@ -1791,12 +1778,11 @@ export function ManagedJobsTable({
                   <span className="text-gray-500 mx-1">|</span>
                   <button
                     onClick={() => {
-                      // When showing all finished jobs, clear all selected statuses
-                      // Use React.startTransition to batch state updates
+                      // When showing all finished jobs, clear all selected
+                      // statuses. showAllMode is derived.
                       React.startTransition(() => {
                         setActiveTab('finished');
                         setSelectedStatuses([]);
-                        setShowAllMode(true);
                         setCurrentPage(1);
                       });
                     }}

--- a/sky/dashboard/src/components/workspaces.jsx
+++ b/sky/dashboard/src/components/workspaces.jsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/router';
+import { useUrlState } from '@/hooks/useUrlState';
 import {
   getWorkspaces,
   getEnabledCloudsBatch,
@@ -268,8 +269,8 @@ export function Workspaces() {
     direction: 'asc',
   });
 
-  // Search state
-  const [searchQuery, setSearchQuery] = useState('');
+  // Search state — synced to `?q=` so a filtered view can be shared.
+  const [searchQuery, setSearchQuery] = useUrlState('q', '');
 
   // Modal states
   const [isAllWorkspacesModalOpen, setIsAllWorkspacesModalOpen] =

--- a/sky/dashboard/src/hooks/useUrlState.js
+++ b/sky/dashboard/src/hooks/useUrlState.js
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/router';
+
+/**
+ * Bind a piece of React state to a single URL query-string key on the
+ * current top-level page.
+ *
+ * Behaviour:
+ *   - When the URL contains the key on mount, the initial state comes from
+ *     the URL via `parse`.
+ *   - When the state changes to a non-default value, the URL is updated via
+ *     `router.replace(..., { shallow: true })` so dependent data fetches
+ *     and the browser back-stack are not perturbed.
+ *   - When the state matches the default, the key is removed from the URL
+ *     so unset state produces clean URLs (e.g. `/jobs` rather than
+ *     `/jobs?tab=all&page=1`).
+ *
+ * The URL writer reads from `window.location.search` rather than
+ * `router.query` so that multiple `useUrlState` setters fired in the same
+ * React tick compose correctly. `history.replaceState` — which `router.replace`
+ * calls under the hood — updates `window.location.search` synchronously,
+ * whereas `router.query` only updates on the next render. Reading from
+ * `window.location.search` therefore avoids the lost-update race when, for
+ * example, a tab button clears both `?jobTab=` and `?status=` at once.
+ *
+ * Intended for use on top-level pages whose `router.pathname` has no
+ * dynamic segments (e.g. `/jobs`, `/clusters`). Routes like `/jobs/[job]`
+ * still work for query-string writes but should be wired up case-by-case.
+ *
+ * @param {string} paramName             query-string key
+ * @param {*}      defaultValue          value that maps to "no param in URL"
+ * @param {object} [options]
+ * @param {(string|string[])=>*} [options.parse]
+ *   Convert the raw query value to the in-state representation.
+ * @param {(*)=>string|string[]|null} [options.serialize]
+ *   Convert state to the URL value. Returning `null` removes the key.
+ * @param {(*,*)=>boolean} [options.isDefault]
+ *   Equality check against `defaultValue`. Defaults to a shallow check
+ *   adequate for primitives and arrays of primitives.
+ *
+ * @returns {[*, (next:*)=>void]}
+ */
+export function useUrlState(paramName, defaultValue, options = {}) {
+  const {
+    parse = (raw) => raw,
+    serialize = (value) =>
+      Array.isArray(value) ? value.map(String) : String(value),
+    isDefault = defaultEquals,
+  } = options;
+
+  const router = useRouter();
+  const [value, setValue] = useState(defaultValue);
+  const hydratedRef = useRef(false);
+
+  // Hydrate once when the router becomes ready. Skipping further runs lets
+  // local state changes win over URL changes the user did not initiate
+  // (e.g. our own router.replace writes).
+  useEffect(() => {
+    if (!router.isReady || hydratedRef.current) return;
+    hydratedRef.current = true;
+    const raw = router.query[paramName];
+    if (raw === undefined) {
+      setValue(defaultValue);
+      return;
+    }
+    try {
+      setValue(parse(raw));
+    } catch {
+      setValue(defaultValue);
+    }
+    // parse / defaultValue intentionally excluded — only re-hydrate when the
+    // router first becomes ready, not when the consumer re-creates a parse fn.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.isReady, paramName]);
+
+  const setAndSync = useCallback(
+    (next) => {
+      setValue((prev) => {
+        const resolved = typeof next === 'function' ? next(prev) : next;
+        if (typeof window === 'undefined' || !router.isReady) return resolved;
+        // Read existing query from window.location.search rather than
+        // router.query so multiple setters in the same tick compose without
+        // lost-updates (router.query only catches up on the next render).
+        const params = new URLSearchParams(window.location.search);
+        params.delete(paramName);
+        if (!isDefault(resolved, defaultValue)) {
+          const serialized = serialize(resolved);
+          if (serialized !== null && serialized !== undefined) {
+            if (Array.isArray(serialized)) {
+              for (const v of serialized) params.append(paramName, v);
+            } else {
+              params.set(paramName, serialized);
+            }
+          }
+        }
+        // Build an object-form query so next/router applies basePath
+        // (e.g. "/dashboard") correctly. Passing a string URL would cause
+        // router.replace to prepend basePath a second time.
+        const queryObj = {};
+        for (const key of new Set([...params.keys()])) {
+          const vals = params.getAll(key);
+          queryObj[key] = vals.length > 1 ? vals : vals[0];
+        }
+        router.replace(
+          { pathname: router.pathname, query: queryObj },
+          undefined,
+          { shallow: true }
+        );
+        return resolved;
+      });
+    },
+    [router, paramName, defaultValue, serialize, isDefault]
+  );
+
+  return [value, setAndSync];
+}
+
+function defaultEquals(a, b) {
+  if (a === b) return true;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+    return true;
+  }
+  return false;
+}
+
+// ── Common parsers ─────────────────────────────────────────────────────────
+
+/** Parse a query value against an allowed set; falls back to `defaultValue`. */
+export function parseEnum(allowed, defaultValue) {
+  return (raw) => {
+    if (Array.isArray(raw)) raw = raw[0];
+    return allowed.includes(raw) ? raw : defaultValue;
+  };
+}
+
+/**
+ * Parse a multi-valued query key into an array of strings, optionally
+ * filtered against an allowlist. Single-value keys arrive as a string;
+ * repeated keys (`?status=A&status=B`) arrive as an array from next/router.
+ */
+export function parseStringList(allowed = null) {
+  return (raw) => {
+    const list = Array.isArray(raw) ? raw : [raw];
+    if (!allowed) return list.filter(Boolean);
+    return list.filter((v) => allowed.includes(v));
+  };
+}

--- a/sky/dashboard/src/hooks/useUrlState.test.js
+++ b/sky/dashboard/src/hooks/useUrlState.test.js
@@ -1,0 +1,177 @@
+/**
+ * Tests for useUrlState — hydration, default-omission, and the URL writer's
+ * compose-from-window.location behavior (which is the property that lets
+ * multiple setters fire in the same tick without lost-updates).
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { useRouter } from 'next/router';
+
+import { parseEnum, parseStringList, useUrlState } from './useUrlState';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+function mockRouter({ search = '', isReady = true } = {}) {
+  const setLocation = (s) => {
+    const u = new URL('http://localhost/page' + s);
+    delete window.location;
+    window.location = u;
+  };
+  setLocation(search);
+  // Build initial query from the search string so the hydration effect sees
+  // the same params the writer reads from window.location.search.
+  const queryFromSearch = () => {
+    const params = new URLSearchParams(window.location.search);
+    const q = {};
+    for (const key of new Set([...params.keys()])) {
+      const vals = params.getAll(key);
+      q[key] = vals.length > 1 ? vals : vals[0];
+    }
+    return q;
+  };
+  const replace = jest.fn((url) => {
+    // Mirror next/router: history.replaceState updates window.location
+    // synchronously; router.query catches up on the next render. Accept
+    // both string and { pathname, query } forms.
+    if (typeof url === 'string') {
+      const u = new URL(url, 'http://localhost/');
+      setLocation(u.search);
+    } else {
+      const params = new URLSearchParams();
+      for (const [k, v] of Object.entries(url.query || {})) {
+        if (Array.isArray(v)) v.forEach((x) => params.append(k, x));
+        else if (v !== undefined && v !== null) params.set(k, String(v));
+      }
+      const s = params.toString();
+      setLocation(s ? `?${s}` : '');
+    }
+    return Promise.resolve(true);
+  });
+  return {
+    pathname: '/page',
+    query: queryFromSearch(),
+    isReady,
+    replace,
+  };
+}
+
+describe('useUrlState', () => {
+  beforeEach(() => {
+    delete window.location;
+    window.location = new URL('http://localhost/page');
+  });
+
+  it('uses the default value when no URL param is set', () => {
+    useRouter.mockReturnValue(mockRouter());
+    const { result } = renderHook(() => useUrlState('jobTab', 'all'));
+    expect(result.current[0]).toBe('all');
+  });
+
+  it('hydrates from URL on mount', () => {
+    useRouter.mockReturnValue(mockRouter({ search: '?jobTab=finished' }));
+    const { result } = renderHook(() =>
+      useUrlState('jobTab', 'all', {
+        parse: parseEnum(['all', 'active', 'finished'], 'all'),
+      })
+    );
+    expect(result.current[0]).toBe('finished');
+  });
+
+  it('writes non-default state to the URL via router.replace', () => {
+    const router = mockRouter();
+    useRouter.mockReturnValue(router);
+    const { result } = renderHook(() => useUrlState('jobTab', 'all'));
+    act(() => result.current[1]('finished'));
+    expect(router.replace).toHaveBeenCalledWith(
+      { pathname: '/page', query: { jobTab: 'finished' } },
+      undefined,
+      { shallow: true }
+    );
+  });
+
+  it('removes the key from the URL when state matches the default', () => {
+    const router = mockRouter({ search: '?jobTab=finished' });
+    useRouter.mockReturnValue(router);
+    const { result } = renderHook(() => useUrlState('jobTab', 'all'));
+    act(() => result.current[1]('all'));
+    expect(router.replace).toHaveBeenCalledWith(
+      { pathname: '/page', query: {} },
+      undefined,
+      { shallow: true }
+    );
+  });
+
+  it('preserves unrelated query params when writing', () => {
+    const router = mockRouter({ search: '?other=keep&jobTab=all' });
+    useRouter.mockReturnValue(router);
+    const { result } = renderHook(() => useUrlState('jobTab', 'all'));
+    act(() => result.current[1]('finished'));
+    const writtenQuery = router.replace.mock.calls[0][0].query;
+    expect(writtenQuery.other).toBe('keep');
+    expect(writtenQuery.jobTab).toBe('finished');
+  });
+
+  it('serializes an array as repeated keys', () => {
+    const router = mockRouter();
+    useRouter.mockReturnValue(router);
+    const { result } = renderHook(() =>
+      useUrlState('status', [], {
+        parse: parseStringList(),
+      })
+    );
+    act(() => result.current[1](['FAILED', 'PENDING']));
+    const writtenQuery = router.replace.mock.calls[0][0].query;
+    expect(writtenQuery.status).toEqual(['FAILED', 'PENDING']);
+  });
+
+  it('hydrates a repeated-key URL into an array', () => {
+    useRouter.mockReturnValue(
+      mockRouter({ search: '?status=FAILED&status=PENDING' })
+    );
+    const { result } = renderHook(() =>
+      useUrlState('status', [], { parse: parseStringList() })
+    );
+    expect(result.current[0]).toEqual(['FAILED', 'PENDING']);
+  });
+
+  it('lets two setters in the same tick compose via window.location', () => {
+    // The race this guards against: setActiveTab + setSelectedStatuses fired
+    // together must not let the second writer clobber the first.
+    const router = mockRouter({ search: '?jobTab=finished&status=FAILED' });
+    useRouter.mockReturnValue(router);
+    const tabHook = renderHook(() => useUrlState('jobTab', 'all'));
+    const statusHook = renderHook(() =>
+      useUrlState('status', [], { parse: parseStringList() })
+    );
+    act(() => {
+      tabHook.result.current[1]('all'); // resets to default → drops jobTab
+      statusHook.result.current[1]([]); // resets to default → drops status
+    });
+    const finalQuery = router.replace.mock.calls.slice(-1)[0][0].query;
+    expect(finalQuery).toEqual({});
+  });
+
+  it('parseEnum falls back to the default when the value is not allowed', () => {
+    useRouter.mockReturnValue(mockRouter({ search: '?jobTab=bogus' }));
+    const { result } = renderHook(() =>
+      useUrlState('jobTab', 'all', {
+        parse: parseEnum(['all', 'active', 'finished'], 'all'),
+      })
+    );
+    expect(result.current[0]).toBe('all');
+  });
+
+  it('parseStringList drops values outside the allowlist', () => {
+    useRouter.mockReturnValue(
+      mockRouter({ search: '?status=FAILED&status=bogus' })
+    );
+    const { result } = renderHook(() =>
+      useUrlState('status', [], {
+        parse: parseStringList(['FAILED', 'PENDING']),
+      })
+    );
+    expect(result.current[0]).toEqual(['FAILED']);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a small `useUrlState` hook that binds a piece of React state to a single URL query-string key, hydrating on mount and writing back via `router.replace(..., { shallow: true })` so dependent data fetches and the browser back-stack are not perturbed.
- Wire it into the Managed Jobs page (tab + status pill selection), Workspaces page (search input), and Infra page (workspace selector).
- Default values are omitted from the URL so unset state produces clean URLs.

## Motivation

Today the dashboard's filter / tab / search / selector state lives only in client-side React state on several pages. The URL doesn't reflect the current view, so users can't:
- Share a link to a specific filtered view (e.g. "all FAILED managed jobs in workspace ``team-a``" in Slack or a doc)
- Bookmark a filtered view
- Reload the page and keep the same view applied

The Clusters and Jobs pages already encode filter-chip state (``?property=…&value=…``) via the shared FilterSystem, and the Volumes / Users pages encode the current tab. This PR closes the remaining gaps for the most common shareable views.

## Pages and new query keys

| Page | Added URL params |
|---|---|
| Managed Jobs | `jobTab` (`all`/`active`/`finished`), `status` (multi) |
| Workspaces | `q` (search input) |
| Infra | `workspace` (selector) |

Existing query-string conventions on every page keep working unchanged — the new keys are purely additive.

## Implementation notes

**Why read the query string from ``window.location.search`` in the writer**, instead of ``router.query``: ``history.replaceState`` — which ``router.replace`` calls under the hood — updates ``window.location.search`` synchronously, but ``router.query`` only catches up on the next render. Two setters fired in the same React tick (for example, the "show all jobs" button that clears both ``jobTab`` and ``status``) would otherwise each read the same stale ``router.query`` and the second writer would clobber the first. Reading from ``window.location.search`` lets them compose correctly.

**Why an object-form ``router.replace({ pathname, query })``**, instead of a string URL: Next.js applies ``basePath`` (``/dashboard``) to object-form replacements but re-prepends it to string URLs, producing ``/dashboard/dashboard/jobs``. The object form avoids the double prefix.

**Why ``showAllMode`` on the Managed Jobs page becomes derived**: it equals ``selectedStatuses.length === 0`` at every call site already (the status pill click handler keeps them coupled), so deriving it removes the need for a reconciling effect on URL hydration — without that change, the previous ``useEffect(() => { setSelectedStatuses([]); setShowAllMode(true); }, [activeTab])`` would wipe URL-loaded statuses on mount because ``activeTab`` itself hydrates from the URL. The three tab buttons already perform their own explicit clearing of ``selectedStatuses``, so the effect was redundant for normal interactions and only fired destructively on hydration.

## Test plan

**Unit tests** (``src/hooks/useUrlState.test.js`` — 10 cases):
- Default value when no URL param is set
- Hydration from URL on mount
- Writing non-default state via ``router.replace`` (object form)
- Removing the key when state matches the default
- Preserving unrelated query params
- Array serialization as repeated keys
- Repeated-key URL → array hydration
- Two setters in the same tick composing correctly via ``window.location``
- ``parseEnum`` and ``parseStringList`` falling back / filtering

```bash
npm --prefix sky/dashboard test -- --testPathPattern=useUrlState
# Test Suites: 1 passed, Tests: 10 passed
```

**Build**: ``npm --prefix sky/dashboard run build`` succeeds with no warnings.

**Manual (``sky api start`` + playwright)**:
- ``/workspaces?q=def`` loads with the search input pre-populated to ``def``; clearing the input via the X button drops ``?q=`` from the URL.
- ``/infra?workspace=default`` loads with the workspace selector showing ``default``.
- ``/jobs?jobTab=finished&status=FAILED&status=CANCELLED`` preserves its URL on reload (status pills only render visually when there are jobs, but the URL state survives the round trip).
- Existing ``/clusters?property=status&operator=:&value=up`` still renders the ``Status: up`` filter chip — no regression on the pre-existing FilterSystem.

## Files

- New: ``sky/dashboard/src/hooks/useUrlState.js`` (~120 LOC) — the hook plus ``parseEnum`` and ``parseStringList`` helpers.
- New: ``sky/dashboard/src/hooks/useUrlState.test.js`` — 10 unit tests.
- Modified: ``sky/dashboard/src/components/jobs.jsx`` — replace two ``useState`` calls with ``useUrlState``; derive ``showAllMode``; remove redundant reset effect and three redundant ``setShowAllMode`` calls.
- Modified: ``sky/dashboard/src/components/workspaces.jsx`` — search input bound to ``?q=``.
- Modified: ``sky/dashboard/src/components/infra.jsx`` — workspace selector bound to ``?workspace=``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9652" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->