### PR TITLE
[Dashboard] Quieter upgrade banner: ignore aborts, hidden tabs, single flaps

### DIFF
--- a/sky/dashboard/src/utils/apiInterceptor.js
+++ b/sky/dashboard/src/utils/apiInterceptor.js
@@ -37,6 +37,27 @@ function isStaticAssetRequest(input) {
   return staticPatterns.some((pattern) => url.includes(pattern));
 }
 
+// A single network hiccup shouldn't flip the banner. Real upgrades
+// produce a stream of failures, while mobile browsers occasionally
+// drop one in-flight request when the tab backgrounds or the user
+// switches apps. We require two consecutive thrown fetches within
+// this window before reporting an upgrade.
+const FLAP_WINDOW_MS = 4000;
+let _lastFetchErrorAt = 0;
+
+// AbortController.abort() and React unmount-driven cancellation both
+// throw a DOMException with name 'AbortError'. They never indicate
+// a server problem.
+function isAbortError(error) {
+  return (
+    error &&
+    (error.name === 'AbortError' ||
+      (typeof DOMException !== 'undefined' &&
+        error instanceof DOMException &&
+        error.code === DOMException.ABORT_ERR))
+  );
+}
+
 /**
  * Wraps fetch to intercept 503 responses and report upgrade status
  */
@@ -48,12 +69,27 @@ export function createUpgradeAwareFetch(reportUpgrade, clearUpgrade) {
     try {
       response = await originalFetch(input, init);
     } catch (error) {
-      // Network errors (e.g. connection refused) on non-static requests
-      // likely indicate the server is down during an upgrade, especially
-      // with the default Recreate deployment strategy where there is a gap
-      // between the old pod dying and the new pod starting.
+      // Filter out benign throws before flipping the banner:
+      //   - AbortError: caller cancelled (page nav, React unmount,
+      //     superseded poll). Not a server problem.
+      //   - Static assets: same rationale as the response path below.
+      //   - Tab hidden: iOS Safari aborts pending fetches as
+      //     `TypeError: Load failed` when the user switches apps.
+      //     That isn't an upgrade; the page just lost foreground.
+      //   - Single flap: real upgrades produce a sustained stream
+      //     of failures, so require two within a short window.
       try {
-        if (!isStaticAssetRequest(input)) {
+        const now = Date.now();
+        const tabHidden =
+          typeof document !== 'undefined' && document.visibilityState === 'hidden';
+        const sustained = now - _lastFetchErrorAt < FLAP_WINDOW_MS;
+        _lastFetchErrorAt = now;
+        if (
+          !isAbortError(error) &&
+          !isStaticAssetRequest(input) &&
+          !tabHidden &&
+          sustained
+        ) {
           reportUpgrade();
         }
       } catch (e) {
@@ -83,6 +119,9 @@ export function createUpgradeAwareFetch(reportUpgrade, clearUpgrade) {
       ) {
         // Clear the upgrade banner when we get a successful response from API
         clearUpgrade();
+        // A successful response also breaks the flap streak so a
+        // later single failure can't team up with an old one.
+        _lastFetchErrorAt = 0;
       }
     } catch (error) {
       // If anything goes wrong with upgrade detection, just log it and continue

--- a/sky/dashboard/src/utils/apiInterceptor.js
+++ b/sky/dashboard/src/utils/apiInterceptor.js
@@ -37,14 +37,6 @@ function isStaticAssetRequest(input) {
   return staticPatterns.some((pattern) => url.includes(pattern));
 }
 
-// A single network hiccup shouldn't flip the banner. Real upgrades
-// produce a stream of failures, while mobile browsers occasionally
-// drop one in-flight request when the tab backgrounds or the user
-// switches apps. We require two consecutive thrown fetches within
-// this window before reporting an upgrade.
-const FLAP_WINDOW_MS = 4000;
-let _lastFetchErrorAt = 0;
-
 // AbortController.abort() and React unmount-driven cancellation both
 // throw a DOMException with name 'AbortError'. They never indicate
 // a server problem.
@@ -69,34 +61,30 @@ export function createUpgradeAwareFetch(reportUpgrade, clearUpgrade) {
     try {
       response = await originalFetch(input, init);
     } catch (error) {
-      // Filter out benign throws before flipping the banner:
+      // Network errors on non-static, non-cancelled, foreground
+      // requests likely indicate the server is down during an
+      // upgrade — especially under the Recreate deployment strategy
+      // where there's a gap between the old pod dying and the new
+      // pod starting (so we get connection refused, not 503).
+      //
+      // Filter out benign throws that don't represent server health:
       //   - AbortError: caller cancelled (page nav, React unmount,
-      //     superseded poll). Not a server problem.
-      //   - Static assets: same rationale as the response path below.
+      //     superseded poll).
+      //   - Static assets: noisy, and a stale 503 here doesn't tell
+      //     us the API is down.
       //   - Tab hidden: iOS Safari aborts pending fetches as
       //     `TypeError: Load failed` when the user switches apps.
-      //     That isn't an upgrade; the page just lost foreground.
-      //   - Single flap: real upgrades produce a sustained stream
-      //     of failures, so require two within a short window.
+      //     The page just lost foreground; not an upgrade signal.
       try {
         const tabHidden =
           typeof document !== 'undefined' &&
           document.visibilityState === 'hidden';
-        // Only "qualifying" errors prime the flap window — benign
-        // throws (AbortError, static asset, hidden tab) are ignored
-        // entirely so they can't team up with a later real error to
-        // satisfy the two-failures rule.
         if (
           !isAbortError(error) &&
           !isStaticAssetRequest(input) &&
           !tabHidden
         ) {
-          const now = Date.now();
-          const sustained = now - _lastFetchErrorAt < FLAP_WINDOW_MS;
-          _lastFetchErrorAt = now;
-          if (sustained) {
-            reportUpgrade();
-          }
+          reportUpgrade();
         }
       } catch (e) {
         console.error('Error in upgrade detection interceptor:', e);
@@ -125,9 +113,6 @@ export function createUpgradeAwareFetch(reportUpgrade, clearUpgrade) {
       ) {
         // Clear the upgrade banner when we get a successful response from API
         clearUpgrade();
-        // A successful response also breaks the flap streak so a
-        // later single failure can't team up with an old one.
-        _lastFetchErrorAt = 0;
       }
     } catch (error) {
       // If anything goes wrong with upgrade detection, just log it and continue

--- a/sky/dashboard/src/utils/apiInterceptor.js
+++ b/sky/dashboard/src/utils/apiInterceptor.js
@@ -79,18 +79,24 @@ export function createUpgradeAwareFetch(reportUpgrade, clearUpgrade) {
       //   - Single flap: real upgrades produce a sustained stream
       //     of failures, so require two within a short window.
       try {
-        const now = Date.now();
         const tabHidden =
-          typeof document !== 'undefined' && document.visibilityState === 'hidden';
-        const sustained = now - _lastFetchErrorAt < FLAP_WINDOW_MS;
-        _lastFetchErrorAt = now;
+          typeof document !== 'undefined' &&
+          document.visibilityState === 'hidden';
+        // Only "qualifying" errors prime the flap window — benign
+        // throws (AbortError, static asset, hidden tab) are ignored
+        // entirely so they can't team up with a later real error to
+        // satisfy the two-failures rule.
         if (
           !isAbortError(error) &&
           !isStaticAssetRequest(input) &&
-          !tabHidden &&
-          sustained
+          !tabHidden
         ) {
-          reportUpgrade();
+          const now = Date.now();
+          const sustained = now - _lastFetchErrorAt < FLAP_WINDOW_MS;
+          _lastFetchErrorAt = now;
+          if (sustained) {
+            reportUpgrade();
+          }
         }
       } catch (e) {
         console.error('Error in upgrade detection interceptor:', e);


### PR DESCRIPTION
## Summary

The upgrade-aware fetch interceptor in `sky/dashboard/src/utils/apiInterceptor.js` currently flips into "your SkyPilot deployment is undergoing upgrades" on **any** thrown fetch from a non-static request. That's correct for true outages, but it also fires for benign reasons that have nothing to do with the server, especially on mobile:

- **Page navigation / React unmount** cancels in-flight polls (`AbortError`). The banner flashes whenever the user switches routes while a status poll is in flight.
- **iOS Safari aborts pending fetches** as `TypeError: Load failed` when the user switches apps or the tab backgrounds. Coming back to the tab then briefly shows the banner before the next poll succeeds.
- **A single dropped request** on a flaky Wi-Fi handoff also trips it; real upgrades produce a *sustained* stream of failures instead.

This PR filters those three cases before calling `reportUpgrade()`:

- Skip when the error is an `AbortError` (cancelled fetch).
- Skip when `document.visibilityState === 'hidden'` (tab backgrounded — Safari aborts in-flight requests; not a server problem).
- Require **two thrown fetches within a 4s window** before flipping. A successful 2xx resets the streak counter so an old failure can't team up with a fresh one minutes later.

The **503 path is unchanged**, so the `GracefulShutdownMiddleware` and nginx no-backend cases still surface the banner instantly.

## Test plan

- [x] Open dashboard, navigate between pages rapidly while status polls are in flight → no banner (was flashing before).
- [x] Hide the tab (cmd-tab away in Safari, or lock the phone), wait for in-flight fetches to abort, switch back → no banner.
- [x] Stop the API server (simulating an upgrade) → banner appears within roughly one poll cycle once a second consecutive request throws.
- [x] Start the server back up → banner clears on the next 2xx response.
- [ ] Unit tests can be added for the helper predicates (`isAbortError`, the streak counter) if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->