### PR TITLE
[Core] Make usage_lib Loki POST non-blocking

### DIFF
--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -548,16 +548,25 @@ messages = _MessagesProxy()
 # hook below gives them a brief window to flush.
 _loki_executor_lock = threading.Lock()
 _loki_executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
+_loki_session: Optional['requests.Session'] = None
 _loki_pending_lock = threading.Lock()
 _loki_pending: 'List[concurrent.futures.Future]' = []
 _LOKI_FLUSH_TIMEOUT_S = 0.3
+# Prune completed futures from _loki_pending only when the list grows past
+# this threshold, instead of scanning the whole list on every send.
+_LOKI_PENDING_PRUNE_THRESHOLD = 64
 
 
 def _get_loki_executor() -> concurrent.futures.ThreadPoolExecutor:
-    global _loki_executor
+    global _loki_executor, _loki_session
     if _loki_executor is None:
         with _loki_executor_lock:
             if _loki_executor is None:
+                # Shared Session so background POSTs reuse the TCP+TLS
+                # connection to Loki instead of paying a fresh handshake
+                # on every send. requests.Session is thread-safe for the
+                # plain post() usage we do here.
+                _loki_session = requests.Session()
                 _loki_executor = concurrent.futures.ThreadPoolExecutor(
                     max_workers=4, thread_name_prefix='loki-send')
                 atexit.register(_flush_pending_loki_sends)
@@ -582,10 +591,11 @@ def _flush_pending_loki_sends() -> None:
 
 def _post_to_loki(payload: str, headers: Dict[str, str]) -> None:
     try:
-        response = requests.post(constants.LOG_URL,
-                                 data=payload,
-                                 headers=headers,
-                                 timeout=0.5)
+        assert _loki_session is not None
+        response = _loki_session.post(constants.LOG_URL,
+                                      data=payload,
+                                      headers=headers,
+                                      timeout=0.5)
         if response.status_code != 204:
             logger.debug(f'Grafana Loki failed with response: '
                          f'{response.text}\n{payload}')
@@ -643,7 +653,9 @@ def _send_to_loki(message_type: MessageType):
     # window to complete when the process exits.
     future = _get_loki_executor().submit(_post_to_loki, payload, headers)
     with _loki_pending_lock:
-        _loki_pending[:] = [f for f in _loki_pending if not f.done()] + [future]
+        _loki_pending.append(future)
+        if len(_loki_pending) > _LOKI_PENDING_PRUNE_THRESHOLD:
+            _loki_pending[:] = [f for f in _loki_pending if not f.done()]
     messages.reset(message_type)
 
 

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -1,11 +1,14 @@
 """Logging events to Grafana Loki."""
 
+import atexit
+import concurrent.futures
 import contextlib
 import contextvars
 import datetime
 import enum
 import json
 import os
+import threading
 import time
 import traceback
 import typing
@@ -540,6 +543,55 @@ class _MessagesProxy:
 
 messages = _MessagesProxy()
 
+# Background executor for fire-and-forget Loki POSTs. Daemon threads so the
+# CLI/server can exit without blocking on in-flight requests; the atexit
+# hook below gives them a brief window to flush.
+_loki_executor_lock = threading.Lock()
+_loki_executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
+_loki_pending_lock = threading.Lock()
+_loki_pending: 'List[concurrent.futures.Future]' = []
+_LOKI_FLUSH_TIMEOUT_S = 0.3
+
+
+def _get_loki_executor() -> concurrent.futures.ThreadPoolExecutor:
+    global _loki_executor
+    if _loki_executor is None:
+        with _loki_executor_lock:
+            if _loki_executor is None:
+                _loki_executor = concurrent.futures.ThreadPoolExecutor(
+                    max_workers=4, thread_name_prefix='loki-send')
+                atexit.register(_flush_pending_loki_sends)
+    return _loki_executor
+
+
+def _flush_pending_loki_sends() -> None:
+    """Best-effort wait for in-flight Loki sends on interpreter shutdown."""
+    with _loki_pending_lock:
+        pending = [f for f in _loki_pending if not f.done()]
+        _loki_pending.clear()
+    deadline = time.monotonic() + _LOKI_FLUSH_TIMEOUT_S
+    for f in pending:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        try:
+            f.result(timeout=remaining)
+        except Exception:  # pylint: disable=broad-except
+            pass
+
+
+def _post_to_loki(payload: str, headers: Dict[str, str]) -> None:
+    try:
+        response = requests.post(constants.LOG_URL,
+                                 data=payload,
+                                 headers=headers,
+                                 timeout=0.5)
+        if response.status_code != 204:
+            logger.debug(f'Grafana Loki failed with response: '
+                         f'{response.text}\n{payload}')
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Grafana Loki send raised: {type(e).__name__}: {e}')
+
 
 def _send_to_loki(message_type: MessageType):
     """Send the message to the Grafana Loki."""
@@ -584,13 +636,14 @@ def _send_to_loki(message_type: MessageType):
         }]
     }
     payload = json.dumps(payload)
-    response = requests.post(constants.LOG_URL,
-                             data=payload,
-                             headers=headers,
-                             timeout=0.5)
-    if response.status_code != 204:
-        logger.debug(
-            f'Grafana Loki failed with response: {response.text}\n{payload}')
+    # Fire-and-forget: hand the POST to a daemon thread so the caller
+    # doesn't block on Loki's response. The 0.5s request timeout inside
+    # _post_to_loki still bounds the background thread's lifetime, and
+    # atexit (_flush_pending_loki_sends) gives in-flight sends a short
+    # window to complete when the process exits.
+    future = _get_loki_executor().submit(_post_to_loki, payload, headers)
+    with _loki_pending_lock:
+        _loki_pending[:] = [f for f in _loki_pending if not f.done()] + [future]
     messages.reset(message_type)
 
 

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -551,7 +551,6 @@ _loki_executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
 _loki_session: Optional['requests.Session'] = None
 _loki_pending_lock = threading.Lock()
 _loki_pending: 'List[concurrent.futures.Future]' = []
-_LOKI_FLUSH_TIMEOUT_S = 0.3
 # Prune completed futures from _loki_pending only when the list grows past
 # this threshold, instead of scanning the whole list on every send.
 _LOKI_PENDING_PRUNE_THRESHOLD = 64
@@ -574,17 +573,21 @@ def _get_loki_executor() -> concurrent.futures.ThreadPoolExecutor:
 
 
 def _flush_pending_loki_sends() -> None:
-    """Best-effort wait for in-flight Loki sends on interpreter shutdown."""
+    """Wait for all in-flight Loki sends on interpreter shutdown.
+
+    Each submitted POST is bounded by the 0.5s timeout inside
+    ``_post_to_loki``, so the worst-case overall drain is
+    ``ceil(pending / max_workers) * 0.5s`` even if Loki is unreachable.
+    For a healthy Loki the drain is typically well under that because
+    most POSTs submitted during the command already completed in the
+    background by the time we get here.
+    """
     with _loki_pending_lock:
         pending = [f for f in _loki_pending if not f.done()]
         _loki_pending.clear()
-    deadline = time.monotonic() + _LOKI_FLUSH_TIMEOUT_S
     for f in pending:
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            break
         try:
-            f.result(timeout=remaining)
+            f.result()
         except Exception:  # pylint: disable=broad-except
             pass
 
@@ -646,11 +649,13 @@ def _send_to_loki(message_type: MessageType):
         }]
     }
     payload = json.dumps(payload)
-    # Fire-and-forget: hand the POST to a daemon thread so the caller
-    # doesn't block on Loki's response. The 0.5s request timeout inside
-    # _post_to_loki still bounds the background thread's lifetime, and
-    # atexit (_flush_pending_loki_sends) gives in-flight sends a short
-    # window to complete when the process exits.
+    # Run the POST in parallel on a daemon thread so the caller doesn't
+    # block on Loki's response, but still record the future so the
+    # atexit hook (_flush_pending_loki_sends) waits for every submitted
+    # POST to complete before the process exits. Net effect: Loki RTTs
+    # overlap with the caller's work and with each other (up to
+    # max_workers in parallel) instead of being sequential on the
+    # critical path, but no submitted send is silently dropped.
     future = _get_loki_executor().submit(_post_to_loki, payload, headers)
     with _loki_pending_lock:
         _loki_pending.append(future)

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -543,17 +543,40 @@ class _MessagesProxy:
 
 messages = _MessagesProxy()
 
-# Background executor for fire-and-forget Loki POSTs. Daemon threads so the
-# CLI/server can exit without blocking on in-flight requests; the atexit
-# hook below gives them a brief window to flush.
+# Background executor for async Loki POSTs. Daemon threads so the CLI/server
+# can exit without blocking on in-flight requests. The atexit hook drains
+# pending work with a hard wall-clock cap (_LOKI_DRAIN_MAX_S), independent
+# of any individual request's timeout, so the process always exits promptly
+# and remains responsive to SIGINT regardless of how Loki misbehaves.
 _loki_executor_lock = threading.Lock()
 _loki_executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
 _loki_session: Optional['requests.Session'] = None
 _loki_pending_lock = threading.Lock()
 _loki_pending: 'List[concurrent.futures.Future]' = []
-# Prune completed futures from _loki_pending only when the list grows past
-# this threshold, instead of scanning the whole list on every send.
+# In-flight count (submitted but not yet done). Maintained explicitly so we
+# can cap submissions in O(1) without scanning _loki_pending, and so the cap
+# works even when nothing is draining (e.g. sustained Loki outage on the API
+# server). Protected by _loki_pending_lock.
+_loki_in_flight = 0
+# Cumulative count of sends dropped at submit because the in-flight cap was
+# reached. Bumped + logged at WARNING the first time it happens and every
+# 1000 thereafter, so a real Loki outage is visible in operator logs but
+# normal usage doesn't get spammed.
+_loki_drops_total = 0
+# Cap on outstanding sends across the whole process. Each pending payload
+# is ~2KB, so 1024 bounds the worst-case memory hit at ~2MB even if Loki
+# is unreachable for a long time. Well above any realistic burst from a
+# single CLI command (~12) or a busy API server.
+_LOKI_MAX_IN_FLIGHT = 1024
+# Prune done futures from _loki_pending when it grows past this. Keeps the
+# atexit drain snapshot from doing extra work in the common (healthy) case.
 _LOKI_PENDING_PRUNE_THRESHOLD = 64
+# Hard wall-clock cap on the atexit drain. Bounds CLI exit regardless of
+# DNS hangs, slow-byte servers, or anything else that can defeat the
+# per-request 0.5s timeout inside _post_to_loki. Sends still in flight at
+# the deadline are abandoned (the same way master abandons any individual
+# POST that hits its socket timeout).
+_LOKI_DRAIN_MAX_S = 0.5
 
 
 def _get_loki_executor() -> concurrent.futures.ThreadPoolExecutor:
@@ -572,24 +595,34 @@ def _get_loki_executor() -> concurrent.futures.ThreadPoolExecutor:
     return _loki_executor
 
 
-def _flush_pending_loki_sends() -> None:
-    """Wait for all in-flight Loki sends on interpreter shutdown.
+def _on_loki_future_done(future: 'concurrent.futures.Future') -> None:
+    # pylint: disable=unused-argument
+    """Decrement the in-flight counter when a submitted POST finishes."""
+    global _loki_in_flight
+    with _loki_pending_lock:
+        if _loki_in_flight > 0:
+            _loki_in_flight -= 1
 
-    Each submitted POST is bounded by the 0.5s timeout inside
-    ``_post_to_loki``, so the worst-case overall drain is
-    ``ceil(pending / max_workers) * 0.5s`` even if Loki is unreachable.
-    For a healthy Loki the drain is typically well under that because
-    most POSTs submitted during the command already completed in the
-    background by the time we get here.
+
+def _flush_pending_loki_sends() -> None:
+    """Drain in-flight Loki sends on interpreter shutdown, bounded by
+    ``_LOKI_DRAIN_MAX_S``.
+
+    ``concurrent.futures.wait`` with a timeout returns control to Python
+    periodically, so SIGINT (Ctrl-C) is honored during the drain. After
+    the timeout, the executor is shut down without waiting and any
+    sends still in flight are abandoned. ``requests``' own ``timeout``
+    parameter doesn't actually bound wall-clock time (it doesn't cover
+    DNS, and on the read side it's a per-byte timeout), so we cannot
+    rely on it to keep the drain prompt; this wall-clock cap does.
     """
     with _loki_pending_lock:
         pending = [f for f in _loki_pending if not f.done()]
         _loki_pending.clear()
-    for f in pending:
-        try:
-            f.result()
-        except Exception:  # pylint: disable=broad-except
-            pass
+    if pending:
+        concurrent.futures.wait(pending, timeout=_LOKI_DRAIN_MAX_S)
+    if _loki_executor is not None:
+        _loki_executor.shutdown(wait=False, cancel_futures=True)
 
 
 def _post_to_loki(payload: str, headers: Dict[str, str]) -> None:
@@ -649,14 +682,44 @@ def _send_to_loki(message_type: MessageType):
         }]
     }
     payload = json.dumps(payload)
-    # Run the POST in parallel on a daemon thread so the caller doesn't
-    # block on Loki's response, but still record the future so the
-    # atexit hook (_flush_pending_loki_sends) waits for every submitted
-    # POST to complete before the process exits. Net effect: Loki RTTs
-    # overlap with the caller's work and with each other (up to
-    # max_workers in parallel) instead of being sequential on the
-    # critical path, but no submitted send is silently dropped.
-    future = _get_loki_executor().submit(_post_to_loki, payload, headers)
+    # Drop new sends at the source when the in-flight queue is already at
+    # _LOKI_MAX_IN_FLIGHT. Prevents unbounded memory growth on a
+    # long-running API server during a sustained Loki outage, where
+    # nothing drains and the executor's internal work queue would
+    # otherwise grow linearly with request rate.
+    global _loki_in_flight, _loki_drops_total
+    with _loki_pending_lock:
+        if _loki_in_flight >= _LOKI_MAX_IN_FLIGHT:
+            _loki_drops_total += 1
+            if _loki_drops_total == 1 or _loki_drops_total % 1000 == 0:
+                logger.warning(
+                    f'Loki usage send backlog at cap '
+                    f'({_LOKI_MAX_IN_FLIGHT}); dropped '
+                    f'{_loki_drops_total} send(s) since startup. '
+                    f'This typically means the Loki ingest endpoint is '
+                    f'unreachable or slow.')
+            messages.reset(message_type)
+            return
+        _loki_in_flight += 1
+
+    # Run the POST on a worker thread so the caller doesn't block on
+    # Loki's response. Loki RTTs then overlap with the caller's work and
+    # with each other up to max_workers, instead of being sequential on
+    # the critical path. The atexit drain (_flush_pending_loki_sends)
+    # waits for in-flight sends to complete on process exit, bounded by
+    # _LOKI_DRAIN_MAX_S.
+    try:
+        future = _get_loki_executor().submit(_post_to_loki, payload, headers)
+    except RuntimeError:
+        # Executor has already been shut down (e.g. during atexit on a
+        # different thread). Roll back the in-flight reservation and
+        # drop the send.
+        with _loki_pending_lock:
+            if _loki_in_flight > 0:
+                _loki_in_flight -= 1
+        messages.reset(message_type)
+        return
+    future.add_done_callback(_on_loki_future_done)
     with _loki_pending_lock:
         _loki_pending.append(future)
         if len(_loki_pending) > _LOKI_PENDING_PRUNE_THRESHOLD:


### PR DESCRIPTION
## Summary

- Every `@usage_lib.entrypoint`-decorated call previously ended with a synchronous `requests.post` to Grafana Loki (`timeout=0.5s`) before returning. On `sky status` that's ~12 sequential POSTs per invocation (7 client-side + 5 server-side), all on the user-visible critical path, and they serialize hard under concurrent load.
- This PR submits each POST to a small daemon `ThreadPoolExecutor` (`max_workers=4`) and returns immediately, so Loki RTTs overlap with the caller's work and with each other instead of being sequential on the critical path.
- An `atexit` hook drains in-flight POSTs with a hard wall-clock cap (`_LOKI_DRAIN_MAX_S = 0.5s`), then shuts the executor down. The cap is independent of any individual request's `timeout=` (which doesn't cover DNS, and on the read side is per-byte) so the process always exits promptly and remains responsive to SIGINT regardless of how Loki misbehaves.
- Background POSTs share a `requests.Session` for TCP+TLS connection reuse.
- The submission path tracks an in-flight counter and drops new sends at the source once the count reaches `_LOKI_MAX_IN_FLIGHT = 1024`, with the cumulative drop count logged at WARNING (first drop + every 1000th). This bounds memory under a sustained Loki outage on the long-running API server.

## Delivery semantics

Master also drops POSTs whenever its synchronous `timeout=0.5` fires; this PR doesn't change *which* POSTs get dropped under stress, it just moves the bound from "per-request socket timeout" to "process-wide drain wall-clock at exit." For a healthy Loki, every POST submitted during a CLI command typically lands. For an unhealthy Loki, both master and this PR drop sends; the difference is that this PR drops them promptly (CLI exits in ~0.5s instead of stalling on serialized retries) and remains responsive to Ctrl-C while doing so.

## Benchmarks

All against a local fake Loki HTTP server returning `204` after a configurable delay, with `SKYPILOT_USAGE_LOG_URL` pointed at it. Plain `pip install -e .` of this branch, no enterprise plugins loaded.

### Sequential CLI (`sky status` x10, single process at a time, 300 ms Loki delay)

| Mode | Per-call avg | Total wall (x10) |
|---|---:|---:|
| Sync (master) | 3463 ms | 34992 ms |
| **This PR** | **2564 ms** | **26041 ms** |

**~26% faster than master** with bounded exit and SIGINT responsiveness.

### Concurrent SDK (`sky.status()` via `ThreadPoolExecutor`, 300 ms Loki delay)

Three back-to-back trials per config, fresh API server before each set. Total wall = time to complete all N calls in parallel.

**N=10 concurrent:**

| Trial | Before (master) | This PR | Per-call avg before | Per-call avg this PR |
|---|---:|---:|---:|---:|
| 1 (cold) | 965 ms | 538 ms | 895 ms | 351 ms |
| 2 (warm) | 992 ms | 372 ms | 961 ms | 296 ms |
| 3 (warm) | 881 ms | 414 ms | 812 ms | 312 ms |

Warm-state speedup: **~2.5x faster total wall, ~3x lower avg latency**.

**N=30 concurrent (heavier load):**

| Trial | Before (master) | This PR | Per-call avg before | Per-call avg this PR |
|---|---:|---:|---:|---:|
| 1 (cold) | 3997 ms | 709 ms | 3278 ms | 509 ms |
| 2 (warm) | 1122 ms | 1060 ms | 1029 ms | 799 ms |
| 3 (warm) | 1031 ms | 1032 ms | 992 ms | 824 ms |

Cold-start speedup: **~5.6x faster** because the original sync code couldn't overlap the 30 inbound requests' Loki sends.

### Failure modes

| Scenario | Master | This PR |
|---|---|---|
| Healthy Loki | All POSTs delivered | All POSTs delivered |
| Slow Loki (within `timeout=0.5`) | Serial RTTs on critical path | Parallel RTTs, bounded exit |
| Slow DNS (>0.5s) | `requests` timeout doesn't help; stalls | Capped at 0.5s drain at exit |
| Dribbling-byte server (<0.5s per byte) | `requests` timeout doesn't help; can hang for 30s+ | Capped at 0.5s drain at exit |
| Connection refused / dead Loki | Up to `12 * 0.5 = 6s` per CLI command | `sky status` exits in ~2.5s (measured) |
| SIGINT during slow Loki | Honored (sync POST in main thread) | Honored (bounded `concurrent.futures.wait`) |
| API server under sustained Loki outage | Each request stalls on Loki | Drops at source past 1024 in-flight; ~2MB memory cap |

## Correctness

Every benchmark trial against a healthy fake Loki delivered the expected number of POSTs with identical entrypoint distribution and well-formed `streams[].values[]` payloads.

## Worst-case exit delay

Bounded by `_LOKI_DRAIN_MAX_S = 0.5s`, regardless of underlying Loki behavior (DNS, slow body, blackhole, etc.). Sends still in flight at the deadline are abandoned, the same way master's `requests.post(timeout=0.5)` abandons a stuck POST.

## Notes on the Session change

A microbenchmark of `requests.Session` vs fresh `requests.post` against the localhost fake Loki shows literally zero difference (2463 ms vs 2469 ms across 30 POSTs at 300 ms delay), because there is no TLS handshake to amortize over localhost HTTP. In production against the real HTTPS Loki ingest endpoint, Session pooling saves a fresh TLS handshake on every POST after the first.

## Tested

- [x] Sequential CLI bench at 300 ms simulated Loki delay, 10 trials, before vs this PR; all 120 POSTs delivered.
- [x] Concurrent SDK bench at N=10 and N=30, 300 ms simulated Loki delay, 3 trials each.
- [x] Dead-Loki (connection refused) `sky status`: exits in ~2.5 s.
- [x] `bash format.sh --files sky/usage/usage_lib.py` to pylint 10.00/10.
- [x] Manual: confirmed `SKYPILOT_USAGE_LOG_URL` env propagates to both client and API server processes; payloads in the fake-Loki log match the original schema.

## Test plan for reviewers

- [ ] Stand up a local fake-Loki sink (returning `204`); set `SKYPILOT_USAGE_LOG_URL=http://127.0.0.1:<port>`; run `sky status` (or any entrypoint) and confirm POSTs still land.
- [ ] Point `SKYPILOT_USAGE_LOG_URL` at a dead endpoint; confirm `sky status` exits in well under 5 s.
- [ ] Trigger Ctrl-C during a CLI invocation pointed at a slow/dead Loki; confirm SIGINT is honored.
- [ ] Sanity-check that errors from a broken Loki endpoint are swallowed at DEBUG (no user-visible regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)