### PR TITLE
[CI Fix] Skip test_batch_diffusion on Nebius and Azure (no L4 GPU)

### DIFF
--- a/tests/smoke_tests/test_batch.py
+++ b/tests/smoke_tests/test_batch.py
@@ -141,6 +141,8 @@ def test_batch_simple(generic_cloud: str):
 @pytest.mark.batch
 @pytest.mark.resource_heavy
 @pytest.mark.no_kubernetes  # pool.yaml hardcodes L4 GPU; K8s CI clusters may not have it
+@pytest.mark.no_nebius  # pool.yaml hardcodes L4 GPU; Nebius only offers L40S
+@pytest.mark.no_azure  # pool.yaml hardcodes L4 GPU; Azure does not offer L4
 @pytest.mark.no_remote_server  # see note 1 above
 def test_batch_diffusion(generic_cloud: str):
     name = smoke_tests_utils.get_cluster_name()


### PR DESCRIPTION
## Summary
- **Test:** `test_batch_diffusion` on `nebius` (also affects `azure`)
- **Classification:** UNKNOWN (manifests as `ResourcesUnavailableError`)
- **Confidence:** HIGH

## Root Cause
`examples/batch/diffusion/pool.yaml` hardcodes `accelerators: L4:1`. Nebius only offers L40S GPUs (the optimizer suggests `L40S:1/2/4` in its error message), and Azure does not offer L4 instances. When the test runs `sky jobs pool apply` against either cloud, the optimizer raises `ResourcesUnavailableError: Catalog does not contain any instances satisfying the request: 1x Nebius({'L4': 1})`.

## Fix
Add `@pytest.mark.no_nebius` and `@pytest.mark.no_azure` to `test_batch_diffusion`, mirroring the existing `@pytest.mark.no_kubernetes` skip on the same test for the exact same reason (clusters without L4s). No production code changes.

## Buildkite Failure
https://buildkite.com/skypilot-1/full-smoke-tests-run/builds/116#019e3dcc-2cd6-4a28-b180-bd24a4b91f07

---
> **Note:** This fix was auto-generated. Confidence level: HIGH.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->