### PR TITLE
[Test] stream_response: count wire progress for resumable streams

### DIFF
--- a/agent/skills/skypilot/references/yaml-spec.md
+++ b/agent/skills/skypilot/references/yaml-spec.md
@@ -637,6 +637,7 @@ If `'best'` is specified, use the best network tier available on the specified i
 - `infra: k8s/my-coreweave-cluster`: Enable InfiniBand for high-performance GPU communication across pods on CoreWeave CKS clusters.
 - `infra: k8s/my-nebius-cluster`: Enable InfiniBand for high-performance GPU communication across pods on Nebius managed Kubernetes.
 - `infra: k8s/my-together-cluster`: Enable InfiniBand for high-performance GPU communication across pods on Together AI Kubernetes clusters.
+- `infra: k8s/my-oke-cluster`: Enable RoCEv2 for high-performance GPU communication across pods on Oracle OKE clusters with bare-metal GPU shapes (BM.GPU.*.8) provisioned via dedicated RDMA capacity pools.
 
 **Slurm-based:**
 

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -164,22 +164,21 @@ def stream_response(request_id: Optional[server_common.RequestId[T]],
         line_count = 0
 
         for line in rich_utils.decode_rich_status(response):
+            # Report forward progress to the retry decorator for every
+            # message received from the wire, including None control
+            # messages (e.g. heartbeats). Receiving any message
+            # indicates the underlying connection is healthy, so the
+            # consecutive-failure counter should reset. Without this,
+            # resumable streams that spend a full retry window only
+            # replaying already-printed lines (or receiving only
+            # heartbeats) never advance `progress_count` and can
+            # exhaust their retry budget even though the stream is
+            # actively making progress over the network.
+            if retry_context is not None:
+                retry_context.progress_count += 1
+
             if line is not None:
                 line_count += 1
-
-                # Report forward progress to the retry decorator for every
-                # line received from the wire, even if the line is later
-                # skipped (e.g. replayed during a resumable retry) or
-                # consumed by an interactive auth handler. Receiving any
-                # line indicates the underlying connection is healthy, so
-                # the consecutive-failure counter should reset. Without
-                # this, resumable streams that spend a full retry window
-                # only replaying already-printed lines never advance
-                # `progress_count` and can exhaust their retry budget even
-                # though the stream is actively making progress over the
-                # network.
-                if retry_context is not None:
-                    retry_context.progress_count += 1
 
                 line = interactive_utils.handle_interactive_auth(line)
                 if line is None:

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -167,6 +167,20 @@ def stream_response(request_id: Optional[server_common.RequestId[T]],
             if line is not None:
                 line_count += 1
 
+                # Report forward progress to the retry decorator for every
+                # line received from the wire, even if the line is later
+                # skipped (e.g. replayed during a resumable retry) or
+                # consumed by an interactive auth handler. Receiving any
+                # line indicates the underlying connection is healthy, so
+                # the consecutive-failure counter should reset. Without
+                # this, resumable streams that spend a full retry window
+                # only replaying already-printed lines never advance
+                # `progress_count` and can exhaust their retry budget even
+                # though the stream is actively making progress over the
+                # network.
+                if retry_context is not None:
+                    retry_context.progress_count += 1
+
                 line = interactive_utils.handle_interactive_auth(line)
                 if line is None:
                     # Line was consumed by interactive auth handler
@@ -179,16 +193,11 @@ def stream_response(request_id: Optional[server_common.RequestId[T]],
 
                 print(line, flush=True, end='', file=output_stream)
 
-                if retry_context is not None:
-                    if resumable:
-                        # Reaching here implies line_count > line_processed
-                        # (otherwise the resumable skip above would have
-                        # `continue`'d). Advance the high-water mark.
-                        retry_context.line_processed = line_count
-                    # Report forward progress to the retry decorator so it
-                    # can reset the consecutive-failure counter even for
-                    # non-resumable streams.
-                    retry_context.progress_count += 1
+                if retry_context is not None and resumable:
+                    # Reaching here implies line_count > line_processed
+                    # (otherwise the resumable skip above would have
+                    # `continue`'d). Advance the high-water mark.
+                    retry_context.line_processed = line_count
         if request_id is not None and get_result:
             return get(request_id)
         else:

--- a/tests/unit_tests/test_sky/server/test_sdk.py
+++ b/tests/unit_tests/test_sky/server/test_sdk.py
@@ -892,10 +892,12 @@ def test_stream_response_resumable_retry_skips_replayed_lines():
     assert decode_call_count == 2
     # Final result is forwarded from get(request_id).
     assert result == 'final_result'
-    # Both progress fields advanced exactly to the number of distinct lines.
+    # line_processed tracks distinct lines (high-water mark for resumable
+    # skip-ahead). progress_count tracks total wire-level messages received
+    # across all attempts: 2 from the first attempt + 5 from the retry = 7.
     ctx = captured_context['ctx']
     assert ctx.line_processed == 5
-    assert ctx.progress_count == 5
+    assert ctx.progress_count == 7
 
 
 def test_stream_response_no_request_id():


### PR DESCRIPTION
## Summary
- **Test:** `test_cli_auto_retry` on `azure` (also affects other clouds)
- **Classification:** Retry-budget exhaustion in chaos-proxy test
- **Confidence:** HIGH

## Root Cause

`test_cli_auto_retry` exercises CLI streaming through a chaos proxy that drops the TCP connection every 30 s. The `sky jobs logs --tail 0` invocation is the *resumable* code path (see `sky/jobs/client/sdk.py::tail_logs`, where `tail=0` maps to `resumable=True`).

In `sky/client/sdk.py::stream_response`, the retry decorator's progress signal (`RetryContext.progress_count`) was only incremented when a line was actually *printed*, i.e. past the `line_processed` high-water mark:

```python
if (resumable and retry_context is not None and
        line_count <= retry_context.line_processed):
    # Already printed on a previous attempt; skip.
    continue

print(line, flush=True, end='', file=output_stream)

if retry_context is not None:
    if resumable:
        retry_context.line_processed = line_count
    retry_context.progress_count += 1
```

After a chaos-proxy disconnect, the server replays from line 1. The client receives those bytes from the wire and decodes them, but every replayed line hits the `continue` branch above, so `progress_count` never advances. Across three consecutive 30 s disconnect windows, the retry decorator in `sky/server/rest.py::retry_transient_errors` saw zero forward progress, treated each `ChunkedEncodingError` as a true consecutive failure, and raised after exhausting `max_retries=3`:

```
File "sky/client/sdk.py", line 166, in stream_response
    for line in rich_utils.decode_rich_status(response):
  File "sky/utils/rich_utils.py", line 313, in decode_rich_status
    for chunk in response.iter_content(chunk_size=None):
  File "requests/models.py", line 824, in generate
    raise ChunkedEncodingError(e)
requests.exceptions.ChunkedEncodingError: Response ended prematurely
```

This is the same class of bug fixed by #9506 for non-resumable streams; the resumable path was missed because progress was tied to printing rather than to wire activity.

## Fix

Move the `progress_count` increment to happen for every line received from the wire (right after `line_count += 1`), before the interactive-auth handler and resumable skip checks. Receiving any line indicates the underlying connection is healthy and forward progress is being made on the wire, which is exactly the signal the retry decorator needs to reset its consecutive-failure counter. `line_processed` retains its original meaning as the high-water mark for resumable skip-ahead.

## Buildkite Failure
https://buildkite.com/skypilot-1/full-smoke-tests-run/builds/116#019e3d8e-7030-4333-ab06-e8bc49c79256

---
> **Note:** This fix was auto-generated. Confidence level: HIGH.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9659" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->