### PR TITLE
[Storage][Azure] Place buckets in cluster region; default to LRS

### DIFF
--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -985,7 +985,11 @@ class Storage(object):
                                              self.mount_cached_config)
         return self.mount_cached_config
 
-    def construct(self):
+    def construct(
+        self,
+        preferred_store_type: Optional[StoreType] = None,
+        preferred_region: Optional[str] = None,
+    ) -> None:
         """Constructs the storage object.
 
         The Storage object is lazily initialized, so that when a user
@@ -1000,6 +1004,17 @@ class Storage(object):
         1. Set the stores field if not specified
         2. Create the bucket or check the existence of the bucket
         3. Sync the data from the source to the bucket if necessary
+
+        Args:
+          preferred_store_type: The preferred store type derived from the
+            owning task's compute resources (e.g. ``StoreType.AZURE`` when the
+            task runs on Azure). Only used as a hint to choose ``region`` for
+            user-specified stores whose type matches.
+          preferred_region: The region of the owning task's compute resources.
+            When the user specifies ``store: <type>`` in YAML but does not pin
+            a region, this lets us place the bucket in the same region as the
+            cluster (avoiding cross-region writes). Has no effect if it does
+            not apply to the user-specified store type.
         """
         if self._constructed:
             return
@@ -1073,27 +1088,43 @@ class Storage(object):
                 file_mount_type=self.file_mount_type,
                 mount_config=self.mount_config)
 
+            def _region_for(store_type: StoreType) -> Optional[str]:
+                # Only forward the preferred region when the task's preferred
+                # store type matches the one we are about to create. Mixing
+                # regions across clouds (e.g. passing an AWS region to Azure)
+                # would otherwise cause bucket creation to fail.
+                if (preferred_store_type is not None and
+                        preferred_store_type == store_type):
+                    return preferred_region
+                return None
+
             for store_type in input_stores:
-                self.add_store(store_type)
+                self.add_store(store_type, region=_region_for(store_type))
 
             if self.source is not None:
                 # If source is a pre-existing bucket, connect to the bucket
                 # If the bucket does not exist, this will error out
                 if isinstance(self.source, str):
                     if self.source.startswith('gs://'):
-                        self.add_store(StoreType.GCS)
+                        self.add_store(StoreType.GCS,
+                                       region=_region_for(StoreType.GCS))
                     elif data_utils.is_az_container_endpoint(self.source):
-                        self.add_store(StoreType.AZURE)
+                        self.add_store(StoreType.AZURE,
+                                       region=_region_for(StoreType.AZURE))
                     elif self.source.startswith('cos://'):
-                        self.add_store(StoreType.IBM)
+                        self.add_store(StoreType.IBM,
+                                       region=_region_for(StoreType.IBM))
                     elif self.source.startswith('oci://'):
-                        self.add_store(StoreType.OCI)
+                        self.add_store(StoreType.OCI,
+                                       region=_region_for(StoreType.OCI))
 
                     s3_compatible_store_type: Optional[StoreType] = (
                         StoreType.find_s3_compatible_config_by_prefix(
                             self.source))
                     if s3_compatible_store_type:
-                        self.add_store(s3_compatible_store_type)
+                        self.add_store(
+                            s3_compatible_store_type,
+                            region=_region_for(s3_compatible_store_type))
 
     def get_bucket_sub_path_prefix(self, blob_path: str) -> str:
         """Adds the bucket sub path prefix to the blob path."""
@@ -3458,11 +3489,19 @@ class AzureBlobStore(AbstractStore):
                 storage account.
         """
         try:
+            # Default to Standard_LRS (locally-redundant storage):
+            #   * SkyPilot uses the storage account as a single-region workdir
+            #     / data staging area, not as a disaster-recovery store.
+            #   * Standard_LRS is the cheapest SKU and lives in the same
+            #     region as the cluster, so reads/writes don't incur
+            #     cross-region transfer cost.
+            # Users who need cross-region replication can pre-create their
+            # own storage account and pass its name via config.yaml.
             creation_response = (
                 self.storage_client.storage_accounts.begin_create(
                     resource_group_name, storage_account_name, {
                         'sku': {
-                            'name': 'Standard_GRS'
+                            'name': 'Standard_LRS'
                         },
                         'kind': 'StorageV2',
                         'location': self.region,

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -268,9 +268,19 @@ def _execute(
             dag.pre_mount_volumes()
         for task in dag.tasks:
             if task.storage_mounts is not None:
+                # Forward the task's preferred (store_type, region) so that
+                # explicit ``store:`` entries (created during ``construct()``)
+                # land in the same region as the cluster instead of falling
+                # back to a hardcoded default. See #8504.
+                try:
+                    preferred_store_type, preferred_region = (
+                        task._get_preferred_store())  # pylint: disable=protected-access
+                except exceptions.NoCloudAccessError:
+                    preferred_store_type, preferred_region = None, None
                 for storage in task.storage_mounts.values():
                     # Ensure the storage is constructed.
-                    storage.construct()
+                    storage.construct(preferred_store_type=preferred_store_type,
+                                      preferred_region=preferred_region)
         _resolve_managed_secrets(dag)
         return _execute_dag(
             dag,

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -275,7 +275,12 @@ def _execute(
                 try:
                     preferred_store_type, preferred_region = (
                         task._get_preferred_store())  # pylint: disable=protected-access
-                except exceptions.NoCloudAccessError:
+                except (exceptions.NoCloudAccessError, ValueError):
+                    # Hint-only path: tolerate compute-only clouds (e.g.
+                    # Kubernetes, Lambda) where ``_get_preferred_store`` may
+                    # raise ``ValueError`` from ``StoreType.from_cloud``. The
+                    # real error, if any, will surface later when the storage
+                    # actually needs a default store.
                     preferred_store_type, preferred_region = None, None
                 for storage in task.storage_mounts.values():
                     # Ensure the storage is constructed.

--- a/sky/task.py
+++ b/sky/task.py
@@ -1660,10 +1660,12 @@ class Task:
             for storage in storage_to_construct:
                 try:
                     preferred_store_type, preferred_region = get_preferred()
-                except exceptions.NoCloudAccessError:
-                    # No storage cloud is enabled. Let ``construct()`` proceed
-                    # without a hint; if the user-specified store still needs
-                    # a cloud, the call will surface the original error.
+                except (exceptions.NoCloudAccessError, ValueError):
+                    # Hint-only path: tolerate cases where the task's compute
+                    # cloud has no associated storage (e.g. Kubernetes,
+                    # Lambda) and ``_get_preferred_store`` raises. If the
+                    # storage actually needs a default store, the lazy call
+                    # below will re-raise with the original error.
                     preferred_store_type, preferred_region = None, None
                 storage.construct(preferred_store_type=preferred_store_type,
                                   preferred_region=preferred_region)

--- a/sky/task.py
+++ b/sky/task.py
@@ -1642,11 +1642,34 @@ class Task:
             storage_to_construct = sorted(storages,
                                           key=lambda x: len(x.stores),
                                           reverse=True)
+            # Compute the task's preferred (store_type, region) lazily and
+            # only once. Both code paths below need it: user-specified stores
+            # created inside ``construct()`` use it to pick a region (so an
+            # Azure bucket lands in the same region as the cluster instead of
+            # the hardcoded ``eastus`` default), and stores created when the
+            # user did not specify any ``store:`` use it too. See #8504.
+            preferred_cache: Optional[Tuple[storage_lib.StoreType,
+                                            Optional[str]]] = None
+
+            def get_preferred() -> Tuple[storage_lib.StoreType, Optional[str]]:
+                nonlocal preferred_cache
+                if preferred_cache is None:
+                    preferred_cache = self._get_preferred_store()
+                return preferred_cache
+
             for storage in storage_to_construct:
-                storage.construct()
+                try:
+                    preferred_store_type, preferred_region = get_preferred()
+                except exceptions.NoCloudAccessError:
+                    # No storage cloud is enabled. Let ``construct()`` proceed
+                    # without a hint; if the user-specified store still needs
+                    # a cloud, the call will surface the original error.
+                    preferred_store_type, preferred_region = None, None
+                storage.construct(preferred_store_type=preferred_store_type,
+                                  preferred_region=preferred_region)
                 assert storage.name is not None, storage
                 if not storage.stores:
-                    store_type, store_region = self._get_preferred_store()
+                    store_type, store_region = get_preferred()
                     self.storage_plans[storage] = store_type
                     storage.add_store(store_type, store_region)
                 else:

--- a/tests/unit_tests/test_sky/storage/test_storage_construct.py
+++ b/tests/unit_tests/test_sky/storage/test_storage_construct.py
@@ -1,0 +1,129 @@
+"""Unit tests for Storage.construct() region propagation and Azure SKU.
+
+Covers the fix for https://github.com/skypilot-org/skypilot/issues/8504,
+where a user-specified ``store: azure`` would always create the underlying
+storage account in ``eastus`` (and as GRS) regardless of the cluster's
+region.
+"""
+from unittest import mock
+
+import pytest
+
+from sky.data import storage as storage_lib
+
+
+@pytest.fixture(autouse=True)
+def _patch_validate_storage_spec():
+    """Skip the validation that requires real cloud credentials."""
+    with mock.patch.object(storage_lib.Storage,
+                           '_validate_storage_spec',
+                           return_value=None):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _patch_global_user_state():
+    """Pretend there's no pre-existing handle so construct() takes the
+    'create new stores' branch.
+    """
+    with mock.patch.object(storage_lib.global_user_state,
+                           'get_handle_from_storage_name',
+                           return_value=None):
+        yield
+
+
+def _make_storage(stores):
+    return storage_lib.Storage(name='sky-test-bucket',
+                               source='/bin',
+                               stores=stores,
+                               mode=storage_lib.StorageMode.MOUNT)
+
+
+class TestConstructRegionForwarding:
+    """Ensure ``construct()`` forwards the task's preferred region to
+    ``add_store`` only when the store type matches the task's cloud.
+    """
+
+    def test_explicit_azure_store_inherits_task_region(self):
+        storage_obj = _make_storage(stores=[storage_lib.StoreType.AZURE])
+
+        with mock.patch.object(storage_lib.Storage,
+                               'add_store') as add_store_mock:
+            storage_obj.construct(
+                preferred_store_type=storage_lib.StoreType.AZURE,
+                preferred_region='westus2')
+
+        add_store_mock.assert_called_once_with(storage_lib.StoreType.AZURE,
+                                               region='westus2')
+
+    def test_explicit_gcs_store_with_azure_task_does_not_get_azure_region(self):
+        # Mismatched clouds: don't pass an Azure region to a GCS bucket.
+        storage_obj = _make_storage(stores=[storage_lib.StoreType.GCS])
+
+        with mock.patch.object(storage_lib.Storage,
+                               'add_store') as add_store_mock:
+            storage_obj.construct(
+                preferred_store_type=storage_lib.StoreType.AZURE,
+                preferred_region='westus2')
+
+        add_store_mock.assert_called_once_with(storage_lib.StoreType.GCS,
+                                               region=None)
+
+    def test_construct_without_preference_preserves_legacy_behavior(self):
+        # Backwards compat: callers that don't pass hints should behave as
+        # before (region=None at the add_store layer).
+        storage_obj = _make_storage(stores=[storage_lib.StoreType.AZURE])
+
+        with mock.patch.object(storage_lib.Storage,
+                               'add_store') as add_store_mock:
+            storage_obj.construct()
+
+        add_store_mock.assert_called_once_with(storage_lib.StoreType.AZURE,
+                                               region=None)
+
+    def test_construct_is_idempotent_with_or_without_hints(self):
+        storage_obj = _make_storage(stores=[storage_lib.StoreType.AZURE])
+
+        with mock.patch.object(storage_lib.Storage,
+                               'add_store') as add_store_mock:
+            storage_obj.construct(
+                preferred_store_type=storage_lib.StoreType.AZURE,
+                preferred_region='westus2')
+            # Second call must short-circuit (already constructed).
+            storage_obj.construct(
+                preferred_store_type=storage_lib.StoreType.AZURE,
+                preferred_region='eastus')
+
+        assert add_store_mock.call_count == 1
+
+
+class TestAzureStorageAccountSku:
+    """The Azure storage account default SKU should be locally-redundant
+    (Standard_LRS), not geo-redundant (Standard_GRS).
+    """
+
+    def test_create_storage_account_uses_lrs_sku(self):
+        store = storage_lib.AzureBlobStore.__new__(storage_lib.AzureBlobStore)
+        store.region = 'westus2'
+        store.storage_client = mock.MagicMock()
+        # The IAM role assignment path is exercised after begin_create; stub
+        # the azure adaptor to make that no-op.
+        creation_response = mock.MagicMock()
+        creation_response.id = ('/subscriptions/x/resourceGroups/rg/providers/'
+                                'Microsoft.Storage/storageAccounts/sa')
+        store.storage_client.storage_accounts.begin_create.return_value.\
+            result.return_value = creation_response
+
+        with mock.patch('sky.adaptors.azure.assign_storage_account_iam_role'):
+            store._create_storage_account(  # pylint: disable=protected-access
+                resource_group_name='rg',
+                storage_account_name='sa')
+
+        store.storage_client.storage_accounts.begin_create.\
+            assert_called_once()
+        _, args, _ = (
+            store.storage_client.storage_accounts.begin_create.mock_calls[0])
+        # begin_create(resource_group_name, storage_account_name, params)
+        params = args[2]
+        assert params['sku']['name'] == 'Standard_LRS'
+        assert params['location'] == 'westus2'


### PR DESCRIPTION
Fixes #8504.

## Summary
- Forward the cluster's region into Azure bucket creation when the user specifies `store: azure`. Previously the bucket landed in the hardcoded `eastus` regardless of `infra: azure/<region>`.
- Default new Azure storage accounts to `Standard_LRS` instead of `Standard_GRS`. SkyPilot uses these accounts as single-region workdir staging, so locally-redundant storage is the cheaper, correct default. Existing storage accounts are unaffected.
- Preserve backward compatibility: callers that pass no region hint behave exactly as before.

## Changes
- `sky/data/storage.py`: `Storage.construct()` now accepts `preferred_store_type` and `preferred_region`. It forwards the region to `add_store()` only when the user's store type matches the task's cloud, so mismatched cloud pairs (e.g. `store: gcs` on an Azure task) still receive `region=None`. `AzureBlobStore._create_storage_account` now uses `Standard_LRS`.
- `sky/task.py`: `sync_storage_mounts()` resolves the preferred (store_type, region) via `_get_preferred_store()` once and passes it into `construct()`. Falls back to `(None, None)` when no storage cloud is enabled.
- `sky/execution.py`: `launch()` passes the same hint into the early `storage.construct()` call.
- `tests/unit_tests/test_sky/storage/test_storage_construct.py`: new unit tests covering region forwarding, cross-cloud isolation, legacy behavior, idempotency, and the LRS SKU default.

Tested:

- [x] Code formatting: `bash format.sh --files sky/data/storage.py sky/task.py sky/execution.py tests/unit_tests/test_sky/storage/test_storage_construct.py` (mypy clean, pylint 10.00/10).
- [x] New unit tests: `pytest tests/unit_tests/test_sky/storage/test_storage_construct.py -o "addopts="` (5 passed).
- [x] Storage + task suites: `pytest tests/test_storage.py tests/unit_tests/test_sky/storage/ tests/unit_tests/test_sky/test_task.py -o "addopts="` (297 passed).
- [ ] Manual Azure verification using the reporter's YAML: confirm the new storage account is created in `westus2` with `Standard_LRS`.
- [ ] All smoke tests: `/smoke-test` (CI).
- [ ] Backward compatibility: `/quicktest-core` (CI).