### PR TITLE
[Jobs] Add preload_content to sky.jobs.tail_logs

### DIFF
--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -3,7 +3,8 @@ import json
 import pathlib
 import threading
 import typing
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import (Any, Dict, Iterator, List, Literal, Optional, Sequence,
+                    Tuple, Union)
 import zlib
 
 import click
@@ -26,6 +27,7 @@ from sky.utils import admin_policy_utils
 from sky.utils import common_utils
 from sky.utils import context
 from sky.utils import dag_utils
+from sky.utils import rich_utils
 
 if typing.TYPE_CHECKING:
     import io
@@ -411,9 +413,23 @@ def cancel(
     return server_common.get_request_id(response=response)
 
 
-@usage_lib.entrypoint
-@server_common.check_server_healthy_or_start
-@rest.retry_transient_errors()
+@typing.overload
+def tail_logs(
+        name: Optional[str] = None,
+        job_id: Optional[int] = None,
+        follow: bool = True,
+        controller: bool = False,
+        refresh: bool = False,
+        tail: Optional[int] = None,
+        tail_offset: Optional[int] = None,
+        output_stream: Optional['io.TextIOBase'] = None,
+        task: Optional[Union[str, int]] = None,
+        *,  # keyword only separator
+        preload_content: Literal[True] = True) -> Optional[int]:
+    ...
+
+
+@typing.overload
 def tail_logs(name: Optional[str] = None,
               job_id: Optional[int] = None,
               follow: bool = True,
@@ -421,8 +437,29 @@ def tail_logs(name: Optional[str] = None,
               refresh: bool = False,
               tail: Optional[int] = None,
               tail_offset: Optional[int] = None,
-              output_stream: Optional['io.TextIOBase'] = None,
-              task: Optional[Union[str, int]] = None) -> Optional[int]:
+              output_stream: None = None,
+              task: Optional[Union[str, int]] = None,
+              *,
+              preload_content: Literal[False]) -> Iterator[Optional[str]]:
+    ...
+
+
+@usage_lib.entrypoint
+@server_common.check_server_healthy_or_start
+@rest.retry_transient_errors()
+def tail_logs(
+    name: Optional[str] = None,
+    job_id: Optional[int] = None,
+    follow: bool = True,
+    controller: bool = False,
+    refresh: bool = False,
+    tail: Optional[int] = None,
+    tail_offset: Optional[int] = None,
+    output_stream: Optional['io.TextIOBase'] = None,
+    task: Optional[Union[str, int]] = None,
+    *,  # keyword only separator
+    preload_content: bool = True
+) -> Union[Optional[int], Iterator[Optional[str]]]:
     """Tails logs of managed jobs.
 
     You can provide either a job name or a job ID to tail logs. If both are not
@@ -436,17 +473,26 @@ def tail_logs(name: Optional[str] = None,
         refresh: Whether to restart the jobs controller if it is stopped.
         tail: Number of lines to tail from the end of the log file.
         output_stream: The stream to write the logs to. If None, print to the
-            console.
+            console. Cannot be used with preload_content=False.
         task: Task identifier to view logs for a specific task in a JobGroup.
             If an int, it is treated as a task ID. If a str, it is treated as
             a task name. If None, logs for all tasks are shown.
+        preload_content: if False, returns an Iterator[str | None] containing
+            the logs without the function blocking on the retrieval of the
+            entire log. Iterator returns None when the log has been completely
+            streamed. Default True. Cannot be used with output_stream.
 
     Returns:
-        Exit code based on success or failure of the job. 0 if success,
-        100 if the job failed. See exceptions.JobExitCode for possible exit
-        codes.
-        Will return None if follow is False
-        (see note in sky/client/sdk.py::stream_response)
+        If preload_content is True:
+            Exit code based on success or failure of the job. 0 if success,
+            100 if the job failed. See exceptions.JobExitCode for possible exit
+            codes.
+            Will return None if follow is False
+            (see note in sky/client/sdk.py::stream_response)
+        If preload_content is False:
+            Iterator[str | None] containing the logs without the function
+            blocking on the retrieval of the entire log. Iterator returns None
+            when the log has been completely streamed.
 
     Request Raises:
         ValueError: invalid arguments.
@@ -458,6 +504,9 @@ def tail_logs(name: Optional[str] = None,
     if tail_offset is not None and tail_offset < 0:
         raise ValueError(f'tail_offset must be None or a non-negative integer, '
                          f'got {tail_offset}.')
+    if output_stream is not None and not preload_content:
+        raise ValueError(
+            'output_stream cannot be specified when preload_content is False')
     body = payloads.JobsLogsBody(
         name=name,
         job_id=job_id,
@@ -476,13 +525,16 @@ def tail_logs(name: Optional[str] = None,
         timeout=(5, None))
     request_id: server_common.RequestId[int] = server_common.get_request_id(
         response)
-    # Log request is idempotent when tail is None or 0 (both stream from
-    # the beginning), thus can resume previous streaming point on retry.
-    return sdk.stream_response(request_id=request_id,
-                               response=response,
-                               output_stream=output_stream,
-                               resumable=(tail is None or tail == 0),
-                               get_result=follow)
+    if preload_content:
+        # Log request is idempotent when tail is None or 0 (both stream from
+        # the beginning), thus can resume previous streaming point on retry.
+        return sdk.stream_response(request_id=request_id,
+                                   response=response,
+                                   output_stream=output_stream,
+                                   resumable=(tail is None or tail == 0),
+                                   get_result=follow)
+    else:
+        return rich_utils.decode_rich_status(response)
 
 
 @context.contextual

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -415,17 +415,18 @@ def cancel(
 
 @typing.overload
 def tail_logs(
-        name: Optional[str] = None,
-        job_id: Optional[int] = None,
-        follow: bool = True,
-        controller: bool = False,
-        refresh: bool = False,
-        tail: Optional[int] = None,
-        tail_offset: Optional[int] = None,
-        output_stream: Optional['io.TextIOBase'] = None,
-        task: Optional[Union[str, int]] = None,
-        *,  # keyword only separator
-        preload_content: Literal[True] = True) -> Optional[int]:
+    name: Optional[str] = None,
+    job_id: Optional[int] = None,
+    follow: bool = True,
+    controller: bool = False,
+    refresh: bool = False,
+    tail: Optional[int] = None,
+    tail_offset: Optional[int] = None,
+    output_stream: Optional['io.TextIOBase'] = None,
+    task: Optional[Union[str, int]] = None,
+    *,  # keyword only separator
+    preload_content: Literal[True] = True
+) -> Optional[int]:
     ...
 
 

--- a/sky/jobs/client/sdk_async.py
+++ b/sky/jobs/client/sdk_async.py
@@ -135,8 +135,11 @@ async def tail_logs(cluster_name: str,
                     tail: int = 0,
                     output_stream: Optional['io.TextIOBase'] = None) -> int:
     """Async version of tail_logs() that tails the logs of a job."""
+    # mypy cannot pick an overload of sdk.tail_logs when it is passed as a
+    # value to asyncio.to_thread; the runtime call is unambiguous because
+    # preload_content defaults to True.
     return await asyncio.to_thread(
-        sdk.tail_logs,
+        sdk.tail_logs,  # type: ignore[arg-type]
         cluster_name,
         job_id,
         follow,


### PR DESCRIPTION
## Summary

Mirror the cluster-level `sky.tail_logs` API (added in #6750) so the managed-jobs counterpart can also return an iterator instead of writing to a blocking `output_stream`. With `preload_content=False` the function returns an `Iterator[str | None]` that yields lines as they arrive, which lets SDK consumers stream managed-job logs without spawning a background thread to bridge the blocking writer into a generator.

Behavior under `preload_content=True` (the default) is unchanged — existing callers are unaffected.

## Why

Today there's an asymmetry between the two log-streaming entry points:

| API                   | `preload_content=False` |
|-----------------------|-------------------------|
| `sky.tail_logs`       | ✅ returns iterator     |
| `sky.jobs.tail_logs`  | ❌ not supported        |

Both call into the same internals (`rich_utils.decode_rich_status` over a streaming HTTP response), so the jobs side just hadn't been backfilled.

A concrete motivating use case: integrating SkyPilot's managed-job log stream into another orchestrator's `Iterator[str]` log API. Without `preload_content=False` on `sky.jobs.tail_logs`, the only option is to spawn a producer thread that calls `tail_logs(follow=True, output_stream=buf)` and a consumer that yields from `buf` — works, but feels heavy when the underlying SDK already has a generator.

## What changed

`sky/jobs/client/sdk.py::tail_logs`:
- Added `preload_content: bool = True` keyword-only parameter.
- Added two `@typing.overload`s to give callers the right return type per the `preload_content` literal (`int | None` vs `Iterator[Optional[str]]`).
- Raise `ValueError` if both `output_stream` and `preload_content=False` are passed (mirrors the cluster-level check).
- When `preload_content=False`, return `rich_utils.decode_rich_status(response)` directly instead of going through `stream_response`.

Code path under `preload_content=True` is unchanged.

## Test plan

- [x] Module imports cleanly (`from sky.jobs.client import sdk`).
- [x] `inspect.signature(sdk.tail_logs)` reflects the new parameter and union return.
- [ ] Existing `sky.jobs.tail_logs` callers still get `Optional[int]` back (overload resolution + default value of `preload_content`).
- [ ] `for line in sky.jobs.tail_logs(job_id=..., preload_content=False): ...` yields managed-job log lines as they arrive.
- [ ] `sky.jobs.tail_logs(output_stream=buf, preload_content=False)` raises `ValueError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->