### PR TITLE
[API] Skip request env overlay for internal daemon requests

### DIFF
--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -371,7 +371,8 @@ def override_request_env_and_config(
             # time by prepare_request_async when is_skypilot_system=True,
             # so no add_or_update_user round-trip is needed per tick.
             user = models.User(id=constants.SKYPILOT_SYSTEM_USER_ID,
-                               name=constants.SKYPILOT_SYSTEM_USER_ID)
+                               name=constants.SKYPILOT_SYSTEM_USER_ID,
+                               user_type=models.UserType.SYSTEM.value)
             # Daemons always run in-process on the server, regardless of
             # what the persisted body recorded.
             using_remote_api_server = False
@@ -418,13 +419,10 @@ def override_request_env_and_config(
         with skypilot_config.override_skypilot_config(
                 request_body.override_skypilot_config,
                 request_body.override_skypilot_config_path):
-            # Skip permission check for sky.workspaces.get request as it is
-            # used to determine which workspaces the user has access to.
-            # Also skip for daemons: the SkyPilot system user has admin
-            # role (see sky/users/permission.py) so this check would always
-            # pass — skipping it is a perf optimization to avoid a DB
-            # round-trip per daemon tick.
-            if not is_daemon and request_name != 'sky.workspaces.get':
+            # Skip permission check for sky.workspaces.get request
+            # as it is used to determine which workspaces the user
+            # has access to.
+            if request_name != 'sky.workspaces.get':
                 try:
                     # Reject requests that the user does not have permission
                     # to access.

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -356,39 +356,61 @@ def override_request_env_and_config(
         request_body: payloads.RequestBody, request_id: str,
         request_name: str) -> Generator[None, None, None]:
     """Override the environment and SkyPilot config for a request."""
+    # Daemons run AS the server, not as any client. Their persisted
+    # request_body.env_vars came from whichever pod first scheduled them,
+    # which may be a previous deployment generation with stale downward-API
+    # values (e.g. SKYPILOT_POD_MEMORY_BYTES_LIMIT, SKYPILOT_APISERVER_UUID).
+    # Overlaying those would clobber the current pod's actual values. So
+    # for daemons, skip the env overlay and use the current process's
+    # os.environ.
+    is_daemon = daemons.is_daemon_request_id(request_id)
     original_env = os.environ.copy()
     try:
-        # Unset SKYPILOT_DEBUG by default, to avoid the value set on the API
-        # server affecting client requests. If set on the client side, it will
-        # be overridden by the request body.
-        os.environ.pop('SKYPILOT_DEBUG', None)
-        # Remove the db connection uri from client supplied env vars, as the
-        # client should not set the db string on server side.
-        request_body.env_vars.pop(constants.ENV_VAR_DB_CONNECTION_URI, None)
-        # Remove the in-cluster context name from client supplied env vars.
-        # When a client runs inside a Kubernetes pod (e.g., a managed job with
-        # api_server_access), its env has SKYPILOT_IN_CLUSTER_CONTEXT_NAME set
-        # pod template. If this leaks into the server's os.environ, it causes
-        # the server to attempt in-cluster auth (load_incluster_config) instead
-        # of using its own kubeconfig, which fails when the server is not
-        # running in a Kubernetes pod.
-        request_body.env_vars.pop(
-            kubernetes_adaptor.IN_CLUSTER_CONTEXT_NAME_ENV_VAR, None)
-        os.environ.update(request_body.env_vars)
-        # Note: may be overridden by AuthProxyMiddleware.
-        # TODO(zhwu): we need to make the entire request a context available to
-        # the entire request execution, so that we can access info like user
-        # through the execution.
-        user = models.User(id=request_body.env_vars[constants.USER_ID_ENV_VAR],
-                           name=request_body.env_vars[constants.USER_ENV_VAR])
-        _, user = global_user_state.add_or_update_user(user, return_user=True)
+        if is_daemon:
+            # The SkyPilot system user is already upserted at scheduling
+            # time by prepare_request_async when is_skypilot_system=True,
+            # so no add_or_update_user round-trip is needed per tick.
+            user = models.User(id=constants.SKYPILOT_SYSTEM_USER_ID,
+                               name=constants.SKYPILOT_SYSTEM_USER_ID)
+            # Daemons always run in-process on the server, regardless of
+            # what the persisted body recorded.
+            using_remote_api_server = False
+        else:
+            # Unset SKYPILOT_DEBUG by default, to avoid the value set on the
+            # API server affecting client requests. If set on the client
+            # side, it will be overridden by the request body.
+            os.environ.pop('SKYPILOT_DEBUG', None)
+            # Remove the db connection uri from client supplied env vars, as
+            # the client should not set the db string on server side.
+            request_body.env_vars.pop(constants.ENV_VAR_DB_CONNECTION_URI, None)
+            # Remove the in-cluster context name from client supplied env
+            # vars. When a client runs inside a Kubernetes pod (e.g., a
+            # managed job with api_server_access), its env has
+            # SKYPILOT_IN_CLUSTER_CONTEXT_NAME set pod template. If this
+            # leaks into the server's os.environ, it causes the server to
+            # attempt in-cluster auth (load_incluster_config) instead of
+            # using its own kubeconfig, which fails when the server is not
+            # running in a Kubernetes pod.
+            request_body.env_vars.pop(
+                kubernetes_adaptor.IN_CLUSTER_CONTEXT_NAME_ENV_VAR, None)
+            os.environ.update(request_body.env_vars)
+            # Note: may be overridden by AuthProxyMiddleware.
+            # TODO(zhwu): we need to make the entire request a context
+            # available to the entire request execution, so that we can
+            # access info like user through the execution.
+            user = models.User(
+                id=request_body.env_vars[constants.USER_ID_ENV_VAR],
+                name=request_body.env_vars[constants.USER_ENV_VAR])
+            _, user = global_user_state.add_or_update_user(user,
+                                                           return_user=True)
+            using_remote_api_server = request_body.using_remote_api_server
 
         # Force color to be enabled.
         os.environ['CLICOLOR_FORCE'] = '1'
         server_common.reload_for_new_request(
             client_entrypoint=request_body.entrypoint,
             client_command=request_body.entrypoint_command,
-            using_remote_api_server=request_body.using_remote_api_server,
+            using_remote_api_server=using_remote_api_server,
             user=user,
             request_id=request_id)
         logger.debug(
@@ -396,10 +418,13 @@ def override_request_env_and_config(
         with skypilot_config.override_skypilot_config(
                 request_body.override_skypilot_config,
                 request_body.override_skypilot_config_path):
-            # Skip permission check for sky.workspaces.get request
-            # as it is used to determine which workspaces the user
-            # has access to.
-            if request_name != 'sky.workspaces.get':
+            # Skip permission check for sky.workspaces.get request as it is
+            # used to determine which workspaces the user has access to.
+            # Also skip for daemons: the SkyPilot system user has admin
+            # role (see sky/users/permission.py) so this check would always
+            # pass — skipping it is a perf optimization to avoid a DB
+            # round-trip per daemon tick.
+            if not is_daemon and request_name != 'sky.workspaces.get':
                 try:
                     # Reject requests that the user does not have permission
                     # to access.
@@ -420,7 +445,11 @@ def override_request_env_and_config(
         # Restore the original environment variables, so that a new request
         # won't be affected by the previous request, e.g. SKYPILOT_DEBUG
         # setting, etc. This is necessary as our executor is reusing the
-        # same process for multiple requests.
+        # same process for multiple requests. The daemon path also relies
+        # on this: daemons mutate os.environ from inside the with block
+        # (e.g. setting SKYPILOT_DISABLE_LOGGING in
+        # InternalRequestDaemon.run_event), and that mutation must not
+        # leak to whichever request the worker handles next.
         os.environ.clear()
         os.environ.update(original_env)
 

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -15,6 +15,7 @@ from sky import exceptions
 from sky import skypilot_config
 from sky.server import config as server_config
 from sky.server import constants as server_constants
+from sky.server import daemons as server_daemons
 from sky.server.requests import executor
 from sky.server.requests import payloads
 from sky.server.requests import process
@@ -684,6 +685,110 @@ def test_resolve_blob_invalid_id(tmp_path, monkeypatch):
     with pytest.raises(ValueError, match='Invalid file_mounts_blob_id'):
         from sky.server import common as server_common
         server_common.resolve_blob_dir('not-a-hash', 'testuser')
+
+
+@pytest.fixture()
+def stub_override_request_env_deps(monkeypatch):
+    """Stub out reload/permissions/user upsert for override_request_env tests.
+
+    Lets the tests assert only what override_request_env_and_config does to
+    os.environ, without needing a real DB / context / permission backend.
+    """
+    monkeypatch.setattr('sky.server.common.reload_for_new_request', mock.Mock())
+    monkeypatch.setattr(
+        'sky.workspaces.core.reject_request_for_unauthorized_workspace',
+        mock.Mock())
+
+    fake_user = mock.Mock()
+    fake_user.id = 'client-user-id'
+    fake_user.name = 'client-user'
+
+    def fake_add_or_update_user(user, return_user=False, **kwargs):
+        if return_user:
+            return True, fake_user
+        return True
+
+    monkeypatch.setattr('sky.global_user_state.add_or_update_user',
+                        fake_add_or_update_user)
+
+
+def test_override_env_skipped_for_daemon_request(stub_override_request_env_deps,
+                                                 monkeypatch):
+    """Daemon request_ids must NOT have their persisted env_vars overlaid.
+
+    Reproduces SKY-5502: a daemon row in PG carrying stale downward-API
+    values from a previous deployment generation must not clobber the
+    current pod's os.environ.
+    """
+    # Seed the "current pod" env with realistic downward-API values.
+    monkeypatch.setenv('SKYPILOT_POD_MEMORY_BYTES_LIMIT', str(300 * 1024**3))
+    monkeypatch.setenv('SKYPILOT_APISERVER_UUID', 'current-pod-uuid')
+
+    # Persisted daemon body has STALE values from a now-dead pod.
+    body = payloads.RequestBody(
+        env_vars={
+            'SKYPILOT_POD_MEMORY_BYTES_LIMIT': str(100 * 1024 * 1024),
+            'SKYPILOT_APISERVER_UUID': 'stale-pod-uuid',
+            constants.USER_ID_ENV_VAR: 'irrelevant',
+            constants.USER_ENV_VAR: 'irrelevant',
+        })
+
+    # Pick a real daemon id so daemons.is_daemon_request_id returns True.
+    daemon_id = server_daemons.INTERNAL_REQUEST_DAEMONS[0].id
+
+    with executor.override_request_env_and_config(body,
+                                                  request_id=daemon_id,
+                                                  request_name='daemon'):
+        assert os.environ['SKYPILOT_POD_MEMORY_BYTES_LIMIT'] == str(
+            300 * 1024**3), ('daemon override clobbered the current pod env')
+        assert os.environ['SKYPILOT_APISERVER_UUID'] == 'current-pod-uuid'
+
+
+def test_override_env_applied_for_client_request(stub_override_request_env_deps,
+                                                 monkeypatch):
+    """Regression guard: client requests must still have env_vars applied."""
+    monkeypatch.setenv('SKYPILOT_POD_MEMORY_BYTES_LIMIT', str(300 * 1024**3))
+
+    body = payloads.RequestBody(
+        env_vars={
+            'SKYPILOT_POD_MEMORY_BYTES_LIMIT': str(100 * 1024 * 1024),
+            constants.USER_ID_ENV_VAR: 'client-user-id',
+            constants.USER_ENV_VAR: 'client-user',
+        })
+
+    with executor.override_request_env_and_config(
+            body, request_id='not-a-daemon-uuid', request_name='sky.launch'):
+        assert os.environ['SKYPILOT_POD_MEMORY_BYTES_LIMIT'] == str(100 * 1024 *
+                                                                    1024)
+
+
+def test_daemon_env_mutations_reverted_on_exit(stub_override_request_env_deps,
+                                               monkeypatch):
+    """Daemon env mutations inside the with block must be reverted on exit.
+
+    Daemons (e.g. InternalRequestDaemon.run_event) set
+    SKYPILOT_DISABLE_LOGGING from inside the with block. If that mutation
+    leaked, the next request handled by the same worker would inherit it.
+    """
+    monkeypatch.setenv('SKYPILOT_PRE_EXISTING', 'before')
+    monkeypatch.delenv('SKYPILOT_NEW_VAR', raising=False)
+
+    body = payloads.RequestBody(
+        env_vars={
+            constants.USER_ID_ENV_VAR: 'irrelevant',
+            constants.USER_ENV_VAR: 'irrelevant',
+        })
+
+    daemon_id = server_daemons.INTERNAL_REQUEST_DAEMONS[0].id
+
+    with executor.override_request_env_and_config(body,
+                                                  request_id=daemon_id,
+                                                  request_name='daemon'):
+        os.environ['SKYPILOT_NEW_VAR'] = 'inside'
+        del os.environ['SKYPILOT_PRE_EXISTING']
+
+    assert 'SKYPILOT_NEW_VAR' not in os.environ
+    assert os.environ['SKYPILOT_PRE_EXISTING'] == 'before'
 
 
 def test_resolve_blob_missing_file(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

`override_request_env_and_config` (`sky/server/requests/executor.py`) overlays
`request_body.env_vars` onto `os.environ` for every dequeued request. For client
requests this is correct — the executor temporarily takes on the client's
identity. For internal daemon requests (`managed-job-status-refresh-daemon`,
`skypilot-status-refresh-daemon`, etc.), the persisted `env_vars` were captured
when the daemon row was first written to the request store, which may have been
by a previous API server process (different pod, different deployment
generation). Overlaying that stale snapshot clobbers the current process's
actual environment, including downward-API values like
`SKYPILOT_POD_MEMORY_BYTES_LIMIT` and `SKYPILOT_APISERVER_UUID`.

Concretely, this can cause `common_utils.get_mem_size_gb()` inside the daemon
to return a stale value from a long-dead pod (e.g. `0.0977` for an old
`SKYPILOT_POD_MEMORY_BYTES_LIMIT=104857600`) instead of the current pod's
actual memory limit — which then breaks
`controller_utils.get_number_of_jobs_controllers()` and any other logic that
depends on the live process environment.

Fix: short-circuit the env_vars overlay (and a handful of related client-only
steps — `add_or_update_user`, the workspace permission check) for daemon
request ids. The shared `try/finally` that restores `os.environ` on exit is
kept for both code paths, so daemons that intentionally mutate `os.environ`
inside the `with` block (e.g. `InternalRequestDaemon.run_event` setting
`SKYPILOT_DISABLE_LOGGING=1`) still get cleaned up and don't leak that
mutation to the next request handled by the same worker.

## Test plan

- [x] New unit tests in `tests/unit_tests/test_sky/server/requests/test_executor.py`:
  - `test_override_env_skipped_for_daemon_request` — daemon path leaves
    current process env intact even when the persisted body has stale values.
  - `test_override_env_applied_for_client_request` — client path still
    overlays env_vars (regression guard).
  - `test_daemon_env_mutations_reverted_on_exit` — env mutations inside the
    daemon `with` block are still reverted on exit (regression guard for the
    shared finally).
- [x] Manual repro script that seeds `os.environ` with current-pod values,
  enters `override_request_env_and_config` with a daemon request id and a
  stale `env_vars`, and calls `common_utils.get_mem_size_gb()`. Without the
  fix: returns `0.0977 GiB` (the stale value). With the fix: returns
  `300.0000 GiB` (the actual pod memory).
- [x] `bash format.sh --files sky/server/requests/executor.py tests/unit_tests/test_sky/server/requests/test_executor.py` clean (the remaining pylint warnings are pre-existing).
- [x] Full `test_executor.py` suite (15 tests) passes.

-Claude