### PR TITLE
[CI] Fix shell injection in run-python-tests composite action

### DIFF
--- a/.github/actions/run-python-tests/action.yaml
+++ b/.github/actions/run-python-tests/action.yaml
@@ -36,24 +36,30 @@ runs:
     - name: Set branch name and commit message
       id: set_env
       shell: bash
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+        HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        MERGE_GROUP_HEAD_COMMIT_MESSAGE: ${{ github.event.merge_group.head_commit.message }}
+        HEAD_REF: ${{ github.head_ref }}
+        REF_NAME: ${{ github.ref_name }}
       run: |
         if [ "${{ github.event_name }}" == "pull_request" ]; then
-          echo "branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
+          echo "branch=$HEAD_REF" >> $GITHUB_OUTPUT
           {
             echo "message<<EOF"
-            echo "${{ github.event.pull_request.title }}"
+            echo "$PR_TITLE"
             echo "EOF"
           } >> $GITHUB_OUTPUT
         else
-          echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          echo "branch=$REF_NAME" >> $GITHUB_OUTPUT
           # For push events after merge, head_commit.message contains the merge commit message
           # which includes the PR title. For merge_group events, use merge_group.head_commit.message
           {
             echo "message<<EOF"
             if [ "${{ github.event_name }}" == "merge_group" ]; then
-              echo "${{ github.event.merge_group.head_commit.message }}"
+              echo "$MERGE_GROUP_HEAD_COMMIT_MESSAGE"
             else
-              echo "${{ github.event.head_commit.message }}"
+              echo "$HEAD_COMMIT_MESSAGE"
             fi
             echo "EOF"
           } >> $GITHUB_OUTPUT

--- a/.github/actions/run-python-tests/action.yaml
+++ b/.github/actions/run-python-tests/action.yaml
@@ -47,7 +47,7 @@ runs:
           echo "branch=$HEAD_REF" >> $GITHUB_OUTPUT
           {
             echo "message<<EOF"
-            echo "$PR_TITLE"
+            printf '%s\n' "$PR_TITLE"
             echo "EOF"
           } >> $GITHUB_OUTPUT
         else
@@ -57,9 +57,9 @@ runs:
           {
             echo "message<<EOF"
             if [ "${{ github.event_name }}" == "merge_group" ]; then
-              echo "$MERGE_GROUP_HEAD_COMMIT_MESSAGE"
+              printf '%s\n' "$MERGE_GROUP_HEAD_COMMIT_MESSAGE"
             else
-              echo "$HEAD_COMMIT_MESSAGE"
+              printf '%s\n' "$HEAD_COMMIT_MESSAGE"
             fi
             echo "EOF"
           } >> $GITHUB_OUTPUT

--- a/tests/unit_tests/test_sky/server/test_sdk.py
+++ b/tests/unit_tests/test_sky/server/test_sdk.py
@@ -333,7 +333,9 @@ def test_api_login_user_hash_needs_auth(monkeypatch: pytest.MonkeyPatch,
             'cookies': {}
         }).encode('utf-8')).decode('utf-8')
 
-    with mock.patch('sky.server.common.check_server_healthy') as mock_check:
+    with mock.patch('sky.server.common.check_server_healthy') as mock_check, \
+         mock.patch('sky.server.versions.get_remote_api_version',
+                    return_value=None):
         # On first call, return needs auth.
         first_return_value = (
             server_common.ApiServerStatus.NEEDS_AUTH,
@@ -393,7 +395,9 @@ def test_api_login_user_hash_needs_auth_both(monkeypatch: pytest.MonkeyPatch,
             'cookies': {}
         }).encode('utf-8')).decode('utf-8')
 
-    with mock.patch('sky.server.common.check_server_healthy') as mock_check:
+    with mock.patch('sky.server.common.check_server_healthy') as mock_check, \
+         mock.patch('sky.server.versions.get_remote_api_version',
+                    return_value=None):
         # On first call, return needs auth.
         first_return_value = (
             server_common.ApiServerStatus.NEEDS_AUTH,


### PR DESCRIPTION
## Summary

Two fixes that together unblock the Python Tests workflow on master.

### 1. Shell injection in the run-python-tests composite action

- The `set_env` step in `.github/actions/run-python-tests/action.yaml` interpolated `${{ github.event.head_commit.message }}` and other untrusted GitHub contexts directly into a bash `run:` script. When the message contained backticks (which bash treats as command substitution) or other shell metacharacters, the runner errored out with `syntax error near unexpected token`. This broke 6 of the matrix jobs in the latest master Python Tests run (https://github.com/skypilot-org/skypilot/actions/runs/26124850396) when commit 3fc18abcd was merged with a multi-page squashed commit body containing many backtick-quoted code spans.
- PR #9531 already applied the env-var indirection fix to `.github/workflows/pytest.yml`, but a parallel refactor moved the matrix jobs to this composite action which kept the original unsafe pattern. The `limited-deps` and `failover` jobs (still inline in `pytest.yml`) were unaffected.
- This PR mirrors the #9531 pattern in the composite action: lift each `${{ ... }}` expression into the step's `env:` and reference it as `$VAR` in the script body. Also switches the three untrusted-value emits to `printf '%s\n'` instead of `echo` (addressing Gemini review), so a leading `-n`/`-e` in the title/message cannot be parsed as a flag and collapse the heredoc `EOF`.

### 2. api_login tests broken by cross-test contextvar pollution

After unblocking the workflow, `Python Tests - Unit Tests` surfaced a separate pre-existing failure:

```
sky/client/sdk.py:2927: in api_login
    if remote_api_version is not None and remote_api_version >= 30:
E   TypeError: '>=' not supported between instances of 'Mock' and 'int'
```

- `api_login()` since #8590 gates a polling-auth code path on `versions.get_remote_api_version() >= 30`. The contextvar defaults to `None`, so the gate is normally False.
- `test_api_login_user_hash_needs_auth` and `test_api_login_user_hash_needs_auth_both` (added in #9252) never mocked `get_remote_api_version`. They passed because the default `None` made the gate False.
- Another test in the suite leaks a non-None value into either `versions.get_remote_api_version` or the `_remote_api_version` contextvar. Under pytest-xdist `worksteal`, whether these tests share a worker with the polluting test depends on the shard layout.
- Commit 3fc18abcd added ~76 lines of new unit tests (3939 -> 3971 collected). The shard rebalance landed the polluting test on the same worker as the api_login tests for the first time, turning a latent bug into a hard failure.

Fix: wrap each `with` block in the two affected tests with `mock.patch('sky.server.versions.get_remote_api_version', return_value=None)`. Mirrors the test-only diff from PR #9659.

## Follow-up (out of scope)

- The composite action's `Run tests with pytest` step does not wire `steps.set_env.outputs.branch`/`message` into `GITHUB_REF`/`TEST_ANALYTICS_COMMIT_MESSAGE` like the original `pytest.yml` did before the refactor, so Buildkite test-analytics is missing those values.
- The underlying contextvar pollution in the unit-test suite (which test is leaking a Mock into `_remote_api_version`) is not chased here; this PR isolates the api_login tests from it but doesn't identify or remove the leak.

## Test plan

- [ ] CI passes on this PR (the workflow now runs against the patched composite action + the test fix).
- [x] Both `test_api_login_user_hash_needs_auth` tests pass locally after the test fix.
- [ ] Verify locally with a synthetic commit message containing backticks, e.g. `` `kubectl get pod` ``, that the `set_env` step echoes the literal characters instead of running command substitution.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->