### PR TITLE
[Kubernetes] Remove `all_includes_in_cluster` from skypilot config

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -72,7 +72,6 @@ Below is the configuration syntax and some example values. See detailed explanat
     :ref:`allowed_contexts <config-yaml-kubernetes-allowed-contexts>`:
       - context1
       - context2
-    :ref:`all_includes_in_cluster <config-yaml-kubernetes-all-includes-in-cluster>`: true
     :ref:`allowed_nodes <config-yaml-kubernetes-allowed-nodes>`:
       names:
         - gpu-node-01
@@ -1612,34 +1611,14 @@ If you want all available contexts to be allowed, set it to 'all' like this:
 You can also set ``SKYPILOT_ALLOW_ALL_KUBERNETES_CONTEXTS`` environment variable to ``"true"``
 for the same effect. Configuration option overrides the environment variable if set.
 
-.. _config-yaml-kubernetes-all-includes-in-cluster:
-
-``kubernetes.all_includes_in_cluster``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Whether ``allowed_contexts: all`` (or the ``SKYPILOT_ALLOW_ALL_KUBERNETES_CONTEXTS``
-env var) should include the API server's own in-cluster context (optional, default ``true``).
-
-When the SkyPilot API server runs inside Kubernetes, the pod's own host cluster is
-discoverable as an ``in-cluster`` context. By default it is included in the
-``allowed_contexts: all`` expansion (backward compatible). Set this to ``false`` to
-exclude it — useful on deployments where the API server's host cluster
-should not be a user-facing compute target. Explicitly listing ``in-cluster`` in
-``allowed_contexts`` always keeps it, regardless of this flag.
-
-.. code-block:: yaml
-
-  kubernetes:
-    allowed_contexts: all
-    all_includes_in_cluster: false
-
-You can also set the ``SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER``
-environment variable on the API server pod. The env var takes precedence over
-the config field — useful for operators of the deployments to enforce a
-value that admins editing SkyPilot config cannot override.
-
-Resolution order (highest first): env var, workspace config, global config,
-default ``true``.
+When the SkyPilot API server runs inside Kubernetes, the pod's own host cluster
+is discoverable as an ``in-cluster`` context and is included in the
+``allowed_contexts: all`` expansion by default. To exclude it — for example,
+when the API server's host cluster should not be a user-facing compute
+target — set the environment variable
+``SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER`` to ``"false"`` on the
+API server pod. Explicitly listing ``in-cluster`` in ``allowed_contexts``
+always keeps it, regardless of this env var.
 
 .. _config-yaml-kubernetes-allowed-nodes:
 

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -1611,15 +1611,6 @@ If you want all available contexts to be allowed, set it to 'all' like this:
 You can also set ``SKYPILOT_ALLOW_ALL_KUBERNETES_CONTEXTS`` environment variable to ``"true"``
 for the same effect. Configuration option overrides the environment variable if set.
 
-When the SkyPilot API server runs inside Kubernetes, the pod's own host cluster
-is discoverable as an ``in-cluster`` context and is included in the
-``allowed_contexts: all`` expansion by default. To exclude it — for example,
-when the API server's host cluster should not be a user-facing compute
-target — set the environment variable
-``SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER`` to ``"false"`` on the
-API server pod. Explicitly listing ``in-cluster`` in ``allowed_contexts``
-always keeps it, regardless of this env var.
-
 .. _config-yaml-kubernetes-allowed-nodes:
 
 ``kubernetes.allowed_nodes``

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -213,8 +213,8 @@ class Kubernetes(clouds.Cloud):
             # `'all'` expansion, so the cluster running the API server is
             # not surfaced as a user-facing compute target. Default is to
             # include in-cluster (backward compatible).
-            if env_options.Options.ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER \
-                    .get():
+            if (env_options.Options.ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER.
+                    get()):
                 allowed_contexts = all_contexts
             else:
                 in_cluster_name = kubernetes.in_cluster_context_name()

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -174,27 +174,6 @@ class Kubernetes(clouds.Cloud):
                 'Ignoring these contexts.')
 
     @classmethod
-    def _resolve_all_includes_in_cluster(cls) -> bool:
-        """Resolve whether 'all' should include the in-cluster context.
-
-        Precedence (highest first):
-          1. SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER env var
-             (operator-level, set on the API server pod;
-             not overridable by admin via config).
-          2. `kubernetes.all_includes_in_cluster` config field (workspace
-             beats global).
-          3. Default: True (backward compatible).
-        """
-        env_val = (env_options.Options.
-                   ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER.get_optional())
-        if env_val is not None:
-            return env_val
-        return skypilot_config.get_effective_workspace_region_config(
-            cloud='kubernetes',
-            keys=('all_includes_in_cluster',),
-            default_value=True)
-
-    @classmethod
     def existing_allowed_contexts(cls, silent: bool = False) -> List[str]:
         """Get existing allowed contexts.
 
@@ -229,8 +208,13 @@ class Kubernetes(clouds.Cloud):
             allowed_contexts is None and
             env_options.Options.ALLOW_ALL_KUBERNETES_CONTEXTS.get())
         if allow_all_contexts:
-            all_includes_in_cluster = cls._resolve_all_includes_in_cluster()
-            if all_includes_in_cluster:
+            # `SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER=false`
+            # excludes the API server's own in-cluster context from the
+            # `'all'` expansion, so the cluster running the API server is
+            # not surfaced as a user-facing compute target. Default is to
+            # include in-cluster (backward compatible).
+            if env_options.Options.ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER \
+                    .get():
                 allowed_contexts = all_contexts
             else:
                 in_cluster_name = kubernetes.in_cluster_context_name()

--- a/sky/utils/env_options.py
+++ b/sky/utils/env_options.py
@@ -1,7 +1,7 @@
 """Global environment options for sky."""
 import enum
 import os
-from typing import Dict, Optional
+from typing import Dict
 
 
 class Options(enum.Enum):
@@ -31,14 +31,13 @@ class Options(enum.Enum):
     # config.
     ALLOW_ALL_KUBERNETES_CONTEXTS = ('SKYPILOT_ALLOW_ALL_KUBERNETES_CONTEXTS',
                                      False)
-    # Operator-level override for whether `allowed_contexts: 'all'` (or the
-    # env-var-triggered allow-all path) should include the API server's own
-    # in-cluster context. Unset by default; falls through to the config field
-    # `kubernetes.all_includes_in_cluster`.
-    # Read via `get_optional()` since "unset" is
-    # semantically distinct from "false".
+    # Whether `allowed_contexts: 'all'` (or the env-var-triggered allow-all
+    # path) should include the API server's own in-cluster context. Default
+    # `True` (backward compatible). Set to `false` on the API server pod to
+    # keep the in-cluster context from being surfaced as a user-facing
+    # compute target via `allowed_contexts: 'all'`.
     ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER = (
-        'SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER', False)
+        'SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER', True)
 
     def __init__(self, env_var: str, default: bool) -> None:
         super().__init__()
@@ -52,17 +51,6 @@ class Options(enum.Enum):
         """Check if an environment variable is set to True."""
         return os.getenv(self.env_var,
                          str(self.default)).lower() in ('true', '1')
-
-    def get_optional(self) -> Optional[bool]:
-        """Parse the env var as a bool, or return None if unset.
-
-        Use when "unset" is semantically distinct from "false" (e.g. for
-        layered resolution where a config field provides the default).
-        """
-        val = os.environ.get(self.env_var)
-        if val is None:
-            return None
-        return val.lower() in ('true', '1')
 
     @property
     def env_key(self) -> str:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1885,9 +1885,6 @@ def get_config_schema():
                         'pattern': '^all$'
                     }]
                 },
-                'all_includes_in_cluster': {
-                    'type': 'boolean',
-                },
                 'context_configs': {
                     'type': 'object',
                     'required': [],
@@ -2348,9 +2345,6 @@ def get_config_schema():
                                 'type': 'string',
                                 'pattern': '^all$'
                             }]
-                        },
-                        'all_includes_in_cluster': {
-                            'type': 'boolean',
                         },
                         'disabled': {
                             'type': 'boolean'

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes.py
@@ -370,7 +370,9 @@ class TestKubernetesExistingAllowedContexts(unittest.TestCase):
 
 
 class TestKubernetesAllIncludesInCluster(unittest.TestCase):
-    """Tests for `kubernetes.all_includes_in_cluster` and its env var."""
+    """Tests for the SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER
+    env var that excludes the in-cluster context from the `'all'` expansion.
+    """
 
     ENV_VAR = 'SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER'
 
@@ -385,33 +387,16 @@ class TestKubernetesAllIncludesInCluster(unittest.TestCase):
         else:
             os.environ.pop(self.ENV_VAR, None)
 
-    @staticmethod
-    def _mk_allowed_contexts_side_effect(allowed_contexts_value):
-        """Side effect for `get_effective_region_config`."""
-
-        def _side_effect(*args, **kwargs):
-            keys = kwargs.get('keys') or (args[1] if len(args) > 1 else None)
-            if keys == ('allowed_contexts',):
-                return allowed_contexts_value
-            return kwargs.get('default_value')
-
-        return _side_effect
-
     @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
     @patch('sky.skypilot_config.get_workspace_cloud')
     @patch('sky.skypilot_config.get_effective_region_config')
-    @patch('sky.skypilot_config.get_effective_workspace_region_config')
-    def test_default_all_includes_in_cluster(self, mock_get_ws_region,
-                                             mock_get_region,
-                                             mock_get_workspace,
-                                             mock_get_all_contexts):
-        """Default behavior: 'all' includes in-cluster (backward compat)."""
+    def test_default_includes_in_cluster(self, mock_get_region,
+                                         mock_get_workspace,
+                                         mock_get_all_contexts):
+        """Default (env unset): 'all' includes in-cluster (backward compat)."""
         mock_get_all_contexts.return_value = ['ctx-a', 'ctx-b', 'in-cluster']
         mock_get_workspace.return_value.get.return_value = None
-        mock_get_region.side_effect = self._mk_allowed_contexts_side_effect(
-            'all')
-        # Flag unset -> default_value=True wins.
-        mock_get_ws_region.return_value = True
+        mock_get_region.return_value = 'all'
 
         result = kubernetes.Kubernetes.existing_allowed_contexts()
 
@@ -420,117 +405,57 @@ class TestKubernetesAllIncludesInCluster(unittest.TestCase):
     @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
     @patch('sky.skypilot_config.get_workspace_cloud')
     @patch('sky.skypilot_config.get_effective_region_config')
-    @patch('sky.skypilot_config.get_effective_workspace_region_config')
-    def test_all_excludes_in_cluster_via_config(self, mock_get_ws_region,
-                                                mock_get_region,
-                                                mock_get_workspace,
-                                                mock_get_all_contexts):
-        """`all_includes_in_cluster: false` in config -> in-cluster excluded."""
+    def test_env_true_includes_in_cluster(self, mock_get_region,
+                                          mock_get_workspace,
+                                          mock_get_all_contexts):
+        """Env var explicitly true: 'all' includes in-cluster."""
+        mock_get_all_contexts.return_value = ['ctx-a', 'in-cluster']
+        mock_get_workspace.return_value.get.return_value = None
+        mock_get_region.return_value = 'all'
+
+        with patch.dict(os.environ, {self.ENV_VAR: 'true'}, clear=False):
+            result = kubernetes.Kubernetes.existing_allowed_contexts()
+
+        self.assertEqual(set(result), {'ctx-a', 'in-cluster'})
+
+    @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
+    @patch('sky.skypilot_config.get_workspace_cloud')
+    @patch('sky.skypilot_config.get_effective_region_config')
+    def test_env_false_excludes_in_cluster(self, mock_get_region,
+                                           mock_get_workspace,
+                                           mock_get_all_contexts):
+        """Env var false: in-cluster is filtered out of the 'all' expansion.
+
+        This is the hosted-product use case.
+        """
         mock_get_all_contexts.return_value = ['ctx-a', 'ctx-b', 'in-cluster']
         mock_get_workspace.return_value.get.return_value = None
-        mock_get_region.side_effect = self._mk_allowed_contexts_side_effect(
-            'all')
-        mock_get_ws_region.return_value = False
+        mock_get_region.return_value = 'all'
 
-        result = kubernetes.Kubernetes.existing_allowed_contexts()
+        with patch.dict(os.environ, {self.ENV_VAR: 'false'}, clear=False):
+            result = kubernetes.Kubernetes.existing_allowed_contexts()
 
         self.assertEqual(set(result), {'ctx-a', 'ctx-b'})
 
     @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
     @patch('sky.skypilot_config.get_workspace_cloud')
     @patch('sky.skypilot_config.get_effective_region_config')
-    @patch('sky.skypilot_config.get_effective_workspace_region_config')
-    def test_env_overrides_config_true(self, mock_get_ws_region,
-                                       mock_get_region, mock_get_workspace,
-                                       mock_get_all_contexts):
-        """Env var true overrides config false."""
-        mock_get_all_contexts.return_value = ['ctx-a', 'in-cluster']
-        mock_get_workspace.return_value.get.return_value = None
-        mock_get_region.side_effect = self._mk_allowed_contexts_side_effect(
-            'all')
-        mock_get_ws_region.return_value = False  # ignored: env wins
-
-        with patch.dict(os.environ, {self.ENV_VAR: 'true'}, clear=False):
-            result = kubernetes.Kubernetes.existing_allowed_contexts()
-
-        self.assertEqual(set(result), {'ctx-a', 'in-cluster'})
-        # Resolution should short-circuit on env var; config flag not read.
-        mock_get_ws_region.assert_not_called()
-
-    @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
-    @patch('sky.skypilot_config.get_workspace_cloud')
-    @patch('sky.skypilot_config.get_effective_region_config')
-    @patch('sky.skypilot_config.get_effective_workspace_region_config')
-    def test_env_overrides_config_false(self, mock_get_ws_region,
-                                        mock_get_region, mock_get_workspace,
-                                        mock_get_all_contexts):
-        """Env var false overrides config true. The hosted-product use case."""
-        mock_get_all_contexts.return_value = ['ctx-a', 'in-cluster']
-        mock_get_workspace.return_value.get.return_value = None
-        mock_get_region.side_effect = self._mk_allowed_contexts_side_effect(
-            'all')
-        mock_get_ws_region.return_value = True  # ignored: env wins
-
-        with patch.dict(os.environ, {self.ENV_VAR: 'false'}, clear=False):
-            result = kubernetes.Kubernetes.existing_allowed_contexts()
-
-        self.assertEqual(set(result), {'ctx-a'})
-        mock_get_ws_region.assert_not_called()
-
-    @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
-    @patch('sky.skypilot_config.get_workspace_cloud')
-    @patch('sky.skypilot_config.get_effective_region_config')
-    @patch('sky.skypilot_config.get_effective_workspace_region_config')
-    def test_workspace_overrides_global(self, mock_get_ws_region,
-                                        mock_get_region, mock_get_workspace,
-                                        mock_get_all_contexts):
-        """Workspace-level all_includes_in_cluster beats global.
-
-        get_effective_workspace_region_config performs the workspace > global
-        resolution internally — we mock its return to be the resolved value.
-        """
-        mock_get_all_contexts.return_value = ['ctx-a', 'in-cluster']
-
-        def _workspace_get(key, default=None):
-            if key == 'allowed_contexts':
-                return 'all'
-            return default
-
-        mock_get_workspace.return_value.get.side_effect = _workspace_get
-        mock_get_region.side_effect = self._mk_allowed_contexts_side_effect(
-            None)
-        # Workspace says False (which is what the helper would return).
-        mock_get_ws_region.return_value = False
-
-        result = kubernetes.Kubernetes.existing_allowed_contexts()
-
-        self.assertEqual(set(result), {'ctx-a'})
-        mock_get_ws_region.assert_called_once_with(
-            cloud='kubernetes',
-            keys=('all_includes_in_cluster',),
-            default_value=True)
-
-    @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
-    @patch('sky.skypilot_config.get_workspace_cloud')
-    @patch('sky.skypilot_config.get_effective_region_config')
-    @patch('sky.skypilot_config.get_effective_workspace_region_config')
-    def test_env_var_path_also_filters(self, mock_get_ws_region,
-                                       mock_get_region, mock_get_workspace,
-                                       mock_get_all_contexts):
+    def test_legacy_allow_all_env_respects_filter(self, mock_get_region,
+                                                  mock_get_workspace,
+                                                  mock_get_all_contexts):
         """`SKYPILOT_ALLOW_ALL_KUBERNETES_CONTEXTS=true` path is symmetric.
 
-        When neither workspace nor global allowed_contexts is set, the env
-        var triggers the same allow-all branch; `all_includes_in_cluster`
-        should still filter in-cluster out.
+        When no `allowed_contexts` is set in config but the legacy
+        allow-all env var is set, the same `'all'` expansion runs and the
+        in-cluster filter env var still applies.
         """
         mock_get_all_contexts.return_value = ['ctx-a', 'in-cluster']
         mock_get_workspace.return_value.get.return_value = None
-        mock_get_region.side_effect = self._mk_allowed_contexts_side_effect(
-            None)
-        mock_get_ws_region.return_value = False
+        mock_get_region.return_value = None
 
         with patch.dict(os.environ, {
                 'SKYPILOT_ALLOW_ALL_KUBERNETES_CONTEXTS': 'true',
+                self.ENV_VAR: 'false',
         },
                         clear=False):
             result = kubernetes.Kubernetes.existing_allowed_contexts()
@@ -541,14 +466,12 @@ class TestKubernetesAllIncludesInCluster(unittest.TestCase):
     @patch('sky.skypilot_config.get_workspace_cloud')
     def test_explicit_in_cluster_in_list_is_kept(self, mock_get_workspace,
                                                  mock_get_all_contexts):
-        """Explicit allowed_contexts list ignores the all_includes flag."""
+        """Explicit allowed_contexts list is honored even with env var false."""
         mock_get_all_contexts.return_value = ['ctx-a', 'in-cluster']
 
         def _workspace_get(key, default=None):
             if key == 'allowed_contexts':
                 return ['ctx-a', 'in-cluster']
-            if key == 'all_includes_in_cluster':
-                return False
             return default
 
         mock_get_workspace.return_value.get.side_effect = _workspace_get
@@ -565,10 +488,12 @@ class TestKubernetesAllIncludesInCluster(unittest.TestCase):
            'get_current_kube_config_context_name')
     @patch('sky.provision.kubernetes.utils.is_incluster_config_available')
     @patch('sky.adaptors.kubernetes.in_cluster_context_name')
-    def test_no_kubeconfig_fallback_unaffected_by_flag(
+    def test_no_kubeconfig_fallback_unaffected_by_env(
             self, mock_in_cluster_name, mock_is_incluster, mock_current,
             mock_get_nested, mock_get_workspace, mock_get_all_contexts):
-        """The "no kubeconfig -> in-cluster" fallback ignores the flag."""
+        """The "no kubeconfig -> in-cluster" fallback is independent of
+        the filter env var: the filter only applies to the `'all'` path.
+        """
         mock_get_all_contexts.return_value = ['in-cluster']
         mock_get_workspace.return_value.get.return_value = None
         mock_get_nested.return_value = None
@@ -584,29 +509,26 @@ class TestKubernetesAllIncludesInCluster(unittest.TestCase):
     @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
     @patch('sky.skypilot_config.get_workspace_cloud')
     @patch('sky.skypilot_config.get_effective_region_config')
-    @patch('sky.skypilot_config.get_effective_workspace_region_config')
     @patch('sky.adaptors.kubernetes.in_cluster_context_name')
     def test_custom_in_cluster_name_is_filtered(self, mock_in_cluster_name,
-                                                mock_get_ws_region,
                                                 mock_get_region,
                                                 mock_get_workspace,
                                                 mock_get_all_contexts):
-        """Custom in-cluster name (via env) is what gets filtered, not the
-        literal 'in-cluster'."""
+        """Custom in-cluster name (via SKYPILOT_IN_CLUSTER_CONTEXT_NAME) is
+        what gets filtered — not the literal string 'in-cluster'."""
         mock_in_cluster_name.return_value = 'my-host-cluster'
         mock_get_all_contexts.return_value = [
             'ctx-a', 'my-host-cluster', 'in-cluster'
         ]
         mock_get_workspace.return_value.get.return_value = None
-        mock_get_region.side_effect = self._mk_allowed_contexts_side_effect(
-            'all')
-        mock_get_ws_region.return_value = False
+        mock_get_region.return_value = 'all'
 
-        result = kubernetes.Kubernetes.existing_allowed_contexts()
+        with patch.dict(os.environ, {self.ENV_VAR: 'false'}, clear=False):
+            result = kubernetes.Kubernetes.existing_allowed_contexts()
 
-        # 'my-host-cluster' (the custom in-cluster name) is excluded; the
-        # literal string 'in-cluster' happens to be a regular kubeconfig
-        # context here and is kept.
+        # 'my-host-cluster' (the configured in-cluster name) is excluded;
+        # the literal string 'in-cluster' here is a regular kubeconfig
+        # context and is kept.
         self.assertEqual(set(result), {'ctx-a', 'in-cluster'})
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Remove all_includes_in_cluster from skypilot config.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  Set `allowed_contexts: all` in SkyPilot config
  - `SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER` is not set, `in-cluster` is included
  - `SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER` set to false, `in-cluster` is not included
  - `SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER` set to true, `in-cluster` is included
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
