### PR TITLE
[CLI] sky api login: continue polling when browser cannot be opened

### DIFF
--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -2716,17 +2716,24 @@ def _try_polling_auth(endpoint: str) -> Optional[str]:
         code_verifier = common_utils.base64_url_encode(secrets.token_bytes(32))
         code_challenge = common_utils.compute_code_challenge(code_verifier)
 
-        # Open browser to authorization page
+        # Open browser to authorization page. The polling flow does not
+        # require the browser to be on this machine, so if we cannot open
+        # one locally, just ask the user to visit the URL themselves.
         auth_url = f'{endpoint}/auth/authorize?code_challenge={code_challenge}'
-        if not common_utils.open_browser(auth_url):
+        if common_utils.open_browser(auth_url):
+            click.echo(f'{colorama.Fore.GREEN}Browser opened at {auth_url}'
+                       f'{colorama.Style.RESET_ALL}\n'
+                       f'Please click "Authorize" to complete login.\n'
+                       f'{colorama.Style.DIM}Press ctrl+c to fall back to '
+                       f'legacy auth method.{colorama.Style.RESET_ALL}')
+        else:
             logger.debug('Failed to open browser.')
-            return None
-
-        click.echo(f'{colorama.Fore.GREEN}Browser opened at {auth_url}'
-                   f'{colorama.Style.RESET_ALL}\n'
-                   f'Please click "Authorize" to complete login.\n'
-                   f'{colorama.Style.DIM}Press ctrl+c to fall back to legacy '
-                   f'auth method.{colorama.Style.RESET_ALL}')
+            click.echo(f'{colorama.Fore.GREEN}Open this URL to complete '
+                       f'login:{colorama.Style.RESET_ALL}\n\n'
+                       f'{colorama.Style.BRIGHT}{auth_url}'
+                       f'{colorama.Style.RESET_ALL}\n\n'
+                       f'{colorama.Style.DIM}Press ctrl+c to fall back to '
+                       f'legacy auth method.{colorama.Style.RESET_ALL}')
 
         # Poll for token
         start_time = time.time()


### PR DESCRIPTION
## Summary

- In `_try_polling_auth`, when `common_utils.open_browser` fails (e.g., headless server, no `DISPLAY`), the function previously returned `None` and the CLI fell through to the localhost-callback flow (which also requires a browser) and then to manual token entry.
- The polling flow does not actually require the browser to be on the same machine as the CLI — the auth URL is opaque and the CLI polls the server independently. So if we can't open a browser locally, we should just print the URL and ask the user to open it themselves, then keep polling.
- Now, when the browser can't be opened locally, the CLI shows:

  ```
  Open this URL to complete login:

  https://api.example.com/auth/authorize?code_challenge=...

  Press ctrl+c to fall back to legacy auth method.
  ```

  and continues polling, instead of silently skipping.

## Test plan

- [x] Reproduced the headless case by unsetting `DISPLAY` and calling `_try_polling_auth` directly: previously returned `None` immediately, now prints the auth URL and polls until timeout / ctrl+c.
- [x] `format.sh` clean (yapf, isort, mypy, pylint 10.00/10).
- [ ] Manual verification against a real auth-proxy-fronted API server from a headless shell.

-Claude