### PR TITLE
[CLI] sky api login: add --no-browser flag for headless environments

### DIFF
--- a/agent/skills/skypilot/references/cli-reference.md
+++ b/agent/skills/skypilot/references/cli-reference.md
@@ -676,6 +676,7 @@ Logs into a SkyPilot API server.
 - `--endpoint`, `-e` — The SkyPilot API server endpoint.
 - `--relogin` — Force relogin with OAuth2 when enabled.
 - `--service-account-token`, `--token`, `-t` — Service account token for authentication (starts with ``sky_``).
+- `--no-browser` — Do not attempt to open a browser locally; print the auth URL and wait for the user to open it manually. Useful on headless machines (SSH sessions, containers, etc.).
 
 ### `sky api logout`
 

--- a/agent/skills/skypilot/references/python-sdk.md
+++ b/agent/skills/skypilot/references/python-sdk.md
@@ -1106,7 +1106,7 @@ Streams the API server logs.
 ### `sky.api_login`
 
 ```python
-sky.api_login(endpoint: Optional[str] = None, relogin: bool = False, service_account_token: Optional[str] = None) -> None
+sky.api_login(endpoint: Optional[str] = None, relogin: bool = False, service_account_token: Optional[str] = None, no_browser: bool = False) -> None
 ```
 
 Logs into a SkyPilot API server.
@@ -1122,6 +1122,9 @@ To temporarily override the endpoint, use the environment variable
         http://1.2.3.4:46580 or https://skypilot.mydomain.com.
     relogin: Whether to force relogin with OAuth2 when enabled.
     service_account_token: Service account token for authentication.
+    no_browser: If True, do not attempt to open a browser locally; print
+        the auth URL and let the user open it themselves. Skips the
+        localhost-callback flow, which requires a local browser.
 
 **Returns:**
     None

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -7732,9 +7732,15 @@ def api_status(request_id_prefixes: Optional[List[str]],
     '-t',
     required=False,
     help='Service account token for authentication (starts with ``sky_``).')
+@click.option('--no-browser',
+              is_flag=True,
+              default=False,
+              help='Do not attempt to open a browser locally; print the '
+              'auth URL and wait for the user to open it manually. Useful '
+              'on headless machines (SSH sessions, containers, etc.).')
 @usage_lib.entrypoint
 def api_login(endpoint: Optional[str], relogin: bool,
-              service_account_token: Optional[str]):
+              service_account_token: Optional[str], no_browser: bool):
     """Logs into a SkyPilot API server.
 
     If your remote API server has enabled OAuth2 authentication, you can use
@@ -7753,11 +7759,17 @@ def api_login(endpoint: Optional[str], relogin: bool,
       # OAuth2 browser login
       sky api login -e https://api.example.com
       \b
+      # OAuth2 login without opening a browser locally (e.g. over SSH)
+      sky api login -e https://api.example.com --no-browser
+      \b
       # Service account token login
       sky api login -e https://api.example.com --token sky_abc123...
 
     """
-    sdk.api_login(endpoint, relogin, service_account_token)
+    sdk.api_login(endpoint,
+                  relogin,
+                  service_account_token,
+                  no_browser=no_browser)
 
 
 @api.command('logout', cls=_DocumentedCodeCommand)

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -2709,7 +2709,7 @@ def _check_endpoint_in_env_var(is_login: bool) -> None:
                                'clear the environment variable.')
 
 
-def _try_polling_auth(endpoint: str) -> Optional[str]:
+def _try_polling_auth(endpoint: str, no_browser: bool = False) -> Optional[str]:
     """Try the polling-based authentication flow."""
     try:
         # Generate code verifier (random secret) and challenge (hash)
@@ -2717,17 +2717,22 @@ def _try_polling_auth(endpoint: str) -> Optional[str]:
         code_challenge = common_utils.compute_code_challenge(code_verifier)
 
         # Open browser to authorization page. The polling flow does not
-        # require the browser to be on this machine, so if we cannot open
-        # one locally, just ask the user to visit the URL themselves.
+        # require the browser to be on this machine, so if --no-browser was
+        # passed or we cannot open one locally, just ask the user to visit
+        # the URL themselves.
         auth_url = f'{endpoint}/auth/authorize?code_challenge={code_challenge}'
-        if common_utils.open_browser(auth_url):
+        browser_opened = False
+        if not no_browser:
+            browser_opened = common_utils.open_browser(auth_url)
+            if not browser_opened:
+                logger.debug('Failed to open browser.')
+        if browser_opened:
             click.echo(f'{colorama.Fore.GREEN}Browser opened at {auth_url}'
                        f'{colorama.Style.RESET_ALL}\n'
                        f'Please click "Authorize" to complete login.\n'
                        f'{colorama.Style.DIM}Press ctrl+c to fall back to '
                        f'legacy auth method.{colorama.Style.RESET_ALL}')
         else:
-            logger.debug('Failed to open browser.')
             click.echo(f'{colorama.Fore.GREEN}Open this URL to complete '
                        f'login:{colorama.Style.RESET_ALL}\n\n'
                        f'{colorama.Style.BRIGHT}{auth_url}'
@@ -2766,8 +2771,14 @@ def _try_polling_auth(endpoint: str) -> Optional[str]:
         return None
 
 
-def _try_localhost_callback_auth(endpoint: str) -> Optional[str]:
+def _try_localhost_callback_auth(endpoint: str,
+                                 no_browser: bool = False) -> Optional[str]:
     """Try the localhost callback authentication flow (legacy)."""
+    if no_browser:
+        # This flow requires the browser to redirect back to a localhost port
+        # on this machine, so it cannot work without a local browser.
+        logger.debug('Skipping localhost callback flow: --no-browser is set.')
+        return None
     server: Optional[oauth_lib.HTTPServer] = None
     try:
         callback_port = common_utils.find_free_port(8000)
@@ -2831,7 +2842,8 @@ def _try_manual_token_entry(endpoint: str) -> Optional[str]:
 @annotations.client_api
 def api_login(endpoint: Optional[str] = None,
               relogin: bool = False,
-              service_account_token: Optional[str] = None) -> None:
+              service_account_token: Optional[str] = None,
+              no_browser: bool = False) -> None:
     """Logs into a SkyPilot API server.
 
     This sets the endpoint globally, i.e., all SkyPilot CLI and SDK calls will
@@ -2845,6 +2857,9 @@ def api_login(endpoint: Optional[str] = None,
             http://1.2.3.4:46580 or https://skypilot.mydomain.com.
         relogin: Whether to force relogin with OAuth2 when enabled.
         service_account_token: Service account token for authentication.
+        no_browser: If True, do not attempt to open a browser locally; print
+            the auth URL and let the user open it themselves. Skips the
+            localhost-callback flow, which requires a local browser.
 
     Returns:
         None
@@ -2940,11 +2955,12 @@ def api_login(endpoint: Optional[str] = None,
         # 3. Manual token entry
         remote_api_version = versions.get_remote_api_version()
         if remote_api_version is not None and remote_api_version >= 30:
-            token = _try_polling_auth(endpoint)
+            token = _try_polling_auth(endpoint, no_browser=no_browser)
 
         if token is None:
             # Polling auth not available or failed, try localhost callback
-            token = _try_localhost_callback_auth(endpoint)
+            token = _try_localhost_callback_auth(endpoint,
+                                                 no_browser=no_browser)
 
         if token is None:
             # All automatic methods failed, fall back to manual entry


### PR DESCRIPTION
## Summary

- Adds an explicit `--no-browser` flag to `sky api login` for headless environments (SSH sessions, containers, CI).
- With `--no-browser`:
  - **Polling auth** (servers >= API v30): never calls `open_browser`; prints the auth URL directly and polls as usual. The polling flow doesn't require the browser to be on this machine, so it works fine when the user opens the URL on a different device.
  - **Localhost-callback auth** (legacy): skipped entirely — this flow requires the browser to redirect back to a localhost port on the CLI host, which is impossible without a local browser.
  - **Manual token entry**: still available as a final fallback (unchanged).
- Follow-up to #9676, which made the polling flow tolerate `open_browser` returning `False` automatically. `--no-browser` lets users opt into that path explicitly without depending on `webbrowser` detection (which is fiddly to suppress with env vars when a real browser is on PATH).

## Test plan

- [x] `sky api login --help` shows the new flag with usage example.
- [x] `_try_polling_auth(endpoint, no_browser=True)` prints `Open this URL to complete login: ...` and polls, never invoking `open_browser`.
- [x] `_try_localhost_callback_auth(endpoint, no_browser=True)` returns `None` immediately, no browser attempt, no port opened.
- [x] End-to-end: `sky api login --no-browser --relogin -e http://127.0.0.1:46580` against a local server prints the polling URL, times out, falls through to manual token entry (skipping the localhost-callback step).
- [x] `format.sh` clean (mypy + pylint 10.00/10).
- [ ] Manual verification against a real auth-proxy-fronted API server from a headless shell.

-Claude