### PR TITLE
[Serve] Force-clean DB on `--purge` when consolidation controller is dead

### DIFF
--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -1306,6 +1306,44 @@ def terminate_services(service_names: Optional[List[str]], purge: bool,
         # `serve_state.add_or_update_version` in service.py.
         purge_cmd = (f'sky jobs pool down {service_name} --purge'
                      if pool else f'sky serve down {service_name} --purge')
+        # Force-clean DB when the consolidation-mode controller subprocess is
+        # provably dead. Without this, the non-terminal-status branch below
+        # writes a TERMINATE signal file that the dead controller will never
+        # read, leaving the row stuck forever. The SHUTTING_DOWN and
+        # failed_statuses branches above already cover their respective
+        # zombie cases via _terminate_failed_services; this is the
+        # non-terminal-status counterpart for consolidation mode.
+        # Only safe to run our local psutil check when we're the pod that
+        # should be running the controller: in HA, controller_ip can point
+        # at a peer pod and the pid is meaningless to us.
+        if purge and is_consolidation_mode(pool):
+            controller_pid = service_status.get('controller_pid')
+            controller_ip = service_status.get('controller_ip')
+            self_ip = os.environ.get('POD_IP')
+            controller_is_local = (controller_ip is None or
+                                   controller_ip == self_ip)
+            if controller_is_local:
+                try:
+                    pid_alive = (controller_pid is not None and
+                                 _controller_process_alive(
+                                     controller_pid, service_name))
+                except Exception:  # pylint: disable=broad-except
+                    # psutil raised (AccessDenied, cmdline race, etc.).
+                    # Be conservative: treat as alive and let the normal
+                    # signal-write path handle it.
+                    pid_alive = True
+                if not pid_alive:
+                    logger.warning(
+                        f'{capnoun} {service_name!r} controller '
+                        f'subprocess (pid={controller_pid}) is not '
+                        'alive. Force-cleaning DB records via --purge. '
+                        'Cloud resources may be leaked.')
+                    message = _terminate_failed_services(
+                        service_name, service_status['status'])
+                    if message is not None:
+                        messages.append(message)
+                    terminated_service_names.append(f'{service_name!r}')
+                    continue
         if (service_status['status']
                 in serve_state.ServiceStatus.failed_statuses()):
             failed_status = service_status['status']

--- a/tests/unit_tests/test_serve_utils.py
+++ b/tests/unit_tests/test_serve_utils.py
@@ -462,6 +462,149 @@ class TestTerminateShuttingDownPurge:
             mock_purge.assert_not_called()
 
 
+class TestTerminateConsolidationDeadController:
+    """In consolidation mode, the controller subprocess can die (OOM, crash)
+    while the service row is still in a non-terminal status (READY,
+    NO_REPLICA, etc.). The default code path writes a TERMINATE signal file
+    that the dead controller will never read, so the row gets stuck forever.
+    `--purge` must short-circuit to a direct DB cleanup when we can prove the
+    controller is dead and we're the pod that should own it."""
+
+    def _service_record(self, status, controller_pid=1234, controller_ip=None):
+        return {
+            'name': 'svc',
+            'status': status,
+            'controller_pid': controller_pid,
+            'controller_port': 20001,
+            'controller_ip': controller_ip,
+            'pool': True,
+        }
+
+    def _patches(self,
+                 status,
+                 controller_pid=1234,
+                 controller_ip=None,
+                 nonterminal_job_ids=None,
+                 consolidation=True,
+                 pid_alive_return=False,
+                 pid_alive_side_effect=None,
+                 pod_ip_env=None):
+        record = self._service_record(status,
+                                      controller_pid=controller_pid,
+                                      controller_ip=controller_ip)
+        env = {} if pod_ip_env is None else {'POD_IP': pod_ip_env}
+        patches = [
+            mock.patch(
+                'sky.serve.serve_utils.serve_state.'
+                'get_glob_service_names',
+                return_value=['svc']),
+            mock.patch('sky.serve.serve_utils._get_service_status',
+                       return_value=record),
+            mock.patch(
+                'sky.serve.serve_utils.managed_job_state.'
+                'get_nonterminal_job_ids_by_pool',
+                return_value=nonterminal_job_ids or []),
+            mock.patch('sky.serve.serve_utils.is_consolidation_mode',
+                       return_value=consolidation),
+            mock.patch.dict('sky.serve.serve_utils.os.environ', env,
+                            clear=True),
+        ]
+        alive_kwargs = {}
+        if pid_alive_side_effect is not None:
+            alive_kwargs['side_effect'] = pid_alive_side_effect
+        else:
+            alive_kwargs['return_value'] = pid_alive_return
+        patches.append(
+            mock.patch('sky.serve.serve_utils._controller_process_alive',
+                       **alive_kwargs))
+        return patches
+
+    def _run(self, patches, purge=True):
+        # Stub signal-file path + filelock so the "controller alive" branch
+        # doesn't write a real file into ~/.sky/signals during tests.
+        # serve_utils calls Path(...).expanduser() and then operates on the
+        # result, so wire expanduser() back to the same mock to make
+        # assertions readable.
+        mock_signal_file = mock.MagicMock()
+        mock_signal_file.expanduser.return_value = mock_signal_file
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patches[5], \
+             mock.patch('sky.serve.serve_utils._terminate_failed_services',
+                        return_value=None) as mock_purge, \
+             mock.patch('sky.serve.serve_utils.pathlib.Path',
+                        return_value=mock_signal_file), \
+             mock.patch('sky.serve.serve_utils.filelock.FileLock'):
+            serve_utils.terminate_services(['svc'], purge=purge, pool=True)
+            return mock_purge, mock_signal_file
+
+    def test_purge_force_cleans_when_local_controller_is_dead(self):
+        # pylint: disable=import-outside-toplevel
+        from sky.serve import serve_state
+        patches = self._patches(serve_state.ServiceStatus.READY,
+                                pid_alive_return=False)
+        mock_purge, mock_signal = self._run(patches)
+        mock_purge.assert_called_once_with('svc',
+                                           serve_state.ServiceStatus.READY)
+        # No signal file should be opened when we force-clean.
+        mock_signal.open.assert_not_called()
+
+    def test_purge_force_cleans_when_controller_pid_is_none(self):
+        # pylint: disable=import-outside-toplevel
+        from sky.serve import serve_state
+        patches = self._patches(serve_state.ServiceStatus.NO_REPLICA,
+                                controller_pid=None)
+        mock_purge, _ = self._run(patches)
+        mock_purge.assert_called_once_with('svc',
+                                           serve_state.ServiceStatus.NO_REPLICA)
+
+    def test_purge_writes_signal_when_controller_is_alive(self):
+        # pylint: disable=import-outside-toplevel
+        from sky.serve import serve_state
+        patches = self._patches(serve_state.ServiceStatus.READY,
+                                pid_alive_return=True)
+        mock_purge, mock_signal = self._run(patches)
+        mock_purge.assert_not_called()
+        mock_signal.open.assert_called()
+
+    def test_no_purge_does_not_force_clean_even_when_dead(self):
+        # pylint: disable=import-outside-toplevel
+        from sky.serve import serve_state
+        patches = self._patches(serve_state.ServiceStatus.READY,
+                                pid_alive_return=False)
+        mock_purge, _ = self._run(patches, purge=False)
+        mock_purge.assert_not_called()
+
+    def test_purge_no_force_clean_when_controller_on_peer_pod(self):
+        # HA: controller_ip points at a different pod, so our local psutil
+        # check would be meaningless. Fall back to the signal-file path.
+        # pylint: disable=import-outside-toplevel
+        from sky.serve import serve_state
+        patches = self._patches(serve_state.ServiceStatus.READY,
+                                controller_ip='10.0.0.42',
+                                pod_ip_env='10.0.0.41',
+                                pid_alive_return=False)
+        mock_purge, _ = self._run(patches)
+        mock_purge.assert_not_called()
+
+    def test_purge_no_force_clean_when_not_consolidation_mode(self):
+        # pylint: disable=import-outside-toplevel
+        from sky.serve import serve_state
+        patches = self._patches(serve_state.ServiceStatus.READY,
+                                consolidation=False,
+                                pid_alive_return=False)
+        mock_purge, _ = self._run(patches)
+        mock_purge.assert_not_called()
+
+    def test_purge_treats_psutil_exception_as_alive(self):
+        # psutil raised (AccessDenied / cmdline race): conservative path.
+        # pylint: disable=import-outside-toplevel
+        from sky.serve import serve_state
+        patches = self._patches(serve_state.ServiceStatus.READY,
+                                pid_alive_side_effect=RuntimeError('boom'))
+        mock_purge, _ = self._run(patches)
+        mock_purge.assert_not_called()
+
+
 class TestPoolStatusBatchedQuery:
     """`_get_service_status(pool=True)` must batch its per-replica job lookups
     into a single grouped query. The previous per-replica fan-out scaled with


### PR DESCRIPTION
## Summary

In consolidation mode the serve / pool controller runs as a subprocess inside the API server pod. When that subprocess dies (OOM, SIGKILL, crash) while the service row is still in a **non-terminal** status (`READY`, `NO_REPLICA`, `REPLICA_FAILED`, ...), `terminate_services` writes a `TERMINATE` signal file expecting the controller subprocess to consume it. With a dead controller no one ever reads the signal, the DB row stays put, and the user gets `"Pool/Service '<name>' is scheduled to be terminated."` while `sky serve status` / `sky jobs pool list` keeps showing the entry. Re-running `--purge` just repeats the same dead-signal write.

The existing `SHUTTING_DOWN` and `failed_statuses` branches already cover their respective zombie cases via `_terminate_failed_services`. This PR adds the non-terminal-status counterpart for consolidation mode: when `--purge` is set and we can prove the controller subprocess is not alive on this pod, fall back to a direct DB cleanup instead of the signal-file path.

## Reproduction

1. Configure the API server with `serve.controller.consolidation_mode: true`.
2. `sky serve up` (or `sky jobs pool apply`) a service / pool; let it reach `READY`.
3. `kill -9 <controller_subprocess_pid>` (or trigger an OOM) before any `down`.
4. Run `sky serve down <name> --purge` (or `sky jobs pool down <name> --purge`).

**Before this PR:** the warning `"Connection to controller http://localhost:<port>/autoscaler/info failed after 3 attempts. Controller may be down, restarting, or mid-HA-flip."` is logged, the success line is printed, but the row remains. Subsequent `--purge` invocations behave identically.

**After this PR:** the row is removed via `_terminate_failed_services` and a clear warning explains that cloud resources may be leaked.

## Safety

- Only triggers under `--purge`. Default `down` is unchanged.
- Only triggers in consolidation mode. The standalone-controller code path is unaffected (it already handles `ClusterNotUpError` in `serve/server/impl.py::down`).
- Only triggers when `controller_ip` is `None` or equals our own `POD_IP`. In HA where the controller lives on a peer pod, our local `psutil` check would be meaningless, so we defer to the signal-write path and let the peer handle it.
- A `psutil` exception (`AccessDenied`, cmdline-read race, etc.) is treated as **alive** rather than dead, so a transient `psutil` failure can't be weaponized into a row delete.

## Test plan

- New test class `TestTerminateConsolidationDeadController` covers:
  - Dead pid → force-clean called with the original status.
  - `controller_pid is None` → force-clean called.
  - Alive pid → signal file written, force-clean **not** called.
  - `--purge=False` + dead pid → signal file written, force-clean **not** called.
  - HA: `controller_ip` points at a peer pod → signal file written, force-clean **not** called.
  - Standalone-controller mode → signal file written, force-clean **not** called.
  - `psutil` raises → treated as alive, signal file written, force-clean **not** called.
- `pytest tests/unit_tests/test_serve_utils.py` — 40 passed locally.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->