### PR TITLE
[Core] Pass to_provision into Provisioner.template_override

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1129,6 +1129,7 @@ class RetryingVmProvisioner(object):
                 to_provision.cloud.canonical_name())
             template_spec = (plugin.template_override(
                 task,
+                to_provision,
                 _extra_launch_context=self._extra_launch_context,
                 _is_launched_by_jobs_controller=self.
                 _is_launched_by_jobs_controller,

--- a/sky/provision/__init__.py
+++ b/sky/provision/__init__.py
@@ -41,6 +41,7 @@ from sky.utils import command_runner
 from sky.utils import timeline
 
 if typing.TYPE_CHECKING:
+    from sky import resources as resources_lib
     from sky import task as task_lib
     from sky.utils import status_lib
 
@@ -71,6 +72,15 @@ class TemplateOverrideFn(Protocol):
     use a custom cluster config template instead of the cloud's
     default (``_get_cluster_config_template(cloud)`` in
     ``cloud_vm_ray_backend``), or ``None`` to use the cloud's default.
+
+    ``to_provision`` is the resource currently being launched — the same
+    one passed into ``Cloud.make_deploy_resources_variables``. Its
+    ``region`` is guaranteed non-None (set by the optimizer and asserted
+    in the backend before dispatch), so implementations can read it
+    directly instead of fishing it out of ``task.best_resources`` or
+    the user's pre-optimizer ``task.resources`` alternatives list. The
+    backend's failover loop may swap ``to_provision`` between retries;
+    ``template_override`` is re-invoked with the current attempt.
     """
 
     # pylint: disable=unnecessary-ellipsis
@@ -78,6 +88,7 @@ class TemplateOverrideFn(Protocol):
     def __call__(
         self,
         task: 'task_lib.Task',
+        to_provision: 'resources_lib.Resources',
         *,
         _extra_launch_context: Dict[str, Any],
         _is_launched_by_jobs_controller: bool,


### PR DESCRIPTION
## Summary

Extend the `TemplateOverrideFn` protocol (`sky/provision/__init__.py`) to pass `to_provision: Resources` alongside `task`. The backend already has the bound resource in scope at the call site — it's the same one immediately forwarded to `Cloud.make_deploy_resources_variables`, with `region` asserted non-None at `cloud_vm_ray_backend.py:1056` (set by the optimizer).

Without this, plugins implementing `template_override` are forced to fish the bound resource out of `task.best_resources` (the optimizer's first pick, which can drift from the current attempt during failover) or `task.resources[0]` (the user's pre-optimizer alternatives list, whose `region` is routinely `None`). Both are workarounds — neither is identical to what the backend is actually about to provision.

## Changes

- `sky/provision/__init__.py`: add `to_provision: 'resources_lib.Resources'` as a positional parameter on `TemplateOverrideFn.__call__`. Document the failover semantics in the protocol docstring (the hook is re-invoked per failover attempt).
- `sky/backends/cloud_vm_ray_backend.py`: pass `to_provision` at the existing call site.

No OSS-side implementer of `template_override` exists today (it's a plugin-only hook), so no other call sites or tests change. Third-party plugin authors implementing the protocol will get a `TypeError` at the call site if they don't accept the new arg — the intended migration signal.

## Test plan

- [ ] Unit tests still pass (no OSS-side coverage of this hook today; behavior of the call site is unchanged for the `plugin is None` and `plugin.template_override is None` branches).
- [ ] Plugin downstream verifies the new parameter is the bound resource (out-of-tree).