### PR TITLE
[RBAC] support viewer role

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -287,7 +287,9 @@ def _caller_is_viewer() -> bool:
         roles = enforcer.get_roles_for_user(user_id)
     except Exception:  # pylint: disable=broad-except
         return False
-    return rbac_mod.RoleName.VIEWER.value in roles
+    # Admin wins over viewer when both roles are present.
+    return (rbac_mod.RoleName.VIEWER.value in roles and
+            rbac_mod.RoleName.ADMIN.value not in roles)
 
 
 def is_command_length_over_limit(command: str) -> bool:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -269,16 +269,7 @@ _FORWARDING_FROM_MESSAGE = 'Forwarding from'
 
 
 def _caller_is_viewer() -> bool:
-    """Return True iff the executor worker is acting for a viewer user.
-
-    Reads the user id from USER_ID_ENV_VAR (set by the executor at
-    sky/server/requests/executor.py:377 when a worker takes a request)
-    and consults the casbin enforcer's in-memory grouping policy.
-    Returns False if the env var is unset (e.g. running outside an
-    executor worker context) or if the permission service has not
-    been initialized — both of which mean we're not on the API
-    server's authenticated request path.
-    """
+    """Return True iff the executor worker is acting for a viewer user."""
     # pylint: disable=import-outside-toplevel
     # In-function import to avoid pulling the permission service into
     # processes that never need it (e.g. the controller image's CLI

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -268,6 +268,37 @@ _ACK_MESSAGE = 'ack'
 _FORWARDING_FROM_MESSAGE = 'Forwarding from'
 
 
+def _caller_is_viewer() -> bool:
+    """Return True iff the executor worker is acting for a viewer user.
+
+    Reads the user id from USER_ID_ENV_VAR (set by the executor at
+    sky/server/requests/executor.py:377 when a worker takes a request)
+    and consults the casbin enforcer's in-memory grouping policy.
+    Returns False if the env var is unset (e.g. running outside an
+    executor worker context) or if the permission service has not
+    been initialized — both of which mean we're not on the API
+    server's authenticated request path.
+    """
+    # pylint: disable=import-outside-toplevel
+    # In-function import to avoid pulling the permission service into
+    # processes that never need it (e.g. the controller image's CLI
+    # entry point), which would also drag in casbin's import cost.
+    from sky.users import permission
+    from sky.users import rbac as rbac_mod
+    user_id = os.environ.get(constants.USER_ID_ENV_VAR)
+    if not user_id:
+        return False
+    try:
+        enforcer = permission.permission_service._ensure_enforcer()  # pylint: disable=protected-access
+    except Exception:  # pylint: disable=broad-except
+        return False
+    try:
+        roles = enforcer.get_roles_for_user(user_id)
+    except Exception:  # pylint: disable=broad-except
+        return False
+    return rbac_mod.RoleName.VIEWER.value in roles
+
+
 def is_command_length_over_limit(command: str) -> bool:
     """Check if the length of the command exceeds the limit.
 
@@ -3718,6 +3749,20 @@ def get_clusters(
         terminated, the record will be omitted from the returned list.
     """
     accessible_workspaces = workspaces_core.get_accessible_workspace_names()
+
+    # Defense-in-depth: even if some caller bypasses the HTTP layer's
+    # role_filter shim and reaches here with include_credentials=True
+    # on behalf of a viewer-roled user, refuse to embed SSH key
+    # contents in the response. We resolve the caller via
+    # USER_ID_ENV_VAR which the executor propagates into the worker
+    # process (sky/server/requests/executor.py:377). Reading from the
+    # in-memory casbin enforcer state (get_roles_for_user) avoids a
+    # DB roundtrip on the hot status path.
+    if include_credentials:
+        if _caller_is_viewer():
+            logger.debug('Suppressing include_credentials for viewer caller')
+            include_credentials = False
+
     if cluster_names is not None:
         if isinstance(cluster_names, str):
             cluster_names = [cluster_names]

--- a/sky/jobs/server/server.py
+++ b/sky/jobs/server/server.py
@@ -13,6 +13,7 @@ from sky.server.requests import executor
 from sky.server.requests import payloads
 from sky.server.requests import request_names
 from sky.server.requests import requests as api_requests
+from sky.server.requests import role_filter
 from sky.skylet import constants
 from sky.utils import common
 
@@ -58,8 +59,11 @@ async def launch(request: fastapi.Request,
 # For backwards compatibility
 # TODO(hailong): Remove before 0.12.0.
 @router.post('/queue')
-async def queue(request: fastapi.Request,
-                jobs_queue_body: payloads.JobsQueueBody) -> None:
+async def queue(
+    request: fastapi.Request,
+    jobs_queue_body: payloads.JobsQueueBody = fastapi.Depends(
+        role_filter.force_viewer_jobs_queue_body),
+) -> None:
     needs_long = _controller_refresh_need_long(jobs_queue_body.refresh)
     await executor.schedule_request_async(
         request_id=request.state.request_id,
@@ -74,8 +78,11 @@ async def queue(request: fastapi.Request,
 
 
 @router.post('/queue/v2')
-async def queue_v2(request: fastapi.Request,
-                   jobs_queue_body_v2: payloads.JobsQueueV2Body) -> None:
+async def queue_v2(
+    request: fastapi.Request,
+    jobs_queue_body_v2: payloads.JobsQueueV2Body = fastapi.Depends(
+        role_filter.force_viewer_jobs_queue_v2_body),
+) -> None:
     needs_long = _controller_refresh_need_long(jobs_queue_body_v2.refresh)
     await executor.schedule_request_async(
         request_id=request.state.request_id,
@@ -121,8 +128,10 @@ async def cancel(request: fastapi.Request,
 
 @router.post('/logs')
 async def logs(
-    request: fastapi.Request, jobs_logs_body: payloads.JobsLogsBody,
-    background_tasks: fastapi.BackgroundTasks
+    request: fastapi.Request,
+    background_tasks: fastapi.BackgroundTasks,
+    jobs_logs_body: payloads.JobsLogsBody = fastapi.Depends(
+        role_filter.force_viewer_jobs_logs_body),
 ) -> fastapi.responses.StreamingResponse:
     schedule_type = api_requests.ScheduleType.SHORT
     if _controller_refresh_need_long(jobs_logs_body.refresh):
@@ -163,8 +172,10 @@ async def logs(
 
 @router.post('/download_logs')
 async def download_logs(
-        request: fastapi.Request,
-        jobs_download_logs_body: payloads.JobsDownloadLogsBody) -> None:
+    request: fastapi.Request,
+    jobs_download_logs_body: payloads.JobsDownloadLogsBody = fastapi.Depends(
+        role_filter.force_viewer_jobs_download_logs_body),
+) -> None:
     user_hash = jobs_download_logs_body.env_vars[constants.USER_ID_ENV_VAR]
     logs_dir_on_api_server = pathlib.Path(
         bs.get_blob_storage().download_tmp_dir(user_hash))

--- a/sky/server/plugins.py
+++ b/sky/server/plugins.py
@@ -300,6 +300,35 @@ class BasePlugin(abc.ABC):
         """
         return []
 
+    @property
+    def viewer_allowlist(self) -> List['RBACRule']:
+        """Endpoints this plugin exposes to viewer-role users.
+
+        Override this property to opt the plugin's read endpoints in to
+        the strictly-read-only `viewer` role.  Endpoints NOT declared
+        here are denied for viewers by default.
+
+        Path patterns use the same Casbin `keyMatch2` syntax as
+        `rbac_rules` (e.g. `/plugins/api/foo/*`, `/plugins/api/foo/:id`).
+
+        Returns:
+            List of `RBACRule` instances (the same dataclass used by
+            `rbac_rules`).  The `description` field is optional; the
+            rule is interpreted as "allow viewers to call this
+            (path, method)".
+
+        Example:
+            @property
+            def viewer_allowlist(self):
+                return [
+                    RBACRule(path='/plugins/api/foo/list',
+                             method='GET'),
+                    RBACRule(path='/plugins/api/foo/status',
+                             method='POST'),
+                ]
+        """
+        return []
+
     @abc.abstractmethod
     def install(self, extension_context: ExtensionContext):
         """Hook called by API server to let the plugin install itself."""
@@ -585,6 +614,69 @@ def get_plugin_rbac_rules() -> Dict[str, List[Dict[str, str]]]:
         }
     """
     return _PLUGIN_RBAC_RULES
+
+
+_PLUGIN_VIEWER_ALLOWLIST: List[Dict[str, str]] = []
+
+
+def load_plugin_viewer_allowlist() -> List[Dict[str, str]]:
+    """Load viewer-allowlist entries from plugins without calling install().
+
+    Mirrors `load_plugin_rbac_rules`: instantiates each configured
+    plugin in API-server-loading contexts and reads its
+    `viewer_allowlist` property.  Side-effect-free.
+
+    Plugins that don't override `viewer_allowlist` inherit the
+    BasePlugin default (empty list), so default behaviour for any
+    plugin endpoint is "denied for viewer".
+
+    Returns:
+        Flat list of `{path, method}` records to add to the viewer
+        allowlist.
+    """
+    global _PLUGIN_VIEWER_ALLOWLIST
+
+    config = _load_plugin_config()
+    if not config:
+        return []
+
+    allowlist: List[Dict[str, str]] = []
+
+    for plugin_config in config.get('plugins', []):
+        class_path = plugin_config['class']
+        module_path, class_name = class_path.rsplit('.', 1)
+        try:
+            module = importlib.import_module(module_path)
+            plugin_cls = getattr(module, class_name)
+            if not issubclass(plugin_cls, BasePlugin):
+                continue
+            # RBAC is an API-server concern; skip plugins that don't load
+            # in either API-server context, even if they declare viewer
+            # rules.
+            if not (plugin_cls.should_load(PluginContext.MAIN) or
+                    plugin_cls.should_load(PluginContext.UVICORN)):
+                continue
+            parameters = plugin_config.get('parameters') or {}
+            plugin = plugin_cls(**parameters)
+
+            for rule in plugin.viewer_allowlist:
+                allowlist.append({
+                    'path': rule.path,
+                    'method': rule.method,
+                })
+                logger.debug(f'Collected viewer allowlist entry from '
+                             f'{class_path}: {rule.method} {rule.path}')
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Failed to load viewer allowlist from '
+                           f'{class_path}: {e}')
+
+    _PLUGIN_VIEWER_ALLOWLIST = allowlist
+    return allowlist
+
+
+def get_plugin_viewer_allowlist() -> List[Dict[str, str]]:
+    """Return the cached viewer-allowlist entries collected from plugins."""
+    return _PLUGIN_VIEWER_ALLOWLIST
 
 
 def get_extension_context() -> Optional[ExtensionContext]:

--- a/sky/server/requests/role_filter.py
+++ b/sky/server/requests/role_filter.py
@@ -1,0 +1,116 @@
+"""Role-aware body filters for the SkyPilot API server.
+
+This module provides per-endpoint shims that mutate incoming request
+bodies when the caller has the strictly-read-only `viewer` role.  The
+viewer endpoint allowlist (in `sky.users.rbac`) is enough to keep
+viewers off write endpoints, but a handful of "ambiguous" endpoints
+have body fields that swing the action between read and write:
+
+  * `POST /status`: `include_credentials` returns SSH private keys;
+    `refresh` queries clouds and mutates state.db.
+  * `POST /jobs/queue`, `/jobs/queue/v2`, `/jobs/logs`,
+    `/jobs/download_logs`: `refresh` restarts the jobs controller.
+  * `GET /volumes`: `refresh` queries cloud volume state.
+
+For viewers, these fields are forced to their read-only / no-side-
+effect values *before* the handler runs.  Non-viewer callers see no
+behaviour change.
+
+The shim is wired into FastAPI as a `Depends()` dependency rather
+than a middleware so it can mutate the parsed pydantic body
+in-place; standard Starlette middlewares run before body parsing.
+"""
+
+import fastapi
+
+from sky.server.requests import payloads
+from sky.users import permission
+from sky.users import rbac
+from sky.utils import common as common_lib
+
+
+def _is_viewer(request: fastapi.Request) -> bool:
+    """Return True if the authenticated caller has the viewer role.
+
+    Uses the in-memory Casbin enforcer state (no DB roundtrip),
+    matching the perf pattern in
+    `PermissionService.check_endpoint_permission`.
+    """
+    auth_user = getattr(request.state, 'auth_user', None)
+    if auth_user is None:
+        return False
+    # Trust the in-memory grouping policy; same source the middleware
+    # already consulted to gate this request to here.
+    enforcer = permission.permission_service._ensure_enforcer()  # pylint: disable=protected-access
+    roles = enforcer.get_roles_for_user(auth_user.id)
+    return rbac.RoleName.VIEWER.value in roles
+
+
+def force_viewer_status_body(
+    request: fastapi.Request,
+    status_body: payloads.StatusBody = fastapi.Body(
+        default_factory=payloads.StatusBody),
+) -> payloads.StatusBody:
+    """Strip side-effecting fields from `POST /status` for viewers.
+
+    Forces:
+      * `refresh = NONE` — viewers cannot trigger cloud refresh or DB
+        mutations like cluster status updates.
+      * `include_credentials = False` — viewers cannot retrieve SSH
+        private keys (which would also write the keys to disk if
+        missing, see backend_utils.create_ssh_key_files_from_db).
+    """
+    if _is_viewer(request):
+        status_body.refresh = common_lib.StatusRefreshMode.NONE
+        status_body.include_credentials = False
+    return status_body
+
+
+def force_viewer_jobs_queue_body(
+    request: fastapi.Request,
+    jobs_queue_body: payloads.JobsQueueBody,
+) -> payloads.JobsQueueBody:
+    """Strip `refresh` from `/jobs/queue` for viewers."""
+    if _is_viewer(request):
+        jobs_queue_body.refresh = False
+    return jobs_queue_body
+
+
+def force_viewer_jobs_queue_v2_body(
+    request: fastapi.Request,
+    jobs_queue_body_v2: payloads.JobsQueueV2Body,
+) -> payloads.JobsQueueV2Body:
+    """Strip `refresh` from `/jobs/queue/v2` for viewers."""
+    if _is_viewer(request):
+        jobs_queue_body_v2.refresh = False
+    return jobs_queue_body_v2
+
+
+def force_viewer_jobs_logs_body(
+    request: fastapi.Request,
+    jobs_logs_body: payloads.JobsLogsBody,
+) -> payloads.JobsLogsBody:
+    """Strip `refresh` from `/jobs/logs` for viewers."""
+    if _is_viewer(request):
+        jobs_logs_body.refresh = False
+    return jobs_logs_body
+
+
+def force_viewer_jobs_download_logs_body(
+    request: fastapi.Request,
+    jobs_download_logs_body: payloads.JobsDownloadLogsBody,
+) -> payloads.JobsDownloadLogsBody:
+    """Strip `refresh` from `/jobs/download_logs` for viewers."""
+    if _is_viewer(request):
+        jobs_download_logs_body.refresh = False
+    return jobs_download_logs_body
+
+
+def force_viewer_volume_refresh(
+    request: fastapi.Request,
+    refresh: bool = False,
+) -> bool:
+    """Strip `refresh` from `GET /volumes` (a query param, not a body)."""
+    if _is_viewer(request):
+        return False
+    return refresh

--- a/sky/server/requests/role_filter.py
+++ b/sky/server/requests/role_filter.py
@@ -43,7 +43,9 @@ def _is_viewer(request: fastapi.Request) -> bool:
     # already consulted to gate this request to here.
     enforcer = permission.permission_service._ensure_enforcer()  # pylint: disable=protected-access
     roles = enforcer.get_roles_for_user(auth_user.id)
-    return rbac.RoleName.VIEWER.value in roles
+    # Admin wins over viewer when both roles are present.
+    return (rbac.RoleName.VIEWER.value in roles and
+            rbac.RoleName.ADMIN.value not in roles)
 
 
 def force_viewer_status_body(

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -85,6 +85,7 @@ from sky.server.requests import payloads
 from sky.server.requests import preconditions
 from sky.server.requests import request_names
 from sky.server.requests import requests as requests_lib
+from sky.server.requests import role_filter
 from sky.skylet import constants
 from sky.ssh_node_pools import server as ssh_node_pools_rest
 from sky.usage import usage_lib
@@ -1834,7 +1835,8 @@ async def stop(request: fastapi.Request,
 @app.post('/status')
 async def status(
     request: fastapi.Request,
-    status_body: payloads.StatusBody = payloads.StatusBody()
+    status_body: payloads.StatusBody = fastapi.Depends(
+        role_filter.force_viewer_status_body),
 ) -> None:
     """Gets cluster statuses."""
     if state.get_block_requests():
@@ -3491,10 +3493,13 @@ if __name__ == '__main__':
     # to check for existing controller clusters. Placed after user hash restore
     # to avoid accidentally using the wrong server hash.
     managed_job_utils.setup_consolidation_mode_on_startup(cmd_args.deploy)
-    # Pre-load plugin RBAC rules before initializing permission service.
-    # This ensures plugin RBAC rules are available when policies are created.
-    logger.info('Pre-loading plugin RBAC rules')
+    # Pre-load plugin RBAC rules + viewer allowlist before initializing
+    # the permission service. The permission service reads both during
+    # _maybe_initialize_policies (blocklist seeded into Casbin; viewer
+    # allowlist built into an in-memory structure).
+    logger.info('Pre-loading plugin RBAC rules + viewer allowlist')
     plugins.load_plugin_rbac_rules()
+    plugins.load_plugin_viewer_allowlist()
     logger.info('Initializing permission service')
     permission.permission_service.initialize()
     logger.info('Permission service initialized')

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -645,6 +645,13 @@ ALL_CLOUDS = ('aws', 'azure', 'gcp', 'ibm', 'lambda', 'scp', 'oci',
 # The user ID of the SkyPilot system.
 SKYPILOT_SYSTEM_USER_ID = 'skypilot-system'
 
+# A built-in viewer-role counterpart to SKYPILOT_SYSTEM_USER_ID. Created
+# automatically so that external auth integrations (e.g. an OIDC bridge that
+# wants to log a user in as a viewer without materializing their identity)
+# have a stable user_id to impersonate as. Pinned to the viewer role at
+# startup; cannot be deleted or have its role changed.
+SKYPILOT_SYSTEM_VIEWER_USER_ID = 'skypilot-system-viewer'
+
 # The directory to store the logging configuration.
 LOGGING_CONFIG_DIR = '~/.sky/logging'
 

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -645,11 +645,7 @@ ALL_CLOUDS = ('aws', 'azure', 'gcp', 'ibm', 'lambda', 'scp', 'oci',
 # The user ID of the SkyPilot system.
 SKYPILOT_SYSTEM_USER_ID = 'skypilot-system'
 
-# A built-in viewer-role counterpart to SKYPILOT_SYSTEM_USER_ID. Created
-# automatically so that external auth integrations (e.g. an OIDC bridge that
-# wants to log a user in as a viewer without materializing their identity)
-# have a stable user_id to impersonate as. Pinned to the viewer role at
-# startup; cannot be deleted or have its role changed.
+# A built-in viewer-role counterpart to SKYPILOT_SYSTEM_USER_ID.
 SKYPILOT_SYSTEM_VIEWER_USER_ID = 'skypilot-system-viewer'
 
 # The directory to store the logging configuration.

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -47,13 +47,7 @@ class PermissionService:
     def __init__(self):
         self.enforcer: Optional[casbin.SyncedEnforcer] = None
         self._lock = threading.Lock()
-        # Viewer role's endpoint allowlist, materialised at boot. Built
-        # in _maybe_initialize_policies from rbac.get_viewer_allowlist()
-        # + any plugin-supplied entries. Stored as a list of
-        # (path_pattern, method) tuples for fast iteration in
-        # check_endpoint_permission. Kept OUT of the Casbin policy
-        # table so that admin/user behaviour is unchanged — see
-        # 02_change_plan.md §2.2.
+        # Viewer role's endpoint allowlist, materialised at boot.
         self._viewer_allowlist: List[tuple] = []
 
     def initialize(self):
@@ -96,12 +90,7 @@ class PermissionService:
                 self.enforcer = _enforcer_instance.enforcer
             # The viewer allowlist is in-process state (not stored in
             # casbin). It MUST be populated in every process that handles
-            # requests — main API server process *and* every uvicorn
-            # worker — otherwise viewer-role requests fall through with
-            # an empty allowlist and 403 on every path. We do this here
-            # (no policy lock needed: read-only, no DB writes), so worker
-            # processes that never call `initialize(full_initialize=True)`
-            # still get the allowlist built on first `_ensure_enforcer()`.
+            # requests.
             self._build_viewer_allowlist_no_lock()
 
     def _ensure_enforcer(self) -> casbin.SyncedEnforcer:
@@ -301,12 +290,6 @@ class PermissionService:
              rbac.RoleName.VIEWER.value),
         ]
         for system_user_id, system_user_role in system_users:
-            # Seed a User row so callers that look the user up via
-            # global_user_state.get_user() — e.g. session middleware
-            # validating an impersonated identity — find one. Otherwise
-            # the row is only created lazily (executor.prepare_request_async
-            # for SKYPILOT_SYSTEM_USER_ID), which doesn't cover the
-            # login path. add_or_update_user is idempotent.
             global_user_state.add_or_update_user(
                 models.User(id=system_user_id,
                             name=system_user_id,
@@ -572,15 +555,7 @@ class PermissionService:
         """
         del action
 
-        # Viewers cannot manage ANY service-account tokens, including
-        # their own.  Allowing them to mint or rotate tokens would be
-        # a privilege-escalation path: a freshly-minted SA defaults to
-        # rbac.get_default_role() (ADMIN unless reconfigured), and the
-        # current update-role endpoint would let the owner promote
-        # the SA arbitrarily.  The SA-token write endpoints are also
-        # off the viewer allowlist at the URL layer; this is
-        # defense-in-depth so a future allowlist addition can't
-        # accidentally open the path.
+        # Viewers cannot manage ANY service-account tokens
         user_roles = self.get_user_roles(user_id)
         if rbac.RoleName.VIEWER.value in user_roles:
             return False

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -94,6 +94,15 @@ class PermissionService:
             else:
                 assert _enforcer_instance is not None
                 self.enforcer = _enforcer_instance.enforcer
+            # The viewer allowlist is in-process state (not stored in
+            # casbin). It MUST be populated in every process that handles
+            # requests — main API server process *and* every uvicorn
+            # worker — otherwise viewer-role requests fall through with
+            # an empty allowlist and 403 on every path. We do this here
+            # (no policy lock needed: read-only, no DB writes), so worker
+            # processes that never call `initialize(full_initialize=True)`
+            # still get the allowlist built on first `_ensure_enforcer()`.
+            self._build_viewer_allowlist_no_lock()
 
     def _ensure_enforcer(self) -> casbin.SyncedEnforcer:
         """Ensure enforcer is initialized and return it."""
@@ -125,6 +134,12 @@ class PermissionService:
     def _get_plugin_viewer_allowlist(self) -> List[dict]:
         """Get viewer-allowlist entries from loaded plugins.
 
+        Lazily populates the module-level plugin allowlist cache if
+        it's empty — this matters in uvicorn worker processes which
+        re-import `sky.server.plugins` from scratch and would otherwise
+        see an empty cache (only the main server process calls
+        `load_plugin_viewer_allowlist()` at startup).
+
         Returns:
             List of `{path, method}` records, or empty list if plugins
             module is not available or no rules are defined.
@@ -132,7 +147,18 @@ class PermissionService:
         try:
             # pylint: disable=import-outside-toplevel
             from sky.server import plugins as server_plugins
-            return server_plugins.get_plugin_viewer_allowlist()
+            cached = server_plugins.get_plugin_viewer_allowlist()
+            if cached:
+                return cached
+            # Cache empty — could be either "no plugin entries" or
+            # "loader hasn't run in this process". Try to populate it;
+            # `load_plugin_viewer_allowlist` is side-effect-free
+            # (instantiates each plugin but doesn't call install) and
+            # idempotent.
+            try:
+                return server_plugins.load_plugin_viewer_allowlist()
+            except AttributeError:
+                return cached
         except ImportError:
             logger.debug('Plugin module not available, '
                          'skipping plugin viewer allowlist')
@@ -145,6 +171,20 @@ class PermissionService:
         except Exception as e:  # pylint: disable=broad-except
             logger.warning(f'Failed to get plugin viewer allowlist: {e}')
             return []
+
+    def _build_viewer_allowlist_no_lock(self) -> None:
+        """Build `self._viewer_allowlist` from defaults + plugin entries.
+
+        Read-only with respect to casbin/DB state — no policy lock
+        required. Safe to call from any process (main server or uvicorn
+        worker); the result is per-process in-memory state.
+        """
+        plugin_viewer_allow = self._get_plugin_viewer_allowlist()
+        self._viewer_allowlist = [(rule['path'], rule['method'])
+                                  for rule in rbac.get_viewer_allowlist(
+                                      plugin_allowlist=plugin_viewer_allow)]
+        logger.debug(f'Viewer allowlist has {len(self._viewer_allowlist)} '
+                     'entries')
 
     def _maybe_initialize_basic_auth_user(self) -> None:
         """Initialize basic auth user if it is enabled."""
@@ -184,17 +224,12 @@ class PermissionService:
         # Get plugin RBAC rules dynamically
         plugin_rules = self._get_plugin_rbac_rules()
 
-        # Build the viewer allowlist (in-memory only; not written to
-        # Casbin). Boot-only: operator-config changes to
-        # rbac.roles.viewer.permissions.allowlist require a server
-        # restart to take effect — same semantics as the existing
-        # blocklist for the user role.
-        plugin_viewer_allow = self._get_plugin_viewer_allowlist()
-        self._viewer_allowlist = [(rule['path'], rule['method'])
-                                  for rule in rbac.get_viewer_allowlist(
-                                      plugin_allowlist=plugin_viewer_allow)]
-        logger.debug(f'Viewer allowlist has {len(self._viewer_allowlist)} '
-                     'entries')
+        # Viewer allowlist is built in `_lazy_initialize` (called above
+        # via `_ensure_enforcer`) so worker processes that never reach
+        # this method still get it. Operator-config changes to
+        # `rbac.roles.viewer.permissions.allowlist` still require a
+        # server restart — same semantics as the existing blocklist
+        # for the user role.
 
         # If we already have policies for the expected roles, skip
         # initialization

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -8,6 +8,7 @@ import time
 from typing import Generator, List, Optional, Set
 
 import casbin
+from casbin import util as casbin_util
 import filelock
 import sqlalchemy_adapter
 
@@ -46,6 +47,14 @@ class PermissionService:
     def __init__(self):
         self.enforcer: Optional[casbin.SyncedEnforcer] = None
         self._lock = threading.Lock()
+        # Viewer role's endpoint allowlist, materialised at boot. Built
+        # in _maybe_initialize_policies from rbac.get_viewer_allowlist()
+        # + any plugin-supplied entries. Stored as a list of
+        # (path_pattern, method) tuples for fast iteration in
+        # check_endpoint_permission. Kept OUT of the Casbin policy
+        # table so that admin/user behaviour is unchanged — see
+        # 02_change_plan.md §2.2.
+        self._viewer_allowlist: List[tuple] = []
 
     def initialize(self):
         self._lazy_initialize(full_initialize=True)
@@ -113,6 +122,30 @@ class PermissionService:
             logger.warning(f'Failed to get plugin RBAC rules: {e}')
             return {}
 
+    def _get_plugin_viewer_allowlist(self) -> List[dict]:
+        """Get viewer-allowlist entries from loaded plugins.
+
+        Returns:
+            List of `{path, method}` records, or empty list if plugins
+            module is not available or no rules are defined.
+        """
+        try:
+            # pylint: disable=import-outside-toplevel
+            from sky.server import plugins as server_plugins
+            return server_plugins.get_plugin_viewer_allowlist()
+        except ImportError:
+            logger.debug('Plugin module not available, '
+                         'skipping plugin viewer allowlist')
+            return []
+        except AttributeError:
+            # Old plugin module that doesn't export this loader.
+            logger.debug('Plugin module does not expose '
+                         'get_plugin_viewer_allowlist; skipping')
+            return []
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Failed to get plugin viewer allowlist: {e}')
+            return []
+
     def _maybe_initialize_basic_auth_user(self) -> None:
         """Initialize basic auth user if it is enabled."""
         basic_auth = os.environ.get(constants.SKYPILOT_INITIAL_BASIC_AUTH)
@@ -150,6 +183,18 @@ class PermissionService:
 
         # Get plugin RBAC rules dynamically
         plugin_rules = self._get_plugin_rbac_rules()
+
+        # Build the viewer allowlist (in-memory only; not written to
+        # Casbin). Boot-only: operator-config changes to
+        # rbac.roles.viewer.permissions.allowlist require a server
+        # restart to take effect — same semantics as the existing
+        # blocklist for the user role.
+        plugin_viewer_allow = self._get_plugin_viewer_allowlist()
+        self._viewer_allowlist = [(rule['path'], rule['method'])
+                                  for rule in rbac.get_viewer_allowlist(
+                                      plugin_allowlist=plugin_viewer_allow)]
+        logger.debug(f'Viewer allowlist has {len(self._viewer_allowlist)} '
+                     'entries')
 
         # If we already have policies for the expected roles, skip
         # initialization
@@ -336,7 +381,18 @@ class PermissionService:
 
     def check_endpoint_permission(self, user_id: str, path: str,
                                   method: str) -> bool:
-        """Check permission."""
+        """Check permission.
+
+        Return True to BLOCK the request (RBAC middleware turns truthy
+        return into 403). Return False to allow.
+
+        Admin / user roles use the Casbin blocklist semantics:
+        True iff a `(role, path, method)` policy matches.
+
+        Viewer role uses an in-memory allowlist:
+        True (block) unless the (path, method) matches an entry in
+        `self._viewer_allowlist`.
+        """
         # We intentionally don't load the policy here, as it is a hot path, and
         # we don't support updating the policy.
         # We don't hold the lock for checking permission, as it is read only and
@@ -344,7 +400,26 @@ class PermissionService:
         # as long as it is eventually consistent.
         # self._load_policy_no_lock()
         enforcer = self._ensure_enforcer()
+        # Read roles from in-memory enforcer state. Do NOT use
+        # self.get_user_roles(...) here — that does a DB roundtrip via
+        # _load_policy_no_lock and would put a query on the request hot
+        # path.
+        roles = enforcer.get_roles_for_user(user_id)
+        if rbac.RoleName.VIEWER.value in roles:
+            return not self._is_viewer_allowed(path, method)
         return enforcer.enforce(user_id, path, method)
+
+    def _is_viewer_allowed(self, path: str, method: str) -> bool:
+        """Test (path, method) against the viewer allowlist."""
+        for allow_path, allow_method in self._viewer_allowlist:
+            if allow_method != method:
+                continue
+            # casbin_util.key_match2: arg1 is the request key, arg2 is
+            # the policy pattern. Pattern supports `:name` placeholders
+            # and `*` wildcards.
+            if casbin_util.key_match2(path, allow_path):
+                return True
+        return False
 
     def _load_policy_no_lock(self):
         """Load policy from storage."""
@@ -446,12 +521,25 @@ class PermissionService:
             True if the user has permission, False otherwise
         """
         del action
+
+        # Viewers cannot manage ANY service-account tokens, including
+        # their own.  Allowing them to mint or rotate tokens would be
+        # a privilege-escalation path: a freshly-minted SA defaults to
+        # rbac.get_default_role() (ADMIN unless reconfigured), and the
+        # current update-role endpoint would let the owner promote
+        # the SA arbitrarily.  The SA-token write endpoints are also
+        # off the viewer allowlist at the URL layer; this is
+        # defense-in-depth so a future allowlist addition can't
+        # accidentally open the path.
+        user_roles = self.get_user_roles(user_id)
+        if rbac.RoleName.VIEWER.value in user_roles:
+            return False
+
         # Users can always manage their own tokens
         if user_id == token_owner_id:
             return True
 
         # Check if user has admin role (admins can manage any token)
-        user_roles = self.get_user_roles(user_id)
         if rbac.RoleName.ADMIN.value in user_roles:
             return True
 

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -438,7 +438,10 @@ class PermissionService:
         # _load_policy_no_lock and would put a query on the request hot
         # path.
         roles = enforcer.get_roles_for_user(user_id)
-        if rbac.RoleName.VIEWER.value in roles:
+        # Admin wins over viewer when a user holds both — viewer's
+        # default-deny semantics shouldn't restrict an admin.
+        if (rbac.RoleName.VIEWER.value in roles and
+                rbac.RoleName.ADMIN.value not in roles):
             return not self._is_viewer_allowed(path, method)
         return enforcer.enforce(user_id, path, method)
 
@@ -555,17 +558,18 @@ class PermissionService:
         """
         del action
 
-        # Viewers cannot manage ANY service-account tokens
         user_roles = self.get_user_roles(user_id)
+        # Admin can manage any token — check this first so a user
+        # holding both admin and viewer isn't blocked by the viewer rule.
+        if rbac.RoleName.ADMIN.value in user_roles:
+            return True
+
+        # Viewers cannot manage ANY service-account tokens.
         if rbac.RoleName.VIEWER.value in user_roles:
             return False
 
         # Users can always manage their own tokens
         if user_id == token_owner_id:
-            return True
-
-        # Check if user has admin role (admins can manage any token)
-        if rbac.RoleName.ADMIN.value in user_roles:
             return True
 
         # Regular users cannot manage tokens owned by others

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -301,6 +301,16 @@ class PermissionService:
              rbac.RoleName.VIEWER.value),
         ]
         for system_user_id, system_user_role in system_users:
+            # Seed a User row so callers that look the user up via
+            # global_user_state.get_user() — e.g. session middleware
+            # validating an impersonated identity — find one. Otherwise
+            # the row is only created lazily (executor.prepare_request_async
+            # for SKYPILOT_SYSTEM_USER_ID), which doesn't cover the
+            # login path. add_or_update_user is idempotent.
+            global_user_state.add_or_update_user(
+                models.User(id=system_user_id,
+                            name=system_user_id,
+                            user_type=models.UserType.SYSTEM.value))
             if system_user_id not in users_with_roles:
                 logger.debug(f'Adding role for system user: {system_user_id} '
                              f'({system_user_role})')

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -294,13 +294,18 @@ class PermissionService:
                 user_added = self._add_user_if_not_exists_no_lock(
                     existing_user.id)
                 policy_updated = policy_updated or user_added
-        for system_user_id in [
-                common.SERVER_ID, constants.SKYPILOT_SYSTEM_USER_ID
-        ]:
+        system_users = [
+            (common.SERVER_ID, rbac.RoleName.ADMIN.value),
+            (constants.SKYPILOT_SYSTEM_USER_ID, rbac.RoleName.ADMIN.value),
+            (constants.SKYPILOT_SYSTEM_VIEWER_USER_ID,
+             rbac.RoleName.VIEWER.value),
+        ]
+        for system_user_id, system_user_role in system_users:
             if system_user_id not in users_with_roles:
-                logger.debug(f'Adding role for system user: {system_user_id}')
+                logger.debug(f'Adding role for system user: {system_user_id} '
+                             f'({system_user_role})')
                 user_added = self._add_user_if_not_exists_no_lock(
-                    system_user_id, rbac.RoleName.ADMIN.value)
+                    system_user_id, system_user_role)
                 policy_updated = policy_updated or user_added
         if policy_updated:
             enforcer.save_policy()

--- a/sky/users/rbac.py
+++ b/sky/users/rbac.py
@@ -286,13 +286,21 @@ _DEFAULT_VIEWER_ALLOWLIST = [
         'path': '/upload_v2/blob',
         'method': 'GET'
     },
-    # --- Dashboard / plugin metadata ---
+    # --- Dashboard / static / auth-flow surface ---
+    # These paths are usually RBAC-skipped at the middleware level
+    # (`/dashboard/`, `/api/` prefix in server.py:200) but are listed
+    # here so the route-coverage test in
+    # tests/unit_tests/test_sky/users/test_viewer_route_coverage.py
+    # treats them as a deliberate allow rather than an
+    # un-categorized route.
     {
-        'path': '/dashboard_config',
+        'path': '/dashboard/*',
         'method': 'GET'
     },
-    # /api/plugins GET is RBAC-skipped at the middleware level but
-    # included here for documentation/coverage consistency.
+    {
+        'path': '/api/v1/auth/token',
+        'method': 'GET'
+    },
     {
         'path': '/api/plugins',
         'method': 'GET'

--- a/sky/users/rbac.py
+++ b/sky/users/rbac.py
@@ -273,24 +273,21 @@ _DEFAULT_VIEWER_ALLOWLIST = [
         'path': '/upload_v2/blob',
         'method': 'GET'
     },
-    # /debug/dump_create is a diagnostic snapshot — operators (including
-    # viewers) need it to collect dumps for support. The corresponding
-    # download (`/debug/dump_download/:filename`) is intentionally NOT
-    # allowlisted: dumps can contain user-scoped data, so reads stay
-    # admin-only via the user-role blocklist semantics.
+    # /debug/dump_create for diagnose
     {
         'path': '/debug/dump_create',
         'method': 'POST'
     },
     # --- Dashboard / static / auth-flow surface ---
-    # These paths are usually RBAC-skipped at the middleware level
-    # (`/dashboard/`, `/api/` prefix in server.py:200) but are listed
-    # here so the route-coverage test in
-    # tests/unit_tests/test_sky/users/test_viewer_route_coverage.py
-    # treats them as a deliberate allow rather than an
-    # un-categorized route.
     {
         'path': '/dashboard/*',
+        'method': 'GET'
+    },
+    # /dashboard_config exposes admin-configured UI settings (e.g.
+    # external_links shown next to logs). The viewer dashboard
+    # rendering reads it on every page load.
+    {
+        'path': '/dashboard_config',
         'method': 'GET'
     },
     {

--- a/sky/users/rbac.py
+++ b/sky/users/rbac.py
@@ -286,6 +286,15 @@ _DEFAULT_VIEWER_ALLOWLIST = [
         'path': '/upload_v2/blob',
         'method': 'GET'
     },
+    # /debug/dump_create is a diagnostic snapshot — operators (including
+    # viewers) need it to collect dumps for support. The corresponding
+    # download (`/debug/dump_download/:filename`) is intentionally NOT
+    # allowlisted: dumps can contain user-scoped data, so reads stay
+    # admin-only via the user-role blocklist semantics.
+    {
+        'path': '/debug/dump_create',
+        'method': 'POST'
+    },
     # --- Dashboard / static / auth-flow surface ---
     # These paths are usually RBAC-skipped at the middleware level
     # (`/dashboard/`, `/api/` prefix in server.py:200) but are listed

--- a/sky/users/rbac.py
+++ b/sky/users/rbac.py
@@ -46,20 +46,7 @@ _DEFAULT_USER_BLOCKLIST = [{
 
 # Default allowlist for the viewer role. Viewer is allowlist-based: any
 # endpoint NOT on this list is denied for viewers, including any new
-# endpoints added in the future. The trade-off vs the blocklist model
-# used for `user`: a useful read endpoint we forget to add here will
-# 403 (loud + safe) rather than silently leak.
-#
-# Operators can extend this list at `rbac.roles.viewer.permissions.
-# allowlist` in `~/.sky/config.yaml` (additive; you only list the
-# *extra* paths you want to grant, not the entire list).
-#
-# Plugins opt their read endpoints in via `BasePlugin.viewer_allowlist`.
-# Plugin endpoints not declared in `viewer_allowlist` are denied by
-# default.
-#
-# Path patterns use the same Casbin `keyMatch2` syntax as the
-# blocklist (`:name` placeholders, `*` wildcards).
+# endpoints added in the future.
 _DEFAULT_VIEWER_ALLOWLIST = [
     # --- Authentication / session ---
     {

--- a/sky/users/rbac.py
+++ b/sky/users/rbac.py
@@ -44,11 +44,272 @@ _DEFAULT_USER_BLOCKLIST = [{
     'method': 'GET'
 }]
 
+# Default allowlist for the viewer role. Viewer is allowlist-based: any
+# endpoint NOT on this list is denied for viewers, including any new
+# endpoints added in the future. The trade-off vs the blocklist model
+# used for `user`: a useful read endpoint we forget to add here will
+# 403 (loud + safe) rather than silently leak.
+#
+# Operators can extend this list at `rbac.roles.viewer.permissions.
+# allowlist` in `~/.sky/config.yaml` (additive; you only list the
+# *extra* paths you want to grant, not the entire list).
+#
+# Plugins opt their read endpoints in via `BasePlugin.viewer_allowlist`.
+# Plugin endpoints not declared in `viewer_allowlist` are denied by
+# default.
+#
+# Path patterns use the same Casbin `keyMatch2` syntax as the
+# blocklist (`:name` placeholders, `*` wildcards).
+_DEFAULT_VIEWER_ALLOWLIST = [
+    # --- Authentication / session ---
+    {
+        'path': '/users/role',
+        'method': 'GET'
+    },
+    {
+        'path': '/token',
+        'method': 'GET'
+    },
+    {
+        'path': '/auth/authorize',
+        'method': 'GET'
+    },
+    # --- Cluster reads ---
+    {
+        'path': '/status',
+        'method': 'POST'
+    },
+    {
+        'path': '/endpoints',
+        'method': 'POST'
+    },
+    {
+        'path': '/cost_report',
+        'method': 'POST'
+    },
+    {
+        'path': '/cluster_events',
+        'method': 'POST'
+    },
+    {
+        'path': '/queue',
+        'method': 'POST'
+    },
+    {
+        'path': '/job_status',
+        'method': 'POST'
+    },
+    {
+        'path': '/logs',
+        'method': 'POST'
+    },
+    {
+        'path': '/download_logs',
+        'method': 'POST'
+    },
+    {
+        'path': '/download',
+        'method': 'POST'
+    },
+    {
+        'path': '/provision_logs',
+        'method': 'POST'
+    },
+    {
+        'path': '/autostop_logs',
+        'method': 'POST'
+    },
+    # --- Managed jobs reads ---
+    {
+        'path': '/jobs/queue',
+        'method': 'POST'
+    },
+    {
+        'path': '/jobs/queue/v2',
+        'method': 'POST'
+    },
+    {
+        'path': '/jobs/wait',
+        'method': 'POST'
+    },
+    {
+        'path': '/jobs/logs',
+        'method': 'POST'
+    },
+    {
+        'path': '/jobs/download_logs',
+        'method': 'POST'
+    },
+    {
+        'path': '/jobs/pool_status',
+        'method': 'POST'
+    },
+    {
+        'path': '/jobs/pool_logs',
+        'method': 'POST'
+    },
+    {
+        'path': '/jobs/pool_sync-down-logs',
+        'method': 'POST'
+    },
+    {
+        'path': '/jobs/events',
+        'method': 'POST'
+    },
+    # --- SkyServe reads ---
+    {
+        'path': '/serve/status',
+        'method': 'POST'
+    },
+    {
+        'path': '/serve/logs',
+        'method': 'POST'
+    },
+    {
+        'path': '/serve/sync-down-logs',
+        'method': 'POST'
+    },
+    # --- Workspaces / volumes / recipes reads ---
+    # NOTE: /workspaces/config GET intentionally NOT on allowlist;
+    # it returns the entire admin config including provider tokens.
+    {
+        'path': '/workspaces',
+        'method': 'GET'
+    },
+    {
+        'path': '/volumes',
+        'method': 'GET'
+    },
+    {
+        'path': '/volumes/validate',
+        'method': 'POST'
+    },
+    {
+        'path': '/recipes',
+        'method': 'GET'
+    },
+    {
+        'path': '/recipes/list',
+        'method': 'POST'
+    },
+    {
+        'path': '/recipes/get',
+        'method': 'POST'
+    },
+    # --- SSH node pool reads ---
+    # NOTE: /ssh_node_pools/keys GET NOT on allowlist (key paths).
+    {
+        'path': '/ssh_node_pools',
+        'method': 'GET'
+    },
+    {
+        'path': '/ssh_node_pools/:pool_name/status',
+        'method': 'GET'
+    },
+    # --- Infra info (read-only catalog/state) ---
+    {
+        'path': '/enabled_clouds',
+        'method': 'GET'
+    },
+    {
+        'path': '/enabled_clouds/batch',
+        'method': 'GET'
+    },
+    {
+        'path': '/realtime_kubernetes_gpu_availability',
+        'method': 'POST'
+    },
+    {
+        'path': '/kubernetes_node_info',
+        'method': 'POST'
+    },
+    {
+        'path': '/slurm_gpu_availability',
+        'method': 'POST'
+    },
+    {
+        'path': '/slurm_node_info',
+        'method': 'GET'
+    },
+    {
+        'path': '/slurm_node_info',
+        'method': 'POST'
+    },
+    {
+        'path': '/status_kubernetes',
+        'method': 'GET'
+    },
+    {
+        'path': '/all_contexts',
+        'method': 'GET'
+    },
+    {
+        'path': '/list_accelerators',
+        'method': 'POST'
+    },
+    {
+        'path': '/list_accelerator_counts',
+        'method': 'POST'
+    },
+    {
+        'path': '/validate',
+        'method': 'POST'
+    },
+    {
+        'path': '/optimize',
+        'method': 'POST'
+    },
+    # --- Users / SA tokens (read-only) ---
+    # /users GET returns name/role only (no password hashes, no
+    # secrets); see sky/users/server.py:60.
+    {
+        'path': '/users',
+        'method': 'GET'
+    },
+    # /users/service-account-tokens GET returns metadata only (no JWT
+    # values). POST and sub-paths (delete/update-role/rotate) are
+    # intentionally NOT allowlisted; viewers cannot mint, rotate, or
+    # modify tokens.  `check_service_account_token_permission` adds
+    # defense-in-depth.
+    {
+        'path': '/users/service-account-tokens',
+        'method': 'GET'
+    },
+    # --- Storage reads ---
+    {
+        'path': '/storage/ls',
+        'method': 'GET'
+    },
+    # /upload_v2/blob GET is a pure existence-check (blob_exists);
+    # see sky/server/server.py:1618.
+    {
+        'path': '/upload_v2/blob',
+        'method': 'GET'
+    },
+    # --- Dashboard / plugin metadata ---
+    {
+        'path': '/dashboard_config',
+        'method': 'GET'
+    },
+    # /api/plugins GET is RBAC-skipped at the middleware level but
+    # included here for documentation/coverage consistency.
+    {
+        'path': '/api/plugins',
+        'method': 'GET'
+    },
+]
+
 
 # Define roles
 class RoleName(str, enum.Enum):
     ADMIN = 'admin'
     USER = 'user'
+    # Strictly read-only role.  Allowlist-based (see
+    # `_DEFAULT_VIEWER_ALLOWLIST`); not currently used by anything by
+    # default — operators opt in by setting
+    # `rbac.default_role: viewer` or by assigning specific users to
+    # this role.
+    VIEWER = 'viewer'
 
 
 def get_supported_roles() -> List[str]:
@@ -58,6 +319,57 @@ def get_supported_roles() -> List[str]:
 def get_default_role() -> str:
     return skypilot_config.get_nested(('rbac', 'default_role'),
                                       default_value=RoleName.ADMIN.value)
+
+
+def get_viewer_allowlist(
+    plugin_allowlist: Optional[List[Dict[str, str]]] = None
+) -> List[Dict[str, str]]:
+    """Get the viewer role's endpoint allowlist.
+
+    Composed of:
+      1. `_DEFAULT_VIEWER_ALLOWLIST` (this module's constant).
+      2. Any rules under
+         `rbac.roles.viewer.permissions.allowlist` in
+         `~/.sky/config.yaml` (additive — operator-supplied entries
+         augment the default, they do not replace it).
+      3. Plugin-supplied rules from `BasePlugin.viewer_allowlist`.
+
+    Args:
+        plugin_allowlist: Optional list of `{path, method}` records
+            collected from loaded plugins.
+
+    Returns:
+        Combined list of `{path, method}` records.  Each record uses
+        Casbin `keyMatch2` path syntax (e.g. `/users/:name`, `/x/*`).
+    """
+    combined: List[Dict[str, str]] = list(_DEFAULT_VIEWER_ALLOWLIST)
+
+    config_roles = skypilot_config.get_nested(('rbac', 'roles'),
+                                              default_value={})
+    viewer_cfg = config_roles.get(RoleName.VIEWER.value, {}) if isinstance(
+        config_roles, dict) else {}
+    extra = ((viewer_cfg.get('permissions') or {}).get('allowlist') or
+             []) if isinstance(viewer_cfg, dict) else []
+    for rule in extra:
+        if not isinstance(rule, dict):
+            logger.warning(f'Invalid viewer allowlist entry (not a dict): '
+                           f'{rule}')
+            continue
+        if 'path' not in rule or 'method' not in rule:
+            logger.warning(f'Viewer allowlist entry missing path/method: '
+                           f'{rule}')
+            continue
+        entry = {'path': rule['path'], 'method': rule['method']}
+        if entry not in combined:
+            combined.append(entry)
+
+    if plugin_allowlist:
+        for rule in plugin_allowlist:
+            entry = {'path': rule['path'], 'method': rule['method']}
+            if entry not in combined:
+                combined.append(entry)
+
+    return combined
 
 
 def get_role_permissions(

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -30,6 +30,14 @@ logger = sky_logging.init_logger(__name__)
 USER_LOCK_PATH = os.path.expanduser('~/.sky/.{user_id}.lock')
 USER_LOCK_TIMEOUT_SECONDS = 20
 
+# Built-in user identities that the server seeds at startup. They must not
+# be deletable or have their role changed via the user-management API.
+_INTERNAL_USER_IDS = (
+    common.SERVER_ID,
+    constants.SKYPILOT_SYSTEM_USER_ID,
+    constants.SKYPILOT_SYSTEM_VIEWER_USER_ID,
+)
+
 router = fastapi.APIRouter()
 
 
@@ -44,11 +52,7 @@ def get_user_type(user: models.User) -> str:
     """
     if user.is_service_account():
         return models.UserType.SA.value
-    if user.id in [
-            common.SERVER_ID,
-            constants.SKYPILOT_SYSTEM_USER_ID,
-            constants.SKYPILOT_SYSTEM_VIEWER_USER_ID,
-    ]:
+    if user.id in _INTERNAL_USER_IDS:
         return models.UserType.SYSTEM.value
     if user.password is not None:
         return models.UserType.BASIC.value
@@ -171,11 +175,7 @@ def user_update(request: fastapi.Request,
         raise fastapi.HTTPException(status_code=400,
                                     detail=f'User {user_id} does not exist')
     # Disallow updating the internal users.
-    if need_update_role and user_info.id in [
-            common.SERVER_ID,
-            constants.SKYPILOT_SYSTEM_USER_ID,
-            constants.SKYPILOT_SYSTEM_VIEWER_USER_ID,
-    ]:
+    if need_update_role and user_info.id in _INTERNAL_USER_IDS:
         raise fastapi.HTTPException(status_code=400,
                                     detail=f'Cannot update role for internal '
                                     f'API server user {user_info.name}')
@@ -204,11 +204,7 @@ def _delete_user(user_id: str) -> None:
         raise fastapi.HTTPException(status_code=400,
                                     detail=f'User {user_id} does not exist')
     # Disallow deleting the internal users.
-    if user_info.id in [
-            common.SERVER_ID,
-            constants.SKYPILOT_SYSTEM_USER_ID,
-            constants.SKYPILOT_SYSTEM_VIEWER_USER_ID,
-    ]:
+    if user_info.id in _INTERNAL_USER_IDS:
         raise fastapi.HTTPException(status_code=400,
                                     detail=f'Cannot delete internal '
                                     f'API server user {user_info.name}')

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -179,7 +179,7 @@ def user_update(request: fastapi.Request,
         raise fastapi.HTTPException(status_code=400,
                                     detail=f'Cannot update role for internal '
                                     f'API server user {user_info.name}')
-    if password and user_info.id == constants.SKYPILOT_SYSTEM_USER_ID:
+    if password and user_info.id in _INTERNAL_USER_IDS:
         raise fastapi.HTTPException(
             status_code=400,
             detail=f'Cannot update password for internal '

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -44,7 +44,11 @@ def get_user_type(user: models.User) -> str:
     """
     if user.is_service_account():
         return models.UserType.SA.value
-    if user.id in [common.SERVER_ID, constants.SKYPILOT_SYSTEM_USER_ID]:
+    if user.id in [
+            common.SERVER_ID,
+            constants.SKYPILOT_SYSTEM_USER_ID,
+            constants.SKYPILOT_SYSTEM_VIEWER_USER_ID,
+    ]:
         return models.UserType.SYSTEM.value
     if user.password is not None:
         return models.UserType.BASIC.value
@@ -168,7 +172,9 @@ def user_update(request: fastapi.Request,
                                     detail=f'User {user_id} does not exist')
     # Disallow updating the internal users.
     if need_update_role and user_info.id in [
-            common.SERVER_ID, constants.SKYPILOT_SYSTEM_USER_ID
+            common.SERVER_ID,
+            constants.SKYPILOT_SYSTEM_USER_ID,
+            constants.SKYPILOT_SYSTEM_VIEWER_USER_ID,
     ]:
         raise fastapi.HTTPException(status_code=400,
                                     detail=f'Cannot update role for internal '
@@ -198,7 +204,11 @@ def _delete_user(user_id: str) -> None:
         raise fastapi.HTTPException(status_code=400,
                                     detail=f'User {user_id} does not exist')
     # Disallow deleting the internal users.
-    if user_info.id in [common.SERVER_ID, constants.SKYPILOT_SYSTEM_USER_ID]:
+    if user_info.id in [
+            common.SERVER_ID,
+            constants.SKYPILOT_SYSTEM_USER_ID,
+            constants.SKYPILOT_SYSTEM_VIEWER_USER_ID,
+    ]:
         raise fastapi.HTTPException(status_code=400,
                                     detail=f'Cannot delete internal '
                                     f'API server user {user_info.name}')

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -2241,7 +2241,24 @@ def get_config_schema():
         'properties': {
             'default_role': {
                 'type': 'string',
-                'case_insensitive_enum': ['admin', 'user']
+                'case_insensitive_enum': ['admin', 'user', 'viewer']
+            },
+            # Per-role permission overrides. Schema is intentionally
+            # permissive (additionalProperties: True on
+            # `permissions`) because admin/user use `blocklist`
+            # entries while `viewer` uses `allowlist`; both shapes
+            # are `[{path, method}, ...]`.
+            'roles': {
+                'type': 'object',
+                'additionalProperties': {
+                    'type': 'object',
+                    'properties': {
+                        'permissions': {
+                            'type': 'object',
+                            'additionalProperties': True,
+                        },
+                    },
+                },
             },
         },
     }

--- a/sky/volumes/server/server.py
+++ b/sky/volumes/server/server.py
@@ -9,6 +9,7 @@ from sky.server.requests import executor
 from sky.server.requests import payloads
 from sky.server.requests import request_names
 from sky.server.requests import requests as requests_lib
+from sky.server.requests import role_filter
 from sky.utils import registry
 from sky.utils import volume as volume_utils
 from sky.volumes.server import core
@@ -19,12 +20,17 @@ router = fastapi.APIRouter()
 
 
 @router.get('')
-async def volume_list(request: fastapi.Request, refresh: bool = False) -> None:
+async def volume_list(
+    request: fastapi.Request,
+    refresh: bool = fastapi.Depends(role_filter.force_viewer_volume_refresh),
+) -> None:
     """Gets the volumes.
 
     Args:
         refresh: If True, refresh volume state from cloud APIs before returning.
             If False (default), return cached data from the database.
+            For viewer-role callers this is forced to False by
+            `role_filter.force_viewer_volume_refresh`.
     """
     request_body = payloads.VolumeListBody(refresh=refresh)
     await executor.schedule_request_async(

--- a/tests/unit_tests/test_sky/backends/test_backend_utils_viewer.py
+++ b/tests/unit_tests/test_sky/backends/test_backend_utils_viewer.py
@@ -1,0 +1,72 @@
+"""Unit tests for the viewer-role defense-in-depth in backend_utils."""
+# pylint: disable=unused-argument
+# Pytest fixtures appear as unused arguments to pylint.
+
+import os
+from unittest import mock
+
+import pytest
+
+from sky.backends import backend_utils
+from sky.skylet import constants
+from sky.users import rbac
+
+
+@pytest.fixture
+def cleanup_user_id_env():
+    yield
+    if constants.USER_ID_ENV_VAR in os.environ:
+        del os.environ[constants.USER_ID_ENV_VAR]
+
+
+@mock.patch('sky.users.permission.permission_service')
+def test_caller_is_viewer_returns_true(mock_svc, cleanup_user_id_env):
+    enforcer = mock.Mock()
+    enforcer.get_roles_for_user.return_value = [rbac.RoleName.VIEWER.value]
+    mock_svc._ensure_enforcer.return_value = enforcer
+
+    os.environ[constants.USER_ID_ENV_VAR] = 'viewer-bob'
+    assert backend_utils._caller_is_viewer() is True
+    enforcer.get_roles_for_user.assert_called_once_with('viewer-bob')
+
+
+@mock.patch('sky.users.permission.permission_service')
+def test_caller_is_viewer_returns_false_for_user(mock_svc, cleanup_user_id_env):
+    enforcer = mock.Mock()
+    enforcer.get_roles_for_user.return_value = [rbac.RoleName.USER.value]
+    mock_svc._ensure_enforcer.return_value = enforcer
+
+    os.environ[constants.USER_ID_ENV_VAR] = 'user-alice'
+    assert backend_utils._caller_is_viewer() is False
+
+
+@mock.patch('sky.users.permission.permission_service')
+def test_caller_is_viewer_returns_false_for_admin(mock_svc,
+                                                  cleanup_user_id_env):
+    enforcer = mock.Mock()
+    enforcer.get_roles_for_user.return_value = [rbac.RoleName.ADMIN.value]
+    mock_svc._ensure_enforcer.return_value = enforcer
+
+    os.environ[constants.USER_ID_ENV_VAR] = 'admin-eve'
+    assert backend_utils._caller_is_viewer() is False
+
+
+def test_caller_is_viewer_returns_false_no_env(cleanup_user_id_env):
+    # USER_ID_ENV_VAR is unset (we are NOT in an executor worker
+    # context — e.g. CLI/SDK on a local laptop). Must return False
+    # without crashing.
+    if constants.USER_ID_ENV_VAR in os.environ:
+        del os.environ[constants.USER_ID_ENV_VAR]
+    assert backend_utils._caller_is_viewer() is False
+
+
+@mock.patch('sky.users.permission.permission_service')
+def test_caller_is_viewer_handles_init_failure(mock_svc, cleanup_user_id_env):
+    # If the permission service is not initialized (e.g. the worker
+    # process started before the API server set things up), we should
+    # fail closed -> "not a viewer", so the check doesn't break
+    # admin/user callers.
+    mock_svc._ensure_enforcer.side_effect = RuntimeError('not ready')
+
+    os.environ[constants.USER_ID_ENV_VAR] = 'someone'
+    assert backend_utils._caller_is_viewer() is False

--- a/tests/unit_tests/test_sky/server/test_plugins.py
+++ b/tests/unit_tests/test_sky/server/test_plugins.py
@@ -320,3 +320,73 @@ def test_api_plugins_endpoint_includes_visible_plugins(monkeypatch):
     plugin_names = [p['name'] for p in plugin_list]
     assert 'VisiblePlugin1' in plugin_names
     assert 'VisiblePlugin2' in plugin_names
+
+
+def test_load_plugin_viewer_allowlist(monkeypatch, tmp_path):
+    """load_plugin_viewer_allowlist reads viewer_allowlist from each plugin."""
+    module_name = 'sky_test_viewer_allowlist_plugin'
+
+    class AllowlistPlugin(plugins.BasePlugin):
+
+        @property
+        def viewer_allowlist(self):
+            return [
+                plugins.RBACRule(path='/plugins/api/foo/list', method='GET'),
+                plugins.RBACRule(path='/plugins/api/foo/status', method='POST'),
+            ]
+
+        def install(self, extension_context):
+            pass
+
+    AllowlistPlugin.__module__ = module_name
+    module = types.ModuleType(module_name)
+    module.AllowlistPlugin = AllowlistPlugin
+    monkeypatch.setitem(sys.modules, module_name, module)
+
+    config = {
+        'plugins': [{
+            'class': f'{module_name}.AllowlistPlugin',
+        }],
+    }
+    config_path = tmp_path / 'plugins.yaml'
+    config_path.write_text(yaml.safe_dump(config))
+    monkeypatch.setenv(plugins._PLUGINS_CONFIG_ENV_VAR, str(config_path))
+    # Reset the module-level cache so this test does not see leftover
+    # state from other tests.
+    monkeypatch.setattr(plugins, '_PLUGIN_VIEWER_ALLOWLIST', [])
+
+    result = plugins.load_plugin_viewer_allowlist()
+
+    assert {'path': '/plugins/api/foo/list', 'method': 'GET'} in result
+    assert {'path': '/plugins/api/foo/status', 'method': 'POST'} in result
+    assert len(result) == 2
+    # Cached for the getter.
+    assert plugins.get_plugin_viewer_allowlist() == result
+
+
+def test_load_plugin_viewer_allowlist_default_empty(monkeypatch, tmp_path):
+    """Plugins that do not override viewer_allowlist contribute nothing."""
+    module_name = 'sky_test_viewer_allowlist_default_plugin'
+
+    class NoOverridePlugin(plugins.BasePlugin):
+
+        def install(self, extension_context):
+            pass
+
+    NoOverridePlugin.__module__ = module_name
+    module = types.ModuleType(module_name)
+    module.NoOverridePlugin = NoOverridePlugin
+    monkeypatch.setitem(sys.modules, module_name, module)
+
+    config = {
+        'plugins': [{
+            'class': f'{module_name}.NoOverridePlugin',
+        }],
+    }
+    config_path = tmp_path / 'plugins.yaml'
+    config_path.write_text(yaml.safe_dump(config))
+    monkeypatch.setenv(plugins._PLUGINS_CONFIG_ENV_VAR, str(config_path))
+    monkeypatch.setattr(plugins, '_PLUGIN_VIEWER_ALLOWLIST', [])
+
+    result = plugins.load_plugin_viewer_allowlist()
+    assert not result

--- a/tests/unit_tests/test_sky/server/test_role_filter.py
+++ b/tests/unit_tests/test_sky/server/test_role_filter.py
@@ -1,0 +1,144 @@
+"""Unit tests for the role_filter body shim used to gate ambiguous endpoints
+for the viewer role."""
+
+from unittest import mock
+
+import fastapi
+
+from sky.server.requests import payloads
+from sky.server.requests import role_filter
+from sky.users import rbac
+from sky.utils import common as common_lib
+
+
+def _viewer_request():
+    request = mock.Mock(spec=fastapi.Request)
+    auth_user = mock.Mock()
+    auth_user.id = 'viewer-bob'
+    request.state.auth_user = auth_user
+    return request
+
+
+def _user_request():
+    request = mock.Mock(spec=fastapi.Request)
+    auth_user = mock.Mock()
+    auth_user.id = 'user-alice'
+    request.state.auth_user = auth_user
+    return request
+
+
+def _anonymous_request():
+    request = mock.Mock(spec=fastapi.Request)
+    request.state.auth_user = None
+    return request
+
+
+@mock.patch.object(role_filter.permission, 'permission_service')
+def test_force_viewer_status_body_for_viewer(mock_svc):
+    enforcer = mock.Mock()
+    enforcer.get_roles_for_user.return_value = [rbac.RoleName.VIEWER.value]
+    mock_svc._ensure_enforcer.return_value = enforcer
+
+    body = payloads.StatusBody(
+        refresh=common_lib.StatusRefreshMode.FORCE,
+        include_credentials=True,
+    )
+    out = role_filter.force_viewer_status_body(_viewer_request(), body)
+
+    assert out.refresh == common_lib.StatusRefreshMode.NONE
+    assert out.include_credentials is False
+
+
+@mock.patch.object(role_filter.permission, 'permission_service')
+def test_force_viewer_status_body_for_user_unchanged(mock_svc):
+    enforcer = mock.Mock()
+    enforcer.get_roles_for_user.return_value = [rbac.RoleName.USER.value]
+    mock_svc._ensure_enforcer.return_value = enforcer
+
+    body = payloads.StatusBody(
+        refresh=common_lib.StatusRefreshMode.FORCE,
+        include_credentials=True,
+    )
+    out = role_filter.force_viewer_status_body(_user_request(), body)
+
+    # Regular user — body must be unchanged.
+    assert out.refresh == common_lib.StatusRefreshMode.FORCE
+    assert out.include_credentials is True
+
+
+def test_force_viewer_status_body_anonymous_unchanged():
+    body = payloads.StatusBody(
+        refresh=common_lib.StatusRefreshMode.FORCE,
+        include_credentials=True,
+    )
+    out = role_filter.force_viewer_status_body(_anonymous_request(), body)
+    # Anonymous (no auth_user) is treated like non-viewer.
+    assert out.refresh == common_lib.StatusRefreshMode.FORCE
+    assert out.include_credentials is True
+
+
+@mock.patch.object(role_filter.permission, 'permission_service')
+def test_force_viewer_jobs_queue_body(mock_svc):
+    enforcer = mock.Mock()
+    enforcer.get_roles_for_user.return_value = [rbac.RoleName.VIEWER.value]
+    mock_svc._ensure_enforcer.return_value = enforcer
+
+    body = payloads.JobsQueueBody(refresh=True)
+    out = role_filter.force_viewer_jobs_queue_body(_viewer_request(), body)
+    assert out.refresh is False
+
+
+@mock.patch.object(role_filter.permission, 'permission_service')
+def test_force_viewer_jobs_queue_v2_body(mock_svc):
+    enforcer = mock.Mock()
+    enforcer.get_roles_for_user.return_value = [rbac.RoleName.VIEWER.value]
+    mock_svc._ensure_enforcer.return_value = enforcer
+
+    body = payloads.JobsQueueV2Body(refresh=True)
+    out = role_filter.force_viewer_jobs_queue_v2_body(_viewer_request(), body)
+    assert out.refresh is False
+
+
+@mock.patch.object(role_filter.permission, 'permission_service')
+def test_force_viewer_jobs_logs_body(mock_svc):
+    enforcer = mock.Mock()
+    enforcer.get_roles_for_user.return_value = [rbac.RoleName.VIEWER.value]
+    mock_svc._ensure_enforcer.return_value = enforcer
+
+    body = payloads.JobsLogsBody(refresh=True)
+    out = role_filter.force_viewer_jobs_logs_body(_viewer_request(), body)
+    assert out.refresh is False
+
+
+@mock.patch.object(role_filter.permission, 'permission_service')
+def test_force_viewer_jobs_download_logs_body(mock_svc):
+    enforcer = mock.Mock()
+    enforcer.get_roles_for_user.return_value = [rbac.RoleName.VIEWER.value]
+    mock_svc._ensure_enforcer.return_value = enforcer
+
+    body = payloads.JobsDownloadLogsBody(name='job', job_id=1, refresh=True)
+    out = role_filter.force_viewer_jobs_download_logs_body(
+        _viewer_request(), body)
+    assert out.refresh is False
+
+
+@mock.patch.object(role_filter.permission, 'permission_service')
+def test_force_viewer_volume_refresh(mock_svc):
+    enforcer = mock.Mock()
+    enforcer.get_roles_for_user.return_value = [rbac.RoleName.VIEWER.value]
+    mock_svc._ensure_enforcer.return_value = enforcer
+
+    out = role_filter.force_viewer_volume_refresh(_viewer_request(),
+                                                  refresh=True)
+    assert out is False
+
+
+@mock.patch.object(role_filter.permission, 'permission_service')
+def test_force_viewer_volume_refresh_user_unchanged(mock_svc):
+    enforcer = mock.Mock()
+    enforcer.get_roles_for_user.return_value = [rbac.RoleName.USER.value]
+    mock_svc._ensure_enforcer.return_value = enforcer
+
+    out = role_filter.force_viewer_volume_refresh(_user_request(), refresh=True)
+    # Non-viewer is unaffected.
+    assert out is True

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -483,6 +483,24 @@ class TestPermissionService:
         assert service.check_endpoint_permission(
             'u', '/ssh_node_pools/myPool/keys', 'GET') is True
 
+    def test_check_endpoint_permission_admin_wins_over_viewer(self):
+        """A user with both admin and viewer roles uses admin semantics."""
+        mock_enforcer = mock.Mock()
+        mock_enforcer.get_roles_for_user.return_value = ['viewer', 'admin']
+        # enforce returns False (allowed) for admin under blocklist semantics.
+        mock_enforcer.enforce.return_value = False
+
+        service = permission.PermissionService()
+        service.enforcer = mock_enforcer
+        # Empty allowlist would deny everything if viewer semantics applied.
+        service._viewer_allowlist = []
+
+        # /launch is not on any allowlist; viewer-only would block it,
+        # but admin+viewer must fall through to enforce() -> allowed.
+        assert service.check_endpoint_permission('u', '/launch',
+                                                 'POST') is False
+        mock_enforcer.enforce.assert_called_once_with('u', '/launch', 'POST')
+
     def test_check_workspace_permission_non_server(self):
         """Test workspace permission check when not on API server."""
         # Ensure ENV_VAR_IS_SKYPILOT_SERVER is not set
@@ -1230,6 +1248,15 @@ class TestPermissionService:
 
         assert service.check_service_account_token_permission(
             'eve', 'someone-else', 'delete') is True
+
+    def test_sa_token_permission_admin_wins_over_viewer(self):
+        """A user holding both admin and viewer can manage any token."""
+        service = permission.PermissionService()
+        service.get_user_roles = mock.Mock(return_value=['admin', 'viewer'])
+
+        # Without admin precedence, the viewer rule would deny this.
+        assert service.check_service_account_token_permission(
+            'dual', 'someone-else', 'delete') is True
 
 
 @pytest.mark.usefixtures("reset_permission_singleton", "cleanup_env_vars")

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -160,6 +160,17 @@ class TestPermissionService:
             mock_enforcer.add_grouping_policy.assert_any_call(
                 user.id, rbac.get_default_role())
 
+        # Verify built-in system users are seeded with the expected roles:
+        # the existing system user + SERVER_ID are admin; the new
+        # system-viewer is viewer.
+        mock_enforcer.add_grouping_policy.assert_any_call(
+            common.SERVER_ID, rbac.RoleName.ADMIN.value)
+        mock_enforcer.add_grouping_policy.assert_any_call(
+            constants.SKYPILOT_SYSTEM_USER_ID, rbac.RoleName.ADMIN.value)
+        mock_enforcer.add_grouping_policy.assert_any_call(
+            constants.SKYPILOT_SYSTEM_VIEWER_USER_ID,
+            rbac.RoleName.VIEWER.value)
+
         # Verify policy was saved
         mock_enforcer.save_policy.assert_called()
 
@@ -1325,13 +1336,16 @@ class TestPermissionServiceMultiProcess:
                                  ('user2', 'workspace1', '*')}
 
         # Should have one grouping policy call per user (for default role assignment)
-        # plus system users (SERVER_ID and SKYPILOT_SYSTEM_USER_ID) with admin role
-        expected_grouping_policy_calls = {('user1', rbac.get_default_role()),
-                                          ('user2', rbac.get_default_role()),
-                                          ('user3', rbac.get_default_role()),
-                                          (common.SERVER_ID, 'admin'),
-                                          (constants.SKYPILOT_SYSTEM_USER_ID,
-                                           'admin')}
+        # plus the three built-in system users — SERVER_ID and the system
+        # admin user with admin role, and the system viewer user with viewer.
+        expected_grouping_policy_calls = {
+            ('user1', rbac.get_default_role()),
+            ('user2', rbac.get_default_role()),
+            ('user3', rbac.get_default_role()),
+            (common.SERVER_ID, 'admin'),
+            (constants.SKYPILOT_SYSTEM_USER_ID, 'admin'),
+            (constants.SKYPILOT_SYSTEM_VIEWER_USER_ID, 'viewer'),
+        }
 
         assert unique_policy_calls == expected_policy_calls
         assert unique_grouping_policy_calls == expected_grouping_policy_calls
@@ -1377,6 +1391,8 @@ class TestPermissionServiceMultiProcess:
                 ]
                 result.append([common.SERVER_ID, 'admin'])
                 result.append([constants.SKYPILOT_SYSTEM_USER_ID, 'admin'])
+                result.append(
+                    [constants.SKYPILOT_SYSTEM_VIEWER_USER_ID, 'viewer'])
                 return result
 
         def get_roles_for_user_side_effect(user_id):
@@ -1416,12 +1432,13 @@ class TestPermissionServiceMultiProcess:
         service._maybe_initialize_policies()
         service._maybe_initialize_policies()
 
-        # Each user should only be added once (3 mock users + 2 system users)
+        # Each user should only be added once (3 mock users + 3 system users)
         expected_calls = {
             (user.id, rbac.get_default_role()) for user in mock_users
         }
         expected_calls.add((common.SERVER_ID, 'admin'))
         expected_calls.add((constants.SKYPILOT_SYSTEM_USER_ID, 'admin'))
+        expected_calls.add((constants.SKYPILOT_SYSTEM_VIEWER_USER_ID, 'viewer'))
         assert len(grouping_policy_calls) == len(expected_calls)
 
         # Verify each user was added exactly once

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -401,9 +401,12 @@ class TestPermissionService:
         mock_enforcer.get_roles_for_user.assert_called_once_with('user1')
 
     def test_check_endpoint_permission(self):
-        """Test checking endpoint permissions."""
+        """Test checking endpoint permissions (admin/user blocklist path)."""
         mock_enforcer = mock.Mock()
         mock_enforcer.enforce.return_value = True
+        # New dispatch reads roles first; return a non-viewer role so the
+        # call falls through to the Casbin blocklist check.
+        mock_enforcer.get_roles_for_user.return_value = ['user']
 
         service = permission.PermissionService()
         service.enforcer = mock_enforcer
@@ -413,6 +416,61 @@ class TestPermissionService:
         assert result is True
         mock_enforcer.enforce.assert_called_once_with('user1', '/api/test',
                                                       'GET')
+
+    def test_check_endpoint_permission_viewer_allowed(self):
+        """Viewer role: allowlist hit returns False (request not blocked)."""
+        mock_enforcer = mock.Mock()
+        mock_enforcer.get_roles_for_user.return_value = ['viewer']
+
+        service = permission.PermissionService()
+        service.enforcer = mock_enforcer
+        service._viewer_allowlist = [('/status', 'POST')]
+
+        result = service.check_endpoint_permission('user1', '/status', 'POST')
+
+        assert result is False
+        # When the viewer dispatch handles the request, the underlying
+        # blocklist enforce() must NOT be called.
+        mock_enforcer.enforce.assert_not_called()
+
+    def test_check_endpoint_permission_viewer_denied(self):
+        """Viewer role: no allowlist hit returns True (request blocked)."""
+        mock_enforcer = mock.Mock()
+        mock_enforcer.get_roles_for_user.return_value = ['viewer']
+
+        service = permission.PermissionService()
+        service.enforcer = mock_enforcer
+        service._viewer_allowlist = [('/status', 'POST')]
+
+        result = service.check_endpoint_permission('user1', '/launch', 'POST')
+
+        assert result is True
+        mock_enforcer.enforce.assert_not_called()
+
+    def test_check_endpoint_permission_viewer_keymatch2(self):
+        """Viewer allowlist uses Casbin keyMatch2 path patterns."""
+        mock_enforcer = mock.Mock()
+        mock_enforcer.get_roles_for_user.return_value = ['viewer']
+
+        service = permission.PermissionService()
+        service.enforcer = mock_enforcer
+        service._viewer_allowlist = [
+            ('/ssh_node_pools/:pool_name/status', 'GET'),
+            ('/plugins/api/foo/*', 'POST'),
+        ]
+
+        # Placeholder match.
+        assert service.check_endpoint_permission(
+            'u', '/ssh_node_pools/myPool/status', 'GET') is False
+        # Wildcard match.
+        assert service.check_endpoint_permission('u', '/plugins/api/foo/bar',
+                                                 'POST') is False
+        # Method mismatch -> denied.
+        assert service.check_endpoint_permission(
+            'u', '/ssh_node_pools/myPool/status', 'POST') is True
+        # Sibling path -> denied.
+        assert service.check_endpoint_permission(
+            'u', '/ssh_node_pools/myPool/keys', 'GET') is True
 
     def test_check_workspace_permission_non_server(self):
         """Test workspace permission check when not on API server."""
@@ -1136,6 +1194,31 @@ class TestPermissionService:
         service.update_role('user1', 'admin')
 
         mock_kv_cache.delete_cache_entries_by_prefix_suffix.assert_not_called()
+
+    def test_sa_token_permission_viewer_denied_for_own(self):
+        """Viewers cannot manage even their own SA tokens."""
+        service = permission.PermissionService()
+        service.get_user_roles = mock.Mock(return_value=['viewer'])
+
+        # Viewer attempting to delete a token they own:
+        assert service.check_service_account_token_permission(
+            'viewer-bob', 'viewer-bob', 'delete') is False
+
+    def test_sa_token_permission_user_can_manage_own(self):
+        """Regular user can still manage their own SA tokens."""
+        service = permission.PermissionService()
+        service.get_user_roles = mock.Mock(return_value=['user'])
+
+        assert service.check_service_account_token_permission(
+            'alice', 'alice', 'delete') is True
+
+    def test_sa_token_permission_admin_can_manage_others(self):
+        """Admins can manage anyone's tokens."""
+        service = permission.PermissionService()
+        service.get_user_roles = mock.Mock(return_value=['admin'])
+
+        assert service.check_service_account_token_permission(
+            'eve', 'someone-else', 'delete') is True
 
 
 @pytest.mark.usefixtures("reset_permission_singleton", "cleanup_env_vars")

--- a/tests/unit_tests/test_sky/users/test_rbac.py
+++ b/tests/unit_tests/test_sky/users/test_rbac.py
@@ -54,8 +54,14 @@ class TestGetViewerAllowlist:
         } not in allowlist
         # User export exposes password hashes.
         assert {'path': '/users/export', 'method': 'GET'} not in allowlist
-        # Debug dump endpoints expose internal state.
-        assert {'path': '/debug/dump_create', 'method': 'POST'} not in allowlist
+        # `/debug/dump_create` is intentionally on the allowlist for
+        # support diagnostics (see _DEFAULT_VIEWER_ALLOWLIST); only the
+        # download endpoint is admin-only because the dump file itself
+        # may contain sensitive state.
+        assert {
+            'path': '/debug/dump_download/{dump_filename}',
+            'method': 'GET',
+        } not in allowlist
 
     def test_websocket_ssh_proxies_NOT_on_default_allowlist(self):
         with mock.patch('sky.skypilot_config.get_nested', return_value={}):

--- a/tests/unit_tests/test_sky/users/test_rbac.py
+++ b/tests/unit_tests/test_sky/users/test_rbac.py
@@ -1,0 +1,142 @@
+"""Unit tests for sky.users.rbac (viewer role helpers)."""
+
+from unittest import mock
+
+import pytest
+
+from sky.users import rbac
+
+
+class TestRoleEnum:
+    """The RoleName enum is the source of truth for accepted role strings."""
+
+    def test_viewer_is_supported(self):
+        assert 'viewer' in rbac.get_supported_roles()
+
+    def test_admin_and_user_still_supported(self):
+        roles = rbac.get_supported_roles()
+        assert 'admin' in roles
+        assert 'user' in roles
+
+
+class TestGetViewerAllowlist:
+    """rbac.get_viewer_allowlist composes defaults + config + plugin entries."""
+
+    def test_default_is_returned_when_config_empty(self):
+        with mock.patch('sky.skypilot_config.get_nested', return_value={}):
+            allowlist = rbac.get_viewer_allowlist()
+        assert allowlist == rbac._DEFAULT_VIEWER_ALLOWLIST  # pylint: disable=protected-access
+
+    def test_status_post_is_on_default_allowlist(self):
+        with mock.patch('sky.skypilot_config.get_nested', return_value={}):
+            allowlist = rbac.get_viewer_allowlist()
+        assert {'path': '/status', 'method': 'POST'} in allowlist
+
+    def test_launch_is_NOT_on_default_allowlist(self):
+        with mock.patch('sky.skypilot_config.get_nested', return_value={}):
+            allowlist = rbac.get_viewer_allowlist()
+        assert {'path': '/launch', 'method': 'POST'} not in allowlist
+        assert {'path': '/down', 'method': 'POST'} not in allowlist
+        assert {
+            'path': '/users/service-account-tokens',
+            'method': 'POST'
+        } not in allowlist
+
+    def test_sensitive_reads_NOT_on_default_allowlist(self):
+        with mock.patch('sky.skypilot_config.get_nested', return_value={}):
+            allowlist = rbac.get_viewer_allowlist()
+        # Workspace config GET exposes provider tokens.
+        assert {'path': '/workspaces/config', 'method': 'GET'} not in allowlist
+        # SSH node-pool keys GET exposes private-key paths.
+        assert {
+            'path': '/ssh_node_pools/keys',
+            'method': 'GET'
+        } not in allowlist
+        # User export exposes password hashes.
+        assert {'path': '/users/export', 'method': 'GET'} not in allowlist
+        # Debug dump endpoints expose internal state.
+        assert {'path': '/debug/dump_create', 'method': 'POST'} not in allowlist
+
+    def test_websocket_ssh_proxies_NOT_on_default_allowlist(self):
+        with mock.patch('sky.skypilot_config.get_nested', return_value={}):
+            allowlist = rbac.get_viewer_allowlist()
+        for path in ('/kubernetes-pod-ssh-proxy', '/slurm-job-ssh-proxy',
+                     '/ssh-interactive-auth'):
+            assert {'path': path, 'method': 'GET'} not in allowlist
+
+    def test_operator_overrides_are_additive(self):
+        extra = {
+            'viewer': {
+                'permissions': {
+                    'allowlist': [{
+                        'path': '/plugins/api/cron/list',
+                        'method': 'POST'
+                    }]
+                }
+            }
+        }
+        # rbac.get_viewer_allowlist calls skypilot_config.get_nested with
+        # ('rbac', 'roles'); we mock that one call.
+        with mock.patch('sky.skypilot_config.get_nested', return_value=extra):
+            allowlist = rbac.get_viewer_allowlist()
+        # The default is still present...
+        assert {'path': '/status', 'method': 'POST'} in allowlist
+        # ...and the operator-supplied entry is added on top.
+        assert {'path': '/plugins/api/cron/list', 'method': 'POST'} in allowlist
+
+    def test_operator_overrides_dedupe(self):
+        # Operator re-asserts an entry that's already in the default;
+        # it should appear once.
+        extra = {
+            'viewer': {
+                'permissions': {
+                    'allowlist': [{
+                        'path': '/status',
+                        'method': 'POST'
+                    }]
+                }
+            }
+        }
+        with mock.patch('sky.skypilot_config.get_nested', return_value=extra):
+            allowlist = rbac.get_viewer_allowlist()
+        count = sum(1 for r in allowlist if r == {
+            'path': '/status',
+            'method': 'POST'
+        })
+        assert count == 1
+
+    def test_plugin_entries_merged(self):
+        with mock.patch('sky.skypilot_config.get_nested', return_value={}):
+            allowlist = rbac.get_viewer_allowlist(plugin_allowlist=[{
+                'path': '/plugins/api/foo/*',
+                'method': 'GET'
+            }])
+        assert {'path': '/plugins/api/foo/*', 'method': 'GET'} in allowlist
+
+    def test_malformed_operator_entry_is_skipped(self):
+        # Missing 'method' field -> should be logged and skipped, not crash.
+        extra = {
+            'viewer': {
+                'permissions': {
+                    'allowlist': [{
+                        'path': '/foo'
+                    }, 'not-a-dict']
+                }
+            }
+        }
+        with mock.patch('sky.skypilot_config.get_nested', return_value=extra):
+            allowlist = rbac.get_viewer_allowlist()
+        # No crash, defaults preserved.
+        assert {'path': '/status', 'method': 'POST'} in allowlist
+
+
+class TestDefaultRoleConfig:
+
+    def test_default_role_falls_back_to_admin(self):
+        with mock.patch('sky.skypilot_config.get_nested', return_value='admin'):
+            assert rbac.get_default_role() == 'admin'
+
+    def test_default_role_can_be_viewer(self):
+        with mock.patch('sky.skypilot_config.get_nested',
+                        return_value='viewer'):
+            assert rbac.get_default_role() == 'viewer'

--- a/tests/unit_tests/test_sky/users/test_server.py
+++ b/tests/unit_tests/test_sky/users/test_server.py
@@ -174,10 +174,12 @@ class TestUsersEndpoints:
 
         # Verify function calls
         mock_get_all_users.assert_called_once()
-        # Should call get_users_for_role for each supported role
-        assert mock_get_users_for_role.call_count == 2  # admin and user roles
+        # Should call get_users_for_role for each supported role:
+        # admin, user, viewer.
+        assert mock_get_users_for_role.call_count == 3
         mock_get_users_for_role.assert_any_call('admin')
         mock_get_users_for_role.assert_any_call('user')
+        mock_get_users_for_role.assert_any_call('viewer')
 
     @mock.patch('sky.global_user_state.get_all_users')
     @mock.patch('sky.users.permission.permission_service.get_users_for_role')
@@ -196,7 +198,7 @@ class TestUsersEndpoints:
         assert result == []
         mock_get_all_users.assert_called_once()
         # Should still call get_users_for_role for each supported role even with no users
-        assert mock_get_users_for_role.call_count == 2  # admin and user roles
+        assert mock_get_users_for_role.call_count == 3  # admin, user, viewer
 
     @mock.patch('sky.users.permission.permission_service.get_user_roles')
     @pytest.mark.asyncio

--- a/tests/unit_tests/test_sky/users/test_viewer_route_coverage.py
+++ b/tests/unit_tests/test_sky/users/test_viewer_route_coverage.py
@@ -117,7 +117,10 @@ _KNOWN_VIEWER_DENIED: set = {
     ('/ssh_node_pools/{pool_name}/down', 'POST'),
     ('/ssh_node_pools/down', 'POST'),
     # --- Debug ---
-    ('/debug/dump_create', 'POST'),
+    # /debug/dump_create is intentionally on the viewer allowlist (see
+    # _DEFAULT_VIEWER_ALLOWLIST) so viewers can capture support diagnostics;
+    # only the download endpoint stays admin-only because the dump file
+    # itself may contain sensitive state.
     ('/debug/dump_download/{dump_filename}', 'GET'),
     # --- /api/* paths: RBAC-skipped at middleware level, not on
     # viewer allowlist; explicitly enumerated here for documentation.

--- a/tests/unit_tests/test_sky/users/test_viewer_route_coverage.py
+++ b/tests/unit_tests/test_sky/users/test_viewer_route_coverage.py
@@ -1,0 +1,233 @@
+"""Route coverage assertion for the viewer-role allowlist.
+
+This test walks every registered FastAPI route on the API server's
+`app` and confirms that the test author made a deliberate
+allow-or-deny decision for each `(path, method)` pair.  The point is
+to catch new endpoints added in future PRs that forget to opt into
+the viewer allowlist (a useful read endpoint that silently 403s) OR
+deliberately stay off it (a write endpoint correctly denied by
+default).
+
+Failure modes:
+  * Test fails with "uncategorized" -> the PR added or renamed an
+    endpoint without thinking about viewer. Decide: put it on
+    `_DEFAULT_VIEWER_ALLOWLIST` (read) or in this file's
+    `_KNOWN_VIEWER_DENIED` (write/sensitive).
+  * Test fails with "allowlist has unknown entry" -> the
+    `_DEFAULT_VIEWER_ALLOWLIST` references a path that no longer
+    exists on the FastAPI app.  Update the constant.
+
+The "known denied" set is the source of truth for endpoints that
+SHOULD remain denied for viewer.  It is intentionally explicit
+rather than catch-all so that the failure on a new endpoint
+forces a deliberate review.
+"""
+
+from casbin import util as casbin_util
+from fastapi.routing import APIRoute
+
+from sky.server import server as server_app
+from sky.users import rbac
+
+
+def _fastapi_path_to_casbin(template: str) -> str:
+    """Convert a FastAPI `{name}` path template to Casbin `:name`."""
+    out = []
+    i = 0
+    while i < len(template):
+        c = template[i]
+        if c == '{':
+            j = template.find('}', i)
+            assert j > i, f'unterminated path placeholder in {template!r}'
+            out.append(':' + template[i + 1:j])
+            i = j + 1
+        else:
+            out.append(c)
+            i += 1
+    return ''.join(out)
+
+
+# Paths that, on the OSS app, are deliberately NOT on the viewer
+# allowlist.  This is the source of truth for "write or sensitive
+# read" classification — keep it in sync with the architecture
+# map's §2.3 and §2.5.
+#
+# Each entry is (path_template_from_fastapi, method).
+_KNOWN_VIEWER_DENIED: set = {
+    # --- Cluster writes ---
+    ('/launch', 'POST'),
+    ('/exec', 'POST'),
+    ('/start', 'POST'),
+    ('/stop', 'POST'),
+    ('/down', 'POST'),
+    ('/autostop', 'POST'),
+    ('/cancel', 'POST'),
+    ('/local_up', 'POST'),
+    ('/local_down', 'POST'),
+    ('/upload', 'POST'),
+    ('/upload_v2', 'POST'),
+    ('/storage/delete', 'POST'),
+    ('/kubernetes_label_gpus', 'POST'),
+    ('/check', 'POST'),  # mutates state.db
+    # --- Auth writes ---
+    ('/api/v1/auth/authorize', 'POST'),
+    ('/api/cancel', 'POST'),
+    # --- Managed jobs writes ---
+    ('/jobs/launch', 'POST'),
+    ('/jobs/cancel', 'POST'),
+    ('/jobs/pool_apply', 'POST'),
+    ('/jobs/pool_down', 'POST'),
+    # --- Serve writes ---
+    ('/serve/up', 'POST'),
+    ('/serve/down', 'POST'),
+    ('/serve/update', 'POST'),
+    ('/serve/terminate-replica', 'POST'),
+    # --- Volumes writes ---
+    ('/volumes/apply', 'POST'),
+    ('/volumes/delete', 'POST'),
+    # --- Users writes (incl. SA token mgmt) ---
+    ('/users/create', 'POST'),
+    ('/users/update', 'POST'),
+    ('/users/delete', 'POST'),
+    ('/users/import', 'POST'),
+    ('/users/export', 'GET'),  # password hashes
+    ('/users/service-account-tokens', 'POST'),
+    ('/users/service-account-tokens/delete', 'POST'),
+    ('/users/service-account-tokens/update-role', 'POST'),
+    ('/users/service-account-tokens/get-role', 'POST'),
+    ('/users/service-account-tokens/rotate', 'POST'),
+    # --- Workspaces writes (incl. sensitive config read) ---
+    ('/workspaces/create', 'POST'),
+    ('/workspaces/update', 'POST'),
+    ('/workspaces/delete', 'POST'),
+    ('/workspaces/config', 'GET'),  # full admin config -> tokens, etc.
+    ('/workspaces/config', 'POST'),
+    # --- Recipes writes ---
+    ('/recipes/create', 'POST'),
+    ('/recipes/update', 'POST'),
+    ('/recipes/delete', 'POST'),
+    ('/recipes/pin', 'POST'),
+    # --- SSH node pool writes ---
+    ('/ssh_node_pools', 'POST'),
+    ('/ssh_node_pools/{pool_name}', 'DELETE'),
+    ('/ssh_node_pools/keys', 'POST'),
+    ('/ssh_node_pools/keys', 'GET'),  # exposes private-key paths
+    ('/ssh_node_pools/{pool_name}/deploy', 'POST'),
+    ('/ssh_node_pools/deploy', 'POST'),
+    ('/ssh_node_pools/{pool_name}/down', 'POST'),
+    ('/ssh_node_pools/down', 'POST'),
+    # --- Debug ---
+    ('/debug/dump_create', 'POST'),
+    ('/debug/dump_download/{dump_filename}', 'GET'),
+    # --- /api/* paths: RBAC-skipped at middleware level, not on
+    # viewer allowlist; explicitly enumerated here for documentation.
+    # These are reachable to viewer regardless of allowlist (the
+    # middleware short-circuits before the role dispatch), but we
+    # mark them "denied" in the *intent* sense so the coverage test
+    # forces a deliberate decision.
+    ('/api/get', 'GET'),
+    ('/api/stream', 'GET'),
+    ('/api/status', 'GET'),
+    ('/api/health', 'GET'),
+    ('/api/cancel', 'POST'),  # request cancellation
+    ('/api/completion/cluster_name', 'GET'),
+    ('/api/completion/storage_name', 'GET'),
+    ('/api/completion/volume_name', 'GET'),
+    ('/api/completion/api_request', 'GET'),
+    # --- Misc index route ---
+    ('/', 'GET'),
+}
+
+# Some FastAPI routes are HEAD/OPTIONS pairs of GET. The coverage
+# test ignores these to focus on user-meaningful HTTP verbs.
+_IGNORED_METHODS = {'HEAD', 'OPTIONS'}
+
+
+def _route_pairs():
+    """Enumerate (path_template, method) for each app route."""
+    for route in server_app.app.routes:
+        if isinstance(route, APIRoute):
+            for method in route.methods or set():
+                if method in _IGNORED_METHODS:
+                    continue
+                yield route.path, method
+
+
+def _matches_any(path_template: str, method: str, allowlist: list) -> bool:
+    casbin_path = _fastapi_path_to_casbin(path_template)
+    for entry in allowlist:
+        if entry['method'] != method:
+            continue
+        if casbin_util.key_match2(casbin_path, entry['path']):
+            return True
+    return False
+
+
+def test_every_route_has_a_viewer_decision():
+    """Every API route must be either viewer-allowed or viewer-denied.
+
+    No silent "neither" state — if you add or rename a route you
+    must update either `rbac._DEFAULT_VIEWER_ALLOWLIST` (it's a
+    read) or this file's `_KNOWN_VIEWER_DENIED` (it's a write or a
+    sensitive read).
+    """
+    allowlist = rbac._DEFAULT_VIEWER_ALLOWLIST  # pylint: disable=protected-access
+    uncategorized = []
+    for path_template, method in _route_pairs():
+        on_allow = _matches_any(path_template, method, allowlist)
+        on_deny = (path_template, method) in _KNOWN_VIEWER_DENIED
+        if on_allow and on_deny:
+            uncategorized.append(
+                f'{method} {path_template} appears in BOTH lists; '
+                'remove from one or the other.')
+        elif not on_allow and not on_deny:
+            uncategorized.append(
+                f'{method} {path_template} has no viewer decision. '
+                'Add to rbac._DEFAULT_VIEWER_ALLOWLIST (read) or to '
+                'this file\'s _KNOWN_VIEWER_DENIED (write/sensitive).')
+    assert not uncategorized, ('Routes with no viewer-role decision:\n  ' +
+                               '\n  '.join(sorted(uncategorized)))
+
+
+def test_allowlist_entries_match_real_routes():
+    """Every allowlist entry must correspond to a real route.
+
+    Forgotten entries (e.g. after an endpoint is renamed) would
+    silently grant viewer access to a path that no longer exists,
+    or worse, to a path that resembles a renamed admin endpoint.
+    """
+    pairs = list(_route_pairs())
+    casbin_pairs = [(_fastapi_path_to_casbin(p), m) for p, m in pairs]
+    allowlist = rbac._DEFAULT_VIEWER_ALLOWLIST  # pylint: disable=protected-access
+
+    # Some allowlist patterns intentionally target endpoints not in
+    # the OSS app's route table — these come from plugins or from
+    # auth flows registered via the auth plugin.  Ignore those
+    # known-out-of-tree entries for this test.
+    out_of_tree = {
+        # /api/plugins is registered at app construction time but
+        # the auth-plugin endpoints are not present in the OSS app.
+        # No entries in the OSS allowlist target the auth plugin
+        # surface today, but keep the carve-out infrastructure here
+        # so future operator overrides via config don't break this
+        # test.
+    }
+    unknown = []
+    for entry in allowlist:
+        pattern_path = entry['path']
+        method = entry['method']
+        if (pattern_path, method) in out_of_tree:
+            continue
+        matched = False
+        for actual_path, actual_method in casbin_pairs:
+            if actual_method != method:
+                continue
+            if casbin_util.key_match2(actual_path, pattern_path):
+                matched = True
+                break
+        if not matched:
+            unknown.append(f'{method} {pattern_path}')
+    assert not unknown, (
+        'Viewer allowlist entries that do not match any registered '
+        f'route: {unknown!r}.  If the endpoint was renamed, update '
+        'rbac._DEFAULT_VIEWER_ALLOWLIST.')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Adds a third built-in role, `viewer`, alongside the existing `admin` and `user`.

Viewer is **strictly read-only** and governed by an explicit allowlist rather than the blocklist used by `user`. Any endpoint not on `_DEFAULT_VIEWER_ALLOWLIST` (or added via operator config) is denied by default — opt-in semantics so new endpoints don't silently leak to viewers as the API surface grows.

Highlights:
- `RoleName.VIEWER` enum; allowlist-based dispatch in `permission.check_endpoint_permission`.
- `_DEFAULT_VIEWER_ALLOWLIST` enumerates safe reads + a handful of carefully scoped non-GET endpoints (e.g. `/debug/dump_create` for on-call diagnostics; the corresponding download stays admin-only).
- Operator can extend per-role permissions via `rbac.roles.viewer.permissions.allowlist` in `~/.sky/config.yaml`.
- Plugins can declare additional viewer-readable endpoints via a new `BasePlugin.viewer_allowlist` contract.
- Worker processes also materialise the allowlist (previously only the main process did, so uvicorn workers default-denied everything).
- `backend_utils` refuses `include_credentials` for viewer-role callers.
- Built-in `SKYPILOT_SYSTEM_VIEWER_USER_ID = 'skypilot-system-viewer'` system user, seeded at startup with the viewer role and a `models.User` row — gives external auth integrations a stable user_id to authenticate a caller as a viewer without materialising the caller's own identity. Protected from delete / role update.
- Route-coverage test asserts every API route has an explicit viewer decision (allow or deny) so route additions can't be uncategorised.

<!-- Describe the tests ran -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR:
    - new unit tests in `tests/unit_tests/test_sky/users/test_rbac.py` (allowlist contents, operator overrides)
    - new unit tests in `tests/unit_tests/test_sky/users/test_permission.py` (system-user + system-viewer seeding, role dispatch)
    - new unit tests in `tests/unit_tests/test_sky/users/test_viewer_route_coverage.py` (every route has a viewer decision)
- [ ] All smoke tests: `/smoke-test`
- [ ] Relevant individual tests: `/smoke-test -k test_name`
- [ ] Backward compatibility: `/quicktest-core`
