### PR TITLE
[Serve] Fix HA recovery double-spawn, catastrophic cleanup, and init lock race

### DIFF
--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -796,11 +796,32 @@ class SkyPilotReplicaManager(ReplicaManager):
         self._down_thread_pool: thread_utils.ThreadSafeDict[
             int, thread_utils.SafeThread] = thread_utils.ThreadSafeDict()
 
+        # Run recovery synchronously before launching the daemon threads.
+        #
+        # If any daemon (especially `_job_status_fetcher`, which SSHes /
+        # gRPC-calls into each replica's head node to query job status)
+        # wins the race for `self.lock`, the main thread blocks on
+        # `_recover_replica_operations`'s `with self.lock:` until that
+        # daemon's per-replica SSH walk completes. With unreachable
+        # replicas (pod / VM gone), each SSH connect hangs at the kernel
+        # TCP timeout (tens of seconds to minutes), so the main thread
+        # never returns from `SkyPilotReplicaManager.__init__` →
+        # `SkyServeController.__init__` → never reaches `uvicorn.run`,
+        # and `_wait_for_controller_ready` times out (60s) in the parent
+        # `_start` process. With HA recovery changes, that
+        # timeout now triggers `os._exit(1)` → daemon retries → same
+        # race → infinite loop.
+        #
+        # Doing recovery first guarantees the main thread has the lock
+        # for the brief window it needs (and `_launch_replica` itself
+        # just queues a SafeThread, no SSH inline). The daemons can
+        # safely start after — they'll wait for the lock only when
+        # `_recover_replica_operations` has already released it.
+        self._recover_replica_operations()
+
         threading.Thread(target=self._thread_pool_refresher).start()
         threading.Thread(target=self._job_status_fetcher).start()
         threading.Thread(target=self._replica_prober).start()
-
-        self._recover_replica_operations()
 
     @with_lock
     def _recover_replica_operations(self):

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -14,7 +14,7 @@ import time
 import traceback
 import typing
 from typing import (Any, Callable, DefaultDict, Deque, Dict, Iterator, List,
-                    Optional, TextIO, Type, Union)
+                    Optional, Set, TextIO, Type, Union)
 import uuid
 
 import colorama
@@ -366,6 +366,11 @@ def ha_recovery_for_consolidation_mode(pool: bool):
     noun = 'pool' if pool else 'serve'
     capnoun = noun.capitalize()
     prefix = f'{noun}_'
+    # Snapshot the set of in-flight _start service names once per iteration
+    # so we don't walk /proc N times for N services. This also gives all
+    # services a consistent view (no torn read where service A is checked
+    # before service B's _start spawns, and B is checked after).
+    in_flight_service_names = _snapshot_in_flight_start_service_names()
     with open(skylet_constants.HA_PERSISTENT_RECOVERY_LOG_PATH.format(prefix),
               'w',
               encoding='utf-8') as f:
@@ -382,7 +387,7 @@ def ha_recovery_for_consolidation_mode(pool: bool):
             status_dbg = svc.get('status')
             f.write(f'ha_recovery candidate {service_name}: '
                     f'pid={controller_pid} ip={controller_ip} '
-                    f'status={status_dbg}')
+                    f'status={status_dbg}\n')
             if controller_pid is not None:
                 try:
                     alive = _controller_process_alive(controller_pid,
@@ -402,6 +407,20 @@ def ha_recovery_for_consolidation_mode(pool: bool):
                             f'{noun} {service_name} is still running. '
                             'Skipping recovery.\n')
                     continue
+
+            # Defense in depth: even if DB controller_pid is stale (e.g. an
+            # older _start hadn't yet pre-claimed it, or pre-claim is
+            # disabled / lost), still skip the recovery launch if any
+            # `python -m sky.serve.service --service-name <name>` is
+            # already running on this pod (snapshot taken once at the
+            # top of the iteration). Otherwise the daemon's ~20s
+            # iteration repeatedly fires recovery during the 0-60s
+            # controller boot window, piling up multiple _start instances.
+            if service_name in in_flight_service_names:
+                f.write(f'{capnoun} {service_name}: _start process already '
+                        f'running on this pod; skipping recovery this '
+                        f'round.\n')
+                continue
 
             script = serve_state.get_ha_recovery_script(service_name)
             if script is None:
@@ -427,6 +446,58 @@ def _controller_process_alive(pid: int, service_name: str) -> bool:
         ) and f'--service-name {service_name}' in cmd_str
     except psutil.NoSuchProcess:
         return False
+
+
+def _snapshot_in_flight_start_service_names() -> Set[str]:
+    """Walk `/proc` once and return the set of service names that have an
+    active (non-zombie) `python -m sky.serve.service --service-name <name>`
+    process on this pod.
+
+    Used by ha_recovery_for_consolidation_mode to deduplicate recovery
+    launches: while a previously-spawned _start is still in its 0-60s
+    boot window waiting for the controller subprocess to bind, DB
+    controller_pid may still point at the dead previous instance.
+    Re-firing the recovery script in that window causes pile-up
+    (multiple _start instances racing on the same service).
+
+    Snapshotting once per daemon iteration (rather than per-service)
+    gives O(processes + N services) instead of O(processes * N), and
+    also a consistent view (all services see the same set).
+
+    Zombies are excluded — a `_start` process that died but hasn't been
+    reaped (pods without a proper init process) would otherwise
+    permanently block recovery for that service.
+
+    Matching is on the argv LIST (not a joined string), so
+    `--service-name pool-a` does not falsely match `--service-name pool-abc`.
+    """
+    in_flight: Set[str] = set()
+    for proc in psutil.process_iter(['cmdline', 'status']):
+        try:
+            if proc.info.get('status') == psutil.STATUS_ZOMBIE:
+                continue
+            cmdline = proc.info.get('cmdline') or []
+            if 'sky.serve.service' not in ' '.join(cmdline):
+                continue
+            try:
+                idx = cmdline.index('--service-name')
+            except ValueError:
+                continue
+            if idx + 1 < len(cmdline):
+                in_flight.add(cmdline[idx + 1])
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+    return in_flight
+
+
+def _start_in_flight(service_name: str) -> bool:
+    """Thin wrapper around `_snapshot_in_flight_start_service_names` for
+    one-off checks (e.g. tests, ad-hoc callers).
+
+    The hot path in `ha_recovery_for_consolidation_mode` calls the
+    snapshot helper directly and reuses the set across services.
+    """
+    return service_name in _snapshot_in_flight_start_service_names()
 
 
 def validate_service_task(task: 'sky.Task', pool: bool) -> None:

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -355,7 +355,14 @@ def _bail_on_boot_failure(service_name: str,
                  f'Killing controller subprocess and exiting WITHOUT '
                  f'cleanup so the daemon can retry. DB state and HA '
                  f'recovery script preserved.')
-    if controller_process is not None:
+    # Defensive: skip kill if pid is None. `Process.start()` populates
+    # pid on success, but if start() raised before setting it the
+    # current code path would never reach here anyway (the outer try
+    # in `_start` would handle that). Still, guard explicitly because
+    # `psutil.Process(None)` returns the *calling* process — so
+    # passing `[None]` to `kill_children_processes` would target
+    # ourselves (and our own children) instead of bailing out cleanly.
+    if controller_process is not None and controller_process.pid is not None:
         try:
             # kill_children_processes with parent_pids != None SIGKILLs
             # the parent itself AND its recursive children (see
@@ -641,7 +648,7 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
         # deletes the HA recovery script and may remove the entire
         # service row, so an audit line (especially with the active
         # exception type if any) is worth it for future post-mortems.
-        # The Fix 1 path (`_wait_for_controller_ready` timeout) and
+        # The path (`_wait_for_controller_ready` timeout) and
         # `_orphan_exit` both bypass this finally entirely via
         # os._exit; anything else reaching here is either the user
         # signal (flag above) or an unexpected propagating exception.

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -8,6 +8,7 @@ import os
 import pathlib
 import shutil
 import socket
+import sys
 import time
 import traceback
 from typing import Any, Dict, Optional
@@ -139,6 +140,26 @@ def cleanup_storage(yaml_content: str) -> bool:
 # calling this function.
 def _cleanup(service_name: str, pool: bool) -> bool:
     """Clean up all service related resources, i.e. replicas and storage."""
+    # Log who we are and what DB state we're cleaning up, so post-mortems
+    # can correlate this with concurrent ha_recovery activity. _cleanup is
+    # destructive (it deletes the HA recovery script on the very next line
+    # and may delete the entire service row at the end), so an audit trail
+    # is worth a few WARN lines.
+    own_pid = os.getpid()
+    try:
+        svc_dbg = serve_state.get_service_from_name(service_name)
+    except Exception:  # pylint: disable=broad-except
+        svc_dbg = None
+    if svc_dbg is not None:
+        logger.warning(
+            f'_cleanup entered for service {service_name} '
+            f'(own_pid={own_pid}, db_controller_pid='
+            f'{svc_dbg.get("controller_pid")}, db_controller_ip='
+            f'{svc_dbg.get("controller_ip")}, status={svc_dbg.get("status")})')
+    else:
+        logger.warning(
+            f'_cleanup entered for service {service_name} '
+            f'(own_pid={own_pid}, db row not found — already removed?)')
     # Cleanup the HA recovery script first as it is possible that some error
     # was raised when we construct the task object (e.g.,
     # sky.exceptions.ResourcesUnavailableError).
@@ -312,6 +333,46 @@ def _orphan_exit(
     os._exit(0)  # pylint: disable=protected-access
 
 
+def _bail_on_boot_failure(service_name: str,
+                          controller_process: Optional[multiprocessing.Process],
+                          timeout_seconds: int,
+                          boot_err: BaseException) -> None:
+    """Exit path when the freshly-spawned controller subprocess failed
+    to bind within SERVICE_REGISTER_TIMEOUT_SECONDS.
+
+    Critical contract: must NOT fall through to `_start`'s outer
+    `try/finally`. That finally calls `_cleanup`, which on its very
+    first line removes the HA recovery script and on a pool with no
+    replicas proceeds to `remove_service_completely` — turning a
+    transient boot failure into permanent data loss for the service.
+
+    Kill the controller subprocess we spawned, then os._exit(1) to
+    bypass everything. The daemon's next ha_recovery iteration sees
+    the (preserved) recovery script and retries with a fresh _start.
+    """
+    logger.error(f'Controller subprocess failed to bind within '
+                 f'{timeout_seconds}s for {service_name}: {boot_err}. '
+                 f'Killing controller subprocess and exiting WITHOUT '
+                 f'cleanup so the daemon can retry. DB state and HA '
+                 f'recovery script preserved.')
+    if controller_process is not None:
+        try:
+            # kill_children_processes with parent_pids != None SIGKILLs
+            # the parent itself AND its recursive children (see
+            # subprocess_utils.py).
+            subprocess_utils.kill_children_processes(
+                parent_pids=[controller_process.pid], force=True)
+        except Exception:  # pylint: disable=broad-except
+            logger.warning(
+                'Failed to kill controller subprocess during boot-failure '
+                'bailout; proceeding with os._exit anyway.')
+    # os._exit() bypasses the outer try/finally; the
+    # PORT_SELECTION_FILE_LOCK_PATH filelock held by the surrounding
+    # `with` block is released by the kernel when our FDs close on
+    # process exit (fcntl advisory lock).
+    os._exit(1)  # pylint: disable=protected-access
+
+
 def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
     """Starts the service.
     This including the controller and load balancer.
@@ -391,15 +452,30 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
         if latest_version is None:
             raise ValueError(f'No version found for service {service_name}')
         version = latest_version
-        # NOTE: do NOT update controller_pid/controller_ip yet. We must wait
-        # until our subprocess is actually listening on the port (see the
-        # update_service_controller_pid_ip_and_port call after
-        # _wait_for_controller_ready below). Otherwise clients in other pods
-        # would route to our pod IP before uvicorn binds and get
-        # ECONNREFUSED for the duration of the boot.
+        # Pre-claim controller_pid immediately so the next
+        # ha_recovery_for_consolidation_mode iteration sees our _start
+        # process as the live controller and does NOT fire a duplicate
+        # recovery script while we are still booting (the controller boot
+        # window is up to SERVICE_REGISTER_TIMEOUT_SECONDS = 60s, but the
+        # daemon retries every ~20s). _controller_process_alive matches by
+        # `--service-name <name>` in cmdline, which our _start process has.
+        #
+        # We deliberately do NOT update controller_ip / controller_port
+        # here — those still flip atomically after _wait_for_controller_ready
+        # succeeds, so clients routing by (ip, port) keep using the prior
+        # endpoint (or hit ECONNREFUSED, handled by
+        # _request_to_controller_with_retry) until the new subprocess is
+        # actually listening.
+        serve_state.update_service_controller_pid(service_name, os.getpid())
 
     controller_process = None
     load_balancer_process = None
+    # Tracks whether we exited the main loop via the user-initiated
+    # SHUTTING_DOWN signal. We can't recover this from sys.exc_info() in
+    # the finally block — Python clears the active exception when the
+    # corresponding `except` clause catches it, so sys.exc_info() in
+    # the finally returns (None, None, None) for the caught path.
+    shutdown_via_user_signal = False
     try:
         with filelock.FileLock(
                 os.path.expanduser(constants.PORT_SELECTION_FILE_LOCK_PATH)):
@@ -457,14 +533,14 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
                     controller_host,
                     controller_port,
                     timeout=constants.SERVICE_REGISTER_TIMEOUT_SECONDS)
-            except RuntimeError:
-                # Controller subprocess failed to start. Bail; the daemon's
-                # next ha_recovery iteration will retry.
-                logger.error('Controller subprocess failed to start within '
-                             f'{constants.SERVICE_REGISTER_TIMEOUT_SECONDS}s; '
-                             'aborting _start. DB state untouched so the '
-                             'previous controller (if any) keeps serving.')
-                raise
+            except RuntimeError as boot_err:
+                # Bail without falling through to the outer try/finally,
+                # which would call _cleanup → remove_ha_recovery_script
+                # and possibly remove_service_completely. See helper for
+                # details.
+                _bail_on_boot_failure(
+                    service_name, controller_process,
+                    constants.SERVICE_REGISTER_TIMEOUT_SECONDS, boot_err)
 
             # Now we know the subprocess is bound on `controller_port`. Write
             # DB.
@@ -557,9 +633,37 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int, entrypoint: str):
     except exceptions.ServeUserTerminatedError:
         logger.debug(f'Caught ServeUserTerminatedError for '
                      f'{service_name}; setting status=SHUTTING_DOWN')
+        shutdown_via_user_signal = True
         serve_state.set_service_status_and_active_versions(
             service_name, serve_state.ServiceStatus.SHUTTING_DOWN)
     finally:
+        # Log why we're entering the destructive cleanup path. _cleanup
+        # deletes the HA recovery script and may remove the entire
+        # service row, so an audit line (especially with the active
+        # exception type if any) is worth it for future post-mortems.
+        # The Fix 1 path (`_wait_for_controller_ready` timeout) and
+        # `_orphan_exit` both bypass this finally entirely via
+        # os._exit; anything else reaching here is either the user
+        # signal (flag above) or an unexpected propagating exception.
+        exc_type, exc_value, _ = sys.exc_info()
+        if shutdown_via_user_signal:
+            logger.info(f'_start for {service_name} entering cleanup path '
+                        '(user-initiated SHUTTING_DOWN).')
+        elif exc_type is None:
+            # _start's `while True` only exits via exception or
+            # os._exit, so a None exc_type here is unexpected. Log it
+            # at WARN so a future code path that adds a `return`
+            # doesn't silently slip into destructive cleanup unnoticed.
+            logger.warning(
+                f'_start for {service_name} entering cleanup path with '
+                'no exception and no user signal — this is unexpected; '
+                '_cleanup is destructive.')
+        else:
+            logger.warning(
+                f'_start for {service_name} entering cleanup path due to '
+                f'unexpected exception {exc_type.__name__}: {exc_value}. '
+                f'_cleanup will delete HA recovery script and may remove '
+                f'the service row.')
         # Kill load balancer process first since it will raise errors if failed
         # to connect to the controller. Then the controller process.
         process_to_kill = [

--- a/tests/unit_tests/test_serve_replica_managers.py
+++ b/tests/unit_tests/test_serve_replica_managers.py
@@ -1,0 +1,139 @@
+"""Tests for sky/serve/replica_managers.py.
+
+Currently focused on `SkyPilotReplicaManager.__init__` startup ordering:
+the daemon threads (especially `_job_status_fetcher`) must NOT race the
+main thread for `self.lock` before `_recover_replica_operations` runs.
+"""
+from unittest import mock
+
+from sky.serve import replica_managers
+
+
+class TestSkyPilotReplicaManagerInitOrdering:
+    """`SkyPilotReplicaManager.__init__` must run `_recover_replica_operations`
+    BEFORE starting the `_job_status_fetcher` / `_thread_pool_refresher` /
+    `_replica_prober` daemon threads.
+
+    If the daemon threads start first, `_job_status_fetcher` will acquire
+    `self.lock` (via the `@with_lock` decorator on `_fetch_job_status`)
+    and perform a per-replica SSH/gRPC call to query job status. When a
+    replica's head node is unreachable (pod / VM gone), each SSH connect
+    hangs at the kernel TCP timeout (tens of seconds to minutes). The
+    main thread then blocks on `_recover_replica_operations`'s
+    `with self.lock:` for the full hang duration, never returns from
+    `SkyPilotReplicaManager.__init__`, and `uvicorn.run` is never called.
+
+    With HA recovery changes, `_wait_for_controller_ready`
+    then times out (60s) → `_bail_on_boot_failure` → `os._exit(1)` →
+    daemon retries → same race → infinite recovery loop.
+
+    The fix: recovery first, daemon threads after.
+    """
+
+    def test_recover_called_before_threads_start(self):
+        """Verify the call order: `_recover_replica_operations` first,
+        then each daemon thread's `.start()`."""
+        call_order = []
+
+        def _record(name):
+
+            def _fn(*_args, **_kwargs):
+                call_order.append(name)
+
+            return _fn
+
+        # Patch the heavy deps so __init__ doesn't actually do work.
+        # We only care about the call order.
+        with mock.patch.object(
+                replica_managers.ReplicaManager, '__init__',
+                return_value=None), \
+             mock.patch(
+                 'sky.serve.replica_managers.serve_state.get_yaml_content',
+                 return_value='dummy: yaml'), \
+             mock.patch(
+                 'sky.serve.replica_managers.task_lib.Task.from_yaml_str',
+                 return_value=mock.MagicMock()), \
+             mock.patch(
+                 'sky.serve.replica_managers.spot_placer.SpotPlacer.from_task',
+                 return_value=None), \
+             mock.patch.object(
+                 replica_managers.SkyPilotReplicaManager,
+                 '_recover_replica_operations',
+                 _record('recover')), \
+             mock.patch(
+                 'sky.serve.replica_managers.threading.Thread') as mock_thread:
+            # Each Thread(target=...).start() records the target's name
+            # via our side_effect on .start().
+            def thread_factory(*_args, **kwargs):
+                target = kwargs.get('target')
+                t = mock.Mock()
+                target_name = getattr(target, '__name__', repr(target))
+                t.start.side_effect = _record(f'thread_start:{target_name}')
+                return t
+
+            mock_thread.side_effect = thread_factory
+
+            spec = mock.MagicMock()
+            replica_managers.SkyPilotReplicaManager(service_name='svc',
+                                                    spec=spec,
+                                                    version=1)
+
+        # `recover` must come before any `thread_start:*` entry. The
+        # daemon threads themselves may be created in any order relative
+        # to each other (we don't constrain that), but ALL of them must
+        # appear after `recover`.
+        assert 'recover' in call_order, (
+            f'_recover_replica_operations was never called; '
+            f'call_order={call_order}')
+        recover_idx = call_order.index('recover')
+        for i, name in enumerate(call_order):
+            if name.startswith('thread_start:'):
+                assert i > recover_idx, (
+                    f'{name} happened at index {i} before recover at '
+                    f'index {recover_idx}; call_order={call_order}. '
+                    f'Daemon threads must NOT start until '
+                    f'_recover_replica_operations has finished — '
+                    f'see the docstring of '
+                    f'TestSkyPilotReplicaManagerInitOrdering.')
+
+    def test_all_three_daemon_threads_are_started(self):
+        """Sanity: regardless of ordering, the three daemon threads
+        (_thread_pool_refresher / _job_status_fetcher / _replica_prober)
+        still all start. The fix is purely a reorder, not a removal."""
+        started_targets = []
+
+        with mock.patch.object(
+                replica_managers.ReplicaManager, '__init__',
+                return_value=None), \
+             mock.patch(
+                 'sky.serve.replica_managers.serve_state.get_yaml_content',
+                 return_value='dummy: yaml'), \
+             mock.patch(
+                 'sky.serve.replica_managers.task_lib.Task.from_yaml_str',
+                 return_value=mock.MagicMock()), \
+             mock.patch(
+                 'sky.serve.replica_managers.spot_placer.SpotPlacer.from_task',
+                 return_value=None), \
+             mock.patch.object(
+                 replica_managers.SkyPilotReplicaManager,
+                 '_recover_replica_operations'), \
+             mock.patch(
+                 'sky.serve.replica_managers.threading.Thread') as mock_thread:
+
+            def thread_factory(*_args, **kwargs):
+                target = kwargs.get('target')
+                started_targets.append(getattr(target, '__name__', None))
+                t = mock.Mock()
+                return t
+
+            mock_thread.side_effect = thread_factory
+
+            spec = mock.MagicMock()
+            replica_managers.SkyPilotReplicaManager(service_name='svc',
+                                                    spec=spec,
+                                                    version=1)
+
+        # Bound methods on the instance — verify by name.
+        assert '_thread_pool_refresher' in started_targets
+        assert '_job_status_fetcher' in started_targets
+        assert '_replica_prober' in started_targets

--- a/tests/unit_tests/test_serve_service.py
+++ b/tests/unit_tests/test_serve_service.py
@@ -171,6 +171,106 @@ class TestOrphanExit:
             mock_exit.assert_called_once_with(0)
 
 
+class TestBailOnBootFailure:
+    """`_bail_on_boot_failure` is the regression fix for the
+    catastrophic-cleanup bug: when `_wait_for_controller_ready` times out
+    in the recovery branch of `_start`, the previous code re-`raise`d the
+    RuntimeError, which fell through to `_start`'s outer `finally` →
+    `_cleanup` → `remove_ha_recovery_script` (+ possibly
+    `remove_service_completely` on pools with no replicas), turning a
+    transient boot failure into permanent service deletion.
+
+    Contract: like `_orphan_exit`, this helper must kill our forked
+    subprocess and `os._exit` to bypass the outer finally — it must NOT
+    touch any DB state and must NOT call `_cleanup`.
+    """
+
+    def test_calls_os_exit_one(self):
+        with mock.patch('os._exit') as mock_exit, \
+             mock.patch('sky.serve.service.subprocess_utils.'
+                        'kill_children_processes'):
+            ctrl = mock.Mock(pid=11111)
+            service._bail_on_boot_failure(
+                'svc',
+                ctrl,
+                timeout_seconds=60,
+                boot_err=RuntimeError('did not become ready'))
+            mock_exit.assert_called_once_with(1)
+
+    def test_does_not_call_cleanup(self):
+        """The whole point of this bailout: do NOT enter the destructive
+        cleanup path. No DB mutations of any kind."""
+        with mock.patch('os._exit'), \
+             mock.patch('sky.serve.service.subprocess_utils.'
+                        'kill_children_processes'), \
+             mock.patch('sky.serve.service._cleanup') as mock_cleanup, \
+             mock.patch('sky.serve.service.serve_state.'
+                        'remove_ha_recovery_script') as mock_remove_script, \
+             mock.patch('sky.serve.service.serve_state.'
+                        'remove_service_completely') as mock_remove_svc, \
+             mock.patch('sky.serve.service.serve_state.'
+                        'remove_service') as mock_remove:
+            ctrl = mock.Mock(pid=11111)
+            service._bail_on_boot_failure(
+                'svc',
+                ctrl,
+                timeout_seconds=60,
+                boot_err=RuntimeError('did not become ready'))
+            mock_cleanup.assert_not_called()
+            mock_remove_script.assert_not_called()
+            mock_remove_svc.assert_not_called()
+            mock_remove.assert_not_called()
+
+    def test_kills_controller_subprocess(self):
+        """Must SIGKILL the controller subprocess we spawned — otherwise
+        the daemon's next ha_recovery iteration spawns a new one and we
+        leak the old one (which never bound)."""
+        with mock.patch('os._exit'), \
+             mock.patch('sky.serve.service.subprocess_utils.'
+                        'kill_children_processes') as mock_kill:
+            ctrl = mock.Mock(pid=11111)
+            service._bail_on_boot_failure(
+                'svc',
+                ctrl,
+                timeout_seconds=60,
+                boot_err=RuntimeError('did not become ready'))
+            _, kwargs = mock_kill.call_args
+            assert kwargs['parent_pids'] == [11111]
+            assert kwargs['force'] is True
+
+    def test_handles_none_controller_process(self):
+        """If the RuntimeError fires before `controller_process.start()`
+        (rare, but possible), `controller_process` is None and we have
+        nothing to kill — but we still must os._exit."""
+        with mock.patch('os._exit') as mock_exit, \
+             mock.patch('sky.serve.service.subprocess_utils.'
+                        'kill_children_processes') as mock_kill:
+            service._bail_on_boot_failure(
+                'svc',
+                None,
+                timeout_seconds=60,
+                boot_err=RuntimeError('did not become ready'))
+            mock_kill.assert_not_called()
+            mock_exit.assert_called_once_with(1)
+
+    def test_swallows_kill_failure(self):
+        """If kill_children_processes raises (e.g. pid already gone
+        between when we read it and when we try to kill it), we still
+        must os._exit. Otherwise the exception bubbles up to the outer
+        try/finally — exactly the cleanup path we are trying to avoid."""
+        with mock.patch('os._exit') as mock_exit, \
+             mock.patch('sky.serve.service.subprocess_utils.'
+                        'kill_children_processes',
+                        side_effect=OSError('no such process')):
+            ctrl = mock.Mock(pid=11111)
+            service._bail_on_boot_failure(
+                'svc',
+                ctrl,
+                timeout_seconds=60,
+                boot_err=RuntimeError('did not become ready'))
+            mock_exit.assert_called_once_with(1)
+
+
 class TestCleanupBlocksHaRecoveryButKeepsVersionSpecs:
     """`_cleanup` must:
 
@@ -204,6 +304,13 @@ class TestCleanupBlocksHaRecoveryButKeepsVersionSpecs:
                        return_value=[1, 2]),
             mock.patch('sky.serve.service.serve_state.get_yaml_content',
                        return_value='dummy: yaml'),
+            # _cleanup audit log reads current DB state for the WARN line.
+            mock.patch('sky.serve.service.serve_state.get_service_from_name',
+                       return_value={
+                           'controller_pid': 9999,
+                           'controller_ip': '10.0.0.1',
+                           'status': 'READY',
+                       }),
         ]
 
     def test_recovery_script_removed_on_storage_success(self):
@@ -257,6 +364,73 @@ class TestCleanupBlocksHaRecoveryButKeepsVersionSpecs:
             mock_delete_versions.assert_not_called()
             # recovery_script gone → HA daemon won't respawn.
             mock_remove_recovery.assert_called_once_with('svc')
+
+
+class TestCleanupAuditLog:
+    """`_cleanup` logs a WARN with the current DB controller_pid / ip /
+    status before deleting anything. _cleanup is destructive (deletes
+    the HA recovery script on its very first line and may remove the
+    entire service row at the end), so an audit trail is essential for
+    debugging double-spawn / unexpected-cleanup incidents.
+    """
+
+    def _common_patches(self, db_record):
+        # sky.serve.service uses sky_logging.init_logger with
+        # propagate=False, so caplog (rooted at the root logger) misses
+        # its records. Patch the module-level logger instead and inspect
+        # its `.warning(...)` calls directly.
+        return [
+            mock.patch('sky.serve.service.serve_state.get_replica_infos',
+                       return_value=[]),
+            mock.patch(
+                'sky.serve.service.global_user_state.'
+                'get_cluster_names_start_with',
+                return_value=[]),
+            mock.patch('sky.serve.service.serve_state.get_service_versions',
+                       return_value=[]),
+            mock.patch('sky.serve.service.serve_state.get_yaml_content',
+                       return_value='dummy: yaml'),
+            mock.patch('sky.serve.service.serve_state.get_service_from_name',
+                       return_value=db_record),
+            mock.patch(
+                'sky.serve.service.serve_state.remove_ha_recovery_script'),
+            mock.patch('sky.serve.service.cleanup_storage', return_value=True),
+        ]
+
+    def test_logs_db_state_when_row_present(self):
+        patches = self._common_patches({
+            'controller_pid': 4242,
+            'controller_ip': '10.4.7.7',
+            'status': 'READY',
+        })
+        for p in patches:
+            p.start()
+        try:
+            with mock.patch.object(service.logger, 'warning') as mock_warn:
+                service._cleanup('audit-svc', pool=True)
+        finally:
+            for p in patches:
+                p.stop()
+        joined = '\n'.join(call.args[0] for call in mock_warn.call_args_list)
+        # Audit line includes the service name and DB state we observed.
+        # Substring checks instead of exact match for copy-edit resilience.
+        assert 'audit-svc' in joined
+        assert 'db_controller_pid=4242' in joined
+        assert 'db_controller_ip=10.4.7.7' in joined
+
+    def test_logs_missing_row_when_db_returns_none(self):
+        patches = self._common_patches(None)
+        for p in patches:
+            p.start()
+        try:
+            with mock.patch.object(service.logger, 'warning') as mock_warn:
+                service._cleanup('gone-svc', pool=True)
+        finally:
+            for p in patches:
+                p.stop()
+        joined = '\n'.join(call.args[0] for call in mock_warn.call_args_list)
+        assert 'gone-svc' in joined
+        assert 'db row not found' in joined
 
 
 class TestCleanupStorageStaleBucket:

--- a/tests/unit_tests/test_serve_service.py
+++ b/tests/unit_tests/test_serve_service.py
@@ -253,6 +253,26 @@ class TestBailOnBootFailure:
             mock_kill.assert_not_called()
             mock_exit.assert_called_once_with(1)
 
+    def test_handles_none_controller_pid(self):
+        """If `controller_process` was created but `start()` never set a
+        pid (e.g. start() itself raised before assigning pid), we must
+        NOT pass `pid=None` to `kill_children_processes`:
+        `psutil.Process(None)` resolves to the *calling* process, so
+        passing `[None]` would SIGKILL ourselves (and our own children)
+        before `os._exit(1)` runs — defeating the cleanup bypass."""
+        with mock.patch('os._exit') as mock_exit, \
+             mock.patch('sky.serve.service.subprocess_utils.'
+                        'kill_children_processes') as mock_kill:
+            ctrl = mock.Mock()
+            ctrl.pid = None
+            service._bail_on_boot_failure(
+                'svc',
+                ctrl,
+                timeout_seconds=60,
+                boot_err=RuntimeError('did not become ready'))
+            mock_kill.assert_not_called()
+            mock_exit.assert_called_once_with(1)
+
     def test_swallows_kill_failure(self):
         """If kill_children_processes raises (e.g. pid already gone
         between when we read it and when we try to kill it), we still

--- a/tests/unit_tests/test_serve_utils.py
+++ b/tests/unit_tests/test_serve_utils.py
@@ -792,6 +792,144 @@ class TestStreamReplicaLogsZeroByteFallback:
         assert 'SHOULD-NOT-APPEAR' not in captured.out
 
 
+class TestStartInFlight:
+    """`_start_in_flight` is the defense-in-depth dedup used by
+    `ha_recovery_for_consolidation_mode` to avoid firing a duplicate
+    recovery script while a previously-spawned _start is still in its
+    0-60s boot window (during which DB controller_pid may still be the
+    stale pre-recovery value).
+    """
+
+    def _make_proc(self, cmdline, status='running'):
+        """Helper: build a mock proc whose .info dict matches what
+        psutil.process_iter yields with the attrs list."""
+        proc = mock.Mock()
+        proc.info = {'cmdline': cmdline, 'status': status}
+        return proc
+
+    def test_returns_true_when_start_process_present(self):
+        proc = self._make_proc([
+            'python', '-m', 'sky.serve.service', '--service-name', 'pool-a',
+            '--job-id', '5'
+        ])
+        with mock.patch('sky.serve.serve_utils.psutil.process_iter',
+                        return_value=[proc]):
+            assert serve_utils._start_in_flight('pool-a') is True
+
+    def test_returns_false_when_no_matching_process(self):
+        proc = self._make_proc([
+            'python', '-m', 'sky.serve.service', '--service-name', 'other-pool'
+        ])
+        with mock.patch('sky.serve.serve_utils.psutil.process_iter',
+                        return_value=[proc]):
+            assert serve_utils._start_in_flight('pool-a') is False
+
+    def test_returns_false_when_no_processes(self):
+        with mock.patch('sky.serve.serve_utils.psutil.process_iter',
+                        return_value=[]):
+            assert serve_utils._start_in_flight('pool-a') is False
+
+    def test_skips_zombie_processes(self):
+        """A zombie `_start` (crashed but not yet reaped by init) must NOT
+        block recovery — otherwise the pool would be stuck in a
+        permanent "recovery in flight" loop until something reaps the
+        zombie, which may never happen in pods without a proper init.
+        """
+        # pylint: disable=import-outside-toplevel
+        import psutil
+        zombie = self._make_proc(
+            ['python', '-m', 'sky.serve.service', '--service-name', 'pool-a'],
+            status=psutil.STATUS_ZOMBIE)
+        with mock.patch('sky.serve.serve_utils.psutil.process_iter',
+                        return_value=[zombie]):
+            assert serve_utils._start_in_flight('pool-a') is False
+
+    def test_swallows_per_process_psutil_errors(self):
+        """If iterating one process raises NoSuchProcess / AccessDenied
+        (race with proc exit), the iteration must continue and check
+        the rest, not raise.
+        """
+        # pylint: disable=import-outside-toplevel
+        import psutil
+
+        # First proc raises on attribute access; second one is a legit match.
+        bad = mock.Mock()
+        type(bad).info = mock.PropertyMock(
+            side_effect=psutil.NoSuchProcess(99999))
+        good = self._make_proc(
+            ['python', '-m', 'sky.serve.service', '--service-name', 'pool-a'])
+        with mock.patch('sky.serve.serve_utils.psutil.process_iter',
+                        return_value=[bad, good]):
+            assert serve_utils._start_in_flight('pool-a') is True
+
+    def test_no_prefix_false_positive(self):
+        """Service name 'pool-a' must NOT match a process for 'pool-abc'.
+        The implementation does exact argv-list matching on the
+        `--service-name <value>` pair (not substring on a joined string),
+        so the prefix collision is rejected.
+        """
+        proc = self._make_proc(
+            ['python', '-m', 'sky.serve.service', '--service-name', 'pool-abc'])
+        with mock.patch('sky.serve.serve_utils.psutil.process_iter',
+                        return_value=[proc]):
+            assert serve_utils._start_in_flight('pool-a') is False
+
+    def test_no_service_name_arg_returns_false(self):
+        """A `sky.serve.service` process with no `--service-name` flag
+        at all (defensive case, shouldn't happen in practice) must not
+        match — index() returning ValueError is caught."""
+        proc = self._make_proc([
+            'python', '-m', 'sky.serve.service', '--some-other-flag', 'whatever'
+        ])
+        with mock.patch('sky.serve.serve_utils.psutil.process_iter',
+                        return_value=[proc]):
+            assert serve_utils._start_in_flight('pool-a') is False
+
+
+class TestHaRecoverySkipsWhenStartInFlight:
+    """When the in-flight snapshot contains the service name,
+    `ha_recovery_for_consolidation_mode` must NOT invoke the recovery
+    script for that service this round. Otherwise the daemon piles up
+    multiple `_start` instances during the 0-60s controller boot window.
+    """
+
+    def test_skip_when_start_in_flight(self, tmp_path, monkeypatch):
+        monkeypatch.setenv('POD_IP', '10.4.0.1')
+        with mock.patch(
+                'sky.serve.serve_utils.serve_state.get_glob_service_names',
+                return_value=['pool-a']), \
+             mock.patch(
+                 'sky.serve.serve_utils._get_service_status',
+                 return_value={'controller_pid': 1234,
+                               'controller_ip': '10.4.0.1',
+                               'status': 'READY'}), \
+             mock.patch(
+                 'sky.serve.serve_utils._controller_process_alive',
+                 return_value=False), \
+             mock.patch(
+                 'sky.serve.serve_utils.'
+                 '_snapshot_in_flight_start_service_names',
+                 return_value={'pool-a'}) as mock_snapshot, \
+             mock.patch(
+                 'sky.serve.serve_utils.serve_state.get_ha_recovery_script',
+                 return_value='dummy script') as mock_script, \
+             mock.patch(
+                 'sky.serve.serve_utils.command_runner.'
+                 'LocalProcessCommandRunner') as mock_runner_cls, \
+             mock.patch(
+                 'sky.serve.serve_utils.skylet_constants.'
+                 'HA_PERSISTENT_RECOVERY_LOG_PATH',
+                 str(tmp_path / 'recovery_log_{}.log')):
+            serve_utils.ha_recovery_for_consolidation_mode(pool=True)
+            # Snapshot is taken once per daemon iteration, not once per
+            # service, so it's exactly one call regardless of N services.
+            assert mock_snapshot.call_count == 1
+            # Script lookup AND runner.run must be skipped — we bailed
+            # before reaching either.
+            mock_script.assert_not_called()
+            mock_runner_cls.return_value.run.assert_not_called()
+
+
 class TestHaRecoveryDefensiveOnAliveCheckException:
     """`ha_recovery_for_consolidation_mode` calls `_controller_process_alive`
     to decide whether to respawn the controller. If that call raises a


### PR DESCRIPTION
## Summary

Three issues surfaced in HA pool recovery on API-server pod restart:

- **Catastrophic cleanup on boot timeout** — `_wait_for_controller_ready` raising `RuntimeError` was supposed to leave DB state untouched, but the `raise` fell through to `_start`'s outer `finally` and triggered `_cleanup` → `remove_ha_recovery_script` + (for pools with no replicas) `remove_service_completely`, silently deleting the service row.
- **Recovery double-spawn during boot window** — the HA daemon (every ~20s) kept seeing stale `controller_pid` in DB during the 0-60s controller boot, re-firing the recovery script and piling up multiple `_start` processes per pool.
- **ReplicaManager init lock race** — `SkyPilotReplicaManager.__init__` started `_job_status_fetcher` before `_recover_replica_operations`; if the fetcher won the race for `self.lock` and SSHed an unreachable replica, the main thread blocked indefinitely, `uvicorn.run` never ran, and `_wait_for_controller_ready` timed out → bailout → daemon retried → infinite loop (observed live in production).

## Changes

- **`_bail_on_boot_failure` helper** ([sky/serve/service.py](sky/serve/service.py)): mirrors `_orphan_exit`, SIGKILLs the spawned controller subprocess and `os._exit(1)`s to bypass the destructive finally.
- **Pre-claim `controller_pid` in `_start`** ([sky/serve/service.py](sky/serve/service.py)): is_recovery branch updates `controller_pid` to its own pid immediately, so the daemon's `_controller_process_alive` check returns True for the boot window. `controller_ip` / `controller_port` still flip atomically after `_wait_for_controller_ready` succeeds.
- **`_snapshot_in_flight_start_service_names`** ([sky/serve/serve_utils.py](sky/serve/serve_utils.py)): defense-in-depth psutil snapshot taken once per daemon iteration (argv exact match on `--service-name <value>`, excludes zombies, tolerates per-process `NoSuchProcess`/`AccessDenied`).
- **Reorder `SkyPilotReplicaManager.__init__`** ([sky/serve/replica_managers.py](sky/serve/replica_managers.py)): run `_recover_replica_operations` first, then start the three daemon threads.
- **Audit logs** in `_cleanup` (own pid + DB state pre-deletion) and in `_start`'s finally (normal / SHUTTING_DOWN / unexpected-exception via a local flag, since `sys.exc_info()` returns None after the `except` clause catches).

## Test plan

- [x] New unit tests:
  - `TestBailOnBootFailure` (5 cases): `os._exit(1)`, `_cleanup`/`remove_service_completely` NOT called, controller subprocess killed, handles None controller_process, swallows kill failure.
  - `TestCleanupAuditLog` (2 cases): WARN logs DB state when row present / when row missing.
  - `TestStartInFlight` (7 cases): present/absent match, no-process baseline, zombie exclusion, per-process psutil error tolerance, no prefix false positive (`pool-a` vs `pool-abc`), no `--service-name` arg case.
  - `TestHaRecoverySkipsWhenStartInFlight`: daemon skips recovery when snapshot contains service.
  - `TestSkyPilotReplicaManagerInitOrdering`: `_recover_replica_operations` runs before any daemon thread `.start()`; all three daemon threads are still started. Verified by `git stash`-ing the reorder: the ordering test fails with the pre-fix order, passes after the fix.
- [x] `bash format.sh` clean.
- [x] 84/84 serve unit tests pass.
- [x] Manual: dev env k8s pod restart shows `SkyServe Controller started on http://...` in controller.log (uvicorn binds), DB `controller_pid`/`controller_ip`/`controller_port` flip within seconds, pool refresh no longer fails on stale ip/port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9683" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->