### PR TITLE
[Serve] Persist SkyletEvent across daemon iterations so consolidation status refresh fires

### DIFF
--- a/sky/server/daemons.py
+++ b/sky/server/daemons.py
@@ -200,6 +200,19 @@ _managed_job_consolidation_mode_lock = None
 _pool_consolidation_mode_lock = None
 _serve_consolidation_mode_lock = None
 
+# Module-scoped SkyletEvent instances. `SkyletEvent.run()` relies on the
+# internal `_n` counter accumulating across calls to throttle the heavy
+# `_run()` work to once per EVENT_INTERVAL_SECONDS. Recreating the event
+# inside each daemon iteration would reset `_n` to 0 every call, run()
+# would advance it only to 1, the `_n == 0` trigger would never fire,
+# and the throttled work (update_service_status / managed_job_utils
+# update) would NEVER execute. The outer `while True` in
+# InternalRequestDaemon.run_event re-invokes the event_fn, so these
+# instances must outlive a single iteration.
+_managed_job_event = None
+_pool_status_update_event = None
+_serve_status_update_event = None
+
 
 # Attempt to gracefully release the lock when the process exits.
 # If this fails, it's okay, the lock will be released when the process dies.
@@ -273,11 +286,16 @@ def managed_job_status_refresh_event():
         # ready to update the job statuses.
         signal_file.unlink()
 
-    # After recovery, we start the event loop.
+    # After recovery, we start the event loop. The event instance is
+    # cached at module scope so its internal throttling counter
+    # accumulates across daemon iterations (see comment near
+    # _managed_job_event declaration).
     from sky.skylet import events
-    refresh_event = events.ManagedJobEvent()
+    global _managed_job_event
+    if _managed_job_event is None:
+        _managed_job_event = events.ManagedJobEvent()
     logger.info('=== Running managed job event ===')
-    refresh_event.run()
+    _managed_job_event.run()
     time.sleep(events.EVENT_CHECKING_INTERVAL_SECONDS)
 
 
@@ -319,9 +337,21 @@ def _serve_status_refresh_event(pool: bool):
     # conflicting. Check PERSISTENT_RUN_RESTARTING_SIGNAL_FILE for details.
     serve_utils.ha_recovery_for_consolidation_mode(pool=pool)
 
-    # After recovery, we start the event loop.
+    # After recovery, we start the event loop. The event instance is
+    # cached at module scope so its internal throttling counter
+    # accumulates across daemon iterations (see comment near
+    # _pool_status_update_event / _serve_status_update_event
+    # declarations).
     from sky.skylet import events
-    event = events.ServiceUpdateEvent(pool=pool)
+    global _pool_status_update_event, _serve_status_update_event
+    if pool:
+        if _pool_status_update_event is None:
+            _pool_status_update_event = events.ServiceUpdateEvent(pool=True)
+        event = _pool_status_update_event
+    else:
+        if _serve_status_update_event is None:
+            _serve_status_update_event = events.ServiceUpdateEvent(pool=False)
+        event = _serve_status_update_event
     noun = 'pool' if pool else 'serve'
     logger.info(f'=== Running {noun} status refresh event ===')
     event.run()

--- a/tests/unit_tests/test_sky/server/test_daemons.py
+++ b/tests/unit_tests/test_sky/server/test_daemons.py
@@ -2,6 +2,9 @@
 import os
 import sys
 import tempfile
+from unittest import mock
+
+import pytest
 
 from sky import skypilot_config
 from sky.server import daemons
@@ -201,3 +204,111 @@ class TestDaemonLogRotation:
             os.close(saved_stdout_fd)
             os.close(saved_stderr_fd)
             os.unlink(tmp_path)
+
+
+class TestConsolidationEventInstancePersistence:
+    """The consolidation-mode refresh daemons must reuse a single
+    SkyletEvent instance across iterations.
+
+    Background: SkyletEvent.run() throttles its expensive `_run()`
+    callback via a per-instance counter `_n` that accumulates across
+    calls. The outer InternalRequestDaemon loop re-invokes the
+    daemon's event_fn repeatedly; if the event is freshly instantiated
+    on every call, `_n` resets to 0, run() only advances it to 1,
+    `_n == 0` never re-fires, and the throttled work
+    (update_service_status / managed-job status refresh) is silently
+    skipped forever.
+
+    These tests assert the instance is created once and reused so the
+    counter persists. With the bug, the constructor is invoked on
+    every iteration; with the fix, exactly once."""
+
+    # Attribute names the fix introduces. Use getattr/setattr so that if
+    # the fix is reverted the fixture still runs cleanly; the actual test
+    # assertions (call_count) then become the failure signal.
+    _EVENT_ATTRS = ('_pool_status_update_event', '_serve_status_update_event',
+                    '_managed_job_event')
+
+    @pytest.fixture(autouse=True)
+    def _reset_module_state(self):
+        # Pre-populate the consolidation locks with mocks that look
+        # already-locked so the daemon never tries to acquire a real
+        # advisory lock during the test.
+        fake_lock = mock.MagicMock()
+        fake_lock.is_locked.return_value = True
+        prior_locks = (daemons._pool_consolidation_mode_lock,
+                       daemons._serve_consolidation_mode_lock,
+                       daemons._managed_job_consolidation_mode_lock)
+        prior_events = {
+            name: getattr(daemons, name, None) for name in self._EVENT_ATTRS
+        }
+        daemons._pool_consolidation_mode_lock = fake_lock
+        daemons._serve_consolidation_mode_lock = fake_lock
+        daemons._managed_job_consolidation_mode_lock = fake_lock
+        for name in self._EVENT_ATTRS:
+            setattr(daemons, name, None)
+        yield
+        (daemons._pool_consolidation_mode_lock,
+         daemons._serve_consolidation_mode_lock,
+         daemons._managed_job_consolidation_mode_lock) = prior_locks
+        for name, value in prior_events.items():
+            setattr(daemons, name, value)
+
+    def test_serve_event_instance_is_reused_across_iterations(self):
+        with mock.patch(
+                'sky.serve.serve_utils.ha_recovery_for_consolidation_mode'), \
+             mock.patch('sky.skylet.events.ServiceUpdateEvent') as mock_event, \
+             mock.patch.object(daemons.time, 'sleep'):
+            for _ in range(3):
+                daemons._serve_status_refresh_event(pool=False)
+            # Without the fix this would be 3 (one ctor per iteration).
+            # With the fix the cached instance is reused.
+            mock_event.assert_called_once_with(pool=False)
+            # run() is invoked on the SAME instance once per iteration,
+            # so its internal `_n` counter accumulates as designed.
+            assert mock_event.return_value.run.call_count == 3
+
+    def test_pool_event_instance_is_reused_across_iterations(self):
+        with mock.patch(
+                'sky.serve.serve_utils.ha_recovery_for_consolidation_mode'), \
+             mock.patch('sky.skylet.events.ServiceUpdateEvent') as mock_event, \
+             mock.patch.object(daemons.time, 'sleep'):
+            for _ in range(3):
+                daemons._serve_status_refresh_event(pool=True)
+            mock_event.assert_called_once_with(pool=True)
+            assert mock_event.return_value.run.call_count == 3
+
+    def test_serve_and_pool_use_independent_instances(self):
+        # Serve (pool=False) and pool (pool=True) must each get their own
+        # cached event — otherwise pool=True daemon iterations would call
+        # run() on the pool=False event (or vice versa).
+        with mock.patch(
+                'sky.serve.serve_utils.ha_recovery_for_consolidation_mode'), \
+             mock.patch('sky.skylet.events.ServiceUpdateEvent') as mock_event, \
+             mock.patch.object(daemons.time, 'sleep'):
+            daemons._serve_status_refresh_event(pool=False)
+            daemons._serve_status_refresh_event(pool=True)
+            daemons._serve_status_refresh_event(pool=False)
+            daemons._serve_status_refresh_event(pool=True)
+            # Exactly two ctor calls: one per pool flag.
+            assert mock_event.call_count == 2
+            assert mock.call(pool=False) in mock_event.call_args_list
+            assert mock.call(pool=True) in mock_event.call_args_list
+
+    def test_managed_job_event_instance_is_reused_across_iterations(self):
+        # signal_file path is real disk I/O in the original function;
+        # patch pathlib.Path directly (daemons.pathlib is a LazyImport
+        # wrapper that proxies to the real pathlib module, so patching
+        # at the module level reaches both lookup paths).
+        fake_signal_file = mock.MagicMock()
+        fake_signal_file.expanduser.return_value = fake_signal_file
+        with mock.patch('pathlib.Path',
+                        return_value=fake_signal_file), \
+             mock.patch(
+                 'sky.jobs.utils.ha_recovery_for_consolidation_mode'), \
+             mock.patch('sky.skylet.events.ManagedJobEvent') as mock_event, \
+             mock.patch.object(daemons.time, 'sleep'):
+            for _ in range(3):
+                daemons.managed_job_status_refresh_event()
+            mock_event.assert_called_once_with()
+            assert mock_event.return_value.run.call_count == 3


### PR DESCRIPTION
## Summary

In consolidation mode, `update_service_status` (the function that transitions a service to `CONTROLLER_FAILED` when its controller process is dead) is gated by `ServiceUpdateEvent.run()`. `SkyletEvent.run()` throttles its `_run()` callback via an internal counter `_n` that accumulates across `run()` calls:

```python
def run(self):
    self._n = (self._n + 1) % self._event_interval
    if self._n % self._event_interval == 0:
        self._run()
```

With `EVENT_INTERVAL_SECONDS=300` and `EVENT_CHECKING_INTERVAL_SECONDS=20`, `_run()` only fires when `_n` rolls from 14 back to 0 (every 15 calls).

But `_serve_status_refresh_event` and `managed_job_status_refresh_event` create a brand-new event instance every iteration of the outer `InternalRequestDaemon.run_event` `while True:` loop:

```python
event = events.ServiceUpdateEvent(pool=pool)  # _n resets to 0
event.run()                                   # _n -> 1, no _run
time.sleep(EVENT_CHECKING_INTERVAL_SECONDS)
```

`_n` resets to 0 every call, `run()` only advances it to 1, the `_n == 0` trigger never re-fires, and the throttled work is **silently skipped forever**. The skylet's `run_event_loop` (where this pattern was originally copied from) keeps event instances at module scope on purpose; the API server port lost that detail.

**Observable symptom**: in consolidation mode, a controller subprocess can die and the service row stays in `READY` / `NO_REPLICA` indefinitely with no log line from `update_service_status`. The same hits the managed-jobs daemon.

## Fix

Cache the three event instances (`_managed_job_event`, `_pool_status_update_event`, `_serve_status_update_event`) at module scope, matching the existing pattern for the consolidation-mode locks already in this file. Lazy-init on first use so the daemon's `should_skip()` short-circuit in non-consolidation mode does not pay for it.

## Test plan

- New `TestConsolidationEventInstancePersistence` class with four cases (serve / pool / independence / managed-job). Each asserts the event constructor is called exactly once across multiple daemon iterations and `run()` is invoked on the same instance per iteration.
- `pytest tests/unit_tests/test_sky/server/test_daemons.py` — 8 passed.
- **Revert check**: with `git stash push sky/server/daemons.py`, all four new tests fail with the assertion `Expected '<Event>' to be called once. Called 3 times.`; restoring the fix returns them to green.
- Manual reproduction in a consolidation-mode deployment: before the fix, killing the controller subprocess for a pool leaves the row stuck at `READY` indefinitely and no `'Update pool status for ...'` log line ever appears. After the fix, the log line appears every ~300s and (with ha_recovery script also deleted, so respawn is suppressed) status transitions to `CONTROLLER_FAILED` on the next tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->