### PR TITLE
[Kubernetes] Merge container-level DRA resource claims by name

### DIFF
--- a/sky/utils/config_utils.py
+++ b/sky/utils/config_utils.py
@@ -29,6 +29,9 @@ _PATCH_MERGE_KEYS = {
     'topologySpreadConstraints': 'topologyKey',
     'ports': 'containerPort',
     'volumeDevices': 'devicePath',
+    # Container-level DRA resource claim refs (Container.resources.claims),
+    # keyed by 'name' per the Kubernetes listMapKey.
+    'claims': 'name',
     # Atomic list fields - replaced entirely, not merged item-by-item
     'args': None,
     'command': None,

--- a/tests/unit_tests/test_sky/utils/test_config_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_config_utils.py
@@ -970,3 +970,48 @@ def test_merge_k8s_configs_env_still_merged_by_name():
     # FOO should be updated
     foo = next(e for e in container['env'] if e['name'] == 'FOO')
     assert foo['value'] == 'updated'
+
+
+def test_merge_k8s_configs_claims_merged_by_name():
+    """Container-level DRA resources.claims merge by name, no duplicates."""
+    base_config = {
+        'containers': [{
+            'name': 'ray-node',
+            'resources': {
+                'claims': [
+                    {
+                        'name': 'roce-claim'
+                    },
+                    {
+                        'name': 'cd'
+                    },
+                ],
+            },
+        }],
+    }
+    override_config = {
+        'containers': [{
+            'name': 'ray-node',
+            'resources': {
+                'claims': [
+                    {
+                        'name': 'roce-claim'
+                    },
+                    {
+                        'name': 'cd'
+                    },
+                    {
+                        'name': 'extra-claim'
+                    },
+                ],
+            },
+        }],
+    }
+
+    config_utils.merge_k8s_configs(base_config, override_config)
+
+    claims = base_config['containers'][0]['resources']['claims']
+    names = [c['name'] for c in claims]
+    assert len(claims) == 3
+    assert names == ['roce-claim', 'cd', 'extra-claim']
+    assert len(names) == len(set(names))


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

## Summary

- `merge_k8s_configs()` patch-merges known Kubernetes list fields by their
  patch merge key, but the container-level DRA `resources.claims` list was
  missing from `_PATCH_MERGE_KEYS`. Overlapping claim refs in the base and
  override pod configs were concatenated instead of merged, producing
  duplicate entries that Kubernetes rejects:
  `spec.containers[0].resources.claims[2]: Duplicate value: "roce-claim"`.
- Adds `'claims': 'name'` to `_PATCH_MERGE_KEYS` so container resource claim
  refs merge by name — overlapping refs are deduplicated, new refs appended.
  This matches the Kubernetes API, where `ResourceRequirements.claims` is
  `listType=map` with `listMapKey=name`.
- Unblocks GB300 / NVL72 jobs using Dynamic Resource Allocation, which
  legitimately require both pod-level `spec.resourceClaims` and
  container-level `resources.claims` refs for IMEX/CD/MNNVL device exposure.

## Context

GB300/NVL72 kubernetes jobs using dynamic resource allocation can require both:

```yaml
spec:
    resourceClaims:
        - name: roce-claim
        - name: cd
```

and container-level claim refs:

```yaml
containers:
- name: ray-node
    resources:
        claims:
            - name: roce-claim
            - name: cd
```

without a merge key for nested resources.claims, Skypilot can render duplicate container claims refs:

```yaml
resources:
    claims:
        - name: roce-claim
        - name: cd
        - name: roce-claim
        - name: cd
```

Kubernetes rejects the pod with errors like:

```
spec.containers[0].resources.claims[2]: Duplicate value: "roce-claim"
spec.containers[0].resources.claims[3]: Duplicate value: "cd"
```

## Test plan

- Added unit test `test_merge_k8s_configs_claims_merged_by_name` in
  `tests/unit_tests/test_sky/utils/test_config_utils.py`: a base container
  with `resources.claims: [roce-claim, cd]` merged with an override
  declaring the same two claims plus a new one yields exactly 3 claims with
  no duplicate names.
- `pytest tests/unit_tests/test_sky/utils/test_config_utils.py` — 25 passed.
- `bash format.sh --files sky/utils/config_utils.py tests/unit_tests/test_sky/utils/test_config_utils.py` — clean.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
    - [x] Added unit test `test_merge_k8s_configs_claims_merged_by_name` in `tests/unit_tests/test_sky/utils/test_config_utils.py`: a base container with `resources.claims: [roce-claim, cd]` merged with an override declaring the same two claims plus a new one yields exactly 3 claims with no duplicate names.
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->