### PR TITLE
[Server] reap multiprocess prometheus files when worker exits

### DIFF
--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -1,6 +1,7 @@
 """Instrumentation for the API server."""
 
 import asyncio
+import atexit
 import multiprocessing
 import os
 import threading
@@ -28,6 +29,34 @@ logger = sky_logging.init_logger(__name__)
 
 _BURN_RATE_UPDATE_INTERVAL_SECONDS = 30
 _COST_TIME_HORIZON_SECONDS = 3600
+
+# Idempotency guard for register_multiproc_cleanup_atexit.
+_multiproc_cleanup_registered = False
+
+
+def register_multiproc_cleanup_atexit() -> None:
+    """Clean up this process's prometheus_client multiproc files on exit.
+
+    Each process that uses pid-labelled multiprocess metrics (uvicorn
+    workers, executor workers) leaves files at
+    ``$PROMETHEUS_MULTIPROC_DIR/<type>_<pid>.db``. The MultiProcessCollector
+    keeps reading those files until ``multiprocess.mark_process_dead(pid)``
+    deletes them. Without this hook, a worker that exits leaves its last
+    written gauge value visible to every future scrape — for ``liveall``
+    gauges this can pin a stale per-pid value indefinitely.
+
+    Safe to call more than once per process; only the first call registers.
+    Only registers when ``PROMETHEUS_MULTIPROC_DIR`` is set; a no-op in
+    single-process / unit-test environments.
+    """
+    global _multiproc_cleanup_registered
+    if _multiproc_cleanup_registered:
+        return
+    if not os.environ.get('PROMETHEUS_MULTIPROC_DIR'):
+        return
+    pid = os.getpid()
+    atexit.register(multiprocess.mark_process_dead, pid)
+    _multiproc_cleanup_registered = True
 
 
 class BurnRateCollector:

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -161,6 +161,9 @@ def executor_initializer(proc_group: str):
     # Load plugins for executor process.
     plugins.load_plugins(
         plugins.ExtensionContext(context=plugins.PluginContext.EXECUTOR))
+    # Same rationale as in sky.server.uvicorn.Server.run: reap this
+    # executor's prometheus multiproc files when it exits.
+    metrics_lib.register_multiproc_cleanup_atexit()
     # Executor never stops, unless the whole process is killed.
     threading.Thread(target=metrics_lib.process_monitor,
                      args=(f'worker:{proc_group}', threading.Event()),

--- a/sky/server/uvicorn.py
+++ b/sky/server/uvicorn.py
@@ -206,6 +206,11 @@ class Server(uvicorn.Server):
         context_utils.hijack_sys_attrs()
         # Use default loop policy of uvicorn (use uvloop if available).
         self.config.setup_event_loop()
+        # Reap this worker's per-pid prometheus multiproc files at exit so
+        # that recycled workers do not leak stale liveall gauge values
+        # (e.g. event-loop-lag peaks recorded just before the worker died)
+        # to every subsequent /metrics scrape and liveall-based probe.
+        metrics_lib.register_multiproc_cleanup_atexit()
         lag_threshold = perf_utils.get_loop_lag_threshold()
         if lag_threshold is not None:
             event_loop = asyncio.get_event_loop()

--- a/tests/unit_tests/test_sky/server/test_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_metrics.py
@@ -102,6 +102,76 @@ def test_register_multiproc_cleanup_atexit_is_idempotent():
         assert mock_register.call_count == 1
 
 
+# End-to-end coverage of the atexit hook. Spawns a real subprocess that
+# writes a liveall gauge file, then exits — exercising the actual
+# `multiprocess.mark_process_dead` path (not mocked). With the fix it
+# reaps its own file; without it, the file leaks. Uses 'spawn' rather
+# than 'fork' so the child does not inherit this test process's atexit
+# handlers or already-imported registries.
+
+_CHILD_SCRIPT = """
+import os
+from prometheus_client import Gauge
+gauge = Gauge(
+    '__test_atexit_liveall',
+    'test',
+    ['pid'],
+    multiprocess_mode='liveall',
+)
+if os.environ.get('WITH_FIX'):
+    from sky.server import metrics
+    metrics.register_multiproc_cleanup_atexit()
+gauge.labels(pid=str(os.getpid())).set(5.2)
+# Write pid to a file rather than stdout — `import sky` logs to stdout
+# on a cold subprocess (skypilot_config debug lines).
+with open(os.environ['_PID_OUT'], 'w') as f:
+    f.write(str(os.getpid()))
+"""
+
+
+def _spawn_writer(multiproc_dir: str, with_fix: bool) -> int:
+    """Run the writer subprocess; return its pid."""
+    import subprocess  # local — only the e2e tests need it
+    import sys
+    import tempfile
+    env = os.environ.copy()
+    env['PROMETHEUS_MULTIPROC_DIR'] = multiproc_dir
+    pid_file = tempfile.NamedTemporaryFile(delete=False, suffix='.pid')
+    pid_file.close()
+    env['_PID_OUT'] = pid_file.name
+    if with_fix:
+        env['WITH_FIX'] = '1'
+    else:
+        env.pop('WITH_FIX', None)
+    try:
+        # Generous timeout: a cold `from sky.server import metrics` in a fresh
+        # subprocess pulls in the full sky import chain (~20s on CI hardware).
+        subprocess.run(
+            [sys.executable, '-c', _CHILD_SCRIPT],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=60,
+        )
+        with open(pid_file.name) as f:
+            return int(f.read().strip())
+    finally:
+        os.unlink(pid_file.name)
+
+
+def test_atexit_reaps_liveall_file_with_fix(tmp_path):
+    pid = _spawn_writer(str(tmp_path), with_fix=True)
+    leftover = sorted(os.listdir(tmp_path))
+    assert f'gauge_liveall_{pid}.db' not in leftover, leftover
+
+
+def test_without_fix_leaks_liveall_file(tmp_path):
+    pid = _spawn_writer(str(tmp_path), with_fix=False)
+    leftover = sorted(os.listdir(tmp_path))
+    assert f'gauge_liveall_{pid}.db' in leftover, leftover
+
+
 @pytest.mark.asyncio
 async def test_metrics_endpoint_with_multiprocess():
     """Test metrics endpoint in multiprocess mode."""

--- a/tests/unit_tests/test_sky/server/test_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_metrics.py
@@ -69,6 +69,39 @@ async def test_metrics_endpoint_without_multiprocess():
             mock_gen.assert_called_once()
 
 
+def test_register_multiproc_cleanup_atexit_noop_without_env_var():
+    """No atexit registration in single-process / unit-test mode."""
+    with patch.dict(os.environ, {}, clear=False), \
+         patch.object(metrics, '_multiproc_cleanup_registered', False), \
+         patch('sky.server.metrics.atexit.register') as mock_register:
+        if 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
+            del os.environ['PROMETHEUS_MULTIPROC_DIR']
+        metrics.register_multiproc_cleanup_atexit()
+        mock_register.assert_not_called()
+
+
+def test_register_multiproc_cleanup_atexit_registers_when_enabled():
+    """When PROMETHEUS_MULTIPROC_DIR is set, register mark_process_dead(pid)."""
+    with patch.dict(os.environ, {'PROMETHEUS_MULTIPROC_DIR': '/tmp/prom'}), \
+         patch.object(metrics, '_multiproc_cleanup_registered', False), \
+         patch('sky.server.metrics.atexit.register') as mock_register, \
+         patch('sky.server.metrics.os.getpid', return_value=4242):
+        metrics.register_multiproc_cleanup_atexit()
+        mock_register.assert_called_once_with(
+            metrics.multiprocess.mark_process_dead, 4242)
+
+
+def test_register_multiproc_cleanup_atexit_is_idempotent():
+    """Repeated calls in the same process only register once."""
+    with patch.dict(os.environ, {'PROMETHEUS_MULTIPROC_DIR': '/tmp/prom'}), \
+         patch.object(metrics, '_multiproc_cleanup_registered', False), \
+         patch('sky.server.metrics.atexit.register') as mock_register:
+        metrics.register_multiproc_cleanup_atexit()
+        metrics.register_multiproc_cleanup_atexit()
+        metrics.register_multiproc_cleanup_atexit()
+        assert mock_register.call_count == 1
+
+
 @pytest.mark.asyncio
 async def test_metrics_endpoint_with_multiprocess():
     """Test metrics endpoint in multiprocess mode."""


### PR DESCRIPTION
## Summary

- Register `prometheus_client.multiprocess.mark_process_dead(os.getpid())` via `atexit` in every process that writes pid-labelled multiprocess metrics (uvicorn worker, executor worker), so that recycled workers do not leak stale gauge values to subsequent `/metrics` scrapes.

## Background

Each uvicorn / executor worker writes per-pid metric files at `$PROMETHEUS_MULTIPROC_DIR/<type>_<pid>.db`. `MultiProcessCollector` aggregates all such files on every scrape. Per the prometheus_client multiprocess docs, callers MUST invoke `multiprocess.mark_process_dead(pid)` when a writer process exits, otherwise its file persists on disk and the collector keeps returning the last-written value.

Today nothing in the API server calls `mark_process_dead`. The result: if a uvicorn worker is replaced (graceful restart, crash, OOM of a single worker, etc.) the stale `gauge_<type>_<dead-pid>.db` file remains, and for `multiprocess_mode='liveall'` gauges (e.g. `sky_apiserver_event_loop_lag_max_seconds`) the dead PID's last value keeps being emitted as its own sample. Anything downstream that reads the metric — Prometheus dashboards, alerts, or in-process consumers of `MultiProcessCollector` — sees a permanently elevated per-PID series for a process that no longer exists. The leak only clears on a full pod restart (which wipes `$PROMETHEUS_MULTIPROC_DIR`).

## Fix

- New `sky.server.metrics.register_multiproc_cleanup_atexit()` helper. Idempotent; no-op when `PROMETHEUS_MULTIPROC_DIR` is unset.
- Called from `sky.server.uvicorn.Server.run` (uvicorn worker entry point) and `sky.server.requests.executor.executor_initializer` (executor worker entry point) — the two places already responsible for kicking off the per-process metrics writers.

`multiprocess.mark_process_dead(pid)` only deletes `gauge_live*_{pid}.db` files (livesum / liveall / livemin / livemax) — counters, histograms, and non-`live` gauges are kept intentionally because their values aggregate beyond the writer's lifetime. So this PR fixes the `liveall`/`livesum` per-pid leak (the operationally painful one) without altering aggregation semantics for any other metric.

## Caveats

- `atexit` does not run on SIGKILL / hard crash. A defense-in-depth filter on the read side (skip samples whose pid label points to a non-existent process) is still worthwhile for read paths that care.
- The metrics dir is process-local (`/tmp/metrics`), so this PR has no cross-pod or HA implications by itself.

## Test plan

- [x] `pytest tests/unit_tests/test_sky/server/test_metrics.py` — added three tests covering the no-op (no `PROMETHEUS_MULTIPROC_DIR`), the registration path, and idempotency. All 18 tests pass.
- [x] `pylint sky/server/metrics.py sky/server/uvicorn.py sky/server/requests/executor.py` clean.
- [x] **End-to-end A/B demo** — spawn a child writer that emits the real `sky_apiserver_event_loop_lag_max_seconds` gauge with `pid=os.getpid()` value=5.2, then exits normally. Check both (a) what files remain in `$PROMETHEUS_MULTIPROC_DIR` and (b) what `MultiProcessCollector` (the same read path used by `/metrics` and the HA probe) returns. Result (script at `/tmp/e2e_oss_atexit.py` in my devspace):

  ```
  === pre-fix (FIX=False) ===
  child pid: 840438
  files: ['gauge_all_840438.db', 'gauge_liveall_840438.db', 'histogram_840438.db']
  gauge_live*_840438.db left behind: ['gauge_liveall_840438.db']
  MultiProcessCollector samples:
    pid=840438 value=5.2
  dead pid 840438 visible to reader? True
  expected (bug): stale files present, dead pid visible — REPRODUCED

  === post-fix (FIX=True) ===
  child pid: 840563
  files: ['gauge_all_840563.db', 'histogram_840563.db']
  gauge_live*_840563.db left behind: []
  MultiProcessCollector samples:
  dead pid 840563 visible to reader? False
  expected: no stale files, dead pid invisible — PASS

  OK: bug reproduced without FIX, gone with FIX
  ```

-Claude