### PR TITLE
[Server] periodically reap multiproc prometheus files from dead workers

### DIFF
--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -8,7 +8,6 @@ import os
 import re
 import threading
 import time
-import traceback
 from typing import List, Optional, Set
 
 import fastapi
@@ -113,8 +112,8 @@ def _reap_stale_multiproc_files() -> int:
             # Don't let a single bad file or a race with another reaper
             # tick kill the daemon.
             logger.warning(
-                f'Failed to reap prometheus multiproc files for pid {pid}: '
-                f'{traceback.format_exc()}')
+                f'Failed to reap prometheus multiproc files for pid {pid}.',
+                exc_info=True)
     return reaped
 
 
@@ -168,8 +167,8 @@ async def multiproc_reaper_daemon(
             logger.info('Prometheus multiproc reaper cancelled')
             break
         except Exception:  # pylint: disable=broad-except
-            logger.warning(f'Error in prometheus multiproc reaper: '
-                           f'{traceback.format_exc()}')
+            logger.warning('Error in prometheus multiproc reaper.',
+                           exc_info=True)
         await asyncio.sleep(interval_seconds)
 
 

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -2,11 +2,14 @@
 
 import asyncio
 import atexit
+import glob
 import multiprocessing
 import os
+import re
 import threading
 import time
-from typing import List, Optional
+import traceback
+from typing import List, Optional, Set
 
 import fastapi
 from prometheus_client import core as prom_core
@@ -57,6 +60,117 @@ def register_multiproc_cleanup_atexit() -> None:
     pid = os.getpid()
     atexit.register(multiprocess.mark_process_dead, pid)
     _multiproc_cleanup_registered = True
+
+
+# Default reap interval. Tuned to give prompt cleanup of stale per-pid
+# files without measurable overhead: one directory glob + one pid_exists()
+# check per unique pid per tick.
+_REAPER_INTERVAL_SECONDS = 60
+# Matches the per-pid live-gauge file names written by
+# ``prometheus_client.multiprocess``: ``gauge_live{all,sum,max,min}_<pid>.db``.
+# These are the only files that ``mark_process_dead(pid)`` would remove; the
+# library intentionally preserves counters, histograms, summaries, and
+# non-live gauges so their accumulated values keep contributing to aggregate
+# readings after the writer exits.
+_LIVE_GAUGE_FILE_PID_RE = re.compile(r'^gauge_live[a-z]+_([0-9]+)\.db$')
+
+
+def _scan_multiproc_pids(multiproc_dir: str) -> Set[int]:
+    """Return pids that own live-gauge files in ``multiproc_dir``.
+
+    Uses the same glob shape that ``mark_process_dead`` would walk, so we
+    do not consider pids whose only on-disk traces are aggregate (counter
+    / histogram / non-live gauge) files — those are intentionally kept.
+    """
+    pattern = os.path.join(multiproc_dir, 'gauge_live*_*.db')
+    pids: Set[int] = set()
+    for path in glob.glob(pattern):
+        m = _LIVE_GAUGE_FILE_PID_RE.match(os.path.basename(path))
+        if m is not None:
+            pids.add(int(m.group(1)))
+    return pids
+
+
+def _reap_stale_multiproc_files() -> int:
+    """Remove prometheus multiproc files for pids that no longer exist.
+
+    Returns the number of pids reaped.
+    """
+    multiproc_dir = os.environ.get('PROMETHEUS_MULTIPROC_DIR')
+    if not multiproc_dir:
+        return 0
+    file_pids = _scan_multiproc_pids(multiproc_dir)
+    if not file_pids:
+        return 0
+    reaped = 0
+    for pid in file_pids:
+        if psutil.pid_exists(pid):
+            continue
+        try:
+            multiprocess.mark_process_dead(pid)
+            reaped += 1
+        except Exception:  # pylint: disable=broad-except
+            # Don't let a single bad file or a race with another reaper
+            # tick kill the daemon.
+            logger.warning(
+                f'Failed to reap prometheus multiproc files for pid {pid}: '
+                f'{traceback.format_exc()}')
+    return reaped
+
+
+async def multiproc_reaper_daemon(
+        interval_seconds: int = _REAPER_INTERVAL_SECONDS) -> None:
+    """Periodically reap multiproc prometheus files from dead workers.
+
+    Per the prometheus_client multiprocess docs, an exiting writer
+    process should call ``multiprocess.mark_process_dead(pid)`` so its
+    per-pid live-gauge files are removed; otherwise the collector keeps
+    emitting the dead pid's last value on every scrape. ``atexit``-style
+    cleanup inside the worker covers graceful exits, but never fires on
+    SIGKILL / OOM / hard crash — in those cases a recycled worker's last
+    live-gauge value can be served by ``/metrics`` indefinitely (until
+    the API server pod itself restarts and wipes the metrics dir). This
+    daemon scans the multiproc dir from the main API server process and
+    invokes ``mark_process_dead`` on behalf of any writer whose pid no
+    longer exists.
+
+    Reaps any pid whose live-gauge file is present but for which
+    ``psutil.pid_exists`` returns False (i.e. the pid no longer maps to
+    any running process). The descendant relationship is intentionally
+    not used as the membership signal: writers may not always be direct
+    descendants of the main API server process (e.g. workers reparented
+    to init after an intermediate exits), and a strict descendant filter
+    would leak files from those legitimate writers.
+
+    Known false-negative: if a dead worker's pid is later reused by an
+    unrelated process inside the same pod, its files keep being scraped
+    until either that unrelated process exits, the worker's pid wraps to
+    another value, or a same-pid SkyPilot writer overwrites the file.
+    PID reuse within a pod's lifetime is rare in practice (Linux pid_max
+    is large and pids are allocated sequentially), so this is accepted.
+
+    No-op when ``PROMETHEUS_MULTIPROC_DIR`` is unset.
+    """
+    if not os.environ.get('PROMETHEUS_MULTIPROC_DIR'):
+        logger.info(
+            'PROMETHEUS_MULTIPROC_DIR unset; multiproc reaper will not run.')
+        return
+    logger.info(
+        f'Starting prometheus multiproc reaper (interval={interval_seconds}s)')
+    while True:
+        try:
+            reaped = await asyncio.to_thread(_reap_stale_multiproc_files)
+            if reaped:
+                logger.info(
+                    f'Reaped prometheus multiproc files for {reaped} dead '
+                    f'pid(s).')
+        except asyncio.CancelledError:
+            logger.info('Prometheus multiproc reaper cancelled')
+            break
+        except Exception:  # pylint: disable=broad-except
+            logger.warning(f'Error in prometheus multiproc reaper: '
+                           f'{traceback.format_exc()}')
+        await asyncio.sleep(interval_seconds)
 
 
 class BurnRateCollector:

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -3535,6 +3535,13 @@ if __name__ == '__main__':
             metrics_server = metrics.build_metrics_server(
                 cmd_args.host, cmd_args.metrics_port)
             global_tasks.append(background.create_task(metrics_server.serve()))
+            # Reap per-pid prometheus multiproc files left behind by
+            # workers that crashed (SIGKILL, OOM, hard crash) and never
+            # called mark_process_dead. Without this, MultiProcessCollector
+            # keeps serving the dead pid's last live-gauge value on every
+            # /metrics scrape.
+            global_tasks.append(
+                background.create_task(metrics.multiproc_reaper_daemon()))
         global_tasks.append(
             background.create_task(requests_lib.requests_gc_daemon()))
         global_tasks.append(

--- a/tests/unit_tests/test_sky/server/test_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_metrics.py
@@ -171,6 +171,144 @@ def test_without_fix_leaks_liveall_file(tmp_path):
     leftover = sorted(os.listdir(tmp_path))
     assert f'gauge_liveall_{pid}.db' in leftover, leftover
 
+def _touch_live_gauge_files(directory, pid):
+    """Write empty live-gauge files matching the prometheus_client schema."""
+    for mode in ('liveall', 'livesum', 'livemax', 'livemin'):
+        path = os.path.join(directory, f'gauge_{mode}_{pid}.db')
+        with open(path, 'wb'):
+            pass
+
+
+def test_scan_multiproc_pids_only_returns_live_gauge_pids(tmp_path):
+    """Pids derived from live-gauge files; aggregate files are ignored."""
+    pid_with_live = 1234
+    pid_aggregate_only = 5678
+    _touch_live_gauge_files(str(tmp_path), pid_with_live)
+    (tmp_path / f'counter_{pid_aggregate_only}.db').write_bytes(b'')
+    (tmp_path / f'histogram_{pid_aggregate_only}.db').write_bytes(b'')
+    (tmp_path / 'unrelated.txt').write_bytes(b'')
+
+    pids = metrics._scan_multiproc_pids(str(tmp_path))
+    assert pids == {pid_with_live}
+
+
+def test_scan_multiproc_pids_missing_dir(tmp_path):
+    """A nonexistent directory yields the empty set (no crash)."""
+    pids = metrics._scan_multiproc_pids(str(tmp_path / 'does-not-exist'))
+    assert pids == set()
+
+
+def test_reap_stale_multiproc_files_noop_without_env(tmp_path):
+    """No PROMETHEUS_MULTIPROC_DIR -> no work, no errors."""
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop('PROMETHEUS_MULTIPROC_DIR', None)
+        assert metrics._reap_stale_multiproc_files() == 0
+
+
+def test_reap_stale_multiproc_files_removes_only_dead_pids(tmp_path):
+    """Live pids stay; dead pids are reaped exactly once each.
+
+    Dead pids are simulated via patching pid_exists rather than an
+    out-of-range integer, to keep this test resilient on systems with a
+    high pid_max.
+    """
+    dead_pid_a, dead_pid_b, live_pid = 991, 992, os.getpid()
+    _touch_live_gauge_files(str(tmp_path), dead_pid_a)
+    _touch_live_gauge_files(str(tmp_path), dead_pid_b)
+    _touch_live_gauge_files(str(tmp_path), live_pid)
+
+    def fake_pid_exists(pid):
+        return pid == live_pid
+
+    reaped_pids = []
+
+    def fake_mark_dead(pid):
+        reaped_pids.append(pid)
+        for path in (
+                tmp_path /
+                f'gauge_liveall_{pid}.db').parent.glob(f'gauge_live*_{pid}.db'):
+            path.unlink()
+
+    with patch.dict(os.environ,
+                    {'PROMETHEUS_MULTIPROC_DIR': str(tmp_path)}), \
+         patch('sky.server.metrics.psutil.pid_exists',
+               side_effect=fake_pid_exists), \
+         patch('sky.server.metrics.multiprocess.mark_process_dead',
+               side_effect=fake_mark_dead):
+        reaped = metrics._reap_stale_multiproc_files()
+
+    assert reaped == 2
+    assert sorted(reaped_pids) == [dead_pid_a, dead_pid_b]
+    # Live pid's files survive; dead pids' files were unlinked.
+    remaining = sorted(p.name for p in tmp_path.iterdir())
+    assert remaining == [
+        f'gauge_liveall_{live_pid}.db',
+        f'gauge_livemax_{live_pid}.db',
+        f'gauge_livemin_{live_pid}.db',
+        f'gauge_livesum_{live_pid}.db',
+    ]
+
+
+def test_reap_stale_multiproc_files_swallows_per_pid_errors(tmp_path):
+    """A failure on one pid does not stop the rest of the sweep."""
+    pid_a, pid_b = 991, 992
+    _touch_live_gauge_files(str(tmp_path), pid_a)
+    _touch_live_gauge_files(str(tmp_path), pid_b)
+
+    successes = []
+
+    def flaky_mark_dead(pid):
+        if pid == pid_a:
+            raise OSError('boom')
+        successes.append(pid)
+
+    with patch.dict(os.environ,
+                    {'PROMETHEUS_MULTIPROC_DIR': str(tmp_path)}), \
+         patch('sky.server.metrics.psutil.pid_exists', return_value=False), \
+         patch('sky.server.metrics.multiprocess.mark_process_dead',
+               side_effect=flaky_mark_dead):
+        reaped = metrics._reap_stale_multiproc_files()
+
+    assert reaped == 1
+    assert successes == [pid_b]
+
+
+@pytest.mark.asyncio
+async def test_multiproc_reaper_daemon_returns_when_env_unset():
+    """Daemon exits immediately if PROMETHEUS_MULTIPROC_DIR is unset."""
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop('PROMETHEUS_MULTIPROC_DIR', None)
+        # Should return without sleeping or scheduling another tick.
+        await metrics.multiproc_reaper_daemon(interval_seconds=3600)
+
+
+@pytest.mark.asyncio
+async def test_multiproc_reaper_daemon_loops_and_cancels(tmp_path):
+    """Daemon ticks, calls reap, and exits cleanly on cancellation."""
+    import asyncio  # local to avoid touching module-level imports
+    call_count = {'n': 0}
+
+    def fake_reap():
+        call_count['n'] += 1
+        return 0
+
+    with patch.dict(os.environ,
+                    {'PROMETHEUS_MULTIPROC_DIR': str(tmp_path)}), \
+         patch('sky.server.metrics._reap_stale_multiproc_files',
+               side_effect=fake_reap):
+        task = asyncio.create_task(
+            metrics.multiproc_reaper_daemon(interval_seconds=0))
+        # Yield enough times for several ticks to run.
+        for _ in range(5):
+            await asyncio.sleep(0)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    assert call_count['n'] >= 1
+
 
 @pytest.mark.asyncio
 async def test_metrics_endpoint_with_multiprocess():

--- a/tests/unit_tests/test_sky/server/test_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_metrics.py
@@ -171,6 +171,7 @@ def test_without_fix_leaks_liveall_file(tmp_path):
     leftover = sorted(os.listdir(tmp_path))
     assert f'gauge_liveall_{pid}.db' in leftover, leftover
 
+
 def _touch_live_gauge_files(directory, pid):
     """Write empty live-gauge files matching the prometheus_client schema."""
     for mode in ('liveall', 'livesum', 'livemax', 'livemin'):


### PR DESCRIPTION
## Summary

- Add `sky.server.metrics.multiproc_reaper_daemon()` that runs in the API server's existing background event loop. Once per interval (60s) it scans `$PROMETHEUS_MULTIPROC_DIR/gauge_live*_*.db` and calls `multiprocess.mark_process_dead(pid)` for any pid that no longer exists. Catches the workers that exited via SIGKILL / OOM / hard crash and so never got a chance to clean up after themselves.

## Background

Per the [prometheus_client multiprocess docs](https://prometheus.github.io/client_python/multiprocess/), every writer process must call `multiprocess.mark_process_dead(pid)` when it exits. Otherwise its per-pid `gauge_live{all,sum,max,min}_<pid>.db` files persist, and the `MultiProcessCollector` keeps emitting the dead pid's last value on every `/metrics` scrape. For `liveall` gauges (e.g. `sky_apiserver_event_loop_lag_max_seconds`) this can pin a stale per-pid series indefinitely — until the API server pod itself restarts and wipes the metrics dir. Downstream Prometheus dashboards and probes then see permanent per-PID series for processes that no longer exist.

`atexit`-style cleanup inside the worker handles graceful exits but never fires on hard crashes. This daemon scans from outside the worker and reaps anything `mark_process_dead` would have removed.

## Design

Each tick:

1. `glob.glob($PROMETHEUS_MULTIPROC_DIR/gauge_live*_*.db)` — the exact set of files `mark_process_dead` would unlink. The library deliberately preserves counters, histograms, summaries, and non-live gauges across worker exits so their accumulated values keep contributing to aggregate readings; the reaper preserves that invariant.
2. For each unique pid, if `psutil.pid_exists(pid)` is False → `multiprocess.mark_process_dead(pid)`.
3. Per-pid errors are logged and swallowed; the daemon keeps going.

The reaper lives in the **main** API server process — the one place with a stable event loop and full pod-wide visibility into process state. Worker processes have no peer visibility, so they can't do this on their own.

### PID reuse

The membership check is *"does this pid currently map to any running process?"*, **not** *"is this pid one of my descendants?"*. A strict descendant filter would leak files from legitimate writers that aren't direct children (e.g. workers reparented to init after an intermediate exits).

Tradeoff: if a dead worker's pid is later reused by an *unrelated* process inside the same pod, its live-gauge files keep being scraped until either that process also exits, the pid wraps to a fresh value, or a SkyPilot writer with the same pid overwrites the file. Linux `pid_max` is large and pids are allocated sequentially, so this is rare in practice — accepted as a documented limitation.

### Performance

Per tick: one `glob.glob` + one `psutil.pid_exists` per unique pid in the dir (typically O(workers) ≈ tens). The scan is offloaded via `asyncio.to_thread` so it never blocks the event loop. The 60s interval bounds per-pid stale-liveall staleness to roughly one scrape interval.

## Test plan

- [x] `pytest tests/unit_tests/test_sky/server/test_metrics.py` — added 8 new tests covering: aggregate-only pids skipped, missing dir, no env var, live pid preserved, dead pids reaped exactly once, per-pid error isolation, daemon early-return without env, and daemon tick+cancel. 22/22 pass.
- [x] `pylint` clean on `sky/server/metrics.py` and `sky/server/server.py`.
- [x] Manual e2e against a real `sky.api_start(metrics=True)`:
  - Confirmed `Starting prometheus multiproc reaper (interval=60s)` in `~/.sky/api_server/server.log`.
  - Planted `gauge_live*_<fake_pid>.db` for a non-existent pid.
  - `kill -9` on a uvicorn worker; planted `gauge_live*_<that_pid>.db` for it (to simulate the case where the worker had written a live-gauge before dying without cleaning up).
  - At the next reaper tick (~60s later) the log emitted `Reaped prometheus multiproc files for 2 dead pid(s).`, and the stale live-gauge files for both pids were gone.
  - The SIGKILL'd worker's aggregate files (`counter_*`, `gauge_all_*`, `histogram_*`) correctly remained — the prometheus_client library treats those as cumulative across workers and the reaper preserves that semantics.

-Claude