### PR TITLE
[Test] Raise sky-jobs-queue SLA in scale test from 10s to 13s

### DIFF
--- a/tests/load_tests/db_scale_tests/test_large_production_performance.sh
+++ b/tests/load_tests/db_scale_tests/test_large_production_performance.sh
@@ -266,8 +266,25 @@ fi
 echo "✓ sky status test passed (${duration}s)"
 
 # Step 6: Test sky jobs queue performance
+#
+# SLA: sky jobs queue (default view, latest 50) with 12,501 in-progress
+# managed jobs must finish in SKY_JOBS_QUEUE_SLA_SECONDS. Survey of the
+# last 12 same-config nightly builds (`nightly-build-pypi --kubernetes
+# --jobs-consolidation --no-resource-heavy`, builds 10660..10837)
+# measured the distribution as:
+#   7, 7, 8, 9, 9, 9, 9, 10, 10, 10, 10,    ← old SLA
+#   11
+#   min 7s | median 9s | mean 9.08s | stdev 1.24s | max 11s
+# Four of the last twelve runs landed *exactly* at the previous 10s
+# ceiling and one (build 10837) crossed it by a single second — well
+# within natural run-to-run jitter on shared CI infrastructure. The 10s
+# SLA had zero headroom and was no longer a regression detector. 13s
+# covers ~mean + 3·stdev (~p99) of observed durations while still being
+# tight enough to surface a real regression in the managed-jobs read
+# path.
+SKY_JOBS_QUEUE_SLA_SECONDS=13
 echo "Step 6: Testing sky jobs queue performance..."
-echo "Expected: Last job ID >= 12452 and finish within 10 seconds"
+echo "Expected: Last job ID >= 12452 and finish within ${SKY_JOBS_QUEUE_SLA_SECONDS} seconds"
 time_start=$(date +%s)
 QUEUE_OUTPUT=$(timeout 60 sky jobs queue 2>&1 || true)
 time_end=$(date +%s)
@@ -285,8 +302,8 @@ if [ "$LAST_JOB_ID" -lt 12452 ]; then
     exit 1
 fi
 
-if [ $duration -gt 10 ]; then
-    echo "ERROR: sky jobs queue took ${duration}s, expected <= 10s"
+if [ $duration -gt $SKY_JOBS_QUEUE_SLA_SECONDS ]; then
+    echo "ERROR: sky jobs queue took ${duration}s, expected <= ${SKY_JOBS_QUEUE_SLA_SECONDS}s"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Raise the `sky jobs queue` SLA in `tests/load_tests/db_scale_tests/test_large_production_performance.sh` (Step 6) from 10s to 13s, with the value extracted into a named constant `SKY_JOBS_QUEUE_SLA_SECONDS` and a comment block documenting the rationale.

**This is a noise-floor SLA fix.** The 10s ceiling sat at the median of the observed distribution and was a coin flip for the natural per-run variance. I tried hard to identify a code regression that would justify a different action; the measurement below shows there isn't one to fix.

## Failing build

Nightly [#10837](https://buildkite.com/skypilot-1/smoke-tests/builds/10837#019e4d77-5dc7-4ad9-99f7-97d4cb7be701) failed Step 6 with:

```
ERROR: sky jobs queue took 11s, expected <= 10s
```

The commit under test (`86aa5d27` — `[Server] reap multiprocess prometheus files when worker exits`, #9689) doesn't touch the managed-jobs read path.

## Historical distribution (109 same-config nightlies since 2026-03-17)

| Window | n | median | mean | stdev | %≥10s |
|---|---|---|---|---|---|
| Mar 18 – May 12 | 70 | 8s | 8.0s | ~1.5s | 4% |
| May 13 – present | 39 | 9s | 8.9s | ~1.5s | 23% |

A ~1s median shift starting around 5/13. The integer-second timer means the underlying distribution can have moved by anywhere from ~0.5s to ~1.5s and the histograms look the same.

## Empirical measurement of the suspected causes

Created an AWS RDS PostgreSQL (db.m5.xlarge, us-east-2) from my dev box, populated with 12,500 synthetic managed-job rows (matching the production test scale), and timed the read path under controlled conditions. 7 samples per condition.

### Result A — does `#9592` populating heavy Text/JSON columns slow the read?

```
HEAVY columns populated     median 9.304s   mean 10.04s   stdev 1.66s
HEAVY columns NULL'd        median 9.144s   mean 9.39s    stdev 1.49s
Δ = +160ms (+1.7%) median
```

`get_managed_jobs_with_filters` selects all `spot.*` and `job_info.*` columns, but only for ~50 rows (the LIMIT 50 page). The other 12,450 rows are scanned by index, not data-read. **The data effect is real but tiny — 160 ms, not seconds.**

### Result B — code change on the read hot path

Ran the same measurement against the same DB with two checkouts: HEAD vs `0e634414a` (Mar 23, near the pre-creep baseline).

```
get_managed_jobs_with_filters (direct call):
  HEAD code, NULL data   median 8.921s   mean 9.57s   stdev 1.86s
  Mar  code, NULL data   median 8.598s   mean 9.73s   stdev 2.01s
  Δ = +323ms median / −160ms mean — within stdev

get_managed_job_queue (full path, limit=50, 4 sub-queries):
  HEAD code, NULL data   median 22.504s  mean 22.25s  stdev 1.77s
  Mar  code, NULL data   median 22.207s  mean 22.32s  stdev 1.96s
  Δ = +297ms median / −72ms mean — within stdev
```

**No code regression.** The medians differ by less than one stdev; the means actually go the other way. Whatever distinguished March from May is not a change in the queue read path.

### What the only-real-diff in the read path is (#8850)

`build_managed_jobs_with_filters_no_status_query` gained a LEFT OUTER JOIN against `_batch_progress_subquery` in commit `df57e9cc6` (#8850, "Introducing sky batch", 2026-04-22). With an empty `batch_state_table` (the case in the test) the subquery is essentially free, which the bisect above confirms.

## Why I'm not chasing a bisect further

The convergent evidence is:

1. **No commit on the read path changes timings by anything close to 1 s** (Result B above; large code search shows only the #8850 join, which the bisect rules out).
2. **The data effect alone is 160 ms** (Result A), an order of magnitude below the threshold for treating this as a regression.
3. **The shift in the historical median is on the order of the per-run stdev** of the test itself.

If a future build comes in clearly ≥14 s we should investigate again with a hard signal. Bumping 10 → 13 keeps the SLA at ~mean + 3·stdev (~p99 of the observed distribution) so it stops failing on jitter while still firing on a real regression.

`sky jobs queue --all` (30 s SLA, observed max 26 s) and `sky status` (25 s SLA after #9599) are unchanged — they have headroom.

## Test plan

- [x] `bash format.sh --files`: exits 0; no diff
- [x] Shell syntax (`bash -n`)
- [x] Empirical: AWS RDS measurement of HEAVY vs NULL data, HEAD vs Mar code — see Results A and B
- [ ] Next `nightly-build-pypi --kubernetes --jobs-consolidation --no-resource-heavy` should pass Step 6 on typical 9–11s draws and still fail on real regressions ≥14s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
