### PR TITLE
[Storage] Treat ASSUME_ROLE as non-static in should_use_env_auth_for_s3

### DIFF
--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -1158,10 +1158,11 @@ class AWS(clouds.Cloud):
     def should_use_env_auth_for_s3(cls) -> bool:
         """Returns True if S3 should use environment-based auth.
 
-        When using non-static AWS credentials (SSO, IAM role, container role),
-        we should not embed credentials into rclone config. Instead, we should
-        use env_auth=true so that rclone uses the AWS SDK credential chain,
-        which properly handles temporary credentials and IAM roles.
+        When using non-static AWS credentials (SSO, IAM role, container role,
+        an assumed role), we should not embed credentials into rclone config.
+        Instead, we should use env_auth=true so that rclone uses the AWS SDK
+        credential chain, which properly handles temporary credentials and
+        IAM roles.
 
         Returns:
             True if environment-based auth should be used, False for static
@@ -1172,11 +1173,16 @@ class AWS(clouds.Cloud):
             return False
         # These credential types use temporary credentials that should not be
         # embedded in config files. They rely on the AWS SDK credential chain.
+        # ASSUME_ROLE covers both `aws sts assume-role` and the
+        # `assume-role-with-web-identity` flow used by EKS IRSA and any other
+        # OIDC federation, both of which mint short-lived session tokens that
+        # expire well before a remote VM gets to use them.
         non_static_types = {
             AWSIdentityType.SSO,
             AWSIdentityType.IAM_ROLE,
             AWSIdentityType.CONTAINER_ROLE,
             AWSIdentityType.LOGIN,
+            AWSIdentityType.ASSUME_ROLE,
         }
         return identity_type in non_static_types
 

--- a/tests/unit_tests/test_sky/clouds/test_aws_cloud.py
+++ b/tests/unit_tests/test_sky/clouds/test_aws_cloud.py
@@ -656,6 +656,61 @@ class TestAwsLoginIdentityDetection:
         assert not aws_mod.AWSIdentityType.LOGIN.can_credential_expire()
 
 
+class TestAwsAssumeRoleEnvAuth:
+    """ASSUME_ROLE-derived sessions (including assume-role-with-web-identity)
+    must route to env_auth=true in the rclone S3 config rather than embedding
+    the short-lived ASIA* session credentials into a profile that ships to a
+    remote VM."""
+
+    @mock.patch('sky.adaptors.aws.get_workspace_profile')
+    @mock.patch('subprocess.run')
+    def test_assume_role_with_web_identity_routes_to_env_auth(
+            self, mock_run, mock_get_profile):
+        """EKS IRSA / OIDC-federated pods: `aws configure list` Type column
+        'assume-role-with-web-identity' → AWSIdentityType.ASSUME_ROLE →
+        should_use_env_auth_for_s3() returns True."""
+        configure_list_output = (
+            b'      Name                    Value             Type    Location\n'
+            b'      ----                    -----             ----    --------\n'
+            b'   profile                <not set>             None    None\n'
+            b'access_key     ****************MAYI assume-role-with-web-identity\n'
+            b'secret_key     ****************ljFI assume-role-with-web-identity\n'
+            b'    region                us-west-2              env    AWS_DEFAULT_REGION\n'
+        )
+        mock_run.return_value = mock.Mock(returncode=0,
+                                          stdout=configure_list_output)
+        mock_get_profile.return_value = None
+        aws_mod.AWS._aws_configure_list.cache_clear()
+
+        assert (aws_mod.AWS._current_identity_type() ==
+                aws_mod.AWSIdentityType.ASSUME_ROLE)
+        assert aws_mod.AWS.should_use_env_auth_for_s3() is True
+
+    @mock.patch('sky.adaptors.aws.get_workspace_profile')
+    @mock.patch('subprocess.run')
+    def test_plain_assume_role_routes_to_env_auth(self, mock_run,
+                                                  mock_get_profile):
+        """`aws sts assume-role` via profile role_arn/source_profile also
+        yields short-lived session tokens that expire before a remote VM uses
+        them; classify as non-static."""
+        configure_list_output = (
+            b'      Name                    Value             Type    Location\n'
+            b'      ----                    -----             ----    --------\n'
+            b'   profile                <not set>             None    None\n'
+            b'access_key     ****************abcd      assume-role\n'
+            b'secret_key     ****************abcd      assume-role\n'
+            b'    region                us-west-2      config-file    ~/.aws/config\n'
+        )
+        mock_run.return_value = mock.Mock(returncode=0,
+                                          stdout=configure_list_output)
+        mock_get_profile.return_value = None
+        aws_mod.AWS._aws_configure_list.cache_clear()
+
+        assert (aws_mod.AWS._current_identity_type() ==
+                aws_mod.AWSIdentityType.ASSUME_ROLE)
+        assert aws_mod.AWS.should_use_env_auth_for_s3() is True
+
+
 class TestAwsConfigureList:
 
     @mock.patch('sky.adaptors.aws.get_workspace_profile')


### PR DESCRIPTION
## Summary

`AWS.should_use_env_auth_for_s3()` (`sky/clouds/aws.py:1158`) decides whether `RcloneStores.S3.get_config()` writes `env_auth = true` into the rclone profile or embeds the current AWS session's access key + secret + session token directly. The `non_static_types` set lists every identity type whose credentials are short-lived enough that embedding them is unsafe (the remote VM consumes the rclone config minutes-to-hours after the SkyPilot client generated it). The set currently omits `AWSIdentityType.ASSUME_ROLE`.

`_current_identity_type()` returns `ASSUME_ROLE` whenever `aws configure list` reports `assume-role` in the credential-source column. The two production paths that surface it:

- `aws sts assume-role` via a profile's `role_arn` + `source_profile` in `~/.aws/config`, the canonical CLI assume-role workflow.
- `sts:AssumeRoleWithWebIdentity`, the underlying call for EKS IRSA, GKE / external OIDC federation to AWS, and the helm chart's `apiService.extraEnvs` `AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE` pattern documented in `docs/source/cloud-setup/cloud-permissions/aws-eks-iam-roles.rst`.

Both mint `ASIA*` session tokens that expire well before the VM uses the rclone config. With the current omission, the SkyPilot client falls through to the embedded-credentials branch in `RcloneStores.S3.get_config()`, bakes the expiring token into the rclone profile, ships it to the VM, and the FUSE mount returns EIO on every op once the token expires.

`AWSIdentityType.ENV` deliberately stays out of the set: long-lived `AKIA*` keys set via `AWS_ACCESS_KEY_ID` are non-expiring and embedding them is correct.

## Repro

A SkyPilot helm release on K8s, configured per the docs with `AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE`, submits a job with a `MOUNT_CACHED` file_mount on an `s3://` source. On the resulting training VM:

```
$ aws configure list
      Name                    Value             Type    Location
      ----                    -----             ----    --------
   profile                <not set>             None    None
access_key     ****************MAYI assume-role-with-web-identity
secret_key     ****************ljFI assume-role-with-web-identity
    region                us-west-2              env    AWS_DEFAULT_REGION

$ python3 -c 'from sky.clouds.aws import AWS; print(AWS._current_identity_type(), AWS.should_use_env_auth_for_s3())'
AWSIdentityType.ASSUME_ROLE False
```

The rendered `~/.config/rclone/rclone.conf` on the VM contains an `access_key_id = ASIA…` and matching `aws_session_token`. Roughly an hour after submission the FUSE mount returns `OSError: [Errno 5] Input/output error` on every write; `~/.sky/rclone_log/<hash>.log` records `operation error S3: …, api error InvalidAccessKeyId: The AWS Access Key Id you provided does not exist in our records.` for each op.

## Fix

Add `AWSIdentityType.ASSUME_ROLE` to the `non_static_types` set in `should_use_env_auth_for_s3`. After the patch, the same identity yields `env_auth = true` and the VM walks its own SDK chain (instance profile via IMDSv2 on AWS-launched VMs).

The substring matching inside `_current_identity_type` already routes `assume-role-with-web-identity` rows from `aws configure list` to `AWSIdentityType.ASSUME_ROLE` (the `'assume-role'` value is a prefix of `'assume-role-with-web-identity'`), so a single enum addition catches both paths without introducing a new enum member.

## Tested

- [x] Code formatting: `bash format.sh` clean against `sky/clouds/aws.py` and `tests/unit_tests/test_sky/clouds/test_aws_cloud.py` (yapf-0.32.0 no-op, pylint 10.00/10, mypy clean).
- [x] New unit tests: `tests/unit_tests/test_sky/clouds/test_aws_cloud.py::TestAwsAssumeRoleEnvAuth` covers both `assume-role-with-web-identity` (IRSA) and plain `assume-role` (CLI) → `AWSIdentityType.ASSUME_ROLE` → `should_use_env_auth_for_s3() is True`. Full `test_aws_cloud.py` module: 39 pre-existing tests + 2 new tests, all pass.
- [x] Manual end-to-end verification on a federated SkyPilot API pod with a real AWS training task: pre-patch the rendered rclone config contains `ASIA*` access_key_id / matching session token and FUSE writes EIO once the token expires; post-patch the config is `env_auth = true` and orbax checkpoint mkdir, dataset reads, and end-of-task model export all succeed against the FUSE mount.

Earlier review on the previous commit (`5864e7491`) suggested an `AWS_WEB_IDENTITY_TOKEN_FILE` env var check; that approach also worked but papered over the deeper classifier gap (`ASSUME_ROLE` already being the correct return value, just missing from `non_static_types`). This revision drops the env-var check in favour of the single-set-entry addition. `AWS_SESSION_TOKEN` was also suggested as an additional signal but is unsafe — that variable is set by many flows including legitimate long-lived ENV-resolved sessions where embedding remains correct.