### PR TITLE
[Dashboard] Batch edit user roles and workspace allowed_users

### DIFF
--- a/sky/dashboard/src/components/elements/ErrorDisplay.jsx
+++ b/sky/dashboard/src/components/elements/ErrorDisplay.jsx
@@ -56,7 +56,10 @@ export const ErrorDisplay = ({ error, title = 'Error', onDismiss }) => {
             </svg>
           </div>
           <div className="ml-3">
-            <div className="text-sm text-red-800">
+            {/* whitespace-pre-wrap so multi-line server error messages
+                (e.g. demotion failure with per-workspace bullets) keep
+                their \n line breaks instead of collapsing to one line. */}
+            <div className="text-sm text-red-800 whitespace-pre-wrap">
               <strong>{title}:</strong> {displayError}
             </div>
           </div>

--- a/sky/dashboard/src/components/users-batch-dialogs.jsx
+++ b/sky/dashboard/src/components/users-batch-dialogs.jsx
@@ -12,12 +12,22 @@ import {
   DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { batchUpdateUserRoles } from '@/data/connectors/users';
 import {
   batchAddUsersToWorkspaces,
   batchRemoveUsersFromWorkspaces,
   getWorkspaces,
 } from '@/data/connectors/workspaces';
+import dashboardCache from '@/lib/cache';
+
+const FOOTER_BUTTON_CLASS = 'min-w-[80px]';
 
 /**
  * Renders the per-item result summary returned by the batch endpoints.
@@ -29,15 +39,15 @@ function ResultSummary({ result, idKey, idLabel }) {
   const succeeded = result.succeeded || [];
   const failed = result.failed || [];
   return (
-    <div className="text-sm space-y-2">
-      <div>
-        <span className="font-medium text-green-700">
+    <div className="space-y-3 py-2 text-sm">
+      <div className="text-gray-700">
+        <span className="font-medium text-green-600">
           {succeeded.length} succeeded
         </span>
         {failed.length > 0 && (
           <>
             {', '}
-            <span className="font-medium text-red-700">
+            <span className="font-medium text-red-600">
               {failed.length} failed
             </span>
           </>
@@ -45,15 +55,17 @@ function ResultSummary({ result, idKey, idLabel }) {
         .
       </div>
       {failed.length > 0 && (
-        <div className="border border-red-200 rounded p-2 bg-red-50 max-h-48 overflow-y-auto">
-          <div className="text-xs font-medium text-red-700 mb-1">Failures:</div>
-          <ul className="list-disc list-inside space-y-1">
+        <div className="border border-gray-200 rounded-md max-h-48 overflow-y-auto">
+          <div className="px-3 py-2 text-xs font-medium text-gray-700 border-b border-gray-200 bg-gray-50">
+            Failures
+          </div>
+          <ul className="divide-y divide-gray-100">
             {failed.map((f, i) => (
-              <li key={i} className="text-xs text-red-700">
-                <span className="font-mono">
+              <li key={i} className="px-3 py-2 text-xs text-gray-700">
+                <span className="font-mono text-gray-500">
                   {idLabel}={f[idKey]}
                 </span>
-                : {f.error}
+                <span className="ml-2 text-red-600">{f.error}</span>
               </li>
             ))}
           </ul>
@@ -69,12 +81,37 @@ ResultSummary.propTypes = {
   idLabel: PropTypes.string.isRequired,
 };
 
-export function BatchRoleDialog({
-  open,
-  onClose,
-  selectedUsers, // [{ userId, usernameDisplay, role }]
-  onCompleted,
-}) {
+function SelectedUsersPanel({ selectedUsers, includeRole = false }) {
+  return (
+    <div className="border border-gray-200 rounded-md">
+      <div className="px-3 py-2 text-xs font-medium text-gray-700 border-b border-gray-200 bg-gray-50">
+        {includeRole
+          ? 'Affected users'
+          : `Selected users (${selectedUsers.length})`}
+      </div>
+      <div className="max-h-32 overflow-y-auto divide-y divide-gray-100">
+        {selectedUsers.map((u) => (
+          <div
+            key={u.userId}
+            className="px-3 py-1.5 text-xs text-gray-700 truncate"
+          >
+            {u.usernameDisplay || u.userId}
+            {includeRole && (
+              <span className="text-gray-400"> ({u.role || '-'})</span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+SelectedUsersPanel.propTypes = {
+  selectedUsers: PropTypes.array.isRequired,
+  includeRole: PropTypes.bool,
+};
+
+export function BatchRoleDialog({ open, onClose, selectedUsers }) {
   const [role, setRole] = useState('user');
   const [submitting, setSubmitting] = useState(false);
   const [result, setResult] = useState(null);
@@ -96,7 +133,6 @@ export function BatchRoleDialog({
       const userIds = selectedUsers.map((u) => u.userId);
       const res = await batchUpdateUserRoles(userIds, role);
       setResult(res);
-      onCompleted?.(res);
     } catch (e) {
       setError(e?.message || String(e));
     } finally {
@@ -126,36 +162,32 @@ export function BatchRoleDialog({
 
         {!result && (
           <>
-            <div className="space-y-3 py-2">
-              <div>
+            <div className="flex flex-col gap-4 py-2">
+              <div className="grid gap-2">
                 <label
                   htmlFor="batch-role-select"
-                  className="block text-sm font-medium text-gray-700 mb-1"
+                  className="text-sm font-medium text-gray-700"
                 >
                   New role
                 </label>
-                <select
-                  id="batch-role-select"
+                <Select
                   value={role}
-                  onChange={(e) => setRole(e.target.value)}
-                  className="block w-full p-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-sky-blue focus:border-sky-blue text-sm"
+                  onValueChange={setRole}
                   disabled={submitting}
                 >
-                  <option value="admin">Admin</option>
-                  <option value="user">User</option>
-                </select>
+                  <SelectTrigger
+                    id="batch-role-select"
+                    className="w-full focus:ring-0 focus:ring-offset-0"
+                  >
+                    <SelectValue placeholder="Select role" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="admin">Admin</SelectItem>
+                    <SelectItem value="user">User</SelectItem>
+                  </SelectContent>
+                </Select>
               </div>
-              <div className="text-xs text-gray-500 border border-gray-200 rounded p-2 max-h-32 overflow-y-auto">
-                <div className="font-medium text-gray-700 mb-1">
-                  Affected users
-                </div>
-                {selectedUsers.map((u) => (
-                  <div key={u.userId} className="truncate">
-                    {u.usernameDisplay || u.userId}
-                    <span className="text-gray-400"> ({u.role || '-'})</span>
-                  </div>
-                ))}
-              </div>
+              <SelectedUsersPanel selectedUsers={selectedUsers} includeRole />
               {error && <div className="text-sm text-red-600">{error}</div>}
             </div>
             <DialogFooter>
@@ -163,10 +195,16 @@ export function BatchRoleDialog({
                 variant="outline"
                 onClick={() => onClose(false)}
                 disabled={submitting}
+                className={FOOTER_BUTTON_CLASS}
               >
                 Cancel
               </Button>
-              <Button onClick={handleApply} disabled={submitting}>
+              <Button
+                variant="default"
+                onClick={handleApply}
+                disabled={submitting}
+                className={`bg-sky-600 text-white hover:bg-sky-700 ${FOOTER_BUTTON_CLASS}`}
+              >
                 {submitting ? (
                   <>
                     <CircularProgress size={14} className="mr-2" /> Applying...
@@ -186,6 +224,7 @@ export function BatchRoleDialog({
               <Button
                 variant="outline"
                 onClick={() => onClose(allDoneSuccessfully)}
+                className={FOOTER_BUTTON_CLASS}
               >
                 Close
               </Button>
@@ -201,7 +240,6 @@ BatchRoleDialog.propTypes = {
   open: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   selectedUsers: PropTypes.array.isRequired,
-  onCompleted: PropTypes.func,
 };
 
 function WorkspacePickerDialog({
@@ -212,7 +250,6 @@ function WorkspacePickerDialog({
   applyLabel,
   selectedUsers,
   variant, // 'add' | 'remove'
-  onCompleted,
 }) {
   const [workspaces, setWorkspaces] = useState({});
   const [loadingWorkspaces, setLoadingWorkspaces] = useState(false);
@@ -224,20 +261,78 @@ function WorkspacePickerDialog({
 
   useEffect(() => {
     if (!open) return;
+    let cancelled = false;
     setPicked(new Set());
     setSubmitting(false);
     setResult(null);
     setError(null);
     setLoadingWorkspaces(true);
     setLoadError(null);
-    getWorkspaces()
+    // Use the shared cache so we hit the same path other dashboard pages use
+    // and avoid making a fresh /workspaces poll for every dialog open.
+    const fetchWithRetry = async () => {
+      const maxAttempts = 3;
+      let lastErr = null;
+      for (let i = 0; i < maxAttempts; i++) {
+        try {
+          return await dashboardCache.get(getWorkspaces);
+        } catch (e) {
+          lastErr = e;
+          // Brief backoff between retries to give the API task time to
+          // finish on slow servers. This addresses transient polling
+          // failures on a fresh /workspaces request.
+          if (i < maxAttempts - 1) {
+            await new Promise((r) => setTimeout(r, 300));
+          }
+        }
+      }
+      throw lastErr;
+    };
+    fetchWithRetry()
       .then((data) => {
+        if (cancelled) return;
         setWorkspaces(data || {});
       })
       .catch((e) => {
-        setLoadError(e?.message || String(e));
+        if (cancelled) return;
+        console.error('Failed to load workspaces for batch dialog', e);
+        // Try to extract a meaningful server-side message from the raw
+        // error string emitted by getWorkspaces ("Error fetching workspace
+        // data for request ID <id>: <innerDetail>") — innerDetail may be a
+        // JSON string with nested {type, message} or already be an object
+        // serialized as "[object Object]".
+        const rawMessage = e?.message || String(e);
+        let detail = '';
+        try {
+          // Look for the JSON tail after the request-id prefix.
+          const jsonStart = rawMessage.indexOf('{');
+          if (jsonStart !== -1) {
+            const tail = rawMessage.slice(jsonStart);
+            const parsed = JSON.parse(tail);
+            if (parsed && typeof parsed.message === 'string') {
+              detail = parsed.message;
+            }
+          }
+        } catch (_parseErr) {
+          /* Fall through to the generic message below. */
+        }
+        if (!detail && !rawMessage.includes('[object Object]')) {
+          // The raw message is human-readable already (e.g. when
+          // pollForTaskCompletion has already extracted a message).
+          detail = rawMessage;
+        }
+        setLoadError(
+          detail
+            ? `Unable to load workspaces: ${detail}`
+            : 'Unable to load workspaces. Check the API server config.'
+        );
       })
-      .finally(() => setLoadingWorkspaces(false));
+      .finally(() => {
+        if (!cancelled) setLoadingWorkspaces(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [open]);
 
   const privateWorkspaces = useMemo(() => {
@@ -246,15 +341,6 @@ function WorkspacePickerDialog({
       .map(([name, cfg]) => ({ name, config: cfg }))
       .sort((a, b) => a.name.localeCompare(b.name));
   }, [workspaces]);
-
-  const userIdSet = useMemo(
-    () => new Set(selectedUsers.map((u) => u.userId)),
-    [selectedUsers]
-  );
-  const usernameSet = useMemo(
-    () => new Set(selectedUsers.map((u) => u.username).filter(Boolean)),
-    [selectedUsers]
-  );
 
   // For the 'remove' variant: show which selected users are currently in
   // each workspace's allowed_users so admins can see what will change.
@@ -280,15 +366,19 @@ function WorkspacePickerDialog({
     setError(null);
     try {
       const workspaceNames = Array.from(picked);
-      const userIds = Array.from(userIdSet);
+      const userIds = selectedUsers.map((u) => u.userId);
       let res;
       if (variant === 'add') {
         res = await batchAddUsersToWorkspaces(workspaceNames, userIds);
       } else {
         res = await batchRemoveUsersFromWorkspaces(workspaceNames, userIds);
       }
+      // Invalidate the workspaces cache so the next dialog open (or any
+      // other workspace consumer) sees the new allowed_users instead of
+      // a stale snapshot. Without this, opening Remove after an Add shows
+      // "No selected user is in this workspace".
+      dashboardCache.invalidate(getWorkspaces);
       setResult(res);
-      onCompleted?.(res);
     } catch (e) {
       setError(e?.message || String(e));
     } finally {
@@ -314,76 +404,66 @@ function WorkspacePickerDialog({
 
         {!result && (
           <>
-            <div className="space-y-3 py-2">
+            <div className="flex flex-col gap-4 py-2">
               {loadingWorkspaces && (
                 <div className="flex items-center text-sm text-gray-500">
                   <CircularProgress size={14} className="mr-2" />
                   Loading workspaces...
                 </div>
               )}
-              {loadError && (
+              {!loadingWorkspaces && loadError && (
                 <div className="text-sm text-red-600">{loadError}</div>
               )}
-              {!loadingWorkspaces && !loadError && (
-                <>
-                  {privateWorkspaces.length === 0 ? (
-                    <div className="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded p-2">
-                      There are no private workspaces. Allowed users only apply
-                      to private workspaces.
-                    </div>
-                  ) : (
-                    <div className="border border-gray-200 rounded max-h-64 overflow-y-auto">
-                      {privateWorkspaces.map(({ name, config }) => {
-                        const isChecked = picked.has(name);
-                        const currentMembers =
-                          variant === 'remove'
-                            ? computeCurrentMembers(config)
-                            : null;
-                        return (
-                          <label
-                            key={name}
-                            className="flex items-start gap-2 p-2 hover:bg-gray-50 border-b border-gray-100 last:border-b-0 cursor-pointer"
-                          >
-                            <input
-                              type="checkbox"
-                              className="mt-1"
-                              checked={isChecked}
-                              onChange={() => togglePick(name)}
-                              disabled={submitting}
-                            />
-                            <div className="flex-1 min-w-0">
-                              <div className="text-sm font-medium text-gray-700 truncate">
-                                {name}
-                              </div>
-                              {variant === 'remove' && (
-                                <div className="text-xs text-gray-500 mt-0.5">
-                                  {currentMembers.length === 0
-                                    ? 'No selected user is in this workspace (no-op).'
-                                    : `Will remove: ${currentMembers
-                                        .map(
-                                          (u) => u.usernameDisplay || u.userId
-                                        )
-                                        .join(', ')}`}
-                                </div>
-                              )}
-                            </div>
-                          </label>
-                        );
-                      })}
-                    </div>
-                  )}
-                </>
-              )}
-              <div className="text-xs text-gray-500 border border-gray-200 rounded p-2 max-h-32 overflow-y-auto">
-                <div className="font-medium text-gray-700 mb-1">
-                  Selected users ({selectedUsers.length})
-                </div>
-                {selectedUsers.map((u) => (
-                  <div key={u.userId} className="truncate">
-                    {u.usernameDisplay || u.userId}
+              {!loadingWorkspaces &&
+                !loadError &&
+                privateWorkspaces.length === 0 && (
+                  <div className="text-sm text-gray-600 border border-gray-200 rounded-md px-3 py-2 bg-gray-50">
+                    No private workspaces are configured. Allowed users only
+                    apply to private workspaces.
                   </div>
-                ))}
-              </div>
+                )}
+              {!loadingWorkspaces &&
+                !loadError &&
+                privateWorkspaces.length > 0 && (
+                  <div className="border border-gray-200 rounded-md max-h-64 overflow-y-auto">
+                    {privateWorkspaces.map(({ name, config }) => {
+                      const isChecked = picked.has(name);
+                      const currentMembers =
+                        variant === 'remove'
+                          ? computeCurrentMembers(config)
+                          : null;
+                      return (
+                        <label
+                          key={name}
+                          className="flex items-start gap-3 px-3 py-2 hover:bg-gray-50 border-b border-gray-100 last:border-b-0 cursor-pointer"
+                        >
+                          <input
+                            type="checkbox"
+                            className="mt-0.5"
+                            checked={isChecked}
+                            onChange={() => togglePick(name)}
+                            disabled={submitting}
+                          />
+                          <div className="flex-1 min-w-0">
+                            <div className="text-sm text-gray-700 truncate">
+                              {name}
+                            </div>
+                            {variant === 'remove' && (
+                              <div className="text-xs text-gray-500 mt-0.5">
+                                {currentMembers.length === 0
+                                  ? 'No selected user is in this workspace (no-op).'
+                                  : `Will remove: ${currentMembers
+                                      .map((u) => u.usernameDisplay || u.userId)
+                                      .join(', ')}`}
+                              </div>
+                            )}
+                          </div>
+                        </label>
+                      );
+                    })}
+                  </div>
+                )}
+              <SelectedUsersPanel selectedUsers={selectedUsers} />
               {error && <div className="text-sm text-red-600">{error}</div>}
             </div>
             <DialogFooter>
@@ -391,21 +471,42 @@ function WorkspacePickerDialog({
                 variant="outline"
                 onClick={() => onClose(false)}
                 disabled={submitting}
+                className={FOOTER_BUTTON_CLASS}
               >
                 Cancel
               </Button>
-              <Button
-                onClick={handleApply}
-                disabled={submitting || picked.size === 0}
-              >
-                {submitting ? (
-                  <>
-                    <CircularProgress size={14} className="mr-2" /> Applying...
-                  </>
-                ) : (
-                  applyLabel
-                )}
-              </Button>
+              {variant === 'remove' ? (
+                <Button
+                  variant="destructive"
+                  onClick={handleApply}
+                  disabled={submitting || picked.size === 0}
+                  className={FOOTER_BUTTON_CLASS}
+                >
+                  {submitting ? (
+                    <>
+                      <CircularProgress size={14} className="mr-2" />{' '}
+                      Removing...
+                    </>
+                  ) : (
+                    applyLabel
+                  )}
+                </Button>
+              ) : (
+                <Button
+                  variant="default"
+                  onClick={handleApply}
+                  disabled={submitting || picked.size === 0}
+                  className={`bg-sky-600 text-white hover:bg-sky-700 ${FOOTER_BUTTON_CLASS}`}
+                >
+                  {submitting ? (
+                    <>
+                      <CircularProgress size={14} className="mr-2" /> Adding...
+                    </>
+                  ) : (
+                    applyLabel
+                  )}
+                </Button>
+              )}
             </DialogFooter>
           </>
         )}
@@ -421,6 +522,7 @@ function WorkspacePickerDialog({
               <Button
                 variant="outline"
                 onClick={() => onClose(allDoneSuccessfully)}
+                className={FOOTER_BUTTON_CLASS}
               >
                 Close
               </Button>
@@ -440,7 +542,6 @@ WorkspacePickerDialog.propTypes = {
   applyLabel: PropTypes.string.isRequired,
   selectedUsers: PropTypes.array.isRequired,
   variant: PropTypes.oneOf(['add', 'remove']).isRequired,
-  onCompleted: PropTypes.func,
 };
 
 export function BatchAddToWorkspacesDialog(props) {

--- a/sky/dashboard/src/components/users-batch-dialogs.jsx
+++ b/sky/dashboard/src/components/users-batch-dialogs.jsx
@@ -268,64 +268,16 @@ function WorkspacePickerDialog({
     setError(null);
     setLoadingWorkspaces(true);
     setLoadError(null);
-    // Use the shared cache so we hit the same path other dashboard pages use
-    // and avoid making a fresh /workspaces poll for every dialog open.
-    const fetchWithRetry = async () => {
-      const maxAttempts = 3;
-      let lastErr = null;
-      for (let i = 0; i < maxAttempts; i++) {
-        try {
-          return await dashboardCache.get(getWorkspaces);
-        } catch (e) {
-          lastErr = e;
-          // Brief backoff between retries to give the API task time to
-          // finish on slow servers. This addresses transient polling
-          // failures on a fresh /workspaces request.
-          if (i < maxAttempts - 1) {
-            await new Promise((r) => setTimeout(r, 300));
-          }
-        }
-      }
-      throw lastErr;
-    };
-    fetchWithRetry()
+    dashboardCache
+      .get(getWorkspaces)
       .then((data) => {
         if (cancelled) return;
         setWorkspaces(data || {});
       })
       .catch((e) => {
         if (cancelled) return;
-        console.error('Failed to load workspaces for batch dialog', e);
-        // Try to extract a meaningful server-side message from the raw
-        // error string emitted by getWorkspaces ("Error fetching workspace
-        // data for request ID <id>: <innerDetail>") — innerDetail may be a
-        // JSON string with nested {type, message} or already be an object
-        // serialized as "[object Object]".
-        const rawMessage = e?.message || String(e);
-        let detail = '';
-        try {
-          // Look for the JSON tail after the request-id prefix.
-          const jsonStart = rawMessage.indexOf('{');
-          if (jsonStart !== -1) {
-            const tail = rawMessage.slice(jsonStart);
-            const parsed = JSON.parse(tail);
-            if (parsed && typeof parsed.message === 'string') {
-              detail = parsed.message;
-            }
-          }
-        } catch (_parseErr) {
-          /* Fall through to the generic message below. */
-        }
-        if (!detail && !rawMessage.includes('[object Object]')) {
-          // The raw message is human-readable already (e.g. when
-          // pollForTaskCompletion has already extracted a message).
-          detail = rawMessage;
-        }
-        setLoadError(
-          detail
-            ? `Unable to load workspaces: ${detail}`
-            : 'Unable to load workspaces. Check the API server config.'
-        );
+        console.error('Error fetching workspaces:', e);
+        setLoadError('Unable to load workspaces. Please try again.');
       })
       .finally(() => {
         if (!cancelled) setLoadingWorkspaces(false);

--- a/sky/dashboard/src/components/users-batch-dialogs.jsx
+++ b/sky/dashboard/src/components/users-batch-dialogs.jsx
@@ -298,8 +298,11 @@ function WorkspacePickerDialog({
       .sort((a, b) => a.name.localeCompare(b.name));
   }, [workspaces]);
 
-  // For the 'remove' variant: show which selected users are currently in
-  // each workspace's allowed_users so admins can see what will change.
+  // Returns the subset of selectedUsers already listed in this
+  // workspace's allowed_users. Used in both variants:
+  //  - 'remove': these are the users that will actually be removed.
+  //  - 'add':    these are the users for whom the add is a no-op
+  //              (already in allowed_users).
   const computeCurrentMembers = (config) => {
     const allowed = config.allowed_users || [];
     return selectedUsers.filter(
@@ -384,10 +387,26 @@ function WorkspacePickerDialog({
                   <div className="border border-gray-200 rounded-md max-h-64 overflow-y-auto">
                     {privateWorkspaces.map(({ name, config }) => {
                       const isChecked = picked.has(name);
-                      const currentMembers =
-                        variant === 'remove'
-                          ? computeCurrentMembers(config)
-                          : null;
+                      const currentMembers = computeCurrentMembers(config);
+                      // currentMembers is `selectedUsers.filter(...)` so the
+                      // elements are the same references as in selectedUsers
+                      // -- a direct .includes(u) gives us the complement.
+                      const newMembers = selectedUsers.filter(
+                        (u) => !currentMembers.includes(u)
+                      );
+                      const fmt = (us) =>
+                        us.map((u) => u.usernameDisplay || u.userId).join(', ');
+                      let addHint = null;
+                      if (variant === 'add') {
+                        if (newMembers.length === 0) {
+                          addHint =
+                            'All selected users are already in this workspace (no-op).';
+                        } else if (currentMembers.length === 0) {
+                          addHint = `Will add: ${fmt(newMembers)}`;
+                        } else {
+                          addHint = `Will add: ${fmt(newMembers)}. Already in: ${fmt(currentMembers)}`;
+                        }
+                      }
                       return (
                         <label
                           key={name}
@@ -408,9 +427,12 @@ function WorkspacePickerDialog({
                               <div className="text-xs text-gray-500 mt-0.5">
                                 {currentMembers.length === 0
                                   ? 'No selected user is in this workspace (no-op).'
-                                  : `Will remove: ${currentMembers
-                                      .map((u) => u.usernameDisplay || u.userId)
-                                      .join(', ')}`}
+                                  : `Will remove: ${fmt(currentMembers)}`}
+                              </div>
+                            )}
+                            {variant === 'add' && (
+                              <div className="text-xs text-gray-500 mt-0.5">
+                                {addHint}
                               </div>
                             )}
                           </div>

--- a/sky/dashboard/src/components/users-batch-dialogs.jsx
+++ b/sky/dashboard/src/components/users-batch-dialogs.jsx
@@ -65,7 +65,11 @@ function ResultSummary({ result, idKey, idLabel }) {
                 <span className="font-mono text-gray-500">
                   {idLabel}={f[idKey]}
                 </span>
-                <span className="ml-2 text-red-600">{f.error}</span>
+                {/* whitespace-pre-wrap renders the \n in server error
+                    messages as actual line breaks. */}
+                <span className="ml-2 text-red-600 whitespace-pre-wrap">
+                  {f.error}
+                </span>
               </li>
             ))}
           </ul>

--- a/sky/dashboard/src/components/users-batch-dialogs.jsx
+++ b/sky/dashboard/src/components/users-batch-dialogs.jsx
@@ -1,0 +1,480 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { CircularProgress } from '@mui/material';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { batchUpdateUserRoles } from '@/data/connectors/users';
+import {
+  batchAddUsersToWorkspaces,
+  batchRemoveUsersFromWorkspaces,
+  getWorkspaces,
+} from '@/data/connectors/workspaces';
+
+/**
+ * Renders the per-item result summary returned by the batch endpoints.
+ * Both the user-role batch and the workspace batch endpoints return the
+ * shape { succeeded: [...], failed: [{ <key>, error }] }.
+ */
+function ResultSummary({ result, idKey, idLabel }) {
+  if (!result) return null;
+  const succeeded = result.succeeded || [];
+  const failed = result.failed || [];
+  return (
+    <div className="text-sm space-y-2">
+      <div>
+        <span className="font-medium text-green-700">
+          {succeeded.length} succeeded
+        </span>
+        {failed.length > 0 && (
+          <>
+            {', '}
+            <span className="font-medium text-red-700">
+              {failed.length} failed
+            </span>
+          </>
+        )}
+        .
+      </div>
+      {failed.length > 0 && (
+        <div className="border border-red-200 rounded p-2 bg-red-50 max-h-48 overflow-y-auto">
+          <div className="text-xs font-medium text-red-700 mb-1">Failures:</div>
+          <ul className="list-disc list-inside space-y-1">
+            {failed.map((f, i) => (
+              <li key={i} className="text-xs text-red-700">
+                <span className="font-mono">
+                  {idLabel}={f[idKey]}
+                </span>
+                : {f.error}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+ResultSummary.propTypes = {
+  result: PropTypes.object,
+  idKey: PropTypes.string.isRequired,
+  idLabel: PropTypes.string.isRequired,
+};
+
+export function BatchRoleDialog({
+  open,
+  onClose,
+  selectedUsers, // [{ userId, usernameDisplay, role }]
+  onCompleted,
+}) {
+  const [role, setRole] = useState('user');
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (open) {
+      setRole('user');
+      setSubmitting(false);
+      setResult(null);
+      setError(null);
+    }
+  }, [open]);
+
+  const handleApply = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const userIds = selectedUsers.map((u) => u.userId);
+      const res = await batchUpdateUserRoles(userIds, role);
+      setResult(res);
+      onCompleted?.(res);
+    } catch (e) {
+      setError(e?.message || String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const allDoneSuccessfully =
+    result && (!result.failed || result.failed.length === 0);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o && !submitting) onClose(allDoneSuccessfully);
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            Change role for {selectedUsers.length} user(s)
+          </DialogTitle>
+          <DialogDescription>
+            Apply the selected role to all selected users.
+          </DialogDescription>
+        </DialogHeader>
+
+        {!result && (
+          <>
+            <div className="space-y-3 py-2">
+              <div>
+                <label
+                  htmlFor="batch-role-select"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
+                  New role
+                </label>
+                <select
+                  id="batch-role-select"
+                  value={role}
+                  onChange={(e) => setRole(e.target.value)}
+                  className="block w-full p-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-sky-blue focus:border-sky-blue text-sm"
+                  disabled={submitting}
+                >
+                  <option value="admin">Admin</option>
+                  <option value="user">User</option>
+                </select>
+              </div>
+              <div className="text-xs text-gray-500 border border-gray-200 rounded p-2 max-h-32 overflow-y-auto">
+                <div className="font-medium text-gray-700 mb-1">
+                  Affected users
+                </div>
+                {selectedUsers.map((u) => (
+                  <div key={u.userId} className="truncate">
+                    {u.usernameDisplay || u.userId}
+                    <span className="text-gray-400"> ({u.role || '-'})</span>
+                  </div>
+                ))}
+              </div>
+              {error && <div className="text-sm text-red-600">{error}</div>}
+            </div>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => onClose(false)}
+                disabled={submitting}
+              >
+                Cancel
+              </Button>
+              <Button onClick={handleApply} disabled={submitting}>
+                {submitting ? (
+                  <>
+                    <CircularProgress size={14} className="mr-2" /> Applying...
+                  </>
+                ) : (
+                  'Apply'
+                )}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {result && (
+          <>
+            <ResultSummary result={result} idKey="user_id" idLabel="user_id" />
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => onClose(allDoneSuccessfully)}
+              >
+                Close
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+BatchRoleDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  selectedUsers: PropTypes.array.isRequired,
+  onCompleted: PropTypes.func,
+};
+
+function WorkspacePickerDialog({
+  open,
+  onClose,
+  title,
+  description,
+  applyLabel,
+  selectedUsers,
+  variant, // 'add' | 'remove'
+  onCompleted,
+}) {
+  const [workspaces, setWorkspaces] = useState({});
+  const [loadingWorkspaces, setLoadingWorkspaces] = useState(false);
+  const [loadError, setLoadError] = useState(null);
+  const [picked, setPicked] = useState(new Set());
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setPicked(new Set());
+    setSubmitting(false);
+    setResult(null);
+    setError(null);
+    setLoadingWorkspaces(true);
+    setLoadError(null);
+    getWorkspaces()
+      .then((data) => {
+        setWorkspaces(data || {});
+      })
+      .catch((e) => {
+        setLoadError(e?.message || String(e));
+      })
+      .finally(() => setLoadingWorkspaces(false));
+  }, [open]);
+
+  const privateWorkspaces = useMemo(() => {
+    return Object.entries(workspaces)
+      .filter(([, cfg]) => cfg && cfg.private)
+      .map(([name, cfg]) => ({ name, config: cfg }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [workspaces]);
+
+  const userIdSet = useMemo(
+    () => new Set(selectedUsers.map((u) => u.userId)),
+    [selectedUsers]
+  );
+  const usernameSet = useMemo(
+    () => new Set(selectedUsers.map((u) => u.username).filter(Boolean)),
+    [selectedUsers]
+  );
+
+  // For the 'remove' variant: show which selected users are currently in
+  // each workspace's allowed_users so admins can see what will change.
+  const computeCurrentMembers = (config) => {
+    const allowed = config.allowed_users || [];
+    return selectedUsers.filter(
+      (u) => allowed.includes(u.userId) || allowed.includes(u.username)
+    );
+  };
+
+  const togglePick = (name) => {
+    const next = new Set(picked);
+    if (next.has(name)) {
+      next.delete(name);
+    } else {
+      next.add(name);
+    }
+    setPicked(next);
+  };
+
+  const handleApply = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const workspaceNames = Array.from(picked);
+      const userIds = Array.from(userIdSet);
+      let res;
+      if (variant === 'add') {
+        res = await batchAddUsersToWorkspaces(workspaceNames, userIds);
+      } else {
+        res = await batchRemoveUsersFromWorkspaces(workspaceNames, userIds);
+      }
+      setResult(res);
+      onCompleted?.(res);
+    } catch (e) {
+      setError(e?.message || String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const allDoneSuccessfully =
+    result && (!result.failed || result.failed.length === 0);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o && !submitting) onClose(allDoneSuccessfully);
+      }}
+    >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        {!result && (
+          <>
+            <div className="space-y-3 py-2">
+              {loadingWorkspaces && (
+                <div className="flex items-center text-sm text-gray-500">
+                  <CircularProgress size={14} className="mr-2" />
+                  Loading workspaces...
+                </div>
+              )}
+              {loadError && (
+                <div className="text-sm text-red-600">{loadError}</div>
+              )}
+              {!loadingWorkspaces && !loadError && (
+                <>
+                  {privateWorkspaces.length === 0 ? (
+                    <div className="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded p-2">
+                      There are no private workspaces. Allowed users only apply
+                      to private workspaces.
+                    </div>
+                  ) : (
+                    <div className="border border-gray-200 rounded max-h-64 overflow-y-auto">
+                      {privateWorkspaces.map(({ name, config }) => {
+                        const isChecked = picked.has(name);
+                        const currentMembers =
+                          variant === 'remove'
+                            ? computeCurrentMembers(config)
+                            : null;
+                        return (
+                          <label
+                            key={name}
+                            className="flex items-start gap-2 p-2 hover:bg-gray-50 border-b border-gray-100 last:border-b-0 cursor-pointer"
+                          >
+                            <input
+                              type="checkbox"
+                              className="mt-1"
+                              checked={isChecked}
+                              onChange={() => togglePick(name)}
+                              disabled={submitting}
+                            />
+                            <div className="flex-1 min-w-0">
+                              <div className="text-sm font-medium text-gray-700 truncate">
+                                {name}
+                              </div>
+                              {variant === 'remove' && (
+                                <div className="text-xs text-gray-500 mt-0.5">
+                                  {currentMembers.length === 0
+                                    ? 'No selected user is in this workspace (no-op).'
+                                    : `Will remove: ${currentMembers
+                                        .map(
+                                          (u) => u.usernameDisplay || u.userId
+                                        )
+                                        .join(', ')}`}
+                                </div>
+                              )}
+                            </div>
+                          </label>
+                        );
+                      })}
+                    </div>
+                  )}
+                </>
+              )}
+              <div className="text-xs text-gray-500 border border-gray-200 rounded p-2 max-h-32 overflow-y-auto">
+                <div className="font-medium text-gray-700 mb-1">
+                  Selected users ({selectedUsers.length})
+                </div>
+                {selectedUsers.map((u) => (
+                  <div key={u.userId} className="truncate">
+                    {u.usernameDisplay || u.userId}
+                  </div>
+                ))}
+              </div>
+              {error && <div className="text-sm text-red-600">{error}</div>}
+            </div>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => onClose(false)}
+                disabled={submitting}
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={handleApply}
+                disabled={submitting || picked.size === 0}
+              >
+                {submitting ? (
+                  <>
+                    <CircularProgress size={14} className="mr-2" /> Applying...
+                  </>
+                ) : (
+                  applyLabel
+                )}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {result && (
+          <>
+            <ResultSummary
+              result={result}
+              idKey="workspace_name"
+              idLabel="workspace"
+            />
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => onClose(allDoneSuccessfully)}
+              >
+                Close
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+WorkspacePickerDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  applyLabel: PropTypes.string.isRequired,
+  selectedUsers: PropTypes.array.isRequired,
+  variant: PropTypes.oneOf(['add', 'remove']).isRequired,
+  onCompleted: PropTypes.func,
+};
+
+export function BatchAddToWorkspacesDialog(props) {
+  return (
+    <WorkspacePickerDialog
+      {...props}
+      title={`Add ${props.selectedUsers.length} user(s) to workspaces`}
+      description="Pick the private workspaces to add the selected users to. Only private workspaces are listed because allowed_users has no effect on public workspaces."
+      applyLabel="Add"
+      variant="add"
+    />
+  );
+}
+
+BatchAddToWorkspacesDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  selectedUsers: PropTypes.array.isRequired,
+};
+
+export function BatchRemoveFromWorkspacesDialog(props) {
+  return (
+    <WorkspacePickerDialog
+      {...props}
+      title={`Remove ${props.selectedUsers.length} user(s) from workspaces`}
+      description="Pick the private workspaces to remove the selected users from. Removal is blocked if a user has active resources in that workspace."
+      applyLabel="Remove"
+      variant="remove"
+    />
+  );
+}
+
+BatchRemoveFromWorkspacesDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  selectedUsers: PropTypes.array.isRequired,
+};

--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -2128,6 +2128,16 @@ function UsersTable({
 
   const clearSelection = () => setSelectedUserIds(new Set());
 
+  // Esc clears the current selection (and dismisses the floating bar).
+  useEffect(() => {
+    if (selectedUserIds.size === 0) return undefined;
+    const handler = (e) => {
+      if (e.key === 'Escape') clearSelection();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [selectedUserIds.size]);
+
   const handleBulkDialogClose = async (fullySucceeded) => {
     setBulkDialog(null);
     if (fullySucceeded) {
@@ -2209,54 +2219,57 @@ function UsersTable({
         </div>
       )}
       {showBulkColumn && (
-        // Bar is always rendered (with disabled buttons + an empty-state
-        // hint when nothing is selected) so checking a row doesn't insert
-        // a new row above the table and shift the row under the cursor.
-        <div className="mb-2 flex items-center justify-between gap-3 px-3 py-2 bg-sky-50 border border-sky-200 rounded-md">
-          <div className="text-sm text-gray-700">
-            {selectedUserIds.size > 0 ? (
-              <>
-                Selected:{' '}
-                <span className="font-medium text-sky-blue">
-                  {selectedUserIds.size}
-                </span>{' '}
-                user(s)
-                <button
-                  type="button"
-                  onClick={clearSelection}
-                  className="ml-2 text-sky-blue hover:text-sky-blue-bright underline"
-                >
-                  Clear
-                </button>
-              </>
-            ) : (
-              <span className="text-gray-500">
-                Select users to enable batch actions
-              </span>
-            )}
-          </div>
-          <div className="flex items-center gap-2">
+        // Floating bottom-center action bar. Always mounted (so the
+        // slide animation works in both directions), but
+        // pointer-events-none + translate-y-full + opacity-0 when no
+        // selection so it occupies no visual space and can't be
+        // interacted with. No layout shift on the table itself.
+        <div
+          className={`fixed bottom-6 left-1/2 -translate-x-1/2 z-30 transition-all duration-200 ease-out ${
+            selectedUserIds.size > 0
+              ? 'opacity-100 translate-y-0'
+              : 'opacity-0 translate-y-[200%] pointer-events-none'
+          }`}
+          role="region"
+          aria-label="Batch user actions"
+          aria-hidden={selectedUserIds.size === 0}
+        >
+          <div className="flex items-center gap-3 px-4 py-2 bg-white border border-gray-200 shadow-lg rounded-full">
+            <div className="text-sm text-gray-700 whitespace-nowrap">
+              <span className="font-medium text-sky-blue">
+                {selectedUserIds.size}
+              </span>{' '}
+              selected
+            </div>
+            <button
+              type="button"
+              onClick={clearSelection}
+              className="text-sm text-sky-blue hover:text-sky-blue-bright underline whitespace-nowrap"
+            >
+              Clear
+            </button>
+            <div className="h-5 w-px bg-gray-200" aria-hidden="true" />
             <button
               type="button"
               onClick={() => openBulkDialog('role')}
-              disabled={roleLoading || selectedUserIds.size === 0}
-              className="bg-sky-600 hover:bg-sky-700 text-white flex items-center rounded-md px-3 py-1 text-sm font-medium transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={roleLoading}
+              className="bg-sky-600 hover:bg-sky-700 text-white flex items-center rounded-md px-3 py-1 text-sm font-medium transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
             >
               Change role
             </button>
             <button
               type="button"
               onClick={() => openBulkDialog('add')}
-              disabled={roleLoading || selectedUserIds.size === 0}
-              className="bg-sky-600 hover:bg-sky-700 text-white flex items-center rounded-md px-3 py-1 text-sm font-medium transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={roleLoading}
+              className="bg-sky-600 hover:bg-sky-700 text-white flex items-center rounded-md px-3 py-1 text-sm font-medium transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
             >
               Add to workspaces
             </button>
             <button
               type="button"
               onClick={() => openBulkDialog('remove')}
-              disabled={roleLoading || selectedUserIds.size === 0}
-              className="bg-sky-600 hover:bg-sky-700 text-white flex items-center rounded-md px-3 py-1 text-sm font-medium transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={roleLoading}
+              className="bg-sky-600 hover:bg-sky-700 text-white flex items-center rounded-md px-3 py-1 text-sm font-medium transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
             >
               Remove from workspaces
             </button>

--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -972,6 +972,7 @@ export function Users() {
           setValueList={setValueList}
           deduplicateUsers={deduplicateUsers}
           setLastFetchedTime={setLastFetchedTime}
+          setCreateError={setCreateError}
         />
       ) : activeMainTab === 'service-accounts' ? (
         serviceAccountTokenEnabled && (
@@ -1407,6 +1408,7 @@ function UsersTable({
   setValueList,
   deduplicateUsers,
   setLastFetchedTime,
+  setCreateError,
 }) {
   const [usersWithCounts, setUsersWithCounts] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -2059,7 +2061,7 @@ function UsersTable({
   const handleSaveEdit = async (userId) => {
     if (!userId || !currentEditingRole) {
       console.error('User ID or role is missing.');
-      alert('Error: User ID or role is missing.');
+      setCreateError(new Error('User ID or role is missing.'));
       return;
     }
     setIsLoading(true); // Or use parent setLoading
@@ -2078,7 +2080,8 @@ function UsersTable({
       handleCancelEdit(); // Exit edit mode
     } catch (error) {
       console.error('Failed to update user role:', error);
-      alert(`Error updating role: ${error.message}`);
+      handleCancelEdit();
+      setCreateError(error);
     } finally {
       setIsLoading(false); // Or use parent setLoading
     }
@@ -2205,27 +2208,38 @@ function UsersTable({
           {filteredAndSortedUsers.length === 1 ? 'user' : 'users'}
         </div>
       )}
-      {showBulkColumn && selectedUserIds.size > 0 && (
+      {showBulkColumn && (
+        // Bar is always rendered (with disabled buttons + an empty-state
+        // hint when nothing is selected) so checking a row doesn't insert
+        // a new row above the table and shift the row under the cursor.
         <div className="mb-2 flex items-center justify-between gap-3 px-3 py-2 bg-sky-50 border border-sky-200 rounded-md">
           <div className="text-sm text-gray-700">
-            Selected:{' '}
-            <span className="font-medium text-sky-blue">
-              {selectedUserIds.size}
-            </span>{' '}
-            user(s)
-            <button
-              type="button"
-              onClick={clearSelection}
-              className="ml-2 text-sky-blue hover:text-sky-blue-bright underline"
-            >
-              Clear
-            </button>
+            {selectedUserIds.size > 0 ? (
+              <>
+                Selected:{' '}
+                <span className="font-medium text-sky-blue">
+                  {selectedUserIds.size}
+                </span>{' '}
+                user(s)
+                <button
+                  type="button"
+                  onClick={clearSelection}
+                  className="ml-2 text-sky-blue hover:text-sky-blue-bright underline"
+                >
+                  Clear
+                </button>
+              </>
+            ) : (
+              <span className="text-gray-500">
+                Select users to enable batch actions
+              </span>
+            )}
           </div>
           <div className="flex items-center gap-2">
             <button
               type="button"
               onClick={() => openBulkDialog('role')}
-              disabled={roleLoading}
+              disabled={roleLoading || selectedUserIds.size === 0}
               className="bg-sky-600 hover:bg-sky-700 text-white flex items-center rounded-md px-3 py-1 text-sm font-medium transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Change role
@@ -2233,7 +2247,7 @@ function UsersTable({
             <button
               type="button"
               onClick={() => openBulkDialog('add')}
-              disabled={roleLoading}
+              disabled={roleLoading || selectedUserIds.size === 0}
               className="bg-sky-600 hover:bg-sky-700 text-white flex items-center rounded-md px-3 py-1 text-sm font-medium transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Add to workspaces
@@ -2241,7 +2255,7 @@ function UsersTable({
             <button
               type="button"
               onClick={() => openBulkDialog('remove')}
-              disabled={roleLoading}
+              disabled={roleLoading || selectedUserIds.size === 0}
               className="bg-sky-600 hover:bg-sky-700 text-white flex items-center rounded-md px-3 py-1 text-sm font-medium transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Remove from workspaces
@@ -2608,6 +2622,7 @@ UsersTable.propTypes = {
   currentUserRole: PropTypes.string,
   currentUserId: PropTypes.string,
   setLastFetchedTime: PropTypes.func,
+  setCreateError: PropTypes.func.isRequired,
 };
 
 // Service Account Tokens Management Component

--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -2206,43 +2206,46 @@ function UsersTable({
         </div>
       )}
       {showBulkColumn && selectedUserIds.size > 0 && (
-        <div className="mb-2 flex items-center justify-between gap-3 px-3 py-2 bg-blue-50 border border-blue-200 rounded">
-          <div className="text-sm text-blue-800">
+        <div className="mb-2 flex items-center justify-between gap-3 px-3 py-2 bg-sky-50 border border-sky-200 rounded-md">
+          <div className="text-sm text-gray-700">
             Selected:{' '}
-            <span className="font-medium">{selectedUserIds.size}</span> user(s)
+            <span className="font-medium text-sky-blue">
+              {selectedUserIds.size}
+            </span>{' '}
+            user(s)
             <button
               type="button"
               onClick={clearSelection}
-              className="ml-2 text-blue-700 underline hover:text-blue-900"
+              className="ml-2 text-sky-blue hover:text-sky-blue-bright underline"
             >
               Clear
             </button>
           </div>
           <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              size="sm"
+            <button
+              type="button"
               onClick={() => openBulkDialog('role')}
               disabled={roleLoading}
+              className="bg-sky-600 hover:bg-sky-700 text-white flex items-center rounded-md px-3 py-1 text-sm font-medium transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Change role
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
+            </button>
+            <button
+              type="button"
               onClick={() => openBulkDialog('add')}
               disabled={roleLoading}
+              className="bg-sky-600 hover:bg-sky-700 text-white flex items-center rounded-md px-3 py-1 text-sm font-medium transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Add to workspaces
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
+            </button>
+            <button
+              type="button"
               onClick={() => openBulkDialog('remove')}
               disabled={roleLoading}
+              className="bg-sky-600 hover:bg-sky-700 text-white flex items-center rounded-md px-3 py-1 text-sm font-medium transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Remove from workspaces
-            </Button>
+            </button>
           </div>
         </div>
       )}

--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -66,6 +66,11 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import { ErrorDisplay } from '@/components/elements/ErrorDisplay';
+import {
+  BatchRoleDialog,
+  BatchAddToWorkspacesDialog,
+  BatchRemoveFromWorkspacesDialog,
+} from '@/components/users-batch-dialogs';
 import { PluginSlot } from '@/plugins/PluginSlot';
 import { statusGroups } from '@/components/jobs';
 import {
@@ -1413,6 +1418,12 @@ function UsersTable({
   const [editingUserId, setEditingUserId] = useState(null);
   const [currentEditingRole, setCurrentEditingRole] = useState('');
 
+  // Multi-select state for batch operations on users.
+  // Only enabled when the current user is an admin (the checkbox column is
+  // hidden otherwise). System users cannot be selected.
+  const [selectedUserIds, setSelectedUserIds] = useState(new Set());
+  const [bulkDialog, setBulkDialog] = useState(null); // 'role' | 'add' | 'remove'
+
   // Lookup dictionary for GPU type and infra filtering
   // Structure: infra -> gpuType -> userId -> { clusterCount, jobCount, gpuCount }
   const [combinedLookup, setCombinedLookup] = useState({});
@@ -2073,6 +2084,72 @@ function UsersTable({
     }
   };
 
+  // Users that are eligible to be selected for batch operations.
+  // System users (e.g., dashboard, system API user) are excluded.
+  const selectableUsers = useMemo(
+    () => (filteredAndSortedUsers || []).filter((u) => u.userType !== 'system'),
+    [filteredAndSortedUsers]
+  );
+
+  const allOnPageSelected =
+    selectableUsers.length > 0 &&
+    selectableUsers.every((u) => selectedUserIds.has(u.userId));
+  const someOnPageSelected =
+    !allOnPageSelected &&
+    selectableUsers.some((u) => selectedUserIds.has(u.userId));
+
+  const showBulkColumn =
+    currentUserRole === 'admin' &&
+    !deduplicateUsers &&
+    !ingressBasicAuthEnabled;
+
+  const toggleSelectAllOnPage = () => {
+    const next = new Set(selectedUserIds);
+    if (allOnPageSelected) {
+      selectableUsers.forEach((u) => next.delete(u.userId));
+    } else {
+      selectableUsers.forEach((u) => next.add(u.userId));
+    }
+    setSelectedUserIds(next);
+  };
+
+  const toggleSelectOne = (userId) => {
+    const next = new Set(selectedUserIds);
+    if (next.has(userId)) {
+      next.delete(userId);
+    } else {
+      next.add(userId);
+    }
+    setSelectedUserIds(next);
+  };
+
+  const clearSelection = () => setSelectedUserIds(new Set());
+
+  const handleBulkDialogClose = async (fullySucceeded) => {
+    setBulkDialog(null);
+    if (fullySucceeded) {
+      clearSelection();
+      dashboardCache.invalidate(getUsers);
+      await fetchDataAndProcess(true);
+    } else {
+      // Refresh even on partial failure so the table reflects the rows that
+      // did succeed; keep the selection so the admin can retry failures.
+      dashboardCache.invalidate(getUsers);
+      await fetchDataAndProcess(false);
+    }
+  };
+
+  const openBulkDialog = async (kind) => {
+    await checkPermissionAndAct(`cannot perform bulk ${kind} on users`, () =>
+      setBulkDialog(kind)
+    );
+  };
+
+  const selectedUserObjects = useMemo(
+    () => (usersWithCounts || []).filter((u) => selectedUserIds.has(u.userId)),
+    [usersWithCounts, selectedUserIds]
+  );
+
   if (isLoading && usersWithCounts.length === 0 && !hasInitiallyLoaded) {
     return (
       <div className="flex justify-center items-center h-64">
@@ -2128,11 +2205,65 @@ function UsersTable({
           {filteredAndSortedUsers.length === 1 ? 'user' : 'users'}
         </div>
       )}
+      {showBulkColumn && selectedUserIds.size > 0 && (
+        <div className="mb-2 flex items-center justify-between gap-3 px-3 py-2 bg-blue-50 border border-blue-200 rounded">
+          <div className="text-sm text-blue-800">
+            Selected:{' '}
+            <span className="font-medium">{selectedUserIds.size}</span> user(s)
+            <button
+              type="button"
+              onClick={clearSelection}
+              className="ml-2 text-blue-700 underline hover:text-blue-900"
+            >
+              Clear
+            </button>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => openBulkDialog('role')}
+              disabled={roleLoading}
+            >
+              Change role
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => openBulkDialog('add')}
+              disabled={roleLoading}
+            >
+              Add to workspaces
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => openBulkDialog('remove')}
+              disabled={roleLoading}
+            >
+              Remove from workspaces
+            </Button>
+          </div>
+        </div>
+      )}
       <Card>
         <div className="overflow-x-auto rounded-lg">
           <Table className="min-w-full">
             <TableHeader>
               <TableRow>
+                {showBulkColumn && (
+                  <TableHead className="w-8 whitespace-nowrap">
+                    <input
+                      type="checkbox"
+                      aria-label="Select all users on this page"
+                      checked={allOnPageSelected}
+                      ref={(el) => {
+                        if (el) el.indeterminate = someOnPageSelected;
+                      }}
+                      onChange={toggleSelectAllOnPage}
+                    />
+                  </TableHead>
+                )}
                 <TableHead
                   onClick={() => requestSort('usernameDisplay')}
                   className="sortable whitespace-nowrap cursor-pointer hover:bg-gray-50 w-1/6"
@@ -2208,6 +2339,18 @@ function UsersTable({
                     user.userId === currentUserId);
                 return (
                   <TableRow key={user.userId}>
+                    {showBulkColumn && (
+                      <TableCell className="w-8 whitespace-nowrap">
+                        {!isSystemUser && (
+                          <input
+                            type="checkbox"
+                            aria-label={`Select user ${user.usernameDisplay || user.userId}`}
+                            checked={selectedUserIds.has(user.userId)}
+                            onChange={() => toggleSelectOne(user.userId)}
+                          />
+                        )}
+                      </TableCell>
+                    )}
                     <TableCell className="truncate" title={user.username}>
                       {user.usernameDisplay}
                     </TableCell>
@@ -2421,6 +2564,27 @@ function UsersTable({
           </Table>
         </div>
       </Card>
+      {bulkDialog === 'role' && (
+        <BatchRoleDialog
+          open={bulkDialog === 'role'}
+          onClose={handleBulkDialogClose}
+          selectedUsers={selectedUserObjects}
+        />
+      )}
+      {bulkDialog === 'add' && (
+        <BatchAddToWorkspacesDialog
+          open={bulkDialog === 'add'}
+          onClose={handleBulkDialogClose}
+          selectedUsers={selectedUserObjects}
+        />
+      )}
+      {bulkDialog === 'remove' && (
+        <BatchRemoveFromWorkspacesDialog
+          open={bulkDialog === 'remove'}
+          onClose={handleBulkDialogClose}
+          selectedUsers={selectedUserObjects}
+        />
+      )}
     </>
   );
 }

--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -50,6 +50,7 @@ import {
   UploadIcon,
   DownloadIcon,
   PlusIcon,
+  MinusIcon,
   CopyIcon,
 } from 'lucide-react';
 import { Layout } from '@/components/elements/layout';
@@ -2128,15 +2129,39 @@ function UsersTable({
 
   const clearSelection = () => setSelectedUserIds(new Set());
 
+  // "Workspaces" dropdown on the floating bar.
+  const [wsDropdownOpen, setWsDropdownOpen] = useState(false);
+  const wsDropdownRef = useRef(null);
+
   // Esc clears the current selection (and dismisses the floating bar).
   useEffect(() => {
     if (selectedUserIds.size === 0) return undefined;
     const handler = (e) => {
-      if (e.key === 'Escape') clearSelection();
+      if (e.key === 'Escape') {
+        // If the workspaces dropdown is open, Esc closes the dropdown
+        // first; pressing Esc again clears the selection.
+        if (wsDropdownOpen) {
+          setWsDropdownOpen(false);
+        } else {
+          clearSelection();
+        }
+      }
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [selectedUserIds.size]);
+  }, [selectedUserIds.size, wsDropdownOpen]);
+
+  // Close the workspaces dropdown on outside click.
+  useEffect(() => {
+    if (!wsDropdownOpen) return undefined;
+    const handler = (e) => {
+      if (wsDropdownRef.current && !wsDropdownRef.current.contains(e.target)) {
+        setWsDropdownOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [wsDropdownOpen]);
 
   const handleBulkDialogClose = async (fullySucceeded) => {
     setBulkDialog(null);
@@ -2255,24 +2280,65 @@ function UsersTable({
               disabled={roleLoading}
               className="bg-sky-600 hover:bg-sky-700 text-white flex items-center rounded-md px-3 py-1 text-sm font-medium transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
             >
-              Change role
+              Role
             </button>
-            <button
-              type="button"
-              onClick={() => openBulkDialog('add')}
-              disabled={roleLoading}
-              className="bg-sky-600 hover:bg-sky-700 text-white flex items-center rounded-md px-3 py-1 text-sm font-medium transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
-            >
-              Add to workspaces
-            </button>
-            <button
-              type="button"
-              onClick={() => openBulkDialog('remove')}
-              disabled={roleLoading}
-              className="bg-sky-600 hover:bg-sky-700 text-white flex items-center rounded-md px-3 py-1 text-sm font-medium transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
-            >
-              Remove from workspaces
-            </button>
+            <div className="relative" ref={wsDropdownRef}>
+              <button
+                type="button"
+                onClick={() => setWsDropdownOpen((v) => !v)}
+                disabled={roleLoading}
+                aria-haspopup="menu"
+                aria-expanded={wsDropdownOpen}
+                className="bg-sky-600 hover:bg-sky-700 text-white inline-flex items-center gap-1 rounded-md px-3 py-1 text-sm font-medium transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+              >
+                <span>Workspaces</span>
+                <svg
+                  className={`w-3.5 h-3.5 transition-transform ${
+                    wsDropdownOpen ? 'rotate-180' : ''
+                  }`}
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                  aria-hidden="true"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </button>
+              {wsDropdownOpen && (
+                <div
+                  role="menu"
+                  className="absolute bottom-full right-0 mb-2 bg-white rounded-lg shadow-xl border border-gray-200 z-40 py-1.5 px-1"
+                >
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      setWsDropdownOpen(false);
+                      openBulkDialog('add');
+                    }}
+                    className="flex items-center gap-2.5 w-full text-left px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors whitespace-nowrap"
+                  >
+                    <PlusIcon className="h-4 w-4 text-gray-500 flex-shrink-0" />
+                    <span>Add to workspaces</span>
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      setWsDropdownOpen(false);
+                      openBulkDialog('remove');
+                    }}
+                    className="flex items-center gap-2.5 w-full text-left px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors whitespace-nowrap"
+                  >
+                    <MinusIcon className="h-4 w-4 text-gray-500 flex-shrink-0" />
+                    <span>Remove from workspaces</span>
+                  </button>
+                </div>
+              )}
+            </div>
           </div>
         </div>
       )}

--- a/sky/dashboard/src/data/connectors/users.js
+++ b/sky/dashboard/src/data/connectors/users.js
@@ -49,6 +49,26 @@ export async function getServiceAccountTokens() {
   }
 }
 
+export async function batchUpdateUserRoles(userIds, role) {
+  const response = await apiClient.post('/users/batch_update', {
+    user_ids: userIds,
+    role,
+  });
+  if (!response.ok) {
+    let detail = '';
+    try {
+      const data = await response.json();
+      detail = data?.detail || JSON.stringify(data);
+    } catch (e) {
+      detail = await response.text().catch(() => '');
+    }
+    throw new Error(
+      detail || `Batch update user roles failed with status ${response.status}`
+    );
+  }
+  return response.json();
+}
+
 export async function getUsers() {
   try {
     const response = await apiClient.get(`/users`);

--- a/sky/dashboard/src/data/connectors/workspaces.jsx
+++ b/sky/dashboard/src/data/connectors/workspaces.jsx
@@ -744,6 +744,63 @@ export async function updateConfig(config) {
   }
 }
 
+export async function batchAddUsersToWorkspaces(workspaceNames, userIds) {
+  try {
+    const scheduleResponse = await apiClient.post(
+      `/workspaces/batch_add_users`,
+      {
+        workspace_names: workspaceNames,
+        user_ids: userIds,
+      }
+    );
+    if (!scheduleResponse.ok) {
+      throw new Error(
+        `Error scheduling batchAddUsersToWorkspaces: ${scheduleResponse.statusText} (status ${scheduleResponse.status})`
+      );
+    }
+    const requestId = scheduleResponse.headers.get('X-Skypilot-Request-ID');
+    if (!requestId) {
+      throw new Error(
+        'Failed to obtain request ID for batchAddUsersToWorkspaces'
+      );
+    }
+    return await pollForTaskCompletion(requestId, 'batchAddUsersToWorkspaces');
+  } catch (error) {
+    console.error('Failed to batch add users to workspaces:', error);
+    throw error;
+  }
+}
+
+export async function batchRemoveUsersFromWorkspaces(workspaceNames, userIds) {
+  try {
+    const scheduleResponse = await apiClient.post(
+      `/workspaces/batch_remove_users`,
+      {
+        workspace_names: workspaceNames,
+        user_ids: userIds,
+      }
+    );
+    if (!scheduleResponse.ok) {
+      throw new Error(
+        `Error scheduling batchRemoveUsersFromWorkspaces: ${scheduleResponse.statusText} (status ${scheduleResponse.status})`
+      );
+    }
+    const requestId = scheduleResponse.headers.get('X-Skypilot-Request-ID');
+    if (!requestId) {
+      throw new Error(
+        'Failed to obtain request ID for batchRemoveUsersFromWorkspaces'
+      );
+    }
+    return await pollForTaskCompletion(
+      requestId,
+      'batchRemoveUsersFromWorkspaces'
+    );
+  } catch (error) {
+    console.error('Failed to batch remove users from workspaces:', error);
+    throw error;
+  }
+}
+
 // Run sky check to refresh cloud credentials
 // This is useful when refreshing the infra page to detect new clouds
 export async function runSkyCheck() {

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -478,6 +478,12 @@ class UserImportBody(RequestBody):
     csv_content: str
 
 
+class UserBatchUpdateBody(RequestBody):
+    """The request body for the user batch update endpoint."""
+    user_ids: List[str]
+    role: str
+
+
 class ServiceAccountTokenCreateBody(RequestBody):
     """The request body for creating a service account token."""
     token_name: str
@@ -912,6 +918,18 @@ class CreateWorkspaceBody(RequestBody):
 class DeleteWorkspaceBody(RequestBody):
     """The request body for deleting a workspace."""
     workspace_name: str
+
+
+class WorkspaceBatchAddUsersBody(RequestBody):
+    """The request body for adding users to multiple workspaces."""
+    workspace_names: List[str]
+    user_ids: List[str]
+
+
+class WorkspaceBatchRemoveUsersBody(RequestBody):
+    """The request body for removing users from multiple workspaces."""
+    workspace_names: List[str]
+    user_ids: List[str]
 
 
 class UpdateConfigBody(RequestBody):

--- a/sky/server/requests/request_names.py
+++ b/sky/server/requests/request_names.py
@@ -79,6 +79,8 @@ class RequestName(str, enum.Enum):
     WORKSPACES_DELETE = 'workspaces.delete'
     WORKSPACES_GET_CONFIG = 'workspaces.get_config'
     WORKSPACES_UPDATE_CONFIG = 'workspaces.update_config'
+    WORKSPACES_BATCH_ADD_USERS = 'workspaces.batch_add_users'
+    WORKSPACES_BATCH_REMOVE_USERS = 'workspaces.batch_remove_users'
     # SSH node pools requests
     SSH_NODE_POOLS_UP = 'ssh_node_pools.up'
     SSH_NODE_POOLS_DOWN = 'ssh_node_pools.down'

--- a/sky/users/rbac.py
+++ b/sky/users/rbac.py
@@ -25,10 +25,19 @@ _DEFAULT_USER_BLOCKLIST = [{
     'path': '/workspaces/delete',
     'method': 'POST'
 }, {
+    'path': '/workspaces/batch_add_users',
+    'method': 'POST'
+}, {
+    'path': '/workspaces/batch_remove_users',
+    'method': 'POST'
+}, {
     'path': '/users/delete',
     'method': 'POST'
 }, {
     'path': '/users/create',
+    'method': 'POST'
+}, {
+    'path': '/users/batch_update',
     'method': 'POST'
 }, {
     'path': '/users/import',

--- a/sky/users/resolver.py
+++ b/sky/users/resolver.py
@@ -1,0 +1,166 @@
+"""User-resolution context shared across batch operations.
+
+The ``UserResolver`` class caches a snapshot of the user table plus the
+derived id->User and name->[ids] lookup maps so per-user calls in a
+batch loop are O(1) instead of rebuilding the maps on every invocation
+or re-fetching ``get_all_users()`` from the DB.
+
+Although several methods deal with the workspace ``allowed_users``
+schema (a mix of user_ids and usernames), the resolver itself only
+operates on plain ``Dict[str, Any]`` workspace configs, so it does not
+introduce a dependency on the ``sky.workspaces`` package.
+"""
+import collections
+from typing import Any, Dict, Iterable, List, Optional, Set
+
+from sky import global_user_state
+from sky import models
+from sky import sky_logging
+from sky.users import permission
+from sky.users import rbac
+
+logger = sky_logging.init_logger(__name__)
+
+
+class UserResolver:
+    """User-resolution context shared across a batch operation.
+
+    Wraps the user list and its derived lookup maps (id -> User, name ->
+    [ids]) plus a lazily-fetched admin user_id set. Batch callers should
+    build a ``UserResolver`` once at the top of the operation and pass
+    it through helpers / per-item loops so each per-user lookup is O(1)
+    instead of rebuilding the maps (or re-fetching ``get_all_users()``)
+    on every call.
+
+    Single-call callers can just call helper free-functions like
+    ``sky.workspaces.utils.get_workspace_users(config)``; those
+    construct a transient resolver internally.
+
+    The resolver is read-only after construction; callers that need to
+    operate against a different user snapshot should build a new
+    resolver.
+    """
+
+    def __init__(
+        self,
+        all_users: Optional[List[models.User]] = None,
+        admin_user_ids: Optional[List[str]] = None,
+    ):
+        if all_users is None:
+            all_users = global_user_state.get_all_users()
+        self._all_users = all_users
+        self._id_to_user: Dict[str, models.User] = {u.id: u for u in all_users}
+        self._name_to_ids: Dict[str, List[str]] = collections.defaultdict(list)
+        for u in all_users:
+            if u.name:
+                self._name_to_ids[u.name].append(u.id)
+        # Lazy: many callers never need the admin set; only fetch on first
+        # access.
+        self._admin_user_ids = admin_user_ids
+
+    @property
+    def admin_user_ids(self) -> List[str]:
+        """User IDs currently assigned the admin role.
+
+        Lazily fetched from the casbin policy on first access so callers
+        that never need it don't pay the DB round-trip.
+        """
+        if self._admin_user_ids is None:
+            self._admin_user_ids = list(
+                permission.permission_service.get_users_for_role(
+                    rbac.RoleName.ADMIN.value))
+        return self._admin_user_ids
+
+    @property
+    def id_to_user(self) -> Dict[str, models.User]:
+        """Mapping from user_id -> ``User``. Read-only; do not mutate."""
+        return self._id_to_user
+
+    def get_user(self, user_id: str) -> Optional[models.User]:
+        """Return the ``User`` for ``user_id`` or ``None`` if not present."""
+        return self._id_to_user.get(user_id)
+
+    def has_id(self, user_id: str) -> bool:
+        return user_id in self._id_to_user
+
+    def preferred_entry(self, user_id: str) -> Optional[str]:
+        """Return the preferred ``allowed_users`` entry for a user_id.
+
+        Prefers the username when it uniquely resolves back to
+        ``user_id``; otherwise falls back to ``user_id``. Returns
+        ``None`` if no user exists for the given id.
+        """
+        user = self._id_to_user.get(user_id)
+        if user is None:
+            return None
+        if user.name and len(self._name_to_ids.get(user.name, [])) == 1:
+            return user.name
+        return user_id
+
+    def entries_for(self, user_id: str) -> List[str]:
+        """Return all ``allowed_users`` entries that resolve to ``user_id``.
+
+        Includes both the user_id itself and the username (when unique).
+        Used to strip every form of a user from a workspace's
+        ``allowed_users`` list.
+        """
+        user = self._id_to_user.get(user_id)
+        if user is None:
+            return [user_id]
+        entries = [user_id]
+        if user.name and len(self._name_to_ids.get(user.name, [])) == 1:
+            entries.append(user.name)
+        return entries
+
+    def resolve_allowed_entries(self, allowed: Iterable[str]) -> List[str]:
+        """Resolve raw ``allowed_users`` entries to user_ids.
+
+        Each entry can be either a user_id or a username; usernames are
+        resolved if unique. Unknown entries are logged and dropped.
+        Raises ``ValueError`` if a username collides with multiple
+        user_ids.
+        """
+        out: List[str] = []
+        for entry in allowed:
+            if entry in self._id_to_user:
+                out.append(entry)
+                continue
+            ids = self._name_to_ids.get(entry)
+            if not ids:
+                logger.warning(f'User {entry!r} not found in all users')
+                continue
+            if len(ids) > 1:
+                user_ids_str = ', '.join(ids)
+                raise ValueError(
+                    f'User {entry!r} has multiple IDs: {user_ids_str}. '
+                    'Please specify the user ID instead.')
+            out.append(ids[0])
+        return out
+
+    def resolve_workspace_users(self, workspace_config: Dict[str,
+                                                             Any]) -> List[str]:
+        """Resolve a workspace's effective user_id list.
+
+        For private workspaces, resolves ``allowed_users`` (mix of
+        user_ids and usernames) to user_ids. For public workspaces,
+        returns ``['*']``.
+        """
+        if not workspace_config.get('private', False):
+            return ['*']
+        return self.resolve_allowed_entries(
+            workspace_config.get('allowed_users', []))
+
+    def resolve_workspaces_allowed_users(
+            self, workspaces: Dict[str, Dict[str, Any]]) -> Dict[str, Set[str]]:
+        """Pre-resolve each private workspace's allowed_users -> user_id set.
+
+        Returned map only contains private workspaces. Useful when the
+        same set of workspaces is consulted repeatedly in a batch.
+        """
+        out: Dict[str, Set[str]] = {}
+        for ws_name, ws_cfg in workspaces.items():
+            if ws_cfg.get('private', False):
+                out[ws_name] = set(
+                    self.resolve_allowed_entries(ws_cfg.get(
+                        'allowed_users', [])))
+        return out

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -247,10 +247,19 @@ def user_batch_update(request: fastapi.Request,
             rbac.RoleName.ADMIN.value))
     if role == rbac.RoleName.ADMIN.value:
         remaining_admin_user_ids = all_admin_user_ids | set(user_ids)
+        # Promotion -> nobody needs the demotion check, so no need to fetch
+        # workspaces / active resources.
+        batch_workspaces = None
+        batch_active_resources = None
     else:
         # Any non-admin target (user, viewer, ...) removes the targets from
         # the admin set.
         remaining_admin_user_ids = all_admin_user_ids - set(user_ids)
+        # Fetch the inputs the per-user demotion check needs ONCE for the
+        # whole batch so we don't re-reload the YAML config and re-fetch
+        # all clusters + managed jobs N times.
+        batch_workspaces = resource_checker.load_fresh_workspaces()
+        batch_active_resources = resource_checker.get_active_resources()
 
     succeeded: List[str] = []
     failed: List[Dict[str, str]] = []
@@ -281,13 +290,17 @@ def user_batch_update(request: fastapi.Request,
                 continue
             # When demoting from admin to a non-admin role (user / viewer),
             # ensure the user has no active resources in private workspaces
-            # they will lose implicit access to.
+            # they will lose implicit access to. Reuse the per-batch
+            # pre-fetched workspaces + active resources to keep this O(C+J)
+            # for the whole batch instead of O(N * (C+J)).
             if (target_user_roles and
                     target_user_roles[0] == rbac.RoleName.ADMIN.value and
                     role != rbac.RoleName.ADMIN.value):
                 resource_checker.check_user_role_demotion(
                     user_info.id,
-                    remaining_admin_user_ids=remaining_admin_user_ids)
+                    remaining_admin_user_ids=remaining_admin_user_ids,
+                    workspaces=batch_workspaces,
+                    active_resources=batch_active_resources)
             with _user_lock(user_info.id):
                 permission.permission_service.update_role(user_info.id, role)
             succeeded.append(user_id)

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -185,11 +185,11 @@ def user_update(request: fastapi.Request,
             detail=f'Cannot update password for internal '
             f'API server user {user_info.name}')
 
-    # When demoting admin -> user, ensure the user has no active
-    # resources in private workspaces they will lose access to.
-    is_demotion = (need_update_role and role == rbac.RoleName.USER.value and
-                   target_user_roles and
-                   target_user_roles[0] == rbac.RoleName.ADMIN.value)
+    # When demoting from admin to a non-admin role, ensure the user has no
+    # active resources in private workspaces they will lose access to.
+    is_demotion = (need_update_role and target_user_roles and
+                   target_user_roles[0] == rbac.RoleName.ADMIN.value and
+                   role != rbac.RoleName.ADMIN.value)
     if is_demotion:
         try:
             resource_checker.check_user_role_demotion(user_info.id)
@@ -245,10 +245,12 @@ def user_batch_update(request: fastapi.Request,
     all_admin_user_ids = set(
         permission.permission_service.get_users_for_role(
             rbac.RoleName.ADMIN.value))
-    if role == rbac.RoleName.USER.value:
-        remaining_admin_user_ids = all_admin_user_ids - set(user_ids)
-    else:
+    if role == rbac.RoleName.ADMIN.value:
         remaining_admin_user_ids = all_admin_user_ids | set(user_ids)
+    else:
+        # Any non-admin target (user, viewer, ...) removes the targets from
+        # the admin set.
+        remaining_admin_user_ids = all_admin_user_ids - set(user_ids)
 
     succeeded: List[str] = []
     failed: List[Dict[str, str]] = []
@@ -262,9 +264,7 @@ def user_batch_update(request: fastapi.Request,
                     'error': f'User {user_id} does not exist'
                 })
                 continue
-            if user_info.id in [
-                    common.SERVER_ID, constants.SKYPILOT_SYSTEM_USER_ID
-            ]:
+            if user_info.id in _INTERNAL_USER_IDS:
                 failed.append({
                     'user_id': user_id,
                     'error': (f'Cannot update role for internal API server '
@@ -279,9 +279,12 @@ def user_batch_update(request: fastapi.Request,
                 # Already in the desired role; record as success no-op.
                 succeeded.append(user_id)
                 continue
-            # Demotion check.
-            if (role == rbac.RoleName.USER.value and target_user_roles and
-                    target_user_roles[0] == rbac.RoleName.ADMIN.value):
+            # When demoting from admin to a non-admin role (user / viewer),
+            # ensure the user has no active resources in private workspaces
+            # they will lose implicit access to.
+            if (target_user_roles and
+                    target_user_roles[0] == rbac.RoleName.ADMIN.value and
+                    role != rbac.RoleName.ADMIN.value):
                 resource_checker.check_user_role_demotion(
                     user_info.id,
                     remaining_admin_user_ids=remaining_admin_user_ids)

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -201,7 +201,8 @@ def user_update(request: fastapi.Request,
                    role != rbac.RoleName.ADMIN.value)
     if is_demotion:
         try:
-            resource_checker.check_user_role_demotion(user_info.id)
+            resource_checker.check_user_role_demotion(
+                user_info.id, user_display=user_info.name or user_info.id)
         except ValueError as e:
             raise fastapi.HTTPException(status_code=400, detail=str(e))
 

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -6,7 +6,7 @@ import os
 import re
 import secrets
 import time
-from typing import Any, Dict, Generator, List
+from typing import Any, Dict, Generator, List, Optional, Set
 
 import fastapi
 import filelock
@@ -23,6 +23,7 @@ from sky.users import token_service
 from sky.utils import common
 from sky.utils import common_utils
 from sky.utils import resource_checker
+from sky.workspaces import utils as workspaces_utils
 
 logger = sky_logging.init_logger(__name__)
 
@@ -238,13 +239,27 @@ def user_batch_update(request: fastapi.Request,
             raise fastapi.HTTPException(
                 status_code=403, detail='Only admin can update user roles')
 
+    # Pre-fetch user + role state ONCE for the whole batch so the per-user
+    # loop is O(1) dict lookups instead of N * (DB get_user + casbin
+    # get_user_roles). For a batch of size N, this drops the per-iteration
+    # round-trip cost from O(N) to O(supported_roles) total.
+    all_users = global_user_state.get_all_users()
+    all_users_map = {u.id: u for u in all_users}
+    users_to_role: Dict[str, str] = {}
+    for supported_role in supported_roles:
+        for uid in permission.permission_service.get_users_for_role(
+                supported_role):
+            users_to_role[uid] = supported_role
+    all_admin_user_ids = {
+        uid for uid, r in users_to_role.items()
+        if r == rbac.RoleName.ADMIN.value
+    }
+
     # Pre-compute the post-batch admin set for the demotion check so
     # we treat the rest of the batch consistently: if A and B are both admins
     # and both being demoted, A losing access can't be saved by "but B is still
     # an admin".
-    all_admin_user_ids = set(
-        permission.permission_service.get_users_for_role(
-            rbac.RoleName.ADMIN.value))
+    batch_workspaces_allowed_users: Optional[Dict[str, Set[str]]] = None
     if role == rbac.RoleName.ADMIN.value:
         remaining_admin_user_ids = all_admin_user_ids | set(user_ids)
         # Promotion -> nobody needs the demotion check, so no need to fetch
@@ -263,13 +278,28 @@ def user_batch_update(request: fastapi.Request,
         batch_active_resources_by_user = (
             resource_checker.index_active_resources_by_user_hash(
                 resource_checker.get_active_resources()))
+        # Pre-resolve each private workspace's allowed_users -> user_id set
+        # ONCE for the batch. Without this, check_user_role_demotion
+        # iterates private workspaces and calls get_workspace_users for
+        # each (every call re-fetches get_all_users() from the DB),
+        # giving N * P * get_all_users() round-trips in a batch.
+        batch_name_to_ids = workspaces_utils.build_username_to_ids_map(
+            all_users)
+        batch_workspaces_allowed_users = {}
+        for ws_name, ws_cfg in batch_workspaces.items():
+            if ws_cfg.get('private', False):
+                batch_workspaces_allowed_users[ws_name] = set(
+                    workspaces_utils.get_workspace_users(
+                        ws_cfg,
+                        all_users=all_users,
+                        name_to_ids=batch_name_to_ids))
 
     succeeded: List[str] = []
     failed: List[Dict[str, str]] = []
 
     for user_id in user_ids:
         try:
-            user_info = global_user_state.get_user(user_id)
+            user_info = all_users_map.get(user_id)
             if user_info is None:
                 failed.append({
                     'user_id': user_id,
@@ -283,8 +313,8 @@ def user_batch_update(request: fastapi.Request,
                               f'user {user_info.name}')
                 })
                 continue
-            target_user_roles = (
-                permission.permission_service.get_user_roles(user_id))
+            current_role = users_to_role.get(user_id)
+            target_user_roles = [current_role] if current_role else []
             need_update_role = (not target_user_roles or
                                 role != target_user_roles[0])
             if not need_update_role:
@@ -303,7 +333,9 @@ def user_batch_update(request: fastapi.Request,
                     user_info.id,
                     remaining_admin_user_ids=remaining_admin_user_ids,
                     workspaces=batch_workspaces,
-                    active_resources_by_user=batch_active_resources_by_user)
+                    active_resources_by_user=batch_active_resources_by_user,
+                    user_display=user_info.name or user_info.id,
+                    workspaces_allowed_users=batch_workspaces_allowed_users)
             with _user_lock(user_info.id):
                 permission.permission_service.update_role(user_info.id, role)
             succeeded.append(user_id)

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -185,6 +185,17 @@ def user_update(request: fastapi.Request,
             detail=f'Cannot update password for internal '
             f'API server user {user_info.name}')
 
+    # When demoting admin -> user, ensure the user has no active
+    # resources in private workspaces they will lose access to.
+    is_demotion = (need_update_role and role == rbac.RoleName.USER.value and
+                   target_user_roles and
+                   target_user_roles[0] == rbac.RoleName.ADMIN.value)
+    if is_demotion:
+        try:
+            resource_checker.check_user_role_demotion(user_info.id)
+        except ValueError as e:
+            raise fastapi.HTTPException(status_code=400, detail=str(e))
+
     with _user_lock(user_info.id):
         if password:
             password_hash = server_common.crypt_ctx.hash(password)
@@ -195,6 +206,95 @@ def user_update(request: fastapi.Request,
         if role and need_update_role:
             # Update user role in casbin policy
             permission.permission_service.update_role(user_info.id, role)
+
+
+@router.post('/batch_update')
+def user_batch_update(request: fastapi.Request,
+                      body: payloads.UserBatchUpdateBody) -> Dict[str, Any]:
+    """Updates the role for a batch of users.
+
+    Returns a per-user result with ``succeeded`` and ``failed`` lists so the
+    caller can show partial failures (e.g. one user is blocked
+    while others are not).
+    """
+    role = body.role
+    user_ids = body.user_ids
+    supported_roles = rbac.get_supported_roles()
+    if not role or role not in supported_roles:
+        raise fastapi.HTTPException(status_code=400,
+                                    detail=f'Invalid role: {role}')
+    if not user_ids:
+        raise fastapi.HTTPException(status_code=400,
+                                    detail='user_ids must not be empty')
+
+    # Only admin can run a batch role update.
+    current_user = request.state.auth_user
+    if current_user is not None:
+        current_user_roles = permission.permission_service.get_user_roles(
+            current_user.id)
+        if not current_user_roles:
+            raise fastapi.HTTPException(status_code=403, detail='Invalid user')
+        if current_user_roles[0] != rbac.RoleName.ADMIN.value:
+            raise fastapi.HTTPException(
+                status_code=403, detail='Only admin can update user roles')
+
+    # Pre-compute the post-batch admin set for the demotion check so
+    # we treat the rest of the batch consistently: if A and B are both admins
+    # and both being demoted, A losing access can't be saved by "but B is still
+    # an admin".
+    all_admin_user_ids = set(
+        permission.permission_service.get_users_for_role(
+            rbac.RoleName.ADMIN.value))
+    if role == rbac.RoleName.USER.value:
+        remaining_admin_user_ids = all_admin_user_ids - set(user_ids)
+    else:
+        remaining_admin_user_ids = all_admin_user_ids | set(user_ids)
+
+    succeeded: List[str] = []
+    failed: List[Dict[str, str]] = []
+
+    for user_id in user_ids:
+        try:
+            user_info = global_user_state.get_user(user_id)
+            if user_info is None:
+                failed.append({
+                    'user_id': user_id,
+                    'error': f'User {user_id} does not exist'
+                })
+                continue
+            if user_info.id in [
+                    common.SERVER_ID, constants.SKYPILOT_SYSTEM_USER_ID
+            ]:
+                failed.append({
+                    'user_id': user_id,
+                    'error': (f'Cannot update role for internal API server '
+                              f'user {user_info.name}')
+                })
+                continue
+            target_user_roles = (
+                permission.permission_service.get_user_roles(user_id))
+            need_update_role = (not target_user_roles or
+                                role != target_user_roles[0])
+            if not need_update_role:
+                # Already in the desired role; record as success no-op.
+                succeeded.append(user_id)
+                continue
+            # Demotion check.
+            if (role == rbac.RoleName.USER.value and target_user_roles and
+                    target_user_roles[0] == rbac.RoleName.ADMIN.value):
+                resource_checker.check_user_role_demotion(
+                    user_info.id,
+                    remaining_admin_user_ids=remaining_admin_user_ids)
+            with _user_lock(user_info.id):
+                permission.permission_service.update_role(user_info.id, role)
+            succeeded.append(user_id)
+        except ValueError as e:
+            failed.append({'user_id': user_id, 'error': str(e)})
+        except Exception as e:  # pylint: disable=broad-except
+            logger.exception(f'Failed to update role for user {user_id}')
+            failed.append({'user_id': user_id, 'error': str(e)})
+
+    return {'succeeded': succeeded, 'failed': failed}
 
 
 def _delete_user(user_id: str) -> None:

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -250,16 +250,19 @@ def user_batch_update(request: fastapi.Request,
         # Promotion -> nobody needs the demotion check, so no need to fetch
         # workspaces / active resources.
         batch_workspaces = None
-        batch_active_resources = None
+        batch_active_resources_by_user = None
     else:
         # Any non-admin target (user, viewer, ...) removes the targets from
         # the admin set.
         remaining_admin_user_ids = all_admin_user_ids - set(user_ids)
-        # Fetch the inputs the per-user demotion check needs ONCE for the
-        # whole batch so we don't re-reload the YAML config and re-fetch
-        # all clusters + managed jobs N times.
+        # Fetch + index the inputs the per-user demotion check needs ONCE
+        # for the whole batch. This drops the per-user O(C+J) filter scan
+        # to an O(1) dict lookup, so the whole batch is O(N + C + J)
+        # instead of O(N * (C+J)).
         batch_workspaces = resource_checker.load_fresh_workspaces()
-        batch_active_resources = resource_checker.get_active_resources()
+        batch_active_resources_by_user = (
+            resource_checker.index_active_resources_by_user_hash(
+                resource_checker.get_active_resources()))
 
     succeeded: List[str] = []
     failed: List[Dict[str, str]] = []
@@ -300,7 +303,7 @@ def user_batch_update(request: fastapi.Request,
                     user_info.id,
                     remaining_admin_user_ids=remaining_admin_user_ids,
                     workspaces=batch_workspaces,
-                    active_resources=batch_active_resources)
+                    active_resources_by_user=batch_active_resources_by_user)
             with _user_lock(user_info.id):
                 permission.permission_service.update_role(user_info.id, role)
             succeeded.append(user_id)

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -159,6 +159,14 @@ def user_update(request: fastapi.Request,
                                  (role != target_user_roles[0]))
     current_user = request.state.auth_user
     if current_user is not None:
+        # This is a sync FastAPI handler, so it doesn't go through the
+        # executor's reload_for_new_request pipeline that normally
+        # populates the per-request user context. Without this, downstream
+        # calls (e.g. resource_checker -> queue_v2 ->
+        # get_accessible_workspace_names) would fall back to the local
+        # machine user and silently filter out anything in private
+        # workspaces the local user can't see.
+        common_utils.set_current_user(current_user)
         current_user_roles = permission.permission_service.get_user_roles(
             current_user.id)
         if not current_user_roles:
@@ -231,6 +239,9 @@ def user_batch_update(request: fastapi.Request,
     # Only admin can run a batch role update.
     current_user = request.state.auth_user
     if current_user is not None:
+        # Sync FastAPI handler -- see comment in user_update for why we
+        # have to set the per-request user context here ourselves.
+        common_utils.set_current_user(current_user)
         current_user_roles = permission.permission_service.get_user_roles(
             current_user.id)
         if not current_user_roles:
@@ -373,7 +384,13 @@ def _delete_user(user_id: str) -> None:
 
 
 @router.post('/delete')
-def user_delete(user_delete_body: payloads.UserDeleteBody) -> None:
+def user_delete(request: fastapi.Request,
+                user_delete_body: payloads.UserDeleteBody) -> None:
+    current_user = request.state.auth_user
+    if current_user is not None:
+        # Sync FastAPI handler -- see comment in user_update for why we
+        # have to set the per-request user context here ourselves.
+        common_utils.set_current_user(current_user)
     user_id = user_delete_body.user_id
     _delete_user(user_id)
 

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -267,7 +267,7 @@ def user_batch_update(request: fastapi.Request,
         # avoiding a full-table scan that gets wasted on this path).
         all_users_map = global_user_state.get_users(set(user_ids))
         batch_workspaces = None
-        batch_active_resources_by_user = None
+        batch_resources = None
     else:
         # Demotion -> we need the full user list anyway to detect
         # username-uniqueness across the whole system when resolving each
@@ -277,9 +277,7 @@ def user_batch_update(request: fastapi.Request,
         resolver = user_resolver.UserResolver()
         all_users_map = resolver.id_to_user
         batch_workspaces = resource_checker.load_fresh_workspaces()
-        batch_active_resources_by_user = (
-            resource_checker.index_active_resources_by_user_hash(
-                resource_checker.get_active_resources()))
+        batch_resources = resource_checker.ResourceSnapshot.fetch_all()
         # Pre-resolve each private workspace's allowed_users -> user_id
         # set ONCE for the batch. Without this, check_user_role_demotion
         # iterates private workspaces and calls get_workspace_users for
@@ -326,7 +324,7 @@ def user_batch_update(request: fastapi.Request,
                 resource_checker.check_user_role_demotion(
                     user_info.id,
                     workspaces=batch_workspaces,
-                    active_resources_by_user=batch_active_resources_by_user,
+                    resources=batch_resources,
                     user_display=user_info.name or user_info.id,
                     workspaces_allowed_users=batch_workspaces_allowed_users)
             with _user_lock(user_info.id):

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -19,11 +19,11 @@ from sky.server.requests import payloads
 from sky.skylet import constants
 from sky.users import permission
 from sky.users import rbac
+from sky.users import resolver as user_resolver
 from sky.users import token_service
 from sky.utils import common
 from sky.utils import common_utils
 from sky.utils import resource_checker
-from sky.workspaces import utils as workspaces_utils
 
 logger = sky_logging.init_logger(__name__)
 
@@ -251,60 +251,42 @@ def user_batch_update(request: fastapi.Request,
             raise fastapi.HTTPException(
                 status_code=403, detail='Only admin can update user roles')
 
-    # Pre-fetch user + role state ONCE for the whole batch so the per-user
-    # loop is O(1) dict lookups instead of N * (DB get_user + casbin
-    # get_user_roles). For a batch of size N, this drops the per-iteration
-    # round-trip cost from O(N) to O(supported_roles) total.
-    all_users = global_user_state.get_all_users()
-    all_users_map = {u.id: u for u in all_users}
+    # Pre-fetch the per-user role state ONCE for the whole batch so the
+    # per-user loop is O(1) dict lookups instead of N * casbin
+    # get_user_roles.
     users_to_role: Dict[str, str] = {}
     for supported_role in supported_roles:
         for uid in permission.permission_service.get_users_for_role(
                 supported_role):
             users_to_role[uid] = supported_role
-    all_admin_user_ids = {
-        uid for uid, r in users_to_role.items()
-        if r == rbac.RoleName.ADMIN.value
-    }
 
-    # Pre-compute the post-batch admin set for the demotion check so
-    # we treat the rest of the batch consistently: if A and B are both admins
-    # and both being demoted, A losing access can't be saved by "but B is still
-    # an admin".
     batch_workspaces_allowed_users: Optional[Dict[str, Set[str]]] = None
     if role == rbac.RoleName.ADMIN.value:
-        remaining_admin_user_ids = all_admin_user_ids | set(user_ids)
-        # Promotion -> nobody needs the demotion check, so no need to fetch
-        # workspaces / active resources.
+        # Promotion -> nobody needs the demotion check, so we only need
+        # user info for the batch's user_ids (one targeted IN query,
+        # avoiding a full-table scan that gets wasted on this path).
+        all_users_map = global_user_state.get_users(set(user_ids))
         batch_workspaces = None
         batch_active_resources_by_user = None
     else:
-        # Any non-admin target (user, viewer, ...) removes the targets from
-        # the admin set.
-        remaining_admin_user_ids = all_admin_user_ids - set(user_ids)
-        # Fetch + index the inputs the per-user demotion check needs ONCE
-        # for the whole batch. This drops the per-user O(C+J) filter scan
-        # to an O(1) dict lookup, so the whole batch is O(N + C + J)
-        # instead of O(N * (C+J)).
+        # Demotion -> we need the full user list anyway to detect
+        # username-uniqueness across the whole system when resolving each
+        # private workspace's ``allowed_users``. Build one shared
+        # UserResolver and derive the per-user map from the same fetch
+        # so we still do exactly one DB round-trip.
+        resolver = user_resolver.UserResolver()
+        all_users_map = resolver.id_to_user
         batch_workspaces = resource_checker.load_fresh_workspaces()
         batch_active_resources_by_user = (
             resource_checker.index_active_resources_by_user_hash(
                 resource_checker.get_active_resources()))
-        # Pre-resolve each private workspace's allowed_users -> user_id set
-        # ONCE for the batch. Without this, check_user_role_demotion
+        # Pre-resolve each private workspace's allowed_users -> user_id
+        # set ONCE for the batch. Without this, check_user_role_demotion
         # iterates private workspaces and calls get_workspace_users for
         # each (every call re-fetches get_all_users() from the DB),
         # giving N * P * get_all_users() round-trips in a batch.
-        batch_name_to_ids = workspaces_utils.build_username_to_ids_map(
-            all_users)
-        batch_workspaces_allowed_users = {}
-        for ws_name, ws_cfg in batch_workspaces.items():
-            if ws_cfg.get('private', False):
-                batch_workspaces_allowed_users[ws_name] = set(
-                    workspaces_utils.get_workspace_users(
-                        ws_cfg,
-                        all_users=all_users,
-                        name_to_ids=batch_name_to_ids))
+        batch_workspaces_allowed_users = (
+            resolver.resolve_workspaces_allowed_users(batch_workspaces))
 
     succeeded: List[str] = []
     failed: List[Dict[str, str]] = []
@@ -343,7 +325,6 @@ def user_batch_update(request: fastapi.Request,
                     role != rbac.RoleName.ADMIN.value):
                 resource_checker.check_user_role_demotion(
                     user_info.id,
-                    remaining_admin_user_ids=remaining_admin_user_ids,
                     workspaces=batch_workspaces,
                     active_resources_by_user=batch_active_resources_by_user,
                     user_display=user_info.name or user_info.id,

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -201,8 +201,7 @@ def user_update(request: fastapi.Request,
                    role != rbac.RoleName.ADMIN.value)
     if is_demotion:
         try:
-            resource_checker.check_user_role_demotion(
-                user_info.id, user_display=user_info.name or user_info.id)
+            resource_checker.check_user_role_demotion(user_info)
         except ValueError as e:
             raise fastapi.HTTPException(status_code=400, detail=str(e))
 
@@ -322,10 +321,9 @@ def user_batch_update(request: fastapi.Request,
                     target_user_roles[0] == rbac.RoleName.ADMIN.value and
                     role != rbac.RoleName.ADMIN.value):
                 resource_checker.check_user_role_demotion(
-                    user_info.id,
+                    user_info,
                     workspaces=batch_workspaces,
                     resources=batch_resources,
-                    user_display=user_info.name or user_info.id,
                     workspaces_allowed_users=batch_workspaces_allowed_users)
             with _user_lock(user_info.id):
                 permission.permission_service.update_role(user_info.id, role)

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -121,6 +121,8 @@ _REQUEST_BODY_ALLOWLIST: Dict[str, Tuple[str, ...]] = {
     'sky.workspaces.delete': (),
     'sky.workspaces.get': (),
     'sky.workspaces.get_config': (),
+    'sky.workspaces.batch_add_users': (),
+    'sky.workspaces.batch_remove_users': (),
     'sky.recipes.list': (),
     'sky.recipes.get': (),
     'sky.recipes.delete': (),

--- a/sky/utils/resource_checker.py
+++ b/sky/utils/resource_checker.py
@@ -1,7 +1,7 @@
 """Resource checking utilities for finding active clusters and managed jobs."""
 
 import concurrent.futures
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 from sky import exceptions
 from sky import global_user_state
@@ -259,6 +259,105 @@ def _get_active_resources_by_names(
         ]
 
     return resource_clusters, resource_active_jobs
+
+
+def check_user_role_demotion(
+        user_id: str,
+        remaining_admin_user_ids: Optional[Set[str]] = None) -> None:
+    """Check whether an admin can be safely demoted to a regular user.
+
+    After demotion the user loses implicit access to all private workspaces
+    where they are not listed in ``allowed_users``. This function ensures
+    the user has no active clusters or managed jobs in private workspaces
+    they would lose access to.
+
+    Args:
+        user_id: The ID of the user being demoted.
+        remaining_admin_user_ids: Optional pre-computed set of user IDs that
+            will remain admins after the demotion. If not provided, it is
+            computed from the casbin policy.
+
+    Raises:
+        ValueError: If the user has active clusters or managed jobs in
+            private workspaces they would lose access to.
+    """
+    # Imports done lazily to avoid circular imports with permission/workspaces.
+    # pylint: disable=import-outside-toplevel
+    from sky import skypilot_config
+    from sky.users import permission
+    from sky.users import rbac
+    from sky.workspaces import utils as workspaces_utils
+
+    workspaces = skypilot_config.get_nested(('workspaces',), default_value={})
+    if not workspaces:
+        return
+
+    if remaining_admin_user_ids is None:
+        remaining_admin_user_ids = set(
+            permission.permission_service.get_users_for_role(
+                rbac.RoleName.ADMIN.value))
+        remaining_admin_user_ids.discard(user_id)
+
+    inaccessible_workspaces: List[str] = []
+    for workspace_name, workspace_config in workspaces.items():
+        if not workspace_config.get('private', False):
+            continue
+        allowed_user_ids = set(
+            workspaces_utils.get_workspace_users(workspace_config))
+        if (user_id in allowed_user_ids or user_id in remaining_admin_user_ids):
+            continue
+        inaccessible_workspaces.append(workspace_name)
+
+    if not inaccessible_workspaces:
+        return
+
+    all_clusters, all_managed_jobs = _get_active_resources()
+    workspace_set = set(inaccessible_workspaces)
+
+    workspace_resources: Dict[str, Dict[str, List[str]]] = {}
+    for cluster in all_clusters:
+        if cluster.get('user_hash') != user_id:
+            continue
+        ws = cluster.get('workspace', constants.SKYPILOT_DEFAULT_WORKSPACE)
+        if ws not in workspace_set:
+            continue
+        workspace_resources.setdefault(ws, {'clusters': [], 'jobs': []})
+        workspace_resources[ws]['clusters'].append(cluster['name'])
+    for job in all_managed_jobs:
+        if job.get('user_hash') != user_id:
+            continue
+        ws = job.get('workspace', constants.SKYPILOT_DEFAULT_WORKSPACE)
+        if ws not in workspace_set:
+            continue
+        workspace_resources.setdefault(ws, {'clusters': [], 'jobs': []})
+        workspace_resources[ws]['jobs'].append(str(job['job_id']))
+
+    if not workspace_resources:
+        return
+
+    user_info = global_user_state.get_user(user_id)
+    user_display = (user_info.name if user_info and user_info.name else user_id)
+
+    error_lines = []
+    for ws, res in workspace_resources.items():
+        parts = []
+        if res['clusters']:
+            n_clusters = len(res['clusters'])
+            cluster_list = ', '.join(res['clusters'])
+            parts.append(f'{n_clusters} active cluster(s): {cluster_list}')
+        if res['jobs']:
+            n_jobs = len(res['jobs'])
+            job_list = ', '.join(res['jobs'])
+            parts.append(f'{n_jobs} active managed job(s): {job_list}')
+        joined = ' and '.join(parts)
+        error_lines.append(f'  - workspace {ws!r}: {joined}')
+
+    raise ValueError(
+        f'Cannot demote user {user_display!r} from admin to user because '
+        f'they have active resources in private workspaces where they are '
+        f'not in allowed_users:\n' + '\n'.join(error_lines) +
+        '\nPlease either terminate these resources or add the user to the '
+        'allowed_users of those workspaces first.')
 
 
 def _get_active_resources(

--- a/sky/utils/resource_checker.py
+++ b/sky/utils/resource_checker.py
@@ -288,6 +288,15 @@ def check_user_role_demotion(
     from sky.users import rbac
     from sky.workspaces import utils as workspaces_utils
 
+    # Ensure the in-memory workspaces config is fresh. /users/update and
+    # /users/batch_update are sync FastAPI handlers, so they don't go through
+    # the executor's reload_for_new_request pipeline -- their per-request
+    # context is inherited from the global one, which is frozen at server
+    # startup. Without this reload, a workspace add (which writes the file
+    # and refreshes its own per-request context) is invisible to a
+    # subsequent demotion check, and we'd incorrectly block the demotion.
+    # Use the file-locked variant to serialize with concurrent writers.
+    skypilot_config.safe_reload_config()
     workspaces = skypilot_config.get_nested(('workspaces',), default_value={})
     if not workspaces:
         return

--- a/sky/utils/resource_checker.py
+++ b/sky/utils/resource_checker.py
@@ -325,8 +325,6 @@ def check_user_role_demotion(
         user_id: str,
         remaining_admin_user_ids: Optional[Set[str]] = None,
         workspaces: Optional[Dict[str, Any]] = None,
-        active_resources: Optional[Tuple[List[Dict[str, Any]],
-                                         List[Dict[str, Any]]]] = None,
         active_resources_by_user: Optional[Tuple[Dict[str, List[Dict[str,
                                                                      Any]]],
                                                  Dict[str,
@@ -350,16 +348,13 @@ def check_user_role_demotion(
             ``load_fresh_workspaces()``). When called in a batch loop, the
             caller should fetch this once and pass it in to avoid the
             per-call ``safe_reload_config`` + YAML read overhead.
-        active_resources: Optional pre-fetched ``(clusters, managed_jobs)``
-            tuple. When called in a batch loop, the caller should fetch
-            this once via ``get_active_resources()`` and pass it in to
-            avoid the per-call cluster+jobs fetch.
         active_resources_by_user: Optional pre-built
             ``(clusters_by_user_hash, jobs_by_user_hash)`` index from
             ``index_active_resources_by_user_hash``. When provided, the
             per-user lookup is O(1) instead of an O(C+J) scan, giving
             O(N + C + J) total for a batch instead of O(N * (C+J)).
-            Takes precedence over ``active_resources`` if both are set.
+            When not provided (single-user path), the function fetches
+            and filters internally.
         user_display: Optional pre-resolved display string (username or
             user_id) used in the error message. Batch callers that already
             hold the user model should pass this to skip the per-call
@@ -422,16 +417,13 @@ def check_user_role_demotion(
 
     # Resolve the demoted user's clusters / jobs. Prefer the pre-built
     # index (O(1) lookup) when the batch caller supplied one; fall back
-    # to the linear filter over the raw (clusters, jobs) tuple.
+    # to a fresh fetch + linear filter for the single-user path.
     if active_resources_by_user is not None:
         clusters_by_user, jobs_by_user = active_resources_by_user
         user_clusters = clusters_by_user.get(user_id, [])
         user_jobs = jobs_by_user.get(user_id, [])
     else:
-        if active_resources is None:
-            all_clusters, all_managed_jobs = _get_active_resources()
-        else:
-            all_clusters, all_managed_jobs = active_resources
+        all_clusters, all_managed_jobs = _get_active_resources()
         user_clusters = [
             c for c in all_clusters if c.get('user_hash') == user_id
         ]

--- a/sky/utils/resource_checker.py
+++ b/sky/utils/resource_checker.py
@@ -477,11 +477,12 @@ def check_user_role_demotion(
         error_lines.append(f'  - workspace {ws!r}: {joined}')
 
     raise ValueError(
-        f'Cannot demote user {user_display!r} from admin to user because '
-        f'they have active resources in private workspaces where they are '
-        f'not in allowed_users:\n' + '\n'.join(error_lines) +
-        '\nPlease either terminate these resources or add the user to the '
-        'allowed_users of those workspaces first.')
+        f'Cannot demote user {user_display!r} from admin to user: user '
+        f'{user_display!r} has active resources in private workspaces '
+        f'where {user_display!r} is not in allowed_users:\n' +
+        '\n'.join(error_lines) +
+        f'\nPlease either terminate these resources or add {user_display!r} '
+        'to the allowed_users of those workspaces first.')
 
 
 def _get_active_resources(
@@ -494,7 +495,10 @@ def _get_active_resources(
     """
 
     def get_all_clusters() -> List[Dict[str, Any]]:
-        return global_user_state.get_clusters()
+        # Exclude is_managed=True clusters: those are the clusters that
+        # back managed jobs and are already represented (and labeled) by
+        # the managed-jobs queue below.
+        return global_user_state.get_clusters(exclude_managed_clusters=True)
 
     def get_all_managed_jobs() -> List[Dict[str, Any]]:
         # pylint: disable=import-outside-toplevel

--- a/sky/utils/resource_checker.py
+++ b/sky/utils/resource_checker.py
@@ -322,15 +322,18 @@ def load_fresh_workspaces() -> Dict[str, Any]:
 
 
 def check_user_role_demotion(
-    user_id: str,
-    remaining_admin_user_ids: Optional[Set[str]] = None,
-    workspaces: Optional[Dict[str, Any]] = None,
-    active_resources: Optional[Tuple[List[Dict[str, Any]],
-                                     List[Dict[str, Any]]]] = None,
-    active_resources_by_user: Optional[Tuple[Dict[str, List[Dict[str, Any]]],
-                                             Dict[str, List[Dict[str,
-                                                                 Any]]]]] = None
-) -> None:
+        user_id: str,
+        remaining_admin_user_ids: Optional[Set[str]] = None,
+        workspaces: Optional[Dict[str, Any]] = None,
+        active_resources: Optional[Tuple[List[Dict[str, Any]],
+                                         List[Dict[str, Any]]]] = None,
+        active_resources_by_user: Optional[Tuple[Dict[str, List[Dict[str,
+                                                                     Any]]],
+                                                 Dict[str,
+                                                      List[Dict[str,
+                                                                Any]]]]] = None,
+        user_display: Optional[str] = None,
+        workspaces_allowed_users: Optional[Dict[str, Set[str]]] = None) -> None:
     """Check whether an admin can be safely demoted to a regular user.
 
     After demotion the user loses implicit access to all private workspaces
@@ -357,6 +360,20 @@ def check_user_role_demotion(
             per-user lookup is O(1) instead of an O(C+J) scan, giving
             O(N + C + J) total for a batch instead of O(N * (C+J)).
             Takes precedence over ``active_resources`` if both are set.
+        user_display: Optional pre-resolved display string (username or
+            user_id) used in the error message. Batch callers that already
+            hold the user model should pass this to skip the per-call
+            ``global_user_state.get_user`` lookup that's only used to
+            format the error string.
+        workspaces_allowed_users: Optional pre-resolved map of
+            ``workspace_name -> set(allowed_user_ids)`` for private
+            workspaces. Batch callers should resolve each private
+            workspace's ``allowed_users`` once (via
+            ``workspaces_utils.get_workspace_users`` with a shared
+            ``all_users`` list) and pass the map. Without this, each
+            invocation re-calls ``get_workspace_users`` for every
+            private workspace, and each of those re-fetches
+            ``get_all_users()`` from the DB.
 
     Raises:
         ValueError: If the user has active clusters or managed jobs in
@@ -388,8 +405,14 @@ def check_user_role_demotion(
     for workspace_name, workspace_config in workspaces.items():
         if not workspace_config.get('private', False):
             continue
-        allowed_user_ids = set(
-            workspaces_utils.get_workspace_users(workspace_config))
+        # Prefer the pre-resolved set (batch path) to avoid re-calling
+        # get_workspace_users -> get_all_users for every workspace.
+        if (workspaces_allowed_users is not None and
+                workspace_name in workspaces_allowed_users):
+            allowed_user_ids = workspaces_allowed_users[workspace_name]
+        else:
+            allowed_user_ids = set(
+                workspaces_utils.get_workspace_users(workspace_config))
         if (user_id in allowed_user_ids or user_id in remaining_admin_user_ids):
             continue
         inaccessible_workspaces.append(workspace_name)
@@ -434,8 +457,10 @@ def check_user_role_demotion(
     if not workspace_resources:
         return
 
-    user_info = global_user_state.get_user(user_id)
-    user_display = (user_info.name if user_info and user_info.name else user_id)
+    if user_display is None:
+        user_info = global_user_state.get_user(user_id)
+        user_display = (user_info.name
+                        if user_info and user_info.name else user_id)
 
     error_lines = []
     for ws, res in workspace_resources.items():

--- a/sky/utils/resource_checker.py
+++ b/sky/utils/resource_checker.py
@@ -139,22 +139,33 @@ def _check_active_resources(resource_operations: List[Tuple[str, str]],
 
 
 def check_users_workspaces_active_resources(
-        user_ids: List[str],
-        workspace_names: List[str]) -> Tuple[str, List[str], Dict[str, str]]:
+    user_ids: List[str],
+    workspace_names: List[str],
+    active_resources: Optional[Tuple[List[Dict[str, Any]],
+                                     List[Dict[str, Any]]]] = None
+) -> Tuple[str, List[str], Dict[str, str]]:
     """Check if all the active clusters or managed jobs in workspaces
        belong to the user_ids. If not, return the error message.
 
     Args:
         user_ids: List of user_id.
         workspace_names: List of workspace_name.
+        active_resources: Optional pre-fetched ``(clusters, managed_jobs)``
+            tuple already filtered to the given ``workspace_names``. Batch
+            callers should fetch this once via
+            ``_get_active_resources_for_workspaces`` and pass it in to avoid
+            paying the per-call fetch cost in a loop.
 
     Returns:
         resource_error_summary: str
         missed_users_names: List[str]
         missed_user_dict: Dict[str, str]
     """
-    all_clusters, all_managed_jobs = _get_active_resources_for_workspaces(
-        workspace_names)
+    if active_resources is None:
+        all_clusters, all_managed_jobs = _get_active_resources_for_workspaces(
+            workspace_names)
+    else:
+        all_clusters, all_managed_jobs = active_resources
     resource_errors = []
     missed_users = set()
     active_cluster_names = []
@@ -261,9 +272,36 @@ def _get_active_resources_by_names(
     return resource_clusters, resource_active_jobs
 
 
+def get_active_resources() -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Public alias for ``_get_active_resources``. Exposed so batch callers
+    can fetch the (clusters, managed_jobs) tuple once and pass it to multiple
+    ``check_user_role_demotion`` / ``check_users_workspaces_active_resources``
+    calls instead of paying the fetch cost per call.
+    """
+    return _get_active_resources()
+
+
+def load_fresh_workspaces() -> Dict[str, Any]:
+    """Reload the skypilot config from disk and return the workspaces dict.
+
+    Exposed so batch callers can do the reload + read once and pass the
+    workspaces dict to multiple ``check_user_role_demotion`` calls.
+    Individual callers should rely on the default ``workspaces=None`` of
+    ``check_user_role_demotion`` instead.
+    """
+    # pylint: disable=import-outside-toplevel
+    from sky import skypilot_config
+    skypilot_config.safe_reload_config()
+    return skypilot_config.get_nested(('workspaces',), default_value={})
+
+
 def check_user_role_demotion(
-        user_id: str,
-        remaining_admin_user_ids: Optional[Set[str]] = None) -> None:
+    user_id: str,
+    remaining_admin_user_ids: Optional[Set[str]] = None,
+    workspaces: Optional[Dict[str, Any]] = None,
+    active_resources: Optional[Tuple[List[Dict[str, Any]],
+                                     List[Dict[str, Any]]]] = None
+) -> None:
     """Check whether an admin can be safely demoted to a regular user.
 
     After demotion the user loses implicit access to all private workspaces
@@ -276,6 +314,14 @@ def check_user_role_demotion(
         remaining_admin_user_ids: Optional pre-computed set of user IDs that
             will remain admins after the demotion. If not provided, it is
             computed from the casbin policy.
+        workspaces: Optional pre-fetched workspaces config (from
+            ``load_fresh_workspaces()``). When called in a batch loop, the
+            caller should fetch this once and pass it in to avoid the
+            per-call ``safe_reload_config`` + YAML read overhead.
+        active_resources: Optional pre-fetched ``(clusters, managed_jobs)``
+            tuple. When called in a batch loop, the caller should fetch
+            this once via ``get_active_resources()`` and pass it in to
+            avoid the per-call cluster+jobs fetch.
 
     Raises:
         ValueError: If the user has active clusters or managed jobs in
@@ -283,21 +329,17 @@ def check_user_role_demotion(
     """
     # Imports done lazily to avoid circular imports with permission/workspaces.
     # pylint: disable=import-outside-toplevel
-    from sky import skypilot_config
     from sky.users import permission
     from sky.users import rbac
     from sky.workspaces import utils as workspaces_utils
 
-    # Ensure the in-memory workspaces config is fresh. /users/update and
-    # /users/batch_update are sync FastAPI handlers, so they don't go through
-    # the executor's reload_for_new_request pipeline -- their per-request
-    # context is inherited from the global one, which is frozen at server
-    # startup. Without this reload, a workspace add (which writes the file
-    # and refreshes its own per-request context) is invisible to a
-    # subsequent demotion check, and we'd incorrectly block the demotion.
-    # Use the file-locked variant to serialize with concurrent writers.
-    skypilot_config.safe_reload_config()
-    workspaces = skypilot_config.get_nested(('workspaces',), default_value={})
+    if workspaces is None:
+        # Single-call path. /users/update and /users/batch_update are sync
+        # FastAPI handlers and don't go through the executor's
+        # reload_for_new_request pipeline; without this reload they would
+        # read the global config snapshot from server startup and miss any
+        # allowed_users writes from a recent /workspaces/batch_add_users.
+        workspaces = load_fresh_workspaces()
     if not workspaces:
         return
 
@@ -320,7 +362,10 @@ def check_user_role_demotion(
     if not inaccessible_workspaces:
         return
 
-    all_clusters, all_managed_jobs = _get_active_resources()
+    if active_resources is None:
+        all_clusters, all_managed_jobs = _get_active_resources()
+    else:
+        all_clusters, all_managed_jobs = active_resources
     workspace_set = set(inaccessible_workspaces)
 
     workspace_resources: Dict[str, Dict[str, List[str]]] = {}

--- a/sky/utils/resource_checker.py
+++ b/sky/utils/resource_checker.py
@@ -1,5 +1,6 @@
 """Resource checking utilities for finding active clusters and managed jobs."""
 
+import collections
 import concurrent.futures
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
@@ -281,6 +282,31 @@ def get_active_resources() -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     return _get_active_resources()
 
 
+def index_active_resources_by_user_hash(
+    active_resources: Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]
+) -> Tuple[Dict[str, List[Dict[str, Any]]], Dict[str, List[Dict[str, Any]]]]:
+    """Group (clusters, jobs) by ``user_hash`` for O(1) per-user lookup.
+
+    For a batch of N users, building this index ONCE up-front and passing it
+    via ``check_user_role_demotion(..., active_resources_by_user=...)``
+    drops the per-user filter from O(C+J) to O(C_user + J_user), giving
+    O(N + C + J) total instead of O(N * (C+J)).
+    """
+    clusters_by_user: Dict[str, List[Dict[str,
+                                          Any]]] = collections.defaultdict(list)
+    jobs_by_user: Dict[str, List[Dict[str,
+                                      Any]]] = collections.defaultdict(list)
+    for cluster in active_resources[0]:
+        user_hash = cluster.get('user_hash')
+        if user_hash:
+            clusters_by_user[user_hash].append(cluster)
+    for job in active_resources[1]:
+        user_hash = job.get('user_hash')
+        if user_hash:
+            jobs_by_user[user_hash].append(job)
+    return clusters_by_user, jobs_by_user
+
+
 def load_fresh_workspaces() -> Dict[str, Any]:
     """Reload the skypilot config from disk and return the workspaces dict.
 
@@ -300,7 +326,10 @@ def check_user_role_demotion(
     remaining_admin_user_ids: Optional[Set[str]] = None,
     workspaces: Optional[Dict[str, Any]] = None,
     active_resources: Optional[Tuple[List[Dict[str, Any]],
-                                     List[Dict[str, Any]]]] = None
+                                     List[Dict[str, Any]]]] = None,
+    active_resources_by_user: Optional[Tuple[Dict[str, List[Dict[str, Any]]],
+                                             Dict[str, List[Dict[str,
+                                                                 Any]]]]] = None
 ) -> None:
     """Check whether an admin can be safely demoted to a regular user.
 
@@ -322,6 +351,12 @@ def check_user_role_demotion(
             tuple. When called in a batch loop, the caller should fetch
             this once via ``get_active_resources()`` and pass it in to
             avoid the per-call cluster+jobs fetch.
+        active_resources_by_user: Optional pre-built
+            ``(clusters_by_user_hash, jobs_by_user_hash)`` index from
+            ``index_active_resources_by_user_hash``. When provided, the
+            per-user lookup is O(1) instead of an O(C+J) scan, giving
+            O(N + C + J) total for a batch instead of O(N * (C+J)).
+            Takes precedence over ``active_resources`` if both are set.
 
     Raises:
         ValueError: If the user has active clusters or managed jobs in
@@ -362,24 +397,34 @@ def check_user_role_demotion(
     if not inaccessible_workspaces:
         return
 
-    if active_resources is None:
-        all_clusters, all_managed_jobs = _get_active_resources()
+    # Resolve the demoted user's clusters / jobs. Prefer the pre-built
+    # index (O(1) lookup) when the batch caller supplied one; fall back
+    # to the linear filter over the raw (clusters, jobs) tuple.
+    if active_resources_by_user is not None:
+        clusters_by_user, jobs_by_user = active_resources_by_user
+        user_clusters = clusters_by_user.get(user_id, [])
+        user_jobs = jobs_by_user.get(user_id, [])
     else:
-        all_clusters, all_managed_jobs = active_resources
-    workspace_set = set(inaccessible_workspaces)
+        if active_resources is None:
+            all_clusters, all_managed_jobs = _get_active_resources()
+        else:
+            all_clusters, all_managed_jobs = active_resources
+        user_clusters = [
+            c for c in all_clusters if c.get('user_hash') == user_id
+        ]
+        user_jobs = [
+            j for j in all_managed_jobs if j.get('user_hash') == user_id
+        ]
 
+    workspace_set = set(inaccessible_workspaces)
     workspace_resources: Dict[str, Dict[str, List[str]]] = {}
-    for cluster in all_clusters:
-        if cluster.get('user_hash') != user_id:
-            continue
+    for cluster in user_clusters:
         ws = cluster.get('workspace', constants.SKYPILOT_DEFAULT_WORKSPACE)
         if ws not in workspace_set:
             continue
         workspace_resources.setdefault(ws, {'clusters': [], 'jobs': []})
         workspace_resources[ws]['clusters'].append(cluster['name'])
-    for job in all_managed_jobs:
-        if job.get('user_hash') != user_id:
-            continue
+    for job in user_jobs:
         ws = job.get('workspace', constants.SKYPILOT_DEFAULT_WORKSPACE)
         if ws not in workspace_set:
             continue

--- a/sky/utils/resource_checker.py
+++ b/sky/utils/resource_checker.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 from sky import exceptions
 from sky import global_user_state
+from sky import models
 from sky import sky_logging
 from sky.skylet import constants
 
@@ -400,10 +401,9 @@ def load_fresh_workspaces() -> Dict[str, Any]:
 
 
 def check_user_role_demotion(
-        user_id: str,
+        user: models.User,
         workspaces: Optional[Dict[str, Any]] = None,
         resources: Optional[ResourceSnapshot] = None,
-        user_display: Optional[str] = None,
         workspaces_allowed_users: Optional[Dict[str, Set[str]]] = None) -> None:
     """Check whether an admin can be safely demoted to a regular user.
 
@@ -413,7 +413,10 @@ def check_user_role_demotion(
     they would lose access to.
 
     Args:
-        user_id: The ID of the user being demoted.
+        user: The user being demoted. Used for both the access check
+            (``user.id`` against each workspace's ``allowed_users``) and
+            the error message (``user.name`` preferred, falling back to
+            ``user.id``).
         workspaces: Optional pre-fetched workspaces config (from
             ``load_fresh_workspaces()``). When called in a batch loop, the
             caller should fetch this once and pass it in to avoid the
@@ -424,11 +427,6 @@ def check_user_role_demotion(
             is O(1) (via the snapshot's user index) instead of an
             O(C+J) scan per user. When not provided, a transient
             snapshot is fetched internally.
-        user_display: Optional pre-resolved display string (username or
-            user_id) used in the error message. Batch callers that already
-            hold the user model should pass this to skip the per-call
-            ``global_user_state.get_user`` lookup that's only used to
-            format the error string.
         workspaces_allowed_users: Optional pre-resolved map of
             ``workspace_name -> set(allowed_user_ids)`` for private
             workspaces. Batch callers should resolve each private
@@ -445,6 +443,9 @@ def check_user_role_demotion(
     # Imports done lazily to avoid circular imports with permission/workspaces.
     # pylint: disable=import-outside-toplevel
     from sky.workspaces import utils as workspaces_utils
+
+    user_id = user.id
+    user_display = user.name or user.id
 
     if workspaces is None:
         # Single-call path. /users/update and /users/batch_update are sync
@@ -499,11 +500,6 @@ def check_user_role_demotion(
 
     if not workspace_resources:
         return
-
-    if user_display is None:
-        user_info = global_user_state.get_user(user_id)
-        user_display = (user_info.name
-                        if user_info and user_info.name else user_id)
 
     error_lines = []
     for ws, res in workspace_resources.items():

--- a/sky/utils/resource_checker.py
+++ b/sky/utils/resource_checker.py
@@ -323,7 +323,6 @@ def load_fresh_workspaces() -> Dict[str, Any]:
 
 def check_user_role_demotion(
         user_id: str,
-        remaining_admin_user_ids: Optional[Set[str]] = None,
         workspaces: Optional[Dict[str, Any]] = None,
         active_resources_by_user: Optional[Tuple[Dict[str, List[Dict[str,
                                                                      Any]]],
@@ -341,9 +340,6 @@ def check_user_role_demotion(
 
     Args:
         user_id: The ID of the user being demoted.
-        remaining_admin_user_ids: Optional pre-computed set of user IDs that
-            will remain admins after the demotion. If not provided, it is
-            computed from the casbin policy.
         workspaces: Optional pre-fetched workspaces config (from
             ``load_fresh_workspaces()``). When called in a batch loop, the
             caller should fetch this once and pass it in to avoid the
@@ -376,8 +372,6 @@ def check_user_role_demotion(
     """
     # Imports done lazily to avoid circular imports with permission/workspaces.
     # pylint: disable=import-outside-toplevel
-    from sky.users import permission
-    from sky.users import rbac
     from sky.workspaces import utils as workspaces_utils
 
     if workspaces is None:
@@ -389,12 +383,6 @@ def check_user_role_demotion(
         workspaces = load_fresh_workspaces()
     if not workspaces:
         return
-
-    if remaining_admin_user_ids is None:
-        remaining_admin_user_ids = set(
-            permission.permission_service.get_users_for_role(
-                rbac.RoleName.ADMIN.value))
-        remaining_admin_user_ids.discard(user_id)
 
     inaccessible_workspaces: List[str] = []
     for workspace_name, workspace_config in workspaces.items():
@@ -408,7 +396,7 @@ def check_user_role_demotion(
         else:
             allowed_user_ids = set(
                 workspaces_utils.get_workspace_users(workspace_config))
-        if (user_id in allowed_user_ids or user_id in remaining_admin_user_ids):
+        if user_id in allowed_user_ids:
             continue
         inaccessible_workspaces.append(workspace_name)
 

--- a/sky/utils/resource_checker.py
+++ b/sky/utils/resource_checker.py
@@ -142,31 +142,48 @@ def _check_active_resources(resource_operations: List[Tuple[str, str]],
 def check_users_workspaces_active_resources(
     user_ids: List[str],
     workspace_names: List[str],
-    active_resources: Optional[Tuple[List[Dict[str, Any]],
-                                     List[Dict[str, Any]]]] = None
+    resources: Optional['ResourceSnapshot'] = None,
 ) -> Tuple[str, List[str], Dict[str, str]]:
     """Check if all the active clusters or managed jobs in workspaces
        belong to the user_ids. If not, return the error message.
 
     Args:
         user_ids: List of user_id.
-        workspace_names: List of workspace_name.
-        active_resources: Optional pre-fetched ``(clusters, managed_jobs)``
-            tuple already filtered to the given ``workspace_names``. Batch
-            callers should fetch this once via
-            ``_get_active_resources_for_workspaces`` and pass it in to avoid
-            paying the per-call fetch cost in a loop.
+        workspace_names: List of workspaces to check.
+        resources: Optional shared ``ResourceSnapshot`` covering at
+            least the given workspaces. Batch callers should construct
+            one ``ResourceSnapshot.fetch_for_workspaces`` and pass it
+            through; the per-workspace slice is taken from the
+            snapshot's workspace index. When not provided, a transient
+            snapshot scoped to ``workspace_names`` is fetched
+            internally.
 
     Returns:
         resource_error_summary: str
         missed_users_names: List[str]
         missed_user_dict: Dict[str, str]
     """
-    if active_resources is None:
-        all_clusters, all_managed_jobs = _get_active_resources_for_workspaces(
-            workspace_names)
+    if resources is None:
+        # Fetch already filters to the given workspaces, so we can use
+        # the raw lists directly (and preserve their original order).
+        resources = ResourceSnapshot.fetch_for_workspaces(workspace_names)
+        all_clusters = resources.clusters
+        all_managed_jobs = resources.managed_jobs
     else:
-        all_clusters, all_managed_jobs = active_resources
+        # Caller-supplied snapshot may cover a superset of workspaces; do
+        # a single linear filter so the relative order of the source
+        # lists is preserved.
+        workspace_set = set(workspace_names)
+        all_clusters = [
+            c for c in resources.clusters
+            if c.get('workspace', constants.SKYPILOT_DEFAULT_WORKSPACE) in
+            workspace_set
+        ]
+        all_managed_jobs = [
+            j for j in resources.managed_jobs
+            if j.get('workspace', constants.SKYPILOT_DEFAULT_WORKSPACE) in
+            workspace_set
+        ]
     resource_errors = []
     missed_users = set()
     active_cluster_names = []
@@ -273,38 +290,99 @@ def _get_active_resources_by_names(
     return resource_clusters, resource_active_jobs
 
 
-def get_active_resources() -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
-    """Public alias for ``_get_active_resources``. Exposed so batch callers
-    can fetch the (clusters, managed_jobs) tuple once and pass it to multiple
-    ``check_user_role_demotion`` / ``check_users_workspaces_active_resources``
-    calls instead of paying the fetch cost per call.
+class ResourceSnapshot:
+    """A point-in-time view of active clusters and managed jobs.
+
+    Holds the raw ``(clusters, managed_jobs)`` lists fetched from the
+    cluster / managed-jobs sources, and builds per-user and per-workspace
+    indices lazily on first access. Batch callers should construct one
+    snapshot at the top of the operation and pass it through helpers;
+    each ``for_user`` / ``for_workspace`` lookup is then O(1) instead of
+    re-filtering the full lists per call.
     """
-    return _get_active_resources()
 
+    def __init__(
+        self,
+        clusters: List[Dict[str, Any]],
+        managed_jobs: List[Dict[str, Any]],
+    ):
+        self._clusters = clusters
+        self._managed_jobs = managed_jobs
+        self._by_workspace: Optional[Dict[str, Tuple[List[Dict[str, Any]],
+                                                     List[Dict[str,
+                                                               Any]]]]] = None
+        self._by_user: Optional[Tuple[Dict[str, List[Dict[str, Any]]],
+                                      Dict[str, List[Dict[str, Any]]]]] = None
 
-def index_active_resources_by_user_hash(
-    active_resources: Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]
-) -> Tuple[Dict[str, List[Dict[str, Any]]], Dict[str, List[Dict[str, Any]]]]:
-    """Group (clusters, jobs) by ``user_hash`` for O(1) per-user lookup.
+    @classmethod
+    def fetch_all(cls) -> 'ResourceSnapshot':
+        """Fetch all active clusters + managed jobs from the DB / controller."""
+        return cls(*_get_active_resources())
 
-    For a batch of N users, building this index ONCE up-front and passing it
-    via ``check_user_role_demotion(..., active_resources_by_user=...)``
-    drops the per-user filter from O(C+J) to O(C_user + J_user), giving
-    O(N + C + J) total instead of O(N * (C+J)).
-    """
-    clusters_by_user: Dict[str, List[Dict[str,
-                                          Any]]] = collections.defaultdict(list)
-    jobs_by_user: Dict[str, List[Dict[str,
-                                      Any]]] = collections.defaultdict(list)
-    for cluster in active_resources[0]:
-        user_hash = cluster.get('user_hash')
-        if user_hash:
-            clusters_by_user[user_hash].append(cluster)
-    for job in active_resources[1]:
-        user_hash = job.get('user_hash')
-        if user_hash:
-            jobs_by_user[user_hash].append(job)
-    return clusters_by_user, jobs_by_user
+    @classmethod
+    def fetch_for_workspaces(cls,
+                             workspace_names: List[str]) -> 'ResourceSnapshot':
+        """Fetch active resources filtered to the given workspaces."""
+        return cls(*_get_active_resources_for_workspaces(workspace_names))
+
+    @property
+    def clusters(self) -> List[Dict[str, Any]]:
+        return self._clusters
+
+    @property
+    def managed_jobs(self) -> List[Dict[str, Any]]:
+        return self._managed_jobs
+
+    def for_user(
+            self,
+            user_id: str) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        """Return ``(clusters, jobs)`` owned by ``user_id``.
+
+        Index is built lazily on first call.
+        """
+        if self._by_user is None:
+            clusters_by_user: Dict[str, List[Dict[
+                str, Any]]] = collections.defaultdict(list)
+            jobs_by_user: Dict[str,
+                               List[Dict[str,
+                                         Any]]] = collections.defaultdict(list)
+            for cluster in self._clusters:
+                uh = cluster.get('user_hash')
+                if uh:
+                    clusters_by_user[uh].append(cluster)
+            for job in self._managed_jobs:
+                uh = job.get('user_hash')
+                if uh:
+                    jobs_by_user[uh].append(job)
+            self._by_user = (dict(clusters_by_user), dict(jobs_by_user))
+        return (self._by_user[0].get(user_id,
+                                     []), self._by_user[1].get(user_id, []))
+
+    def for_workspace(
+        self, workspace_name: str
+    ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        """Return ``(clusters, jobs)`` in the given workspace.
+
+        Index is built lazily on first call.
+        """
+        if self._by_workspace is None:
+            clusters_by_ws: Dict[str, List[Dict[
+                str, Any]]] = collections.defaultdict(list)
+            jobs_by_ws: Dict[str,
+                             List[Dict[str,
+                                       Any]]] = collections.defaultdict(list)
+            for cluster in self._clusters:
+                ws = cluster.get('workspace',
+                                 constants.SKYPILOT_DEFAULT_WORKSPACE)
+                clusters_by_ws[ws].append(cluster)
+            for job in self._managed_jobs:
+                ws = job.get('workspace', constants.SKYPILOT_DEFAULT_WORKSPACE)
+                jobs_by_ws[ws].append(job)
+            self._by_workspace = {
+                name: (clusters_by_ws.get(name, []), jobs_by_ws.get(name, []))
+                for name in set(clusters_by_ws) | set(jobs_by_ws)
+            }
+        return self._by_workspace.get(workspace_name, ([], []))
 
 
 def load_fresh_workspaces() -> Dict[str, Any]:
@@ -324,11 +402,7 @@ def load_fresh_workspaces() -> Dict[str, Any]:
 def check_user_role_demotion(
         user_id: str,
         workspaces: Optional[Dict[str, Any]] = None,
-        active_resources_by_user: Optional[Tuple[Dict[str, List[Dict[str,
-                                                                     Any]]],
-                                                 Dict[str,
-                                                      List[Dict[str,
-                                                                Any]]]]] = None,
+        resources: Optional[ResourceSnapshot] = None,
         user_display: Optional[str] = None,
         workspaces_allowed_users: Optional[Dict[str, Set[str]]] = None) -> None:
     """Check whether an admin can be safely demoted to a regular user.
@@ -344,13 +418,12 @@ def check_user_role_demotion(
             ``load_fresh_workspaces()``). When called in a batch loop, the
             caller should fetch this once and pass it in to avoid the
             per-call ``safe_reload_config`` + YAML read overhead.
-        active_resources_by_user: Optional pre-built
-            ``(clusters_by_user_hash, jobs_by_user_hash)`` index from
-            ``index_active_resources_by_user_hash``. When provided, the
-            per-user lookup is O(1) instead of an O(C+J) scan, giving
-            O(N + C + J) total for a batch instead of O(N * (C+J)).
-            When not provided (single-user path), the function fetches
-            and filters internally.
+        resources: Optional shared ``ResourceSnapshot``. Batch callers
+            should build one ``ResourceSnapshot.fetch_all()`` at the top
+            of the operation and pass it through, so the per-user lookup
+            is O(1) (via the snapshot's user index) instead of an
+            O(C+J) scan per user. When not provided, a transient
+            snapshot is fetched internally.
         user_display: Optional pre-resolved display string (username or
             user_id) used in the error message. Batch callers that already
             hold the user model should pass this to skip the per-call
@@ -360,11 +433,10 @@ def check_user_role_demotion(
             ``workspace_name -> set(allowed_user_ids)`` for private
             workspaces. Batch callers should resolve each private
             workspace's ``allowed_users`` once (via
-            ``workspaces_utils.get_workspace_users`` with a shared
-            ``all_users`` list) and pass the map. Without this, each
-            invocation re-calls ``get_workspace_users`` for every
-            private workspace, and each of those re-fetches
-            ``get_all_users()`` from the DB.
+            ``UserResolver.resolve_workspaces_allowed_users``) and pass
+            the map. Without this, each invocation re-calls
+            ``get_workspace_users`` for every private workspace, and each
+            of those re-fetches ``get_all_users()`` from the DB.
 
     Raises:
         ValueError: If the user has active clusters or managed jobs in
@@ -403,21 +475,12 @@ def check_user_role_demotion(
     if not inaccessible_workspaces:
         return
 
-    # Resolve the demoted user's clusters / jobs. Prefer the pre-built
-    # index (O(1) lookup) when the batch caller supplied one; fall back
-    # to a fresh fetch + linear filter for the single-user path.
-    if active_resources_by_user is not None:
-        clusters_by_user, jobs_by_user = active_resources_by_user
-        user_clusters = clusters_by_user.get(user_id, [])
-        user_jobs = jobs_by_user.get(user_id, [])
-    else:
-        all_clusters, all_managed_jobs = _get_active_resources()
-        user_clusters = [
-            c for c in all_clusters if c.get('user_hash') == user_id
-        ]
-        user_jobs = [
-            j for j in all_managed_jobs if j.get('user_hash') == user_id
-        ]
+    # Resolve the demoted user's clusters / jobs via the snapshot's
+    # per-user index. Build a transient snapshot for the single-user
+    # path; batch callers pass a shared one.
+    if resources is None:
+        resources = ResourceSnapshot.fetch_all()
+    user_clusters, user_jobs = resources.for_user(user_id)
 
     workspace_set = set(inaccessible_workspaces)
     workspace_resources: Dict[str, Dict[str, List[str]]] = {}

--- a/sky/workspaces/core.py
+++ b/sky/workspaces/core.py
@@ -729,19 +729,27 @@ def batch_add_users_to_workspaces(workspace_names: List[str],
 
     # Resolve each user_id to its preferred allowed_users entry ONCE for the
     # whole batch (avoids O(W * N * M) work where W=workspaces, N=batch,
-    # M=total users). Preserve the input order for stable test output.
+    # M=total users). Build name_to_ids and user_id_to_user once so
+    # preferred_identifier_for_user is O(1) instead of O(M) per call.
     all_users = global_user_state.get_all_users()
     name_to_ids = workspaces_utils.build_username_to_ids_map(all_users)
+    user_id_to_user = workspaces_utils.build_user_id_to_user_map(all_users)
     user_id_to_entry: Dict[str, str] = {}
     failed: List[Dict[str, str]] = []
     for user_id in user_ids:
         if user_id in user_id_to_entry:
             continue
         entry = workspaces_utils.preferred_identifier_for_user(
-            user_id, all_users=all_users, name_to_ids=name_to_ids)
+            user_id,
+            all_users=all_users,
+            name_to_ids=name_to_ids,
+            user_id_to_user=user_id_to_user)
         if entry is None:
+            # User resolution failure is not workspace-scoped; use a
+            # placeholder so the UI doesn't render "workspace=" with an
+            # empty value.
             failed.append({
-                'workspace_name': '',
+                'workspace_name': '-',
                 'error': f'User {user_id} does not exist',
             })
             continue
@@ -846,16 +854,19 @@ def batch_remove_users_from_workspaces(workspace_names: List[str],
     if not user_ids:
         raise ValueError('user_ids must not be empty')
 
-    # Build the username->ids map once for the batch so each
-    # entries_for_user call below is O(1) lookup instead of O(M) rebuild.
+    # Build the lookup maps once for the batch so each entries_for_user call
+    # is O(1) instead of O(M) rebuild + O(M) linear scan.
     all_users = global_user_state.get_all_users()
     name_to_ids = workspaces_utils.build_username_to_ids_map(all_users)
+    user_id_to_user = workspaces_utils.build_user_id_to_user_map(all_users)
     user_entries_map: Dict[str, List[str]] = {}
     failed: List[Dict[str, str]] = []
     for user_id in user_ids:
-        entries = workspaces_utils.entries_for_user(user_id,
-                                                    all_users=all_users,
-                                                    name_to_ids=name_to_ids)
+        entries = workspaces_utils.entries_for_user(
+            user_id,
+            all_users=all_users,
+            name_to_ids=name_to_ids,
+            user_id_to_user=user_id_to_user)
         # If the user doesn't exist, entries_for_user returns [user_id]; we
         # still allow removal in case the workspace has a stale entry.
         user_entries_map[user_id] = entries

--- a/sky/workspaces/core.py
+++ b/sky/workspaces/core.py
@@ -165,12 +165,22 @@ def _validate_workspace_config(workspace_name: str,
 def _compare_workspace_configs(
     current_config: Dict[str, Any],
     new_config: Dict[str, Any],
+    admin_user_ids: Optional[List[str]] = None,
+    all_users: Optional[List[models.User]] = None,
+    name_to_ids: Optional[Dict[str, List[str]]] = None,
 ) -> WorkspaceConfigComparison:
     """Compare current and new workspace configurations.
 
     Args:
         current_config: The current workspace configuration.
         new_config: The new workspace configuration.
+        admin_user_ids: Optional pre-fetched list of admin user_ids. Batch
+            callers should pass this so we don't call
+            ``get_users_for_role(ADMIN)`` once per workspace.
+        all_users: Optional pre-fetched user list for the inner
+            ``get_workspace_users`` calls (avoids two ``get_all_users()``
+            DB round-trips per workspace in a batch).
+        name_to_ids: Optional pre-built username -> [user_id] map.
 
     Returns:
         WorkspaceConfigComparison object containing the comparison results.
@@ -180,14 +190,17 @@ def _compare_workspace_configs(
     private_new = new_config.get('private', False)
     private_changed = private_old != private_new
 
-    admin_user_ids = permission.permission_service.get_users_for_role(
-        rbac.RoleName.ADMIN.value)
+    if admin_user_ids is None:
+        admin_user_ids = permission.permission_service.get_users_for_role(
+            rbac.RoleName.ADMIN.value)
     # Get allowed users (resolve to user IDs for comparison)
     allowed_users_old = workspaces_utils.get_workspace_users(
-        current_config) if private_old else []
+        current_config, all_users=all_users,
+        name_to_ids=name_to_ids) if private_old else []
     allowed_users_old += admin_user_ids
     allowed_users_new = workspaces_utils.get_workspace_users(
-        new_config) if private_new else []
+        new_config, all_users=all_users,
+        name_to_ids=name_to_ids) if private_new else []
     allowed_users_new += admin_user_ids
 
     # Convert to sets for easier comparison
@@ -232,6 +245,9 @@ def _validate_workspace_config_changes_with_lock(
     active_resources_for_workspace: Optional[Tuple[List[Dict[str, Any]],
                                                    List[Dict[str,
                                                              Any]]]] = None,
+    admin_user_ids: Optional[List[str]] = None,
+    all_users: Optional[List[models.User]] = None,
+    name_to_ids: Optional[Dict[str, List[str]]] = None,
 ) -> None:
     lock_id = backend_utils.workspace_lock_id(workspace_name)
     lock_timeout = backend_utils.WORKSPACE_LOCK_TIMEOUT_SECONDS
@@ -242,7 +258,10 @@ def _validate_workspace_config_changes_with_lock(
                 workspace_name,
                 current_config,
                 new_config,
-                active_resources_for_workspace=active_resources_for_workspace)
+                active_resources_for_workspace=active_resources_for_workspace,
+                admin_user_ids=admin_user_ids,
+                all_users=all_users,
+                name_to_ids=name_to_ids)
     except locks.LockTimeout as e:
         raise RuntimeError(
             f'Failed to validate workspace {workspace_name!r} due to '
@@ -258,6 +277,9 @@ def _validate_workspace_config_changes(
     active_resources_for_workspace: Optional[Tuple[List[Dict[str, Any]],
                                                    List[Dict[str,
                                                              Any]]]] = None,
+    admin_user_ids: Optional[List[str]] = None,
+    all_users: Optional[List[models.User]] = None,
+    name_to_ids: Optional[Dict[str, List[str]]] = None,
 ) -> None:
     """Validate workspace configuration changes based on active resources.
 
@@ -285,7 +307,12 @@ def _validate_workspace_config_changes(
         ValueError: If the configuration change is not allowed due to active
         resources.
     """
-    config_comparison = _compare_workspace_configs(current_config, new_config)
+    config_comparison = _compare_workspace_configs(
+        current_config,
+        new_config,
+        admin_user_ids=admin_user_ids,
+        all_users=all_users,
+        name_to_ids=name_to_ids)
 
     if config_comparison.only_user_access_changes:
         # Only user access settings changed
@@ -807,10 +834,11 @@ def batch_add_users_to_workspaces(workspace_names: List[str],
                 # Update casbin policy inside the file lock so the config
                 # file and the policy table can't drift out of sync if the
                 # process crashes between the two updates. update_workspace
-                # follows the same pattern.
+                # follows the same pattern. resolved_current is the post-add
+                # user_id set we just computed, so reuse it instead of
+                # re-resolving (which would hit get_all_users() again).
                 permission_service.update_workspace_policy(
-                    workspace_name,
-                    workspaces_utils.get_workspace_users(new_config))
+                    workspace_name, list(resolved_current))
                 succeeded.append(workspace_name)
             except ValueError as e:
                 failed.append({
@@ -876,6 +904,11 @@ def batch_remove_users_from_workspaces(workspace_names: List[str],
         entries_to_strip.update(entries)
 
     succeeded: List[str] = []
+    # Pre-fetch the admin user_ids ONCE for the batch; otherwise
+    # _compare_workspace_configs would call get_users_for_role(ADMIN) per
+    # workspace.
+    admin_user_ids = permission.permission_service.get_users_for_role(
+        rbac.RoleName.ADMIN.value)
     # Pre-pass OUTSIDE the global config file lock: validate per-workspace
     # changes (which acquire a per-workspace lock). The single-workspace
     # update_workspace path also validates before acquiring the config
@@ -884,7 +917,11 @@ def batch_remove_users_from_workspaces(workspace_names: List[str],
     # config lock.
     current_config = skypilot_config.to_dict()
     current_workspaces = current_config.get('workspaces', {})
-    validated_new_configs: Dict[str, Dict[str, Any]] = {}
+    # Map workspace -> (new_config, new_resolved_user_ids). We pre-resolve
+    # the post-removal user_id set during validation so the modifier doesn't
+    # have to call get_workspace_users (which would hit get_all_users) again
+    # under the file lock.
+    validated_changes: Dict[str, Tuple[Dict[str, Any], List[str]]] = {}
 
     # Pre-fetch active resources for the WHOLE batch of workspaces ONCE.
     # Otherwise each per-workspace _validate_workspace_config_changes call
@@ -938,8 +975,17 @@ def batch_remove_users_from_workspaces(workspace_names: List[str],
                 workspace_name,
                 current_ws_config,
                 new_ws_config,
-                active_resources_for_workspace=ws_resources[workspace_name])
-            validated_new_configs[workspace_name] = new_ws_config
+                active_resources_for_workspace=ws_resources[workspace_name],
+                admin_user_ids=admin_user_ids,
+                all_users=all_users,
+                name_to_ids=name_to_ids)
+            # Pre-resolve the post-removal user_id set ONCE here, using the
+            # batch maps, so update_workspace_policy in the modifier (under
+            # the config file lock) doesn't have to do another
+            # get_all_users() round-trip.
+            new_resolved = workspaces_utils.get_workspace_users(
+                new_ws_config, all_users=all_users, name_to_ids=name_to_ids)
+            validated_changes[workspace_name] = (new_ws_config, new_resolved)
         except ValueError as e:
             failed.append({
                 'workspace_name': workspace_name,
@@ -953,13 +999,14 @@ def batch_remove_users_from_workspaces(workspace_names: List[str],
                 'error': str(e),
             })
 
-    if not validated_new_configs:
+    if not validated_changes:
         return {'succeeded': succeeded, 'failed': failed}
 
     permission_service = permission.permission_service
 
     def modifier(workspaces: Dict[str, Any]) -> None:
-        for workspace_name, new_ws_config in validated_new_configs.items():
+        for workspace_name, (new_ws_config,
+                             new_resolved) in validated_changes.items():
             try:
                 # Defensive re-check: the workspace might have been deleted
                 # between validation and acquiring the file lock.
@@ -972,10 +1019,11 @@ def batch_remove_users_from_workspaces(workspace_names: List[str],
                 workspaces[workspace_name] = new_ws_config
                 # Update casbin policy inside the file lock so the config
                 # file and the policy table can't drift out of sync if the
-                # process crashes between the two updates.
+                # process crashes between the two updates. Use the
+                # pre-resolved user_id list (computed during validation)
+                # so we don't re-call get_workspace_users -> get_all_users.
                 permission_service.update_workspace_policy(
-                    workspace_name,
-                    workspaces_utils.get_workspace_users(new_ws_config))
+                    workspace_name, new_resolved)
                 succeeded.append(workspace_name)
             except Exception as e:  # pylint: disable=broad-except
                 logger.exception(

--- a/sky/workspaces/core.py
+++ b/sky/workspaces/core.py
@@ -728,7 +728,7 @@ def batch_add_users_to_workspaces(workspace_names: List[str],
         return {'succeeded': [], 'failed': failed}
 
     succeeded: List[str] = []
-    succeeded_users_for_policy: Dict[str, List[str]] = {}
+    permission_service = permission.permission_service
 
     def modifier(workspaces: Dict[str, Any]) -> None:
         for workspace_name in workspace_names:
@@ -773,13 +773,20 @@ def batch_add_users_to_workspaces(workspace_names: List[str],
                     continue
                 new_config = dict(current_config)
                 new_config['allowed_users'] = new_allowed
+                # Schema check only. The active-resource validation in
+                # _validate_workspace_config_changes is a no-op for pure
+                # adds (it only fires on removed users / private toggles),
+                # so we skip it here.
                 _validate_workspace_config(workspace_name, new_config)
-                _validate_workspace_config_changes_with_lock(
-                    workspace_name, current_config, new_config)
                 workspaces[workspace_name] = new_config
-                succeeded.append(workspace_name)
-                succeeded_users_for_policy[workspace_name] = (
+                # Update casbin policy inside the file lock so the config
+                # file and the policy table can't drift out of sync if the
+                # process crashes between the two updates. update_workspace
+                # follows the same pattern.
+                permission_service.update_workspace_policy(
+                    workspace_name,
                     workspaces_utils.get_workspace_users(new_config))
+                succeeded.append(workspace_name)
             except ValueError as e:
                 failed.append({
                     'workspace_name': workspace_name,
@@ -794,10 +801,6 @@ def batch_add_users_to_workspaces(workspace_names: List[str],
                 })
 
     _update_workspaces_config(modifier)
-
-    permission_service = permission.permission_service
-    for workspace_name, users in succeeded_users_for_policy.items():
-        permission_service.update_workspace_policy(workspace_name, users)
 
     return {'succeeded': succeeded, 'failed': failed}
 
@@ -836,65 +839,97 @@ def batch_remove_users_from_workspaces(workspace_names: List[str],
         # still allow removal in case the workspace has a stale entry.
         user_entries_map[user_id] = entries
 
+    entries_to_strip: Set[str] = set()
+    for entries in user_entries_map.values():
+        entries_to_strip.update(entries)
+
     succeeded: List[str] = []
-    succeeded_users_for_policy: Dict[str, List[str]] = {}
+    # Pre-pass OUTSIDE the global config file lock: validate per-workspace
+    # changes (which acquire a per-workspace lock). The single-workspace
+    # update_workspace path also validates before acquiring the config
+    # file lock, so we match that nesting order to avoid an ABBA deadlock
+    # against any caller that holds the workspace lock and waits on the
+    # config lock.
+    current_config = skypilot_config.to_dict()
+    current_workspaces = current_config.get('workspaces', {})
+    validated_new_configs: Dict[str, Dict[str, Any]] = {}
+
+    for workspace_name in workspace_names:
+        try:
+            if workspace_name not in current_workspaces:
+                failed.append({
+                    'workspace_name': workspace_name,
+                    'error': f'Workspace {workspace_name!r} does not exist',
+                })
+                continue
+            current_ws_config = current_workspaces[workspace_name]
+            if not current_ws_config.get('private', False):
+                failed.append({
+                    'workspace_name': workspace_name,
+                    'error': (f'Workspace {workspace_name!r} is not private; '
+                              'allowed_users has no effect.'),
+                })
+                continue
+            current_allowed = list(current_ws_config.get('allowed_users', []))
+            new_allowed = [
+                entry for entry in current_allowed
+                if entry not in entries_to_strip
+            ]
+            if new_allowed == current_allowed:
+                succeeded.append(workspace_name)
+                continue
+            new_ws_config = dict(current_ws_config)
+            new_ws_config['allowed_users'] = new_allowed
+            _validate_workspace_config(workspace_name, new_ws_config)
+            _validate_workspace_config_changes_with_lock(
+                workspace_name, current_ws_config, new_ws_config)
+            validated_new_configs[workspace_name] = new_ws_config
+        except ValueError as e:
+            failed.append({
+                'workspace_name': workspace_name,
+                'error': str(e),
+            })
+        except Exception as e:  # pylint: disable=broad-except
+            logger.exception(
+                f'Failed to validate removal from workspace {workspace_name!r}')
+            failed.append({
+                'workspace_name': workspace_name,
+                'error': str(e),
+            })
+
+    if not validated_new_configs:
+        return {'succeeded': succeeded, 'failed': failed}
+
+    permission_service = permission.permission_service
 
     def modifier(workspaces: Dict[str, Any]) -> None:
-        for workspace_name in workspace_names:
+        for workspace_name, new_ws_config in validated_new_configs.items():
             try:
+                # Defensive re-check: the workspace might have been deleted
+                # between validation and acquiring the file lock.
                 if workspace_name not in workspaces:
                     failed.append({
                         'workspace_name': workspace_name,
                         'error': f'Workspace {workspace_name!r} does not exist',
                     })
                     continue
-                current_config = workspaces[workspace_name]
-                if not current_config.get('private', False):
-                    failed.append({
-                        'workspace_name': workspace_name,
-                        'error':
-                            (f'Workspace {workspace_name!r} is not private; '
-                             'allowed_users has no effect.'),
-                    })
-                    continue
-                current_allowed = list(current_config.get('allowed_users', []))
-                entries_to_strip = set()
-                for entries in user_entries_map.values():
-                    entries_to_strip.update(entries)
-                new_allowed = [
-                    entry for entry in current_allowed
-                    if entry not in entries_to_strip
-                ]
-                if new_allowed == current_allowed:
-                    succeeded.append(workspace_name)
-                    continue
-                new_config = dict(current_config)
-                new_config['allowed_users'] = new_allowed
-                _validate_workspace_config(workspace_name, new_config)
-                _validate_workspace_config_changes_with_lock(
-                    workspace_name, current_config, new_config)
-                workspaces[workspace_name] = new_config
+                workspaces[workspace_name] = new_ws_config
+                # Update casbin policy inside the file lock so the config
+                # file and the policy table can't drift out of sync if the
+                # process crashes between the two updates.
+                permission_service.update_workspace_policy(
+                    workspace_name,
+                    workspaces_utils.get_workspace_users(new_ws_config))
                 succeeded.append(workspace_name)
-                succeeded_users_for_policy[workspace_name] = (
-                    workspaces_utils.get_workspace_users(new_config))
-            except ValueError as e:
-                failed.append({
-                    'workspace_name': workspace_name,
-                    'error': str(e),
-                })
             except Exception as e:  # pylint: disable=broad-except
                 logger.exception(
-                    f'Failed to remove users from workspace {workspace_name!r}')
+                    f'Failed to apply removal for workspace {workspace_name!r}')
                 failed.append({
                     'workspace_name': workspace_name,
                     'error': str(e),
                 })
 
     _update_workspaces_config(modifier)
-
-    permission_service = permission.permission_service
-    for workspace_name, users in succeeded_users_for_policy.items():
-        permission_service.update_workspace_policy(workspace_name, users)
 
     return {'succeeded': succeeded, 'failed': failed}
 

--- a/sky/workspaces/core.py
+++ b/sky/workspaces/core.py
@@ -7,6 +7,7 @@ import filelock
 
 from sky import check as sky_check
 from sky import exceptions
+from sky import global_user_state
 from sky import models
 from sky import sky_logging
 from sky import skypilot_config
@@ -679,6 +680,223 @@ def is_workspace_private(workspace_config: Dict[str, Any]) -> bool:
         True if the workspace is private, False if it's public.
     """
     return workspace_config.get('private', False)
+
+
+@usage_lib.entrypoint
+def batch_add_users_to_workspaces(workspace_names: List[str],
+                                  user_ids: List[str]) -> Dict[str, Any]:
+    """Adds users to the ``allowed_users`` of multiple private workspaces.
+
+    Per-workspace failures are isolated so a single bad workspace doesn't
+    block the rest of the batch. Public workspaces are rejected because
+    ``allowed_users`` has no effect there.
+
+    Args:
+        workspace_names: Names of workspaces to update.
+        user_ids: User IDs to add. Each is written as the username (if it
+            uniquely resolves) or the user_id (if there is ambiguity).
+
+    Returns:
+        ``{'succeeded': [workspace_name, ...], 'failed': [{
+            'workspace_name': ..., 'error': ...
+        }, ...]}``.
+    """
+    if not workspace_names:
+        raise ValueError('workspace_names must not be empty')
+    if not user_ids:
+        raise ValueError('user_ids must not be empty')
+
+    all_users = global_user_state.get_all_users()
+    entries_to_add: List[str] = []
+    failed: List[Dict[str, str]] = []
+    user_id_set = set()
+    for user_id in user_ids:
+        entry = workspaces_utils.preferred_identifier_for_user(
+            user_id, all_users=all_users)
+        if entry is None:
+            failed.append({
+                'workspace_name': '',
+                'error': f'User {user_id} does not exist',
+            })
+            continue
+        if user_id in user_id_set:
+            continue
+        user_id_set.add(user_id)
+        entries_to_add.append(entry)
+
+    if not entries_to_add:
+        return {'succeeded': [], 'failed': failed}
+
+    succeeded: List[str] = []
+    succeeded_users_for_policy: Dict[str, List[str]] = {}
+
+    def modifier(workspaces: Dict[str, Any]) -> None:
+        for workspace_name in workspace_names:
+            try:
+                if workspace_name not in workspaces:
+                    failed.append({
+                        'workspace_name': workspace_name,
+                        'error': f'Workspace {workspace_name!r} does not exist',
+                    })
+                    continue
+                current_config = workspaces[workspace_name]
+                if not current_config.get('private', False):
+                    failed.append({
+                        'workspace_name': workspace_name,
+                        'error':
+                            (f'Workspace {workspace_name!r} is not private; '
+                             'allowed_users has no effect.'),
+                    })
+                    continue
+                current_allowed = list(current_config.get('allowed_users', []))
+                # Resolve the currently-listed entries to user_ids so we
+                # don't add a duplicate row for users already present under
+                # a different form (username vs user_id).
+                resolved_current = set(
+                    workspaces_utils.get_workspace_users(current_config))
+                new_allowed = list(current_allowed)
+                added = False
+                for user_id, entry in zip(user_ids, [
+                        workspaces_utils.preferred_identifier_for_user(
+                            uid, all_users=all_users) for uid in user_ids
+                ]):
+                    if entry is None:
+                        # Already reported above.
+                        continue
+                    if user_id in resolved_current:
+                        continue
+                    new_allowed.append(entry)
+                    resolved_current.add(user_id)
+                    added = True
+                if not added:
+                    succeeded.append(workspace_name)
+                    continue
+                new_config = dict(current_config)
+                new_config['allowed_users'] = new_allowed
+                _validate_workspace_config(workspace_name, new_config)
+                _validate_workspace_config_changes_with_lock(
+                    workspace_name, current_config, new_config)
+                workspaces[workspace_name] = new_config
+                succeeded.append(workspace_name)
+                succeeded_users_for_policy[workspace_name] = (
+                    workspaces_utils.get_workspace_users(new_config))
+            except ValueError as e:
+                failed.append({
+                    'workspace_name': workspace_name,
+                    'error': str(e),
+                })
+            except Exception as e:  # pylint: disable=broad-except
+                logger.exception(
+                    f'Failed to add users to workspace {workspace_name!r}')
+                failed.append({
+                    'workspace_name': workspace_name,
+                    'error': str(e),
+                })
+
+    _update_workspaces_config(modifier)
+
+    permission_service = permission.permission_service
+    for workspace_name, users in succeeded_users_for_policy.items():
+        permission_service.update_workspace_policy(workspace_name, users)
+
+    return {'succeeded': succeeded, 'failed': failed}
+
+
+@usage_lib.entrypoint
+def batch_remove_users_from_workspaces(workspace_names: List[str],
+                                       user_ids: List[str]) -> Dict[str, Any]:
+    """Removes users from the ``allowed_users`` of multiple private workspaces.
+
+    Per-workspace failures are isolated. Removal of a user with active
+    resources in the workspace is rejected via the existing
+    ``_validate_workspace_config_changes`` "removed users" branch.
+
+    Args:
+        workspace_names: Names of workspaces to update.
+        user_ids: User IDs to remove. Both the user_id and the username
+            forms are stripped from each workspace's ``allowed_users``.
+
+    Returns:
+        ``{'succeeded': [workspace_name, ...], 'failed': [{
+            'workspace_name': ..., 'error': ...
+        }, ...]}``.
+    """
+    if not workspace_names:
+        raise ValueError('workspace_names must not be empty')
+    if not user_ids:
+        raise ValueError('user_ids must not be empty')
+
+    all_users = global_user_state.get_all_users()
+    user_entries_map: Dict[str, List[str]] = {}
+    failed: List[Dict[str, str]] = []
+    for user_id in user_ids:
+        entries = workspaces_utils.entries_for_user(user_id,
+                                                    all_users=all_users)
+        # If the user doesn't exist, entries_for_user returns [user_id]; we
+        # still allow removal in case the workspace has a stale entry.
+        user_entries_map[user_id] = entries
+
+    succeeded: List[str] = []
+    succeeded_users_for_policy: Dict[str, List[str]] = {}
+
+    def modifier(workspaces: Dict[str, Any]) -> None:
+        for workspace_name in workspace_names:
+            try:
+                if workspace_name not in workspaces:
+                    failed.append({
+                        'workspace_name': workspace_name,
+                        'error': f'Workspace {workspace_name!r} does not exist',
+                    })
+                    continue
+                current_config = workspaces[workspace_name]
+                if not current_config.get('private', False):
+                    failed.append({
+                        'workspace_name': workspace_name,
+                        'error':
+                            (f'Workspace {workspace_name!r} is not private; '
+                             'allowed_users has no effect.'),
+                    })
+                    continue
+                current_allowed = list(current_config.get('allowed_users', []))
+                entries_to_strip = set()
+                for entries in user_entries_map.values():
+                    entries_to_strip.update(entries)
+                new_allowed = [
+                    entry for entry in current_allowed
+                    if entry not in entries_to_strip
+                ]
+                if new_allowed == current_allowed:
+                    succeeded.append(workspace_name)
+                    continue
+                new_config = dict(current_config)
+                new_config['allowed_users'] = new_allowed
+                _validate_workspace_config(workspace_name, new_config)
+                _validate_workspace_config_changes_with_lock(
+                    workspace_name, current_config, new_config)
+                workspaces[workspace_name] = new_config
+                succeeded.append(workspace_name)
+                succeeded_users_for_policy[workspace_name] = (
+                    workspaces_utils.get_workspace_users(new_config))
+            except ValueError as e:
+                failed.append({
+                    'workspace_name': workspace_name,
+                    'error': str(e),
+                })
+            except Exception as e:  # pylint: disable=broad-except
+                logger.exception(
+                    f'Failed to remove users from workspace {workspace_name!r}')
+                failed.append({
+                    'workspace_name': workspace_name,
+                    'error': str(e),
+                })
+
+    _update_workspaces_config(modifier)
+
+    permission_service = permission.permission_service
+    for workspace_name, users in succeeded_users_for_policy.items():
+        permission_service.update_workspace_policy(workspace_name, users)
+
+    return {'succeeded': succeeded, 'failed': failed}
 
 
 @annotations.lru_cache(scope='request', maxsize=1)

--- a/sky/workspaces/core.py
+++ b/sky/workspaces/core.py
@@ -1,7 +1,7 @@
 """Workspace management core."""
 
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 import filelock
 
@@ -226,15 +226,23 @@ def _compare_workspace_configs(
 
 
 def _validate_workspace_config_changes_with_lock(
-        workspace_name: str, current_config: Dict[str, Any],
-        new_config: Dict[str, Any]) -> None:
+    workspace_name: str,
+    current_config: Dict[str, Any],
+    new_config: Dict[str, Any],
+    active_resources_for_workspace: Optional[Tuple[List[Dict[str, Any]],
+                                                   List[Dict[str,
+                                                             Any]]]] = None,
+) -> None:
     lock_id = backend_utils.workspace_lock_id(workspace_name)
     lock_timeout = backend_utils.WORKSPACE_LOCK_TIMEOUT_SECONDS
     try:
         with locks.get_lock(lock_id, lock_timeout):
             # Validate the configuration changes based on active resources
-            _validate_workspace_config_changes(workspace_name, current_config,
-                                               new_config)
+            _validate_workspace_config_changes(
+                workspace_name,
+                current_config,
+                new_config,
+                active_resources_for_workspace=active_resources_for_workspace)
     except locks.LockTimeout as e:
         raise RuntimeError(
             f'Failed to validate workspace {workspace_name!r} due to '
@@ -243,9 +251,14 @@ def _validate_workspace_config_changes_with_lock(
             f'{common_utils.format_exception(e)}') from None
 
 
-def _validate_workspace_config_changes(workspace_name: str,
-                                       current_config: Dict[str, Any],
-                                       new_config: Dict[str, Any]) -> None:
+def _validate_workspace_config_changes(
+    workspace_name: str,
+    current_config: Dict[str, Any],
+    new_config: Dict[str, Any],
+    active_resources_for_workspace: Optional[Tuple[List[Dict[str, Any]],
+                                                   List[Dict[str,
+                                                             Any]]]] = None,
+) -> None:
     """Validate workspace configuration changes based on active resources.
 
     This function implements the logic:
@@ -261,6 +274,12 @@ def _validate_workspace_config_changes(workspace_name: str,
         workspace_name: The name of the workspace.
         current_config: The current workspace configuration.
         new_config: The new workspace configuration.
+        active_resources_for_workspace: Optional pre-fetched
+            ``(clusters, managed_jobs)`` tuple already filtered to this
+            workspace. Batch callers should fetch this once for all
+            workspaces in the batch (via
+            ``resource_checker._get_active_resources_for_workspaces``) and
+            pass the per-workspace slice to avoid the per-call fetch.
 
     Raises:
         ValueError: If the configuration change is not allowed due to active
@@ -289,7 +308,8 @@ def _validate_workspace_config_changes(workspace_name: str,
 
                 error_summary, missed_users_names, _ = (
                     resource_checker.check_users_workspaces_active_resources(
-                        config_comparison.allowed_users_new, [workspace_name]))
+                        config_comparison.allowed_users_new, [workspace_name],
+                        active_resources=active_resources_for_workspace))
                 if error_summary:
                     error_msg=f'Cannot change workspace {workspace_name!r}' \
                     f' to private '
@@ -316,7 +336,8 @@ def _validate_workspace_config_changes(workspace_name: str,
                     f' active resources in workspace {workspace_name!r}.')
                 error_summary, missed_users_names, missed_user_dict = (
                     resource_checker.check_users_workspaces_active_resources(
-                        config_comparison.allowed_users_new, [workspace_name]))
+                        config_comparison.allowed_users_new, [workspace_name],
+                        active_resources=active_resources_for_workspace))
                 if error_summary:
                     error_user_ids = []
                     for user_id in config_comparison.removed_users:
@@ -706,25 +727,27 @@ def batch_add_users_to_workspaces(workspace_names: List[str],
     if not user_ids:
         raise ValueError('user_ids must not be empty')
 
+    # Resolve each user_id to its preferred allowed_users entry ONCE for the
+    # whole batch (avoids O(W * N * M) work where W=workspaces, N=batch,
+    # M=total users). Preserve the input order for stable test output.
     all_users = global_user_state.get_all_users()
-    entries_to_add: List[str] = []
+    name_to_ids = workspaces_utils.build_username_to_ids_map(all_users)
+    user_id_to_entry: Dict[str, str] = {}
     failed: List[Dict[str, str]] = []
-    user_id_set = set()
     for user_id in user_ids:
+        if user_id in user_id_to_entry:
+            continue
         entry = workspaces_utils.preferred_identifier_for_user(
-            user_id, all_users=all_users)
+            user_id, all_users=all_users, name_to_ids=name_to_ids)
         if entry is None:
             failed.append({
                 'workspace_name': '',
                 'error': f'User {user_id} does not exist',
             })
             continue
-        if user_id in user_id_set:
-            continue
-        user_id_set.add(user_id)
-        entries_to_add.append(entry)
+        user_id_to_entry[user_id] = entry
 
-    if not entries_to_add:
+    if not user_id_to_entry:
         return {'succeeded': [], 'failed': failed}
 
     succeeded: List[str] = []
@@ -756,13 +779,7 @@ def batch_add_users_to_workspaces(workspace_names: List[str],
                     workspaces_utils.get_workspace_users(current_config))
                 new_allowed = list(current_allowed)
                 added = False
-                for user_id, entry in zip(user_ids, [
-                        workspaces_utils.preferred_identifier_for_user(
-                            uid, all_users=all_users) for uid in user_ids
-                ]):
-                    if entry is None:
-                        # Already reported above.
-                        continue
+                for user_id, entry in user_id_to_entry.items():
                     if user_id in resolved_current:
                         continue
                     new_allowed.append(entry)
@@ -829,12 +846,16 @@ def batch_remove_users_from_workspaces(workspace_names: List[str],
     if not user_ids:
         raise ValueError('user_ids must not be empty')
 
+    # Build the username->ids map once for the batch so each
+    # entries_for_user call below is O(1) lookup instead of O(M) rebuild.
     all_users = global_user_state.get_all_users()
+    name_to_ids = workspaces_utils.build_username_to_ids_map(all_users)
     user_entries_map: Dict[str, List[str]] = {}
     failed: List[Dict[str, str]] = []
     for user_id in user_ids:
         entries = workspaces_utils.entries_for_user(user_id,
-                                                    all_users=all_users)
+                                                    all_users=all_users,
+                                                    name_to_ids=name_to_ids)
         # If the user doesn't exist, entries_for_user returns [user_id]; we
         # still allow removal in case the workspace has a stale entry.
         user_entries_map[user_id] = entries
@@ -853,6 +874,27 @@ def batch_remove_users_from_workspaces(workspace_names: List[str],
     current_config = skypilot_config.to_dict()
     current_workspaces = current_config.get('workspaces', {})
     validated_new_configs: Dict[str, Dict[str, Any]] = {}
+
+    # Pre-fetch active resources for the WHOLE batch of workspaces ONCE.
+    # Otherwise each per-workspace _validate_workspace_config_changes call
+    # would re-query clusters + managed jobs from scratch (the
+    # managed-jobs fetch in particular is a blocking RPC to the
+    # controller), giving O(W * (C+J)) instead of O(C+J).
+    # pylint: disable=protected-access
+    batch_clusters, batch_jobs = (
+        resource_checker._get_active_resources_for_workspaces(workspace_names))
+    ws_resources: Dict[str, Tuple[List[Dict[str, Any]],
+                                  List[Dict[str, Any]]]] = {
+                                      name: ([], []) for name in workspace_names
+                                  }
+    for cluster in batch_clusters:
+        ws = cluster.get('workspace', constants.SKYPILOT_DEFAULT_WORKSPACE)
+        if ws in ws_resources:
+            ws_resources[ws][0].append(cluster)
+    for job in batch_jobs:
+        ws = job.get('workspace', constants.SKYPILOT_DEFAULT_WORKSPACE)
+        if ws in ws_resources:
+            ws_resources[ws][1].append(job)
 
     for workspace_name in workspace_names:
         try:
@@ -882,7 +924,10 @@ def batch_remove_users_from_workspaces(workspace_names: List[str],
             new_ws_config['allowed_users'] = new_allowed
             _validate_workspace_config(workspace_name, new_ws_config)
             _validate_workspace_config_changes_with_lock(
-                workspace_name, current_ws_config, new_ws_config)
+                workspace_name,
+                current_ws_config,
+                new_ws_config,
+                active_resources_for_workspace=ws_resources[workspace_name])
             validated_new_configs[workspace_name] = new_ws_config
         except ValueError as e:
             failed.append({

--- a/sky/workspaces/core.py
+++ b/sky/workspaces/core.py
@@ -7,7 +7,6 @@ import filelock
 
 from sky import check as sky_check
 from sky import exceptions
-from sky import global_user_state
 from sky import models
 from sky import sky_logging
 from sky import skypilot_config
@@ -15,7 +14,7 @@ from sky.backends import backend_utils
 from sky.skylet import constants
 from sky.usage import usage_lib
 from sky.users import permission
-from sky.users import rbac
+from sky.users import resolver as user_resolver
 from sky.utils import annotations
 from sky.utils import common_utils
 from sky.utils import config_utils
@@ -165,22 +164,17 @@ def _validate_workspace_config(workspace_name: str,
 def _compare_workspace_configs(
     current_config: Dict[str, Any],
     new_config: Dict[str, Any],
-    admin_user_ids: Optional[List[str]] = None,
-    all_users: Optional[List[models.User]] = None,
-    name_to_ids: Optional[Dict[str, List[str]]] = None,
+    resolver: Optional[user_resolver.UserResolver] = None,
 ) -> WorkspaceConfigComparison:
     """Compare current and new workspace configurations.
 
     Args:
         current_config: The current workspace configuration.
         new_config: The new workspace configuration.
-        admin_user_ids: Optional pre-fetched list of admin user_ids. Batch
-            callers should pass this so we don't call
-            ``get_users_for_role(ADMIN)`` once per workspace.
-        all_users: Optional pre-fetched user list for the inner
-            ``get_workspace_users`` calls (avoids two ``get_all_users()``
-            DB round-trips per workspace in a batch).
-        name_to_ids: Optional pre-built username -> [user_id] map.
+        resolver: Optional shared ``UserResolver`` so batch callers don't
+            re-fetch ``get_all_users()`` / ``get_users_for_role(ADMIN)``
+            per workspace. If not provided, a transient resolver is built
+            internally.
 
     Returns:
         WorkspaceConfigComparison object containing the comparison results.
@@ -190,17 +184,17 @@ def _compare_workspace_configs(
     private_new = new_config.get('private', False)
     private_changed = private_old != private_new
 
-    if admin_user_ids is None:
-        admin_user_ids = permission.permission_service.get_users_for_role(
-            rbac.RoleName.ADMIN.value)
-    # Get allowed users (resolve to user IDs for comparison)
-    allowed_users_old = workspaces_utils.get_workspace_users(
-        current_config, all_users=all_users,
-        name_to_ids=name_to_ids) if private_old else []
+    if resolver is None:
+        resolver = user_resolver.UserResolver()
+    admin_user_ids = resolver.admin_user_ids
+    # Get allowed users (resolve to user IDs for comparison).
+    # Routed through the free helper so test seams that patch
+    # ``workspaces_utils.get_workspace_users`` keep working.
+    allowed_users_old = (workspaces_utils.get_workspace_users(
+        current_config, resolver=resolver) if private_old else [])
     allowed_users_old += admin_user_ids
-    allowed_users_new = workspaces_utils.get_workspace_users(
-        new_config, all_users=all_users,
-        name_to_ids=name_to_ids) if private_new else []
+    allowed_users_new = (workspaces_utils.get_workspace_users(
+        new_config, resolver=resolver) if private_new else [])
     allowed_users_new += admin_user_ids
 
     # Convert to sets for easier comparison
@@ -245,9 +239,7 @@ def _validate_workspace_config_changes_with_lock(
     active_resources_for_workspace: Optional[Tuple[List[Dict[str, Any]],
                                                    List[Dict[str,
                                                              Any]]]] = None,
-    admin_user_ids: Optional[List[str]] = None,
-    all_users: Optional[List[models.User]] = None,
-    name_to_ids: Optional[Dict[str, List[str]]] = None,
+    resolver: Optional[user_resolver.UserResolver] = None,
 ) -> None:
     lock_id = backend_utils.workspace_lock_id(workspace_name)
     lock_timeout = backend_utils.WORKSPACE_LOCK_TIMEOUT_SECONDS
@@ -259,9 +251,7 @@ def _validate_workspace_config_changes_with_lock(
                 current_config,
                 new_config,
                 active_resources_for_workspace=active_resources_for_workspace,
-                admin_user_ids=admin_user_ids,
-                all_users=all_users,
-                name_to_ids=name_to_ids)
+                resolver=resolver)
     except locks.LockTimeout as e:
         raise RuntimeError(
             f'Failed to validate workspace {workspace_name!r} due to '
@@ -277,9 +267,7 @@ def _validate_workspace_config_changes(
     active_resources_for_workspace: Optional[Tuple[List[Dict[str, Any]],
                                                    List[Dict[str,
                                                              Any]]]] = None,
-    admin_user_ids: Optional[List[str]] = None,
-    all_users: Optional[List[models.User]] = None,
-    name_to_ids: Optional[Dict[str, List[str]]] = None,
+    resolver: Optional[user_resolver.UserResolver] = None,
 ) -> None:
     """Validate workspace configuration changes based on active resources.
 
@@ -307,12 +295,9 @@ def _validate_workspace_config_changes(
         ValueError: If the configuration change is not allowed due to active
         resources.
     """
-    config_comparison = _compare_workspace_configs(
-        current_config,
-        new_config,
-        admin_user_ids=admin_user_ids,
-        all_users=all_users,
-        name_to_ids=name_to_ids)
+    config_comparison = _compare_workspace_configs(current_config,
+                                                   new_config,
+                                                   resolver=resolver)
 
     if config_comparison.only_user_access_changes:
         # Only user access settings changed
@@ -756,21 +741,15 @@ def batch_add_users_to_workspaces(workspace_names: List[str],
 
     # Resolve each user_id to its preferred allowed_users entry ONCE for the
     # whole batch (avoids O(W * N * M) work where W=workspaces, N=batch,
-    # M=total users). Build name_to_ids and user_id_to_user once so
-    # preferred_identifier_for_user is O(1) instead of O(M) per call.
-    all_users = global_user_state.get_all_users()
-    name_to_ids = workspaces_utils.build_username_to_ids_map(all_users)
-    user_id_to_user = workspaces_utils.build_user_id_to_user_map(all_users)
+    # M=total users). UserResolver builds the id->User and name->[ids]
+    # maps once so each preferred_entry call is O(1).
+    resolver = user_resolver.UserResolver()
     user_id_to_entry: Dict[str, str] = {}
     failed: List[Dict[str, str]] = []
     for user_id in user_ids:
         if user_id in user_id_to_entry:
             continue
-        entry = workspaces_utils.preferred_identifier_for_user(
-            user_id,
-            all_users=all_users,
-            name_to_ids=name_to_ids,
-            user_id_to_user=user_id_to_user)
+        entry = resolver.preferred_entry(user_id)
         if entry is None:
             # User resolution failure is not workspace-scoped; use a
             # placeholder so the UI doesn't render "workspace=" with an
@@ -811,7 +790,7 @@ def batch_add_users_to_workspaces(workspace_names: List[str],
                 # don't add a duplicate row for users already present under
                 # a different form (username vs user_id).
                 resolved_current = set(
-                    workspaces_utils.get_workspace_users(current_config))
+                    resolver.resolve_workspace_users(current_config))
                 new_allowed = list(current_allowed)
                 added = False
                 for user_id, entry in user_id_to_entry.items():
@@ -882,33 +861,25 @@ def batch_remove_users_from_workspaces(workspace_names: List[str],
     if not user_ids:
         raise ValueError('user_ids must not be empty')
 
-    # Build the lookup maps once for the batch so each entries_for_user call
-    # is O(1) instead of O(M) rebuild + O(M) linear scan.
-    all_users = global_user_state.get_all_users()
-    name_to_ids = workspaces_utils.build_username_to_ids_map(all_users)
-    user_id_to_user = workspaces_utils.build_user_id_to_user_map(all_users)
+    # Build one shared UserResolver for the whole batch so each
+    # entries_for / preferred_entry / resolve_workspace_users call is
+    # O(1) instead of rebuilding the id->User and name->[ids] maps.
+    # Admin user_ids is lazily fetched on first access (used by
+    # _compare_workspace_configs inside the per-workspace validation
+    # loop below).
+    resolver = user_resolver.UserResolver()
     user_entries_map: Dict[str, List[str]] = {}
     failed: List[Dict[str, str]] = []
     for user_id in user_ids:
-        entries = workspaces_utils.entries_for_user(
-            user_id,
-            all_users=all_users,
-            name_to_ids=name_to_ids,
-            user_id_to_user=user_id_to_user)
-        # If the user doesn't exist, entries_for_user returns [user_id]; we
+        # If the user doesn't exist, entries_for returns [user_id]; we
         # still allow removal in case the workspace has a stale entry.
-        user_entries_map[user_id] = entries
+        user_entries_map[user_id] = resolver.entries_for(user_id)
 
     entries_to_strip: Set[str] = set()
     for entries in user_entries_map.values():
         entries_to_strip.update(entries)
 
     succeeded: List[str] = []
-    # Pre-fetch the admin user_ids ONCE for the batch; otherwise
-    # _compare_workspace_configs would call get_users_for_role(ADMIN) per
-    # workspace.
-    admin_user_ids = permission.permission_service.get_users_for_role(
-        rbac.RoleName.ADMIN.value)
     # Pre-pass OUTSIDE the global config file lock: validate per-workspace
     # changes (which acquire a per-workspace lock). The single-workspace
     # update_workspace path also validates before acquiring the config
@@ -976,15 +947,12 @@ def batch_remove_users_from_workspaces(workspace_names: List[str],
                 current_ws_config,
                 new_ws_config,
                 active_resources_for_workspace=ws_resources[workspace_name],
-                admin_user_ids=admin_user_ids,
-                all_users=all_users,
-                name_to_ids=name_to_ids)
+                resolver=resolver)
             # Pre-resolve the post-removal user_id set ONCE here, using the
-            # batch maps, so update_workspace_policy in the modifier (under
-            # the config file lock) doesn't have to do another
+            # shared resolver, so update_workspace_policy in the modifier
+            # (under the config file lock) doesn't have to do another
             # get_all_users() round-trip.
-            new_resolved = workspaces_utils.get_workspace_users(
-                new_ws_config, all_users=all_users, name_to_ids=name_to_ids)
+            new_resolved = resolver.resolve_workspace_users(new_ws_config)
             validated_changes[workspace_name] = (new_ws_config, new_resolved)
         except ValueError as e:
             failed.append({

--- a/sky/workspaces/core.py
+++ b/sky/workspaces/core.py
@@ -236,9 +236,7 @@ def _validate_workspace_config_changes_with_lock(
     workspace_name: str,
     current_config: Dict[str, Any],
     new_config: Dict[str, Any],
-    active_resources_for_workspace: Optional[Tuple[List[Dict[str, Any]],
-                                                   List[Dict[str,
-                                                             Any]]]] = None,
+    resources: Optional[resource_checker.ResourceSnapshot] = None,
     resolver: Optional[user_resolver.UserResolver] = None,
 ) -> None:
     lock_id = backend_utils.workspace_lock_id(workspace_name)
@@ -246,12 +244,11 @@ def _validate_workspace_config_changes_with_lock(
     try:
         with locks.get_lock(lock_id, lock_timeout):
             # Validate the configuration changes based on active resources
-            _validate_workspace_config_changes(
-                workspace_name,
-                current_config,
-                new_config,
-                active_resources_for_workspace=active_resources_for_workspace,
-                resolver=resolver)
+            _validate_workspace_config_changes(workspace_name,
+                                               current_config,
+                                               new_config,
+                                               resources=resources,
+                                               resolver=resolver)
     except locks.LockTimeout as e:
         raise RuntimeError(
             f'Failed to validate workspace {workspace_name!r} due to '
@@ -264,9 +261,7 @@ def _validate_workspace_config_changes(
     workspace_name: str,
     current_config: Dict[str, Any],
     new_config: Dict[str, Any],
-    active_resources_for_workspace: Optional[Tuple[List[Dict[str, Any]],
-                                                   List[Dict[str,
-                                                             Any]]]] = None,
+    resources: Optional[resource_checker.ResourceSnapshot] = None,
     resolver: Optional[user_resolver.UserResolver] = None,
 ) -> None:
     """Validate workspace configuration changes based on active resources.
@@ -284,12 +279,13 @@ def _validate_workspace_config_changes(
         workspace_name: The name of the workspace.
         current_config: The current workspace configuration.
         new_config: The new workspace configuration.
-        active_resources_for_workspace: Optional pre-fetched
-            ``(clusters, managed_jobs)`` tuple already filtered to this
-            workspace. Batch callers should fetch this once for all
-            workspaces in the batch (via
-            ``resource_checker._get_active_resources_for_workspaces``) and
-            pass the per-workspace slice to avoid the per-call fetch.
+        resources: Optional shared ``ResourceSnapshot`` covering this
+            workspace. Batch callers build one
+            ``ResourceSnapshot.fetch_for_workspaces`` and pass it
+            through so the per-workspace slice is taken from the
+            snapshot's index instead of fetching per call.
+        resolver: Optional shared ``UserResolver`` (see
+            ``_compare_workspace_configs``).
 
     Raises:
         ValueError: If the configuration change is not allowed due to active
@@ -321,7 +317,7 @@ def _validate_workspace_config_changes(
                 error_summary, missed_users_names, _ = (
                     resource_checker.check_users_workspaces_active_resources(
                         config_comparison.allowed_users_new, [workspace_name],
-                        active_resources=active_resources_for_workspace))
+                        resources=resources))
                 if error_summary:
                     error_msg=f'Cannot change workspace {workspace_name!r}' \
                     f' to private '
@@ -349,7 +345,7 @@ def _validate_workspace_config_changes(
                 error_summary, missed_users_names, missed_user_dict = (
                     resource_checker.check_users_workspaces_active_resources(
                         config_comparison.allowed_users_new, [workspace_name],
-                        active_resources=active_resources_for_workspace))
+                        resources=resources))
                 if error_summary:
                     error_user_ids = []
                     for user_id in config_comparison.removed_users:
@@ -898,22 +894,11 @@ def batch_remove_users_from_workspaces(workspace_names: List[str],
     # Otherwise each per-workspace _validate_workspace_config_changes call
     # would re-query clusters + managed jobs from scratch (the
     # managed-jobs fetch in particular is a blocking RPC to the
-    # controller), giving O(W * (C+J)) instead of O(C+J).
-    # pylint: disable=protected-access
-    batch_clusters, batch_jobs = (
-        resource_checker._get_active_resources_for_workspaces(workspace_names))
-    ws_resources: Dict[str, Tuple[List[Dict[str, Any]],
-                                  List[Dict[str, Any]]]] = {
-                                      name: ([], []) for name in workspace_names
-                                  }
-    for cluster in batch_clusters:
-        ws = cluster.get('workspace', constants.SKYPILOT_DEFAULT_WORKSPACE)
-        if ws in ws_resources:
-            ws_resources[ws][0].append(cluster)
-    for job in batch_jobs:
-        ws = job.get('workspace', constants.SKYPILOT_DEFAULT_WORKSPACE)
-        if ws in ws_resources:
-            ws_resources[ws][1].append(job)
+    # controller), giving O(W * (C+J)) instead of O(C+J). The
+    # snapshot's per-workspace index is built lazily on first
+    # ``for_workspace`` call.
+    resources = resource_checker.ResourceSnapshot.fetch_for_workspaces(
+        workspace_names)
 
     for workspace_name in workspace_names:
         try:
@@ -942,12 +927,11 @@ def batch_remove_users_from_workspaces(workspace_names: List[str],
             new_ws_config = dict(current_ws_config)
             new_ws_config['allowed_users'] = new_allowed
             _validate_workspace_config(workspace_name, new_ws_config)
-            _validate_workspace_config_changes_with_lock(
-                workspace_name,
-                current_ws_config,
-                new_ws_config,
-                active_resources_for_workspace=ws_resources[workspace_name],
-                resolver=resolver)
+            _validate_workspace_config_changes_with_lock(workspace_name,
+                                                         current_ws_config,
+                                                         new_ws_config,
+                                                         resources=resources,
+                                                         resolver=resolver)
             # Pre-resolve the post-removal user_id set ONCE here, using the
             # shared resolver, so update_workspace_policy in the modifier
             # (under the config file lock) doesn't have to do another

--- a/sky/workspaces/server.py
+++ b/sky/workspaces/server.py
@@ -67,6 +67,35 @@ async def delete(request: fastapi.Request,
     )
 
 
+@router.post('/batch_add_users')
+async def batch_add_users(request: fastapi.Request,
+                          body: payloads.WorkspaceBatchAddUsersBody) -> None:
+    """Adds users to ``allowed_users`` of multiple private workspaces."""
+    await executor.schedule_request_async(
+        request_id=request.state.request_id,
+        request_name=request_names.RequestName.WORKSPACES_BATCH_ADD_USERS,
+        request_body=body,
+        func=core.batch_add_users_to_workspaces,
+        schedule_type=api_requests.ScheduleType.SHORT,
+        auth_user=request.state.auth_user,
+    )
+
+
+@router.post('/batch_remove_users')
+async def batch_remove_users(
+        request: fastapi.Request,
+        body: payloads.WorkspaceBatchRemoveUsersBody) -> None:
+    """Removes users from ``allowed_users`` of multiple private workspaces."""
+    await executor.schedule_request_async(
+        request_id=request.state.request_id,
+        request_name=request_names.RequestName.WORKSPACES_BATCH_REMOVE_USERS,
+        request_body=body,
+        func=core.batch_remove_users_from_workspaces,
+        schedule_type=api_requests.ScheduleType.SHORT,
+        auth_user=request.state.auth_user,
+    )
+
+
 @router.get('/config')
 async def get_config(request: fastapi.Request) -> None:
     """Gets the entire SkyPilot configuration."""

--- a/sky/workspaces/utils.py
+++ b/sky/workspaces/utils.py
@@ -9,8 +9,13 @@ from sky import sky_logging
 logger = sky_logging.init_logger(__name__)
 
 
-def _build_username_to_ids_map(
+def build_username_to_ids_map(
         all_users: List[models.User]) -> Dict[str, List[str]]:
+    """Build a name -> [user_id] map. Exposed so batch callers can compute it
+    once and pass it to ``preferred_identifier_for_user`` /
+    ``entries_for_user`` per user, instead of rebuilding it on every call
+    (each rebuild is O(len(all_users))).
+    """
     name_to_ids: Dict[str, List[str]] = collections.defaultdict(list)
     for user in all_users:
         if user.name:
@@ -20,12 +25,16 @@ def _build_username_to_ids_map(
 
 def preferred_identifier_for_user(
         user_id: str,
-        all_users: Optional[List[models.User]] = None) -> Optional[str]:
+        all_users: Optional[List[models.User]] = None,
+        name_to_ids: Optional[Dict[str, List[str]]] = None) -> Optional[str]:
     """Return the preferred ``allowed_users`` entry for a given user_id.
 
     Prefers the username when it uniquely resolves back to ``user_id``;
     otherwise falls back to ``user_id``. Returns ``None`` if no user exists
     for the given id.
+
+    ``name_to_ids`` is an optional pre-built map (see
+    ``build_username_to_ids_map``) for batch callers to avoid recomputing it.
     """
     if all_users is None:
         all_users = global_user_state.get_all_users()
@@ -38,7 +47,8 @@ def preferred_identifier_for_user(
         return None
     if not user_info.name:
         return user_id
-    name_to_ids = _build_username_to_ids_map(all_users)
+    if name_to_ids is None:
+        name_to_ids = build_username_to_ids_map(all_users)
     if len(name_to_ids.get(user_info.name, [])) == 1:
         return user_info.name
     return user_id
@@ -46,11 +56,15 @@ def preferred_identifier_for_user(
 
 def entries_for_user(
         user_id: str,
-        all_users: Optional[List[models.User]] = None) -> List[str]:
+        all_users: Optional[List[models.User]] = None,
+        name_to_ids: Optional[Dict[str, List[str]]] = None) -> List[str]:
     """Return all ``allowed_users`` entries that resolve to ``user_id``.
 
     Includes both the user_id itself and the username (when unique). Used to
     strip every form of a user from a workspace's ``allowed_users`` list.
+
+    ``name_to_ids`` is an optional pre-built map (see
+    ``build_username_to_ids_map``) for batch callers.
     """
     if all_users is None:
         all_users = global_user_state.get_all_users()
@@ -63,7 +77,8 @@ def entries_for_user(
         return [user_id]
     entries = [user_id]
     if user_info.name:
-        name_to_ids = _build_username_to_ids_map(all_users)
+        if name_to_ids is None:
+            name_to_ids = build_username_to_ids_map(all_users)
         if len(name_to_ids.get(user_info.name, [])) == 1:
             entries.append(user_info.name)
     return entries

--- a/sky/workspaces/utils.py
+++ b/sky/workspaces/utils.py
@@ -1,11 +1,72 @@
 """Utils for workspaces."""
 import collections
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from sky import global_user_state
+from sky import models
 from sky import sky_logging
 
 logger = sky_logging.init_logger(__name__)
+
+
+def _build_username_to_ids_map(
+        all_users: List[models.User]) -> Dict[str, List[str]]:
+    name_to_ids: Dict[str, List[str]] = collections.defaultdict(list)
+    for user in all_users:
+        if user.name:
+            name_to_ids[user.name].append(user.id)
+    return name_to_ids
+
+
+def preferred_identifier_for_user(
+        user_id: str,
+        all_users: Optional[List[models.User]] = None) -> Optional[str]:
+    """Return the preferred ``allowed_users`` entry for a given user_id.
+
+    Prefers the username when it uniquely resolves back to ``user_id``;
+    otherwise falls back to ``user_id``. Returns ``None`` if no user exists
+    for the given id.
+    """
+    if all_users is None:
+        all_users = global_user_state.get_all_users()
+    user_info = None
+    for user in all_users:
+        if user.id == user_id:
+            user_info = user
+            break
+    if user_info is None:
+        return None
+    if not user_info.name:
+        return user_id
+    name_to_ids = _build_username_to_ids_map(all_users)
+    if len(name_to_ids.get(user_info.name, [])) == 1:
+        return user_info.name
+    return user_id
+
+
+def entries_for_user(
+        user_id: str,
+        all_users: Optional[List[models.User]] = None) -> List[str]:
+    """Return all ``allowed_users`` entries that resolve to ``user_id``.
+
+    Includes both the user_id itself and the username (when unique). Used to
+    strip every form of a user from a workspace's ``allowed_users`` list.
+    """
+    if all_users is None:
+        all_users = global_user_state.get_all_users()
+    user_info = None
+    for user in all_users:
+        if user.id == user_id:
+            user_info = user
+            break
+    if user_info is None:
+        return [user_id]
+    entries = [user_id]
+    if user_info.name:
+        name_to_ids = _build_username_to_ids_map(all_users)
+        if len(name_to_ids.get(user_info.name, [])) == 1:
+            entries.append(user_info.name)
+    return entries
 
 
 def get_workspace_users(workspace_config: Dict[str, Any]) -> List[str]:

--- a/sky/workspaces/utils.py
+++ b/sky/workspaces/utils.py
@@ -104,7 +104,10 @@ def entries_for_user(
     return entries
 
 
-def get_workspace_users(workspace_config: Dict[str, Any]) -> List[str]:
+def get_workspace_users(
+        workspace_config: Dict[str, Any],
+        all_users: Optional[List[models.User]] = None,
+        name_to_ids: Optional[Dict[str, List[str]]] = None) -> List[str]:
     """Get the users that should have access to a workspace.
 
     workspace_config is a dict with the following keys:
@@ -115,6 +118,10 @@ def get_workspace_users(workspace_config: Dict[str, Any]) -> List[str]:
 
     Args:
         workspace_config: The configuration of the workspace.
+        all_users: Optional pre-fetched list of all users so batch callers
+            don't pay a fresh ``get_all_users()`` per workspace.
+        name_to_ids: Optional pre-built username -> [user_id] map (see
+            ``build_username_to_ids_map``). Pair with ``all_users``.
 
     Returns:
         List of user IDs that should have access to the workspace.
@@ -124,24 +131,24 @@ def get_workspace_users(workspace_config: Dict[str, Any]) -> List[str]:
     if workspace_config.get('private', False):
         user_ids = []
         workspace_user_name_or_ids = workspace_config.get('allowed_users', [])
-        all_users = global_user_state.get_all_users()
+        if all_users is None:
+            all_users = global_user_state.get_all_users()
         all_user_ids = {user.id for user in all_users}
-        all_user_map = collections.defaultdict(list)
-        for user in all_users:
-            all_user_map[user.name].append(user.id)
+        if name_to_ids is None:
+            name_to_ids = build_username_to_ids_map(all_users)
 
         # Resolve user names to IDs
         for user_name_or_id in workspace_user_name_or_ids:
             if user_name_or_id in all_user_ids:
                 user_ids.append(user_name_or_id)
-            elif user_name_or_id in all_user_map:
-                if len(all_user_map[user_name_or_id]) > 1:
-                    user_ids_str = ', '.join(all_user_map[user_name_or_id])
+            elif user_name_or_id in name_to_ids:
+                if len(name_to_ids[user_name_or_id]) > 1:
+                    user_ids_str = ', '.join(name_to_ids[user_name_or_id])
                     raise ValueError(
                         f'User {user_name_or_id!r} has multiple IDs: '
                         f'{user_ids_str}. Please specify the user '
                         f'ID instead.')
-                user_ids.append(all_user_map[user_name_or_id][0])
+                user_ids.append(name_to_ids[user_name_or_id][0])
             else:
                 logger.warning(
                     f'User {user_name_or_id!r} not found in all users')

--- a/sky/workspaces/utils.py
+++ b/sky/workspaces/utils.py
@@ -23,26 +23,49 @@ def build_username_to_ids_map(
     return name_to_ids
 
 
+def build_user_id_to_user_map(
+        all_users: List[models.User]) -> Dict[str, models.User]:
+    """Build a user_id -> User map. Exposed so batch callers can avoid the
+    O(len(all_users)) linear scan inside ``preferred_identifier_for_user`` /
+    ``entries_for_user``.
+    """
+    return {user.id: user for user in all_users}
+
+
+def _resolve_user_info(
+        user_id: str, all_users: Optional[List[models.User]],
+        user_id_to_user: Optional[Dict[str,
+                                       models.User]]) -> Optional[models.User]:
+    if user_id_to_user is not None:
+        return user_id_to_user.get(user_id)
+    # Defensive: a future caller could pass both args as None.
+    if all_users is None:
+        return None
+    for user in all_users:
+        if user.id == user_id:
+            return user
+    return None
+
+
 def preferred_identifier_for_user(
         user_id: str,
         all_users: Optional[List[models.User]] = None,
-        name_to_ids: Optional[Dict[str, List[str]]] = None) -> Optional[str]:
+        name_to_ids: Optional[Dict[str, List[str]]] = None,
+        user_id_to_user: Optional[Dict[str,
+                                       models.User]] = None) -> Optional[str]:
     """Return the preferred ``allowed_users`` entry for a given user_id.
 
     Prefers the username when it uniquely resolves back to ``user_id``;
     otherwise falls back to ``user_id``. Returns ``None`` if no user exists
     for the given id.
 
-    ``name_to_ids`` is an optional pre-built map (see
-    ``build_username_to_ids_map``) for batch callers to avoid recomputing it.
+    ``name_to_ids`` and ``user_id_to_user`` are optional pre-built maps
+    (see ``build_username_to_ids_map`` / ``build_user_id_to_user_map``) so
+    batch callers can avoid the O(M) scan + O(M) map rebuild on every call.
     """
     if all_users is None:
         all_users = global_user_state.get_all_users()
-    user_info = None
-    for user in all_users:
-        if user.id == user_id:
-            user_info = user
-            break
+    user_info = _resolve_user_info(user_id, all_users, user_id_to_user)
     if user_info is None:
         return None
     if not user_info.name:
@@ -57,22 +80,19 @@ def preferred_identifier_for_user(
 def entries_for_user(
         user_id: str,
         all_users: Optional[List[models.User]] = None,
-        name_to_ids: Optional[Dict[str, List[str]]] = None) -> List[str]:
+        name_to_ids: Optional[Dict[str, List[str]]] = None,
+        user_id_to_user: Optional[Dict[str, models.User]] = None) -> List[str]:
     """Return all ``allowed_users`` entries that resolve to ``user_id``.
 
     Includes both the user_id itself and the username (when unique). Used to
     strip every form of a user from a workspace's ``allowed_users`` list.
 
-    ``name_to_ids`` is an optional pre-built map (see
-    ``build_username_to_ids_map``) for batch callers.
+    ``name_to_ids`` and ``user_id_to_user`` are optional pre-built maps
+    for batch callers; see ``preferred_identifier_for_user``.
     """
     if all_users is None:
         all_users = global_user_state.get_all_users()
-    user_info = None
-    for user in all_users:
-        if user.id == user_id:
-            user_info = user
-            break
+    user_info = _resolve_user_info(user_id, all_users, user_id_to_user)
     if user_info is None:
         return [user_id]
     entries = [user_id]

--- a/sky/workspaces/utils.py
+++ b/sky/workspaces/utils.py
@@ -1,159 +1,28 @@
 """Utils for workspaces."""
-import collections
 from typing import Any, Dict, List, Optional
 
-from sky import global_user_state
-from sky import models
-from sky import sky_logging
-
-logger = sky_logging.init_logger(__name__)
-
-
-def build_username_to_ids_map(
-        all_users: List[models.User]) -> Dict[str, List[str]]:
-    """Build a name -> [user_id] map. Exposed so batch callers can compute it
-    once and pass it to ``preferred_identifier_for_user`` /
-    ``entries_for_user`` per user, instead of rebuilding it on every call
-    (each rebuild is O(len(all_users))).
-    """
-    name_to_ids: Dict[str, List[str]] = collections.defaultdict(list)
-    for user in all_users:
-        if user.name:
-            name_to_ids[user.name].append(user.id)
-    return name_to_ids
-
-
-def build_user_id_to_user_map(
-        all_users: List[models.User]) -> Dict[str, models.User]:
-    """Build a user_id -> User map. Exposed so batch callers can avoid the
-    O(len(all_users)) linear scan inside ``preferred_identifier_for_user`` /
-    ``entries_for_user``.
-    """
-    return {user.id: user for user in all_users}
-
-
-def _resolve_user_info(
-        user_id: str, all_users: Optional[List[models.User]],
-        user_id_to_user: Optional[Dict[str,
-                                       models.User]]) -> Optional[models.User]:
-    if user_id_to_user is not None:
-        return user_id_to_user.get(user_id)
-    # Defensive: a future caller could pass both args as None.
-    if all_users is None:
-        return None
-    for user in all_users:
-        if user.id == user_id:
-            return user
-    return None
-
-
-def preferred_identifier_for_user(
-        user_id: str,
-        all_users: Optional[List[models.User]] = None,
-        name_to_ids: Optional[Dict[str, List[str]]] = None,
-        user_id_to_user: Optional[Dict[str,
-                                       models.User]] = None) -> Optional[str]:
-    """Return the preferred ``allowed_users`` entry for a given user_id.
-
-    Prefers the username when it uniquely resolves back to ``user_id``;
-    otherwise falls back to ``user_id``. Returns ``None`` if no user exists
-    for the given id.
-
-    ``name_to_ids`` and ``user_id_to_user`` are optional pre-built maps
-    (see ``build_username_to_ids_map`` / ``build_user_id_to_user_map``) so
-    batch callers can avoid the O(M) scan + O(M) map rebuild on every call.
-    """
-    if all_users is None:
-        all_users = global_user_state.get_all_users()
-    user_info = _resolve_user_info(user_id, all_users, user_id_to_user)
-    if user_info is None:
-        return None
-    if not user_info.name:
-        return user_id
-    if name_to_ids is None:
-        name_to_ids = build_username_to_ids_map(all_users)
-    if len(name_to_ids.get(user_info.name, [])) == 1:
-        return user_info.name
-    return user_id
-
-
-def entries_for_user(
-        user_id: str,
-        all_users: Optional[List[models.User]] = None,
-        name_to_ids: Optional[Dict[str, List[str]]] = None,
-        user_id_to_user: Optional[Dict[str, models.User]] = None) -> List[str]:
-    """Return all ``allowed_users`` entries that resolve to ``user_id``.
-
-    Includes both the user_id itself and the username (when unique). Used to
-    strip every form of a user from a workspace's ``allowed_users`` list.
-
-    ``name_to_ids`` and ``user_id_to_user`` are optional pre-built maps
-    for batch callers; see ``preferred_identifier_for_user``.
-    """
-    if all_users is None:
-        all_users = global_user_state.get_all_users()
-    user_info = _resolve_user_info(user_id, all_users, user_id_to_user)
-    if user_info is None:
-        return [user_id]
-    entries = [user_id]
-    if user_info.name:
-        if name_to_ids is None:
-            name_to_ids = build_username_to_ids_map(all_users)
-        if len(name_to_ids.get(user_info.name, [])) == 1:
-            entries.append(user_info.name)
-    return entries
+from sky.users import resolver as user_resolver
 
 
 def get_workspace_users(
         workspace_config: Dict[str, Any],
-        all_users: Optional[List[models.User]] = None,
-        name_to_ids: Optional[Dict[str, List[str]]] = None) -> List[str]:
-    """Get the users that should have access to a workspace.
+        resolver: Optional[user_resolver.UserResolver] = None) -> List[str]:
+    """Get the user_ids that should have access to a workspace.
 
-    workspace_config is a dict with the following keys:
-    - private: bool
-    - allowed_users: list of user names or IDs
-
-    This function will automatically resolve the user names to IDs.
+    For private workspaces, resolves ``allowed_users`` (which may contain
+    a mix of user_ids and usernames) to user_ids. For public workspaces,
+    returns ``['*']``.
 
     Args:
-        workspace_config: The configuration of the workspace.
-        all_users: Optional pre-fetched list of all users so batch callers
-            don't pay a fresh ``get_all_users()`` per workspace.
-        name_to_ids: Optional pre-built username -> [user_id] map (see
-            ``build_username_to_ids_map``). Pair with ``all_users``.
+        workspace_config: Dict with optional ``private: bool`` and
+            ``allowed_users: List[str]`` keys.
+        resolver: Optional ``UserResolver`` so batch callers don't pay a
+            fresh ``get_all_users()`` per workspace. If not provided, a
+            transient resolver is built internally.
 
     Returns:
-        List of user IDs that should have access to the workspace.
-        For private workspaces, returns specific user IDs.
-        For public workspaces, returns ['*'] to indicate all users.
+        List of user IDs. ``['*']`` for public workspaces.
     """
-    if workspace_config.get('private', False):
-        user_ids = []
-        workspace_user_name_or_ids = workspace_config.get('allowed_users', [])
-        if all_users is None:
-            all_users = global_user_state.get_all_users()
-        all_user_ids = {user.id for user in all_users}
-        if name_to_ids is None:
-            name_to_ids = build_username_to_ids_map(all_users)
-
-        # Resolve user names to IDs
-        for user_name_or_id in workspace_user_name_or_ids:
-            if user_name_or_id in all_user_ids:
-                user_ids.append(user_name_or_id)
-            elif user_name_or_id in name_to_ids:
-                if len(name_to_ids[user_name_or_id]) > 1:
-                    user_ids_str = ', '.join(name_to_ids[user_name_or_id])
-                    raise ValueError(
-                        f'User {user_name_or_id!r} has multiple IDs: '
-                        f'{user_ids_str}. Please specify the user '
-                        f'ID instead.')
-                user_ids.append(name_to_ids[user_name_or_id][0])
-            else:
-                logger.warning(
-                    f'User {user_name_or_id!r} not found in all users')
-                continue
-        return user_ids
-    else:
-        # Public workspace - return '*' to indicate all users should have access
-        return ['*']
+    if resolver is None:
+        resolver = user_resolver.UserResolver()
+    return resolver.resolve_workspace_users(workspace_config)

--- a/tests/unit_tests/test_sky/users/test_batch_update.py
+++ b/tests/unit_tests/test_sky/users/test_batch_update.py
@@ -73,6 +73,8 @@ class TestUserBatchUpdate:
                 return _mk_user(uid, name='good')
             if uid == constants.SKYPILOT_SYSTEM_USER_ID:
                 return _mk_user(uid, name='system')
+            if uid == constants.SKYPILOT_SYSTEM_VIEWER_USER_ID:
+                return _mk_user(uid, name='system-viewer')
             if uid == common.SERVER_ID:
                 return _mk_user(uid, name='server')
             return None
@@ -80,8 +82,11 @@ class TestUserBatchUpdate:
         mock_get_user.side_effect = fake_get_user
 
         body = payloads.UserBatchUpdateBody(user_ids=[
-            'good', constants.SKYPILOT_SYSTEM_USER_ID, common.SERVER_ID,
-            'unknown'
+            'good',
+            constants.SKYPILOT_SYSTEM_USER_ID,
+            constants.SKYPILOT_SYSTEM_VIEWER_USER_ID,
+            common.SERVER_ID,
+            'unknown',
         ],
                                             role='admin')
 
@@ -89,8 +94,12 @@ class TestUserBatchUpdate:
 
         assert result['succeeded'] == ['good']
         failed_ids = sorted(f['user_id'] for f in result['failed'])
-        assert failed_ids == sorted(
-            [constants.SKYPILOT_SYSTEM_USER_ID, common.SERVER_ID, 'unknown'])
+        assert failed_ids == sorted([
+            constants.SKYPILOT_SYSTEM_USER_ID,
+            constants.SKYPILOT_SYSTEM_VIEWER_USER_ID,
+            common.SERVER_ID,
+            'unknown',
+        ])
         # update_role only called for the good user.
         mock_update_role.assert_called_once_with('good', 'admin')
 
@@ -149,6 +158,33 @@ class TestUserBatchUpdate:
         assert mock_update_role.call_count == 2
 
     @mock.patch('sky.users.server._user_lock')
+    @mock.patch('sky.utils.resource_checker.check_user_role_demotion')
+    @mock.patch('sky.users.permission.permission_service.update_role')
+    @mock.patch('sky.users.permission.permission_service.get_user_roles')
+    @mock.patch('sky.users.permission.permission_service.get_users_for_role')
+    @mock.patch('sky.global_user_state.get_user')
+    def test_demotion_check_also_fires_for_admin_to_viewer(
+            self, mock_get_user, mock_get_users_for_role, mock_get_user_roles,
+            mock_update_role, mock_demotion_check, mock_user_lock,
+            admin_request):
+        mock_user_lock.return_value = mock.MagicMock(__enter__=mock.MagicMock(),
+                                                     __exit__=mock.MagicMock())
+        mock_get_users_for_role.return_value = ['u1']  # u1 is the only admin
+        mock_get_user_roles.return_value = ['admin']
+        mock_get_user.return_value = _mk_user('u1', name='alice')
+
+        body = payloads.UserBatchUpdateBody(user_ids=['u1'], role='viewer')
+        result = server.user_batch_update(admin_request, body)
+
+        assert result == {'succeeded': ['u1'], 'failed': []}
+        mock_demotion_check.assert_called_once()
+        # When demoting to viewer, the target is removed from the remaining
+        # admin set (same as demoting to user).
+        _, kwargs = mock_demotion_check.call_args
+        assert kwargs['remaining_admin_user_ids'] == set()
+        mock_update_role.assert_called_once_with('u1', 'viewer')
+
+    @mock.patch('sky.users.server._user_lock')
     @mock.patch('sky.users.permission.permission_service.update_role')
     @mock.patch('sky.users.permission.permission_service.get_user_roles')
     @mock.patch('sky.users.permission.permission_service.get_users_for_role')
@@ -173,6 +209,15 @@ class TestUserBatchUpdate:
 
 class TestUserRoleDemotion:
     """Tests for resource_checker.check_user_role_demotion."""
+
+    # check_user_role_demotion calls skypilot_config.safe_reload_config() at
+    # the top to guarantee fresh workspace data for sync endpoint callers
+    # (see resource_checker.py). Stub it out in unit tests so we don't hit
+    # the real filesystem / file lock.
+    @pytest.fixture(autouse=True)
+    def _stub_safe_reload(self):
+        with mock.patch('sky.skypilot_config.safe_reload_config'):
+            yield
 
     @mock.patch('sky.utils.resource_checker._get_active_resources')
     @mock.patch('sky.skypilot_config.get_nested')

--- a/tests/unit_tests/test_sky/users/test_batch_update.py
+++ b/tests/unit_tests/test_sky/users/test_batch_update.py
@@ -33,18 +33,22 @@ class TestUserBatchUpdate:
     @mock.patch('sky.users.permission.permission_service.update_role')
     @mock.patch('sky.users.permission.permission_service.get_user_roles')
     @mock.patch('sky.users.permission.permission_service.get_users_for_role')
-    @mock.patch('sky.global_user_state.get_user')
-    def test_promote_two_users_to_admin(self, mock_get_user,
+    @mock.patch('sky.global_user_state.get_all_users')
+    def test_promote_two_users_to_admin(self, mock_get_all_users,
                                         mock_get_users_for_role,
                                         mock_get_user_roles, mock_update_role,
                                         mock_demotion_check, mock_user_lock,
                                         admin_request):
         mock_user_lock.return_value = mock.MagicMock(__enter__=mock.MagicMock(),
                                                      __exit__=mock.MagicMock())
-        mock_get_users_for_role.return_value = []
+        mock_get_all_users.return_value = [
+            _mk_user('u1', name='name-u1'),
+            _mk_user('u2', name='name-u2'),
+        ]
+        # Both users are currently role=user; nobody is admin or viewer.
+        mock_get_users_for_role.side_effect = (lambda r: ['u1', 'u2']
+                                               if r == 'user' else [])
         mock_get_user_roles.return_value = ['user']
-        mock_get_user.side_effect = lambda uid: _mk_user(uid,
-                                                         name=f'name-{uid}')
 
         body = payloads.UserBatchUpdateBody(user_ids=['u1', 'u2'], role='admin')
 
@@ -59,27 +63,26 @@ class TestUserBatchUpdate:
     @mock.patch('sky.users.permission.permission_service.update_role')
     @mock.patch('sky.users.permission.permission_service.get_user_roles')
     @mock.patch('sky.users.permission.permission_service.get_users_for_role')
-    @mock.patch('sky.global_user_state.get_user')
+    @mock.patch('sky.global_user_state.get_all_users')
     def test_internal_user_and_missing_user_are_isolated_failures(
-            self, mock_get_user, mock_get_users_for_role, mock_get_user_roles,
-            mock_update_role, mock_user_lock, admin_request):
+            self, mock_get_all_users, mock_get_users_for_role,
+            mock_get_user_roles, mock_update_role, mock_user_lock,
+            admin_request):
         mock_user_lock.return_value = mock.MagicMock(__enter__=mock.MagicMock(),
                                                      __exit__=mock.MagicMock())
-        mock_get_users_for_role.return_value = []
+        # 'unknown' is intentionally NOT in get_all_users so the lookup
+        # returns None and the batch records it as a failure.
+        known_users = [
+            _mk_user('good', name='good'),
+            _mk_user(constants.SKYPILOT_SYSTEM_USER_ID, name='system'),
+            _mk_user(constants.SKYPILOT_SYSTEM_VIEWER_USER_ID,
+                     name='system-viewer'),
+            _mk_user(common.SERVER_ID, name='server'),
+        ]
+        mock_get_all_users.return_value = known_users
+        mock_get_users_for_role.side_effect = (
+            lambda r: [u.id for u in known_users] if r == 'user' else [])
         mock_get_user_roles.return_value = ['user']
-
-        def fake_get_user(uid):
-            if uid == 'good':
-                return _mk_user(uid, name='good')
-            if uid == constants.SKYPILOT_SYSTEM_USER_ID:
-                return _mk_user(uid, name='system')
-            if uid == constants.SKYPILOT_SYSTEM_VIEWER_USER_ID:
-                return _mk_user(uid, name='system-viewer')
-            if uid == common.SERVER_ID:
-                return _mk_user(uid, name='server')
-            return None
-
-        mock_get_user.side_effect = fake_get_user
 
         body = payloads.UserBatchUpdateBody(user_ids=[
             'good',
@@ -131,18 +134,22 @@ class TestUserBatchUpdate:
     @mock.patch('sky.users.permission.permission_service.update_role')
     @mock.patch('sky.users.permission.permission_service.get_user_roles')
     @mock.patch('sky.users.permission.permission_service.get_users_for_role')
-    @mock.patch('sky.global_user_state.get_user')
+    @mock.patch('sky.global_user_state.get_all_users')
     def test_demotion_failure_isolated_to_offending_user(
-            self, mock_get_user, mock_get_users_for_role, mock_get_user_roles,
-            mock_update_role, mock_demotion_check, mock_user_lock,
-            mock_load_fresh_workspaces, mock_get_active_resources,
-            admin_request):
+            self, mock_get_all_users, mock_get_users_for_role,
+            mock_get_user_roles, mock_update_role, mock_demotion_check,
+            mock_user_lock, mock_load_fresh_workspaces,
+            mock_get_active_resources, admin_request):
         mock_user_lock.return_value = mock.MagicMock(__enter__=mock.MagicMock(),
                                                      __exit__=mock.MagicMock())
-        mock_get_users_for_role.return_value = ['u1', 'u2', 'u3']  # all admins
+        mock_get_all_users.return_value = [
+            _mk_user('u1', name='name-u1'),
+            _mk_user('u2', name='name-u2'),
+            _mk_user('u3', name='name-u3'),
+        ]
+        mock_get_users_for_role.side_effect = (lambda r: ['u1', 'u2', 'u3']
+                                               if r == 'admin' else [])
         mock_get_user_roles.return_value = ['admin']
-        mock_get_user.side_effect = lambda uid: _mk_user(uid,
-                                                         name=f'name-{uid}')
 
         def fake_demotion_check(uid, **_kwargs):
             if uid == 'u2':
@@ -171,17 +178,18 @@ class TestUserBatchUpdate:
     @mock.patch('sky.users.permission.permission_service.update_role')
     @mock.patch('sky.users.permission.permission_service.get_user_roles')
     @mock.patch('sky.users.permission.permission_service.get_users_for_role')
-    @mock.patch('sky.global_user_state.get_user')
+    @mock.patch('sky.global_user_state.get_all_users')
     def test_demotion_check_also_fires_for_admin_to_viewer(
-            self, mock_get_user, mock_get_users_for_role, mock_get_user_roles,
-            mock_update_role, mock_demotion_check, mock_user_lock,
-            mock_load_fresh_workspaces, mock_get_active_resources,
-            admin_request):
+            self, mock_get_all_users, mock_get_users_for_role,
+            mock_get_user_roles, mock_update_role, mock_demotion_check,
+            mock_user_lock, mock_load_fresh_workspaces,
+            mock_get_active_resources, admin_request):
         mock_user_lock.return_value = mock.MagicMock(__enter__=mock.MagicMock(),
                                                      __exit__=mock.MagicMock())
-        mock_get_users_for_role.return_value = ['u1']  # u1 is the only admin
+        mock_get_all_users.return_value = [_mk_user('u1', name='alice')]
+        mock_get_users_for_role.side_effect = (lambda r: ['u1']
+                                               if r == 'admin' else [])
         mock_get_user_roles.return_value = ['admin']
-        mock_get_user.return_value = _mk_user('u1', name='alice')
 
         body = payloads.UserBatchUpdateBody(user_ids=['u1'], role='viewer')
         result = server.user_batch_update(admin_request, body)
@@ -198,16 +206,18 @@ class TestUserBatchUpdate:
     @mock.patch('sky.users.permission.permission_service.update_role')
     @mock.patch('sky.users.permission.permission_service.get_user_roles')
     @mock.patch('sky.users.permission.permission_service.get_users_for_role')
-    @mock.patch('sky.global_user_state.get_user')
-    def test_noop_when_role_unchanged(self, mock_get_user,
+    @mock.patch('sky.global_user_state.get_all_users')
+    def test_noop_when_role_unchanged(self, mock_get_all_users,
                                       mock_get_users_for_role,
                                       mock_get_user_roles, mock_update_role,
                                       mock_user_lock, admin_request):
         mock_user_lock.return_value = mock.MagicMock(__enter__=mock.MagicMock(),
                                                      __exit__=mock.MagicMock())
-        mock_get_users_for_role.return_value = []
+        mock_get_all_users.return_value = [_mk_user('u1', name='alice')]
+        # u1 is already an admin; the batch is a no-op.
+        mock_get_users_for_role.side_effect = (lambda r: ['u1']
+                                               if r == 'admin' else [])
         mock_get_user_roles.return_value = ['admin']
-        mock_get_user.return_value = _mk_user('u1', name='alice')
 
         body = payloads.UserBatchUpdateBody(user_ids=['u1'], role='admin')
 

--- a/tests/unit_tests/test_sky/users/test_batch_update.py
+++ b/tests/unit_tests/test_sky/users/test_batch_update.py
@@ -122,6 +122,10 @@ class TestUserBatchUpdate:
             server.user_batch_update(admin_request, body)
         assert exc_info.value.status_code == 400
 
+    @mock.patch('sky.utils.resource_checker.get_active_resources',
+                return_value=([], []))
+    @mock.patch('sky.utils.resource_checker.load_fresh_workspaces',
+                return_value={})
     @mock.patch('sky.users.server._user_lock')
     @mock.patch('sky.utils.resource_checker.check_user_role_demotion')
     @mock.patch('sky.users.permission.permission_service.update_role')
@@ -131,6 +135,7 @@ class TestUserBatchUpdate:
     def test_demotion_failure_isolated_to_offending_user(
             self, mock_get_user, mock_get_users_for_role, mock_get_user_roles,
             mock_update_role, mock_demotion_check, mock_user_lock,
+            mock_load_fresh_workspaces, mock_get_active_resources,
             admin_request):
         mock_user_lock.return_value = mock.MagicMock(__enter__=mock.MagicMock(),
                                                      __exit__=mock.MagicMock())
@@ -139,7 +144,7 @@ class TestUserBatchUpdate:
         mock_get_user.side_effect = lambda uid: _mk_user(uid,
                                                          name=f'name-{uid}')
 
-        def fake_demotion_check(uid, remaining_admin_user_ids=None):
+        def fake_demotion_check(uid, **_kwargs):
             if uid == 'u2':
                 raise ValueError(
                     "user 'u2' has active resources in 'private-ws'")
@@ -157,6 +162,10 @@ class TestUserBatchUpdate:
         # update_role only called for the two that passed the check.
         assert mock_update_role.call_count == 2
 
+    @mock.patch('sky.utils.resource_checker.get_active_resources',
+                return_value=([], []))
+    @mock.patch('sky.utils.resource_checker.load_fresh_workspaces',
+                return_value={})
     @mock.patch('sky.users.server._user_lock')
     @mock.patch('sky.utils.resource_checker.check_user_role_demotion')
     @mock.patch('sky.users.permission.permission_service.update_role')
@@ -166,6 +175,7 @@ class TestUserBatchUpdate:
     def test_demotion_check_also_fires_for_admin_to_viewer(
             self, mock_get_user, mock_get_users_for_role, mock_get_user_roles,
             mock_update_role, mock_demotion_check, mock_user_lock,
+            mock_load_fresh_workspaces, mock_get_active_resources,
             admin_request):
         mock_user_lock.return_value = mock.MagicMock(__enter__=mock.MagicMock(),
                                                      __exit__=mock.MagicMock())

--- a/tests/unit_tests/test_sky/users/test_batch_update.py
+++ b/tests/unit_tests/test_sky/users/test_batch_update.py
@@ -1,0 +1,308 @@
+"""Unit tests for /users/batch_update and the admin demotion check."""
+
+from unittest import mock
+
+import fastapi
+import pytest
+
+from sky import models
+from sky.server.requests import payloads
+from sky.skylet import constants
+from sky.users import server
+from sky.utils import common
+from sky.utils import resource_checker
+
+
+@pytest.fixture
+def admin_request():
+    request = mock.MagicMock(spec=fastapi.Request)
+    request.state = mock.MagicMock()
+    request.state.auth_user = None  # Unauthenticated == admin in current logic
+    return request
+
+
+def _mk_user(user_id, name='User'):
+    return models.User(id=user_id, name=name)
+
+
+class TestUserBatchUpdate:
+    """Tests for POST /users/batch_update."""
+
+    @mock.patch('sky.users.server._user_lock')
+    @mock.patch('sky.utils.resource_checker.check_user_role_demotion')
+    @mock.patch('sky.users.permission.permission_service.update_role')
+    @mock.patch('sky.users.permission.permission_service.get_user_roles')
+    @mock.patch('sky.users.permission.permission_service.get_users_for_role')
+    @mock.patch('sky.global_user_state.get_user')
+    def test_promote_two_users_to_admin(self, mock_get_user,
+                                        mock_get_users_for_role,
+                                        mock_get_user_roles, mock_update_role,
+                                        mock_demotion_check, mock_user_lock,
+                                        admin_request):
+        mock_user_lock.return_value = mock.MagicMock(__enter__=mock.MagicMock(),
+                                                     __exit__=mock.MagicMock())
+        mock_get_users_for_role.return_value = []
+        mock_get_user_roles.return_value = ['user']
+        mock_get_user.side_effect = lambda uid: _mk_user(uid,
+                                                         name=f'name-{uid}')
+
+        body = payloads.UserBatchUpdateBody(user_ids=['u1', 'u2'], role='admin')
+
+        result = server.user_batch_update(admin_request, body)
+
+        assert result == {'succeeded': ['u1', 'u2'], 'failed': []}
+        assert mock_update_role.call_count == 2
+        # Promotions never trigger the demotion check.
+        mock_demotion_check.assert_not_called()
+
+    @mock.patch('sky.users.server._user_lock')
+    @mock.patch('sky.users.permission.permission_service.update_role')
+    @mock.patch('sky.users.permission.permission_service.get_user_roles')
+    @mock.patch('sky.users.permission.permission_service.get_users_for_role')
+    @mock.patch('sky.global_user_state.get_user')
+    def test_internal_user_and_missing_user_are_isolated_failures(
+            self, mock_get_user, mock_get_users_for_role, mock_get_user_roles,
+            mock_update_role, mock_user_lock, admin_request):
+        mock_user_lock.return_value = mock.MagicMock(__enter__=mock.MagicMock(),
+                                                     __exit__=mock.MagicMock())
+        mock_get_users_for_role.return_value = []
+        mock_get_user_roles.return_value = ['user']
+
+        def fake_get_user(uid):
+            if uid == 'good':
+                return _mk_user(uid, name='good')
+            if uid == constants.SKYPILOT_SYSTEM_USER_ID:
+                return _mk_user(uid, name='system')
+            if uid == common.SERVER_ID:
+                return _mk_user(uid, name='server')
+            return None
+
+        mock_get_user.side_effect = fake_get_user
+
+        body = payloads.UserBatchUpdateBody(user_ids=[
+            'good', constants.SKYPILOT_SYSTEM_USER_ID, common.SERVER_ID,
+            'unknown'
+        ],
+                                            role='admin')
+
+        result = server.user_batch_update(admin_request, body)
+
+        assert result['succeeded'] == ['good']
+        failed_ids = sorted(f['user_id'] for f in result['failed'])
+        assert failed_ids == sorted(
+            [constants.SKYPILOT_SYSTEM_USER_ID, common.SERVER_ID, 'unknown'])
+        # update_role only called for the good user.
+        mock_update_role.assert_called_once_with('good', 'admin')
+
+    @mock.patch('sky.users.permission.permission_service.get_user_roles')
+    def test_non_admin_caller_is_forbidden(self, mock_get_user_roles):
+        request = mock.MagicMock(spec=fastapi.Request)
+        request.state = mock.MagicMock()
+        request.state.auth_user = _mk_user('caller', name='caller')
+        mock_get_user_roles.return_value = ['user']
+
+        body = payloads.UserBatchUpdateBody(user_ids=['u1'], role='admin')
+
+        with pytest.raises(fastapi.HTTPException) as exc_info:
+            server.user_batch_update(request, body)
+        assert exc_info.value.status_code == 403
+
+    def test_empty_user_ids_rejected(self, admin_request):
+        body = payloads.UserBatchUpdateBody(user_ids=[], role='admin')
+        with pytest.raises(fastapi.HTTPException) as exc_info:
+            server.user_batch_update(admin_request, body)
+        assert exc_info.value.status_code == 400
+
+    @mock.patch('sky.users.server._user_lock')
+    @mock.patch('sky.utils.resource_checker.check_user_role_demotion')
+    @mock.patch('sky.users.permission.permission_service.update_role')
+    @mock.patch('sky.users.permission.permission_service.get_user_roles')
+    @mock.patch('sky.users.permission.permission_service.get_users_for_role')
+    @mock.patch('sky.global_user_state.get_user')
+    def test_demotion_failure_isolated_to_offending_user(
+            self, mock_get_user, mock_get_users_for_role, mock_get_user_roles,
+            mock_update_role, mock_demotion_check, mock_user_lock,
+            admin_request):
+        mock_user_lock.return_value = mock.MagicMock(__enter__=mock.MagicMock(),
+                                                     __exit__=mock.MagicMock())
+        mock_get_users_for_role.return_value = ['u1', 'u2', 'u3']  # all admins
+        mock_get_user_roles.return_value = ['admin']
+        mock_get_user.side_effect = lambda uid: _mk_user(uid,
+                                                         name=f'name-{uid}')
+
+        def fake_demotion_check(uid, remaining_admin_user_ids=None):
+            if uid == 'u2':
+                raise ValueError(
+                    "user 'u2' has active resources in 'private-ws'")
+
+        mock_demotion_check.side_effect = fake_demotion_check
+
+        body = payloads.UserBatchUpdateBody(user_ids=['u1', 'u2', 'u3'],
+                                            role='user')
+
+        result = server.user_batch_update(admin_request, body)
+
+        assert sorted(result['succeeded']) == ['u1', 'u3']
+        assert len(result['failed']) == 1
+        assert result['failed'][0]['user_id'] == 'u2'
+        # update_role only called for the two that passed the check.
+        assert mock_update_role.call_count == 2
+
+    @mock.patch('sky.users.server._user_lock')
+    @mock.patch('sky.users.permission.permission_service.update_role')
+    @mock.patch('sky.users.permission.permission_service.get_user_roles')
+    @mock.patch('sky.users.permission.permission_service.get_users_for_role')
+    @mock.patch('sky.global_user_state.get_user')
+    def test_noop_when_role_unchanged(self, mock_get_user,
+                                      mock_get_users_for_role,
+                                      mock_get_user_roles, mock_update_role,
+                                      mock_user_lock, admin_request):
+        mock_user_lock.return_value = mock.MagicMock(__enter__=mock.MagicMock(),
+                                                     __exit__=mock.MagicMock())
+        mock_get_users_for_role.return_value = []
+        mock_get_user_roles.return_value = ['admin']
+        mock_get_user.return_value = _mk_user('u1', name='alice')
+
+        body = payloads.UserBatchUpdateBody(user_ids=['u1'], role='admin')
+
+        result = server.user_batch_update(admin_request, body)
+
+        assert result == {'succeeded': ['u1'], 'failed': []}
+        mock_update_role.assert_not_called()
+
+
+class TestUserRoleDemotion:
+    """Tests for resource_checker.check_user_role_demotion."""
+
+    @mock.patch('sky.utils.resource_checker._get_active_resources')
+    @mock.patch('sky.skypilot_config.get_nested')
+    @mock.patch('sky.workspaces.utils.get_workspace_users')
+    @mock.patch('sky.users.permission.permission_service.get_users_for_role')
+    def test_no_workspaces_is_a_noop(self, mock_get_users_for_role,
+                                     mock_get_ws_users, mock_get_nested,
+                                     mock_get_active):
+        mock_get_nested.return_value = {}
+        # Should not raise.
+        resource_checker.check_user_role_demotion('u1')
+        mock_get_active.assert_not_called()
+
+    @mock.patch('sky.global_user_state.get_user')
+    @mock.patch('sky.utils.resource_checker._get_active_resources')
+    @mock.patch('sky.skypilot_config.get_nested')
+    @mock.patch('sky.workspaces.utils.get_workspace_users')
+    @mock.patch('sky.users.permission.permission_service.get_users_for_role')
+    def test_blocks_when_user_has_active_cluster_in_lost_workspace(
+            self, mock_get_users_for_role, mock_get_ws_users, mock_get_nested,
+            mock_get_active, mock_get_user):
+        mock_get_nested.return_value = {
+            'private-locked': {
+                'private': True,
+                'allowed_users': []
+            },
+        }
+        mock_get_ws_users.return_value = []  # demoted user not allowed
+        mock_get_users_for_role.return_value = []  # no other admins
+        mock_get_active.return_value = ([{
+            'name': 'c1',
+            'user_hash': 'u1',
+            'workspace': 'private-locked'
+        }], [])
+        mock_get_user.return_value = _mk_user('u1', name='alice')
+
+        with pytest.raises(ValueError) as exc_info:
+            resource_checker.check_user_role_demotion('u1')
+        msg = str(exc_info.value)
+        assert "'alice'" in msg
+        assert 'private-locked' in msg
+        assert 'c1' in msg
+
+    @mock.patch('sky.global_user_state.get_user')
+    @mock.patch('sky.utils.resource_checker._get_active_resources')
+    @mock.patch('sky.skypilot_config.get_nested')
+    @mock.patch('sky.workspaces.utils.get_workspace_users')
+    @mock.patch('sky.users.permission.permission_service.get_users_for_role')
+    def test_allows_when_user_remains_in_allowed_users(
+            self, mock_get_users_for_role, mock_get_ws_users, mock_get_nested,
+            mock_get_active, mock_get_user):
+        mock_get_nested.return_value = {
+            'private-still-allowed': {
+                'private': True,
+                'allowed_users': ['u1']
+            },
+        }
+        mock_get_ws_users.return_value = ['u1']  # demoted user is allowed
+        mock_get_users_for_role.return_value = []
+        mock_get_active.return_value = ([{
+            'name': 'c1',
+            'user_hash': 'u1',
+            'workspace': 'private-still-allowed'
+        }], [])
+        mock_get_user.return_value = _mk_user('u1', name='alice')
+
+        # Should not raise.
+        resource_checker.check_user_role_demotion('u1')
+
+    @mock.patch('sky.global_user_state.get_user')
+    @mock.patch('sky.utils.resource_checker._get_active_resources')
+    @mock.patch('sky.skypilot_config.get_nested')
+    @mock.patch('sky.workspaces.utils.get_workspace_users')
+    @mock.patch('sky.users.permission.permission_service.get_users_for_role')
+    def test_allows_when_user_only_has_resources_in_public_workspace(
+            self, mock_get_users_for_role, mock_get_ws_users, mock_get_nested,
+            mock_get_active, mock_get_user):
+        mock_get_nested.return_value = {
+            'public-ws': {
+                'private': False
+            },
+        }
+        mock_get_users_for_role.return_value = []
+        mock_get_active.return_value = ([{
+            'name': 'c1',
+            'user_hash': 'u1',
+            'workspace': 'public-ws'
+        }], [])
+        mock_get_user.return_value = _mk_user('u1', name='alice')
+
+        # Should not raise (public workspace not even checked).
+        resource_checker.check_user_role_demotion('u1')
+        mock_get_ws_users.assert_not_called()
+
+    @mock.patch('sky.global_user_state.get_user')
+    @mock.patch('sky.utils.resource_checker._get_active_resources')
+    @mock.patch('sky.skypilot_config.get_nested')
+    @mock.patch('sky.workspaces.utils.get_workspace_users')
+    @mock.patch('sky.users.permission.permission_service.get_users_for_role')
+    def test_remaining_admin_set_overrides_lookup(self, mock_get_users_for_role,
+                                                  mock_get_ws_users,
+                                                  mock_get_nested,
+                                                  mock_get_active,
+                                                  mock_get_user):
+        """When two admins are demoted at once, only the post-batch admin
+        set should be considered for access."""
+        mock_get_nested.return_value = {
+            'private-locked': {
+                'private': True,
+                'allowed_users': []
+            },
+        }
+        mock_get_ws_users.return_value = []
+        # Live policy says u1 and u2 are admins; pretend they're both being
+        # demoted in this batch.
+        mock_get_users_for_role.return_value = ['u1', 'u2']
+        mock_get_active.return_value = ([{
+            'name': 'c1',
+            'user_hash': 'u1',
+            'workspace': 'private-locked'
+        }], [])
+        mock_get_user.return_value = _mk_user('u1', name='alice')
+
+        # Without the override, u2 would "save" u1. With the override
+        # (remaining = empty set), u1 has nothing to fall back on.
+        with pytest.raises(ValueError):
+            resource_checker.check_user_role_demotion(
+                'u1', remaining_admin_user_ids=set())
+
+        # And if the caller passes a remaining admin set that does include
+        # u1 (somehow), the check is satisfied.
+        resource_checker.check_user_role_demotion(
+            'u1', remaining_admin_user_ids={'u1'})

--- a/tests/unit_tests/test_sky/users/test_batch_update.py
+++ b/tests/unit_tests/test_sky/users/test_batch_update.py
@@ -127,8 +127,8 @@ class TestUserBatchUpdate:
             server.user_batch_update(admin_request, body)
         assert exc_info.value.status_code == 400
 
-    @mock.patch('sky.utils.resource_checker.get_active_resources',
-                return_value=([], []))
+    @mock.patch('sky.utils.resource_checker.ResourceSnapshot.fetch_all',
+                return_value=mock.MagicMock())
     @mock.patch('sky.utils.resource_checker.load_fresh_workspaces',
                 return_value={})
     @mock.patch('sky.users.server._user_lock')
@@ -171,8 +171,8 @@ class TestUserBatchUpdate:
         # update_role only called for the two that passed the check.
         assert mock_update_role.call_count == 2
 
-    @mock.patch('sky.utils.resource_checker.get_active_resources',
-                return_value=([], []))
+    @mock.patch('sky.utils.resource_checker.ResourceSnapshot.fetch_all',
+                return_value=mock.MagicMock())
     @mock.patch('sky.utils.resource_checker.load_fresh_workspaces',
                 return_value={})
     @mock.patch('sky.users.server._user_lock')

--- a/tests/unit_tests/test_sky/users/test_batch_update.py
+++ b/tests/unit_tests/test_sky/users/test_batch_update.py
@@ -33,18 +33,20 @@ class TestUserBatchUpdate:
     @mock.patch('sky.users.permission.permission_service.update_role')
     @mock.patch('sky.users.permission.permission_service.get_user_roles')
     @mock.patch('sky.users.permission.permission_service.get_users_for_role')
-    @mock.patch('sky.global_user_state.get_all_users')
-    def test_promote_two_users_to_admin(self, mock_get_all_users,
+    @mock.patch('sky.global_user_state.get_users')
+    def test_promote_two_users_to_admin(self, mock_get_users,
                                         mock_get_users_for_role,
                                         mock_get_user_roles, mock_update_role,
                                         mock_demotion_check, mock_user_lock,
                                         admin_request):
         mock_user_lock.return_value = mock.MagicMock(__enter__=mock.MagicMock(),
                                                      __exit__=mock.MagicMock())
-        mock_get_all_users.return_value = [
-            _mk_user('u1', name='name-u1'),
-            _mk_user('u2', name='name-u2'),
-        ]
+        # Promotion path uses get_users(set(user_ids)), which returns
+        # {id -> User}.
+        mock_get_users.return_value = {
+            'u1': _mk_user('u1', name='name-u1'),
+            'u2': _mk_user('u2', name='name-u2'),
+        }
         # Both users are currently role=user; nobody is admin or viewer.
         mock_get_users_for_role.side_effect = (lambda r: ['u1', 'u2']
                                                if r == 'user' else [])
@@ -63,15 +65,15 @@ class TestUserBatchUpdate:
     @mock.patch('sky.users.permission.permission_service.update_role')
     @mock.patch('sky.users.permission.permission_service.get_user_roles')
     @mock.patch('sky.users.permission.permission_service.get_users_for_role')
-    @mock.patch('sky.global_user_state.get_all_users')
+    @mock.patch('sky.global_user_state.get_users')
     def test_internal_user_and_missing_user_are_isolated_failures(
-            self, mock_get_all_users, mock_get_users_for_role,
-            mock_get_user_roles, mock_update_role, mock_user_lock,
-            admin_request):
+            self, mock_get_users, mock_get_users_for_role, mock_get_user_roles,
+            mock_update_role, mock_user_lock, admin_request):
         mock_user_lock.return_value = mock.MagicMock(__enter__=mock.MagicMock(),
                                                      __exit__=mock.MagicMock())
-        # 'unknown' is intentionally NOT in get_all_users so the lookup
-        # returns None and the batch records it as a failure.
+        # 'unknown' is intentionally NOT in the get_users return so the
+        # lookup returns None and the batch records it as a failure.
+        # Promotion path uses get_users(set(user_ids)) -> {id -> User}.
         known_users = [
             _mk_user('good', name='good'),
             _mk_user(constants.SKYPILOT_SYSTEM_USER_ID, name='system'),
@@ -79,7 +81,7 @@ class TestUserBatchUpdate:
                      name='system-viewer'),
             _mk_user(common.SERVER_ID, name='server'),
         ]
-        mock_get_all_users.return_value = known_users
+        mock_get_users.return_value = {u.id: u for u in known_users}
         mock_get_users_for_role.side_effect = (
             lambda r: [u.id for u in known_users] if r == 'user' else [])
         mock_get_user_roles.return_value = ['user']
@@ -196,24 +198,21 @@ class TestUserBatchUpdate:
 
         assert result == {'succeeded': ['u1'], 'failed': []}
         mock_demotion_check.assert_called_once()
-        # When demoting to viewer, the target is removed from the remaining
-        # admin set (same as demoting to user).
-        _, kwargs = mock_demotion_check.call_args
-        assert kwargs['remaining_admin_user_ids'] == set()
         mock_update_role.assert_called_once_with('u1', 'viewer')
 
     @mock.patch('sky.users.server._user_lock')
     @mock.patch('sky.users.permission.permission_service.update_role')
     @mock.patch('sky.users.permission.permission_service.get_user_roles')
     @mock.patch('sky.users.permission.permission_service.get_users_for_role')
-    @mock.patch('sky.global_user_state.get_all_users')
-    def test_noop_when_role_unchanged(self, mock_get_all_users,
+    @mock.patch('sky.global_user_state.get_users')
+    def test_noop_when_role_unchanged(self, mock_get_users,
                                       mock_get_users_for_role,
                                       mock_get_user_roles, mock_update_role,
                                       mock_user_lock, admin_request):
         mock_user_lock.return_value = mock.MagicMock(__enter__=mock.MagicMock(),
                                                      __exit__=mock.MagicMock())
-        mock_get_all_users.return_value = [_mk_user('u1', name='alice')]
+        # Promotion path -> get_users(set(user_ids)) returns {id -> User}.
+        mock_get_users.return_value = {'u1': _mk_user('u1', name='alice')}
         # u1 is already an admin; the batch is a no-op.
         mock_get_users_for_role.side_effect = (lambda r: ['u1']
                                                if r == 'admin' else [])
@@ -331,43 +330,3 @@ class TestUserRoleDemotion:
         # Should not raise (public workspace not even checked).
         resource_checker.check_user_role_demotion('u1')
         mock_get_ws_users.assert_not_called()
-
-    @mock.patch('sky.global_user_state.get_user')
-    @mock.patch('sky.utils.resource_checker._get_active_resources')
-    @mock.patch('sky.skypilot_config.get_nested')
-    @mock.patch('sky.workspaces.utils.get_workspace_users')
-    @mock.patch('sky.users.permission.permission_service.get_users_for_role')
-    def test_remaining_admin_set_overrides_lookup(self, mock_get_users_for_role,
-                                                  mock_get_ws_users,
-                                                  mock_get_nested,
-                                                  mock_get_active,
-                                                  mock_get_user):
-        """When two admins are demoted at once, only the post-batch admin
-        set should be considered for access."""
-        mock_get_nested.return_value = {
-            'private-locked': {
-                'private': True,
-                'allowed_users': []
-            },
-        }
-        mock_get_ws_users.return_value = []
-        # Live policy says u1 and u2 are admins; pretend they're both being
-        # demoted in this batch.
-        mock_get_users_for_role.return_value = ['u1', 'u2']
-        mock_get_active.return_value = ([{
-            'name': 'c1',
-            'user_hash': 'u1',
-            'workspace': 'private-locked'
-        }], [])
-        mock_get_user.return_value = _mk_user('u1', name='alice')
-
-        # Without the override, u2 would "save" u1. With the override
-        # (remaining = empty set), u1 has nothing to fall back on.
-        with pytest.raises(ValueError):
-            resource_checker.check_user_role_demotion(
-                'u1', remaining_admin_user_ids=set())
-
-        # And if the caller passes a remaining admin set that does include
-        # u1 (somehow), the check is satisfied.
-        resource_checker.check_user_role_demotion(
-            'u1', remaining_admin_user_ids={'u1'})

--- a/tests/unit_tests/test_sky/users/test_batch_update.py
+++ b/tests/unit_tests/test_sky/users/test_batch_update.py
@@ -153,8 +153,8 @@ class TestUserBatchUpdate:
                                                if r == 'admin' else [])
         mock_get_user_roles.return_value = ['admin']
 
-        def fake_demotion_check(uid, **_kwargs):
-            if uid == 'u2':
+        def fake_demotion_check(user, **_kwargs):
+            if user.id == 'u2':
                 raise ValueError(
                     "user 'u2' has active resources in 'private-ws'")
 
@@ -247,7 +247,7 @@ class TestUserRoleDemotion:
                                      mock_get_active):
         mock_get_nested.return_value = {}
         # Should not raise.
-        resource_checker.check_user_role_demotion('u1')
+        resource_checker.check_user_role_demotion(_mk_user('u1', name='alice'))
         mock_get_active.assert_not_called()
 
     @mock.patch('sky.global_user_state.get_user')
@@ -274,7 +274,8 @@ class TestUserRoleDemotion:
         mock_get_user.return_value = _mk_user('u1', name='alice')
 
         with pytest.raises(ValueError) as exc_info:
-            resource_checker.check_user_role_demotion('u1')
+            resource_checker.check_user_role_demotion(
+                _mk_user('u1', name='alice'))
         msg = str(exc_info.value)
         assert "'alice'" in msg
         assert 'private-locked' in msg
@@ -304,7 +305,7 @@ class TestUserRoleDemotion:
         mock_get_user.return_value = _mk_user('u1', name='alice')
 
         # Should not raise.
-        resource_checker.check_user_role_demotion('u1')
+        resource_checker.check_user_role_demotion(_mk_user('u1', name='alice'))
 
     @mock.patch('sky.global_user_state.get_user')
     @mock.patch('sky.utils.resource_checker._get_active_resources')
@@ -328,5 +329,5 @@ class TestUserRoleDemotion:
         mock_get_user.return_value = _mk_user('u1', name='alice')
 
         # Should not raise (public workspace not even checked).
-        resource_checker.check_user_role_demotion('u1')
+        resource_checker.check_user_role_demotion(_mk_user('u1', name='alice'))
         mock_get_ws_users.assert_not_called()

--- a/tests/unit_tests/test_sky/users/test_server.py
+++ b/tests/unit_tests/test_sky/users/test_server.py
@@ -558,15 +558,17 @@ class TestUsersEndpoints:
     @mock.patch('sky.users.permission.permission_service.delete_user')
     @pytest.mark.asyncio
     async def test_user_delete_success(self, mock_delete_user_role,
-                                       mock_delete_user, mock_get_user):
+                                       mock_delete_user, mock_get_user,
+                                       mock_request):
         """Test successful POST /users/delete endpoint."""
         # Setup
         test_user = models.User(id='test_user', name='Test User')
         mock_get_user.return_value = test_user
+        mock_request.state.auth_user = None
         delete_body = payloads.UserDeleteBody(user_id='test_user')
 
         # Execute
-        result = server.user_delete(delete_body)
+        result = server.user_delete(mock_request, delete_body)
 
         # Verify
         assert result is None
@@ -576,15 +578,17 @@ class TestUsersEndpoints:
 
     @mock.patch('sky.global_user_state.get_user')
     @pytest.mark.asyncio
-    async def test_user_delete_user_not_found(self, mock_get_user):
+    async def test_user_delete_user_not_found(self, mock_get_user,
+                                              mock_request):
         """Test POST /users/delete endpoint with non-existent user."""
         # Setup
         mock_get_user.return_value = None
+        mock_request.state.auth_user = None
         delete_body = payloads.UserDeleteBody(user_id='nonexistent_user')
 
         # Execute & Verify
         with pytest.raises(fastapi.HTTPException) as exc_info:
-            server.user_delete(delete_body)
+            server.user_delete(mock_request, delete_body)
         assert exc_info.value.status_code == 400
         assert 'does not exist' in str(exc_info.value.detail)
         mock_get_user.assert_called_once_with('nonexistent_user')
@@ -839,14 +843,16 @@ class TestUsersEndpoints:
     async def test_user_delete_forbidden_internal_users(self,
                                                         mock_delete_user_role,
                                                         mock_delete_user,
-                                                        mock_get_user):
+                                                        mock_get_user,
+                                                        mock_request):
         """Test POST /users/delete endpoint forbidden for internal users."""
+        mock_request.state.auth_user = None
         # Internal server user
         server_user = models.User(id=common.SERVER_ID, name='Server User')
         mock_get_user.return_value = server_user
         delete_body = payloads.UserDeleteBody(user_id=common.SERVER_ID)
         with pytest.raises(fastapi.HTTPException) as exc_info:
-            server.user_delete(delete_body)
+            server.user_delete(mock_request, delete_body)
         assert exc_info.value.status_code == 400
         assert 'Cannot delete internal API server user' in str(
             exc_info.value.detail)
@@ -857,7 +863,7 @@ class TestUsersEndpoints:
         delete_body = payloads.UserDeleteBody(
             user_id=constants.SKYPILOT_SYSTEM_USER_ID)
         with pytest.raises(fastapi.HTTPException) as exc_info:
-            server.user_delete(delete_body)
+            server.user_delete(mock_request, delete_body)
         assert exc_info.value.status_code == 400
         assert 'Cannot delete internal API server user' in str(
             exc_info.value.detail)

--- a/tests/unit_tests/test_sky/users/test_viewer_route_coverage.py
+++ b/tests/unit_tests/test_sky/users/test_viewer_route_coverage.py
@@ -88,6 +88,7 @@ _KNOWN_VIEWER_DENIED: set = {
     # --- Users writes (incl. SA token mgmt) ---
     ('/users/create', 'POST'),
     ('/users/update', 'POST'),
+    ('/users/batch_update', 'POST'),
     ('/users/delete', 'POST'),
     ('/users/import', 'POST'),
     ('/users/export', 'GET'),  # password hashes
@@ -100,6 +101,8 @@ _KNOWN_VIEWER_DENIED: set = {
     ('/workspaces/create', 'POST'),
     ('/workspaces/update', 'POST'),
     ('/workspaces/delete', 'POST'),
+    ('/workspaces/batch_add_users', 'POST'),
+    ('/workspaces/batch_remove_users', 'POST'),
     ('/workspaces/config', 'GET'),  # full admin config -> tokens, etc.
     ('/workspaces/config', 'POST'),
     # --- Recipes writes ---

--- a/tests/unit_tests/test_sky/workspaces/test_batch_users.py
+++ b/tests/unit_tests/test_sky/workspaces/test_batch_users.py
@@ -179,6 +179,17 @@ class TestBatchAddUsersToWorkspaces:
 
 class TestBatchRemoveUsersFromWorkspaces:
 
+    # batch_remove_users_from_workspaces pre-fetches active resources for the
+    # whole workspace batch via _get_active_resources_for_workspaces (which
+    # hits the cluster DB + managed-jobs controller). Stub it out so unit
+    # tests don't hit the real backends.
+    @pytest.fixture(autouse=True)
+    def _stub_active_resources(self):
+        with mock.patch(
+                'sky.utils.resource_checker._get_active_resources_for_workspaces',
+                return_value=([], [])):
+            yield
+
     @staticmethod
     def _patch_initial_workspaces(workspaces):
         """Patch skypilot_config.to_dict to return the given workspaces.

--- a/tests/unit_tests/test_sky/workspaces/test_batch_users.py
+++ b/tests/unit_tests/test_sky/workspaces/test_batch_users.py
@@ -165,8 +165,15 @@ class TestBatchAddUsersToWorkspaces:
         result = core.batch_add_users_to_workspaces(['p1'], ['unknown'])
         # No real workspaces touched; the unknown user surfaces as a failure.
         assert result['succeeded'] == []
-        assert any(f['error'].startswith('User unknown does not exist')
-                   for f in result['failed'])
+        unknown_failures = [
+            f for f in result['failed']
+            if f['error'].startswith('User unknown does not exist')
+        ]
+        assert len(unknown_failures) == 1
+        # The failure is not workspace-scoped, so workspace_name uses the
+        # '-' placeholder (not an empty string, which would render as
+        # "workspace=" in the UI).
+        assert unknown_failures[0]['workspace_name'] == '-'
         # Modifier never reached config-update path.
         mock_update_config.assert_not_called()
 

--- a/tests/unit_tests/test_sky/workspaces/test_batch_users.py
+++ b/tests/unit_tests/test_sky/workspaces/test_batch_users.py
@@ -49,7 +49,9 @@ class TestBatchAddUsersToWorkspaces:
         # Username preferred over user_id since 'alice' is unique.
         assert captured['workspaces']['p1']['allowed_users'] == ['alice']
         mock_validate_config.assert_called_once()
-        mock_validate_changes.assert_called_once()
+        # batch_add does not need the workspace-change validation: it only
+        # adds users (no removed_users, no private toggle).
+        mock_validate_changes.assert_not_called()
 
     @mock.patch(
         'sky.users.permission.permission_service.update_workspace_policy')
@@ -177,6 +179,17 @@ class TestBatchAddUsersToWorkspaces:
 
 class TestBatchRemoveUsersFromWorkspaces:
 
+    @staticmethod
+    def _patch_initial_workspaces(workspaces):
+        """Patch skypilot_config.to_dict to return the given workspaces.
+
+        batch_remove_users_from_workspaces reads the pre-modification
+        workspace config OUTSIDE the file lock (in the validation pre-pass),
+        so tests need to stub that read in addition to the modifier flow.
+        """
+        return mock.patch('sky.skypilot_config.to_dict',
+                          return_value={'workspaces': workspaces})
+
     @mock.patch(
         'sky.users.permission.permission_service.update_workspace_policy')
     @mock.patch('sky.workspaces.utils.get_workspace_users', return_value=[])
@@ -190,21 +203,18 @@ class TestBatchRemoveUsersFromWorkspaces:
                                    mock_validate_config, mock_validate_changes,
                                    mock_update_config, mock_get_ws_users,
                                    mock_update_policy):
+        initial = {'p1': {'private': True, 'allowed_users': ['alice', 'bob']}}
         captured = {}
 
         def fake_update(modifier):
-            workspaces = {
-                'p1': {
-                    'private': True,
-                    'allowed_users': ['alice', 'bob']
-                },
-            }
+            workspaces = {k: dict(v) for k, v in initial.items()}
             modifier(workspaces)
             captured['workspaces'] = workspaces
 
         mock_update_config.side_effect = fake_update
 
-        result = core.batch_remove_users_from_workspaces(['p1'], ['u1'])
+        with self._patch_initial_workspaces(initial):
+            result = core.batch_remove_users_from_workspaces(['p1'], ['u1'])
         assert result == {'succeeded': ['p1'], 'failed': []}
         assert captured['workspaces']['p1']['allowed_users'] == ['bob']
 
@@ -221,22 +231,56 @@ class TestBatchRemoveUsersFromWorkspaces:
                                   mock_validate_config, mock_validate_changes,
                                   mock_update_config, mock_get_ws_users,
                                   mock_update_policy):
+        initial = {'p1': {'private': True, 'allowed_users': ['u1', 'bob']}}
         captured = {}
 
         def fake_update(modifier):
-            workspaces = {
-                'p1': {
-                    'private': True,
-                    'allowed_users': ['u1', 'bob']
-                },
-            }
+            workspaces = {k: dict(v) for k, v in initial.items()}
             modifier(workspaces)
             captured['workspaces'] = workspaces
 
         mock_update_config.side_effect = fake_update
 
-        result = core.batch_remove_users_from_workspaces(['p1'], ['u1'])
+        with self._patch_initial_workspaces(initial):
+            result = core.batch_remove_users_from_workspaces(['p1'], ['u1'])
         assert result == {'succeeded': ['p1'], 'failed': []}
+        assert captured['workspaces']['p1']['allowed_users'] == ['bob']
+
+    @mock.patch(
+        'sky.users.permission.permission_service.update_workspace_policy')
+    @mock.patch('sky.workspaces.utils.get_workspace_users', return_value=[])
+    @mock.patch('sky.workspaces.core._update_workspaces_config')
+    @mock.patch(
+        'sky.workspaces.core._validate_workspace_config_changes_with_lock')
+    @mock.patch('sky.workspaces.core._validate_workspace_config')
+    @mock.patch('sky.global_user_state.get_all_users',
+                return_value=[_mk_user('u1', 'alice')])
+    def test_removes_both_forms_when_stale_dual_entry(self, mock_get_all_users,
+                                                      mock_validate_config,
+                                                      mock_validate_changes,
+                                                      mock_update_config,
+                                                      mock_get_ws_users,
+                                                      mock_update_policy):
+        # Workspace has the same user listed under BOTH forms (stale state).
+        initial = {
+            'p1': {
+                'private': True,
+                'allowed_users': ['alice', 'u1', 'bob']
+            }
+        }
+        captured = {}
+
+        def fake_update(modifier):
+            workspaces = {k: dict(v) for k, v in initial.items()}
+            modifier(workspaces)
+            captured['workspaces'] = workspaces
+
+        mock_update_config.side_effect = fake_update
+
+        with self._patch_initial_workspaces(initial):
+            result = core.batch_remove_users_from_workspaces(['p1'], ['u1'])
+        assert result == {'succeeded': ['p1'], 'failed': []}
+        # Both stale entries for u1 must be stripped in one call.
         assert captured['workspaces']['p1']['allowed_users'] == ['bob']
 
     @mock.patch(
@@ -247,16 +291,14 @@ class TestBatchRemoveUsersFromWorkspaces:
     def test_public_workspace_is_rejected(self, mock_get_all_users,
                                           mock_update_config,
                                           mock_update_policy):
+        initial = {'pub': {'private': False}}
 
-        def fake_update(modifier):
-            workspaces = {'pub': {'private': False}}
-            modifier(workspaces)
-
-        mock_update_config.side_effect = fake_update
-
-        result = core.batch_remove_users_from_workspaces(['pub'], ['u1'])
+        with self._patch_initial_workspaces(initial):
+            result = core.batch_remove_users_from_workspaces(['pub'], ['u1'])
         assert result['succeeded'] == []
         assert result['failed'][0]['workspace_name'] == 'pub'
+        # No modifier should run because nothing validated.
+        mock_update_config.assert_not_called()
 
     @mock.patch(
         'sky.users.permission.permission_service.update_workspace_policy')
@@ -266,15 +308,13 @@ class TestBatchRemoveUsersFromWorkspaces:
     def test_user_not_in_allowed_is_noop_success(self, mock_get_all_users,
                                                  mock_update_config,
                                                  mock_update_policy):
+        initial = {'p1': {'private': True, 'allowed_users': ['bob']}}
 
-        def fake_update(modifier):
-            workspaces = {'p1': {'private': True, 'allowed_users': ['bob']}}
-            modifier(workspaces)
-
-        mock_update_config.side_effect = fake_update
-
-        result = core.batch_remove_users_from_workspaces(['p1'], ['u1'])
+        with self._patch_initial_workspaces(initial):
+            result = core.batch_remove_users_from_workspaces(['p1'], ['u1'])
         assert result == {'succeeded': ['p1'], 'failed': []}
+        # No-op should not enter the modifier path.
+        mock_update_config.assert_not_called()
 
     @mock.patch(
         'sky.users.permission.permission_service.update_workspace_policy')
@@ -284,7 +324,7 @@ class TestBatchRemoveUsersFromWorkspaces:
         'sky.workspaces.core._validate_workspace_config_changes_with_lock',
         side_effect=ValueError(
             "Cannot remove user 'alice' because the user has 1 active "
-            "cluster(s)"))
+            'cluster(s)'))
     @mock.patch('sky.workspaces.core._validate_workspace_config')
     @mock.patch('sky.global_user_state.get_all_users',
                 return_value=[_mk_user('u1', 'alice')])
@@ -294,22 +334,16 @@ class TestBatchRemoveUsersFromWorkspaces:
                                              mock_update_config,
                                              mock_get_ws_users,
                                              mock_update_policy):
+        initial = {'p1': {'private': True, 'allowed_users': ['alice']}}
 
-        def fake_update(modifier):
-            workspaces = {
-                'p1': {
-                    'private': True,
-                    'allowed_users': ['alice']
-                },
-            }
-            modifier(workspaces)
+        with self._patch_initial_workspaces(initial):
+            result = core.batch_remove_users_from_workspaces(['p1'], ['u1'])
 
-        mock_update_config.side_effect = fake_update
-
-        result = core.batch_remove_users_from_workspaces(['p1'], ['u1'])
         assert result['succeeded'] == []
         assert result['failed'][0]['workspace_name'] == 'p1'
         assert 'active cluster' in result['failed'][0]['error']
+        # Validation failed in the pre-pass, so the modifier never runs.
+        mock_update_config.assert_not_called()
 
     def test_empty_args_rejected(self):
         with pytest.raises(ValueError):

--- a/tests/unit_tests/test_sky/workspaces/test_batch_users.py
+++ b/tests/unit_tests/test_sky/workspaces/test_batch_users.py
@@ -1,0 +1,318 @@
+"""Unit tests for workspace batch_add_users / batch_remove_users."""
+
+from unittest import mock
+
+import pytest
+
+from sky import models
+from sky.workspaces import core
+
+
+def _mk_user(user_id, name):
+    return models.User(id=user_id, name=name)
+
+
+class TestBatchAddUsersToWorkspaces:
+
+    @mock.patch(
+        'sky.users.permission.permission_service.update_workspace_policy')
+    @mock.patch('sky.workspaces.utils.get_workspace_users')
+    @mock.patch('sky.workspaces.core._update_workspaces_config')
+    @mock.patch(
+        'sky.workspaces.core._validate_workspace_config_changes_with_lock')
+    @mock.patch('sky.workspaces.core._validate_workspace_config')
+    @mock.patch('sky.global_user_state.get_all_users',
+                return_value=[_mk_user('u1', 'alice')])
+    def test_happy_path_adds_username(self, mock_get_all_users,
+                                      mock_validate_config,
+                                      mock_validate_changes, mock_update_config,
+                                      mock_get_ws_users, mock_update_policy):
+        captured = {}
+
+        # Workspace starts empty; after the add, the post-update lookup
+        # returns just the added user.
+        mock_get_ws_users.side_effect = [
+            [],  # initial resolved_current for p1
+            ['u1'],  # post-update lookup for policy refresh
+        ]
+
+        def fake_update(modifier):
+            workspaces = {'p1': {'private': True, 'allowed_users': []}}
+            modifier(workspaces)
+            captured['workspaces'] = workspaces
+
+        mock_update_config.side_effect = fake_update
+
+        result = core.batch_add_users_to_workspaces(['p1'], ['u1'])
+
+        assert result == {'succeeded': ['p1'], 'failed': []}
+        # Username preferred over user_id since 'alice' is unique.
+        assert captured['workspaces']['p1']['allowed_users'] == ['alice']
+        mock_validate_config.assert_called_once()
+        mock_validate_changes.assert_called_once()
+
+    @mock.patch(
+        'sky.users.permission.permission_service.update_workspace_policy')
+    @mock.patch('sky.workspaces.utils.get_workspace_users')
+    @mock.patch('sky.workspaces.core._update_workspaces_config')
+    @mock.patch(
+        'sky.workspaces.core._validate_workspace_config_changes_with_lock')
+    @mock.patch('sky.workspaces.core._validate_workspace_config')
+    @mock.patch(
+        'sky.global_user_state.get_all_users',
+        return_value=[
+            _mk_user('u1', 'alice'),
+            _mk_user('u2', 'alice'),  # username collision
+        ])
+    def test_collision_falls_back_to_user_id(self, mock_get_all_users,
+                                             mock_validate_config,
+                                             mock_validate_changes,
+                                             mock_update_config,
+                                             mock_get_ws_users,
+                                             mock_update_policy):
+        captured = {}
+        mock_get_ws_users.side_effect = [[], ['u1']]
+
+        def fake_update(modifier):
+            workspaces = {'p1': {'private': True, 'allowed_users': []}}
+            modifier(workspaces)
+            captured['workspaces'] = workspaces
+
+        mock_update_config.side_effect = fake_update
+
+        result = core.batch_add_users_to_workspaces(['p1'], ['u1'])
+        assert result == {'succeeded': ['p1'], 'failed': []}
+        # username 'alice' is ambiguous → must use user_id.
+        assert captured['workspaces']['p1']['allowed_users'] == ['u1']
+
+    @mock.patch(
+        'sky.users.permission.permission_service.update_workspace_policy')
+    @mock.patch('sky.workspaces.utils.get_workspace_users', return_value=['u1'])
+    @mock.patch('sky.workspaces.core._update_workspaces_config')
+    @mock.patch(
+        'sky.workspaces.core._validate_workspace_config_changes_with_lock')
+    @mock.patch('sky.workspaces.core._validate_workspace_config')
+    @mock.patch('sky.global_user_state.get_all_users',
+                return_value=[_mk_user('u1', 'alice')])
+    def test_public_workspace_is_rejected_per_workspace(
+            self, mock_get_all_users, mock_validate_config,
+            mock_validate_changes, mock_update_config, mock_get_ws_users,
+            mock_update_policy):
+
+        def fake_update(modifier):
+            workspaces = {
+                'p1': {
+                    'private': True,
+                    'allowed_users': []
+                },
+                'pub': {
+                    'private': False
+                },
+            }
+            modifier(workspaces)
+
+        mock_update_config.side_effect = fake_update
+
+        result = core.batch_add_users_to_workspaces(['p1', 'pub'], ['u1'])
+        assert result['succeeded'] == ['p1']
+        assert len(result['failed']) == 1
+        assert result['failed'][0]['workspace_name'] == 'pub'
+        assert 'not private' in result['failed'][0]['error']
+
+    @mock.patch(
+        'sky.users.permission.permission_service.update_workspace_policy')
+    @mock.patch('sky.workspaces.utils.get_workspace_users', return_value=['u1'])
+    @mock.patch('sky.workspaces.core._update_workspaces_config')
+    @mock.patch(
+        'sky.workspaces.core._validate_workspace_config_changes_with_lock')
+    @mock.patch('sky.workspaces.core._validate_workspace_config')
+    @mock.patch('sky.global_user_state.get_all_users',
+                return_value=[_mk_user('u1', 'alice')])
+    def test_user_already_present_is_a_noop_success(self, mock_get_all_users,
+                                                    mock_validate_config,
+                                                    mock_validate_changes,
+                                                    mock_update_config,
+                                                    mock_get_ws_users,
+                                                    mock_update_policy):
+
+        def fake_update(modifier):
+            workspaces = {
+                'p1': {
+                    'private': True,
+                    'allowed_users': ['alice']
+                },
+            }
+            modifier(workspaces)
+
+        mock_update_config.side_effect = fake_update
+
+        result = core.batch_add_users_to_workspaces(['p1'], ['u1'])
+        assert result == {'succeeded': ['p1'], 'failed': []}
+        # No validation calls because there was no change.
+        mock_validate_config.assert_not_called()
+        mock_validate_changes.assert_not_called()
+
+    @mock.patch(
+        'sky.users.permission.permission_service.update_workspace_policy')
+    @mock.patch('sky.workspaces.core._update_workspaces_config')
+    @mock.patch('sky.global_user_state.get_all_users',
+                return_value=[_mk_user('u1', 'alice')])
+    def test_unknown_user_id_is_recorded_as_failure(self, mock_get_all_users,
+                                                    mock_update_config,
+                                                    mock_update_policy):
+        result = core.batch_add_users_to_workspaces(['p1'], ['unknown'])
+        # No real workspaces touched; the unknown user surfaces as a failure.
+        assert result['succeeded'] == []
+        assert any(f['error'].startswith('User unknown does not exist')
+                   for f in result['failed'])
+        # Modifier never reached config-update path.
+        mock_update_config.assert_not_called()
+
+    def test_empty_args_rejected(self):
+        with pytest.raises(ValueError):
+            core.batch_add_users_to_workspaces([], ['u1'])
+        with pytest.raises(ValueError):
+            core.batch_add_users_to_workspaces(['p1'], [])
+
+
+class TestBatchRemoveUsersFromWorkspaces:
+
+    @mock.patch(
+        'sky.users.permission.permission_service.update_workspace_policy')
+    @mock.patch('sky.workspaces.utils.get_workspace_users', return_value=[])
+    @mock.patch('sky.workspaces.core._update_workspaces_config')
+    @mock.patch(
+        'sky.workspaces.core._validate_workspace_config_changes_with_lock')
+    @mock.patch('sky.workspaces.core._validate_workspace_config')
+    @mock.patch('sky.global_user_state.get_all_users',
+                return_value=[_mk_user('u1', 'alice')])
+    def test_removes_username_form(self, mock_get_all_users,
+                                   mock_validate_config, mock_validate_changes,
+                                   mock_update_config, mock_get_ws_users,
+                                   mock_update_policy):
+        captured = {}
+
+        def fake_update(modifier):
+            workspaces = {
+                'p1': {
+                    'private': True,
+                    'allowed_users': ['alice', 'bob']
+                },
+            }
+            modifier(workspaces)
+            captured['workspaces'] = workspaces
+
+        mock_update_config.side_effect = fake_update
+
+        result = core.batch_remove_users_from_workspaces(['p1'], ['u1'])
+        assert result == {'succeeded': ['p1'], 'failed': []}
+        assert captured['workspaces']['p1']['allowed_users'] == ['bob']
+
+    @mock.patch(
+        'sky.users.permission.permission_service.update_workspace_policy')
+    @mock.patch('sky.workspaces.utils.get_workspace_users', return_value=[])
+    @mock.patch('sky.workspaces.core._update_workspaces_config')
+    @mock.patch(
+        'sky.workspaces.core._validate_workspace_config_changes_with_lock')
+    @mock.patch('sky.workspaces.core._validate_workspace_config')
+    @mock.patch('sky.global_user_state.get_all_users',
+                return_value=[_mk_user('u1', 'alice')])
+    def test_removes_user_id_form(self, mock_get_all_users,
+                                  mock_validate_config, mock_validate_changes,
+                                  mock_update_config, mock_get_ws_users,
+                                  mock_update_policy):
+        captured = {}
+
+        def fake_update(modifier):
+            workspaces = {
+                'p1': {
+                    'private': True,
+                    'allowed_users': ['u1', 'bob']
+                },
+            }
+            modifier(workspaces)
+            captured['workspaces'] = workspaces
+
+        mock_update_config.side_effect = fake_update
+
+        result = core.batch_remove_users_from_workspaces(['p1'], ['u1'])
+        assert result == {'succeeded': ['p1'], 'failed': []}
+        assert captured['workspaces']['p1']['allowed_users'] == ['bob']
+
+    @mock.patch(
+        'sky.users.permission.permission_service.update_workspace_policy')
+    @mock.patch('sky.workspaces.core._update_workspaces_config')
+    @mock.patch('sky.global_user_state.get_all_users',
+                return_value=[_mk_user('u1', 'alice')])
+    def test_public_workspace_is_rejected(self, mock_get_all_users,
+                                          mock_update_config,
+                                          mock_update_policy):
+
+        def fake_update(modifier):
+            workspaces = {'pub': {'private': False}}
+            modifier(workspaces)
+
+        mock_update_config.side_effect = fake_update
+
+        result = core.batch_remove_users_from_workspaces(['pub'], ['u1'])
+        assert result['succeeded'] == []
+        assert result['failed'][0]['workspace_name'] == 'pub'
+
+    @mock.patch(
+        'sky.users.permission.permission_service.update_workspace_policy')
+    @mock.patch('sky.workspaces.core._update_workspaces_config')
+    @mock.patch('sky.global_user_state.get_all_users',
+                return_value=[_mk_user('u1', 'alice')])
+    def test_user_not_in_allowed_is_noop_success(self, mock_get_all_users,
+                                                 mock_update_config,
+                                                 mock_update_policy):
+
+        def fake_update(modifier):
+            workspaces = {'p1': {'private': True, 'allowed_users': ['bob']}}
+            modifier(workspaces)
+
+        mock_update_config.side_effect = fake_update
+
+        result = core.batch_remove_users_from_workspaces(['p1'], ['u1'])
+        assert result == {'succeeded': ['p1'], 'failed': []}
+
+    @mock.patch(
+        'sky.users.permission.permission_service.update_workspace_policy')
+    @mock.patch('sky.workspaces.utils.get_workspace_users', return_value=[])
+    @mock.patch('sky.workspaces.core._update_workspaces_config')
+    @mock.patch(
+        'sky.workspaces.core._validate_workspace_config_changes_with_lock',
+        side_effect=ValueError(
+            "Cannot remove user 'alice' because the user has 1 active "
+            "cluster(s)"))
+    @mock.patch('sky.workspaces.core._validate_workspace_config')
+    @mock.patch('sky.global_user_state.get_all_users',
+                return_value=[_mk_user('u1', 'alice')])
+    def test_active_resources_blocks_removal(self, mock_get_all_users,
+                                             mock_validate_config,
+                                             mock_validate_changes,
+                                             mock_update_config,
+                                             mock_get_ws_users,
+                                             mock_update_policy):
+
+        def fake_update(modifier):
+            workspaces = {
+                'p1': {
+                    'private': True,
+                    'allowed_users': ['alice']
+                },
+            }
+            modifier(workspaces)
+
+        mock_update_config.side_effect = fake_update
+
+        result = core.batch_remove_users_from_workspaces(['p1'], ['u1'])
+        assert result['succeeded'] == []
+        assert result['failed'][0]['workspace_name'] == 'p1'
+        assert 'active cluster' in result['failed'][0]['error']
+
+    def test_empty_args_rejected(self):
+        with pytest.raises(ValueError):
+            core.batch_remove_users_from_workspaces([], ['u1'])
+        with pytest.raises(ValueError):
+            core.batch_remove_users_from_workspaces(['p1'], [])

--- a/tests/unit_tests/test_sky/workspaces/test_workspace_management.py
+++ b/tests/unit_tests/test_sky/workspaces/test_workspace_management.py
@@ -475,7 +475,8 @@ class TestWorkspaceManagement(unittest.TestCase):
 
         # Should call resource checker with new allowed users
         mock_check_resources.assert_called_once_with(['user1', 'user2'],
-                                                     ['test-workspace'])
+                                                     ['test-workspace'],
+                                                     active_resources=None)
 
     @mock.patch(
         'sky.utils.resource_checker.check_users_workspaces_active_resources')
@@ -599,7 +600,8 @@ class TestWorkspaceManagement(unittest.TestCase):
         core._validate_workspace_config_changes('test-workspace', {}, {})
 
         # Should call resource checker for removed users
-        mock_check_resources.assert_called_once_with([], ['test-workspace'])
+        mock_check_resources.assert_called_once_with([], ['test-workspace'],
+                                                     active_resources=None)
 
     @mock.patch(
         'sky.utils.resource_checker.check_no_active_resources_for_workspaces')

--- a/tests/unit_tests/test_sky/workspaces/test_workspace_management.py
+++ b/tests/unit_tests/test_sky/workspaces/test_workspace_management.py
@@ -274,9 +274,8 @@ class TestWorkspaceManagement(unittest.TestCase):
     def test_compare_workspace_configs_private_changed_to_public(
             self, mock_get_users_for_role, mock_get_users):
         """Test changing workspace from private to public."""
-        mock_get_users.side_effect = lambda config: (['user1', 'user2']
-                                                     if config.get('private')
-                                                     else [])
+        mock_get_users.side_effect = lambda config, **_kw: (
+            ['user1', 'user2'] if config.get('private') else [])
         mock_get_users_for_role.return_value = []
         current_config = {
             'private': True,
@@ -305,9 +304,8 @@ class TestWorkspaceManagement(unittest.TestCase):
     def test_compare_workspace_configs_private_changed_to_private(
             self, mock_get_users_for_role, mock_get_users):
         """Test changing workspace from public to private."""
-        mock_get_users.side_effect = lambda config: (['user1', 'user2']
-                                                     if config.get('private')
-                                                     else [])
+        mock_get_users.side_effect = lambda config, **_kw: (
+            ['user1', 'user2'] if config.get('private') else [])
         mock_get_users_for_role.return_value = []
         current_config = {
             'private': False,
@@ -341,7 +339,7 @@ class TestWorkspaceManagement(unittest.TestCase):
     def test_compare_workspace_configs_allowed_users_changed(
             self, mock_get_users_for_role, mock_get_users):
         """Test changing allowed users without changing private setting."""
-        mock_get_users.side_effect = lambda config: config.get(
+        mock_get_users.side_effect = lambda config, **_kw: config.get(
             'allowed_users', [])
         mock_get_users_for_role.return_value = []
         current_config = {
@@ -412,7 +410,7 @@ class TestWorkspaceManagement(unittest.TestCase):
         new_config = {'private': True, 'allowed_users': ['user1']}
 
         # Mock get_workspace_users to return different values for different configs
-        def mock_get_users_side_effect(config):
+        def mock_get_users_side_effect(config, **_kw):
             if config.get('allowed_users') == ['*']:
                 return ['*']
             else:

--- a/tests/unit_tests/test_sky/workspaces/test_workspace_management.py
+++ b/tests/unit_tests/test_sky/workspaces/test_workspace_management.py
@@ -474,7 +474,7 @@ class TestWorkspaceManagement(unittest.TestCase):
         # Should call resource checker with new allowed users
         mock_check_resources.assert_called_once_with(['user1', 'user2'],
                                                      ['test-workspace'],
-                                                     active_resources=None)
+                                                     resources=None)
 
     @mock.patch(
         'sky.utils.resource_checker.check_users_workspaces_active_resources')
@@ -599,7 +599,7 @@ class TestWorkspaceManagement(unittest.TestCase):
 
         # Should call resource checker for removed users
         mock_check_resources.assert_called_once_with([], ['test-workspace'],
-                                                     active_resources=None)
+                                                     resources=None)
 
     @mock.patch(
         'sky.utils.resource_checker.check_no_active_resources_for_workspaces')

--- a/tests/unit_tests/test_sky/workspaces/test_workspace_permissions.py
+++ b/tests/unit_tests/test_sky/workspaces/test_workspace_permissions.py
@@ -163,7 +163,7 @@ class TestWorkspacePermissions(unittest.TestCase):
             "Private workspace should resolve unique user name to ID")
 
     @mock.patch('sky.global_user_state.get_all_users')
-    @mock.patch('sky.workspaces.utils.logger')
+    @mock.patch('sky.users.resolver.logger')
     def test_private_workspace_logs_warning_for_unknown_user(
             self, mock_logger, mock_get_users):
         """Test that warning is logged for unknown users."""


### PR DESCRIPTION
## Summary

Adds three batch operations to the dashboard Users page so admins can manage many users at once:

- **Change role** — set selected users to `admin` or `user` in a single action.
- **Add to workspaces** — add the selected users to one or more private workspaces' `allowed_users`.
- **Remove from workspaces** — remove the selected users from one or more private workspaces' `allowed_users`.

And some other improvements:
- Check active resources when updating user role from admin to non-admin
- Fix the issue that active clusters include the ones for managed jobs when deleting users
- Fix the issue that active managed jobs are not shown when deleting users
- Align the pop up style for editing role in line and deleting users

The Users table grows a checkbox column (admin-only, page-scoped) and a bulk-action toolbar that appears when at least one row is selected. Per-item failures are isolated so a single bad user / workspace doesn't sink the rest of the batch.

The admin→user role-update path (single and batch) now blocks demotions that would orphan active resources in private workspaces where the demoted user is not in ``allowed_users``. The batch path computes the post-batch admin set so two co-demoted admins can't accidentally save each other from the check.

For workspace ``allowed_users`` writes, the new entry prefers the username form when it uniquely resolves and falls back to user_id on collision — matching the existing resolver semantics in ``workspaces/utils.get_workspace_users``. Removal strips both the user_id and the username form, in case the workspace has a stale dual-entry.

### Backend

- ``POST /users/batch_update`` — per-user ``succeeded`` / ``failed`` result.
- ``POST /workspaces/batch_add_users`` — drops the no-op ``_validate_workspace_config_changes`` call for pure adds; policy update is inside the file lock so the config file and the casbin policy can't drift on crash.
- ``POST /workspaces/batch_remove_users`` — validates per-workspace OUTSIDE the global config file lock (matches ``update_workspace``'s nesting: workspace lock first, then config file lock) so the two locks can't ABBA deadlock against a concurrent ``update_workspace`` caller.
- ``check_user_role_demotion`` (in ``sky/utils/resource_checker.py``) — calls ``safe_reload_config()`` before reading workspaces. The ``/users/update`` and ``/users/batch_update`` handlers are sync FastAPI handlers and don't go through the executor's ``reload_for_new_request`` pipeline, so without an explicit reload they would read the startup snapshot and miss any ``allowed_users`` write from a recent ``batch_add_users`` call.

### Frontend

- New ``BatchRoleDialog``, ``BatchAddToWorkspacesDialog``, ``BatchRemoveFromWorkspacesDialog`` in ``users-batch-dialogs.jsx``. Use the dashboard's shadcn ``Select`` for the role picker so it matches the top filter dropdown.
- Bulk-action toolbar uses the dashboard's standard filled sky-600 button style (same as ``Create Workspace`` / ``Create Service Account``).
- Workspace fetch routes through ``dashboardCache.get(getWorkspaces)`` with a friendly fallback error message; the cache is invalidated after a successful batch add/remove so the next dialog open shows the new ``allowed_users``.

## Test plan

Unit tests under ``tests/unit_tests/test_sky/users/test_batch_update.py`` and ``tests/unit_tests/test_sky/workspaces/test_batch_users.py`` cover:

- batch_update: happy path, mixed success/failure (internal user, unknown user, system viewer user), non-admin caller → 403, no-op when role unchanged, admin→user demotion blocks the offender but lets the rest of the batch succeed, admin→viewer demotion fires the same check.
- batch_add_users: happy path (username preferred), username collision falls back to user_id, public workspace rejected, no-op when user already present, unknown user surfaces as failure, empty args rejected.
- batch_remove_users: removes both username and user_id form (stale dual-entry), public workspace rejected, no-op when user not listed, active-resource validation blocks removal.

End-to-end verified via the dashboard:

- [x] Select multiple users → change role → check applies; if a demoted admin owns resources in a private workspace they're not allowed in, that user reports the block and the rest succeed.
- [x] Add to workspaces dialog only lists private workspaces; adding writes ``allowed_users`` to the config file and updates the casbin policy.
- [x] Remove from workspaces dialog shows which selected users are currently in each workspace; removal of a user with active resources reports the per-workspace block.
- [x] After ``batch_add_users``, the cache is invalidated and reopening the Remove dialog shows the new ``allowed_users``.
- [x] After ``batch_add_users``, a subsequent ``/users/update`` demotion sees the fresh config (the reload-in-check fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)