### PR TITLE
[CLI] Add entry-point hook so plugins can extend sky jobs launch

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -26,6 +26,7 @@ each other.
 import collections
 import concurrent.futures
 import fnmatch
+import importlib.metadata
 import io
 import json
 import os
@@ -5780,6 +5781,39 @@ def jobs_launch(
                     f'\n{ux_utils.INDENT_LAST_SYMBOL}To cancel all jobs on the '
                     f'pool:\t{ux_utils.BOLD}sky jobs cancel --pool {pool}'
                     f'{ux_utils.RESET_BOLD}')
+
+
+# Plugin hook: allow downstream packages to attach options or wrap the
+# callback of `sky jobs launch`. Each entry point in the
+# ``sky.cli.jobs_launch_extensions`` group is called once at module import
+# with the jobs_launch click.Command. Failures are logged and do not block
+# CLI startup. Re-imports will call extensions again, so extensions must
+# guard against double-install.
+def _load_jobs_launch_extensions() -> None:
+    try:
+        eps = importlib.metadata.entry_points(
+            group='sky.cli.jobs_launch_extensions')
+    except TypeError:
+        # Python 3.9 fallback: entry_points() takes no kwargs.
+        eps = importlib.metadata.entry_points().get(
+            'sky.cli.jobs_launch_extensions', [])
+    # Editable installs can yield duplicates (pypa/setuptools#3649); dedupe
+    # by (name, value).
+    seen: Set[Tuple[str, str]] = set()
+    for ep in eps:
+        key = (ep.name, ep.value)
+        if key in seen:
+            continue
+        seen.add(key)
+        try:
+            ep.load()(jobs_launch)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(
+                'Failed to load sky.cli.jobs_launch_extensions entry point '
+                '%r: %s', ep.name, e)
+
+
+_load_jobs_launch_extensions()
 
 
 @jobs.command('queue', cls=_DocumentedCodeCommand)


### PR DESCRIPTION
## Summary

Add a generic plugin hook in `sky/client/cli/command.py`: at module
import, iterate `importlib.metadata.entry_points(group='sky.cli.jobs_launch_extensions')`
and call each loaded callable with the `jobs_launch` click.Command.
Plugins can append options, wrap the callback, or both — same shape as
the existing server-side plugin loader (`BasePlugin.install()`), just on
the client.

Failures during entry-point load are logged and do not block CLI
startup. Editable installs can yield duplicate entry points
(pypa/setuptools#3649) so the loader dedupes by (name, value).

## Motivation

Downstream packages that ship a SkyPilot server plugin often want to
extend the matching client command (e.g. add a flag to `sky jobs launch`
that POSTs to a `/plugins/api/...` endpoint). Today that requires either
forking `sky.cli` or monkey-patching it from afar — both fragile. This
hook gives the same affordance the server-side plugin system already
provides, scoped narrowly to `jobs launch` to limit blast radius. Easy
to widen later (`sky.cli.jobs.*`, `sky.cli.*`) if demand emerges.

## Test plan

- [x] No entry points installed: `sky jobs launch --help` works unchanged.
- [x] Local package registering the entry point: `sky jobs launch --help`
      shows the injected flag and `sky jobs launch --new-flag ...` reaches
      the plugin handler.
- [x] Broken entry point (raises on load): warning is logged and CLI
      starts normally.

## Security notes for reviewers

Entry-point plugin discovery/loading is a common Python OSS pattern, but
projects vary on when and how they execute plugin code:

- Autoload with explicit disable controls: `pytest` (`PYTEST_DISABLE_PLUGIN_AUTOLOAD`, `--disable-plugin-autoload`), `poetry` (`--no-plugins`).
- Explicit activation from config/runtime path: `mkdocs` (plugins listed in `mkdocs.yml`), `sphinx` (`extensions` in `conf.py`; entry-point themes are deferred until selected), `pluggy` (host explicitly calls `load_setuptools_entrypoints`).
- Import-time plugin loading also exists in some projects (`featuretools`, `khal`).

This PR is in the import-time bucket (loader runs when `sky.client.cli.command`
imports). Security implication: trust boundary expands to installed packages in
the current Python environment that declare this entry-point group.

For this use case (local plugin in sibling repo / controlled environment), this
is acceptable. If we want stricter hardening later, options include:

- Add an opt-out/opt-in control (env var or CLI flag).
- Defer loading until `sky jobs launch` execution path.
- Restrict to an allowlist of plugin distribution names.
