### PR TITLE
[Jobs] Mirror executor.monitor_task() dispatch into JobGroup path

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1265,6 +1265,21 @@ class JobController:
             await job_group_networking.setup_job_group_networking(
                 job_group_name, updated_handles)
 
+        # Mirror the dispatch in `_run_one_task`: give the recovery
+        # strategy first refusal at owning the per-task monitor loop so
+        # both code paths behave consistently. Strategies that return
+        # None fall through to `_monitor_one_task` below unchanged.
+        result = await executor.monitor_task(
+            task_id=task_id,
+            task=task,
+            cluster_name=cluster_name,
+            job_id_on_pool_cluster=None,
+            cleanup_cluster_on_success=False,  # JobGroup cleans up all at end
+            force_transit_to_recovering=force_transit_to_recovering,
+            on_recovery=on_recovery,
+        )
+        if result is not None:
+            return result
         return await self._monitor_one_task(
             task_id=task_id,
             task=task,


### PR DESCRIPTION
## Summary

In `_run_one_task` (the chain-DAG single-task entrypoint), the
controller gives the `StrategyExecutor` first refusal at owning the
per-task monitor loop via `executor.monitor_task()`, only falling
through to `_monitor_one_task` when the executor returns `None`.

The JobGroup path (`_run_one_job_group_task`) currently jumps straight
to `_monitor_one_task` without that dispatch. Mirror the pattern so
both paths behave consistently — a recovery strategy that overrides
`monitor_task()` now gets invoked for both single-task and JobGroup
tasks.

## Why

Without this, a `StrategyExecutor.monitor_task()` override behaves
correctly for chain-DAG tasks but is silently skipped for JobGroup
tasks. The asymmetry is easy to miss when implementing a custom
recovery strategy.

## Test plan

- [x] No-op for the default `StrategyExecutor.monitor_task()` (returns
      `None`, fall-through preserved). Existing JobGroup tests under
      `tests/test_job_groups/` continue to pass.
- [x] A `StrategyExecutor` subclass whose `monitor_task()` returns a
      truthy value is now invoked for JobGroup tasks (previously
      unreachable).