### PR TITLE
[Docs] Link to GitHub examples in job groups docs

### DIFF
--- a/docs/source/examples/job-groups.rst
+++ b/docs/source/examples/job-groups.rst
@@ -227,7 +227,7 @@ a Kubernetes PVC volume:
     run: |
       python evaluate.py --checkpoint-dir /checkpoints
 
-See the full example at ``llm/train-eval-jobgroup/`` in the SkyPilot repository.
+See the `full example <https://github.com/skypilot-org/skypilot/tree/master/llm/train-eval-jobgroup>`_ in the SkyPilot repository.
 
 RL post-training architecture
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -289,7 +289,7 @@ This example demonstrates a distributed RL post-training architecture with 5 tas
    The same Job Group running in production, viewed from the SkyPilot dashboard.
    Each task has independent resources and can be monitored separately.
 
-See the full RL post-training example at ``llm/rl-post-training-jobgroup/`` in the SkyPilot repository.
+See the `full RL post-training example <https://github.com/skypilot-org/skypilot/tree/master/llm/rl-post-training-jobgroup>`_ in the SkyPilot repository.
 
 Primary and auxiliary tasks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary
- Replace plain file paths (`llm/train-eval-jobgroup/`, `llm/rl-post-training-jobgroup/`) with clickable GitHub links in the job groups documentation page.

## Test plan
- [ ] Verify links resolve correctly on the rendered docs page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->