### PR TITLE
[API] Omit echoed input from 422 validation error responses

### DIFF
--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1051,6 +1051,28 @@ def handle_concurrent_worker_exhausted_error(
         })
 
 
+@app.exception_handler(fastapi.exceptions.RequestValidationError)
+async def handle_request_validation_error(
+        request: fastapi.Request, e: fastapi.exceptions.RequestValidationError):
+    """Return a 422 with the rejected `input` field omitted.
+
+    FastAPI's default 422 handler echoes the entire validated body
+    inside each error entry's `input` field. Request payloads in this
+    server frequently nest large config/env dicts, and clients already
+    know what they sent, so the echo only inflates error responses
+    without adding signal. Keep `loc`/`msg`/`type` so SDK callers can
+    still tell which field was bad.
+    """
+    del request  # request is not used
+    safe = [
+        {k: v for k, v in err.items() if k != 'input'} for err in e.errors()
+    ]
+    return fastapi.responses.JSONResponse(
+        status_code=422,
+        content={'detail': safe},
+    )
+
+
 @app.get('/token')
 async def token(request: fastapi.Request,
                 local_port: Optional[int] = None) -> fastapi.responses.Response:

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -755,3 +755,60 @@ class TestResolveDynamicRoute:
             result = server._resolve_dynamic_route(str(d), 'cron')
         assert result is not None
         assert result.endswith('[...path].html')
+
+
+class TestRequestValidationErrorHandler:
+    """Tests for the global 422 RequestValidationError handler."""
+
+    def _make_client(self):
+        # pylint: disable=import-outside-toplevel
+        from fastapi.testclient import TestClient
+
+        from sky.server.requests import payloads
+
+        class _Body(payloads.RequestBody):
+            required_field: str
+
+        test_app = fastapi.FastAPI()
+        test_app.add_exception_handler(
+            fastapi.exceptions.RequestValidationError,
+            server.handle_request_validation_error,
+        )
+
+        @test_app.post('/_test')
+        async def _endpoint(body: _Body):
+            return {'ok': body.required_field}
+
+        return TestClient(test_app)
+
+    def test_input_field_is_omitted(self):
+        client = self._make_client()
+        resp = client.post('/_test', json={})
+        assert resp.status_code == 422
+        body = resp.json()
+        assert 'detail' in body
+        assert body['detail'], 'expected at least one error entry'
+        for err in body['detail']:
+            assert 'input' not in err, (f'`input` was echoed back: {err!r}')
+
+    def test_loc_msg_type_are_preserved(self):
+        client = self._make_client()
+        resp = client.post('/_test', json={})
+        assert resp.status_code == 422
+        err = resp.json()['detail'][0]
+        assert err.get('type') == 'missing'
+        assert err.get('loc') == ['body', 'required_field']
+        assert 'msg' in err
+
+    def test_server_side_default_values_are_not_leaked(self, monkeypatch):
+        # RequestBody.__init__ populates `env_vars` from the process
+        # environment, so without the handler the default 422 echoes
+        # those values back. Use a sentinel env var and assert the
+        # response body never contains it.
+        sentinel = 'a-sentinel-value-the-caller-never-sent'
+        monkeypatch.setenv('SKYPILOT_FAKE_SENTINEL', sentinel)
+
+        client = self._make_client()
+        resp = client.post('/_test', json={})
+        assert resp.status_code == 422
+        assert sentinel not in resp.text


### PR DESCRIPTION
The FastAPI default RequestValidationError handler serializes each error with an `input` field that echoes the entire validated body back to the caller. Request payloads for this server frequently nest large config / env dicts, and `RequestBody.__init__` fills in server-derived defaults that the caller never sent, so the echo only inflates error responses without adding signal: the caller already knows what they sent.

This PR adds a global handler that drops `input` and keeps `loc` / `msg` / `type`, so the 422 still tells the caller which field was bad without echoing values back.

## Tested

- Added unit tests in `tests/unit_tests/test_sky/server/test_server.py` covering the new handler (empty body 422, `loc`/`msg`/`type` preserved, server-side defaults not echoed).
- `pytest tests/unit_tests/test_sky/server/test_server.py` -> 30 passed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->