### PR TITLE
[o11y] Fix misleading 'Pulling image' status during init container execution for cluster on k8s

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -700,10 +700,13 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
     # Create a set of pod names we're waiting for
     expected_pod_names = {pod.metadata.name for pod in new_pods}
 
-    def _check_init_containers(pod):
-        # Check if any of the init containers failed
-        # to start. Could be because the init container
-        # command failed or failed to pull image etc.
+    def _check_init_containers(pod) -> Optional[str]:
+        """Check init containers for errors and return running container name.
+
+        Returns the name of the currently running init container, or None.
+        Raises KubernetesError if any init container failed.
+        """
+        running_name: Optional[str] = None
         for init_status in pod.status.init_container_statuses:
             init_terminated = init_status.state.terminated
             if init_terminated:
@@ -714,6 +717,9 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
                         'Failed to run init container for pod '
                         f'{pod.metadata.name}. Error details: {msg}.')
                 continue
+            if (init_status.state.running is not None and
+                    running_name is None):
+                running_name = init_status.name
             init_waiting = init_status.state.waiting
             if (init_waiting is not None and init_waiting.reason
                     not in ['ContainerCreating', 'PodInitializing']):
@@ -728,6 +734,7 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
                     f'Failed to create init container for pod '
                     f'{pod.metadata.name}. Error details: '
                     f'{reason_text}: {msg}.')
+        return running_name
 
     def _inspect_pod_status(pod):
         # Check if pod is terminated/preempted/failed (unchanged).
@@ -757,6 +764,7 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
             # Today's raise block -- control flow preserved, message enriched
             # via _unmask_crashloopbackoff_reason when the waiting state is
             # CrashLoopBackOff. msg body (waiting.message) is always preserved.
+            init_reason: Optional[str] = None
             if container_statuses is not None:
                 for container_status in container_statuses:
                     waiting = (container_status.state.waiting
@@ -764,7 +772,12 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
                     if waiting is None:
                         continue
                     if waiting.reason == 'PodInitializing':
-                        _check_init_containers(pod)
+                        running_init = _check_init_containers(pod)
+                        if running_init is not None:
+                            init_reason = (f'init container '
+                                           f'{running_init!r} running')
+                        else:
+                            init_reason = 'init container running'
                     elif waiting.reason != 'ContainerCreating':
                         msg = waiting.message if (
                             waiting.message) else str(waiting)
@@ -775,17 +788,22 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
                         raise config_lib.KubernetesError(
                             f'{reason_text}: {msg}')
 
-            # Tier 1 wins; fall back to Tier 2/3 events (semantics changed --
-            # see _get_pod_pending_reason: Warning beats Normal regardless
-            # of timestamp).
-            reason: Optional[str] = container_reason
+            # Init container reason wins over all event-based reasons,
+            # since events can retain stale "Pulling image" entries long
+            # after the pull completed.  Otherwise, Tier 1 (container
+            # status) wins; fall back to Tier 2/3 events.
+            reason: Optional[str] = init_reason or container_reason
+            event_message: Optional[str] = None
             if reason is None:
                 pending_reason = _get_pod_pending_reason(
                     context, namespace, pod.metadata.name)
                 if pending_reason is not None:
-                    reason, message = pending_reason
-                    logger.debug(f'Pod {pod.metadata.name} is pending: '
-                                 f'{reason}: {message}')
+                    reason, event_message = pending_reason
+            if reason is not None:
+                log_msg = f'Pod {pod.metadata.name} is pending: {reason}'
+                if event_message:
+                    log_msg += f': {event_message}'
+                logger.debug(log_msg)
             return False, reason
 
         # phase == 'Running' but not all containers running (e.g. one is in

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -717,8 +717,7 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
                         'Failed to run init container for pod '
                         f'{pod.metadata.name}. Error details: {msg}.')
                 continue
-            if (init_status.state.running is not None and
-                    running_name is None):
+            if (init_status.state.running is not None and running_name is None):
                 running_name = init_status.name
             init_waiting = init_status.state.waiting
             if (init_waiting is not None and init_waiting.reason

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -700,14 +700,17 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
     # Create a set of pod names we're waiting for
     expected_pod_names = {pod.metadata.name for pod in new_pods}
 
-    def _check_init_containers(pod) -> Optional[str]:
-        """Check init containers for errors and return running container name.
+    def _check_init_containers(pod) -> Optional[Tuple[str, int, int]]:
+        """Check init containers for errors and return running container info.
 
-        Returns the name of the currently running init container, or None.
+        Returns (name, 1-based index, total) of the currently running init
+        container, or None if none is running.
         Raises KubernetesError if any init container failed.
         """
-        running_name: Optional[str] = None
-        for init_status in pod.status.init_container_statuses:
+        init_statuses = pod.status.init_container_statuses
+        total = len(init_statuses)
+        running_info: Optional[Tuple[str, int, int]] = None
+        for idx, init_status in enumerate(init_statuses):
             init_terminated = init_status.state.terminated
             if init_terminated:
                 if init_terminated.exit_code != 0:
@@ -717,8 +720,8 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
                         'Failed to run init container for pod '
                         f'{pod.metadata.name}. Error details: {msg}.')
                 continue
-            if (init_status.state.running is not None and running_name is None):
-                running_name = init_status.name
+            if (init_status.state.running is not None and running_info is None):
+                running_info = (init_status.name, idx + 1, total)
             init_waiting = init_status.state.waiting
             if (init_waiting is not None and init_waiting.reason
                     not in ['ContainerCreating', 'PodInitializing']):
@@ -733,7 +736,7 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
                     f'Failed to create init container for pod '
                     f'{pod.metadata.name}. Error details: '
                     f'{reason_text}: {msg}.')
-        return running_name
+        return running_info
 
     def _inspect_pod_status(pod):
         # Check if pod is terminated/preempted/failed (unchanged).
@@ -773,8 +776,9 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
                     if waiting.reason == 'PodInitializing':
                         running_init = _check_init_containers(pod)
                         if running_init is not None:
-                            init_reason = (f'init container '
-                                           f'{running_init!r} running')
+                            name, idx, total = running_init
+                            init_reason = (f'init container {name!r} '
+                                           f'running ({idx}/{total})')
                         else:
                             init_reason = 'init container running'
                     elif waiting.reason != 'ContainerCreating':

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -2823,11 +2823,12 @@ class TestInspectPodStatusInitContainerReason:
 
         results, log_msgs = self._run_wait(monkeypatch, [pending_init, running])
 
-        assert results[0] == [(False, "init container 'init-copy-home' running")
-                             ]
+        assert results[0] == [(False,
+                               "init container 'init-copy-home' running (1/1)")]
         init_logs = [m for m in log_msgs if 'init container' in m]
         assert len(init_logs) >= 1
         assert "'init-copy-home'" in init_logs[0]
+        assert '(1/1)' in init_logs[0]
         assert 'Pulling' not in init_logs[0]
 
     def test_pod_initializing_no_running_init_container(self, monkeypatch):
@@ -2887,8 +2888,8 @@ class TestInspectPodStatusInitContainerReason:
             ]
 
         results, _ = self._run_wait(monkeypatch, [pending_init, running])
-        assert results[0] == [(False, "init container 'init-copy-home' running")
-                             ]
+        assert results[0] == [(False,
+                               "init container 'init-copy-home' running (2/2)")]
 
     def test_log_message_includes_image_during_pull(self, monkeypatch):
         """The provision log must include the image name during actual pull."""

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -2655,3 +2655,307 @@ class TestCheckInitContainersEnrichedRaise:
         assert 'Failed to create init container' in err
         assert 'ImagePullBackOff' in err
         assert 'init-img:bad' in err
+
+
+# ---------------------------------------------------------------------------
+# Tests for _inspect_pod_status init container pending reason reporting
+# ---------------------------------------------------------------------------
+
+
+def _make_init_status_with_name(name='init-copy-home',
+                                running=False,
+                                terminated_exit_code=None,
+                                waiting_reason=None,
+                                waiting_message=None):
+    """Build a mock init container status with an explicit name."""
+    cs = mock.MagicMock()
+    cs.name = name
+    cs.state.running = mock.MagicMock() if running else None
+    cs.state.terminated = None
+    cs.state.waiting = None
+    if terminated_exit_code is not None:
+        cs.state.terminated = mock.MagicMock()
+        cs.state.terminated.exit_code = terminated_exit_code
+        cs.state.terminated.message = None
+    if waiting_reason is not None:
+        cs.state.waiting = mock.MagicMock()
+        cs.state.waiting.reason = waiting_reason
+        cs.state.waiting.message = waiting_message
+    return cs
+
+
+class TestInspectPodStatusInitContainerReason:
+    """Tests that _inspect_pod_status reports init container running
+    instead of the stale 'Pulling' event reason."""
+
+    @staticmethod
+    def _make_pod(name='test-pod', cluster_name_on_cloud='test-cluster'):
+        from sky.provision import constants as prov_constants
+        pod = mock.MagicMock()
+        pod.metadata.name = name
+        pod.metadata.deletion_timestamp = None
+        pod.metadata.labels = {
+            prov_constants.TAG_SKYPILOT_CLUSTER_NAME: cluster_name_on_cloud,
+        }
+        return pod
+
+    def _run_wait(self, monkeypatch, pod_sequence):
+        """Run _wait_for_pods_to_run with a sequence of pod states.
+
+        Each entry in pod_sequence is a callable that configures the pod
+        for that iteration. The last entry must make the pod Running.
+        Returns the list of (is_running, reason) tuples from each
+        iteration and captured log messages.
+        """
+        cluster_name_on_cloud = 'test-cluster'
+        pod = self._make_pod(cluster_name_on_cloud=cluster_name_on_cloud)
+
+        iteration = [0]
+        results = []
+
+        def configure_and_list(*_args, **_kwargs):
+            if iteration[0] < len(pod_sequence):
+                pod_sequence[iteration[0]](pod)
+            pods_list = mock.MagicMock()
+            pods_list.items = [pod]
+            return pods_list
+
+        core_api = mock.MagicMock()
+        core_api.list_namespaced_pod.side_effect = configure_and_list
+        monkeypatch.setattr('sky.adaptors.kubernetes.core_api',
+                            lambda *a, **kw: core_api)
+
+        def passthrough_parallel(fn, items, n):
+            r = [fn(item) for item in items]
+            results.append(r)
+            iteration[0] += 1
+            return r
+
+        monkeypatch.setattr('sky.utils.subprocess_utils.run_in_parallel',
+                            passthrough_parallel)
+        monkeypatch.setattr('sky.utils.rich_utils.force_update_status',
+                            lambda *a, **kw: None)
+        monkeypatch.setattr(instance.time, 'sleep', lambda *a, **kw: None)
+        monkeypatch.setattr(instance.global_user_state, 'add_cluster_event',
+                            mock.MagicMock())
+
+        log_messages = []
+
+        def capture_debug(msg, *args, **kwargs):
+            log_messages.append(msg % args if args else msg)
+
+        monkeypatch.setattr(logger, 'debug', capture_debug)
+
+        instance._wait_for_pods_to_run(
+            namespace='ns',
+            context='ctx',
+            cluster_name='cn',
+            new_pods=[pod],
+        )
+        return results, log_messages
+
+    @staticmethod
+    def _make_running_container_status():
+        cs = mock.MagicMock()
+        cs.state.running = True
+        cs.state.waiting = None
+        cs.state.terminated = None
+        cs.last_state.terminated = None
+        return cs
+
+    def test_pulling_image_reason_during_actual_pull(self, monkeypatch):
+        """While containers are in ContainerCreating, the event-based
+        'Pulling' reason (with image name) should be reported."""
+        monkeypatch.setattr(
+            instance, '_get_pod_pending_reason',
+            lambda *a, **kw: ('Pulling',
+                              'Pulling image "us-docker.pkg.dev/foo:v1"'))
+
+        def pending_creating(pod):
+            pod.status.phase = 'Pending'
+            cs = _make_container_status(waiting_reason='ContainerCreating')
+            cs.state = mock.MagicMock()
+            cs.state.waiting = mock.MagicMock()
+            cs.state.waiting.reason = 'ContainerCreating'
+            cs.state.terminated = None
+            cs.last_state.terminated = None
+            pod.status.container_statuses = [cs]
+            pod.status.init_container_statuses = []
+
+        def running(pod):
+            pod.status.phase = 'Running'
+            pod.status.container_statuses = [
+                self._make_running_container_status()
+            ]
+
+        results, log_msgs = self._run_wait(monkeypatch,
+                                           [pending_creating, running])
+
+        assert results[0] == [(False, 'Pulling')]
+        pull_logs = [m for m in log_msgs if 'Pulling' in m]
+        assert any('us-docker.pkg.dev/foo:v1' in m for m in pull_logs)
+
+    def test_pod_initializing_overrides_pulling_reason(self, monkeypatch):
+        """When containers show PodInitializing with a running init
+        container, the reason must reflect the init container name."""
+        monkeypatch.setattr(
+            instance, '_get_pod_pending_reason',
+            lambda *a, **kw: ('Pulling',
+                              'Pulling image "us-docker.pkg.dev/foo:v1"'))
+
+        def pending_init(pod):
+            pod.status.phase = 'Pending'
+            cs = mock.MagicMock()
+            cs.state = mock.MagicMock()
+            cs.state.waiting = mock.MagicMock()
+            cs.state.waiting.reason = 'PodInitializing'
+            cs.state.terminated = None
+            cs.last_state.terminated = None
+            pod.status.container_statuses = [cs]
+            pod.status.init_container_statuses = [
+                _make_init_status_with_name(name='init-copy-home',
+                                            running=True),
+            ]
+
+        def running(pod):
+            pod.status.phase = 'Running'
+            pod.status.container_statuses = [
+                self._make_running_container_status()
+            ]
+
+        results, log_msgs = self._run_wait(monkeypatch,
+                                           [pending_init, running])
+
+        assert results[0] == [
+            (False, "init container 'init-copy-home' running")
+        ]
+        init_logs = [m for m in log_msgs if 'init container' in m]
+        assert len(init_logs) >= 1
+        assert "'init-copy-home'" in init_logs[0]
+        assert 'Pulling' not in init_logs[0]
+
+    def test_pod_initializing_no_running_init_container(self, monkeypatch):
+        """When PodInitializing but no init container is in running state,
+        fall back to generic message."""
+        monkeypatch.setattr(instance, '_get_pod_pending_reason',
+                            lambda *a, **kw: None)
+
+        def pending_init(pod):
+            pod.status.phase = 'Pending'
+            cs = mock.MagicMock()
+            cs.state = mock.MagicMock()
+            cs.state.waiting = mock.MagicMock()
+            cs.state.waiting.reason = 'PodInitializing'
+            cs.state.terminated = None
+            cs.last_state.terminated = None
+            pod.status.container_statuses = [cs]
+            pod.status.init_container_statuses = [
+                _make_init_status_with_name(name='init-copy-home',
+                                            terminated_exit_code=0),
+            ]
+
+        def running(pod):
+            pod.status.phase = 'Running'
+            pod.status.container_statuses = [
+                self._make_running_container_status()
+            ]
+
+        results, _ = self._run_wait(monkeypatch, [pending_init, running])
+        assert results[0] == [(False, 'init container running')]
+
+    def test_pod_initializing_multiple_init_containers(self, monkeypatch):
+        """With multiple init containers, report the currently running one."""
+        monkeypatch.setattr(instance, '_get_pod_pending_reason',
+                            lambda *a, **kw: None)
+
+        def pending_init(pod):
+            pod.status.phase = 'Pending'
+            cs = mock.MagicMock()
+            cs.state = mock.MagicMock()
+            cs.state.waiting = mock.MagicMock()
+            cs.state.waiting.reason = 'PodInitializing'
+            cs.state.terminated = None
+            cs.last_state.terminated = None
+            pod.status.container_statuses = [cs]
+            pod.status.init_container_statuses = [
+                _make_init_status_with_name(name='init-setup-ssh',
+                                            terminated_exit_code=0),
+                _make_init_status_with_name(name='init-copy-home',
+                                            running=True),
+            ]
+
+        def running(pod):
+            pod.status.phase = 'Running'
+            pod.status.container_statuses = [
+                self._make_running_container_status()
+            ]
+
+        results, _ = self._run_wait(monkeypatch, [pending_init, running])
+        assert results[0] == [
+            (False, "init container 'init-copy-home' running")
+        ]
+
+    def test_log_message_includes_image_during_pull(self, monkeypatch):
+        """The provision log must include the image name during actual pull."""
+        monkeypatch.setattr(
+            instance, '_get_pod_pending_reason',
+            lambda *a, **kw: ('Pulling',
+                              'Pulling image "registry.io/myimg:latest"'))
+
+        def pending_creating(pod):
+            pod.status.phase = 'Pending'
+            cs = mock.MagicMock()
+            cs.state = mock.MagicMock()
+            cs.state.waiting = mock.MagicMock()
+            cs.state.waiting.reason = 'ContainerCreating'
+            cs.state.terminated = None
+            cs.last_state.terminated = None
+            pod.status.container_statuses = [cs]
+            pod.status.init_container_statuses = []
+
+        def running(pod):
+            pod.status.phase = 'Running'
+            pod.status.container_statuses = [
+                self._make_running_container_status()
+            ]
+
+        _, log_msgs = self._run_wait(monkeypatch,
+                                     [pending_creating, running])
+        pending_logs = [m for m in log_msgs if 'is pending' in m]
+        assert len(pending_logs) == 1
+        assert 'Pulling' in pending_logs[0]
+        assert 'registry.io/myimg:latest' in pending_logs[0]
+
+    def test_log_message_no_image_during_init(self, monkeypatch):
+        """The provision log must NOT include stale image pull info
+        when the pod is actually waiting for init containers."""
+        monkeypatch.setattr(
+            instance, '_get_pod_pending_reason',
+            lambda *a, **kw: ('Pulling',
+                              'Pulling image "us-docker.pkg.dev/foo:v1"'))
+
+        def pending_init(pod):
+            pod.status.phase = 'Pending'
+            cs = mock.MagicMock()
+            cs.state = mock.MagicMock()
+            cs.state.waiting = mock.MagicMock()
+            cs.state.waiting.reason = 'PodInitializing'
+            cs.state.terminated = None
+            cs.last_state.terminated = None
+            pod.status.container_statuses = [cs]
+            pod.status.init_container_statuses = [
+                _make_init_status_with_name(name='init-copy-home',
+                                            running=True),
+            ]
+
+        def running(pod):
+            pod.status.phase = 'Running'
+            pod.status.container_statuses = [
+                self._make_running_container_status()
+            ]
+
+        _, log_msgs = self._run_wait(monkeypatch, [pending_init, running])
+        pending_logs = [m for m in log_msgs if 'is pending' in m]
+        assert len(pending_logs) == 1
+        assert 'init container' in pending_logs[0]
+        assert 'Pulling image' not in pending_logs[0]

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -2767,9 +2767,8 @@ class TestInspectPodStatusInitContainerReason:
         """While containers are in ContainerCreating, the event-based
         'Pulling' reason (with image name) should be reported."""
         monkeypatch.setattr(
-            instance, '_get_pod_pending_reason',
-            lambda *a, **kw: ('Pulling',
-                              'Pulling image "us-docker.pkg.dev/foo:v1"'))
+            instance, '_get_pod_pending_reason', lambda *a, **kw:
+            ('Pulling', 'Pulling image "us-docker.pkg.dev/foo:v1"'))
 
         def pending_creating(pod):
             pod.status.phase = 'Pending'
@@ -2799,9 +2798,8 @@ class TestInspectPodStatusInitContainerReason:
         """When containers show PodInitializing with a running init
         container, the reason must reflect the init container name."""
         monkeypatch.setattr(
-            instance, '_get_pod_pending_reason',
-            lambda *a, **kw: ('Pulling',
-                              'Pulling image "us-docker.pkg.dev/foo:v1"'))
+            instance, '_get_pod_pending_reason', lambda *a, **kw:
+            ('Pulling', 'Pulling image "us-docker.pkg.dev/foo:v1"'))
 
         def pending_init(pod):
             pod.status.phase = 'Pending'
@@ -2823,12 +2821,10 @@ class TestInspectPodStatusInitContainerReason:
                 self._make_running_container_status()
             ]
 
-        results, log_msgs = self._run_wait(monkeypatch,
-                                           [pending_init, running])
+        results, log_msgs = self._run_wait(monkeypatch, [pending_init, running])
 
-        assert results[0] == [
-            (False, "init container 'init-copy-home' running")
-        ]
+        assert results[0] == [(False, "init container 'init-copy-home' running")
+                             ]
         init_logs = [m for m in log_msgs if 'init container' in m]
         assert len(init_logs) >= 1
         assert "'init-copy-home'" in init_logs[0]
@@ -2891,16 +2887,14 @@ class TestInspectPodStatusInitContainerReason:
             ]
 
         results, _ = self._run_wait(monkeypatch, [pending_init, running])
-        assert results[0] == [
-            (False, "init container 'init-copy-home' running")
-        ]
+        assert results[0] == [(False, "init container 'init-copy-home' running")
+                             ]
 
     def test_log_message_includes_image_during_pull(self, monkeypatch):
         """The provision log must include the image name during actual pull."""
         monkeypatch.setattr(
-            instance, '_get_pod_pending_reason',
-            lambda *a, **kw: ('Pulling',
-                              'Pulling image "registry.io/myimg:latest"'))
+            instance, '_get_pod_pending_reason', lambda *a, **kw:
+            ('Pulling', 'Pulling image "registry.io/myimg:latest"'))
 
         def pending_creating(pod):
             pod.status.phase = 'Pending'
@@ -2919,8 +2913,7 @@ class TestInspectPodStatusInitContainerReason:
                 self._make_running_container_status()
             ]
 
-        _, log_msgs = self._run_wait(monkeypatch,
-                                     [pending_creating, running])
+        _, log_msgs = self._run_wait(monkeypatch, [pending_creating, running])
         pending_logs = [m for m in log_msgs if 'is pending' in m]
         assert len(pending_logs) == 1
         assert 'Pulling' in pending_logs[0]
@@ -2930,9 +2923,8 @@ class TestInspectPodStatusInitContainerReason:
         """The provision log must NOT include stale image pull info
         when the pod is actually waiting for init containers."""
         monkeypatch.setattr(
-            instance, '_get_pod_pending_reason',
-            lambda *a, **kw: ('Pulling',
-                              'Pulling image "us-docker.pkg.dev/foo:v1"'))
+            instance, '_get_pod_pending_reason', lambda *a, **kw:
+            ('Pulling', 'Pulling image "us-docker.pkg.dev/foo:v1"'))
 
         def pending_init(pod):
             pod.status.phase = 'Pending'


### PR DESCRIPTION
## Summary
- When a pod has init containers, the provision log and spinner kept reporting `Pulling image "..."` for the entire duration of init container execution. On Kubernetes clusters with slow NFS-backed PVCs (e.g. Azure Files NFS), init containers can take 25+ minutes, but the status misleadingly showed image pulling the whole time.
- Root cause: `_inspect_pod_status` fell back to the event-based pending reason (Tier 2/3) when `_get_pod_pending_reason_from_container_status` (Tier 1) returned `None` for the `PodInitializing` state. The most recent event was the stale `Pulling` from the already-completed image pull.
- Fix: `_check_init_containers` now returns the name and progress of the currently running init container. When containers are in `PodInitializing` state, this is used as the pending reason, taking priority over event-based reasons.

**Before:** `Launching (1 pod(s) pending due to Pulling)` for 25+ minutes  
**After:** `Launching (1 pod(s) pending due to init container 'init-copy-home' running (2/3))`

## Test plan
- Added 6 unit tests in `TestInspectPodStatusInitContainerReason` covering:
  - Actual image pull correctly shows `Pulling` with image name in log
  - `PodInitializing` overrides stale `Pulling` reason with init container name and progress
  - Fallback to generic message when no init container is in running state
  - Multiple init containers: reports the currently running one with correct index
  - Log message includes image name during actual pull
  - Log message excludes stale image info during init container execution
- All 103 tests in `test_provision.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)