### PR TITLE
[Test] Increase test_managed_jobs_basic RUNNING timeout for GCP to 360s

### DIFF
--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -76,8 +76,8 @@ def test_managed_jobs_basic(generic_cloud: str):
             get_cmd_wait_until_managed_job_status_contains_matching_job_name(
                 job_name=f'{name}-2',
                 job_status=[sky.ManagedJobStatus.RUNNING],
-                timeout=360
-                if generic_cloud in ['azure', 'kubernetes', 'nebius'] else 120),
+                timeout=360 if generic_cloud
+                in ['azure', 'gcp', 'kubernetes', 'nebius'] else 120),
             f'sky jobs cancel -y -n {name}-1',
             smoke_tests_utils.
             get_cmd_wait_until_managed_job_status_contains_matching_job_name(


### PR DESCRIPTION
## Summary
- **Test:** `test_managed_jobs_basic` on `gcp`
- **Classification:** TIMEOUT_USER_FLAGGED (3 consecutive attempts hit the same 120s timeout)
- **Confidence:** HIGH

## Root Cause
`test_managed_jobs_basic` launches two managed jobs back-to-back and waits up to 120s for the second one to reach `RUNNING` on GCP. In recent runs, the second job is consistently still in `STARTING` at the 120s mark (TOT. DURATION ~2 minutes), because GCP VM provisioning for managed job workers reliably takes longer than that. Azure, Kubernetes, and Nebius already use a 360s timeout in this exact code path.

The sibling tests `test_managed_jobs_cancelled_job_logs` and `test_pipeline_cancelled_logs` were updated to use a 360s timeout for GCP (and other slow clouds) in #9335 to fix the same flake. `test_managed_jobs_basic` was missed in that PR.

## Fix
Add `'gcp'` to the list of clouds that get a 360s `RUNNING` wait timeout in `test_managed_jobs_basic`. One-line semantic change in `tests/smoke_tests/test_managed_job.py`.

## Buildkite Failure
https://buildkite.com/skypilot-1/full-smoke-tests-run/builds/118#019e50f8-5763-401e-9130-8810e2512ec9

---
> **Note:** This fix was auto-generated. Confidence level: HIGH.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->