### PR TITLE
[Test] Poll for Azure non-persistent bucket removal in test_managed_jobs_storage

### DIFF
--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -1204,11 +1204,25 @@ def test_managed_jobs_storage(generic_cloud: str):
             storage_account_name=storage_account_name)
         output_check_cmd = smoke_tests_utils.run_cloud_cmd_on_cluster(
             name, f'{az_check_file_count} | grep 1')
-        non_persistent_bucket_removed_check_cmd = test_mount_and_storage.TestStorageWithCredentials.cli_ls_cmd(
+        az_ls_cmd = test_mount_and_storage.TestStorageWithCredentials.cli_ls_cmd(
             storage_lib.StoreType.AZURE, storage_name)
+        # Azure controller cleanup (worker VM teardown plus blob container
+        # deletion) regularly exceeds the universal `sleep 50` post-SUCCEEDED
+        # wait. Poll for up to 300s for the container to be removed.
         non_persistent_bucket_removed_check_cmd = smoke_tests_utils.run_cloud_cmd_on_cluster(
-            name,
-            f'{non_persistent_bucket_removed_check_cmd} && exit 1 || true')
+            name, 'start_time=$SECONDS; '
+            'timeout_s=300; '
+            'while true; do '
+            '  if (( $SECONDS - start_time > timeout_s )); then '
+            '    echo "Timeout waiting for non-persistent bucket removal"; '
+            '    exit 1; '
+            '  fi; '
+            f'  if ! ({az_ls_cmd}) > /dev/null 2>&1; then '
+            '    echo "Bucket removed."; break; '
+            '  fi; '
+            '  echo "Bucket still present, retrying in 10s..."; '
+            '  sleep 10; '
+            'done')
         timeout *= 2
     elif generic_cloud in ('kubernetes', 'slurm'):
         # With Kubernetes, we don't know which object storage provider is used.


### PR DESCRIPTION
## Summary

- `test_managed_jobs_storage on azure` has been failing on the release branch (build #118 of `full-smoke-tests-run` for 0.12.3rc1, four consecutive attempts).
- Root cause: the universal `sleep 50` wait after the managed job hits `SUCCEEDED` is not enough on Azure. The jobs controller still has to tear down the worker VM and then delete the non-persistent blob container, which regularly takes longer than 50s. When the `az storage blob list ... && exit 1 || true` assertion runs too early, the container still has blobs, the `&& exit 1` branch fires, and the step fails. The same code passed two days earlier on build #117, where Azure was just fast enough.
- Fix: wrap the Azure bucket-removed assertion in a polling loop with up to 300s of extra wait. Other clouds keep their single-shot check.

## Test plan

- [ ] Trigger a smoke test on this PR for the Azure variant: `/smoke-test -k test_managed_jobs_storage --azure`
- [ ] Confirm the step passes (or fails with the new explicit "Timeout waiting for non-persistent bucket removal" message rather than the old `exit 1` from the assertion).
- [ ] Sanity check the AWS / GCP / Kubernetes variants are unchanged: `/smoke-test -k test_managed_jobs_storage` on a non-Azure cloud should still pass with the original single-shot check.

## Notes

- This is intentionally a minimal experimental change: bump the effective timeout to confirm whether the failure is purely an Azure timing race, or whether there is a real product regression in the controller's storage cleanup. If the polling loop reliably succeeds, the hypothesis is confirmed and we can keep this as the fix. If it instead times out after 300s, we have a real bug to chase in the controller's `_delete_az_bucket` path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->