### PR TITLE
[Tests] Bump test_api_server_start_stop timeout to 1800s

### DIFF
--- a/tests/smoke_tests/test_api_server.py
+++ b/tests/smoke_tests/test_api_server.py
@@ -500,7 +500,7 @@ def test_api_server_start_stop(generic_cloud: str):
             f'sky launch -n {name} --cloud {generic_cloud} tests/test_yamls/apiserver-start-stop.yaml -y {smoke_tests_utils.LOW_RESOURCE_ARG}'
         ],
         f'sky down -y {name} || true',
-        timeout=1200,
+        timeout=1800,
     )
     smoke_tests_utils.run_one_test(test)
 


### PR DESCRIPTION
## Summary
- **Test:** `test_api_server_start_stop` on `azure`
- **Classification:** TIMEOUT_REPEATED
- **Confidence:** MEDIUM

## Root Cause
The test runs a 20-iteration loop of chaotic `sky api start`/`sky api stop` plus a `sky launch --dryrun` per iteration. On Azure, wall-time has been gradually creeping up: build 117 (same release branch, 2 days earlier) passed in 1260s wall time, while build 118 timed out at 1200s on iteration 20 across 5 consecutive attempts (4 retries + 1 babysit retry, all identical).

The previous timeout bump (#9056) from 900s to 1200s is no longer enough headroom for Azure. AWS and Kubernetes still pass comfortably; Azure is the slow tail.

## Fix
Bump the per-test timeout from 1200s to 1800s, giving ~50% headroom over the observed worst-case (~1240s wall time for the inner command on Azure in the most recent passing run).

This is a test-only change. No production code is touched. The underlying test logic and the on-cluster YAML (20 iterations, chaotic start/stop) are unchanged, so test coverage of the race-condition path is preserved.

## Why not reduce iteration count
Reducing the YAML's loop from 20 to 15 iterations would also fix the timeout, but it would lose test coverage of long-running start/stop sequences that the test is specifically designed to catch. Timeout bump is the lower-risk change.

## Buildkite Failure
https://buildkite.com/skypilot-1/full-smoke-tests-run/builds/118#019e5153-d68e-4696-bc2c-3389bf29e325

All 5 attempts failed in exactly the same way (timeout at iteration 20 of 20):
- Attempt 1: 17:31 to 17:52 (21:15 wall)
- Attempt 2: 17:52 to 18:13 (21:16 wall)
- Attempt 3: 18:13 to 18:35 (21:15 wall)
- Attempt 4: 20:15 to 20:36 (21:13 wall)
- Attempt 5: 22:10 to 22:31 (21:11 wall)

---
> **Note:** This fix was auto-generated. Confidence level: MEDIUM. The fix is mechanical and well-scoped, but the underlying test cost on Azure may continue to creep up over time. A follow-up could either parametrize the iteration count or split this test into a lighter chaos-only variant.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>