### PR TITLE
[Dashboard] Managed Jobs filter polish: More dropdown, Active/All toggle, default to Mine

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -2037,7 +2037,13 @@ export function ManagedJobsTable({
                   </div>
                 );
               })()}
-              {totalNoFilter > 0 &&
+              {/* Show the toggles whenever there are jobs anywhere in the
+                  view we could switch to — including the Everyone scope
+                  when the user's own list is empty. Without the
+                  everyoneTotal fallback, a user with zero personal jobs
+                  would lose the toggle and have only the empty-state
+                  CTA, with no way to switch back to Mine afterward. */}
+              {(totalNoFilter > 0 || (everyoneTotal && everyoneTotal > 0)) &&
                 (() => {
                   const selectTab = (tab) => {
                     React.startTransition(() => {
@@ -2083,7 +2089,16 @@ export function ManagedJobsTable({
                   );
                 })()}
               {(() => {
-                if (totalNoFilter === 0 || !currentUser) return null;
+                if (!currentUser) return null;
+                // Hide only when there are zero jobs in any scope —
+                // otherwise users with empty Mine views still need
+                // the toggle so they can return to Mine after taking
+                // the "View all jobs" CTA.
+                if (
+                  totalNoFilter === 0 &&
+                  !(everyoneTotal && everyoneTotal > 0)
+                )
+                  return null;
                 const explicitUserFilter = (filters || []).find(
                   (f) => (f.property || '').toLowerCase() === 'user' && f.value
                 );

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -1996,7 +1996,7 @@ export function ManagedJobsTable({
                       />
                     </button>
                     {moreMenuOpen && (
-                      <div className="absolute left-0 z-20 mt-1 w-60 rounded-md border border-gray-200 bg-white shadow-md py-1">
+                      <div className="absolute left-0 z-50 mt-1 w-60 rounded-md border border-gray-200 bg-white shadow-md py-1">
                         {OTHER_STATUSES.map((status) => {
                           const count = statusCounts[status] ?? 0;
                           // A status is included in the current view either
@@ -2037,13 +2037,13 @@ export function ManagedJobsTable({
                   </div>
                 );
               })()}
-              {/* Show the toggles whenever there are jobs anywhere in the
-                  view we could switch to — including the Everyone scope
-                  when the user's own list is empty. Without the
-                  everyoneTotal fallback, a user with zero personal jobs
-                  would lose the toggle and have only the empty-state
-                  CTA, with no way to switch back to Mine afterward. */}
-              {(totalNoFilter > 0 || (everyoneTotal && everyoneTotal > 0)) &&
+              {/* Activity toggle stays visible past the loading state.
+                  Hiding it on totalNoFilter===0 stranded users who'd
+                  narrowed Everyone with a filter that returned zero,
+                  or whose Mine view was empty — they had no easy way
+                  back. The toggle is harmless when the table is empty
+                  and indispensable as soon as anything else changes. */}
+              {!isInitialLoad &&
                 (() => {
                   const selectTab = (tab) => {
                     React.startTransition(() => {
@@ -2090,15 +2090,7 @@ export function ManagedJobsTable({
                 })()}
               {(() => {
                 if (!currentUser) return null;
-                // Hide only when there are zero jobs in any scope —
-                // otherwise users with empty Mine views still need
-                // the toggle so they can return to Mine after taking
-                // the "View all jobs" CTA.
-                if (
-                  totalNoFilter === 0 &&
-                  !(everyoneTotal && everyoneTotal > 0)
-                )
-                  return null;
+                if (isInitialLoad) return null;
                 const explicitUserFilter = (filters || []).find(
                   (f) => (f.property || '').toLowerCase() === 'user' && f.value
                 );
@@ -2364,6 +2356,8 @@ export function ManagedJobsTable({
                         !controllerLaunching &&
                         (userScope === 'mine' &&
                         currentUser &&
+                        activeTab === 'all' &&
+                        showAllMode &&
                         everyoneTotal > 0 ? (
                           <div className="flex flex-col items-center space-y-2 max-w-md">
                             <p className="text-gray-700">
@@ -2371,8 +2365,8 @@ export function ManagedJobsTable({
                             </p>
                             <p className="text-sm text-gray-500">
                               {everyoneTotal.toLocaleString()} job
-                              {everyoneTotal === 1 ? '' : 's'} from other users
-                              — switch to All Jobs to see them.
+                              {everyoneTotal === 1 ? '' : 's'} in total — switch
+                              to All Jobs to see them.
                             </p>
                             <Button
                               variant="outline"

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -1147,12 +1147,18 @@ export function ManagedJobsTable({
   // submitted anything yet, but N jobs from others are out there —
   // click to see them". Avoids leaving the user staring at a blank
   // table wondering whether SkyPilot has any activity at all.
+  //
+  // We use the client-side rendered row count (data.length) as the
+  // empty signal rather than the server's totalNoFilter — totalNoFilter
+  // currently reflects the unfiltered (including-other-users) total and
+  // doesn't honor userMatch, so it would suppress this CTA for any
+  // installation where other users have jobs.
   const [everyoneTotal, setEveryoneTotal] = useState(null);
   useEffect(() => {
     if (userScope !== 'mine') return;
     if (!currentUser) return;
     if (loading || isInitialLoad) return;
-    if (totalNoFilter !== 0) return;
+    if (data.length > 0) return;
     if (everyoneTotal !== null) return;
     let cancelled = false;
     (async () => {
@@ -1176,7 +1182,7 @@ export function ManagedJobsTable({
     currentUser,
     loading,
     isInitialLoad,
-    totalNoFilter,
+    data.length,
     everyoneTotal,
   ]);
 
@@ -2309,7 +2315,6 @@ export function ManagedJobsTable({
                         !controllerLaunching &&
                         (userScope === 'mine' &&
                         currentUser &&
-                        totalNoFilter === 0 &&
                         everyoneTotal > 0 ? (
                           <div className="flex flex-col items-center space-y-2 max-w-md">
                             <p className="text-gray-700">

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -2232,7 +2232,18 @@ export function ManagedJobsTable({
               </TableRow>
             </TableHeader>
             <TableBody>
-              {loading && isInitialLoad ? (
+              {(loading ||
+                (userScope === 'mine' &&
+                  currentUser &&
+                  everyoneTotal === null)) &&
+              paginatedData.length === 0 ? (
+                // Show the loading row both on initial fetch AND whenever
+                // a refetch starts with an empty table (e.g. right after
+                // clicking "View all jobs" or flipping the My Jobs/All
+                // Jobs toggle from a zero-row scope). Also covers the
+                // brief window between the empty Mine fetch returning
+                // and the Everyone probe answering, so the user doesn't
+                // flash through "No active jobs" before the CTA renders.
                 <TableRow>
                   <TableCell
                     colSpan={totalColSpan}
@@ -2384,6 +2395,8 @@ export function ManagedJobsTable({
                               onClick={() => {
                                 React.startTransition(() => {
                                   setUserScope('all');
+                                  setSelectedStatuses([]);
+                                  setShowAllMode(true);
                                   setCurrentPage(1);
                                 });
                               }}

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -2114,7 +2114,7 @@ export function ManagedJobsTable({
                           : 'text-gray-600 hover:text-gray-900'
                       }`}
                     >
-                      Mine
+                      My Jobs
                     </button>
                     <button
                       role="tab"
@@ -2126,7 +2126,7 @@ export function ManagedJobsTable({
                           : 'text-gray-600 hover:text-gray-900'
                       }`}
                     >
-                      Everyone
+                      All Jobs
                     </button>
                   </div>
                 );
@@ -2357,7 +2357,7 @@ export function ManagedJobsTable({
                             <p className="text-sm text-gray-500">
                               {everyoneTotal.toLocaleString()} job
                               {everyoneTotal === 1 ? '' : 's'} from other users
-                              — switch to Everyone to see them.
+                              — switch to All Jobs to see them.
                             </p>
                             <Button
                               variant="outline"
@@ -2370,7 +2370,7 @@ export function ManagedJobsTable({
                               }}
                               className="text-sky-blue hover:text-sky-blue-bright"
                             >
-                              View everyone&apos;s jobs
+                              View all jobs
                             </Button>
                           </div>
                         ) : (

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -618,12 +618,16 @@ export function ManagedJobsTable({
         const jobIdFilter = getFilterValue('id');
         // Explicit user picked via FilterDropdown wins over the Mine/Everyone
         // toggle. Otherwise, scope to the current user when toggle is "mine".
+        // Send the username (not the id/hash): the server resolves
+        // `user_match` via `get_user_by_name_match` which does a LIKE on the
+        // `name` column. Passing the hash on multi-user tenants where id and
+        // name differ would silently return zero results.
         const explicitUserMatch = getFilterValue('user');
         const effectiveUserMatch =
           explicitUserMatch !== undefined
             ? explicitUserMatch
             : userScope === 'mine' && currentUser
-              ? currentUser.id
+              ? currentUser.name
               : undefined;
         const params = {
           allUsers: true,
@@ -994,6 +998,20 @@ export function ManagedJobsTable({
     ).length;
     return { active, finished };
   }, [data]);
+
+  // Non-primary statuses currently selected — surface them as inline chips
+  // alongside the More dropdown so active filters are always visible.
+  const nonPrimarySelectedStatuses = React.useMemo(
+    () => selectedStatuses.filter((s) => !PRIMARY_STATUSES.includes(s)),
+    [selectedStatuses]
+  );
+
+  // Total count of jobs across all "other" (More dropdown) statuses; surfaced
+  // on the dropdown pill so users see how many jobs the long tail covers.
+  const otherStatusesTotalCount = React.useMemo(
+    () => OTHER_STATUSES.reduce((sum, s) => sum + (statusCounts[s] ?? 0), 0),
+    [statusCounts]
+  );
 
   // Helper function to determine if a status should be highlighted
   const isStatusHighlighted = (status) => {
@@ -1930,23 +1948,21 @@ export function ManagedJobsTable({
               {/* Selected non-primary statuses surface as inline chips so the
                   user can always see which filters are active without opening
                   the dropdown. */}
-              {selectedStatuses
-                .filter((s) => !PRIMARY_STATUSES.includes(s))
-                .map((status) => {
-                  const count = statusCounts[status] ?? 0;
-                  return (
-                    <button
-                      key={status}
-                      onClick={() => handleStatusClick(status)}
-                      className={`px-3 py-0.5 rounded-full flex items-center space-x-2 ${getBadgeStyle(status)}`}
-                    >
-                      <span>{status}</span>
-                      <span className="text-xs tabular-nums text-center min-w-[1.5rem] bg-white/50 px-1.5 py-0.5 rounded">
-                        {count}
-                      </span>
-                    </button>
-                  );
-                })}
+              {nonPrimarySelectedStatuses.map((status) => {
+                const count = statusCounts[status] ?? 0;
+                return (
+                  <button
+                    key={status}
+                    onClick={() => handleStatusClick(status)}
+                    className={`px-3 py-0.5 rounded-full flex items-center space-x-2 ${getBadgeStyle(status)}`}
+                  >
+                    <span>{status}</span>
+                    <span className="text-xs tabular-nums text-center min-w-[1.5rem] bg-white/50 px-1.5 py-0.5 rounded">
+                      {count}
+                    </span>
+                  </button>
+                );
+              })}
               {/* More dropdown: holds the long tail of statuses
                   (PENDING, STARTING, CANCELLED, FAILED_*, …). */}
               {(() => {
@@ -1958,10 +1974,7 @@ export function ManagedJobsTable({
                 const otherIncludedCount = OTHER_STATUSES.filter((s) =>
                   isStatusHighlighted(s)
                 ).length;
-                const otherTotalCount = OTHER_STATUSES.reduce(
-                  (sum, s) => sum + (statusCounts[s] ?? 0),
-                  0
-                );
+                const otherTotalCount = otherStatusesTotalCount;
                 const isNarrowed =
                   activeTab !== 'all' || selectedStatuses.length > 0;
                 return (

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -97,16 +97,18 @@ export const statusGroups = {
 };
 
 // Statuses shown as primary chips on the Statuses filter bar.
-// All other statuses are tucked behind the "More" dropdown to keep the
-// summary line balanced and avoid over-emphasizing failure variants.
-const PRIMARY_STATUSES = ['RUNNING', 'SUCCEEDED', 'FAILED'];
+// Ordered along the typical job lifecycle (STARTING → RUNNING →
+// SUCCEEDED) so the bar reads left-to-right as a progress story.
+// FAILED and other terminal variants live in the "More" dropdown to
+// keep the summary line calm.
+const PRIMARY_STATUSES = ['STARTING', 'RUNNING', 'SUCCEEDED'];
 const OTHER_STATUSES = [
   'PENDING',
   'SUBMITTED',
-  'STARTING',
   'RECOVERING',
   'CANCELLING',
   'CANCELLED',
+  'FAILED',
   'FAILED_SETUP',
   'FAILED_PRECHECKS',
   'FAILED_NO_RESOURCE',
@@ -167,14 +169,16 @@ export function getAggregatedStatus(tasks) {
 }
 
 // Define filter options for the filter dropdown
+// Name is first so it's the default when users open the dropdown —
+// users typically search by job name, not ID.
 const PROPERTY_OPTIONS = [
-  {
-    label: 'ID',
-    value: 'id',
-  },
   {
     label: 'Name',
     value: 'name',
+  },
+  {
+    label: 'ID',
+    value: 'id',
   },
   {
     label: 'User',
@@ -1868,21 +1872,27 @@ export function ManagedJobsTable({
                       <div className="absolute left-0 z-20 mt-1 w-60 rounded-md border border-gray-200 bg-white shadow-md py-1">
                         {OTHER_STATUSES.map((status) => {
                           const count = statusCounts[status] ?? 0;
-                          const selected = selectedStatuses.includes(status);
+                          // A status is included in the current view either
+                          // explicitly (selectedStatuses) or implicitly via
+                          // the Active/All toggle (e.g. PENDING/STARTING are
+                          // implicitly included when Active is selected).
+                          // Both cases should light up the check + label.
+                          const included = isStatusHighlighted(status);
+                          const explicit = selectedStatuses.includes(status);
                           return (
                             <button
                               key={status}
                               onClick={() => handleStatusClick(status)}
                               className={`w-full px-3 py-1.5 flex items-center justify-between text-sm hover:bg-gray-50 ${
-                                selected ? 'bg-gray-50' : ''
+                                explicit ? 'bg-gray-50' : ''
                               }`}
                             >
                               <span className="flex items-center gap-2 min-w-0">
                                 <CheckIcon
-                                  className={`w-3.5 h-3.5 shrink-0 ${selected ? 'text-sky-blue' : 'text-transparent'}`}
+                                  className={`w-3.5 h-3.5 shrink-0 ${included ? 'text-sky-blue' : 'text-transparent'}`}
                                 />
                                 <span
-                                  className={`truncate ${selected ? 'font-medium text-gray-900' : count === 0 ? 'text-gray-400' : 'text-gray-700'}`}
+                                  className={`truncate ${included ? 'font-medium text-gray-900' : count === 0 ? 'text-gray-400' : 'text-gray-700'}`}
                                 >
                                   {status}
                                 </span>

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -30,6 +30,7 @@ import jobsCacheManager from '@/lib/jobs-cache-manager';
 import { getClusters, downloadJobLogs } from '@/data/connectors/clusters';
 import { getWorkspaces } from '@/data/connectors/workspaces';
 import { getUsers } from '@/data/connectors/users';
+import { apiClient } from '@/data/connectors/client';
 import {
   CustomTooltip as Tooltip,
   NonCapitalizedTooltip,
@@ -493,6 +494,12 @@ export function ManagedJobsTable({
   const [isRestarting, setIsRestarting] = useState(false);
   const [activeTab, setActiveTab] = useState('all');
   const [showAllMode, setShowAllMode] = useState(true);
+  // Default to scoping the table to the current user's jobs. Flips to
+  // 'all' when the user clicks the Everyone toggle, or implicitly when
+  // they pick a different user via the FilterDropdown (explicit user
+  // filter wins; see effectiveUserMatch in fetchData).
+  const [userScope, setUserScope] = useState('mine');
+  const [currentUser, setCurrentUser] = useState(null);
   const [confirmationModal, setConfirmationModal] = useState({
     isOpen: false,
     title: '',
@@ -604,11 +611,20 @@ export function ManagedJobsTable({
 
         // Build params for jobsCacheManager
         const jobIdFilter = getFilterValue('id');
+        // Explicit user picked via FilterDropdown wins over the Mine/Everyone
+        // toggle. Otherwise, scope to the current user when toggle is "mine".
+        const explicitUserMatch = getFilterValue('user');
+        const effectiveUserMatch =
+          explicitUserMatch !== undefined
+            ? explicitUserMatch
+            : userScope === 'mine' && currentUser
+              ? currentUser.id
+              : undefined;
         const params = {
           allUsers: true,
           jobIdMatch: jobIdFilter,
           nameMatch: getFilterValue('name'),
-          userMatch: getFilterValue('user'),
+          userMatch: effectiveUserMatch,
           workspaceMatch: getFilterValue('workspace'),
           poolMatch: getFilterValue('pool'),
           statuses: computedStatuses.length > 0 ? computedStatuses : undefined,
@@ -710,6 +726,8 @@ export function ManagedJobsTable({
       computedStatuses,
       sortBy,
       sortOrder,
+      userScope,
+      currentUser,
     ]
   );
 
@@ -735,13 +753,20 @@ export function ManagedJobsTable({
 
   // Initial load - runs immediately on mount, don't wait for full preloading
   // The preloader will warm the cache in background, but we fetch jobs data
-  // right away so the table displays as fast as possible
+  // right away so the table displays as fast as possible. When the Mine
+  // scope is active we wait until the current user has loaded so the
+  // first fetch already carries userMatch — avoids an extra "Everyone"
+  // round-trip that would briefly flash other users' jobs.
   React.useEffect(() => {
+    if (!isInitialFetch.current) return;
+    const explicitUserFilter = (filters || []).find(
+      (f) => (f.property || '').toLowerCase() === 'user' && f.value
+    );
+    if (userScope === 'mine' && !currentUser && !explicitUserFilter) return;
     fetchData({ includeStatus: true });
-    // Mark that initial fetch is complete so other effects can run
     isInitialFetch.current = false;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [currentUser, userScope]);
 
   // Fetch on pagination (page) changes without status request
   // Skip on initial fetch (page defaults to 1)
@@ -1096,6 +1121,31 @@ export function ManagedJobsTable({
 
   // Check if a job group is expanded
   const isJobGroupExpanded = (jobId) => expandedJobGroups.has(jobId);
+
+  // Fetch the current user once so the Mine/Everyone toggle can scope
+  // results to the logged-in user. Falls back to null if unauthenticated
+  // or the role endpoint fails, which forces the table into the
+  // Everyone view (no userMatch is sent).
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const response = await apiClient.get('/users/role');
+        if (!response.ok) return;
+        const data = await response.json();
+        if (cancelled) return;
+        if (data && data.id) {
+          setCurrentUser({ id: data.id, name: data.name || data.id });
+        }
+      } catch (e) {
+        // Swallow: toggle simply degrades to "Everyone" if we can't id
+        // the caller.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // After ~1s of a non-initial load, fade a spinner overlay onto the
   // table so the user knows their toggle/filter click is in-flight.
@@ -1950,6 +2000,65 @@ export function ManagedJobsTable({
                       }`}
                     >
                       All
+                    </button>
+                  </div>
+                );
+              })()}
+              {(() => {
+                // Mine/Everyone toggle. Suppressed when there are no jobs at
+                // all (parallels the Active/All toggle's gating) and also
+                // when the current user couldn't be resolved (anonymous /
+                // basic-auth path): the toggle has no meaningful "Mine".
+                if (totalNoFilter === 0 || !currentUser) return null;
+                const explicitUserFilter = (filters || []).find(
+                  (f) =>
+                    (f.property || '').toLowerCase() === 'user' && f.value
+                );
+                // If the user picked a specific user via FilterDropdown,
+                // that wins. We light up "Mine" only when that pick happens
+                // to match the current user; otherwise neither segment is
+                // highlighted so it's clear an explicit narrow filter is in
+                // effect.
+                const isMine = explicitUserFilter
+                  ? String(explicitUserFilter.value) === currentUser.id ||
+                    String(explicitUserFilter.value) === currentUser.name
+                  : userScope === 'mine';
+                const isEveryone = !explicitUserFilter && userScope === 'all';
+                const selectScope = (scope) => {
+                  React.startTransition(() => {
+                    setUserScope(scope);
+                    setCurrentPage(1);
+                  });
+                };
+                return (
+                  <div
+                    role="tablist"
+                    aria-label="Filter jobs by owner"
+                    className="inline-flex items-center bg-gray-100 rounded-md p-0.5 ml-2 shrink-0"
+                  >
+                    <button
+                      role="tab"
+                      aria-selected={isMine}
+                      onClick={() => selectScope('mine')}
+                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                        isMine
+                          ? 'bg-white text-gray-900 shadow-sm'
+                          : 'text-gray-600 hover:text-gray-900'
+                      }`}
+                    >
+                      Mine
+                    </button>
+                    <button
+                      role="tab"
+                      aria-selected={isEveryone}
+                      onClick={() => selectScope('all')}
+                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                        isEveryone
+                          ? 'bg-white text-gray-900 shadow-sm'
+                          : 'text-gray-600 hover:text-gray-900'
+                      }`}
+                    >
+                      Everyone
                     </button>
                   </div>
                 );

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -753,20 +753,15 @@ export function ManagedJobsTable({
 
   // Initial load - runs immediately on mount, don't wait for full preloading
   // The preloader will warm the cache in background, but we fetch jobs data
-  // right away so the table displays as fast as possible. When the Mine
-  // scope is active we wait until the current user has loaded so the
-  // first fetch already carries userMatch — avoids an extra "Everyone"
-  // round-trip that would briefly flash other users' jobs.
+  // right away so the table displays as fast as possible. The initial
+  // fetch fires with userMatch=undefined (Everyone) and is followed by a
+  // narrow refetch when currentUser resolves — that's cheaper than
+  // blocking the whole page on the /users/role round-trip.
   React.useEffect(() => {
-    if (!isInitialFetch.current) return;
-    const explicitUserFilter = (filters || []).find(
-      (f) => (f.property || '').toLowerCase() === 'user' && f.value
-    );
-    if (userScope === 'mine' && !currentUser && !explicitUserFilter) return;
     fetchData({ includeStatus: true });
     isInitialFetch.current = false;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentUser, userScope]);
+  }, []);
 
   // Fetch on pagination (page) changes without status request
   // Skip on initial fetch (page defaults to 1)

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -44,6 +44,7 @@ import {
   Download,
   ChevronDownIcon,
   ChevronRightIcon,
+  CheckIcon,
 } from 'lucide-react';
 import {
   handleJobAction,
@@ -94,6 +95,23 @@ export const statusGroups = {
     'FAILED_CONTROLLER',
   ],
 };
+
+// Statuses shown as primary chips on the Statuses filter bar.
+// All other statuses are tucked behind the "More" dropdown to keep the
+// summary line balanced and avoid over-emphasizing failure variants.
+const PRIMARY_STATUSES = ['RUNNING', 'SUCCEEDED', 'FAILED'];
+const OTHER_STATUSES = [
+  'PENDING',
+  'SUBMITTED',
+  'STARTING',
+  'RECOVERING',
+  'CANCELLING',
+  'CANCELLED',
+  'FAILED_SETUP',
+  'FAILED_PRECHECKS',
+  'FAILED_NO_RESOURCE',
+  'FAILED_CONTROLLER',
+];
 
 // Status priority for aggregation (higher index = worse status)
 const STATUS_PRIORITY = {
@@ -464,6 +482,8 @@ export function ManagedJobsTable({
   const [expandedJobGroups, setExpandedJobGroups] = useState(new Set());
   const [selectedStatuses, setSelectedStatuses] = useState([]);
   const [statusCounts, setStatusCounts] = useState({});
+  const [moreMenuOpen, setMoreMenuOpen] = useState(false);
+  const moreMenuRef = useRef(null);
   const [controllerStopped, setControllerStopped] = useState(false);
   const [controllerLaunching, setControllerLaunching] = useState(false);
   const [isRestarting, setIsRestarting] = useState(false);
@@ -1072,6 +1092,18 @@ export function ManagedJobsTable({
 
   // Check if a job group is expanded
   const isJobGroupExpanded = (jobId) => expandedJobGroups.has(jobId);
+
+  // Close the "More" status menu when clicking outside of it.
+  useEffect(() => {
+    if (!moreMenuOpen) return undefined;
+    const onPointerDown = (e) => {
+      if (moreMenuRef.current && !moreMenuRef.current.contains(e.target)) {
+        setMoreMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    return () => document.removeEventListener('mousedown', onPointerDown);
+  }, [moreMenuOpen]);
 
   // Handle status selection
   const handleStatusClick = (status) => {
@@ -1722,95 +1754,183 @@ export function ManagedJobsTable({
         {/* Combined Status Filter */}
         <div className="flex items-center justify-between text-sm mb-1">
           <div className="flex flex-wrap items-center min-w-0">
-            <span className="mr-2 text-sm font-medium">Statuses:</span>
+            <span className="mr-2 text-sm font-medium">
+              Statuses
+              {!loading && totalNoFilter > 0 && (
+                <span className="ml-1 font-normal text-gray-400">
+                  ({totalNoFilter.toLocaleString()})
+                </span>
+              )}
+              :
+            </span>
             <div className="flex flex-wrap gap-2 items-center">
               {!loading && totalNoFilter === 0 && !isInitialLoad && (
                 <span className="text-gray-500 mr-2">No jobs found</span>
               )}
-              {Object.entries(statusCounts).map(([status, count]) => (
-                <button
-                  key={status}
-                  onClick={() => handleStatusClick(status)}
-                  className={`px-3 py-0.5 rounded-full flex items-center space-x-2 ${
-                    isStatusHighlighted(status) ||
-                    selectedStatuses.includes(status)
-                      ? getBadgeStyle(status)
-                      : 'bg-gray-50 text-gray-600 hover:bg-gray-100'
-                  }`}
-                >
-                  <span>{status}</span>
-                  <span
-                    className={`text-xs ${isStatusHighlighted(status) || selectedStatuses.includes(status) ? 'bg-white/50' : 'bg-gray-200'} px-1.5 py-0.5 rounded`}
-                  >
-                    {count}
-                  </span>
-                </button>
-              ))}
-              {totalNoFilter > 0 && (
-                <div className="flex items-center ml-2 gap-2">
-                  <span className="text-gray-500">(</span>
+              {/* Primary statuses: always rendered in fixed order so the bar
+                  doesn't jitter when counts change. */}
+              {PRIMARY_STATUSES.map((status) => {
+                const count = statusCounts[status] ?? 0;
+                const highlighted =
+                  isStatusHighlighted(status) ||
+                  selectedStatuses.includes(status);
+                return (
                   <button
-                    onClick={() => {
-                      // When showing all jobs, clear all selected statuses
-                      // Use React.startTransition to batch state updates
-                      React.startTransition(() => {
-                        setActiveTab('all');
-                        setSelectedStatuses([]);
-                        setShowAllMode(true);
-                        setCurrentPage(1);
-                      });
-                    }}
-                    className={`text-sm font-medium ${
-                      activeTab === 'all' && showAllMode
-                        ? 'text-purple-700 underline'
-                        : 'text-gray-600 hover:text-purple-700 hover:underline'
+                    key={status}
+                    onClick={() => handleStatusClick(status)}
+                    className={`px-3 py-0.5 rounded-full flex items-center space-x-2 ${
+                      highlighted
+                        ? getBadgeStyle(status)
+                        : 'bg-gray-50 text-gray-600 hover:bg-gray-100'
                     }`}
                   >
-                    show all jobs
+                    <span>{status}</span>
+                    <span
+                      className={`text-xs ${highlighted ? 'bg-white/50' : 'bg-gray-200'} px-1.5 py-0.5 rounded`}
+                    >
+                      {count}
+                    </span>
                   </button>
-                  <span className="text-gray-500 mx-1">|</span>
-                  <button
-                    onClick={() => {
-                      // When showing all active jobs, clear all selected statuses
-                      // Use React.startTransition to batch state updates
-                      React.startTransition(() => {
-                        setActiveTab('active');
-                        setSelectedStatuses([]);
-                        setShowAllMode(true);
-                        setCurrentPage(1);
-                      });
-                    }}
-                    className={`text-sm font-medium ${
-                      activeTab === 'active' && showAllMode
-                        ? 'text-green-700 underline'
-                        : 'text-gray-600 hover:text-green-700 hover:underline'
-                    }`}
+                );
+              })}
+              {/* Selected non-primary statuses surface as inline chips so the
+                  user can always see which filters are active without opening
+                  the dropdown. */}
+              {selectedStatuses
+                .filter((s) => !PRIMARY_STATUSES.includes(s))
+                .map((status) => {
+                  const count = statusCounts[status] ?? 0;
+                  return (
+                    <button
+                      key={status}
+                      onClick={() => handleStatusClick(status)}
+                      className={`px-3 py-0.5 rounded-full flex items-center space-x-2 ${getBadgeStyle(status)}`}
+                    >
+                      <span>{status}</span>
+                      <span className="text-xs bg-white/50 px-1.5 py-0.5 rounded">
+                        {count}
+                      </span>
+                    </button>
+                  );
+                })}
+              {/* More dropdown: holds the long tail of statuses
+                  (PENDING, STARTING, CANCELLED, FAILED_*, …). */}
+              {(() => {
+                const otherSelectedCount = selectedStatuses.filter(
+                  (s) => !PRIMARY_STATUSES.includes(s)
+                ).length;
+                const otherTotalCount = OTHER_STATUSES.reduce(
+                  (sum, s) => sum + (statusCounts[s] ?? 0),
+                  0
+                );
+                return (
+                  <div className="relative" ref={moreMenuRef}>
+                    <button
+                      onClick={() => setMoreMenuOpen((v) => !v)}
+                      className={`px-3 py-0.5 rounded-full flex items-center space-x-1.5 ${
+                        otherSelectedCount > 0
+                          ? 'bg-gray-200 text-gray-800'
+                          : 'bg-gray-50 text-gray-600 hover:bg-gray-100'
+                      }`}
+                      aria-haspopup="true"
+                      aria-expanded={moreMenuOpen}
+                    >
+                      <span>More</span>
+                      {otherSelectedCount > 0 ? (
+                        <span className="text-xs bg-white/70 px-1.5 py-0.5 rounded">
+                          {otherSelectedCount} selected
+                        </span>
+                      ) : (
+                        otherTotalCount > 0 && (
+                          <span className="text-xs bg-gray-200 px-1.5 py-0.5 rounded">
+                            {otherTotalCount}
+                          </span>
+                        )
+                      )}
+                      <ChevronDownIcon
+                        className={`w-3.5 h-3.5 transition-transform ${moreMenuOpen ? 'rotate-180' : ''}`}
+                      />
+                    </button>
+                    {moreMenuOpen && (
+                      <div className="absolute left-0 z-20 mt-1 w-60 rounded-md border border-gray-200 bg-white shadow-md py-1">
+                        {OTHER_STATUSES.map((status) => {
+                          const count = statusCounts[status] ?? 0;
+                          const selected = selectedStatuses.includes(status);
+                          return (
+                            <button
+                              key={status}
+                              onClick={() => handleStatusClick(status)}
+                              className={`w-full px-3 py-1.5 flex items-center justify-between text-sm hover:bg-gray-50 ${
+                                selected ? 'bg-gray-50' : ''
+                              }`}
+                            >
+                              <span className="flex items-center gap-2 min-w-0">
+                                <CheckIcon
+                                  className={`w-3.5 h-3.5 shrink-0 ${selected ? 'text-sky-blue' : 'text-transparent'}`}
+                                />
+                                <span
+                                  className={`truncate ${selected ? 'font-medium text-gray-900' : count === 0 ? 'text-gray-400' : 'text-gray-700'}`}
+                                >
+                                  {status}
+                                </span>
+                              </span>
+                              <span
+                                className={`ml-2 text-xs ${count === 0 ? 'text-gray-400' : 'text-gray-500'}`}
+                              >
+                                {count}
+                              </span>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                );
+              })()}
+              {totalNoFilter > 0 && (() => {
+                const selectTab = (tab) => {
+                  React.startTransition(() => {
+                    setActiveTab(tab);
+                    setSelectedStatuses([]);
+                    setShowAllMode(true);
+                    setCurrentPage(1);
+                  });
+                };
+                const isActive = activeTab === 'active' && showAllMode;
+                const isAll = activeTab === 'all' && showAllMode;
+                return (
+                  <div
+                    role="tablist"
+                    aria-label="Filter jobs by activity"
+                    className="inline-flex items-center bg-gray-100 rounded-md p-0.5 ml-2 shrink-0"
                   >
-                    show all active jobs
-                  </button>
-                  <span className="text-gray-500 mx-1">|</span>
-                  <button
-                    onClick={() => {
-                      // When showing all finished jobs, clear all selected statuses
-                      // Use React.startTransition to batch state updates
-                      React.startTransition(() => {
-                        setActiveTab('finished');
-                        setSelectedStatuses([]);
-                        setShowAllMode(true);
-                        setCurrentPage(1);
-                      });
-                    }}
-                    className={`text-sm font-medium ${
-                      activeTab === 'finished' && showAllMode
-                        ? 'text-blue-700 underline'
-                        : 'text-gray-600 hover:text-blue-700 hover:underline'
-                    }`}
-                  >
-                    show all finished jobs
-                  </button>
-                  <span className="text-gray-500">)</span>
-                </div>
-              )}
+                    <button
+                      role="tab"
+                      aria-selected={isActive}
+                      onClick={() => selectTab('active')}
+                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                        isActive
+                          ? 'bg-white text-gray-900 shadow-sm'
+                          : 'text-gray-600 hover:text-gray-900'
+                      }`}
+                    >
+                      Active
+                    </button>
+                    <button
+                      role="tab"
+                      aria-selected={isAll}
+                      onClick={() => selectTab('all')}
+                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                        isAll
+                          ? 'bg-white text-gray-900 shadow-sm'
+                          : 'text-gray-600 hover:text-gray-900'
+                      }`}
+                    >
+                      All
+                    </button>
+                  </div>
+                );
+              })()}
             </div>
           </div>
           <div className="flex items-center gap-2 shrink-0 ml-2">

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -30,7 +30,7 @@ import jobsCacheManager from '@/lib/jobs-cache-manager';
 import { getClusters, downloadJobLogs } from '@/data/connectors/clusters';
 import { getWorkspaces } from '@/data/connectors/workspaces';
 import { getUsers } from '@/data/connectors/users';
-import { apiClient } from '@/data/connectors/client';
+import { apiClient, getCurrentUserInfo } from '@/data/connectors/client';
 import {
   CustomTooltip as Tooltip,
   NonCapitalizedTooltip,
@@ -751,15 +751,36 @@ export function ManagedJobsTable({
   // only trigger on actual user interactions (page change, filter change, etc.)
   const isInitialFetch = React.useRef(true);
 
-  // Initial load - runs immediately on mount, don't wait for full preloading
-  // The preloader will warm the cache in background, but we fetch jobs data
-  // right away so the table displays as fast as possible. The initial
-  // fetch fires with userMatch=undefined (Everyone) and is followed by a
-  // narrow refetch when currentUser resolves — that's cheaper than
-  // blocking the whole page on the /users/role round-trip.
+  // Initial load - wait for currentUser (resolved via the shared
+  // getCurrentUserInfo() cache, usually already warm) before firing the
+  // first jobs fetch. Going Mine-first matters on tenants with tens of
+  // thousands of finished jobs: the Everyone query is expensive (full
+  // count + status aggregation) and we'd pay it twice — once on the
+  // unscoped initial fetch, once on the narrow Mine refetch — if we
+  // didn't gate. With the cache warm this gate adds essentially zero
+  // latency. If currentUser doesn't resolve (anonymous / role endpoint
+  // down) we still fire the initial fetch with userMatch=undefined so
+  // the page doesn't get stuck on the spinner.
   React.useEffect(() => {
+    if (!isInitialFetch.current) return;
     fetchData({ includeStatus: true });
     isInitialFetch.current = false;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentUser]);
+
+  // Safety net: if /users/role takes more than 1.5s, give up waiting and
+  // fall back to the Everyone fetch so the page still renders. Cheap
+  // because getCurrentUserInfo() is cached — most page loads resolve
+  // well under this timeout.
+  React.useEffect(() => {
+    if (!isInitialFetch.current) return undefined;
+    const t = setTimeout(() => {
+      if (isInitialFetch.current) {
+        fetchData({ includeStatus: true });
+        isInitialFetch.current = false;
+      }
+    }, 1500);
+    return () => clearTimeout(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -1118,19 +1139,20 @@ export function ManagedJobsTable({
   const isJobGroupExpanded = (jobId) => expandedJobGroups.has(jobId);
 
   // Fetch the current user once so the Mine/Everyone toggle can scope
-  // results to the logged-in user. Falls back to null if unauthenticated
-  // or the role endpoint fails, which forces the table into the
-  // Everyone view (no userMatch is sent).
+  // results to the logged-in user. Routes through the shared
+  // getCurrentUserInfo() cache in client.js so we don't pay the
+  // /users/role round-trip more than once per page session (sidebar /
+  // config / etc. typically already populated the cache by the time we
+  // get here). The 'local' sentinel id means the caller is anonymous —
+  // treat that the same as null so we don't send userMatch='local'.
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
-        const response = await apiClient.get('/users/role');
-        if (!response.ok) return;
-        const data = await response.json();
+        const info = await getCurrentUserInfo();
         if (cancelled) return;
-        if (data && data.id) {
-          setCurrentUser({ id: data.id, name: data.name || data.id });
+        if (info && info.id && info.id !== 'local') {
+          setCurrentUser({ id: info.id, name: info.name || info.id });
         }
       } catch (e) {
         // Swallow: toggle simply degrades to "Everyone" if we can't id

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -500,6 +500,11 @@ export function ManagedJobsTable({
   // filter wins; see effectiveUserMatch in fetchData).
   const [userScope, setUserScope] = useState('mine');
   const [currentUser, setCurrentUser] = useState(null);
+  // True once the /users/role lookup has resolved (with a real user, with
+  // the 'local'/anonymous sentinel, or by erroring out). Used to gate the
+  // initial fetch so we never make the expensive unscoped Everyone request
+  // ahead of the Mine narrow.
+  const [userResolved, setUserResolved] = useState(false);
   const [confirmationModal, setConfirmationModal] = useState({
     isOpen: false,
     title: '',
@@ -751,35 +756,34 @@ export function ManagedJobsTable({
   // only trigger on actual user interactions (page change, filter change, etc.)
   const isInitialFetch = React.useRef(true);
 
-  // Initial load - wait for currentUser (resolved via the shared
-  // getCurrentUserInfo() cache, usually already warm) before firing the
-  // first jobs fetch. Going Mine-first matters on tenants with tens of
-  // thousands of finished jobs: the Everyone query is expensive (full
-  // count + status aggregation) and we'd pay it twice — once on the
-  // unscoped initial fetch, once on the narrow Mine refetch — if we
-  // didn't gate. With the cache warm this gate adds essentially zero
-  // latency. If currentUser doesn't resolve (anonymous / role endpoint
-  // down) we still fire the initial fetch with userMatch=undefined so
-  // the page doesn't get stuck on the spinner.
+  // Initial load - wait for the /users/role lookup to settle (real
+  // user, 'local' sentinel, or error) before firing the first jobs
+  // fetch. Going Mine-first matters on tenants with tens of thousands
+  // of finished jobs: the Everyone query is expensive (full count +
+  // status aggregation) and we'd pay it twice — once on the unscoped
+  // initial fetch, once on the narrow Mine refetch — if we didn't gate.
+  // With the shared cache warm this gate adds essentially zero latency;
+  // cold loads pay a single ~200ms /users/role wait.
   React.useEffect(() => {
     if (!isInitialFetch.current) return;
+    if (!userResolved) return;
     fetchData({ includeStatus: true });
     isInitialFetch.current = false;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentUser]);
+  }, [userResolved]);
 
-  // Safety net: if /users/role takes more than 1.5s, give up waiting and
-  // fall back to the Everyone fetch so the page still renders. Cheap
-  // because getCurrentUserInfo() is cached — most page loads resolve
-  // well under this timeout.
+  // Safety net: if /users/role somehow never resolves (network hang),
+  // fall back to the unscoped fetch so the page still renders. Almost
+  // never triggers in practice — getCurrentUserInfo() catches its own
+  // errors and resolves with the 'local' sentinel.
   React.useEffect(() => {
     if (!isInitialFetch.current) return undefined;
     const t = setTimeout(() => {
       if (isInitialFetch.current) {
-        fetchData({ includeStatus: true });
-        isInitialFetch.current = false;
+        setUserScope('all');
+        setUserResolved(true);
       }
-    }, 1500);
+    }, 3000);
     return () => clearTimeout(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -1143,8 +1147,11 @@ export function ManagedJobsTable({
   // getCurrentUserInfo() cache in client.js so we don't pay the
   // /users/role round-trip more than once per page session (sidebar /
   // config / etc. typically already populated the cache by the time we
-  // get here). The 'local' sentinel id means the caller is anonymous —
-  // treat that the same as null so we don't send userMatch='local'.
+  // get here). The 'local' sentinel id means the caller is anonymous
+  // (no auth / basic-auth without a logged-in user) — there's no
+  // meaningful "Mine" view in that case, so flip to Everyone and hide
+  // the Mine/Everyone toggle so the dashboard works the way every
+  // unauthenticated tenant expects.
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -1153,10 +1160,15 @@ export function ManagedJobsTable({
         if (cancelled) return;
         if (info && info.id && info.id !== 'local') {
           setCurrentUser({ id: info.id, name: info.name || info.id });
+        } else {
+          setUserScope('all');
         }
       } catch (e) {
-        // Swallow: toggle simply degrades to "Everyone" if we can't id
-        // the caller.
+        // Role endpoint unreachable — assume no usable identity and
+        // default to Everyone rather than leaving the page stuck.
+        if (!cancelled) setUserScope('all');
+      } finally {
+        if (!cancelled) setUserResolved(true);
       }
     })();
     return () => {

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -1821,15 +1821,7 @@ export function ManagedJobsTable({
         {/* Combined Status Filter */}
         <div className="flex items-center justify-between text-sm mb-1">
           <div className="flex flex-wrap items-center min-w-0">
-            <span className="mr-2 text-sm font-medium">
-              Statuses
-              {!loading && totalNoFilter > 0 && (
-                <span className="ml-1 font-normal text-gray-400 tabular-nums">
-                  ({totalNoFilter.toLocaleString()})
-                </span>
-              )}
-              :
-            </span>
+            <span className="mr-2 text-sm font-medium">Statuses:</span>
             <div className="flex flex-wrap gap-2 items-center">
               {!loading && totalNoFilter === 0 && !isInitialLoad && (
                 <span className="text-gray-500 mr-2">No jobs found</span>

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -2100,8 +2100,18 @@ export function ManagedJobsTable({
                   : userScope === 'mine';
                 const isEveryone = !explicitUserFilter && userScope === 'all';
                 const selectScope = (scope) => {
+                  // Reset status narrowing the same way the Active/All
+                  // toggle does — without this, a status chip selected
+                  // in one scope (e.g., RUNNING in My Jobs) carries
+                  // over to the other and the table renders empty
+                  // because that status has zero rows under the new
+                  // scope. Leave activeTab alone so a user who picked
+                  // Active in one scope keeps that activity filter
+                  // when they switch scope.
                   React.startTransition(() => {
                     setUserScope(scope);
+                    setSelectedStatuses([]);
+                    setShowAllMode(true);
                     setCurrentPage(1);
                   });
                 };

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -1093,6 +1093,19 @@ export function ManagedJobsTable({
   // Check if a job group is expanded
   const isJobGroupExpanded = (jobId) => expandedJobGroups.has(jobId);
 
+  // After ~1s of a non-initial load, fade a spinner overlay onto the
+  // table so the user knows their toggle/filter click is in-flight.
+  // We delay so quick (sub-second) fetches don't flash a spinner.
+  const [showSlowSpinner, setShowSlowSpinner] = useState(false);
+  useEffect(() => {
+    if (!loading || isInitialLoad) {
+      setShowSlowSpinner(false);
+      return undefined;
+    }
+    const t = setTimeout(() => setShowSlowSpinner(true), 1000);
+    return () => clearTimeout(t);
+  }, [loading, isInitialLoad]);
+
   // Close the "More" status menu when clicking outside of it.
   useEffect(() => {
     if (!moreMenuOpen) return undefined;
@@ -1997,7 +2010,15 @@ export function ManagedJobsTable({
         )}
 
       <Card className="overflow-hidden">
-        <div className="overflow-x-auto">
+        <div className="overflow-x-auto relative">
+          {showSlowSpinner && (
+            <div
+              className="absolute inset-0 z-10 flex items-center justify-center bg-white/70 pointer-events-none transition-opacity"
+              aria-hidden="true"
+            >
+              <CircularProgress size={28} />
+            </div>
+          )}
           <Table className="min-w-full border-collapse">
             <TableHeader>
               <TableRow>

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -1147,6 +1147,44 @@ export function ManagedJobsTable({
     };
   }, []);
 
+  // When the Mine view comes up empty, fire a one-shot probe for the
+  // Everyone total so the empty state can tell the user "you haven't
+  // submitted anything yet, but N jobs from others are out there —
+  // click to see them". Avoids leaving the user staring at a blank
+  // table wondering whether SkyPilot has any activity at all.
+  const [everyoneTotal, setEveryoneTotal] = useState(null);
+  useEffect(() => {
+    if (userScope !== 'mine') return;
+    if (!currentUser) return;
+    if (loading || isInitialLoad) return;
+    if (totalNoFilter !== 0) return;
+    if (everyoneTotal !== null) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const resp = await jobsCacheManager.getPaginatedJobs({
+          allUsers: true,
+          page: 1,
+          limit: 1,
+        });
+        if (cancelled) return;
+        setEveryoneTotal(resp?.totalNoFilter ?? resp?.total ?? 0);
+      } catch (e) {
+        if (!cancelled) setEveryoneTotal(0);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    userScope,
+    currentUser,
+    loading,
+    isInitialLoad,
+    totalNoFilter,
+    everyoneTotal,
+  ]);
+
   // After ~1s of a non-initial load, fade a spinner overlay onto the
   // table so the user knows their toggle/filter click is in-flight.
   // We delay so quick (sub-second) fetches don't flash a spinner.
@@ -1964,55 +2002,55 @@ export function ManagedJobsTable({
                   </div>
                 );
               })()}
-              {totalNoFilter > 0 && (() => {
-                const selectTab = (tab) => {
-                  React.startTransition(() => {
-                    setActiveTab(tab);
-                    setSelectedStatuses([]);
-                    setShowAllMode(true);
-                    setCurrentPage(1);
-                  });
-                };
-                const isActive = activeTab === 'active' && showAllMode;
-                const isAll = activeTab === 'all' && showAllMode;
-                return (
-                  <div
-                    role="tablist"
-                    aria-label="Filter jobs by activity"
-                    className="inline-flex items-center bg-gray-100 rounded-md p-0.5 shrink-0"
-                  >
-                    <button
-                      role="tab"
-                      aria-selected={isActive}
-                      onClick={() => selectTab('active')}
-                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                        isActive
-                          ? 'bg-white text-gray-900 shadow-sm'
-                          : 'text-gray-600 hover:text-gray-900'
-                      }`}
+              {totalNoFilter > 0 &&
+                (() => {
+                  const selectTab = (tab) => {
+                    React.startTransition(() => {
+                      setActiveTab(tab);
+                      setSelectedStatuses([]);
+                      setShowAllMode(true);
+                      setCurrentPage(1);
+                    });
+                  };
+                  const isActive = activeTab === 'active' && showAllMode;
+                  const isAll = activeTab === 'all' && showAllMode;
+                  return (
+                    <div
+                      role="tablist"
+                      aria-label="Filter jobs by activity"
+                      className="inline-flex items-center bg-gray-100 rounded-md p-0.5 shrink-0"
                     >
-                      Active
-                    </button>
-                    <button
-                      role="tab"
-                      aria-selected={isAll}
-                      onClick={() => selectTab('all')}
-                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                        isAll
-                          ? 'bg-white text-gray-900 shadow-sm'
-                          : 'text-gray-600 hover:text-gray-900'
-                      }`}
-                    >
-                      All
-                    </button>
-                  </div>
-                );
-              })()}
+                      <button
+                        role="tab"
+                        aria-selected={isActive}
+                        onClick={() => selectTab('active')}
+                        className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                          isActive
+                            ? 'bg-white text-gray-900 shadow-sm'
+                            : 'text-gray-600 hover:text-gray-900'
+                        }`}
+                      >
+                        Active
+                      </button>
+                      <button
+                        role="tab"
+                        aria-selected={isAll}
+                        onClick={() => selectTab('all')}
+                        className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                          isAll
+                            ? 'bg-white text-gray-900 shadow-sm'
+                            : 'text-gray-600 hover:text-gray-900'
+                        }`}
+                      >
+                        All
+                      </button>
+                    </div>
+                  );
+                })()}
               {(() => {
                 if (totalNoFilter === 0 || !currentUser) return null;
                 const explicitUserFilter = (filters || []).find(
-                  (f) =>
-                    (f.property || '').toLowerCase() === 'user' && f.value
+                  (f) => (f.property || '').toLowerCase() === 'user' && f.value
                 );
                 const isMine = explicitUserFilter
                   ? String(explicitUserFilter.value) === currentUser.id ||
@@ -2272,9 +2310,38 @@ export function ManagedJobsTable({
                           </div>
                         </div>
                       )}
-                      {!controllerStopped && !controllerLaunching && (
-                        <p className="text-gray-500">No active jobs</p>
-                      )}
+                      {!controllerStopped &&
+                        !controllerLaunching &&
+                        (userScope === 'mine' &&
+                        currentUser &&
+                        totalNoFilter === 0 &&
+                        everyoneTotal > 0 ? (
+                          <div className="flex flex-col items-center space-y-2 max-w-md">
+                            <p className="text-gray-700">
+                              You haven&apos;t submitted any managed jobs yet.
+                            </p>
+                            <p className="text-sm text-gray-500">
+                              {everyoneTotal.toLocaleString()} job
+                              {everyoneTotal === 1 ? '' : 's'} from other users
+                              — switch to Everyone to see them.
+                            </p>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => {
+                                React.startTransition(() => {
+                                  setUserScope('all');
+                                  setCurrentPage(1);
+                                });
+                              }}
+                              className="text-sky-blue hover:text-sky-blue-bright"
+                            >
+                              View everyone&apos;s jobs
+                            </Button>
+                          </div>
+                        ) : (
+                          <p className="text-gray-500">No active jobs</p>
+                        ))}
                       {/* Desktop controller stopped message stays in table */}
                       {!isMobile && controllerStopped && (
                         <div className="flex flex-col items-center space-y-3 px-4">

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -1826,107 +1826,6 @@ export function ManagedJobsTable({
               {!loading && totalNoFilter === 0 && !isInitialLoad && (
                 <span className="text-gray-500 mr-2">No jobs found</span>
               )}
-              {/* Toggles render BEFORE the chips so their position is
-                  anchored to the start of the bar. As status counts and
-                  the More pill text change in response to a click, only
-                  the items after the toggles shift — the toggles
-                  themselves stay put, which is easier to track than the
-                  earlier layout where chip-width changes pushed the
-                  toggles around. */}
-              {totalNoFilter > 0 && (() => {
-                const selectTab = (tab) => {
-                  React.startTransition(() => {
-                    setActiveTab(tab);
-                    setSelectedStatuses([]);
-                    setShowAllMode(true);
-                    setCurrentPage(1);
-                  });
-                };
-                const isActive = activeTab === 'active' && showAllMode;
-                const isAll = activeTab === 'all' && showAllMode;
-                return (
-                  <div
-                    role="tablist"
-                    aria-label="Filter jobs by activity"
-                    className="inline-flex items-center bg-gray-100 rounded-md p-0.5 shrink-0"
-                  >
-                    <button
-                      role="tab"
-                      aria-selected={isActive}
-                      onClick={() => selectTab('active')}
-                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                        isActive
-                          ? 'bg-white text-gray-900 shadow-sm'
-                          : 'text-gray-600 hover:text-gray-900'
-                      }`}
-                    >
-                      Active
-                    </button>
-                    <button
-                      role="tab"
-                      aria-selected={isAll}
-                      onClick={() => selectTab('all')}
-                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                        isAll
-                          ? 'bg-white text-gray-900 shadow-sm'
-                          : 'text-gray-600 hover:text-gray-900'
-                      }`}
-                    >
-                      All
-                    </button>
-                  </div>
-                );
-              })()}
-              {(() => {
-                if (totalNoFilter === 0 || !currentUser) return null;
-                const explicitUserFilter = (filters || []).find(
-                  (f) =>
-                    (f.property || '').toLowerCase() === 'user' && f.value
-                );
-                const isMine = explicitUserFilter
-                  ? String(explicitUserFilter.value) === currentUser.id ||
-                    String(explicitUserFilter.value) === currentUser.name
-                  : userScope === 'mine';
-                const isEveryone = !explicitUserFilter && userScope === 'all';
-                const selectScope = (scope) => {
-                  React.startTransition(() => {
-                    setUserScope(scope);
-                    setCurrentPage(1);
-                  });
-                };
-                return (
-                  <div
-                    role="tablist"
-                    aria-label="Filter jobs by owner"
-                    className="inline-flex items-center bg-gray-100 rounded-md p-0.5 shrink-0"
-                  >
-                    <button
-                      role="tab"
-                      aria-selected={isMine}
-                      onClick={() => selectScope('mine')}
-                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                        isMine
-                          ? 'bg-white text-gray-900 shadow-sm'
-                          : 'text-gray-600 hover:text-gray-900'
-                      }`}
-                    >
-                      Mine
-                    </button>
-                    <button
-                      role="tab"
-                      aria-selected={isEveryone}
-                      onClick={() => selectScope('all')}
-                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                        isEveryone
-                          ? 'bg-white text-gray-900 shadow-sm'
-                          : 'text-gray-600 hover:text-gray-900'
-                      }`}
-                    >
-                      Everyone
-                    </button>
-                  </div>
-                );
-              })()}
               {/* Primary statuses: always rendered in fixed order so the bar
                   doesn't jitter when counts change. The count badge uses
                   tabular-nums + a fixed min-width so the chip width stays
@@ -2062,6 +1961,100 @@ export function ManagedJobsTable({
                         })}
                       </div>
                     )}
+                  </div>
+                );
+              })()}
+              {totalNoFilter > 0 && (() => {
+                const selectTab = (tab) => {
+                  React.startTransition(() => {
+                    setActiveTab(tab);
+                    setSelectedStatuses([]);
+                    setShowAllMode(true);
+                    setCurrentPage(1);
+                  });
+                };
+                const isActive = activeTab === 'active' && showAllMode;
+                const isAll = activeTab === 'all' && showAllMode;
+                return (
+                  <div
+                    role="tablist"
+                    aria-label="Filter jobs by activity"
+                    className="inline-flex items-center bg-gray-100 rounded-md p-0.5 shrink-0"
+                  >
+                    <button
+                      role="tab"
+                      aria-selected={isActive}
+                      onClick={() => selectTab('active')}
+                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                        isActive
+                          ? 'bg-white text-gray-900 shadow-sm'
+                          : 'text-gray-600 hover:text-gray-900'
+                      }`}
+                    >
+                      Active
+                    </button>
+                    <button
+                      role="tab"
+                      aria-selected={isAll}
+                      onClick={() => selectTab('all')}
+                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                        isAll
+                          ? 'bg-white text-gray-900 shadow-sm'
+                          : 'text-gray-600 hover:text-gray-900'
+                      }`}
+                    >
+                      All
+                    </button>
+                  </div>
+                );
+              })()}
+              {(() => {
+                if (totalNoFilter === 0 || !currentUser) return null;
+                const explicitUserFilter = (filters || []).find(
+                  (f) =>
+                    (f.property || '').toLowerCase() === 'user' && f.value
+                );
+                const isMine = explicitUserFilter
+                  ? String(explicitUserFilter.value) === currentUser.id ||
+                    String(explicitUserFilter.value) === currentUser.name
+                  : userScope === 'mine';
+                const isEveryone = !explicitUserFilter && userScope === 'all';
+                const selectScope = (scope) => {
+                  React.startTransition(() => {
+                    setUserScope(scope);
+                    setCurrentPage(1);
+                  });
+                };
+                return (
+                  <div
+                    role="tablist"
+                    aria-label="Filter jobs by owner"
+                    className="inline-flex items-center bg-gray-100 rounded-md p-0.5 shrink-0"
+                  >
+                    <button
+                      role="tab"
+                      aria-selected={isMine}
+                      onClick={() => selectScope('mine')}
+                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                        isMine
+                          ? 'bg-white text-gray-900 shadow-sm'
+                          : 'text-gray-600 hover:text-gray-900'
+                      }`}
+                    >
+                      Mine
+                    </button>
+                    <button
+                      role="tab"
+                      aria-selected={isEveryone}
+                      onClick={() => selectScope('all')}
+                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                        isEveryone
+                          ? 'bg-white text-gray-900 shadow-sm'
+                          : 'text-gray-600 hover:text-gray-900'
+                      }`}
+                    >
+                      Everyone
+                    </button>
                   </div>
                 );
               })()}

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -1824,7 +1824,7 @@ export function ManagedJobsTable({
             <span className="mr-2 text-sm font-medium">
               Statuses
               {!loading && totalNoFilter > 0 && (
-                <span className="ml-1 font-normal text-gray-400">
+                <span className="ml-1 font-normal text-gray-400 tabular-nums">
                   ({totalNoFilter.toLocaleString()})
                 </span>
               )}
@@ -1834,8 +1834,111 @@ export function ManagedJobsTable({
               {!loading && totalNoFilter === 0 && !isInitialLoad && (
                 <span className="text-gray-500 mr-2">No jobs found</span>
               )}
+              {/* Toggles render BEFORE the chips so their position is
+                  anchored to the start of the bar. As status counts and
+                  the More pill text change in response to a click, only
+                  the items after the toggles shift — the toggles
+                  themselves stay put, which is easier to track than the
+                  earlier layout where chip-width changes pushed the
+                  toggles around. */}
+              {totalNoFilter > 0 && (() => {
+                const selectTab = (tab) => {
+                  React.startTransition(() => {
+                    setActiveTab(tab);
+                    setSelectedStatuses([]);
+                    setShowAllMode(true);
+                    setCurrentPage(1);
+                  });
+                };
+                const isActive = activeTab === 'active' && showAllMode;
+                const isAll = activeTab === 'all' && showAllMode;
+                return (
+                  <div
+                    role="tablist"
+                    aria-label="Filter jobs by activity"
+                    className="inline-flex items-center bg-gray-100 rounded-md p-0.5 shrink-0"
+                  >
+                    <button
+                      role="tab"
+                      aria-selected={isActive}
+                      onClick={() => selectTab('active')}
+                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                        isActive
+                          ? 'bg-white text-gray-900 shadow-sm'
+                          : 'text-gray-600 hover:text-gray-900'
+                      }`}
+                    >
+                      Active
+                    </button>
+                    <button
+                      role="tab"
+                      aria-selected={isAll}
+                      onClick={() => selectTab('all')}
+                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                        isAll
+                          ? 'bg-white text-gray-900 shadow-sm'
+                          : 'text-gray-600 hover:text-gray-900'
+                      }`}
+                    >
+                      All
+                    </button>
+                  </div>
+                );
+              })()}
+              {(() => {
+                if (totalNoFilter === 0 || !currentUser) return null;
+                const explicitUserFilter = (filters || []).find(
+                  (f) =>
+                    (f.property || '').toLowerCase() === 'user' && f.value
+                );
+                const isMine = explicitUserFilter
+                  ? String(explicitUserFilter.value) === currentUser.id ||
+                    String(explicitUserFilter.value) === currentUser.name
+                  : userScope === 'mine';
+                const isEveryone = !explicitUserFilter && userScope === 'all';
+                const selectScope = (scope) => {
+                  React.startTransition(() => {
+                    setUserScope(scope);
+                    setCurrentPage(1);
+                  });
+                };
+                return (
+                  <div
+                    role="tablist"
+                    aria-label="Filter jobs by owner"
+                    className="inline-flex items-center bg-gray-100 rounded-md p-0.5 shrink-0"
+                  >
+                    <button
+                      role="tab"
+                      aria-selected={isMine}
+                      onClick={() => selectScope('mine')}
+                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                        isMine
+                          ? 'bg-white text-gray-900 shadow-sm'
+                          : 'text-gray-600 hover:text-gray-900'
+                      }`}
+                    >
+                      Mine
+                    </button>
+                    <button
+                      role="tab"
+                      aria-selected={isEveryone}
+                      onClick={() => selectScope('all')}
+                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                        isEveryone
+                          ? 'bg-white text-gray-900 shadow-sm'
+                          : 'text-gray-600 hover:text-gray-900'
+                      }`}
+                    >
+                      Everyone
+                    </button>
+                  </div>
+                );
+              })()}
               {/* Primary statuses: always rendered in fixed order so the bar
-                  doesn't jitter when counts change. */}
+                  doesn't jitter when counts change. The count badge uses
+                  tabular-nums + a fixed min-width so the chip width stays
+                  stable as counts change between 1 and many digits. */}
               {PRIMARY_STATUSES.map((status) => {
                 const count = statusCounts[status] ?? 0;
                 const highlighted =
@@ -1853,7 +1956,7 @@ export function ManagedJobsTable({
                   >
                     <span>{status}</span>
                     <span
-                      className={`text-xs ${highlighted ? 'bg-white/50' : 'bg-gray-200'} px-1.5 py-0.5 rounded`}
+                      className={`text-xs tabular-nums text-center min-w-[1.5rem] ${highlighted ? 'bg-white/50' : 'bg-gray-200'} px-1.5 py-0.5 rounded`}
                     >
                       {count}
                     </span>
@@ -1874,7 +1977,7 @@ export function ManagedJobsTable({
                       className={`px-3 py-0.5 rounded-full flex items-center space-x-2 ${getBadgeStyle(status)}`}
                     >
                       <span>{status}</span>
-                      <span className="text-xs bg-white/50 px-1.5 py-0.5 rounded">
+                      <span className="text-xs tabular-nums text-center min-w-[1.5rem] bg-white/50 px-1.5 py-0.5 rounded">
                         {count}
                       </span>
                     </button>
@@ -1911,12 +2014,15 @@ export function ManagedJobsTable({
                     >
                       <span>More</span>
                       {isNarrowed ? (
-                        <span className="text-xs bg-white/70 px-1.5 py-0.5 rounded">
-                          {otherIncludedCount} selected
+                        <span className="text-xs tabular-nums bg-white/70 px-1.5 py-0.5 rounded">
+                          <span className="inline-block text-center min-w-[1rem]">
+                            {otherIncludedCount}
+                          </span>{' '}
+                          selected
                         </span>
                       ) : (
                         otherTotalCount > 0 && (
-                          <span className="text-xs bg-gray-200 px-1.5 py-0.5 rounded">
+                          <span className="text-xs tabular-nums text-center min-w-[1.5rem] inline-block bg-gray-200 px-1.5 py-0.5 rounded">
                             {otherTotalCount}
                           </span>
                         )
@@ -1955,7 +2061,7 @@ export function ManagedJobsTable({
                                 </span>
                               </span>
                               <span
-                                className={`ml-2 text-xs ${count === 0 ? 'text-gray-400' : 'text-gray-500'}`}
+                                className={`ml-2 text-xs tabular-nums text-right min-w-[2rem] ${count === 0 ? 'text-gray-400' : 'text-gray-500'}`}
                               >
                                 {count}
                               </span>
@@ -1964,109 +2070,6 @@ export function ManagedJobsTable({
                         })}
                       </div>
                     )}
-                  </div>
-                );
-              })()}
-              {totalNoFilter > 0 && (() => {
-                const selectTab = (tab) => {
-                  React.startTransition(() => {
-                    setActiveTab(tab);
-                    setSelectedStatuses([]);
-                    setShowAllMode(true);
-                    setCurrentPage(1);
-                  });
-                };
-                const isActive = activeTab === 'active' && showAllMode;
-                const isAll = activeTab === 'all' && showAllMode;
-                return (
-                  <div
-                    role="tablist"
-                    aria-label="Filter jobs by activity"
-                    className="inline-flex items-center bg-gray-100 rounded-md p-0.5 ml-2 shrink-0"
-                  >
-                    <button
-                      role="tab"
-                      aria-selected={isActive}
-                      onClick={() => selectTab('active')}
-                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                        isActive
-                          ? 'bg-white text-gray-900 shadow-sm'
-                          : 'text-gray-600 hover:text-gray-900'
-                      }`}
-                    >
-                      Active
-                    </button>
-                    <button
-                      role="tab"
-                      aria-selected={isAll}
-                      onClick={() => selectTab('all')}
-                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                        isAll
-                          ? 'bg-white text-gray-900 shadow-sm'
-                          : 'text-gray-600 hover:text-gray-900'
-                      }`}
-                    >
-                      All
-                    </button>
-                  </div>
-                );
-              })()}
-              {(() => {
-                // Mine/Everyone toggle. Suppressed when there are no jobs at
-                // all (parallels the Active/All toggle's gating) and also
-                // when the current user couldn't be resolved (anonymous /
-                // basic-auth path): the toggle has no meaningful "Mine".
-                if (totalNoFilter === 0 || !currentUser) return null;
-                const explicitUserFilter = (filters || []).find(
-                  (f) =>
-                    (f.property || '').toLowerCase() === 'user' && f.value
-                );
-                // If the user picked a specific user via FilterDropdown,
-                // that wins. We light up "Mine" only when that pick happens
-                // to match the current user; otherwise neither segment is
-                // highlighted so it's clear an explicit narrow filter is in
-                // effect.
-                const isMine = explicitUserFilter
-                  ? String(explicitUserFilter.value) === currentUser.id ||
-                    String(explicitUserFilter.value) === currentUser.name
-                  : userScope === 'mine';
-                const isEveryone = !explicitUserFilter && userScope === 'all';
-                const selectScope = (scope) => {
-                  React.startTransition(() => {
-                    setUserScope(scope);
-                    setCurrentPage(1);
-                  });
-                };
-                return (
-                  <div
-                    role="tablist"
-                    aria-label="Filter jobs by owner"
-                    className="inline-flex items-center bg-gray-100 rounded-md p-0.5 ml-2 shrink-0"
-                  >
-                    <button
-                      role="tab"
-                      aria-selected={isMine}
-                      onClick={() => selectScope('mine')}
-                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                        isMine
-                          ? 'bg-white text-gray-900 shadow-sm'
-                          : 'text-gray-600 hover:text-gray-900'
-                      }`}
-                    >
-                      Mine
-                    </button>
-                    <button
-                      role="tab"
-                      aria-selected={isEveryone}
-                      onClick={() => selectScope('all')}
-                      className={`px-2.5 py-0.5 rounded text-xs font-medium transition-colors ${
-                        isEveryone
-                          ? 'bg-white text-gray-900 shadow-sm'
-                          : 'text-gray-600 hover:text-gray-900'
-                      }`}
-                    >
-                      Everyone
-                    </button>
                   </div>
                 );
               })()}

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -1883,19 +1883,26 @@ export function ManagedJobsTable({
               {/* More dropdown: holds the long tail of statuses
                   (PENDING, STARTING, CANCELLED, FAILED_*, …). */}
               {(() => {
-                const otherSelectedCount = selectedStatuses.filter(
-                  (s) => !PRIMARY_STATUSES.includes(s)
+                // Count dropdown items currently included in the filter
+                // (either explicitly via selectedStatuses or implicitly
+                // because Active is selected). When the user is in any
+                // narrowed state, surface that count on the pill so the
+                // button itself signals filtering is active.
+                const otherIncludedCount = OTHER_STATUSES.filter((s) =>
+                  isStatusHighlighted(s)
                 ).length;
                 const otherTotalCount = OTHER_STATUSES.reduce(
                   (sum, s) => sum + (statusCounts[s] ?? 0),
                   0
                 );
+                const isNarrowed =
+                  activeTab !== 'all' || selectedStatuses.length > 0;
                 return (
                   <div className="relative" ref={moreMenuRef}>
                     <button
                       onClick={() => setMoreMenuOpen((v) => !v)}
                       className={`px-3 py-0.5 rounded-full flex items-center space-x-1.5 ${
-                        otherSelectedCount > 0
+                        isNarrowed
                           ? 'bg-gray-200 text-gray-800'
                           : 'bg-gray-50 text-gray-600 hover:bg-gray-100'
                       }`}
@@ -1903,9 +1910,9 @@ export function ManagedJobsTable({
                       aria-expanded={moreMenuOpen}
                     >
                       <span>More</span>
-                      {otherSelectedCount > 0 ? (
+                      {isNarrowed ? (
                         <span className="text-xs bg-white/70 px-1.5 py-0.5 rounded">
-                          {otherSelectedCount} selected
+                          {otherIncludedCount} selected
                         </span>
                       ) : (
                         otherTotalCount > 0 && (

--- a/sky/dashboard/src/data/connectors/client.js
+++ b/sky/dashboard/src/data/connectors/client.js
@@ -8,7 +8,7 @@ let cachedUserInfo = null;
 let userInfoPromise = null;
 
 // Fetch and cache the current user info
-async function getCurrentUserInfo() {
+export async function getCurrentUserInfo() {
   if (cachedUserInfo) {
     return cachedUserInfo;
   }


### PR DESCRIPTION
## Summary

Several related improvements to the Managed Jobs status filter:

1. **Collapse non-primary statuses behind a "More" dropdown.** Show only `STARTING`, `RUNNING`, `SUCCEEDED` as primary chips on the filter bar (left-to-right as a lifecycle progression). All other statuses — `PENDING`, `SUBMITTED`, `RECOVERING`, `CANCELLING`, `CANCELLED`, `FAILED`, `FAILED_SETUP`, `FAILED_PRECHECKS`, `FAILED_NO_RESOURCE`, `FAILED_CONTROLLER` — tuck behind a "More ▾" dropdown that still surfaces counts and click-to-toggle. The primary chips render at zero counts so the bar layout doesn't jitter. Selected non-primary statuses also surface inline as chips so the active filter is always visible without opening the dropdown.
2. **Total count next to the `Statuses:` label.** Pulled from the existing `totalNoFilter` value the server already returns.
3. **`( show all jobs | show all active jobs | show all finished jobs )` → compact `[Active | All]` segmented toggle.** The parenthesized link cluster wrapped awkwardly at narrow widths and over-emphasized a rarely-useful "finished only" view. Finished statuses are still reachable via chips + More.
4. **Default the table to the current user's jobs with a `[Mine | Everyone]` toggle.** Resolves the current user from `/users/role`; gates the initial fetch on that resolve so the first request already carries `userMatch` (no one-flash "Everyone" round-trip). Coexists with the existing FilterDropdown user filter — an explicit `?user=…` filter wins, and the toggle highlights "Mine" only when that explicit value matches the current user. Hidden when the role endpoint can't id the caller (anonymous/basic-auth degrades to "Everyone" view).
5. **Dropdown rows reflect implicit Active-tab membership.** When the Active toggle is selected, statuses like `PENDING`/`STARTING`/`RECOVERING`/`CANCELLING` light up their check + label in the dropdown — same way they're implicitly included in the fetch.
6. **Delayed table spinner on slow fetches.** After ~1s of a non-initial load, a subtle spinner fades in over the table body so it's obvious the toggle/filter click is in-flight. Sub-second fetches stay quiet.
7. **FilterDropdown defaults to `Name` instead of `ID`.** Users typically search jobs by name.

## Test plan

- [x] Built the dashboard locally (`npm run build`) — clean.
- [x] Verified primary chips render at zero counts (layout stable when there are no `STARTING` jobs).
- [x] Toggled Active/All and Mine/Everyone — fetch params updated, table refreshed, page reset to 1.
- [x] Selected and deselected statuses from the More dropdown — explicit selections appear as inline chips, dropdown rows highlight correctly.
- [x] With Active toggled on, dropdown rows for PENDING/STARTING/RECOVERING/CANCELLING are highlighted to reflect implicit inclusion.
- [x] Explicit `?user=X` URL filter overrides the Mine/Everyone toggle (segments un-highlight, behavior preserved).
- [x] Slow fetch (simulated by throttling) shows the spinner overlay after ~1s.
- [x] Deployed to an internal dev tenant and exercised the full filter end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)