### PR TITLE
[Dashboard] Preload plugin bundles from cached manifest

### DIFF
--- a/sky/dashboard/src/plugins/PluginProvider.jsx
+++ b/sky/dashboard/src/plugins/PluginProvider.jsx
@@ -284,6 +284,72 @@ function extractJsPath(pluginDescriptor) {
   return null;
 }
 
+// Cache the plugin manifest's JS paths in localStorage so subsequent page
+// loads can begin fetching the bundles in parallel with React hydration,
+// rather than waiting for the in-React useEffect to run `/api/plugins`
+// before queuing any <script> tag. The common cold-cache path (Cloudflare
+// RTT + manifest fetch + serial script downloads) regularly exceeds the
+// 1000ms safety timeout in `LayoutContent`, causing the fallback TopBar
+// to flash before the sidebar plugin can register `layout.navigation`.
+const PLUGIN_MANIFEST_CACHE_KEY = 'sky-plugin-manifest-cache-v1';
+
+function loadCachedManifest() {
+  if (typeof window === 'undefined') return [];
+  try {
+    const cached = localStorage.getItem(PLUGIN_MANIFEST_CACHE_KEY);
+    if (cached) {
+      const parsed = JSON.parse(cached);
+      if (Array.isArray(parsed)) return parsed;
+    }
+  } catch {
+    // Ignore parse errors
+  }
+  return [];
+}
+
+function saveManifestCache(plugins) {
+  if (typeof window === 'undefined') return;
+  try {
+    // Persist only the minimum needed to start a bundle download on the
+    // next page load. We deliberately drop everything else so a stale
+    // cache can't carry forward a stale registration.
+    const minimal = plugins
+      .filter((p) => p && p.js_extension_path)
+      .map((p) => ({
+        js_extension_path: p.js_extension_path,
+        requires_early_init: p.requires_early_init === true,
+      }));
+    localStorage.setItem(PLUGIN_MANIFEST_CACHE_KEY, JSON.stringify(minimal));
+  } catch {
+    // Ignore storage errors (e.g. quota exceeded, private browsing)
+  }
+}
+
+// At module-init time (this runs once when the bundle is parsed, before
+// React mounts), kick off plugin-bundle downloads from the cached
+// manifest. The dedup map (`pluginScriptPromises`) ensures that when the
+// in-React fetch resolves and calls `loadPluginScript` again with the
+// same URL, the existing promise is reused instead of appending a second
+// <script> tag. Plugin bundles deferred-register against
+// `window.SkyDashboardPluginAPI`, so executing before React's hydrate is
+// safe: the plugin code stays idle until the React-side init fires the
+// `plugins-ready` event.
+if (typeof window !== 'undefined') {
+  try {
+    const cached = loadCachedManifest();
+    cached.forEach((entry) => {
+      if (entry && entry.js_extension_path) {
+        loadPluginScript(
+          entry.js_extension_path,
+          entry.requires_early_init === true
+        );
+      }
+    });
+  } catch {
+    // Never block module init on cache replay
+  }
+}
+
 function normalizeNavLink(link) {
   if (!link || !link.id || !link.label || !link.href) {
     console.warn(
@@ -884,6 +950,10 @@ export function PluginProvider({ children }) {
       if (cancelled) {
         return;
       }
+      // Persist the freshly-fetched manifest so the next page load can
+      // begin downloading plugin bundles in parallel with React hydration
+      // (see the module-level cache replay above).
+      saveManifestCache(manifest);
       const loadPromises = [];
       manifest.forEach((pluginDescriptor) => {
         const jsPath = extractJsPath(pluginDescriptor);


### PR DESCRIPTION
## Summary

When the dashboard loads, the plugin manifest is fetched via `/api/plugins` inside a `useEffect` in `PluginProvider`. Plugin `<script>` tags are appended only after that fetch resolves, and the registration happens later still. Through a slow network (e.g. Cloudflare-fronted deployments) the manifest fetch + bundle downloads commonly take longer than the 1000ms safety timeout in `LayoutContent`. The fallback `DefaultNavbarLayout` (horizontal TopBar) paints, then the sidebar plugin finishes loading and registers `layout.navigation`, and React swaps the entire navigation layout — producing a visible "top bar appears immediately, sidebar appears a few seconds later" flash.

This PR caches the manifest's `js_extension_path`s in `localStorage` and, at module-init time (before React hydrates), replays the cache by calling `loadPluginScript()` for each cached entry. Result: on every page load after the first, plugin bundles begin downloading in parallel with React's bundle parse/hydrate, rather than after it. The sidebar plugin registers before the 1000ms safety timeout fires, so the fallback TopBar no longer flashes.

## Safety

- Plugin bundles already defer their registration on `window.SkyDashboardPluginAPI`, which is set by `PluginProvider`'s `useEffect`. Executing the bundle code before React hydrates is a no-op until the API appears; the bundle listens for `plugins-ready` and registers then.
- `pluginScriptPromises` (existing dedup keyed by resolved URL) means the in-React `loadPluginScript` call reuses the early promise instead of appending a second `<script>` tag with the same `src`.
- If a cached URL no longer exists (plugin removed/renamed): the early load 404s silently; the fresh manifest fetch loads the new URLs as usual. No double-registration, no broken state.
- First-ever cold load: unchanged (no cache to replay). Improvement kicks in from the second load onward.

## Test plan

- [ ] Load the dashboard once, then hard-reload. Verify the sidebar renders alongside the page content with no horizontal TopBar flash.
- [ ] Clear `localStorage` and reload. Verify behavior matches today's cold-load (sidebar still appears, possibly after a brief fallback flash). 
- [ ] Disable JavaScript caching in DevTools and reload. Verify the early `<script>` tags appear in the DOM with the cached URLs.
- [ ] Confirm no duplicate plugin registration: open DevTools console, verify each "Registered" log line appears once per plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->