### PR TITLE
[Dashboard] Hint that the managed jobs table is filtered to current user

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -46,6 +46,7 @@ import {
   ChevronDownIcon,
   ChevronRightIcon,
   CheckIcon,
+  InfoIcon,
 } from 'lucide-react';
 import {
   handleJobAction,
@@ -882,6 +883,19 @@ export function ManagedJobsTable({
     setSelectedStatuses([]);
     setShowAllMode(true); // Default to show all mode when changing tabs
   }, [activeTab]);
+
+  // Switch ownership scope (My Jobs vs All Jobs). Resets status narrowing
+  // so a status chip selected in one scope (e.g. RUNNING in My Jobs)
+  // doesn't carry over and silently empty the table under the new scope.
+  // Leaves `activeTab` alone — Active/All is orthogonal to ownership.
+  const selectScope = React.useCallback((scope) => {
+    React.startTransition(() => {
+      setUserScope(scope);
+      setSelectedStatuses([]);
+      setShowAllMode(true);
+      setCurrentPage(1);
+    });
+  }, []);
 
   // Populate valueList for filter dropdown
   useEffect(() => {
@@ -2112,22 +2126,6 @@ export function ManagedJobsTable({
                     String(explicitUserFilter.value) === currentUser.name
                   : userScope === 'mine';
                 const isEveryone = !explicitUserFilter && userScope === 'all';
-                const selectScope = (scope) => {
-                  // Reset status narrowing the same way the Active/All
-                  // toggle does — without this, a status chip selected
-                  // in one scope (e.g., RUNNING in My Jobs) carries
-                  // over to the other and the table renders empty
-                  // because that status has zero rows under the new
-                  // scope. Leave activeTab alone so a user who picked
-                  // Active in one scope keeps that activity filter
-                  // when they switch scope.
-                  React.startTransition(() => {
-                    setUserScope(scope);
-                    setSelectedStatuses([]);
-                    setShowAllMode(true);
-                    setCurrentPage(1);
-                  });
-                };
                 return (
                   <div
                     role="tablist"
@@ -2157,6 +2155,44 @@ export function ManagedJobsTable({
                       }`}
                     >
                       All Jobs
+                    </button>
+                  </div>
+                );
+              })()}
+              {/* Scope hint: when filtered to the current user's jobs,
+                  remind them and offer a one-click path to All Jobs.
+                  Sits at the tail of the chip + toggle row (same flex-wrap
+                  container) so it flows inline with the filter bar on
+                  wide screens and wraps below on narrow ones. Suppress
+                  in the empty state (the CTA already says this) and
+                  when an explicit user filter has overridden the toggle. */}
+              {(() => {
+                const explicitUserFilter = (filters || []).find(
+                  (f) => (f.property || '').toLowerCase() === 'user' && f.value
+                );
+                const showHint =
+                  userScope === 'mine' &&
+                  currentUser &&
+                  !explicitUserFilter &&
+                  !isInitialLoad &&
+                  paginatedData.length > 0;
+                if (!showHint) return null;
+                return (
+                  <div
+                    className="inline-flex items-center gap-2 rounded-full border border-sky-200/70 bg-sky-50 pl-2 pr-2.5 py-0.5 text-xs shrink-0"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    <InfoIcon className="h-3 w-3 text-sky-600 shrink-0" />
+                    <span className="text-gray-700">
+                      Showing your jobs only.
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => selectScope('all')}
+                      className="font-medium text-sky-700 transition-colors hover:text-sky-800 hover:underline"
+                    >
+                      View all jobs
                     </button>
                   </div>
                 );


### PR DESCRIPTION
## Summary

The Managed Jobs page now defaults to "My Jobs" scope, which silently filters out any jobs submitted by other users. When the user *has* jobs, the My Jobs / All Jobs toggle alone isn't loud enough — a fresh visitor easily reads the populated table as "all jobs on this server" and misses teammates' work entirely. The existing empty-state CTA only fires when the user's own list is empty.

Add a small inline hint above the table when the scope is \"mine\" and the table has rows:

> ℹ️ Showing your jobs only. **View all jobs**

The \"View all jobs\" link flips the scope to All Jobs in one click. Hidden when:
- The empty-state CTA is already conveying the same message (no own-rows visible)
- The user has explicitly picked a different user via the FilterDropdown (the toggle is already overridden)
- The initial load hasn't settled yet

Also hoists `selectScope` out of the inline IIFE so the hint can reuse the same scope-reset logic. Switching scope still clears status narrowing — a chip selected in one scope (e.g. RUNNING in My Jobs) shouldn't carry over and silently empty the table under the new scope.

## Test plan

- [ ] Visit `/dashboard/jobs` as a user with own jobs. Verify the hint appears above the table.
- [ ] Click \"View all jobs\". Verify the table reloads with everyone's jobs and the hint disappears.
- [ ] In My Jobs scope, pick a different user via the FilterDropdown. Verify the hint hides.
- [ ] In My Jobs scope, click a status chip that yields zero rows. Verify the hint hides (empty-state CTA takes over).
- [ ] Toggle Active / All. Verify the hint stays put.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->