### PR TITLE
[Kubernetes] Fix custom Docker images that lack sudo

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1259,6 +1259,9 @@ def write_cluster_config(
             cluster_config_overrides=cluster_config_overrides,
             cloud=cloud,
             context=region.name)
+        if to_provision.extract_docker_image() is not None:
+            kubernetes_utils.ensure_custom_image_container_runs_as_root(
+                combined_yaml_obj)
         # Write the updated YAML back to the file
         yaml_utils.dump_yaml(tmp_yaml_path, combined_yaml_obj)
 

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -21,8 +21,8 @@ logger = sky_logging.init_logger(__name__)
 # but it causes FAILED_DRIVER errors with SkyPilot's Ray 2.9.3.
 # See: https://github.com/skypilot-org/skypilot/pull/7181
 SETUP_ENV_VARS_CMD = (
-    constants.PREFIX_CMD_SHELL_SNIPPET + ' '
-    + constants.REQUIRE_ROOT_OR_SUDO_SHELL_SNIPPET + ' '
+    constants.PREFIX_CMD_SHELL_SNIPPET + ' ' +
+    constants.REQUIRE_ROOT_OR_SUDO_SHELL_SNIPPET + ' '
     'export -p | grep -v RAY_RUNTIME_ENV_HOOK > ~/container_env_var.sh && '
     '$(prefix_cmd) '
     'mv ~/container_env_var.sh /etc/profile.d/container_env_var.sh;')

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -21,7 +21,8 @@ logger = sky_logging.init_logger(__name__)
 # but it causes FAILED_DRIVER errors with SkyPilot's Ray 2.9.3.
 # See: https://github.com/skypilot-org/skypilot/pull/7181
 SETUP_ENV_VARS_CMD = (
-    constants.PREFIX_CMD_SHELL_SNIPPET + ' && '
+    constants.PREFIX_CMD_SHELL_SNIPPET + ' '
+    + constants.REQUIRE_ROOT_OR_SUDO_SHELL_SNIPPET + ' '
     'export -p | grep -v RAY_RUNTIME_ENV_HOOK > ~/container_env_var.sh && '
     '$(prefix_cmd) '
     'mv ~/container_env_var.sh /etc/profile.d/container_env_var.sh;')

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -21,8 +21,7 @@ logger = sky_logging.init_logger(__name__)
 # but it causes FAILED_DRIVER errors with SkyPilot's Ray 2.9.3.
 # See: https://github.com/skypilot-org/skypilot/pull/7181
 SETUP_ENV_VARS_CMD = (
-    'prefix_cmd() '
-    '{ if [ $(id -u) -ne 0 ]; then echo "sudo"; else echo ""; fi; } && '
+    constants.PREFIX_CMD_SHELL_SNIPPET + ' && '
     'export -p | grep -v RAY_RUNTIME_ENV_HOOK > ~/container_env_var.sh && '
     '$(prefix_cmd) '
     'mv ~/container_env_var.sh /etc/profile.d/container_env_var.sh;')

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -21,6 +21,7 @@ from sky.provision.kubernetes import constants as k8s_constants
 from sky.provision.kubernetes import host_network_probe
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.provision.kubernetes import volume
+from sky.skylet import constants as skylet_constants
 from sky.utils import command_runner
 from sky.utils import common_utils
 from sky.utils import config_utils
@@ -977,8 +978,8 @@ def pre_init(namespace: str, context: Optional[str], new_nodes: List) -> None:
         'echo "apt update complete."; ')
 
     install_ssh_k8s_cmd = (
-        'prefix_cmd() '
-        '{ if [ $(id -u) -ne 0 ]; then echo "sudo"; else echo ""; fi; }; '
+        skylet_constants.PREFIX_CMD_SHELL_SNIPPET + ' ' +
+        skylet_constants.REQUIRE_ROOT_OR_SUDO_SHELL_SNIPPET + ' '
         'export DEBIAN_FRONTEND=noninteractive;'
         'echo "Installing missing packages..."; '
         'for i in {1..5}; do '

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -3466,10 +3466,16 @@ def ensure_custom_image_container_runs_as_root(
 
 
 def _apply_run_as_root_to_ray_node_container(spec: Dict[str, Any]) -> None:
-    for container in spec.get('containers', []):
+    containers = spec.get('containers')
+    if not isinstance(containers, list):
+        return
+    for container in containers:
         if container.get('name') != RAY_NODE_CONTAINER_NAME:
             continue
-        sec_ctx = container.setdefault('securityContext', {})
+        sec_ctx = container.get('securityContext')
+        if not isinstance(sec_ctx, dict):
+            sec_ctx = {}
+            container['securityContext'] = sec_ctx
         if 'runAsUser' in sec_ctx or sec_ctx.get('runAsNonRoot') is True:
             return
         sec_ctx['runAsUser'] = 0

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -3444,6 +3444,39 @@ def resolve_effective_pod_config(
     return kubernetes_config
 
 
+RAY_NODE_CONTAINER_NAME = 'ray-node'
+
+
+def ensure_custom_image_container_runs_as_root(
+        cluster_yaml_obj: Dict[str, Any]) -> None:
+    """Set ``runAsUser: 0`` on the ray-node container for custom images.
+
+    Minimal container images (e.g. NVIDIA NGC) often default to a non-root
+    user without ``sudo``, which breaks SkyPilot's apt/ssh bootstrap. This is
+    applied only when the user has not already set ``runAsUser`` or
+    ``runAsNonRoot`` via ``pod_config``.
+    """
+    for node_type_cfg in cluster_yaml_obj.get('available_node_types',
+                                              {}).values():
+        node_config = node_type_cfg.get('node_config', {})
+        spec = node_config.get('spec')
+        if not isinstance(spec, dict):
+            continue
+        _apply_run_as_root_to_ray_node_container(spec)
+
+
+def _apply_run_as_root_to_ray_node_container(spec: Dict[str, Any]) -> None:
+    for container in spec.get('containers', []):
+        if container.get('name') != RAY_NODE_CONTAINER_NAME:
+            continue
+        sec_ctx = container.setdefault('securityContext', {})
+        if 'runAsUser' in sec_ctx or sec_ctx.get('runAsNonRoot') is True:
+            return
+        sec_ctx['runAsUser'] = 0
+        sec_ctx.setdefault('runAsGroup', 0)
+        return
+
+
 def combine_pod_config_fields(
     cluster_yaml_obj: Dict[str, Any],
     cluster_config_overrides: Dict[str, Any],

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -211,6 +211,24 @@ SETUP_SKY_DIRS_COMMANDS = (f'mkdir -p ~/sky_workdir && '
                            f'mkdir -p ~/.sky/sky_app && '
                            f'mkdir -p {SKY_RUNTIME_DIR}/.sky;')
 
+# Shell helpers for container bootstrap (Kubernetes/Docker). ``prefix_cmd``
+# only emits ``sudo`` when sudo is installed; many minimal images omit it.
+PREFIX_CMD_SHELL_SNIPPET = (
+    'prefix_cmd() { '
+    'if [ "$(id -u)" -eq 0 ]; then echo ""; '
+    'elif command -v sudo >/dev/null 2>&1; then echo "sudo"; '
+    'else echo ""; fi; }; '
+    '[ "$(id -u)" -eq 0 ] && function sudo() { "$@"; } || true;')
+
+# Fail fast when bootstrap needs root but the container is non-root without
+# sudo.
+REQUIRE_ROOT_OR_SUDO_SHELL_SNIPPET = (
+    'if [ "$(id -u)" -ne 0 ] && ! command -v sudo >/dev/null 2>&1; then '
+    'echo "SkyPilot node setup requires root or sudo, but this container '
+    'runs as $(id -un) (uid $(id -u)) without sudo installed. '
+    'For Kubernetes custom images, set pod_config securityContext '
+    'runAsUser: 0." >&2; exit 1; fi;')
+
 # Install conda on the remote cluster if it is not already installed.
 # We use conda with python 3.10 to be consistent across multiple clouds with
 # best effort.

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -761,10 +761,23 @@ available_node_types:
               {%- endfor %}
               {%- endif %}
 
-              # Helper function to conditionally use sudo
+              # Helper function to conditionally use sudo. Only prefix with sudo
+              # when sudo is installed; many minimal container images omit it.
               # TODO(zhwu): consolidate the two prefix_cmd and sudo replacements
-              prefix_cmd() { if [ $(id -u) -ne 0 ]; then echo "sudo"; else echo ""; fi; }
-              [ $(id -u) -eq 0 ] && function sudo() { "$@"; } || true;
+              prefix_cmd() {
+                if [ "$(id -u)" -eq 0 ]; then
+                  echo ""
+                elif command -v sudo >/dev/null 2>&1; then
+                  echo "sudo"
+                else
+                  echo ""
+                fi
+              }
+              [ "$(id -u)" -eq 0 ] && function sudo() { "$@"; } || true;
+              if [ "$(id -u)" -ne 0 ] && ! command -v sudo >/dev/null 2>&1; then
+                echo "SkyPilot node setup requires root or sudo, but this container runs as $(id -un) (uid $(id -u)) without sudo installed. For Kubernetes custom images, set config.kubernetes.pod_config.spec.containers[].securityContext.runAsUser: 0." >&2
+                exit 1
+              fi
 
               {% for path in volume_mount_rw_paths %}
               # Fix write permissions for volume mount if needed.

--- a/tests/unit_tests/test_sky/provision/test_k8s_custom_image_security.py
+++ b/tests/unit_tests/test_sky/provision/test_k8s_custom_image_security.py
@@ -1,0 +1,59 @@
+"""Tests for Kubernetes custom-image security context handling (issue #8566)."""
+from sky.provision.kubernetes import utils as kubernetes_utils
+from sky.skylet import constants as skylet_constants
+
+
+def _minimal_cluster_yaml():
+    return {
+        'available_node_types': {
+            'ray_head_default': {
+                'node_config': {
+                    'spec': {
+                        'containers': [{
+                            'name': 'ray-node',
+                            'image': ('nvcr.io/nvidia/ai-dynamo/'
+                                      'sglang-runtime:0.7.1'),
+                        }],
+                    },
+                },
+            },
+        },
+    }
+
+
+def test_ensure_custom_image_sets_run_as_root():
+    cluster_yaml = _minimal_cluster_yaml()
+    kubernetes_utils.ensure_custom_image_container_runs_as_root(cluster_yaml)
+    sec = cluster_yaml['available_node_types']['ray_head_default'][
+        'node_config']['spec']['containers'][0]['securityContext']
+    assert sec['runAsUser'] == 0
+    assert sec['runAsGroup'] == 0
+
+
+def test_ensure_custom_image_respects_existing_run_as_user():
+    cluster_yaml = _minimal_cluster_yaml()
+    container = cluster_yaml['available_node_types']['ray_head_default'][
+        'node_config']['spec']['containers'][0]
+    container['securityContext'] = {'runAsUser': 1000}
+    kubernetes_utils.ensure_custom_image_container_runs_as_root(cluster_yaml)
+    assert container['securityContext']['runAsUser'] == 1000
+    assert 'runAsGroup' not in container['securityContext']
+
+
+def test_ensure_custom_image_respects_run_as_non_root():
+    cluster_yaml = _minimal_cluster_yaml()
+    container = cluster_yaml['available_node_types']['ray_head_default'][
+        'node_config']['spec']['containers'][0]
+    container['securityContext'] = {'runAsNonRoot': True}
+    kubernetes_utils.ensure_custom_image_container_runs_as_root(cluster_yaml)
+    assert 'runAsUser' not in container['securityContext']
+
+
+def test_prefix_cmd_snippet_checks_sudo_availability():
+    assert 'command -v sudo' in skylet_constants.PREFIX_CMD_SHELL_SNIPPET
+
+
+def test_require_root_or_sudo_snippet_exits_without_privilege():
+    assert 'exit 1' in skylet_constants.REQUIRE_ROOT_OR_SUDO_SHELL_SNIPPET
+    snippet = skylet_constants.REQUIRE_ROOT_OR_SUDO_SHELL_SNIPPET
+    assert 'command -v sudo' in snippet

--- a/tests/unit_tests/test_sky/provision/test_k8s_custom_image_security.py
+++ b/tests/unit_tests/test_sky/provision/test_k8s_custom_image_security.py
@@ -40,6 +40,22 @@ def test_ensure_custom_image_respects_existing_run_as_user():
     assert 'runAsGroup' not in container['securityContext']
 
 
+def test_ensure_custom_image_handles_null_security_context():
+    cluster_yaml = _minimal_cluster_yaml()
+    container = cluster_yaml['available_node_types']['ray_head_default'][
+        'node_config']['spec']['containers'][0]
+    container['securityContext'] = None
+    kubernetes_utils.ensure_custom_image_container_runs_as_root(cluster_yaml)
+    assert container['securityContext']['runAsUser'] == 0
+
+
+def test_ensure_custom_image_handles_null_containers_list():
+    cluster_yaml = _minimal_cluster_yaml()
+    cluster_yaml['available_node_types']['ray_head_default']['node_config'][
+        'spec']['containers'] = None
+    kubernetes_utils.ensure_custom_image_container_runs_as_root(cluster_yaml)
+
+
 def test_ensure_custom_image_respects_run_as_non_root():
     cluster_yaml = _minimal_cluster_yaml()
     container = cluster_yaml['available_node_types']['ray_head_default'][


### PR DESCRIPTION
Fixes #8566.

## Summary

Custom Kubernetes images such as `nvcr.io/nvidia/ai-dynamo/sglang-runtime` often run as a non-root user without `sudo`. SkyPilot's node bootstrap called `sudo` anyway and failed during package install.

This change sets `runAsUser: 0` on the `ray-node` container when you launch with a custom `docker:` image, unless `pod_config` already sets `runAsUser` or `runAsNonRoot`. The bootstrap script also checks that `sudo` exists before using it, and prints a clear error if the container cannot get root.

## Tested

- [x] Code formatting: `bash format.sh` on the touched Python files
- [x] New unit tests: `pytest tests/unit_tests/test_sky/provision/test_k8s_custom_image_security.py` (5 passed)
- [ ] Manual verification with `sky launch --infra k8s --image-id docker:nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.1`
- [ ] All smoke tests: `/smoke-test` (CI)
- [ ] Backward compatibility: `/quicktest-core` (CI)