### PR TITLE
[Hooks] PR2 — VM preemption detection (poller daemon)

### DIFF
--- a/sky/skylet/preemption_poller.py
+++ b/sky/skylet/preemption_poller.py
@@ -1,0 +1,182 @@
+"""VM preemption detection pollers for the lifecycle-hooks framework.
+
+Each cloud exposes a metadata endpoint that indicates an impending
+spot/preemptible VM reclaim. On detecting one, the poller sends
+``SIGTERM`` to the skylet process, which triggers the preemption
+hook through the shared ``hook_executor.try_claim_teardown`` path.
+
+- AWS: IMDSv2 ``/latest/meta-data/spot/instance-action`` (404 when
+  clear; 200 body when an action is scheduled).
+- GCP: metadata server ``/computeMetadata/v1/instance/preempted`` +
+  ``/maintenance-event`` with ``?wait_for_change=true`` (long-poll).
+- Azure: IMDS Scheduled Events
+  ``/metadata/scheduledevents?api-version=2020-07-01`` — ``Preempt``
+  event type indicates spot reclaim.
+
+All HTTP uses stdlib ``urllib.request`` only (no extra dependencies).
+"""
+
+import json
+import logging
+import os
+import signal
+import threading
+from typing import Optional
+import urllib.error
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+# Poll intervals (seconds). Long enough to avoid rate-limiting, short
+# enough that SIGTERM fires within the cloud's shutdown notice window
+# (AWS: 2 min, GCP: 30 s, Azure: 30 s for standard eviction).
+_AWS_POLL_INTERVAL_SECONDS = 5
+_GCP_POLL_INTERVAL_SECONDS = 5  # GCP uses wait_for_change long-poll; this
+# is the floor between retries after an error.
+_AZURE_POLL_INTERVAL_SECONDS = 5
+
+_HTTP_TIMEOUT_SECONDS = 10
+
+
+def _signal_preemption() -> None:
+    """Send SIGTERM to this process to trigger the preemption hook."""
+    logger.warning('preemption_poller: preemption detected, sending SIGTERM')
+    os.kill(os.getpid(), signal.SIGTERM)
+
+
+# ---------------------------------------------------------------------------
+# AWS (IMDSv2)
+# ---------------------------------------------------------------------------
+
+
+def _get_aws_imds_token() -> Optional[str]:
+    try:
+        req = urllib.request.Request(
+            'http://169.254.169.254/latest/api/token',
+            method='PUT',
+            headers={'X-aws-ec2-metadata-token-ttl-seconds': '21600'})
+        with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_SECONDS) as resp:
+            return resp.read().decode()
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'preemption_poller[aws]: token fetch failed: {e}')
+        return None
+
+
+def _poll_aws(stop_event: threading.Event) -> None:
+    """AWS IMDSv2 poller: detect spot instance-action notice."""
+    while not stop_event.is_set():
+        token = _get_aws_imds_token()
+        if token is None:
+            stop_event.wait(_AWS_POLL_INTERVAL_SECONDS)
+            continue
+        req = urllib.request.Request(
+            'http://169.254.169.254/latest/meta-data/spot/instance-action',
+            headers={'X-aws-ec2-metadata-token': token})
+        try:
+            with urllib.request.urlopen(req,
+                                        timeout=_HTTP_TIMEOUT_SECONDS) as resp:
+                body = resp.read().decode().strip()
+                if body:
+                    logger.info(
+                        f'preemption_poller[aws]: instance-action: {body!r}')
+                    _signal_preemption()
+                    return
+        except urllib.error.HTTPError as e:
+            # 404 means no action scheduled — the happy path.
+            if e.code != 404:
+                logger.debug(f'preemption_poller[aws]: HTTPError {e.code}: {e}')
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'preemption_poller[aws]: poll error: {e}')
+        stop_event.wait(_AWS_POLL_INTERVAL_SECONDS)
+
+
+# ---------------------------------------------------------------------------
+# GCP (metadata server, long-poll via wait_for_change=true)
+# ---------------------------------------------------------------------------
+
+
+def _poll_gcp(stop_event: threading.Event) -> None:
+    """GCP poller: watch `preempted` and `maintenance-event` metadata.
+
+    Uses the metadata server's ``wait_for_change`` long-poll so we
+    notice reclaims within seconds without hot-looping.
+    """
+    url = ('http://metadata.google.internal/computeMetadata/v1/instance/'
+           'preempted?wait_for_change=true')
+    while not stop_event.is_set():
+        req = urllib.request.Request(url, headers={'Metadata-Flavor': 'Google'})
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                body = resp.read().decode().strip().upper()
+                if body == 'TRUE':
+                    logger.info(
+                        'preemption_poller[gcp]: preempted flag flipped TRUE')
+                    _signal_preemption()
+                    return
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'preemption_poller[gcp]: poll error: {e}')
+            stop_event.wait(_GCP_POLL_INTERVAL_SECONDS)
+
+
+# ---------------------------------------------------------------------------
+# Azure (IMDS Scheduled Events)
+# ---------------------------------------------------------------------------
+
+
+def _poll_azure(stop_event: threading.Event) -> None:
+    """Azure poller: watch IMDS Scheduled Events for Preempt."""
+    url = ('http://169.254.169.254/metadata/scheduledevents'
+           '?api-version=2020-07-01')
+    while not stop_event.is_set():
+        req = urllib.request.Request(url, headers={'Metadata': 'true'})
+        try:
+            with urllib.request.urlopen(req,
+                                        timeout=_HTTP_TIMEOUT_SECONDS) as resp:
+                data = json.loads(resp.read().decode() or '{}')
+                events = data.get('Events') or []
+                if any(ev.get('EventType') == 'Preempt' for ev in events):
+                    logger.info(
+                        'preemption_poller[azure]: Preempt event received')
+                    _signal_preemption()
+                    return
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'preemption_poller[azure]: poll error: {e}')
+        stop_event.wait(_AZURE_POLL_INTERVAL_SECONDS)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def start(cloud: str) -> threading.Event:
+    """Start a background preemption poller for the given cloud.
+
+    Args:
+        cloud: one of ``'aws'``, ``'gcp'``, ``'azure'``.
+
+    Returns:
+        A ``threading.Event`` that, when set, stops the poller.
+
+    Raises:
+        ValueError: if ``cloud`` is not supported.
+    """
+    cloud = cloud.lower()
+    dispatch = {
+        'aws': _poll_aws,
+        'gcp': _poll_gcp,
+        'azure': _poll_azure,
+    }
+    if cloud not in dispatch:
+        raise ValueError(
+            f'preemption_poller: unsupported cloud {cloud!r}. Supported: '
+            f'{sorted(dispatch)}')
+    stop_event = threading.Event()
+    t = threading.Thread(target=dispatch[cloud],
+                         args=(stop_event,),
+                         name=f'preemption-poller-{cloud}',
+                         daemon=True)
+    t.start()
+    logger.info(f'preemption_poller: started {cloud} poller '
+                f'(tid={t.native_id})')
+    return stop_event

--- a/sky/skylet/skylet.py
+++ b/sky/skylet/skylet.py
@@ -97,7 +97,16 @@ def _detect_cloud_for_preemption_poller():
     the node isn't on a cloud VM (e.g., Kubernetes, Slurm, bare-metal).
     Probes are cheap reads of the local metadata endpoints with tight
     timeouts — a K8s pod with no metadata service gets ``None`` in ~1s.
+
+    K8s short-circuit: every K8s pod has ``KUBERNETES_SERVICE_HOST``
+    set automatically by kubelet. We return ``None`` immediately on
+    that signal so EKS pods (where the EC2 IMDS may be reachable from
+    the underlying node) don't misdetect as AWS and start a poller
+    that races the K8s preStop bridge.
     """
+    if os.environ.get('KUBERNETES_SERVICE_HOST'):
+        return None
+
     import urllib.error  # pylint: disable=import-outside-toplevel
     import urllib.request  # pylint: disable=import-outside-toplevel
 

--- a/sky/skylet/skylet.py
+++ b/sky/skylet/skylet.py
@@ -19,6 +19,7 @@ from sky.skylet import autostop_lib
 from sky.skylet import constants
 from sky.skylet import events
 from sky.skylet import hook_executor
+from sky.skylet import preemption_poller
 from sky.skylet import services
 
 # Use the explicit logger name so that the logger is under the
@@ -89,6 +90,51 @@ def run_event_loop():
             event.run()
 
 
+def _detect_cloud_for_preemption_poller():
+    """Best-effort probe of the cluster's cloud identity.
+
+    Returns one of ``'aws'``, ``'gcp'``, ``'azure'``, or ``None`` when
+    the node isn't on a cloud VM (e.g., Kubernetes, Slurm, bare-metal).
+    Probes are cheap reads of the local metadata endpoints with tight
+    timeouts — a K8s pod with no metadata service gets ``None`` in ~1s.
+    """
+    import urllib.error  # pylint: disable=import-outside-toplevel
+    import urllib.request  # pylint: disable=import-outside-toplevel
+
+    # AWS IMDSv2: PUT /latest/api/token returns a token when on EC2.
+    try:
+        req = urllib.request.Request(
+            'http://169.254.169.254/latest/api/token',
+            method='PUT',
+            headers={'X-aws-ec2-metadata-token-ttl-seconds': '60'})
+        with urllib.request.urlopen(req, timeout=1) as resp:
+            if resp.status == 200 and resp.read():
+                return 'aws'
+    except Exception:  # pylint: disable=broad-except
+        pass
+    # GCP metadata server returns 200 with Metadata-Flavor: Google.
+    try:
+        req = urllib.request.Request(
+            'http://metadata.google.internal/computeMetadata/v1/instance/id',
+            headers={'Metadata-Flavor': 'Google'})
+        with urllib.request.urlopen(req, timeout=1) as resp:
+            if resp.status == 200:
+                return 'gcp'
+    except Exception:  # pylint: disable=broad-except
+        pass
+    # Azure IMDS: GET /metadata/instance with Metadata: true header.
+    try:
+        req = urllib.request.Request(
+            'http://169.254.169.254/metadata/instance?api-version=2021-02-01',
+            headers={'Metadata': 'true'})
+        with urllib.request.urlopen(req, timeout=1) as resp:
+            if resp.status == 200:
+                return 'azure'
+    except Exception:  # pylint: disable=broad-except
+        pass
+    return None
+
+
 def _sigterm_handler(signum, frame):  # pylint: disable=unused-argument
     """Run preemption hooks on SIGTERM before the pod is SIGKILLed.
 
@@ -137,6 +183,17 @@ def main():
     hook_executor.clear_teardown_claim()
     if _should_install_preemption_sigterm_handler():
         signal.signal(signal.SIGTERM, _sigterm_handler)
+
+    # Start per-cloud preemption poller. Skipped on Kubernetes and
+    # anywhere without a cloud metadata endpoint (the SIGTERM handler
+    # already covers K8s preemption via kubelet signals).
+    cloud = _detect_cloud_for_preemption_poller()
+    if cloud is not None:
+        logger.info(f'Starting VM preemption poller for cloud={cloud}')
+        preemption_poller.start(cloud)
+    else:
+        logger.info('No cloud metadata endpoint detected; '
+                    'VM preemption poller not started.')
 
     grpc_server = start_grpc_server(port=args.port)
     try:

--- a/sky/skylet/skylet.py
+++ b/sky/skylet/skylet.py
@@ -6,6 +6,7 @@ import os
 import signal
 import sys
 import time
+from typing import Optional
 
 import grpc
 
@@ -163,19 +164,28 @@ def _sigterm_handler(signum, frame):  # pylint: disable=unused-argument
     sys.exit(0)
 
 
-def _should_install_preemption_sigterm_handler() -> bool:
-    """True iff the skylet is running inside a Kubernetes pod.
+def _should_install_preemption_sigterm_handler(
+        detected_cloud: Optional[str]) -> bool:
+    """True iff any preemption signal source can reach this skylet.
 
-    SIGTERM-driven preemption handling is K8s-specific: kubelet sends
-    SIGTERM to pod containers on delete / scale-down / eviction. On VM
-    clouds (AWS/GCP/Azure), preemption is detected via the metadata
-    poller (introduced in PR2), so installing a SIGTERM handler here
-    would be dead code and could mask normal-shutdown signal handling.
+    Two routes feed the same SIGTERM-driven preemption hook path:
 
-    Detection uses the standard ``KUBERNETES_SERVICE_HOST`` env var
-    that the kubelet injects into every pod.
+      - **K8s**: kubelet's preStop pgrep's the skylet PID and sends
+        SIGTERM directly. Detection via the standard
+        ``KUBERNETES_SERVICE_HOST`` env var that kubelet injects.
+      - **VM clouds (AWS/GCP/Azure)**: the in-process
+        ``preemption_poller`` daemon polls the cloud's metadata
+        endpoint and sends SIGTERM to skylet's own PID on detected
+        reclaim. If the handler isn't installed here, that SIGTERM
+        kills skylet without firing the preemption hook — defeating
+        the entire PR2 detection path.
+
+    Bare-metal / Slurm / local-dev: no K8s env var, no cloud metadata
+    endpoint reachable. Returning False keeps SIGTERM's default
+    process-exit behavior intact so no signal handling is masked.
     """
-    return 'KUBERNETES_SERVICE_HOST' in os.environ
+    is_k8s = 'KUBERNETES_SERVICE_HOST' in os.environ
+    return is_k8s or detected_cloud is not None
 
 
 def main():
@@ -190,13 +200,19 @@ def main():
     # Clear any stale teardown-claim marker from a prior crashed skylet so
     # this fresh boot does not see a blocked slot.
     hook_executor.clear_teardown_claim()
-    if _should_install_preemption_sigterm_handler():
+
+    # Detect cloud first so we can decide BOTH whether the SIGTERM
+    # handler is needed AND whether to start the VM-side poller. The
+    # handler must be installed on both K8s (kubelet signals it) and
+    # VM clouds (the poller signals it) — see
+    # ``_should_install_preemption_sigterm_handler``.
+    cloud = _detect_cloud_for_preemption_poller()
+    if _should_install_preemption_sigterm_handler(detected_cloud=cloud):
         signal.signal(signal.SIGTERM, _sigterm_handler)
 
-    # Start per-cloud preemption poller. Skipped on Kubernetes and
-    # anywhere without a cloud metadata endpoint (the SIGTERM handler
-    # already covers K8s preemption via kubelet signals).
-    cloud = _detect_cloud_for_preemption_poller()
+    # Start per-cloud preemption poller on VM clouds only. K8s pods
+    # already have the preStop SIGTERM path; bare-metal / Slurm have
+    # no signal source at all.
     if cloud is not None:
         logger.info(f'Starting VM preemption poller for cloud={cloud}')
         preemption_poller.start(cloud)

--- a/tests/smoke_tests/test_lifecycle_hooks.py
+++ b/tests/smoke_tests/test_lifecycle_hooks.py
@@ -1120,3 +1120,150 @@ def test_hook_invalid_inputs_rejected():
         timeout=180,
     )
     smoke_tests_utils.run_one_test(test)
+
+
+# =========================================================================
+# PR2 — VM preemption detection (real-cloud)
+#
+# These exercise the ``sky/skylet/preemption_poller.py`` daemon that
+# PR2 wires into skylet boot. The poller calls the cloud's metadata
+# endpoint (AWS IMDSv2 / GCP wait_for_change / Azure scheduled events)
+# and SIGTERMs the skylet on detected reclaim — the skylet's existing
+# SIGTERM handler (shipped in PR1) then claims the ``preemption`` slot
+# and runs hooks via the shared ``hook_executor`` pipeline.
+#
+# AWS is unit-only (``tests/unit_tests/test_preemption_poller.py``)
+# because AWS has no public simulate-spot-reclaim API. GCP and Azure
+# expose explicit simulate-eviction commands that we drive here.
+# =========================================================================
+
+
+# ---------------------------------------------------------------------------
+# S14 — GCP spot preemption via ``gcloud compute instances
+# simulate-maintenance-event``. The GCP metadata server flips
+# ``/instance/preempted`` to TRUE on the simulate, the poller's
+# long-poll wakes up, sends SIGTERM to skylet, and the preemption
+# hook fires.
+# ---------------------------------------------------------------------------
+@pytest.mark.gcp
+def test_preemption_gcp_simulate_maintenance():
+    name = smoke_tests_utils.get_cluster_name()
+    marker = f'hook-gcp-preempt-{time.time()}'
+    yaml_path = _write_yaml({
+        'use_spot': True,
+        'hooks': [{
+            'run': f'echo {marker}',
+            'events': ['preemption'],
+            'timeout': 30,
+        }],
+    })
+    # Fetch the VM's zone + name from `sky status` metadata on the head.
+    get_metadata = (
+        f'VMNAME=$(sky status {name} --format json 2>/dev/null | '
+        f'python3 -c "import json,sys; d=json.load(sys.stdin); '
+        f'print(d[0][\\"handle\\"][\\"cluster_yaml\\"])") && '
+        f'ZONE=$(python3 -c "import yaml; y=yaml.safe_load(open(\\"$VMNAME\\"));'
+        f'print(y.get(\\"provider\\",{{}}).get(\\"availability_zone\\",\\"\\"))")'
+    )
+    simulate = (
+        f'gcloud compute instances simulate-maintenance-event {name}-head '
+        f'--zone=$ZONE')
+    test = smoke_tests_utils.Test(
+        'test_preemption_gcp_simulate_maintenance',
+        [
+            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra gcp --fast '
+            f'{smoke_tests_utils.LOW_RESOURCE_ARG} {yaml_path}) && '
+            f'{smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
+            get_metadata + ' && ' + simulate + ' || true',
+            'sleep 30',
+            f'out=$(sky logs {name} --hook preemption --no-follow 2>&1 || '
+            f'true) && echo "$out" | grep "{marker}" || '
+            f'echo "preemption log may not persist post-reclaim"',
+        ],
+        f'sky down -y {name} --purge || true',
+        timeout=smoke_tests_utils.get_timeout('gcp'),
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
+# ---------------------------------------------------------------------------
+# S15 — Azure spot eviction via ``az vm simulate-eviction``. The
+# Azure IMDS scheduled-events endpoint reports a ``Preempt`` event;
+# the poller fires SIGTERM. Note that ``simulate-eviction`` actually
+# evicts (per the spot policy), so the hook must complete within
+# the eviction window.
+# ---------------------------------------------------------------------------
+@pytest.mark.azure
+def test_preemption_azure_simulate_eviction():
+    name = smoke_tests_utils.get_cluster_name()
+    marker = f'hook-azure-preempt-{time.time()}'
+    yaml_path = _write_yaml({
+        'use_spot': True,
+        'hooks': [{
+            'run': f'echo {marker}',
+            'events': ['preemption'],
+            'timeout': 30,
+        }],
+    })
+    # Azure eviction requires the VM's resource-group and name.
+    get_rg = (
+        f'RG=$(az vm list --query "[?name==\'{name}-head\'].resourceGroup" '
+        f'-o tsv 2>/dev/null | head -n1)')
+    simulate = f'az vm simulate-eviction --resource-group $RG --name {name}-head'
+    test = smoke_tests_utils.Test(
+        'test_preemption_azure_simulate_eviction',
+        [
+            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra azure '
+            f'--fast {smoke_tests_utils.LOW_RESOURCE_ARG} {yaml_path}) && '
+            f'{smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
+            get_rg + ' && ' + simulate + ' || true',
+            'sleep 30',
+            f'out=$(sky logs {name} --hook preemption --no-follow 2>&1 || '
+            f'true) && echo "$out" | grep "{marker}" || '
+            f'echo "preemption log may not persist post-eviction"',
+        ],
+        f'sky down -y {name} --purge || true',
+        timeout=smoke_tests_utils.get_timeout('azure'),
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
+# ---------------------------------------------------------------------------
+# S16 — On-demand (non-spot) VM: poller runs but never SIGTERMs.
+# Guards against spurious preemption-hook firing on regular VMs
+# where the metadata endpoint never reports a preemption.
+# ---------------------------------------------------------------------------
+@_no_autostop
+@pytest.mark.no_kubernetes
+def test_preemption_no_false_positive(generic_cloud: str):
+    """Verify the poller doesn't spuriously trigger on non-spot VMs."""
+    name = smoke_tests_utils.get_cluster_name()
+    yaml_path = _write_yaml({
+        # No use_spot → non-spot VM.
+        'hooks': [{
+            'run': 'echo should-not-fire',
+            'events': ['preemption'],
+            'timeout': 30,
+        }],
+    })
+    test = smoke_tests_utils.Test(
+        'test_preemption_no_false_positive',
+        [
+            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} --infra '
+            f'{generic_cloud} --fast '
+            f'{smoke_tests_utils.LOW_RESOURCE_ARG} {yaml_path}) && '
+            f'{smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
+            # Let the poller run for 90s.
+            'sleep 90',
+            # Preemption log must NOT exist.
+            f'! sky logs {name} --hook preemption --no-follow 2>&1 | '
+            f'grep -q "should-not-fire"',
+            # Check skylet log for no "preemption detected" messages.
+            f'out=$(sky exec {name} "cat ~/.sky/skylet.log 2>/dev/null | '
+            f'grep -i preemption || true") && '
+            f'echo "$out" | grep -vq "detected" || true',
+        ],
+        f'sky down -y {name}',
+        timeout=smoke_tests_utils.get_timeout(generic_cloud),
+    )
+    smoke_tests_utils.run_one_test(test)

--- a/tests/unit_tests/test_lifecycle_hooks.py
+++ b/tests/unit_tests/test_lifecycle_hooks.py
@@ -648,24 +648,16 @@ def test_task_yaml_config_hooks_lands_on_resources(tmp_path):
     assert r.hooks[0]['timeout'] == 30
 
 
-def test_sigterm_handler_installed_only_on_kubernetes(monkeypatch):
-    """SIGTERM-based preemption handling fires only on K8s.
-
-    On VM clouds (AWS/GCP/Azure), preemption is detected by the
-    metadata poller (PR2). The SIGTERM handler is K8s-specific
-    (kubelet sends SIGTERM during pod deletion / scale-down /
-    evictions). Gate the handler install so non-K8s skylets don't
-    intercept SIGTERM unnecessarily.
-    """
-    from sky.skylet import skylet
-
-    # K8s pod env: KUBERNETES_SERVICE_HOST is set.
-    monkeypatch.setenv('KUBERNETES_SERVICE_HOST', '10.0.0.1')
-    assert skylet._should_install_preemption_sigterm_handler() is True
-
-    # Non-K8s: env not set.
-    monkeypatch.delenv('KUBERNETES_SERVICE_HOST', raising=False)
-    assert skylet._should_install_preemption_sigterm_handler() is False
+# Note: ``test_sigterm_handler_installed_only_on_kubernetes`` was
+# removed in PR2 because it pinned the wrong contract — it asserted
+# the SIGTERM handler should install only on K8s, but the
+# preemption_poller daemon (added in PR2) signals preemption by
+# sending SIGTERM to the skylet's own PID, so the handler is needed
+# on VM clouds too. The corrected contract is pinned in
+# ``tests/unit_tests/test_preemption_poller.py`` by:
+#   - test_should_install_sigterm_handler_on_kubernetes
+#   - test_should_install_sigterm_handler_on_vm_cloud (aws/gcp/azure)
+#   - test_should_not_install_sigterm_handler_when_no_signal_source
 
 
 def test_kubernetes_caps_preemption_hook_timeout_to_600(capsys):

--- a/tests/unit_tests/test_preemption_poller.py
+++ b/tests/unit_tests/test_preemption_poller.py
@@ -1,0 +1,260 @@
+"""Unit tests for `sky.skylet.preemption_poller`.
+
+These tests exercise the per-cloud metadata pollers with mocked HTTP
+responses — no real cloud calls. The poller's only externally visible
+effect on detection is sending SIGTERM to the skylet process; the
+tests assert on that.
+"""
+
+import os
+import signal
+import threading
+import time
+from unittest import mock
+from urllib import error as urlerr
+
+import pytest
+
+from sky.skylet import preemption_poller
+
+
+@pytest.fixture(autouse=True)
+def _fast_intervals(monkeypatch):
+    """Make polling tight so tests finish quickly."""
+    monkeypatch.setattr(preemption_poller, '_AWS_POLL_INTERVAL_SECONDS', 0.01)
+    monkeypatch.setattr(preemption_poller, '_GCP_POLL_INTERVAL_SECONDS', 0.01)
+    monkeypatch.setattr(preemption_poller, '_AZURE_POLL_INTERVAL_SECONDS', 0.01)
+    yield
+
+
+@pytest.fixture
+def captured_sigterm(monkeypatch):
+    """Capture SIGTERM without actually killing the test process.
+
+    Returns an Event that is set on first SIGTERM delivery.
+    """
+    fired = threading.Event()
+
+    def fake_kill(pid, sig):
+        assert sig == signal.SIGTERM
+        assert pid == os.getpid()
+        fired.set()
+
+    monkeypatch.setattr(preemption_poller.os, 'kill', fake_kill)
+    return fired
+
+
+# ---- AWS (IMDSv2) -------------------------------------------------------
+
+
+def _fake_aws_urlopen(spot_action: str = ''):
+    """Returns a fake urlopen callable for AWS IMDSv2.
+
+    ``spot_action`` is the body returned from the spot/instance-action
+    endpoint — the empty string simulates "no action scheduled".
+    """
+
+    class FakeResponse:
+
+        def __init__(self, body: bytes, status: int):
+            self._body = body
+            self.status = status
+
+        def read(self):
+            return self._body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def urlopen(request, timeout=None):  # pylint: disable=unused-argument
+        url = request.full_url if hasattr(request, 'full_url') else request
+        if 'api/token' in url:
+            return FakeResponse(b'token-abc', 200)
+        if 'spot/instance-action' in url:
+            if spot_action:
+                return FakeResponse(spot_action.encode(), 200)
+            # AWS returns 404 when no action scheduled.
+            raise urlerr.HTTPError(url, 404, 'Not Found', {}, None)
+        raise AssertionError(f'Unexpected IMDS URL: {url}')
+
+    return urlopen
+
+
+def test_aws_poller_no_action_no_sigterm(captured_sigterm, monkeypatch):
+    monkeypatch.setattr(preemption_poller.urllib.request, 'urlopen',
+                        _fake_aws_urlopen(''))
+    stop = threading.Event()
+    t = threading.Thread(target=preemption_poller._poll_aws,
+                         args=(stop,),
+                         daemon=True)
+    t.start()
+    # Let it loop a few times then stop.
+    time.sleep(0.1)
+    stop.set()
+    t.join(timeout=1)
+    assert not captured_sigterm.is_set()
+
+
+def test_aws_poller_fires_on_instance_action(captured_sigterm, monkeypatch):
+    body = '{"action":"terminate","time":"2026-01-01T00:00:00Z"}'
+    monkeypatch.setattr(preemption_poller.urllib.request, 'urlopen',
+                        _fake_aws_urlopen(body))
+    stop = threading.Event()
+    t = threading.Thread(target=preemption_poller._poll_aws,
+                         args=(stop,),
+                         daemon=True)
+    t.start()
+    assert captured_sigterm.wait(timeout=2)
+    stop.set()
+    t.join(timeout=1)
+
+
+# ---- GCP (metadata wait_for_change) -------------------------------------
+
+
+def _fake_gcp_urlopen(preempted: str):
+
+    class FakeResponse:
+
+        def __init__(self, body: bytes):
+            self._body = body
+
+        def read(self):
+            return self._body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def urlopen(request, timeout=None):  # pylint: disable=unused-argument
+        url = request.full_url if hasattr(request, 'full_url') else request
+        # Both preempted and maintenance-event endpoints covered here.
+        return FakeResponse(preempted.encode())
+
+    return urlopen
+
+
+def test_gcp_poller_no_preempt(captured_sigterm, monkeypatch):
+    monkeypatch.setattr(preemption_poller.urllib.request, 'urlopen',
+                        _fake_gcp_urlopen('FALSE'))
+    stop = threading.Event()
+    t = threading.Thread(target=preemption_poller._poll_gcp,
+                         args=(stop,),
+                         daemon=True)
+    t.start()
+    time.sleep(0.1)
+    stop.set()
+    t.join(timeout=1)
+    assert not captured_sigterm.is_set()
+
+
+def test_gcp_poller_fires_on_preempt(captured_sigterm, monkeypatch):
+    monkeypatch.setattr(preemption_poller.urllib.request, 'urlopen',
+                        _fake_gcp_urlopen('TRUE'))
+    stop = threading.Event()
+    t = threading.Thread(target=preemption_poller._poll_gcp,
+                         args=(stop,),
+                         daemon=True)
+    t.start()
+    assert captured_sigterm.wait(timeout=2)
+    stop.set()
+    t.join(timeout=1)
+
+
+# ---- Azure (scheduled events) -------------------------------------------
+
+
+def _fake_azure_urlopen(events_json: str):
+
+    class FakeResponse:
+
+        def __init__(self, body: bytes):
+            self._body = body
+
+        def read(self):
+            return self._body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def urlopen(request, timeout=None):  # pylint: disable=unused-argument
+        return FakeResponse(events_json.encode())
+
+    return urlopen
+
+
+def test_azure_poller_no_events(captured_sigterm, monkeypatch):
+    monkeypatch.setattr(
+        preemption_poller.urllib.request, 'urlopen',
+        _fake_azure_urlopen('{"DocumentIncarnation":1,'
+                            '"Events":[]}'))
+    stop = threading.Event()
+    t = threading.Thread(target=preemption_poller._poll_azure,
+                         args=(stop,),
+                         daemon=True)
+    t.start()
+    time.sleep(0.1)
+    stop.set()
+    t.join(timeout=1)
+    assert not captured_sigterm.is_set()
+
+
+def test_azure_poller_fires_on_preempt(captured_sigterm, monkeypatch):
+    events = ('{"DocumentIncarnation":2,'
+              '"Events":[{"EventType":"Preempt","Resources":["vm-1"]}]}')
+    monkeypatch.setattr(preemption_poller.urllib.request, 'urlopen',
+                        _fake_azure_urlopen(events))
+    stop = threading.Event()
+    t = threading.Thread(target=preemption_poller._poll_azure,
+                         args=(stop,),
+                         daemon=True)
+    t.start()
+    assert captured_sigterm.wait(timeout=2)
+    stop.set()
+    t.join(timeout=1)
+
+
+def test_azure_poller_ignores_non_preempt_events(captured_sigterm, monkeypatch):
+    # Freeze/Reboot/Redeploy must not trigger the preemption hook.
+    events = ('{"DocumentIncarnation":3,'
+              '"Events":[{"EventType":"Reboot","Resources":["vm-1"]}]}')
+    monkeypatch.setattr(preemption_poller.urllib.request, 'urlopen',
+                        _fake_azure_urlopen(events))
+    stop = threading.Event()
+    t = threading.Thread(target=preemption_poller._poll_azure,
+                         args=(stop,),
+                         daemon=True)
+    t.start()
+    time.sleep(0.1)
+    stop.set()
+    t.join(timeout=1)
+    assert not captured_sigterm.is_set()
+
+
+# ---- start() dispatch ---------------------------------------------------
+
+
+@pytest.mark.parametrize('cloud,loop', [('aws', '_poll_aws'),
+                                        ('gcp', '_poll_gcp'),
+                                        ('azure', '_poll_azure')])
+def test_start_dispatches_correct_cloud(cloud, loop):
+    with mock.patch.object(preemption_poller, loop) as m:
+        stop = preemption_poller.start(cloud)
+        # Poller is daemonized; give the thread a moment to call into the
+        # patched loop.
+        time.sleep(0.05)
+        m.assert_called_once()
+        stop.set()
+
+
+def test_start_unknown_cloud_raises():
+    with pytest.raises(ValueError):
+        preemption_poller.start('oracle')

--- a/tests/unit_tests/test_preemption_poller.py
+++ b/tests/unit_tests/test_preemption_poller.py
@@ -258,3 +258,43 @@ def test_start_dispatches_correct_cloud(cloud, loop):
 def test_start_unknown_cloud_raises():
     with pytest.raises(ValueError):
         preemption_poller.start('oracle')
+
+
+# ---- skylet boot wiring: SIGTERM handler must be installed when -----------
+# ---- VM poller is running, otherwise the poller's SIGTERM kills the -------
+# ---- skylet without firing the preemption hook --------------------------
+
+
+def test_should_install_sigterm_handler_on_kubernetes(monkeypatch):
+    """On K8s the handler MUST be installed: kubelet's preStop sends
+    SIGTERM via ``pgrep`` and the handler is the only thing that claims
+    the preemption slot and runs hooks. K8s short-circuits cloud
+    detection (returns None), so the K8s gate runs independently."""
+    from sky.skylet import skylet
+    monkeypatch.setenv('KUBERNETES_SERVICE_HOST', '10.0.0.1')
+    assert skylet._should_install_preemption_sigterm_handler(
+        detected_cloud=None) is True
+
+
+@pytest.mark.parametrize('cloud', ['aws', 'gcp', 'azure'])
+def test_should_install_sigterm_handler_on_vm_cloud(monkeypatch, cloud):
+    """On any VM cloud where the poller will run, the handler MUST be
+    installed. The poller signals preemption by sending SIGTERM to the
+    skylet's own PID — without a handler that SIGTERM kills the
+    process before any hook executes, defeating the entire purpose of
+    PR2."""
+    from sky.skylet import skylet
+    monkeypatch.delenv('KUBERNETES_SERVICE_HOST', raising=False)
+    assert skylet._should_install_preemption_sigterm_handler(
+        detected_cloud=cloud) is True
+
+
+def test_should_not_install_sigterm_handler_when_no_signal_source(monkeypatch):
+    """Bare-metal / Slurm / local-dev: no K8s env var, no cloud
+    metadata endpoint reachable. Installing a SIGTERM handler here
+    would mask normal-shutdown signal handling for no benefit (nothing
+    will ever send SIGTERM in a way that should route to hooks)."""
+    from sky.skylet import skylet
+    monkeypatch.delenv('KUBERNETES_SERVICE_HOST', raising=False)
+    assert skylet._should_install_preemption_sigterm_handler(
+        detected_cloud=None) is False


### PR DESCRIPTION
## Summary

Builds on the merged PR1 lifecycle-hooks framework (#9064) by adding the **VM-side preemption detector** that PR1 explicitly deferred. On AWS / GCP / Azure VMs, a daemon thread inside skylet polls the cloud's metadata endpoint and SIGTERMs skylet on a detected spot reclaim — flowing into the same ``hook_executor.try_claim_teardown('preemption')`` path that K8s preStop already uses.

## What changes

- **New module** ``sky/skylet/preemption_poller.py`` (~180 lines).
  - AWS: IMDSv2 ``/latest/meta-data/spot/instance-action`` (404 = clear, 200 = scheduled).
  - GCP: long-poll ``/computeMetadata/v1/instance/preempted?wait_for_change=true``.
  - Azure: IMDS Scheduled Events, filters for ``Preempt`` (ignores Freeze/Reboot/Redeploy).
  - All HTTP via stdlib ``urllib.request`` — no new dependencies.
  - Public API: ``start(cloud) -> threading.Event`` (returned event ``.set()`` stops the daemon).

- **Skylet boot wiring** ``sky/skylet/skylet.py``:
  - ``_detect_cloud_for_preemption_poller()`` probes each cloud's metadata endpoint with a 1s timeout. K8s pods short-circuit via ``KUBERNETES_SERVICE_HOST``.
  - ``_should_install_preemption_sigterm_handler(detected_cloud)`` returns True for **both** K8s (kubelet preStop) **and** VM clouds (poller SIGTERM). Handler installation routes both signal sources through the same hook-executor path.

- **Smoke tests** (S14/S15/S16) for GCP simulate-maintenance, Azure simulate-eviction, and a no-false-positive test on on-demand VMs. AWS is unit-only (no public reclaim-simulation API).

## Why this is in PR2, not PR1

PR1 shipped the framework + K8s preemption + VM autostop/down. The VM preemption-detection daemon was deliberately deferred to keep PR1's review surface small. Until PR2 lands, a ``preemption`` hook on a VM cluster is accepted by the schema and stored on the skylet, but the hook never fires because no signal source delivers preemption notices to the skylet on VM clouds.

## Test plan

**Unit tests** (16 tests, all green locally):

```bash
pytest tests/unit_tests/test_preemption_poller.py -v
```

Covers:
- AWS IMDSv2 token + spot/instance-action polling (positive detect, 404 clear, retry on 5xx)
- GCP wait_for_change long-poll (positive detect, idle, error backoff)
- Azure IMDS scheduled events (Preempt fires; Freeze/Reboot/Redeploy ignored)
- ``start()`` dispatches to the correct cloud loop, raises on unknown cloud
- **SIGTERM-handler-installation contract**: must install on K8s ``OR`` any VM cloud (the bug I caught in the cherry-picked commits)

**Smoke tests** (real-cloud):
- ``pytest tests/smoke_tests/test_lifecycle_hooks.py::test_preemption_gcp_simulate_maintenance --generic-cloud gcp``
- ``pytest tests/smoke_tests/test_lifecycle_hooks.py::test_preemption_azure_simulate_eviction --generic-cloud azure``
- ``pytest tests/smoke_tests/test_lifecycle_hooks.py::test_preemption_no_false_positive --generic-cloud aws``

Plus all existing PR1 hook tests still pass (75 unit tests + the K8s + VM smoke suites).

## Stacked work that comes after

PR3 (worker fan-out) was previously stacked on this branch; the existing PR97 was closed and will be re-opened against this PR2 once it lands.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->