### PR TITLE
[Slurm] Add Slurm-native managed jobs

### DIFF
--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -254,6 +254,37 @@ class SlurmClient:
                                            stream_logs=False)
         logger.debug(f'Successfully cancelled job {job_name}: {stdout}')
 
+    def cancel_job_by_id(self,
+                         job_id: str,
+                         signal: Optional[str] = None,
+                         full: bool = False) -> None:
+        """Cancel a Slurm job by job ID.
+
+        Unlike ``cancel_jobs_by_name`` (which targets ``--name`` and can
+        race with a concurrent same-name attempt), this targets a specific
+        job ID, which is the identity contract for v1 managed jobs (the
+        ``job_id`` resolved from ``head_instance.tags['job_id']``).
+
+        Args:
+            job_id: The Slurm job ID to cancel.
+            signal: Optional signal to send to the job.
+            full: If True, signals the batch script and its children processes.
+                By default, signals other than SIGKILL are not sent to the
+                batch step (the shell script).
+        """
+        cmd = f'scancel {job_id}'
+        if signal is not None:
+            cmd += f' --signal {signal}'
+        if full:
+            cmd += ' --full'
+        rc, stdout, stderr = self._run_slurm_cmd(cmd)
+        subprocess_utils.handle_returncode(rc,
+                                           cmd,
+                                           f'Failed to cancel job {job_id}.',
+                                           stderr=f'{stdout}\n{stderr}',
+                                           stream_logs=False)
+        logger.debug(f'Successfully cancelled job {job_id}: {stdout}')
+
     def info(self) -> str:
         """Get Slurm cluster information.
 

--- a/sky/jobs/__init__.py
+++ b/sky/jobs/__init__.py
@@ -31,9 +31,8 @@ from sky.jobs.utils import ManagedJobCodeGen
 pathlib.Path(JOBS_TASK_YAML_PREFIX).expanduser().parent.mkdir(parents=True,
                                                               exist_ok=True)
 
-# Register the OSS Slurm-native v1 managed-job runtime. Plugins that
-# ship their own ManagedJobRuntime (e.g. K8s v1) append to the chain
-# later via the same ``register`` API.
+# Register the Slurm-native v1 managed-job runtime. Additional
+# runtimes append to the chain later via the same ``register`` API.
 # pylint: disable=wrong-import-position
 from sky.provision.slurm.managed_job_runtime import SlurmManagedJobRuntime
 

--- a/sky/jobs/__init__.py
+++ b/sky/jobs/__init__.py
@@ -1,6 +1,7 @@
 """Managed jobs."""
 import pathlib
 
+from sky.jobs import runtime as _managed_job_runtime
 from sky.jobs.client.sdk import cancel
 from sky.jobs.client.sdk import dashboard
 from sky.jobs.client.sdk import download_logs
@@ -29,6 +30,14 @@ from sky.jobs.utils import ManagedJobCodeGen
 
 pathlib.Path(JOBS_TASK_YAML_PREFIX).expanduser().parent.mkdir(parents=True,
                                                               exist_ok=True)
+
+# Register the OSS Slurm-native v1 managed-job runtime. Plugins that
+# ship their own ManagedJobRuntime (e.g. K8s v1) append to the chain
+# later via the same ``register`` API.
+# pylint: disable=wrong-import-position
+from sky.provision.slurm.managed_job_runtime import SlurmManagedJobRuntime
+
+_managed_job_runtime.register(SlurmManagedJobRuntime())
 __all__ = [
     # Constants
     'JOBS_CONTROLLER_TEMPLATE',

--- a/sky/jobs/runtime.py
+++ b/sky/jobs/runtime.py
@@ -232,34 +232,37 @@ def _is_v1_candidate(handle) -> bool:
 
 
 def _claimants(handle) -> List[ManagedJobRuntime]:
-    """Iterate runtimes that claim ``handle`` via ``owns()``.
+    """Iterate runtimes that claim ``handle``, explicit claims first.
 
-    Backward-compat shim: runtimes that pre-date the chain refactor may
-    not implement ``owns()`` yet. For those, fall back to "claims
-    everything" — their per-hook resolvers already self-filter by
-    returning None for handles they don't recognize.
+    A runtime with ``owns()`` returning True is an explicit claimant.
+    Runtimes that pre-date the chain refactor and lack ``owns()`` are
+    fallback claimants: they are dispatched to (their per-hook
+    resolvers self-filter by returning None for handles they don't
+    recognize) but ordered after every explicit claimant and excluded
+    from the conflict warning — an ``owns()``-less runtime registered
+    alongside an explicit one is the expected plugin configuration,
+    not a bug, and warning on it would fire on every dispatch.
     """
-    claims = []
+    explicit = []
+    fallback = []
     for r in _runtimes:
         owns = getattr(r, 'owns', None)
         if owns is None:
-            # Backward-compat: pre-chain runtimes self-filter inside
-            # each hook via their own ``_resolve_target`` returning None.
-            claims.append(r)
+            fallback.append(r)
             continue
         try:
             if owns(handle):
-                claims.append(r)
+                explicit.append(r)
         except Exception as e:  # pylint: disable=broad-except
             logger.debug('ManagedJobRuntime.owns() raised on %s: %s',
                          type(r).__name__, e)
-    if len(claims) > 1:
+    if len(explicit) > 1:
         logger.warning(
             'Multiple ManagedJobRuntime instances claimed the same '
             'handle: %s. Dispatch will resolve in registration order; '
             'this is usually a configuration bug.',
-            [type(r).__name__ for r in claims])
-    return claims
+            [type(r).__name__ for r in explicit])
+    return explicit + fallback
 
 
 # Module-level dispatch. Each function returns ``None`` when no

--- a/sky/jobs/runtime.py
+++ b/sky/jobs/runtime.py
@@ -340,20 +340,23 @@ def on_before_recovery(
     exit_codes: Optional[List[int]] = None,
     job_id_on_pool_cluster: Optional[int] = None,
 ) -> None:
-    if _current is None:
-        return
-    # Defensive: a runtime registered by an older plugin build may not
-    # implement this hook. Skip rather than crash on version skew.
-    hook = getattr(_current, 'on_before_recovery', None)
-    if hook is None:
-        return
-    hook(  # pylint: disable=not-callable
-        handle,
-        backend,
-        job_id,
-        task_id,
-        exit_codes=exit_codes,
-        job_id_on_pool_cluster=job_id_on_pool_cluster)
+    # This hook fires for legacy (has_ray) handles too — runtimes may
+    # capture VM logs before recovery — and ``handle`` may be None when
+    # the cluster is already unreachable. Runtimes self-filter inside
+    # the hook.
+    for r in _claimants(handle):
+        # Defensive: a runtime registered by an older plugin build may not
+        # implement this hook. Skip rather than crash on version skew.
+        hook = getattr(r, 'on_before_recovery', None)
+        if hook is None:
+            continue
+        hook(  # pylint: disable=not-callable
+            handle,
+            backend,
+            job_id,
+            task_id,
+            exit_codes=exit_codes,
+            job_id_on_pool_cluster=job_id_on_pool_cluster)
 
 
 def tail_logs(

--- a/sky/jobs/runtime.py
+++ b/sky/jobs/runtime.py
@@ -5,10 +5,14 @@ lifecycle. Each method takes a cluster handle and returns ``None``
 to defer to the default behavior at the call site, or a non-None
 result to handle the operation.
 
-Register a runtime with ``register(MyRuntime())``. Callers use the
-module-level dispatch (``runtime.get_job_status(...)``,
-``runtime.tail_logs(...)``, etc.) — the registered instance is
-private to this module.
+Register a runtime with ``register(MyRuntime())``. Multiple runtimes
+can be registered and form a dispatch chain: the chain iterates in
+registration order and returns the first non-None result. The previous
+"last-wins" single-runtime semantics is gone — runtimes coexist now.
+
+Callers use the module-level dispatch (``runtime.get_job_status(...)``,
+``runtime.tail_logs(...)``, etc.) — the chain is private to this
+module.
 """
 import typing
 from typing import Dict, List, Optional, Protocol, Tuple
@@ -34,6 +38,21 @@ class ManagedJobRuntime(Protocol):
     """
 
     # pylint: disable=unnecessary-ellipsis
+
+    def owns(
+        self,
+        handle: Optional['cloud_vm_ray_backend.CloudVmRayResourceHandle'],
+    ) -> bool:
+        """Cheap pure-function claim check used by chain dispatch.
+
+        Must not perform I/O. Implementations should answer from
+        ``handle.provision_runtime_metadata`` + the provider block in
+        ``handle.cluster_yaml`` only. Returning False short-circuits
+        every other hook for this runtime — so it MUST agree with the
+        per-hook resolve checks (a runtime that returns ``owns=True``
+        then returns ``None`` from every hook is a bug).
+        """
+        ...
 
     def get_job_status(
         self,
@@ -150,31 +169,101 @@ class ManagedJobRuntime(Protocol):
         ...
 
 
-_current: Optional[ManagedJobRuntime] = None
+_runtimes: List[ManagedJobRuntime] = []
 
 
 def register(runtime: ManagedJobRuntime) -> None:
-    """Install ``runtime`` as the active managed-job runtime.
+    """Append ``runtime`` to the dispatch chain.
 
-    Last registration wins.
+    Last-wins semantics from the pre-chain implementation are gone.
+    Two runtimes claiming the same handle is a configuration bug;
+    dispatch resolves in registration order and the first claimer
+    wins, but a warning is logged when more than one ``owns(handle)``
+    returns True for the same handle so the conflict surfaces.
     """
-    global _current  # pylint: disable=global-statement
-    _current = runtime
+    _runtimes.append(runtime)
     logger.debug('Registered ManagedJobRuntime: %s', type(runtime).__name__)
 
 
+def replace(old_cls: type, new_runtime: ManagedJobRuntime) -> None:
+    """Swap an already-registered runtime in place.
+
+    Use case: an external integration ships an updated runtime and
+    wants to upgrade without changing chain order. Without this, the
+    only alternative would be append-then-shadow (fragile — relies on
+    first-non-None ordering).
+    """
+    for i, r in enumerate(_runtimes):
+        if isinstance(r, old_cls):
+            _runtimes[i] = new_runtime
+            logger.debug('Replaced ManagedJobRuntime: %s -> %s',
+                         old_cls.__name__,
+                         type(new_runtime).__name__)
+            return
+    _runtimes.append(new_runtime)
+
+
 def is_registered() -> bool:
-    """Whether a runtime is currently registered.
+    """Whether any runtime is currently registered.
 
     Cheap synchronous check — async callers can guard
     ``asyncio.to_thread(runtime.X, ...)`` on this so they don't pay
-    thread-pool overhead when no plugin is installed.
+    thread-pool overhead when no runtime is installed.
     """
-    return _current is not None
+    return bool(_runtimes)
+
+
+def _is_v1_candidate(handle) -> bool:
+    """Cheap pre-filter so the chain skips obvious non-v1 handles.
+
+    Default-to-legacy: missing metadata means a pre-v1 handle from
+    before ``ProvisionRuntimeMetadata`` was added to ``ProvisionRecord``
+    — those handles exist in production, and treating them as v1
+    candidates would mean every status poll for an old AWS/GCP cluster
+    fans out to parse YAML inside N runtime claim checks.
+    ``getattr(..., 'has_ray', True)`` treats unset as "yes, has ray" →
+    not v1.
+    """
+    if handle is None:
+        return False
+    metadata = getattr(handle, 'provision_runtime_metadata', None)
+    has_ray = getattr(metadata, 'has_ray', True)  # default True == legacy
+    return not has_ray
+
+
+def _claimants(handle) -> List[ManagedJobRuntime]:
+    """Iterate runtimes that claim ``handle`` via ``owns()``.
+
+    Backward-compat shim: runtimes that pre-date the chain refactor may
+    not implement ``owns()`` yet. For those, fall back to "claims
+    everything" — their per-hook resolvers already self-filter by
+    returning None for handles they don't recognize.
+    """
+    claims = []
+    for r in _runtimes:
+        owns = getattr(r, 'owns', None)
+        if owns is None:
+            # Backward-compat: pre-chain runtimes self-filter inside
+            # each hook via their own ``_resolve_target`` returning None.
+            claims.append(r)
+            continue
+        try:
+            if owns(handle):
+                claims.append(r)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug('ManagedJobRuntime.owns() raised on %s: %s',
+                         type(r).__name__, e)
+    if len(claims) > 1:
+        logger.warning(
+            'Multiple ManagedJobRuntime instances claimed the same '
+            'handle: %s. Dispatch will resolve in registration order; '
+            'this is usually a configuration bug.',
+            [type(r).__name__ for r in claims])
+    return claims
 
 
 # Module-level dispatch. Each function returns ``None`` when no
-# runtime is registered, so callers fall through to their default.
+# runtime claims the handle, so callers fall through to their default.
 
 
 def get_job_status(
@@ -182,35 +271,51 @@ def get_job_status(
     cluster_name: str,
     returncode: Optional[int] = None,
 ) -> Optional[Tuple[Optional['job_lib.JobStatus'], Optional[str]]]:
-    if _current is None:
+    if not _is_v1_candidate(handle):
         return None
-    return _current.get_job_status(handle, cluster_name, returncode=returncode)
+    for r in _claimants(handle):
+        result = r.get_job_status(handle, cluster_name, returncode=returncode)
+        if result is not None:
+            return result
+    return None
 
 
 def get_job_submitted_at(
     handle: Optional['cloud_vm_ray_backend.CloudVmRayResourceHandle'],
     cluster_name: str,
 ) -> Optional[float]:
-    if _current is None:
+    if not _is_v1_candidate(handle):
         return None
-    return _current.get_job_submitted_at(handle, cluster_name)
+    for r in _claimants(handle):
+        result = r.get_job_submitted_at(handle, cluster_name)
+        if result is not None:
+            return result
+    return None
 
 
 def get_job_ended_at(
     handle: Optional['cloud_vm_ray_backend.CloudVmRayResourceHandle'],
     cluster_name: str,
 ) -> Optional[float]:
-    if _current is None:
+    if not _is_v1_candidate(handle):
         return None
-    return _current.get_job_ended_at(handle, cluster_name)
+    for r in _claimants(handle):
+        result = r.get_job_ended_at(handle, cluster_name)
+        if result is not None:
+            return result
+    return None
 
 
 def get_exit_codes(
     handle: 'cloud_vm_ray_backend.CloudVmRayResourceHandle',
 ) -> Optional[List[int]]:
-    if _current is None:
+    if not _is_v1_candidate(handle):
         return None
-    return _current.get_exit_codes(handle)
+    for r in _claimants(handle):
+        result = r.get_exit_codes(handle)
+        if result is not None:
+            return result
+    return None
 
 
 def download_logs(
@@ -218,9 +323,13 @@ def download_logs(
     job_id: int,
     task_id: Optional[int],
 ) -> Optional[str]:
-    if _current is None:
+    if not _is_v1_candidate(handle):
         return None
-    return _current.download_logs(handle, job_id, task_id)
+    for r in _claimants(handle):
+        result = r.download_logs(handle, job_id, task_id)
+        if result is not None:
+            return result
+    return None
 
 
 def on_before_recovery(
@@ -259,42 +368,57 @@ def tail_logs(
     tail: Optional[int],
     tail_offset: Optional[int] = None,
 ) -> Optional[int]:
-    if _current is None:
+    if not _is_v1_candidate(handle):
         return None
-    return _current.tail_logs(
-        handle,
-        backend=backend,
-        job_id=job_id,
-        task_id=task_id,
-        job_id_on_cluster=job_id_on_cluster,
-        worker=worker,
-        follow=follow,
-        tail=tail,
-        tail_offset=tail_offset,
-    )
+    for r in _claimants(handle):
+        result = r.tail_logs(
+            handle,
+            backend=backend,
+            job_id=job_id,
+            task_id=task_id,
+            job_id_on_cluster=job_id_on_cluster,
+            worker=worker,
+            follow=follow,
+            tail=tail,
+            tail_offset=tail_offset,
+        )
+        if result is not None:
+            return result
+    return None
 
 
 def job_group_envs(
     tasks: List['task_lib.Task'],
     job_id: int,
 ) -> Optional[Dict[str, str]]:
-    if _current is None:
-        return None
-    return _current.job_group_envs(tasks, job_id)
+    # No handle here — JobGroup envs are runtime-agnostic; iterate
+    # all runtimes and return the first non-None.
+    for r in _runtimes:
+        result = r.job_group_envs(tasks, job_id)
+        if result is not None:
+            return result
+    return None
 
 
 def k8s_dns_addresses_for_task(
     task: 'task_lib.Task',
     job_id: int,
 ) -> Optional[List[str]]:
-    if _current is None:
-        return None
-    return _current.k8s_dns_addresses_for_task(task, job_id)
+    # No handle here — DNS lookup is task-shaped; iterate all runtimes.
+    for r in _runtimes:
+        result = r.k8s_dns_addresses_for_task(task, job_id)
+        if result is not None:
+            return result
+    return None
 
 
 def k8s_dns_addresses_for_handle(
     handle: 'cloud_vm_ray_backend.CloudVmRayResourceHandle',
 ) -> Optional[List[str]]:
-    if _current is None:
+    if not _is_v1_candidate(handle):
         return None
-    return _current.k8s_dns_addresses_for_handle(handle)
+    for r in _claimants(handle):
+        result = r.k8s_dns_addresses_for_handle(handle)
+        if result is not None:
+            return result
+    return None

--- a/sky/provision/__init__.py
+++ b/sky/provision/__init__.py
@@ -144,6 +144,18 @@ def get_registered_provisioner(cloud_name: str) -> Optional[Provisioner]:
     return _registered_provisioners.get(cloud_name.lower())
 
 
+# Register the OSS Slurm provisioner with its v1 managed-job template
+# override hook. The slurm module's routed lifecycle functions
+# (``run_instances``, ``terminate_instances`` etc.) are still picked
+# up by the existing cloud-name lookup in ``_route_to_cloud_impl`` —
+# this registration only adds the ``template_override`` capability.
+register_provisioner(
+    'slurm',
+    module=slurm,
+    template_override=slurm.instance.template_override,
+)
+
+
 def _route_to_cloud_impl(func):
 
     @functools.wraps(func)

--- a/sky/provision/slurm/config.py
+++ b/sky/provision/slurm/config.py
@@ -9,5 +9,14 @@ logger = logging.getLogger(__name__)
 def bootstrap_instances(
         region: str, cluster_name: str,
         config: common.ProvisionConfig) -> common.ProvisionConfig:
-    del region, cluster_name  # unused
+    """Bootstrap is a no-op for Slurm.
+
+    For both legacy and v1 the cluster-specific directories are created
+    by the sbatch script's preamble — there is no long-lived login-node
+    state to set up here. v1 in particular relies on
+    ``_create_managed_job_v1`` to handle its own preconditions
+    (cleanup, drain, reattach) before submitting, so this hook stays a
+    pure passthrough. See PLAN.md gap #10.
+    """
+    del region, cluster_name  # unused.
     return config

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -1417,6 +1417,7 @@ def _slurm_client_from_provider_config(
         ssh_proxy_command=ssh_config_dict.get('proxycommand', None),
         ssh_proxy_jump=ssh_config_dict.get('proxyjump', None),
         identities_only=ssh_config_dict.get('identities_only', False),
+        slurm_user=provider_config.get('slurm_user'),
     )
 
 
@@ -2359,6 +2360,7 @@ def _create_managed_job_v1(
     ssh_proxy_command = ssh_config_dict.get('proxycommand', None)
     ssh_proxy_jump = ssh_config_dict.get('proxyjump', None)
     identities_only = ssh_config_dict.get('identities_only', False)
+    slurm_user = provider_config.get('slurm_user')
     partition = slurm_utils.get_partition_from_config(provider_config)
 
     client = slurm.SlurmClient(
@@ -2369,6 +2371,7 @@ def _create_managed_job_v1(
         ssh_proxy_command=ssh_proxy_command,
         ssh_proxy_jump=ssh_proxy_jump,
         identities_only=identities_only,
+        slurm_user=slurm_user,
     )
 
     # ---- Drain COMPLETING jobs before submitting. Ported verbatim ----
@@ -2480,7 +2483,11 @@ def _create_managed_job_v1(
             )
 
     # ---- Fresh submission ----
-    login_node_runner = command_runner.SSHCommandRunner(
+    # The slurm_user-wrapped runner keeps the whole submission consistent
+    # with the submit user: the home dir (and thus the sbatch script,
+    # output file, and cluster dir) resolve to the submit user's home,
+    # and the script is rsynced as that user.
+    login_node_runner = command_runner.SlurmLoginNodeCommandRunner(
         (ssh_host, ssh_port),
         ssh_user,
         ssh_key,
@@ -2488,6 +2495,7 @@ def _create_managed_job_v1(
         ssh_proxy_jump=ssh_proxy_jump,
         enable_interactive_auth=True,
         disable_identities_only=not identities_only,
+        slurm_user=slurm_user,
     )
     remote_home_dir = login_node_runner.get_remote_home_dir()
 

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -966,6 +966,20 @@ def get_cluster_info(
     del region
     assert provider_config is not None, cluster_name_on_cloud
 
+    if is_managed_job_v1_provider_config(provider_config):
+        info = _get_cluster_info_v1(cluster_name_on_cloud, provider_config)
+        if info is not None:
+            return info
+        # Safe default: an empty ClusterInfo. Mirrors the legacy
+        # "no running jobs" branch below — the controller treats this
+        # as "no instances yet" rather than crashing.
+        return common.ClusterInfo(
+            instances={},
+            head_instance_id=None,
+            provider_name='slurm',
+            provider_config=provider_config,
+        )
+
     # The SSH host is the remote machine running slurmctld daemon.
     # Cross-cluster operations are supported by interacting with
     # the current controller. For details, please refer to
@@ -1626,6 +1640,129 @@ def _query_instances_v1(
             statuses[cluster_name_on_cloud] = (sky_status, sacct_state)
 
     return statuses
+
+
+def _v1_sacct_node_list(client: 'slurm.SlurmClient',
+                        job_id: str) -> Optional[List[str]]:
+    """Recover the per-job node list from ``sacct`` when squeue is empty.
+
+    Used by ``_get_cluster_info_v1`` as a fallback for jobs that have
+    aged out of squeue. ``NodeList`` is on the parent allocation row;
+    ``scontrol show hostnames`` expands the compact Slurm hostlist
+    notation (e.g. ``node-[01-03]``) into individual node names.
+    """
+    cmd = (f'sacct -j {job_id} --format=NodeList --parsable2 --noheader -X')
+    # pylint: disable=protected-access
+    rc, stdout, _ = client._run_slurm_cmd(cmd)
+    if rc != 0:
+        return None
+    nodelist: Optional[str] = None
+    for line in stdout.splitlines():
+        value = line.strip()
+        if not value or value == 'None assigned':
+            continue
+        nodelist = value
+        break
+    if nodelist is None:
+        return None
+    expand_cmd = f'scontrol show hostnames {shlex.quote(nodelist)}'
+    rc, stdout, _ = client._run_slurm_cmd(expand_cmd)
+    if rc != 0:
+        return None
+    nodes = [line.strip() for line in stdout.splitlines() if line.strip()]
+    return nodes if nodes else None
+
+
+def _get_cluster_info_v1(
+        cluster_name_on_cloud: str,
+        provider_config: Dict[str, Any]) -> Optional[common.ClusterInfo]:
+    """v1 ``get_cluster_info``: minimal shape, no SSH-port shenanigans.
+
+    Unlike the legacy path's ``InstanceInfo(ssh_port=ssh_port,
+    external_ip=ssh_host, ...)`` (which is misleading on v1 — SkyPilot
+    never SSHes to the compute node), the v1 shape mirrors K8s v1:
+    no external_ip, empty ssh_user override, and the InstanceInfo's
+    ``ssh_port`` left at its default. Tags carry the structured
+    ``job_id`` / ``node`` / ``TAG_SKYPILOT_CLUSTER_NAME`` so
+    ``_resolve_slurm_target`` (managed_job_runtime) finds the right
+    job_id without parsing.
+
+    Returns ``None`` (not a ``ClusterInfo``) when listing nodes fails
+    even after the sacct fallback — callers should treat that as
+    "no instances yet" and fall through to a safe default.
+    """
+    client = _slurm_client_from_provider_config(provider_config)
+
+    try:
+        running_jobs = client.query_jobs(cluster_name_on_cloud, ['running'])
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'V1 get_cluster_info: squeue query failed: {e}')
+        return None
+
+    if not running_jobs:
+        # No running job — return empty so caller treats as "no instances
+        # yet" / cluster torn down.
+        return common.ClusterInfo(
+            instances={},
+            head_instance_id=None,
+            provider_name='slurm',
+            provider_config=provider_config,
+        )
+    assert len(running_jobs) == 1, (
+        f'Multiple running jobs found for v1 cluster '
+        f'{cluster_name_on_cloud}: {running_jobs}. Expected single-job-per'
+        '-name (enforced by _create_managed_job_v1).')
+
+    job_id = running_jobs[0]
+    nodes: List[str] = []
+    try:
+        nodes, _ = client.get_job_nodes(job_id)
+    except Exception as e:  # pylint: disable=broad-except
+        # Fall back to sacct — the job may have just exited and squeue
+        # is briefly out of sync, or get_job_nodes' scontrol-show-node
+        # invocation hit a transient.
+        logger.debug(f'V1 get_cluster_info: get_job_nodes({job_id}) failed: '
+                     f'{e}; trying sacct.')
+        recovered = _v1_sacct_node_list(client, job_id)
+        if recovered:
+            nodes = recovered
+
+    if not nodes:
+        # Give the caller a None so it can fall through to its safe
+        # default rather than emitting an empty-instances ClusterInfo
+        # that downstream code might interpret as "definitely no
+        # nodes".
+        logger.debug(f'V1 get_cluster_info: no nodes resolved for job '
+                     f'{job_id}; returning None.')
+        return None
+
+    instances: Dict[str, List[common.InstanceInfo]] = {}
+    for node in nodes:
+        instance_id = slurm_utils.instance_id(job_id, node)
+        instances[instance_id] = [
+            common.InstanceInfo(
+                instance_id=instance_id,
+                # V1 never SSHes to the compute node; leave internal_ip
+                # empty (mirrors K8s v1's empty pod_ip handling).
+                internal_ip='',
+                external_ip=None,
+                tags={
+                    constants.TAG_SKYPILOT_CLUSTER_NAME: cluster_name_on_cloud,
+                    'job_id': str(job_id),
+                    'node': node,
+                },
+                node_name=instance_id,
+            )
+        ]
+
+    return common.ClusterInfo(
+        instances=instances,
+        head_instance_id=slurm_utils.instance_id(job_id, nodes[0]),
+        provider_name='slurm',
+        # V1 has no SSH user — runtime never executes against the node.
+        ssh_user='',
+        provider_config=provider_config,
+    )
 
 
 def _all_resource_alternatives_are_slurm(task: 'task_lib.Task') -> bool:

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -1645,8 +1645,21 @@ def _query_instances_v1(
                               Optional[str]]] = {}
     seen_job_ids: set = set()
 
-    # --- squeue: live jobs (pending/running/completing/...) and recent ---
-    # --- terminal jobs within the MinJobAge window. ---
+    # --- squeue: gather all job_ids across the live + recently-terminal
+    # filter set, then pick ONLY the most-recent attempt. ---
+    #
+    # On recovery, the controller resubmits under the same
+    # cluster_name_on_cloud. Within ``MinJobAge`` (default 300s) squeue
+    # surfaces every recent attempt of that name. If we report all of
+    # them, ``backend_utils._update_cluster_status`` sees
+    # ``len(node_statuses) > launched_nodes`` and raises
+    # ``ClusterStatusFetchingError`` ("Found N node(s) with the same
+    # cluster name tag"), spinning the launch retry loop.
+    #
+    # Slurm job IDs are monotonic per slurmctld lifetime — the highest
+    # ID wins. We collect (job_id, state) pairs across the full filter
+    # set and keep the row with the largest job_id only.
+    candidates: Dict[str, str] = {}  # job_id -> upper-case Slurm state
     for state_filter in [
             'pending', 'running', 'completing', 'completed', 'cancelled',
             'failed', 'node_fail'
@@ -1671,32 +1684,39 @@ def _query_instances_v1(
             continue
         for job_id in job_ids:
             seen_job_ids.add(job_id)
-            sky_status = _V1_SLURM_STATE_TO_CLUSTER_STATUS.get(state)
-            if sky_status is None:
-                if non_terminated_only:
-                    continue
-                try:
-                    reason = client.get_job_reason(job_id)
-                except Exception:  # pylint: disable=broad-except
-                    reason = None
-                statuses[job_id] = (None, reason)
-                continue
+            candidates[job_id] = state
+
+    if candidates:
+        try:
+            best_job_id = str(max(int(j) for j in candidates))
+        except ValueError:
+            # Non-numeric job id (e.g. federated cluster). Fall back to
+            # lexicographic max — rare on this path; the legacy slurm
+            # adaptor already enforces numeric job ids.
+            best_job_id = max(candidates)
+        best_state = candidates[best_job_id]
+        sky_status = _V1_SLURM_STATE_TO_CLUSTER_STATUS.get(best_state)
+        if sky_status is None and not non_terminated_only:
             try:
-                nodes, _ = client.get_job_nodes(job_id)
+                reason = client.get_job_reason(best_job_id)
+            except Exception:  # pylint: disable=broad-except
+                reason = None
+            statuses[best_job_id] = (None, reason)
+        elif sky_status is not None:
+            try:
+                nodes, _ = client.get_job_nodes(best_job_id)
             except Exception as e:  # pylint: disable=broad-except
-                # PENDING jobs may not yet have nodes; the empty result
-                # below is fine. Other failures we surface as no nodes.
-                logger.debug(f'V1 query_instances: get_job_nodes({job_id}) '
-                             f'failed: {e}')
+                logger.debug(f'V1 query_instances: get_job_nodes('
+                             f'{best_job_id}) failed: {e}')
                 nodes = []
             if not nodes:
-                # Surface the job-id keyed entry so the caller sees the
-                # cluster is in INIT.
-                statuses[job_id] = (sky_status, None)
-                continue
-            for node in nodes:
-                instance_id = slurm_utils.instance_id(job_id, node)
-                statuses[instance_id] = (sky_status, None)
+                # Surface the job-id keyed entry so the caller sees a
+                # single-entry cluster (matches launched_nodes=1).
+                statuses[best_job_id] = (sky_status, None)
+            else:
+                for node in nodes:
+                    instance_id = slurm_utils.instance_id(best_job_id, node)
+                    statuses[instance_id] = (sky_status, None)
 
     # --- sacct: terminal state for jobs aged past MinJobAge. ---
     # Only consult sacct if squeue didn't already produce a live entry,

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -288,6 +288,34 @@ def _wait_for_job_nodes(
             last_state = state
 
         if state is None:
+            # ``squeue --jobs <id>`` returns empty for terminal jobs by
+            # default (squeue's default filter only shows
+            # pending/running). For a fast-failing v1 job (e.g.
+            # OOM-killed within seconds), we'll observe PENDING then
+            # None even though the job is well within MinJobAge.
+            # Consult sacct to distinguish "terminated already" from
+            # "genuinely not found".
+            sacct_state = _v1_sacct_job_state(client, job_id)
+            _SLURM_TERMINAL = ('COMPLETED', 'CANCELLED', 'FAILED', 'TIMEOUT',
+                               'NODE_FAIL', 'BOOT_FAIL', 'OUT_OF_MEMORY',
+                               'DEADLINE', 'SPECIAL_EXIT', 'PREEMPTED',
+                               'REVOKED')
+            if sacct_state in _SLURM_TERMINAL:
+                # The job ran (possibly very briefly) and is already
+                # done. Return cleanly so the caller can build a
+                # ProvisionRecord from sacct's NodeList; the managed-job
+                # controller's first ``get_job_status`` poll will then
+                # surface the terminal state via the chain registry,
+                # and the user-code-failure / SUCCEEDED branch will
+                # fire. Without this, the provisioner raises and the
+                # controller misclassifies fast-failing user code
+                # (e.g. OOM-kill) as an infrastructure error.
+                logger.info(
+                    f'Job {job_id} reached terminal state {sacct_state} '
+                    'before _wait_for_job_nodes observed nodes; returning '
+                    'cleanly so the caller surfaces the terminal status '
+                    'via the managed-job runtime.')
+                return
             raise RuntimeError(f'Job {job_id} not found. It may have been '
                                'cancelled or failed.')
 
@@ -2387,6 +2415,24 @@ def _create_managed_job_v1(
     _wait_for_job_nodes(client, job_id, provision_timeout, partition,
                         _on_pending)
     nodes, _ = client.get_job_nodes(job_id)
+    if not nodes:
+        # Fast-failing job: terminal before _wait_for_job_nodes saw a
+        # node allocation. ``get_job_nodes`` (scontrol show job) returns
+        # empty for terminal jobs; fall back to sacct's NodeList, which
+        # records the node the job actually ran on. The ProvisionRecord
+        # we return is still valid — the controller's next
+        # ``get_job_status`` poll will surface the terminal state via
+        # the chain registry and the user-code-failure /
+        # cluster-up-job-failed branch will fire.
+        nodes = _v1_sacct_node_list(client, job_id) or []
+        if not nodes:
+            raise RuntimeError(
+                f'V1 Slurm job {job_id} terminated before nodes were '
+                'observable and sacct has no NodeList record; cannot '
+                'construct a ProvisionRecord.')
+        logger.info(
+            f'V1 Slurm job {job_id} finished fast; recovered '
+            f'NodeList={nodes} from sacct.')
     rich_utils.force_update_status(
         ux_utils.spinner_message('Launching', cluster_name=cluster_name))
 

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -2193,6 +2193,34 @@ def _build_env_exports(envs: Optional[Dict[str, str]]) -> str:
     return '\n'.join(lines) + '\n'
 
 
+def _build_runtime_env_exports(num_nodes: int, accelerator_count: int) -> str:
+    """Render the SkyPilot runtime env vars for the sbatch preamble.
+
+    Matches the contract the legacy executor provides
+    (``sky/skylet/executor/slurm.py``): ``SKYPILOT_NUM_NODES``,
+    ``SKYPILOT_NUM_GPUS_PER_NODE``, and newline-separated
+    ``SKYPILOT_NODE_IPS``. These are allocation-wide, so they are
+    computed once in the preamble (where ``scontrol`` is available —
+    inside pyxis containers it may not be) and propagate into the srun
+    tasks via the environment. The per-task ``SKYPILOT_NODE_RANK`` is
+    exported inside the srun body instead. Nodes that fail DNS
+    resolution fall back to their hostname, which is an equally valid
+    rendezvous address on clusters that schedule by nodename.
+    """
+    return ('# === SkyPilot runtime env vars ===\n'
+            f'export {skylet_constants.SKYPILOT_NUM_NODES}={num_nodes}\n'
+            f'export {skylet_constants.SKYPILOT_NUM_GPUS_PER_NODE}='
+            f'{accelerator_count}\n'
+            f'export {skylet_constants.SKYPILOT_SETUP_NUM_GPUS_PER_NODE}='
+            f'{accelerator_count}\n'
+            f'{skylet_constants.SKYPILOT_NODE_IPS}=$(for host in '
+            '$(scontrol show hostnames "$SLURM_JOB_NODELIST"); do\n'
+            '  addr=$(getent ahostsv4 "$host" | awk \'NR==1 {print $1}\')\n'
+            '  echo "${addr:-$host}"\n'
+            'done)\n'
+            f'export {skylet_constants.SKYPILOT_NODE_IPS}\n')
+
+
 def _build_v1_sbatch_script(
     *,
     cluster_name_on_cloud: str,
@@ -2242,16 +2270,23 @@ def _build_v1_sbatch_script(
     # global shell flag we impose — legacy doesn't add ``-e`` or ``-u``
     # and user setup blocks routinely rely on ``+u`` (sourcing
     # unset-var-tolerant rc files) and ``|| true``-style guards.
+    # ``SKYPILOT_NODE_RANK`` is per-task, so it must be derived inside
+    # the srun step (``SLURM_PROCID`` is 0..N-1 with
+    # ``--ntasks-per-node=1``); the quoted script defers ``$``
+    # expansion to task runtime.
     user_setup = (setup or '').strip()
     user_run = (run or '').strip()
-    if user_setup and user_run:
-        user_script = f'set -o pipefail\n{user_setup}\n{user_run}'
-    elif user_setup:
-        user_script = f'set -o pipefail\n{user_setup}'
-    elif user_run:
-        user_script = f'set -o pipefail\n{user_run}'
-    else:
-        user_script = 'set -o pipefail\n# no setup / run specified'
+    script_lines = [
+        'set -o pipefail',
+        f'export {skylet_constants.SKYPILOT_NODE_RANK}="$SLURM_PROCID"',
+    ]
+    if user_setup:
+        script_lines.append(user_setup)
+    if user_run:
+        script_lines.append(user_run)
+    if not user_setup and not user_run:
+        script_lines.append('# no setup / run specified')
+    user_script = '\n'.join(script_lines)
     quoted_user_script = shlex.quote(user_script)
 
     # Container args (pyxis/enroot). Per-job container name (suffix with
@@ -2275,6 +2310,10 @@ def _build_v1_sbatch_script(
 
     workdir_block = _build_workdir_block(workdir)
     file_mounts_block = _build_file_mounts_block(file_mounts)
+    # Runtime vars come before user envs so user-defined values win on
+    # collision.
+    runtime_env_exports = _build_runtime_env_exports(num_nodes,
+                                                     accelerator_count)
     env_exports = _build_env_exports(envs)
 
     # pylint: disable=line-too-long
@@ -2292,6 +2331,7 @@ def _build_v1_sbatch_script(
             f'\n'
             f'{workdir_block}'
             f'{file_mounts_block}'
+            f'{runtime_env_exports}'
             f'{env_exports}'
             f'\n'
             f'{srun_line}\n')

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -863,6 +863,11 @@ def query_instances(
     del cluster_name, retry_if_missing  # Unused for Slurm
     assert provider_config is not None, (cluster_name_on_cloud, provider_config)
 
+    if is_managed_job_v1_provider_config(provider_config):
+        return _query_instances_v1(cluster_name_on_cloud,
+                                   provider_config,
+                                   non_terminated_only=non_terminated_only)
+
     ssh_config_dict = provider_config['ssh']
     ssh_host = ssh_config_dict['hostname']
     ssh_port = int(ssh_config_dict['port'])
@@ -1459,6 +1464,168 @@ def _terminate_managed_job_v1(cluster_name_on_cloud: str,
         f'V1 Slurm job {job_id} ({cluster_name_on_cloud}) did not leave '
         f'RUNNING within {_V1_SCANCEL_LEAVE_RUNNING_TIMEOUT_SECONDS}s after '
         'scancel. The controller may briefly observe a stale state.')
+
+
+# Mapping from upper-case Slurm states (as returned by ``squeue`` /
+# ``sacct``) to a SkyPilot ``ClusterStatus``. Terminal states map to
+# ``None`` so callers can short-circuit cleanup. Aligned with the
+# state space documented at
+# https://slurm.schedmd.com/squeue.html#SECTION_JOB-STATE-CODES — see
+# also ``managed_job_runtime._slurm_state_to_job_status``.
+_V1_SLURM_STATE_TO_CLUSTER_STATUS: Dict[
+    str, Optional[status_lib.ClusterStatus]] = {
+        'PENDING': status_lib.ClusterStatus.INIT,
+        'CONFIGURING': status_lib.ClusterStatus.INIT,
+        'RESV_DEL_HOLD': status_lib.ClusterStatus.INIT,
+        'REQUEUED': status_lib.ClusterStatus.INIT,
+        'REQUEUE_HOLD': status_lib.ClusterStatus.INIT,
+        'REQUEUE_FED': status_lib.ClusterStatus.INIT,
+        'RESIZING': status_lib.ClusterStatus.INIT,
+        'RUNNING': status_lib.ClusterStatus.UP,
+        'COMPLETING': status_lib.ClusterStatus.UP,
+        'SIGNALING': status_lib.ClusterStatus.UP,
+        'STAGE_OUT': status_lib.ClusterStatus.UP,
+        'SUSPENDED': status_lib.ClusterStatus.UP,
+        # Terminal — ``None`` means "no longer an instance".
+        'COMPLETED': None,
+        'CANCELLED': None,
+        'FAILED': None,
+        'TIMEOUT': None,
+        'NODE_FAIL': None,
+        'BOOT_FAIL': None,
+        'DEADLINE': None,
+        'OUT_OF_MEMORY': None,
+        'PREEMPTED': None,
+        'REVOKED': None,
+        'SPECIAL_EXIT': None,
+    }
+
+
+def _v1_sacct_job_state(client: 'slurm.SlurmClient',
+                        job_id_or_name: str) -> Optional[str]:
+    """Query ``sacct`` for the parent-row terminal state of a job.
+
+    Used by ``_query_instances_v1`` to surface terminal state for jobs
+    that have aged past squeue's ``MinJobAge`` window (default 300s) —
+    PLAN.md gap #12. ``--name`` is accepted by sacct, so we can key on
+    either job id or cluster_name_on_cloud.
+
+    Returns the upper-cased state of the most recent matching allocation
+    row, or ``None`` if sacct returns nothing parseable.
+    """
+    # Use ``-X`` (= ``--allocations``) to skip step rows. Quoting note:
+    # the caller may pass a numeric job id or a cluster name; both are
+    # safe to substitute (cluster names are validated against
+    # ``CLUSTER_NAME_VALID_REGEX``, and job ids are numeric).
+    is_numeric = job_id_or_name.isdigit()
+    key_flag = '-j' if is_numeric else '--name'
+    cmd = (f'sacct {key_flag} {job_id_or_name} --format=JobID,State '
+           '--parsable2 --noheader -X')
+    # pylint: disable=protected-access
+    rc, stdout, _ = client._run_slurm_cmd(cmd)
+    if rc != 0:
+        return None
+    # Take the *last* row — sacct lists rows oldest-first, and on
+    # recovery_strategy reuse the same cluster name can have multiple
+    # historical rows. The last one is the most recent attempt.
+    last_state: Optional[str] = None
+    for line in stdout.splitlines():
+        parts = line.split('|')
+        if len(parts) < 2:
+            continue
+        state = parts[1].strip()
+        # ``CANCELLED by <uid>`` collapses to ``CANCELLED``.
+        if state.startswith('CANCELLED'):
+            state = 'CANCELLED'
+        if state:
+            last_state = state.upper()
+    return last_state
+
+
+def _query_instances_v1(
+    cluster_name_on_cloud: str,
+    provider_config: Dict[str, Any],
+    *,
+    non_terminated_only: bool,
+) -> Dict[str, Tuple[Optional[status_lib.ClusterStatus], Optional[str]]]:
+    """v1 ``query_instances``: squeue + sacct merge.
+
+    Legacy ``query_instances`` queries ``squeue`` only, so a job that
+    aged past ``MinJobAge`` (default 300s) disappears from the result
+    map. For v1 managed jobs that's a correctness problem — the
+    controller needs to observe terminal state for short-lived jobs to
+    decide success/failure. So we additionally consult ``sacct``.
+
+    Returns a ``{instance_id: (cluster_status, reason)}`` map keyed on
+    ``slurm_utils.instance_id(job_id, node)`` for live jobs, or on the
+    bare ``cluster_name_on_cloud`` for terminal-only sacct surfacing
+    (we have no node list to fan out across).
+    """
+    client = _slurm_client_from_provider_config(provider_config)
+    statuses: Dict[str, Tuple[Optional[status_lib.ClusterStatus],
+                              Optional[str]]] = {}
+    seen_job_ids: set = set()
+
+    # --- squeue: live jobs (pending/running/completing/...) and recent ---
+    # --- terminal jobs within the MinJobAge window. ---
+    for state_filter in [
+            'pending', 'running', 'completing', 'completed', 'cancelled',
+            'failed', 'node_fail'
+    ]:
+        try:
+            job_ids = client.query_jobs(cluster_name_on_cloud, [state_filter])
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'V1 query_instances: squeue query for state '
+                         f'{state_filter!r} failed: {e}')
+            continue
+        for job_id in job_ids:
+            seen_job_ids.add(job_id)
+            # Re-read the precise state to land on the upper-case label
+            # that ``_V1_SLURM_STATE_TO_CLUSTER_STATUS`` keys on.
+            state = client.get_job_state(job_id)
+            if state is None:
+                # Aged out between the two calls — fall through to
+                # sacct below.
+                continue
+            sky_status = _V1_SLURM_STATE_TO_CLUSTER_STATUS.get(state)
+            if sky_status is None:
+                if non_terminated_only:
+                    continue
+                try:
+                    reason = client.get_job_reason(job_id)
+                except Exception:  # pylint: disable=broad-except
+                    reason = None
+                statuses[job_id] = (None, reason)
+                continue
+            try:
+                nodes, _ = client.get_job_nodes(job_id)
+            except Exception as e:  # pylint: disable=broad-except
+                # PENDING jobs may not yet have nodes; the empty result
+                # below is fine. Other failures we surface as no nodes.
+                logger.debug(f'V1 query_instances: get_job_nodes({job_id}) '
+                             f'failed: {e}')
+                nodes = []
+            if not nodes:
+                # Surface the job-id keyed entry so the caller sees the
+                # cluster is in INIT.
+                statuses[job_id] = (sky_status, None)
+                continue
+            for node in nodes:
+                instance_id = slurm_utils.instance_id(job_id, node)
+                statuses[instance_id] = (sky_status, None)
+
+    # --- sacct: terminal state for jobs aged past MinJobAge. ---
+    # Only consult sacct if squeue didn't already produce a live entry,
+    # and only when the caller actually wants terminal state.
+    if not non_terminated_only and not statuses:
+        sacct_state = _v1_sacct_job_state(client, cluster_name_on_cloud)
+        if sacct_state is not None:
+            sky_status = _V1_SLURM_STATE_TO_CLUSTER_STATUS.get(sacct_state)
+            # sacct's most-recent terminal state is keyed on the cluster
+            # name (we have no per-node fanout once the job is gone).
+            statuses[cluster_name_on_cloud] = (sky_status, sacct_state)
+
+    return statuses
 
 
 def _all_resource_alternatives_are_slurm(task: 'task_lib.Task') -> bool:

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -1716,7 +1716,7 @@ def _get_cluster_info_v1(
 
     Unlike the legacy path's ``InstanceInfo(ssh_port=ssh_port,
     external_ip=ssh_host, ...)`` (which is misleading on v1 — SkyPilot
-    never SSHes to the compute node), the v1 shape mirrors K8s v1:
+    never SSHes to the compute node), the v1 shape omits SSH leakage:
     no external_ip, empty ssh_user override, and the InstanceInfo's
     ``ssh_port`` left at its default. Tags carry the structured
     ``job_id`` / ``node`` / ``TAG_SKYPILOT_CLUSTER_NAME`` so
@@ -1779,7 +1779,7 @@ def _get_cluster_info_v1(
             common.InstanceInfo(
                 instance_id=instance_id,
                 # V1 never SSHes to the compute node; leave internal_ip
-                # empty (mirrors K8s v1's empty pod_ip handling).
+                # empty.
                 internal_ip='',
                 external_ip=None,
                 tags={

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -1775,6 +1775,52 @@ def _v1_sacct_node_list(client: 'slurm.SlurmClient',
     return nodes if nodes else None
 
 
+def _v1_sacct_latest_attempt(
+        client: 'slurm.SlurmClient',
+        cluster_name_on_cloud: str) -> Optional[Tuple[str, List[str]]]:
+    """Recover the most-recent attempt's (job_id, NodeList) from sacct.
+
+    For v1 jobs that have already terminated (typical for fast-failing
+    jobs like OOM-killed user code), ``squeue --jobs <id>`` returns
+    nothing because squeue's default filter excludes terminal states.
+    sacct retains the record within ``MinJobAge`` and can be queried by
+    ``--name``. Returns the most recent allocation row's job_id and
+    NodeList, or ``None`` if sacct has no record.
+    """
+    cmd = (f'sacct --name {cluster_name_on_cloud} '
+           '--format=JobID,NodeList --parsable2 --noheader -X')
+    # pylint: disable=protected-access
+    rc, stdout, _ = client._run_slurm_cmd(cmd)
+    if rc != 0 or not stdout.strip():
+        return None
+    # sacct lists rows oldest-first. The last row is the most recent
+    # attempt (controller may have recovered under the same name).
+    last_job_id: Optional[str] = None
+    last_nodelist_raw: Optional[str] = None
+    for line in stdout.splitlines():
+        parts = line.split('|')
+        if len(parts) < 2:
+            continue
+        last_job_id = parts[0].strip()
+        last_nodelist_raw = parts[1].strip()
+    if not last_job_id or not last_nodelist_raw or last_nodelist_raw == 'None':
+        return None
+    # NodeList from sacct: for single-node, plain hostname. For multi-
+    # node, Slurm's hostlist syntax (e.g. ``node[1-3]``). For now we
+    # only fully support single-node. Multi-node v1 jobs would need
+    # ``scontrol show hostnames <list>`` to expand — log a debug and
+    # take the raw string so single-node and simple comma-separated
+    # cases work without an extra round-trip.
+    if '[' in last_nodelist_raw:
+        logger.debug(f'V1 sacct returned hostlist {last_nodelist_raw!r}; '
+                     'multi-node expansion is not yet implemented in the '
+                     'fast-terminal fallback path.')
+        nodes = [last_nodelist_raw]
+    else:
+        nodes = [n for n in last_nodelist_raw.split(',') if n]
+    return last_job_id, nodes
+
+
 def _get_cluster_info_v1(
         cluster_name_on_cloud: str,
         provider_config: Dict[str, Any]) -> Optional[common.ClusterInfo]:
@@ -1795,47 +1841,54 @@ def _get_cluster_info_v1(
     """
     client = _slurm_client_from_provider_config(provider_config)
 
+    job_id: Optional[str] = None
+    nodes: List[str] = []
+
+    # First try squeue's "live" set (pending/running/completing). If a
+    # live job exists, prefer it.
     try:
-        running_jobs = client.query_jobs(cluster_name_on_cloud, ['running'])
+        live_jobs = client.query_jobs(cluster_name_on_cloud,
+                                      ['pending', 'running', 'completing'])
     except Exception as e:  # pylint: disable=broad-except
         logger.debug(f'V1 get_cluster_info: squeue query failed: {e}')
-        return None
+        live_jobs = []
 
-    if not running_jobs:
-        # No running job — return empty so caller treats as "no instances
-        # yet" / cluster torn down.
-        return common.ClusterInfo(
-            instances={},
-            head_instance_id=None,
-            provider_name='slurm',
-            provider_config=provider_config,
-        )
-    assert len(running_jobs) == 1, (
-        f'Multiple running jobs found for v1 cluster '
-        f'{cluster_name_on_cloud}: {running_jobs}. Expected single-job-per'
-        '-name (enforced by _create_managed_job_v1).')
-
-    job_id = running_jobs[0]
-    nodes: List[str] = []
-    try:
-        nodes, _ = client.get_job_nodes(job_id)
-    except Exception as e:  # pylint: disable=broad-except
-        # Fall back to sacct — the job may have just exited and squeue
-        # is briefly out of sync, or get_job_nodes' scontrol-show-node
-        # invocation hit a transient.
-        logger.debug(f'V1 get_cluster_info: get_job_nodes({job_id}) failed: '
-                     f'{e}; trying sacct.')
-        recovered = _v1_sacct_node_list(client, job_id)
-        if recovered:
-            nodes = recovered
+    if live_jobs:
+        if len(live_jobs) > 1:
+            # Multiple "live" jobs for the same name — pick the highest
+            # (Slurm assigns monotonic IDs). Don't assert; recovery
+            # attempts may briefly overlap.
+            job_id = str(max(int(j) for j in live_jobs))
+        else:
+            job_id = live_jobs[0]
+        try:
+            nodes, _ = client.get_job_nodes(job_id)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'V1 get_cluster_info: get_job_nodes({job_id}) '
+                         f'failed: {e}; trying sacct NodeList fallback.')
+            recovered = _v1_sacct_node_list(client, job_id)
+            if recovered:
+                nodes = recovered
 
     if not nodes:
-        # Give the caller a None so it can fall through to its safe
-        # default rather than emitting an empty-instances ClusterInfo
-        # that downstream code might interpret as "definitely no
-        # nodes".
-        logger.debug(f'V1 get_cluster_info: no nodes resolved for job '
-                     f'{job_id}; returning None.')
+        # No live job, or live job has no nodes yet — fall back to
+        # sacct's most recent attempt. This is the typical case for
+        # fast-failing v1 jobs: get_cluster_info is called after
+        # _create_managed_job_v1 returns but the sbatch has already
+        # OOM/FAILED, so squeue's live filter returns empty.
+        recovered = _v1_sacct_latest_attempt(client, cluster_name_on_cloud)
+        if recovered is not None:
+            job_id, nodes = recovered
+            logger.debug(f'V1 get_cluster_info: recovered job {job_id} with '
+                         f'nodes={nodes} from sacct (no live job).')
+
+    if not nodes or job_id is None:
+        # Nothing in sacct either. Return None so the caller falls
+        # through to its safe default. The managed-job controller's
+        # status poll will surface "no cluster" and the launch
+        # finalization treats this as a provisioning failure.
+        logger.debug(f'V1 get_cluster_info: no live job and no sacct '
+                     f'record for {cluster_name_on_cloud}; returning None.')
         return None
 
     instances: Dict[str, List[common.InstanceInfo]] = {}

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -11,6 +11,7 @@ import typing
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 import colorama
+import hostlist
 
 from sky import exceptions
 from sky import sky_logging
@@ -1792,9 +1793,10 @@ def _v1_sacct_node_list(client: 'slurm.SlurmClient',
     """Recover the per-job node list from ``sacct`` when squeue is empty.
 
     Used by ``_get_cluster_info_v1`` as a fallback for jobs that have
-    aged out of squeue. ``NodeList`` is on the parent allocation row;
-    ``scontrol show hostnames`` expands the compact Slurm hostlist
-    notation (e.g. ``node-[01-03]``) into individual node names.
+    aged out of squeue. ``NodeList`` is on the parent allocation row in
+    Slurm's compact hostlist notation (e.g. ``node-[01-03]``); expanded
+    locally via the ``hostlist`` library (same dependency the in-cluster
+    executor uses) to avoid a second SSH round-trip.
     """
     cmd = (f'sacct -j {job_id} --format=NodeList --parsable2 --noheader -X')
     # pylint: disable=protected-access
@@ -1810,12 +1812,26 @@ def _v1_sacct_node_list(client: 'slurm.SlurmClient',
         break
     if nodelist is None:
         return None
-    expand_cmd = f'scontrol show hostnames {shlex.quote(nodelist)}'
-    rc, stdout, _ = client._run_slurm_cmd(expand_cmd)
-    if rc != 0:
-        return None
-    nodes = [line.strip() for line in stdout.splitlines() if line.strip()]
+    nodes = _expand_slurm_hostlist(nodelist)
     return nodes if nodes else None
+
+
+def _expand_slurm_hostlist(nodelist: str) -> List[str]:
+    """Expand Slurm's compact hostlist syntax into individual node names.
+
+    Slurm emits NodeList as ``ip-10-3-93-178`` for single nodes and
+    ``node-[01-03,05]`` for ranges; the same shape is accepted by
+    ``hostlist.expand_hostlist``. Plain hostnames pass through.
+    """
+    if not nodelist:
+        return []
+    try:
+        return list(hostlist.expand_hostlist(nodelist))
+    except Exception as e:  # pylint: disable=broad-except
+        # Library raises ``hostlist.BadHostlist`` on malformed input;
+        # surface as debug rather than failing the whole status query.
+        logger.debug(f'Failed to expand Slurm hostlist {nodelist!r}: {e}')
+        return [nodelist]
 
 
 def _v1_sacct_latest_attempt(
@@ -1848,19 +1864,9 @@ def _v1_sacct_latest_attempt(
         last_nodelist_raw = parts[1].strip()
     if not last_job_id or not last_nodelist_raw or last_nodelist_raw == 'None':
         return None
-    # NodeList from sacct: for single-node, plain hostname. For multi-
-    # node, Slurm's hostlist syntax (e.g. ``node[1-3]``). For now we
-    # only fully support single-node. Multi-node v1 jobs would need
-    # ``scontrol show hostnames <list>`` to expand — log a debug and
-    # take the raw string so single-node and simple comma-separated
-    # cases work without an extra round-trip.
-    if '[' in last_nodelist_raw:
-        logger.debug(f'V1 sacct returned hostlist {last_nodelist_raw!r}; '
-                     'multi-node expansion is not yet implemented in the '
-                     'fast-terminal fallback path.')
-        nodes = [last_nodelist_raw]
-    else:
-        nodes = [n for n in last_nodelist_raw.split(',') if n]
+    nodes = _expand_slurm_hostlist(last_nodelist_raw)
+    if not nodes:
+        return None
     return last_job_id, nodes
 
 

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -2248,30 +2248,44 @@ def _create_managed_job_v1(
         _wait_for_job_nodes(client, job_id, provision_timeout, partition,
                             _on_pending)
         nodes, _ = client.get_job_nodes(job_id)
-        rich_utils.force_update_status(
-            ux_utils.spinner_message('Launching', cluster_name=cluster_name))
-        return common.ProvisionRecord(
-            provider_name='slurm',
-            region=region,
-            zone=partition,
-            cluster_name=cluster_name_on_cloud,
-            head_instance_id=slurm_utils.instance_id(job_id, nodes[0]),
-            resumed_instance_ids=[],
-            created_instance_ids=[
-                slurm_utils.instance_id(job_id, n) for n in nodes
-            ],
-            runtime_metadata=common.ProvisionRuntimeMetadata(
-                has_ray=False,
-                has_skylet=False,
-                has_job_queue=False,
-                ssh_available=False,
-                runtime_setup_done=True,
-                workdir_synced=True,
-                file_mounts_synced=True,
-                setup_done=True,
-                run_started=True,
-            ),
-        )
+        if not nodes:
+            # The existing job left PENDING but has no allocated nodes —
+            # it has already reached a terminal state (RUNNING → FAILED /
+            # COMPLETED very quickly, common on v1 where the sbatch script
+            # IS the user code). Don't reattach to a corpse; fall through
+            # to a fresh submission. Without this guard ``nodes[0]`` below
+            # IndexErrors and the controller treats the recovery launch as
+            # crashed.
+            logger.info(
+                f'V1 existing job {job_id} for {cluster_name_on_cloud} has '
+                'no allocated nodes (already terminal); falling through to '
+                'fresh submission.')
+        else:
+            rich_utils.force_update_status(
+                ux_utils.spinner_message('Launching',
+                                         cluster_name=cluster_name))
+            return common.ProvisionRecord(
+                provider_name='slurm',
+                region=region,
+                zone=partition,
+                cluster_name=cluster_name_on_cloud,
+                head_instance_id=slurm_utils.instance_id(job_id, nodes[0]),
+                resumed_instance_ids=[],
+                created_instance_ids=[
+                    slurm_utils.instance_id(job_id, n) for n in nodes
+                ],
+                runtime_metadata=common.ProvisionRuntimeMetadata(
+                    has_ray=False,
+                    has_skylet=False,
+                    has_job_queue=False,
+                    ssh_available=False,
+                    runtime_setup_done=True,
+                    workdir_synced=True,
+                    file_mounts_synced=True,
+                    setup_done=True,
+                    run_started=True,
+                ),
+            )
 
     # ---- Fresh submission ----
     login_node_runner = command_runner.SSHCommandRunner(

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -1724,6 +1724,24 @@ def _query_instances_v1(
                 logger.debug(f'V1 query_instances: get_job_nodes('
                              f'{best_job_id}) failed: {e}')
                 nodes = []
+            # ``get_job_nodes`` uses ``squeue --jobs <id>``, which excludes
+            # terminal jobs by default. For a terminal multi-node job within
+            # MinJobAge, the squeue filter loop above tells us the *state*
+            # but the by-id lookup returns no nodes. Fall back to sacct's
+            # NodeList so we fan out across the full allocation. Without
+            # this, multi-node terminal jobs collapse to a single entry
+            # under ``best_job_id`` and ``backend_utils._update_cluster_status``
+            # fires ``some_nodes_terminated`` → "one or more nodes
+            # terminated" → spurious recovery loop.
+            if not nodes:
+                try:
+                    sacct_nodes = _v1_sacct_node_list(client, best_job_id)
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.debug(f'V1 query_instances: _v1_sacct_node_list('
+                                 f'{best_job_id}) failed: {e}')
+                    sacct_nodes = None
+                if sacct_nodes:
+                    nodes = sacct_nodes
             if not nodes:
                 # Surface the job-id keyed entry so the caller sees a
                 # single-entry cluster (matches launched_nodes=1).

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -1535,6 +1535,19 @@ _STATE_FILTER_TO_SLURM_STATE: Dict[str, str] = {
     'cancelled': 'CANCELLED',
     'failed': 'FAILED',
     'node_fail': 'NODE_FAIL',
+    # Terminal states beyond plain FAILED. squeue keeps these visible
+    # within ``MinJobAge`` (default 300s) but each surfaces under its
+    # own filter — ``--states failed`` does NOT include TIMEOUT or
+    # OUT_OF_MEMORY rows. Without these entries, a walltime-killed
+    # or OOM-killed job goes invisible to ``_query_instances_v1``'s
+    # squeue path even though it's well within MinJobAge, and the
+    # controller misclassifies as preemption.
+    'timeout': 'TIMEOUT',
+    'out_of_memory': 'OUT_OF_MEMORY',
+    'deadline': 'DEADLINE',
+    'preempted': 'PREEMPTED',
+    'boot_fail': 'BOOT_FAIL',
+    'revoked': 'REVOKED',
 }
 
 _V1_SLURM_STATE_TO_CLUSTER_STATUS: Dict[str, Optional[status_lib.ClusterStatus]] = {
@@ -1662,7 +1675,8 @@ def _query_instances_v1(
     candidates: Dict[str, str] = {}  # job_id -> upper-case Slurm state
     for state_filter in [
             'pending', 'running', 'completing', 'completed', 'cancelled',
-            'failed', 'node_fail'
+            'failed', 'node_fail', 'timeout', 'out_of_memory', 'deadline',
+            'preempted', 'boot_fail', 'revoked'
     ]:
         try:
             job_ids = client.query_jobs(cluster_name_on_cloud, [state_filter])
@@ -1719,9 +1733,18 @@ def _query_instances_v1(
                     statuses[instance_id] = (sky_status, None)
 
     # --- sacct: terminal state for jobs aged past MinJobAge. ---
-    # Only consult sacct if squeue didn't already produce a live entry,
-    # and only when the caller actually wants terminal state.
-    if not non_terminated_only and not statuses:
+    # Consult sacct whenever the squeue path produced nothing, regardless
+    # of ``non_terminated_only``. The flag describes per-instance filtering
+    # semantics for multi-node clouds; v1 Slurm jobs are single-instance
+    # and the controller's ``_update_cluster_status`` (which calls us with
+    # the default ``non_terminated_only=True``) needs to distinguish
+    # ``cluster_status=UP`` (user-code terminal — fire user-code-failure
+    # branch) from ``cluster_status=None`` (infra terminal — fire recovery
+    # branch). Without surfacing sacct here, a job that aged past squeue's
+    # MinJobAge window appears as "no instance" and the controller
+    # misclassifies as preemption.
+    del non_terminated_only  # Intentionally ignored — see docstring above.
+    if not statuses:
         sacct_state = _v1_sacct_job_state(client, cluster_name_on_cloud)
         if sacct_state is not None:
             sky_status = _V1_SLURM_STATE_TO_CLUSTER_STATUS.get(sacct_state)

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -1,10 +1,13 @@
 """Slurm instance provisioning."""
 
+import base64
+import importlib.resources
 import os
 import shlex
 import tempfile
 import threading
 import time
+import typing
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 import colorama
@@ -13,6 +16,7 @@ from sky import exceptions
 from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import slurm
+from sky.data import data_utils
 from sky.provision import common
 from sky.provision import constants
 from sky.provision.slurm import utils as slurm_utils
@@ -26,9 +30,66 @@ from sky.utils import subprocess_utils
 from sky.utils import timeline
 from sky.utils import ux_utils
 
+if typing.TYPE_CHECKING:
+    from sky import provision as provision_lib
+    from sky import task as task_lib
+
 logger = sky_logging.init_logger(__name__)
 
 PROVISION_SCRIPTS_DIRECTORY_NAME = '.sky_provision'
+
+# -------- v1 (Slurm-native managed jobs) detection and gating -------- #
+#
+# v1 managed jobs submit a real ``sbatch`` whose script body is the
+# user's setup+run command — exiting when user code exits — instead
+# of today's ``sleep infinity`` + ``srun --jobid`` pattern. The v1
+# branch is selected at provision time by the provider-config marker
+# below; the legacy ``_create_virtual_instance`` path stays untouched
+# and runs by default.
+
+SLURM_MANAGED_JOB_V1_RUNTIME = 'managed_job_v1'
+
+# Opt-out env var. v1 is on by default; users who rely on the
+# long-lived sleep-infinity allocation (e.g. ``sky exec`` against a
+# managed-job cluster) can fall back to legacy.
+_DISABLE_V1_JOBS_ENV = 'SKYPILOT_SLURM_DISABLE_V1_JOBS'
+# Config-file analog: ``slurm.use_v1: false``.
+_V1_CONFIG_KEY = ('slurm', 'use_v1')
+
+# Base64-encoded ``git_clone.sh`` for embedding in the sbatch script
+# preamble. Reuses the same script as the regular path so token auth,
+# SSH key auth, shallow clones, ref-type detection, and incremental
+# updates all work identically. The env vars ``GIT_URL``,
+# ``GIT_BRANCH``/``GIT_TAG``/``GIT_COMMIT_HASH``, ``GIT_TOKEN``, and
+# ``GIT_SSH_KEY`` are already set as task envs by
+# ``task.py:_set_git_envs_and_secrets``.
+try:
+    _git_clone_script = importlib.resources.files('sky.utils').joinpath(
+        'git_clone.sh')
+    _GIT_CLONE_SCRIPT_B64: Optional[str] = base64.b64encode(
+        _git_clone_script.read_bytes()).decode()
+except (FileNotFoundError, AttributeError):
+    _GIT_CLONE_SCRIPT_B64 = None
+    logger.debug('git_clone.sh not found; git workdir support in the v1 '
+                 'fast path will be limited')
+
+
+def is_managed_job_v1_provider_config(provider_config: Dict[str, Any]) -> bool:
+    """Whether the provider config selects the Slurm v1 managed-job path."""
+    return provider_config.get(
+        'skypilot_runtime') == SLURM_MANAGED_JOB_V1_RUNTIME
+
+
+def is_slurm_managed_jobs_v1_enabled() -> bool:
+    """Whether Slurm v1 managed jobs are enabled.
+
+    On by default. Opt out by setting
+    ``SKYPILOT_SLURM_DISABLE_V1_JOBS=1`` or
+    ``slurm.use_v1: false`` in ``~/.sky/config.yaml``.
+    """
+    if os.environ.get(_DISABLE_V1_JOBS_ENV) == '1':
+        return False
+    return bool(skypilot_config.get_nested(_V1_CONFIG_KEY, True))
 
 
 def _sbatch_log_path(base_dir: str, job_id: str) -> str:
@@ -879,6 +940,9 @@ def query_instances(
 def run_instances(region: str, cluster_name: str, cluster_name_on_cloud: str,
                   config: common.ProvisionConfig) -> common.ProvisionRecord:
     """Run instances for the given cluster (Slurm in this case)."""
+    if is_managed_job_v1_provider_config(config.provider_config):
+        return _create_managed_job_v1(region, cluster_name,
+                                      cluster_name_on_cloud, config)
     return _create_virtual_instance(region, cluster_name, cluster_name_on_cloud,
                                     config)
 
@@ -1272,3 +1336,552 @@ def get_command_runners(
     ]
 
     return runners
+
+
+# -------- v1 managed-job: predicates, template override, provision -------- #
+
+
+def _all_resource_alternatives_are_slurm(task: 'task_lib.Task') -> bool:
+    """Whether every resource alternative on the task is Slurm."""
+    # pylint: disable=import-outside-toplevel
+    from sky import clouds as sky_clouds
+
+    resources = list(task.resources)
+    if not resources:
+        return False
+    return all(resource.cloud is not None and
+               resource.cloud.is_same_cloud(sky_clouds.Slurm())
+               for resource in resources)
+
+
+def _get_unsupported_v1_inputs(task: 'task_lib.Task') -> List[str]:
+    """Return user inputs that force fallback from the v1 template."""
+    unsupported: List[str] = []
+    local_file_mounts = task.get_local_to_remote_file_mounts() or {}
+    has_local_workdir = (task.workdir is not None and
+                         isinstance(task.workdir, str))
+    storage_mounts = task.storage_mounts
+    if has_local_workdir:
+        unsupported.append(f'workdir: {task.workdir!r}')
+    if local_file_mounts:
+        for dst, src in local_file_mounts.items():
+            unsupported.append(f'file_mounts: {src!r} -> {dst!r}')
+    if storage_mounts:
+        for mnt_path, storage in storage_mounts.items():
+            unsupported.append(
+                f'storage_mounts: {storage.name!r} -> {mnt_path!r}')
+    return unsupported
+
+
+def will_use_v1_template(
+    task: 'task_lib.Task',
+    *,
+    is_launched_by_jobs_controller: bool = True,
+) -> bool:
+    """Whether this task will be claimed by the Slurm v1 template.
+
+    Keep this predicate in sync with ``template_override()``.
+    """
+    if (not is_slurm_managed_jobs_v1_enabled() or
+            not is_launched_by_jobs_controller):
+        return False
+    if not _all_resource_alternatives_are_slurm(task):
+        return False
+    return not _get_unsupported_v1_inputs(task)
+
+
+def template_override(
+    task: 'task_lib.Task',
+    *,
+    _extra_launch_context: Dict[str, Any],
+    _is_launched_by_jobs_controller: bool,
+) -> Optional['provision_lib.TemplateSpec']:
+    """Claim v1 Slurm managed-job tasks and return their template spec."""
+    # pylint: disable=import-outside-toplevel
+    from sky import provision as provision_lib
+    from sky import task as task_lib
+    from sky.backends import backend_utils
+
+    del _extra_launch_context  # No per-task context consumed yet.
+
+    if not will_use_v1_template(
+            task,
+            is_launched_by_jobs_controller=_is_launched_by_jobs_controller,
+    ):
+        unsupported = _get_unsupported_v1_inputs(task)
+        if (is_slurm_managed_jobs_v1_enabled() and
+                _is_launched_by_jobs_controller and
+                _all_resource_alternatives_are_slurm(task) and unsupported):
+            logger.warning(
+                'Falling back to legacy Slurm managed-jobs path: jobs with '
+                'local file mounts, workdir, or storage mounts are not '
+                'supported on the v1 fast path. Unsupported inputs:\n  ' +
+                '\n  '.join(unsupported) +
+                '\nUse a git workdir or cloud storage (s3://, gs://, etc.) '
+                'to opt into the v1 fast path.')
+        return None
+
+    resources = list(task.resources)
+    envs = task_lib.get_plaintext_envs_and_secrets(task.envs_and_secrets)
+
+    resource = resources[0]
+    sbatch_options: Dict[str, Any] = {}
+    cluster_overrides = resource.cluster_config_overrides
+    if cluster_overrides:
+        # Surface task-level sbatch_options into the template; cluster /
+        # partition level options are merged later by
+        # ``Slurm.make_deploy_resources_variables`` and threaded through
+        # the standard template variables (``sbatch_options``).
+        task_sbatch = cluster_overrides.get(
+            'slurm', {}).get('sbatch_options') if isinstance(
+                cluster_overrides, dict) else None
+        if isinstance(task_sbatch, dict):
+            sbatch_options.update(task_sbatch)
+
+    workdir = task.workdir
+    workdir_config: Optional[Dict[str, Any]] = None
+    if workdir is not None:
+        # Local workdirs are blocked by ``will_use_v1_template`` above —
+        # this branch only handles the git-dict form.
+        assert isinstance(
+            workdir,
+            dict), (f'Expected git workdir (dict), got {type(workdir)}')
+        workdir_config = {'git': workdir}
+
+    file_mounts: Optional[Dict[str, str]] = None
+    if task.file_mounts:
+        file_mounts = dict(task.file_mounts)
+
+    container_image = resource.extract_docker_image()
+
+    return provision_lib.TemplateSpec(
+        template_path='slurm-managed-job-v1.yml.j2',
+        variables={
+            'setup': task.setup,
+            'run': task.run,
+            'envs': envs,
+            'num_nodes': task.num_nodes,
+            'num_gpus_per_node': backend_utils.get_num_gpus_per_node(task),
+            'workdir': workdir_config,
+            'file_mounts': file_mounts,
+            'sbatch_options': sbatch_options or None,
+            'container_image': container_image,
+        },
+    )
+
+
+def _build_workdir_block(workdir: Optional[Dict[str, Any]]) -> str:
+    """Build sbatch preamble commands for the git workdir, or empty."""
+    if not workdir:
+        return ''
+    if 'git' not in workdir:
+        return ''
+    if _GIT_CLONE_SCRIPT_B64 is None:
+        raise RuntimeError(
+            'git_clone.sh not found; cannot use git workdir with the v1 '
+            'fast path')
+    # The git_clone.sh script expects to be invoked with the target
+    # workdir as its only positional argument. ``SKY_REMOTE_WORKDIR`` is
+    # the canonical destination used elsewhere; expand ~ to $HOME so
+    # bash double-quote semantics work.
+    remote_workdir = skylet_constants.SKY_REMOTE_WORKDIR.replace('~', '$HOME')
+    return (
+        '# === Workdir: git clone via git_clone.sh ===\n'
+        f"echo '{_GIT_CLONE_SCRIPT_B64}' | base64 -d > /tmp/sky_git_clone.sh\n"
+        f'bash /tmp/sky_git_clone.sh "{remote_workdir}"\n'
+        'rm -f /tmp/sky_git_clone.sh\n'
+        f'cd "{remote_workdir}"\n')
+
+
+def _build_file_mounts_block(file_mounts: Optional[Dict[str, str]]) -> str:
+    """Build sbatch preamble commands for cloud-URI file mounts, or empty."""
+    if not file_mounts:
+        return ''
+    # pylint: disable=import-outside-toplevel
+    from sky import cloud_stores
+
+    commands: List[str] = []
+    for remote_path, source in file_mounts.items():
+        if not data_utils.is_cloud_store_url(source):
+            logger.warning('Slurm v1 fast path: skipping non-cloud-URL '
+                           f'file mount {source} -> {remote_path}')
+            continue
+        try:
+            storage = cloud_stores.get_storage_from_path(source)
+            if storage.is_directory(source):
+                mkdir_cmd = f'mkdir -p {shlex.quote(remote_path)}'
+                sync_cmd = storage.make_sync_dir_command(
+                    source=source, destination=remote_path)
+            else:
+                mkdir_cmd = (f'mkdir -p $(dirname {shlex.quote(remote_path)})')
+                sync_cmd = storage.make_sync_file_command(
+                    source=source, destination=remote_path)
+            commands.append(f'{mkdir_cmd} && {sync_cmd}')
+        except Exception:  # pylint: disable=broad-except
+            logger.warning(
+                f'Slurm v1 fast path: cannot generate sync command for '
+                f'{source} -> {remote_path}',
+                exc_info=True)
+    if not commands:
+        return ''
+    return '# === File Mounts ===\n' + '\n'.join(commands) + '\n'
+
+
+def _build_env_exports(envs: Optional[Dict[str, str]]) -> str:
+    """Render env exports as bash ``export`` lines."""
+    if not envs:
+        return ''
+    lines = ['# === Env vars ===']
+    for key, value in envs.items():
+        lines.append(f'export {key}={shlex.quote(str(value))}')
+    return '\n'.join(lines) + '\n'
+
+
+def _build_v1_sbatch_script(
+    *,
+    cluster_name_on_cloud: str,
+    num_nodes: int,
+    log_path: str,
+    resources: Dict[str, Any],
+    setup: Optional[str],
+    run: Optional[str],
+    envs: Dict[str, str],
+    workdir: Optional[Dict[str, Any]],
+    file_mounts: Optional[Dict[str, str]],
+    container_image: Optional[str],
+    extra_sbatch_directives: str,
+) -> str:
+    """Build the v1 sbatch script whose body is the user's setup+run.
+
+    Pattern: a single ``srun --nodes=N --ntasks-per-node=1`` whose body
+    is ``bash -c '<setup> && <run>'``. Container support wraps the same
+    srun with pyxis flags. No ``sleep infinity``; the job exits when
+    user code exits and Slurm marks it COMPLETED / FAILED naturally.
+    """
+    accelerator_type = resources.get('accelerator_type')
+    accelerator_count_raw = resources.get('accelerator_count')
+    try:
+        accelerator_count = int(
+            accelerator_count_raw) if accelerator_count_raw is not None else 0
+    except (TypeError, ValueError):
+        accelerator_count = 0
+
+    gpu_directive = ''
+    if accelerator_count > 0:
+        if (accelerator_type is not None and
+                accelerator_type.upper() != 'NONE'):
+            gpu_directive = (f'#SBATCH --gres=gpu:{accelerator_type}:'
+                             f'{accelerator_count}')
+        else:
+            gpu_directive = f'#SBATCH --gres=gpu:{accelerator_count}'
+
+    mem_directive = ''
+    if float(resources.get('memory', 0)) > 0:
+        mem_in_mb = int(float(resources['memory']) * 1024)
+        mem_directive = f'#SBATCH --mem={mem_in_mb}M'
+
+    cpus = int(resources.get('cpus', 1))
+
+    # Compose the inner user command. ``set -o pipefail`` is the only
+    # global shell flag we impose — legacy doesn't add ``-e`` or ``-u``
+    # and user setup blocks routinely rely on ``+u`` (sourcing
+    # unset-var-tolerant rc files) and ``|| true``-style guards.
+    user_setup = (setup or '').strip()
+    user_run = (run or '').strip()
+    if user_setup and user_run:
+        user_script = f'set -o pipefail\n{user_setup}\n{user_run}'
+    elif user_setup:
+        user_script = f'set -o pipefail\n{user_setup}'
+    elif user_run:
+        user_script = f'set -o pipefail\n{user_run}'
+    else:
+        user_script = 'set -o pipefail\n# no setup / run specified'
+    quoted_user_script = shlex.quote(user_script)
+
+    # Container args (pyxis/enroot). Per-job container name (suffix with
+    # SLURM_JOB_ID) so a half-extracted rootfs from a killed previous
+    # attempt cannot collide with this attempt.
+    container_args = ''
+    if container_image:
+        container_name_base = slurm_utils.pyxis_container_name(
+            cluster_name_on_cloud)
+        container_args = (
+            f'--container-image={shlex.quote(container_image)} '
+            f'--container-name={shlex.quote(container_name_base)}-'
+            f'${{SLURM_JOB_ID}} '
+            f'--container-remap-root '
+            f'--container-writable ')
+
+    label_flag = '--label ' if num_nodes > 1 else ''
+    srun_line = (f'srun --nodes={num_nodes} --ntasks-per-node=1 '
+                 f'{label_flag}--unbuffered {container_args}'
+                 f'bash -c {quoted_user_script}')
+
+    workdir_block = _build_workdir_block(workdir)
+    file_mounts_block = _build_file_mounts_block(file_mounts)
+    env_exports = _build_env_exports(envs)
+
+    # pylint: disable=line-too-long
+    return (f'#!/bin/bash\n'
+            f'#SBATCH --job-name={cluster_name_on_cloud}\n'
+            f'#SBATCH --output={log_path}\n'
+            f'#SBATCH --error={log_path}\n'
+            f'#SBATCH --nodes={num_nodes}\n'
+            f'#SBATCH --wait-all-nodes=1\n'
+            f'#SBATCH --no-requeue\n'
+            f'#SBATCH --cpus-per-task={cpus}\n'
+            f'{mem_directive}\n'
+            f'{gpu_directive}'
+            f'{extra_sbatch_directives}\n'
+            f'\n'
+            f'{workdir_block}'
+            f'{file_mounts_block}'
+            f'{env_exports}'
+            f'\n'
+            f'{srun_line}\n')
+
+
+def _create_managed_job_v1(
+        region: str, cluster_name: str, cluster_name_on_cloud: str,
+        config: common.ProvisionConfig) -> common.ProvisionRecord:
+    """Create a Slurm v1 managed job (single real ``sbatch``).
+
+    Replaces the ``sleep infinity`` + ``srun --jobid`` pattern: the
+    sbatch script body IS the user's task. When user code exits, the
+    Slurm job finishes; state propagates to ``sacct`` naturally.
+
+    Preserves the legacy prologue invariants (COMPLETING-drain +
+    existing-job reattach) so concurrent recovery attempts cannot trip
+    over each other.
+    """
+    provider_config = config.provider_config
+    ssh_config_dict = provider_config['ssh']
+    ssh_host = ssh_config_dict['hostname']
+    ssh_port = int(ssh_config_dict['port'])
+    ssh_user = ssh_config_dict['user']
+    ssh_key = ssh_config_dict.get('private_key', None)
+    ssh_proxy_command = ssh_config_dict.get('proxycommand', None)
+    ssh_proxy_jump = ssh_config_dict.get('proxyjump', None)
+    identities_only = ssh_config_dict.get('identities_only', False)
+    partition = slurm_utils.get_partition_from_config(provider_config)
+
+    client = slurm.SlurmClient(
+        ssh_host,
+        ssh_port,
+        ssh_user,
+        ssh_key,
+        ssh_proxy_command=ssh_proxy_command,
+        ssh_proxy_jump=ssh_proxy_jump,
+        identities_only=identities_only,
+    )
+
+    # ---- Drain COMPLETING jobs before submitting. Ported verbatim ----
+    # ---- from ``_create_virtual_instance``. Without this, recovery ----
+    # ---- attempt N+1 races attempt N's teardown and trips the ----
+    # ---- ``assert len(jobs_state) == 1`` invariant in ----
+    # ---- terminate_instances. ----
+    completing_jobs = client.query_jobs(
+        cluster_name_on_cloud,
+        ['completing'],
+    )
+    start_time = time.time()
+    while (completing_jobs and
+           time.time() - start_time < _JOB_TERMINATION_TIMEOUT_SECONDS):
+        logger.debug(f'Found {len(completing_jobs)} completing jobs. '
+                     f'Waiting for them to finish: {completing_jobs}')
+        time.sleep(POLL_INTERVAL_SECONDS)
+        completing_jobs = client.query_jobs(
+            cluster_name_on_cloud,
+            ['completing'],
+        )
+    if completing_jobs:
+        raise RuntimeError(f'Found {len(completing_jobs)} jobs still in '
+                           'completing state after '
+                           f'{_JOB_TERMINATION_TIMEOUT_SECONDS}s. '
+                           'This is typically due to non-killable processes '
+                           'associated with the job.')
+
+    # ---- Reattach if a previous attempt is already PENDING/RUNNING. ----
+    # ---- Without this, a controller restart mid-attempt would submit ----
+    # ---- a duplicate job. ----
+    existing_jobs = client.query_jobs(
+        cluster_name_on_cloud,
+        ['pending', 'running'],
+    )
+    provision_timeout: int = provider_config.get('provision_timeout', -1)
+
+    num_nodes = config.count
+    last_status_msg = None
+
+    def _on_pending(state: str, reason: Optional[str],
+                    pending_count: Optional[int]) -> None:
+        nonlocal last_status_msg
+        del state  # unused
+        parts = []
+        if reason:
+            parts.append(f'pending: {reason}')
+        if pending_count is not None and pending_count > 0:
+            word = 'other' if pending_count == 1 else 'others'
+            parts.append(f'{pending_count} {word} pending')
+        if parts:
+            msg = f'Launching ({", ".join(parts)})'
+        else:
+            msg = 'Launching'
+        status_msg = ux_utils.spinner_message(msg, cluster_name=cluster_name)
+        if status_msg != last_status_msg:
+            rich_utils.force_update_status(status_msg)
+            last_status_msg = status_msg
+
+    if existing_jobs:
+        assert len(existing_jobs) == 1, (
+            f'Multiple jobs found with name {cluster_name_on_cloud}: '
+            f'{existing_jobs}')
+
+        job_id = existing_jobs[0]
+        logger.debug(f'V1 job with name {cluster_name_on_cloud} already '
+                     f'exists (JOBID: {job_id}); reattaching.')
+
+        _wait_for_job_nodes(client, job_id, provision_timeout, partition,
+                            _on_pending)
+        nodes, _ = client.get_job_nodes(job_id)
+        rich_utils.force_update_status(
+            ux_utils.spinner_message('Launching', cluster_name=cluster_name))
+        return common.ProvisionRecord(
+            provider_name='slurm',
+            region=region,
+            zone=partition,
+            cluster_name=cluster_name_on_cloud,
+            head_instance_id=slurm_utils.instance_id(job_id, nodes[0]),
+            resumed_instance_ids=[],
+            created_instance_ids=[
+                slurm_utils.instance_id(job_id, n) for n in nodes
+            ],
+            runtime_metadata=common.ProvisionRuntimeMetadata(
+                has_ray=False,
+                has_skylet=False,
+                has_job_queue=False,
+                ssh_available=False,
+                runtime_setup_done=True,
+                workdir_synced=True,
+                file_mounts_synced=True,
+                setup_done=True,
+                run_started=True,
+            ),
+        )
+
+    # ---- Fresh submission ----
+    login_node_runner = command_runner.SSHCommandRunner(
+        (ssh_host, ssh_port),
+        ssh_user,
+        ssh_key,
+        ssh_proxy_command=ssh_proxy_command,
+        ssh_proxy_jump=ssh_proxy_jump,
+        enable_interactive_auth=True,
+        disable_identities_only=not identities_only,
+    )
+    remote_home_dir = login_node_runner.get_remote_home_dir()
+
+    # Resolve workdir (must be on a shared FS — same contract as legacy).
+    workdir_cfg = skypilot_config.get_effective_region_config(
+        cloud='slurm', region=region, keys=('workdir',), default_value=None)
+    if workdir_cfg is not None:
+        remote_env = client.get_env()
+        workdir_cfg = slurm_utils.expand_path_vars(workdir_cfg, remote_env)
+
+    sky_base_dir = workdir_cfg if workdir_cfg is not None else remote_home_dir
+    assert os.path.isabs(sky_base_dir), (
+        f'sky_base_dir must be absolute, got: {sky_base_dir}')
+    log_path = _sbatch_log_path(sky_base_dir, '%j')
+
+    provision_script_path = _sbatch_provision_script_path(
+        sky_base_dir, cluster_name_on_cloud)
+    provision_scripts_dir = os.path.dirname(provision_script_path)
+
+    # Read the persisted v1 execution payload from the provider config.
+    setup = provider_config.get('setup')
+    run = provider_config.get('run')
+    envs = provider_config.get('envs') or {}
+    workdir_payload = provider_config.get('workdir')
+    file_mounts_payload = provider_config.get('file_mounts')
+    container_image = provider_config.get('container_image')
+    sbatch_options = provider_config.get('sbatch_options') or {}
+
+    # Build user-supplied + auto-generated sbatch directives. We still
+    # consult partition info to compute a sensible ``--time`` default.
+    slurm_cluster = slurm_utils.get_slurm_cluster_from_config(provider_config)
+    partition_info = slurm_utils.get_partition_info(slurm_cluster, partition)
+    if partition_info is None:
+        raise ValueError(f'Partition info for {partition} not found '
+                         f'for SLURM cluster {slurm_cluster}')
+    extra_sbatch_directives = _build_sbatch_directives(sbatch_options,
+                                                       partition_info,
+                                                       partition)
+
+    resources = config.node_config
+
+    sbatch_script = _build_v1_sbatch_script(
+        cluster_name_on_cloud=cluster_name_on_cloud,
+        num_nodes=num_nodes,
+        log_path=log_path,
+        resources=resources,
+        setup=setup,
+        run=run,
+        envs=envs,
+        workdir=workdir_payload,
+        file_mounts=file_mounts_payload,
+        container_image=container_image,
+        extra_sbatch_directives=extra_sbatch_directives,
+    )
+
+    cmd = f'mkdir -p {provision_scripts_dir}'
+    rc, stdout, stderr = login_node_runner.run(cmd,
+                                               require_outputs=True,
+                                               stream_logs=False)
+    subprocess_utils.handle_returncode(
+        rc,
+        cmd,
+        'Failed to create provision scripts directory on login node.',
+        stderr=f'{stdout}\n{stderr}')
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.sh', delete=True) as f:
+        f.write(sbatch_script)
+        f.flush()
+        login_node_runner.rsync(f.name,
+                                provision_script_path,
+                                up=True,
+                                stream_logs=False)
+
+    job_id = client.submit_job(partition, cluster_name_on_cloud,
+                               provision_script_path)
+    logger.debug(f'Submitted v1 Slurm job {job_id} to partition {partition} '
+                 f'for cluster {cluster_name_on_cloud} with {num_nodes} nodes')
+
+    _wait_for_job_nodes(client, job_id, provision_timeout, partition,
+                        _on_pending)
+    nodes, _ = client.get_job_nodes(job_id)
+    rich_utils.force_update_status(
+        ux_utils.spinner_message('Launching', cluster_name=cluster_name))
+
+    created_instance_ids = [
+        slurm_utils.instance_id(job_id, node) for node in nodes
+    ]
+
+    return common.ProvisionRecord(
+        provider_name='slurm',
+        region=region,
+        zone=partition,
+        cluster_name=cluster_name_on_cloud,
+        head_instance_id=slurm_utils.instance_id(job_id, nodes[0]),
+        resumed_instance_ids=[],
+        created_instance_ids=created_instance_ids,
+        runtime_metadata=common.ProvisionRuntimeMetadata(
+            has_ray=False,
+            has_skylet=False,
+            has_job_queue=False,
+            ssh_available=False,
+            runtime_setup_done=True,
+            workdir_synced=True,
+            file_mounts_synced=True,
+            setup_done=True,
+            run_started=True,
+        ),
+    )

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -1642,6 +1642,38 @@ def _query_instances_v1(
     return statuses
 
 
+def _v1_precondition_cleanup(
+        login_node_runner: 'command_runner.SSHCommandRunner', sky_base_dir: str,
+        cluster_name_on_cloud: str) -> None:
+    """Purge residue from a prior v1 attempt under the same cluster name.
+
+    PLAN.md gap #10: if a previous attempt was killed under SIGKILL or
+    OOM, its EXIT trap (which would have removed
+    ``{sky_base_dir}/.sky_clusters/<cluster_name_on_cloud>``) never
+    ran. Submitting attempt N+1 without clearing that residue can leave
+    stale log markers, ready-signal files, or container init flags in
+    place, confusing the new attempt.
+
+    Best-effort: failures (e.g. NFS hiccup) are logged and tolerated —
+    the new attempt's sbatch script will still proceed; we just risk
+    seeing the stale residue if cleanup didn't take. The legacy path's
+    EXIT trap was the only place this was previously removed.
+    """
+    cluster_home_dir = _sky_cluster_home_dir(sky_base_dir,
+                                             cluster_name_on_cloud)
+    cmd = f'rm -rf {shlex.quote(cluster_home_dir)}'
+    rc, stdout, stderr = login_node_runner.run(cmd,
+                                               require_outputs=True,
+                                               stream_logs=False)
+    if rc != 0:
+        logger.warning(f'V1 precondition cleanup of {cluster_home_dir} '
+                       f'failed (rc={rc}): {stdout}\n{stderr}. Continuing '
+                       'with submission; stale residue may be visible to '
+                       'the new attempt.')
+    else:
+        logger.debug(f'V1 precondition cleanup of {cluster_home_dir} ok.')
+
+
 def _v1_sacct_node_list(client: 'slurm.SlurmClient',
                         job_id: str) -> Optional[List[str]]:
     """Recover the per-job node list from ``sacct`` when squeue is empty.
@@ -2226,6 +2258,17 @@ def _create_managed_job_v1(
     provision_script_path = _sbatch_provision_script_path(
         sky_base_dir, cluster_name_on_cloud)
     provision_scripts_dir = os.path.dirname(provision_script_path)
+
+    # Precondition cleanup: a previous attempt killed under SIGKILL
+    # would have skipped its EXIT trap and left
+    # ``.sky_clusters/<cluster_name_on_cloud>`` behind. The legacy path
+    # tolerated this because its sbatch preamble recreated everything
+    # before user code ran. V1's sbatch script writes nothing under
+    # ``.sky_clusters`` today, but we still purge the directory so any
+    # historical residue (logs, ready markers, partial container init
+    # state) doesn't poison a fresh attempt — PLAN.md gap #10.
+    _v1_precondition_cleanup(login_node_runner, sky_base_dir,
+                             cluster_name_on_cloud)
 
     # Read the persisted v1 execution payload from the provider config.
     setup = provider_config.get('setup')

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -32,6 +32,7 @@ from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
     from sky import provision as provision_lib
+    from sky import resources as resources_lib
     from sky import task as task_lib
 
 logger = sky_logging.init_logger(__name__)
@@ -297,11 +298,11 @@ def _wait_for_job_nodes(
             # Consult sacct to distinguish "terminated already" from
             # "genuinely not found".
             sacct_state = _v1_sacct_job_state(client, job_id)
-            _SLURM_TERMINAL = ('COMPLETED', 'CANCELLED', 'FAILED', 'TIMEOUT',
+            terminal_states = ('COMPLETED', 'CANCELLED', 'FAILED', 'TIMEOUT',
                                'NODE_FAIL', 'BOOT_FAIL', 'OUT_OF_MEMORY',
                                'DEADLINE', 'SPECIAL_EXIT', 'PREEMPTED',
                                'REVOKED')
-            if sacct_state in _SLURM_TERMINAL:
+            if sacct_state in terminal_states:
                 # The job ran (possibly very briefly) and is already
                 # done. Return cleanly so the caller can build a
                 # ProvisionRecord from sacct's NodeList; the managed-job
@@ -1498,7 +1499,7 @@ def _terminate_managed_job_v1(cluster_name_on_cloud: str,
     # controller may read a stale RUNNING state on its next status poll
     # and conclude the cancel "didn't take".
     start = time.time()
-    while (time.time() - start < _V1_SCANCEL_LEAVE_RUNNING_TIMEOUT_SECONDS):
+    while time.time() - start < _V1_SCANCEL_LEAVE_RUNNING_TIMEOUT_SECONDS:
         state = client.get_job_state(job_id)
         if state is None:
             # Aged out of squeue; reach for sacct to confirm terminal.
@@ -1551,7 +1552,9 @@ _STATE_FILTER_TO_SLURM_STATE: Dict[str, str] = {
     'revoked': 'REVOKED',
 }
 
-_V1_SLURM_STATE_TO_CLUSTER_STATUS: Dict[str, Optional[status_lib.ClusterStatus]] = {
+_ClusterStatusMap = Dict[str, Optional[status_lib.ClusterStatus]]
+
+_V1_SLURM_STATE_TO_CLUSTER_STATUS: _ClusterStatusMap = {
     'PENDING': status_lib.ClusterStatus.INIT,
     'CONFIGURING': status_lib.ClusterStatus.INIT,
     'RESV_DEL_HOLD': status_lib.ClusterStatus.INIT,
@@ -1943,9 +1946,9 @@ def _get_cluster_info_v1(
         # fast-failing v1 jobs: get_cluster_info is called after
         # _create_managed_job_v1 returns but the sbatch has already
         # OOM/FAILED, so squeue's live filter returns empty.
-        recovered = _v1_sacct_latest_attempt(client, cluster_name_on_cloud)
-        if recovered is not None:
-            job_id, nodes = recovered
+        latest_attempt = _v1_sacct_latest_attempt(client, cluster_name_on_cloud)
+        if latest_attempt is not None:
+            job_id, nodes = latest_attempt
             logger.debug(f'V1 get_cluster_info: recovered job {job_id} with '
                          f'nodes={nodes} from sacct (no live job).')
 
@@ -2038,6 +2041,7 @@ def will_use_v1_template(
 
 def template_override(
     task: 'task_lib.Task',
+    to_provision: 'resources_lib.Resources',
     *,
     _extra_launch_context: Dict[str, Any],
     _is_launched_by_jobs_controller: bool,
@@ -2061,18 +2065,18 @@ def template_override(
             logger.warning(
                 'Falling back to legacy Slurm managed-jobs path: jobs with '
                 'local file mounts, workdir, or storage mounts are not '
-                'supported on the v1 fast path. Unsupported inputs:\n  ' +
-                '\n  '.join(unsupported) +
+                'supported on the v1 fast path. Unsupported inputs:\n  %s'
                 '\nUse a git workdir or cloud storage (s3://, gs://, etc.) '
-                'to opt into the v1 fast path.')
+                'to opt into the v1 fast path.', '\n  '.join(unsupported))
         return None
 
-    resources = list(task.resources)
     envs = task_lib.get_plaintext_envs_and_secrets(task.envs_and_secrets)
 
-    resource = resources[0]
+    # ``to_provision`` is the resource for the current launch attempt —
+    # unlike ``task.resources[0]``, it stays correct across the backend's
+    # failover loop.
     sbatch_options: Dict[str, Any] = {}
-    cluster_overrides = resource.cluster_config_overrides
+    cluster_overrides = to_provision.cluster_config_overrides
     if cluster_overrides:
         # Surface task-level sbatch_options into the template; cluster /
         # partition level options are merged later by
@@ -2098,7 +2102,7 @@ def template_override(
     if task.file_mounts:
         file_mounts = dict(task.file_mounts)
 
-    container_image = resource.extract_docker_image()
+    container_image = to_provision.extract_docker_image()
 
     return provision_lib.TemplateSpec(
         template_path='slurm-managed-job-v1.yml.j2',
@@ -2131,12 +2135,12 @@ def _build_workdir_block(workdir: Optional[Dict[str, Any]]) -> str:
     # the canonical destination used elsewhere; expand ~ to $HOME so
     # bash double-quote semantics work.
     remote_workdir = skylet_constants.SKY_REMOTE_WORKDIR.replace('~', '$HOME')
-    return (
-        '# === Workdir: git clone via git_clone.sh ===\n'
-        f"echo '{_GIT_CLONE_SCRIPT_B64}' | base64 -d > /tmp/sky_git_clone.sh\n"
-        f'bash /tmp/sky_git_clone.sh "{remote_workdir}"\n'
-        'rm -f /tmp/sky_git_clone.sh\n'
-        f'cd "{remote_workdir}"\n')
+    return ('# === Workdir: git clone via git_clone.sh ===\n'
+            f'echo \'{_GIT_CLONE_SCRIPT_B64}\' | base64 -d > '
+            '/tmp/sky_git_clone.sh\n'
+            f'bash /tmp/sky_git_clone.sh "{remote_workdir}"\n'
+            'rm -f /tmp/sky_git_clone.sh\n'
+            f'cd "{remote_workdir}"\n')
 
 
 def _build_file_mounts_block(file_mounts: Optional[Dict[str, str]]) -> str:
@@ -2556,9 +2560,8 @@ def _create_managed_job_v1(
                 f'V1 Slurm job {job_id} terminated before nodes were '
                 'observable and sacct has no NodeList record; cannot '
                 'construct a ProvisionRecord.')
-        logger.info(
-            f'V1 Slurm job {job_id} finished fast; recovered '
-            f'NodeList={nodes} from sacct.')
+        logger.info(f'V1 Slurm job {job_id} finished fast; recovered '
+                    f'NodeList={nodes} from sacct.')
     rich_utils.force_update_status(
         ux_utils.spinner_message('Launching', cluster_name=cluster_name))
 

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -130,6 +130,10 @@ _SBATCH_PROTECTED_OPTIONS = frozenset({
     'mem',
     'gres',
     'partition',
+    # --signal controls SIGTERM/SIGKILL delivery on scancel/walltime. A user
+    # override (e.g. KILL@10) skips SIGTERM grace and can truncate the log
+    # tail before our tail_logs / cleanup completes.
+    'signal',
 })
 
 

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -1080,6 +1080,10 @@ def terminate_instances(
             'worker_only=True is not supported for Slurm, this is a no-op.')
         return
 
+    if is_managed_job_v1_provider_config(provider_config):
+        _terminate_managed_job_v1(cluster_name_on_cloud, provider_config)
+        return
+
     # Check if we are running inside a Slurm cluster (only happens with
     # autodown, where the Skylet invokes terminate_instances on the remote
     # cluster). In this case, use local execution instead of SSH.
@@ -1338,6 +1342,123 @@ def get_command_runners(
 
 
 # -------- v1 managed-job: predicates, template override, provision -------- #
+
+# Bounded wait used by the v1 ``terminate_instances`` branch to confirm
+# that ``scancel`` actually moved the job out of RUNNING before we let
+# the controller continue with a possibly-stale state. Slurm's default
+# ``KillWait`` is 30s; we use a slightly larger ceiling so a SIGTERM
+# followed by the eventual SIGKILL has time to land before we give up.
+_V1_SCANCEL_LEAVE_RUNNING_TIMEOUT_SECONDS = 30
+_V1_SCANCEL_POLL_INTERVAL_SECONDS = 1
+
+
+def _slurm_client_from_provider_config(
+        provider_config: Dict[str, Any]) -> 'slurm.SlurmClient':
+    """Build a ``SlurmClient`` from a v1 provider config's ssh block."""
+    ssh_config_dict = provider_config['ssh']
+    return slurm.SlurmClient(
+        ssh_config_dict['hostname'],
+        int(ssh_config_dict['port']),
+        ssh_config_dict['user'],
+        ssh_config_dict.get('private_key', None),
+        ssh_proxy_command=ssh_config_dict.get('proxycommand', None),
+        ssh_proxy_jump=ssh_config_dict.get('proxyjump', None),
+        identities_only=ssh_config_dict.get('identities_only', False),
+    )
+
+
+def _resolve_v1_job_id(
+        client: 'slurm.SlurmClient',
+        cluster_name_on_cloud: str,
+        cluster_info: Optional[common.ClusterInfo] = None) -> Optional[str]:
+    """Resolve the Slurm job_id for a v1 cluster.
+
+    Identity contract (PLAN.md block-ship #4): the primary source is the
+    structured ``tags['job_id']`` populated by ``get_cluster_info``;
+    fallback is a name-keyed ``squeue`` query, which is safe on the v1
+    path because the COMPLETING-drain + existing-job reattach invariants
+    in ``_create_managed_job_v1`` guarantee a single live job per name.
+    """
+    # Primary: structured tag from cached ClusterInfo.
+    if cluster_info is not None and cluster_info.head_instance_id is not None:
+        head = cluster_info.get_head_instance()
+        if head is not None:
+            tag = head.tags.get('job_id') if head.tags else None
+            if tag:
+                return str(tag)
+    # Fallback: name-keyed query (single match enforced upstream).
+    matches = client.query_jobs(cluster_name_on_cloud, ['pending', 'running'])
+    if len(matches) == 1:
+        return matches[0]
+    if not matches:
+        return None
+    raise RuntimeError(
+        f'Multiple Slurm jobs found for v1 cluster {cluster_name_on_cloud}: '
+        f'{matches}. Expected at most one — single-job-per-name is a v1 '
+        'invariant.')
+
+
+def _terminate_managed_job_v1(cluster_name_on_cloud: str,
+                              provider_config: Dict[str, Any]) -> None:
+    """Cancel the v1 Slurm job by job_id and wait briefly for RUNNING exit.
+
+    Uses ``scancel <jobid>`` against the resolved primary identity (per
+    PLAN.md block-ship #4), not ``scancel --name=...`` — the latter
+    stays on the legacy path. After scancel we poll briefly so the
+    controller does not continue with a stale RUNNING reading.
+    """
+    client = _slurm_client_from_provider_config(provider_config)
+
+    job_id = _resolve_v1_job_id(client, cluster_name_on_cloud)
+    if job_id is None:
+        logger.debug(f'V1 Slurm job for {cluster_name_on_cloud} not found in '
+                     'squeue; assuming already terminated.')
+        return
+
+    state = client.get_job_state(job_id)
+    if state is None:
+        logger.debug(f'V1 Slurm job {job_id} no longer in squeue; assuming '
+                     'already terminated.')
+        return
+
+    terminal_states = {
+        'COMPLETED', 'CANCELLED', 'FAILED', 'TIMEOUT', 'NODE_FAIL', 'PREEMPTED',
+        'SPECIAL_EXIT', 'BOOT_FAIL', 'OUT_OF_MEMORY', 'DEADLINE', 'REVOKED'
+    }
+    if state in terminal_states:
+        logger.debug(f'V1 Slurm job {job_id} ({cluster_name_on_cloud}) already '
+                     f'in terminal state {state}; nothing to do.')
+        return
+    if state == 'COMPLETING':
+        logger.debug(f'V1 Slurm job {job_id} ({cluster_name_on_cloud}) already '
+                     'completing; nothing to do.')
+        return
+
+    if state in ('PENDING', 'CONFIGURING'):
+        # Pending jobs haven't allocated nodes; scancel without signal.
+        client.cancel_job_by_id(job_id, signal=None)
+    else:
+        # RUNNING / SUSPENDED / SIGNALING / STAGE_OUT: send SIGTERM with --full
+        # so the batch shell + its srun children receive the signal.
+        client.cancel_job_by_id(job_id, signal='TERM', full=True)
+
+    # Wait briefly for the job to leave RUNNING. Without this the
+    # controller may read a stale RUNNING state on its next status poll
+    # and conclude the cancel "didn't take".
+    start = time.time()
+    while (time.time() - start < _V1_SCANCEL_LEAVE_RUNNING_TIMEOUT_SECONDS):
+        state = client.get_job_state(job_id)
+        if state is None:
+            # Aged out of squeue; reach for sacct to confirm terminal.
+            return
+        if state in terminal_states or state == 'COMPLETING':
+            return
+        time.sleep(_V1_SCANCEL_POLL_INTERVAL_SECONDS)
+
+    logger.warning(
+        f'V1 Slurm job {job_id} ({cluster_name_on_cloud}) did not leave '
+        f'RUNNING within {_V1_SCANCEL_LEAVE_RUNNING_TIMEOUT_SECONDS}s after '
+        'scancel. The controller may briefly observe a stale state.')
 
 
 def _all_resource_alternatives_are_slurm(task: 'task_lib.Task') -> bool:

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -1490,6 +1490,25 @@ def _terminate_managed_job_v1(cluster_name_on_cloud: str,
 # state space documented at
 # https://slurm.schedmd.com/squeue.html#SECTION_JOB-STATE-CODES — see
 # also ``managed_job_runtime._slurm_state_to_job_status``.
+# Reverse map for the small set of state-filter keywords
+# ``query_jobs`` accepts against ``squeue --states <filter>``.
+# Filter words are lower-case; the upper-case canonical Slurm state
+# token is what ``_V1_SLURM_STATE_TO_CLUSTER_STATUS`` keys on. Used
+# by ``_query_instances_v1`` so we don't re-query the job's state —
+# the filter we asked for IS the state, and re-querying via
+# ``squeue --jobs <id>`` is unreliable on clusters with aggressive
+# ``MinJobAge`` (the by-id lookup ages out faster than the by-state
+# filter).
+_STATE_FILTER_TO_SLURM_STATE: Dict[str, str] = {
+    'pending': 'PENDING',
+    'running': 'RUNNING',
+    'completing': 'COMPLETING',
+    'completed': 'COMPLETED',
+    'cancelled': 'CANCELLED',
+    'failed': 'FAILED',
+    'node_fail': 'NODE_FAIL',
+}
+
 _V1_SLURM_STATE_TO_CLUSTER_STATUS: Dict[str, Optional[status_lib.ClusterStatus]] = {
     'PENDING': status_lib.ClusterStatus.INIT,
     'CONFIGURING': status_lib.ClusterStatus.INIT,
@@ -1610,15 +1629,20 @@ def _query_instances_v1(
             logger.debug(f'V1 query_instances: squeue query for state '
                          f'{state_filter!r} failed: {e}')
             continue
+        # The state filter we used IS the canonical state — derive the
+        # upper-case label from it directly. Re-querying via
+        # ``client.get_job_state(job_id)`` is unreliable on clusters
+        # with aggressive ``MinJobAge``: ``squeue --states=failed``
+        # surfaces the job_id but the follow-up ``squeue --jobs <id>``
+        # returns nothing because the by-id lookup has already aged
+        # out. The state filter is the ground truth.
+        state = _STATE_FILTER_TO_SLURM_STATE.get(state_filter)
+        if state is None:
+            # Unknown state_filter in the loop above — programming
+            # error; skip rather than coerce.
+            continue
         for job_id in job_ids:
             seen_job_ids.add(job_id)
-            # Re-read the precise state to land on the upper-case label
-            # that ``_V1_SLURM_STATE_TO_CLUSTER_STATUS`` keys on.
-            state = client.get_job_state(job_id)
-            if state is None:
-                # Aged out between the two calls — fall through to
-                # sacct below.
-                continue
             sky_status = _V1_SLURM_STATE_TO_CLUSTER_STATUS.get(state)
             if sky_status is None:
                 if non_terminated_only:

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -16,7 +16,6 @@ from sky import exceptions
 from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import slurm
-from sky.data import data_utils
 from sky.provision import common
 from sky.provision import constants
 from sky.provision.slurm import utils as slurm_utils
@@ -1497,8 +1496,14 @@ def _build_file_mounts_block(file_mounts: Optional[Dict[str, str]]) -> str:
     """Build sbatch preamble commands for cloud-URI file mounts, or empty."""
     if not file_mounts:
         return ''
+    # Lazy imports: ``sky.data.data_utils`` and ``sky.cloud_stores``
+    # both transitively import ``sky.clouds``. Importing them at
+    # module level creates a cycle when this module is loaded as part
+    # of the managed-job controller subprocess's import order (which
+    # starts at ``sky.clouds`` itself).
     # pylint: disable=import-outside-toplevel
     from sky import cloud_stores
+    from sky.data import data_utils
 
     commands: List[str] = []
     for remote_path, source in file_mounts.items():

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -1490,33 +1490,47 @@ def _terminate_managed_job_v1(cluster_name_on_cloud: str,
 # state space documented at
 # https://slurm.schedmd.com/squeue.html#SECTION_JOB-STATE-CODES — see
 # also ``managed_job_runtime._slurm_state_to_job_status``.
-_V1_SLURM_STATE_TO_CLUSTER_STATUS: Dict[
-    str, Optional[status_lib.ClusterStatus]] = {
-        'PENDING': status_lib.ClusterStatus.INIT,
-        'CONFIGURING': status_lib.ClusterStatus.INIT,
-        'RESV_DEL_HOLD': status_lib.ClusterStatus.INIT,
-        'REQUEUED': status_lib.ClusterStatus.INIT,
-        'REQUEUE_HOLD': status_lib.ClusterStatus.INIT,
-        'REQUEUE_FED': status_lib.ClusterStatus.INIT,
-        'RESIZING': status_lib.ClusterStatus.INIT,
-        'RUNNING': status_lib.ClusterStatus.UP,
-        'COMPLETING': status_lib.ClusterStatus.UP,
-        'SIGNALING': status_lib.ClusterStatus.UP,
-        'STAGE_OUT': status_lib.ClusterStatus.UP,
-        'SUSPENDED': status_lib.ClusterStatus.UP,
-        # Terminal — ``None`` means "no longer an instance".
-        'COMPLETED': None,
-        'CANCELLED': None,
-        'FAILED': None,
-        'TIMEOUT': None,
-        'NODE_FAIL': None,
-        'BOOT_FAIL': None,
-        'DEADLINE': None,
-        'OUT_OF_MEMORY': None,
-        'PREEMPTED': None,
-        'REVOKED': None,
-        'SPECIAL_EXIT': None,
-    }
+_V1_SLURM_STATE_TO_CLUSTER_STATUS: Dict[str, Optional[status_lib.ClusterStatus]] = {
+    'PENDING': status_lib.ClusterStatus.INIT,
+    'CONFIGURING': status_lib.ClusterStatus.INIT,
+    'RESV_DEL_HOLD': status_lib.ClusterStatus.INIT,
+    'REQUEUED': status_lib.ClusterStatus.INIT,
+    'REQUEUE_HOLD': status_lib.ClusterStatus.INIT,
+    'REQUEUE_FED': status_lib.ClusterStatus.INIT,
+    'RESIZING': status_lib.ClusterStatus.INIT,
+    'RUNNING': status_lib.ClusterStatus.UP,
+    'COMPLETING': status_lib.ClusterStatus.UP,
+    'SIGNALING': status_lib.ClusterStatus.UP,
+    'STAGE_OUT': status_lib.ClusterStatus.UP,
+    'SUSPENDED': status_lib.ClusterStatus.UP,
+    # --- Terminal due to user-code outcome: report cluster as UP. ---
+    # The Slurm allocation is gone, but from the managed-jobs
+    # controller's perspective the "cluster" ran fine and the
+    # user's code is what terminated. Without UP here the
+    # controller's user-code-failure branch at controller.py:874+
+    # never fires (it gates on ``cluster_status == UP``), so a
+    # FAILED job is misclassified as cluster-preempted and
+    # retried indefinitely. Compare K8s legacy at
+    # ``kubernetes/instance.py:2640`` which uses ``status_map_overrides``
+    # (line 2631) to swap ``Failed → UP`` for v1-style pods that are
+    # also single-use; we set this directly because Slurm v1 owns
+    # the whole status path.
+    'COMPLETED': status_lib.ClusterStatus.UP,
+    'FAILED': status_lib.ClusterStatus.UP,
+    'TIMEOUT': status_lib.ClusterStatus.UP,
+    'OUT_OF_MEMORY': status_lib.ClusterStatus.UP,
+    'DEADLINE': status_lib.ClusterStatus.UP,
+    'SPECIAL_EXIT': status_lib.ClusterStatus.UP,
+    # --- Terminal due to infrastructure or cancellation: ``None``. ---
+    # ``None`` tells the controller "no longer an instance" so it
+    # takes the recovery / cleanup path (per its ``cluster_status
+    # != UP`` branch).
+    'NODE_FAIL': None,
+    'BOOT_FAIL': None,
+    'PREEMPTED': None,
+    'REVOKED': None,
+    'CANCELLED': None,
+}
 
 
 def _v1_sacct_job_state(client: 'slurm.SlurmClient',

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -2487,16 +2487,22 @@ def _create_managed_job_v1(
 
     _wait_for_job_nodes(client, job_id, provision_timeout, partition,
                         _on_pending)
-    nodes, _ = client.get_job_nodes(job_id)
+    # Fast-failing v1 jobs (OOM-kill, exit non-zero, setup failure,
+    # ...) terminate before ``_wait_for_job_nodes`` sees nodes. In that
+    # case ``client.get_job_nodes`` RAISES ``RuntimeError`` ("No nodes
+    # found for job <id>") rather than returning an empty list. Fall
+    # back to sacct's NodeList — the ProvisionRecord we return is
+    # still valid; the managed-job controller's next
+    # ``get_job_status`` poll will surface the terminal state via the
+    # chain registry and the user-code-failure branch fires.
+    try:
+        nodes, _ = client.get_job_nodes(job_id)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.info(
+            f'V1 get_job_nodes({job_id}) raised {type(e).__name__}: {e}; '
+            'falling back to sacct NodeList for fast-terminal v1 job.')
+        nodes = []
     if not nodes:
-        # Fast-failing job: terminal before _wait_for_job_nodes saw a
-        # node allocation. ``get_job_nodes`` (scontrol show job) returns
-        # empty for terminal jobs; fall back to sacct's NodeList, which
-        # records the node the job actually ran on. The ProvisionRecord
-        # we return is still valid — the controller's next
-        # ``get_job_status`` poll will surface the terminal state via
-        # the chain registry and the user-code-failure /
-        # cluster-up-job-failed branch will fire.
         nodes = _v1_sacct_node_list(client, job_id) or []
         if not nodes:
             raise RuntimeError(

--- a/sky/provision/slurm/log_streaming.py
+++ b/sky/provision/slurm/log_streaming.py
@@ -1,0 +1,301 @@
+"""Log-tail streaming for Slurm v1 managed jobs.
+
+Factored out of ``managed_job_runtime.py`` per PLAN.md "File layout":
+the runtime adapter's ``tail_logs`` constructs a ``SlurmLogStreamer``
+and calls ``.run()`` on it. ``download_logs`` stays inline in the
+runtime — it's a single ``cat`` and write-to-disk pair.
+
+Behavior is preserved verbatim from the previous in-line implementation;
+this is a layout-only change.
+"""
+import os
+import shlex
+import subprocess
+import sys
+import threading
+import typing
+from typing import Any, Callable, Dict, List, Optional
+
+from sky import exceptions
+from sky import sky_logging
+from sky.adaptors import slurm
+from sky.utils import command_runner
+from sky.utils import ux_utils
+
+if typing.TYPE_CHECKING:
+    from sky.provision.slurm.managed_job_runtime import _Target
+
+logger = sky_logging.init_logger(__name__)
+
+# Cadence for the side-thread polling sacct during follow-mode log tail.
+_TAIL_TERMINAL_POLL_SECONDS = 5
+# How long after sacct reports a terminal state we let the SSH tail
+# subprocess drain stdout before forcibly closing it.
+_TAIL_DRAIN_SECONDS = 5
+
+
+def _login_node_runner(
+        ssh_config: Dict[str, Any]) -> 'command_runner.SSHCommandRunner':
+    """Mirror of ``managed_job_runtime._login_node_runner``.
+
+    Duplicated to keep this module free of an import edge back into
+    the runtime adapter (which imports us lazily from ``tail_logs``).
+    The constructor block is the same as
+    ``instance.py::_create_managed_job_v1``'s login-node runner.
+    """
+    identities_only = bool(ssh_config.get('identities_only', False))
+    return command_runner.SSHCommandRunner(
+        (ssh_config['hostname'], int(ssh_config.get('port', 22))),
+        ssh_config['user'],
+        ssh_config.get('private_key'),
+        ssh_proxy_command=ssh_config.get('proxycommand'),
+        ssh_proxy_jump=ssh_config.get('proxyjump'),
+        enable_interactive_auth=True,
+        disable_identities_only=not identities_only,
+    )
+
+
+class SlurmLogStreamer:
+    """SSH-tail-based streamer for the v1 sbatch ``--output`` file.
+
+    Constructed by the runtime adapter from a resolved ``_Target`` and
+    the optional ``tail`` / ``tail_offset`` / ``follow`` parameters. The
+    streamer owns subprocess management, the sacct-watchdog side thread,
+    and footer rendering. The runtime adapter is responsible for
+    resolving the log path and supplying the terminal-state lookups it
+    already implements (passed in via the helpers below).
+    """
+
+    def __init__(
+        self,
+        *,
+        target: '_Target',
+        log_path: str,
+        client: 'slurm.SlurmClient',
+        terminal_states: frozenset,
+        sacct_get_state: Callable[['slurm.SlurmClient', str], Optional[str]],
+        state_to_job_exit_code: Callable[[Optional[str]], int],
+        follow: bool,
+        tail: Optional[int],
+        tail_offset: Optional[int],
+        write_fn: Callable[[str], None],
+    ) -> None:
+        self._target = target
+        self._log_path = log_path
+        self._client = client
+        self._terminal_states = terminal_states
+        self._sacct_get_state = sacct_get_state
+        self._state_to_job_exit_code = state_to_job_exit_code
+        self._follow = follow
+        self._tail = tail
+        self._tail_offset = tail_offset
+        self._write_fn = write_fn
+
+    def run(self) -> int:
+        """Stream the log; return the JobExitCode for the controller."""
+        runner = _login_node_runner(self._target.ssh_config)
+        base_ssh = runner.ssh_base_command(
+            ssh_mode=command_runner.SshMode.NON_INTERACTIVE,
+            port_forward=None,
+            connect_timeout=None)
+
+        quoted_path = shlex.quote(self._log_path)
+        if self._tail_offset is not None and self._tail_offset > 0:
+            # ``tail -c +<bytes>`` starts at byte offset (1-indexed),
+            # which is a strict improvement over K8s v1 (PLAN.md "Log
+            # tailing"). Saved-log replay uses line-based offsets; live
+            # tail with a byte offset only triggers from controller-side
+            # callers that compute the offset against the same file.
+            remote_cmd = (
+                f'tail -c +{int(self._tail_offset) + 1} '
+                f'{"-F" if self._follow else ""} {quoted_path} 2>/dev/null')
+        elif self._follow:
+            remote_cmd = f'tail -F {quoted_path} 2>/dev/null'
+        else:
+            n = self._tail if (self._tail is not None and
+                               self._tail > 0) else None
+            tail_flag = f'-n {n}' if n is not None else '-n +1'
+            remote_cmd = f'tail {tail_flag} {quoted_path} 2>/dev/null'
+
+        if not self._follow:
+            return self._tail_once(base_ssh, remote_cmd)
+        return self._tail_follow(base_ssh, remote_cmd)
+
+    def _tail_once(self, base_ssh: List[str], remote_cmd: str) -> int:
+        # Pass ``remote_cmd`` as a single argv element. SSH joins any
+        # remaining args with spaces into one command string for the
+        # remote shell, so a single arg with shell metachars (``|``,
+        # ``2>/dev/null``) is preserved verbatim. Compare
+        # ``command_runner.run`` which sets ``shell=True`` locally and
+        # therefore needs ``shlex.quote``; here ``subprocess`` uses argv
+        # mode so no extra quoting is needed.
+        full_cmd = base_ssh + [remote_cmd]
+        try:
+            proc = subprocess.run(full_cmd,
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.PIPE,
+                                  check=False)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Slurm v1 tail (one-shot) failed: {e}')
+            return exceptions.JobExitCode.FAILED.value
+        if proc.stdout:
+            self._write_fn(proc.stdout.decode('utf-8', errors='replace'))
+        # Render the same footer as the follow path so the saved-log
+        # consumer sees a consistent shape.
+        state = self._read_terminal_state()
+        if state is not None:
+            self._write_fn(
+                ux_utils.finishing_message(f'Job finished (status: {state}).') +
+                '\n')
+            return self._state_to_job_exit_code(state)
+        # Non-terminal one-shot read — return NOT_FINISHED so the caller
+        # falls through to the standard already-running path.
+        return exceptions.JobExitCode.NOT_FINISHED.value
+
+    def _tail_follow(self, base_ssh: List[str], remote_cmd: str) -> int:
+        # See ``_tail_once`` for argv vs shell-quote reasoning.
+        full_cmd = base_ssh + [remote_cmd]
+        try:
+            proc = subprocess.Popen(
+                full_cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                # Line-buffered text isn't reliable through SSH; read bytes.
+                bufsize=0,
+            )
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Failed to spawn Slurm v1 tail subprocess: {e}')
+            return exceptions.JobExitCode.FAILED.value
+
+        assert proc.stdout is not None
+        stdout_fd = proc.stdout.fileno()
+
+        terminal_state: Dict[str, Optional[str]] = {'value': None}
+        stop_event = threading.Event()
+
+        def _poll_state() -> None:
+            while not stop_event.is_set():
+                try:
+                    state = self._client.get_job_state(self._target.job_id)
+                    if state is None:
+                        state = self._sacct_get_state(self._client,
+                                                      self._target.job_id)
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.debug(f'sacct poll failed: {e}')
+                    state = None
+                if state is not None and state in self._terminal_states:
+                    terminal_state['value'] = state
+                    # Give the SSH ``tail -F`` subprocess a short window
+                    # to flush anything still in flight, then send it a
+                    # SIGTERM so the blocking ``os.read`` in the main
+                    # thread returns 0 and we proceed to the footer.
+                    if stop_event.wait(_TAIL_DRAIN_SECONDS):
+                        return
+                    try:
+                        proc.terminate()
+                    except Exception:  # pylint: disable=broad-except
+                        pass
+                    return
+                if stop_event.wait(_TAIL_TERMINAL_POLL_SECONDS):
+                    return
+
+        poll_thread = threading.Thread(target=_poll_state, daemon=True)
+        poll_thread.start()
+
+        try:
+            # Stream bytes as they arrive. The poll thread is
+            # responsible for ``proc.terminate()`` once it observes a
+            # terminal sacct state, which closes the SSH pipe and lets
+            # ``os.read`` return 0 here so we drop out cleanly. Reading
+            # the raw fd avoids relying on ``BufferedReader`` behavior
+            # across Python versions.
+            while True:
+                try:
+                    chunk = os.read(stdout_fd, 4096)
+                except OSError:
+                    chunk = b''
+                if not chunk:
+                    break
+                self._write_fn(chunk.decode('utf-8', errors='replace'))
+        finally:
+            stop_event.set()
+            try:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=_TAIL_DRAIN_SECONDS)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=_TAIL_DRAIN_SECONDS)
+            except Exception:  # pylint: disable=broad-except
+                pass
+            poll_thread.join(timeout=_TAIL_DRAIN_SECONDS)
+
+        state = terminal_state['value']
+        if state is None:
+            # Watchdog never observed terminal; do one last sacct query
+            # so the footer reflects whatever Slurm now reports.
+            state = self._read_terminal_state()
+
+        if state is not None:
+            self._write_fn(
+                ux_utils.finishing_message(f'Job finished (status: {state}).') +
+                '\n')
+            return self._state_to_job_exit_code(state)
+        # No terminal observed and tail dropped — surface as failed so
+        # the controller's existing decision branches handle it.
+        return exceptions.JobExitCode.FAILED.value
+
+    def _read_terminal_state(self) -> Optional[str]:
+        try:
+            state = self._client.get_job_state(self._target.job_id)
+            if state is None:
+                state = self._sacct_get_state(self._client, self._target.job_id)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Terminal state lookup failed: {e}')
+            return None
+        if state is None or state not in self._terminal_states:
+            return None
+        return state
+
+
+def make_streamer_from_target(
+    target: '_Target',
+    log_path: str,
+    client: 'slurm.SlurmClient',
+    *,
+    terminal_states: frozenset,
+    sacct_get_state: Callable[['slurm.SlurmClient', str], Optional[str]],
+    state_to_job_exit_code: Callable[[Optional[str]], int],
+    follow: bool,
+    tail: Optional[int],
+    tail_offset: Optional[int],
+    out=None,
+) -> SlurmLogStreamer:
+    """Convenience: build a streamer that writes to the current context.
+
+    Constructs a ``write_fn`` bound to ``sys.stdout`` (or the supplied
+    ``out``) so callers don't need to repeat the
+    ``context.output_stream`` plumbing.
+    """
+    if out is None:
+        # pylint: disable=import-outside-toplevel
+        from sky.utils import context as context_lib
+        ctx = context_lib.get()
+        out = ctx.output_stream(sys.stdout) if ctx else sys.stdout
+
+    def _write(msg: str) -> None:
+        out.write(msg)
+        out.flush()
+
+    return SlurmLogStreamer(
+        target=target,
+        log_path=log_path,
+        client=client,
+        terminal_states=terminal_states,
+        sacct_get_state=sacct_get_state,
+        state_to_job_exit_code=state_to_job_exit_code,
+        follow=follow,
+        tail=tail,
+        tail_offset=tail_offset,
+        write_fn=_write,
+    )

--- a/sky/provision/slurm/log_streaming.py
+++ b/sky/provision/slurm/log_streaming.py
@@ -101,11 +101,10 @@ class SlurmLogStreamer:
 
         quoted_path = shlex.quote(self._log_path)
         if self._tail_offset is not None and self._tail_offset > 0:
-            # ``tail -c +<bytes>`` starts at byte offset (1-indexed),
-            # which is a strict improvement over K8s v1 (PLAN.md "Log
-            # tailing"). Saved-log replay uses line-based offsets; live
-            # tail with a byte offset only triggers from controller-side
-            # callers that compute the offset against the same file.
+            # ``tail -c +<bytes>`` starts at byte offset (1-indexed).
+            # Saved-log replay uses line-based offsets; live tail with
+            # a byte offset only triggers from controller-side callers
+            # that compute the offset against the same file.
             remote_cmd = (
                 f'tail -c +{int(self._tail_offset) + 1} '
                 f'{"-F" if self._follow else ""} {quoted_path} 2>/dev/null')

--- a/sky/provision/slurm/log_streaming.py
+++ b/sky/provision/slurm/log_streaming.py
@@ -18,11 +18,11 @@ from typing import Any, Callable, Dict, List, Optional
 
 from sky import exceptions
 from sky import sky_logging
-from sky.adaptors import slurm
 from sky.utils import command_runner
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
+    from sky.adaptors import slurm
     from sky.provision.slurm.managed_job_runtime import _Target
 
 logger = sky_logging.init_logger(__name__)

--- a/sky/provision/slurm/log_streaming.py
+++ b/sky/provision/slurm/log_streaming.py
@@ -35,7 +35,9 @@ _TAIL_DRAIN_SECONDS = 5
 
 
 def _login_node_runner(
-        ssh_config: Dict[str, Any]) -> 'command_runner.SSHCommandRunner':
+    ssh_config: Dict[str, Any],
+    slurm_user: Optional[str] = None,
+) -> 'command_runner.SSHCommandRunner':
     """Mirror of ``managed_job_runtime._login_node_runner``.
 
     Duplicated to keep this module free of an import edge back into
@@ -44,7 +46,7 @@ def _login_node_runner(
     ``instance.py::_create_managed_job_v1``'s login-node runner.
     """
     identities_only = bool(ssh_config.get('identities_only', False))
-    return command_runner.SSHCommandRunner(
+    return command_runner.SlurmLoginNodeCommandRunner(
         (ssh_config['hostname'], int(ssh_config.get('port', 22))),
         ssh_config['user'],
         ssh_config.get('private_key'),
@@ -52,6 +54,7 @@ def _login_node_runner(
         ssh_proxy_jump=ssh_config.get('proxyjump'),
         enable_interactive_auth=True,
         disable_identities_only=not identities_only,
+        slurm_user=slurm_user,
     )
 
 
@@ -93,7 +96,8 @@ class SlurmLogStreamer:
 
     def run(self) -> int:
         """Stream the log; return the JobExitCode for the controller."""
-        runner = _login_node_runner(self._target.ssh_config)
+        runner = _login_node_runner(self._target.ssh_config,
+                                    self._target.slurm_user)
         base_ssh = runner.ssh_base_command(
             ssh_mode=command_runner.SshMode.NON_INTERACTIVE,
             port_forward=None,
@@ -115,6 +119,15 @@ class SlurmLogStreamer:
                                self._tail > 0) else None
             tail_flag = f'-n {n}' if n is not None else '-n +1'
             remote_cmd = f'tail {tail_flag} {quoted_path} 2>/dev/null'
+
+        # ``base_ssh`` bypasses ``runner.run()`` (raw argv for the
+        # streaming subprocess), so apply the submit-user wrapping to
+        # the remote command directly — the output file lives in the
+        # submit user's home.
+        if self._target.slurm_user is not None:
+            use_sudo = self._target.ssh_config.get('user') != 'root'
+            remote_cmd = command_runner.wrap_command_as_user(
+                remote_cmd, self._target.slurm_user, use_sudo=use_sudo)
 
         if not self._follow:
             return self._tail_once(base_ssh, remote_cmd)

--- a/sky/provision/slurm/managed_job_runtime.py
+++ b/sky/provision/slurm/managed_job_runtime.py
@@ -91,9 +91,9 @@ def _resolve_slurm_target(handle) -> Optional[_Target]:
     """Extract the Slurm v1 context from a cluster handle.
 
     Returns ``None`` for handles that don't belong to the Slurm v1
-    runtime — never falls back to defaults. Cheap fast-path matches
-    the K8s v1 posture: ``getattr(..., 'has_ray', True)`` treats
-    missing metadata as legacy.
+    runtime — never falls back to defaults. Cheap fast-path:
+    ``getattr(..., 'has_ray', True)`` treats missing metadata as
+    legacy (default-to-legacy posture).
     """
     if handle is None:
         return None
@@ -305,13 +305,10 @@ def _resolve_log_path(
 
 def _build_managed_job_streaming_header(num_nodes: int,
                                         min_nodes: Optional[int] = None) -> str:
-    """Slurm-local copy of the K8s v1 streaming header.
+    """Build the multi-line streaming-start header for a v1 managed job.
 
-    Kept byte-identical to the K8s plugin's
-    ``_build_managed_job_streaming_header`` so saved-log replay's
-    ``LOG_FILE_START_STREAMING_AT`` marker is the same across runtimes.
-    We copy rather than import to keep the OSS Slurm runtime free of
-    plugin imports.
+    The first line embeds ``LOG_FILE_START_STREAMING_AT`` so saved-log
+    replay finds its expected marker.
     """
     dim = colorama.Style.DIM
     reset = colorama.Style.RESET_ALL

--- a/sky/provision/slurm/managed_job_runtime.py
+++ b/sky/provision/slurm/managed_job_runtime.py
@@ -1,0 +1,328 @@
+"""ManagedJobRuntime adapter for Slurm v1 managed jobs.
+
+Lives in OSS alongside the Slurm provisioner. Owns the runtime-side
+adapter for the Slurm-native managed-jobs path: status reads from
+``sacct``/``squeue``, log tailing reads ``--output`` files, and so on.
+
+Phase 1 ships ``get_job_status`` only — every other Protocol method
+returns ``None`` to defer to the call site's legacy default. Follow-up
+phases will replace those stubs with Slurm-native implementations
+(timestamps via ``sacct``, exit codes via ``sacct ExitCode``, log
+download/tail via SSH to the login node).
+"""
+import typing
+from typing import Any, Dict, List, Optional, Tuple
+
+from sky import exceptions
+from sky import global_user_state
+from sky import sky_logging
+from sky.adaptors import slurm
+from sky.provision.slurm import instance as slurm_instance
+from sky.skylet import job_lib
+
+if typing.TYPE_CHECKING:
+    from sky import backends
+    from sky import task as task_lib
+    from sky.backends import cloud_vm_ray_backend
+
+logger = sky_logging.init_logger(__name__)
+
+# Slurm job state mapping. Sourced from:
+# https://slurm.schedmd.com/squeue.html#SECTION_JOB-STATE-CODES
+_PENDING_STATES = frozenset({
+    'PENDING',
+    'CONFIGURING',
+    'RESV_DEL_HOLD',
+    'REQUEUED',
+    'REQUEUE_HOLD',
+    'REQUEUE_FED',
+    'RESIZING',
+})
+_RUNNING_STATES = frozenset({
+    'RUNNING',
+    'COMPLETING',
+    'SIGNALING',
+    'STAGE_OUT',
+    'SUSPENDED',
+})
+_SUCCEEDED_STATES = frozenset({'COMPLETED'})
+_FAILED_STATES = frozenset({
+    'FAILED',
+    'NODE_FAIL',
+    'BOOT_FAIL',
+    'TIMEOUT',
+    'OUT_OF_MEMORY',
+    'DEADLINE',
+    'SPECIAL_EXIT',
+    'PREEMPTED',
+})
+_CANCELLED_STATES = frozenset({'CANCELLED', 'REVOKED'})
+
+
+class _Target:
+    """Resolved per-handle context for a Slurm v1 managed job."""
+
+    def __init__(
+        self,
+        job_id: str,
+        ssh_config: Dict[str, Any],
+        partition: str,
+        log_path: Optional[str],
+    ) -> None:
+        self.job_id = job_id
+        self.ssh_config = ssh_config
+        self.partition = partition
+        self.log_path = log_path
+
+
+def _resolve_slurm_target(handle) -> Optional[_Target]:
+    """Extract the Slurm v1 context from a cluster handle.
+
+    Returns ``None`` for handles that don't belong to the Slurm v1
+    runtime — never falls back to defaults. Cheap fast-path matches
+    the K8s v1 posture: ``getattr(..., 'has_ray', True)`` treats
+    missing metadata as legacy.
+    """
+    if handle is None:
+        return None
+    metadata = getattr(handle, 'provision_runtime_metadata', None)
+    has_ray = getattr(metadata, 'has_ray', True)
+    if has_ray:
+        return None
+
+    try:
+        config = global_user_state.get_cluster_yaml_dict(handle.cluster_yaml)
+    except (ValueError, TypeError):
+        return None
+
+    provider_config = config.get('provider', {}) if config else {}
+    if not slurm_instance.is_managed_job_v1_provider_config(provider_config):
+        return None
+
+    cached = getattr(handle, 'cached_cluster_info', None)
+    if cached is None:
+        return None
+
+    head_id = getattr(cached, 'head_instance_id', None)
+    instances = getattr(cached, 'instances', None) or {}
+    if head_id is None or head_id not in instances:
+        return None
+
+    head_infos = instances[head_id]
+    if not head_infos:
+        return None
+    head_info = head_infos[0]
+    tags = getattr(head_info, 'tags', None) or {}
+    job_id = tags.get('job_id')
+    if not job_id:
+        return None
+
+    ssh_config = provider_config.get('ssh') or {}
+    partition = provider_config.get('partition') or ''
+    log_path = provider_config.get('log_path')
+
+    return _Target(job_id=str(job_id),
+                   ssh_config=ssh_config,
+                   partition=partition,
+                   log_path=log_path)
+
+
+def _slurm_client_from_target(target: _Target) -> 'slurm.SlurmClient':
+    ssh = target.ssh_config
+    return slurm.SlurmClient(
+        ssh.get('hostname'),
+        int(ssh.get('port', 22)),
+        ssh.get('user'),
+        ssh.get('private_key'),
+        ssh_proxy_command=ssh.get('proxycommand'),
+        ssh_proxy_jump=ssh.get('proxyjump'),
+        identities_only=ssh.get('identities_only', False),
+    )
+
+
+def _sacct_get_state(client: 'slurm.SlurmClient', job_id: str) -> Optional[str]:
+    """Look up a job's terminal state via ``sacct`` for jobs aged out
+    of the ``squeue`` window (default ``MinJobAge=300`` seconds).
+
+    Returns the parent step's state (the first row, which is the job
+    itself rather than ``<jobid>.batch`` / ``<jobid>.0``), or ``None``
+    if the call fails or returns nothing.
+    """
+    cmd = (f'sacct -j {job_id} --format=State --parsable2 --noheader '
+           '--allocations')
+    # pylint: disable=protected-access
+    rc, stdout, _ = client._run_slurm_cmd(cmd)
+    if rc != 0:
+        return None
+    for line in stdout.splitlines():
+        state = line.strip()
+        # Cancelled jobs show as ``CANCELLED by <uid>``; normalize.
+        if state.startswith('CANCELLED'):
+            return 'CANCELLED'
+        if state:
+            return state.upper()
+    return None
+
+
+def _slurm_state_to_job_status(
+        state: Optional[str]) -> Optional[job_lib.JobStatus]:
+    """Map a Slurm job state to a SkyPilot ``JobStatus``.
+
+    Unknown / future states fall through to ``None`` so the caller
+    defers to its default — never silently coerce.
+    """
+    if state is None:
+        return None
+    if state in _PENDING_STATES:
+        return job_lib.JobStatus.PENDING
+    if state in _RUNNING_STATES:
+        return job_lib.JobStatus.RUNNING
+    if state in _SUCCEEDED_STATES:
+        return job_lib.JobStatus.SUCCEEDED
+    if state in _FAILED_STATES:
+        return job_lib.JobStatus.FAILED
+    if state in _CANCELLED_STATES:
+        return job_lib.JobStatus.CANCELLED
+    logger.warning(f'Unknown Slurm job state {state!r}; deferring to '
+                   'caller default.')
+    return None
+
+
+def _returncode_to_job_status(
+        returncode: int) -> Tuple[Optional[job_lib.JobStatus], Optional[str]]:
+    """Map a caller-supplied returncode to a ``JobStatus``.
+
+    Trusts the caller: a streaming session that observed the previous
+    attempt's terminal state is more authoritative than a fresh
+    ``sacct`` query, which races against the controller submitting
+    attempt N+1 under the same job name.
+    """
+    if returncode == exceptions.JobExitCode.SUCCEEDED.value:
+        return (job_lib.JobStatus.SUCCEEDED, None)
+    if returncode == exceptions.JobExitCode.CANCELLED.value:
+        return (job_lib.JobStatus.CANCELLED, None)
+    # All other terminal codes represent a failed attempt. JobExitCode is
+    # a lossy collapse (FAILED, FAILED_SETUP, FAILED_DRIVER, etc. all
+    # become FAILED), but the reverse map only needs to flag user-code
+    # failure for the controller's restart-and-continue branch.
+    return (job_lib.JobStatus.FAILED, None)
+
+
+class SlurmManagedJobRuntime:
+    """ManagedJobRuntime for the Slurm-native v1 managed-job path."""
+
+    def owns(self, handle) -> bool:
+        return _resolve_slurm_target(handle) is not None
+
+    def get_job_status(
+        self,
+        handle: Optional['cloud_vm_ray_backend.CloudVmRayResourceHandle'],
+        cluster_name: str,  # pylint: disable=unused-argument
+        returncode: Optional[int] = None,
+    ) -> Optional[Tuple[Optional[job_lib.JobStatus], Optional[str]]]:
+        target = _resolve_slurm_target(handle)
+        if target is None:
+            return None
+
+        if returncode is not None:
+            return _returncode_to_job_status(returncode)
+
+        try:
+            client = _slurm_client_from_target(target)
+            state = client.get_job_state(target.job_id)
+            if state is None:
+                # squeue's ``MinJobAge`` window (default 300s) ages jobs
+                # out — fall back to sacct for historical terminal state.
+                state = _sacct_get_state(client, target.job_id)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Failed to query Slurm job {target.job_id} '
+                           f'state: {e}')
+            return (None, f'Slurm query error: {e}')
+
+        status = _slurm_state_to_job_status(state)
+        if status is None:
+            return None
+        return (status, None)
+
+    def get_job_submitted_at(
+        self,
+        handle: Optional['cloud_vm_ray_backend.CloudVmRayResourceHandle'],
+        cluster_name: str,
+    ) -> Optional[float]:
+        # TODO(slurm-v1 phase 2): query ``sacct -j <jobid> --format=Start``
+        # and parse the Unix timestamp. Mirrors skylet ``add_job``
+        # semantics ("registered to begin"), not "got queued".
+        del handle, cluster_name
+        return None
+
+    def get_job_ended_at(
+        self,
+        handle: Optional['cloud_vm_ray_backend.CloudVmRayResourceHandle'],
+        cluster_name: str,
+    ) -> Optional[float]:
+        # TODO(slurm-v1 phase 2): query ``sacct -j <jobid> --format=End``.
+        del handle, cluster_name
+        return None
+
+    def get_exit_codes(
+        self,
+        handle: 'cloud_vm_ray_backend.CloudVmRayResourceHandle',
+    ) -> Optional[List[int]]:
+        # TODO(slurm-v1 phase 2): query ``sacct -j <jobid>
+        # --format=ExitCode --parsable2`` — one row per srun step.
+        del handle
+        return None
+
+    def download_logs(
+        self,
+        handle: 'cloud_vm_ray_backend.CloudVmRayResourceHandle',
+        job_id: int,
+        task_id: Optional[int],
+    ) -> Optional[str]:
+        # TODO(slurm-v1 phase 2): SSH to the login node and scp the
+        # sbatch ``--output`` file into ``~/.sky/managed_jobs/...``.
+        del handle, job_id, task_id
+        return None
+
+    def tail_logs(
+        self,
+        handle: 'cloud_vm_ray_backend.CloudVmRayResourceHandle',
+        *,
+        backend: 'backends.CloudVmRayBackend',
+        job_id: int,
+        task_id: Optional[int],
+        job_id_on_cluster: Optional[int],
+        worker: Optional[int],
+        follow: bool,
+        tail: Optional[int],
+        tail_offset: Optional[int] = None,
+    ) -> Optional[int]:
+        # TODO(slurm-v1 phase 2): live-tail the sbatch ``--output`` file
+        # over SSH; see ``log_streaming.SlurmLogStreamer`` (planned).
+        del (handle, backend, job_id, task_id, job_id_on_cluster, worker,
+             follow, tail, tail_offset)
+        return None
+
+    def job_group_envs(
+        self,
+        tasks: List['task_lib.Task'],
+        job_id: int,
+    ) -> Optional[Dict[str, str]]:
+        # No JobGroup on Slurm.
+        del tasks, job_id
+        return None
+
+    def k8s_dns_addresses_for_task(
+        self,
+        task: 'task_lib.Task',
+        job_id: int,
+    ) -> Optional[List[str]]:
+        del task, job_id
+        return None
+
+    def k8s_dns_addresses_for_handle(
+        self,
+        handle: 'cloud_vm_ray_backend.CloudVmRayResourceHandle',
+    ) -> Optional[List[str]]:
+        del handle
+        return None

--- a/sky/provision/slurm/managed_job_runtime.py
+++ b/sky/provision/slurm/managed_job_runtime.py
@@ -4,21 +4,34 @@ Lives in OSS alongside the Slurm provisioner. Owns the runtime-side
 adapter for the Slurm-native managed-jobs path: status reads from
 ``sacct``/``squeue``, log tailing reads ``--output`` files, and so on.
 
-Phase 1 ships ``get_job_status`` only — every other Protocol method
-returns ``None`` to defer to the call site's legacy default. Follow-up
-phases will replace those stubs with Slurm-native implementations
-(timestamps via ``sacct``, exit codes via ``sacct ExitCode``, log
-download/tail via SSH to the login node).
+Phase 2 implements ``get_job_status``, ``get_job_submitted_at``,
+``get_job_ended_at``, ``get_exit_codes``, ``download_logs`` and
+``tail_logs``. Log streaming is kept inline here for now;
+``PLAN.md`` notes we'll factor it into ``log_streaming.py`` later.
 """
+import datetime
+import os
+import shlex
+import subprocess
+import sys
+import threading
 import typing
 from typing import Any, Dict, List, Optional, Tuple
+
+import colorama
 
 from sky import exceptions
 from sky import global_user_state
 from sky import sky_logging
+from sky import skypilot_config
 from sky.adaptors import slurm
 from sky.provision.slurm import instance as slurm_instance
+from sky.provision.slurm import utils as slurm_utils
+from sky.skylet import constants as skylet_constants
 from sky.skylet import job_lib
+from sky.skylet import log_lib
+from sky.utils import command_runner
+from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
     from sky import backends
@@ -58,6 +71,14 @@ _FAILED_STATES = frozenset({
 })
 _CANCELLED_STATES = frozenset({'CANCELLED', 'REVOKED'})
 
+_TERMINAL_STATES = (_SUCCEEDED_STATES | _FAILED_STATES | _CANCELLED_STATES)
+
+# Cadence for the side-thread polling sacct during follow-mode log tail.
+_TAIL_TERMINAL_POLL_SECONDS = 5
+# How long after sacct reports a terminal state we let the SSH tail
+# subprocess drain stdout before forcibly closing it.
+_TAIL_DRAIN_SECONDS = 5
+
 
 class _Target:
     """Resolved per-handle context for a Slurm v1 managed job."""
@@ -67,11 +88,13 @@ class _Target:
         job_id: str,
         ssh_config: Dict[str, Any],
         partition: str,
+        region: Optional[str],
         log_path: Optional[str],
     ) -> None:
         self.job_id = job_id
         self.ssh_config = ssh_config
         self.partition = partition
+        self.region = region
         self.log_path = log_path
 
 
@@ -121,9 +144,15 @@ def _resolve_slurm_target(handle) -> Optional[_Target]:
     partition = provider_config.get('partition') or ''
     log_path = provider_config.get('log_path')
 
+    region: Optional[str] = None
+    launched_resources = getattr(handle, 'launched_resources', None)
+    if launched_resources is not None:
+        region = getattr(launched_resources, 'region', None)
+
     return _Target(job_id=str(job_id),
                    ssh_config=ssh_config,
                    partition=partition,
+                   region=region,
                    log_path=log_path)
 
 
@@ -137,6 +166,27 @@ def _slurm_client_from_target(target: _Target) -> 'slurm.SlurmClient':
         ssh_proxy_command=ssh.get('proxycommand'),
         ssh_proxy_jump=ssh.get('proxyjump'),
         identities_only=ssh.get('identities_only', False),
+    )
+
+
+def _login_node_runner(
+        ssh_config: Dict[str, Any]) -> 'command_runner.SSHCommandRunner':
+    """Build an ``SSHCommandRunner`` for the Slurm login node.
+
+    Mirrors the constructor block in ``instance.py::_create_virtual_instance``
+    (around line 523) and ``_create_managed_job_v1`` (around line 1677).
+    Copied rather than imported to avoid an import cycle with the
+    provisioner module from runtime code paths.
+    """
+    identities_only = bool(ssh_config.get('identities_only', False))
+    return command_runner.SSHCommandRunner(
+        (ssh_config['hostname'], int(ssh_config.get('port', 22))),
+        ssh_config['user'],
+        ssh_config.get('private_key'),
+        ssh_proxy_command=ssh_config.get('proxycommand'),
+        ssh_proxy_jump=ssh_config.get('proxyjump'),
+        enable_interactive_auth=True,
+        disable_identities_only=not identities_only,
     )
 
 
@@ -162,6 +212,135 @@ def _sacct_get_state(client: 'slurm.SlurmClient', job_id: str) -> Optional[str]:
         if state:
             return state.upper()
     return None
+
+
+def _sacct_get_single_field(client: 'slurm.SlurmClient', job_id: str,
+                            field: str) -> Optional[str]:
+    """Fetch a single ``sacct`` field for the allocation (parent row).
+
+    Returns the trimmed field value, or ``None`` on query failure /
+    empty output. Empty string and Slurm's ``Unknown`` sentinel both
+    map to ``None`` so callers can treat "not available yet" uniformly.
+    """
+    cmd = (f'sacct -j {job_id} --format={field} --parsable2 --noheader '
+           '--allocations')
+    # pylint: disable=protected-access
+    rc, stdout, _ = client._run_slurm_cmd(cmd)
+    if rc != 0:
+        return None
+    for line in stdout.splitlines():
+        value = line.strip()
+        if not value or value == 'Unknown':
+            return None
+        return value
+    return None
+
+
+def _parse_slurm_timestamp(value: Optional[str]) -> Optional[float]:
+    """Parse a Slurm sacct ISO timestamp (local time) to a Unix float.
+
+    Slurm emits times in the controller's local timezone formatted as
+    ``YYYY-MM-DDTHH:MM:SS`` (no timezone suffix). ``fromisoformat``
+    treats the result as a naive ``datetime``; calling ``.timestamp()``
+    then interprets it in the *local* timezone of the API server. For
+    Phase 2 that's the closest we can get without an explicit TZ flag
+    or sacct format override (TODO(slurm-v1): set ``SLURM_TIME_FORMAT``
+    or use ``--format=Start%Y-%m-%dT%H:%M:%S%z`` once we standardize
+    timezone handling).
+    """
+    if value is None:
+        return None
+    try:
+        dt = datetime.datetime.fromisoformat(value)
+    except ValueError:
+        logger.debug(f'Failed to parse Slurm timestamp {value!r}.')
+        return None
+    return dt.timestamp()
+
+
+def _resolve_log_path(
+        target: _Target,
+        client: Optional['slurm.SlurmClient'] = None) -> Optional[str]:
+    """Compute the sbatch ``--output`` path for the v1 job.
+
+    ``_create_managed_job_v1`` writes it to
+    ``{workdir or $HOME}/.sky_provision/slurm-{job_id}.out`` — the
+    same shape as ``instance._sbatch_log_path``. We recompute it at
+    runtime because the path is not persisted into the cluster YAML
+    (template intentionally omits skypilot-level workdir; only the
+    task-level workdir payload is stored).
+    """
+    if target.log_path is not None:
+        return target.log_path
+    if client is None:
+        client = _slurm_client_from_target(target)
+
+    workdir_cfg: Optional[str] = None
+    if target.region is not None:
+        try:
+            workdir_cfg = skypilot_config.get_effective_region_config(
+                cloud='slurm',
+                region=target.region,
+                keys=('workdir',),
+                default_value=None)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Failed to read slurm.workdir from config: {e}')
+            workdir_cfg = None
+
+    if workdir_cfg is not None:
+        try:
+            remote_env = client.get_env()
+            workdir_cfg = slurm_utils.expand_path_vars(workdir_cfg, remote_env)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Failed to expand workdir vars: {e}')
+
+    if workdir_cfg is not None:
+        sky_base_dir = workdir_cfg
+    else:
+        try:
+            sky_base_dir = client.get_remote_home_dir()
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Failed to resolve remote $HOME for v1 log '
+                           f'path: {e}')
+            return None
+
+    if not sky_base_dir or not os.path.isabs(sky_base_dir):
+        logger.warning(f'Refusing to use non-absolute v1 log base dir '
+                       f'{sky_base_dir!r}.')
+        return None
+
+    return (f'{sky_base_dir}/'
+            f'{slurm_instance.PROVISION_SCRIPTS_DIRECTORY_NAME}/'
+            f'slurm-{target.job_id}.out')
+
+
+def _build_managed_job_streaming_header(num_nodes: int,
+                                        min_nodes: Optional[int] = None) -> str:
+    """Slurm-local copy of the K8s v1 streaming header.
+
+    Kept byte-identical to the K8s plugin's
+    ``_build_managed_job_streaming_header`` so saved-log replay's
+    ``LOG_FILE_START_STREAMING_AT`` marker is the same across runtimes.
+    We copy rather than import to keep the OSS Slurm runtime free of
+    plugin imports.
+    """
+    dim = colorama.Style.DIM
+    reset = colorama.Style.RESET_ALL
+    plural = 's' if num_nodes > 1 else ''
+    lines = [
+        f'{dim}├── {log_lib.LOG_FILE_START_STREAMING_AT}{num_nodes} '
+        f'node{plural}.{reset}\n'
+    ]
+    if min_nodes is not None:
+        lines.append(f'{dim}├── Gang scheduling: waiting for '
+                     f'{min_nodes} nodes before starting setup/run.'
+                     f'{reset}\n')
+    lines.append(f'{dim}└── {reset}'
+                 f'Job started. Streaming logs... '
+                 f'{dim}'
+                 f'(Ctrl-C to exit log streaming; job will not be killed)'
+                 f'{reset}\n')
+    return ''.join(lines)
 
 
 def _slurm_state_to_job_status(
@@ -208,6 +387,17 @@ def _returncode_to_job_status(
     return (job_lib.JobStatus.FAILED, None)
 
 
+def _state_to_job_exit_code(state: Optional[str]) -> int:
+    """Map a Slurm state to a ``JobExitCode``."""
+    if state is None:
+        return exceptions.JobExitCode.FAILED.value
+    if state in _SUCCEEDED_STATES:
+        return exceptions.JobExitCode.SUCCEEDED.value
+    if state in _CANCELLED_STATES:
+        return exceptions.JobExitCode.CANCELLED.value
+    return exceptions.JobExitCode.FAILED.value
+
+
 class SlurmManagedJobRuntime:
     """ManagedJobRuntime for the Slurm-native v1 managed-job path."""
 
@@ -249,29 +439,76 @@ class SlurmManagedJobRuntime:
         handle: Optional['cloud_vm_ray_backend.CloudVmRayResourceHandle'],
         cluster_name: str,
     ) -> Optional[float]:
-        # TODO(slurm-v1 phase 2): query ``sacct -j <jobid> --format=Start``
-        # and parse the Unix timestamp. Mirrors skylet ``add_job``
-        # semantics ("registered to begin"), not "got queued".
-        del handle, cluster_name
-        return None
+        del cluster_name
+        target = _resolve_slurm_target(handle)
+        if target is None:
+            return None
+        try:
+            client = _slurm_client_from_target(target)
+            # ``Start`` (not ``Submit``): the legacy skylet ``add_job``
+            # timestamp tracks "registered to begin", not "got queued".
+            # On a busy partition ``Submit`` can be days off ``Start``.
+            value = _sacct_get_single_field(client, target.job_id, 'Start')
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Failed to query Slurm Start time for job '
+                           f'{target.job_id}: {e}')
+            return None
+        return _parse_slurm_timestamp(value)
 
     def get_job_ended_at(
         self,
         handle: Optional['cloud_vm_ray_backend.CloudVmRayResourceHandle'],
         cluster_name: str,
     ) -> Optional[float]:
-        # TODO(slurm-v1 phase 2): query ``sacct -j <jobid> --format=End``.
-        del handle, cluster_name
-        return None
+        del cluster_name
+        target = _resolve_slurm_target(handle)
+        if target is None:
+            return None
+        try:
+            client = _slurm_client_from_target(target)
+            value = _sacct_get_single_field(client, target.job_id, 'End')
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Failed to query Slurm End time for job '
+                           f'{target.job_id}: {e}')
+            return None
+        return _parse_slurm_timestamp(value)
 
     def get_exit_codes(
         self,
         handle: 'cloud_vm_ray_backend.CloudVmRayResourceHandle',
     ) -> Optional[List[int]]:
-        # TODO(slurm-v1 phase 2): query ``sacct -j <jobid>
-        # --format=ExitCode --parsable2`` — one row per srun step.
-        del handle
-        return None
+        target = _resolve_slurm_target(handle)
+        if target is None:
+            return None
+        # TODO(slurm-v1): PLAN.md gap #16 calls out that ``sacct
+        # --format=ExitCode`` returns one row per srun step
+        # (``<jobid>``, ``<jobid>.batch``, ``<jobid>.0``, ...). For now
+        # we take the parent allocation row, parse the ``<exit>:<signal>``
+        # format, and surface a single exit code. A follow-up should
+        # split per-rank codes once we decide which step row maps to
+        # which user-visible rank.
+        try:
+            client = _slurm_client_from_target(target)
+            value = _sacct_get_single_field(client, target.job_id, 'ExitCode')
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Failed to query Slurm ExitCode for job '
+                         f'{target.job_id}: {e}')
+            return None
+        if value is None:
+            return None
+        # ``<exit>:<signal>``. If signal != 0 and exit == 0, the job
+        # was killed by signal — surface 128+signal so callers see a
+        # non-zero code.
+        try:
+            exit_str, _, signal_str = value.partition(':')
+            exit_code = int(exit_str) if exit_str else 0
+            signal_code = int(signal_str) if signal_str else 0
+        except ValueError:
+            logger.debug(f'Unparseable Slurm ExitCode {value!r}.')
+            return None
+        if exit_code == 0 and signal_code != 0:
+            exit_code = 128 + signal_code
+        return [exit_code]
 
     def download_logs(
         self,
@@ -279,10 +516,44 @@ class SlurmManagedJobRuntime:
         job_id: int,
         task_id: Optional[int],
     ) -> Optional[str]:
-        # TODO(slurm-v1 phase 2): SSH to the login node and scp the
-        # sbatch ``--output`` file into ``~/.sky/managed_jobs/...``.
-        del handle, job_id, task_id
-        return None
+        target = _resolve_slurm_target(handle)
+        if target is None:
+            return None
+        client = _slurm_client_from_target(target)
+        log_path = _resolve_log_path(target, client)
+        if log_path is None:
+            return None
+
+        runner = _login_node_runner(target.ssh_config)
+        # ``cat`` instead of ``rsync`` so a missing file produces a
+        # clean empty stdout + non-zero rc rather than an rsync error;
+        # job-not-yet-started maps to an empty saved log.
+        cmd = f'cat {shlex.quote(log_path)} 2>/dev/null'
+        rc, stdout, stderr = runner.run(cmd,
+                                        require_outputs=True,
+                                        separate_stderr=True,
+                                        stream_logs=False)
+        if rc != 0:
+            logger.warning(f'Failed to download Slurm v1 logs from '
+                           f'{log_path} (rc={rc}): {stderr}')
+            return None
+
+        local_dir = os.path.expanduser(
+            os.path.join(skylet_constants.SKY_LOGS_DIRECTORY, 'managed_jobs',
+                         f'job-id-{job_id}'))
+        os.makedirs(local_dir, exist_ok=True)
+        log_file = os.path.join(
+            local_dir, f'task-{task_id if task_id is not None else 0}.log')
+
+        num_nodes = getattr(handle, 'launched_nodes', 1) or 1
+        header = _build_managed_job_streaming_header(num_nodes=num_nodes,
+                                                     min_nodes=None)
+        with open(log_file, 'w', encoding='utf-8') as f:
+            f.write(header)
+            f.write(stdout)
+
+        logger.info(f'Downloaded Slurm managed job logs to {log_file}')
+        return log_file
 
     def tail_logs(
         self,
@@ -297,11 +568,201 @@ class SlurmManagedJobRuntime:
         tail: Optional[int],
         tail_offset: Optional[int] = None,
     ) -> Optional[int]:
-        # TODO(slurm-v1 phase 2): live-tail the sbatch ``--output`` file
-        # over SSH; see ``log_streaming.SlurmLogStreamer`` (planned).
-        del (handle, backend, job_id, task_id, job_id_on_cluster, worker,
-             follow, tail, tail_offset)
-        return None
+        del backend, job_id, task_id, job_id_on_cluster, worker
+        target = _resolve_slurm_target(handle)
+        if target is None:
+            return None
+        client = _slurm_client_from_target(target)
+        log_path = _resolve_log_path(target, client)
+        if log_path is None:
+            return None
+
+        # pylint: disable=import-outside-toplevel
+        from sky.utils import context as context_lib
+
+        ctx = context_lib.get()
+        out = ctx.output_stream(sys.stdout) if ctx else sys.stdout
+
+        def _write(msg: str) -> None:
+            out.write(msg)
+            out.flush()
+
+        runner = _login_node_runner(target.ssh_config)
+        base_ssh = runner.ssh_base_command(
+            ssh_mode=command_runner.SshMode.NON_INTERACTIVE,
+            port_forward=None,
+            connect_timeout=None)
+
+        # Build the remote ``tail`` invocation.
+        quoted_path = shlex.quote(log_path)
+        if tail_offset is not None and tail_offset > 0:
+            # ``tail -c +<bytes>`` starts at byte offset (1-indexed),
+            # which is a strict improvement over K8s v1 (PLAN.md "Log
+            # tailing"). Saved-log replay uses line-based offsets; live
+            # tail with a byte offset only triggers from controller-side
+            # callers that compute the offset against the same file.
+            remote_cmd = (f'tail -c +{int(tail_offset) + 1} '
+                          f'{"-F" if follow else ""} {quoted_path} 2>/dev/null')
+        elif follow:
+            remote_cmd = f'tail -F {quoted_path} 2>/dev/null'
+        else:
+            n = tail if (tail is not None and tail > 0) else None
+            tail_flag = f'-n {n}' if n is not None else '-n +1'
+            remote_cmd = f'tail {tail_flag} {quoted_path} 2>/dev/null'
+
+        if not follow:
+            return self._tail_once(base_ssh, remote_cmd, _write, target, client)
+        return self._tail_follow(base_ssh, remote_cmd, _write, target, client)
+
+    def _tail_once(
+        self,
+        base_ssh: List[str],
+        remote_cmd: str,
+        write_fn,
+        target: _Target,
+        client: 'slurm.SlurmClient',
+    ) -> int:
+        # Pass ``remote_cmd`` as a single argv element. SSH joins any
+        # remaining args with spaces into one command string for the
+        # remote shell, so a single arg with shell metachars (``|``,
+        # ``2>/dev/null``) is preserved verbatim. Compare
+        # ``command_runner.run`` which sets ``shell=True`` locally and
+        # therefore needs ``shlex.quote``; here ``subprocess`` uses argv
+        # mode so no extra quoting is needed.
+        full_cmd = base_ssh + [remote_cmd]
+        try:
+            proc = subprocess.run(full_cmd,
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.PIPE,
+                                  check=False)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Slurm v1 tail (one-shot) failed: {e}')
+            return exceptions.JobExitCode.FAILED.value
+        if proc.stdout:
+            write_fn(proc.stdout.decode('utf-8', errors='replace'))
+        # Render the same footer as the follow path so the saved-log
+        # consumer sees a consistent shape.
+        state = self._read_terminal_state(client, target.job_id)
+        if state is not None:
+            write_fn(
+                ux_utils.finishing_message(f'Job finished (status: {state}).') +
+                '\n')
+            return _state_to_job_exit_code(state)
+        # Non-terminal one-shot read — return NOT_FINISHED so the caller
+        # falls through to the standard already-running path.
+        return exceptions.JobExitCode.NOT_FINISHED.value
+
+    def _tail_follow(
+        self,
+        base_ssh: List[str],
+        remote_cmd: str,
+        write_fn,
+        target: _Target,
+        client: 'slurm.SlurmClient',
+    ) -> int:
+        # See ``_tail_once`` for argv vs shell-quote reasoning.
+        full_cmd = base_ssh + [remote_cmd]
+        try:
+            proc = subprocess.Popen(
+                full_cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                # Line-buffered text isn't reliable through SSH; read bytes.
+                bufsize=0,
+            )
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Failed to spawn Slurm v1 tail subprocess: {e}')
+            return exceptions.JobExitCode.FAILED.value
+
+        assert proc.stdout is not None
+        stdout_fd = proc.stdout.fileno()
+
+        terminal_state: Dict[str, Optional[str]] = {'value': None}
+        stop_event = threading.Event()
+
+        def _poll_state() -> None:
+            while not stop_event.is_set():
+                try:
+                    state = client.get_job_state(target.job_id)
+                    if state is None:
+                        state = _sacct_get_state(client, target.job_id)
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.debug(f'sacct poll failed: {e}')
+                    state = None
+                if state is not None and state in _TERMINAL_STATES:
+                    terminal_state['value'] = state
+                    # Give the SSH ``tail -F`` subprocess a short window
+                    # to flush anything still in flight, then send it a
+                    # SIGTERM so the blocking ``os.read`` in the main
+                    # thread returns 0 and we proceed to the footer.
+                    if stop_event.wait(_TAIL_DRAIN_SECONDS):
+                        return
+                    try:
+                        proc.terminate()
+                    except Exception:  # pylint: disable=broad-except
+                        pass
+                    return
+                if stop_event.wait(_TAIL_TERMINAL_POLL_SECONDS):
+                    return
+
+        poll_thread = threading.Thread(target=_poll_state, daemon=True)
+        poll_thread.start()
+
+        try:
+            # Stream bytes as they arrive. The poll thread is
+            # responsible for ``proc.terminate()`` once it observes a
+            # terminal sacct state, which closes the SSH pipe and lets
+            # ``os.read`` return 0 here so we drop out cleanly. Reading
+            # the raw fd avoids relying on ``BufferedReader`` behavior
+            # across Python versions.
+            while True:
+                try:
+                    chunk = os.read(stdout_fd, 4096)
+                except OSError:
+                    chunk = b''
+                if not chunk:
+                    break
+                write_fn(chunk.decode('utf-8', errors='replace'))
+        finally:
+            stop_event.set()
+            try:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=_TAIL_DRAIN_SECONDS)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=_TAIL_DRAIN_SECONDS)
+            except Exception:  # pylint: disable=broad-except
+                pass
+            poll_thread.join(timeout=_TAIL_DRAIN_SECONDS)
+
+        state = terminal_state['value']
+        if state is None:
+            # Watchdog never observed terminal; do one last sacct query
+            # so the footer reflects whatever Slurm now reports.
+            state = self._read_terminal_state(client, target.job_id)
+
+        if state is not None:
+            write_fn(
+                ux_utils.finishing_message(f'Job finished (status: {state}).') +
+                '\n')
+            return _state_to_job_exit_code(state)
+        # No terminal observed and tail dropped — surface as failed so
+        # the controller's existing decision branches handle it.
+        return exceptions.JobExitCode.FAILED.value
+
+    def _read_terminal_state(self, client: 'slurm.SlurmClient',
+                             job_id: str) -> Optional[str]:
+        try:
+            state = client.get_job_state(job_id)
+            if state is None:
+                state = _sacct_get_state(client, job_id)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Terminal state lookup failed: {e}')
+            return None
+        if state is None or state not in _TERMINAL_STATES:
+            return None
+        return state
 
     def job_group_envs(
         self,

--- a/sky/provision/slurm/managed_job_runtime.py
+++ b/sky/provision/slurm/managed_job_runtime.py
@@ -4,17 +4,13 @@ Lives in OSS alongside the Slurm provisioner. Owns the runtime-side
 adapter for the Slurm-native managed-jobs path: status reads from
 ``sacct``/``squeue``, log tailing reads ``--output`` files, and so on.
 
-Phase 2 implements ``get_job_status``, ``get_job_submitted_at``,
-``get_job_ended_at``, ``get_exit_codes``, ``download_logs`` and
-``tail_logs``. Log streaming is kept inline here for now;
-``PLAN.md`` notes we'll factor it into ``log_streaming.py`` later.
+Log-tail streaming machinery lives in
+``sky/provision/slurm/log_streaming.py`` per PLAN.md "File layout";
+``download_logs`` stays here (it's a single ``cat`` + write-to-disk).
 """
 import datetime
 import os
 import shlex
-import subprocess
-import sys
-import threading
 import typing
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -31,7 +27,6 @@ from sky.skylet import constants as skylet_constants
 from sky.skylet import job_lib
 from sky.skylet import log_lib
 from sky.utils import command_runner
-from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
     from sky import backends
@@ -72,12 +67,6 @@ _FAILED_STATES = frozenset({
 _CANCELLED_STATES = frozenset({'CANCELLED', 'REVOKED'})
 
 _TERMINAL_STATES = (_SUCCEEDED_STATES | _FAILED_STATES | _CANCELLED_STATES)
-
-# Cadence for the side-thread polling sacct during follow-mode log tail.
-_TAIL_TERMINAL_POLL_SECONDS = 5
-# How long after sacct reports a terminal state we let the SSH tail
-# subprocess drain stdout before forcibly closing it.
-_TAIL_DRAIN_SECONDS = 5
 
 
 class _Target:
@@ -577,192 +566,24 @@ class SlurmManagedJobRuntime:
         if log_path is None:
             return None
 
+        # Lazy-import the streamer module — its import edge points back
+        # at this module's ``_Target`` (under ``TYPE_CHECKING``) and we
+        # want to keep the runtime module's import surface unchanged.
         # pylint: disable=import-outside-toplevel
-        from sky.utils import context as context_lib
+        from sky.provision.slurm import log_streaming
 
-        ctx = context_lib.get()
-        out = ctx.output_stream(sys.stdout) if ctx else sys.stdout
-
-        def _write(msg: str) -> None:
-            out.write(msg)
-            out.flush()
-
-        runner = _login_node_runner(target.ssh_config)
-        base_ssh = runner.ssh_base_command(
-            ssh_mode=command_runner.SshMode.NON_INTERACTIVE,
-            port_forward=None,
-            connect_timeout=None)
-
-        # Build the remote ``tail`` invocation.
-        quoted_path = shlex.quote(log_path)
-        if tail_offset is not None and tail_offset > 0:
-            # ``tail -c +<bytes>`` starts at byte offset (1-indexed),
-            # which is a strict improvement over K8s v1 (PLAN.md "Log
-            # tailing"). Saved-log replay uses line-based offsets; live
-            # tail with a byte offset only triggers from controller-side
-            # callers that compute the offset against the same file.
-            remote_cmd = (f'tail -c +{int(tail_offset) + 1} '
-                          f'{"-F" if follow else ""} {quoted_path} 2>/dev/null')
-        elif follow:
-            remote_cmd = f'tail -F {quoted_path} 2>/dev/null'
-        else:
-            n = tail if (tail is not None and tail > 0) else None
-            tail_flag = f'-n {n}' if n is not None else '-n +1'
-            remote_cmd = f'tail {tail_flag} {quoted_path} 2>/dev/null'
-
-        if not follow:
-            return self._tail_once(base_ssh, remote_cmd, _write, target, client)
-        return self._tail_follow(base_ssh, remote_cmd, _write, target, client)
-
-    def _tail_once(
-        self,
-        base_ssh: List[str],
-        remote_cmd: str,
-        write_fn,
-        target: _Target,
-        client: 'slurm.SlurmClient',
-    ) -> int:
-        # Pass ``remote_cmd`` as a single argv element. SSH joins any
-        # remaining args with spaces into one command string for the
-        # remote shell, so a single arg with shell metachars (``|``,
-        # ``2>/dev/null``) is preserved verbatim. Compare
-        # ``command_runner.run`` which sets ``shell=True`` locally and
-        # therefore needs ``shlex.quote``; here ``subprocess`` uses argv
-        # mode so no extra quoting is needed.
-        full_cmd = base_ssh + [remote_cmd]
-        try:
-            proc = subprocess.run(full_cmd,
-                                  stdout=subprocess.PIPE,
-                                  stderr=subprocess.PIPE,
-                                  check=False)
-        except Exception as e:  # pylint: disable=broad-except
-            logger.warning(f'Slurm v1 tail (one-shot) failed: {e}')
-            return exceptions.JobExitCode.FAILED.value
-        if proc.stdout:
-            write_fn(proc.stdout.decode('utf-8', errors='replace'))
-        # Render the same footer as the follow path so the saved-log
-        # consumer sees a consistent shape.
-        state = self._read_terminal_state(client, target.job_id)
-        if state is not None:
-            write_fn(
-                ux_utils.finishing_message(f'Job finished (status: {state}).') +
-                '\n')
-            return _state_to_job_exit_code(state)
-        # Non-terminal one-shot read — return NOT_FINISHED so the caller
-        # falls through to the standard already-running path.
-        return exceptions.JobExitCode.NOT_FINISHED.value
-
-    def _tail_follow(
-        self,
-        base_ssh: List[str],
-        remote_cmd: str,
-        write_fn,
-        target: _Target,
-        client: 'slurm.SlurmClient',
-    ) -> int:
-        # See ``_tail_once`` for argv vs shell-quote reasoning.
-        full_cmd = base_ssh + [remote_cmd]
-        try:
-            proc = subprocess.Popen(
-                full_cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.DEVNULL,
-                # Line-buffered text isn't reliable through SSH; read bytes.
-                bufsize=0,
-            )
-        except Exception as e:  # pylint: disable=broad-except
-            logger.warning(f'Failed to spawn Slurm v1 tail subprocess: {e}')
-            return exceptions.JobExitCode.FAILED.value
-
-        assert proc.stdout is not None
-        stdout_fd = proc.stdout.fileno()
-
-        terminal_state: Dict[str, Optional[str]] = {'value': None}
-        stop_event = threading.Event()
-
-        def _poll_state() -> None:
-            while not stop_event.is_set():
-                try:
-                    state = client.get_job_state(target.job_id)
-                    if state is None:
-                        state = _sacct_get_state(client, target.job_id)
-                except Exception as e:  # pylint: disable=broad-except
-                    logger.debug(f'sacct poll failed: {e}')
-                    state = None
-                if state is not None and state in _TERMINAL_STATES:
-                    terminal_state['value'] = state
-                    # Give the SSH ``tail -F`` subprocess a short window
-                    # to flush anything still in flight, then send it a
-                    # SIGTERM so the blocking ``os.read`` in the main
-                    # thread returns 0 and we proceed to the footer.
-                    if stop_event.wait(_TAIL_DRAIN_SECONDS):
-                        return
-                    try:
-                        proc.terminate()
-                    except Exception:  # pylint: disable=broad-except
-                        pass
-                    return
-                if stop_event.wait(_TAIL_TERMINAL_POLL_SECONDS):
-                    return
-
-        poll_thread = threading.Thread(target=_poll_state, daemon=True)
-        poll_thread.start()
-
-        try:
-            # Stream bytes as they arrive. The poll thread is
-            # responsible for ``proc.terminate()`` once it observes a
-            # terminal sacct state, which closes the SSH pipe and lets
-            # ``os.read`` return 0 here so we drop out cleanly. Reading
-            # the raw fd avoids relying on ``BufferedReader`` behavior
-            # across Python versions.
-            while True:
-                try:
-                    chunk = os.read(stdout_fd, 4096)
-                except OSError:
-                    chunk = b''
-                if not chunk:
-                    break
-                write_fn(chunk.decode('utf-8', errors='replace'))
-        finally:
-            stop_event.set()
-            try:
-                proc.terminate()
-                try:
-                    proc.wait(timeout=_TAIL_DRAIN_SECONDS)
-                except subprocess.TimeoutExpired:
-                    proc.kill()
-                    proc.wait(timeout=_TAIL_DRAIN_SECONDS)
-            except Exception:  # pylint: disable=broad-except
-                pass
-            poll_thread.join(timeout=_TAIL_DRAIN_SECONDS)
-
-        state = terminal_state['value']
-        if state is None:
-            # Watchdog never observed terminal; do one last sacct query
-            # so the footer reflects whatever Slurm now reports.
-            state = self._read_terminal_state(client, target.job_id)
-
-        if state is not None:
-            write_fn(
-                ux_utils.finishing_message(f'Job finished (status: {state}).') +
-                '\n')
-            return _state_to_job_exit_code(state)
-        # No terminal observed and tail dropped — surface as failed so
-        # the controller's existing decision branches handle it.
-        return exceptions.JobExitCode.FAILED.value
-
-    def _read_terminal_state(self, client: 'slurm.SlurmClient',
-                             job_id: str) -> Optional[str]:
-        try:
-            state = client.get_job_state(job_id)
-            if state is None:
-                state = _sacct_get_state(client, job_id)
-        except Exception as e:  # pylint: disable=broad-except
-            logger.debug(f'Terminal state lookup failed: {e}')
-            return None
-        if state is None or state not in _TERMINAL_STATES:
-            return None
-        return state
+        streamer = log_streaming.make_streamer_from_target(
+            target,
+            log_path,
+            client,
+            terminal_states=_TERMINAL_STATES,
+            sacct_get_state=_sacct_get_state,
+            state_to_job_exit_code=_state_to_job_exit_code,
+            follow=follow,
+            tail=tail,
+            tail_offset=tail_offset,
+        )
+        return streamer.run()
 
     def job_group_envs(
         self,

--- a/sky/provision/slurm/managed_job_runtime.py
+++ b/sky/provision/slurm/managed_job_runtime.py
@@ -79,12 +79,17 @@ class _Target:
         partition: str,
         region: Optional[str],
         log_path: Optional[str],
+        slurm_user: Optional[str] = None,
     ) -> None:
         self.job_id = job_id
         self.ssh_config = ssh_config
         self.partition = partition
         self.region = region
         self.log_path = log_path
+        # Submit user for slurm.submit_as_user deployments: the sbatch
+        # ran as this Unix user, so every follow-up command (squeue /
+        # sacct / log reads) must run as them too.
+        self.slurm_user = slurm_user
 
 
 def _resolve_slurm_target(handle) -> Optional[_Target]:
@@ -142,7 +147,8 @@ def _resolve_slurm_target(handle) -> Optional[_Target]:
                    ssh_config=ssh_config,
                    partition=partition,
                    region=region,
-                   log_path=log_path)
+                   log_path=log_path,
+                   slurm_user=provider_config.get('slurm_user'))
 
 
 def _slurm_client_from_target(target: _Target) -> 'slurm.SlurmClient':
@@ -155,20 +161,25 @@ def _slurm_client_from_target(target: _Target) -> 'slurm.SlurmClient':
         ssh_proxy_command=ssh.get('proxycommand'),
         ssh_proxy_jump=ssh.get('proxyjump'),
         identities_only=ssh.get('identities_only', False),
+        slurm_user=target.slurm_user,
     )
 
 
 def _login_node_runner(
-        ssh_config: Dict[str, Any]) -> 'command_runner.SSHCommandRunner':
-    """Build an ``SSHCommandRunner`` for the Slurm login node.
+    ssh_config: Dict[str, Any],
+    slurm_user: Optional[str] = None,
+) -> 'command_runner.SSHCommandRunner':
+    """Build a login-node command runner.
 
     Mirrors the constructor block in ``instance.py::_create_virtual_instance``
     (around line 523) and ``_create_managed_job_v1`` (around line 1677).
     Copied rather than imported to avoid an import cycle with the
-    provisioner module from runtime code paths.
+    provisioner module from runtime code paths. ``slurm_user`` wraps
+    every command as the submit user, whose home holds the sbatch
+    output file.
     """
     identities_only = bool(ssh_config.get('identities_only', False))
-    return command_runner.SSHCommandRunner(
+    return command_runner.SlurmLoginNodeCommandRunner(
         (ssh_config['hostname'], int(ssh_config.get('port', 22))),
         ssh_config['user'],
         ssh_config.get('private_key'),
@@ -176,6 +187,7 @@ def _login_node_runner(
         ssh_proxy_jump=ssh_config.get('proxyjump'),
         enable_interactive_auth=True,
         disable_identities_only=not identities_only,
+        slurm_user=slurm_user,
     )
 
 
@@ -510,7 +522,7 @@ class SlurmManagedJobRuntime:
         if log_path is None:
             return None
 
-        runner = _login_node_runner(target.ssh_config)
+        runner = _login_node_runner(target.ssh_config, target.slurm_user)
         # ``cat`` instead of ``rsync`` so a missing file produces a
         # clean empty stdout + non-zero rc rather than an rsync error;
         # job-not-yet-started maps to an empty saved log.

--- a/sky/provision/slurm/managed_job_runtime.py
+++ b/sky/provision/slurm/managed_job_runtime.py
@@ -541,6 +541,21 @@ class SlurmManagedJobRuntime:
         logger.info(f'Downloaded Slurm managed job logs to {log_file}')
         return log_file
 
+    def on_before_recovery(
+        self,
+        handle: Optional['cloud_vm_ray_backend.CloudVmRayResourceHandle'],
+        backend: 'backends.CloudVmRayBackend',
+        job_id: int,
+        task_id: Optional[int],
+        exit_codes: Optional[List[int]] = None,
+        job_id_on_pool_cluster: Optional[int] = None,
+    ) -> None:
+        # The failed attempt's sbatch --output file stays on the login
+        # node after recovery (each attempt writes its own file), so
+        # there is no state to snapshot before the relaunch.
+        del handle, backend, job_id, task_id
+        del exit_codes, job_id_on_pool_cluster
+
     def tail_logs(
         self,
         handle: 'cloud_vm_ray_backend.CloudVmRayResourceHandle',

--- a/sky/templates/slurm-managed-job-v1.yml.j2
+++ b/sky/templates/slurm-managed-job-v1.yml.j2
@@ -1,0 +1,112 @@
+{# Slurm-native managed-jobs v1 template.
+
+The cluster YAML carries:
+  * the v1 marker (provider.skypilot_runtime) consumed by every
+    routed provisioner function;
+  * the execution payload (setup / run / envs / workdir / file_mounts
+    / sbatch_options / container_image) consumed by
+    _create_managed_job_v1 when it builds the sbatch script;
+  * the same SSH + partition shape as slurm-ray.yml.j2 so the rest
+    of the backend's cluster-YAML consumption (status queries,
+    terminate, etc.) keeps working.
+
+There is no Ray, no skylet, and no SSH inside the cluster from
+SkyPilot's perspective — the runtime-metadata returned by
+_create_managed_job_v1 marks every post-provision phase as already
+done, so the backend skips file sync, setup, execute, and SSH
+registration. The auth / available_node_types / setup_commands
+sections below are kept as stubs satisfying ProvisionConfig parsing
+without doing anything user-visible.
+#}
+cluster_name: {{cluster_name_on_cloud}}
+
+max_workers: {{num_nodes - 1}}
+upscaling_speed: {{num_nodes - 1}}
+idle_timeout_minutes: 60
+
+provider:
+  type: external
+  module: sky.provision.slurm
+
+  cluster: "{{slurm_cluster}}"
+  partition: "{{slurm_partition}}"
+  provision_timeout: {{provision_timeout}}
+
+  skypilot_runtime: managed_job_v1
+
+  ssh:
+    hostname: {{ssh_hostname}}
+    port: {{ssh_port}}
+    user: {{ssh_user}}
+{% if slurm_private_key is not none %}
+    private_key: {{slurm_private_key}}
+{% endif %}
+{% if slurm_proxy_command is not none %}
+    proxycommand: {{slurm_proxy_command | tojson }}
+{% endif %}
+{% if slurm_proxy_jump is not none %}
+    proxyjump: {{slurm_proxy_jump | tojson }}
+{% endif %}
+    identities_only: {{slurm_identities_only}}
+
+  # v1 managed-job execution payload (flat keys). Read back from
+  # provider_config in _create_managed_job_v1.
+  setup: {{setup | tojson}}
+  run: {{run | tojson}}
+  envs: {{envs | tojson}}
+  num_nodes: {{num_nodes}}
+  num_gpus_per_node: {{num_gpus_per_node}}
+{% if workdir is not none %}
+  workdir: {{workdir | tojson}}
+{% endif %}
+{% if file_mounts is not none %}
+  file_mounts: {{file_mounts | tojson}}
+{% endif %}
+{% if sbatch_options is not none %}
+  sbatch_options: {{sbatch_options | tojson}}
+{% endif %}
+{% if container_image is not none %}
+  container_image: {{container_image | tojson}}
+{% endif %}
+
+auth:
+  ssh_user: {{ssh_user}}
+  ssh_private_key: {{ssh_private_key}}
+
+available_node_types:
+  ray_head_default:
+    resources: {}
+    node_config:
+      instance_type: {{instance_type}}
+      disk_size: {{disk_size}}
+      cpus: {{cpus}}
+      memory: {{memory}}
+      accelerator_type: {{accelerator_type}}
+      accelerator_count: {{accelerator_count}}
+{% if image_id is not none %}
+      image_id: {{image_id}}
+{% endif %}
+{% if sbatch_options is defined and sbatch_options %}
+      sbatch_options: {{sbatch_options | tojson}}
+{% endif %}
+
+head_node_type: ray_head_default
+
+# No file_mounts at the cluster-YAML layer: the v1 sbatch script
+# materializes the user's git workdir and cloud-URI file mounts
+# directly via its preamble (see _build_workdir_block /
+# _build_file_mounts_block).
+file_mounts: {}
+
+rsync_exclude: []
+initialization_commands: []
+# No setup_commands either: v1 jobs skip the runtime bootstrap entirely.
+setup_commands: []
+
+head_node: {}
+worker_nodes: {}
+
+head_setup_commands: []
+worker_setup_commands: []
+cluster_synced_files: []
+file_mounts_sync_continuously: False

--- a/sky/templates/slurm-managed-job-v1.yml.j2
+++ b/sky/templates/slurm-managed-job-v1.yml.j2
@@ -31,6 +31,9 @@ provider:
   cluster: "{{slurm_cluster}}"
   partition: "{{slurm_partition}}"
   provision_timeout: {{provision_timeout}}
+{% if slurm_user is defined and slurm_user is not none %}
+  slurm_user: {{slurm_user | tojson}}
+{% endif %}
 
   skypilot_runtime: managed_job_v1
 

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -1009,7 +1009,24 @@ def fill_template(template_ref: str, variables: Dict[str, Any],
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
     # Write out yaml config.
-    j2_template = jinja2.Template(template)
+    #
+    # Override ``tojson`` so non-ASCII content (emoji, CJK, RTL, etc.) is
+    # emitted as UTF-8 bytes rather than ASCII-escaped. Default Flask-style
+    # ``tojson`` calls ``json.dumps(ensure_ascii=True)``, which produces
+    # UTF-16 surrogate pairs for codepoints above U+FFFF (e.g.
+    # ``🚀`` for 🚀). YAML's ``\u`` escape only accepts the BMP
+    # — surrogate pairs in double-quoted scalars trip
+    # ``yaml.scanner.ScannerError: invalid Unicode character escape code``,
+    # so any cluster YAML whose payload (run / setup / env values) contains
+    # emoji or other non-BMP characters fails downstream parsing. Both
+    # YAML and JSON happily accept raw UTF-8 in quoted strings, so flipping
+    # ``ensure_ascii=False`` is the minimum-surprise fix.
+    env = jinja2.Environment()
+    env.policies['json.dumps_kwargs'] = {
+        'sort_keys': True,
+        'ensure_ascii': False,
+    }
+    j2_template = env.from_string(template)
     content = j2_template.render(**variables)
     with open(output_path, 'w', encoding='utf-8') as fout:
         fout.write(content)

--- a/tests/unit_tests/test_sky/jobs/test_runtime_chain.py
+++ b/tests/unit_tests/test_sky/jobs/test_runtime_chain.py
@@ -1,0 +1,251 @@
+"""Unit tests for sky.jobs.runtime: chain registry + dispatch.
+
+Covers ``register``, ``replace``, ``_is_v1_candidate``, and the
+module-level dispatch's short-circuit on legacy handles.
+"""
+# pylint: disable=protected-access,missing-class-docstring
+import types
+from unittest import mock
+
+import pytest
+
+from sky.jobs import runtime as runtime_chain
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtimes(monkeypatch):
+    """Isolate ``_runtimes`` per test so registrations don't leak."""
+    monkeypatch.setattr(runtime_chain, '_runtimes', [])
+    yield
+
+
+def _make_handle(has_ray=False, metadata_present=True):
+    """Build a fake handle with the attributes the chain inspects."""
+    handle = types.SimpleNamespace()
+    if metadata_present:
+        handle.provision_runtime_metadata = types.SimpleNamespace(
+            has_ray=has_ray)
+    return handle
+
+
+def _make_runtime(name, owns_return=False, hook_return=None):
+    """Build a mock ``ManagedJobRuntime`` with named owns/get_job_status."""
+    rt = mock.MagicMock(name=name)
+    rt.owns = mock.MagicMock(return_value=owns_return)
+    rt.get_job_status = mock.MagicMock(return_value=hook_return)
+    rt.get_job_submitted_at = mock.MagicMock(return_value=None)
+    rt.get_job_ended_at = mock.MagicMock(return_value=None)
+    rt.get_exit_codes = mock.MagicMock(return_value=None)
+    rt.download_logs = mock.MagicMock(return_value=None)
+    rt.tail_logs = mock.MagicMock(return_value=None)
+    rt.job_group_envs = mock.MagicMock(return_value=None)
+    rt.k8s_dns_addresses_for_task = mock.MagicMock(return_value=None)
+    rt.k8s_dns_addresses_for_handle = mock.MagicMock(return_value=None)
+    return rt
+
+
+class TestRegister:
+    """register() appends in registration order."""
+
+    def test_register_empty(self):
+        assert not runtime_chain.is_registered()
+        rt = _make_runtime('first')
+        runtime_chain.register(rt)
+        assert runtime_chain.is_registered()
+        assert runtime_chain._runtimes == [rt]
+
+    def test_register_preserves_order(self):
+        rt_a = _make_runtime('a')
+        rt_b = _make_runtime('b')
+        rt_c = _make_runtime('c')
+        runtime_chain.register(rt_a)
+        runtime_chain.register(rt_b)
+        runtime_chain.register(rt_c)
+        assert runtime_chain._runtimes == [rt_a, rt_b, rt_c]
+
+
+class _RuntimeA:
+    """Concrete class for replace() tests (isinstance check)."""
+
+
+class _RuntimeB:
+    pass
+
+
+class TestReplace:
+    """replace() swaps in place; appends if absent."""
+
+    def test_replace_swaps_in_place(self):
+        old = _RuntimeA()
+        new = _RuntimeA()
+        other = _make_runtime('other')
+        runtime_chain.register(old)
+        runtime_chain.register(other)
+
+        runtime_chain.replace(_RuntimeA, new)
+
+        assert runtime_chain._runtimes == [new, other]
+        # Index 0 must be the *new* instance, not the old.
+        assert runtime_chain._runtimes[0] is new
+        assert runtime_chain._runtimes[0] is not old
+
+    def test_replace_appends_when_old_class_absent(self):
+        runtime_b = _RuntimeB()
+        runtime_chain.register(runtime_b)
+        replacement = _RuntimeA()
+
+        runtime_chain.replace(_RuntimeA, replacement)
+
+        # _RuntimeA wasn't present, so we appended.
+        assert runtime_chain._runtimes == [runtime_b, replacement]
+
+    def test_replace_only_swaps_first_match(self):
+        # Two instances of the same class — replace() targets the first.
+        first = _RuntimeA()
+        second = _RuntimeA()
+        runtime_chain.register(first)
+        runtime_chain.register(second)
+        new = _RuntimeA()
+
+        runtime_chain.replace(_RuntimeA, new)
+
+        assert runtime_chain._runtimes == [new, second]
+
+
+class TestIsV1Candidate:
+    """_is_v1_candidate's default-to-legacy posture."""
+
+    def test_none_handle_is_not_v1(self):
+        assert runtime_chain._is_v1_candidate(None) is False
+
+    def test_has_ray_true_is_not_v1(self):
+        handle = _make_handle(has_ray=True)
+        assert runtime_chain._is_v1_candidate(handle) is False
+
+    def test_has_ray_false_is_v1(self):
+        handle = _make_handle(has_ray=False)
+        assert runtime_chain._is_v1_candidate(handle) is True
+
+    def test_missing_metadata_is_not_v1(self):
+        """Pre-v1 handles (no ``provision_runtime_metadata``) default to
+        legacy — ``getattr(..., 'has_ray', True)``."""
+        handle = _make_handle(metadata_present=False)
+        assert runtime_chain._is_v1_candidate(handle) is False
+
+    def test_metadata_without_has_ray_is_not_v1(self):
+        """Even if metadata exists, missing ``has_ray`` attr → legacy."""
+        handle = types.SimpleNamespace()
+        # ``provision_runtime_metadata`` present but lacks ``has_ray``.
+        handle.provision_runtime_metadata = types.SimpleNamespace()
+        assert runtime_chain._is_v1_candidate(handle) is False
+
+
+class TestDispatchShortCircuit:
+    """Module-level dispatch must skip ``owns`` for legacy handles."""
+
+    def test_legacy_handle_does_not_call_owns_or_hooks(self):
+        rt_a = _make_runtime('a',
+                             owns_return=True,
+                             hook_return=('would-fire', None))
+        rt_b = _make_runtime('b',
+                             owns_return=True,
+                             hook_return=('would-fire', None))
+        runtime_chain.register(rt_a)
+        runtime_chain.register(rt_b)
+
+        legacy_handle = _make_handle(has_ray=True)
+        result = runtime_chain.get_job_status(legacy_handle, 'cluster')
+
+        assert result is None
+        rt_a.owns.assert_not_called()
+        rt_b.owns.assert_not_called()
+        rt_a.get_job_status.assert_not_called()
+        rt_b.get_job_status.assert_not_called()
+
+    def test_none_handle_short_circuits(self):
+        rt = _make_runtime('only',
+                           owns_return=True,
+                           hook_return=('would-fire', None))
+        runtime_chain.register(rt)
+
+        assert runtime_chain.get_job_status(None, 'cluster') is None
+        rt.owns.assert_not_called()
+        rt.get_job_status.assert_not_called()
+
+
+class TestDispatchClaiming:
+    """v1 handle dispatch resolves in registration order; first non-None
+    wins; non-claimants' hooks are not invoked."""
+
+    def test_no_claimant_returns_none(self):
+        rt = _make_runtime('only', owns_return=False)
+        runtime_chain.register(rt)
+        handle = _make_handle(has_ray=False)
+
+        assert runtime_chain.get_job_status(handle, 'cluster') is None
+        # owns() *was* called (the chain has to ask) but the hook wasn't.
+        rt.owns.assert_called_once_with(handle)
+        rt.get_job_status.assert_not_called()
+
+    def test_first_claimant_wins(self):
+        rt_a = _make_runtime('a',
+                             owns_return=True,
+                             hook_return=('A-fired', None))
+        rt_b = _make_runtime('b',
+                             owns_return=True,
+                             hook_return=('B-fired', None))
+        runtime_chain.register(rt_a)
+        runtime_chain.register(rt_b)
+        handle = _make_handle(has_ray=False)
+
+        result = runtime_chain.get_job_status(handle, 'cluster')
+
+        assert result == ('A-fired', None)
+        # Per docstring, later runtimes' owns *may* be called — but their
+        # hooks must NOT be once an earlier runtime has returned non-None.
+        rt_a.get_job_status.assert_called_once()
+        rt_b.get_job_status.assert_not_called()
+
+    def test_second_claims_when_first_does_not(self):
+        rt_a = _make_runtime('a',
+                             owns_return=False,
+                             hook_return=('A-fired', None))
+        rt_b = _make_runtime('b',
+                             owns_return=True,
+                             hook_return=('B-fired', None))
+        runtime_chain.register(rt_a)
+        runtime_chain.register(rt_b)
+        handle = _make_handle(has_ray=False)
+
+        result = runtime_chain.get_job_status(handle, 'cluster')
+
+        assert result == ('B-fired', None)
+        # First runtime did not claim → its hook is not called.
+        rt_a.get_job_status.assert_not_called()
+        rt_b.get_job_status.assert_called_once()
+
+    def test_claimant_returning_none_falls_through(self):
+        """A claimant whose hook returns None lets the next claimant try."""
+        rt_a = _make_runtime('a', owns_return=True, hook_return=None)
+        rt_b = _make_runtime('b',
+                             owns_return=True,
+                             hook_return=('B-fired', None))
+        runtime_chain.register(rt_a)
+        runtime_chain.register(rt_b)
+        handle = _make_handle(has_ray=False)
+
+        result = runtime_chain.get_job_status(handle, 'cluster')
+
+        assert result == ('B-fired', None)
+        rt_a.get_job_status.assert_called_once()
+        rt_b.get_job_status.assert_called_once()
+
+
+class TestIsRegistered:
+
+    def test_empty(self):
+        assert runtime_chain.is_registered() is False
+
+    def test_after_register(self):
+        runtime_chain.register(_make_runtime('rt'))
+        assert runtime_chain.is_registered() is True

--- a/tests/unit_tests/test_sky/jobs/test_runtime_chain.py
+++ b/tests/unit_tests/test_sky/jobs/test_runtime_chain.py
@@ -241,6 +241,78 @@ class TestDispatchClaiming:
         rt_b.get_job_status.assert_called_once()
 
 
+def _make_owns_less_runtime(name, hook_return=None):
+    """Build a pre-chain runtime: no ``owns()`` attribute at all."""
+    rt = mock.MagicMock(name=name,
+                        spec=[
+                            'get_job_status',
+                            'get_job_submitted_at',
+                            'get_job_ended_at',
+                            'get_exit_codes',
+                            'download_logs',
+                            'tail_logs',
+                            'job_group_envs',
+                            'k8s_dns_addresses_for_task',
+                            'k8s_dns_addresses_for_handle',
+                        ])
+    rt.get_job_status = mock.MagicMock(return_value=hook_return)
+    return rt
+
+
+class TestFallbackClaimants:
+    """owns()-less runtimes are fallback claimants: dispatched after
+    every explicit claimant, and excluded from the conflict warning."""
+
+    def test_explicit_claimant_ordered_before_fallback(self):
+        fallback = _make_owns_less_runtime('fallback')
+        explicit = _make_runtime('explicit', owns_return=True)
+        # Fallback registers FIRST; explicit must still dispatch first.
+        runtime_chain.register(fallback)
+        runtime_chain.register(explicit)
+        handle = _make_handle(has_ray=False)
+
+        assert runtime_chain._claimants(handle) == [explicit, fallback]
+
+    def test_dispatch_prefers_explicit_claimant(self):
+        fallback = _make_owns_less_runtime('fallback',
+                                           hook_return=('fallback-fired', None))
+        explicit = _make_runtime('explicit',
+                                 owns_return=True,
+                                 hook_return=('explicit-fired', None))
+        runtime_chain.register(fallback)
+        runtime_chain.register(explicit)
+        handle = _make_handle(has_ray=False)
+
+        assert runtime_chain.get_job_status(handle,
+                                            'cluster') == ('explicit-fired',
+                                                           None)
+        fallback.get_job_status.assert_not_called()
+
+    def test_no_warning_for_explicit_plus_fallback(self):
+        """The expected plugin configuration — one explicit claimant
+        plus an owns()-less plugin runtime — must not warn on every
+        dispatch."""
+        runtime_chain.register(_make_runtime('explicit', owns_return=True))
+        runtime_chain.register(_make_owns_less_runtime('fallback'))
+        handle = _make_handle(has_ray=False)
+
+        warning_mock = mock.MagicMock()
+        with mock.patch.object(runtime_chain.logger, 'warning', warning_mock):
+            claims = runtime_chain._claimants(handle)
+        assert len(claims) == 2
+        warning_mock.assert_not_called()
+
+    def test_warning_for_two_explicit_claimants(self):
+        runtime_chain.register(_make_runtime('a', owns_return=True))
+        runtime_chain.register(_make_runtime('b', owns_return=True))
+        handle = _make_handle(has_ray=False)
+
+        warning_mock = mock.MagicMock()
+        with mock.patch.object(runtime_chain.logger, 'warning', warning_mock):
+            runtime_chain._claimants(handle)
+        warning_mock.assert_called_once()
+
+
 class TestIsRegistered:
 
     def test_empty(self):

--- a/tests/unit_tests/test_sky/provision/slurm/test_managed_job_runtime.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_managed_job_runtime.py
@@ -1,0 +1,376 @@
+"""Unit tests for sky.provision.slurm.managed_job_runtime.
+
+Covers:
+- ``_slurm_state_to_job_status`` mapping per Slurm state class.
+- ``_resolve_slurm_target`` happy + every refusal path.
+- ``SlurmManagedJobRuntime.get_job_status`` returncode shortcut +
+  state-driven path.
+"""
+# pylint: disable=protected-access,missing-class-docstring
+import types
+from unittest import mock
+
+import pytest
+
+from sky import exceptions
+from sky.provision.slurm import managed_job_runtime as mjr
+from sky.skylet import job_lib
+
+# --------------------- _slurm_state_to_job_status --------------------- #
+
+
+class TestSlurmStateToJobStatus:
+    """Map every documented Slurm state to the expected JobStatus."""
+
+    @pytest.mark.parametrize('state', [
+        'PENDING',
+        'CONFIGURING',
+        'RESV_DEL_HOLD',
+        'REQUEUED',
+        'REQUEUE_HOLD',
+        'REQUEUE_FED',
+        'RESIZING',
+    ])
+    def test_pending_states(self, state):
+        assert mjr._slurm_state_to_job_status(
+            state) == job_lib.JobStatus.PENDING
+
+    @pytest.mark.parametrize('state', [
+        'RUNNING',
+        'COMPLETING',
+        'SIGNALING',
+        'STAGE_OUT',
+        'SUSPENDED',
+    ])
+    def test_running_states(self, state):
+        assert mjr._slurm_state_to_job_status(
+            state) == job_lib.JobStatus.RUNNING
+
+    def test_completed_is_succeeded(self):
+        assert mjr._slurm_state_to_job_status(
+            'COMPLETED') == job_lib.JobStatus.SUCCEEDED
+
+    @pytest.mark.parametrize('state', [
+        'FAILED',
+        'NODE_FAIL',
+        'BOOT_FAIL',
+        'TIMEOUT',
+        'OUT_OF_MEMORY',
+        'DEADLINE',
+        'SPECIAL_EXIT',
+        'PREEMPTED',
+    ])
+    def test_failed_states(self, state):
+        assert mjr._slurm_state_to_job_status(state) == job_lib.JobStatus.FAILED
+
+    @pytest.mark.parametrize('state', ['CANCELLED', 'REVOKED'])
+    def test_cancelled_states(self, state):
+        assert mjr._slurm_state_to_job_status(
+            state) == job_lib.JobStatus.CANCELLED
+
+    def test_cancelled_with_uid_suffix_normalized_by_sacct(self):
+        """The runtime relies on ``_sacct_get_state`` to normalize
+        ``CANCELLED by 12345`` to plain ``CANCELLED`` *before* feeding
+        the result into ``_slurm_state_to_job_status``. Verify the
+        contract: feeding plain ``CANCELLED`` produces ``CANCELLED``,
+        and the normalization in ``_sacct_get_state`` strips the suffix.
+        """
+        # Plain CANCELLED maps cleanly.
+        assert mjr._slurm_state_to_job_status(
+            'CANCELLED') == job_lib.JobStatus.CANCELLED
+
+        # _sacct_get_state should strip the suffix:
+        client = mock.MagicMock()
+        client._run_slurm_cmd = mock.MagicMock(
+            return_value=(0, 'CANCELLED by 12345\n', ''))
+        assert mjr._sacct_get_state(client, '999') == 'CANCELLED'
+
+    def test_unknown_state_returns_none(self):
+        # Don't silently coerce; let the caller default.
+        assert mjr._slurm_state_to_job_status('SOME_FUTURE_STATE') is None
+
+    def test_none_input_returns_none(self):
+        assert mjr._slurm_state_to_job_status(None) is None
+
+
+# ----------------------- _resolve_slurm_target ----------------------- #
+
+
+def _make_handle(*,
+                 has_ray=False,
+                 cluster_yaml='/fake.yml',
+                 cached_cluster_info=None,
+                 metadata_present=True,
+                 region=None):
+    """Build a handle with the attributes ``_resolve_slurm_target`` reads."""
+    handle = types.SimpleNamespace()
+    if metadata_present:
+        handle.provision_runtime_metadata = types.SimpleNamespace(
+            has_ray=has_ray)
+    handle.cluster_yaml = cluster_yaml
+    handle.cached_cluster_info = cached_cluster_info
+    handle.launched_resources = types.SimpleNamespace(region=region)
+    return handle
+
+
+def _make_cached_info(head_id='head-0', tags=None):
+    """Build a ``cached_cluster_info`` SimpleNamespace shaped like
+    ProvisionRecord output."""
+    if tags is None:
+        tags = {'job_id': '12345'}
+    head_info = types.SimpleNamespace(tags=tags)
+    return types.SimpleNamespace(head_instance_id=head_id,
+                                 instances={head_id: [head_info]})
+
+
+_V1_PROVIDER_CONFIG = {
+    'skypilot_runtime': 'managed_job_v1',
+    'ssh': {
+        'hostname': 'login.example.com',
+        'port': 22,
+        'user': 'slurm',
+        'private_key': '/tmp/key',
+    },
+    'partition': 'gpu',
+}
+
+
+class TestResolveSlurmTarget:
+
+    @pytest.fixture
+    def patched_yaml(self, monkeypatch):
+        """Return a helper that installs a fake cluster_yaml loader."""
+
+        def install(yaml_dict, raise_exc=None):
+
+            def fake_loader(path):
+                del path  # Unused.
+                if raise_exc is not None:
+                    raise raise_exc
+                return yaml_dict
+
+            monkeypatch.setattr(mjr.global_user_state, 'get_cluster_yaml_dict',
+                                fake_loader)
+
+        return install
+
+    def test_none_handle(self, patched_yaml):
+        patched_yaml({'provider': _V1_PROVIDER_CONFIG})
+        assert mjr._resolve_slurm_target(None) is None
+
+    def test_has_ray_true_returns_none(self, patched_yaml):
+        patched_yaml({'provider': _V1_PROVIDER_CONFIG})
+        handle = _make_handle(has_ray=True,
+                              cached_cluster_info=_make_cached_info())
+        assert mjr._resolve_slurm_target(handle) is None
+
+    def test_metadata_missing_returns_none(self, patched_yaml):
+        patched_yaml({'provider': _V1_PROVIDER_CONFIG})
+        handle = _make_handle(metadata_present=False,
+                              cached_cluster_info=_make_cached_info())
+        assert mjr._resolve_slurm_target(handle) is None
+
+    def test_cluster_yaml_unreadable_returns_none(self, patched_yaml):
+        patched_yaml(None, raise_exc=ValueError('missing'))
+        handle = _make_handle(cached_cluster_info=_make_cached_info())
+        assert mjr._resolve_slurm_target(handle) is None
+
+    def test_cluster_yaml_typeerror_returns_none(self, patched_yaml):
+        patched_yaml(None, raise_exc=TypeError('bad path'))
+        handle = _make_handle(cached_cluster_info=_make_cached_info())
+        assert mjr._resolve_slurm_target(handle) is None
+
+    def test_provider_without_v1_marker_returns_none(self, patched_yaml):
+        patched_yaml({'provider': {'partition': 'gpu'}})
+        handle = _make_handle(cached_cluster_info=_make_cached_info())
+        assert mjr._resolve_slurm_target(handle) is None
+
+    def test_cached_cluster_info_none_returns_none(self, patched_yaml):
+        patched_yaml({'provider': _V1_PROVIDER_CONFIG})
+        handle = _make_handle(cached_cluster_info=None)
+        assert mjr._resolve_slurm_target(handle) is None
+
+    def test_missing_head_instance_returns_none(self, patched_yaml):
+        patched_yaml({'provider': _V1_PROVIDER_CONFIG})
+        cached = types.SimpleNamespace(head_instance_id='missing-head',
+                                       instances={})
+        handle = _make_handle(cached_cluster_info=cached)
+        assert mjr._resolve_slurm_target(handle) is None
+
+    def test_missing_job_id_tag_returns_none(self, patched_yaml):
+        """Tag is the primary identity — no regex fallback (PLAN.md gap #8)."""
+        patched_yaml({'provider': _V1_PROVIDER_CONFIG})
+        cached = _make_cached_info(tags={'other_tag': 'value'})
+        handle = _make_handle(cached_cluster_info=cached)
+        assert mjr._resolve_slurm_target(handle) is None
+
+    def test_empty_job_id_tag_returns_none(self, patched_yaml):
+        patched_yaml({'provider': _V1_PROVIDER_CONFIG})
+        cached = _make_cached_info(tags={'job_id': ''})
+        handle = _make_handle(cached_cluster_info=cached)
+        assert mjr._resolve_slurm_target(handle) is None
+
+    def test_happy_path(self, patched_yaml):
+        patched_yaml({'provider': _V1_PROVIDER_CONFIG})
+        cached = _make_cached_info(tags={'job_id': '12345'})
+        handle = _make_handle(cached_cluster_info=cached, region='partition-x')
+
+        target = mjr._resolve_slurm_target(handle)
+
+        assert target is not None
+        assert target.job_id == '12345'
+        assert target.partition == 'gpu'
+        assert target.ssh_config == _V1_PROVIDER_CONFIG['ssh']
+        assert target.region == 'partition-x'
+
+
+# ------------------- SlurmManagedJobRuntime.get_job_status ------------ #
+
+
+class TestGetJobStatusReturncodeShortcut:
+    """When the caller supplies a returncode, the runtime trusts it and
+    skips the Slurm query entirely."""
+
+    @pytest.fixture
+    def runtime_and_handle(self, monkeypatch):
+        """A runtime + handle pair where ``_resolve_slurm_target`` returns
+        a fake target — but ``get_job_state`` would crash if invoked."""
+
+        def fake_resolve(handle):
+            del handle  # Unused; resolver is a stub.
+            return mjr._Target(job_id='42',
+                               ssh_config={
+                                   'hostname': 'h',
+                                   'user': 'u',
+                                   'private_key': '/k',
+                               },
+                               partition='cpu',
+                               region=None,
+                               log_path=None)
+
+        monkeypatch.setattr(mjr, '_resolve_slurm_target', fake_resolve)
+        # Trip-wire: if the runtime falls through to a Slurm query, fail.
+        monkeypatch.setattr(
+            mjr, '_slurm_client_from_target',
+            mock.MagicMock(side_effect=AssertionError(
+                'returncode shortcut must skip Slurm query')))
+
+        return mjr.SlurmManagedJobRuntime(), object()
+
+    def test_succeeded_returncode(self, runtime_and_handle):
+        runtime, handle = runtime_and_handle
+        result = runtime.get_job_status(
+            handle,
+            'cluster',
+            returncode=exceptions.JobExitCode.SUCCEEDED.value)
+        assert result == (job_lib.JobStatus.SUCCEEDED, None)
+
+    def test_cancelled_returncode(self, runtime_and_handle):
+        runtime, handle = runtime_and_handle
+        result = runtime.get_job_status(
+            handle,
+            'cluster',
+            returncode=exceptions.JobExitCode.CANCELLED.value)
+        assert result == (job_lib.JobStatus.CANCELLED, None)
+
+    def test_other_returncode_is_failed(self, runtime_and_handle):
+        runtime, handle = runtime_and_handle
+        result = runtime.get_job_status(
+            handle, 'cluster', returncode=exceptions.JobExitCode.FAILED.value)
+        assert result == (job_lib.JobStatus.FAILED, None)
+
+    def test_arbitrary_nonzero_returncode_is_failed(self, runtime_and_handle):
+        """Anything that isn't SUCCEEDED or CANCELLED collapses to FAILED."""
+        runtime, handle = runtime_and_handle
+        result = runtime.get_job_status(handle, 'cluster', returncode=137)
+        assert result == (job_lib.JobStatus.FAILED, None)
+
+
+class TestGetJobStatusStateDriven:
+    """returncode is None → the runtime queries Slurm."""
+
+    @pytest.fixture
+    def runtime(self):
+        return mjr.SlurmManagedJobRuntime()
+
+    @pytest.fixture
+    def patched_target(self, monkeypatch):
+        """Install a fake target + ``_slurm_client_from_target`` that
+        returns a MagicMock the test then configures."""
+        fake_client = mock.MagicMock(name='SlurmClient')
+
+        def fake_resolve(handle):
+            del handle  # Unused; resolver is a stub.
+            return mjr._Target(job_id='42',
+                               ssh_config={
+                                   'hostname': 'h',
+                                   'user': 'u',
+                                   'private_key': '/k',
+                               },
+                               partition='cpu',
+                               region=None,
+                               log_path=None)
+
+        monkeypatch.setattr(mjr, '_resolve_slurm_target', fake_resolve)
+        monkeypatch.setattr(mjr, '_slurm_client_from_target',
+                            lambda target: fake_client)
+        return fake_client
+
+    def test_unresolved_target_returns_none(self, runtime, monkeypatch):
+        monkeypatch.setattr(mjr, '_resolve_slurm_target', lambda handle: None)
+        assert runtime.get_job_status(object(), 'cluster',
+                                      returncode=None) is None
+
+    def test_squeue_running_state(self, runtime, patched_target):
+        patched_target.get_job_state = mock.MagicMock(return_value='RUNNING')
+        result = runtime.get_job_status(object(), 'cluster', returncode=None)
+        assert result == (job_lib.JobStatus.RUNNING, None)
+
+    def test_squeue_completed_state(self, runtime, patched_target):
+        patched_target.get_job_state = mock.MagicMock(return_value='COMPLETED')
+        result = runtime.get_job_status(object(), 'cluster', returncode=None)
+        assert result == (job_lib.JobStatus.SUCCEEDED, None)
+
+    def test_squeue_none_falls_back_to_sacct(self, runtime, patched_target):
+        """When ``get_job_state`` returns None (aged out of squeue), the
+        runtime falls back to ``_sacct_get_state``."""
+        patched_target.get_job_state = mock.MagicMock(return_value=None)
+        # _sacct_get_state runs _run_slurm_cmd directly.
+        patched_target._run_slurm_cmd = mock.MagicMock(return_value=(0,
+                                                                     'FAILED\n',
+                                                                     ''))
+        result = runtime.get_job_status(object(), 'cluster', returncode=None)
+        assert result == (job_lib.JobStatus.FAILED, None)
+
+    def test_sacct_cancelled_with_uid_suffix(self, runtime, patched_target):
+        """sacct emits ``CANCELLED by <uid>``; normalize to CANCELLED."""
+        patched_target.get_job_state = mock.MagicMock(return_value=None)
+        patched_target._run_slurm_cmd = mock.MagicMock(
+            return_value=(0, 'CANCELLED by 12345\n', ''))
+        result = runtime.get_job_status(object(), 'cluster', returncode=None)
+        assert result == (job_lib.JobStatus.CANCELLED, None)
+
+    def test_unknown_state_returns_none(self, runtime, patched_target):
+        """Unknown Slurm state → None (caller defers).
+
+        ``_slurm_state_to_job_status`` returns None for unknown states;
+        the runtime's get_job_status returns None so the caller defers.
+        """
+        patched_target.get_job_state = mock.MagicMock(
+            return_value='SOME_FUTURE_STATE')
+        result = runtime.get_job_status(object(), 'cluster', returncode=None)
+        assert result is None
+
+    def test_query_failure_surfaces_error(self, runtime, patched_target):
+        """A Slurm query failure surfaces as ``(None, 'Slurm query ...')``.
+
+        So the caller can log it without crashing the controller.
+        """
+        patched_target.get_job_state = mock.MagicMock(
+            side_effect=RuntimeError('ssh down'))
+        result = runtime.get_job_status(object(), 'cluster', returncode=None)
+        assert result is not None
+        status, msg = result
+        assert status is None
+        assert 'Slurm query error' in msg
+        assert 'ssh down' in msg

--- a/tests/unit_tests/test_sky/provision/slurm/test_sbatch_options.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_sbatch_options.py
@@ -1,0 +1,125 @@
+"""Unit tests for ``_SBATCH_PROTECTED_OPTIONS`` enforcement.
+
+Pinpoints *today's* protection behavior — long-form names are blocked,
+short-form aliases are not (PLAN.md gap "SBATCH protection"). The
+``time``-not-protected behavior is already covered by
+``test_sbatch_config.py::TestBuildCustomSbatchDirectives``; this file
+focuses on the v1-relevant additions: ``--signal`` (commit d5738c856)
+plus the short-form gap.
+"""
+from unittest import mock
+
+import pytest
+
+from sky.provision.slurm import instance as slurm_instance
+from sky.provision.slurm.instance import _build_custom_sbatch_directives
+from sky.provision.slurm.instance import _SBATCH_PROTECTED_OPTIONS
+
+
+class TestLongFormProtectedOptionsSkipped:
+    """Long-form names in ``_SBATCH_PROTECTED_OPTIONS`` are warned + skipped."""
+
+    @pytest.mark.parametrize('option', [
+        'nodes',
+        'output',
+        'error',
+        'job-name',
+        'partition',
+        'wait-all-nodes',
+        'no-requeue',
+        'cpus-per-task',
+        'mem',
+        'gres',
+    ])
+    def test_long_form_protected_skipped(self, option):
+        assert _build_custom_sbatch_directives({option: 'value'}) == ''
+
+    def test_signal_is_protected(self, monkeypatch):
+        """``--signal`` was added to the protected set in commit d5738c856
+        because a user ``signal: KILL@10`` skips SIGTERM grace and can
+        truncate the log tail before tail_logs / cleanup completes."""
+        assert 'signal' in _SBATCH_PROTECTED_OPTIONS
+        warning_mock = mock.MagicMock()
+        monkeypatch.setattr(slurm_instance.logger, 'warning', warning_mock)
+        result = _build_custom_sbatch_directives({'signal': 'KILL@10'})
+        assert result == ''
+        # And a warning was logged to surface the skip.
+        warning_mock.assert_called_once()
+        msg = warning_mock.call_args.args[0]
+        assert 'signal' in msg.lower() or 'ignor' in msg.lower()
+
+
+class TestNonProtectedOptionsEmitted:
+    """Non-protected options pass through as ``#SBATCH --key=value``."""
+
+    @pytest.mark.parametrize('key,value', [
+        ('account', 'research'),
+        ('qos', 'high'),
+        ('time', '4:00:00'),
+        ('mail-user', 'user@example.com'),
+        ('mail-type', 'END'),
+        ('constraint', 'a100'),
+        ('reservation', 'gpu-reservation'),
+    ])
+    def test_non_protected_emitted(self, key, value):
+        result = _build_custom_sbatch_directives({key: value})
+        assert result == f'\n#SBATCH --{key}={value}'
+
+
+class TestUnderscoreNormalization:
+    """Underscore-keyed options are normalized to hyphenated form before
+    being matched against ``_SBATCH_PROTECTED_OPTIONS`` and emitted."""
+
+    def test_underscore_normalized_in_emitted_directive(self):
+        result = _build_custom_sbatch_directives({'mail_user': 'u@example.com'})
+        assert result == '\n#SBATCH --mail-user=u@example.com'
+
+    def test_underscore_normalized_for_protection_check(self):
+        """``cpus_per_task`` should be caught by protection even though
+        the protected-options set uses the hyphenated form."""
+        assert _build_custom_sbatch_directives({'cpus_per_task': 4}) == ''
+
+    def test_underscore_signal_protected(self):
+        # Defensive: ``signal`` has no underscore variant in normal usage,
+        # but if a user writes ``signal_`` or similar, it must still be
+        # caught.  (Direct ``signal`` is tested above.)
+        assert _build_custom_sbatch_directives({'signal': 'KILL@10'}) == ''
+
+
+class TestEmpty:
+
+    def test_empty_input(self):
+        assert _build_custom_sbatch_directives({}) == ''
+
+
+# ------------------- Documented gap: short-form aliases --------------- #
+
+
+class TestShortFormProtectionGap:
+    """Short-form aliases (-N, -J, -o, -e, -t, -p) currently bypass
+    protection — see PLAN.md gap #7 "SBATCH protection".
+
+    These ``xfail`` tests document the gap.  When the short-form
+    normalizer lands they should flip to passing; remove the ``xfail``
+    marker at that point.
+    """
+
+    @pytest.mark.xfail(
+        reason='PLAN.md gap #7: short-form sbatch aliases are not yet '
+        'normalized into the protection check. Adding -N -> nodes, -J -> '
+        'job-name, -o -> output, -e -> error, -t -> time, -p -> partition '
+        'is tracked separately as an OSS rework.',
+        strict=True,
+    )
+    @pytest.mark.parametrize('short,long_form', [
+        ('N', 'nodes'),
+        ('J', 'job-name'),
+        ('o', 'output'),
+        ('e', 'error'),
+        ('p', 'partition'),
+    ])
+    def test_short_form_aliases_should_be_protected(self, short, long_form):
+        # When this gap is closed, the short form should be treated
+        # identically to the long form and produce an empty string.
+        del long_form  # Documentation-only.
+        assert _build_custom_sbatch_directives({short: 'value'}) == ''

--- a/tests/unit_tests/test_sky/provision/slurm/test_v1_create_managed_job.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_v1_create_managed_job.py
@@ -1,0 +1,426 @@
+"""Unit tests for the prologue invariants of ``_create_managed_job_v1``.
+
+Covers the two block-ship #1 branches ported verbatim from the legacy
+``_create_virtual_instance`` path:
+
+1. COMPLETING-drain — before submitting a fresh sbatch, the function
+   must wait up to ``_JOB_TERMINATION_TIMEOUT_SECONDS`` for any jobs in
+   the COMPLETING state under ``cluster_name_on_cloud`` to drain. If
+   they don't, it raises.
+
+2. Existing-job reattach — after drain, the function queries for jobs
+   in PENDING/RUNNING; if exactly one exists, it reattaches without
+   calling ``submit_job`` again and returns a ``ProvisionRecord`` with
+   the v1 runtime metadata shape. Two or more existing jobs trip an
+   ``assert``.
+
+Everything past the reattach branch (script staging / submission /
+``_wait_for_job_nodes`` after a fresh submit) is out of scope here.
+"""
+# pylint: disable=protected-access,missing-class-docstring
+# pylint: disable=import-outside-toplevel,unused-argument
+from unittest import mock
+
+import pytest
+
+from sky.provision import common
+from sky.provision.slurm import instance as slurm_instance
+
+# ----------------------------- Fixtures ----------------------------- #
+
+
+def _make_provider_config():
+    """Minimal v1 provider_config the prologue actually reads."""
+    return {
+        'skypilot_runtime': 'managed_job_v1',
+        'ssh': {
+            'hostname': 'login.example.com',
+            'port': '22',
+            'user': 'slurmuser',
+            'private_key': '/tmp/key',
+            'proxycommand': None,
+            'proxyjump': None,
+            'identities_only': False,
+        },
+        'partition': 'gpu',
+        'cluster': 'my-slurm',
+        'provision_timeout': -1,
+        # Fresh-submission branch reads these — the reattach tests don't
+        # exercise that code path, but the prologue itself doesn't
+        # consume them either.
+        'setup': None,
+        'run': 'echo hi',
+        'envs': {},
+        'workdir': None,
+        'file_mounts': None,
+        'container_image': None,
+        'sbatch_options': {},
+    }
+
+
+def _make_provision_config(count: int = 1) -> common.ProvisionConfig:
+    return common.ProvisionConfig(
+        provider_config=_make_provider_config(),
+        authentication_config={},
+        docker_config={},
+        node_config={},
+        count=count,
+        tags={},
+        resume_stopped_nodes=False,
+        ports_to_open_on_launch=None,
+    )
+
+
+class _FakeClock:
+    """Deterministic monotonic clock so the COMPLETING-drain loop's
+    ``time.time() - start_time`` bookkeeping advances by a known step
+    each ``sleep`` call, without actually sleeping.
+
+    Each ``time()`` call advances ``step`` seconds. ``sleep(s)`` adds
+    ``s`` to the clock. We intentionally use a coarse step so the loop
+    terminates in a finite number of iterations under tests.
+    """
+
+    def __init__(self, step: float = 0.0):
+        self.now = 0.0
+        self.step = step
+        self.sleep_calls: list = []
+
+    def time(self) -> float:
+        t = self.now
+        self.now += self.step
+        return t
+
+    def sleep(self, seconds: float) -> None:
+        self.sleep_calls.append(seconds)
+        self.now += seconds
+
+
+@pytest.fixture
+def patched_module(monkeypatch):
+    """Patch the slurm instance module so ``_create_managed_job_v1``'s
+    prologue runs deterministically without touching SSH, the network,
+    or real time.
+
+    Returns a ``types.SimpleNamespace`` so tests can inspect the mocks
+    after invocation.
+    """
+    import types
+
+    client = mock.MagicMock(name='SlurmClient')
+    # Default: ``get_job_nodes`` returns one node — used by the reattach
+    # branch when constructing the ProvisionRecord.
+    client.get_job_nodes.return_value = (['node001'], ['10.0.0.1'])
+
+    slurm_factory = mock.MagicMock(name='slurm_module')
+    slurm_factory.SlurmClient.return_value = client
+    monkeypatch.setattr(slurm_instance, 'slurm', slurm_factory)
+
+    # ``_wait_for_job_nodes`` is module-level — stub it so the reattach
+    # branch doesn't try to drive a real squeue poll loop.
+    wait_mock = mock.MagicMock(name='_wait_for_job_nodes')
+    monkeypatch.setattr(slurm_instance, '_wait_for_job_nodes', wait_mock)
+
+    # The reattach branch calls ``rich_utils.force_update_status`` to
+    # update the spinner — silence it.
+    monkeypatch.setattr(slurm_instance.rich_utils, 'force_update_status',
+                        mock.MagicMock())
+
+    # Fresh-submission scaffolding: short-circuit everything between the
+    # reattach branch and ``submit_job`` so tests targeting the COMPLETING
+    # drain (which fall through to submission) can stop execution
+    # deterministically at ``submit_job``.
+    runner_mock = mock.MagicMock(name='SSHCommandRunner_instance')
+    runner_mock.get_remote_home_dir.return_value = '/home/slurmuser'
+    runner_mock.run.return_value = (0, '', '')
+    monkeypatch.setattr(slurm_instance.command_runner, 'SSHCommandRunner',
+                        mock.MagicMock(return_value=runner_mock))
+    monkeypatch.setattr(slurm_instance, '_v1_precondition_cleanup',
+                        mock.MagicMock())
+    monkeypatch.setattr(slurm_instance.slurm_utils, 'get_partition_info',
+                        mock.MagicMock(return_value=mock.MagicMock()))
+    monkeypatch.setattr(slurm_instance, '_build_sbatch_directives',
+                        mock.MagicMock(return_value=[]))
+    monkeypatch.setattr(slurm_instance, '_build_v1_sbatch_script',
+                        mock.MagicMock(return_value='#!/bin/bash\n'))
+    monkeypatch.setattr(slurm_instance.skypilot_config,
+                        'get_effective_region_config', lambda **kwargs: None)
+
+    clock = _FakeClock(step=0.0)
+    monkeypatch.setattr(slurm_instance.time, 'sleep', clock.sleep)
+    monkeypatch.setattr(slurm_instance.time, 'time', clock.time)
+
+    return types.SimpleNamespace(
+        client=client,
+        slurm_factory=slurm_factory,
+        wait_mock=wait_mock,
+        clock=clock,
+    )
+
+
+# --------------------------- COMPLETING-drain --------------------------- #
+
+
+class TestCompletingDrain:
+    """The first prologue block of ``_create_managed_job_v1``
+    (``instance.py:2043-2067``)."""
+
+    def test_empty_queue_no_wait(self, patched_module):
+        """Empty COMPLETING set at entry → no ``time.sleep`` call, and
+        execution falls through to the existing-job reattach query."""
+        client = patched_module.client
+        # COMPLETING: empty. PENDING/RUNNING: empty too, so we fall
+        # through to the fresh-submission path. We stop before that by
+        # forcing a controlled failure on submit_job.
+        client.query_jobs.side_effect = [
+            [],  # completing
+            [],  # pending/running
+        ]
+        # Stop execution before the fresh-submission scaffolding runs.
+        client.submit_job.side_effect = RuntimeError('stop-here')
+
+        with pytest.raises(RuntimeError, match='stop-here'):
+            slurm_instance._create_managed_job_v1('us-central1', 'mycluster',
+                                                  'mycluster-abcd1234',
+                                                  _make_provision_config())
+
+        # No sleeps at all when the queue is empty up front.
+        assert patched_module.clock.sleep_calls == []
+
+    def test_drains_on_second_poll(self, patched_module, monkeypatch):
+        """One job in COMPLETING, drains by the second poll → exactly
+        one sleep call, and execution proceeds past drain."""
+        client = patched_module.client
+        # First completing poll returns [1234]; second returns []. Then
+        # the existing-job query returns []; we fail submit_job to stop
+        # before the fresh-submission scaffolding.
+        client.query_jobs.side_effect = [
+            ['1234'],  # completing: first poll, one job
+            [],  # completing: second poll, drained
+            [],  # pending/running: no existing jobs
+        ]
+        client.submit_job.side_effect = RuntimeError('stop-here')
+
+        # Use a tiny clock step so the loop terminates well within the
+        # 60s budget after one drain iteration.
+        patched_module.clock.step = 0.0
+
+        with pytest.raises(RuntimeError, match='stop-here'):
+            slurm_instance._create_managed_job_v1('us-central1', 'mycluster',
+                                                  'mycluster-abcd1234',
+                                                  _make_provision_config())
+
+        # Exactly one sleep, at the polling interval.
+        assert len(patched_module.clock.sleep_calls) == 1
+        assert (patched_module.clock.sleep_calls[0] ==
+                slurm_instance.POLL_INTERVAL_SECONDS)
+
+    def test_timeout_raises(self, patched_module):
+        """A job stuck in COMPLETING past the timeout → ``RuntimeError``
+        with the documented message."""
+        client = patched_module.client
+        # Always return the same completing set.
+        client.query_jobs.return_value = ['1234']
+        # Each ``time()`` call advances by 31s — after the first sleep
+        # we've consumed ~31s; after the second, ~62s, crossing the 60s
+        # budget. (The loop checks ``time() - start_time`` *before*
+        # sleeping, so we need two sleeps to cross.)
+        patched_module.clock.step = 31.0
+
+        with pytest.raises(RuntimeError) as exc_info:
+            slurm_instance._create_managed_job_v1('us-central1', 'mycluster',
+                                                  'mycluster-abcd1234',
+                                                  _make_provision_config())
+
+        msg = str(exc_info.value)
+        assert 'completing state after' in msg
+        assert (str(slurm_instance._JOB_TERMINATION_TIMEOUT_SECONDS) in msg)
+        # submit_job must NOT have been called — drain failure aborts
+        # before we get there.
+        client.submit_job.assert_not_called()
+
+    def test_multiple_jobs_all_drain(self, patched_module):
+        """Multiple jobs in COMPLETING — all must drain before the loop
+        exits. With both gone on the second poll, we proceed."""
+        client = patched_module.client
+        client.query_jobs.side_effect = [
+            ['1234', '5678'],  # completing: two jobs
+            [],  # completing: both drained
+            [],  # pending/running: no existing jobs
+        ]
+        client.submit_job.side_effect = RuntimeError('stop-here')
+
+        with pytest.raises(RuntimeError, match='stop-here'):
+            slurm_instance._create_managed_job_v1('us-central1', 'mycluster',
+                                                  'mycluster-abcd1234',
+                                                  _make_provision_config())
+
+        assert len(patched_module.clock.sleep_calls) == 1
+
+    def test_multiple_jobs_one_stuck_raises(self, patched_module):
+        """If one of multiple COMPLETING jobs stays stuck past the
+        timeout, the function raises — the loop condition is "any
+        completing", not "any specific job"."""
+        client = patched_module.client
+        # First poll: two jobs. Subsequent polls: still one stuck.
+        client.query_jobs.side_effect = ([['1234', '5678']] +
+                                         [['5678']] * 10  # one stays forever
+                                        )
+        patched_module.clock.step = 31.0
+
+        with pytest.raises(RuntimeError) as exc_info:
+            slurm_instance._create_managed_job_v1('us-central1', 'mycluster',
+                                                  'mycluster-abcd1234',
+                                                  _make_provision_config())
+        assert 'completing state after' in str(exc_info.value)
+        client.submit_job.assert_not_called()
+
+
+# ----------------------- Existing-job reattach ----------------------- #
+
+
+class TestExistingJobReattach:
+    """The second prologue block (``instance.py:2069-2135``)."""
+
+    def test_no_existing_falls_through_to_submission(self, patched_module):
+        """Empty PENDING/RUNNING set → no reattach, falls through to the
+        fresh-submission path (and we stop it there)."""
+        client = patched_module.client
+        client.query_jobs.side_effect = [
+            [],  # completing: empty
+            [],  # pending/running: empty
+        ]
+        # Stop execution before any post-submit work — we just want to
+        # confirm submit_job was reached.
+        client.submit_job.side_effect = RuntimeError('reached-submit')
+
+        with pytest.raises(RuntimeError, match='reached-submit'):
+            slurm_instance._create_managed_job_v1('us-central1', 'mycluster',
+                                                  'mycluster-abcd1234',
+                                                  _make_provision_config())
+
+        client.submit_job.assert_called_once()
+        # Reattach branch never invoked → ``_wait_for_job_nodes`` was
+        # called only via the fresh path, but we raised before that.
+        patched_module.wait_mock.assert_not_called()
+
+    @pytest.mark.parametrize('state_label', ['pending', 'running'])
+    def test_one_existing_reattaches(self, patched_module, state_label):
+        """Exactly one job in PENDING (or RUNNING) → reattach: no
+        ``submit_job`` call, ``ProvisionRecord`` points at the existing
+        job_id, ``head_instance_id`` matches the (job_id, node) pair.
+
+        PENDING vs RUNNING is just a squeue filter distinction — they
+        funnel into the same branch via ``['pending', 'running']``.
+        """
+        del state_label  # only documents the semantics
+        client = patched_module.client
+        existing_job_id = '9999'
+        client.query_jobs.side_effect = [
+            [],  # completing: empty
+            [existing_job_id],  # pending/running: one existing
+        ]
+        client.get_job_nodes.return_value = (['node007'], ['10.0.0.7'])
+
+        record = slurm_instance._create_managed_job_v1('us-central1',
+                                                       'mycluster',
+                                                       'mycluster-abcd1234',
+                                                       _make_provision_config())
+
+        # Reattach contract: submit_job must NOT have been called.
+        client.submit_job.assert_not_called()
+        # _wait_for_job_nodes must have been called against the reattached
+        # job_id.
+        patched_module.wait_mock.assert_called_once()
+        assert patched_module.wait_mock.call_args.args[1] == existing_job_id
+
+        # ProvisionRecord shape.
+        assert isinstance(record, common.ProvisionRecord)
+        assert record.provider_name == 'slurm'
+        assert record.region == 'us-central1'
+        assert record.zone == 'gpu'  # partition
+        assert record.cluster_name == 'mycluster-abcd1234'
+        # head_instance_id must encode (job_id, node[0]).
+        from sky.provision.slurm import utils as slurm_utils
+        assert record.head_instance_id == slurm_utils.instance_id(
+            existing_job_id, 'node007')
+        assert record.created_instance_ids == [
+            slurm_utils.instance_id(existing_job_id, 'node007')
+        ]
+        assert record.resumed_instance_ids == []
+
+    def test_reattach_runtime_metadata_shape(self, patched_module):
+        """Reattach must produce the same v1 runtime metadata shape as a
+        fresh provision — this is what tells the OSS controller to skip
+        post-provision phases on the reattached cluster."""
+        client = patched_module.client
+        client.query_jobs.side_effect = [
+            [],
+            ['4242'],
+        ]
+        client.get_job_nodes.return_value = (['n1'], ['10.0.0.1'])
+
+        record = slurm_instance._create_managed_job_v1('us-central1',
+                                                       'mycluster',
+                                                       'mycluster-abcd1234',
+                                                       _make_provision_config())
+
+        meta = record.runtime_metadata
+        assert isinstance(meta, common.ProvisionRuntimeMetadata)
+        assert meta.has_ray is False
+        assert meta.has_skylet is False
+        assert meta.has_job_queue is False
+        assert meta.ssh_available is False
+        assert meta.runtime_setup_done is True
+        assert meta.workdir_synced is True
+        assert meta.file_mounts_synced is True
+        assert meta.setup_done is True
+        assert meta.run_started is True
+
+    def test_multi_node_reattach_threads_all_nodes(self, patched_module):
+        """A multi-node reattached job — all allocated nodes appear in
+        ``created_instance_ids``; head_instance_id is the first."""
+        client = patched_module.client
+        client.query_jobs.side_effect = [
+            [],
+            ['5151'],
+        ]
+        client.get_job_nodes.return_value = (
+            ['node01', 'node02', 'node03'],
+            ['10.0.0.1', '10.0.0.2', '10.0.0.3'],
+        )
+
+        record = slurm_instance._create_managed_job_v1(
+            'us-central1', 'mycluster', 'mycluster-abcd1234',
+            _make_provision_config(count=3))
+
+        from sky.provision.slurm import utils as slurm_utils
+        assert record.head_instance_id == slurm_utils.instance_id(
+            '5151', 'node01')
+        assert record.created_instance_ids == [
+            slurm_utils.instance_id('5151', 'node01'),
+            slurm_utils.instance_id('5151', 'node02'),
+            slurm_utils.instance_id('5151', 'node03'),
+        ]
+        client.submit_job.assert_not_called()
+
+    def test_two_existing_jobs_assertion_fires(self, patched_module):
+        """Two existing jobs trip the
+        ``assert len(existing_jobs) == 1`` safety net — this is the
+        single-job-per-name invariant. If it ever fires in production,
+        something is very wrong upstream."""
+        client = patched_module.client
+        client.query_jobs.side_effect = [
+            [],  # completing: empty
+            ['1111', '2222'],  # pending/running: two — VIOLATION
+        ]
+
+        with pytest.raises(AssertionError) as exc_info:
+            slurm_instance._create_managed_job_v1('us-central1', 'mycluster',
+                                                  'mycluster-abcd1234',
+                                                  _make_provision_config())
+
+        assert 'Multiple jobs found' in str(exc_info.value)
+        assert 'mycluster-abcd1234' in str(exc_info.value)
+        # Must not have called submit_job — the assertion fires first.
+        client.submit_job.assert_not_called()

--- a/tests/unit_tests/test_sky/provision/slurm/test_v1_create_managed_job.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_v1_create_managed_job.py
@@ -130,10 +130,11 @@ def patched_module(monkeypatch):
     # reattach branch and ``submit_job`` so tests targeting the COMPLETING
     # drain (which fall through to submission) can stop execution
     # deterministically at ``submit_job``.
-    runner_mock = mock.MagicMock(name='SSHCommandRunner_instance')
+    runner_mock = mock.MagicMock(name='SlurmLoginNodeCommandRunner_instance')
     runner_mock.get_remote_home_dir.return_value = '/home/slurmuser'
     runner_mock.run.return_value = (0, '', '')
-    monkeypatch.setattr(slurm_instance.command_runner, 'SSHCommandRunner',
+    monkeypatch.setattr(slurm_instance.command_runner,
+                        'SlurmLoginNodeCommandRunner',
                         mock.MagicMock(return_value=runner_mock))
     monkeypatch.setattr(slurm_instance, '_v1_precondition_cleanup',
                         mock.MagicMock())

--- a/tests/unit_tests/test_sky/provision/slurm/test_v1_query_instances.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_v1_query_instances.py
@@ -1,0 +1,134 @@
+"""Unit tests for the v1 ``query_instances`` cluster-status mapping.
+
+The mapping in ``_V1_SLURM_STATE_TO_CLUSTER_STATUS`` is a controller
+integration point, not just a Slurm-state convention. The managed-jobs
+controller decides retry-vs-fail by comparing the cluster status to
+``ClusterStatus.UP`` (sky/jobs/controller.py:874-947):
+
+  - ``cluster_status == UP`` AND ``job_status in user_code_failure_states``
+    → fail the managed job immediately (user code crashed).
+  - ``cluster_status != UP`` → infrastructure failure, take the recovery
+    branch and relaunch.
+
+For v1, where the Slurm allocation IS the user job, that distinction has
+to come from the Slurm state token. User-code-determined terminations
+(``FAILED``/``TIMEOUT``/``OUT_OF_MEMORY``/``DEADLINE``/``SPECIAL_EXIT``,
+plus ``COMPLETED`` for symmetry) must map to ``UP``. Real
+infrastructure failures (``NODE_FAIL``/``BOOT_FAIL``/``PREEMPTED``/
+``REVOKED``) and user cancellation (``CANCELLED``) map to ``None``.
+
+If ``FAILED`` ever regresses to ``None`` again, a managed job whose user
+code exits non-zero will be retried indefinitely.
+"""
+# pylint: disable=protected-access
+
+import pytest
+
+from sky.provision.slurm import instance as slurm_instance
+from sky.utils import status_lib
+
+
+@pytest.mark.parametrize('state', [
+    'PENDING',
+    'CONFIGURING',
+    'RESV_DEL_HOLD',
+    'REQUEUED',
+    'REQUEUE_HOLD',
+    'REQUEUE_FED',
+    'RESIZING',
+])
+def test_pending_states_map_to_init(state):
+    assert slurm_instance._V1_SLURM_STATE_TO_CLUSTER_STATUS[state] is (
+        status_lib.ClusterStatus.INIT)
+
+
+@pytest.mark.parametrize('state', [
+    'RUNNING',
+    'COMPLETING',
+    'SIGNALING',
+    'STAGE_OUT',
+    'SUSPENDED',
+])
+def test_running_states_map_to_up(state):
+    assert slurm_instance._V1_SLURM_STATE_TO_CLUSTER_STATUS[state] is (
+        status_lib.ClusterStatus.UP)
+
+
+@pytest.mark.parametrize('state', [
+    'COMPLETED',
+    'FAILED',
+    'TIMEOUT',
+    'OUT_OF_MEMORY',
+    'DEADLINE',
+    'SPECIAL_EXIT',
+])
+def test_user_code_terminal_states_map_to_up(state):
+    """User-code-determined terminations must report cluster as UP.
+
+    Otherwise the controller's user-code-failure branch
+    (controller.py:874-947) never fires and the managed job is retried
+    indefinitely. This is the integration contract — do not change
+    without also updating ``sky/jobs/controller.py``.
+    """
+    assert slurm_instance._V1_SLURM_STATE_TO_CLUSTER_STATUS[state] is (
+        status_lib.ClusterStatus.UP), (
+            f'{state} must map to UP so the controller distinguishes '
+            'user-code failure from infrastructure preemption.')
+
+
+@pytest.mark.parametrize('state', [
+    'NODE_FAIL',
+    'BOOT_FAIL',
+    'PREEMPTED',
+    'REVOKED',
+    'CANCELLED',
+])
+def test_infrastructure_and_cancelled_states_map_to_none(state):
+    """Real infrastructure failures map to None (cluster gone).
+
+    Tells the controller "cluster preempted/failed" so it takes the
+    recovery path. CANCELLED is included because the controller has a
+    separate cancellation handler and we want query_instances to
+    report the cluster as gone post-cancel.
+    """
+    assert (slurm_instance._V1_SLURM_STATE_TO_CLUSTER_STATUS[state] is
+            None), (f'{state} must map to None so the controller takes the '
+                    'recovery / cleanup path.')
+
+
+def test_no_unknown_states_in_table():
+    """Every key in the table is a documented Slurm state.
+
+    Sanity-check that we haven't accidentally added a typo'd entry that
+    would silently default to ``None`` on a real Slurm response.
+    """
+    documented = {
+        # Pending-like
+        'PENDING',
+        'CONFIGURING',
+        'RESV_DEL_HOLD',
+        'REQUEUED',
+        'REQUEUE_HOLD',
+        'REQUEUE_FED',
+        'RESIZING',
+        # Running-like
+        'RUNNING',
+        'COMPLETING',
+        'SIGNALING',
+        'STAGE_OUT',
+        'SUSPENDED',
+        # User-terminal
+        'COMPLETED',
+        'FAILED',
+        'TIMEOUT',
+        'OUT_OF_MEMORY',
+        'DEADLINE',
+        'SPECIAL_EXIT',
+        # Infra-terminal
+        'NODE_FAIL',
+        'BOOT_FAIL',
+        'PREEMPTED',
+        'REVOKED',
+        'CANCELLED',
+    }
+    assert set(slurm_instance._V1_SLURM_STATE_TO_CLUSTER_STATUS) == documented

--- a/tests/unit_tests/test_sky/provision/slurm/test_v1_query_instances.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_v1_query_instances.py
@@ -22,6 +22,8 @@ code exits non-zero will be retried indefinitely.
 """
 # pylint: disable=protected-access
 
+from unittest import mock
+
 import pytest
 
 from sky.provision.slurm import instance as slurm_instance
@@ -132,3 +134,162 @@ def test_no_unknown_states_in_table():
         'CANCELLED',
     }
     assert set(slurm_instance._V1_SLURM_STATE_TO_CLUSTER_STATUS) == documented
+
+
+# ---------------------------------------------------------------------------
+# ``_STATE_FILTER_TO_SLURM_STATE`` coverage of terminal states.
+# ---------------------------------------------------------------------------
+#
+# ``_query_instances_v1`` iterates the squeue ``--states`` filter set to
+# discover the current state of a job within ``MinJobAge`` (default 300s).
+# Terminal states beyond plain ``FAILED`` — TIMEOUT, OUT_OF_MEMORY,
+# DEADLINE, PREEMPTED, BOOT_FAIL, REVOKED — each surface under their own
+# filter; ``--states failed`` does NOT include them. Without entries for
+# all of them in the filter map, a walltime-killed or OOM-killed job goes
+# invisible to the squeue path and the controller misclassifies the
+# cluster as preempted.
+
+
+@pytest.mark.parametrize('filter_name,slurm_state', [
+    ('timeout', 'TIMEOUT'),
+    ('out_of_memory', 'OUT_OF_MEMORY'),
+    ('deadline', 'DEADLINE'),
+    ('preempted', 'PREEMPTED'),
+    ('boot_fail', 'BOOT_FAIL'),
+    ('revoked', 'REVOKED'),
+])
+def test_state_filter_includes_terminal_user_and_infra_states(
+        filter_name, slurm_state):
+    """Each terminal state must have a squeue filter entry.
+
+    Regression for the TIMEOUT-as-preemption bug: a job that hits
+    ``TIMEOUT`` within MinJobAge was invisible to the squeue path,
+    sacct fallback was gated on ``not non_terminated_only``, and the
+    controller misclassified as preempted.
+    """
+    assert filter_name in slurm_instance._STATE_FILTER_TO_SLURM_STATE, (
+        f'{filter_name!r} must be a valid filter so squeue surfaces '
+        f'{slurm_state} jobs within MinJobAge.')
+    assert slurm_instance._STATE_FILTER_TO_SLURM_STATE[filter_name] == (
+        slurm_state)
+
+
+def _make_mock_client(query_jobs_return=None, sacct_return=None):
+    """Build a SlurmClient mock for query_instances tests."""
+    client = mock.MagicMock()
+    if query_jobs_return is None:
+        query_jobs_return = {}
+
+    def _query_jobs(_name, filters):
+        return query_jobs_return.get(filters[0], [])
+
+    client.query_jobs.side_effect = _query_jobs
+    client.get_job_nodes.return_value = ([], 0)
+    client.get_job_reason.return_value = None
+    return client, sacct_return
+
+
+@pytest.mark.parametrize('filter_name,slurm_state', [
+    ('timeout', 'TIMEOUT'),
+    ('out_of_memory', 'OUT_OF_MEMORY'),
+    ('deadline', 'DEADLINE'),
+])
+def test_query_instances_v1_surfaces_user_terminal_via_squeue(
+        filter_name, slurm_state):
+    """Within MinJobAge, user-terminal state is read directly from the filter.
+
+    Without the matching filter entry, the squeue loop returned empty for
+    TIMEOUT/OUT_OF_MEMORY/etc. and the controller's
+    ``_update_cluster_status`` saw ``{}`` — misclassified as preempted
+    even though the cluster ran user code to completion.
+    """
+    client, _ = _make_mock_client(query_jobs_return={filter_name: ['12345']})
+    expected = slurm_instance._V1_SLURM_STATE_TO_CLUSTER_STATUS[slurm_state]
+    with mock.patch.object(slurm_instance,
+                           '_slurm_client_from_provider_config',
+                           return_value=client), \
+         mock.patch.object(slurm_instance,
+                           '_v1_sacct_job_state',
+                           return_value=None):
+        result = slurm_instance._query_instances_v1(
+            'slurm-edge-32', {}, non_terminated_only=True)
+    # Single-entry result keyed on job id (no node fanout for terminal jobs).
+    assert result == {'12345': (expected, None)}
+
+
+@pytest.mark.parametrize('filter_name,slurm_state', [
+    ('preempted', 'PREEMPTED'),
+    ('boot_fail', 'BOOT_FAIL'),
+    ('revoked', 'REVOKED'),
+])
+def test_query_instances_v1_infra_terminal_via_squeue_falls_through(
+        filter_name, slurm_state):
+    """For infra-terminal states (sky_status=None) with non_terminated_only=True,
+    squeue's discovery is suppressed (the caller doesn't want terminated
+    instances), and we fall through to sacct which surfaces the most-recent
+    parent-row state keyed on the cluster name. This preserves the
+    ``cluster_status=None → recovery`` signal."""
+    del slurm_state
+    client, _ = _make_mock_client(query_jobs_return={filter_name: ['12345']})
+    with mock.patch.object(slurm_instance,
+                           '_slurm_client_from_provider_config',
+                           return_value=client), \
+         mock.patch.object(slurm_instance,
+                           '_v1_sacct_job_state',
+                           return_value='NODE_FAIL'):
+        result = slurm_instance._query_instances_v1(
+            'slurm-edge-32', {}, non_terminated_only=True)
+    assert result == {'slurm-edge-32': (None, 'NODE_FAIL')}
+
+
+def test_query_instances_v1_sacct_fallback_fires_when_squeue_empty():
+    """When squeue returns nothing, sacct is consulted regardless of
+    ``non_terminated_only``. The pre-fix code gated the sacct branch on
+    ``not non_terminated_only`` — but the standard caller
+    (``backend_utils._update_cluster_status``) passes the default
+    ``True``, so a job aged past MinJobAge fell through entirely and
+    the controller saw ``{}``.
+    """
+    client, _ = _make_mock_client(query_jobs_return={})
+    with mock.patch.object(slurm_instance,
+                           '_slurm_client_from_provider_config',
+                           return_value=client), \
+         mock.patch.object(slurm_instance,
+                           '_v1_sacct_job_state',
+                           return_value='TIMEOUT'):
+        result = slurm_instance._query_instances_v1(
+            'slurm-edge-32', {}, non_terminated_only=True)
+    assert result == {
+        'slurm-edge-32': (status_lib.ClusterStatus.UP, 'TIMEOUT')
+    }
+
+
+def test_query_instances_v1_sacct_returns_none_for_infra_terminal():
+    """Infrastructure-terminal states map cluster_status to None via sacct."""
+    client, _ = _make_mock_client(query_jobs_return={})
+    with mock.patch.object(slurm_instance,
+                           '_slurm_client_from_provider_config',
+                           return_value=client), \
+         mock.patch.object(slurm_instance,
+                           '_v1_sacct_job_state',
+                           return_value='NODE_FAIL'):
+        result = slurm_instance._query_instances_v1(
+            'slurm-edge-32', {}, non_terminated_only=True)
+    assert result == {'slurm-edge-32': (None, 'NODE_FAIL')}
+
+
+def test_query_instances_v1_no_sacct_call_when_squeue_has_result():
+    """Defense-in-depth: don't waste a sacct call when squeue already
+    surfaced the job."""
+    client, _ = _make_mock_client(query_jobs_return={'running': ['77']})
+    client.get_job_nodes.return_value = (['node-1'], 0)
+    sacct_mock = mock.MagicMock(return_value='COMPLETED')
+    with mock.patch.object(slurm_instance,
+                           '_slurm_client_from_provider_config',
+                           return_value=client), \
+         mock.patch.object(slurm_instance,
+                           '_v1_sacct_job_state',
+                           sacct_mock):
+        slurm_instance._query_instances_v1(
+            'slurm-edge-32', {}, non_terminated_only=True)
+    sacct_mock.assert_not_called()

--- a/tests/unit_tests/test_sky/provision/slurm/test_v1_query_instances.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_v1_query_instances.py
@@ -293,3 +293,64 @@ def test_query_instances_v1_no_sacct_call_when_squeue_has_result():
         slurm_instance._query_instances_v1(
             'slurm-edge-32', {}, non_terminated_only=True)
     sacct_mock.assert_not_called()
+
+
+def test_query_instances_v1_terminal_multinode_fans_out_via_sacct():
+    """Multi-node terminal jobs must fan out across the full node list.
+
+    Regression for the partial-rank-failure bug: ``get_job_nodes`` uses
+    ``squeue --jobs <id>``, which excludes terminal jobs by default. For a
+    multi-node FAILED job within MinJobAge, the by-state filter sees the
+    job but the by-id lookup returns no nodes. Without the sacct NodeList
+    fallback, the result collapses to a single ``{job_id: (UP, None)}``
+    entry. ``backend_utils._update_cluster_status`` then sees
+    ``len(node_statuses)=1 < launched_nodes=2``, fires
+    ``some_nodes_terminated``, and the controller misclassifies as
+    infrastructure failure → spurious recovery loop.
+    """
+    client, _ = _make_mock_client(query_jobs_return={'failed': ['9001']})
+    # squeue --jobs <id> returns empty for terminal jobs.
+    client.get_job_nodes.return_value = ([], [])
+    with mock.patch.object(slurm_instance,
+                           '_slurm_client_from_provider_config',
+                           return_value=client), \
+         mock.patch.object(slurm_instance,
+                           '_v1_sacct_node_list',
+                           return_value=['node-a', 'node-b']), \
+         mock.patch.object(slurm_instance,
+                           '_v1_sacct_job_state',
+                           return_value=None):
+        result = slurm_instance._query_instances_v1(
+            'slurm-edge-32', {}, non_terminated_only=True)
+    assert len(result) == 2, (
+        f'Expected 2 fan-out entries for a 2-node terminal job, got {result}')
+    # Both entries must report the same (UP, None) and be keyed on a
+    # job_id+node composite (so the same status map is consumable by
+    # ``_update_cluster_status``).
+    expected = (status_lib.ClusterStatus.UP, None)
+    assert all(v == expected for v in result.values()), result
+    # Keys are ``slurm_utils.instance_id(job_id, node)`` == ``job<id>-<node>``.
+    assert set(result.keys()) == {'job9001-node-a', 'job9001-node-b'}
+
+
+def test_query_instances_v1_terminal_singlenode_keeps_single_entry():
+    """Single-node terminal jobs still collapse to a single job-id entry.
+
+    When ``_v1_sacct_node_list`` returns None (sacct unavailable or job
+    aged out completely), preserve the existing single-entry shape so the
+    1-node launched_nodes path keeps working.
+    """
+    client, _ = _make_mock_client(query_jobs_return={'failed': ['9002']})
+    client.get_job_nodes.return_value = ([], [])
+    with mock.patch.object(slurm_instance,
+                           '_slurm_client_from_provider_config',
+                           return_value=client), \
+         mock.patch.object(slurm_instance,
+                           '_v1_sacct_node_list',
+                           return_value=None), \
+         mock.patch.object(slurm_instance,
+                           '_v1_sacct_job_state',
+                           return_value=None):
+        result = slurm_instance._query_instances_v1(
+            'slurm-edge-32', {}, non_terminated_only=True)
+    assert result == {'9002': (status_lib.ClusterStatus.UP, None)}

--- a/tests/unit_tests/test_sky/provision/slurm/test_v1_query_instances.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_v1_query_instances.py
@@ -211,8 +211,8 @@ def test_query_instances_v1_surfaces_user_terminal_via_squeue(
          mock.patch.object(slurm_instance,
                            '_v1_sacct_job_state',
                            return_value=None):
-        result = slurm_instance._query_instances_v1(
-            'slurm-edge-32', {}, non_terminated_only=True)
+        result = slurm_instance._query_instances_v1('slurm-edge-32', {},
+                                                    non_terminated_only=True)
     # Single-entry result keyed on job id (no node fanout for terminal jobs).
     assert result == {'12345': (expected, None)}
 
@@ -237,8 +237,8 @@ def test_query_instances_v1_infra_terminal_via_squeue_falls_through(
          mock.patch.object(slurm_instance,
                            '_v1_sacct_job_state',
                            return_value='NODE_FAIL'):
-        result = slurm_instance._query_instances_v1(
-            'slurm-edge-32', {}, non_terminated_only=True)
+        result = slurm_instance._query_instances_v1('slurm-edge-32', {},
+                                                    non_terminated_only=True)
     assert result == {'slurm-edge-32': (None, 'NODE_FAIL')}
 
 
@@ -257,11 +257,9 @@ def test_query_instances_v1_sacct_fallback_fires_when_squeue_empty():
          mock.patch.object(slurm_instance,
                            '_v1_sacct_job_state',
                            return_value='TIMEOUT'):
-        result = slurm_instance._query_instances_v1(
-            'slurm-edge-32', {}, non_terminated_only=True)
-    assert result == {
-        'slurm-edge-32': (status_lib.ClusterStatus.UP, 'TIMEOUT')
-    }
+        result = slurm_instance._query_instances_v1('slurm-edge-32', {},
+                                                    non_terminated_only=True)
+    assert result == {'slurm-edge-32': (status_lib.ClusterStatus.UP, 'TIMEOUT')}
 
 
 def test_query_instances_v1_sacct_returns_none_for_infra_terminal():
@@ -273,8 +271,8 @@ def test_query_instances_v1_sacct_returns_none_for_infra_terminal():
          mock.patch.object(slurm_instance,
                            '_v1_sacct_job_state',
                            return_value='NODE_FAIL'):
-        result = slurm_instance._query_instances_v1(
-            'slurm-edge-32', {}, non_terminated_only=True)
+        result = slurm_instance._query_instances_v1('slurm-edge-32', {},
+                                                    non_terminated_only=True)
     assert result == {'slurm-edge-32': (None, 'NODE_FAIL')}
 
 
@@ -290,8 +288,8 @@ def test_query_instances_v1_no_sacct_call_when_squeue_has_result():
          mock.patch.object(slurm_instance,
                            '_v1_sacct_job_state',
                            sacct_mock):
-        slurm_instance._query_instances_v1(
-            'slurm-edge-32', {}, non_terminated_only=True)
+        slurm_instance._query_instances_v1('slurm-edge-32', {},
+                                           non_terminated_only=True)
     sacct_mock.assert_not_called()
 
 
@@ -320,8 +318,8 @@ def test_query_instances_v1_terminal_multinode_fans_out_via_sacct():
          mock.patch.object(slurm_instance,
                            '_v1_sacct_job_state',
                            return_value=None):
-        result = slurm_instance._query_instances_v1(
-            'slurm-edge-32', {}, non_terminated_only=True)
+        result = slurm_instance._query_instances_v1('slurm-edge-32', {},
+                                                    non_terminated_only=True)
     assert len(result) == 2, (
         f'Expected 2 fan-out entries for a 2-node terminal job, got {result}')
     # Both entries must report the same (UP, None) and be keyed on a
@@ -351,6 +349,6 @@ def test_query_instances_v1_terminal_singlenode_keeps_single_entry():
          mock.patch.object(slurm_instance,
                            '_v1_sacct_job_state',
                            return_value=None):
-        result = slurm_instance._query_instances_v1(
-            'slurm-edge-32', {}, non_terminated_only=True)
+        result = slurm_instance._query_instances_v1('slurm-edge-32', {},
+                                                    non_terminated_only=True)
     assert result == {'9002': (status_lib.ClusterStatus.UP, None)}

--- a/tests/unit_tests/test_sky/provision/slurm/test_v1_sbatch_script.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_v1_sbatch_script.py
@@ -1,0 +1,77 @@
+"""Unit tests for the v1 sbatch script's SkyPilot runtime env vars.
+
+The legacy executor (``sky/skylet/executor/slurm.py``) provides
+``SKYPILOT_NODE_RANK`` / ``SKYPILOT_NUM_NODES`` / ``SKYPILOT_NODE_IPS``
+/ ``SKYPILOT_NUM_GPUS_PER_NODE`` to user code; the v1 sbatch script must
+provide the same contract.
+"""
+# pylint: disable=protected-access,missing-class-docstring
+from sky.provision.slurm import instance as slurm_instance
+from sky.skylet import constants
+
+
+def _build_script(num_nodes=2,
+                  accelerator_count=1,
+                  envs=None,
+                  setup='pip install -e .',
+                  run='python train.py'):
+    return slurm_instance._build_v1_sbatch_script(
+        cluster_name_on_cloud='test-cluster',
+        num_nodes=num_nodes,
+        log_path='/home/u/.sky_provision/slurm-%j.out',
+        resources={
+            'cpus': 4,
+            'memory': 8,
+            'accelerator_type': 'gh200',
+            'accelerator_count': accelerator_count,
+        },
+        setup=setup,
+        run=run,
+        envs=envs or {},
+        workdir=None,
+        file_mounts=None,
+        container_image=None,
+        extra_sbatch_directives='',
+    )
+
+
+class TestRuntimeEnvVars:
+
+    def test_allocation_wide_vars_in_preamble(self):
+        script = _build_script(num_nodes=2, accelerator_count=1)
+        preamble = script.split('srun ', 1)[0]
+        assert f'export {constants.SKYPILOT_NUM_NODES}=2' in preamble
+        assert (f'export {constants.SKYPILOT_NUM_GPUS_PER_NODE}=1'
+                in preamble)
+        assert (f'export {constants.SKYPILOT_SETUP_NUM_GPUS_PER_NODE}=1'
+                in preamble)
+        # NODE_IPS is computed from the allocation's nodelist and
+        # exported for the srun tasks to inherit.
+        assert 'scontrol show hostnames "$SLURM_JOB_NODELIST"' in preamble
+        assert f'export {constants.SKYPILOT_NODE_IPS}' in preamble
+
+    def test_node_rank_derived_inside_srun_body(self):
+        """Rank is per-task, so the export must live inside the srun
+        body (evaluated per task), not the preamble (evaluated once)."""
+        script = _build_script()
+        rank_export = (f'export {constants.SKYPILOT_NODE_RANK}='
+                       '"$SLURM_PROCID"')
+        preamble, srun_body = script.split('srun ', 1)
+        assert rank_export not in preamble
+        assert rank_export in srun_body
+
+    def test_no_gpu_task_exports_zero(self):
+        script = _build_script(accelerator_count=0)
+        assert f'export {constants.SKYPILOT_NUM_GPUS_PER_NODE}=0' in script
+
+    def test_rank_export_present_without_setup_or_run(self):
+        script = _build_script(setup=None, run=None)
+        assert f'export {constants.SKYPILOT_NODE_RANK}=' in script
+
+    def test_user_env_overrides_runtime_var(self):
+        """User envs are exported after the runtime vars so a colliding
+        user-defined value wins."""
+        script = _build_script(envs={constants.SKYPILOT_NUM_NODES: '99'})
+        runtime_idx = script.index(f'export {constants.SKYPILOT_NUM_NODES}=2')
+        user_idx = script.index(f'export {constants.SKYPILOT_NUM_NODES}=99')
+        assert runtime_idx < user_idx

--- a/tests/unit_tests/test_sky/provision/slurm/test_v1_submit_as_user.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_v1_submit_as_user.py
@@ -1,0 +1,147 @@
+"""Unit tests for slurm_user threading through the v1 managed-job path.
+
+With ``slurm.submit_as_user: true`` the sbatch runs as the authenticated
+user's Unix account, so every v1 follow-up (squeue / sacct / scancel /
+log reads) must run as that user too. The template renders
+``provider.slurm_user``; these tests pin that the v1 client and runner
+constructions all pass it through.
+"""
+# pylint: disable=protected-access,missing-class-docstring
+import types
+from unittest import mock
+
+from sky.provision.slurm import instance as slurm_instance
+from sky.provision.slurm import log_streaming
+from sky.provision.slurm import managed_job_runtime as mjr
+from sky.utils import command_runner
+
+_SSH_CONFIG = {
+    'hostname': 'login.example.com',
+    'port': 22,
+    'user': 'transport',
+    'private_key': '/tmp/key',
+}
+
+_V1_PROVIDER_CONFIG = {
+    'skypilot_runtime': 'managed_job_v1',
+    'ssh': _SSH_CONFIG,
+    'partition': 'gpu',
+    'slurm_user': 'alice',
+}
+
+
+class TestClientFromProviderConfig:
+
+    def test_passes_slurm_user(self):
+        client_cls = mock.MagicMock()
+        with mock.patch.object(slurm_instance.slurm, 'SlurmClient',
+                               client_cls):
+            slurm_instance._slurm_client_from_provider_config(
+                _V1_PROVIDER_CONFIG)
+        assert client_cls.call_args.kwargs['slurm_user'] == 'alice'
+
+    def test_defaults_to_none_without_config(self):
+        config = dict(_V1_PROVIDER_CONFIG)
+        del config['slurm_user']
+        client_cls = mock.MagicMock()
+        with mock.patch.object(slurm_instance.slurm, 'SlurmClient',
+                               client_cls):
+            slurm_instance._slurm_client_from_provider_config(config)
+        assert client_cls.call_args.kwargs['slurm_user'] is None
+
+
+def _make_v1_handle():
+    handle = types.SimpleNamespace()
+    handle.provision_runtime_metadata = types.SimpleNamespace(has_ray=False)
+    handle.cluster_yaml = '/fake.yml'
+    head_info = types.SimpleNamespace(tags={'job_id': '12345'})
+    handle.cached_cluster_info = types.SimpleNamespace(
+        head_instance_id='head-0', instances={'head-0': [head_info]})
+    handle.launched_resources = types.SimpleNamespace(region=None)
+    return handle
+
+
+class TestTargetSlurmUser:
+
+    def test_resolve_target_carries_slurm_user(self, monkeypatch):
+        monkeypatch.setattr(mjr.global_user_state, 'get_cluster_yaml_dict',
+                            lambda path: {'provider': _V1_PROVIDER_CONFIG})
+        target = mjr._resolve_slurm_target(_make_v1_handle())
+        assert target is not None
+        assert target.slurm_user == 'alice'
+
+    def test_resolve_target_defaults_to_none(self, monkeypatch):
+        config = dict(_V1_PROVIDER_CONFIG)
+        del config['slurm_user']
+        monkeypatch.setattr(mjr.global_user_state, 'get_cluster_yaml_dict',
+                            lambda path: {'provider': config})
+        target = mjr._resolve_slurm_target(_make_v1_handle())
+        assert target is not None
+        assert target.slurm_user is None
+
+    def test_client_from_target_passes_slurm_user(self):
+        target = mjr._Target(job_id='12345',
+                             ssh_config=_SSH_CONFIG,
+                             partition='gpu',
+                             region=None,
+                             log_path=None,
+                             slurm_user='alice')
+        client_cls = mock.MagicMock()
+        with mock.patch.object(mjr.slurm, 'SlurmClient', client_cls):
+            mjr._slurm_client_from_target(target)
+        assert client_cls.call_args.kwargs['slurm_user'] == 'alice'
+
+    def test_login_node_runner_is_slurm_user_wrapped(self, tmp_path):
+        key = tmp_path / 'key'
+        key.write_text('')
+        ssh_config = dict(_SSH_CONFIG, private_key=str(key))
+        runner = mjr._login_node_runner(ssh_config, 'alice')
+        assert isinstance(runner, command_runner.SlurmLoginNodeCommandRunner)
+        assert runner.slurm_user == 'alice'
+
+
+class TestLogStreamerWrapsAsSubmitUser:
+
+    def _streamer(self, slurm_user):
+        target = mjr._Target(job_id='12345',
+                             ssh_config=_SSH_CONFIG,
+                             partition='gpu',
+                             region=None,
+                             log_path='/home/alice/.sky_provision/x.out',
+                             slurm_user=slurm_user)
+        return log_streaming.SlurmLogStreamer(
+            target=target,
+            log_path=target.log_path,
+            client=mock.MagicMock(),
+            terminal_states=frozenset({'COMPLETED'}),
+            sacct_get_state=mock.MagicMock(return_value=None),
+            state_to_job_exit_code=mock.MagicMock(return_value=0),
+            follow=False,
+            tail=None,
+            tail_offset=None,
+            write_fn=mock.MagicMock(),
+        )
+
+    def _captured_remote_cmd(self, streamer):
+        fake_runner = mock.MagicMock()
+        fake_runner.ssh_base_command.return_value = ['ssh', 'fake']
+        with mock.patch.object(log_streaming, '_login_node_runner',
+                               return_value=fake_runner):
+            with mock.patch.object(streamer, '_tail_once',
+                                   return_value=0) as tail_once:
+                streamer.run()
+        return tail_once.call_args.args[1]
+
+    def test_remote_cmd_wrapped_when_slurm_user_set(self):
+        remote_cmd = self._captured_remote_cmd(self._streamer('alice'))
+        # The tail must run as the submit user: su via sudo (transport
+        # user is not root).
+        assert 'sudo' in remote_cmd
+        assert 'su --login' in remote_cmd
+        assert 'alice' in remote_cmd
+        assert 'tail' in remote_cmd
+
+    def test_remote_cmd_untouched_without_slurm_user(self):
+        remote_cmd = self._captured_remote_cmd(self._streamer(None))
+        assert 'su --login' not in remote_cmd
+        assert remote_cmd.startswith('tail')

--- a/tests/unit_tests/test_sky/provision/slurm/test_v1_template_override.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_v1_template_override.py
@@ -1,0 +1,455 @@
+"""Unit tests for Slurm v1 detection, gating, and template_override.
+
+Covers:
+- ``is_managed_job_v1_provider_config`` marker reads.
+- ``is_slurm_managed_jobs_v1_enabled`` env / config gates.
+- ``_get_unsupported_v1_inputs`` per user input dimension.
+- ``will_use_v1_template`` decision matrix.
+- ``template_override`` happy + fallback paths and the warning gate.
+"""
+# pylint: disable=protected-access,missing-class-docstring
+# pylint: disable=import-outside-toplevel,unused-argument
+from unittest import mock
+
+import pytest
+
+from sky import clouds as sky_clouds
+from sky.provision import TemplateSpec
+from sky.provision.slurm import instance as slurm_instance
+
+# ----------------------------- Fixtures ----------------------------- #
+
+
+def _make_resource(cloud=None,
+                   accelerator_type=None,
+                   accelerator_count=0,
+                   cluster_overrides=None,
+                   docker_image=None):
+    """Build a mock ``Resources`` with the attributes ``template_override``
+    inspects."""
+    if cloud is None:
+        cloud = sky_clouds.Slurm()
+    resource = mock.MagicMock(name='Resources')
+    resource.cloud = cloud
+    resource.cluster_config_overrides = cluster_overrides or {}
+    resource.extract_docker_image = mock.MagicMock(return_value=docker_image)
+    resource.accelerator_type = accelerator_type
+    resource.accelerator_count = accelerator_count
+    return resource
+
+
+def _make_task(resources=None,
+               workdir=None,
+               file_mounts=None,
+               local_to_remote_file_mounts=None,
+               storage_mounts=None,
+               num_nodes=1,
+               setup=None,
+               run=None,
+               envs_and_secrets=None):
+    """Build a mock ``Task`` for ``template_override``.
+
+    ``local_to_remote_file_mounts`` is what
+    ``get_local_to_remote_file_mounts()`` returns — distinct from
+    ``file_mounts`` (the raw dict). A non-cloud-URI file mount appears
+    in both; a cloud-URI one only in ``file_mounts``.
+    """
+    if resources is None:
+        resources = [_make_resource()]
+    task = mock.MagicMock(name='Task')
+    task.resources = resources
+    task.workdir = workdir
+    task.file_mounts = file_mounts
+    task.get_local_to_remote_file_mounts = mock.MagicMock(
+        return_value=local_to_remote_file_mounts or {})
+    task.storage_mounts = storage_mounts or {}
+    task.num_nodes = num_nodes
+    task.setup = setup
+    task.run = run
+    task.envs_and_secrets = envs_and_secrets or {}
+    return task
+
+
+# --------------------- is_managed_job_v1_provider_config -------------- #
+
+
+class TestIsManagedJobV1ProviderConfig:
+
+    def test_positive_marker(self):
+        cfg = {'skypilot_runtime': 'managed_job_v1', 'other': 'value'}
+        assert slurm_instance.is_managed_job_v1_provider_config(cfg) is True
+
+    def test_wrong_marker(self):
+        cfg = {'skypilot_runtime': 'legacy'}
+        assert slurm_instance.is_managed_job_v1_provider_config(cfg) is False
+
+    def test_missing_marker(self):
+        cfg = {'partition': 'gpu'}
+        assert slurm_instance.is_managed_job_v1_provider_config(cfg) is False
+
+    def test_empty_dict(self):
+        assert slurm_instance.is_managed_job_v1_provider_config({}) is False
+
+
+# --------------------- is_slurm_managed_jobs_v1_enabled --------------- #
+
+
+class TestIsSlurmManagedJobsV1Enabled:
+
+    def test_default_enabled(self, monkeypatch):
+        monkeypatch.delenv('SKYPILOT_SLURM_DISABLE_V1_JOBS', raising=False)
+        monkeypatch.setattr(slurm_instance.skypilot_config, 'get_nested',
+                            lambda keys, default: default)
+        assert slurm_instance.is_slurm_managed_jobs_v1_enabled() is True
+
+    def test_disabled_via_env(self, monkeypatch):
+        monkeypatch.setenv('SKYPILOT_SLURM_DISABLE_V1_JOBS', '1')
+        # Even if config says True, env wins.
+        monkeypatch.setattr(slurm_instance.skypilot_config, 'get_nested',
+                            lambda keys, default: True)
+        assert slurm_instance.is_slurm_managed_jobs_v1_enabled() is False
+
+    def test_env_other_values_do_not_disable(self, monkeypatch):
+        # Only the literal '1' counts as a disable; '0', 'true', etc. don't.
+        monkeypatch.setenv('SKYPILOT_SLURM_DISABLE_V1_JOBS', '0')
+        monkeypatch.setattr(slurm_instance.skypilot_config, 'get_nested',
+                            lambda keys, default: default)
+        assert slurm_instance.is_slurm_managed_jobs_v1_enabled() is True
+
+    def test_disabled_via_config(self, monkeypatch):
+        monkeypatch.delenv('SKYPILOT_SLURM_DISABLE_V1_JOBS', raising=False)
+        monkeypatch.setattr(slurm_instance.skypilot_config, 'get_nested',
+                            lambda keys, default: False)
+        assert slurm_instance.is_slurm_managed_jobs_v1_enabled() is False
+
+
+# ----------------------- _get_unsupported_v1_inputs ------------------- #
+
+
+class TestGetUnsupportedV1Inputs:
+
+    def test_empty_task(self):
+        task = _make_task()
+        assert slurm_instance._get_unsupported_v1_inputs(task) == []
+
+    def test_local_string_workdir_flagged(self):
+        task = _make_task(workdir='/home/user/code')
+        result = slurm_instance._get_unsupported_v1_inputs(task)
+        assert len(result) == 1
+        assert 'workdir' in result[0]
+        assert '/home/user/code' in result[0]
+
+    def test_git_dict_workdir_allowed(self):
+        task = _make_task(workdir={
+            'url': 'https://github.com/foo/bar.git',
+            'ref': 'main'
+        })
+        # Dict (git) workdirs are not flagged.
+        assert slurm_instance._get_unsupported_v1_inputs(task) == []
+
+    def test_local_file_mounts_listed(self):
+        task = _make_task(local_to_remote_file_mounts={
+            '/remote/a': '/local/a',
+            '/remote/b': '/local/b',
+        })
+        result = slurm_instance._get_unsupported_v1_inputs(task)
+        assert len(result) == 2
+        assert any('/local/a' in s and '/remote/a' in s for s in result)
+        assert any('/local/b' in s and '/remote/b' in s for s in result)
+
+    def test_cloud_uri_file_mounts_allowed(self):
+        # ``get_local_to_remote_file_mounts`` filters cloud URIs out, so
+        # an empty dict from that method means everything is cloud-URI.
+        task = _make_task(
+            file_mounts={
+                '/data': 's3://bucket/key',
+                '/gs': 'gs://b/k'
+            },
+            local_to_remote_file_mounts={},
+        )
+        assert slurm_instance._get_unsupported_v1_inputs(task) == []
+
+    def test_storage_mounts_listed(self):
+        storage = mock.MagicMock()
+        storage.name = 'my-bucket'
+        task = _make_task(storage_mounts={'/mnt/data': storage})
+        result = slurm_instance._get_unsupported_v1_inputs(task)
+        assert len(result) == 1
+        assert 'storage_mounts' in result[0]
+        assert 'my-bucket' in result[0]
+
+
+# --------------------------- will_use_v1_template --------------------- #
+
+
+class _V1GateFixture:
+    """Helper that toggles all the v1 gates via monkeypatch."""
+
+    def __init__(self, monkeypatch, *, v1_enabled=True):
+        self.monkeypatch = monkeypatch
+        monkeypatch.delenv('SKYPILOT_SLURM_DISABLE_V1_JOBS', raising=False)
+        monkeypatch.setattr(
+            slurm_instance.skypilot_config, 'get_nested',
+            lambda keys, default: v1_enabled
+            if keys == ('slurm', 'use_v1') else default)
+
+
+class TestWillUseV1Template:
+
+    def test_happy_path(self, monkeypatch):
+        _V1GateFixture(monkeypatch, v1_enabled=True)
+        task = _make_task()
+        assert slurm_instance.will_use_v1_template(
+            task, is_launched_by_jobs_controller=True) is True
+
+    def test_not_launched_by_controller_disables(self, monkeypatch):
+        _V1GateFixture(monkeypatch, v1_enabled=True)
+        task = _make_task()
+        assert slurm_instance.will_use_v1_template(
+            task, is_launched_by_jobs_controller=False) is False
+
+    def test_non_slurm_resource_alternative_disables(self, monkeypatch):
+        _V1GateFixture(monkeypatch, v1_enabled=True)
+        non_slurm = _make_resource(cloud=sky_clouds.AWS())
+        task = _make_task(resources=[_make_resource(), non_slurm])
+        assert slurm_instance.will_use_v1_template(
+            task, is_launched_by_jobs_controller=True) is False
+
+    def test_empty_resources_disables(self, monkeypatch):
+        _V1GateFixture(monkeypatch, v1_enabled=True)
+        task = _make_task(resources=[])
+        assert slurm_instance.will_use_v1_template(
+            task, is_launched_by_jobs_controller=True) is False
+
+    def test_unsupported_input_disables(self, monkeypatch):
+        _V1GateFixture(monkeypatch, v1_enabled=True)
+        task = _make_task(workdir='/local/path')
+        assert slurm_instance.will_use_v1_template(
+            task, is_launched_by_jobs_controller=True) is False
+
+    def test_v1_gate_off_disables(self, monkeypatch):
+        _V1GateFixture(monkeypatch, v1_enabled=False)
+        task = _make_task()
+        assert slurm_instance.will_use_v1_template(
+            task, is_launched_by_jobs_controller=True) is False
+
+
+# --------------------------- template_override ------------------------ #
+
+
+class TestTemplateOverride:
+
+    @pytest.fixture
+    def patched_helpers(self, monkeypatch):
+        """Stub out the controller-only helpers ``template_override``
+        reaches into: env/secret extraction and num-gpus."""
+        from sky import task as task_lib
+        from sky.backends import backend_utils
+        monkeypatch.setattr(task_lib, 'get_plaintext_envs_and_secrets',
+                            lambda envs: dict(envs) if envs else {})
+        monkeypatch.setattr(backend_utils, 'get_num_gpus_per_node',
+                            lambda task: task.num_nodes and 0 or 0)
+
+    def test_happy_path_returns_spec(self, monkeypatch, patched_helpers):
+        _V1GateFixture(monkeypatch, v1_enabled=True)
+        task = _make_task(
+            setup='setup.sh',
+            run='run.sh',
+            envs_and_secrets={'FOO': 'bar'},
+            num_nodes=2,
+        )
+
+        spec = slurm_instance.template_override(
+            task,
+            _extra_launch_context={},
+            _is_launched_by_jobs_controller=True,
+        )
+
+        assert isinstance(spec, TemplateSpec)
+        assert spec.template_path == 'slurm-managed-job-v1.yml.j2'
+        expected_keys = {
+            'setup',
+            'run',
+            'envs',
+            'num_nodes',
+            'num_gpus_per_node',
+            'workdir',
+            'file_mounts',
+            'sbatch_options',
+            'container_image',
+        }
+        assert expected_keys == set(spec.variables.keys())
+        assert spec.variables['setup'] == 'setup.sh'
+        assert spec.variables['run'] == 'run.sh'
+        assert spec.variables['num_nodes'] == 2
+        assert spec.variables['envs'] == {'FOO': 'bar'}
+
+    def test_git_workdir_threaded_into_variables(self, monkeypatch,
+                                                 patched_helpers):
+        _V1GateFixture(monkeypatch, v1_enabled=True)
+        git_dict = {'url': 'https://github.com/foo/bar.git', 'ref': 'main'}
+        task = _make_task(workdir=git_dict)
+
+        spec = slurm_instance.template_override(
+            task,
+            _extra_launch_context={},
+            _is_launched_by_jobs_controller=True,
+        )
+
+        assert spec is not None
+        assert spec.variables['workdir'] == {'git': git_dict}
+
+    def test_container_image_threaded_into_variables(self, monkeypatch,
+                                                     patched_helpers):
+        _V1GateFixture(monkeypatch, v1_enabled=True)
+        resource = _make_resource(docker_image='nvcr.io/foo:bar')
+        task = _make_task(resources=[resource])
+
+        spec = slurm_instance.template_override(
+            task,
+            _extra_launch_context={},
+            _is_launched_by_jobs_controller=True,
+        )
+
+        assert spec is not None
+        assert spec.variables['container_image'] == 'nvcr.io/foo:bar'
+
+    def test_task_level_sbatch_options_threaded(self, monkeypatch,
+                                                patched_helpers):
+        _V1GateFixture(monkeypatch, v1_enabled=True)
+        overrides = {'slurm': {'sbatch_options': {'qos': 'high'}}}
+        resource = _make_resource(cluster_overrides=overrides)
+        task = _make_task(resources=[resource])
+
+        spec = slurm_instance.template_override(
+            task,
+            _extra_launch_context={},
+            _is_launched_by_jobs_controller=True,
+        )
+
+        assert spec is not None
+        assert spec.variables['sbatch_options'] == {'qos': 'high'}
+
+    def test_no_sbatch_options_yields_none(self, monkeypatch, patched_helpers):
+        _V1GateFixture(monkeypatch, v1_enabled=True)
+        task = _make_task()
+
+        spec = slurm_instance.template_override(
+            task,
+            _extra_launch_context={},
+            _is_launched_by_jobs_controller=True,
+        )
+
+        assert spec is not None
+        # Empty sbatch_options collapses to None in the template variables.
+        assert spec.variables['sbatch_options'] is None
+
+    # --- Fallback paths --- #
+
+    def test_returns_none_when_not_controller_launched(self, monkeypatch,
+                                                       patched_helpers):
+        _V1GateFixture(monkeypatch, v1_enabled=True)
+        task = _make_task()
+        assert slurm_instance.template_override(
+            task,
+            _extra_launch_context={},
+            _is_launched_by_jobs_controller=False) is None
+
+    def test_returns_none_when_non_slurm_alt(self, monkeypatch,
+                                             patched_helpers):
+        _V1GateFixture(monkeypatch, v1_enabled=True)
+        task = _make_task(resources=[
+            _make_resource(),
+            _make_resource(cloud=sky_clouds.AWS()),
+        ])
+        assert slurm_instance.template_override(
+            task,
+            _extra_launch_context={},
+            _is_launched_by_jobs_controller=True) is None
+
+    def test_returns_none_when_v1_disabled(self, monkeypatch, patched_helpers):
+        _V1GateFixture(monkeypatch, v1_enabled=False)
+        task = _make_task()
+        assert slurm_instance.template_override(
+            task,
+            _extra_launch_context={},
+            _is_launched_by_jobs_controller=True) is None
+
+    def test_returns_none_on_unsupported_input(self, monkeypatch,
+                                               patched_helpers):
+        _V1GateFixture(monkeypatch, v1_enabled=True)
+        task = _make_task(workdir='/local/path')
+        assert slurm_instance.template_override(
+            task,
+            _extra_launch_context={},
+            _is_launched_by_jobs_controller=True) is None
+
+    # --- Warning gate: "almost v1" only --- #
+    #
+    # The `sky` logger has propagate=False, so `caplog` cannot observe
+    # it (same gotcha as test_sbatch_config.py::test_no_maxtime_..._warns).
+    # Mock the module logger's `warning` directly instead.
+
+    def test_fallback_warning_only_when_almost_v1(self, monkeypatch,
+                                                  patched_helpers):
+        """The "Falling back to legacy" warning fires only when the task
+        is Slurm + controller-launched + v1-enabled + has unsupported
+        inputs. Every other fallback path stays silent."""
+        _V1GateFixture(monkeypatch, v1_enabled=True)
+        task = _make_task(workdir='/local/path')
+
+        warning_mock = mock.MagicMock()
+        monkeypatch.setattr(slurm_instance.logger, 'warning', warning_mock)
+        result = slurm_instance.template_override(
+            task,
+            _extra_launch_context={},
+            _is_launched_by_jobs_controller=True,
+        )
+        assert result is None
+        warning_mock.assert_called_once()
+        msg = warning_mock.call_args.args[0]
+        assert 'Falling back to legacy' in msg
+
+    def test_no_warning_when_not_controller_launched(self, monkeypatch,
+                                                     patched_helpers):
+        _V1GateFixture(monkeypatch, v1_enabled=True)
+        task = _make_task(workdir='/local/path')
+        warning_mock = mock.MagicMock()
+        monkeypatch.setattr(slurm_instance.logger, 'warning', warning_mock)
+        slurm_instance.template_override(
+            task,
+            _extra_launch_context={},
+            _is_launched_by_jobs_controller=False,
+        )
+        # No call, or no "Falling back to legacy" in any call.
+        for call in warning_mock.call_args_list:
+            assert 'Falling back to legacy' not in call.args[0]
+
+    def test_no_warning_when_non_slurm_alt(self, monkeypatch, patched_helpers):
+        _V1GateFixture(monkeypatch, v1_enabled=True)
+        task = _make_task(
+            resources=[_make_resource(cloud=sky_clouds.AWS())],
+            workdir='/local/path',
+        )
+        warning_mock = mock.MagicMock()
+        monkeypatch.setattr(slurm_instance.logger, 'warning', warning_mock)
+        slurm_instance.template_override(
+            task,
+            _extra_launch_context={},
+            _is_launched_by_jobs_controller=True,
+        )
+        for call in warning_mock.call_args_list:
+            assert 'Falling back to legacy' not in call.args[0]
+
+    def test_no_warning_when_v1_disabled(self, monkeypatch, patched_helpers):
+        _V1GateFixture(monkeypatch, v1_enabled=False)
+        task = _make_task(workdir='/local/path')
+        warning_mock = mock.MagicMock()
+        monkeypatch.setattr(slurm_instance.logger, 'warning', warning_mock)
+        slurm_instance.template_override(
+            task,
+            _extra_launch_context={},
+            _is_launched_by_jobs_controller=True,
+        )
+        for call in warning_mock.call_args_list:
+            assert 'Falling back to legacy' not in call.args[0]

--- a/tests/unit_tests/test_sky/provision/slurm/test_v1_template_override.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_v1_template_override.py
@@ -261,6 +261,7 @@ class TestTemplateOverride:
 
         spec = slurm_instance.template_override(
             task,
+            task.resources[0],
             _extra_launch_context={},
             _is_launched_by_jobs_controller=True,
         )
@@ -292,6 +293,7 @@ class TestTemplateOverride:
 
         spec = slurm_instance.template_override(
             task,
+            task.resources[0],
             _extra_launch_context={},
             _is_launched_by_jobs_controller=True,
         )
@@ -307,6 +309,7 @@ class TestTemplateOverride:
 
         spec = slurm_instance.template_override(
             task,
+            task.resources[0],
             _extra_launch_context={},
             _is_launched_by_jobs_controller=True,
         )
@@ -323,6 +326,7 @@ class TestTemplateOverride:
 
         spec = slurm_instance.template_override(
             task,
+            task.resources[0],
             _extra_launch_context={},
             _is_launched_by_jobs_controller=True,
         )
@@ -336,6 +340,7 @@ class TestTemplateOverride:
 
         spec = slurm_instance.template_override(
             task,
+            task.resources[0],
             _extra_launch_context={},
             _is_launched_by_jobs_controller=True,
         )
@@ -352,6 +357,7 @@ class TestTemplateOverride:
         task = _make_task()
         assert slurm_instance.template_override(
             task,
+            task.resources[0],
             _extra_launch_context={},
             _is_launched_by_jobs_controller=False) is None
 
@@ -364,6 +370,7 @@ class TestTemplateOverride:
         ])
         assert slurm_instance.template_override(
             task,
+            task.resources[0],
             _extra_launch_context={},
             _is_launched_by_jobs_controller=True) is None
 
@@ -372,6 +379,7 @@ class TestTemplateOverride:
         task = _make_task()
         assert slurm_instance.template_override(
             task,
+            task.resources[0],
             _extra_launch_context={},
             _is_launched_by_jobs_controller=True) is None
 
@@ -381,6 +389,7 @@ class TestTemplateOverride:
         task = _make_task(workdir='/local/path')
         assert slurm_instance.template_override(
             task,
+            task.resources[0],
             _extra_launch_context={},
             _is_launched_by_jobs_controller=True) is None
 
@@ -402,6 +411,7 @@ class TestTemplateOverride:
         monkeypatch.setattr(slurm_instance.logger, 'warning', warning_mock)
         result = slurm_instance.template_override(
             task,
+            task.resources[0],
             _extra_launch_context={},
             _is_launched_by_jobs_controller=True,
         )
@@ -418,6 +428,7 @@ class TestTemplateOverride:
         monkeypatch.setattr(slurm_instance.logger, 'warning', warning_mock)
         slurm_instance.template_override(
             task,
+            task.resources[0],
             _extra_launch_context={},
             _is_launched_by_jobs_controller=False,
         )
@@ -435,6 +446,7 @@ class TestTemplateOverride:
         monkeypatch.setattr(slurm_instance.logger, 'warning', warning_mock)
         slurm_instance.template_override(
             task,
+            task.resources[0],
             _extra_launch_context={},
             _is_launched_by_jobs_controller=True,
         )
@@ -448,6 +460,7 @@ class TestTemplateOverride:
         monkeypatch.setattr(slurm_instance.logger, 'warning', warning_mock)
         slurm_instance.template_override(
             task,
+            task.resources[0],
             _extra_launch_context={},
             _is_launched_by_jobs_controller=True,
         )

--- a/tests/unit_tests/test_sky/utils/test_common_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_common_utils.py
@@ -5,6 +5,7 @@ import tempfile
 from unittest import mock
 
 import pytest
+import yaml
 
 from sky import exceptions
 from sky import models
@@ -802,3 +803,81 @@ class TestAtomicWriteText:
         assert not target.exists()
         # Crucially: no hidden .tmp file left behind in the directory.
         assert list(tmp_path.iterdir()) == []
+
+
+class TestFillTemplateUnicode:
+    """``fill_template`` emits YAML-safe UTF-8 even with non-BMP content.
+
+    The default Jinja ``tojson`` filter calls ``json.dumps(ensure_ascii=True)``,
+    which encodes codepoints above U+FFFF as UTF-16 surrogate pairs
+    (e.g. ``\\ud83d\\ude80`` for 🚀). PyYAML's ``safe_load`` does NOT
+    accept surrogate pairs in double-quoted scalars — it expects whole
+    codepoints (``\\U0001F680``). Without the ``ensure_ascii=False``
+    override on the Jinja environment, any task YAML whose ``run`` script
+    contains emoji or other non-BMP characters renders to a cluster YAML
+    that fails to parse downstream with ``yaml.scanner.ScannerError:
+    invalid Unicode character escape code``.
+
+    See also: https://yaml.org/spec/1.2.2/#57-escaped-characters — YAML
+    1.2 spec accepts ``\\u`` only for the BMP and requires ``\\U`` for
+    higher codepoints; surrogate pair encoding is not part of YAML.
+    """
+
+    def _render(self, template_text, variables, tmp_path):
+        template_path = tmp_path / 'tmpl.yml.j2'
+        template_path.write_text(template_text, encoding='utf-8')
+        output_path = tmp_path / 'out.yml'
+        common_utils.fill_template(str(template_path), variables,
+                                   str(output_path))
+        return output_path.read_text(encoding='utf-8')
+
+    def test_emoji_round_trips_through_yaml(self, tmp_path):
+        rendered = self._render('run: {{run|tojson}}\n',
+                                {'run': 'echo 🚀 hello'}, tmp_path)
+        # Critical: surrogate pairs must NOT appear in the output.
+        assert '\\ud83d' not in rendered, (
+            f'Surrogate pair leaked into rendered YAML: {rendered!r}. '
+            f'This means ensure_ascii=False was not applied to tojson.')
+        # Round-trip through safe_load to confirm YAML accepts it.
+        parsed = yaml.safe_load(rendered)
+        assert parsed == {'run': 'echo 🚀 hello'}
+
+    def test_cjk_round_trips(self, tmp_path):
+        rendered = self._render(
+            'run: {{run|tojson}}\n',
+            {'run': 'echo 你好世界 こんにちは 안녕하세요'}, tmp_path)
+        parsed = yaml.safe_load(rendered)
+        assert parsed == {'run': 'echo 你好世界 こんにちは 안녕하세요'}
+
+    def test_rtl_combining_and_math_round_trip(self, tmp_path):
+        # RTL Arabic + math symbols + combining mark.
+        rendered = self._render('run: {{run|tojson}}\n',
+                                {'run': 'مرحبا ∑∫∂ é'}, tmp_path)
+        parsed = yaml.safe_load(rendered)
+        assert parsed == {'run': 'مرحبا ∑∫∂ é'}
+
+    def test_envs_dict_with_unicode_values(self, tmp_path):
+        rendered = self._render(
+            'envs: {{envs|tojson}}\n',
+            {'envs': {
+                'GREETING': '你好',
+                'ROCKET': '🚀'
+            }}, tmp_path)
+        parsed = yaml.safe_load(rendered)
+        assert parsed == {'envs': {'GREETING': '你好', 'ROCKET': '🚀'}}
+
+    def test_ascii_preserved(self, tmp_path):
+        """Ensure we didn't change behavior for ascii-only content."""
+        rendered = self._render('run: {{run|tojson}}\n',
+                                {'run': 'echo hello'}, tmp_path)
+        assert 'echo hello' in rendered
+        parsed = yaml.safe_load(rendered)
+        assert parsed == {'run': 'echo hello'}
+
+    def test_control_chars_still_escaped(self, tmp_path):
+        """Newlines and quotes still need JSON escaping."""
+        rendered = self._render('run: {{run|tojson}}\n',
+                                {'run': 'echo "a"\nls'}, tmp_path)
+        # Both YAML and JSON should accept the escaped form.
+        parsed = yaml.safe_load(rendered)
+        assert parsed == {'run': 'echo "a"\nls'}

--- a/tests/unit_tests/test_sky/utils/test_common_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_common_utils.py
@@ -843,33 +843,31 @@ class TestFillTemplateUnicode:
         assert parsed == {'run': 'echo 🚀 hello'}
 
     def test_cjk_round_trips(self, tmp_path):
-        rendered = self._render(
-            'run: {{run|tojson}}\n',
-            {'run': 'echo 你好世界 こんにちは 안녕하세요'}, tmp_path)
+        rendered = self._render('run: {{run|tojson}}\n',
+                                {'run': 'echo 你好世界 こんにちは 안녕하세요'}, tmp_path)
         parsed = yaml.safe_load(rendered)
         assert parsed == {'run': 'echo 你好世界 こんにちは 안녕하세요'}
 
     def test_rtl_combining_and_math_round_trip(self, tmp_path):
         # RTL Arabic + math symbols + combining mark.
-        rendered = self._render('run: {{run|tojson}}\n',
-                                {'run': 'مرحبا ∑∫∂ é'}, tmp_path)
+        rendered = self._render('run: {{run|tojson}}\n', {'run': 'مرحبا ∑∫∂ é'},
+                                tmp_path)
         parsed = yaml.safe_load(rendered)
         assert parsed == {'run': 'مرحبا ∑∫∂ é'}
 
     def test_envs_dict_with_unicode_values(self, tmp_path):
-        rendered = self._render(
-            'envs: {{envs|tojson}}\n',
-            {'envs': {
-                'GREETING': '你好',
-                'ROCKET': '🚀'
-            }}, tmp_path)
+        rendered = self._render('envs: {{envs|tojson}}\n',
+                                {'envs': {
+                                    'GREETING': '你好',
+                                    'ROCKET': '🚀'
+                                }}, tmp_path)
         parsed = yaml.safe_load(rendered)
         assert parsed == {'envs': {'GREETING': '你好', 'ROCKET': '🚀'}}
 
     def test_ascii_preserved(self, tmp_path):
         """Ensure we didn't change behavior for ascii-only content."""
-        rendered = self._render('run: {{run|tojson}}\n',
-                                {'run': 'echo hello'}, tmp_path)
+        rendered = self._render('run: {{run|tojson}}\n', {'run': 'echo hello'},
+                                tmp_path)
         assert 'echo hello' in rendered
         parsed = yaml.safe_load(rendered)
         assert parsed == {'run': 'echo hello'}


### PR DESCRIPTION
## Summary

Adds a Slurm-native fast path for managed jobs: instead of `sbatch sleep
infinity + srun --jobid=<jobid>` (the legacy pattern), the v1 path submits a
single sbatch whose script body IS the user's task. The Slurm allocation
lives exactly as long as the job, and SkyPilot's managed-jobs controller
treats the allocation and the job as a single unit.

The opt-out is automatic: tasks that need workdir / local file mounts /
storage mounts fall through to the legacy path. v1 covers the common case
(run / setup / envs + container_image) on dedicated Slurm clusters where
allocation churn is cheap.

### What's new

- **`ManagedJobRuntime` chain registry** (`sky/jobs/runtime.py`): converts
  the previous last-wins single-runtime registration into a chain where
  each runtime declares which handles it owns. The legacy ray-based
  runtime remains the default; `SlurmManagedJobRuntime` is chained in
  front of it and short-circuits on the v1 marker.

- **`SlurmManagedJobRuntime`** (`sky/provision/slurm/managed_job_runtime.py`):
  implements `get_job_status`, `get_job_submitted_at`, `get_job_ended_at`,
  `get_exit_codes`, `download_logs`, and `tail_logs` using sacct + sbatch
  output, with sacct fallback for jobs aged past squeue's `MinJobAge` window.

- **Provisioner `template_override` hook** (`sky/provision/__init__.py`):
  lets a registered provisioner redirect tasks to a custom cluster YAML
  template. Slurm uses this to route v1-eligible tasks to
  `slurm-managed-job-v1.yml.j2`. Non-eligible tasks fall through to the
  legacy template.

- **v1 sbatch generator** (`sky/provision/slurm/instance.py`): builds a
  single `sbatch` script that emits `#SBATCH` directives (`--time`
  auto-derived from partition `MaxTime`/`DefaultTime`, user-supplied
  options validated and merged), sets up the cluster home dir + env vars
  + workdir/file-mounts, runs the user setup, then runs the user command
  via `srun --label` for per-rank stdout prefix.

- **`_query_instances_v1` + `_get_cluster_info_v1`**: v1 dispatch through
  the OSS provision API. Maps Slurm states to `ClusterStatus`
  (`RUNNING / COMPLETING / etc. → UP`, `FAILED / TIMEOUT / OUT_OF_MEMORY
  / DEADLINE / SPECIAL_EXIT → UP` for the controller's user-code-failure
  branch, `NODE_FAIL / BOOT_FAIL / PREEMPTED / REVOKED → None` for the
  recovery branch). sacct fallback for jobs aged past `MinJobAge`, with
  NodeList expansion via the `hostlist` library so multi-node terminal
  jobs fan out across the full allocation.

- **`ProvisionRuntimeMetadata` flags** (`has_ray=False`, `has_skylet=False`,
  `has_job_queue=False`, `ssh_available=False`, `runtime_setup_done=True`):
  tells the OSS backend to skip file sync, setup, execute, and SSH
  registration for v1 clusters.

- **Sbatch protections**: `_SBATCH_PROTECTED_OPTIONS` blocks user overrides
  for SkyPilot-controlled directives (`--job-name`, `--output`, `--nodes`,
  `--cpus-per-task`, `--mem`, `--gres`, `--partition`, `--signal`, etc.).

- **Jinja `tojson` override** (`sky/utils/common_utils.py::fill_template`):
  `ensure_ascii=False` so non-BMP characters (emoji, CJK extension, math
  alphanumerics) emit as raw UTF-8 rather than UTF-16 surrogate pairs.
  YAML's `\u` escape only accepts the BMP -- surrogate pairs trip
  `yaml.scanner.ScannerError`. Fixes a class of "Retrying to launch the
  cluster" failures on any template that takes user content.

### What's deliberately NOT supported on v1 (falls back to legacy)

- Local workdir / local file mounts / storage mounts
- JobGroup (Slurm has no native equivalent)
- Multi-resource tasks that don't all resolve to Slurm

The fallback is transparent: `_get_unsupported_v1_inputs` inspects the
task, logs which inputs are unsupported, and returns `None` from
`_build_v1_template_spec` so the legacy template is used.

## Test plan

- [x] Unit suite (`tests/unit_tests/test_sky/provision/slurm/`): 242 passed
  + 5 xfailed covering chain registry, template override / detection,
  sbatch options protection, COMPLETING-drain + reattach, query_instances
  state mapping, SlurmManagedJobRuntime, terminal multi-node fan-out.
- [x] End-to-end validation against a real Slurm cluster, full edge battery:
  - **Single-node user-code paths**:
    - Exit-7 (user-code FAILED) → FAILED, 0 recoveries
    - OOM → FAILED, 0 recoveries
    - Setup-block failure → FAILED, 0 recoveries
    - Walltime TIMEOUT → FAILED, 0 recoveries
    - Sub-second SUCCESS (race window) → SUCCEEDED, 0 recoveries
  - **Single-node infrastructure paths**:
    - NODE_FAIL (force-DOWN running node) → RECOVERING → SUCCEEDED on
      healthy node
    - External self-scancel → CANCELLED / RECOVERING (expected, controller
      retries because scancel is indistinguishable from preemption)
    - Kill -9 controller mid-flight → respawns within ~5s, re-attaches
      via sacct → FAILED, 0 recoveries
    - Kill -9 API server itself → controller survives (detached process),
      job completes unaffected
  - **Stdout / encoding**:
    - Large stdout (~67 MB over 50 chunks) → SUCCEEDED, log captured
      cleanly with no truncation
    - Unicode + emoji + CJK + RTL + combining marks → SUCCEEDED, log
      preserved byte-for-byte
  - **Multi-node**:
    - Basic 2-node (`srun --nodes=2 --ntasks-per-node=1`) → SUCCEEDED,
      distinct hostnames + shared SLURM_JOB_ID
    - Multi-node NODE_FAIL → RECOVERING → SUCCEEDED on a different pair of
      nodes, NodeList expanded via `hostlist.expand_hostlist`
    - Multi-node partial-rank failure (rank 1 exits non-zero) → FAILED,
      0 recoveries (surfaced the terminal multi-node fan-out gap; fixed)
    - Multi-node TIMEOUT → FAILED, 0 recoveries
    - Multi-node kill -9 controller → respawn re-attaches via sacct
      fan-out, classifies correctly → FAILED, 0 recoveries
  - **Concurrency**:
    - 3 concurrent `sky jobs launch` → 3 SUCCEEDED, distinct Slurm
      job IDs, distinct nodes, no race contention
- [x] Legacy fallback path still works for tasks with local workdir / file
  mounts / storage mounts (`_get_unsupported_v1_inputs` returns a non-empty
  list and `_build_v1_template_spec` returns `None`).