### PR TITLE
[Test] Make viewer-route coverage plugin-aware

### DIFF
--- a/sky/server/plugins.py
+++ b/sky/server/plugins.py
@@ -329,6 +329,40 @@ class BasePlugin(abc.ABC):
         """
         return []
 
+    @property
+    def viewer_denied(self) -> List['RBACRule']:
+        """Endpoints this plugin exposes that are write/sensitive.
+
+        Mirrors ``viewer_allowlist`` but on the deny side.  Use this to
+        declare write or sensitive plugin endpoints that should be
+        explicitly denied for the ``viewer`` role.
+
+        The runtime middleware already denies anything not on the
+        merged viewer allowlist, so declaring an entry here does not
+        change the runtime decision — denial is implicit either way.
+        The list exists so the OSS route-coverage test
+        (``tests/unit_tests/test_sky/users/test_viewer_route_coverage.py``)
+        can verify that every plugin-registered route carries an
+        EXPLICIT decision (allow or deny), the same contract OSS
+        endpoints follow via ``_KNOWN_VIEWER_DENIED``.  Skipping a
+        write endpoint here will surface as a test failure on the
+        next CI run, forcing a deliberate classification.
+
+        Path patterns use the same Casbin ``keyMatch2`` syntax as
+        ``rbac_rules`` and ``viewer_allowlist``.
+
+        Example:
+            @property
+            def viewer_denied(self):
+                return [
+                    RBACRule(path='/plugins/api/foo/create',
+                             method='POST'),
+                    RBACRule(path='/plugins/api/foo/:id',
+                             method='DELETE'),
+                ]
+        """
+        return []
+
     @abc.abstractmethod
     def install(self, extension_context: ExtensionContext):
         """Hook called by API server to let the plugin install itself."""
@@ -677,6 +711,68 @@ def load_plugin_viewer_allowlist() -> List[Dict[str, str]]:
 def get_plugin_viewer_allowlist() -> List[Dict[str, str]]:
     """Return the cached viewer-allowlist entries collected from plugins."""
     return _PLUGIN_VIEWER_ALLOWLIST
+
+
+_PLUGIN_VIEWER_DENIED: List[Dict[str, str]] = []
+
+
+def load_plugin_viewer_denied() -> List[Dict[str, str]]:
+    """Load viewer-denied entries from plugins without calling install().
+
+    Mirror of `load_plugin_viewer_allowlist` for the deny side.
+    Plugins that don't override `viewer_denied` inherit the BasePlugin
+    default (empty list).  The runtime decision is unaffected by this
+    list (anything not on the merged allowlist is already denied); it
+    exists so the route-coverage test can verify EVERY plugin-
+    registered route carries an explicit allow-or-deny classification.
+
+    Returns:
+        Flat list of `{path, method}` records collected from each
+        plugin's `viewer_denied` property.
+    """
+    global _PLUGIN_VIEWER_DENIED
+
+    config = _load_plugin_config()
+    if not config:
+        return []
+
+    denied: List[Dict[str, str]] = []
+
+    for plugin_config in config.get('plugins', []):
+        class_path = plugin_config['class']
+        module_path, class_name = class_path.rsplit('.', 1)
+        try:
+            module = importlib.import_module(module_path)
+            plugin_cls = getattr(module, class_name)
+            if not issubclass(plugin_cls, BasePlugin):
+                continue
+            # Mirror the load_plugin_viewer_allowlist filter: the deny
+            # list is also an API-server concern, so skip plugins that
+            # don't load in either API-server context.
+            if not (plugin_cls.should_load(PluginContext.MAIN) or
+                    plugin_cls.should_load(PluginContext.UVICORN)):
+                continue
+            parameters = plugin_config.get('parameters') or {}
+            plugin = plugin_cls(**parameters)
+
+            for rule in plugin.viewer_denied:
+                denied.append({
+                    'path': rule.path,
+                    'method': rule.method,
+                })
+                logger.debug(f'Collected viewer denied entry from '
+                             f'{class_path}: {rule.method} {rule.path}')
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Failed to load viewer denied from '
+                           f'{class_path}: {e}')
+
+    _PLUGIN_VIEWER_DENIED = denied
+    return denied
+
+
+def get_plugin_viewer_denied() -> List[Dict[str, str]]:
+    """Return the cached viewer-denied entries collected from plugins."""
+    return _PLUGIN_VIEWER_DENIED
 
 
 def get_extension_context() -> Optional[ExtensionContext]:

--- a/tests/unit_tests/test_sky/users/test_viewer_route_coverage.py
+++ b/tests/unit_tests/test_sky/users/test_viewer_route_coverage.py
@@ -26,6 +26,7 @@ forces a deliberate review.
 from casbin import util as casbin_util
 from fastapi.routing import APIRoute
 
+from sky.server import plugins as server_plugins
 from sky.server import server as server_app
 from sky.users import rbac
 
@@ -166,19 +167,50 @@ def _matches_any(path_template: str, method: str, allowlist: list) -> bool:
     return False
 
 
+def _matches_deny(path_template: str, method: str, denied_pattern_list,
+                  denied_pair_set) -> bool:
+    """True if a route is on either deny source.
+
+    ``denied_pair_set`` holds OSS deny entries as exact
+    ``(path_template, method)`` tuples (the ``_KNOWN_VIEWER_DENIED``
+    set), since OSS paths are always exact templates.  Plugin deny
+    entries arrive as ``{'path': pattern, 'method': method}`` dicts
+    and may use Casbin ``keyMatch2`` wildcards, so they're matched
+    the same way the allowlist is.
+    """
+    if (path_template, method) in denied_pair_set:
+        return True
+    return _matches_any(path_template, method, denied_pattern_list)
+
+
 def test_every_route_has_a_viewer_decision():
     """Every API route must be either viewer-allowed or viewer-denied.
 
     No silent "neither" state — if you add or rename a route you
-    must update either `rbac._DEFAULT_VIEWER_ALLOWLIST` (it's a
-    read) or this file's `_KNOWN_VIEWER_DENIED` (it's a write or a
-    sensitive read).
+    must update either:
+
+      - ``rbac._DEFAULT_VIEWER_ALLOWLIST`` (OSS read), or
+      - this file's ``_KNOWN_VIEWER_DENIED`` (OSS write/sensitive), or
+      - the plugin's ``viewer_allowlist`` (plugin read), or
+      - the plugin's ``viewer_denied`` (plugin write/sensitive).
+
+    Plugin contributions are loaded via ``load_plugin_viewer_allowlist``
+    and ``load_plugin_viewer_denied`` so the coverage check holds the
+    same contract for plugin routes as for OSS routes.
     """
-    allowlist = rbac._DEFAULT_VIEWER_ALLOWLIST  # pylint: disable=protected-access
+    # Importing ``server`` above triggers plugin loading via the
+    # UVICORN extension context, so ``app.routes`` already includes
+    # any plugin-registered routes by the time we enumerate it.
+    plugin_allowlist = server_plugins.load_plugin_viewer_allowlist()
+    plugin_denied = server_plugins.load_plugin_viewer_denied()
+    allowlist = (
+        list(rbac._DEFAULT_VIEWER_ALLOWLIST) +  # pylint: disable=protected-access
+        plugin_allowlist)
     uncategorized = []
     for path_template, method in _route_pairs():
         on_allow = _matches_any(path_template, method, allowlist)
-        on_deny = (path_template, method) in _KNOWN_VIEWER_DENIED
+        on_deny = _matches_deny(path_template, method, plugin_denied,
+                                _KNOWN_VIEWER_DENIED)
         if on_allow and on_deny:
             uncategorized.append(
                 f'{method} {path_template} appears in BOTH lists; '
@@ -186,8 +218,11 @@ def test_every_route_has_a_viewer_decision():
         elif not on_allow and not on_deny:
             uncategorized.append(
                 f'{method} {path_template} has no viewer decision. '
-                'Add to rbac._DEFAULT_VIEWER_ALLOWLIST (read) or to '
-                'this file\'s _KNOWN_VIEWER_DENIED (write/sensitive).')
+                'OSS routes: add to rbac._DEFAULT_VIEWER_ALLOWLIST '
+                '(read) or to this file\'s _KNOWN_VIEWER_DENIED '
+                '(write/sensitive).  Plugin routes: add to the '
+                'plugin\'s viewer_allowlist (read) or viewer_denied '
+                '(write/sensitive).')
     assert not uncategorized, ('Routes with no viewer-role decision:\n  ' +
                                '\n  '.join(sorted(uncategorized)))
 
@@ -201,7 +236,12 @@ def test_allowlist_entries_match_real_routes():
     """
     pairs = list(_route_pairs())
     casbin_pairs = [(_fastapi_path_to_casbin(p), m) for p, m in pairs]
-    allowlist = rbac._DEFAULT_VIEWER_ALLOWLIST  # pylint: disable=protected-access
+    # Same composition as ``test_every_route_has_a_viewer_decision``
+    # so plugin-supplied entries are matched against the live route
+    # table rather than flagged as unknown.
+    allowlist = (
+        list(rbac._DEFAULT_VIEWER_ALLOWLIST) +  # pylint: disable=protected-access
+        server_plugins.load_plugin_viewer_allowlist())
 
     # Some allowlist patterns intentionally target endpoints not in
     # the OSS app's route table — these come from plugins or from


### PR DESCRIPTION
## Summary

`tests/unit_tests/test_sky/users/test_viewer_route_coverage.py::test_every_route_has_a_viewer_decision` enumerates every route on `server.app` and requires each to appear in either `rbac._DEFAULT_VIEWER_ALLOWLIST` or the test-local `_KNOWN_VIEWER_DENIED`. Importing `sky.server.server` triggers plugin loading via the UVICORN extension context, so `app.routes` already includes plugin-registered routes — but the test only consulted the OSS-side static lists. Any non-trivial plugin set installed on a downstream server thus blew up `OSS Tests - Unit Tests` with every plugin route surfacing as "uncategorized".

The goal of this PR is to keep the test's strong contract — every registered route must carry an EXPLICIT allow-or-deny decision — without inventing heuristics that silently shorten coverage for plugin routes.

## Changes

1. **`BasePlugin.viewer_denied`** (new): symmetric to the existing `BasePlugin.viewer_allowlist`. Lets a plugin EXPLICITLY classify its write or sensitive routes. The list does **not** change the runtime RBAC decision — anything not on the merged viewer allowlist is already denied by the middleware. The list exists so the route-coverage test can verify each plugin route carries the same explicit classification OSS routes carry via `_KNOWN_VIEWER_DENIED`.

2. **`load_plugin_viewer_denied()` / `get_plugin_viewer_denied()`** (new): mirror of the existing `load_plugin_viewer_allowlist()` family in `sky/server/plugins.py`.

3. **Test update**: `test_every_route_has_a_viewer_decision` now composes its allow + deny sets as:

   - allow = `rbac._DEFAULT_VIEWER_ALLOWLIST` ∪ `plugins.load_plugin_viewer_allowlist()`
   - deny  = `_KNOWN_VIEWER_DENIED` ∪ `plugins.load_plugin_viewer_denied()`

   Every route — OSS or plugin — must land on exactly one side. Anything else fails the assertion, naming the route and pointing the author at the four classification sites (OSS allow, OSS deny, plugin allow, plugin deny).

## Why a deny mechanism rather than a heuristic

An earlier draft of this fix treated routes under `/plugins/*` (or matching any plugin allowlist pattern) as "implicitly denied by the plugin's own RBAC contract" and skipped them from the uncategorized check. That weakens the test: a plugin author could add a new write endpoint, never list it anywhere, and CI would stay green even though there's no documented intent for the route. Requiring an explicit `viewer_denied` entry restores the original "force a deliberate decision" property for plugin routes.

The runtime behaviour is unchanged either way — write endpoints are denied via the middleware's "not on the merged allowlist → deny" rule. This PR only changes what CI demands of plugin authors.

## Test plan

- [x] **OSS-only** (no `SKYPILOT_SERVER_PLUGINS_CONFIG` set):
      `pytest tests/unit_tests/test_sky/users/test_viewer_route_coverage.py` → **2/2 passed** (baseline preserved).
- [x] **With a plugin set loaded that declares routes but no `viewer_denied`**:
      the test correctly fails with one "uncategorized" entry per unclassified plugin write route, naming the route and pointing the plugin author at `viewer_allowlist` / `viewer_denied` for the decision.
- [x] Adding the missing routes to the plugin's `viewer_denied` then makes the test pass — confirms the new mechanism resolves the failure as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)