### PR TITLE
[Test] Resolve K8s context dynamically + dual-mode host_network test

### DIFF
--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -440,6 +440,29 @@ def is_eks_cluster() -> bool:
     return result.returncode == 0
 
 
+def kubectl_for_cluster(cluster_name: str) -> str:
+    """``kubectl --context <ctx>`` with <ctx> resolved at *shell* runtime
+    to the kubeconfig context that contains a pod for ``cluster_name``.
+
+    Smoke pipelines fall into two shapes:
+
+    * Single-context (kind-based): only ``kind-skypilot`` exists, so the
+      discovery loop short-circuits on the first iteration.
+    * Multi-context (shared-GKE): the runner has the API server's
+      cluster as current-context and the workload cluster as a second
+      entry; the loop picks the one that actually owns the pod.
+
+    The returned string is meant to be interpolated into an f-string
+    command, e.g. ``f'{kubectl_for_cluster(name)} delete pod foo'``.
+    The context lookup runs at command-execution time (not test-collection
+    time), so it sees the pod created by an earlier ``sky launch`` step.
+    """
+    return (
+        f'kubectl --context "$(for c in $(kubectl config get-contexts -o name); '
+        f'do kubectl --context "$c" get pods -o name 2>/dev/null '
+        f'| grep -q {cluster_name} && echo "$c" && break; done)"')
+
+
 def get_replica_cluster_name_on_gcp(name: str, replica_id: int) -> str:
     cluster_name = serve.generate_replica_cluster_name(name, replica_id)
     return common_utils.make_cluster_name_on_cloud(

--- a/tests/smoke_tests/test_kubernetes_host_network.py
+++ b/tests/smoke_tests/test_kubernetes_host_network.py
@@ -25,6 +25,11 @@ import uuid
 import pytest
 from smoke_tests import smoke_tests_utils
 
+import sky
+from sky.client import sdk as sky_sdk
+
+_kc = smoke_tests_utils.kubectl_for_cluster
+
 
 @pytest.mark.kubernetes
 @pytest.mark.no_dependency
@@ -134,37 +139,51 @@ def test_kubernetes_host_network_coexistence():
 @pytest.mark.kubernetes
 @pytest.mark.no_dependency
 def test_kubernetes_host_network_multi_node_same_node():
-    """A 2-node SkyPilot cluster, spread across two K8s nodes, hostNetwork on.
+    """A 2-node hostNetwork SkyPilot cluster exercises mode-b's
+    per-cluster ``podAntiAffinity`` in *both* documented regimes —
+    the branch is picked at runtime from the API server's view of
+    the target K8s cluster.
 
-    This asserts fail-loud guarantee on the infra the smoke
-    suite actually runs against (single-node K8s clusters). The required,
-    per-cluster ``podAntiAffinity`` SkyPilot injects for every hostNetwork
-    pod forbids the head and worker of one cluster from sharing a node;
-    with only one node available the worker cannot be scheduled, so the
-    launch must fail with the scheduler's pod-anti-affinity error rather
-    than silently packing both pods onto one host (which is exactly the
-    raylet-collapse / port-collision race mode b exists to prevent).
+    Single-node K8s
+        Anti-affinity makes the worker unschedulable, so
+        ``sky launch --num-nodes 2`` must fail with the scheduler's
+        actual rejection (verbatim ``didn't match pod anti-affinity
+        rules`` from kube-scheduler). This is the fail-loud guarantee
+        that protects against same-node port collisions / raylet
+        identity collapse on Kind-style smoke pipelines.
 
-    On a >=2-node K8s cluster this same config would instead succeed and
-    spread one pod per node (the cross-node capability mode b unlocks);
-    that path is not exercised here because the smoke clusters are
-    single-node.
+    Multi-node K8s
+        Anti-affinity is satisfied by spreading pods across nodes, so
+        the same launch must succeed *and* the head + worker pods must
+        land on distinct K8s nodes (mode-b's cross-node happy path).
+        This exercises the capability mode b actually unlocks — a
+        regime the test previously did not cover.
 
-    Verifies:
-
-    1. ``sky launch --num-nodes 2`` returns non-zero (it must not
-       succeed by co-locating the pods).
-    2. The failure is specifically the pod-anti-affinity scheduling
-       rejection (SkyPilot surfaces the verbatim kube-scheduler
-       ``FailedScheduling`` message, which contains "anti-affinity"),
-       not some unrelated error.
+    The single-node grep is strict (``didn't match.*anti-affinity``)
+    rather than the bare substring ``anti-affinity``: the looser form
+    also matched SkyPilot's debug dump of the generated pod spec
+    (``"podAntiAffinity":``), so a transient connection error
+    incidentally containing that field could pass the test for the
+    wrong reason — observed historically on the shared-API-server
+    pipeline.
     """
+    # Resolve which regime to exercise. Failing closed (treat as
+    # single-node) is the right default: that assertion is strictly
+    # stricter, so a misclassified multi-node pipeline still fails
+    # loudly rather than silently giving up coverage.
+    try:
+        nodes_info = sky.get(sky_sdk.kubernetes_node_info())
+        schedulable = sum(1 for n in nodes_info.node_info_dict.values()
+                          if n.is_ready and not n.is_cordoned)
+    except Exception:  # pylint: disable=broad-except
+        schedulable = 1
+    multi_node = schedulable > 1
+
     name = smoke_tests_utils.get_cluster_name()
     cfg = f'/tmp/sky-hostnet-multinode-{uuid.uuid4().hex[:12]}.yaml'
 
     # hostNetwork only. SkyPilot injects the per-cluster podAntiAffinity
-    # (mode b); on a single-node cluster that leaves the 2nd pod
-    # unschedulable.
+    # (mode b).
     write_cfg = (f'cat > {cfg} <<EOF\n'
                  f'kubernetes:\n'
                  f'  pod_config:\n'
@@ -172,35 +191,51 @@ def test_kubernetes_host_network_multi_node_same_node():
                  f'      hostNetwork: true\n'
                  f'EOF')
 
-    # One self-contained command: capture the launch, assert it failed,
-    # and assert it failed *for the anti-affinity reason* (so an
-    # unrelated failure — image pull, quota — doesn't spuriously pass).
-    # grep -iE "anti-?affinity" matches the kube-scheduler phrasings
-    # ("...didn't match pod anti-affinity rules", "antiaffinity").
-    expect_fail = (
-        f'set +e; '
-        f'OUT=$(sky launch -y -c {name} --infra kubernetes '
-        f'--config {cfg} --num-nodes 2 --cpus 1 --memory 2 2>&1); '
-        f'RC=$?; set -e; '
-        f'echo "$OUT"; '
-        f'if [ $RC -eq 0 ]; then '
-        f'echo "FAIL: 2-node hostNetwork launch unexpectedly SUCCEEDED on '
-        f'single-node K8s; mode-b anti-affinity should have blocked it"; '
-        f'exit 1; fi; '
-        f'echo "$OUT" | grep -qiE "anti-?affinity" || {{ '
-        f'echo "FAIL: launch failed but NOT via the pod anti-affinity '
-        f'scheduling rule (unexpected failure reason)"; exit 1; }}; '
-        f'echo "OK: mode-b anti-affinity correctly rejected the 2-node '
-        f'hostNetwork cluster on single-node K8s"')
+    launch = (f'sky launch -y -c {name} --infra kubernetes '
+              f'--config {cfg} --num-nodes 2 --cpus 1 --memory 2')
+
+    if not multi_node:
+        assertion = (
+            f'set +e; OUT=$({launch} 2>&1); RC=$?; set -e; '
+            f'echo "$OUT"; '
+            f'if [ $RC -eq 0 ]; then '
+            f'echo "FAIL: 2-node hostNetwork launch unexpectedly SUCCEEDED '
+            f'on single-node K8s; mode-b anti-affinity should have blocked '
+            f'it"; exit 1; fi; '
+            f'echo "$OUT" | grep -qiE "didn.t match.*anti-?affinity" || {{ '
+            f'echo "FAIL: launch failed but NOT via the pod anti-affinity '
+            f'scheduling rule (unexpected failure reason)"; exit 1; }}; '
+            f'echo "OK: mode-b anti-affinity correctly rejected the 2-node '
+            f'hostNetwork cluster on single-node K8s"')
+    else:
+        # Read {.spec.nodeName} for every pod whose name contains the
+        # cluster name; sort -u | wc -l gives the unique-node count.
+        node_count = (f'{_kc(name)} get pods -o name 2>/dev/null '
+                      f'| grep {name} | while read p; do '
+                      f'{_kc(name)} get $p '
+                      f'-o jsonpath=\'{{.spec.nodeName}}{{"\\n"}}\'; '
+                      f'done | sort -u | grep -c .')
+        assertion = (
+            f'{launch} || {{ '
+            f'echo "FAIL: 2-node hostNetwork launch FAILED on multi-node '
+            f'K8s; mode-b should let pods spread across nodes"; exit 1; }}; '
+            f'NODES=$({node_count}); '
+            f'if [ "$NODES" -lt 2 ]; then '
+            f'echo "FAIL: head+worker landed on the same K8s node '
+            f'($NODES distinct nodes); mode-b anti-affinity should have '
+            f'spread them"; exit 1; fi; '
+            f'echo "OK: 2-node hostNetwork cluster spread across $NODES '
+            f'distinct K8s nodes (mode-b cross-node happy path)"')
 
     test = smoke_tests_utils.Test(
         'kubernetes_host_network_multi_node_same_node',
         [
             write_cfg,
-            expect_fail,
+            assertion,
         ],
         # Best-effort cleanup: a failed launch still leaves a cluster
-        # record (and the head pod that did schedule).
+        # record (and the head pod that did schedule); a successful
+        # multi-node launch leaves both pods.
         teardown=f'sky down -y {name}; rm -f {cfg}',
         timeout=10 * 60,
     )

--- a/tests/smoke_tests/test_lifecycle_hooks.py
+++ b/tests/smoke_tests/test_lifecycle_hooks.py
@@ -86,6 +86,13 @@ def _write_yaml_raw(top_level: dict) -> str:
     return f.name
 
 
+# Shorthand for the shared helper — every kubectl invocation in this
+# module needs to resolve the workload cluster's kubeconfig context
+# at runtime (the API server's K8s cluster differs from the workload
+# cluster on shared-API-server pipelines).
+_kc = smoke_tests_utils.kubectl_for_cluster
+
+
 # ---------------------------------------------------------------------------
 # Combined stop + retrieval coverage. One launch + one autostop cycle
 # verifies the union of:
@@ -588,12 +595,12 @@ def test_hook_k8s_preemption_sigterm():
             'timeout': 60,
         }],
     })
-    pod_query = (f'kubectl get pods --context kind-skypilot -o name '
+    pod_query = (f'{_kc(name)} get pods -o name '
                  f'2>/dev/null | grep {name} | head -n1')
     k8s_delete = (f'pod=$({pod_query}) && '
-                  f'kubectl delete --context kind-skypilot --wait=false "$pod"')
+                  f'{_kc(name)} delete --wait=false "$pod"')
     read_log = (f'sleep 3 && pod=$({pod_query}) && '
-                f'kubectl exec --context kind-skypilot "$pod" -- '
+                f'{_kc(name)} exec "$pod" -- '
                 f'cat /home/sky/.sky/hooks/preemption.log')
     test = smoke_tests_utils.Test(
         'test_hook_k8s_preemption_sigterm',
@@ -643,9 +650,9 @@ def test_hook_grace_capped_at_autoscaler_limit():
             f'echo "$s" | grep -i "cluster-autoscaler" && '
             f'echo "$s" | grep -i "Capping"',
             # (2) pod's terminationGracePeriodSeconds is 600 (capped), not 800
-            f'pod=$(kubectl get pods --context kind-skypilot -o name '
+            f'pod=$({_kc(name)} get pods -o name '
             f'2>/dev/null | grep {name} | head -n1) && '
-            f'val=$(kubectl get --context kind-skypilot "$pod" '
+            f'val=$({_kc(name)} get "$pod" '
             f'-o jsonpath={chr(39)}{{.spec.terminationGracePeriodSeconds}}{chr(39)}) && '
             f'[ "$val" = "600" ]',
         ],
@@ -693,9 +700,9 @@ def test_hook_k8s_relaunch_warns_when_preemption_grace_increases():
             f'{smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT} && '
             f'! (echo "$s" | grep -i "preemption-hook grace requirement")',
             # (2) Confirm pod's grace is 60.
-            f'pod=$(kubectl get pods --context kind-skypilot -o name '
+            f'pod=$({_kc(name)} get pods -o name '
             f'2>/dev/null | grep {name} | head -n1) && '
-            f'val=$(kubectl get --context kind-skypilot "$pod" '
+            f'val=$({_kc(name)} get "$pod" '
             f'-o jsonpath={chr(39)}{{.spec.terminationGracePeriodSeconds}}{chr(39)}) && '
             f'[ "$val" = "60" ]',
             # (3) Re-launch with larger timeout. Warning expected on
@@ -710,9 +717,9 @@ def test_hook_k8s_relaunch_warns_when_preemption_grace_increases():
             # (4) Confirm the existing pod's grace is STILL 60 — re-launch
             # cannot mutate the pod spec; warning is the only thing the
             # user can act on.
-            f'pod=$(kubectl get pods --context kind-skypilot -o name '
+            f'pod=$({_kc(name)} get pods -o name '
             f'2>/dev/null | grep {name} | head -n1) && '
-            f'val=$(kubectl get --context kind-skypilot "$pod" '
+            f'val=$({_kc(name)} get "$pod" '
             f'-o jsonpath={chr(39)}{{.spec.terminationGracePeriodSeconds}}{chr(39)}) && '
             f'[ "$val" = "60" ]',
         ],
@@ -759,7 +766,7 @@ def test_hook_k8s_sky_down_does_not_fire_preemption():
             },
         ],
     })
-    pod_query = (f'kubectl get pods --context kind-skypilot -o name '
+    pod_query = (f'{_kc(name)} get pods -o name '
                  f'2>/dev/null | grep {name} | head -n1')
     # Capture per-event log contents into a temp file BEFORE teardown
     # completes (pod will be gone after sky down). We use a job
@@ -831,9 +838,9 @@ def test_hook_k8s_prestop_pgrep_is_skylet_only():
             # (`\\.` for one regex `\.`), making a literal grep
             # fragile. The two checks above are sufficient to catch
             # the regression.
-            f'pod=$(kubectl get pods --context kind-skypilot -o name '
+            f'pod=$({_kc(name)} get pods -o name '
             f'2>/dev/null | grep {name} | head -n1) && '
-            f'cmd=$(kubectl get --context kind-skypilot "$pod" '
+            f'cmd=$({_kc(name)} get "$pod" '
             f'-o jsonpath={chr(39)}{{.spec.containers[0].lifecycle.preStop.exec.command}}{chr(39)}) && '
             f'echo "preStop: $cmd" && '
             f'echo "$cmd" | grep -q "pgrep -of" && '
@@ -883,10 +890,10 @@ def test_hook_k8s_autodown_fires_down_event():
             'timeout': 240,
         }],
     })
-    pod_query = (f'kubectl get pods --context kind-skypilot -o name '
+    pod_query = (f'{_kc(name)} get pods -o name '
                  f'2>/dev/null | grep {name} | head -n1')
     cat_log = (f'pod=$({pod_query}) && '
-               f'kubectl exec --context kind-skypilot "$pod" -- '
+               f'{_kc(name)} exec "$pod" -- '
                f'cat /home/sky/.sky/hooks/down.log')
     # Poll up to ~5 min for the hook log to appear, then assert the
     # marker is in it. The hook fires ~120s after the SetAutostop RPC
@@ -999,10 +1006,10 @@ def test_hook_k8s_autodown_lifecycle_combined():
             },
         ],
     })
-    pod_query = (f'kubectl get pods --context kind-skypilot -o name '
+    pod_query = (f'{_kc(name)} get pods -o name '
                  f'2>/dev/null | grep {name} | head -n1')
     cat_log = (f'pod=$({pod_query}) && '
-               f'kubectl exec --context kind-skypilot "$pod" -- '
+               f'{_kc(name)} exec "$pod" -- '
                f'cat /home/sky/.sky/hooks/down.log')
     # Poll until the legacy hook's marker appears (it writes first
     # because the legacy autostop.hook routes into the hooks list and
@@ -1049,7 +1056,7 @@ def test_hook_k8s_autodown_lifecycle_combined():
             # the `events:[down, preemption]` hook only fires on the
             # event that matched (down here), not on preemption.
             f'pod=$({pod_query}) && '
-            f'kubectl exec --context kind-skypilot "$pod" -- '
+            f'{_kc(name)} exec "$pod" -- '
             f'test ! -e /home/sky/.sky/hooks/preemption.log',
             # Wait for autodown to complete (sleep 180 in legacy hook +
             # teardown). Cluster row is gone after autodown finishes.


### PR DESCRIPTION
## Summary

Two test-only fixes for the 7 failures in nightly `nightly-build-shared-gke-api-server` [build 378](https://buildkite.com/skypilot-1/nightly-build-shared-gke-api-server/builds/378).

### 1. Hook tests: dynamic K8s context resolution (6 of 7 failures)

Tests in `tests/smoke_tests/test_lifecycle_hooks.py` were hard-coded to `kubectl --context kind-skypilot`. That context only exists on the single-context kind pipeline. On shared-API-server pipelines (shared-GKE) the runner's kubeconfig has *two* contexts — the API-server's cluster and the workload cluster — and neither is `kind-skypilot`, so every `kubectl` invocation in those tests blew up.

- New helper `smoke_tests_utils.kubectl_for_cluster(name)` returns `kubectl --context "$(...)"` where the context is resolved **at shell runtime** by enumerating the runner's local kubeconfig and probing each context for a pod whose name matches `name`. Single-context runners (kind) short-circuit on the first iteration; multi-context runners (shared-GKE) pick the entry that actually owns the pod. The discovery is **purely local** — no API-server call — so this is a test-only change with no server-side dependency. It works because (a) the buildkite runner image already has both contexts in `~/.kube/config`, and (b) by the time any `kubectl` call in a hook test runs, an earlier `sky launch -c <name>` step has already created the pod on the workload cluster, so exactly one context's `kubectl get pods | grep <name>` returns a hit.
- 7 hook tests in `test_lifecycle_hooks.py` rewritten via `_kc = smoke_tests_utils.kubectl_for_cluster`, replacing every `kubectl --context kind-skypilot` call site.

### 2. `test_kubernetes_host_network_multi_node_same_node`: dual-mode (1 of 7 failures)

The test asserted a single-node-only invariant (mode-b `podAntiAffinity` blocks the worker), but the shared-GKE pipeline runs against a multi-node cluster, where the same launch is the documented multi-node *happy path* and succeeds — the test then failed with `FAIL: 2-node hostNetwork launch unexpectedly SUCCEEDED on single-node K8s`.

The fix branches at test start on `sky.kubernetes_node_info()`:

- **Single-node** — original fail-loud assertion, with the grep tightened from the bare `anti-?affinity` substring to `didn't match.*anti-?affinity`. The looser form also matched SkyPilot's debug dump of the generated pod spec (`"podAntiAffinity":` is a *field name*, not a scheduler rejection), so a transient connection error could pass the test for the wrong reason — observed historically.
- **≥2 nodes** — launch must succeed *and* head + worker pods must land on distinct K8s nodes (mode-b's cross-node happy path; previously uncovered — net gain in coverage).

Failing closed on `kubernetes_node_info()` lookup error defaults to the stricter single-node assertion, so a misclassified pipeline still fails loudly rather than silently giving up coverage.

#### Why query the API server for the node count (and not local `kubectl get nodes`)?

*Applies only to §2's branch decision — §1's context discovery is purely local kubectl probing.*

On the shared-GKE buildkite runner the local `kubectl` *current* context points at a paused control-plane cluster — distinct from the workload cluster where the remote SkyPilot API server actually schedules pods. A `kubectl get nodes` from the runner would report 0 schedulable nodes against the wrong cluster and silently fall back to the single-node branch (giving up the multi-node assertion). `sky.kubernetes_node_info()` is an existing SDK call that routes through the active API server and returns its authoritative view of the workload cluster — no API-server change required, server-side this is read-only.

## Test plan

- [x] `bash format.sh --files <changed files>` — yapf, isort, mypy, pylint clean.
- [x] [`/shared-gke-postgres` build 381](https://buildkite.com/skypilot-1/nightly-build-shared-gke-api-server/builds/381) — full multi-node shared-GKE suite, **176 / 176 jobs green**, including all 10 hook tests and all 3 host_network tests (the multi-node branch hit + passed live).
- [x] [`/shared-gke-postgres -k test_hook_k8s` build 379](https://buildkite.com/skypilot-1/nightly-build-shared-gke-api-server/builds/379) — confirmed the context-helper alone fixes the 6 hook failures.
- [x] [`/smoke-test --kubernetes` build 10929](https://buildkite.com/skypilot-1/smoke-tests/builds/10929) — full kind k8s suite (single-context) still green; the helper short-circuits to `kind-skypilot` correctly.
- [x] [`/smoke-test --kubernetes -k test_hook_k8s` build 10927](https://buildkite.com/skypilot-1/smoke-tests/builds/10927) — hook fix backward-compatible with the single-context kind pipeline.

Open follow-up (non-blocking): [Gemini's review comment](https://github.com/skypilot-org/skypilot/pull/9716#discussion_r) on `test_kubernetes_host_network.py` notes that the schedulable-node count includes control-plane / `NoSchedule`-tainted nodes. Filterable via `KubernetesNodeInfo.taints`; doesn't affect the workload cluster the shared-GKE pipeline runs against (clean worker nodes), but a worthwhile tightening.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
