### PR TITLE
[Test] Skip autostop hook back-compat tests on Kubernetes

### DIFF
--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -945,6 +945,7 @@ class TestBackwardCompatibility:
             self.run_compatibility_test(f'{volume_name}-compat', commands,
                                         teardown)
 
+    @pytest.mark.no_kubernetes
     def test_autostop_hook_compatibility(self, generic_cloud: str):
         """Master's `autostop.hook` YAML works end-to-end across versions.
 
@@ -1019,6 +1020,7 @@ class TestBackwardCompatibility:
         teardown = f'{self.ACTIVATE_CURRENT} && sky down {cluster_name}* -y'
         self.run_compatibility_test(cluster_name, commands, teardown)
 
+    @pytest.mark.no_kubernetes
     def test_autostop_hook_sdk_legacy_param(self, generic_cloud: str):
         """Pin: SDK-side ``sky.autostop(cluster, idle_minutes=N, hook=...)``
         routes the legacy ``hook=`` arg into the new hooks-list framework

--- a/tests/unit_tests/test_admin_policy.py
+++ b/tests/unit_tests/test_admin_policy.py
@@ -696,9 +696,12 @@ def _policy_server(policy: str) -> Iterator[str]:
         env=env)
     start_time = time.time()
     server_ready = False
-    while time.time() - start_time < 5.0:
+    # 30s budget: cold-start of a uvicorn subprocess (interpreter + fastapi
+    # + sky imports) routinely exceeds the prior 5s on CI runners.
+    timeout_s = 30.0
+    while time.time() - start_time < timeout_s:
         try:
-            response = requests.get(f'http://localhost:{port}', timeout=0.1)
+            response = requests.get(f'http://localhost:{port}', timeout=0.5)
             if response.status_code == 200:
                 server_ready = True
                 break
@@ -710,7 +713,8 @@ def _policy_server(policy: str) -> Iterator[str]:
     if not server_ready:
         proc.terminate()
         raise RuntimeError(
-            f'Policy server on port {port} failed to start within 5 seconds')
+            f'Policy server on port {port} failed to start within '
+            f'{timeout_s:.0f} seconds')
     try:
         yield f'http://localhost:{port}'
     finally:


### PR DESCRIPTION
## Summary
- Add `@pytest.mark.no_kubernetes` to `test_autostop_hook_compatibility` and `test_autostop_hook_sdk_legacy_param`. Both exercise autostop, which neither the base (`pypi/skypilot-nightly`) nor current SkyPilot supports on Kubernetes, so the test launch step fails every run.
- The `test_autostop_hook_sdk_legacy_param` docstring already states "K8s is excluded because autostop.down=False (autostop, not autodown) is not supported on Kubernetes" — but the marker was missing.

## Evidence

Failing build: https://buildkite.com/skypilot-1/quicktest-core/builds/3280 (3 auto-retries + 1 manual retry, all failed identically).

`test_autostop_hook_compatibility` job log:
```
sky.exceptions.ResourcesUnavailableError: Failed to provision all possible launchable resources.
  Relax the task's resource requirements: 1x Kubernetes(cpus=2+, mem=4+)
  The following features are not supported by Kubernetes:
  Feature   Reason
  autostop  Auto-stop is not supported on Kubernetes.
```

`test_autostop_hook_sdk_legacy_param` job log:
```
Autostop is not supported on Kubernetes - see reason above.
```

Tests were added in #9064 / `4a5de4027` without the K8s skip marker.

## Test plan
- [x] `pytest --collect-only --kubernetes ...test_autostop_hook_compatibility ...test_autostop_hook_sdk_legacy_param` shows both tests collected with `marks: ['no_kubernetes', 'skip', 'xdist_group']` — they get the auto-applied `skip` mark from `tests/conftest.py:417`.
- [x] `pytest --collect-only --aws ...` shows both collected WITHOUT `skip` — they still run on AWS / other non-K8s clouds.
- [x] Identical pattern already in use for the same reason elsewhere (e.g. `tests/smoke_tests/test_cluster_job.py:1837` and `:1914`, both autostop tests with `# Kubernetes does not autostop yet`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->