### PR TITLE
[Debug DO NOT MERGE] Surface SkyServe replica launch log into controller log

### DIFF
--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -1226,6 +1226,34 @@ class SkyPilotReplicaManager(ReplicaManager):
                             f'Launch thread for replica {replica_id} '
                             f'exited abnormally with exception '
                             f'{t.format_exc}. Terminating...')
+                        # DEBUG (issue #N/A): also surface the per-replica
+                        # launch log into the controller serve.log so the
+                        # AWS-side provisioner error survives even after the
+                        # replica VM never existed / the service dir is wiped.
+                        # Remove after root cause for SkyServe FAILED_PROVISION
+                        # on AWS (smoke-tests 10892/10899/10917) is identified.
+                        try:
+                            launch_log_path = (
+                                serve_utils.
+                                generate_replica_launch_log_file_name(
+                                    self._service_name, replica_id))
+                            with open(launch_log_path,
+                                      'r',
+                                      encoding='utf-8',
+                                      errors='replace') as launch_log_f:
+                                launch_log_content = launch_log_f.read()
+                            launch_log_tail = '\n'.join(
+                                launch_log_content.splitlines()[-400:])
+                            logger.warning(
+                                f'[DEBUG] === Replica {replica_id} launch '
+                                f'log (last 400 lines of {launch_log_path}) '
+                                f'===\n{launch_log_tail}\n[DEBUG] === End '
+                                f'of replica {replica_id} launch log ===')
+                        except Exception as dbg_e:  # pylint: disable=broad-except
+                            logger.warning(
+                                f'[DEBUG] Could not read replica '
+                                f'{replica_id} launch log: '
+                                f'{common_utils.format_exception(dbg_e)}')
                         info.status_property.sky_launch_status = (
                             common_utils.ProcessStatus.FAILED)
                         error_in_sky_launch = True


### PR DESCRIPTION
**This is a temporary debug PR — DO NOT MERGE.**

The smoke-test `test_skyserve_new_autoscaler_update on aws` has failed in 3 consecutive
nightly `--aws` builds (10892, 10899, 10917) with a SkyServe replica reaching
`FAILED_PROVISION` after the controller's launch thread exhausts 3 retries.

The current logging surfaces only the final `RuntimeError: Failed to launch ... after
3 retries` in the controller's serve.log. The actual AWS-side provisioner error (one of
3 retry tracebacks) lives in `~/.sky/serve/<svc>/replica_<id>_launch.log` on the serve
controller VM, which is torn down by the test cleanup before any post-mortem is
possible.

This patch teaches the controller, when a launch thread exits abnormally, to also dump
the last 400 lines of the per-replica launch log via `logger.warning` so the AWS error
makes it into the buildkite stdout capture.

Used to root-cause the AWS provisioning flake. Will be reverted once the underlying
cause is identified and a proper fix shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)