### PR TITLE
[Server] Return 404 for missing dashboard _next/ assets instead of index.html

### DIFF
--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -3371,6 +3371,14 @@ async def serve_dashboard(request: fastapi.Request, full_path: str):
             return _serve_html_with_nonce(request, file_path)
         return fastapi.responses.FileResponse(file_path)
 
+    # Build assets under _next/ are content-hashed static files; a missing
+    # one must 404 instead of falling through to the index.html SPA shell
+    # below. Returning HTML (200) for a missing .js/.css lets a CDN cache the
+    # shell under the asset URL, which then fails the browser's strict MIME
+    # check and blanks the dashboard until the cache entry expires.
+    if safe_full_path.startswith('_next/'):
+        raise fastapi.HTTPException(status_code=404, detail='Not found')
+
     # Try serving a pre-rendered HTML page for the path.
     # e.g. /clusters -> clusters.html, /jobs -> jobs.html
     html_path = os.path.join(server_constants.DASHBOARD_DIR,

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -3377,7 +3377,9 @@ async def serve_dashboard(request: fastapi.Request, full_path: str):
     # shell under the asset URL, which then fails the browser's strict MIME
     # check and blanks the dashboard until the cache entry expires.
     if safe_full_path.startswith('_next/'):
-        raise fastapi.HTTPException(status_code=404, detail='Not found')
+        raise fastapi.HTTPException(status_code=404,
+                                    detail='Not found',
+                                    headers={'Cache-Control': 'no-store'})
 
     # Try serving a pre-rendered HTML page for the path.
     # e.g. /clusters -> clusters.html, /jobs -> jobs.html

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -755,3 +755,37 @@ class TestResolveDynamicRoute:
             result = server._resolve_dynamic_route(str(d), 'cron')
         assert result is not None
         assert result.endswith('[...path].html')
+
+
+# --- Tests for serve_dashboard _next/ asset handling ---
+
+
+@pytest.mark.asyncio
+async def test_serve_dashboard_missing_next_asset_returns_404_no_store(
+        tmp_path):
+    """Missing _next/ asset 404s with Cache-Control: no-store, not index.html."""
+    d = _build_dashboard_tree(tmp_path)
+    request = mock.MagicMock(spec=fastapi.Request)
+
+    with mock.patch.object(server_constants, 'DASHBOARD_DIR', str(d)):
+        with pytest.raises(fastapi.HTTPException) as exc_info:
+            await server.serve_dashboard(
+                request, full_path='_next/static/chunks/missing-abc123.js')
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.headers.get('Cache-Control') == 'no-store'
+
+
+@pytest.mark.asyncio
+async def test_serve_dashboard_client_route_falls_back_to_index(tmp_path):
+    """Client-side routes (no extension) fall through to index.html, not 404."""
+    d = _build_dashboard_tree(tmp_path)
+    request = mock.MagicMock(spec=fastapi.Request)
+
+    with mock.patch.object(server_constants, 'DASHBOARD_DIR', str(d)), \
+         mock.patch('sky.server.server._serve_html_with_nonce',
+                    return_value=fastapi.responses.HTMLResponse(
+                        content='<html/>', status_code=200)):
+        response = await server.serve_dashboard(request, full_path='clusters')
+
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary

`serve_dashboard` returns `index.html` (HTTP 200, `text/html`) as a last resort for any unmatched `/dashboard/` path. This also fires for missing `/_next/` build assets: when a content-hashed `.js`/`.css` is not present on the serving instance (for example, one replica is serving a different build during a rolling update), the request receives the HTML app shell with a `200` and a cacheable `Cache-Control`.

A CDN or caching proxy then stores that HTML under the asset URL. On subsequent loads the browser refuses to execute the `text/html` body as a script (strict MIME type checking), so the dashboard renders blank until the cache entry expires, and a hard refresh does not help because the stale entry is served from the cache.

This changes `serve_dashboard` to return `404` for missing paths under `_next/`, so they are never served (or cached) as HTML. The `index.html` SPA fallback is preserved for client-side page routes (extensionless paths such as `/clusters`).

## Test plan

- `GET /dashboard/_next/static/chunks/does-not-exist.js` now returns `404` (previously `200 text/html`).
- Existing `_next/` assets are still served normally.
- Client-side routes (`/dashboard/clusters`, `/dashboard/jobs/123`) still fall back to `index.html` and render.
- `bash format.sh --files sky/server/server.py` → 10.00/10.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->