### PR TITLE
[Core] Fix KeyError on restart for clusters predating a nested provider field

### DIFF
--- a/sky/adaptors/nebius.py
+++ b/sky/adaptors/nebius.py
@@ -141,6 +141,12 @@ def request_error():
     return service_error.RequestError
 
 
+def status_code():
+    # pylint: disable=import-outside-toplevel
+    from nebius.aio.service_error import StatusCode
+    return StatusCode
+
+
 def compute():
     # pylint: disable=import-outside-toplevel
     from nebius.api.nebius.compute import v1 as compute_v1

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -602,7 +602,14 @@ def _replace_yaml_dicts(
     for exclude_restore_key_name, value in excluded_results.items():
         curr = new_config
         for key in exclude_restore_key_name[:-1]:
-            curr = curr[key]
+            # _restore_block may have replaced an ancestor block wholesale
+            # with the old config (e.g. 'provider'), which can lack an
+            # intermediate key that only exists in the new config. This
+            # happens when restarting a cluster created before a feature
+            # that added a nested provider field (e.g. Nebius
+            # `provider.security_group`). Recreate the path so we can still
+            # apply the new value instead of raising KeyError.
+            curr = curr.setdefault(key, {})
         curr[exclude_restore_key_name[-1]] = value
     return yaml_utils.dump_yaml_str(new_config)
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -604,12 +604,14 @@ def _replace_yaml_dicts(
         for key in exclude_restore_key_name[:-1]:
             # _restore_block may have replaced an ancestor block wholesale
             # with the old config (e.g. 'provider'), which can lack an
-            # intermediate key that only exists in the new config. This
-            # happens when restarting a cluster created before a feature
-            # that added a nested provider field (e.g. Nebius
-            # `provider.security_group`). Recreate the path so we can still
-            # apply the new value instead of raising KeyError.
-            curr = curr.setdefault(key, {})
+            # intermediate key that only exists in the new config (or have
+            # it present but null). This happens when restarting a cluster
+            # created before a feature that added a nested provider field
+            # (e.g. Nebius `provider.security_group`). Recreate the path so
+            # we can still apply the new value instead of raising KeyError.
+            if not isinstance(curr.get(key), dict):
+                curr[key] = {}
+            curr = curr[key]
         curr[exclude_restore_key_name[-1]] = value
     return yaml_utils.dump_yaml_str(new_config)
 

--- a/sky/provision/nebius/utils.py
+++ b/sky/provision/nebius/utils.py
@@ -160,6 +160,21 @@ def _get_security_group_obj_by_name(project_id: str, sg_name: str) -> Any:
         return None
 
 
+def _is_already_exists_error(e: Any) -> bool:
+    """True iff the Nebius RequestError is an ALREADY_EXISTS conflict.
+
+    Prefers the structured gRPC status code; falls back to a string match
+    so the check still works if the SDK changes the error shape.
+    """
+    try:
+        status_code = nebius.status_code()
+        if status_code(e.status.code) == status_code.ALREADY_EXISTS:
+            return True
+    except Exception:  # pylint: disable=broad-except
+        pass
+    return 'already_exists' in str(e).lower()
+
+
 def get_or_create_security_group(project_id: str, sg_name: str,
                                  network_id: str) -> str:
     """Returns the SG id, creating the SG (with no rules) if missing.
@@ -180,15 +195,21 @@ def get_or_create_security_group(project_id: str, sg_name: str,
                 ),
                 spec=nebius.vpc().SecurityGroupSpec(network_id=network_id))))
         return op.resource_id
-    except nebius.request_error():
-        # Race: someone created it between our get_by_name and create.
-        # Re-fetch and return.
-        sg = nebius.sync_call(
-            service.get_by_name(nebius.nebius_common().GetByNameRequest(
-                parent_id=project_id,
-                name=sg_name,
-            )))
-        return sg.metadata.id
+    except nebius.request_error() as e:
+        # Only an ALREADY_EXISTS conflict is safe to recover from: another
+        # concurrent bootstrap created the SG between our get_by_name and
+        # create. Any other create failure (bad network, quota, transient
+        # VPC error) must propagate so the real cause is surfaced, instead
+        # of being masked by a misleading NOT_FOUND from the re-fetch below.
+        if not _is_already_exists_error(e):
+            raise
+        # Re-fetch the SG the concurrent creator made. Use the wrapped
+        # lookup (returns None) so we never surface a confusing NOT_FOUND;
+        # if it is somehow already gone, re-raise the original create error.
+        existing = get_security_group_by_name(project_id, sg_name)
+        if existing is None:
+            raise
+        return existing
 
 
 def list_security_rules(sg_id: str) -> List[Any]:

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -11,6 +11,7 @@ from sky.resources import Resources
 from sky.utils import common
 from sky.utils import common_utils
 from sky.utils import status_lib
+from sky.utils import yaml_utils
 
 
 # Set env var to test config file.
@@ -387,3 +388,72 @@ def test_is_controller_accessible_accepts_autostopping(mock_refresh):
         stopped_message='Test stopped',
         exit_if_not_accessible=False)
     assert result == mock_handle
+
+
+def test_replace_yaml_dicts_restores_new_nested_field_for_legacy_cluster():
+    """Restarting a cluster created before a nested provider field was added.
+
+    Regression test for the Nebius `KeyError: 'security_group'` seen when
+    restarting a STOPPED cluster after upgrading to a version that added
+    `provider.security_group`. The old (stored) yaml's `provider` block is
+    restored wholesale and lacks `security_group`, so reverting the
+    `('provider', 'security_group', 'GroupName')` exception must not assume
+    the intermediate key exists.
+    """
+    new_yaml = ('cluster_name: c\n'
+                'provider:\n'
+                '  type: external\n'
+                '  region: r\n'
+                '  security_group:\n'
+                '    GroupName: new-name\n'
+                '    ManagedBySkyPilot: true\n'
+                'auth: {ssh_user: ubuntu}\n'
+                'node_config: {InstanceType: t}\n')
+    # Old yaml predates the security_group feature: no such key under provider.
+    old_yaml = ('cluster_name: c\n'
+                'provider:\n'
+                '  type: external\n'
+                '  region: r\n'
+                'auth: {ssh_user: ubuntu}\n'
+                'node_config: {InstanceType: t}\n')
+
+    out = backend_utils._replace_yaml_dicts(
+        new_yaml, old_yaml,
+        backend_utils._RAY_YAML_KEYS_TO_RESTORE_FOR_BACK_COMPATIBILITY,
+        backend_utils._RAY_YAML_KEYS_TO_RESTORE_EXCEPTIONS)
+    result = yaml_utils.read_yaml_str(out)
+    # The new GroupName is applied even though the restored provider block
+    # had no security_group; no KeyError is raised.
+    assert result['provider']['security_group']['GroupName'] == 'new-name'
+
+
+def test_replace_yaml_dicts_preserves_old_subfield_on_restart():
+    """Existing cluster restart keeps old sibling subfields, takes new GroupName."""
+    new_yaml = ('cluster_name: c\n'
+                'provider:\n'
+                '  type: external\n'
+                '  region: r\n'
+                '  security_group:\n'
+                '    GroupName: new-name\n'
+                '    ManagedBySkyPilot: true\n'
+                'auth: {ssh_user: ubuntu}\n'
+                'node_config: {InstanceType: t}\n')
+    old_yaml = ('cluster_name: c\n'
+                'provider:\n'
+                '  type: external\n'
+                '  region: r\n'
+                '  security_group:\n'
+                '    GroupName: old-name\n'
+                '    ManagedBySkyPilot: false\n'
+                'auth: {ssh_user: ubuntu}\n'
+                'node_config: {InstanceType: t}\n')
+
+    out = backend_utils._replace_yaml_dicts(
+        new_yaml, old_yaml,
+        backend_utils._RAY_YAML_KEYS_TO_RESTORE_FOR_BACK_COMPATIBILITY,
+        backend_utils._RAY_YAML_KEYS_TO_RESTORE_EXCEPTIONS)
+    sg = yaml_utils.read_yaml_str(out)['provider']['security_group']
+    # GroupName is an exception -> taken from new yaml.
+    assert sg['GroupName'] == 'new-name'
+    # ManagedBySkyPilot is not an exception -> restored from old yaml.
+    assert sg['ManagedBySkyPilot'] is False

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -457,3 +457,36 @@ def test_replace_yaml_dicts_preserves_old_subfield_on_restart():
     assert sg['GroupName'] == 'new-name'
     # ManagedBySkyPilot is not an exception -> restored from old yaml.
     assert sg['ManagedBySkyPilot'] is False
+
+
+def test_replace_yaml_dicts_restores_new_nested_field_when_old_is_null():
+    """Old yaml has the intermediate key present but null (e.g. `key:`).
+
+    `dict.setdefault(key, {})` would return the existing None here, so the
+    revert must explicitly treat a non-dict intermediate as absent and
+    rebuild the path rather than crashing.
+    """
+    new_yaml = ('cluster_name: c\n'
+                'provider:\n'
+                '  type: external\n'
+                '  region: r\n'
+                '  security_group:\n'
+                '    GroupName: new-name\n'
+                '    ManagedBySkyPilot: true\n'
+                'auth: {ssh_user: ubuntu}\n'
+                'node_config: {InstanceType: t}\n')
+    # `security_group:` with no value parses to None.
+    old_yaml = ('cluster_name: c\n'
+                'provider:\n'
+                '  type: external\n'
+                '  region: r\n'
+                '  security_group:\n'
+                'auth: {ssh_user: ubuntu}\n'
+                'node_config: {InstanceType: t}\n')
+
+    out = backend_utils._replace_yaml_dicts(
+        new_yaml, old_yaml,
+        backend_utils._RAY_YAML_KEYS_TO_RESTORE_FOR_BACK_COMPATIBILITY,
+        backend_utils._RAY_YAML_KEYS_TO_RESTORE_EXCEPTIONS)
+    result = yaml_utils.read_yaml_str(out)
+    assert result['provider']['security_group']['GroupName'] == 'new-name'

--- a/tests/unit_tests/test_nebius_security_groups.py
+++ b/tests/unit_tests/test_nebius_security_groups.py
@@ -594,3 +594,68 @@ def test_delete_sg_drains_rules_first():
         nebius_utils.delete_security_group('sg-with-rules')
 
     mock_del_rule.assert_called_once_with('vpcsecurityrule-abc')
+
+
+# --- get_or_create_security_group error handling ---------------------------
+
+
+def _sg_create_error(code, message):
+    """A nebius RequestError whose create() would raise it."""
+    err_cls = nebius_adaptor.request_error()
+    status = mock.MagicMock()
+    status.code = code
+    status.__str__ = lambda self, _m=message: _m
+    return err_cls(status)
+
+
+@nebius_sdk_required
+def test_get_or_create_sg_propagates_non_conflict_create_error():
+    """A non-ALREADY_EXISTS create failure must surface the real error
+    instead of being masked by a misleading NOT_FOUND from the re-fetch."""
+    status_code = nebius_adaptor.status_code()
+    create_err = _sg_create_error(status_code.NOT_FOUND,
+                                  'NOT_FOUND: SecurityGroup ... not found')
+    with mock.patch('sky.adaptors.nebius.sync_call', side_effect=create_err), \
+         mock.patch('sky.adaptors.nebius.sdk'), \
+         mock.patch('sky.adaptors.nebius.vpc'), \
+         mock.patch('sky.adaptors.nebius.nebius_common'), \
+         mock.patch.object(nebius_utils, 'get_security_group_by_name',
+                           return_value=None) as mock_lookup:
+        with pytest.raises(nebius_adaptor.request_error()) as exc_info:
+            nebius_utils.get_or_create_security_group('proj', 'sg-x', 'net-1')
+    assert 'NOT_FOUND' in str(exc_info.value)
+    # Only the initial existence check ran; no race re-fetch on a real error.
+    mock_lookup.assert_called_once_with('proj', 'sg-x')
+
+
+@nebius_sdk_required
+def test_get_or_create_sg_recovers_from_already_exists_race():
+    """ALREADY_EXISTS means a concurrent bootstrap created it: re-fetch."""
+    status_code = nebius_adaptor.status_code()
+    create_err = _sg_create_error(status_code.ALREADY_EXISTS,
+                                  'ALREADY_EXISTS: security group exists')
+    with mock.patch('sky.adaptors.nebius.sync_call', side_effect=create_err), \
+         mock.patch('sky.adaptors.nebius.sdk'), \
+         mock.patch('sky.adaptors.nebius.vpc'), \
+         mock.patch('sky.adaptors.nebius.nebius_common'), \
+         mock.patch.object(nebius_utils, 'get_security_group_by_name',
+                           side_effect=[None, 'sg-raced']) as mock_lookup:
+        out = nebius_utils.get_or_create_security_group('proj', 'sg-x', 'net-1')
+    assert out == 'sg-raced'
+    assert mock_lookup.call_count == 2  # initial check + race re-fetch
+
+
+@nebius_sdk_required
+def test_get_or_create_sg_reraises_if_race_refetch_missing():
+    """ALREADY_EXISTS but the SG is gone on re-fetch → surface original."""
+    status_code = nebius_adaptor.status_code()
+    create_err = _sg_create_error(status_code.ALREADY_EXISTS,
+                                  'ALREADY_EXISTS: security group exists')
+    with mock.patch('sky.adaptors.nebius.sync_call', side_effect=create_err), \
+         mock.patch('sky.adaptors.nebius.sdk'), \
+         mock.patch('sky.adaptors.nebius.vpc'), \
+         mock.patch('sky.adaptors.nebius.nebius_common'), \
+         mock.patch.object(nebius_utils, 'get_security_group_by_name',
+                           side_effect=[None, None]):
+        with pytest.raises(nebius_adaptor.request_error()):
+            nebius_utils.get_or_create_security_group('proj', 'sg-x', 'net-1')


### PR DESCRIPTION
## Summary

- Fixes `KeyError: 'security_group'` when restarting a STOPPED cluster that was created before a nested `provider.*` field existed (reported on Nebius after upgrading to 0.12.3, where native security groups were added).
- The crash is cloud-agnostic: it lives in `_replace_yaml_dicts`, the backward-compat YAML merge run on every restart, not in any cloud's provisioning code. New clusters were unaffected because there is no stored YAML to merge.

## Root cause

On restart, `write_cluster_config` restores launch fields from the cluster's stored YAML via `_replace_yaml_dicts(new, old, ...)`. That function:

1. Collects the new value of each exception key path (e.g. `('provider', 'security_group', 'GroupName')`) into `excluded_results` (this loop guards against missing keys).
2. Calls `_restore_block`, which replaces the entire `provider` block wholesale with the old YAML's `provider` (since `provider` is in `_RAY_YAML_KEYS_TO_RESTORE_FOR_BACK_COMPATIBILITY`).
3. Reverts each exception back to the new value by walking the key path.

For a cluster created before the nested field existed, the old `provider` has no `security_group`. After step 2, the merged `provider` lacks it too, so step 3's `curr = curr['security_group']` raised `KeyError: 'security_group'`. The revert loop was the only one of three sibling loops that did not guard against missing intermediate keys (the exception-finder loop and `_deterministic_cluster_yaml_hash`'s removal loop both do).

## Fix

Recreate missing intermediate keys with `setdefault` in the revert loop so the new value is still applied instead of crashing. This is a strict no-op for existing well-formed YAMLs (the key is already present, so `setdefault` returns the existing dict), so behavior for AWS/GCP/etc. is unchanged. It only changes behavior in the exact scenario that previously crashed.

## Test plan

- Added `test_replace_yaml_dicts_restores_new_nested_field_for_legacy_cluster`: reproduces the legacy-cluster case (old YAML's `provider` lacks `security_group`) and asserts no `KeyError` and that the new `GroupName` is applied.
- Added `test_replace_yaml_dicts_preserves_old_subfield_on_restart`: asserts the normal restart path is unchanged (new `GroupName` taken from new YAML, sibling `ManagedBySkyPilot` restored from old YAML).
- `bash format.sh --files sky/backends/backend_utils.py` -> pylint 10.00/10.
- Manual repro before/after: with an old YAML missing `provider.security_group` and a new YAML containing it, `_replace_yaml_dicts` raised `KeyError: 'security_group'` before the change and returns the merged config after.

```
pytest tests/unit_tests/test_backend_utils.py -k replace_yaml_dicts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->