### PR TITLE
Fix Vast.ai GPU name query format to prevent wrong GPU selection

### DIFF
--- a/sky/provision/vast/utils.py
+++ b/sky/provision/vast/utils.py
@@ -112,7 +112,7 @@ def launch(name: str,
     # compatibility and future use (port-forwarding is handled separately).
     del ports
     cpu_ram = float(instance_type.split('-')[-1]) / 1024
-    gpu_name = instance_type.split('-')[1].replace('_', ' ')
+    gpu_name = instance_type.split('-')[1]
     num_gpus = int(instance_type.split('-')[0].replace('x', ''))
 
     query = [
@@ -121,7 +121,7 @@ def launch(name: str,
         f'geolocation="{region[-2:]}"',
         f'disk_space>={disk_size}',
         f'num_gpus={num_gpus}',
-        f'gpu_name="{gpu_name}"',
+        f'gpu_name={gpu_name}',
         f'cpu_ram>="{cpu_ram}"',
     ]
     if secure_only:


### PR DESCRIPTION
## Problem

When launching tasks on Vast.ai with a specific GPU requirement (e.g. `accelerators: RTX3090:1`), SkyPilot may provision an instance with a different GPU model (e.g. RTX PRO 6000 WS instead of RTX 3090).

## Root Cause

The Vast query constructed in `sky/provision/vast/utils.py` uses `gpu_name="RTX 3090"` (quoted string with spaces). The Vast.ai SDK performs fuzzy matching on this format, which can return offers for different GPU models with similar specs (same VRAM, etc.) as the top result.

Per the [Vast.ai CLI documentation](https://docs.vast.ai/cli#search-offers):
> *For string values (e.g. `gpu_name`), replace spaces with underscores: `RTX_3090` not `RTX 3090`*

## Fix

Two changes in `sky/provision/vast/utils.py`:

1. `gpu_name = instance_type.split('-')[1].replace('_', ' ')` → `gpu_name = instance_type.split('-')[1]` (keep the underscore-separated format)
2. `f'gpu_name="{gpu_name}"'` → `f'gpu_name={gpu_name}'` (remove quotes)

This ensures the query sends `gpu_name=RTX_3090` matching Vast's expected format, resulting in exact GPU model matching.

## Testing

- Verified with `vastai_sdk` directly: `gpu_name=RTX_3090` returns only RTX 3090 offers, while `gpu_name="RTX 3090"` can return RTX PRO 6000 WS as the first result
- Verified with `sky launch`: instance now correctly provisions with the requested GPU
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->