### PR TITLE
[Kubernetes] Fix owner identity check for scoped kubeconfig names

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2108,6 +2108,23 @@ async def async_check_network_connection():
                 continue
 
 
+# Kubeconfig assembly may rewrite a context's cluster/user `name` fields to
+# `<original>__sky__<context>` so that multiple source kubeconfigs declaring
+# the same internal name (e.g. a shared service-account user) do not collide
+# when merged into a single file. The owner identity string is
+# `<cluster>_<user>_<namespace>`, so those suffixes change the identity shape
+# for every context. Strip them before comparing a stored owner against the
+# current identity, otherwise clusters whose owner was recorded before the
+# convention existed are flagged as owner mismatches. (Assumes the context
+# token carries no underscore; real context names are DNS-style, e.g.
+# hyphenated.)
+_KUBE_NAME_SCOPE_RE = re.compile(r'__sky__[^_]*')
+
+
+def _normalize_kube_identity(identity_str: str) -> str:
+    return _KUBE_NAME_SCOPE_RE.sub('', identity_str)
+
+
 @timeline.event
 def check_owner_identity(cluster_name: str) -> None:
     """Check if current user is the same as the user who created the cluster.
@@ -2201,7 +2218,16 @@ def _check_owner_identity_with_record(cluster_name: str,
             # Clean up the owner identity for the backslash and newlines, caused
             # by the cloud CLI output, e.g. gcloud.
             owner = owner.replace('\n', '').replace('\\', '')
-            if owner == current:
+            # On Kubernetes, the stored owner may predate kubeconfig name
+            # scoping (see `_normalize_kube_identity`). Treat an owner that
+            # matches only after stripping the `__sky__<context>` suffixes as
+            # a match, and self-heal the row to the current identity so later
+            # checks match exactly and `sky status` stops reporting a stale
+            # mismatch.
+            scope_only_match = (is_k8s_cloud and owner != current and
+                                _normalize_kube_identity(owner)
+                                == _normalize_kube_identity(current))
+            if owner == current or scope_only_match:
                 if not is_k8s_cloud:
                     # We skip patching owner identities for Kubernetes as
                     # we expect users to naturally have multiple clusters
@@ -2229,6 +2255,11 @@ def _check_owner_identity_with_record(cluster_name: str,
                         # showing the warning above again.
                         global_user_state.set_owner_identity_for_cluster(
                             cluster_name, identity)
+                elif scope_only_match:
+                    # Migrate a pre-scoping owner string to the current scoped
+                    # identity so the row stops looking mismatched.
+                    global_user_state.set_owner_identity_for_cluster(
+                        cluster_name, identity)
                 return  # The user identity matches.
     _raise_identity_error()
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2112,17 +2112,37 @@ async def async_check_network_connection():
 # `<original>__sky__<context>` so that multiple source kubeconfigs declaring
 # the same internal name (e.g. a shared service-account user) do not collide
 # when merged into a single file. The owner identity string is
-# `<cluster>_<user>_<namespace>`, so those suffixes change the identity shape
-# for every context. Strip them before comparing a stored owner against the
-# current identity, otherwise clusters whose owner was recorded before the
-# convention existed are flagged as owner mismatches. (Assumes the context
-# token carries no underscore; real context names are DNS-style, e.g.
-# hyphenated.)
-_KUBE_NAME_SCOPE_RE = re.compile(r'__sky__[^_]*')
+# `<cluster>_<user>_<namespace>`, so each rewritten field contributes a
+# `__sky__<context>` segment and changes the identity shape. Strip those
+# segments before comparing a stored owner against the current identity,
+# otherwise clusters whose owner was recorded before the convention existed
+# are flagged as owner mismatches.
+_KUBE_NAME_SCOPE_SEP = '__sky__'
 
 
 def _normalize_kube_identity(identity_str: str) -> str:
-    return _KUBE_NAME_SCOPE_RE.sub('', identity_str)
+    """Strip `__sky__<context>` scope segments from a k8s owner identity.
+
+    Both the cluster and user fields are scoped by the *same* context, and a
+    Kubernetes namespace cannot contain `_`, so the context token is exactly
+    the text between the last `__sky__` and the final `_<namespace>`. Removing
+    every occurrence of that token recovers the pre-scoping identity even when
+    the context, cluster, or user names contain underscores (e.g. GKE contexts
+    like `gke_<project>_<zone>_<cluster>`).
+    """
+    sep = _KUBE_NAME_SCOPE_SEP
+    last = identity_str.rfind(sep)
+    if last == -1:
+        return identity_str
+    ctx_start = last + len(sep)
+    # The namespace is the final underscore-free field, so the last `_` in the
+    # whole string is the namespace separator; the context token sits between
+    # the last scope separator and it.
+    ns_sep = identity_str.rfind('_')
+    if ns_sep <= ctx_start:
+        return identity_str
+    ctx = identity_str[ctx_start:ns_sep]
+    return identity_str.replace(f'{sep}{ctx}', '')
 
 
 @timeline.event

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -412,6 +412,10 @@ def test_check_owner_identity_k8s_ignores_name_scope(monkeypatch):
 
     record = _k8s_owner_check_record([old_identity])
 
+    # CI runs unit tests with SKYPILOT_SKIP_CLOUD_IDENTITY_CHECK=1, which would
+    # short-circuit the check before our logic runs; ensure it is enabled here.
+    monkeypatch.delenv('SKYPILOT_SKIP_CLOUD_IDENTITY_CHECK', raising=False)
+
     patched = {}
 
     def fake_set_owner(cluster_name, identity):
@@ -449,6 +453,10 @@ def test_check_owner_identity_k8s_name_scope_underscored_context(monkeypatch):
 
     record = _k8s_owner_check_record([old_identity])
 
+    # CI runs unit tests with SKYPILOT_SKIP_CLOUD_IDENTITY_CHECK=1, which would
+    # short-circuit the check before our logic runs; ensure it is enabled here.
+    monkeypatch.delenv('SKYPILOT_SKIP_CLOUD_IDENTITY_CHECK', raising=False)
+
     patched = {}
 
     def fake_set_owner(cluster_name, identity):
@@ -476,6 +484,10 @@ def test_check_owner_identity_k8s_scope_does_not_overmatch(monkeypatch):
     other_scoped = 'ctx-b__sky__ctx-b_user-b__sky__ctx-b_default'
 
     record = _k8s_owner_check_record(owner_identity)
+
+    # CI runs unit tests with SKYPILOT_SKIP_CLOUD_IDENTITY_CHECK=1, which would
+    # short-circuit the check before our logic runs; ensure it is enabled here.
+    monkeypatch.delenv('SKYPILOT_SKIP_CLOUD_IDENTITY_CHECK', raising=False)
 
     monkeypatch.setattr('sky.skypilot_config.get_active_workspace',
                         lambda: 'default')

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -2,8 +2,12 @@ import os
 import pathlib
 from unittest import mock
 
+import pytest
+
+from sky import backends
 from sky import check as sky_check
 from sky import clouds
+from sky import exceptions
 from sky import skypilot_config
 from sky.backends import backend_utils
 from sky.exceptions import ClusterNotUpError
@@ -369,6 +373,86 @@ def test_check_cluster_available_rejects_init(mock_refresh, mock_get_backend):
         assert False, 'Expected ClusterNotUpError to be raised'
     except ClusterNotUpError:
         pass
+
+
+def _k8s_owner_check_record(owner_identity):
+    launchable = mock.MagicMock()
+    launchable.cloud = clouds.Kubernetes()
+    # `unsafe=True` so the `assert_launchable` attribute (which MagicMock
+    # would otherwise guard as a misspelled assert method) is mockable.
+    launched_resources = mock.MagicMock(unsafe=True)
+    launched_resources.assert_launchable.return_value = launchable
+
+    handle = mock.MagicMock()
+    # Make `isinstance(handle, CloudVmRayResourceHandle)` pass without the
+    # attribute restrictions that `spec=` imposes (launched_resources is set
+    # in __init__, not on the class).
+    handle.__class__ = backends.CloudVmRayResourceHandle
+    handle.launched_resources = launched_resources
+    return {
+        'handle': handle,
+        'workspace': 'default',
+        'owner': owner_identity,
+    }
+
+
+def test_check_owner_identity_k8s_ignores_name_scope(monkeypatch):
+    """A pre-scoping owner should still match the current scoped identity.
+
+    Regression: a Kubernetes cluster whose owner was recorded before the
+    kubeconfig `__sky__<context>` name-scoping convention existed must keep
+    matching the current (scoped) identity instead of raising an owner
+    mismatch, and the stored owner should self-heal to the scoped identity.
+    """
+    # Identity string shape is `<cluster>_<user>_<namespace>`. The scoped
+    # variant appends `__sky__<context>` to the cluster and user names.
+    old_identity = 'kube-cluster_kube-user_default'
+    scoped_identity = ('kube-cluster__sky__my-context_'
+                       'kube-user__sky__my-context_default')
+
+    record = _k8s_owner_check_record([old_identity])
+
+    patched = {}
+
+    def fake_set_owner(cluster_name, identity):
+        patched['cluster_name'] = cluster_name
+        patched['identity'] = identity
+
+    monkeypatch.setattr('sky.skypilot_config.get_active_workspace',
+                        lambda: 'default')
+    monkeypatch.setattr('sky.global_user_state.set_owner_identity_for_cluster',
+                        fake_set_owner)
+    monkeypatch.setattr(clouds.Kubernetes, 'get_user_identities',
+                        classmethod(lambda cls: [[scoped_identity]]))
+
+    # Should not raise despite the stored owner predating name scoping.
+    backend_utils._check_owner_identity_with_record(  # pylint: disable=protected-access
+        'my-cluster', record)
+
+    # The stale, pre-scoping owner should self-heal to the scoped identity.
+    assert patched['cluster_name'] == 'my-cluster'
+    assert patched['identity'] == [scoped_identity]
+
+
+def test_check_owner_identity_k8s_scope_does_not_overmatch(monkeypatch):
+    """Stripping scope suffixes must not let a different identity match."""
+    owner_identity = ['ctx-a_user-a_default']
+    # Different cluster/user; normalizing the scope suffix still leaves it
+    # distinct from the stored owner.
+    other_scoped = 'ctx-b__sky__ctx-b_user-b__sky__ctx-b_default'
+
+    record = _k8s_owner_check_record(owner_identity)
+
+    monkeypatch.setattr('sky.skypilot_config.get_active_workspace',
+                        lambda: 'default')
+    monkeypatch.setattr('sky.global_user_state.set_owner_identity_for_cluster',
+                        lambda *a, **k: None)
+    monkeypatch.setattr(clouds.Kubernetes, 'get_user_identities',
+                        classmethod(lambda cls: [[other_scoped]]))
+
+    with pytest.raises(exceptions.ClusterOwnerIdentityMismatchError):
+        backend_utils._check_owner_identity_with_record(  # pylint: disable=protected-access
+            'my-cluster', record)
 
 
 @mock.patch('sky.backends.backend_utils.refresh_cluster_status_handle')

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -434,6 +434,40 @@ def test_check_owner_identity_k8s_ignores_name_scope(monkeypatch):
     assert patched['identity'] == [scoped_identity]
 
 
+def test_check_owner_identity_k8s_name_scope_underscored_context(monkeypatch):
+    """Scope stripping must work when the context name contains underscores.
+
+    Default GKE contexts look like `gke_<project>_<zone>_<cluster>`, so the
+    scope suffix itself carries underscores. A naive `__sky__[^_]*` strip would
+    only remove up to the first underscore of the context and still report a
+    mismatch. The cluster/user names here are underscore-free so the test
+    isolates the underscored-context case.
+    """
+    ctx = 'gke_my-project_us-central1-a_my-cluster'
+    old_identity = 'kube-cluster_kube-user_default'
+    scoped_identity = f'kube-cluster__sky__{ctx}_kube-user__sky__{ctx}_default'
+
+    record = _k8s_owner_check_record([old_identity])
+
+    patched = {}
+
+    def fake_set_owner(cluster_name, identity):
+        patched['cluster_name'] = cluster_name
+        patched['identity'] = identity
+
+    monkeypatch.setattr('sky.skypilot_config.get_active_workspace',
+                        lambda: 'default')
+    monkeypatch.setattr('sky.global_user_state.set_owner_identity_for_cluster',
+                        fake_set_owner)
+    monkeypatch.setattr(clouds.Kubernetes, 'get_user_identities',
+                        classmethod(lambda cls: [[scoped_identity]]))
+
+    backend_utils._check_owner_identity_with_record(  # pylint: disable=protected-access
+        'my-cluster', record)
+
+    assert patched['identity'] == [scoped_identity]
+
+
 def test_check_owner_identity_k8s_scope_does_not_overmatch(monkeypatch):
     """Stripping scope suffixes must not let a different identity match."""
     owner_identity = ['ctx-a_user-a_default']


### PR DESCRIPTION
## Summary

- The cluster owner-identity check compares the stored owner against the current identity by exact string equality. On Kubernetes the identity is derived from the kubeconfig as `<cluster>_<user>_<namespace>`.
- When a context's cluster/user `name` fields are rewritten with a `__sky__<context>` suffix during kubeconfig assembly (e.g. to keep two source kubeconfigs that share an internal name from colliding when merged), the derived identity string changes shape. A cluster whose owner was recorded *before* that suffix existed then fails the equality check, which aborts `refresh_cluster_record` and propagates `ClusterOwnerIdentityMismatchError` through `check_cluster_available` — blocking `sky exec/logs/cancel/queue/stop/down` and relaunch, and leaving the dashboard/`sky status` showing a stale status because refresh never reaches the cloud query.
- Fix: in `_check_owner_identity_with_record`, normalize both sides by stripping `__sky__<context>` scope segments before comparing (Kubernetes only), and self-heal the stored owner to the current identity on a scope-only match so subsequent checks pass exactly. Non-Kubernetes behavior is unchanged.
- The stripping is anchored on the namespace (a Kubernetes namespace cannot contain `_`, so the last `_` is the namespace separator and the scope token is the text between the final `__sky__` and it). This correctly strips the suffix even when the context name itself contains underscores, e.g. GKE contexts like `gke_<project>_<zone>_<cluster>`.

## Test plan

- Added `tests/unit_tests/test_backend_utils.py::test_check_owner_identity_k8s_ignores_name_scope` — a pre-scoping owner matches the current scoped identity (no raise) and the stored owner self-heals to the scoped identity.
- Added `tests/unit_tests/test_backend_utils.py::test_check_owner_identity_k8s_scope_does_not_overmatch` — a genuinely different scoped identity still raises `ClusterOwnerIdentityMismatchError`.
- Added `tests/unit_tests/test_backend_utils.py::test_check_owner_identity_k8s_name_scope_underscored_context`: a GKE-style context whose name contains underscores is stripped correctly and still matches.
- `pytest tests/unit_tests/test_backend_utils.py -k owner_identity_k8s` passes.
- `pylint sky/backends/backend_utils.py` rates 10.00/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
