### PR TITLE
Use FLEX_START provisioning model for GCP DWS/MIG resize requests

### DIFF
--- a/sky/provision/gcp/mig_utils.py
+++ b/sky/provision/gcp/mig_utils.py
@@ -128,6 +128,9 @@ def resize_managed_instance_group(project_id: str, zone: str, group_name: str,
             'resizeBy': resize_by,
             'requestedRunDuration': {
                 'seconds': run_duration,
+            },
+            'queuingPolicy': {
+                'provisioningModel': 'FLEX_START',
             }
         }).execute()
     return operation


### PR DESCRIPTION
Bug:
When launching VM instances on GCP using Managed Instance Groups (MIG) with Dynamic Workload Scheduler (DWS), the instances are created with a "STANDARD" provisioning model instead of the expected "FLEX_START" model.

Root Cause:
In `sky/provision/gcp/mig_utils.py`, the `resize_managed_instance_group` method makes an `insert` request to the `instanceGroupManagerResizeRequests` API collection but does not specify a `queuingPolicy` in the body. Compute Engine defaults the queuing policy's provisioning model to "STANDARD" if it is omitted.

Why Fix is Correct:
By explicitly adding `queuingPolicy: {'provisioningModel': 'FLEX_START'}` to the `insert` API request body, the DWS queued VM requests are correctly configured to use the "FLEX_START" model, satisfying the correct provisioning requirements.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9726" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->