### PR TITLE
Fallback to tagless security group creation if ec2:CreateTags permission is missing

### DIFF
--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -756,7 +756,26 @@ def _get_or_create_vpc_security_group(ec2: 'mypy_boto3_ec2.ServiceResource',
             }],
         )
     except ec2.meta.client.exceptions.ClientError as e:
-        if e.response['Error']['Code'] == 'InvalidGroup.Duplicate':
+        if e.response['Error']['Code'] == 'UnauthorizedOperation':
+            logger.warning(
+                'Unauthorized to create security group with tags. '
+                'Retrying without tags.'
+            )
+            try:
+                ec2.meta.client.create_security_group(
+                    Description='Auto-created security group for Ray workers',
+                    GroupName=expected_sg_name,
+                    VpcId=vpc_id,
+                )
+            except ec2.meta.client.exceptions.ClientError as e_inner:
+                if e_inner.response['Error']['Code'] == 'InvalidGroup.Duplicate':
+                    pass
+                else:
+                    message = ('Failed to create security group. Error: '
+                               f'{common_utils.format_exception(e_inner)}')
+                    logger.warning(message)
+                    raise exceptions.NoClusterLaunchedError(message) from e_inner
+        elif e.response['Error']['Code'] == 'InvalidGroup.Duplicate':
             # The security group already exists, but we didn't see it
             # because of eventual consistency.
             logger.warning(f'{expected_sg_name} already exists when creating.')
@@ -770,10 +789,11 @@ def _get_or_create_vpc_security_group(ec2: 'mypy_boto3_ec2.ServiceResource',
                 f'{security_group.group_name}{colorama.Style.RESET_ALL} '
                 f'[id={security_group.id}]')
             return security_group
-        message = ('Failed to create security group. Error: '
-                   f'{common_utils.format_exception(e)}')
-        logger.warning(message)
-        raise exceptions.NoClusterLaunchedError(message) from e
+        else:
+            message = ('Failed to create security group. Error: '
+                       f'{common_utils.format_exception(e)}')
+            logger.warning(message)
+            raise exceptions.NoClusterLaunchedError(message) from e
 
     security_group = get_security_group_from_vpc_id(ec2, vpc_id,
                                                     expected_sg_name)


### PR DESCRIPTION
Bug:
When creating default security groups, if the user's AWS IAM policy does not grant `ec2:CreateTags` permissions on `security-group/*` resources (even if they specify an existing group via `aws.security_group_name`), the security group creation fails and crashes.

Root Cause:
In `sky/provision/aws/config.py`, the `_get_or_create_vpc_security_group` method calls `create_security_group` and specifies `TagSpecifications` to attach the `SKYPILOT` tag. If the caller's IAM role lacks the `ec2:CreateTags` permission on the `security-group` resource type, the API call raises a `ClientError` with the code `UnauthorizedOperation`.

Why Fix is Correct:
By catching the `UnauthorizedOperation` error code, logging a warning, and retrying the `create_security_group` call without `TagSpecifications`, we gracefully fall back to creating a functional untagged security group rather than crashing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->