### PR TITLE
[Core] Skip teardown-hook codegen on clusters with no hooks declared

### DIFF
--- a/sky/core.py
+++ b/sky/core.py
@@ -905,6 +905,21 @@ def _maybe_run_teardown_hooks(handle: 'backends.ResourceHandle',
     # Only the VM/Ray backend is supported; other backends simply skip.
     if not isinstance(backend, cloud_vm_ray_backend.CloudVmRayBackend):
         return
+    # Skip the head SSH entirely when the cluster has NO hooks declared.
+    # The codegen exists to (a) run user-declared hooks and (b) claim
+    # the per-event teardown slot so a later SIGTERM cannot fire a
+    # competing preemption hook on what was an intentional teardown.
+    # With no hooks at all, both are no-ops — there's nothing to run
+    # and no preemption hook can race. SSH-ing the head anyway is pure
+    # overhead and surfaces a misleading ``Failed to run <event> hook
+    # on '<cluster>': . Proceeding with teardown.`` warning whenever
+    # the head IP is transiently unreachable (already partway shut
+    # down, stale cached handle, etc.) — for a user who never declared
+    # a hook in their YAML.
+    declared_hooks = getattr(getattr(handle, 'launched_resources', None),
+                             'hooks', None)
+    if not declared_hooks:
+        return
     # Claim the event slot unconditionally — even if no hook declares
     # this event. For 'down', the claim blocks the SIGTERM handler
     # (kubelet's SIGTERM at K8s pod delete) from later claiming

--- a/tests/smoke_tests/test_lifecycle_hooks.py
+++ b/tests/smoke_tests/test_lifecycle_hooks.py
@@ -1127,3 +1127,59 @@ def test_hook_invalid_inputs_rejected():
         timeout=180,
     )
     smoke_tests_utils.run_one_test(test)
+
+
+# ---------------------------------------------------------------------------
+# `sky down` on a cluster that declared NO hooks must NOT SSH to the
+# head to run the teardown codegen.
+#
+# Before the fix, `_maybe_run_teardown_hooks` always ran the codegen
+# on the head, even when the cluster had no hooks at all. The codegen
+# was a no-op functionally, but if the head IP was transiently
+# unreachable (already partway shut down, stale cached handle, network
+# blip) it surfaced a misleading warning:
+#
+#   Failed to run down hook on '<cluster>': . Proceeding with teardown.
+#
+# …on a cluster the user never put a hook on. The visible
+# user-facing signal of the codegen actually running is the spinner
+# message ``Running down hook on '<cluster>'`` (sky/core.py:925),
+# which is emitted just before the head SSH. This test launches a
+# bare minimal cluster (zero hooks declared anywhere), runs
+# ``sky down`` with the spinner not suppressed, and asserts that
+# neither the spinner message nor the failure warning appears in the
+# output. Pre-fix: spinner appears (and on a flaky head, the failure
+# warning too). Post-fix: codegen is skipped → neither appears.
+# ---------------------------------------------------------------------------
+@_no_autostop
+@pytest.mark.no_kubernetes
+def test_hook_sky_down_no_hooks_skips_head_codegen(generic_cloud: str):
+    name = smoke_tests_utils.get_cluster_name()
+    test = smoke_tests_utils.Test(
+        'test_hook_sky_down_no_hooks_skips_head_codegen',
+        [
+            # (1) Launch with the bare minimal YAML — no hooks anywhere.
+            f's=$(SKYPILOT_DEBUG=0 sky launch -y -c {name} '
+            f'--infra {generic_cloud} --fast '
+            f'{smoke_tests_utils.LOW_RESOURCE_ARG} '
+            f'tests/test_yamls/minimal.yaml) && '
+            f'{smoke_tests_utils.VALIDATE_LAUNCH_OUTPUT}',
+            # (2) `sky down` and capture stdout + stderr. The codegen's
+            # only visible user-facing signal is the spinner message
+            # "Running down hook on '<cluster>'"; the failure warning
+            # only fires when the head SSH itself errors, but the
+            # spinner appears unconditionally pre-fix. Assert neither
+            # appears, AND that teardown still succeeded (final
+            # "Terminating cluster <name>...done" line is present).
+            f'out=$(sky down -y {name} 2>&1) && '
+            f'echo "$out" | grep "Terminating cluster {name}...done" && '
+            f'! echo "$out" | grep -qE "Running (down|stop) hook on" && '
+            f'! echo "$out" | grep -qE "Failed to run (down|stop) hook on"',
+            # (3) Cluster is gone — `sky status` no longer lists it.
+            f'sky status {name} 2>/dev/null | grep -v "{name}" || true',
+        ],
+        # Belt-and-suspenders teardown in case step (2) somehow left it.
+        f'sky down -y {name} --purge || true',
+        timeout=smoke_tests_utils.get_timeout(generic_cloud),
+    )
+    smoke_tests_utils.run_one_test(test)

--- a/tests/unit_tests/test_lifecycle_hooks.py
+++ b/tests/unit_tests/test_lifecycle_hooks.py
@@ -809,8 +809,14 @@ def test_sky_stop_fires_stop_hook_via_codegen():
 
     captured = {}
 
+    class _FakeResources:
+        # At least one hook must be declared for the codegen to run;
+        # the no-hooks shortcut is covered by
+        # ``test_sky_down_skips_codegen_when_no_hooks_declared``.
+        hooks = [{'run': 'echo s', 'events': ['stop'], 'timeout': 30}]
+
     class _FakeHandle:
-        pass
+        launched_resources = _FakeResources()
 
     class _FakeBackend(cloud_vm_ray_backend.CloudVmRayBackend):
 
@@ -835,7 +841,8 @@ def test_sky_stop_fires_stop_hook_via_codegen():
 
 
 def test_sky_down_claims_teardown_even_without_down_hooks():
-    """`sky down` must claim the 'down' teardown slot unconditionally.
+    """`sky down` must claim the 'down' teardown slot unconditionally
+    whenever the cluster has ANY hooks declared.
 
     Otherwise a cluster declaring only ``events: [preemption]`` hooks
     leaves the slot unclaimed during ``sky down`` → the kubelet SIGTERM
@@ -852,8 +859,14 @@ def test_sky_down_claims_teardown_even_without_down_hooks():
 
     captured = {}
 
+    class _FakeResources:
+        # Cluster has a preemption hook (no `down` hook). The codegen
+        # must still run so the SIGTERM-driven preemption hook cannot
+        # later claim the slot on what was an intentional `sky down`.
+        hooks = [{'run': 'echo p', 'events': ['preemption'], 'timeout': 30}]
+
     class _FakeHandle:
-        pass
+        launched_resources = _FakeResources()
 
     class _FakeBackend(cloud_vm_ray_backend.CloudVmRayBackend):
 
@@ -882,6 +895,60 @@ def test_sky_down_claims_teardown_even_without_down_hooks():
         "subsequent kubelet SIGTERM (during the K8s pod delete) cannot "
         "claim 'preemption' and fire the preemption hook on a sky "
         f"down. Codegen was:\n{cmd}")
+
+
+def test_sky_down_skips_codegen_when_no_hooks_declared():
+    """`sky down` on a cluster with NO hooks declared must NOT SSH to
+    the head to run the teardown codegen.
+
+    The codegen exists only to (a) run user-declared hooks and (b)
+    claim the per-event teardown slot so a later SIGTERM cannot fire
+    a competing preemption hook on what was an intentional teardown.
+    When the cluster has no hooks at all, both (a) and (b) are no-ops
+    — there are no hooks to run, and no preemption hook can race.
+    SSH-ing to the head anyway wastes time and, more importantly,
+    surfaces a noisy ``Failed to run down hook on '<cluster>': .
+    Proceeding with teardown.`` warning whenever the head IP is
+    transiently unreachable (already partway shut down, stale cached
+    handle, network blip) — even though the user never declared any
+    hook in their YAML.
+
+    Pins: when ``handle.launched_resources.hooks`` is None or empty,
+    ``run_on_head`` MUST NOT be called.
+    """
+    from sky import core
+    from sky.backends import cloud_vm_ray_backend
+
+    for hooks_value in (None, []):
+        called = {'count': 0}
+
+        class _FakeResources:
+            hooks = hooks_value  # type: ignore[misc]
+
+        class _FakeHandle:
+            launched_resources = _FakeResources()
+
+        class _FakeBackend(cloud_vm_ray_backend.CloudVmRayBackend):
+
+            def __init__(self):  # pylint: disable=super-init-not-called
+                pass
+
+            def run_on_head(self, handle, cmd, **kw):  # type: ignore[override]
+                del handle, cmd, kw
+                called['count'] += 1
+                return 0
+
+        core._maybe_run_down_hooks(_FakeHandle(), _FakeBackend(), 'mycluster')
+        core._maybe_run_stop_hooks(_FakeHandle(), _FakeBackend(), 'mycluster')
+
+        assert called['count'] == 0, (
+            f'`_maybe_run_teardown_hooks` SSHed to the head despite '
+            f'`handle.launched_resources.hooks={hooks_value!r}`. The codegen '
+            f'should be skipped entirely when no hooks are declared, '
+            f'otherwise `sky down`/`sky stop` on a cluster that never used '
+            f'hooks emits a misleading "Failed to run down hook" warning '
+            f'whenever the head IP is transiently unreachable. '
+            f'run_on_head was called {called["count"]} time(s).')
 
 
 def test_relaunch_hooks_only_preserves_autostop(monkeypatch):


### PR DESCRIPTION
## Summary

`sky down` / `sky stop` on a cluster that never declared any lifecycle hook still SSHes to the head to run a Python codegen whose only purpose is to (a) execute user-declared hooks and (b) claim a per-event teardown slot to block a racing preemption-hook fire. With no hooks declared, both jobs are no-ops — there's nothing to run and no competing preemption hook can race. The SSH itself is pure overhead, and worse, surfaces a misleading warning whenever the head IP is transiently unreachable (already partway shut down, stale cached handle, network blip):

```
Failed to run down hook on '<cluster>': . Proceeding with teardown.
```

…on a cluster the user never put a hook on. Reported by a user who'd never used lifecycle hooks and was confused by the warning appearing on every teardown.

## Fix

Bail early in `_maybe_run_teardown_hooks` (`sky/core.py`) when `handle.launched_resources.hooks` is None / empty. The slot-claim still runs unconditionally as soon as ANY hook is declared (even just a `preemption` hook), so the SIGTERM ↔ sky-down race fix from #9064 remains intact.

```python
declared_hooks = getattr(getattr(handle, 'launched_resources', None),
                         'hooks', None)
if not declared_hooks:
    return
```

## Tests

Two test additions/updates pin the contract on both sides:

### Unit (`tests/unit_tests/test_lifecycle_hooks.py`)

- New `test_sky_down_skips_codegen_when_no_hooks_declared` pins the no-SSH contract for both `_maybe_run_down_hooks` and `_maybe_run_stop_hooks` against `hooks=None` and `hooks=[]`. Fails pre-fix (`run_on_head` called twice when `hooks=None`), passes post-fix.
- Updated `test_sky_down_claims_teardown_even_without_down_hooks` and `test_sky_stop_fires_stop_hook_via_codegen` to give their `_FakeHandle.launched_resources` a populated `hooks` list, so the contract they pin (codegen MUST run when ANY hook is declared) is preserved cleanly under the new guard.

### Smoke (`tests/smoke_tests/test_lifecycle_hooks.py`)

New `test_hook_sky_down_no_hooks_skips_head_codegen` launches a cluster from the bare `tests/test_yamls/minimal.yaml` (zero hooks anywhere), runs `sky down`, and asserts the output contains neither the spinner message (`Running down hook on '<cluster>'`) nor the failure warning (`Failed to run down hook on '<cluster>': …`). Both signals fire pre-fix and are absent post-fix.

## Test plan

- [x] `conda activate sky && pytest tests/unit_tests/test_lifecycle_hooks.py` → **75 passed** (1 unrelated pre-existing api-server-start failure on `test_tail_hook_logs_minimal_api_version_required`, reproduces on master without this PR).
- [x] Pre-fix unit-test run shows `test_sky_down_skips_codegen_when_no_hooks_declared` fails with `run_on_head was called 2 time(s)` — confirming the test bites on the bug.
- [x] Post-fix unit-test run shows the new test plus both updated tests pass.
- [ ] CI: needs `/smoke-test -k test_hook_sky_down_no_hooks_skips_head_codegen` for the smoke test on real cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->