### PR TITLE
[Jobs] Run managed-job-status-refresh as a main-process thread

### DIFF
--- a/sky/jobs/managed_job_refresh_thread.py
+++ b/sky/jobs/managed_job_refresh_thread.py
@@ -43,6 +43,16 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         while True:
             try:
                 self._become_leader_and_run()
+                # _become_leader_and_run only returns normally after
+                # _suicide_on_lock_loss sent SIGTERM. Re-entering would
+                # skip the lock acquire (stale local `_acquired` flag),
+                # touch the signal file, and call ha_recovery →
+                # maybe_start_controllers — which would spawn fresh
+                # controllers under a now-released lock while the new
+                # leader on another replica is doing the same. Stop the
+                # thread instead so the SIGTERM-driven drain runs to
+                # completion without further controller churn.
+                return
             except Exception as e:  # pylint: disable=broad-except
                 logger.exception(
                     f'managed-job refresh error: {e}, '

--- a/sky/jobs/managed_job_refresh_thread.py
+++ b/sky/jobs/managed_job_refresh_thread.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 from sky import sky_logging
 from sky.jobs import constants as managed_job_constants
+from sky.jobs import scheduler as managed_job_scheduler
 from sky.jobs import utils as managed_job_utils
 from sky.skylet import constants
 from sky.skylet import events
@@ -112,6 +113,22 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         logger.error(
             f'Lost consolidation mode lock {self._lock}; sending SIGTERM '
             'to the API server to step down')
+        # Re-touch the recovery signal file so no new controllers will be
+        # started
+        try:
+            signal_file = pathlib.Path(
+                constants.PERSISTENT_RUN_RESTARTING_SIGNAL_FILE).expanduser()
+            signal_file.parent.mkdir(parents=True, exist_ok=True)
+            signal_file.touch()
+        except OSError:
+            logger.warning('Failed to touch recovery signal file on lock-loss')
+        # The lock is already released, kill job controllers to avoid split
+        # brain, e.g. new job controllers might have been launched on the new
+        # replica during rolling-update
+        try:
+            managed_job_scheduler.kill_local_job_controllers()
+        except Exception:  # pylint: disable=broad-except
+            logger.exception('Failed to kill local controllers on lock-loss')
         # SIGTERM to trigger graceful shutdown
         os.kill(os.getpid(), signal.SIGTERM)
 

--- a/sky/jobs/managed_job_refresh_thread.py
+++ b/sky/jobs/managed_job_refresh_thread.py
@@ -8,6 +8,7 @@ import typing
 from typing import Optional
 
 from sky import sky_logging
+from sky.jobs import constants as managed_job_constants
 from sky.jobs import utils as managed_job_utils
 from sky.skylet import constants
 from sky.skylet import events
@@ -35,16 +36,12 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         self._lock: Optional[locks.DistributedLock] = None
 
     def run(self) -> None:
-        from sky.jobs import constants as managed_job_constants
-
         self._lock = locks.get_lock(
             managed_job_constants.CONSOLIDATION_MODE_LOCK_ID)
 
         while True:
             try:
                 self._become_leader_and_run()
-            except (SystemExit, KeyboardInterrupt):
-                raise
             except Exception as e:  # pylint: disable=broad-except
                 logger.exception(
                     f'managed-job refresh error: {e}, '

--- a/sky/jobs/managed_job_refresh_thread.py
+++ b/sky/jobs/managed_job_refresh_thread.py
@@ -1,0 +1,217 @@
+"""Run the managed-job-status-refresh loop as a thread in the API server.
+
+Background
+==========
+
+The managed-job-status-refresh daemon owns two responsibilities in
+consolidation mode:
+
+1. Run ``ha_recovery_for_consolidation_mode`` on becoming leader, which
+   restarts in-flight controllers for jobs whose controller PID is no
+   longer alive.
+2. Periodically run ``ManagedJobEvent`` to refresh job status across the
+   fleet.
+
+Historically the daemon was scheduled as an internal request on the shared
+executor task queue, which means in HA mode it could move freely between
+replicas: any executor worker that dequeued it became the leader.  The
+``consolidation_mode_lock`` (a postgres advisory lock) was the only thing
+gating concurrent execution.
+
+In practice this produced a class of bug where two replicas concurrently
+ran controllers for the same managed job.  The trigger could be as
+innocuous as a ``BrokenProcessPool`` on the worker holding the daemon:
+the executor and ``Pass D`` of the HA failover loop both re-enqueued the
+task, the next dequeue landed on a different replica, the new leader's
+``ha_recovery_for_consolidation_mode`` ran ``controller_process_alive`` on
+the *old* leader's PIDs in its own PID namespace (where they don't
+exist), declared all those controllers dead, and spawned a fresh pool of
+controllers in parallel with the still-alive ones.
+
+Design
+======
+
+Bind the daemon's lifecycle to the API server main process by running it
+as a thread.  Now the daemon, the lock it holds, and the controllers it
+spawns all live and die together with one OS process (and with one pod,
+since the container PID namespace tears down on main exit).  The
+cross-replica controller orphan can no longer happen as long as one
+invariant holds: while this thread is alive and believes it is leader,
+its postgres advisory lock is genuinely held server-side.
+
+The advisory lock can in principle be lost while the main process is
+alive — RDS maintenance restarts, NLB idle timeouts,
+``idle_in_transaction_session_timeout``, ``pg_terminate_backend``,
+transient network drops — and the lock's ``_acquired`` flag will stay
+``True`` locally because nothing in the daemon's normal codepath
+exercises the lock connection.  To recover the invariant, every tick we
+probe the lock's session via ``PostgresLock.is_session_alive``; on
+failure we ``SIGTERM`` the API server so K8s restarts the pod and the
+remaining replicas re-elect a leader.
+
+Catch-all on each event tick is kept (mirroring the old
+``InternalRequestDaemon.run_event`` semantics): a transient exception
+during ``event.run()`` should not take down the pod.  Only a confirmed
+lock loss does.
+"""
+import os
+import pathlib
+import signal
+import threading
+import time
+import typing
+from typing import Optional
+
+from sky import sky_logging
+from sky.skylet import constants
+from sky.utils import locks
+
+if typing.TYPE_CHECKING:
+    pass
+
+logger = sky_logging.init_logger(__name__)
+
+# Probe the lock's PG session this often.  Short enough to react within
+# seconds of a silent drop, long enough to be cheap; this is the bound
+# on how long a stale leader can keep doing work after lock loss.
+_LOCK_PROBE_INTERVAL_SECONDS = 5
+
+# When the outer (acquire) loop fails — another replica still holds the
+# lock, or our acquire connection died mid-wait — wait this long before
+# retrying.  PostgresLock.acquire already polls internally at 1s, so
+# this is just a safety sleep when its acquire raises.
+_ACQUIRE_RETRY_INTERVAL_SECONDS = 5
+
+
+class ManagedJobRefreshDaemonThread(threading.Thread):
+    """Leader-elected thread that runs ha_recovery + ManagedJobEvent.
+
+    See module docstring for motivation and invariants.
+    """
+
+    def __init__(self) -> None:
+        # daemon=True: when the main interpreter exits we want this thread
+        # to go with it; the leader role is meant to track main's lifecycle.
+        super().__init__(name='managed-job-refresh', daemon=True)
+        self._lock: Optional[locks.DistributedLock] = None
+
+    # ------------------------------------------------------------------ #
+    # Thread entrypoint
+    # ------------------------------------------------------------------ #
+
+    def run(self) -> None:
+        # pylint: disable=import-outside-toplevel
+        from sky.jobs import constants as managed_job_constants
+
+        # Build the lock object in this thread so any PG connectivity
+        # error at construction time surfaces here rather than at import.
+        self._lock = locks.get_lock(
+            managed_job_constants.CONSOLIDATION_MODE_LOCK_ID)
+
+        while True:
+            try:
+                self._become_leader_and_run()
+            except SystemExit:
+                # _become_leader_and_run uses os.kill(SIGTERM) — let the
+                # process tear down without an outer retry.
+                raise
+            except Exception:  # pylint: disable=broad-except
+                logger.exception(
+                    'managed-job refresh thread crashed outside the inner '
+                    f'loop; retrying in {_ACQUIRE_RETRY_INTERVAL_SECONDS}s')
+                time.sleep(_ACQUIRE_RETRY_INTERVAL_SECONDS)
+
+    # ------------------------------------------------------------------ #
+    # Leader path: acquire lock, run recovery, then loop event ticks
+    # ------------------------------------------------------------------ #
+
+    def _become_leader_and_run(self) -> None:
+        # pylint: disable=import-outside-toplevel
+        from sky.jobs import utils as managed_job_utils
+        from sky.skylet import events
+
+        assert self._lock is not None
+
+        # Touch the rolling-restart signal file before acquiring the
+        # lock.  Same semantics as the historical event_fn: any peer
+        # checking this file sees "leader handover in progress" until
+        # we've finished recovery.
+        signal_file = pathlib.Path(
+            constants.PERSISTENT_RUN_RESTARTING_SIGNAL_FILE).expanduser()
+        signal_file.touch()
+        try:
+            if not self._lock.is_locked():
+                logger.info(
+                    f'Acquiring the consolidation mode lock: {self._lock}')
+                self._lock.acquire()
+                logger.info('Consolidation mode lock acquired')
+            # Recovery before any event-loop work: same ordering as the
+            # original ``managed_job_status_refresh_event``.
+            managed_job_utils.ha_recovery_for_consolidation_mode()
+        finally:
+            try:
+                signal_file.unlink()
+            except FileNotFoundError:
+                pass
+
+        # Steady-state event loop with periodic lock-liveness probe.
+        refresh_event = events.ManagedJobEvent()
+        last_probe = time.monotonic()
+        while True:
+            now = time.monotonic()
+            if now - last_probe >= _LOCK_PROBE_INTERVAL_SECONDS:
+                if not self._lock_still_held():
+                    self._suicide_on_lock_loss()
+                    return
+                last_probe = now
+            try:
+                logger.debug('=== Running managed job event ===')
+                refresh_event.run()
+            except Exception:  # pylint: disable=broad-except
+                # Tick failures are non-fatal — mirror the old
+                # InternalRequestDaemon.run_event catch-all.  Lock loss
+                # is the only thing that should take the pod down.
+                logger.exception('ManagedJobEvent tick failed; will retry')
+            time.sleep(events.EVENT_CHECKING_INTERVAL_SECONDS)
+
+    # ------------------------------------------------------------------ #
+    # Lock liveness
+    # ------------------------------------------------------------------ #
+
+    def _lock_still_held(self) -> bool:
+        """True iff we are confident this replica still owns the lock."""
+        assert self._lock is not None
+        if isinstance(self._lock, locks.PostgresLock):
+            return self._lock.is_session_alive()
+        # FileLock and any other DistributedLock implementation: the
+        # "session" concept doesn't apply (the lock is grounded in the
+        # filesystem, which doesn't suffer silent loss the way a TCP
+        # session does).  Trust the local flag.
+        return self._lock.is_locked()
+
+    def _suicide_on_lock_loss(self) -> None:
+        """SIGTERM the API server process so the pod can restart cleanly."""
+        logger.error(
+            f'Lost consolidation mode lock {self._lock}; sending SIGTERM '
+            'to the API server so the pod can be restarted and the '
+            'leader re-elected on a sibling replica.')
+        # SIGTERM rather than os._exit so uvicorn's lifespan shutdown
+        # runs (atexit handlers, log flush, etc.).  K8s will restart
+        # the container regardless.
+        os.kill(os.getpid(), signal.SIGTERM)
+
+
+def start_managed_job_refresh_daemon() -> None:
+    """Start the refresh thread for this API server process, if needed.
+
+    No-op when consolidation mode is off — mirrors the gating that the
+    historical ``should_skip_managed_job_status_refresh`` provided.
+    """
+    # pylint: disable=import-outside-toplevel
+    from sky.jobs import utils as managed_job_utils
+    if not managed_job_utils.is_consolidation_mode():
+        logger.debug('Consolidation mode is off; not starting the managed-job '
+                     'refresh thread.')
+        return
+    logger.info('Starting the managed-job refresh thread')
+    ManagedJobRefreshDaemonThread().start()

--- a/sky/jobs/managed_job_refresh_thread.py
+++ b/sky/jobs/managed_job_refresh_thread.py
@@ -1,59 +1,4 @@
-"""Run the managed-job-status-refresh loop as a thread in the API server.
-
-Background
-==========
-
-The managed-job-status-refresh daemon owns two responsibilities in
-consolidation mode:
-
-1. Run ``ha_recovery_for_consolidation_mode`` on becoming leader, which
-   restarts in-flight controllers for jobs whose controller PID is no
-   longer alive.
-2. Periodically run ``ManagedJobEvent`` to refresh job status across the
-   fleet.
-
-Historically the daemon was scheduled as an internal request on the shared
-executor task queue, which means in HA mode it could move freely between
-replicas: any executor worker that dequeued it became the leader.  The
-``consolidation_mode_lock`` (a postgres advisory lock) was the only thing
-gating concurrent execution.
-
-In practice this produced a class of bug where two replicas concurrently
-ran controllers for the same managed job.  The trigger could be as
-innocuous as a ``BrokenProcessPool`` on the worker holding the daemon:
-the executor and ``Pass D`` of the HA failover loop both re-enqueued the
-task, the next dequeue landed on a different replica, the new leader's
-``ha_recovery_for_consolidation_mode`` ran ``controller_process_alive`` on
-the *old* leader's PIDs in its own PID namespace (where they don't
-exist), declared all those controllers dead, and spawned a fresh pool of
-controllers in parallel with the still-alive ones.
-
-Design
-======
-
-Bind the daemon's lifecycle to the API server main process by running it
-as a thread.  Now the daemon, the lock it holds, and the controllers it
-spawns all live and die together with one OS process (and with one pod,
-since the container PID namespace tears down on main exit).  The
-cross-replica controller orphan can no longer happen as long as one
-invariant holds: while this thread is alive and believes it is leader,
-its postgres advisory lock is genuinely held server-side.
-
-The advisory lock can in principle be lost while the main process is
-alive — RDS maintenance restarts, NLB idle timeouts,
-``idle_in_transaction_session_timeout``, ``pg_terminate_backend``,
-transient network drops — and the lock's ``_acquired`` flag will stay
-``True`` locally because nothing in the daemon's normal codepath
-exercises the lock connection.  To recover the invariant, every tick we
-probe the lock's session via ``PostgresLock.is_session_alive``; on
-failure we ``SIGTERM`` the API server so K8s restarts the pod and the
-remaining replicas re-elect a leader.
-
-Catch-all on each event tick is kept (mirroring the old
-``InternalRequestDaemon.run_event`` semantics): a transient exception
-during ``event.run()`` should not take down the pod.  Only a confirmed
-lock loss does.
-"""
+"""Run the managed-job-status-refresh loop as a thread in the API server."""
 import os
 import pathlib
 import signal
@@ -65,21 +10,15 @@ from typing import Optional
 from sky import sky_logging
 from sky.skylet import constants
 from sky.utils import locks
+from sky.jobs import utils as managed_job_utils
+from sky.skylet import events
 
 if typing.TYPE_CHECKING:
     pass
 
 logger = sky_logging.init_logger(__name__)
 
-# Probe the lock's PG session this often.  Short enough to react within
-# seconds of a silent drop, long enough to be cheap; this is the bound
-# on how long a stale leader can keep doing work after lock loss.
 _LOCK_PROBE_INTERVAL_SECONDS = 5
-
-# When the outer (acquire) loop fails — another replica still holds the
-# lock, or our acquire connection died mid-wait — wait this long before
-# retrying.  PostgresLock.acquire already polls internally at 1s, so
-# this is just a safety sleep when its acquire raises.
 _ACQUIRE_RETRY_INTERVAL_SECONDS = 5
 
 
@@ -95,40 +34,26 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
         super().__init__(name='managed-job-refresh', daemon=True)
         self._lock: Optional[locks.DistributedLock] = None
 
-    # ------------------------------------------------------------------ #
-    # Thread entrypoint
-    # ------------------------------------------------------------------ #
-
     def run(self) -> None:
-        # pylint: disable=import-outside-toplevel
         from sky.jobs import constants as managed_job_constants
 
-        # Build the lock object in this thread so any PG connectivity
-        # error at construction time surfaces here rather than at import.
         self._lock = locks.get_lock(
             managed_job_constants.CONSOLIDATION_MODE_LOCK_ID)
 
         while True:
             try:
                 self._become_leader_and_run()
-            except SystemExit:
-                # _become_leader_and_run uses os.kill(SIGTERM) — let the
-                # process tear down without an outer retry.
+            except (SystemExit, KeyboardInterrupt):
                 raise
-            except Exception:  # pylint: disable=broad-except
+            except Exception as e:  # pylint: disable=broad-except
                 logger.exception(
-                    'managed-job refresh thread crashed outside the inner '
-                    f'loop; retrying in {_ACQUIRE_RETRY_INTERVAL_SECONDS}s')
+                    f'managed-job refresh error: {e}, '
+                    f'retrying in {_ACQUIRE_RETRY_INTERVAL_SECONDS}s')
                 time.sleep(_ACQUIRE_RETRY_INTERVAL_SECONDS)
 
-    # ------------------------------------------------------------------ #
-    # Leader path: acquire lock, run recovery, then loop event ticks
-    # ------------------------------------------------------------------ #
 
     def _become_leader_and_run(self) -> None:
         # pylint: disable=import-outside-toplevel
-        from sky.jobs import utils as managed_job_utils
-        from sky.skylet import events
 
         assert self._lock is not None
 
@@ -174,30 +99,20 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
                 logger.exception('ManagedJobEvent tick failed; will retry')
             time.sleep(events.EVENT_CHECKING_INTERVAL_SECONDS)
 
-    # ------------------------------------------------------------------ #
-    # Lock liveness
-    # ------------------------------------------------------------------ #
-
     def _lock_still_held(self) -> bool:
         """True iff we are confident this replica still owns the lock."""
         assert self._lock is not None
         if isinstance(self._lock, locks.PostgresLock):
+            # Check is only relevant for PG lock
             return self._lock.is_session_alive()
-        # FileLock and any other DistributedLock implementation: the
-        # "session" concept doesn't apply (the lock is grounded in the
-        # filesystem, which doesn't suffer silent loss the way a TCP
-        # session does).  Trust the local flag.
-        return self._lock.is_locked()
+        return True
 
     def _suicide_on_lock_loss(self) -> None:
         """SIGTERM the API server process so the pod can restart cleanly."""
         logger.error(
             f'Lost consolidation mode lock {self._lock}; sending SIGTERM '
-            'to the API server so the pod can be restarted and the '
-            'leader re-elected on a sibling replica.')
-        # SIGTERM rather than os._exit so uvicorn's lifespan shutdown
-        # runs (atexit handlers, log flush, etc.).  K8s will restart
-        # the container regardless.
+            'to the API server to step down')
+        # SIGTERM to trigger graceful shutdown
         os.kill(os.getpid(), signal.SIGTERM)
 
 
@@ -207,8 +122,6 @@ def start_managed_job_refresh_daemon() -> None:
     No-op when consolidation mode is off — mirrors the gating that the
     historical ``should_skip_managed_job_status_refresh`` provided.
     """
-    # pylint: disable=import-outside-toplevel
-    from sky.jobs import utils as managed_job_utils
     if not managed_job_utils.is_consolidation_mode():
         logger.debug('Consolidation mode is off; not starting the managed-job '
                      'refresh thread.')

--- a/sky/jobs/managed_job_refresh_thread.py
+++ b/sky/jobs/managed_job_refresh_thread.py
@@ -8,10 +8,10 @@ import typing
 from typing import Optional
 
 from sky import sky_logging
-from sky.skylet import constants
-from sky.utils import locks
 from sky.jobs import utils as managed_job_utils
+from sky.skylet import constants
 from sky.skylet import events
+from sky.utils import locks
 
 if typing.TYPE_CHECKING:
     pass
@@ -49,29 +49,31 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
                 logger.exception(
                     f'managed-job refresh error: {e}, '
                     f'retrying in {_ACQUIRE_RETRY_INTERVAL_SECONDS}s')
+                # If we previously held the lock and lost the session
+                # mid-recovery, retrying would run as a stale leader
+                # (local `_acquired` flag still True, server-side lock
+                # released, another replica can grab it).  Hand off via
+                # SIGTERM, same as the steady-state probe path.
+                if self._lock.is_locked() and not self._lock_still_held():
+                    self._suicide_on_lock_loss()
+                    return
                 time.sleep(_ACQUIRE_RETRY_INTERVAL_SECONDS)
 
-
     def _become_leader_and_run(self) -> None:
-        # pylint: disable=import-outside-toplevel
-
         assert self._lock is not None
 
-        # Touch the rolling-restart signal file before acquiring the
-        # lock.  Same semantics as the historical event_fn: any peer
-        # checking this file sees "leader handover in progress" until
-        # we've finished recovery.
+        if not self._lock.is_locked():
+            logger.info(f'Acquiring the consolidation mode lock: {self._lock}')
+            self._lock.acquire()
+            logger.info('Consolidation mode lock acquired')
+
+        # Touch signal file only after we hold the lock: standby
+        # replicas blocked on acquire() must not leave it lying around
+        # — update_managed_jobs_statuses early-returns when it exists.
         signal_file = pathlib.Path(
             constants.PERSISTENT_RUN_RESTARTING_SIGNAL_FILE).expanduser()
         signal_file.touch()
         try:
-            if not self._lock.is_locked():
-                logger.info(
-                    f'Acquiring the consolidation mode lock: {self._lock}')
-                self._lock.acquire()
-                logger.info('Consolidation mode lock acquired')
-            # Recovery before any event-loop work: same ordering as the
-            # original ``managed_job_status_refresh_event``.
             managed_job_utils.ha_recovery_for_consolidation_mode()
         finally:
             try:
@@ -79,9 +81,12 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
             except FileNotFoundError:
                 pass
 
-        # Steady-state event loop with periodic lock-liveness probe.
+        # Event-loop tick at events.EVENT_CHECKING_INTERVAL_SECONDS,
+        # lock probe at _LOCK_PROBE_INTERVAL_SECONDS, sleep 1s between.
         refresh_event = events.ManagedJobEvent()
-        last_probe = time.monotonic()
+        now = time.monotonic()
+        last_probe = now
+        last_event = now - events.EVENT_CHECKING_INTERVAL_SECONDS
         while True:
             now = time.monotonic()
             if now - last_probe >= _LOCK_PROBE_INTERVAL_SECONDS:
@@ -89,15 +94,13 @@ class ManagedJobRefreshDaemonThread(threading.Thread):
                     self._suicide_on_lock_loss()
                     return
                 last_probe = now
-            try:
-                logger.debug('=== Running managed job event ===')
-                refresh_event.run()
-            except Exception:  # pylint: disable=broad-except
-                # Tick failures are non-fatal — mirror the old
-                # InternalRequestDaemon.run_event catch-all.  Lock loss
-                # is the only thing that should take the pod down.
-                logger.exception('ManagedJobEvent tick failed; will retry')
-            time.sleep(events.EVENT_CHECKING_INTERVAL_SECONDS)
+            if now - last_event >= events.EVENT_CHECKING_INTERVAL_SECONDS:
+                try:
+                    refresh_event.run()
+                except Exception:  # pylint: disable=broad-except
+                    logger.exception('ManagedJobEvent tick failed; will retry')
+                last_event = now
+            time.sleep(1)
 
     def _lock_still_held(self) -> bool:
         """True iff we are confident this replica still owns the lock."""

--- a/sky/jobs/scheduler.py
+++ b/sky/jobs/scheduler.py
@@ -47,6 +47,7 @@ import contextlib
 import os
 import pathlib
 import shutil
+import signal
 import sys
 import typing
 from typing import List, Optional, Set
@@ -191,6 +192,33 @@ def get_alive_controllers() -> Optional[int]:
         if managed_job_utils.controller_process_alive(record, quiet=False):
             alive += 1
     return alive
+
+
+def kill_local_job_controllers(sig: int = signal.SIGTERM) -> int:
+    """SIGTERM all live controller PIDs recorded on this replica.
+
+    Returns:
+        The number of signals delivered.
+    """
+    records = get_controller_process_records()
+    if not records:
+        return 0
+    signaled = 0
+    for record in records:
+        if not managed_job_utils.controller_process_alive(record):
+            continue
+        try:
+            os.kill(record.pid, sig)
+            signaled += 1
+        except ProcessLookupError:
+            # Already gone between the alive-check and the kill — fine.
+            pass
+        except OSError as e:
+            logger.warning(f'Failed to signal controller pid={record.pid}: {e}')
+    if signaled:
+        logger.info(f'Sent {sig.name if hasattr(sig, "name") else sig} to '
+                    f'{signaled} job controller(s)')
+    return signaled
 
 
 def maybe_start_controllers(from_scheduler: bool = False) -> None:

--- a/sky/server/daemons.py
+++ b/sky/server/daemons.py
@@ -339,12 +339,6 @@ INTERNAL_REQUEST_DAEMONS = [
         id='skypilot-volume-status-refresh-daemon',
         name=request_names.RequestName.REQUEST_DAEMON_VOLUME_REFRESH,
         event_fn=refresh_volume_status_event),
-    # NOTE: managed-job-status-refresh runs as a thread inside the API
-    # server main process (see sky/jobs/managed_job_refresh_thread.py);
-    # it is intentionally absent from this list because routing it through
-    # the executor task queue allows the daemon to drift to a different
-    # replica from the controllers it spawned (cross-replica controller
-    # orphan).  Tying it to main's lifecycle removes that drift.
     InternalRequestDaemon(
         id='sky-serve-status-refresh-daemon',
         name=request_names.RequestName.REQUEST_DAEMON_SKY_SERVE_STATUS_REFRESH,

--- a/sky/server/daemons.py
+++ b/sky/server/daemons.py
@@ -5,12 +5,10 @@ import os
 import shutil
 import sys
 import time
-import typing
 from typing import Callable, Optional
 
 from sky import sky_logging
 from sky import skypilot_config
-from sky.adaptors import common as adaptors_common
 from sky.server import constants as server_constants
 from sky.server.requests import request_names
 from sky.skylet import constants
@@ -21,11 +19,6 @@ from sky.utils import locks
 from sky.utils import subprocess_utils
 from sky.utils import timeline
 from sky.utils import ux_utils
-
-if typing.TYPE_CHECKING:
-    import pathlib
-else:
-    pathlib = adaptors_common.LazyImport('pathlib')
 
 logger = sky_logging.init_logger(__name__)
 
@@ -196,20 +189,12 @@ def refresh_volume_status_event():
     time.sleep(server_constants.VOLUME_REFRESH_DAEMON_INTERVAL_SECONDS)
 
 
-_managed_job_consolidation_mode_lock = None
 _pool_consolidation_mode_lock = None
 _serve_consolidation_mode_lock = None
 
 
 # Attempt to gracefully release the lock when the process exits.
 # If this fails, it's okay, the lock will be released when the process dies.
-def _release_managed_job_consolidation_mode_lock() -> None:
-    global _managed_job_consolidation_mode_lock
-    if _managed_job_consolidation_mode_lock is not None:
-        _managed_job_consolidation_mode_lock.release()
-        _managed_job_consolidation_mode_lock = None
-
-
 def _release_serve_and_pool_consolidation_mode_locks() -> None:
     global _pool_consolidation_mode_lock, _serve_consolidation_mode_lock
     if _pool_consolidation_mode_lock is not None:
@@ -220,72 +205,7 @@ def _release_serve_and_pool_consolidation_mode_locks() -> None:
         _serve_consolidation_mode_lock = None
 
 
-atexit.register(_release_managed_job_consolidation_mode_lock)
 atexit.register(_release_serve_and_pool_consolidation_mode_locks)
-
-
-def managed_job_status_refresh_event():
-    """Refresh the managed job status for controller consolidation mode."""
-    # pylint: disable=import-outside-toplevel
-    from sky.jobs import constants as managed_job_constants
-    from sky.jobs import utils as managed_job_utils
-
-    global _managed_job_consolidation_mode_lock
-    if _managed_job_consolidation_mode_lock is None:
-        _managed_job_consolidation_mode_lock = locks.get_lock(
-            managed_job_constants.CONSOLIDATION_MODE_LOCK_ID)
-
-    # Touch the signal file here to avoid conflict with
-    # update_managed_jobs_statuses. Although we run
-    # ha_recovery_for_consolidation_mode before checking the job statuses
-    # (events.ManagedJobEvent), update_managed_jobs_statuses is also called in
-    # cancel_jobs_by_id.
-    # We also need to make sure that new controllers are not started until we
-    # acquire the consolidation mode lock, since if we have controllers on both
-    # the new and old API server during a rolling update, calling
-    # update_managed_jobs_statuses on the old API server could lead to
-    # FAILED_CONTROLLER.
-    signal_file = pathlib.Path(
-        constants.PERSISTENT_RUN_RESTARTING_SIGNAL_FILE).expanduser()
-    try:
-        signal_file.touch()
-
-        # Make sure the lock is acquired for this process before proceeding to
-        # do recovery. This will block if another API server is still running,
-        # but should proceed once it is terminated and releases the lock.
-        if not _managed_job_consolidation_mode_lock.is_locked():
-            logger.info('Acquiring the consolidation mode lock: '
-                        f'{_managed_job_consolidation_mode_lock}')
-            _managed_job_consolidation_mode_lock.acquire()
-            logger.info('Lock acquired!')
-        # We don't explicitly release the lock until the process exits.
-        # Even if _release_managed_job_consolidation_mode_lock is not called,
-        # the lock should be released when the process dies (either due to the
-        # advisory file lock being released or the postgres session dying).
-
-        # We run the recovery logic before checking the job statuses as those
-        # two are conflicting. Check PERSISTENT_RUN_RESTARTING_SIGNAL_FILE for
-        # details.
-        managed_job_utils.ha_recovery_for_consolidation_mode()
-    finally:
-        # Now, we should be sure that this is the only API server, we have
-        # started the new controllers and unclaimed all the jobs, and we are
-        # ready to update the job statuses.
-        signal_file.unlink()
-
-    # After recovery, we start the event loop.
-    from sky.skylet import events
-    refresh_event = events.ManagedJobEvent()
-    logger.info('=== Running managed job event ===')
-    refresh_event.run()
-    time.sleep(events.EVENT_CHECKING_INTERVAL_SECONDS)
-
-
-def should_skip_managed_job_status_refresh():
-    """Check if the managed job status refresh event should be skipped."""
-    # pylint: disable=import-outside-toplevel
-    from sky.jobs import utils as managed_job_utils
-    return not managed_job_utils.is_consolidation_mode()
 
 
 def _serve_status_refresh_event(pool: bool):
@@ -419,11 +339,12 @@ INTERNAL_REQUEST_DAEMONS = [
         id='skypilot-volume-status-refresh-daemon',
         name=request_names.RequestName.REQUEST_DAEMON_VOLUME_REFRESH,
         event_fn=refresh_volume_status_event),
-    InternalRequestDaemon(id='managed-job-status-refresh-daemon',
-                          name=request_names.RequestName.
-                          REQUEST_DAEMON_MANAGED_JOB_STATUS_REFRESH,
-                          event_fn=managed_job_status_refresh_event,
-                          should_skip=should_skip_managed_job_status_refresh),
+    # NOTE: managed-job-status-refresh runs as a thread inside the API
+    # server main process (see sky/jobs/managed_job_refresh_thread.py);
+    # it is intentionally absent from this list because routing it through
+    # the executor task queue allows the daemon to drift to a different
+    # replica from the controllers it spawned (cross-replica controller
+    # orphan).  Tying it to main's lifecycle removes that drift.
     InternalRequestDaemon(
         id='sky-serve-status-refresh-daemon',
         name=request_names.RequestName.REQUEST_DAEMON_SKY_SERVE_STATUS_REFRESH,

--- a/sky/server/daemons.py
+++ b/sky/server/daemons.py
@@ -208,6 +208,27 @@ def _release_serve_and_pool_consolidation_mode_locks() -> None:
 atexit.register(_release_serve_and_pool_consolidation_mode_locks)
 
 
+# Backward-compatibility no-op stubs for rolling upgrade. Pickled
+# InternalRequestDaemon rows from older server versions reference these
+# symbols via the `event_fn` / `should_skip` attributes, so pickle.loads
+# raises AttributeError without them. Orphan rows are then cleaned up by
+# the request-daemon restart path because no matching
+# INTERNAL_REQUEST_DAEMONS entry exists for the pickled daemon id.
+def managed_job_status_refresh_event():
+    """No-op stub for pickle compatibility with older server versions.
+
+    The managed-job-status refresh now runs in-process as a thread; the
+    daemon-based variant is no longer scheduled. This stub exists only so
+    that old pickled daemon rows can be deserialized and then deleted by
+    the daemon-orphan cleanup path.
+    """
+
+
+def should_skip_managed_job_status_refresh():
+    """No-op stub for pickle compatibility with older server versions."""
+    return True
+
+
 def _serve_status_refresh_event(pool: bool):
     """Refresh the sky serve status for controller consolidation mode."""
     # pylint: disable=import-outside-toplevel

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -429,6 +429,44 @@ def _sigterm_handler(signum: int, frame: Optional['types.FrameType']) -> None:
     raise KeyboardInterrupt
 
 
+# Worker-pool subprocess state. Each ProcessPoolExecutor worker has its own
+# copy of these module-level flags (spawn'd subprocesses are independent
+# processes). They guard the SIGTERM-from-cancel race
+_in_request_execution: bool = False
+_pending_sigterm: bool = False
+
+
+def _gated_sigterm_handler(signum: int,
+                           frame: Optional['types.FrameType']) -> None:
+    """Worker-side SIGTERM handler — only raises while a request is running.
+
+    Cancel paths deliver SIGTERM to a worker by reading the pid stored on
+    a RUNNING request row. Because the pid is a long-lived pool worker
+    PID (workers handle many requests sequentially), a stale RUNNING row
+    can route SIGTERM to a worker that has long since finished that
+    request and moved on, potentially sitting idle in
+    concurrent.futures._process_worker's `call_queue.get(block=True)`.
+    Raising KeyboardInterrupt from there is unhandled — the worker
+    process dies, ProcessPoolExecutor marks the pool BROKEN, and every
+    in-flight future plus subsequent submits fail with
+    BrokenProcessPool.
+
+    Gate raises behind a flag that's set only while
+    _request_execution_wrapper is inside its try block. If SIGTERM
+    arrives outside that window (idle worker, finally cleanup), latch
+    a pending-cancel flag and let the next request-execution check it
+    on entry so the cancel intent is preserved without killing the
+    worker.
+    """
+    del signum, frame
+    global _pending_sigterm  # pylint: disable=global-statement
+    if _in_request_execution:
+        raise KeyboardInterrupt
+    _pending_sigterm = True
+    logger.info('SIGTERM received while worker idle; deferring to '
+                'next request entry to preserve the process pool.')
+
+
 def _request_execution_wrapper(request_id: str,
                                ignore_return_value: bool,
                                num_db_connections_per_worker: int = 0) -> None:
@@ -449,8 +487,14 @@ def _request_execution_wrapper(request_id: str,
     # Handle the SIGTERM signal to abort the request processing gracefully.
     # Only set up signal handlers in the main thread, as signal.signal() raises
     # ValueError if called from a non-main thread (e.g., in tests).
+    #
+    # Use the gated variant: between requests this worker may be idle in
+    # concurrent.futures._process_worker's call_queue.get(); a SIGTERM
+    # there would kill the worker and break the entire pool. The gated
+    # handler only raises KeyboardInterrupt while we are inside the
+    # protected try-block below.
     if threading.current_thread() is threading.main_thread():
-        signal.signal(signal.SIGTERM, _sigterm_handler)
+        signal.signal(signal.SIGTERM, _gated_sigterm_handler)
 
     logger.info(f'Running request {request_id} with pid {pid}')
 
@@ -484,7 +528,18 @@ def _request_execution_wrapper(request_id: str,
             original_stderr = None
 
     request_name = None
+    # Enter the protected region: from here on, the gated SIGTERM handler is
+    # allowed to raise KeyboardInterrupt. If a SIGTERM was deferred while the
+    # worker was idle between requests (see _gated_sigterm_handler), honor it
+    # now by raising immediately — the cancel intent was for whatever request
+    # this worker was/is processing.
+    global _in_request_execution, _pending_sigterm  # pylint: disable=global-statement
+    _in_request_execution = True
+    pending = _pending_sigterm
+    _pending_sigterm = False
     try:
+        if pending:
+            raise KeyboardInterrupt
         # As soon as the request is updated with the executor PID, we can
         # receive SIGTERM from cancellation. So, we update the request inside
         # the try block to ensure we have the KeyboardInterrupt handling.
@@ -572,6 +627,10 @@ def _request_execution_wrapper(request_id: str,
         _restore_output()
         logger.info(f'Request {request_id} finished')
     finally:
+        # Leave the protected region. From here until the next request,
+        # SIGTERM is latched (not raised) so an in-flight cancel can't kill
+        # this worker while it's idle in call_queue.get().
+        _in_request_execution = False
         _restore_output()
         try:
             # Capture the peak RSS before GC.

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -429,42 +429,30 @@ def _sigterm_handler(signum: int, frame: Optional['types.FrameType']) -> None:
     raise KeyboardInterrupt
 
 
-# Worker-pool subprocess state. Each ProcessPoolExecutor worker has its own
-# copy of these module-level flags (spawn'd subprocesses are independent
-# processes). They guard the SIGTERM-from-cancel race
+# Per-worker-process flags consumed by _gated_sigterm_handler.
 _in_request_execution: bool = False
 _pending_sigterm: bool = False
 
 
 def _gated_sigterm_handler(signum: int,
                            frame: Optional['types.FrameType']) -> None:
-    """Worker-side SIGTERM handler — only raises while a request is running.
+    """Raise KeyboardInterrupt only while actively executing a request.
 
-    Cancel paths deliver SIGTERM to a worker by reading the pid stored on
-    a RUNNING request row. Because the pid is a long-lived pool worker
-    PID (workers handle many requests sequentially), a stale RUNNING row
-    can route SIGTERM to a worker that has long since finished that
-    request and moved on, potentially sitting idle in
-    concurrent.futures._process_worker's `call_queue.get(block=True)`.
-    Raising KeyboardInterrupt from there is unhandled — the worker
-    process dies, ProcessPoolExecutor marks the pool BROKEN, and every
-    in-flight future plus subsequent submits fail with
-    BrokenProcessPool.
-
-    Gate raises behind a flag that's set only while
-    _request_execution_wrapper is inside its try block. If SIGTERM
-    arrives outside that window (idle worker, finally cleanup), latch
-    a pending-cancel flag and let the next request-execution check it
-    on entry so the cancel intent is preserved without killing the
-    worker.
+    SIGTERM landing on an idle worker (blocked in
+    concurrent.futures._process_worker's call_queue.get) would escape
+    _process_worker unhandled and break the entire pool. Latch instead
+    and honor at the next wrapper entry.
     """
     del signum, frame
     global _pending_sigterm  # pylint: disable=global-statement
     if _in_request_execution:
         raise KeyboardInterrupt
     _pending_sigterm = True
-    logger.info('SIGTERM received while worker idle; deferring to '
-                'next request entry to preserve the process pool.')
+    # logger isn't async-signal-safe (re-entrant lock); use os.write.
+    try:
+        os.write(2, b'SIGTERM received while worker idle; deferred.\n')
+    except Exception:  # pylint: disable=broad-except
+        pass
 
 
 def _request_execution_wrapper(request_id: str,
@@ -487,12 +475,6 @@ def _request_execution_wrapper(request_id: str,
     # Handle the SIGTERM signal to abort the request processing gracefully.
     # Only set up signal handlers in the main thread, as signal.signal() raises
     # ValueError if called from a non-main thread (e.g., in tests).
-    #
-    # Use the gated variant: between requests this worker may be idle in
-    # concurrent.futures._process_worker's call_queue.get(); a SIGTERM
-    # there would kill the worker and break the entire pool. The gated
-    # handler only raises KeyboardInterrupt while we are inside the
-    # protected try-block below.
     if threading.current_thread() is threading.main_thread():
         signal.signal(signal.SIGTERM, _gated_sigterm_handler)
 
@@ -528,17 +510,15 @@ def _request_execution_wrapper(request_id: str,
             original_stderr = None
 
     request_name = None
-    # Enter the protected region: from here on, the gated SIGTERM handler is
-    # allowed to raise KeyboardInterrupt. If a SIGTERM was deferred while the
-    # worker was idle between requests (see _gated_sigterm_handler), honor it
-    # now by raising immediately — the cancel intent was for whatever request
-    # this worker was/is processing.
+    # Set _in_request_execution inside the try so `finally` always clears it,
+    # even if a SIGTERM lands before any wrapper code runs.
     global _in_request_execution, _pending_sigterm  # pylint: disable=global-statement
-    _in_request_execution = True
-    pending = _pending_sigterm
-    _pending_sigterm = False
     try:
+        _in_request_execution = True
+        pending = _pending_sigterm
+        _pending_sigterm = False
         if pending:
+            logger.info(f'Request {request_id}: honoring deferred SIGTERM.')
             raise KeyboardInterrupt
         # As soon as the request is updated with the executor PID, we can
         # receive SIGTERM from cancellation. So, we update the request inside
@@ -627,9 +607,6 @@ def _request_execution_wrapper(request_id: str,
         _restore_output()
         logger.info(f'Request {request_id} finished')
     finally:
-        # Leave the protected region. From here until the next request,
-        # SIGTERM is latched (not raised) so an in-flight cancel can't kill
-        # this worker while it's idle in call_queue.get().
         _in_request_execution = False
         _restore_output()
         try:

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -179,20 +179,23 @@ class Request:
         }
 
     def set_return_value(self, return_value: Any) -> None:
-        """Set the return value.
+        """Set the encoded return value.
 
-        Encoders may be overridden by plugins. A failure in a plugin encoder
-        must not bubble out of set_return_value. Fall back to the OSS default
-        pickle encoding on any failure.
+        On encoder failure, drop to None. An exception here would escape the
+        wrapper's else-block (outside its try/except) and leave the row stuck
+        in RUNNING with the worker pid populated — enabling the
+        SIGTERM-to-idle-worker pool break. All return-value serializers
+        already guard `if return_value is not None`, so None persists as JSON
+        `null`.
         """
         encoder = encoders.get_encoder(self.name)
         try:
             self.return_value = encoder(return_value)
         except Exception as e:  # pylint: disable=broad-except
-            logger.warning(f'Encoder {encoder!r} for request {self.request_id} '
-                           f'({self.name}) failed, falling back to pickle: '
-                           f'{common_utils.format_exception(e)}')
-            self.return_value = encoders.pickle_and_encode(return_value)
+            logger.warning(
+                f'Encoder for request {self.request_id} ({self.name}) '
+                f'failed; storing None: {common_utils.format_exception(e)}')
+            self.return_value = None
 
     def get_return_value(self) -> Any:
         """Get the return value."""

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -179,8 +179,20 @@ class Request:
         }
 
     def set_return_value(self, return_value: Any) -> None:
-        """Set the return value."""
-        self.return_value = encoders.get_encoder(self.name)(return_value)
+        """Set the return value.
+
+        Encoders may be overridden by plugins. A failure in a plugin encoder
+        must not bubble out of set_return_value. Fall back to the OSS default
+        pickle encoding on any failure.
+        """
+        encoder = encoders.get_encoder(self.name)
+        try:
+            self.return_value = encoder(return_value)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Encoder {encoder!r} for request {self.request_id} '
+                           f'({self.name}) failed, falling back to pickle: '
+                           f'{common_utils.format_exception(e)}')
+            self.return_value = encoders.pickle_and_encode(return_value)
 
     def get_return_value(self) -> Any:
         """Get the return value."""

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -52,6 +52,7 @@ from sky import models
 from sky import sky_logging
 from sky.data import storage_utils
 from sky.jobs import state as managed_job_state
+from sky.jobs import managed_job_refresh_thread
 from sky.jobs import utils as managed_job_utils
 from sky.jobs.server import server as jobs_rest
 from sky.metrics import utils as metrics_utils
@@ -3495,13 +3496,7 @@ if __name__ == '__main__':
 
         # managed-job-status-refresh runs as a thread inside this
         # supervisor process so the leader role and the controller
-        # subprocesses it spawns share a single OS lifecycle.  Routing
-        # this daemon through the executor task queue (as other daemons
-        # do) lets it drift between replicas while the controllers stay
-        # behind, which causes cross-replica controller orphans.  See
-        # sky/jobs/managed_job_refresh_thread.py for details.
-        # pylint: disable=import-outside-toplevel
-        from sky.jobs import managed_job_refresh_thread
+        # subprocesses it spawns share a single OS lifecycle.
         managed_job_refresh_thread.start_managed_job_refresh_daemon()
 
         queue_server, workers = executor.start(config)

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -51,8 +51,8 @@ from sky import global_user_state
 from sky import models
 from sky import sky_logging
 from sky.data import storage_utils
-from sky.jobs import state as managed_job_state
 from sky.jobs import managed_job_refresh_thread
+from sky.jobs import state as managed_job_state
 from sky.jobs import utils as managed_job_utils
 from sky.jobs.server import server as jobs_rest
 from sky.metrics import utils as metrics_utils

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -3493,6 +3493,17 @@ if __name__ == '__main__':
         global_tasks.append(background.create_task(cleanup_download_tmp()))
         threading.Thread(target=background.run_forever, daemon=True).start()
 
+        # managed-job-status-refresh runs as a thread inside this
+        # supervisor process so the leader role and the controller
+        # subprocesses it spawns share a single OS lifecycle.  Routing
+        # this daemon through the executor task queue (as other daemons
+        # do) lets it drift between replicas while the controllers stay
+        # behind, which causes cross-replica controller orphans.  See
+        # sky/jobs/managed_job_refresh_thread.py for details.
+        # pylint: disable=import-outside-toplevel
+        from sky.jobs import managed_job_refresh_thread
+        managed_job_refresh_thread.start_managed_job_refresh_daemon()
+
         queue_server, workers = executor.start(config)
 
         logger.info(f'Starting SkyPilot API server, workers={num_workers}')

--- a/sky/utils/locks.py
+++ b/sky/utils/locks.py
@@ -359,7 +359,7 @@ class PostgresLock(DistributedLock):
         a daemon/leader process, not just one transaction) need a way to
         detect that the underlying session has been killed without an
         exception propagating into their code path: RDS maintenance restarts,
-        NLB / load-balancer idle-timeout, ``idle_in_transaction_session_timeout``,
+        NLB idle-timeout, ``idle_in_transaction_session_timeout``,
         manual ``pg_terminate_backend``, network partitions.  All of these
         free the advisory lock server-side while ``self._acquired`` stays
         ``True`` locally, leaving the holder unaware that another replica

--- a/sky/utils/locks.py
+++ b/sky/utils/locks.py
@@ -352,6 +352,40 @@ class PostgresLock(DistributedLock):
         """Check if the postgres advisory lock is acquired."""
         return self._acquired
 
+    def is_session_alive(self) -> bool:
+        """Return True if the underlying PG session can still run queries.
+
+        Callers that hold a long-lived advisory lock (held for the lifetime of
+        a daemon/leader process, not just one transaction) need a way to
+        detect that the underlying session has been killed without an
+        exception propagating into their code path: RDS maintenance restarts,
+        NLB / load-balancer idle-timeout, ``idle_in_transaction_session_timeout``,
+        manual ``pg_terminate_backend``, network partitions.  All of these
+        free the advisory lock server-side while ``self._acquired`` stays
+        ``True`` locally, leaving the holder unaware that another replica
+        could now hold the same lock.
+
+        This method exposes a cheap ``SELECT 1`` probe on the very connection
+        that holds the lock so the holder can detect the loss and react
+        (typically by exiting and letting the orchestrator restart it).
+
+        Returns ``False`` if the lock was never acquired, if the connection
+        is missing, or if the probe raises any exception.  Returns ``True``
+        only when the probe succeeds.
+        """
+        if not self._acquired or self._connection is None:
+            return False
+        try:
+            cursor = self._connection.cursor()
+            try:
+                cursor.execute('SELECT 1')
+                cursor.fetchone()
+            finally:
+                cursor.close()
+            return True
+        except Exception:  # pylint: disable=broad-except
+            return False
+
 
 def get_lock(lock_id: str,
              timeout: Optional[float] = None,

--- a/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
+++ b/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
@@ -1,0 +1,96 @@
+"""Unit tests for sky.jobs.managed_job_refresh_thread.
+
+These tests cover the state machine of the leader-elected refresh thread,
+not the full daemon loop:
+
+* ``_lock_still_held`` dispatches correctly between ``PostgresLock``
+  (probes the underlying PG session) and any other ``DistributedLock``
+  (trusts the local ``is_locked`` flag).
+* ``_suicide_on_lock_loss`` sends ``SIGTERM`` to the API server PID so
+  K8s restarts the pod and the leader is re-elected on another replica.
+* ``start_managed_job_refresh_daemon`` gates on consolidation mode,
+  preserving the historical ``should_skip_managed_job_status_refresh``
+  semantics now that the daemon no longer lives in
+  ``INTERNAL_REQUEST_DAEMONS``.
+"""
+import signal
+from unittest import mock
+
+import pytest
+
+from sky.jobs import managed_job_refresh_thread as mjrt
+from sky.utils import locks
+
+
+class TestLockStillHeld:
+    """`_lock_still_held` dispatches on lock type."""
+
+    def test_postgres_lock_session_alive(self):
+        thread = mjrt.ManagedJobRefreshDaemonThread()
+        thread._lock = mock.create_autospec(locks.PostgresLock,
+                                            instance=True,
+                                            spec_set=True)
+        thread._lock.is_session_alive.return_value = True
+        assert thread._lock_still_held() is True
+        thread._lock.is_session_alive.assert_called_once_with()
+
+    def test_postgres_lock_session_dead(self):
+        """Silent PG conn loss: PostgresLock thinks acquired locally but
+        ``is_session_alive`` says otherwise.  Probe must return False so
+        the caller can SIGTERM the process."""
+        thread = mjrt.ManagedJobRefreshDaemonThread()
+        thread._lock = mock.create_autospec(locks.PostgresLock,
+                                            instance=True,
+                                            spec_set=True)
+        thread._lock.is_session_alive.return_value = False
+        assert thread._lock_still_held() is False
+
+    def test_non_postgres_lock_uses_is_locked(self):
+        """Non-PG locks (e.g. FileLock in non-HA deployments) don't have
+        a session concept; trust ``is_locked``."""
+        thread = mjrt.ManagedJobRefreshDaemonThread()
+        thread._lock = mock.create_autospec(locks.FileLock,
+                                            instance=True,
+                                            spec_set=True)
+        thread._lock.is_locked.return_value = True
+        assert thread._lock_still_held() is True
+        thread._lock.is_locked.assert_called_once_with()
+        # Must NOT call any PostgresLock-only method.
+        assert not hasattr(thread._lock, 'is_session_alive') or \
+            not thread._lock.is_session_alive.called
+
+
+class TestSuicideOnLockLoss:
+    """Lock-loss must SIGTERM the current process, not the thread."""
+
+    def test_sends_sigterm_to_current_pid(self):
+        thread = mjrt.ManagedJobRefreshDaemonThread()
+        thread._lock = mock.create_autospec(locks.PostgresLock,
+                                            instance=True,
+                                            spec_set=True)
+        with mock.patch.object(mjrt.os, 'kill') as kill_mock, \
+                mock.patch.object(mjrt.os, 'getpid', return_value=12345):
+            thread._suicide_on_lock_loss()
+        kill_mock.assert_called_once_with(12345, signal.SIGTERM)
+
+
+class TestStart:
+    """`start_managed_job_refresh_daemon` honors consolidation mode."""
+
+    def test_skips_when_consolidation_mode_off(self):
+        with mock.patch.object(mjrt.ManagedJobRefreshDaemonThread,
+                               'start') as start_mock, \
+                mock.patch(
+                    'sky.jobs.utils.is_consolidation_mode',
+                    return_value=False):
+            mjrt.start_managed_job_refresh_daemon()
+        start_mock.assert_not_called()
+
+    def test_starts_when_consolidation_mode_on(self):
+        with mock.patch.object(mjrt.ManagedJobRefreshDaemonThread,
+                               'start') as start_mock, \
+                mock.patch(
+                    'sky.jobs.utils.is_consolidation_mode',
+                    return_value=True):
+            mjrt.start_managed_job_refresh_daemon()
+        start_mock.assert_called_once_with()

--- a/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
+++ b/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
@@ -64,6 +64,95 @@ class TestSuicideOnLockLoss:
                                             instance=True,
                                             spec_set=True)
         with mock.patch.object(mjrt.os, 'kill') as kill_mock, \
+                mock.patch.object(mjrt.os, 'getpid', return_value=12345), \
+                mock.patch.object(mjrt.managed_job_scheduler,
+                                  'kill_local_job_controllers'):
+            thread._suicide_on_lock_loss()
+        kill_mock.assert_called_once_with(12345, signal.SIGTERM)
+
+    def test_kills_local_controllers_before_sigterm(self):
+        """Controllers must be SIGTERMed before the API server SIGTERM —
+        the lock is already released here, so a new leader can schedule
+        within milliseconds. Killing first prevents split-brain."""
+        thread = mjrt.ManagedJobRefreshDaemonThread()
+        thread._lock = mock.create_autospec(locks.PostgresLock,
+                                            instance=True,
+                                            spec_set=True)
+        call_order = []
+        with mock.patch.object(
+                mjrt.managed_job_scheduler,
+                'kill_local_job_controllers',
+                side_effect=lambda: call_order.append('kill_controllers')), \
+                mock.patch.object(
+                    mjrt.os, 'kill',
+                    side_effect=lambda *a, **kw: call_order.append('sigterm')), \
+                mock.patch.object(mjrt.os, 'getpid', return_value=12345):
+            thread._suicide_on_lock_loss()
+        assert call_order == ['kill_controllers', 'sigterm']
+
+    def test_sigterm_still_sent_when_controller_kill_raises(self):
+        """A failure killing controllers must not block the SIGTERM —
+        otherwise the replica would stay up holding nothing useful."""
+        thread = mjrt.ManagedJobRefreshDaemonThread()
+        thread._lock = mock.create_autospec(locks.PostgresLock,
+                                            instance=True,
+                                            spec_set=True)
+        with mock.patch.object(
+                mjrt.managed_job_scheduler,
+                'kill_local_job_controllers',
+                side_effect=RuntimeError('boom')), \
+                mock.patch.object(mjrt.os, 'kill') as kill_mock, \
+                mock.patch.object(mjrt.os, 'getpid', return_value=12345):
+            thread._suicide_on_lock_loss()
+        kill_mock.assert_called_once_with(12345, signal.SIGTERM)
+
+    def test_touches_recovery_signal_file(self, tmp_path, monkeypatch):
+        """The signal file must be touched BEFORE we kill controllers, so
+        any in-flight submit_jobs racing this path on another worker
+        process short-circuits maybe_start_controllers rather than
+        spawning a new controller that we'd then orphan."""
+        signal_file = tmp_path / 'restart_signal'
+        monkeypatch.setattr(mjrt.constants,
+                            'PERSISTENT_RUN_RESTARTING_SIGNAL_FILE',
+                            str(signal_file))
+
+        thread = mjrt.ManagedJobRefreshDaemonThread()
+        thread._lock = mock.create_autospec(locks.PostgresLock,
+                                            instance=True,
+                                            spec_set=True)
+        order = []
+        with mock.patch.object(
+                mjrt.managed_job_scheduler,
+                'kill_local_job_controllers',
+                side_effect=lambda: order.append('kill')), \
+                mock.patch.object(
+                    mjrt.os, 'kill',
+                    side_effect=lambda *a, **kw: order.append('sigterm')), \
+                mock.patch.object(mjrt.os, 'getpid', return_value=12345):
+            thread._suicide_on_lock_loss()
+
+        assert signal_file.exists()
+        # File must be created BEFORE kill_controllers and SIGTERM,
+        # otherwise a fresh submit_jobs slipped in just before the
+        # kill could still spawn a controller.
+        assert order == ['kill', 'sigterm']
+
+    def test_signal_file_touch_failure_does_not_block_sigterm(
+            self, monkeypatch):
+        """If the FS refuses the touch (read-only, full, etc.), proceed
+        with kill + SIGTERM anyway. Better than blocking shutdown."""
+
+        def boom_touch(self, *args, **kwargs):  # pylint: disable=unused-argument
+            raise OSError('read-only fs')
+
+        thread = mjrt.ManagedJobRefreshDaemonThread()
+        thread._lock = mock.create_autospec(locks.PostgresLock,
+                                            instance=True,
+                                            spec_set=True)
+        with mock.patch.object(mjrt.pathlib.Path, 'touch', boom_touch), \
+                mock.patch.object(mjrt.managed_job_scheduler,
+                                  'kill_local_job_controllers'), \
+                mock.patch.object(mjrt.os, 'kill') as kill_mock, \
                 mock.patch.object(mjrt.os, 'getpid', return_value=12345):
             thread._suicide_on_lock_loss()
         kill_mock.assert_called_once_with(12345, signal.SIGTERM)

--- a/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
+++ b/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
@@ -45,19 +45,14 @@ class TestLockStillHeld:
         thread._lock.is_session_alive.return_value = False
         assert thread._lock_still_held() is False
 
-    def test_non_postgres_lock_uses_is_locked(self):
-        """Non-PG locks (e.g. FileLock in non-HA deployments) don't have
-        a session concept; trust ``is_locked``."""
+    def test_non_postgres_lock_returns_true(self):
+        """Non-PG locks (FileLock in non-HA) have no session concept;
+        _lock_still_held returns True unconditionally."""
         thread = mjrt.ManagedJobRefreshDaemonThread()
         thread._lock = mock.create_autospec(locks.FileLock,
                                             instance=True,
                                             spec_set=True)
-        thread._lock.is_locked.return_value = True
         assert thread._lock_still_held() is True
-        thread._lock.is_locked.assert_called_once_with()
-        # Must NOT call any PostgresLock-only method.
-        assert not hasattr(thread._lock, 'is_session_alive') or \
-            not thread._lock.is_session_alive.called
 
 
 class TestSuicideOnLockLoss:
@@ -72,6 +67,78 @@ class TestSuicideOnLockLoss:
                 mock.patch.object(mjrt.os, 'getpid', return_value=12345):
             thread._suicide_on_lock_loss()
         kill_mock.assert_called_once_with(12345, signal.SIGTERM)
+
+
+class TestOuterLoopExceptionHandling:
+    """When _become_leader_and_run throws, decide between SIGTERM and retry
+    based on whether we previously held a now-dead lock."""
+
+    @staticmethod
+    def _patches(is_locked: bool, session_alive: bool):
+        """run() overwrites self._lock via locks.get_lock; we have to
+        substitute the lock at that boundary instead of post-init."""
+        lock = mock.create_autospec(locks.PostgresLock,
+                                    instance=True,
+                                    spec_set=True)
+        lock.is_locked.return_value = is_locked
+        lock.is_session_alive.return_value = session_alive
+        return mock.patch('sky.utils.locks.get_lock', return_value=lock), lock
+
+    def test_sigterm_when_was_leader_and_session_dead(self):
+        """Acquired the lock, then recovery threw because the underlying
+        PG session died — running again would race the new leader."""
+        thread = mjrt.ManagedJobRefreshDaemonThread()
+        get_lock_p, lock = self._patches(is_locked=True, session_alive=False)
+        with get_lock_p, \
+                mock.patch.object(
+                    mjrt.ManagedJobRefreshDaemonThread,
+                    '_become_leader_and_run',
+                    side_effect=RuntimeError('recovery boom')), \
+                mock.patch.object(
+                    mjrt.ManagedJobRefreshDaemonThread,
+                    '_suicide_on_lock_loss') as suicide, \
+                mock.patch.object(mjrt.time, 'sleep'):
+            thread.run()
+        suicide.assert_called_once()
+
+    def test_retry_when_acquire_threw(self):
+        """acquire() itself failed (e.g. another replica holds the lock,
+        or transient PG hiccup); is_locked stays False, just retry."""
+        thread = mjrt.ManagedJobRefreshDaemonThread()
+        get_lock_p, lock = self._patches(is_locked=False, session_alive=False)
+        with get_lock_p, \
+                mock.patch.object(
+                    mjrt.ManagedJobRefreshDaemonThread,
+                    '_become_leader_and_run',
+                    side_effect=[RuntimeError('boom'),
+                                 RuntimeError('boom'),
+                                 SystemExit()]), \
+                mock.patch.object(
+                    mjrt.ManagedJobRefreshDaemonThread,
+                    '_suicide_on_lock_loss') as suicide, \
+                mock.patch.object(mjrt.time, 'sleep'):
+            with pytest.raises(SystemExit):
+                thread.run()
+        suicide.assert_not_called()
+
+    def test_retry_when_lock_still_held(self):
+        """Recovery threw on transient error but our lock session is
+        still alive — keep retrying as leader."""
+        thread = mjrt.ManagedJobRefreshDaemonThread()
+        get_lock_p, lock = self._patches(is_locked=True, session_alive=True)
+        with get_lock_p, \
+                mock.patch.object(
+                    mjrt.ManagedJobRefreshDaemonThread,
+                    '_become_leader_and_run',
+                    side_effect=[RuntimeError('boom'),
+                                 SystemExit()]), \
+                mock.patch.object(
+                    mjrt.ManagedJobRefreshDaemonThread,
+                    '_suicide_on_lock_loss') as suicide, \
+                mock.patch.object(mjrt.time, 'sleep'):
+            with pytest.raises(SystemExit):
+                thread.run()
+        suicide.assert_not_called()
 
 
 class TestStart:

--- a/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
+++ b/tests/unit_tests/test_sky/jobs/test_managed_job_refresh_thread.py
@@ -158,6 +158,41 @@ class TestSuicideOnLockLoss:
         kill_mock.assert_called_once_with(12345, signal.SIGTERM)
 
 
+class TestOuterLoopStopsAfterSuicide:
+    """Normal return from _become_leader_and_run only happens after the
+    inner loop's probe detected lock loss and called _suicide_on_lock_loss.
+    The outer run() loop must stop the thread instead of re-entering —
+    otherwise the next iteration would skip the lock acquire (the local
+    _acquired flag is stale) and run ha_recovery_for_consolidation_mode,
+    which would spawn fresh controllers under a now-released lock while
+    the new leader on another replica is doing the same.
+    """
+
+    def test_run_returns_after_become_leader_returns_normally(self):
+        thread = mjrt.ManagedJobRefreshDaemonThread()
+        lock = mock.create_autospec(locks.PostgresLock,
+                                    instance=True,
+                                    spec_set=True)
+        # If the outer loop incorrectly iterates, _become_leader_and_run
+        # would be called more than once. Use a side_effect that fails
+        # the test if that happens.
+        call_count = {'n': 0}
+
+        def normal_return(self):
+            call_count['n'] += 1
+
+        with mock.patch('sky.utils.locks.get_lock', return_value=lock), \
+                mock.patch.object(
+                    mjrt.ManagedJobRefreshDaemonThread,
+                    '_become_leader_and_run',
+                    normal_return), \
+                mock.patch.object(mjrt.time, 'sleep'):
+            thread.run()
+        assert call_count['n'] == 1, (
+            'run() must not re-enter _become_leader_and_run after a '
+            'normal return — that path can only follow a suicide.')
+
+
 class TestOuterLoopExceptionHandling:
     """When _become_leader_and_run throws, decide between SIGTERM and retry
     based on whether we previously held a now-dead lock."""

--- a/tests/unit_tests/test_sky/jobs/test_scheduler.py
+++ b/tests/unit_tests/test_sky/jobs/test_scheduler.py
@@ -1,0 +1,112 @@
+"""Unit tests for sky.jobs.scheduler.kill_local_job_controllers.
+
+Used during shutdown (lock-loss suicide and uvicorn graceful shutdown) to
+prevent split-brain: this replica's controllers must not outlive the
+moment another replica's refresh daemon could acquire the consolidation
+lock. The helper must be best-effort — it runs on shutdown paths where
+raising would either prevent SIGTERM or stall drain.
+"""
+import signal
+from unittest import mock
+
+from sky.jobs import scheduler
+from sky.jobs import state as managed_job_state
+
+
+def _record(pid: int, started_at: float = 0.0):
+    return managed_job_state.ControllerPidRecord(pid=pid, started_at=started_at)
+
+
+class TestKillLocalConsolidationControllers:
+
+    def test_no_pid_file_returns_zero(self):
+        with mock.patch.object(scheduler,
+                               'get_controller_process_records',
+                               return_value=[]):
+            assert scheduler.kill_local_job_controllers() == 0
+
+    def test_records_none_returns_zero(self):
+        """Helper must tolerate the PID-file read failing (returns None)."""
+        with mock.patch.object(scheduler,
+                               'get_controller_process_records',
+                               return_value=None):
+            assert scheduler.kill_local_job_controllers() == 0
+
+    def test_signals_live_records(self):
+        recs = [_record(101), _record(202), _record(303)]
+        with mock.patch.object(scheduler,
+                               'get_controller_process_records',
+                               return_value=recs), \
+                mock.patch.object(scheduler.managed_job_utils,
+                                  'controller_process_alive',
+                                  return_value=True), \
+                mock.patch.object(scheduler.os, 'kill') as kill_mock:
+            n = scheduler.kill_local_job_controllers()
+        assert n == 3
+        kill_mock.assert_has_calls([
+            mock.call(101, signal.SIGTERM),
+            mock.call(202, signal.SIGTERM),
+            mock.call(303, signal.SIGTERM)
+        ],
+                                   any_order=True)
+
+    def test_skips_dead_records(self):
+        """Stale entries (process exited or wrong started_at) are skipped —
+        otherwise we'd SIGTERM unrelated PIDs that the OS reused."""
+        recs = [_record(101), _record(202)]
+        alive_lookup = {101: True, 202: False}
+        with mock.patch.object(scheduler,
+                               'get_controller_process_records',
+                               return_value=recs), \
+                mock.patch.object(
+                    scheduler.managed_job_utils,
+                    'controller_process_alive',
+                    side_effect=lambda r: alive_lookup[r.pid]), \
+                mock.patch.object(scheduler.os, 'kill') as kill_mock:
+            n = scheduler.kill_local_job_controllers()
+        assert n == 1
+        kill_mock.assert_called_once_with(101, signal.SIGTERM)
+
+    def test_tolerates_process_lookup_error(self):
+        """Race between alive-check and kill: the PID died in between.
+        Not counted as signaled, but doesn't abort the loop."""
+        recs = [_record(101), _record(202)]
+        with mock.patch.object(scheduler,
+                               'get_controller_process_records',
+                               return_value=recs), \
+                mock.patch.object(scheduler.managed_job_utils,
+                                  'controller_process_alive',
+                                  return_value=True), \
+                mock.patch.object(
+                    scheduler.os, 'kill',
+                    side_effect=[ProcessLookupError(), None]) as kill_mock:
+            n = scheduler.kill_local_job_controllers()
+        assert n == 1  # Only the second succeeded.
+        assert kill_mock.call_count == 2
+
+    def test_continues_on_oserror(self):
+        """Per-PID OSError (e.g. EPERM) must not stop the rest."""
+        recs = [_record(101), _record(202)]
+        with mock.patch.object(scheduler,
+                               'get_controller_process_records',
+                               return_value=recs), \
+                mock.patch.object(scheduler.managed_job_utils,
+                                  'controller_process_alive',
+                                  return_value=True), \
+                mock.patch.object(
+                    scheduler.os, 'kill',
+                    side_effect=[OSError('EPERM'), None]):
+            n = scheduler.kill_local_job_controllers()
+        assert n == 1
+
+    def test_custom_signal(self):
+        recs = [_record(101)]
+        with mock.patch.object(scheduler,
+                               'get_controller_process_records',
+                               return_value=recs), \
+                mock.patch.object(scheduler.managed_job_utils,
+                                  'controller_process_alive',
+                                  return_value=True), \
+                mock.patch.object(scheduler.os, 'kill') as kill_mock:
+            scheduler.kill_local_job_controllers(sig=signal.SIGKILL)
+        kill_mock.assert_called_once_with(101, signal.SIGKILL)

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -696,3 +696,212 @@ def test_resolve_blob_missing_file(tmp_path, monkeypatch):
     from sky.server import common as server_common
     with pytest.raises(FileNotFoundError, match='Blob not found'):
         server_common.resolve_blob_dir(blob_id, 'testuser')
+
+
+# ---------------------------------------------------------------------------
+# Gated SIGTERM handler tests.
+#
+# Background. A cancel sends SIGTERM by reading the pid stored on a RUNNING
+# request row. The pid is a long-lived ProcessPoolExecutor worker PID, so a
+# stale RUNNING row (e.g. one whose wrapper exited without writing a terminal
+# status, or one cancelled cross-replica while the row state didn't catch up)
+# can route SIGTERM to a worker that is now sitting idle inside
+# concurrent.futures._process_worker's `call_queue.get(block=True)`. Raising
+# KeyboardInterrupt from that frame is unhandled — the worker dies,
+# ProcessPoolExecutor marks the whole pool BROKEN, and every in-flight future
+# plus subsequent submits fail with BrokenProcessPool.
+#
+# The gated handler raises KI only while the worker is inside the
+# wrapper's protected region (_in_request_execution=True). When idle, it
+# latches a pending flag instead so the next request's wrapper entry honors
+# the cancel intent without killing the worker.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def reset_sigterm_gate():
+    """Reset the gated-handler module flags around each test.
+
+    These are module-level and shared across tests in the same process.
+    """
+    import signal as _signal
+    original_handler = _signal.getsignal(_signal.SIGTERM)
+    executor._in_request_execution = False
+    executor._pending_sigterm = False
+    yield
+    executor._in_request_execution = False
+    executor._pending_sigterm = False
+    _signal.signal(_signal.SIGTERM, original_handler)
+
+
+def test_gated_sigterm_handler_raises_when_active(reset_sigterm_gate):
+    """SIGTERM during request execution → KeyboardInterrupt, no latch."""
+    import signal as _signal
+    executor._in_request_execution = True
+    with pytest.raises(KeyboardInterrupt):
+        executor._gated_sigterm_handler(_signal.SIGTERM, None)
+    # Active path doesn't latch — the cancel was delivered as an exception.
+    assert executor._pending_sigterm is False
+
+
+def test_gated_sigterm_handler_latches_when_idle(reset_sigterm_gate):
+    """SIGTERM while idle → no raise, _pending_sigterm latched.
+
+    This is the regression-shaped invariant: if this raised, an idle worker
+    sitting in call_queue.get() would die and break the pool.
+    """
+    import signal as _signal
+    executor._in_request_execution = False
+    executor._pending_sigterm = False
+    # Must not raise.
+    executor._gated_sigterm_handler(_signal.SIGTERM, None)
+    assert executor._pending_sigterm is True
+
+
+@pytest.mark.asyncio
+async def test_wrapper_honors_pending_sigterm_on_entry(isolated_database,
+                                                       reset_sigterm_gate):
+    """A pending SIGTERM latched while idle is honored at the next entry.
+
+    The wrapper raises KeyboardInterrupt before touching the row, the except-
+    block returns, and the latch is cleared. The entrypoint must not run.
+    """
+    _pending_sigterm_entrypoint_called[0] = False
+    req = requests_lib.Request(request_id='pending-sigterm-test',
+                               name='test',
+                               entrypoint=_pending_sigterm_test_entrypoint,
+                               request_body=payloads.RequestBody(),
+                               status=requests_lib.RequestStatus.PENDING,
+                               created_at=0.0,
+                               user_id='test-user')
+    assert await requests_lib.create_if_not_exists_async(req) is True
+
+    executor._in_request_execution = False
+    executor._pending_sigterm = True
+
+    # Wrapper should observe the latch, raise+catch KI, and return cleanly.
+    executor._request_execution_wrapper('pending-sigterm-test',
+                                        ignore_return_value=False)
+
+    assert _pending_sigterm_entrypoint_called[0] is False, (
+        'Entrypoint must not run when SIGTERM is pending')
+    # Latch was consumed.
+    assert executor._pending_sigterm is False
+    # Protected-region flag was cleared in `finally`.
+    assert executor._in_request_execution is False
+
+
+@pytest.mark.asyncio
+async def test_wrapper_clears_in_request_execution_after_success(
+        isolated_database, reset_sigterm_gate):
+    """After a normal request the gate must return to the idle state."""
+
+    req = requests_lib.Request(request_id='gate-cleared-on-success',
+                               name='test',
+                               entrypoint=_gate_clears_after_success_entrypoint,
+                               request_body=payloads.RequestBody(),
+                               status=requests_lib.RequestStatus.PENDING,
+                               created_at=0.0,
+                               user_id='test-user')
+    assert await requests_lib.create_if_not_exists_async(req) is True
+
+    executor._request_execution_wrapper('gate-cleared-on-success',
+                                        ignore_return_value=False)
+
+    # finally must have flipped this back to False so the next SIGTERM
+    # arriving between requests gets latched, not raised.
+    assert executor._in_request_execution is False
+    assert executor._pending_sigterm is False
+
+
+# ---------------------------------------------------------------------------
+# Integration regression: an idle worker hit by SIGTERM must not break the
+# ProcessPoolExecutor it lives in. Without the gated handler, this test
+# reliably fails with BrokenProcessPool.
+# ---------------------------------------------------------------------------
+
+_pending_sigterm_entrypoint_called = [False]
+
+
+def _pending_sigterm_test_entrypoint():
+    _pending_sigterm_entrypoint_called[0] = True
+    return 'should-not-happen'
+
+
+def _gate_clears_after_success_entrypoint():
+    return 'ok'
+
+
+def _install_gated_handler_in_worker():
+    """ProcessPoolExecutor initializer that installs the gated SIGTERM
+    handler in the worker subprocess and leaves _in_request_execution=False,
+    mimicking a worker that has finished a task and is about to block on
+    call_queue.get() for the next one.
+    """
+    import signal as _signal
+
+    from sky.server.requests import executor as _executor
+    _signal.signal(_signal.SIGTERM, _executor._gated_sigterm_handler)
+    _executor._in_request_execution = False
+    _executor._pending_sigterm = False
+
+
+def _worker_pid():
+    return os.getpid()
+
+
+def _identity(x):
+    return x
+
+
+def test_idle_worker_survives_sigterm_with_gated_handler():
+    """Regression: SIGTERM to an idle worker must not break the pool.
+
+    Reproduces the production observation where a cancel-all's SIGTERM
+    landed on a worker that was already done with the row recorded as
+    its pid, taking down the entire SHORT/LONG process pool with
+    BrokenProcessPool. With the gated handler installed in the worker
+    initializer, the signal is latched instead of raised, the worker
+    keeps running, and subsequent submits succeed normally.
+
+    Without the gated handler (i.e. using the bare _sigterm_handler that
+    always raises KeyboardInterrupt), the second submit below would
+    raise concurrent.futures.process.BrokenProcessPool.
+    """
+    import signal as _signal
+    with concurrent.futures.ProcessPoolExecutor(
+            max_workers=2,
+            initializer=_install_gated_handler_in_worker) as pool:
+        # Warm up a worker and capture its pid.
+        pid = pool.submit(_worker_pid).result(timeout=10)
+
+        # The worker has returned its result and is now blocking on
+        # call_queue.get() waiting for the next task. Hit it with the
+        # SIGTERM that the cancel path would deliver.
+        os.kill(pid, _signal.SIGTERM)
+
+        # Give the signal time to be delivered. We don't have a reliable
+        # synchronization handle for "signal handled by worker", so
+        # poll-submit a few times — under the bug, the very first
+        # post-SIGTERM submit raises BrokenProcessPool.
+        deadline = time.time() + 5
+        last_exc = None
+        while time.time() < deadline:
+            try:
+                result = pool.submit(_identity, 'alive').result(timeout=5)
+                assert result == 'alive'
+                last_exc = None
+                break
+            except concurrent.futures.process.BrokenProcessPool as e:
+                last_exc = e
+                break  # Bug reproduces — fail fast, don't retry.
+            except Exception as e:  # pylint: disable=broad-except
+                last_exc = e
+                time.sleep(0.1)
+        assert last_exc is None, (
+            f'Pool should remain usable after SIGTERM to an idle worker, '
+            f'but got: {type(last_exc).__name__}: {last_exc}')
+
+        # Submit a few more to convince ourselves the pool is healthy.
+        for i in range(3):
+            assert pool.submit(_identity, i).result(timeout=5) == i

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -698,32 +698,12 @@ def test_resolve_blob_missing_file(tmp_path, monkeypatch):
         server_common.resolve_blob_dir(blob_id, 'testuser')
 
 
-# ---------------------------------------------------------------------------
 # Gated SIGTERM handler tests.
-#
-# Background. A cancel sends SIGTERM by reading the pid stored on a RUNNING
-# request row. The pid is a long-lived ProcessPoolExecutor worker PID, so a
-# stale RUNNING row (e.g. one whose wrapper exited without writing a terminal
-# status, or one cancelled cross-replica while the row state didn't catch up)
-# can route SIGTERM to a worker that is now sitting idle inside
-# concurrent.futures._process_worker's `call_queue.get(block=True)`. Raising
-# KeyboardInterrupt from that frame is unhandled — the worker dies,
-# ProcessPoolExecutor marks the whole pool BROKEN, and every in-flight future
-# plus subsequent submits fail with BrokenProcessPool.
-#
-# The gated handler raises KI only while the worker is inside the
-# wrapper's protected region (_in_request_execution=True). When idle, it
-# latches a pending flag instead so the next request's wrapper entry honors
-# the cancel intent without killing the worker.
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture()
 def reset_sigterm_gate():
-    """Reset the gated-handler module flags around each test.
-
-    These are module-level and shared across tests in the same process.
-    """
+    """Reset module-level flags (shared across tests in same process)."""
     import signal as _signal
     original_handler = _signal.getsignal(_signal.SIGTERM)
     executor._in_request_execution = False
@@ -735,25 +715,17 @@ def reset_sigterm_gate():
 
 
 def test_gated_sigterm_handler_raises_when_active(reset_sigterm_gate):
-    """SIGTERM during request execution → KeyboardInterrupt, no latch."""
     import signal as _signal
     executor._in_request_execution = True
     with pytest.raises(KeyboardInterrupt):
         executor._gated_sigterm_handler(_signal.SIGTERM, None)
-    # Active path doesn't latch — the cancel was delivered as an exception.
     assert executor._pending_sigterm is False
 
 
 def test_gated_sigterm_handler_latches_when_idle(reset_sigterm_gate):
-    """SIGTERM while idle → no raise, _pending_sigterm latched.
-
-    This is the regression-shaped invariant: if this raised, an idle worker
-    sitting in call_queue.get() would die and break the pool.
-    """
     import signal as _signal
     executor._in_request_execution = False
     executor._pending_sigterm = False
-    # Must not raise.
     executor._gated_sigterm_handler(_signal.SIGTERM, None)
     assert executor._pending_sigterm is True
 
@@ -761,11 +733,6 @@ def test_gated_sigterm_handler_latches_when_idle(reset_sigterm_gate):
 @pytest.mark.asyncio
 async def test_wrapper_honors_pending_sigterm_on_entry(isolated_database,
                                                        reset_sigterm_gate):
-    """A pending SIGTERM latched while idle is honored at the next entry.
-
-    The wrapper raises KeyboardInterrupt before touching the row, the except-
-    block returns, and the latch is cleared. The entrypoint must not run.
-    """
     _pending_sigterm_entrypoint_called[0] = False
     req = requests_lib.Request(request_id='pending-sigterm-test',
                                name='test',
@@ -779,23 +746,17 @@ async def test_wrapper_honors_pending_sigterm_on_entry(isolated_database,
     executor._in_request_execution = False
     executor._pending_sigterm = True
 
-    # Wrapper should observe the latch, raise+catch KI, and return cleanly.
     executor._request_execution_wrapper('pending-sigterm-test',
                                         ignore_return_value=False)
 
-    assert _pending_sigterm_entrypoint_called[0] is False, (
-        'Entrypoint must not run when SIGTERM is pending')
-    # Latch was consumed.
+    assert _pending_sigterm_entrypoint_called[0] is False
     assert executor._pending_sigterm is False
-    # Protected-region flag was cleared in `finally`.
     assert executor._in_request_execution is False
 
 
 @pytest.mark.asyncio
 async def test_wrapper_clears_in_request_execution_after_success(
         isolated_database, reset_sigterm_gate):
-    """After a normal request the gate must return to the idle state."""
-
     req = requests_lib.Request(request_id='gate-cleared-on-success',
                                name='test',
                                entrypoint=_gate_clears_after_success_entrypoint,
@@ -808,17 +769,9 @@ async def test_wrapper_clears_in_request_execution_after_success(
     executor._request_execution_wrapper('gate-cleared-on-success',
                                         ignore_return_value=False)
 
-    # finally must have flipped this back to False so the next SIGTERM
-    # arriving between requests gets latched, not raised.
     assert executor._in_request_execution is False
     assert executor._pending_sigterm is False
 
-
-# ---------------------------------------------------------------------------
-# Integration regression: an idle worker hit by SIGTERM must not break the
-# ProcessPoolExecutor it lives in. Without the gated handler, this test
-# reliably fails with BrokenProcessPool.
-# ---------------------------------------------------------------------------
 
 _pending_sigterm_entrypoint_called = [False]
 
@@ -833,11 +786,6 @@ def _gate_clears_after_success_entrypoint():
 
 
 def _install_gated_handler_in_worker():
-    """ProcessPoolExecutor initializer that installs the gated SIGTERM
-    handler in the worker subprocess and leaves _in_request_execution=False,
-    mimicking a worker that has finished a task and is about to block on
-    call_queue.get() for the next one.
-    """
     import signal as _signal
 
     from sky.server.requests import executor as _executor
@@ -857,33 +805,17 @@ def _identity(x):
 def test_idle_worker_survives_sigterm_with_gated_handler():
     """Regression: SIGTERM to an idle worker must not break the pool.
 
-    Reproduces the production observation where a cancel-all's SIGTERM
-    landed on a worker that was already done with the row recorded as
-    its pid, taking down the entire SHORT/LONG process pool with
-    BrokenProcessPool. With the gated handler installed in the worker
-    initializer, the signal is latched instead of raised, the worker
-    keeps running, and subsequent submits succeed normally.
-
-    Without the gated handler (i.e. using the bare _sigterm_handler that
-    always raises KeyboardInterrupt), the second submit below would
-    raise concurrent.futures.process.BrokenProcessPool.
+    With the bare _sigterm_handler (always raises KI), the post-SIGTERM
+    submit below fails with BrokenProcessPool.
     """
     import signal as _signal
     with concurrent.futures.ProcessPoolExecutor(
             max_workers=2,
             initializer=_install_gated_handler_in_worker) as pool:
-        # Warm up a worker and capture its pid.
         pid = pool.submit(_worker_pid).result(timeout=10)
-
-        # The worker has returned its result and is now blocking on
-        # call_queue.get() waiting for the next task. Hit it with the
-        # SIGTERM that the cancel path would deliver.
         os.kill(pid, _signal.SIGTERM)
 
-        # Give the signal time to be delivered. We don't have a reliable
-        # synchronization handle for "signal handled by worker", so
-        # poll-submit a few times — under the bug, the very first
-        # post-SIGTERM submit raises BrokenProcessPool.
+        # Poll-submit until signal delivers; bug surfaces on first attempt.
         deadline = time.time() + 5
         last_exc = None
         while time.time() < deadline:
@@ -894,7 +826,7 @@ def test_idle_worker_survives_sigterm_with_gated_handler():
                 break
             except concurrent.futures.process.BrokenProcessPool as e:
                 last_exc = e
-                break  # Bug reproduces — fail fast, don't retry.
+                break
             except Exception as e:  # pylint: disable=broad-except
                 last_exc = e
                 time.sleep(0.1)
@@ -902,6 +834,5 @@ def test_idle_worker_survives_sigterm_with_gated_handler():
             f'Pool should remain usable after SIGTERM to an idle worker, '
             f'but got: {type(last_exc).__name__}: {last_exc}')
 
-        # Submit a few more to convince ourselves the pool is healthy.
         for i in range(3):
             assert pool.submit(_identity, i).result(timeout=5) == i

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -1838,3 +1838,28 @@ async def test_get_requests_with_prefix(isolated_database, test_async):
         assert req.finished_at is None
         assert req.should_retry is False
         assert req.status_msg is None
+
+
+def _raising_encoder(value):
+    raise RuntimeError('encoder boom')
+
+
+def _dummy_for_encoder_test():
+    return None
+
+
+def test_set_return_value_swallows_encoder_failure():
+    """Encoder failure must not propagate; return_value drops to None."""
+    req = requests.Request(
+        request_id='encoder-failure',
+        name='test',
+        entrypoint=_dummy_for_encoder_test,
+        request_body=payloads.RequestBody(),
+        status=RequestStatus.RUNNING,
+        created_at=0.0,
+        user_id='u',
+    )
+    with mock.patch('sky.server.requests.serializers.encoders.get_encoder',
+                    return_value=_raising_encoder):
+        req.set_return_value({'some': 'unencodable'})
+    assert req.return_value is None

--- a/tests/unit_tests/test_sky/utils/test_locks.py
+++ b/tests/unit_tests/test_sky/utils/test_locks.py
@@ -533,6 +533,45 @@ class TestPostgresLock:
 
         assert 'shared' in str(exc_info.value).lower()
 
+    def test_is_session_alive_not_acquired(self):
+        """is_session_alive returns False if the lock was never acquired."""
+        lock = locks.PostgresLock('test_lock')
+        assert lock.is_session_alive() is False
+
+    def test_is_session_alive_no_connection(self):
+        """is_session_alive returns False if the conn handle is missing."""
+        lock = locks.PostgresLock('test_lock')
+        lock._acquired = True
+        lock._connection = None
+        assert lock.is_session_alive() is False
+
+    def test_is_session_alive_success(self, mock_connection):
+        """is_session_alive returns True when SELECT 1 succeeds."""
+        connection, cursor = mock_connection
+        cursor.fetchone.return_value = [1]
+        lock = locks.PostgresLock('test_lock')
+        lock._acquired = True
+        lock._connection = connection
+        assert lock.is_session_alive() is True
+        cursor.execute.assert_called_with('SELECT 1')
+        cursor.close.assert_called_once()
+
+    def test_is_session_alive_probe_raises(self, mock_connection):
+        """is_session_alive returns False on any probe exception.
+
+        This is the silent-conn-loss path the daemon thread relies on:
+        the lock thinks it still has the PG session locally, but the
+        server-side session is gone (idle timeout, RDS restart,
+        pg_terminate_backend, network partition).  The next SELECT 1
+        surfaces the failure.
+        """
+        connection, cursor = mock_connection
+        cursor.execute.side_effect = Exception('connection lost')
+        lock = locks.PostgresLock('test_lock')
+        lock._acquired = True
+        lock._connection = connection
+        assert lock.is_session_alive() is False
+
     @mock.patch.object(locks.PostgresLock, '_get_connection')
     def test_postgres_lock_shared_non_blocking(self, mock_get_connection,
                                                mock_connection):


### PR DESCRIPTION
## Summary

Bind the managed-job-status-refresh daemon to the API server main process by running it as a thread (started in the supervisor), instead of scheduling it on the shared executor task queue.