### PR TITLE
Fix: security_group_name config fails when ec2:CreateTags is denied

### DIFF
--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -124,8 +124,7 @@ def bootstrap_instances(
                                           [], enable_efa)
                 logger.debug('Default security group created.')
             except exceptions.NoClusterLaunchedError as e:
-                if 'not authorized to perform: ec2:CreateSecurityGroup' in str(
-                        e):
+                if 'UnauthorizedOperation' in str(e):
                     # User does not have permission to create the default
                     # security group.
                     logger.debug('User does not have permission to create '


### PR DESCRIPTION
Bug: When using a custom security group, SkyPilot attempts to create the default SG and hits an ec2:CreateTags error, but the error handler only checks for ec2:CreateSecurityGroup. Root cause: The exception message changed in 0.12.x because TagSpecifications was added to CreateSecurityGroup. The error handler fell through and crashed the launch. Why fix is correct: Checking for UnauthorizedOperation gracefully ignores both CreateSecurityGroup and CreateTags permission errors as originally intended.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->