### PR TITLE
[Core] Capture Kubernetes state in debug dumps

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -885,6 +885,36 @@ def _catch_to_errors(errors: List[Dict[str, str]], component: str,
         })
 
 
+_DEBUG_DUMP_TMP_ROOT = pathlib.Path('~/.sky/debug_dumps_tmp').expanduser()
+# Best-effort cleanup TTL for per-run controller temp dirs. The caller
+# rsyncs them right after the CodeGen call completes, so a 1h TTL is
+# plenty of safety margin.
+_DEBUG_DUMP_TMP_TTL_SECONDS = 3600
+
+
+def _prepare_debug_dump_tmp_dir() -> pathlib.Path:
+    """Create a fresh per-run temp dir for files we'll rsync to the caller.
+
+    Also best-effort cleans up older dirs so they don't accumulate if a
+    previous run died after writing files but before rsync.
+    """
+    _DEBUG_DUMP_TMP_ROOT.mkdir(parents=True, exist_ok=True)
+    now = time.time()
+    for entry in _DEBUG_DUMP_TMP_ROOT.iterdir():
+        try:
+            if entry.is_dir() and entry.stat().st_mtime < (
+                    now - _DEBUG_DUMP_TMP_TTL_SECONDS):
+                # pylint: disable=import-outside-toplevel
+                import shutil
+                shutil.rmtree(entry, ignore_errors=True)
+        except OSError:
+            pass
+    run_dir = _DEBUG_DUMP_TMP_ROOT / common_utils.get_user_hash()[:8] / str(
+        int(now * 1000))
+    run_dir.mkdir(parents=True, exist_ok=True)
+    return run_dir
+
+
 def collect_debug_dump_manifest(job_ids: List[int]) -> Dict[str, Any]:
     """Collect a debug dump manifest from the controller.
 
@@ -902,6 +932,17 @@ def collect_debug_dump_manifest(job_ids: List[int]) -> Dict[str, Any]:
     file_paths: List[Dict[str, str]] = []
     errors: List[Dict[str, str]] = []
 
+    # Controller-local temp dir for files we want the caller to rsync
+    # (e.g. Kubernetes pod logs). Best-effort created here so an
+    # individual cluster's failure to set it up doesn't block the whole
+    # manifest.
+    try:
+        log_temp_root: Optional[pathlib.Path] = _prepare_debug_dump_tmp_dir()
+    except Exception as e:  # pylint: disable=broad-except
+        log_temp_root = None
+        debug_dump_helpers.append_error(errors, 'managed_jobs',
+                                        'debug_dump_tmp_root', e)
+
     # Collect per-job data in parallel
     with concurrent.futures.ThreadPoolExecutor() as executor:
         results = list(executor.map(_collect_job_debug_manifest, job_ids))
@@ -917,7 +958,8 @@ def collect_debug_dump_manifest(job_ids: List[int]) -> Dict[str, Any]:
             seen_cluster_names.add(cluster_name)
             job_prefix = f'managed_jobs/{job_id}'
             _collect_cluster_debug_manifest(cluster_name, job_prefix,
-                                            inline_data, errors)
+                                            inline_data, file_paths, errors,
+                                            log_temp_root)
 
     # Collect controller system log paths (shared, not per-job)
     _collect_controller_system_log_paths(file_paths, errors)
@@ -1017,11 +1059,13 @@ def _collect_job_debug_manifest(
     return inline_data, file_paths, errors, cluster_name
 
 
-def _collect_cluster_debug_manifest(cluster_name: str, job_prefix: str,
-                                    inline_data: List[Dict[str, str]],
-                                    errors: List[Dict[str, str]]) -> None:
-    """Collect cluster info and events for a managed job's cluster."""
+def _collect_cluster_debug_manifest(
+        cluster_name: str, job_prefix: str, inline_data: List[Dict[str, str]],
+        file_paths: List[Dict[str, str]], errors: List[Dict[str, str]],
+        log_temp_root: Optional[pathlib.Path]) -> None:
+    """Collect cluster info, events, and (when on k8s) pod state."""
     cluster_prefix = f'{job_prefix}/clusters/{cluster_name}'
+    cluster_record: Optional[Dict[str, Any]] = None
 
     with _catch_to_errors(errors, 'managed_jobs',
                           f'{cluster_name}/cluster_info'):
@@ -1036,17 +1080,107 @@ def _collect_cluster_debug_manifest(cluster_name: str, job_prefix: str,
         })
 
         cluster_hash = cluster_record.get('cluster_hash')
-        if not cluster_hash:
-            return
-        for event_data in debug_dump_helpers.get_cluster_events_data(
-                cluster_hash):
+        if cluster_hash:
+            for event_data in debug_dump_helpers.get_cluster_events_data(
+                    cluster_hash):
+                inline_data.append({
+                    'relative_path': f'{cluster_prefix}/'
+                                     f'events_{event_data["event_type"]}.json',
+                    'content': json.dumps(event_data['events'],
+                                          indent=2,
+                                          default=str),
+                })
+
+    if cluster_record is None or log_temp_root is None:
+        return
+
+    # Capture underlying Kubernetes state when the job's cluster is on k8s.
+    access = debug_dump_helpers.get_kubernetes_access(cluster_record)
+    if access is None:
+        return
+    try:
+        result = debug_dump_helpers.collect_kubernetes_state(access)
+    except Exception as e:  # pylint: disable=broad-except
+        debug_dump_helpers.append_error(errors, 'managed_jobs',
+                                        f'{cluster_name}/kubernetes', e)
+        return
+    _add_kubernetes_result_to_manifest(result,
+                                       inline_data=inline_data,
+                                       file_paths=file_paths,
+                                       errors=errors,
+                                       log_temp_root=log_temp_root,
+                                       path_prefix=f'{cluster_prefix}/'
+                                       f'kubernetes',
+                                       resource_prefix=cluster_name)
+
+
+def _add_kubernetes_result_to_manifest(
+        result: debug_dump_helpers.KubernetesDumpResult, *,
+        inline_data: List[Dict[str, str]], file_paths: List[Dict[str, str]],
+        errors: List[Dict[str, str]], log_temp_root: pathlib.Path,
+        path_prefix: str, resource_prefix: str) -> None:
+    """Emit k8s capture into the manifest.
+
+    Pods + events go inline (KB-sized). Logs are written to a controller-
+    local temp dir and added to file_paths for the caller to rsync, since
+    they can collectively exceed what fits through the CodeGen/SSH stdout
+    payload channel.
+    """
+    # Pods (inline).
+    if result.pods:
+        try:
             inline_data.append({
-                'relative_path': f'{cluster_prefix}/'
-                                 f'events_{event_data["event_type"]}.json',
-                'content': json.dumps(event_data['events'],
-                                      indent=2,
-                                      default=str),
+                'relative_path': f'{path_prefix}/pods.json',
+                'content': json.dumps(result.pods, indent=2, default=str),
             })
+        except Exception as e:  # pylint: disable=broad-except
+            debug_dump_helpers.append_error(
+                errors, 'managed_jobs',
+                f'{resource_prefix}/kubernetes/pods.json', e)
+
+    # Events (inline, one file per pod).
+    for pod_name, events in result.events.items():
+        try:
+            inline_data.append({
+                'relative_path': f'{path_prefix}/events/{pod_name}.json',
+                'content': json.dumps(events, indent=2, default=str),
+            })
+        except Exception as e:  # pylint: disable=broad-except
+            debug_dump_helpers.append_error(
+                errors, 'managed_jobs',
+                f'{resource_prefix}/kubernetes/events/{pod_name}', e)
+
+    # Logs (file_paths → rsync).
+    def _emit_logs(log_map: Dict[Tuple[str, str], str], suffix: str) -> None:
+        if not log_map:
+            return
+        for (pod_name, container), log in log_map.items():
+            filename = f'{pod_name}__{container}{suffix}'
+            relative_path = f'{path_prefix}/logs/{filename}'
+            try:
+                local_path = log_temp_root / relative_path
+                local_path.parent.mkdir(parents=True, exist_ok=True)
+                local_path.write_text(log, encoding='utf-8')
+                file_paths.append({
+                    'remote_path': str(local_path),
+                    'relative_path': relative_path,
+                })
+            except Exception as e:  # pylint: disable=broad-except
+                debug_dump_helpers.append_error(
+                    errors, 'managed_jobs',
+                    f'{resource_prefix}/kubernetes/logs/{filename}', e)
+
+    _emit_logs(result.logs, '.log')
+    _emit_logs(result.previous_logs, '.prev.log')
+
+    # Propagate helper-recorded errors.
+    for err in result.errors:
+        errors.append({
+            'component': 'managed_jobs',
+            'resource': f'{resource_prefix}/{err.get("resource", "")}',
+            'error': err.get('error', ''),
+            'traceback': err.get('traceback', ''),
+        })
 
 
 def _collect_controller_system_log_paths(file_paths: List[Dict[str, str]],

--- a/sky/utils/debug_dump_helpers.py
+++ b/sky/utils/debug_dump_helpers.py
@@ -6,13 +6,20 @@ Extracted to avoid a circular import:
   debug_utils -> jobs.server.core -> jobs.utils -> debug_utils
 """
 import copy
+import dataclasses
 import datetime
+import re
+import traceback
 from typing import Any, Dict, List, Optional, Tuple
 
 from sky import global_user_state
+from sky import sky_logging
 from sky import task as task_lib
 from sky.utils import config_utils
+from sky.utils import subprocess_utils
 from sky.utils import yaml_utils
+
+logger = sky_logging.init_logger(__name__)
 
 # Sensitive config paths to redact in debug dumps, following the same
 # pattern as provision/common.py:ProvisionConfig.get_redacted_config().
@@ -20,6 +27,31 @@ _SENSITIVE_CONFIG_KEYS: List[Tuple[str, ...]] = [
     ('api_server', 'endpoint'),
     ('api_server', 'service_account_token'),
 ]
+
+# Env var names whose values should always be redacted in debug dumps.
+# Canonical home is here (not debug_utils) so the controller-side manifest
+# can use the same list without recreating the circular import that this
+# module exists to break.
+SENSITIVE_ENV_VARS = frozenset({
+    'SKYPILOT_DB_CONNECTION_URI',
+    'SKYPILOT_INITIAL_BASIC_AUTH',
+    'SKYPILOT_SERVICE_ACCOUNT_TOKEN',
+    'SKYPILOT_DOCKER_PASSWORD',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN',
+    'AWS_ACCESS_KEY_ID',
+    'AZURE_CLIENT_SECRET',
+})
+
+# Heuristic match for any env-var key likely to carry a secret. Used to
+# catch user-defined keys we can't enumerate ahead of time.
+_SENSITIVE_ENV_KEY_PATTERN = re.compile(
+    r'(?i)(TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL)')
+
+# Label set on every SkyPilot pod by sky/templates/kubernetes-ray.yml.j2 and
+# sky/provision/kubernetes/instance.py. The value is the cluster name on
+# cloud, so this is the right selector for "all pods of this cluster."
+_SKYPILOT_CLUSTER_LABEL = 'skypilot-cluster-name'
 
 
 def redact_config(config: Dict[str, Any]) -> Dict[str, Any]:
@@ -114,6 +146,357 @@ def serialize_cluster_record(cluster_record: Dict[str, Any]) -> Dict[str, Any]:
         'last_event': cluster_record.get('last_event'),
         'handle': handle_info,
     }
+
+
+@dataclasses.dataclass
+class K8sAccess:
+    """How to reach a SkyPilot cluster's pods on Kubernetes."""
+    # None means use in-cluster auth.
+    context: Optional[str]
+    # None means search across all namespaces (used when cluster_yaml is
+    # missing, e.g. during a failover transition).
+    namespace: Optional[str]
+    cluster_name_on_cloud: str
+
+
+@dataclasses.dataclass
+class KubernetesDumpResult:
+    """The data we capture from Kubernetes for one cluster."""
+    # pod name -> sanitized V1Pod dict.
+    pods: Dict[str, Dict[str, Any]] = dataclasses.field(default_factory=dict)
+    # pod name -> list of event dicts (most recent first, capped).
+    events: Dict[str, List[Dict[str,
+                                Any]]] = dataclasses.field(default_factory=dict)
+    # (pod, container) -> log tail.
+    logs: Dict[Tuple[str, str], str] = dataclasses.field(default_factory=dict)
+    # (pod, container) -> previous container instance log tail.
+    previous_logs: Dict[Tuple[str, str],
+                        str] = dataclasses.field(default_factory=dict)
+    errors: List[Dict[str, str]] = dataclasses.field(default_factory=list)
+
+
+def append_error(errors: List[Dict[str, str]], component: str, resource: str,
+                 exc: BaseException) -> None:
+    """Append a structured error entry to a debug-dump errors list.
+
+    Shared between the API-server dump path and the controller-side manifest
+    so both sides record errors in the same shape.
+    """
+    errors.append({
+        'component': component,
+        'resource': resource,
+        'error': str(exc),
+        'traceback': traceback.format_exc(),
+    })
+
+
+def get_kubernetes_access(
+        cluster_record: Dict[str, Any]) -> Optional[K8sAccess]:
+    """Return how to reach the cluster's pods on k8s, or None.
+
+    Pure: no network calls. Safe to invoke for every cluster in the dump,
+    including ones not on Kubernetes.
+    """
+    # pylint: disable=import-outside-toplevel
+    from sky import clouds
+    handle = cluster_record.get('handle')
+    if handle is None:
+        return None
+    launched_resources = getattr(handle, 'launched_resources', None)
+    if launched_resources is None:
+        return None
+    cloud = getattr(launched_resources, 'cloud', None)
+    if not isinstance(cloud, clouds.Kubernetes):
+        return None
+    cluster_name_on_cloud = getattr(handle, 'cluster_name_on_cloud', None)
+    if not cluster_name_on_cloud:
+        return None
+
+    context: Optional[str] = None
+    namespace: Optional[str] = None
+
+    cluster_yaml = getattr(handle, 'cluster_yaml', None)
+    if cluster_yaml is not None:
+        try:
+            yaml_dict = global_user_state.get_cluster_yaml_dict(cluster_yaml)
+            provider_config = yaml_dict.get('provider', {})
+            # pylint: disable=import-outside-toplevel
+            from sky.provision.kubernetes import utils as k8s_utils
+            context = k8s_utils.get_context_from_config(provider_config)
+            namespace = k8s_utils.get_namespace_from_config(provider_config)
+        except Exception as e:  # pylint: disable=broad-except
+            # cluster_yaml might be gone (failover transition) or unreadable;
+            # fall through to the region-as-context fallback below.
+            logger.debug(f'k8s access: cluster_yaml unreadable for '
+                         f'{cluster_record.get("name")!r}: {e}')
+
+    if context is None and namespace is None:
+        # Fall back to the kube context name stored in launched_resources
+        # (set by the v9 state upgrade in cloud_vm_ray_backend.py). Namespace
+        # stays None — the caller will search all namespaces and rely on the
+        # per-cluster label being unique enough.
+        # pylint: disable=import-outside-toplevel
+        from sky.adaptors import kubernetes
+        region = getattr(launched_resources, 'region', None)
+        if region == kubernetes.in_cluster_context_name():
+            context = None
+        else:
+            context = region
+
+    return K8sAccess(context=context,
+                     namespace=namespace,
+                     cluster_name_on_cloud=cluster_name_on_cloud)
+
+
+def _redact_pod_env(pod_dict: Dict[str, Any]) -> None:
+    """Redact sensitive env-var values in-place on a sanitized pod dict.
+
+    Walks containers + init_containers, replacing inline `env[].value` for
+    any key in SENSITIVE_ENV_VARS or matching the heuristic regex. Does not
+    touch `env[].valueFrom` references (those carry only names).
+    """
+    spec = pod_dict.get('spec')
+    if not isinstance(spec, dict):
+        return
+    for key in ('containers', 'initContainers'):
+        containers = spec.get(key)
+        if not isinstance(containers, list):
+            continue
+        for container in containers:
+            if not isinstance(container, dict):
+                continue
+            env = container.get('env')
+            if not isinstance(env, list):
+                continue
+            for entry in env:
+                if not isinstance(entry, dict):
+                    continue
+                name = entry.get('name')
+                if 'value' not in entry or not isinstance(name, str):
+                    continue
+                if (name in SENSITIVE_ENV_VARS or
+                        _SENSITIVE_ENV_KEY_PATTERN.search(name)):
+                    entry['value'] = '<redacted>'
+
+
+def _truncate_log(log: str, log_tail_bytes: int) -> str:
+    encoded = log.encode('utf-8', errors='replace')
+    if len(encoded) <= log_tail_bytes:
+        return log
+    truncated = encoded[-log_tail_bytes:].decode('utf-8', errors='replace')
+    return ('[... truncated, showing last '
+            f'{log_tail_bytes} bytes ...]\n') + truncated
+
+
+def _container_last_terminated(pod_obj: Any, container_name: str) -> bool:
+    """Return True if the named container's last_state shows a terminated
+    instance — i.e. a previous-instance log is likely available."""
+    statuses = []
+    status = getattr(pod_obj, 'status', None)
+    if status is not None:
+        for attr in ('container_statuses', 'init_container_statuses'):
+            v = getattr(status, attr, None)
+            if v:
+                statuses.extend(v)
+    for cs in statuses:
+        if getattr(cs, 'name', None) != container_name:
+            continue
+        last_state = getattr(cs, 'last_state', None)
+        if last_state is None:
+            return False
+        return getattr(last_state, 'terminated', None) is not None
+    return False
+
+
+def collect_kubernetes_state(
+    access: K8sAccess,
+    *,
+    log_tail_lines: int = 5000,
+    log_tail_bytes: int = 1 * 1024 * 1024,
+    max_events: int = 200,
+    log_timeout_seconds: int = 30,
+    max_workers: int = 4,
+) -> KubernetesDumpResult:
+    """Fetch pods, events, and container logs for a SkyPilot k8s cluster.
+
+    Never raises; all failures are recorded in `result.errors`. Network
+    calls happen here, all wrapped in try/except. Per-pod work runs with
+    bounded parallelism to avoid hammering the apiserver.
+    """
+    result = KubernetesDumpResult()
+
+    # Lazy import — keeps this module importable without the kubernetes
+    # extra installed.
+    try:
+        # pylint: disable=import-outside-toplevel
+        from sky.adaptors import kubernetes
+    except Exception as e:  # pylint: disable=broad-except
+        append_error(result.errors, 'clusters/kubernetes', 'import_adaptor', e)
+        return result
+
+    label_selector = f'{_SKYPILOT_CLUSTER_LABEL}={access.cluster_name_on_cloud}'
+
+    # 1. Pod list.
+    try:
+        if access.namespace is None:
+            pod_list = kubernetes.core_api(access.context).\
+                list_pod_for_all_namespaces(
+                    label_selector=label_selector,
+                    _request_timeout=kubernetes.API_TIMEOUT)
+        else:
+            pod_list = kubernetes.core_api(access.context).list_namespaced_pod(
+                access.namespace,
+                label_selector=label_selector,
+                _request_timeout=kubernetes.API_TIMEOUT)
+    except Exception as e:  # pylint: disable=broad-except
+        append_error(result.errors, 'clusters/kubernetes', 'list_pods', e)
+        return result
+
+    pods = list(pod_list.items)
+    if not pods:
+        return result
+
+    # Sanitize + redact pod dicts upfront so we have the JSON form available.
+    try:
+        # pylint: disable=import-outside-toplevel
+        from sky.adaptors import kubernetes as _k
+        sanitizer = _k.api_client(access.context).sanitize_for_serialization
+    except Exception as e:  # pylint: disable=broad-except
+        append_error(result.errors, 'clusters/kubernetes', 'sanitizer', e)
+        sanitizer = None  # type: ignore[assignment]
+
+    # Build a list of work units for parallel fetching.
+    @dataclasses.dataclass
+    class _PodWork:
+        pod_obj: Any
+        pod_name: str
+        namespace: str
+        containers: List[str]
+        init_containers: List[str]
+
+    work: List[_PodWork] = []
+    for pod in pods:
+        pod_name = getattr(getattr(pod, 'metadata', None), 'name', None)
+        pod_ns = (getattr(getattr(pod, 'metadata', None), 'namespace', None) or
+                  access.namespace or 'default')
+        if not pod_name:
+            continue
+        if sanitizer is not None:
+            try:
+                pod_dict = sanitizer(pod)
+                if isinstance(pod_dict, dict):
+                    _redact_pod_env(pod_dict)
+                    result.pods[pod_name] = pod_dict
+            except Exception as e:  # pylint: disable=broad-except
+                append_error(result.errors, 'clusters/kubernetes',
+                             f'sanitize/{pod_name}', e)
+        spec = getattr(pod, 'spec', None)
+        containers = [
+            getattr(c, 'name', None)
+            for c in (getattr(spec, 'containers', None) or [])
+        ]
+        init_containers = [
+            getattr(c, 'name', None)
+            for c in (getattr(spec, 'init_containers', None) or [])
+        ]
+        work.append(
+            _PodWork(pod_obj=pod,
+                     pod_name=pod_name,
+                     namespace=pod_ns,
+                     containers=[c for c in containers if c],
+                     init_containers=[c for c in init_containers if c]))
+
+    api_exception = kubernetes.api_exception()
+
+    def _fetch_events(w: '_PodWork') -> None:
+        try:
+            events = kubernetes.core_api(access.context).list_namespaced_event(
+                w.namespace,
+                field_selector=(f'involvedObject.name={w.pod_name},'
+                                'involvedObject.kind=Pod'),
+                _request_timeout=kubernetes.API_TIMEOUT).items
+        except Exception as e:  # pylint: disable=broad-except
+            append_error(result.errors, 'clusters/kubernetes',
+                         f'events/{w.pod_name}', e)
+            return
+
+        def _ts(ev: Any) -> float:
+            t = (getattr(ev, 'last_timestamp', None) or
+                 getattr(ev, 'event_time', None) or getattr(
+                     getattr(ev, 'metadata', None), 'creation_timestamp', None))
+            if t is None:
+                return 0.0
+            try:
+                return t.timestamp()
+            except Exception:  # pylint: disable=broad-except
+                return 0.0
+
+        events_sorted = sorted(events, key=_ts, reverse=True)[:max_events]
+        try:
+            result.events[w.pod_name] = ([sanitizer(e) for e in events_sorted]
+                                         if sanitizer else [])
+        except Exception as e:  # pylint: disable=broad-except
+            append_error(result.errors, 'clusters/kubernetes',
+                         f'events_serialize/{w.pod_name}', e)
+
+    def _fetch_log(w: '_PodWork', container: str, previous: bool) -> None:
+        try:
+            log = kubernetes.core_api(access.context).read_namespaced_pod_log(
+                name=w.pod_name,
+                namespace=w.namespace,
+                container=container,
+                tail_lines=log_tail_lines,
+                previous=previous,
+                _request_timeout=log_timeout_seconds,
+            )
+        except api_exception as e:
+            # 400 with "previous terminated container … not found" is fine
+            # to drop silently when we asked for the previous instance.
+            if previous and e.status == 400:
+                logger.debug(f'No previous log for {w.pod_name}/{container}')
+                return
+            append_error(
+                result.errors, 'clusters/kubernetes',
+                f'log{".prev" if previous else ""}/{w.pod_name}/{container}', e)
+            return
+        except Exception as e:  # pylint: disable=broad-except
+            append_error(
+                result.errors, 'clusters/kubernetes',
+                f'log{".prev" if previous else ""}/{w.pod_name}/{container}', e)
+            return
+        if not isinstance(log, str):
+            return
+        truncated = _truncate_log(log, log_tail_bytes)
+        target = result.previous_logs if previous else result.logs
+        target[(w.pod_name, container)] = truncated
+
+    # Build the full list of tasks: events per pod + logs per (pod, container).
+    # We mix events and logs in the same parallel pool to maximise concurrency.
+    tasks: List[Tuple[str, Any]] = []
+    for w in work:
+        tasks.append(('events', w))
+        for c in w.containers + w.init_containers:
+            tasks.append(('log', (w, c, False)))
+            if _container_last_terminated(w.pod_obj, c):
+                tasks.append(('log', (w, c, True)))
+
+    def _dispatch(task: Tuple[str, Any]) -> None:
+        kind, payload = task
+        if kind == 'events':
+            _fetch_events(payload)
+        else:
+            w, c, previous = payload
+            _fetch_log(w, c, previous)
+
+    if tasks:
+        try:
+            subprocess_utils.run_in_parallel(_dispatch,
+                                             tasks,
+                                             num_threads=max_workers)
+        except Exception as e:  # pylint: disable=broad-except
+            append_error(result.errors, 'clusters/kubernetes', 'fetch', e)
+
+    return result
 
 
 def get_cluster_events_data(cluster_hash: str) -> List[Dict[str, Any]]:

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -49,16 +49,8 @@ DEBUG_DUMP_DIR = '~/.sky/debug_dumps'
 
 # Env var names whose values should be redacted (show bool presence only).
 # Used for both server_info environment and request body sanitization.
-_SENSITIVE_ENV_VARS = {
-    'SKYPILOT_DB_CONNECTION_URI',
-    'SKYPILOT_INITIAL_BASIC_AUTH',
-    'SKYPILOT_SERVICE_ACCOUNT_TOKEN',
-    'SKYPILOT_DOCKER_PASSWORD',
-    'AWS_SECRET_ACCESS_KEY',
-    'AWS_SESSION_TOKEN',
-    'AWS_ACCESS_KEY_ID',
-    'AZURE_CLIENT_SECRET',
-}
+# Canonical home is debug_dump_helpers (shared with controller-side manifest).
+_SENSITIVE_ENV_VARS = debug_dump_helpers.SENSITIVE_ENV_VARS
 
 # Maps request name → field names containing task/dag YAML to redact.
 # Empty tuple means include body verbatim (no YAML fields).
@@ -811,7 +803,139 @@ def _dump_cluster_info(cluster_names: Set[str],
                     'traceback': _full_traceback()
                 })
 
+        # Capture underlying Kubernetes state when the cluster is on k8s.
+        if cluster_record is not None:
+            access = debug_dump_helpers.get_kubernetes_access(cluster_record)
+            if access is not None:
+                _dump_kubernetes_state_to_disk(access,
+                                               out_dir=os.path.join(
+                                                   cluster_dir, 'kubernetes'),
+                                               resource_prefix=cluster_name,
+                                               errors=errors)
+
     logger.debug('Exiting _dump_cluster_info')
+
+
+def _dump_kubernetes_state_to_disk(
+        access: 'debug_dump_helpers.K8sAccess',
+        out_dir: str,
+        resource_prefix: str,
+        errors: Optional[List[Dict[str, str]]] = None) -> None:
+    """Fetch k8s state via the shared helper and write it to disk.
+
+    Layout (relative to out_dir):
+      pods.json
+      events/<pod>.json
+      logs/<pod>__<container>.log
+      logs/<pod>__<container>.prev.log   (if available)
+    """
+    try:
+        os.makedirs(out_dir, exist_ok=True)
+    except Exception as e:  # pylint: disable=broad-except
+        if errors is not None:
+            errors.append({
+                'component': 'clusters',
+                'resource': f'{resource_prefix}/kubernetes',
+                'error': str(e),
+                'traceback': _full_traceback(),
+            })
+        return
+
+    result = debug_dump_helpers.collect_kubernetes_state(access)
+
+    # Pods.
+    if result.pods:
+        try:
+            with open(os.path.join(out_dir, 'pods.json'), 'w',
+                      encoding='utf-8') as f:
+                json.dump(result.pods, f, indent=2, default=str)
+        except Exception as e:  # pylint: disable=broad-except
+            if errors is not None:
+                errors.append({
+                    'component': 'clusters',
+                    'resource': f'{resource_prefix}/kubernetes/pods.json',
+                    'error': str(e),
+                    'traceback': _full_traceback(),
+                })
+
+    # Events.
+    if result.events:
+        events_dir = os.path.join(out_dir, 'events')
+        try:
+            os.makedirs(events_dir, exist_ok=True)
+        except Exception as e:  # pylint: disable=broad-except
+            if errors is not None:
+                errors.append({
+                    'component': 'clusters',
+                    'resource': f'{resource_prefix}/kubernetes/events',
+                    'error': str(e),
+                    'traceback': _full_traceback(),
+                })
+        else:
+            for pod_name, events in result.events.items():
+                try:
+                    with open(os.path.join(events_dir, f'{pod_name}.json'),
+                              'w',
+                              encoding='utf-8') as f:
+                        json.dump(events, f, indent=2, default=str)
+                except Exception as e:  # pylint: disable=broad-except
+                    if errors is not None:
+                        errors.append({
+                            'component': 'clusters',
+                            'resource': (f'{resource_prefix}/kubernetes/'
+                                         f'events/{pod_name}'),
+                            'error': str(e),
+                            'traceback': _full_traceback(),
+                        })
+
+    # Logs.
+    if result.logs or result.previous_logs:
+        logs_dir = os.path.join(out_dir, 'logs')
+        try:
+            os.makedirs(logs_dir, exist_ok=True)
+        except Exception as e:  # pylint: disable=broad-except
+            if errors is not None:
+                errors.append({
+                    'component': 'clusters',
+                    'resource': f'{resource_prefix}/kubernetes/logs',
+                    'error': str(e),
+                    'traceback': _full_traceback(),
+                })
+        else:
+            _write_logs(logs_dir, result.logs, '.log', resource_prefix, errors)
+            _write_logs(logs_dir, result.previous_logs, '.prev.log',
+                        resource_prefix, errors)
+
+    # Propagate helper-recorded errors with a cluster-scoped resource path.
+    if errors is not None:
+        for err in result.errors:
+            errors.append({
+                'component': 'clusters',
+                'resource': f'{resource_prefix}/{err.get("resource", "")}',
+                'error': err.get('error', ''),
+                'traceback': err.get('traceback', ''),
+            })
+
+
+def _write_logs(logs_dir: str, log_map: Dict[Tuple[str, str], str], suffix: str,
+                resource_prefix: str,
+                errors: Optional[List[Dict[str, str]]]) -> None:
+    """Write per-(pod, container) logs to disk."""
+    for (pod_name, container), log in log_map.items():
+        filename = f'{pod_name}__{container}{suffix}'
+        try:
+            with open(os.path.join(logs_dir, filename), 'w',
+                      encoding='utf-8') as f:
+                f.write(log)
+        except Exception as e:  # pylint: disable=broad-except
+            if errors is not None:
+                errors.append({
+                    'component': 'clusters',
+                    'resource': (f'{resource_prefix}/kubernetes/logs/'
+                                 f'{filename}'),
+                    'error': str(e),
+                    'traceback': _full_traceback(),
+                })
 
 
 def _dump_managed_job_info(

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -2221,3 +2221,317 @@ class TestDumpClusterInfo:
             data = json.load(f)
         assert len(data) == 1
         assert data[0]['request_id'] == 'req-a'
+
+
+# --- Kubernetes capture --------------------------------------------------
+
+
+def _make_k8s_cluster_record(name: str = 'k8s-cluster',
+                             cluster_name_on_cloud: str = 'k8s-cluster-abcd',
+                             cluster_yaml: Optional[str] = '/tmp/yaml',
+                             region: Optional[str] = 'kubernetes-ctx-1',
+                             cloud_cls=None) -> Dict[str, Any]:
+    """Build a minimal cluster record whose handle looks like a k8s one."""
+    from sky import clouds
+    if cloud_cls is None:
+        cloud_cls = clouds.Kubernetes
+    handle = SimpleNamespace(
+        launched_resources=SimpleNamespace(cloud=cloud_cls(), region=region),
+        cluster_name_on_cloud=cluster_name_on_cloud,
+        cluster_yaml=cluster_yaml,
+    )
+    return {'name': name, 'handle': handle, 'status': 'UP'}
+
+
+def _make_pod(name: str,
+              namespace: str = 'default',
+              containers: Optional[List[str]] = None,
+              init_containers: Optional[List[str]] = None,
+              with_last_terminated: bool = False) -> Any:
+    """Build a V1Pod-like mock with metadata, spec, status."""
+    containers = containers or ['ray-node']
+    spec_containers = [SimpleNamespace(name=c, env=[]) for c in containers]
+    spec_init = [
+        SimpleNamespace(name=c, env=[]) for c in (init_containers or [])
+    ]
+    last_state = SimpleNamespace(terminated=SimpleNamespace(
+        exit_code=1) if with_last_terminated else None)
+    container_statuses = [
+        SimpleNamespace(name=c, last_state=last_state) for c in containers
+    ]
+    return SimpleNamespace(
+        metadata=SimpleNamespace(name=name, namespace=namespace),
+        spec=SimpleNamespace(containers=spec_containers,
+                             init_containers=spec_init),
+        status=SimpleNamespace(container_statuses=container_statuses,
+                               init_container_statuses=[]),
+    )
+
+
+class TestGetKubernetesAccess:
+    """Tests for debug_dump_helpers.get_kubernetes_access."""
+
+    def test_returns_none_for_non_kubernetes(self):
+        from sky import clouds
+        record = _make_k8s_cluster_record(cloud_cls=clouds.AWS)
+        assert debug_dump_helpers.get_kubernetes_access(record) is None
+
+    def test_returns_none_when_no_handle(self):
+        assert debug_dump_helpers.get_kubernetes_access({
+            'name': 'x',
+            'handle': None
+        }) is None
+
+    @mock.patch('sky.utils.debug_dump_helpers.global_user_state'
+                '.get_cluster_yaml_dict')
+    def test_happy_path_uses_yaml(self, mock_yaml):
+        mock_yaml.return_value = {
+            'provider': {
+                'context': 'kubernetes-ctx-1',
+                'namespace': 'sky-ns'
+            }
+        }
+        record = _make_k8s_cluster_record()
+        access = debug_dump_helpers.get_kubernetes_access(record)
+        assert access is not None
+        assert access.context == 'kubernetes-ctx-1'
+        assert access.namespace == 'sky-ns'
+        assert access.cluster_name_on_cloud == 'k8s-cluster-abcd'
+
+    @mock.patch('sky.utils.debug_dump_helpers.global_user_state'
+                '.get_cluster_yaml_dict',
+                side_effect=ValueError('yaml gone'))
+    def test_fallback_when_yaml_unreadable(self, _):
+        record = _make_k8s_cluster_record(region='ctx-from-region')
+        access = debug_dump_helpers.get_kubernetes_access(record)
+        assert access is not None
+        # Falls back to region-as-context, namespace=None (search all).
+        assert access.context == 'ctx-from-region'
+        assert access.namespace is None
+
+    def test_fallback_when_yaml_is_none(self):
+        record = _make_k8s_cluster_record(cluster_yaml=None,
+                                          region='ctx-from-region')
+        access = debug_dump_helpers.get_kubernetes_access(record)
+        assert access is not None
+        assert access.context == 'ctx-from-region'
+        assert access.namespace is None
+
+
+class TestRedactPodEnv:
+    """Tests for debug_dump_helpers._redact_pod_env."""
+
+    def test_redacts_known_keys(self):
+        pod = {
+            'spec': {
+                'containers': [{
+                    'env': [
+                        {
+                            'name': 'AWS_SECRET_ACCESS_KEY',
+                            'value': 'shhh'
+                        },
+                        {
+                            'name': 'PLAIN',
+                            'value': 'visible'
+                        },
+                    ]
+                }]
+            }
+        }
+        debug_dump_helpers._redact_pod_env(pod)  # pylint: disable=protected-access
+        env = pod['spec']['containers'][0]['env']
+        assert env[0]['value'] == '<redacted>'
+        assert env[1]['value'] == 'visible'
+
+    def test_redacts_by_regex(self):
+        pod = {
+            'spec': {
+                'containers': [{
+                    'env': [
+                        {
+                            'name': 'MY_API_TOKEN',
+                            'value': 'leak'
+                        },
+                        {
+                            'name': 'CUSTOM_PASSWORD',
+                            'value': 'leak2'
+                        },
+                        {
+                            'name': 'BORING_VAR',
+                            'value': 'safe'
+                        },
+                    ]
+                }]
+            }
+        }
+        debug_dump_helpers._redact_pod_env(pod)  # pylint: disable=protected-access
+        env = pod['spec']['containers'][0]['env']
+        assert env[0]['value'] == '<redacted>'
+        assert env[1]['value'] == '<redacted>'
+        assert env[2]['value'] == 'safe'
+
+    def test_handles_missing_fields(self):
+        # No spec.
+        debug_dump_helpers._redact_pod_env({})  # pylint: disable=protected-access
+        # No containers.
+        debug_dump_helpers._redact_pod_env({'spec': {}})  # pylint: disable=protected-access
+        # No env, but valueFrom (untouched).
+        pod = {
+            'spec': {
+                'containers': [{
+                    'env': [{
+                        'name': 'TOKEN',
+                        'valueFrom': {
+                            'secretKeyRef': {
+                                'name': 's',
+                                'key': 'k'
+                            }
+                        }
+                    }]
+                }]
+            }
+        }
+        debug_dump_helpers._redact_pod_env(pod)  # pylint: disable=protected-access
+        assert 'value' not in pod['spec']['containers'][0]['env'][0]
+
+
+class TestCollectKubernetesState:
+    """Tests for debug_dump_helpers.collect_kubernetes_state."""
+
+    @mock.patch('sky.adaptors.kubernetes.api_client')
+    @mock.patch('sky.adaptors.kubernetes.core_api')
+    def test_happy_path(self, mock_core_api, mock_api_client):
+        access = debug_dump_helpers.K8sAccess(context='ctx',
+                                              namespace='ns',
+                                              cluster_name_on_cloud='c1-abcd')
+        pod1 = _make_pod('c1-head', namespace='ns', containers=['ray-node'])
+        pod2 = _make_pod('c1-worker1',
+                         namespace='ns',
+                         containers=['ray-node'],
+                         with_last_terminated=True)
+        core_api = mock_core_api.return_value
+        core_api.list_namespaced_pod.return_value = SimpleNamespace(
+            items=[pod1, pod2])
+        core_api.list_namespaced_event.return_value = SimpleNamespace(items=[])
+
+        def _read_log(*, name, namespace, container, tail_lines, previous,
+                      _request_timeout):
+            del namespace, tail_lines, _request_timeout
+            if previous and name == 'c1-worker1' and container == 'ray-node':
+                return 'previous instance log'
+            return f'log for {name}/{container} previous={previous}'
+
+        core_api.read_namespaced_pod_log.side_effect = _read_log
+        # api_client.sanitize_for_serialization → identity-ish for dict input.
+        sanitizer = mock_api_client.return_value.sanitize_for_serialization
+        sanitizer.side_effect = lambda obj: {
+            'name': getattr(getattr(obj, 'metadata', None), 'name', None),
+            'spec': {
+                'containers': [{
+                    'name': 'ray-node',
+                    'env': []
+                }]
+            },
+        }
+
+        result = debug_dump_helpers.collect_kubernetes_state(access)
+
+        assert set(result.pods.keys()) == {'c1-head', 'c1-worker1'}
+        # Both pods got log entries for their one container.
+        assert ('c1-head', 'ray-node') in result.logs
+        assert ('c1-worker1', 'ray-node') in result.logs
+        # Only the pod with last_terminated gets a previous log.
+        assert ('c1-worker1', 'ray-node') in result.previous_logs
+        assert ('c1-head', 'ray-node') not in result.previous_logs
+        assert not result.errors
+
+    @mock.patch('sky.adaptors.kubernetes.core_api')
+    def test_list_pods_403_records_single_error(self, mock_core_api):
+        from sky.adaptors import kubernetes as k8s_adaptor
+        api_exc_cls = k8s_adaptor.api_exception()
+        err = api_exc_cls(status=403)
+        mock_core_api.return_value.list_namespaced_pod.side_effect = err
+        access = debug_dump_helpers.K8sAccess(context='ctx',
+                                              namespace='ns',
+                                              cluster_name_on_cloud='c1')
+        result = debug_dump_helpers.collect_kubernetes_state(access)
+        assert not result.pods
+        assert len(result.errors) == 1
+        assert result.errors[0]['resource'].endswith('list_pods')
+
+    @mock.patch('sky.adaptors.kubernetes.api_client')
+    @mock.patch('sky.adaptors.kubernetes.core_api')
+    def test_log_400_for_current_records_error(self, mock_core_api,
+                                               mock_api_client):
+        access = debug_dump_helpers.K8sAccess(context=None,
+                                              namespace='ns',
+                                              cluster_name_on_cloud='c1')
+        pod = _make_pod('c1-head', namespace='ns', containers=['ray-node'])
+        core_api = mock_core_api.return_value
+        core_api.list_namespaced_pod.return_value = SimpleNamespace(items=[pod])
+        core_api.list_namespaced_event.return_value = SimpleNamespace(items=[])
+        from sky.adaptors import kubernetes as k8s_adaptor
+        api_exc_cls = k8s_adaptor.api_exception()
+        core_api.read_namespaced_pod_log.side_effect = api_exc_cls(status=400)
+        mock_api_client.return_value.sanitize_for_serialization.side_effect = (
+            lambda obj: {
+                'name': obj.metadata.name
+            })
+
+        result = debug_dump_helpers.collect_kubernetes_state(access)
+        # No logs captured, but pod metadata captured and error recorded.
+        assert 'c1-head' in result.pods
+        assert not result.logs
+        assert any('log/' in (e.get('resource') or '') for e in result.errors)
+
+    @mock.patch('sky.adaptors.kubernetes.api_client')
+    @mock.patch('sky.adaptors.kubernetes.core_api')
+    def test_log_400_for_previous_is_silent(self, mock_core_api,
+                                            mock_api_client):
+        access = debug_dump_helpers.K8sAccess(context=None,
+                                              namespace='ns',
+                                              cluster_name_on_cloud='c1')
+        pod = _make_pod('c1-head',
+                        namespace='ns',
+                        containers=['ray-node'],
+                        with_last_terminated=True)
+        core_api = mock_core_api.return_value
+        core_api.list_namespaced_pod.return_value = SimpleNamespace(items=[pod])
+        core_api.list_namespaced_event.return_value = SimpleNamespace(items=[])
+        from sky.adaptors import kubernetes as k8s_adaptor
+        api_exc_cls = k8s_adaptor.api_exception()
+
+        def _read_log(*, name, namespace, container, tail_lines, previous,
+                      _request_timeout):
+            del name, namespace, container, tail_lines, _request_timeout
+            if previous:
+                raise api_exc_cls(status=400)
+            return 'current log'
+
+        core_api.read_namespaced_pod_log.side_effect = _read_log
+        mock_api_client.return_value.sanitize_for_serialization.side_effect = (
+            lambda obj: {
+                'name': obj.metadata.name
+            })
+
+        result = debug_dump_helpers.collect_kubernetes_state(access)
+        # Current logs ok, previous silently dropped.
+        assert ('c1-head', 'ray-node') in result.logs
+        assert ('c1-head', 'ray-node') not in result.previous_logs
+        # No errors recorded for the dropped previous-log 400.
+        assert not any(
+            'log.prev/' in (e.get('resource') or '') for e in result.errors)
+
+
+class TestKubernetesLazyImport:
+    """The helper module must import without the kubernetes extra installed."""
+
+    def test_module_importable_without_kubernetes_extra(self):
+        # Already imported by the test module — confirm no top-level k8s import.
+        import sky.utils.debug_dump_helpers as helpers
+        src = open(helpers.__file__).read()
+        # Heuristic: 'from sky.adaptors import kubernetes' must not appear
+        # at module top level (i.e. unindented at the start of a line).
+        for line in src.splitlines():
+            assert not line.startswith('from sky.adaptors import kubernetes'), (
+                'k8s adaptor must be lazily imported, not at top level')


### PR DESCRIPTION
## Summary

`sky debug-dump` did not capture pod state, events, or container logs for clusters and managed jobs running on Kubernetes. Adds capture of all three, behind the existing debug-dump entry points, with no schema or CLI changes.

Per Kubernetes cluster, the zip now contains (under `clusters/<name>/kubernetes/` for cluster-collected and `managed_jobs/<job>/clusters/<name>/kubernetes/` for controller-collected):

- `pods.json` — sanitized `V1Pod` dicts (status, conditions, container statuses, restart counts, image, scheduling info)
- `events/<pod>.json` — pod-scoped events, capped to last 200
- `logs/<pod>__<container>.log` and `.prev.log` — current and previous container logs, capped to 5000 lines and 1 MiB each

Shared helpers in `sky/utils/debug_dump_helpers.py` (lazy-imported kubernetes adaptor) feed both the API-server dump path and the controller-side manifest path, so the layout is consistent regardless of where the cluster lives. On the controller side, logs go via `file_paths` + rsync to keep the existing CodeGen/SSH stdout payload small; pods + events stay inline.

Safety:

- All failures are recorded in `errors.json` — the dump never crashes on a missing kubeconfig context, a 403 from RBAC, or a torn-down pod.
- Env-var values are redacted by the existing `SENSITIVE_ENV_VARS` set (now canonical-homed in helpers) **and** by a heuristic regex on `TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL`.
- 30s timeout for log reads (vs the global 5s `API_TIMEOUT`), bounded concurrency via `run_in_parallel(num_threads=4)`.
- Falls back to `(region-as-context, all-namespaces)` when `cluster_yaml` is missing — i.e. the failover-transition case where users most need pod state.
- No manifest schema change, no API version bump, no CLI/SDK signature change. Older controllers simply return no k8s entries to a newer API server.

## Test plan

Unit tests added in `tests/unit_tests/test_sky/utils/test_debug_utils.py` (13 new, full file passes — 122 tests):

- [x] `get_kubernetes_access` returns None for non-k8s, populated tuple for k8s, fallback when `cluster_yaml` is None
- [x] `collect_kubernetes_state` happy path (pods, events, logs, previous-container logs when restart observed)
- [x] 403 on list_pods → empty result + single error
- [x] 400 on current-container log → error recorded; 400 on previous-container log → silent drop
- [x] env-var redaction: static `SENSITIVE_ENV_VARS` keys, regex-matched keys, `valueFrom` untouched, missing fields handled
- [x] `debug_dump_helpers` importable without the `kubernetes` extra (lazy import guard)

Manual e2e to run before un-drafting:

```bash
# Cluster path
sky launch -c dbg-k8s --cloud kubernetes --cpus 2 -- 'echo hi'
sky debug-dump -c dbg-k8s
unzip -l ~/.sky/debug_dumps/debug_dump_*.zip | grep kubernetes/
unzip -p ~/.sky/debug_dumps/debug_dump_*.zip \
    clusters/dbg-k8s/kubernetes/pods.json | jq 'keys'
sky down -y dbg-k8s

# Managed-job path (controller-side manifest + rsync)
sky jobs launch --cloud kubernetes --cpus 2 -- 'echo hi; sleep 60' -y
JOB_ID=$(sky jobs queue | awk 'NR==2{print $1}')
sky debug-dump -j $JOB_ID
unzip -l ~/.sky/debug_dumps/debug_dump_*.zip \
    | grep "managed_jobs/$JOB_ID/clusters/.*/kubernetes/"
```

-Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)