### PR TITLE
Release 0.12.3.post1 

### DIFF
--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -37,7 +37,7 @@ def _get_git_commit():
 
 
 __commit__ = _get_git_commit()
-__version__ = '1.0.0-dev0'
+__version__ = '0.12.3.post1 '
 __root_dir__ = directory_utils.get_sky_dir()
 
 


### PR DESCRIPTION
Release 0.12.3.post1 

Cherry picks the fix from https://github.com/skypilot-org/skypilot/pull/9723 to solve issues with restart Nebius clusters created before 0.12.2.

⚠️ **Smoke tests were SKIPPED** - Please ensure manual testing was performed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->