### PR TITLE
[Bug] Fix get_ingress_external_ip_and_ports for custom ingress namespaces

### DIFF
--- a/sky/provision/kubernetes/network_utils.py
+++ b/sky/provision/kubernetes/network_utils.py
@@ -246,11 +246,16 @@ def get_ingress_external_ip_and_ports(
 ) -> Tuple[Optional[str], Optional[Tuple[int, int]]]:
     """Returns external ip and ports for the ingress controller."""
     core_api = kubernetes.core_api(context)
-    ingress_services = [
-        item for item in core_api.list_namespaced_service(
-            namespace, _request_timeout=kubernetes.API_TIMEOUT).items
-        if item.metadata.name == 'ingress-nginx-controller'
-    ]
+    try:
+        ingress_services = core_api.list_service_for_all_namespaces(
+            field_selector='metadata.name=ingress-nginx-controller',
+            _request_timeout=kubernetes.API_TIMEOUT).items
+    except kubernetes.kubernetes.client.ApiException:
+        ingress_services = [
+            item for item in core_api.list_namespaced_service(
+                namespace, _request_timeout=kubernetes.API_TIMEOUT).items
+            if item.metadata.name == 'ingress-nginx-controller'
+        ]
     if not ingress_services:
         return (None, None)
 


### PR DESCRIPTION
Bug: sky status --endpoints uses a hardcoded ingress-nginx namespace, so it fails if the ingress controller is installed elsewhere.
Root cause: get_ingress_external_ip_and_ports hardcodes the namespace parameter without searching across all namespaces.
Fix: Uses list_service_for_all_namespaces with field_selector metadata.name=ingress-nginx-controller to find the controller service globally, falling back to namespaced query if cluster-level access is denied.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9737" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->