### PR TITLE
ci(nightly): trigger a downstream workflow after PyPI publish

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -324,7 +324,7 @@ jobs:
 
       - name: Mint downstream dispatch token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.CI_APP_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -304,6 +304,41 @@ jobs:
       package_name: skypilot-nightly
     secrets: inherit
 
+  # Optional downstream notification: emit a repository_dispatch event so a
+  # configured downstream repo can react to a fresh nightly publish without
+  # polling PyPI. Configured via repo-level secrets — when unset (e.g. forks)
+  # the step exits silently.
+  notify-downstream:
+    runs-on: ubuntu-latest
+    needs: [check-date, nightly-build-pypi, publish-and-validate-both]
+    if: ${{ always() && needs.check-date.outputs.is_preflight != 'true' && needs.publish-and-validate-both.result == 'success' }}
+    steps:
+      - name: Emit repository_dispatch to downstream repo
+        env:
+          DISPATCH_REPO: ${{ secrets.NIGHTLY_DOWNSTREAM_REPO }}
+          DISPATCH_TOKEN: ${{ secrets.NIGHTLY_DOWNSTREAM_TOKEN }}
+          DISPATCH_EVENT_TYPE: ${{ vars.NIGHTLY_DOWNSTREAM_EVENT_TYPE || 'skypilot-nightly-published' }}
+          NIGHTLY_VERSION: ${{ needs.nightly-build-pypi.outputs.version }}
+        run: |
+          if [[ -z "${DISPATCH_REPO}" || -z "${DISPATCH_TOKEN}" ]]; then
+            echo "No downstream repo configured (NIGHTLY_DOWNSTREAM_REPO/NIGHTLY_DOWNSTREAM_TOKEN unset); skipping."
+            exit 0
+          fi
+          echo "Dispatching ${DISPATCH_EVENT_TYPE} (version=${NIGHTLY_VERSION})"
+          http_code=$(curl -sS -o /tmp/dispatch-resp -w '%{http_code}' \
+            -X POST \
+            -H 'Accept: application/vnd.github+json' \
+            -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${DISPATCH_REPO}/dispatches" \
+            -d "{\"event_type\":\"${DISPATCH_EVENT_TYPE}\",\"client_payload\":{\"version\":\"${NIGHTLY_VERSION}\"}}")
+          if [[ "${http_code}" != "204" ]]; then
+            echo "Dispatch failed (HTTP ${http_code}):"
+            cat /tmp/dispatch-resp || true
+            exit 1
+          fi
+          echo "Dispatch accepted."
+
   summary:
     runs-on: ubuntu-latest
     needs: [check-date, nightly-build-pypi, smoke-tests-aws, smoke-tests-kubernetes-resource-heavy, smoke-tests-kubernetes-no-resource-heavy, smoke-tests-kubernetes-no-resource-heavy-limit-deps, smoke-tests-remote-server-kubernetes, smoke-tests-kubernetes-jobs-consolidation, smoke-tests-shared-gke-api-server, smoke-tests-slurm-minimal, backward-compat-test-nightly, backward-compat-test-stable]

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -304,14 +304,15 @@ jobs:
       package_name: skypilot-nightly
     secrets: inherit
 
-  # Optional downstream notification: emit a repository_dispatch event so a
-  # configured downstream repo can react to a fresh nightly publish without
-  # polling PyPI. Gated on a repo-level variable so forks and the default
-  # upstream config are unaffected — when unset, the job is skipped entirely.
+  # Optional downstream notification: trigger a workflow in a configured
+  # downstream repo (via workflow_dispatch) so it can react to a fresh nightly
+  # publish without polling PyPI. Gated on repo-level variables so forks and the
+  # default upstream config are unaffected — when unset, the job is skipped
+  # entirely.
   notify-downstream:
     runs-on: ubuntu-latest
     needs: [check-date, nightly-build-pypi, publish-and-validate-both]
-    if: ${{ always() && needs.publish-and-validate-both.result == 'success' && vars.NIGHTLY_DOWNSTREAM_REPO != '' }}
+    if: ${{ always() && needs.publish-and-validate-both.result == 'success' && vars.NIGHTLY_DOWNSTREAM_REPO != '' && vars.NIGHTLY_DOWNSTREAM_WORKFLOW != '' }}
     steps:
       - name: Parse downstream repo
         id: parse
@@ -330,21 +331,22 @@ jobs:
           owner: ${{ steps.parse.outputs.owner }}
           repositories: ${{ steps.parse.outputs.name }}
 
-      - name: Emit repository_dispatch to downstream repo
+      - name: Trigger downstream workflow
         env:
           DISPATCH_REPO: ${{ vars.NIGHTLY_DOWNSTREAM_REPO }}
           DISPATCH_TOKEN: ${{ steps.app-token.outputs.token }}
-          DISPATCH_EVENT_TYPE: ${{ vars.NIGHTLY_DOWNSTREAM_EVENT_TYPE || 'skypilot-nightly-published' }}
+          DISPATCH_WORKFLOW: ${{ vars.NIGHTLY_DOWNSTREAM_WORKFLOW }}
+          DISPATCH_REF: ${{ vars.NIGHTLY_DOWNSTREAM_REF || 'main' }}
           NIGHTLY_VERSION: ${{ needs.nightly-build-pypi.outputs.version }}
         run: |
-          echo "Dispatching ${DISPATCH_EVENT_TYPE} (version=${NIGHTLY_VERSION})"
+          echo "Dispatching ${DISPATCH_WORKFLOW} on ${DISPATCH_REPO}@${DISPATCH_REF} (version=${NIGHTLY_VERSION})"
           http_code=$(curl -sS -o /tmp/dispatch-resp -w '%{http_code}' \
             -X POST \
             -H 'Accept: application/vnd.github+json' \
             -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
             -H 'X-GitHub-Api-Version: 2022-11-28' \
-            "https://api.github.com/repos/${DISPATCH_REPO}/dispatches" \
-            -d "{\"event_type\":\"${DISPATCH_EVENT_TYPE}\",\"client_payload\":{\"version\":\"${NIGHTLY_VERSION}\"}}")
+            "https://api.github.com/repos/${DISPATCH_REPO}/actions/workflows/${DISPATCH_WORKFLOW}/dispatches" \
+            -d "{\"ref\":\"${DISPATCH_REF}\",\"inputs\":{\"version\":\"${NIGHTLY_VERSION}\"}}")
           if [[ "${http_code}" != "204" ]]; then
             echo "Dispatch failed (HTTP ${http_code}):"
             cat /tmp/dispatch-resp || true

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -304,21 +304,28 @@ jobs:
       package_name: skypilot-nightly
     secrets: inherit
 
-  # Optional downstream notification: trigger a workflow in a configured
-  # downstream repo (via workflow_dispatch) so it can react to a fresh nightly
-  # publish without polling PyPI. Gated on repo-level variables so forks and the
-  # default upstream config are unaffected — when unset, the job is skipped
-  # entirely.
+  # After a nightly is published, dispatch the downstream repo's workflow so it
+  # can react without polling PyPI. Fail-loud: a missing secret, bad App creds,
+  # or a non-204 turns the run red rather than silently skipping.
   notify-downstream:
     runs-on: ubuntu-latest
     needs: [check-date, nightly-build-pypi, publish-and-validate-both]
-    if: ${{ always() && needs.publish-and-validate-both.result == 'success' && vars.NIGHTLY_DOWNSTREAM_REPO != '' && vars.NIGHTLY_DOWNSTREAM_WORKFLOW != '' }}
+    if: ${{ always() && needs.publish-and-validate-both.result == 'success' }}
     steps:
       - name: Parse downstream repo
         id: parse
         env:
-          DOWNSTREAM_REPO: ${{ vars.NIGHTLY_DOWNSTREAM_REPO }}
+          DOWNSTREAM_REPO: ${{ secrets.NIGHTLY_DOWNSTREAM_REPO }}
+          DOWNSTREAM_WORKFLOW: ${{ secrets.NIGHTLY_DOWNSTREAM_WORKFLOW }}
         run: |
+          if [[ -z "${DOWNSTREAM_REPO}" ]]; then
+            echo "::error::NIGHTLY_DOWNSTREAM_REPO secret is not set; cannot dispatch the downstream nightly."
+            exit 1
+          fi
+          if [[ -z "${DOWNSTREAM_WORKFLOW}" ]]; then
+            echo "::error::NIGHTLY_DOWNSTREAM_WORKFLOW secret is not set; cannot dispatch the downstream nightly."
+            exit 1
+          fi
           echo "owner=${DOWNSTREAM_REPO%/*}" >> "$GITHUB_OUTPUT"
           echo "name=${DOWNSTREAM_REPO#*/}"  >> "$GITHUB_OUTPUT"
 
@@ -326,17 +333,17 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.CI_APP_ID }}
-          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.NIGHTLY_DOWNSTREAM_CI_APP_ID }}
+          private-key: ${{ secrets.NIGHTLY_DOWNSTREAM_CI_APP_PRIVATE_KEY }}
           owner: ${{ steps.parse.outputs.owner }}
           repositories: ${{ steps.parse.outputs.name }}
 
       - name: Trigger downstream workflow
         env:
-          DISPATCH_REPO: ${{ vars.NIGHTLY_DOWNSTREAM_REPO }}
+          DISPATCH_REPO: ${{ secrets.NIGHTLY_DOWNSTREAM_REPO }}
           DISPATCH_TOKEN: ${{ steps.app-token.outputs.token }}
-          DISPATCH_WORKFLOW: ${{ vars.NIGHTLY_DOWNSTREAM_WORKFLOW }}
-          DISPATCH_REF: ${{ vars.NIGHTLY_DOWNSTREAM_REF || 'main' }}
+          DISPATCH_WORKFLOW: ${{ secrets.NIGHTLY_DOWNSTREAM_WORKFLOW }}
+          DISPATCH_REF: ${{ secrets.NIGHTLY_DOWNSTREAM_REF || 'main' }}
           NIGHTLY_VERSION: ${{ needs.nightly-build-pypi.outputs.version }}
         run: |
           echo "Dispatching ${DISPATCH_WORKFLOW} on ${DISPATCH_REPO}@${DISPATCH_REF} (version=${NIGHTLY_VERSION})"
@@ -348,7 +355,8 @@ jobs:
             "https://api.github.com/repos/${DISPATCH_REPO}/actions/workflows/${DISPATCH_WORKFLOW}/dispatches" \
             -d "{\"ref\":\"${DISPATCH_REF}\",\"inputs\":{\"version\":\"${NIGHTLY_VERSION}\"}}")
           if [[ "${http_code}" != "204" ]]; then
-            echo "Dispatch failed (HTTP ${http_code}):"
+            echo "::error::Downstream dispatch to ${DISPATCH_REPO} (${DISPATCH_WORKFLOW}) failed with HTTP ${http_code}."
+            echo "Response body:"
             cat /tmp/dispatch-resp || true
             exit 1
           fi

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -306,24 +306,37 @@ jobs:
 
   # Optional downstream notification: emit a repository_dispatch event so a
   # configured downstream repo can react to a fresh nightly publish without
-  # polling PyPI. Configured via repo-level secrets — when unset (e.g. forks)
-  # the step exits silently.
+  # polling PyPI. Gated on a repo-level variable so forks and the default
+  # upstream config are unaffected — when unset, the job is skipped entirely.
   notify-downstream:
     runs-on: ubuntu-latest
     needs: [check-date, nightly-build-pypi, publish-and-validate-both]
-    if: ${{ always() && needs.check-date.outputs.is_preflight != 'true' && needs.publish-and-validate-both.result == 'success' }}
+    if: ${{ always() && needs.publish-and-validate-both.result == 'success' && vars.NIGHTLY_DOWNSTREAM_REPO != '' }}
     steps:
+      - name: Parse downstream repo
+        id: parse
+        env:
+          DOWNSTREAM_REPO: ${{ vars.NIGHTLY_DOWNSTREAM_REPO }}
+        run: |
+          echo "owner=${DOWNSTREAM_REPO%/*}" >> "$GITHUB_OUTPUT"
+          echo "name=${DOWNSTREAM_REPO#*/}"  >> "$GITHUB_OUTPUT"
+
+      - name: Mint downstream dispatch token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+          owner: ${{ steps.parse.outputs.owner }}
+          repositories: ${{ steps.parse.outputs.name }}
+
       - name: Emit repository_dispatch to downstream repo
         env:
-          DISPATCH_REPO: ${{ secrets.NIGHTLY_DOWNSTREAM_REPO }}
-          DISPATCH_TOKEN: ${{ secrets.NIGHTLY_DOWNSTREAM_TOKEN }}
+          DISPATCH_REPO: ${{ vars.NIGHTLY_DOWNSTREAM_REPO }}
+          DISPATCH_TOKEN: ${{ steps.app-token.outputs.token }}
           DISPATCH_EVENT_TYPE: ${{ vars.NIGHTLY_DOWNSTREAM_EVENT_TYPE || 'skypilot-nightly-published' }}
           NIGHTLY_VERSION: ${{ needs.nightly-build-pypi.outputs.version }}
         run: |
-          if [[ -z "${DISPATCH_REPO}" || -z "${DISPATCH_TOKEN}" ]]; then
-            echo "No downstream repo configured (NIGHTLY_DOWNSTREAM_REPO/NIGHTLY_DOWNSTREAM_TOKEN unset); skipping."
-            exit 0
-          fi
           echo "Dispatching ${DISPATCH_EVENT_TYPE} (version=${NIGHTLY_VERSION})"
           http_code=$(curl -sS -o /tmp/dispatch-resp -w '%{http_code}' \
             -X POST \


### PR DESCRIPTION
## Summary

Adds a `notify-downstream` job that triggers a workflow in a configured downstream repository (via `workflow_dispatch`) after a fresh `skypilot-nightly` is published. This lets a downstream repo react to a new nightly without polling PyPI.

The dispatch token is minted at runtime via [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token) — short-lived (1h), scoped to a single downstream repository, and not stored as a long-lived secret. Because the job uses `workflow_dispatch`, the App only needs `Actions: write` on the downstream repo — enough to trigger a workflow, but not to write repository contents.

## Configuration

All config is provisioned on the upstream repo as **secrets** (Settings → Secrets and variables → Actions → Secrets):

| Secret | Purpose |
|---|---|
| `NIGHTLY_DOWNSTREAM_REPO` | Target repo as `owner/repo`. |
| `NIGHTLY_DOWNSTREAM_WORKFLOW` | Downstream workflow file name or ID to dispatch (e.g. `nightly-build.yml`). |
| `NIGHTLY_DOWNSTREAM_REF` | (optional) Git ref of the downstream workflow. Defaults to `main`. |
| `NIGHTLY_DOWNSTREAM_CI_APP_ID` | GitHub App ID. The App must be installed on the downstream repo with `Actions: write`. |
| `NIGHTLY_DOWNSTREAM_CI_APP_PRIVATE_KEY` | App private key (`.pem` contents). |

## Failure behavior (fail-loud)

The job runs whenever `publish-and-validate-both` succeeds and is **not** gated on the downstream config being present — the `secrets` context can't be used in a job-level `if:`, and gating on it would let a missing/typo'd secret silently skip the job and report green. Instead, any failure to notify the downstream turns the nightly run **red** with an `::error::` annotation:

- A missing `NIGHTLY_DOWNSTREAM_REPO` / `NIGHTLY_DOWNSTREAM_WORKFLOW` secret → explicit error, job fails.
- Bad/missing App credentials → token mint fails, job fails.
- Dispatch returns non-204 → error with HTTP code + response body, job fails.

Because it runs only after `publish-and-validate-both`, a failure here does not block the nightly publish or the docker/helm release — it flags that the downstream was not notified. (Forks that lack the secrets fail here, but in practice never reach this job since `publish-and-validate-both` doesn't succeed without publish credentials.)

## Request

```
POST /repos/{NIGHTLY_DOWNSTREAM_REPO}/actions/workflows/{NIGHTLY_DOWNSTREAM_WORKFLOW}/dispatches
{ "ref": "<NIGHTLY_DOWNSTREAM_REF>", "inputs": { "version": "1.0.0.devYYYYMMDD" } }
```

The downstream workflow declares a `workflow_dispatch:` trigger with a `version` input and reads `inputs.version`.

## Test plan

- [ ] With the secrets configured, verify the App token is minted and the dispatch returns HTTP 204, and the downstream workflow run is created with the expected `version` input.
- [ ] Temporarily unset/typo a secret and verify the job fails red with an `::error::` annotation (no silent green skip).
- [ ] Verify a non-204 dispatch (e.g. wrong workflow name) fails the job with the HTTP code + response body logged.
