### PR TITLE
[Test] Swap gated NeMo image for public test image in custom-image parametrize

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2296,9 +2296,15 @@ def test_aws_custom_docker_image_with_motd(image_id):
         # Test image with custom MOTD that can potentially interfere with
         # SSH user/rsync path detection.
         'docker:nvcr.io/nvidia/quantum/cuda-quantum:cu12-0.10.0',
-        # Test image with PYTHONPATH set and with pyproject.toml.
-        # Update this image periodically, nemo does not support :latest tag.
-        'docker:nvcr.io/nvidia/nemo:25.09',
+        # TODO: Add back a variant that exercises a custom image with
+        # PYTHONPATH set. nvcr.io/nvidia/nemo:* is no longer publicly pullable
+        # (NVIDIA gated the entire repo behind NGC auth — every tag from 24.07
+        # through 25.09 returns "DENIED" anonymously), and the EKS test
+        # cluster has no NGC imagePullSecret configured, so the pod sat in
+        # ImagePullBackOff until --retry-until-up timed out at 30 min.
+        # Replace with a small public image that has PYTHONPATH set once one
+        # is built and hosted (see PR #7539 for the underlying behavior this
+        # was guarding).
         # Test image with Python 3.12 site-packages as WORKDIR, which causes
         # import failures if CWD is not handled properly. When SkyPilot's Python
         # 3.10 venv runs, it finds Python 3.12 compiled packages (like rpds) in

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2296,15 +2296,6 @@ def test_aws_custom_docker_image_with_motd(image_id):
         # Test image with custom MOTD that can potentially interfere with
         # SSH user/rsync path detection.
         'docker:nvcr.io/nvidia/quantum/cuda-quantum:cu12-0.10.0',
-        # TODO: Add back a variant that exercises a custom image with
-        # PYTHONPATH set. nvcr.io/nvidia/nemo:* is no longer publicly pullable
-        # (NVIDIA gated the entire repo behind NGC auth — every tag from 24.07
-        # through 25.09 returns "DENIED" anonymously), and the EKS test
-        # cluster has no NGC imagePullSecret configured, so the pod sat in
-        # ImagePullBackOff until --retry-until-up timed out at 30 min.
-        # Replace with a small public image that has PYTHONPATH set once one
-        # is built and hosted (see PR #7539 for the underlying behavior this
-        # was guarding).
         # Test image with Python 3.12 site-packages as WORKDIR, which causes
         # import failures if CWD is not handled properly. When SkyPilot's Python
         # 3.10 venv runs, it finds Python 3.12 compiled packages (like rpds) in

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2296,6 +2296,12 @@ def test_aws_custom_docker_image_with_motd(image_id):
         # Test image with custom MOTD that can potentially interfere with
         # SSH user/rsync path detection.
         'docker:nvcr.io/nvidia/quantum/cuda-quantum:cu12-0.10.0',
+        # Test image with PYTHONPATH set and with pyproject.toml at that path
+        # (PYTHONPATH=/sklearnserver, /sklearnserver/pyproject.toml). Guards
+        # the `env -u PYTHONPATH` step in kubernetes-ray.yml.j2 (PR #7539).
+        # Replaces the previously-used nvcr.io/nvidia/nemo:25.09, which NVIDIA
+        # gated behind NGC auth on 2026-05-27.
+        'docker:kserve/sklearnserver:v0.19.0-rc0',
         # Test image with Python 3.12 site-packages as WORKDIR, which causes
         # import failures if CWD is not handled properly. When SkyPilot's Python
         # 3.10 venv runs, it finds Python 3.12 compiled packages (like rpds) in

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2296,12 +2296,6 @@ def test_aws_custom_docker_image_with_motd(image_id):
         # Test image with custom MOTD that can potentially interfere with
         # SSH user/rsync path detection.
         'docker:nvcr.io/nvidia/quantum/cuda-quantum:cu12-0.10.0',
-        # Test image with PYTHONPATH set and with pyproject.toml at that path
-        # (PYTHONPATH=/sklearnserver, /sklearnserver/pyproject.toml). Guards
-        # the `env -u PYTHONPATH` step in kubernetes-ray.yml.j2 (PR #7539).
-        # Replaces the previously-used nvcr.io/nvidia/nemo:25.09, which NVIDIA
-        # gated behind NGC auth on 2026-05-27.
-        'docker:kserve/sklearnserver:v0.19.0-rc0',
         # Test image with Python 3.12 site-packages as WORKDIR, which causes
         # import failures if CWD is not handled properly. When SkyPilot's Python
         # 3.10 venv runs, it finds Python 3.12 compiled packages (like rpds) in


### PR DESCRIPTION
## Summary

Replace `nvcr.io/nvidia/nemo:25.09` (gated by NVIDIA on 2026-05-27, broke nightly smoke runs) with `us-central1-docker.pkg.dev/sky-dev-465/skypilot-public-test-images/pythonpath-pyproject:v1`, a tiny purpose-built image that exercises the same regression surface (PYTHONPATH set + pyproject.toml at that path) and is ~120× smaller than NeMo.

**When NeMo broke (proven from CI history):**

| Event | Build | Started | Result |
|---|---|---|---|
| Last passing `nemo:25.09` pull in CI | [#10950](https://buildkite.com/skypilot-1/smoke-tests/builds/10950) | 2026-05-27 10:47:50 UTC | ✅ passed |
| First failing `nemo:25.09` pull in CI | [#10960](https://buildkite.com/skypilot-1/smoke-tests/builds/10960) | 2026-05-28 02:45:02 UTC | ❌ ImagePullBackOff → 30-min timeout |

Gating happened in a ~16-hour window on **2026-05-27 UTC**. Affected nightly builds: #10960, #10965, #10966, #10972, #10974.

## Proven root cause

SSHed into the buildkite EKS test host:

```
$ docker pull nvcr.io/nvidia/nemo:25.09
denied: Access Denied
```

Repo-wide gating, not tag-specific. Every NeMo tag 24.07 → 25.09 returns the same denial. Control: `nvcr.io/nvidia/cuda:12.4.0-base-ubuntu22.04` still pulls anonymously. The EKS test cluster has no NGC `imagePullSecret` and no NGC `~/.docker/config.json` on the buildkite host, so the pod pulls anonymously → `ImagePullBackOff` → SkyPilot reports `1 pod(s) pending due to Failed` → `--retry-until-up` exhausts the 1800s test timeout.

## Why the obvious replacement (`kserve/sklearnserver`) didn't work

First attempt swapped to `kserve/sklearnserver:v0.19.0-rc0` (smaller, has PYTHONPATH=/sklearnserver + pyproject.toml). The Buildkite smoke test failed with `ttrpc: closed` exec errors on the head pod. Diagnosed on a local kind cluster — the kserve image runs as non-root (`USER 1000`, no `sudo` binary):

```
+ id -u  → 1000
+ sudo mkdir -p /etc/apt/sources.list.backup_skypilot
environment: line 90: sudo: command not found
+ exit 1
Error: setup step 'apt-ssh-setup' failed. Pod will exit.
```

SkyPilot's pod setup (`kubernetes-ray.yml.j2` apt-ssh-setup step) requires root for `apt`. All other passing test images run as root (`USER=''`); none of the existing public images I checked combined `USER=root + PYTHONPATH set + pyproject.toml at PYTHONPATH + ≤500MB`.

## The replacement image

Purpose-built, 212 MB compressed, root user, hosted on a dedicated public GCP Artifact Registry repo (`skypilot-public-test-images`, `allUsers/artifactregistry.reader`):

```dockerfile
FROM python:3.11-slim
RUN mkdir -p /opt/pythonpath_pkg && \
    printf '[project]\nname = "pythonpath_pkg"\nversion = "0.0.1"\n' \
      > /opt/pythonpath_pkg/pyproject.toml && \
    printf 'def hello(): return "pythonpath_pkg"\n' \
      > /opt/pythonpath_pkg/__init__.py
ENV PYTHONPATH=/opt/pythonpath_pkg
```

Verified end-to-end on local kind cluster (same auth shape as buildkite kind agents): `sky launch --image-id docker:<image> ...` → pod pulled anonymously, started, setup completed, task ran as root, status SUCCEEDED.

## Test plan

- [x] `/smoke-test --kubernetes -k test_kubernetes_custom_image` on previous commit (NeMo removed only) — passed: [#10976](https://buildkite.com/skypilot-1/smoke-tests/builds/10976), [#10979](https://buildkite.com/skypilot-1/smoke-tests/builds/10979).
- [ ] `/smoke-test --kubernetes -k test_kubernetes_custom_image` on this commit (with replacement image) — pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)