### PR TITLE
[Volume] Don't rewrite region to 'in-cluster' when in-cluster auth unavailable

### DIFF
--- a/sky/provision/kubernetes/volume.py
+++ b/sky/provision/kubernetes/volume.py
@@ -437,14 +437,22 @@ def get_volume_usedby(
 def refresh_volume_config(
     config: models.VolumeConfig,) -> Tuple[bool, models.VolumeConfig]:
     """Refreshes the volume config.
-    For volume config with region None, we need to set the region to the
-    in-cluster context name.
+
+    For volumes created without an explicit region before PR #8386, the
+    region is None. If we're currently running with in-cluster auth, those
+    volumes belong to the in-cluster context, so rewrite the region. If
+    in-cluster auth is NOT available (e.g. the API server authenticates via
+    kubeconfig), leave region=None so it gets resolved from the task's
+    --infra at launch time. Otherwise the optimizer would compare a literal
+    'in-cluster' against the kubeconfig contexts and raise
+    ResourcesUnavailableError on every launch that references the volume.
 
     Returns:
         need_refresh: Whether need to refresh the volume config.
         volume_config: The volume config to be refreshed.
     """
-    if config.region is None:
+    if (config.region is None and
+            kubernetes_utils.is_incluster_config_available()):
         config.region = kubernetes.in_cluster_context_name()
         return True, config
     return False, config

--- a/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
@@ -1645,14 +1645,32 @@ class TestRefreshVolumeConfig:
     @patch('sky.provision.kubernetes.volume.kubernetes.in_cluster_context_name')
     def test_refresh_volume_config_region_none_kubeconfig_only(
             self, mock_in_cluster_context, mock_is_incluster):
-        """region=None + no in-cluster auth: keep region as None.
+        """region=None + no in-cluster auth: must NOT rewrite to 'in-cluster'.
 
-        Regression test: when the API server authenticates via kubeconfig and
-        has no in-cluster service-account token, rewriting region to the
-        literal 'in-cluster' string would cause every subsequent ``sky launch``
-        referencing the volume to fail with ``ResourcesUnavailableError``
-        (the optimizer compares against the kubeconfig context names, which
-        do not include 'in-cluster').
+        Regression test for the race surfaced by build #10973
+        (test_hostpath_volume_on_kubernetes). Mechanism:
+
+        1. ``sky volumes apply`` (no ``infra:`` field) inserts a row with
+           region=None.
+        2. The 60s volume-refresh daemon ticks (sky/server/daemons.py:182,
+           VOLUME_REFRESH_DAEMON_INTERVAL_SECONDS=60).
+        3. The unfixed ``refresh_volume_config`` unconditionally rewrites
+           region=None to ``kubernetes.in_cluster_context_name()``, which
+           returns the literal string ``'in-cluster'`` when
+           SKYPILOT_IN_CLUSTER_CONTEXT_NAME is unset (the default).
+        4. On the next ``sky launch``, Task topology forces
+           ``task.resources.region = volume.region`` (sky/task.py:1122-1134),
+           and the optimizer's ``_check_specified_regions`` rejects
+           ``'in-cluster'`` because it isn't in the kubeconfig contexts
+           (sky/optimizer.py:1647-1668) -> raises
+           ``ResourcesUnavailableError: ... requires volume X with infra
+           Kubernetes/in-cluster which is not enabled``.
+
+        Pass-then-fail-then-pass-on-retry pattern in the wild is purely the
+        60s daemon-tick race: if the tick fires in the window between
+        ``apply`` and ``launch``, the row is poisoned. The fix is to NOT
+        rewrite when in-cluster auth isn't actually available — leaving
+        region=None lets the launch resolve the context from ``--infra``.
         """
         mock_is_incluster.return_value = False
 
@@ -1670,9 +1688,22 @@ class TestRefreshVolumeConfig:
 
         need_refresh, new_config = k8s_volume.refresh_volume_config(config)
 
-        assert need_refresh is False
-        assert new_config.region is None
-        assert config.region is None
+        # If these assertions ever fail, the production bug is back:
+        # any sky launch referencing this volume on a kubeconfig-only host
+        # will raise ResourcesUnavailableError after the next daemon tick.
+        assert need_refresh is False, (
+            'refresh_volume_config rewrote region=None to '
+            f'{new_config.region!r} even though in-cluster auth is '
+            'unavailable. Production effect: every subsequent sky launch '
+            'referencing this volume on a kubeconfig-only host '
+            '(e.g. kind buildkite agent) will raise '
+            'ResourcesUnavailableError: "requires volume X with infra '
+            'Kubernetes/in-cluster which is not enabled" once the 60s '
+            'volume-refresh daemon ticks.')
+        assert new_config.region is None, (
+            f'Expected region to stay None; got {new_config.region!r}.')
+        assert config.region is None, (
+            f'Expected in-place region to stay None; got {config.region!r}.')
         mock_in_cluster_context.assert_not_called()
 
     def test_refresh_volume_config_region_set(self):

--- a/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
+++ b/tests/unit_tests/test_sky/volumes/test_k8s_volume.py
@@ -1611,10 +1611,14 @@ class MockPV:
 class TestRefreshVolumeConfig:
     """Tests for refresh_volume_config function."""
 
+    @patch('sky.provision.kubernetes.volume.kubernetes_utils.'
+           'is_incluster_config_available')
     @patch('sky.provision.kubernetes.volume.kubernetes.in_cluster_context_name')
-    def test_refresh_volume_config_region_none(self, mock_in_cluster_context):
-        """When region is None, it should be set from in-cluster context."""
+    def test_refresh_volume_config_region_none_incluster(
+            self, mock_in_cluster_context, mock_is_incluster):
+        """region=None + in-cluster auth available: rewrite to in-cluster name."""
         mock_in_cluster_context.return_value = 'in-cluster-context'
+        mock_is_incluster.return_value = True
 
         config = models.VolumeConfig(
             _version=1,
@@ -1635,6 +1639,41 @@ class TestRefreshVolumeConfig:
         # The original object should also be updated in place
         assert config.region == 'in-cluster-context'
         mock_in_cluster_context.assert_called_once()
+
+    @patch('sky.provision.kubernetes.volume.kubernetes_utils.'
+           'is_incluster_config_available')
+    @patch('sky.provision.kubernetes.volume.kubernetes.in_cluster_context_name')
+    def test_refresh_volume_config_region_none_kubeconfig_only(
+            self, mock_in_cluster_context, mock_is_incluster):
+        """region=None + no in-cluster auth: keep region as None.
+
+        Regression test: when the API server authenticates via kubeconfig and
+        has no in-cluster service-account token, rewriting region to the
+        literal 'in-cluster' string would cause every subsequent ``sky launch``
+        referencing the volume to fail with ``ResourcesUnavailableError``
+        (the optimizer compares against the kubeconfig context names, which
+        do not include 'in-cluster').
+        """
+        mock_is_incluster.return_value = False
+
+        config = models.VolumeConfig(
+            _version=1,
+            name='test-vol',
+            type='k8s-pvc',
+            cloud='kubernetes',
+            region=None,
+            zone=None,
+            name_on_cloud='test-pvc',
+            size=None,
+            config={},
+        )
+
+        need_refresh, new_config = k8s_volume.refresh_volume_config(config)
+
+        assert need_refresh is False
+        assert new_config.region is None
+        assert config.region is None
+        mock_in_cluster_context.assert_not_called()
 
     def test_refresh_volume_config_region_set(self):
         """When region is already set, it should be kept and no refresh needed."""


### PR DESCRIPTION
## Summary

`refresh_volume_config` (`sky/provision/kubernetes/volume.py`) previously rewrote `volume.region=None` to the literal string `'in-cluster'` unconditionally. That value is only valid when the API server is actually running with in-cluster service-account auth; when it authenticates via kubeconfig (buildkite kind agents, dev workstations, anywhere `/var/run/secrets/kubernetes.io/serviceaccount/token` doesn't exist), the optimizer compares `'in-cluster'` against the kubeconfig context names and raises `ResourcesUnavailableError`.

## Proven reproduction (local kind cluster, real API server + daemon)

Reproduced on a kubeconfig-only host (`kubectl config current-context = kind-skypilot`, `/var/run/secrets/kubernetes.io/serviceaccount/token` does not exist — identical to the buildkite kind agents) by adding a one-line probe to `refresh_volume_config` and walking the daemon-tick race deterministically.

### Without the fix (unfixed `refresh_volume_config`)

1. `sky volumes apply` with no `infra:` field — volume stored with `region=None`.
2. Wait 65s for the volume-refresh daemon tick (`sky/server/daemons.py:182`, `VOLUME_REFRESH_DAEMON_INTERVAL_SECONDS = 60`). Daemon log:
   ```
   [REPRO-PROBE] refresh_volume_config rewrote region None -> 'in-cluster' for volume
   'repro-hp-42642' (is_incluster_config_available=False)
   ```
3. DB row inspected directly via `sqlite3 ~/.sky/state.db` + `pickle.loads(handle)`: `region='in-cluster'`.
4. `sky launch -y --infra kubernetes <task referencing the volume>` fails with the **verbatim production error**:
   ```
   sky.exceptions.ResourcesUnavailableError: Task 'repro-min' requires volume
   repro-hp-42642 with infra Kubernetes/in-cluster which is not enabled.
   ```

### With the fix applied

1. Same `sky volumes apply`.
2. Wait 65s for the daemon tick. Daemon log:
   ```
   [REPRO-PROBE] refresh_volume_config left region None for volume
   'repro-fixed-43245' (is_incluster_config_available=False)
   ```
3. DB row: `region=None`.
4. Same `sky launch` succeeds — cluster created, job 1 submitted.

The race in production: whichever 60-second window the `sky launch` lands in. If the daemon tick fires between `apply` and `launch`, the row is poisoned and the launch raises. This surfaced as a flaky nightly smoke-test failure: same test (`test_hostpath_volume_on_kubernetes`), same commit, failed once (~54s — inside the 60s window) then passed on retry. The prior nightly on `3a5503dd2` passed too, and `git diff 3a5503dd2..28400dc43` shows zero volume/task/optimizer churn, ruling out a code regression.

## Code path

1. `sky volumes apply` inserts the row with `region=None`.
2. The volume-refresh daemon (`sky/server/daemons.py:182`) runs `volume_refresh()` immediately at API server boot then sleeps 60s.
3. **Unfixed `refresh_volume_config`** (`sky/provision/kubernetes/volume.py:437`) unconditionally calls `kubernetes.in_cluster_context_name()`, which returns the literal `'in-cluster'` when `SKYPILOT_IN_CLUSTER_CONTEXT_NAME` is unset (`sky/adaptors/kubernetes.py:425-432`). Stores back to DB.
4. On the next `sky launch`, Task topology forces `task.resources.region = volume.region` (`sky/task.py:1122-1134`).
5. Optimizer's `_check_specified_regions` (`sky/optimizer.py:1647-1668`) rejects `'in-cluster'` because it isn't in `Kubernetes.existing_allowed_contexts()` (the kubeconfig context here is `kind-skypilot`).

## The fix

```diff
-    if config.region is None:
+    if (config.region is None and
+            kubernetes_utils.is_incluster_config_available()):
         config.region = kubernetes.in_cluster_context_name()
         return True, config
     return False, config
```

Only rewrite when in-cluster auth is actually available (i.e. the service-account token file exists). Otherwise leave `region=None` so `sky launch` resolves the context from `--infra` at task time. The backwards-compat path the original comment describes (volumes created via in-cluster auth before #8386) is preserved: on a real in-cluster API server, the token file exists and the rewrite still fires.

## Test plan

- [x] `test_refresh_volume_config_region_none_incluster` (existing, renamed) — region=None + in-cluster auth available → still rewrites to the context name.
- [x] `test_refresh_volume_config_region_none_kubeconfig_only` (new) — region=None + no in-cluster auth → region stays None. Test docstring walks the daemon-tick race with file:line citations; assertion messages name the exact `ResourcesUnavailableError` chain that surfaces in production.
- [x] `test_refresh_volume_config_region_set` — untouched, still passes.
- [x] **Test verified to fail on unfixed code**: reverted `sky/provision/kubernetes/volume.py` to upstream master, ran the new test, it failed with:
  ```
  AssertionError: refresh_volume_config rewrote region=None to <MagicMock ...>
  even though in-cluster auth is unavailable. Production effect: every
  subsequent sky launch referencing this volume on a kubeconfig-only host
  (e.g. kind buildkite agent) will raise ResourcesUnavailableError:
  "requires volume X with infra Kubernetes/in-cluster which is not enabled"
  once the 60s volume-refresh daemon ticks.
  ```
  Restored the fix; same test passes.
- [x] **End-to-end reproduction** on local kind cluster (see "Proven reproduction" above) — without fix the daemon poisons the row and `sky launch` raises the production error; with fix the row stays clean and `sky launch` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
