### PR TITLE
[Test] Re-add NeMo image to k8s custom-image test (26.04.00)

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2296,6 +2296,9 @@ def test_aws_custom_docker_image_with_motd(image_id):
         # Test image with custom MOTD that can potentially interfere with
         # SSH user/rsync path detection.
         'docker:nvcr.io/nvidia/quantum/cuda-quantum:cu12-0.10.0',
+        # Verify the NeMo framework image works with SkyPilot. nemo has no
+        # :latest tag, so update this tag periodically.
+        'docker:nvcr.io/nvidia/nemo:26.04.00',
         # Test image with Python 3.12 site-packages as WORKDIR, which causes
         # import failures if CWD is not handled properly. When SkyPilot's Python
         # 3.10 venv runs, it finds Python 3.12 compiled packages (like rpds) in


### PR DESCRIPTION
## Summary

Follow-up to #9741. That PR removed `nvcr.io/nvidia/nemo:25.09` from the `test_kubernetes_custom_image` parametrize because NVIDIA had gated the entire NeMo repo behind NGC auth on 2026-05-27, breaking nightly smoke runs (anonymous pull → `ImagePullBackOff` → `--retry-until-up` burns the 1800s timeout).

NVIDIA has since made the NeMo repo anonymously pullable again. This PR re-adds the image at the current `26.04.00` tag so the nightly keeps verifying that the **NeMo image works with SkyPilot**.

Tracked by **SKY-5610**.

## Verification that the repo is pullable again

Checked the `nvcr.io` registry v2 API with an anonymous token (`proxy_auth` scope `repository:nvidia/nemo:pull`):

| Object | `nemo:26.04.00` |
|---|---|
| Multi-arch manifest list | `200` (amd64 + arm64) |
| amd64 config blob | `200` |
| amd64 layer blob | `200` |

Control: this matches the gating diagnosis in #9741, where the same blobs returned `denied: Access Denied`.

`nvcr.io/nvidia/nemo` has no `:latest` tag, so the tag is pinned and should be bumped periodically (the comment in the test notes this).

## Note on the previous PYTHONPATH framing

The old `nemo:25.09` entry was commented as "PYTHONPATH set + pyproject.toml" (guarding PR #7539's `env -u PYTHONPATH` step). The new `26.04.00` image dropped that env var — it switched to a `VIRTUAL_ENV=/opt/venv` layout and no longer sets `PYTHONPATH`. The purpose of keeping NeMo in this test is to verify the NeMo image itself works with SkyPilot (it's a large, non-standard GPU image that has historically surfaced pod-setup edge cases), so the comment was updated to reflect that rather than the PYTHONPATH-specific framing.

## Test plan

- [x] `/smoke-test --kubernetes -k test_kubernetes_custom_image` — **passed**: [#10995](https://buildkite.com/skypilot-1/smoke-tests/builds/10995). The `docker:nvcr.io/nvidia/nemo:26.04.00` parametrization passed (exit 0, no retries): the pod pulled the multi-GB NeMo image anonymously, launched, ran the task, and SSH succeeded — all within the 30-min timeout. All other custom-image parametrizations passed too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
