### PR TITLE
[AWS] Propagate tags (labels) to AWS Volumes

### DIFF
--- a/docs/source/cloud-setup/cloud-permissions/aws.rst
+++ b/docs/source/cloud-setup/cloud-permissions/aws.rst
@@ -355,6 +355,13 @@ These are the minimal policy rules required by SkyPilot:
             {
                 "Effect": "Allow",
                 "Action": [
+                    "ec2:CreateTags"
+                ],
+                "Resource": "arn:aws:ec2:*:<account-ID-without-hyphens>:volume/*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
                     "ec2:Describe*"
                 ],
                 "Resource": "*"

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -79,6 +79,7 @@ _EFA_INSTANCE_TYPE_PREFIXES = [
     'g6.',
     'gr6.',
     'g6e.',
+    'g7e.',
     'p4d.',
     'p4de.',
     'p5.',

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -160,9 +160,9 @@ def _merge_tag_specs(tag_specs: List[Dict[str, Any]],
     node provider tag specs is modified in-place.
 
     This allows users to add tags and override values of existing
-    tags with their own, and only applies to the resource type
-    'instance'. All other resource types are appended to the list of
-    tag specs.
+    tags with their own for any resource type already present in the
+    base specs. New resource types are appended to the list of tag
+    specs.
 
     Args:
         tag_specs (List[Dict[str, Any]]): base node provider tag specs
@@ -170,18 +170,23 @@ def _merge_tag_specs(tag_specs: List[Dict[str, Any]],
     """
 
     for user_tag_spec in user_tag_specs:
-        if user_tag_spec['ResourceType'] == 'instance':
-            for user_tag in user_tag_spec['Tags']:
-                exists = False
-                for tag in tag_specs[0]['Tags']:
-                    if user_tag['Key'] == tag['Key']:
-                        exists = True
-                        tag['Value'] = user_tag['Value']
-                        break
-                if not exists:
-                    tag_specs[0]['Tags'] += [user_tag]
-        else:
-            tag_specs += [user_tag_spec]
+        resource_type = user_tag_spec['ResourceType']
+        existing_tag_spec = next((tag_spec for tag_spec in tag_specs
+                                  if tag_spec['ResourceType'] == resource_type),
+                                 None)
+        if existing_tag_spec is None:
+            tag_specs.append(copy.deepcopy(user_tag_spec))
+            continue
+
+        for user_tag in user_tag_spec['Tags']:
+            exists = False
+            for tag in existing_tag_spec['Tags']:
+                if user_tag['Key'] == tag['Key']:
+                    exists = True
+                    tag['Value'] = user_tag['Value']
+                    break
+            if not exists:
+                existing_tag_spec['Tags'].append(user_tag)
 
 
 def _create_instances(
@@ -203,6 +208,9 @@ def _create_instances(
 
     tag_specs = [{
         'ResourceType': 'instance',
+        'Tags': _format_tags(tags),
+    }, {
+        'ResourceType': 'volume',
         'Tags': _format_tags(tags),
     }]
     user_tag_specs = conf.get('TagSpecifications', [])

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -319,6 +319,19 @@ def _get_head_instance_id(instances: List) -> Optional[str]:
     return head_instance_id
 
 
+def _get_attached_volume_ids(instances: List[Any]) -> List[str]:
+    """Collect attached EBS volume IDs from instances."""
+    volume_ids: List[str] = []
+    seen: Set[str] = set()
+    for inst in instances:
+        for mapping in getattr(inst, 'block_device_mappings', []) or []:
+            volume_id = mapping.get('Ebs', {}).get('VolumeId')
+            if volume_id is not None and volume_id not in seen:
+                seen.add(volume_id)
+                volume_ids.append(volume_id)
+    return volume_ids
+
+
 def run_instances(region: str, cluster_name: str, cluster_name_on_cloud: str,
                   config: common.ProvisionConfig) -> common.ProvisionRecord:
     """See sky/provision/__init__.py"""
@@ -479,6 +492,15 @@ def run_instances(region: str, cluster_name: str, cluster_name_on_cloud: str,
             # empty tags will result in error in the API call
             ec2.meta.client.create_tags(Resources=resumed_instance_ids,
                                         Tags=_format_tags(tags))
+            resumed_volume_ids = _get_attached_volume_ids(resumed_instances)
+            if resumed_volume_ids:
+                try:
+                    ec2.meta.client.create_tags(Resources=resumed_volume_ids,
+                                                Tags=_format_tags(tags))
+                except aws.botocore_exceptions().ClientError as e:
+                    logger.warning(
+                        'Failed to update tags for resumed AWS volumes '
+                        f'{resumed_volume_ids}: {e}')
             for inst in resumed_instances:
                 inst.tags = _format_tags(tags)  # sync the tags info
         placement_zone = resumed_instances[0].placement['AvailabilityZone']

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -325,7 +325,7 @@ def _get_attached_volume_ids(instances: List[Any]) -> List[str]:
     seen: Set[str] = set()
     for inst in instances:
         for mapping in getattr(inst, 'block_device_mappings', []) or []:
-            volume_id = mapping.get('Ebs', {}).get('VolumeId')
+            volume_id = (mapping.get('Ebs') or {}).get('VolumeId')
             if volume_id is not None and volume_id not in seen:
                 seen.add(volume_id)
                 volume_ids.append(volume_id)

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -186,7 +186,7 @@ def _merge_tag_specs(tag_specs: List[Dict[str, Any]],
                     tag['Value'] = user_tag['Value']
                     break
             if not exists:
-                existing_tag_spec['Tags'].append(user_tag)
+                existing_tag_spec['Tags'].append(copy.deepcopy(user_tag))
 
 
 def _create_instances(

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -151,6 +151,14 @@ available_node_types:
             - Key: {{ label_key }}
               Value: {{ label_value|tojson }}
             {%- endfor %}
+        - ResourceType: volume
+          Tags:
+            - Key: skypilot-user
+              Value: {{ user }}
+            {%- for label_key, label_value in labels.items() %}
+            - Key: {{ label_key }}
+              Value: {{ label_value|tojson }}
+            {%- endfor %}
       # Use IDMSv2
       MetadataOptions:
         HttpTokens: required

--- a/tests/unit_tests/test_aws.py
+++ b/tests/unit_tests/test_aws.py
@@ -14,6 +14,7 @@ from sky.clouds import Zone
 from sky.clouds.aws import AWS
 from sky.provision import constants as provision_constants
 from sky.provision.aws import config
+from sky.provision.aws import instance as aws_instance
 from sky.utils import common_utils
 from sky.utils import config_utils
 
@@ -36,6 +37,101 @@ def test_aws_label():
         'sprinto:short',
         'thisiexample_string_with_123_characters_length_thing_thing_thing_thing_thing_thing_thing_thin_thing_thing_thing_thing_thing_thingthisiexample_string_with_123_characters_length_thing_thing_thing_thing_thing_thing_thing_thin_thing_thing_thing_thing_thing_thing',
     )[0])
+
+
+def test_create_instances_adds_volume_tag_spec():
+    ec2_fail_fast = MagicMock()
+    ec2_fail_fast.create_instances.return_value = ['instance']
+
+    node_config = {
+        'SubnetIds': ['subnet-123'],
+        'SecurityGroupIds': ['sg-123'],
+        'InstanceType': 'g5.xlarge',
+    }
+    tags = {
+        'Owner': 'alice',
+    }
+
+    result = aws_instance._create_instances(
+        ec2_fail_fast=ec2_fail_fast,
+        cluster_name='cluster',
+        node_config=node_config,
+        tags=tags,
+        count=1,
+        associate_public_ip_address=True,
+        max_efa_interfaces=0,
+    )
+
+    assert result == ['instance']
+
+    call_kwargs = ec2_fail_fast.create_instances.call_args.kwargs
+    assert call_kwargs['MinCount'] == 1
+    assert call_kwargs['MaxCount'] == 1
+
+    tag_specs = {
+        tag_spec['ResourceType']: tag_spec['Tags']
+        for tag_spec in call_kwargs['TagSpecifications']
+    }
+    expected_tags = [{
+        'Key': 'Name',
+        'Value': 'cluster'
+    }, {
+        'Key': provision_constants.TAG_RAY_CLUSTER_NAME,
+        'Value': 'cluster'
+    }, {
+        'Key': provision_constants.TAG_SKYPILOT_CLUSTER_NAME,
+        'Value': 'cluster'
+    }, {
+        'Key': 'Owner',
+        'Value': 'alice'
+    }]
+    assert tag_specs['instance'] == expected_tags
+    assert tag_specs['volume'] == expected_tags
+
+
+def test_merge_tag_specs_merges_volume_tags():
+    base_tag_specs = [{
+        'ResourceType': 'instance',
+        'Tags': [{
+            'Key': 'Name',
+            'Value': 'cluster'
+        }],
+    }, {
+        'ResourceType': 'volume',
+        'Tags': [{
+            'Key': 'Name',
+            'Value': 'cluster'
+        }, {
+            'Key': 'Owner',
+            'Value': 'alice'
+        }],
+    }]
+    user_tag_specs = [{
+        'ResourceType': 'volume',
+        'Tags': [{
+            'Key': 'Owner',
+            'Value': 'bob'
+        }, {
+            'Key': 'Team',
+            'Value': 'ml'
+        }],
+    }]
+
+    aws_instance._merge_tag_specs(base_tag_specs, user_tag_specs)
+
+    volume_tags = next(tag_spec['Tags']
+                       for tag_spec in base_tag_specs
+                       if tag_spec['ResourceType'] == 'volume')
+    assert volume_tags == [{
+        'Key': 'Name',
+        'Value': 'cluster'
+    }, {
+        'Key': 'Owner',
+        'Value': 'bob'
+    }, {
+        'Key': 'Team',
+        'Value': 'ml'
+    }]
 
 
 def test_usable_subnets(monkeypatch):

--- a/tests/unit_tests/test_aws.py
+++ b/tests/unit_tests/test_aws.py
@@ -1,4 +1,5 @@
 import pathlib
+from types import SimpleNamespace
 import typing
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -12,6 +13,7 @@ from sky.backends import backend_utils
 from sky.clouds import Region
 from sky.clouds import Zone
 from sky.clouds.aws import AWS
+from sky.provision import common as provision_common
 from sky.provision import constants as provision_constants
 from sky.provision.aws import config
 from sky.provision.aws import instance as aws_instance
@@ -132,6 +134,144 @@ def test_merge_tag_specs_merges_volume_tags():
         'Key': 'Team',
         'Value': 'ml'
     }]
+
+
+def test_run_instances_tags_resumed_instance_volumes():
+    stopped_instance = SimpleNamespace(
+        id='i-stopped',
+        state={'Name': 'stopped'},
+        placement={'AvailabilityZone': 'us-east-1a'},
+        tags=[{
+            'Key': key,
+            'Value': value
+        } for key, value in provision_constants.HEAD_NODE_TAGS.items()],
+        block_device_mappings=[{
+            'Ebs': {
+                'VolumeId': 'vol-1'
+            }
+        }, {
+            'Ebs': {
+                'VolumeId': 'vol-2'
+            }
+        }],
+    )
+
+    mock_ec2 = MagicMock()
+    mock_ec2.meta.client.meta.region_name = 'us-east-1'
+    mock_ec2.instances.filter.return_value = [stopped_instance]
+
+    mock_ec2_fail_fast = MagicMock()
+    mock_ec2_fail_fast.meta.client.start_instances.return_value = {}
+
+    provision_config = provision_common.ProvisionConfig(
+        provider_config={'use_internal_ips': False},
+        authentication_config={},
+        docker_config={},
+        node_config={},
+        count=1,
+        tags={'Owner': 'alice'},
+        resume_stopped_nodes=True,
+        ports_to_open_on_launch=None,
+    )
+
+    with patch.object(aws_instance,
+                      '_default_ec2_resource',
+                      return_value=mock_ec2), patch.object(
+                          aws_instance.aws,
+                          'resource',
+                          return_value=mock_ec2_fail_fast):
+        record = aws_instance.run_instances(region='us-east-1',
+                                            cluster_name='cluster',
+                                            cluster_name_on_cloud='cluster',
+                                            config=provision_config)
+
+    assert record.resumed_instance_ids == ['i-stopped']
+    assert record.created_instance_ids == []
+
+    create_tags_calls = mock_ec2.meta.client.create_tags.call_args_list
+    assert len(create_tags_calls) == 2
+    assert create_tags_calls[0].kwargs == {
+        'Resources': ['i-stopped'],
+        'Tags': [{
+            'Key': 'Owner',
+            'Value': 'alice'
+        }],
+    }
+    assert create_tags_calls[1].kwargs == {
+        'Resources': ['vol-1', 'vol-2'],
+        'Tags': [{
+            'Key': 'Owner',
+            'Value': 'alice'
+        }],
+    }
+
+
+@patch.object(aws_instance, 'logger')
+def test_run_instances_volume_tag_failure_does_not_abort_resume(mock_logger):
+    stopped_instance = SimpleNamespace(
+        id='i-stopped',
+        state={'Name': 'stopped'},
+        placement={'AvailabilityZone': 'us-east-1a'},
+        tags=[{
+            'Key': key,
+            'Value': value
+        } for key, value in provision_constants.HEAD_NODE_TAGS.items()],
+        block_device_mappings=[{
+            'Ebs': {
+                'VolumeId': 'vol-1'
+            }
+        }],
+    )
+
+    mock_ec2 = MagicMock()
+    mock_ec2.meta.client.meta.region_name = 'us-east-1'
+    mock_ec2.instances.filter.return_value = [stopped_instance]
+
+    def create_tags_side_effect(**kwargs):
+        if kwargs['Resources'] == ['vol-1']:
+            raise aws_instance.aws.botocore_exceptions().ClientError(
+                error_response={
+                    'Error': {
+                        'Code': 'UnauthorizedOperation',
+                        'Message': 'not allowed',
+                    }
+                },
+                operation_name='CreateTags',
+            )
+        return {}
+
+    mock_ec2.meta.client.create_tags.side_effect = create_tags_side_effect
+
+    mock_ec2_fail_fast = MagicMock()
+    mock_ec2_fail_fast.meta.client.start_instances.return_value = {}
+
+    provision_config = provision_common.ProvisionConfig(
+        provider_config={'use_internal_ips': False},
+        authentication_config={},
+        docker_config={},
+        node_config={},
+        count=1,
+        tags={'Owner': 'alice'},
+        resume_stopped_nodes=True,
+        ports_to_open_on_launch=None,
+    )
+
+    with patch.object(aws_instance,
+                      '_default_ec2_resource',
+                      return_value=mock_ec2), patch.object(
+                          aws_instance.aws,
+                          'resource',
+                          return_value=mock_ec2_fail_fast):
+        record = aws_instance.run_instances(region='us-east-1',
+                                            cluster_name='cluster',
+                                            cluster_name_on_cloud='cluster',
+                                            config=provision_config)
+
+    assert record.resumed_instance_ids == ['i-stopped']
+    mock_logger.warning.assert_any_call(
+        'Failed to update tags for resumed AWS volumes '
+        "['vol-1']: An error occurred (UnauthorizedOperation) when calling "
+        'the CreateTags operation: not allowed')
 
 
 def test_usable_subnets(monkeypatch):

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -214,6 +214,24 @@ def test_write_cluster_config_w_post_provision_runcmd_kubernetes(
         'runcmd'] == expected_runcmd, "runcmd not passed correctly"
 
 
+@mock.patch.object(skypilot_config, '_global_config_context',
+                   skypilot_config.ConfigContext())
+def test_aws_template_applies_labels_to_volume_tags() -> None:
+    template_path = pathlib.Path('sky/templates/aws-ray.yml.j2')
+    template = template_path.read_text(encoding='utf-8')
+
+    expected_block = """        - ResourceType: volume
+          Tags:
+            - Key: skypilot-user
+              Value: {{ user }}
+            {%- for label_key, label_value in labels.items() %}
+            - Key: {{ label_key }}
+              Value: {{ label_value|tojson }}
+            {%- endfor %}"""
+
+    assert expected_block in template
+
+
 def test_get_clusters_launch_refresh(monkeypatch):
     # verifies that `get_clusters` works when one cluster is launching
     # and other is not.

--- a/tests/unit_tests/test_sky/clouds/test_aws_cloud.py
+++ b/tests/unit_tests/test_sky/clouds/test_aws_cloud.py
@@ -341,6 +341,7 @@ class TestEfaHelpers:
     def test_is_efa_instance_type(self):
         # True for EFA families
         assert aws_mod._is_efa_instance_type('g6.12xlarge') is True
+        assert aws_mod._is_efa_instance_type('g7e.12xlarge') is True
         assert aws_mod._is_efa_instance_type('p5.48xlarge') is True
         assert aws_mod._is_efa_instance_type('p6-b200.24xlarge') is True
         # False for non-EFA families


### PR DESCRIPTION
Previously, only Instances were being tagged. However, in some situations compliance reasons may require volume tagging as well. This PR updates the system to tag instance associated volumes with the desired tags.

Added tests in:
* tests/unit_tests/test_aws.py
* tests/unit_tests/test_backend_utils.py
* tests/unit_tests/test_sky/clouds/test_aws_cloud.py

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
    - [x] pytest tests/unit_tests/test_aws.py
    - [x] pytest tests/unit_tests/test_backend_utils.py
    - [x] pytest tests/unit_tests/test_sky/clouds/test_aws_cloud.py
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)


Closes: https://github.com/skypilot-org/skypilot/issues/9746

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->