### PR TITLE
[Kubernetes] Respect configured pod tolerations in node-health display

### DIFF
--- a/sky/catalog/kubernetes_catalog.py
+++ b/sky/catalog/kubernetes_catalog.py
@@ -200,6 +200,9 @@ def _list_accelerators(
     total_accelerators_available: Dict[str, int] = {}
     min_quantity_filter = quantity_filter if quantity_filter else 1
 
+    configured_tolerations = kubernetes_utils.get_configured_tolerations(
+        context)
+
     for node in nodes:
         # Check if node is ready
         node_is_ready = node.is_ready()
@@ -208,8 +211,14 @@ def _list_accelerators(
             exclude_cordon=True,
             exclude_not_ready=True,
             exclude_effects=['PreferNoSchedule'],
-            exclude_keys=kubernetes_utils.get_handled_taint_keys())
-        node_is_tainted = len(node_taints) > 0
+            exclude_keys=kubernetes_utils.get_handled_taint_keys(),
+            tolerations=configured_tolerations)
+        # A taint that is tolerated by the user's configured pod tolerations
+        # does not make the node un-schedulable for the user's workloads.
+        # Without configured tolerations, every retained taint has
+        # `tolerated=False` so this is equivalent to `len(node_taints) > 0`.
+        node_is_tainted = any(
+            not t.get('tolerated', False) for t in node_taints)
 
         for key in keys:
             if key in node.metadata.labels:

--- a/sky/catalog/kubernetes_catalog.py
+++ b/sky/catalog/kubernetes_catalog.py
@@ -217,8 +217,7 @@ def _list_accelerators(
         # does not make the node un-schedulable for the user's workloads.
         # Without configured tolerations, every retained taint has
         # `tolerated=False` so this is equivalent to `len(node_taints) > 0`.
-        node_is_tainted = any(
-            not t.get('tolerated', False) for t in node_taints)
+        node_is_tainted = kubernetes_utils.has_untolerated_taint(node_taints)
 
         for key in keys:
             if key in node.metadata.labels:

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -4230,7 +4230,12 @@ def _show_gpus_impl(
                 node_is_ready = getattr(node_info, 'is_ready', True)
                 node_is_cordoned = getattr(node_info, 'is_cordoned', False)
                 node_taints = getattr(node_info, 'taints', None) or []
-                node_is_tainted = len(node_taints) > 0
+                # Only un-tolerated taints count toward the "not ready" GPU
+                # tally. Taints matched by `kubernetes.pod_config.spec
+                # .tolerations` arrive with `tolerated=True` and don't make
+                # the node unschedulable for the user's workloads.
+                node_is_tainted = any(
+                    not t.get('tolerated', False) for t in node_taints)
                 if not node_is_ready or node_is_cordoned or node_is_tainted:
                     not_ready_counts[accelerator_type] += accelerator_count
             return not_ready_counts
@@ -4470,24 +4475,31 @@ def _show_gpus_impl(
                 node_is_cordoned = getattr(node_info, 'is_cordoned', False)
                 if node_is_cordoned:
                     status_info.append('Cordoned')
-                # Add taint info grouped by effect
+                # Add taint info grouped by effect. Only un-tolerated taints
+                # count toward node status — taints matched by the user's
+                # configured `kubernetes.pod_config.spec.tolerations` arrive
+                # with `tolerated=True` and don't make the node unhealthy.
                 taints = getattr(node_info, 'taints', None)
                 if taints:
-                    # Group taints by effect: 'NoSchedule Taint [key1, key2],
-                    # NoExecute Taint [key3]'
-                    taints_by_effect: Dict[str, List[str]] = {}
-                    for taint in taints:
-                        effect = taint['effect']
-                        key = taint['key']
-                        if effect not in taints_by_effect:
-                            taints_by_effect[effect] = []
-                        taints_by_effect[effect].append(key)
-                    taints_strs = []
-                    for effect, keys in taints_by_effect.items():
-                        taints_strs.append(
-                            f'{effect} Taint [{", ".join(keys)}]')
-                    if taints_strs:
-                        status_info.append(', '.join(taints_strs))
+                    untolerated_taints = [
+                        t for t in taints if not t.get('tolerated', False)
+                    ]
+                    if untolerated_taints:
+                        # Group taints by effect: 'NoSchedule Taint [key1,
+                        # key2], NoExecute Taint [key3]'
+                        taints_by_effect: Dict[str, List[str]] = {}
+                        for taint in untolerated_taints:
+                            effect = taint['effect']
+                            key = taint['key']
+                            if effect not in taints_by_effect:
+                                taints_by_effect[effect] = []
+                            taints_by_effect[effect].append(key)
+                        taints_strs = []
+                        for effect, keys in taints_by_effect.items():
+                            taints_strs.append(
+                                f'{effect} Taint [{", ".join(keys)}]')
+                        if taints_strs:
+                            status_info.append(', '.join(taints_strs))
 
                 status_str = ', '.join(
                     status_info) if status_info else 'Healthy'

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -4229,14 +4229,13 @@ def _show_gpus_impl(
 
                 node_is_ready = getattr(node_info, 'is_ready', True)
                 node_is_cordoned = getattr(node_info, 'is_cordoned', False)
-                node_taints = getattr(node_info, 'taints', None) or []
+                node_taints = getattr(node_info, 'taints', None)
                 # Only un-tolerated taints count toward the "not ready" GPU
                 # tally. Taints matched by `kubernetes.pod_config.spec
                 # .tolerations` arrive with `tolerated=True` and don't make
                 # the node unschedulable for the user's workloads.
-                node_is_tainted = any(
-                    not t.get('tolerated', False) for t in node_taints)
-                if not node_is_ready or node_is_cordoned or node_is_tainted:
+                if (not node_is_ready or node_is_cordoned or
+                        kubernetes_utils.has_untolerated_taint(node_taints)):
                     not_ready_counts[accelerator_type] += accelerator_count
             return not_ready_counts
 

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -4479,27 +4479,26 @@ def _show_gpus_impl(
                 # count toward node status — taints matched by the user's
                 # configured `kubernetes.pod_config.spec.tolerations` arrive
                 # with `tolerated=True` and don't make the node unhealthy.
-                taints = getattr(node_info, 'taints', None)
-                if taints:
-                    untolerated_taints = [
-                        t for t in taints if not t.get('tolerated', False)
+                untolerated_taints = [
+                    t for t in (getattr(node_info, 'taints', None) or [])
+                    if not t.get('tolerated', False)
+                ]
+                if untolerated_taints:
+                    # Group taints by effect: 'NoSchedule Taint [key1, key2],
+                    # NoExecute Taint [key3]'
+                    taints_by_effect: Dict[str, List[str]] = {}
+                    for taint in untolerated_taints:
+                        effect = taint['effect']
+                        key = taint['key']
+                        if effect not in taints_by_effect:
+                            taints_by_effect[effect] = []
+                        taints_by_effect[effect].append(key)
+                    taints_strs = [
+                        f'{effect} Taint [{", ".join(keys)}]'
+                        for effect, keys in taints_by_effect.items()
                     ]
-                    if untolerated_taints:
-                        # Group taints by effect: 'NoSchedule Taint [key1,
-                        # key2], NoExecute Taint [key3]'
-                        taints_by_effect: Dict[str, List[str]] = {}
-                        for taint in untolerated_taints:
-                            effect = taint['effect']
-                            key = taint['key']
-                            if effect not in taints_by_effect:
-                                taints_by_effect[effect] = []
-                            taints_by_effect[effect].append(key)
-                        taints_strs = []
-                        for effect, keys in taints_by_effect.items():
-                            taints_strs.append(
-                                f'{effect} Taint [{", ".join(keys)}]')
-                        if taints_strs:
-                            status_info.append(', '.join(taints_strs))
+                    if taints_strs:
+                        status_info.append(', '.join(taints_strs))
 
                 status_str = ', '.join(
                     status_info) if status_info else 'Healthy'

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -879,12 +879,19 @@ export function ContextDetails({
                       statusInfo.push('Cordoned');
                     }
 
-                    // Build taint info separately
+                    // Build taint info separately. Taints whose
+                    // `tolerated` flag is set by the backend (i.e. matched
+                    // by `kubernetes.pod_config.spec.tolerations`) do not
+                    // count against node health on the Infra page — they're
+                    // surfaced in the GPU Manager drawer instead.
                     const taints = node.taints || [];
+                    const untoleratedTaints = taints.filter(
+                      (t) => t && t.tolerated !== true
+                    );
                     let taintInfo = null;
-                    if (taints.length > 0) {
+                    if (untoleratedTaints.length > 0) {
                       const taintsByEffect = {};
-                      for (const taint of taints) {
+                      for (const taint of untoleratedTaints) {
                         const effect = taint.effect;
                         const key = taint.key;
                         if (!taintsByEffect[effect]) {

--- a/sky/dashboard/src/data/connectors/infra.jsx
+++ b/sky/dashboard/src/data/connectors/infra.jsx
@@ -431,9 +431,12 @@ export async function getContextGPUData(context) {
         const isReady = nodeData['is_ready'] !== false;
         // Check if node is cordoned (defaults to false for backward compatibility)
         const isCordoned = nodeData['is_cordoned'] === true;
-        // Check if node has taints (defaults to empty for backward compatibility)
+        // Check if node has taints (defaults to empty for backward compatibility).
+        // Only un-tolerated taints make a node "not ready" — taints matched by
+        // the configured `kubernetes.pod_config.spec.tolerations` arrive with
+        // `tolerated=true` and don't suppress GPU availability.
         const taints = nodeData['taints'] || [];
-        const isTainted = taints.length > 0;
+        const isTainted = taints.some((t) => t && t.tolerated !== true);
         // Node is considered not ready if it's not ready, cordoned, or tainted
         const isNodeNotReady = !isReady || isCordoned || isTainted;
 
@@ -569,9 +572,11 @@ async function getKubernetesGPUsFromContexts(contextNames) {
           const isReady = nodeData['is_ready'] !== false;
           // Check if node is cordoned (defaults to false for backward compatibility)
           const isCordoned = nodeData['is_cordoned'] === true;
-          // Check if node has taints (defaults to empty for backward compatibility)
+          // Check if node has taints (defaults to empty for backward
+          // compatibility). Only un-tolerated taints make a node "not
+          // ready" — see the same logic above.
           const taints = nodeData['taints'] || [];
-          const isTainted = taints.length > 0;
+          const isTainted = taints.some((t) => t && t.tolerated !== true);
           // Node is considered not ready if it's not ready, cordoned, or tainted
           const isNodeNotReady = !isReady || isCordoned || isTainted;
 

--- a/sky/dashboard/src/data/connectors/infra.jsx
+++ b/sky/dashboard/src/data/connectors/infra.jsx
@@ -7,6 +7,23 @@ import dashboardCache from '@/lib/cache';
 import { buildContextStatsKeyFromCloud } from '@/utils/infraUtils';
 
 /**
+ * Returns true iff `nodeData` (a `KubernetesNodeInfo`-shaped object from
+ * the API) should be excluded from free-GPU availability counts — i.e.,
+ * it's not ready, cordoned, or carries at least one taint that the
+ * configured `kubernetes.pod_config.spec.tolerations` does NOT tolerate.
+ * Taints with `tolerated: true` (set by the backend for matching
+ * tolerations) don't suppress availability.
+ */
+function isNodeNotReadyForGpus(nodeData) {
+  const isReady = nodeData['is_ready'] !== false;
+  const isCordoned = nodeData['is_cordoned'] === true;
+  const isTainted = (nodeData['taints'] || []).some(
+    (t) => t && t.tolerated !== true
+  );
+  return !isReady || isCordoned || isTainted;
+}
+
+/**
  * Fast function to get just the list of enabled clouds (without counts).
  * Used for progressive loading - display cloud rows immediately, then overlay counts.
  */
@@ -428,17 +445,7 @@ export async function getContextGPUData(context) {
         const gpuName = nodeData['accelerator_type'] || '-';
         const totalCount = nodeData['total']?.['accelerator_count'] || 0;
         const freeCount = nodeData['free']?.['accelerators_available'] || 0;
-        const isReady = nodeData['is_ready'] !== false;
-        // Check if node is cordoned (defaults to false for backward compatibility)
-        const isCordoned = nodeData['is_cordoned'] === true;
-        // Check if node has taints (defaults to empty for backward compatibility).
-        // Only un-tolerated taints make a node "not ready" — taints matched by
-        // the configured `kubernetes.pod_config.spec.tolerations` arrive with
-        // `tolerated=true` and don't suppress GPU availability.
-        const taints = nodeData['taints'] || [];
-        const isTainted = taints.some((t) => t && t.tolerated !== true);
-        // Node is considered not ready if it's not ready, cordoned, or tainted
-        const isNodeNotReady = !isReady || isCordoned || isTainted;
+        const isNodeNotReady = isNodeNotReadyForGpus(nodeData);
 
         // Per-node data - use same field names as original getKubernetesGPUsFromContexts
         perNodeGPUs.push({
@@ -446,9 +453,9 @@ export async function getContextGPUData(context) {
           gpu_name: gpuName,
           gpu_total: totalCount,
           gpu_free: freeCount,
-          is_ready: isReady,
-          is_cordoned: isCordoned,
-          taints: taints,
+          is_ready: nodeData['is_ready'] !== false,
+          is_cordoned: nodeData['is_cordoned'] === true,
+          taints: nodeData['taints'] || [],
           context: context,
           ip_address: nodeData['ip_address'] || null,
           cpu_count: nodeData['cpu_count'] ?? null,
@@ -568,17 +575,7 @@ async function getKubernetesGPUsFromContexts(contextNames) {
           const gpuName = nodeData['accelerator_type'] || '-';
           const totalCount = nodeData['total']?.['accelerator_count'] || 0;
           const freeCount = nodeData['free']?.['accelerators_available'] || 0;
-          // Check if node is ready (defaults to true for backward compatibility)
-          const isReady = nodeData['is_ready'] !== false;
-          // Check if node is cordoned (defaults to false for backward compatibility)
-          const isCordoned = nodeData['is_cordoned'] === true;
-          // Check if node has taints (defaults to empty for backward
-          // compatibility). Only un-tolerated taints make a node "not
-          // ready" — see the same logic above.
-          const taints = nodeData['taints'] || [];
-          const isTainted = taints.some((t) => t && t.tolerated !== true);
-          // Node is considered not ready if it's not ready, cordoned, or tainted
-          const isNodeNotReady = !isReady || isCordoned || isTainted;
+          const isNodeNotReady = isNodeNotReadyForGpus(nodeData);
 
           if (totalCount > 0) {
             if (!gpuToData[gpuName]) {

--- a/sky/models.py
+++ b/sky/models.py
@@ -95,7 +95,9 @@ class KubernetesNodeInfo:
     # Whether the node is cordoned (spec.unschedulable is true)
     is_cordoned: bool = False
     # List of taints on the node, each taint is a dict with 'key', 'value',
-    # 'effect'
+    # 'effect', and optionally 'tolerated' (a bool indicating whether the
+    # taint is matched by an entry in the configured
+    # `kubernetes.pod_config.spec.tolerations`).
     taints: Optional[List[Dict[str, Any]]] = None
 
 

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1495,6 +1495,7 @@ class V1Node:
         exclude_effects: Optional[List[str]] = None,
         exclude_keys: Optional[List[str]] = None,
         exclude_key_prefixes: Optional[List[str]] = None,
+        tolerations: Optional[List[Dict[str, Any]]] = None,
     ) -> List[Dict[str, Any]]:
         """Get the taints on the node.
 
@@ -1506,6 +1507,13 @@ class V1Node:
             exclude_keys: The taint keys to exclude.
             exclude_key_prefixes: Taint key prefixes to exclude,
               e.g. ['node-role.kubernetes.io/'].
+            tolerations: Optional list of Kubernetes toleration dicts
+              (typically read from `kubernetes.pod_config.spec.tolerations`).
+              When provided, each retained taint dict gains a
+              `'tolerated': bool` key indicating whether any of the
+              tolerations matches it (Kubernetes semantics).
+              When omitted, returned dicts have no `'tolerated'` key
+              (backwards-compatible with existing callers).
 
         Returns:
             List[Dict[str, Any]]: The taints on the node.
@@ -1527,11 +1535,15 @@ class V1Node:
             if exclude_key_prefixes and any(
                     t.key.startswith(p) for p in exclude_key_prefixes):
                 continue
-            taints.append({
+            taint_dict: Dict[str, Any] = {
                 'key': t.key,
                 'value': t.value if t.value else None,
-                'effect': t.effect
-            })
+                'effect': t.effect,
+            }
+            if tolerations is not None:
+                taint_dict['tolerated'] = taint_is_tolerated(
+                    taint_dict, tolerations)
+            taints.append(taint_dict)
         return taints
 
 
@@ -1545,6 +1557,104 @@ def get_allowed_nodes_config(
                                                        region=context,
                                                        keys=('allowed_nodes',),
                                                        default_value=None)
+
+
+def get_configured_tolerations(
+        context: Optional[str] = None) -> Optional[List[Dict[str, Any]]]:
+    """Returns the configured pod tolerations for the given K8s context.
+
+    Reads `kubernetes.pod_config.spec.tolerations` from ~/.sky/config.yaml,
+    respecting context_configs overrides. Returns `None` if no tolerations
+    are configured (which is the case for the vast majority of setups) so
+    that downstream callers can pass the result through to
+    `V1Node.get_taints(tolerations=...)` and get byte-identical
+    output to today.
+
+    Fetches the entire `pod_config` dict (rather than the nested
+    `('pod_config', 'spec', 'tolerations')` key directly) so the
+    Kubernetes-specific dict merge fires inside
+    `get_effective_region_config` — that path appends per-context
+    list entries onto the global list (see `merge_k8s_configs`),
+    matching the toleration list that an actual pod gets at
+    scheduling time via `resolve_effective_pod_config`. Fetching the
+    leaf `tolerations` key directly would bypass the dict merge and
+    let a per-context list clobber the global one.
+
+    Each toleration is a dict in standard Kubernetes shape, e.g.
+    `{'key': 'workload_pool', 'operator': 'Equal', 'value': 'research',
+      'effect': 'NoSchedule'}`.
+    """
+    pod_config = skypilot_config.get_effective_region_config(
+        cloud='kubernetes',
+        region=context,
+        keys=('pod_config',),
+        default_value=None)
+    if not isinstance(pod_config, dict):
+        return None
+    spec = pod_config.get('spec')
+    if not isinstance(spec, dict):
+        return None
+    tolerations = spec.get('tolerations')
+    if not isinstance(tolerations, list):
+        return None
+    # Filter to dict entries only — be defensive against malformed config.
+    return [t for t in tolerations if isinstance(t, dict)]
+
+
+def taint_is_tolerated(taint: Dict[str, Any],
+                       tolerations: List[Dict[str, Any]]) -> bool:
+    """Returns True if any of `tolerations` matches the given taint.
+
+    Implements Kubernetes toleration semantics
+    (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/):
+
+    - `operator: Equal` (the default if unset) requires the toleration's
+      `key` and `value` to match the taint's `key` and `value` exactly.
+    - `operator: Exists` requires the toleration's `key` to match the
+      taint's `key`; the toleration's `value` is ignored.
+    - An empty (or missing) `key` is only valid with `operator: Exists`
+      and matches all taint keys (wildcard).
+    - An empty (or missing) `effect` matches all taint effects;
+      otherwise the toleration's `effect` must match the taint's `effect`
+      exactly.
+
+    Args:
+        taint: A taint dict with at least `'key'` and `'effect'` keys
+          (and optionally `'value'`), as produced by
+          `V1Node.get_taints`.
+        tolerations: List of toleration dicts (Kubernetes shape).
+
+    Returns:
+        True if at least one toleration in the list matches the taint.
+    """
+    # Coerce to str defensively — YAML can parse unquoted numbers/booleans
+    # as non-string types (e.g. `value: 123` → int), which would silently
+    # fail to match the K8s API's always-string taint fields.
+    taint_key = str(taint.get('key') or '')
+    taint_effect = str(taint.get('effect') or '')
+    taint_value = str(taint.get('value') or '')
+    for tol in tolerations:
+        if not isinstance(tol, dict):
+            continue
+        tol_effect = str(tol.get('effect') or '')
+        if tol_effect and tol_effect != taint_effect:
+            continue
+        tol_op = str(tol.get('operator') or 'Equal')
+        tol_key = str(tol.get('key') or '')
+        tol_value = str(tol.get('value') or '')
+        if not tol_key:
+            # Empty key is only valid with Exists; matches any key.
+            if tol_op == 'Exists':
+                return True
+            continue
+        if tol_key != taint_key:
+            continue
+        if tol_op == 'Exists':
+            return True
+        # Equal (default): values must match (treating absent value as '').
+        if tol_value == taint_value:
+            return True
+    return False
 
 
 def _filter_allowed_nodes(nodes: List[V1Node],
@@ -3951,6 +4061,7 @@ def get_kubernetes_node_info(
         # Fall through to direct Kubernetes API query if provider returns None
 
     nodes = get_kubernetes_nodes(context=context)
+    configured_tolerations = get_configured_tolerations(context)
 
     lf, _ = detect_gpu_label_formatter(context)
     if not lf:
@@ -4064,8 +4175,14 @@ def get_kubernetes_node_info(
             exclude_not_ready=True,
             exclude_effects=['PreferNoSchedule'],
             exclude_keys=get_handled_taint_keys(),
-            exclude_key_prefixes=_ROLE_TAINT_KEY_PREFIXES)
-        node_is_tainted = len(node_taints) > 0
+            exclude_key_prefixes=_ROLE_TAINT_KEY_PREFIXES,
+            tolerations=configured_tolerations)
+        # A node is "tainted" (un-schedulable from a taint perspective) only if
+        # it has at least one taint not tolerated by the configured pod
+        # tolerations. Without configured tolerations, every retained taint has
+        # `tolerated=False` so this is equivalent to `len(node_taints) > 0`.
+        node_is_tainted = any(
+            not t.get('tolerated', False) for t in node_taints)
 
         if accelerator_count == 0:
             node_info_dict[node.metadata.name] = models.KubernetesNodeInfo(

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1627,21 +1627,31 @@ def taint_is_tolerated(taint: Dict[str, Any],
     Returns:
         True if at least one toleration in the list matches the taint.
     """
+
     # Coerce to str defensively — YAML can parse unquoted numbers/booleans
     # as non-string types (e.g. `value: 123` → int), which would silently
-    # fail to match the K8s API's always-string taint fields.
-    taint_key = str(taint.get('key') or '')
-    taint_effect = str(taint.get('effect') or '')
-    taint_value = str(taint.get('value') or '')
+    # fail to match the K8s API's always-string taint fields. Use the
+    # `None`-explicit form rather than `str(x or '')` so falsy-but-set
+    # values like `value: 0` and `value: false` survive the coercion
+    # (`str(0 or '')` would collapse to `''` and never match `'0'`).
+    def _str_or_empty(v: Any) -> str:
+        return '' if v is None else str(v)
+
+    taint_key = _str_or_empty(taint.get('key'))
+    taint_effect = _str_or_empty(taint.get('effect'))
+    taint_value = _str_or_empty(taint.get('value'))
     for tol in tolerations:
         if not isinstance(tol, dict):
             continue
-        tol_effect = str(tol.get('effect') or '')
+        tol_effect = _str_or_empty(tol.get('effect'))
         if tol_effect and tol_effect != taint_effect:
             continue
-        tol_op = str(tol.get('operator') or 'Equal')
-        tol_key = str(tol.get('key') or '')
-        tol_value = str(tol.get('value') or '')
+        # `operator` is the only field where Equal is the documented
+        # default per the K8s API spec, so a missing/empty value should
+        # resolve to 'Equal' rather than ''.
+        tol_op = _str_or_empty(tol.get('operator')) or 'Equal'
+        tol_key = _str_or_empty(tol.get('key'))
+        tol_value = _str_or_empty(tol.get('value'))
         if not tol_key:
             # Empty key is only valid with Exists; matches any key.
             if tol_op == 'Exists':

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1570,35 +1570,35 @@ def get_configured_tolerations(
     `V1Node.get_taints(tolerations=...)` and get byte-identical
     output to today.
 
-    Fetches the entire `pod_config` dict (rather than the nested
-    `('pod_config', 'spec', 'tolerations')` key directly) so the
-    Kubernetes-specific dict merge fires inside
-    `get_effective_region_config` — that path appends per-context
-    list entries onto the global list (see `merge_k8s_configs`),
-    matching the toleration list that an actual pod gets at
-    scheduling time via `resolve_effective_pod_config`. Fetching the
-    leaf `tolerations` key directly would bypass the dict merge and
-    let a per-context list clobber the global one.
+    Goes through `resolve_effective_pod_config` rather than fetching the
+    `tolerations` leaf directly so the per-context list is merged onto
+    the global one (Kubernetes-specific dict merge appends list
+    entries — see `merge_k8s_configs`) and matches what an actual pod
+    gets at scheduling time. Fetching the leaf directly would let a
+    per-context list clobber the global one.
 
     Each toleration is a dict in standard Kubernetes shape, e.g.
     `{'key': 'workload_pool', 'operator': 'Equal', 'value': 'research',
       'effect': 'NoSchedule'}`.
     """
-    pod_config = skypilot_config.get_effective_region_config(
-        cloud='kubernetes',
-        region=context,
-        keys=('pod_config',),
-        default_value=None)
-    if not isinstance(pod_config, dict):
-        return None
-    spec = pod_config.get('spec')
-    if not isinstance(spec, dict):
-        return None
-    tolerations = spec.get('tolerations')
+    pod_config = resolve_effective_pod_config(cluster_config_overrides={},
+                                              context=context)
+    spec = pod_config.get('spec') if isinstance(pod_config, dict) else None
+    tolerations = spec.get('tolerations') if isinstance(spec, dict) else None
     if not isinstance(tolerations, list):
         return None
     # Filter to dict entries only — be defensive against malformed config.
     return [t for t in tolerations if isinstance(t, dict)]
+
+
+# Coerce to str defensively — YAML can parse unquoted numbers/booleans
+# as non-string types (e.g. `value: 123` → int), which would silently
+# fail to match the K8s API's always-string taint fields. The
+# `None`-explicit form rather than `str(x or '')` is what lets falsy-but-set
+# values like `value: 0` and `value: false` survive the coercion
+# (`str(0 or '')` would collapse to `''` and never match `'0'`).
+def _str_or_empty(v: Any) -> str:
+    return '' if v is None else str(v)
 
 
 def taint_is_tolerated(taint: Dict[str, Any],
@@ -1627,16 +1627,6 @@ def taint_is_tolerated(taint: Dict[str, Any],
     Returns:
         True if at least one toleration in the list matches the taint.
     """
-
-    # Coerce to str defensively — YAML can parse unquoted numbers/booleans
-    # as non-string types (e.g. `value: 123` → int), which would silently
-    # fail to match the K8s API's always-string taint fields. Use the
-    # `None`-explicit form rather than `str(x or '')` so falsy-but-set
-    # values like `value: 0` and `value: false` survive the coercion
-    # (`str(0 or '')` would collapse to `''` and never match `'0'`).
-    def _str_or_empty(v: Any) -> str:
-        return '' if v is None else str(v)
-
     taint_key = _str_or_empty(taint.get('key'))
     taint_effect = _str_or_empty(taint.get('effect'))
     taint_value = _str_or_empty(taint.get('value'))
@@ -1665,6 +1655,25 @@ def taint_is_tolerated(taint: Dict[str, Any],
         if tol_value == taint_value:
             return True
     return False
+
+
+def has_untolerated_taint(taints: Optional[List[Dict[str, Any]]]) -> bool:
+    """Returns True if any taint in the list is NOT tolerated.
+
+    Reads the `'tolerated'` flag previously attached to each taint dict by
+    `V1Node.get_taints(tolerations=...)`. Taints without the flag (the
+    backward-compatible shape from servers that don't know about
+    tolerations, or callers that don't pass `tolerations=`) are treated as
+    un-tolerated, matching the pre-toleration-aware behavior where any
+    non-empty taint list made the node un-schedulable.
+
+    This is the single source of truth for the "is this node tainted for
+    user workloads?" predicate used by the catalog, `get_kubernetes_node_info`,
+    and `sky show-gpus` aggregation.
+    """
+    if not taints:
+        return False
+    return any(not t.get('tolerated', False) for t in taints)
 
 
 def _filter_allowed_nodes(nodes: List[V1Node],
@@ -4191,8 +4200,7 @@ def get_kubernetes_node_info(
         # it has at least one taint not tolerated by the configured pod
         # tolerations. Without configured tolerations, every retained taint has
         # `tolerated=False` so this is equivalent to `len(node_taints) > 0`.
-        node_is_tainted = any(
-            not t.get('tolerated', False) for t in node_taints)
+        node_is_tainted = has_untolerated_taint(node_taints)
 
         if accelerator_count == 0:
             node_info_dict[node.metadata.name] = models.KubernetesNodeInfo(

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1563,12 +1563,13 @@ def get_configured_tolerations(
         context: Optional[str] = None) -> Optional[List[Dict[str, Any]]]:
     """Returns the configured pod tolerations for the given K8s context.
 
-    Reads `kubernetes.pod_config.spec.tolerations` from ~/.sky/config.yaml,
-    respecting context_configs overrides. Returns `None` if no tolerations
-    are configured (which is the case for the vast majority of setups) so
-    that downstream callers can pass the result through to
-    `V1Node.get_taints(tolerations=...)` and get byte-identical
-    output to today.
+    Reads `kubernetes.pod_config.spec.tolerations` (or `ssh.pod_config
+    .spec.tolerations` for an `ssh-<pool>` context) from
+    ~/.sky/config.yaml, respecting context_configs overrides. Returns
+    `None` if no tolerations are configured (the case for the vast
+    majority of setups) so downstream callers can pass the result
+    through to `V1Node.get_taints(tolerations=...)` and get
+    byte-identical output to today.
 
     Goes through `resolve_effective_pod_config` rather than fetching the
     `tolerations` leaf directly so the per-context list is merged onto
@@ -1577,11 +1578,23 @@ def get_configured_tolerations(
     gets at scheduling time. Fetching the leaf directly would let a
     per-context list clobber the global one.
 
+    SSH-pool contexts (`ssh-<pool>`) read from the `ssh` config namespace
+    and need their `ssh-` prefix stripped before looking up
+    `context_configs.<pool>` — both handled inside
+    `resolve_effective_pod_config` when `cloud` is an SSH instance.
+    Auto-detect from the context name to preserve the signature.
+
     Each toleration is a dict in standard Kubernetes shape, e.g.
     `{'key': 'workload_pool', 'operator': 'Equal', 'value': 'research',
       'effect': 'NoSchedule'}`.
     """
+    # Pass `cloud=clouds.SSH()` for ssh-prefixed contexts so
+    # `resolve_effective_pod_config` reads the `ssh.*` namespace and
+    # strips the `ssh-` prefix before applying context overrides.
+    cloud: Optional[clouds.Cloud] = (clouds.SSH() if context and
+                                     context.startswith('ssh-') else None)
     pod_config = resolve_effective_pod_config(cluster_config_overrides={},
+                                              cloud=cloud,
                                               context=context)
     spec = pod_config.get('spec') if isinstance(pod_config, dict) else None
     tolerations = spec.get('tolerations') if isinstance(spec, dict) else None
@@ -4079,6 +4092,14 @@ def get_kubernetes_node_info(
                 return result
         # Fall through to direct Kubernetes API query if provider returns None
 
+    # Resolve `context=None` to the current kubeconfig context BEFORE
+    # reading tolerations — otherwise `get_kubernetes_nodes` and
+    # `get_configured_tolerations` see different contexts (the former
+    # resolves None internally; the latter would skip `context_configs`
+    # overrides and miss per-context tolerations the user configured for
+    # the current context).
+    if context is None:
+        context = get_current_kube_config_context_name()
     nodes = get_kubernetes_nodes(context=context)
     configured_tolerations = get_configured_tolerations(context)
 

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -4434,3 +4434,470 @@ class TestCheckCredentials:
                                                        cloud='ssh')
         finally:
             self._stop(patches)
+
+
+# ----------------------------------------------------------------------------
+# Taint toleration tests (kubernetes.pod_config.spec.tolerations)
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'taint,tolerations,expected',
+    [
+        # 1. Exact Equal match (the customer's case).
+        ({
+            'key': 'workload_pool',
+            'value': 'research',
+            'effect': 'NoSchedule'
+        }, [{
+            'key': 'workload_pool',
+            'operator': 'Equal',
+            'value': 'research',
+            'effect': 'NoSchedule'
+        }], True),
+        # 2. Value mismatch under Equal.
+        ({
+            'key': 'workload_pool',
+            'value': 'research',
+            'effect': 'NoSchedule'
+        }, [{
+            'key': 'workload_pool',
+            'operator': 'Equal',
+            'value': 'staging',
+            'effect': 'NoSchedule'
+        }], False),
+        # 3. Exists ignores value.
+        ({
+            'key': 'workload_pool',
+            'value': 'research',
+            'effect': 'NoSchedule'
+        }, [{
+            'key': 'workload_pool',
+            'operator': 'Exists',
+            'effect': 'NoSchedule'
+        }], True),
+        # 4. Empty effect on toleration matches all effects.
+        ({
+            'key': 'workload_pool',
+            'value': 'research',
+            'effect': 'NoSchedule'
+        }, [{
+            'key': 'workload_pool',
+            'operator': 'Equal',
+            'value': 'research'
+        }], True),
+        # 5. Effect mismatch.
+        ({
+            'key': 'workload_pool',
+            'value': 'research',
+            'effect': 'NoExecute'
+        }, [{
+            'key': 'workload_pool',
+            'operator': 'Equal',
+            'value': 'research',
+            'effect': 'NoSchedule'
+        }], False),
+        # 6. Empty key + Exists is a universal wildcard.
+        ({
+            'key': 'whatever',
+            'value': 'any',
+            'effect': 'NoSchedule'
+        }, [{
+            'operator': 'Exists'
+        }], True),
+        # 7. Wildcard restricted to a specific effect.
+        ({
+            'key': 'whatever',
+            'value': 'any',
+            'effect': 'NoSchedule'
+        }, [{
+            'operator': 'Exists',
+            'effect': 'NoExecute'
+        }], False),
+        # 8. Default operator (Equal) when unspecified.
+        ({
+            'key': 'workload_pool',
+            'value': 'research',
+            'effect': 'NoSchedule'
+        }, [{
+            'key': 'workload_pool',
+            'value': 'research',
+            'effect': 'NoSchedule'
+        }], True),
+        # 9. Taint with no value, toleration with empty-string value.
+        ({
+            'key': 'workload_pool',
+            'value': None,
+            'effect': 'NoSchedule'
+        }, [{
+            'key': 'workload_pool',
+            'operator': 'Equal',
+            'value': '',
+            'effect': 'NoSchedule'
+        }], True),
+        # 10. Taint with no value, toleration with explicit non-empty value.
+        ({
+            'key': 'workload_pool',
+            'value': None,
+            'effect': 'NoSchedule'
+        }, [{
+            'key': 'workload_pool',
+            'operator': 'Equal',
+            'value': 'research',
+            'effect': 'NoSchedule'
+        }], False),
+        # 11. Any-of-list match (second toleration matches).
+        ({
+            'key': 'a',
+            'value': 'b',
+            'effect': 'NoSchedule'
+        }, [
+            {
+                'key': 'a',
+                'value': 'c',
+                'effect': 'NoSchedule'
+            },
+            {
+                'key': 'a',
+                'value': 'b',
+                'effect': 'NoSchedule'
+            },
+        ], True),
+        # 12. Empty toleration list never matches.
+        ({
+            'key': 'a',
+            'value': 'b',
+            'effect': 'NoSchedule'
+        }, [], False),
+        # 13. Malformed (non-dict) toleration entries are skipped, not errors.
+        ({
+            'key': 'workload_pool',
+            'value': 'research',
+            'effect': 'NoSchedule'
+        }, [
+            'not-a-dict',
+            None,
+            {
+                'key': 'workload_pool',
+                'value': 'research',
+                'effect': 'NoSchedule'
+            },
+        ], True),
+        # 14. Empty-key Equal is invalid (only Exists is valid with empty
+        # key), so it must not match.
+        ({
+            'key': 'a',
+            'value': 'b',
+            'effect': 'NoSchedule'
+        }, [{
+            'operator': 'Equal',
+            'value': 'b',
+            'effect': 'NoSchedule'
+        }], False),
+    ])
+def test_taint_is_tolerated(taint, tolerations, expected):
+    assert utils.taint_is_tolerated(taint, tolerations) is expected
+
+
+def test_get_configured_tolerations_global_only():
+    """When only a global toleration is configured, it's returned."""
+    global_tols = [{
+        'key': 'workload_pool',
+        'operator': 'Equal',
+        'value': 'research',
+        'effect': 'NoSchedule',
+    }]
+    with patch('sky.skypilot_config.get_effective_region_config') as mock_get:
+        mock_get.return_value = {'spec': {'tolerations': global_tols}}
+        result = utils.get_configured_tolerations(context='ctx-a')
+        assert result == global_tols
+        mock_get.assert_called_once_with(cloud='kubernetes',
+                                         region='ctx-a',
+                                         keys=('pod_config',),
+                                         default_value=None)
+
+
+def test_get_configured_tolerations_none_configured():
+    """No tolerations configured → None (preserves today's wire shape).
+
+    Returning None ensures downstream get_taints(tolerations=None) skips
+    the tolerated decoration entirely, so users without configured
+    tolerations see byte-identical taint dicts to today.
+    """
+    with patch('sky.skypilot_config.get_effective_region_config') as mock_get:
+        mock_get.return_value = None
+        result = utils.get_configured_tolerations(context='ctx-a')
+        assert result is None
+
+
+def test_get_configured_tolerations_defensive_against_garbage():
+    """Non-dict pod_config / non-dict spec / non-list tolerations / non-dict
+    entries — all defaulted away without crashing the caller."""
+    with patch('sky.skypilot_config.get_effective_region_config') as mock_get:
+        # Whole pod_config isn't a dict (impossible in practice but
+        # defensive).
+        mock_get.return_value = 'not-a-dict'
+        assert utils.get_configured_tolerations(context='ctx-a') is None
+        # spec isn't a dict.
+        mock_get.return_value = {'spec': 'garbage'}
+        assert utils.get_configured_tolerations(context='ctx-a') is None
+        # tolerations isn't a list.
+        mock_get.return_value = {'spec': {'tolerations': 'garbage'}}
+        assert utils.get_configured_tolerations(context='ctx-a') is None
+        # List with non-dict entries gets filtered.
+        mock_get.return_value = {
+            'spec': {
+                'tolerations': [
+                    {
+                        'key': 'a',
+                        'operator': 'Exists'
+                    },
+                    'garbage-string',
+                    None,
+                    42,
+                ],
+            },
+        }
+        result = utils.get_configured_tolerations(context='ctx-a')
+        assert result == [{'key': 'a', 'operator': 'Exists'}]
+
+
+def test_get_configured_tolerations_empty_list_preserved():
+    """Explicit empty list in config → empty list (not None).
+
+    Distinguishes "I'm setting an empty list" from "I didn't set anything".
+    """
+    with patch('sky.skypilot_config.get_effective_region_config') as mock_get:
+        mock_get.return_value = {'spec': {'tolerations': []}}
+        result = utils.get_configured_tolerations(context='ctx-a')
+        assert result == []
+
+
+def test_get_configured_tolerations_fetches_pod_config_dict():
+    """Fetches `('pod_config',)` (the whole dict) — NOT
+    `('pod_config', 'spec', 'tolerations')` directly.
+
+    Fetching the leaf list bypasses the K8s-specific dict merge in
+    `get_cloud_config_value_from_dict`, letting a per-context
+    `tolerations` list clobber the global one. Fetching the dict
+    triggers `merge_k8s_configs`, which appends list elements — matching
+    what `resolve_effective_pod_config` does for the actual pod spec.
+    """
+    captured_keys = []
+
+    def fake_get(cloud, region, keys, default_value):
+        captured_keys.append(keys)
+        return default_value
+
+    with patch('sky.skypilot_config.get_effective_region_config',
+               side_effect=fake_get):
+        utils.get_configured_tolerations(context='ctx-a')
+        assert ('pod_config',) in captured_keys, (
+            f'Expected pod_config dict to be fetched (so the merge fires), '
+            f'got: {captured_keys}')
+
+
+def test_get_configured_tolerations_extracts_from_pod_config_dict():
+    """Merged pod_config dict → extract spec.tolerations."""
+    with patch('sky.skypilot_config.get_effective_region_config') as mock_get:
+        mock_get.return_value = {
+            'metadata': {
+                'labels': {
+                    'team': 'research'
+                }
+            },
+            'spec': {
+                'tolerations': [
+                    {
+                        'key': 'global-key',
+                        'operator': 'Exists'
+                    },
+                    {
+                        'key': 'context-key',
+                        'operator': 'Equal',
+                        'value': 'v',
+                        'effect': 'NoSchedule'
+                    },
+                ],
+            },
+        }
+        result = utils.get_configured_tolerations(context='ctx-a')
+        assert result == [
+            {
+                'key': 'global-key',
+                'operator': 'Exists'
+            },
+            {
+                'key': 'context-key',
+                'operator': 'Equal',
+                'value': 'v',
+                'effect': 'NoSchedule'
+            },
+        ]
+
+
+def test_taint_is_tolerated_coerces_yaml_int_value_to_str():
+    """YAML-parsed int taint/toleration values must still match via str().
+
+    Without explicit `str()` coercion, a user-configured
+    `value: 123` (unquoted YAML → int) would not match a K8s taint value
+    of '123' (str) and the node would falsely render as un-tolerated.
+    """
+    taint = {'key': 'foo', 'value': '123', 'effect': 'NoSchedule'}
+    tolerations = [{
+        'key': 'foo',
+        'operator': 'Equal',
+        'value': 123,  # unquoted in YAML → int after parse
+        'effect': 'NoSchedule',
+    }]
+    assert utils.taint_is_tolerated(taint, tolerations) is True
+
+
+def test_taint_is_tolerated_coerces_yaml_bool_value_to_str():
+    """YAML-parsed bool taint/toleration values must still match via str()."""
+    taint = {'key': 'foo', 'value': 'True', 'effect': 'NoSchedule'}
+    tolerations = [{
+        'key': 'foo',
+        'operator': 'Equal',
+        'value': True,  # YAML `value: true` → bool
+        'effect': 'NoSchedule',
+    }]
+    assert utils.taint_is_tolerated(taint, tolerations) is True
+
+
+def _make_v1node_with_taints(taints):
+    """Helper to build a V1Node with the supplied taints."""
+    return utils.V1Node.from_dict({
+        'metadata': {
+            'name': 'worker-1',
+            'labels': {},
+        },
+        'status': {
+            'allocatable': {},
+            'capacity': {},
+            'addresses': [],
+            'conditions': [{
+                'type': 'Ready',
+                'status': 'True',
+            }],
+        },
+        'spec': {
+            'unschedulable': False,
+            'taints': taints,
+        },
+    })
+
+
+def test_v1node_get_taints_tolerations_none_is_backward_compatible():
+    """tolerations=None: dicts have no 'tolerated' key (identical to today)."""
+    node = _make_v1node_with_taints([{
+        'key': 'workload_pool',
+        'value': 'research',
+        'effect': 'NoSchedule',
+    }])
+    out = node.get_taints()
+    assert out == [{
+        'key': 'workload_pool',
+        'value': 'research',
+        'effect': 'NoSchedule',
+    }]
+    # And explicit None matches.
+    assert node.get_taints(tolerations=None) == out
+
+
+def test_v1node_get_taints_tolerations_empty_marks_all_false():
+    """tolerations=[]: every retained taint gets tolerated=False."""
+    node = _make_v1node_with_taints([{
+        'key': 'workload_pool',
+        'value': 'research',
+        'effect': 'NoSchedule',
+    }])
+    out = node.get_taints(tolerations=[])
+    assert out == [{
+        'key': 'workload_pool',
+        'value': 'research',
+        'effect': 'NoSchedule',
+        'tolerated': False,
+    }]
+
+
+def test_v1node_get_taints_tolerations_matches_user_taint():
+    """A matching configured toleration sets tolerated=True."""
+    node = _make_v1node_with_taints([{
+        'key': 'workload_pool',
+        'value': 'research',
+        'effect': 'NoSchedule',
+    }])
+    tols = [{
+        'key': 'workload_pool',
+        'operator': 'Equal',
+        'value': 'research',
+        'effect': 'NoSchedule',
+    }]
+    out = node.get_taints(tolerations=tols)
+    assert out == [{
+        'key': 'workload_pool',
+        'value': 'research',
+        'effect': 'NoSchedule',
+        'tolerated': True,
+    }]
+
+
+def test_v1node_get_taints_exclude_filters_still_apply_with_tolerations():
+    """exclude_* filters drop taints regardless of tolerations.
+
+    A tolerated handled-key taint is still dropped by exclude_keys, so it
+    doesn't appear in the output. The non-excluded taint comes through
+    with tolerated=True from the user toleration.
+    """
+    node = _make_v1node_with_taints([
+        {
+            'key': 'nvidia.com/gpu',
+            'effect': 'NoSchedule',
+        },
+        {
+            'key': 'workload_pool',
+            'value': 'research',
+            'effect': 'NoSchedule',
+        },
+    ])
+    tols = [{
+        # Wildcard toleration that would otherwise mark every taint
+        # tolerated.
+        'operator': 'Exists',
+    }]
+    out = node.get_taints(
+        exclude_keys=['nvidia.com/gpu'],
+        tolerations=tols,
+    )
+    assert out == [{
+        'key': 'workload_pool',
+        'value': 'research',
+        'effect': 'NoSchedule',
+        'tolerated': True,
+    }]
+
+
+def test_v1node_get_taints_mixed_tolerated_and_untolerated():
+    """Mixed taints get individual tolerated flags."""
+    node = _make_v1node_with_taints([
+        {
+            'key': 'workload_pool',
+            'value': 'research',
+            'effect': 'NoSchedule',
+        },
+        {
+            'key': 'dangerous',
+            'value': 'true',
+            'effect': 'NoSchedule',
+        },
+    ])
+    tols = [{
+        'key': 'workload_pool',
+        'operator': 'Equal',
+        'value': 'research',
+        'effect': 'NoSchedule',
+    }]
+    out = node.get_taints(tolerations=tols)
+    by_key = {t['key']: t['tolerated'] for t in out}
+    assert by_key == {'workload_pool': True, 'dangerous': False}

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -4611,10 +4611,13 @@ def test_get_configured_tolerations_global_only():
         mock_get.return_value = {'spec': {'tolerations': global_tols}}
         result = utils.get_configured_tolerations(context='ctx-a')
         assert result == global_tols
+        # Goes through resolve_effective_pod_config, which fetches the whole
+        # pod_config dict (so the K8s dict-merge fires for per-context
+        # overrides) with default_value={}.
         mock_get.assert_called_once_with(cloud='kubernetes',
                                          region='ctx-a',
                                          keys=('pod_config',),
-                                         default_value=None)
+                                         default_value={})
 
 
 def test_get_configured_tolerations_none_configured():
@@ -4631,13 +4634,14 @@ def test_get_configured_tolerations_none_configured():
 
 
 def test_get_configured_tolerations_defensive_against_garbage():
-    """Non-dict pod_config / non-dict spec / non-list tolerations / non-dict
-    entries — all defaulted away without crashing the caller."""
+    """Non-dict spec / non-list tolerations / non-dict entries — all
+    defaulted away without crashing the caller.
+
+    `resolve_effective_pod_config` is typed to return `Dict[str, Any]`
+    so we don't defend against the top-level `pod_config` itself being
+    non-dict; only against malformed nested values.
+    """
     with patch('sky.skypilot_config.get_effective_region_config') as mock_get:
-        # Whole pod_config isn't a dict (impossible in practice but
-        # defensive).
-        mock_get.return_value = 'not-a-dict'
-        assert utils.get_configured_tolerations(context='ctx-a') is None
         # spec isn't a dict.
         mock_get.return_value = {'spec': 'garbage'}
         assert utils.get_configured_tolerations(context='ctx-a') is None
@@ -4736,73 +4740,78 @@ def test_get_configured_tolerations_extracts_from_pod_config_dict():
         ]
 
 
-def test_taint_is_tolerated_coerces_yaml_int_value_to_str():
-    """YAML-parsed int taint/toleration values must still match via str().
+@pytest.mark.parametrize(
+    'case_id,taint_value,tol_value,expected',
+    [
+        # YAML-parsed int taint/toleration values must still match via
+        # str(). Without coercion, `value: 123` (unquoted YAML → int)
+        # would not match a K8s taint value of '123' (str).
+        ('yaml-int', '123', 123, True),
+        # YAML-parsed bool: `value: true` → Python True must still match
+        # taint string 'True'.
+        ('yaml-bool', 'True', True, True),
+        # Falsy YAML-int (`value: 0`) survives coercion. Regression for
+        # the `str(x or '')` idiom which silently collapses 0 → ''.
+        ('yaml-int-zero', '0', 0, True),
+        # Falsy YAML-bool (`value: false`) — same regression risk as
+        # int-zero.
+        ('yaml-bool-false', 'False', False, True),
+        # Inverse collapse: taint has value='' and toleration has
+        # value=0. Must NOT match (toleration's 0 → '0' ≠ taint's '').
+        ('inverse-collapse', '', 0, False),
+    ],
+    ids=lambda v: v if isinstance(v, str) else repr(v))
+def test_taint_is_tolerated_str_coercion(case_id, taint_value, tol_value,
+                                         expected):
+    """YAML-parsed non-string taint/toleration values must coerce to str
+    before comparison. Guards against the `str(x or '')` idiom which
+    silently collapses falsy values (`0`, `False`) to `''`."""
+    del case_id  # for pytest id only
+    taint = {'key': 'foo', 'value': taint_value, 'effect': 'NoSchedule'}
+    tolerations = [{
+        'key': 'foo',
+        'operator': 'Equal',
+        'value': tol_value,
+        'effect': 'NoSchedule',
+    }]
+    assert utils.taint_is_tolerated(taint, tolerations) is expected
 
-    Without explicit `str()` coercion, a user-configured
-    `value: 123` (unquoted YAML → int) would not match a K8s taint value
-    of '123' (str) and the node would falsely render as un-tolerated.
+
+@pytest.mark.parametrize('taints,expected', [
+    (None, False),
+    ([], False),
+    ([{
+        'key': 'a',
+        'effect': 'NoSchedule'
+    }], True),
+    ([{
+        'key': 'a',
+        'effect': 'NoSchedule',
+        'tolerated': True
+    }], False),
+    ([{
+        'key': 'a',
+        'effect': 'NoSchedule',
+        'tolerated': False
+    }], True),
+    ([{
+        'key': 'a',
+        'effect': 'NoSchedule',
+        'tolerated': True
+    }, {
+        'key': 'b',
+        'effect': 'NoSchedule'
+    }], True),
+])
+def test_has_untolerated_taint(taints, expected):
+    """The shared predicate used by catalog / get_kubernetes_node_info /
+    sky-show-gpus aggregation.
+
+    A missing `tolerated` key counts as un-tolerated (backwards-compat
+    with servers that don't decorate the field), and an empty/None list
+    is never un-tolerated.
     """
-    taint = {'key': 'foo', 'value': '123', 'effect': 'NoSchedule'}
-    tolerations = [{
-        'key': 'foo',
-        'operator': 'Equal',
-        'value': 123,  # unquoted in YAML → int after parse
-        'effect': 'NoSchedule',
-    }]
-    assert utils.taint_is_tolerated(taint, tolerations) is True
-
-
-def test_taint_is_tolerated_coerces_yaml_bool_value_to_str():
-    """YAML-parsed bool taint/toleration values must still match via str()."""
-    taint = {'key': 'foo', 'value': 'True', 'effect': 'NoSchedule'}
-    tolerations = [{
-        'key': 'foo',
-        'operator': 'Equal',
-        'value': True,  # YAML `value: true` → bool
-        'effect': 'NoSchedule',
-    }]
-    assert utils.taint_is_tolerated(taint, tolerations) is True
-
-
-def test_taint_is_tolerated_coerces_falsy_yaml_int_zero_to_str():
-    """Falsy YAML-int (`value: 0`) survives coercion — regression for the
-    `str(x or '')` idiom which silently collapses `0` to `''`."""
-    taint = {'key': 'foo', 'value': '0', 'effect': 'NoSchedule'}
-    tolerations = [{
-        'key': 'foo',
-        'operator': 'Equal',
-        'value': 0,  # YAML `value: 0` → int(0), Python-falsy
-        'effect': 'NoSchedule',
-    }]
-    assert utils.taint_is_tolerated(taint, tolerations) is True
-
-
-def test_taint_is_tolerated_coerces_falsy_yaml_bool_false_to_str():
-    """Falsy YAML-bool (`value: false`) survives coercion — same regression
-    risk as the int-zero case."""
-    taint = {'key': 'foo', 'value': 'False', 'effect': 'NoSchedule'}
-    tolerations = [{
-        'key': 'foo',
-        'operator': 'Equal',
-        'value': False,  # YAML `value: false` → bool(False), Python-falsy
-        'effect': 'NoSchedule',
-    }]
-    assert utils.taint_is_tolerated(taint, tolerations) is True
-
-
-def test_taint_is_tolerated_does_not_match_when_only_taint_has_value():
-    """Taint has `value: ''` (or absent) and toleration has `value: '0'`
-    must NOT match — guards against the inverse collapse where the
-    toleration's `0` becomes `''` and matches a value-less taint."""
-    taint = {'key': 'foo', 'value': '', 'effect': 'NoSchedule'}
-    tolerations = [{
-        'key': 'foo',
-        'operator': 'Equal',
-        'value': 0,  # → '0' after str-coerce, ≠ taint's ''
-        'effect': 'NoSchedule',
-    }]
-    assert utils.taint_is_tolerated(taint, tolerations) is False
+    assert utils.has_untolerated_taint(taints) is expected
 
 
 def _make_v1node_with_taints(taints):

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -4765,6 +4765,46 @@ def test_taint_is_tolerated_coerces_yaml_bool_value_to_str():
     assert utils.taint_is_tolerated(taint, tolerations) is True
 
 
+def test_taint_is_tolerated_coerces_falsy_yaml_int_zero_to_str():
+    """Falsy YAML-int (`value: 0`) survives coercion — regression for the
+    `str(x or '')` idiom which silently collapses `0` to `''`."""
+    taint = {'key': 'foo', 'value': '0', 'effect': 'NoSchedule'}
+    tolerations = [{
+        'key': 'foo',
+        'operator': 'Equal',
+        'value': 0,  # YAML `value: 0` → int(0), Python-falsy
+        'effect': 'NoSchedule',
+    }]
+    assert utils.taint_is_tolerated(taint, tolerations) is True
+
+
+def test_taint_is_tolerated_coerces_falsy_yaml_bool_false_to_str():
+    """Falsy YAML-bool (`value: false`) survives coercion — same regression
+    risk as the int-zero case."""
+    taint = {'key': 'foo', 'value': 'False', 'effect': 'NoSchedule'}
+    tolerations = [{
+        'key': 'foo',
+        'operator': 'Equal',
+        'value': False,  # YAML `value: false` → bool(False), Python-falsy
+        'effect': 'NoSchedule',
+    }]
+    assert utils.taint_is_tolerated(taint, tolerations) is True
+
+
+def test_taint_is_tolerated_does_not_match_when_only_taint_has_value():
+    """Taint has `value: ''` (or absent) and toleration has `value: '0'`
+    must NOT match — guards against the inverse collapse where the
+    toleration's `0` becomes `''` and matches a value-less taint."""
+    taint = {'key': 'foo', 'value': '', 'effect': 'NoSchedule'}
+    tolerations = [{
+        'key': 'foo',
+        'operator': 'Equal',
+        'value': 0,  # → '0' after str-coerce, ≠ taint's ''
+        'effect': 'NoSchedule',
+    }]
+    assert utils.taint_is_tolerated(taint, tolerations) is False
+
+
 def _make_v1node_with_taints(taints):
     """Helper to build a V1Node with the supplied taints."""
     return utils.V1Node.from_dict({

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -4701,6 +4701,30 @@ def test_get_configured_tolerations_fetches_pod_config_dict():
             f'got: {captured_keys}')
 
 
+def test_get_configured_tolerations_ssh_context_uses_ssh_namespace():
+    """An `ssh-<pool>` context must be read under the `ssh.*` config
+    namespace with the `ssh-` prefix stripped before applying
+    `context_configs.<pool>` overrides — matching the SSH branch of
+    `resolve_effective_pod_config`. The Kubernetes branch (cloud=None)
+    would read the wrong namespace AND skip the prefix-stripping, so an
+    `ssh-cluster1`-scoped toleration would be missed and a global
+    `kubernetes.pod_config` toleration would leak onto SSH node health.
+    """
+    captured = []
+
+    def fake_get(cloud, region, keys, default_value):
+        captured.append((cloud, region))
+        return default_value
+
+    with patch('sky.skypilot_config.get_effective_region_config',
+               side_effect=fake_get):
+        utils.get_configured_tolerations(context='ssh-cluster1')
+        # Expect (cloud='ssh', region='cluster1') — NOT
+        # (cloud='kubernetes', region='ssh-cluster1').
+        assert ('ssh', 'cluster1') in captured, (
+            f'Expected SSH namespace + stripped prefix; got {captured}')
+
+
 def test_get_configured_tolerations_extracts_from_pod_config_dict():
     """Merged pod_config dict → extract spec.tolerations."""
     with patch('sky.skypilot_config.get_effective_region_config') as mock_get:


### PR DESCRIPTION
## Summary

Today the dashboard's Infra page, `sky show-gpus`, and any caller of `get_kubernetes_node_info()` flag a node as not-ready (and report 0 free GPUs) whenever it carries *any* taint that isn't already in the silently-filtered set (cordon, not-ready, `PreferNoSchedule`, GPU/TPU resource keys, role prefixes). This is wrong for the common case where the user has tolerated a custom taint via `kubernetes.pod_config.spec.tolerations`: jobs schedule fine, but the dashboard still says the node is broken.

This PR layers user-toleration awareness on top of the existing taint extraction:

- **New** `get_configured_tolerations(context)` reads `kubernetes.pod_config.spec.tolerations` via `get_effective_region_config`, mirroring the existing `get_allowed_nodes_config`. Returns `None` when nothing is configured so downstream call sites are byte-identical to today.
- **New** `taint_is_tolerated(taint, tolerations)` implements standard Kubernetes toleration semantics (`Equal` vs. `Exists`; empty effect matches all; empty key + `Exists` is a wildcard).
- **`V1Node.get_taints(...)`** gains one optional `tolerations=` kwarg. When passed, each retained taint dict gets a `'tolerated': bool` key. Existing `exclude_*` filtering is unchanged.
- **`get_kubernetes_node_info()` and `_get_total_accelerators()`** thread the configured tolerations through and compute `node_is_tainted = any(not t.tolerated for t in node_taints)`. The separate `is_ready`/`is_cordoned` gating is intentionally untouched — a cordoned or not-ready node still reports 0 free GPUs and keeps its dedicated status badge.
- **Infra page** narrows the existing gray taint chip to un-tolerated taints; tolerated-only nodes fall into the existing green "Healthy" rendering (no new chip type).

## Test plan

- [x] 23 new unit tests in tests/unit_tests/kubernetes/test_kubernetes_utils.py:
    - test_taint_is_tolerated - 14-row parametrized table covering Equal/Exists, empty key + Exists wildcard, empty effect matches all, value/effect mismatch, multiple-toleration any-match, and defensive handling of malformed entries.
    - test_get_configured_tolerations_* - None / configured / explicit-empty / malformed-garbage paths.
    - test_v1node_get_taints_tolerations_* - tolerations=None returns byte-identical dicts to today; tolerations=[] marks every retained taint tolerated=False; matching tolerations mark the right entries True; exclude_* filtering still applies regardless of tolerations.
- [x] Full tests/unit_tests/kubernetes/test_kubernetes_utils.py passes (165 tests).
- [x] Dashboard builds clean with npm run build in sky/dashboard.
- [ ] Manual e2e on a live Kubernetes cluster (taint a node + configure a matching toleration + confirm sky show-gpus and Infra page reflect the node as Healthy) - to do before merge.

Also runnable via /quicktest-core and /smoke-test --kubernetes on this PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->