### PR TITLE
[Jobs] expanduser the consolidated-launch managed_jobs log dir

### DIFF
--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -385,7 +385,8 @@ def _consolidated_launch(
     run_script = '\n'.join(env_cmds + [run_script])
     # Dump script for high availability recovery.
     assert job_ids is not None, 'job_ids not set'
-    log_dir = os.path.join(skylet_constants.SKY_LOGS_DIRECTORY, 'managed_jobs')
+    log_dir = os.path.expanduser(
+        os.path.join(skylet_constants.SKY_LOGS_DIRECTORY, 'managed_jobs'))
     os.makedirs(log_dir, exist_ok=True)
     job_ids_str = _job_ids_to_str(job_ids)
     log_path = os.path.join(log_dir, f'submit-job-{job_ids_str}.log')


### PR DESCRIPTION
## Summary

In `_consolidated_launch` (`sky/jobs/server/core.py`), the submit-job log directory is built from `SKY_LOGS_DIRECTORY` (`~/sky_logs`) and passed straight to `os.makedirs` without `os.path.expanduser`:

```python
log_dir = os.path.join(skylet_constants.SKY_LOGS_DIRECTORY, 'managed_jobs')
os.makedirs(log_dir, exist_ok=True)
```

`os.makedirs` does not expand `~`, so this creates a directory **literally named `~`** relative to the API server's working directory (e.g. `./~/sky_logs/managed_jobs/`) instead of `$HOME/sky_logs/managed_jobs/`. The submit-job log written there is never read back, so the effect is a stray `~` directory plus submit logs landing somewhere operators won't look — not a crash, but confusing litter.

This fix wraps the path in `os.path.expanduser`, matching the existing pattern used elsewhere for the same directory, e.g.:
- `sky/jobs/scheduler.py`: `os.path.expanduser(managed_job_constants.JOBS_CONTROLLER_LOGS_DIR)`
- `sky/utils/controller_utils.py`: `os.makedirs(os.path.expanduser(local_dir), exist_ok=True)`

## Test plan

- `python -c "import ast; ast.parse(open('sky/jobs/server/core.py').read())"` passes.
- Manual: launching a managed job in consolidation mode now writes the submit-job log under `$HOME/sky_logs/managed_jobs/` and no longer creates a `~` directory in the server's working directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->