### PR TITLE
[Jobs] Scope debug-dump controller_system logs to the relevant controllers

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -97,14 +97,15 @@ JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS = 60
 # Pattern matching the "From controller <UUID>" line that the controller
 # emits at job-claim time (see sky/jobs/controller.py: run_job). Used by
 # the debug-dump manifest to scope controller_system/*.log files to the
-# controllers that actually ran the requested jobs.
+# controllers that actually ran the requested jobs. HA recovery causes
+# the per-job log (opened in append mode at sky/utils/context.py:146) to
+# receive a fresh "From controller …" line each time a new controller
+# picks up the job — and that line can land arbitrarily far into the
+# file after hours of intervening status-check output, so we scan the
+# whole file rather than just the head.
 _CONTROLLER_UUID_LOG_RE = re.compile(
     r'From controller ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-'
     r'[0-9a-f]{4}-[0-9a-f]{12})')
-# Bytes read from the head of each <jobid>.log when extracting UUIDs. A
-# job that migrated controllers (HA recovery) can produce multiple lines;
-# all of them live near the top of the file.
-_CONTROLLER_UUID_LOG_HEAD_BYTES = 16 * 1024
 
 _JOB_WAITING_STATUS_MESSAGE = ux_utils.spinner_message(
     'Waiting for task to start[/]'
@@ -979,10 +980,16 @@ def _collect_job_debug_manifest(
                 'relative_path': f'{job_prefix}/{job_id}.log',
             })
             try:
+                # Stream the file line by line: HA recovery appends a
+                # fresh "From controller <UUID>" line after the prior
+                # controller's entire output, which can be many MB into
+                # the file. Bounded memory regardless of file size.
                 with open(log_file, 'r', encoding='utf-8',
                           errors='replace') as f:
-                    head = f.read(_CONTROLLER_UUID_LOG_HEAD_BYTES)
-                controller_uuids.update(_CONTROLLER_UUID_LOG_RE.findall(head))
+                    for line in f:
+                        match = _CONTROLLER_UUID_LOG_RE.search(line)
+                        if match is not None:
+                            controller_uuids.add(match.group(1))
             except OSError:
                 # File disappeared / unreadable between is_file() and open;
                 # leave controller_uuids unchanged.

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -94,6 +94,18 @@ _LOG_STREAM_CHECK_CONTROLLER_GAP_SECONDS = 5
 _JOB_STATUS_FETCH_TIMEOUT_SECONDS = 30
 JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS = 60
 
+# Pattern matching the "From controller <UUID>" line that the controller
+# emits at job-claim time (see sky/jobs/controller.py: run_job). Used by
+# the debug-dump manifest to scope controller_system/*.log files to the
+# controllers that actually ran the requested jobs.
+_CONTROLLER_UUID_LOG_RE = re.compile(
+    r'From controller ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-'
+    r'[0-9a-f]{4}-[0-9a-f]{12})')
+# Bytes read from the head of each <jobid>.log when extracting UUIDs. A
+# job that migrated controllers (HA recovery) can produce multiple lines;
+# all of them live near the top of the file.
+_CONTROLLER_UUID_LOG_HEAD_BYTES = 16 * 1024
+
 _JOB_WAITING_STATUS_MESSAGE = ux_utils.spinner_message(
     'Waiting for task to start[/]'
     '{status_str}. It may take a few minutes.\n'
@@ -908,19 +920,25 @@ def collect_debug_dump_manifest(job_ids: List[int]) -> Dict[str, Any]:
 
     # Merge results and collect cluster info for unique clusters
     seen_cluster_names: Set[str] = set()
-    for job_id, (job_inline, job_files, job_errors,
-                 cluster_name) in zip(job_ids, results):
+    seen_controller_uuids: Set[str] = set()
+    for job_id, (job_inline, job_files, job_errors, cluster_name,
+                 controller_uuids) in zip(job_ids, results):
         inline_data.extend(job_inline)
         file_paths.extend(job_files)
         errors.extend(job_errors)
+        seen_controller_uuids.update(controller_uuids)
         if cluster_name and cluster_name not in seen_cluster_names:
             seen_cluster_names.add(cluster_name)
             job_prefix = f'managed_jobs/{job_id}'
             _collect_cluster_debug_manifest(cluster_name, job_prefix,
                                             inline_data, errors)
 
-    # Collect controller system log paths (shared, not per-job)
-    _collect_controller_system_log_paths(file_paths, errors)
+    # Collect controller system log paths (shared, not per-job). Scope to
+    # the controllers that actually ran the requested jobs — globbing the
+    # whole directory would drag in thousands of unrelated controller
+    # processes' logs.
+    _collect_controller_system_log_paths(file_paths, errors,
+                                         seen_controller_uuids)
 
     return {
         'inline_data': inline_data,
@@ -932,18 +950,25 @@ def collect_debug_dump_manifest(job_ids: List[int]) -> Dict[str, Any]:
 def _collect_job_debug_manifest(
     job_id: int,
 ) -> Tuple[List[Dict[str, str]], List[Dict[str, str]], List[Dict[str, str]],
-           Optional[str]]:
+           Optional[str], Set[str]]:
     """Collect debug manifest entries for a single managed job.
 
     Returns:
-        (inline_data, file_paths, errors, cluster_name) for this job.
+        (inline_data, file_paths, errors, cluster_name, controller_uuids)
+        for this job. ``controller_uuids`` is the set of parent controller
+        UUIDs that ran this job (empty if no <jobid>.log exists yet or the
+        log doesn't contain the marker — e.g., the job never started).
     """
     inline_data: List[Dict[str, str]] = []
     file_paths: List[Dict[str, str]] = []
     errors: List[Dict[str, str]] = []
+    controller_uuids: Set[str] = set()
     job_prefix = f'managed_jobs/{job_id}'
 
-    # 1. Controller log for this job (FILE — needs rsync)
+    # 1. Controller log for this job (FILE — needs rsync). Also parse its
+    # head for "From controller <UUID>" so the caller can scope the
+    # shared controller_system/*.log set to only the controllers that
+    # actually ran this job.
     with _catch_to_errors(errors, 'managed_jobs', f'{job_id}/controller_log'):
         controller_logs_dir = pathlib.Path(
             managed_job_constants.JOBS_CONTROLLER_LOGS_DIR).expanduser()
@@ -953,6 +978,15 @@ def _collect_job_debug_manifest(
                 'remote_path': str(log_file),
                 'relative_path': f'{job_prefix}/{job_id}.log',
             })
+            try:
+                with open(log_file, 'r', encoding='utf-8',
+                          errors='replace') as f:
+                    head = f.read(_CONTROLLER_UUID_LOG_HEAD_BYTES)
+                controller_uuids.update(_CONTROLLER_UUID_LOG_RE.findall(head))
+            except OSError:
+                # File disappeared / unreadable between is_file() and open;
+                # leave controller_uuids unchanged.
+                pass
 
     # 2. Job info from DB (inline — small data)
     with _catch_to_errors(errors, 'managed_jobs', f'{job_id}/job_info'):
@@ -1014,7 +1048,7 @@ def _collect_job_debug_manifest(
                 cluster_name = generate_managed_job_cluster_name(
                     task_name, job_id)
 
-    return inline_data, file_paths, errors, cluster_name
+    return inline_data, file_paths, errors, cluster_name, controller_uuids
 
 
 def _collect_cluster_debug_manifest(cluster_name: str, job_prefix: str,
@@ -1050,14 +1084,26 @@ def _collect_cluster_debug_manifest(cluster_name: str, job_prefix: str,
 
 
 def _collect_controller_system_log_paths(file_paths: List[Dict[str, str]],
-                                         errors: List[Dict[str, str]]) -> None:
-    """Collect controller system log file paths (controller_*.log files)."""
+                                         errors: List[Dict[str, str]],
+                                         relevant_uuids: Set[str]) -> None:
+    """Collect controller system log file paths (controller_*.log files).
+
+    Only the controllers whose UUIDs appear in ``relevant_uuids`` are
+    included. UUIDs are sourced from "From controller <UUID>" lines in
+    each requested job's <jobid>.log (see _collect_job_debug_manifest).
+    If ``relevant_uuids`` is empty (no requested job has a log yet, or
+    none of them recorded a controller marker), no controller_system
+    files are included — we do not fall back to globbing.
+    """
+    if not relevant_uuids:
+        return
     with _catch_to_errors(errors, 'managed_jobs', 'controller_system/logs'):
         controller_logs_dir = pathlib.Path(
             managed_job_constants.JOBS_CONTROLLER_LOGS_DIR).expanduser()
         if not controller_logs_dir.exists():
             return
-        for log_file in controller_logs_dir.glob('controller_*.log'):
+        for uuid_str in relevant_uuids:
+            log_file = controller_logs_dir / f'controller_{uuid_str}.log'
             if log_file.is_file():
                 file_paths.append({
                     'remote_path': str(log_file),

--- a/tests/unit_tests/test_jobs_utils.py
+++ b/tests/unit_tests/test_jobs_utils.py
@@ -793,6 +793,169 @@ class TestCollectDebugDumpManifestParallel:
         assert len(job_info_items) == len(ok_jobs)
 
 
+class TestControllerSystemLogScoping:
+    """Scope managed_jobs/controller_system/*.log to the controllers that
+    actually ran the requested jobs.
+
+    The unscoped behavior (glob controller_*.log) dragged thousands of
+    unrelated controller-process logs into every dump.
+    """
+
+    _UUID_A = '4cfc2dc5-5b4e-47eb-a517-079aa7ba6757'
+    _UUID_B = '276636dc-a8dd-4210-86f1-31f43b4f9d05'
+
+    @staticmethod
+    def _job_log_head(uuids):
+        lines = [
+            'Starting job loop for 1',
+            '  log_file=/tmp/1.log',
+            '  pool=None',
+        ]
+        for u in uuids:
+            lines.append(f'From controller {u}')
+            lines.append('  pid=27476')
+        return '\n'.join(lines) + '\n'
+
+    def _setup_logs_dir(self, tmpdir, jobid_log_contents, controller_uuids):
+        """Build a fake controller logs dir.
+
+        ``jobid_log_contents`` maps job_id -> string content for <jobid>.log.
+        ``controller_uuids`` is the iterable of controller UUIDs whose
+        ``controller_<uuid>.log`` should exist on disk.
+        """
+        for jid, content in jobid_log_contents.items():
+            (pathlib.Path(tmpdir) / f'{jid}.log').write_text(content)
+        for u in controller_uuids:
+            (pathlib.Path(tmpdir) / f'controller_{u}.log').write_text('hi')
+        return str(tmpdir)
+
+    def test_extracts_single_uuid(self):
+        """One "From controller" line → UUID set with one element."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._setup_logs_dir(tmpdir,
+                                 {1: self._job_log_head([self._UUID_A])}, [])
+            with mock.patch(
+                    'sky.jobs.utils.managed_job_constants'
+                    '.JOBS_CONTROLLER_LOGS_DIR', tmpdir):
+                with mock.patch(
+                        'sky.jobs.utils.managed_job_state'
+                        '.get_managed_job_tasks',
+                        return_value=[]):
+                    with mock.patch(
+                            'sky.jobs.utils.managed_job_state'
+                            '.get_job_events',
+                            return_value=[]):
+                        with mock.patch(
+                                'sky.jobs.utils.managed_job_state'
+                                '.get_all_task_ids_names_statuses_logs',
+                                return_value=[]):
+                            with mock.patch(
+                                    'sky.jobs.utils.managed_job_state'
+                                    '.get_pool_submit_info',
+                                    return_value=(None, None)):
+                                _, _, _, _, uuids = (
+                                    utils._collect_job_debug_manifest(1))
+        assert uuids == {self._UUID_A}
+
+    def test_extracts_multiple_uuids_for_ha_recovered_job(self):
+        """An HA-recovered job has multiple "From controller" lines."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._setup_logs_dir(
+                tmpdir, {1: self._job_log_head([self._UUID_A, self._UUID_B])},
+                [])
+            with mock.patch(
+                    'sky.jobs.utils.managed_job_constants'
+                    '.JOBS_CONTROLLER_LOGS_DIR', tmpdir):
+                with mock.patch(
+                        'sky.jobs.utils.managed_job_state'
+                        '.get_managed_job_tasks',
+                        return_value=[]):
+                    with mock.patch(
+                            'sky.jobs.utils.managed_job_state'
+                            '.get_job_events',
+                            return_value=[]):
+                        with mock.patch(
+                                'sky.jobs.utils.managed_job_state'
+                                '.get_all_task_ids_names_statuses_logs',
+                                return_value=[]):
+                            with mock.patch(
+                                    'sky.jobs.utils.managed_job_state'
+                                    '.get_pool_submit_info',
+                                    return_value=(None, None)):
+                                _, _, _, _, uuids = (
+                                    utils._collect_job_debug_manifest(1))
+        assert uuids == {self._UUID_A, self._UUID_B}
+
+    def test_missing_job_log_returns_empty_set(self):
+        """No <jobid>.log → empty UUID set, no exception."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch(
+                    'sky.jobs.utils.managed_job_constants'
+                    '.JOBS_CONTROLLER_LOGS_DIR', tmpdir):
+                with mock.patch(
+                        'sky.jobs.utils.managed_job_state'
+                        '.get_managed_job_tasks',
+                        return_value=[]):
+                    with mock.patch(
+                            'sky.jobs.utils.managed_job_state'
+                            '.get_job_events',
+                            return_value=[]):
+                        with mock.patch(
+                                'sky.jobs.utils.managed_job_state'
+                                '.get_all_task_ids_names_statuses_logs',
+                                return_value=[]):
+                            with mock.patch(
+                                    'sky.jobs.utils.managed_job_state'
+                                    '.get_pool_submit_info',
+                                    return_value=(None, None)):
+                                _, _, errs, _, uuids = (
+                                    utils._collect_job_debug_manifest(1))
+        assert uuids == set()
+        assert errs == []
+
+    def test_collect_controller_system_with_empty_uuids_emits_no_files(self):
+        """Empty relevant_uuids must NOT fall back to globbing the dir.
+
+        This is the regression we are fixing — globbing dragged in 8 000+
+        unrelated controller process logs.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._setup_logs_dir(tmpdir, {}, [self._UUID_A, self._UUID_B])
+            file_paths: list = []
+            errors: list = []
+            with mock.patch(
+                    'sky.jobs.utils.managed_job_constants'
+                    '.JOBS_CONTROLLER_LOGS_DIR', tmpdir):
+                utils._collect_controller_system_log_paths(
+                    file_paths, errors, set())
+        assert file_paths == []
+        assert errors == []
+
+    def test_collect_controller_system_filters_to_relevant_uuids(self):
+        """Only UUIDs in the relevant set become file_paths entries.
+
+        ``relevant_uuids`` includes a UUID that isn't on disk → silently
+        skipped. The on-disk-but-not-relevant UUID is also skipped.
+        """
+        missing_uuid = '00000000-0000-0000-0000-000000000000'
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._setup_logs_dir(tmpdir, {},
+                                 [self._UUID_A, self._UUID_B])  # both on disk
+            file_paths: list = []
+            errors: list = []
+            with mock.patch(
+                    'sky.jobs.utils.managed_job_constants'
+                    '.JOBS_CONTROLLER_LOGS_DIR', tmpdir):
+                utils._collect_controller_system_log_paths(
+                    file_paths, errors, {self._UUID_A, missing_uuid})
+        # Only the on-disk + relevant UUID survives.
+        rel_paths = sorted(p['relative_path'] for p in file_paths)
+        assert rel_paths == [
+            f'managed_jobs/controller_system/controller_{self._UUID_A}.log'
+        ]
+        assert errors == []
+
+
 class TestCleanupExpiredApiAccessTokens:
     """Unit tests for the expired managed-job token sweep."""
 

--- a/tests/unit_tests/test_jobs_utils.py
+++ b/tests/unit_tests/test_jobs_utils.py
@@ -886,6 +886,44 @@ class TestControllerSystemLogScoping:
                                     utils._collect_job_debug_manifest(1))
         assert uuids == {self._UUID_A, self._UUID_B}
 
+    def test_extracts_ha_recovery_uuid_far_from_head(self):
+        """HA recovery appends a second "From controller …" line after
+        an arbitrary amount of intervening output (the per-job log is
+        opened in append mode at sky/utils/context.py:146). A 16 KB-only
+        head read would miss it; the scan must traverse the whole file.
+        """
+        gap_bytes = 200 * 1024  # 200 KB of intervening status output
+        content = (
+            f'Starting job loop for 1\nFrom controller {self._UUID_A}\n'
+            # Realistic-ish filler: many short status lines.
+            + ('Status check: still running\n' * (gap_bytes // 28)) +
+            f'=== Recovery ===\nFrom controller {self._UUID_B}\n')
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (pathlib.Path(tmpdir) / '1.log').write_text(content)
+            assert (pathlib.Path(tmpdir) / '1.log').stat().st_size > 16 * 1024
+            with mock.patch(
+                    'sky.jobs.utils.managed_job_constants'
+                    '.JOBS_CONTROLLER_LOGS_DIR', tmpdir):
+                with mock.patch(
+                        'sky.jobs.utils.managed_job_state'
+                        '.get_managed_job_tasks',
+                        return_value=[]):
+                    with mock.patch(
+                            'sky.jobs.utils.managed_job_state'
+                            '.get_job_events',
+                            return_value=[]):
+                        with mock.patch(
+                                'sky.jobs.utils.managed_job_state'
+                                '.get_all_task_ids_names_statuses_logs',
+                                return_value=[]):
+                            with mock.patch(
+                                    'sky.jobs.utils.managed_job_state'
+                                    '.get_pool_submit_info',
+                                    return_value=(None, None)):
+                                _, _, _, _, uuids = (
+                                    utils._collect_job_debug_manifest(1))
+        assert uuids == {self._UUID_A, self._UUID_B}
+
     def test_missing_job_log_returns_empty_set(self):
         """No <jobid>.log → empty UUID set, no exception."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

`_collect_controller_system_log_paths` globbed every `~/sky_logs/jobs_controller/controller_*.log` regardless of which jobs the dump targeted. On a long-lived controller this means thousands of unrelated process logs (in one real case: 8 495 files / 3.46 GB / ~19 min of rsync) for a single-job dump.

Each managed-job controller writes `From controller <UUID>` at the head of its `<jobid>.log` when it claims the job. Parse that line in `_collect_job_debug_manifest`, aggregate UUIDs across the requested jobs in `collect_debug_dump_manifest`, and have `_collect_controller_system_log_paths` look up `controller_<uuid>.log` directly instead of globbing. HA-recovered jobs with multiple "From controller" lines contribute all of their UUIDs. If no requested job has emitted the marker yet, no controller_system files are included — we do not fall back to globbing.

## Test plan

- [x] Code formatting: `bash format.sh` (yapf, pylint 10.00/10)
- [x] Unit tests: `pytest tests/unit_tests/test_jobs_utils.py` — 40 passed (5 new cases in `TestControllerSystemLogScoping`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->