### PR TITLE
[Debug] Break same-type cross-link cycles in debug-dump

### DIFF
--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -167,6 +167,15 @@ class DebugDumpContext(TypedDict):
     request_ids: Set[str]
     cluster_names: Set[str]
     managed_job_ids: Set[int]
+    # Provenance sidecars: requests added by a cross-link helper because
+    # they reference a job (resp. cluster). When we later iterate
+    # request_ids to expand the context further, we skip these to break
+    # the job→request→job and cluster→request→cluster cycles. Without
+    # these, an over-broad matcher (body.name, body.all_users, body.all,
+    # or any cluster touching many requests) drags unrelated resources
+    # into the dump.
+    request_ids_via_job: Set[str]
+    request_ids_via_cluster: Set[str]
     errors: List[Dict[str, str]]
 
 
@@ -187,6 +196,7 @@ def _get_requests_from_clusters(debug_dump_context: DebugDumpContext) -> None:
                 logger.debug(f'Cross-link: cluster {cluster_name!r} -> '
                              f'{len(new_ids)} requests: {sorted(new_ids)}')
             debug_dump_context['request_ids'] |= new_ids
+            debug_dump_context['request_ids_via_cluster'] |= new_ids
         except Exception as e:  # pylint: disable=broad-except
             logger.warning(f'Failed to get requests for cluster '
                            f'{cluster_name}: {e}')
@@ -287,6 +297,8 @@ def _get_requests_from_managed_jobs(
                              f'{request.request_id} ({request.name}) '
                              f'via {match_reason}')
                 debug_dump_context['request_ids'].add(request.request_id)
+                debug_dump_context['request_ids_via_job'].add(
+                    request.request_id)
     except Exception as e:  # pylint: disable=broad-except
         logger.warning(f'Failed to get requests for managed jobs: {e}')
         debug_dump_context['errors'].append({
@@ -298,13 +310,22 @@ def _get_requests_from_managed_jobs(
 
 
 def _get_clusters_from_requests(debug_dump_context: DebugDumpContext) -> None:
-    """Get cluster names from the given request IDs."""
-    if not debug_dump_context['request_ids']:
+    """Get cluster names from the given request IDs.
+
+    Skips requests that were themselves added because they reference a
+    cluster — that's a same-type re-expansion (cluster -> request ->
+    cluster) and would let a cluster that touched many requests drag
+    every other cluster touched by those requests into the dump.
+    """
+    # Requests added by _get_requests_from_clusters must not re-seed
+    # cluster_names here. Other origins (user seed, recent context,
+    # _get_requests_from_managed_jobs) remain free to expand.
+    request_ids = (debug_dump_context['request_ids'] -
+                   debug_dump_context['request_ids_via_cluster'])
+    if not request_ids:
         return
-    logger.debug(
-        f'Getting clusters for {len(debug_dump_context["request_ids"])} '
-        f'requests')
-    for request_id in debug_dump_context['request_ids']:
+    logger.debug(f'Getting clusters for {len(request_ids)} requests')
+    for request_id in request_ids:
         try:
             request = requests_lib.get_request(request_id,
                                                fields=['cluster_name'])
@@ -329,13 +350,22 @@ def _get_managed_jobs_from_requests(
 
     If any request in the context is a managed job request (launch, cancel,
     logs), extract the job IDs from its body and add them to the context.
-    """
-    if not debug_dump_context['request_ids']:
-        return
-    logger.debug(f'Getting managed jobs for '
-                 f'{len(debug_dump_context["request_ids"])} requests')
 
-    for request_id in debug_dump_context['request_ids']:
+    Skips requests that were themselves added because they reference a
+    job — that's a same-type re-expansion (job -> request -> job) which
+    would let an over-broad matcher (body.name, body.all_users, body.all)
+    drag every sibling job of a batch-style request into the dump.
+    """
+    # Requests added by _get_requests_from_managed_jobs must not re-seed
+    # managed_job_ids here. Other origins (user seed, recent context,
+    # _get_requests_from_clusters) remain free to expand.
+    request_ids = (debug_dump_context['request_ids'] -
+                   debug_dump_context['request_ids_via_job'])
+    if not request_ids:
+        return
+    logger.debug(f'Getting managed jobs for {len(request_ids)} requests')
+
+    for request_id in request_ids:
         try:
             request = requests_lib.get_request(
                 request_id, fields=['name', 'request_body', 'return_value'])
@@ -1166,6 +1196,11 @@ def create_debug_dump(
         request_ids=resolved_request_ids,
         cluster_names=set(cluster_names or []),
         managed_job_ids=set(managed_job_ids or []),
+        # User-seeded and recent-context requests have no provenance
+        # restriction; only requests added by cross-link helpers
+        # populate these sidecars (see DebugDumpContext docstring).
+        request_ids_via_job=set(),
+        request_ids_via_cluster=set(),
         errors=[],
     )
 

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -195,8 +195,13 @@ def _get_requests_from_clusters(debug_dump_context: DebugDumpContext) -> None:
             if new_ids:
                 logger.debug(f'Cross-link: cluster {cluster_name!r} -> '
                              f'{len(new_ids)} requests: {sorted(new_ids)}')
+            # Only tag IDs that weren't already in the context. Otherwise
+            # a user-seeded or recent-context request would inherit the
+            # via_cluster restriction and get skipped in
+            # _get_clusters_from_requests.
+            newly_added = new_ids - debug_dump_context['request_ids']
             debug_dump_context['request_ids'] |= new_ids
-            debug_dump_context['request_ids_via_cluster'] |= new_ids
+            debug_dump_context['request_ids_via_cluster'] |= newly_added
         except Exception as e:  # pylint: disable=broad-except
             logger.warning(f'Failed to get requests for cluster '
                            f'{cluster_name}: {e}')
@@ -296,9 +301,15 @@ def _get_requests_from_managed_jobs(
                 logger.debug(f'Cross-link: managed jobs -> request '
                              f'{request.request_id} ({request.name}) '
                              f'via {match_reason}')
+                # Only tag IDs that weren't already in the context.
+                # Otherwise a user-seeded or recent-context request
+                # would inherit the via_job restriction and get skipped
+                # in _get_managed_jobs_from_requests.
+                if (request.request_id
+                        not in debug_dump_context['request_ids']):
+                    debug_dump_context['request_ids_via_job'].add(
+                        request.request_id)
                 debug_dump_context['request_ids'].add(request.request_id)
-                debug_dump_context['request_ids_via_job'].add(
-                    request.request_id)
     except Exception as e:  # pylint: disable=broad-except
         logger.warning(f'Failed to get requests for managed jobs: {e}')
         debug_dump_context['errors'].append({

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -904,6 +904,51 @@ class TestCrossLinkCycleBreak:
         assert ctx['request_ids_via_cluster'] == {'req-1', 'req-2'}
         assert ctx['request_ids_via_job'] == set()
 
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_requests_from_clusters_does_not_tag_preexisting(
+            self, mock_get_tasks):
+        """A user-seeded request that also matches a cluster scan must
+        not inherit the via_cluster tag, otherwise the user's explicit
+        request would be wrongly skipped by _get_clusters_from_requests."""
+        mock_get_tasks.return_value = [
+            _make_request(request_id='user-seeded', cluster_name='c1'),
+            _make_request(request_id='new-from-cluster', cluster_name='c1'),
+        ]
+        # 'user-seeded' was already in request_ids before the helper ran.
+        ctx = _make_context(cluster_names={'c1'}, request_ids={'user-seeded'})
+
+        debug_utils._get_requests_from_clusters(ctx)
+
+        assert ctx['request_ids'] == {'user-seeded', 'new-from-cluster'}
+        # Only the genuinely new one carries the via_cluster tag.
+        assert ctx['request_ids_via_cluster'] == {'new-from-cluster'}
+
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_requests_from_managed_jobs_does_not_tag_preexisting(
+            self, mock_get_tasks):
+        """Symmetric: a user-seeded request that also matches the
+        managed-job scan must not inherit the via_job tag."""
+        body = SimpleNamespace(job_id=42,
+                               job_ids=None,
+                               name='task',
+                               all_users=False,
+                               all=False)
+        mock_get_tasks.return_value = [
+            _make_request(request_id='user-seeded',
+                          request_body=body,
+                          name='sky.jobs.launch'),
+        ]
+        with mock.patch('sky.utils.debug_utils.managed_jobs_core.queue_v2',
+                        return_value=([], 0, {}, 0)):
+            # 'user-seeded' was already in request_ids before the helper ran.
+            ctx = _make_context(managed_job_ids={42},
+                                request_ids={'user-seeded'})
+            debug_utils._get_requests_from_managed_jobs(ctx)
+
+        assert 'user-seeded' in ctx['request_ids']
+        # Pre-existing request was not tagged → still expandable downstream.
+        assert ctx['request_ids_via_job'] == set()
+
     @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
     @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
     def test_all_users_cancel_does_not_drag_unrelated_jobs(

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -21,12 +21,16 @@ def _make_context(
     cluster_names: Optional[Set[str]] = None,
     managed_job_ids: Optional[Set[int]] = None,
     errors: Optional[List[Dict[str, str]]] = None,
+    request_ids_via_job: Optional[Set[str]] = None,
+    request_ids_via_cluster: Optional[Set[str]] = None,
 ) -> debug_utils.DebugDumpContext:
     """Helper to create a DebugDumpContext."""
     return debug_utils.DebugDumpContext(
         request_ids=request_ids or set(),
         cluster_names=cluster_names or set(),
         managed_job_ids=managed_job_ids or set(),
+        request_ids_via_job=request_ids_via_job or set(),
+        request_ids_via_cluster=request_ids_via_cluster or set(),
         errors=errors if errors is not None else [],
     )
 
@@ -780,6 +784,167 @@ class TestPopulateRecentContext:
 
 
 # ---------------------------------------------------------------------------
+# Tests for cross-link cycle prevention via provenance sidecars.
+#
+# Without these guards, a request linked in via a job (e.g. a
+# sky.jobs.launch matched on body.name) would re-seed managed_job_ids
+# with that request's return_value.job_id, dragging every sibling job
+# of a batch launch into the dump. Symmetric story for clusters.
+# ---------------------------------------------------------------------------
+class TestCrossLinkCycleBreak:
+
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
+    def test_request_added_via_job_does_not_reseed_managed_jobs(
+            self, mock_get_request):
+        """job → request → job cycle is broken."""
+        # Simulate: req-from-job was added by _get_requests_from_managed_jobs
+        # (e.g. matched on body.name="sb-sweep-8"). Its body.job_id would
+        # point at a SIBLING job (B) that shares the task name with our
+        # seed job A. Without the guard, B would be added to
+        # managed_job_ids.
+        body = SimpleNamespace(job_id=999, job_ids=None)
+        mock_get_request.return_value = _make_request(request_id='req-from-job',
+                                                      request_body=body,
+                                                      name='sky.jobs.launch')
+        ctx = _make_context(
+            request_ids={'req-from-job'},
+            request_ids_via_job={'req-from-job'},
+            managed_job_ids={42},  # original seed job
+        )
+
+        debug_utils._get_managed_jobs_from_requests(ctx)
+
+        assert ctx['managed_job_ids'] == {42}
+        # The guarded request was never even fetched.
+        mock_get_request.assert_not_called()
+
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
+    def test_request_added_via_cluster_does_not_reseed_clusters(
+            self, mock_get_request):
+        """cluster → request → cluster cycle is broken."""
+        # Simulate: req-from-cluster was added by
+        # _get_requests_from_clusters. Its cluster_name points at a
+        # DIFFERENT cluster than the seed (since the request also
+        # touched another cluster). Without the guard, that other
+        # cluster would be added to cluster_names.
+        mock_get_request.return_value = _make_request(
+            request_id='req-from-cluster', cluster_name='other-cluster')
+        ctx = _make_context(
+            request_ids={'req-from-cluster'},
+            request_ids_via_cluster={'req-from-cluster'},
+            cluster_names={'seed-cluster'},
+        )
+
+        debug_utils._get_clusters_from_requests(ctx)
+
+        assert ctx['cluster_names'] == {'seed-cluster'}
+        mock_get_request.assert_not_called()
+
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
+    def test_unrestricted_request_still_expands_jobs(self, mock_get_request):
+        """A user-seeded request (no provenance tag) still expands."""
+        body = SimpleNamespace(job_id=42, job_ids=None)
+        mock_get_request.return_value = _make_request(request_id='req-seed',
+                                                      request_body=body,
+                                                      name='sky.jobs.launch')
+        # No provenance tag — this came from user input or recent context.
+        ctx = _make_context(request_ids={'req-seed'})
+
+        debug_utils._get_managed_jobs_from_requests(ctx)
+
+        assert 42 in ctx['managed_job_ids']
+
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
+    def test_unrestricted_request_still_expands_clusters(
+            self, mock_get_request):
+        """A user-seeded request (no provenance tag) still expands."""
+        mock_get_request.return_value = _make_request(request_id='req-seed',
+                                                      cluster_name='c1')
+        ctx = _make_context(request_ids={'req-seed'})
+
+        debug_utils._get_clusters_from_requests(ctx)
+
+        assert 'c1' in ctx['cluster_names']
+
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_requests_from_managed_jobs_tags_provenance(self, mock_get_tasks):
+        """Requests added by job-cross-link are tagged."""
+        body = SimpleNamespace(job_id=42,
+                               job_ids=None,
+                               name='task',
+                               all_users=False,
+                               all=False)
+        mock_get_tasks.return_value = [
+            _make_request(request_id='req-1',
+                          request_body=body,
+                          name='sky.jobs.launch'),
+        ]
+        # queue_v2 must not raise — patch it as a no-op.
+        with mock.patch('sky.utils.debug_utils.managed_jobs_core.queue_v2',
+                        return_value=([], 0, {}, 0)):
+            ctx = _make_context(managed_job_ids={42})
+            debug_utils._get_requests_from_managed_jobs(ctx)
+
+        assert 'req-1' in ctx['request_ids']
+        assert 'req-1' in ctx['request_ids_via_job']
+        assert 'req-1' not in ctx['request_ids_via_cluster']
+
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_requests_from_clusters_tags_provenance(self, mock_get_tasks):
+        """Requests added by cluster-cross-link are tagged."""
+        mock_get_tasks.return_value = [
+            _make_request(request_id='req-1', cluster_name='c1'),
+            _make_request(request_id='req-2', cluster_name='c1'),
+        ]
+        ctx = _make_context(cluster_names={'c1'})
+
+        debug_utils._get_requests_from_clusters(ctx)
+
+        assert ctx['request_ids'] == {'req-1', 'req-2'}
+        assert ctx['request_ids_via_cluster'] == {'req-1', 'req-2'}
+        assert ctx['request_ids_via_job'] == set()
+
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_all_users_cancel_does_not_drag_unrelated_jobs(
+            self, mock_get_tasks, mock_get_request):
+        """A historic `cancel --all-users` request must not pollute the
+        dump.
+
+        Before this fix: `_get_requests_from_managed_jobs` matches the
+        request via body.all_users=True → adds it to request_ids →
+        `_get_managed_jobs_from_requests` reads it back and would
+        normally extract any job_ids from its body. The guard means
+        none of that re-expansion happens.
+        """
+        cancel_body = SimpleNamespace(job_id=None,
+                                      job_ids=None,
+                                      name=None,
+                                      all_users=True,
+                                      all=False)
+        # The cancel request that matched body.all_users in step 1.
+        mock_get_tasks.return_value = [
+            _make_request(request_id='cancel-req',
+                          request_body=cancel_body,
+                          name='sky.jobs.cancel'),
+        ]
+        with mock.patch('sky.utils.debug_utils.managed_jobs_core.queue_v2',
+                        return_value=([], 0, {}, 0)):
+            ctx = _make_context(managed_job_ids={1})
+            debug_utils._get_requests_from_managed_jobs(ctx)
+
+        assert 'cancel-req' in ctx['request_ids']
+        assert 'cancel-req' in ctx['request_ids_via_job']
+
+        # Step 2: the cancel request would normally be re-examined here.
+        # It must be skipped because it's tagged via_job.
+        debug_utils._get_managed_jobs_from_requests(ctx)
+
+        assert ctx['managed_job_ids'] == {1}
+        mock_get_request.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Tests for create_debug_dump (end-to-end)
 # ---------------------------------------------------------------------------
 class TestCreateDebugDump:
@@ -1207,6 +1372,8 @@ class TestDebugDumpContext:
         assert ctx['request_ids'] == {'r1', 'r2'}
         assert ctx['cluster_names'] == {'c1'}
         assert ctx['managed_job_ids'] == {1, 2, 3}
+        assert ctx['request_ids_via_job'] == set()
+        assert ctx['request_ids_via_cluster'] == set()
         assert ctx['errors'] == []
 
     def test_context_sets_are_mutable(self):


### PR DESCRIPTION
## Summary

`sky debug-dump -j <one-job>` pulled in many unrelated sibling jobs because the cross-link helpers form a job → request → job cycle: `_get_requests_from_managed_jobs` matches `sky.jobs.launch` requests on `body.name` (task name), and `_get_managed_jobs_from_requests` reads each matched launch's `return_value.job_id` back into `managed_job_ids`. A symmetric cluster → request → cluster cycle exists.

Track linkage provenance via two sidecar sets on `DebugDumpContext` (`request_ids_via_job`, `request_ids_via_cluster`). When a cross-link helper iterates `request_ids` to expand into another resource, it skips requests that were themselves added by the same resource type. User-seeded and recent-context requests have no provenance tag and remain free to expand. Covers `body.name`, `body.all_users`, and `body.all` over-broad matchers in one place.

## Test plan

- [x] Code formatting: ``bash format.sh`` (yapf, pylint 10.00/10)
- [x] Unit tests: ``pytest tests/unit_tests/test_sky/utils/test_debug_utils.py`` — 116 passed (7 new cases in ``TestCrossLinkCycleBreak``)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->