### PR TITLE
[Chart] Optional server log mirror via SKYPILOT_SERVER_LOG_MIRROR_DIR

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -275,7 +275,18 @@ spec:
           # Use a FIFO instead of a pipe so that exec replaces the shell,
           # allowing tini to send SIGTERM directly to the API server process
           rm -f /tmp/skylog && mkfifo /tmp/skylog
-          tee -a /root/.sky/api_server/server.log < /tmp/skylog &
+          # Optional: also mirror server log to a directory specified by
+          # $SKYPILOT_SERVER_LOG_MIRROR_DIR. Each pod boot creates a new file
+          # under <dir>/<HOSTNAME>/ so history survives local logrotate
+          # (copytruncate) and pod restarts, and replicas don't clobber each
+          # other when the dir lives on shared (RWX) storage.
+          SKYPILOT_LOG_MIRROR_FILE=""
+          if [ -n "${SKYPILOT_SERVER_LOG_MIRROR_DIR:-}" ]; then
+            SKYPILOT_LOG_MIRROR_PER_POD_DIR="$SKYPILOT_SERVER_LOG_MIRROR_DIR/${HOSTNAME:-$(hostname)}"
+            mkdir -p "$SKYPILOT_LOG_MIRROR_PER_POD_DIR"
+            SKYPILOT_LOG_MIRROR_FILE="$SKYPILOT_LOG_MIRROR_PER_POD_DIR/server-$(date -u +%Y%m%dT%H%M%SZ).log"
+          fi
+          tee -a /root/.sky/api_server/server.log ${SKYPILOT_LOG_MIRROR_FILE:+"$SKYPILOT_LOG_MIRROR_FILE"} < /tmp/skylog &
           exec sky api start {{ include "skypilot.apiArgs" . }} --foreground > /tmp/skylog 2>&1
           {{- else }}
           exec sky api start {{ include "skypilot.apiArgs" . }} --foreground

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -279,14 +279,22 @@ spec:
           # $SKYPILOT_SERVER_LOG_MIRROR_DIR. Each pod boot creates a new file
           # under <dir>/<HOSTNAME>/ so history survives local logrotate
           # (copytruncate) and pod restarts, and replicas don't clobber each
-          # other when the dir lives on shared (RWX) storage.
-          SKYPILOT_LOG_MIRROR_FILE=""
+          # other when the dir lives on shared (RWX) storage. Mirroring is
+          # opportunistic — if directory creation fails (e.g. RO mount,
+          # permissions, NFS blip) we log a warning and continue without
+          # mirroring rather than crash-loop the API server pod.
           if [ -n "${SKYPILOT_SERVER_LOG_MIRROR_DIR:-}" ]; then
-            SKYPILOT_LOG_MIRROR_PER_POD_DIR="$SKYPILOT_SERVER_LOG_MIRROR_DIR/${HOSTNAME:-$(hostname)}"
-            mkdir -p "$SKYPILOT_LOG_MIRROR_PER_POD_DIR"
-            SKYPILOT_LOG_MIRROR_FILE="$SKYPILOT_LOG_MIRROR_PER_POD_DIR/server-$(date -u +%Y%m%dT%H%M%SZ).log"
+            SKYPILOT_LOG_MIRROR_PER_POD_DIR="${SKYPILOT_SERVER_LOG_MIRROR_DIR}/${HOSTNAME:-unknown}"
+            if mkdir -p "$SKYPILOT_LOG_MIRROR_PER_POD_DIR"; then
+              SKYPILOT_LOG_MIRROR_FILE="${SKYPILOT_LOG_MIRROR_PER_POD_DIR}/server-$(date -u +%Y%m%dT%H%M%SZ).log"
+              tee -a /root/.sky/api_server/server.log "$SKYPILOT_LOG_MIRROR_FILE" < /tmp/skylog &
+            else
+              echo "warning: failed to create log mirror directory $SKYPILOT_LOG_MIRROR_PER_POD_DIR; mirroring disabled" >&2
+              tee -a /root/.sky/api_server/server.log < /tmp/skylog &
+            fi
+          else
+            tee -a /root/.sky/api_server/server.log < /tmp/skylog &
           fi
-          tee -a /root/.sky/api_server/server.log ${SKYPILOT_LOG_MIRROR_FILE:+"$SKYPILOT_LOG_MIRROR_FILE"} < /tmp/skylog &
           exec sky api start {{ include "skypilot.apiArgs" . }} --foreground > /tmp/skylog 2>&1
           {{- else }}
           exec sky api start {{ include "skypilot.apiArgs" . }} --foreground

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -270,34 +270,47 @@ spec:
           # developer can drive `sky api start` / `sky api stop` via kubectl exec.
           exec tail -f /dev/null
           {{- else }}
+          # Optional log mirror: when $SKYPILOT_SERVER_LOG_MIRROR_DIR is set,
+          # also write server stdout/stderr to a per-pod, per-boot file under
+          # <dir>/<HOSTNAME>/server-<UTC_ISO>.log. Survives local logrotate
+          # (copytruncate) and pod restarts; placing $HOSTNAME in the path
+          # keeps replicas from clobbering each other when the dir is shared
+          # (RWX) storage. Mirroring is opportunistic — if directory creation
+          # fails (RO mount, permissions, NFS blip) we log a warning and
+          # carry on rather than crash-loop the API server pod.
+          # Resolve mirror sink first so both the serveServerLog=true and the
+          # =false branch can use it.
+          SKYPILOT_LOG_MIRROR_FILE=""
+          if [ -n "${SKYPILOT_SERVER_LOG_MIRROR_DIR:-}" ]; then
+            SKYPILOT_LOG_MIRROR_PER_POD_DIR="${SKYPILOT_SERVER_LOG_MIRROR_DIR}/${HOSTNAME:-unknown}"
+            if mkdir -p "$SKYPILOT_LOG_MIRROR_PER_POD_DIR"; then
+              SKYPILOT_LOG_MIRROR_FILE="${SKYPILOT_LOG_MIRROR_PER_POD_DIR}/server-$(date -u +%Y%m%dT%H%M%SZ).log"
+            else
+              echo "warning: failed to create log mirror directory $SKYPILOT_LOG_MIRROR_PER_POD_DIR; mirroring disabled" >&2
+            fi
+          fi
           {{- if .Values.apiService.serveServerLog }}
           mkdir -p /root/.sky/api_server
           # Use a FIFO instead of a pipe so that exec replaces the shell,
           # allowing tini to send SIGTERM directly to the API server process
           rm -f /tmp/skylog && mkfifo /tmp/skylog
-          # Optional: also mirror server log to a directory specified by
-          # $SKYPILOT_SERVER_LOG_MIRROR_DIR. Each pod boot creates a new file
-          # under <dir>/<HOSTNAME>/ so history survives local logrotate
-          # (copytruncate) and pod restarts, and replicas don't clobber each
-          # other when the dir lives on shared (RWX) storage. Mirroring is
-          # opportunistic — if directory creation fails (e.g. RO mount,
-          # permissions, NFS blip) we log a warning and continue without
-          # mirroring rather than crash-loop the API server pod.
-          if [ -n "${SKYPILOT_SERVER_LOG_MIRROR_DIR:-}" ]; then
-            SKYPILOT_LOG_MIRROR_PER_POD_DIR="${SKYPILOT_SERVER_LOG_MIRROR_DIR}/${HOSTNAME:-unknown}"
-            if mkdir -p "$SKYPILOT_LOG_MIRROR_PER_POD_DIR"; then
-              SKYPILOT_LOG_MIRROR_FILE="${SKYPILOT_LOG_MIRROR_PER_POD_DIR}/server-$(date -u +%Y%m%dT%H%M%SZ).log"
-              tee -a /root/.sky/api_server/server.log "$SKYPILOT_LOG_MIRROR_FILE" < /tmp/skylog &
-            else
-              echo "warning: failed to create log mirror directory $SKYPILOT_LOG_MIRROR_PER_POD_DIR; mirroring disabled" >&2
-              tee -a /root/.sky/api_server/server.log < /tmp/skylog &
-            fi
+          if [ -n "$SKYPILOT_LOG_MIRROR_FILE" ]; then
+            tee -a /root/.sky/api_server/server.log "$SKYPILOT_LOG_MIRROR_FILE" < /tmp/skylog &
           else
             tee -a /root/.sky/api_server/server.log < /tmp/skylog &
           fi
           exec sky api start {{ include "skypilot.apiArgs" . }} --foreground > /tmp/skylog 2>&1
           {{- else }}
-          exec sky api start {{ include "skypilot.apiArgs" . }} --foreground
+          if [ -n "$SKYPILOT_LOG_MIRROR_FILE" ]; then
+            # Mirror without local server.log. Still route through a FIFO so
+            # tee can fan out; tee's stdout inherits the container's stdout,
+            # so k8s pod logs continue to work just like the no-mirror case.
+            rm -f /tmp/skylog && mkfifo /tmp/skylog
+            tee -a "$SKYPILOT_LOG_MIRROR_FILE" < /tmp/skylog &
+            exec sky api start {{ include "skypilot.apiArgs" . }} --foreground > /tmp/skylog 2>&1
+          else
+            exec sky api start {{ include "skypilot.apiArgs" . }} --foreground
+          fi
           {{- end }}
           {{- end }}
         ports:

--- a/charts/skypilot/tests/deployment_test.yaml
+++ b/charts/skypilot/tests/deployment_test.yaml
@@ -988,6 +988,39 @@ tests:
           path: spec.template.spec.containers[0].args[2]
           pattern: "exec sky api start .* --foreground"
 
+  - it: should resolve mirror sink regardless of serveServerLog (both branches)
+    asserts:
+      # The runtime check on $SKYPILOT_SERVER_LOG_MIRROR_DIR is emitted in
+      # both serveServerLog=true and =false renders so the mirror feature
+      # works in either mode.
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: 'if \[ -n "\$\{SKYPILOT_SERVER_LOG_MIRROR_DIR'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: "SKYPILOT_LOG_MIRROR_PER_POD_DIR"
+
+  - it: should resolve mirror sink when serveServerLog is false
+    set:
+      apiService.serveServerLog: false
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: 'if \[ -n "\$\{SKYPILOT_SERVER_LOG_MIRROR_DIR'
+      # Mirror-only branch must still set up the FIFO + tee fan-out (gated
+      # at runtime by $SKYPILOT_LOG_MIRROR_FILE being non-empty).
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: 'tee -a "\$SKYPILOT_LOG_MIRROR_FILE" < /tmp/skylog'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: "exec sky api start .* --foreground"
+      # And the direct-exec path must still be present as the no-mirror
+      # fallback in the same render.
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: "else\\s+exec sky api start"
+
   - it: should include logrotate sidecar when serveServerLog is true and retention is enabled
     set:
       apiService.serveServerLog: true


### PR DESCRIPTION
## Summary

Adds an optional, env-driven log mirror to the API server chart so server stdout/stderr can be duplicated to a secondary location (e.g. an NFS-backed PVC, a sidecar collector, an observability stack).

* When `SKYPILOT_SERVER_LOG_MIRROR_DIR` is unset, behavior is unchanged — the chart's existing `tee` writes only to `/root/.sky/api_server/server.log`.
* When set, the same `tee` additionally writes to `<dir>/$HOSTNAME/server-<UTC_ISO>.log`. Each pod boot creates a new mirror file, so log history survives the chart's `logrotate` (`copytruncate`, default 10M) **and** pod restarts. Embedding `$HOSTNAME` lets multiple replicas write to the same shared directory without clobbering each other.

Why a single source-side `tee` rather than a separate shipper: the chart already runs `tee` reading from the FIFO; piggybacking on it adds zero new processes and preserves logs up to the moment the writer dies (kernel closes the pipe → tee receives EOF → flushes both fds), which a periodic shipper can't do.

## Test plan

Local:

- `cd charts/skypilot && helm unittest .` — 75 chart unit tests pass, including the existing `apiService.serveServerLog` cases. The "must match `exec sky api start ... --foreground`" assertion still holds (the changed line is the `tee` invocation above it).
- Render with mirror **off** (default) — `helm template ./charts/skypilot` — output identical to before this change in the relevant section.
- Render with mirror **on** — `helm template ./charts/skypilot --set apiService.extraEnvs[0].name=SKYPILOT_SERVER_LOG_MIRROR_DIR --set apiService.extraEnvs[0].value=/var/log/skypilot-mirror` and confirm the rendered script contains the `if [ -n "${SKYPILOT_SERVER_LOG_MIRROR_DIR:-}" ]; then ...` branch.

Runtime (single-replica sanity):

- Deploy the chart with `apiService.extraEnvs=[{name: SKYPILOT_SERVER_LOG_MIRROR_DIR, value: /tmp/mirror}]`.
- After the pod is ready, `kubectl exec ... -- ls /tmp/mirror/<pod-name>/` shows a `server-<UTC_ISO>.log`.
- `diff /tmp/mirror/<pod-name>/server-*.log /root/.sky/api_server/server.log` — content matches modulo any logrotate truncation on the local copy.
- `kill -9 $(pgrep -f 'sky.server.server')` inside the pod — the last log lines before the kill appear in the mirror file (the `tee` is in the same kernel pipeline as the writer, so its buffer is flushed on writer death).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->