### PR TITLE
[Kubernetes] Coerce Python bool tolerations to lowercase for taint match

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1610,8 +1610,20 @@ def get_configured_tolerations(
 # `None`-explicit form rather than `str(x or '')` is what lets falsy-but-set
 # values like `value: 0` and `value: false` survive the coercion
 # (`str(0 or '')` would collapse to `''` and never match `'0'`).
+#
+# Booleans need special-casing because `str(True)` is Python-cased
+# `'True'` but K8s stores taint values lowercase (`'true'` / `'false'`)
+# — Go's YAML serializer (which K8s uses internally) always emits
+# lowercase, and `kubectl taint nodes X foo=true:NoSchedule` stores
+# `value: "true"`. Without the lowercase coercion, a config
+# `value: true` (unquoted YAML → Python `True`) coerces to `'True'` and
+# silently fails the exact string compare against the K8s `'true'`.
 def _str_or_empty(v: Any) -> str:
-    return '' if v is None else str(v)
+    if v is None:
+        return ''
+    if isinstance(v, bool):
+        return 'true' if v else 'false'
+    return str(v)
 
 
 def taint_is_tolerated(taint: Dict[str, Any],

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -4771,15 +4771,24 @@ def test_get_configured_tolerations_extracts_from_pod_config_dict():
         # str(). Without coercion, `value: 123` (unquoted YAML → int)
         # would not match a K8s taint value of '123' (str).
         ('yaml-int', '123', 123, True),
-        # YAML-parsed bool: `value: true` → Python True must still match
-        # taint string 'True'.
-        ('yaml-bool', 'True', True, True),
+        # YAML-parsed bool: `value: true` → Python True must match a
+        # taint string 'true' (lowercase). K8s stores taint values as
+        # whatever Go's YAML serializer emits, which is always lowercase
+        # for booleans. Without the bool-lowercase coercion, Python's
+        # `str(True)` would yield 'True' and silently mismatch.
+        ('yaml-bool', 'true', True, True),
         # Falsy YAML-int (`value: 0`) survives coercion. Regression for
         # the `str(x or '')` idiom which silently collapses 0 → ''.
         ('yaml-int-zero', '0', 0, True),
         # Falsy YAML-bool (`value: false`) — same regression risk as
-        # int-zero.
-        ('yaml-bool-false', 'False', False, True),
+        # int-zero, plus the same lowercase requirement as `yaml-bool`.
+        ('yaml-bool-false', 'false', False, True),
+        # Defensive: a Python-cased 'True'/'False' string on the K8s
+        # side must NOT match a Python-bool toleration. The lowercase
+        # coercion is strict; mismatches against 'True'/'False' don't
+        # accidentally pass.
+        ('python-cased-bool-no-match', 'True', True, False),
+        ('python-cased-bool-false-no-match', 'False', False, False),
         # Inverse collapse: taint has value='' and toleration has
         # value=0. Must NOT match (toleration's 0 → '0' ≠ taint's '').
         ('inverse-collapse', '', 0, False),


### PR DESCRIPTION
## Summary

Follow-up to #9750. `_str_or_empty` (used by `taint_is_tolerated` to
compare toleration values against K8s taint values) coerces non-string
scalars to string so unquoted YAML values like `value: 0` and
`value: 1.5` still match real K8s taints. But for Python `bool`,
`str(True)` produces the **Python-cased** `'True'` — while K8s stores
taint values as whatever Go's YAML serializer emits, which is always
**lowercase** (`'true'` / `'false'`). Even `kubectl taint nodes X foo=true:NoSchedule` lands on the node as `value: "true"`.

That silent mismatch means a config

```yaml
tolerations:
  - key: foo
    operator: Equal
    value: true   # unquoted YAML → Python True → 'True'
    effect: NoSchedule
```

never matches a real K8s taint with `value: "true"` — the operator
sees `'True' != 'true'` and the taint reads un-tolerated. The user has
to remember to quote the value (`value: "true"`) to work around it.

Special-case `bool` inside `_str_or_empty` to lowercase. Mirrors what
Go's `strconv.FormatBool` / `fmt.Sprintf("%t", ...)` produce, so the
matcher stays in lockstep with how K8s actually stores taint values.

## Test plan

- Updates the `yaml-bool` / `yaml-bool-false` parametrize cases in
  `test_taint_is_tolerated_str_coercion` to use `'true'` / `'false'`
  taint values (the realistic K8s shape).
- Adds two `python-cased-bool-no-match` cases asserting the coercion
  is one-directional / strict: a hypothetical taint stored as
  Python-cased `'True'` must NOT match a Python-bool toleration. We
  fix the toleration side to match K8s reality, not loosen the
  comparison to be case-insensitive.

```
pytest tests/unit_tests/kubernetes/test_kubernetes_utils.py -k taint_is_tolerated_str_coercion
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->