### PR TITLE
[Kubernetes][Jobs] Surface pod OOM and eviction reasons for jobs and clusters

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2904,6 +2904,25 @@ def _update_cluster_status(
                                                handle.launched_nodes,
                                                node_health)
 
+        # When the per-pod status doesn't yet name a cause, recover it from pod
+        # events. An eviction (ephemeral-storage / disk / memory pressure) is
+        # emitted as a kubelet event while the pod can still report
+        # Running/Ready and pod.status.reason has not caught up, so at abnormal-
+        # detection time the only signal is the event. Bounded: only on an
+        # abnormal k8s cluster with no status-derived reason.
+        if not status_reason and isinstance(launched_resources.cloud,
+                                            clouds.Kubernetes):
+            try:
+                ray_config = global_user_state.get_cluster_yaml_dict(
+                    handle.cluster_yaml)
+                status_reason = (
+                    k8s_instance.get_cluster_failure_reason_from_events(
+                        ray_config['provider'], list(node_statuses.keys())) or
+                    '')
+            except Exception as e:  # pylint: disable=broad-except
+                logger.debug('Failed to get pod failure events for '
+                             f'{cluster_name!r}: {e}')
+
         # Nodes not in UP/STOPPED (e.g. INIT for a Failed k8s pod) — must
         # be checked before some_nodes_not_stopped, which would otherwise
         # report the misleading "some but not all nodes are stopped" for

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2915,10 +2915,11 @@ def _update_cluster_status(
             try:
                 ray_config = global_user_state.get_cluster_yaml_dict(
                     handle.cluster_yaml)
-                status_reason = (
-                    k8s_instance.get_cluster_failure_reason_from_events(
-                        ray_config['provider'], list(node_statuses.keys())) or
-                    '')
+                if ray_config and 'provider' in ray_config:
+                    status_reason = (
+                        k8s_instance.get_cluster_failure_reason_from_events(
+                            ray_config['provider'], list(
+                                node_statuses.keys())) or '')
             except Exception as e:  # pylint: disable=broad-except
                 logger.debug('Failed to get pod failure events for '
                              f'{cluster_name!r}: {e}')

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2904,24 +2904,30 @@ def _update_cluster_status(
                                                handle.launched_nodes,
                                                node_health)
 
-        # When the per-pod status doesn't yet name a cause, recover it from pod
-        # events. An eviction (ephemeral-storage / disk / memory pressure) is
-        # emitted as a kubelet event while the pod can still report
-        # Running/Ready and pod.status.reason has not caught up, so at abnormal-
-        # detection time the only signal is the event. Bounded: only on an
-        # abnormal k8s cluster with no status-derived reason.
+        # When the per-pod live status doesn't name a cause, recover it from a
+        # durable signal. Two races are covered:
+        # - Eviction (ephemeral-storage / disk / memory pressure) is emitted as
+        #   a kubelet event while the pod can still report Running/Ready and
+        #   pod.status.reason has not caught up -> read the events.
+        # - A run-phase OOMKilled lives in the container's last_state and
+        #   survives the restart, but the Ready condition flips back to True
+        #   once the container is running again, so a snapshot that raced the
+        #   restart misses it -> re-read the pods' current+previous states.
+        # Bounded: only on an abnormal k8s cluster with no status reason.
         if not status_reason and isinstance(launched_resources.cloud,
                                             clouds.Kubernetes):
             try:
                 ray_config = global_user_state.get_cluster_yaml_dict(
                     handle.cluster_yaml)
                 if ray_config and 'provider' in ray_config:
+                    pod_names = list(node_statuses.keys())
                     status_reason = (
                         k8s_instance.get_cluster_failure_reason_from_events(
-                            ray_config['provider'], list(
-                                node_statuses.keys())) or '')
+                            ray_config['provider'], pod_names) or
+                        k8s_instance.get_cluster_failure_reason_from_pods(
+                            ray_config['provider'], pod_names) or '')
             except Exception as e:  # pylint: disable=broad-except
-                logger.debug('Failed to get pod failure events for '
+                logger.debug('Failed to get pod failure reason for '
                              f'{cluster_name!r}: {e}')
 
         # Nodes not in UP/STOPPED (e.g. INIT for a Failed k8s pod) — must

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -209,43 +209,35 @@ _EXCEPTION_MSG_AND_RETURNCODE_FOR_DUMP_INLINE_SCRIPT = [
 _RESOURCES_UNAVAILABLE_LOG = (
     'Reasons for provision failures (for details, please check the log above):')
 
-# Hints currently only cover Kubernetes failure modes. Scoped to k8s blocks
-# in _format_provision_failure_blocks to avoid false positives on cloud
-# error messages (e.g., AWS "InsufficientInstanceCapacity").
-_KUBERNETES_FAILURE_HINTS = [
-    (['ImagePullBackOff', 'ErrImagePull'],
-     'Verify the image tag exists and registry credentials are configured.'),
-    (['OOMKilled'], 'The container ran out of memory. '
-     'Try requesting more with `memory: <size>` in resources.'),
-    (['Insufficient'],
-     'The cluster does not have enough free resources. View node '
-     'allocations at {dashboard_url} or run `kubectl describe nodes`.'),
-]
-
 
 def _get_kubernetes_hint(reason: str,
                          context: Optional[str] = None) -> Optional[str]:
     """Return a hint for the given Kubernetes failure reason, or None.
 
-    Hints may contain a literal `{dashboard_url}` token, which is replaced
-    with the SkyPilot dashboard infra page URL — scoped to the failing
-    context when one is available. If URL resolution fails for any reason,
-    the token is replaced with a generic fallback so we never raise from
-    failure-rendering code (which would mask the original provision error).
+    Sources the canonical hint table from
+    ``kubernetes_utils.KUBERNETES_FAILURE_HINTS``. Hints may contain a literal
+    `{dashboard_url}` token, which is replaced with the SkyPilot dashboard
+    infra page URL — scoped to the failing context when one is available. If
+    URL resolution fails for any reason, the token is replaced with a generic
+    fallback so we never raise from failure-rendering code (which would mask
+    the original provision error).
+
+    Only called from the Kubernetes branch of
+    ``_format_provision_failure_blocks`` to avoid false positives on other
+    clouds' error messages (e.g., AWS "InsufficientInstanceCapacity").
     """
-    for substrings, hint in _KUBERNETES_FAILURE_HINTS:
-        if any(s in reason for s in substrings):
-            if '{dashboard_url}' in hint:
-                try:
-                    starting_page = (f'infra/{context}' if context else 'infra')
-                    dashboard_url = server_common.get_dashboard_url(
-                        server_common.get_server_url(),
-                        starting_page=starting_page)
-                except Exception:  # pylint: disable=broad-except
-                    dashboard_url = 'the SkyPilot dashboard infra page'
-                hint = hint.replace('{dashboard_url}', dashboard_url)
-            return hint
-    return None
+    hint = kubernetes_utils.match_kubernetes_failure_hint(reason)
+    if hint is None:
+        return None
+    if '{dashboard_url}' in hint:
+        try:
+            starting_page = (f'infra/{context}' if context else 'infra')
+            dashboard_url = server_common.get_dashboard_url(
+                server_common.get_server_url(), starting_page=starting_page)
+        except Exception:  # pylint: disable=broad-except
+            dashboard_url = 'the SkyPilot dashboard infra page'
+        hint = hint.replace('{dashboard_url}', dashboard_url)
+    return hint
 
 
 def _format_provision_failure_blocks(

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1804,6 +1804,17 @@ class JobController:
             await self._update_failed_task_state(
                 task_id, managed_job_state.ManagedJobStatus.FAILED_NO_RESOURCE,
                 failure_reason)
+        except exceptions.ClusterSetUpError as e:
+            # Raised by the launch path for a non-retryable setup failure, e.g.
+            # the job's pod was OOMKilled during cluster/runtime setup. The
+            # failure is deterministic, so we mark the job terminal (rather than
+            # retrying forever) and surface the reason to the CLI/dashboard.
+            logger.error(f'Cluster setup failed for task {task_id}')
+            failure_reason = common_utils.format_exception(e, use_bracket=True)
+            logger.error(failure_reason)
+            await self._update_failed_task_state(
+                task_id, managed_job_state.ManagedJobStatus.FAILED_SETUP,
+                failure_reason)
         except asyncio.CancelledError:  # pylint: disable=try-except-raise
             # have this here to avoid getting caught by the general except block
             # below.

--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -50,6 +50,20 @@ MAX_JOB_CHECKING_RETRY = 10
 # cluster before its status can be updated by the job controller.
 _AUTODOWN_MINUTES = 10
 
+# Substrings (case-insensitive) that identify an out-of-memory failure in a
+# launch/setup exception message. The Kubernetes command runner enriches exec
+# failures with the pod's termination reason (see
+# kubernetes_utils.diagnose_terminated_pod), so 'OOMKilled' reliably appears
+# here when a managed-job pod is OOM-killed during cluster/runtime setup.
+_OOM_FAILURE_SIGNATURES = ('oomkilled', 'out of memory', 'out-of-memory')
+
+
+def _is_oom_failure(exception: Exception) -> bool:
+    """Whether `exception` indicates an out-of-memory pod termination."""
+    message = common_utils.format_exception(exception).lower()
+    return any(sig in message for sig in _OOM_FAILURE_SIGNATURES)
+
+
 ENV_VARS_TO_CLEAR = [
     skypilot_config.ENV_VAR_SKYPILOT_CONFIG,
     constants.USER_ID_ENV_VAR,
@@ -663,8 +677,19 @@ class StrategyExecutor:
                         logger.info('Failed to launch a cluster with error: '
                                     f'{common_utils.format_exception(e)})')
                     except Exception as e:  # pylint: disable=broad-except
-                        # If the launch fails, it will be recovered by the
-                        # following code.
+                        # A pod OOM during cluster/runtime setup is
+                        # deterministic (e.g. the requested memory is too
+                        # low) -- retrying just OOMs again. Fail fast with a
+                        # terminal error carrying the OOM reason instead of
+                        # looping forever in the launch-retry path below. Other
+                        # failures fall through and are recovered below.
+                        if raise_on_failure and _is_oom_failure(e):
+                            logger.error(
+                                'Cluster setup failed due to out-of-memory: '
+                                f'{common_utils.format_exception(e)}')
+                            with ux_utils.print_exception_no_traceback():
+                                raise exceptions.ClusterSetUpError(
+                                    str(e)) from e
                         logger.info('Failed to launch a cluster with error: '
                                     f'{common_utils.format_exception(e)})')
                         with ux_utils.enable_traceback():

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -443,8 +443,9 @@ class ManagedJobStatus(enum.Enum):
     CANCELLED = 'CANCELLED'
     # FAILED: The job is finished with failure from the user's program.
     FAILED = 'FAILED'
-    # FAILED_SETUP: The job is finished with failure from the user's setup
-    # script.
+    # FAILED_SETUP: The job is finished with failure during setup -- either the
+    # user's setup script, or a deterministic cluster/runtime setup failure such
+    # as the job's pod being OOMKilled before the job started.
     FAILED_SETUP = 'FAILED_SETUP'
     # FAILED_PRECHECKS: the underlying `sky.launch` fails due to precheck
     # errors only. I.e., none of the failover exceptions, if any, is due to
@@ -3359,6 +3360,35 @@ def get_job_events(job_id: int,
         'reason': row[4],
         'timestamp': row[5],
     } for row in rows]
+
+
+def get_latest_recovery_reasons(job_ids: List[int]) -> Dict[int, str]:
+    """Return {job_id: reason} for the most recent RECOVERING event per job.
+
+    Only jobs with a non-empty RECOVERING reason are included. Used to surface
+    why a job is currently recovering (e.g. an OOMKilled pod) in the
+    `details` column. A single batched query keeps this off the per-job path.
+    """
+    if not job_ids:
+        return {}
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        rows = session.execute(
+            sqlalchemy.select(
+                job_events_table.c.spot_job_id,
+                job_events_table.c.reason,
+            ).where(
+                sqlalchemy.and_(
+                    job_events_table.c.spot_job_id.in_(job_ids),
+                    job_events_table.c.new_status ==
+                    ManagedJobStatus.RECOVERING.value,
+                )).order_by(job_events_table.c.timestamp.desc())).fetchall()
+    # rows are newest-first; keep the first (latest) non-empty reason per job.
+    reasons: Dict[int, str] = {}
+    for spot_job_id, reason in rows:
+        if spot_job_id not in reasons and reason:
+            reasons[spot_job_id] = reason
+    return reasons
 
 
 async def cleanup_job_events_with_retention_async(

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -2035,9 +2035,11 @@ def _cluster_handle_not_required(fields: List[str]) -> bool:
     return not any(field in fields for field in _CLUSTER_HANDLE_FIELDS)
 
 
-def _format_job_details(*, job: Dict[str, Any],
-                        highest_blocking_priority: int) -> None:
-    """Add details about schedule state / backoff."""
+def _format_job_details(*,
+                        job: Dict[str, Any],
+                        highest_blocking_priority: int,
+                        recovery_reason: Optional[str] = None) -> None:
+    """Add details about schedule state / backoff / recovery."""
     state_details = None
     if job['schedule_state'] == 'ALIVE_BACKOFF':
         state_details = 'In backoff, waiting for resources'
@@ -2055,6 +2057,14 @@ def _format_job_details(*, job: Dict[str, Any],
         job['details'] = state_details
     elif job['failure_reason']:
         job['details'] = f'Failure: {job["failure_reason"]}'
+    elif recovery_reason:
+        # Surface why a job is recovering (e.g. an OOMKilled pod) so the
+        # transient recovery cause is visible in the CLI and dashboard, not
+        # just the controller logs. The reason (e.g. from
+        # _get_pod_termination_reason) may be multi-line; collapse whitespace
+        # so it renders as a single line in the details column.
+        flattened = ' '.join(recovery_reason.split())
+        job['details'] = f'Recovering: {flattened}'
     else:
         job['details'] = None
 
@@ -2243,10 +2253,25 @@ def get_managed_job_queue(
 
     _populate_job_records_from_handles(jobs_with_handle)
 
+    # Batch-fetch the reason a recovering job is recovering (e.g. an OOMKilled
+    # pod), so it can be surfaced in `details`. Scoped to RECOVERING jobs (a
+    # small, transient subset) and done in one query to stay off the per-job
+    # path. `job['status']` is already stringified above.
+    recovery_reasons: Dict[int, str] = {}
+    if not fields or 'details' in fields:
+        recovering_job_ids = [
+            job['job_id'] for job in jobs if job['status'] ==
+            managed_job_state.ManagedJobStatus.RECOVERING.value
+        ]
+        recovery_reasons = managed_job_state.get_latest_recovery_reasons(
+            recovering_job_ids)
+
     for job in jobs:
         if not fields or 'details' in fields:
             _format_job_details(
-                job=job, highest_blocking_priority=highest_blocking_priority)
+                job=job,
+                highest_blocking_priority=highest_blocking_priority,
+                recovery_reason=recovery_reasons.get(job['job_id']))
 
         # Derive is_job_group from execution column
         job['is_job_group'] = (

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -2068,15 +2068,13 @@ def _format_job_details(*,
         detail = f'Recovering: {flattened}'
         # Append an actionable remediation hint when the cause is a known
         # Kubernetes pod failure (e.g. OOMKilled -> raise resources.memory).
-        # Guarded on the job's cloud so a non-k8s reason that happens to
-        # contain a matched word (e.g. 'Insufficient') is not mis-hinted.
-        if 'kubernetes' in str(job.get('cloud', '')).lower():
-            hint = kubernetes_utils.match_kubernetes_failure_hint(flattened)
+        # Guarded on the job's cloud (job['cloud'] is str(cloud), exactly
+        # 'Kubernetes') so a non-k8s reason that happens to contain a matched
+        # word (e.g. 'Insufficient') is not mis-hinted.
+        if str(job.get('cloud', '')).lower() == 'kubernetes':
+            hint = kubernetes_utils.match_kubernetes_failure_hint_text(
+                flattened)
             if hint is not None:
-                # This listing has no scoped dashboard URL to resolve, so use
-                # the generic phrase if the hint references it.
-                hint = hint.replace('{dashboard_url}',
-                                    'the SkyPilot dashboard infra page')
                 detail += f' ({hint})'
         job['details'] = detail
     else:

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -43,6 +43,7 @@ from sky.jobs import constants as managed_job_constants
 from sky.jobs import runtime as managed_job_runtime
 from sky.jobs import scheduler
 from sky.jobs import state as managed_job_state
+from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.schemas.api import responses
 from sky.skylet import constants
 from sky.skylet import job_lib
@@ -2064,7 +2065,20 @@ def _format_job_details(*,
         # _get_pod_termination_reason) may be multi-line; collapse whitespace
         # so it renders as a single line in the details column.
         flattened = ' '.join(recovery_reason.split())
-        job['details'] = f'Recovering: {flattened}'
+        detail = f'Recovering: {flattened}'
+        # Append an actionable remediation hint when the cause is a known
+        # Kubernetes pod failure (e.g. OOMKilled -> raise resources.memory).
+        # Guarded on the job's cloud so a non-k8s reason that happens to
+        # contain a matched word (e.g. 'Insufficient') is not mis-hinted.
+        if 'kubernetes' in str(job.get('cloud', '')).lower():
+            hint = kubernetes_utils.match_kubernetes_failure_hint(flattened)
+            if hint is not None:
+                # This listing has no scoped dashboard URL to resolve, so use
+                # the generic phrase if the hint references it.
+                hint = hint.replace('{dashboard_url}',
+                                    'the SkyPilot dashboard infra page')
+                detail += f' ({hint})'
+        job['details'] = detail
     else:
         job['details'] = None
 

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -2042,11 +2042,28 @@ def _get_pod_health_issues(pod: Any) -> Optional[str]:
             continue
         waiting = getattr(cs.state, 'waiting', None)
         terminated = getattr(cs.state, 'terminated', None)
+        # A container that was OOMKilled (or otherwise died) and is now
+        # restarting records the failure in last_state, not the current state
+        # (which may be a generic 'waiting' or already running-again). Surface
+        # it so an OOM that briefly blips the cluster into recovery is not
+        # masked as a generic 'ray cluster is unhealthy' message.
+        last_state = getattr(cs, 'last_state', None)
+        last_terminated = getattr(last_state, 'terminated', None)
+        prior = None
+        if (last_terminated is not None and last_terminated.exit_code != 0 and
+                last_terminated.reason):
+            prior = (f'{last_terminated.reason} '
+                     f'(exit code {last_terminated.exit_code})')
         if waiting and waiting.reason:
-            container_issues.append(waiting.reason)
+            issue = waiting.reason
+            if prior is not None:
+                issue += f'; previously {prior}'
+            container_issues.append(issue)
         elif terminated and terminated.exit_code != 0:
             container_issues.append(f'{terminated.reason or "terminated"}'
                                     f' (exit code {terminated.exit_code})')
+        elif prior is not None:
+            container_issues.append(prior)
 
     if container_issues:
         parts.append('; '.join(container_issues))

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -744,7 +744,8 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
                 pod.status.phase == 'Failed'):
             # Get the reason and write to cluster events before
             # the pod gets completely deleted from the API.
-            termination_reason = _get_pod_termination_reason(pod, cluster_name)
+            termination_reason = _get_pod_termination_reason(
+                pod, cluster_name, context, namespace)
             logger.warning(
                 f'Pod {pod.metadata.name} terminated: {termination_reason}')
             condensed = _condensed_pod_reason(pod)
@@ -2195,11 +2196,14 @@ def get_node_health_for_cluster(
     return result
 
 
-def _get_pod_termination_reason(pod: Any, cluster_name: str) -> str:
+def _get_pod_termination_reason(pod: Any, cluster_name: str,
+                                context: Optional[str], namespace: str) -> str:
     """Get pod termination reason and write to cluster events.
 
-    Checks both pod conditions (for preemption/disruption) and
-    container statuses (for exit codes/errors).
+    Checks pod conditions (for preemption/disruption), the pod-level kubelet
+    reason, container statuses (for exit codes/errors), and -- as a last resort
+    -- an 'Evicted' pod event (ephemeral-storage / disk / memory pressure,
+    which the kubelet records only as an Event, not in pod.status).
     """
     utc_min_time = datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
     latest_timestamp = (pod.status.start_time or utc_min_time)
@@ -2231,6 +2235,27 @@ def _get_pod_termination_reason(pod: Any, cluster_name: str) -> str:
         if condition.last_transition_time is not None:
             latest_timestamp = max(latest_timestamp,
                                    condition.last_transition_time)
+
+    # When no preemption/disruption condition explained the failure, fall back
+    # to (a) the pod-level kubelet reason, then (b) an 'Evicted' pod event. The
+    # kubelet records ephemeral-storage / disk / memory-pressure evictions as an
+    # Event with a descriptive message -- not in pod.status -- and the container
+    # exit (e.g. 'Error') is only a side effect of the kill, so the event is the
+    # authoritative cause.
+    if termination_reason == 'Terminated unexpectedly':
+        pod_status_reason = getattr(pod.status, 'reason', None)
+        if pod_status_reason:
+            termination_reason = pod_status_reason
+            pod_status_message = getattr(pod.status, 'message', None)
+            if pod_status_message:
+                termination_reason += f' ({pod_status_message})'
+        else:
+            evicted_event = _get_pod_eviction_event(context, namespace,
+                                                    pod.metadata.name)
+            if evicted_event is not None:
+                termination_reason = evicted_event.reason or 'Evicted'
+                if evicted_event.message:
+                    termination_reason += f' ({evicted_event.message})'
 
     pod_reason = (f'{termination_reason}.\n'
                   f'Last known state: {ready_state}.')
@@ -2296,6 +2321,24 @@ def _get_pod_events(context: Optional[str], namespace: str,
         key=lambda event: event.metadata.creation_timestamp,
         # latest event appears first
         reverse=True)
+
+
+def _get_pod_eviction_event(context: Optional[str], namespace: str,
+                            pod_name: str) -> Optional[Any]:
+    """Return the most recent 'Evicted' pod event, or None.
+
+    The kubelet records evictions (ephemeral-storage / disk / memory pressure)
+    as an Event with reason 'Evicted' and a descriptive message. This is not
+    reflected in pod.status, so the pod object alone cannot explain the cause.
+    Best-effort: never raises.
+    """
+    try:
+        for event in _get_pod_events(context, namespace, pod_name):
+            if event.reason == 'Evicted':
+                return event
+    except Exception:  # pylint: disable=broad-except
+        return None
+    return None
 
 
 def _unmask_crashloopbackoff_reason(cs: Any) -> Optional[str]:
@@ -2686,7 +2729,8 @@ def query_instances(
         pod_status = status_map[phase]
         reason = None
         if phase in ('Failed', 'Unknown') or is_terminating:
-            reason = _get_pod_termination_reason(pod, cluster_name)
+            reason = _get_pod_termination_reason(pod, cluster_name, context,
+                                                 namespace)
             logger.debug(f'Pod Status ({phase}) Reason(s): {reason}')
         elif phase == 'Running':
             reason = _get_pod_health_issues(pod)

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -2385,8 +2385,11 @@ def get_cluster_failure_reason_from_pods(provider_config: Dict[str, Any],
     derives the reason from current *and* previous terminated states, so the OOM
     is recovered regardless of where the read landed in the restart cycle.
 
-    Returns the condensed reason for the first pod that terminated abnormally,
-    else None. Best-effort (per-pod reads never raise).
+    Returns '<pod> is not ready (<condensed reason>)' for the first pod that
+    terminated abnormally, else None. The framing mirrors the single-pod output
+    of backend_utils._summarize_pod_reasons so the abnormal message reads the
+    same whether the live status or this fallback caught the failure.
+    Best-effort (per-pod reads never raise).
     """
     namespace = kubernetes_utils.get_namespace_from_config(provider_config)
     context = kubernetes_utils.get_context_from_config(provider_config)
@@ -2397,7 +2400,8 @@ def get_cluster_failure_reason_from_pods(provider_config: Dict[str, Any],
         except Exception:  # pylint: disable=broad-except
             continue
         if kubernetes_utils.pod_terminated_abnormally(pod):
-            return kubernetes_utils.get_condensed_pod_reason(pod)
+            reason = kubernetes_utils.get_condensed_pod_reason(pod)
+            return f'{pod_name} is not ready ({reason})'
     return None
 
 

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -2258,48 +2258,11 @@ def _get_pod_termination_reason(pod: Any, cluster_name: str) -> str:
 def _condensed_pod_reason(pod: 'V1Pod') -> str:
     """Condense pod failure into a single-line user-facing summary.
 
-    Checks pod conditions and container statuses to produce a concise
-    reason string suitable for display in the provision failure output.
+    Thin wrapper around ``kubernetes_utils.get_condensed_pod_reason`` (the
+    canonical implementation, shared with the command-runner OOM diagnosis
+    path).
     """
-    # Check pod conditions for preemption/disruption (highest priority).
-    if pod.status.conditions:
-        for condition in pod.status.conditions:
-            reason = condition.reason or 'Unknown reason'
-            message = condition.message or ''
-            if condition.type == 'TerminationTarget':
-                summary = f'Preempted by Kueue: {reason}'
-                if message:
-                    summary += f' ({message})'
-                return summary
-            if condition.type == 'DisruptionTarget':
-                summary = f'Disrupted: {reason}'
-                if message:
-                    summary += f' ({message})'
-                return summary
-
-    # Check container statuses for waiting states (ImagePullBackOff, etc.).
-    if pod.status.container_statuses:
-        for cs in pod.status.container_statuses:
-            if cs.state.waiting is not None:
-                waiting = cs.state.waiting
-                if waiting.reason and waiting.reason not in (
-                        'ContainerCreating', 'PodInitializing'):
-                    msg = waiting.message or ''
-                    return f'{waiting.reason}: {msg}'.rstrip(': ')
-
-    # Check container statuses for terminated states (OOMKilled, Error, etc.).
-    if pod.status.container_statuses:
-        for cs in pod.status.container_statuses:
-            if cs.state.terminated is not None:
-                terminated = cs.state.terminated
-                if terminated.exit_code != 0:
-                    if terminated.reason:
-                        return (f'{terminated.reason} '
-                                f'(exit code {terminated.exit_code})')
-                    return (f'Terminated with exit code '
-                            f'{terminated.exit_code}')
-
-    return 'Terminated unexpectedly'
+    return kubernetes_utils.get_condensed_pod_reason(pod)
 
 
 def _get_pod_events(context: Optional[str], namespace: str,

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -2309,6 +2309,47 @@ def _get_pod_events(context: Optional[str], namespace: str,
         reverse=True)
 
 
+# kubelet pod-event reasons that carry a terminal failure cause which is not
+# always reflected in pod.status in time -- notably an eviction for
+# ephemeral-storage / disk / memory pressure, where the kubelet emits the event
+# while pod.status.phase is still 'Running' and status.reason/message lag.
+_FAILURE_EVENT_REASONS = ('Evicted',)
+
+# Substrings that already name a specific failure cause; when a status-derived
+# reason contains one, consulting events would add nothing.
+_SPECIFIC_FAILURE_REASON_SUBSTRINGS = ('OOMKilled', 'ImagePullBackOff',
+                                       'ErrImagePull', 'CrashLoopBackOff',
+                                       'Evicted', 'ephemeral', 'Insufficient',
+                                       'Preempted', 'Disrupted')
+
+
+def _reason_lacks_specific_cause(reason: Optional[str]) -> bool:
+    """Whether `reason` does not already name a specific failure cause."""
+    return not reason or not any(s in reason
+                                 for s in _SPECIFIC_FAILURE_REASON_SUBSTRINGS)
+
+
+def _get_pod_failure_reason_from_events(context: Optional[str], namespace: str,
+                                        pod_name: str) -> Optional[str]:
+    """Best-effort failure reason from the pod's most recent kubelet event.
+
+    Some failures (notably evictions for ephemeral-storage / disk / memory
+    pressure) are recorded in pod events before they propagate to
+    pod.status.reason / phase. Returns '<reason>: <message>' for the most
+    recent event whose reason is in ``_FAILURE_EVENT_REASONS``, else None.
+    Never raises -- this is additive diagnostics.
+    """
+    try:
+        events = _get_pod_events(context, namespace, pod_name)
+    except Exception:  # pylint: disable=broad-except
+        return None
+    for event in events:  # most recent first
+        if event.reason in _FAILURE_EVENT_REASONS:
+            message = (event.message or '').strip()
+            return f'{event.reason}: {message}'.rstrip(': ')
+    return None
+
+
 def _unmask_crashloopbackoff_reason(cs: Any) -> Optional[str]:
     """Return `last_state.terminated.reason` iff cs is in CrashLoopBackOff
     and a previous terminated reason is available; else None.
@@ -2701,6 +2742,17 @@ def query_instances(
             logger.debug(f'Pod Status ({phase}) Reason(s): {reason}')
         elif phase == 'Running':
             reason = _get_pod_health_issues(pod)
+        # An eviction (ephemeral-storage / disk / memory pressure) is recorded
+        # in the pod's kubelet events before it reaches pod.status -- often
+        # while the pod still reports 'Running'. When a flagged pod's
+        # status-derived reason is missing the specific cause, recover it from
+        # events. Scoped to already-flagged pods (reason set) with a generic
+        # reason, so healthy pods incur no extra events API call.
+        if reason is not None and _reason_lacks_specific_cause(reason):
+            event_reason = _get_pod_failure_reason_from_events(
+                context, namespace, pod.metadata.name)
+            if event_reason is not None:
+                reason = f'{reason}; {event_reason}'
         if non_terminated_only and pod_status is None:
             logger.debug(f'Pod {pod.metadata.name} is terminated, but '
                          'query_instances is called with '

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -2372,6 +2372,35 @@ def get_cluster_failure_reason_from_events(
     return None
 
 
+def get_cluster_failure_reason_from_pods(provider_config: Dict[str, Any],
+                                         pod_names: List[str]) -> Optional[str]:
+    """Return a durable failure reason from the cluster pods' status, or None.
+
+    Used when a cluster is abnormal but the live per-pod status did not name a
+    cause. A run-phase OOMKilled is recorded in the container's
+    ``last_state.terminated`` and survives the restart, but the live ``Ready``
+    condition flips back to True once the container is running again -- so a
+    snapshot taken outside that window (the read raced the restart) misses it.
+    Unlike the live ``_get_pod_health_issues`` check, this re-reads each pod and
+    derives the reason from current *and* previous terminated states, so the OOM
+    is recovered regardless of where the read landed in the restart cycle.
+
+    Returns the condensed reason for the first pod that terminated abnormally,
+    else None. Best-effort (per-pod reads never raise).
+    """
+    namespace = kubernetes_utils.get_namespace_from_config(provider_config)
+    context = kubernetes_utils.get_context_from_config(provider_config)
+    for pod_name in pod_names:
+        try:
+            pod = kubernetes.core_api(context).read_namespaced_pod(
+                pod_name, namespace, _request_timeout=kubernetes.API_TIMEOUT)
+        except Exception:  # pylint: disable=broad-except
+            continue
+        if kubernetes_utils.pod_terminated_abnormally(pod):
+            return kubernetes_utils.get_condensed_pod_reason(pod)
+    return None
+
+
 def _unmask_crashloopbackoff_reason(cs: Any) -> Optional[str]:
     """Return `last_state.terminated.reason` iff cs is in CrashLoopBackOff
     and a previous terminated reason is available; else None.

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -744,8 +744,7 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
                 pod.status.phase == 'Failed'):
             # Get the reason and write to cluster events before
             # the pod gets completely deleted from the API.
-            termination_reason = _get_pod_termination_reason(
-                pod, cluster_name, context, namespace)
+            termination_reason = _get_pod_termination_reason(pod, cluster_name)
             logger.warning(
                 f'Pod {pod.metadata.name} terminated: {termination_reason}')
             condensed = _condensed_pod_reason(pod)
@@ -2196,14 +2195,11 @@ def get_node_health_for_cluster(
     return result
 
 
-def _get_pod_termination_reason(pod: Any, cluster_name: str,
-                                context: Optional[str], namespace: str) -> str:
+def _get_pod_termination_reason(pod: Any, cluster_name: str) -> str:
     """Get pod termination reason and write to cluster events.
 
-    Checks pod conditions (for preemption/disruption), the pod-level kubelet
-    reason, container statuses (for exit codes/errors), and -- as a last resort
-    -- an 'Evicted' pod event (ephemeral-storage / disk / memory pressure,
-    which the kubelet records only as an Event, not in pod.status).
+    Checks both pod conditions (for preemption/disruption) and
+    container statuses (for exit codes/errors).
     """
     utc_min_time = datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
     latest_timestamp = (pod.status.start_time or utc_min_time)
@@ -2236,26 +2232,16 @@ def _get_pod_termination_reason(pod: Any, cluster_name: str,
             latest_timestamp = max(latest_timestamp,
                                    condition.last_transition_time)
 
-    # When no preemption/disruption condition explained the failure, fall back
-    # to (a) the pod-level kubelet reason, then (b) an 'Evicted' pod event. The
-    # kubelet records ephemeral-storage / disk / memory-pressure evictions as an
-    # Event with a descriptive message -- not in pod.status -- and the container
-    # exit (e.g. 'Error') is only a side effect of the kill, so the event is the
-    # authoritative cause.
-    if termination_reason == 'Terminated unexpectedly':
-        pod_status_reason = getattr(pod.status, 'reason', None)
-        if pod_status_reason:
-            termination_reason = pod_status_reason
-            pod_status_message = getattr(pod.status, 'message', None)
-            if pod_status_message:
-                termination_reason += f' ({pod_status_message})'
-        else:
-            evicted_event = _get_pod_eviction_event(context, namespace,
-                                                    pod.metadata.name)
-            if evicted_event is not None:
-                termination_reason = evicted_event.reason or 'Evicted'
-                if evicted_event.message:
-                    termination_reason += f' ({evicted_event.message})'
+    # Fall back to the pod-level kubelet reason (e.g. 'Evicted' for
+    # ephemeral-storage / disk / memory pressure) when no preemption/disruption
+    # condition explained the failure. This is often the only place an eviction
+    # cause is recorded (container statuses may be uninformative).
+    pod_status_reason = getattr(pod.status, 'reason', None)
+    if termination_reason == 'Terminated unexpectedly' and pod_status_reason:
+        termination_reason = pod_status_reason
+        pod_status_message = getattr(pod.status, 'message', None)
+        if pod_status_message:
+            termination_reason += f' ({pod_status_message})'
 
     pod_reason = (f'{termination_reason}.\n'
                   f'Last known state: {ready_state}.')
@@ -2321,24 +2307,6 @@ def _get_pod_events(context: Optional[str], namespace: str,
         key=lambda event: event.metadata.creation_timestamp,
         # latest event appears first
         reverse=True)
-
-
-def _get_pod_eviction_event(context: Optional[str], namespace: str,
-                            pod_name: str) -> Optional[Any]:
-    """Return the most recent 'Evicted' pod event, or None.
-
-    The kubelet records evictions (ephemeral-storage / disk / memory pressure)
-    as an Event with reason 'Evicted' and a descriptive message. This is not
-    reflected in pod.status, so the pod object alone cannot explain the cause.
-    Best-effort: never raises.
-    """
-    try:
-        for event in _get_pod_events(context, namespace, pod_name):
-            if event.reason == 'Evicted':
-                return event
-    except Exception:  # pylint: disable=broad-except
-        return None
-    return None
 
 
 def _unmask_crashloopbackoff_reason(cs: Any) -> Optional[str]:
@@ -2729,8 +2697,7 @@ def query_instances(
         pod_status = status_map[phase]
         reason = None
         if phase in ('Failed', 'Unknown') or is_terminating:
-            reason = _get_pod_termination_reason(pod, cluster_name, context,
-                                                 namespace)
+            reason = _get_pod_termination_reason(pod, cluster_name)
             logger.debug(f'Pod Status ({phase}) Reason(s): {reason}')
         elif phase == 'Running':
             reason = _get_pod_health_issues(pod)

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -2239,7 +2239,8 @@ def _get_pod_termination_reason(pod: Any, cluster_name: str) -> str:
     pod_status_reason = getattr(pod.status, 'reason', None)
     if termination_reason == 'Terminated unexpectedly' and pod_status_reason:
         termination_reason = pod_status_reason
-        pod_status_message = getattr(pod.status, 'message', None)
+        pod_status_message = (getattr(pod.status, 'message', None) or
+                              '').strip()
         if pod_status_message:
             termination_reason += f' ({pod_status_message})'
 
@@ -2347,6 +2348,26 @@ def _get_pod_failure_reason_from_events(context: Optional[str], namespace: str,
         if event.reason in _FAILURE_EVENT_REASONS:
             message = (event.message or '').strip()
             return f'{event.reason}: {message}'.rstrip(': ')
+    return None
+
+
+def get_cluster_failure_reason_from_events(
+        provider_config: Dict[str, Any], pod_names: List[str]) -> Optional[str]:
+    """Return a failure reason from the cluster pods' kubelet events, or None.
+
+    Used when a cluster is abnormal but pod.status does not yet name a cause --
+    e.g. an eviction (ephemeral-storage / disk / memory pressure) that the
+    kubelet has emitted as a pod event while the pod still reports
+    Running/Ready and status.reason has not caught up. Returns the first
+    matching pod's event reason. Best-effort (per-pod lookups never raise).
+    """
+    namespace = kubernetes_utils.get_namespace_from_config(provider_config)
+    context = kubernetes_utils.get_context_from_config(provider_config)
+    for pod_name in pod_names:
+        reason = _get_pod_failure_reason_from_events(context, namespace,
+                                                     pod_name)
+        if reason is not None:
+            return reason
     return None
 
 

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -2316,11 +2316,13 @@ def _get_pod_events(context: Optional[str], namespace: str,
 _FAILURE_EVENT_REASONS = ('Evicted',)
 
 # Substrings that already name a specific failure cause; when a status-derived
-# reason contains one, consulting events would add nothing.
-_SPECIFIC_FAILURE_REASON_SUBSTRINGS = ('OOMKilled', 'ImagePullBackOff',
-                                       'ErrImagePull', 'CrashLoopBackOff',
-                                       'Evicted', 'ephemeral', 'Insufficient',
-                                       'Preempted', 'Disrupted')
+# reason contains one, consulting events would add nothing. Every reason we
+# carry a remediation hint for is specific by definition, so derive those from
+# the canonical hint table; add the few specific reasons that have no hint
+# (CrashLoopBackOff and the Kueue/disruption conditions).
+_SPECIFIC_FAILURE_REASON_SUBSTRINGS = tuple(
+    kubernetes_utils.get_failure_hint_reasons()) + ('CrashLoopBackOff',
+                                                    'Preempted', 'Disrupted')
 
 
 def _reason_lacks_specific_cause(reason: Optional[str]) -> bool:

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -2047,8 +2047,7 @@ def _get_pod_health_issues(pod: Any) -> Optional[str]:
         # (which may be a generic 'waiting' or already running-again). Surface
         # it so an OOM that briefly blips the cluster into recovery is not
         # masked as a generic 'ray cluster is unhealthy' message.
-        last_state = getattr(cs, 'last_state', None)
-        last_terminated = getattr(last_state, 'terminated', None)
+        last_terminated = cs.last_state.terminated if cs.last_state else None
         prior = None
         if (last_terminated is not None and last_terminated.exit_code != 0 and
                 last_terminated.reason):

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -5,7 +5,7 @@ import json
 import re
 import sys
 import time
-from typing import (Any, Dict, List, Mapping, Optional, Set, Tuple,
+from typing import (Any, Callable, Dict, List, Mapping, Optional, Set, Tuple,
                     TYPE_CHECKING, Union)
 
 from sky import exceptions
@@ -2352,57 +2352,73 @@ def _get_pod_failure_reason_from_events(context: Optional[str], namespace: str,
     return None
 
 
-def get_cluster_failure_reason_from_events(
-        provider_config: Dict[str, Any], pod_names: List[str]) -> Optional[str]:
-    """Return a failure reason from the cluster pods' kubelet events, or None.
+def _get_pod_failure_reason_from_status(context: Optional[str], namespace: str,
+                                        pod_name: str) -> Optional[str]:
+    """Best-effort durable failure reason from the pod's terminated states.
 
-    Used when a cluster is abnormal but pod.status does not yet name a cause --
-    e.g. an eviction (ephemeral-storage / disk / memory pressure) that the
-    kubelet has emitted as a pod event while the pod still reports
-    Running/Ready and status.reason has not caught up. Returns the first
-    matching pod's event reason. Best-effort (per-pod lookups never raise).
+    A run-phase OOMKilled is recorded in the container's
+    ``last_state.terminated`` and survives the restart, but the live ``Ready``
+    condition flips back to True once the container is running again -- so a
+    snapshot taken outside that window (the read raced the restart) misses it.
+    Re-reads the pod and derives the reason from current *and* previous
+    terminated states, so the OOM is recovered regardless of where the read
+    landed in the restart cycle. Returns '<pod> is not ready (<reason>)' (the
+    framing mirrors the single-pod output of
+    backend_utils._summarize_pod_reasons so the message reads the same whether
+    the live status or this fallback caught it), else None. Never raises.
+    """
+    try:
+        pod = kubernetes.core_api(context).read_namespaced_pod(
+            pod_name, namespace, _request_timeout=kubernetes.API_TIMEOUT)
+    except Exception:  # pylint: disable=broad-except
+        return None
+    if not kubernetes_utils.pod_terminated_abnormally(pod):
+        return None
+    return (f'{pod_name} is not ready '
+            f'({kubernetes_utils.get_condensed_pod_reason(pod)})')
+
+
+def _first_pod_failure_reason(
+    provider_config: Dict[str, Any], pod_names: List[str],
+    per_pod_fn: Callable[[Optional[str], str, str], Optional[str]]
+) -> Optional[str]:
+    """Return the first non-None ``per_pod_fn(context, namespace, pod)``.
+
+    Resolves namespace/context from the provider config and probes each pod in
+    order. Used when a cluster is abnormal but the live per-pod status did not
+    name a cause. Best-effort -- per_pod_fn is expected to never raise.
     """
     namespace = kubernetes_utils.get_namespace_from_config(provider_config)
     context = kubernetes_utils.get_context_from_config(provider_config)
     for pod_name in pod_names:
-        reason = _get_pod_failure_reason_from_events(context, namespace,
-                                                     pod_name)
+        reason = per_pod_fn(context, namespace, pod_name)
         if reason is not None:
             return reason
     return None
 
 
+def get_cluster_failure_reason_from_events(
+        provider_config: Dict[str, Any], pod_names: List[str]) -> Optional[str]:
+    """First pod eviction reason from kubelet events (status lags), or None.
+
+    An eviction (ephemeral-storage / disk / memory pressure) is emitted as a
+    pod event while the pod can still report Running/Ready and status.reason
+    has not caught up. See _get_pod_failure_reason_from_events.
+    """
+    return _first_pod_failure_reason(provider_config, pod_names,
+                                     _get_pod_failure_reason_from_events)
+
+
 def get_cluster_failure_reason_from_pods(provider_config: Dict[str, Any],
                                          pod_names: List[str]) -> Optional[str]:
-    """Return a durable failure reason from the cluster pods' status, or None.
+    """First pod's durable terminated-state reason (e.g. a restarted OOM).
 
-    Used when a cluster is abnormal but the live per-pod status did not name a
-    cause. A run-phase OOMKilled is recorded in the container's
-    ``last_state.terminated`` and survives the restart, but the live ``Ready``
-    condition flips back to True once the container is running again -- so a
-    snapshot taken outside that window (the read raced the restart) misses it.
-    Unlike the live ``_get_pod_health_issues`` check, this re-reads each pod and
-    derives the reason from current *and* previous terminated states, so the OOM
-    is recovered regardless of where the read landed in the restart cycle.
-
-    Returns '<pod> is not ready (<condensed reason>)' for the first pod that
-    terminated abnormally, else None. The framing mirrors the single-pod output
-    of backend_utils._summarize_pod_reasons so the abnormal message reads the
-    same whether the live status or this fallback caught the failure.
-    Best-effort (per-pod reads never raise).
+    See _get_pod_failure_reason_from_status. Complements the events lookup:
+    catches an OOMKilled recovered from last_state when no kubelet event names
+    the cause.
     """
-    namespace = kubernetes_utils.get_namespace_from_config(provider_config)
-    context = kubernetes_utils.get_context_from_config(provider_config)
-    for pod_name in pod_names:
-        try:
-            pod = kubernetes.core_api(context).read_namespaced_pod(
-                pod_name, namespace, _request_timeout=kubernetes.API_TIMEOUT)
-        except Exception:  # pylint: disable=broad-except
-            continue
-        if kubernetes_utils.pod_terminated_abnormally(pod):
-            reason = kubernetes_utils.get_condensed_pod_reason(pod)
-            return f'{pod_name} is not ready ({reason})'
-    return None
+    return _first_pod_failure_reason(provider_config, pod_names,
+                                     _get_pod_failure_reason_from_status)
 
 
 def _unmask_crashloopbackoff_reason(cs: Any) -> Optional[str]:

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1915,6 +1915,142 @@ def get_kubernetes_nodes(*, context: Optional[str] = None) -> List[V1Node]:
     return nodes
 
 
+def _iter_terminated_states(cs):
+    """Yield a container status's current then previous terminated state.
+
+    Skips states that are absent. Both are checked because an OOMKilled
+    container that has since restarted records the kill only in ``last_state``.
+    """
+    for term in (cs.state.terminated if cs.state else None,
+                 cs.last_state.terminated if cs.last_state else None):
+        if term is not None:
+            yield term
+
+
+def get_condensed_pod_reason(pod: 'kubernetes_models.V1Pod') -> str:
+    """Condense a pod failure into a single-line user-facing summary.
+
+    Checks pod conditions and container statuses to produce a concise reason
+    string suitable for display (e.g. 'OOMKilled (exit code 137)'). Always
+    returns a string; falls back to 'Terminated unexpectedly' when no specific
+    cause is found.
+    """
+    # Check pod conditions for preemption/disruption (highest priority).
+    if pod.status.conditions:
+        for condition in pod.status.conditions:
+            reason = condition.reason or 'Unknown reason'
+            message = condition.message or ''
+            if condition.type == 'TerminationTarget':
+                summary = f'Preempted by Kueue: {reason}'
+                if message:
+                    summary += f' ({message})'
+                return summary
+            if condition.type == 'DisruptionTarget':
+                summary = f'Disrupted: {reason}'
+                if message:
+                    summary += f' ({message})'
+                return summary
+
+    # Check container statuses for waiting states (ImagePullBackOff, etc.).
+    if pod.status.container_statuses:
+        for cs in pod.status.container_statuses:
+            if cs.state.waiting is not None:
+                waiting = cs.state.waiting
+                if waiting.reason and waiting.reason not in (
+                        'ContainerCreating', 'PodInitializing'):
+                    msg = waiting.message or ''
+                    return f'{waiting.reason}: {msg}'.rstrip(': ')
+
+    # Check container statuses for terminated states (OOMKilled, Error, etc.),
+    # both the current state and the previous run (last_state).
+    if pod.status.container_statuses:
+        for cs in pod.status.container_statuses:
+            for term in _iter_terminated_states(cs):
+                if term.exit_code != 0:
+                    if term.reason:
+                        return f'{term.reason} (exit code {term.exit_code})'
+                    return f'Terminated with exit code {term.exit_code}'
+
+    return 'Terminated unexpectedly'
+
+
+def _pod_terminated_abnormally(pod: 'kubernetes_models.V1Pod') -> bool:
+    """True if the pod failed or any container terminated with a nonzero exit.
+
+    Used to avoid emitting a spurious reason for a pod that merely finished
+    successfully (e.g. an exec lost a race against a clean Completed pod).
+    """
+    if getattr(pod.status, 'phase', None) == 'Failed':
+        return True
+    for cs in (pod.status.container_statuses or []):
+        if any(term.exit_code != 0 for term in _iter_terminated_states(cs)):
+            return True
+        # OOMKilled while restarting shows up as a waiting CrashLoopBackOff.
+        waiting = cs.state.waiting if cs.state else None
+        if waiting is not None and waiting.reason == 'CrashLoopBackOff':
+            return True
+    return False
+
+
+# Canonical Kubernetes failure-reason -> remediation hint table, shared by the
+# provision-failure formatter (sky/backends/cloud_vm_ray_backend.py, via
+# match_kubernetes_failure_hint) and the pod-OOM diagnosis path
+# (diagnose_terminated_pod). Each entry maps a list of case-sensitive
+# substrings (matched against a failure reason) to a hint. A hint may contain a
+# literal `{dashboard_url}` token; callers that can resolve the dashboard URL
+# substitute the real URL, others fall back to a generic phrase.
+KUBERNETES_FAILURE_HINTS: List[Tuple[List[str], str]] = [
+    (['ImagePullBackOff', 'ErrImagePull'],
+     'Verify the image tag exists and registry credentials are configured.'),
+    (['OOMKilled'],
+     'The container ran out of memory.'),
+    (['Insufficient'],
+     'The cluster does not have enough free resources. View node '
+     'allocations at {dashboard_url} or run `kubectl describe nodes`.'),
+]
+
+
+def match_kubernetes_failure_hint(reason: str) -> Optional[str]:
+    """Return the remediation hint whose substrings match `reason`, or None.
+
+    The returned hint may contain a literal `{dashboard_url}` token for the
+    caller to substitute.
+    """
+    for substrings, hint in KUBERNETES_FAILURE_HINTS:
+        if any(s in reason for s in substrings):
+            return hint
+    return None
+
+
+def diagnose_terminated_pod(context: Optional[str], namespace: str,
+                            pod_name: str) -> Optional[str]:
+    """Best-effort diagnosis of a pod that an exec/attach found already gone.
+
+    Reads the pod and, if it terminated abnormally, returns a user-facing
+    message including the condensed reason (e.g. OOMKilled) and a remediation
+    hint when one applies. Returns None if the pod is healthy, finished
+    cleanly, missing, or cannot be read -- this is purely additive context, so
+    it must never raise.
+    """
+    try:
+        pod = kubernetes.core_api(context).read_namespaced_pod(
+            pod_name, namespace, _request_timeout=kubernetes.API_TIMEOUT)
+    except Exception:  # pylint: disable=broad-except
+        return None
+    if not _pod_terminated_abnormally(pod):
+        return None
+    reason = get_condensed_pod_reason(pod)
+    msg = f'Pod {pod_name} terminated: {reason}.'
+    hint = match_kubernetes_failure_hint(reason)
+    if hint is not None:
+        # This module has no server dependency to resolve the dashboard URL, so
+        # fall back to a generic phrase if the matched hint references it.
+        hint = hint.replace('{dashboard_url}',
+                            'the SkyPilot dashboard infra page')
+        msg += f'\nHint: {hint}'
+    return msg
+
+
 @dataclasses.dataclass
 class V1PodStatus:
     phase: str

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2015,12 +2015,19 @@ def _pod_terminated_abnormally(pod: 'kubernetes_models.V1Pod') -> bool:
 KUBERNETES_FAILURE_HINTS: List[Tuple[List[str], str]] = [
     (['ImagePullBackOff', 'ErrImagePull'],
      'Verify the image tag exists and registry credentials are configured.'),
-    (['OOMKilled'], 'The container ran out of memory.'),
+    (['OOMKilled'],
+     'The container ran out of memory. Increase the memory request with '
+     '`resources.memory` in your task YAML; if `kubernetes.'
+     'set_pod_resource_limits` is set, the memory limit scales with it.'),
     # 'ephemeral' must precede 'Evicted': an ephemeral-storage eviction reason
     # contains both, and the first match wins.
     (['ephemeral'],
-     'The pod exceeded its ephemeral (local) storage limit and was evicted.'),
-    (['Evicted'], 'The pod was evicted by the node under resource pressure.'),
+     'The pod exceeded its ephemeral (local) storage limit and was evicted. '
+     'Increase `resources.ephemeral_storage` in your task YAML.'),
+    (['Evicted'],
+     'The pod was evicted by the node under resource pressure. Increase the '
+     'relevant request (`resources.memory` or `resources.ephemeral_storage`) '
+     'in your task YAML.'),
     (['Insufficient'],
      'The cluster does not have enough free resources. View node '
      'allocations at {dashboard_url} or run `kubectl describe nodes`.'),

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1951,6 +1951,15 @@ def get_condensed_pod_reason(pod: 'kubernetes_models.V1Pod') -> str:
                     summary += f' ({message})'
                 return summary
 
+    # Pod-level kubelet reason (e.g. 'Evicted' for ephemeral-storage / disk /
+    # memory pressure, 'Preempted', 'Shutdown'). This is the authoritative
+    # cause when set; container-level failures (e.g. OOMKilled) do not populate
+    # it, so they still fall through to the container checks below.
+    pod_status_reason = getattr(pod.status, 'reason', None)
+    if pod_status_reason:
+        pod_status_message = getattr(pod.status, 'message', None) or ''
+        return f'{pod_status_reason}: {pod_status_message}'.rstrip(': ')
+
     # Check container statuses for waiting states (ImagePullBackOff, etc.).
     if pod.status.container_statuses:
         for cs in pod.status.container_statuses:
@@ -2002,8 +2011,12 @@ def _pod_terminated_abnormally(pod: 'kubernetes_models.V1Pod') -> bool:
 KUBERNETES_FAILURE_HINTS: List[Tuple[List[str], str]] = [
     (['ImagePullBackOff', 'ErrImagePull'],
      'Verify the image tag exists and registry credentials are configured.'),
-    (['OOMKilled'],
-     'The container ran out of memory.'),
+    (['OOMKilled'], 'The container ran out of memory.'),
+    # 'ephemeral' must precede 'Evicted': an ephemeral-storage eviction reason
+    # contains both, and the first match wins.
+    (['ephemeral'],
+     'The pod exceeded its ephemeral (local) storage limit and was evicted.'),
+    (['Evicted'], 'The pod was evicted by the node under resource pressure.'),
     (['Insufficient'],
      'The cluster does not have enough free resources. View node '
      'allocations at {dashboard_url} or run `kubectl describe nodes`.'),

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2039,6 +2039,16 @@ def match_kubernetes_failure_hint(reason: str) -> Optional[str]:
     return None
 
 
+def get_failure_hint_reasons() -> List[str]:
+    """The reason substrings KUBERNETES_FAILURE_HINTS recognizes, flattened.
+
+    A reason matching one of these names a specific failure cause (since we
+    carry a remediation hint for it). Callers that gate work on "is the cause
+    already specific" can derive from this instead of duplicating the list.
+    """
+    return [s for substrings, _ in KUBERNETES_FAILURE_HINTS for s in substrings]
+
+
 def diagnose_terminated_pod(context: Optional[str], namespace: str,
                             pod_name: str) -> Optional[str]:
     """Best-effort diagnosis of a pod that an exec/attach found already gone.

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2046,6 +2046,18 @@ def match_kubernetes_failure_hint(reason: str) -> Optional[str]:
     return None
 
 
+def match_kubernetes_failure_hint_text(reason: str) -> Optional[str]:
+    """Like match_kubernetes_failure_hint, but ready to display.
+
+    Resolves the `{dashboard_url}` token to a generic phrase, for callers
+    without a server context to build a real URL. Returns the hint or None.
+    """
+    hint = match_kubernetes_failure_hint(reason)
+    if hint is None:
+        return None
+    return hint.replace('{dashboard_url}', 'the SkyPilot dashboard infra page')
+
+
 def get_failure_hint_reasons() -> List[str]:
     """The reason substrings KUBERNETES_FAILURE_HINTS recognizes, flattened.
 
@@ -2075,12 +2087,8 @@ def diagnose_terminated_pod(context: Optional[str], namespace: str,
         return None
     reason = get_condensed_pod_reason(pod)
     msg = f'Pod {pod_name} terminated: {reason}.'
-    hint = match_kubernetes_failure_hint(reason)
+    hint = match_kubernetes_failure_hint_text(reason)
     if hint is not None:
-        # This module has no server dependency to resolve the dashboard URL, so
-        # fall back to a generic phrase if the matched hint references it.
-        hint = hint.replace('{dashboard_url}',
-                            'the SkyPilot dashboard infra page')
         msg += f'\nHint: {hint}'
     return msg
 

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1985,7 +1985,7 @@ def get_condensed_pod_reason(pod: 'kubernetes_models.V1Pod') -> str:
     return 'Terminated unexpectedly'
 
 
-def _pod_terminated_abnormally(pod: 'kubernetes_models.V1Pod') -> bool:
+def pod_terminated_abnormally(pod: 'kubernetes_models.V1Pod') -> bool:
     """True if the pod failed or any container terminated with a nonzero exit.
 
     Used to avoid emitting a spurious reason for a pod that merely finished
@@ -2071,7 +2071,7 @@ def diagnose_terminated_pod(context: Optional[str], namespace: str,
             pod_name, namespace, _request_timeout=kubernetes.API_TIMEOUT)
     except Exception:  # pylint: disable=broad-except
         return None
-    if not _pod_terminated_abnormally(pod):
+    if not pod_terminated_abnormally(pod):
         return None
     reason = get_condensed_pod_reason(pod)
     msg = f'Pod {pod_name} terminated: {reason}.'

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1935,6 +1935,8 @@ def get_condensed_pod_reason(pod: 'kubernetes_models.V1Pod') -> str:
     returns a string; falls back to 'Terminated unexpectedly' when no specific
     cause is found.
     """
+    if pod.status is None:
+        return 'Terminated unexpectedly'
     # Check pod conditions for preemption/disruption (highest priority).
     if pod.status.conditions:
         for condition in pod.status.conditions:
@@ -1989,7 +1991,9 @@ def _pod_terminated_abnormally(pod: 'kubernetes_models.V1Pod') -> bool:
     Used to avoid emitting a spurious reason for a pod that merely finished
     successfully (e.g. an exec lost a race against a clean Completed pod).
     """
-    if getattr(pod.status, 'phase', None) == 'Failed':
+    if pod.status is None:
+        return False
+    if pod.status.phase == 'Failed':
         return True
     for cs in (pod.status.container_statuses or []):
         if any(term.exit_code != 0 for term in _iter_terminated_states(cs)):

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -1620,14 +1620,64 @@ class KubernetesCommandRunner(CommandRunner):
             # immediately at EOF, making it impossible to detect
             # disconnection.
             kwargs.setdefault('stdin', subprocess.PIPE)
-        return log_lib.run_with_log(' '.join(command),
-                                    log_path,
-                                    require_outputs=require_outputs,
-                                    stream_logs=stream_logs,
-                                    process_stream=process_stream,
-                                    shell=True,
-                                    executable=executable,
-                                    **kwargs)
+        result = log_lib.run_with_log(' '.join(command),
+                                      log_path,
+                                      require_outputs=require_outputs,
+                                      stream_logs=stream_logs,
+                                      process_stream=process_stream,
+                                      shell=True,
+                                      executable=executable,
+                                      **kwargs)
+        # When `kubectl exec` fails because the target pod is already gone
+        # (e.g. it was OOMKilled), the bare kubectl error ("cannot exec into a
+        # container in a completed pod") hides the real cause. Enrich stderr
+        # with the pod's termination reason so callers (setup/run failure
+        # messages) surface OOMKilled etc. Only possible when outputs were
+        # captured.
+        if require_outputs and isinstance(result, tuple):
+            returncode, stdout, stderr = result
+            if returncode != 0:
+                diagnosis = self._diagnose_dead_pod(stderr)
+                if diagnosis is not None:
+                    stderr = f'{stderr}\n{diagnosis}'
+            return returncode, stdout, stderr
+        return result
+
+    # kubectl exec/attach errors that indicate the target pod is terminal (and
+    # so its container exit reason is worth surfacing). Matched case-
+    # insensitively against stderr. Kept specific to kubectl phrasings to avoid
+    # firing on ordinary command failures (e.g. "command not found", exit 127).
+    _POD_GONE_EXEC_SIGNATURES = (
+        'cannot exec into a container in a completed pod',
+        'current phase is failed',
+        'current phase is succeeded',
+        'unable to upgrade connection',
+        'container not found',
+    )
+
+    def _diagnose_dead_pod(self, stderr: str) -> Optional[str]:
+        """Return a termination reason for this runner's pod if `stderr`
+        indicates the exec target pod is gone, else None.
+
+        Purely additive diagnostics; never raises. Skipped for deployment
+        targets, where ``pod_name`` does not identify a specific live pod.
+        """
+        if self.deployment is not None:
+            return None
+        lowered = stderr.lower()
+        if not any(sig in lowered for sig in self._POD_GONE_EXEC_SIGNATURES):
+            return None
+        try:
+            # In-function import: `sky.provision.kubernetes` imports `instance`,
+            # which imports this module at top level, so a module-level import
+            # here forms a circular dependency. By call time the package is
+            # fully initialized.
+            # pylint: disable-next=import-outside-toplevel
+            from sky.provision.kubernetes import utils as kubernetes_utils
+            return kubernetes_utils.diagnose_terminated_pod(
+                self.context, self.namespace, self.pod_name)
+        except Exception:  # pylint: disable=broad-except
+            return None
 
     @timeline.event
     def rsync(

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -4987,7 +4987,7 @@ def test_v1node_get_taints_mixed_tolerated_and_untolerated():
 
 # ---------------------------------------------------------------------------
 # Pod termination reason / OOM diagnosis helpers
-# (get_condensed_pod_reason, _pod_terminated_abnormally,
+# (get_condensed_pod_reason, pod_terminated_abnormally,
 #  diagnose_terminated_pod)
 # ---------------------------------------------------------------------------
 
@@ -5113,7 +5113,7 @@ def test_get_condensed_pod_reason_status_none():
 
 
 def test_pod_terminated_abnormally_failed_phase():
-    assert utils._pod_terminated_abnormally(_make_pod(phase='Failed')) is True
+    assert utils.pod_terminated_abnormally(_make_pod(phase='Failed')) is True
 
 
 def test_pod_terminated_abnormally_nonzero_container_exit():
@@ -5122,7 +5122,7 @@ def test_pod_terminated_abnormally_nonzero_container_exit():
                         _make_container_status(terminated_reason='OOMKilled',
                                                terminated_exit_code=137)
                     ])
-    assert utils._pod_terminated_abnormally(pod) is True
+    assert utils.pod_terminated_abnormally(pod) is True
 
 
 def test_pod_terminated_abnormally_crashloopbackoff():
@@ -5131,7 +5131,7 @@ def test_pod_terminated_abnormally_crashloopbackoff():
         container_statuses=[
             _make_container_status(waiting_reason='CrashLoopBackOff')
         ])
-    assert utils._pod_terminated_abnormally(pod) is True
+    assert utils.pod_terminated_abnormally(pod) is True
 
 
 def test_pod_terminated_abnormally_clean_success():
@@ -5140,13 +5140,13 @@ def test_pod_terminated_abnormally_clean_success():
                         _make_container_status(terminated_reason='Completed',
                                                terminated_exit_code=0)
                     ])
-    assert utils._pod_terminated_abnormally(pod) is False
+    assert utils.pod_terminated_abnormally(pod) is False
 
 
 def test_pod_terminated_abnormally_status_none():
     # A pod with no status must not crash and is not considered abnormal.
     pod = kubernetes.client.V1Pod(status=None)
-    assert utils._pod_terminated_abnormally(pod) is False
+    assert utils.pod_terminated_abnormally(pod) is False
 
 
 def _patch_read_pod(monkeypatch, pod=None, side_effect=None):

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -5244,6 +5244,15 @@ def test_match_kubernetes_failure_hint_generic_eviction():
     assert hint == 'The pod was evicted by the node under resource pressure.'
 
 
+def test_get_failure_hint_reasons_flattens_table():
+    reasons = utils.get_failure_hint_reasons()
+    # Every reason with a hint must report as a specific cause; otherwise each
+    # reason has a match_kubernetes_failure_hint hit.
+    for reason in reasons:
+        assert utils.match_kubernetes_failure_hint(reason) is not None
+    assert 'OOMKilled' in reasons and 'Evicted' in reasons
+
+
 def test_diagnose_terminated_pod_substitutes_dashboard_url_token(monkeypatch):
     # A matched hint containing {dashboard_url} is rendered with a generic
     # phrase, since this module can't resolve the real URL.

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -4983,3 +4983,202 @@ def test_v1node_get_taints_mixed_tolerated_and_untolerated():
     out = node.get_taints(tolerations=tols)
     by_key = {t['key']: t['tolerated'] for t in out}
     assert by_key == {'workload_pool': True, 'dangerous': False}
+# ---------------------------------------------------------------------------
+# Pod termination reason / OOM diagnosis helpers
+# (get_condensed_pod_reason, _pod_terminated_abnormally,
+#  diagnose_terminated_pod)
+# ---------------------------------------------------------------------------
+
+
+def _make_container_status(*,
+                           terminated_reason=None,
+                           terminated_exit_code=None,
+                           last_terminated_reason=None,
+                           last_terminated_exit_code=None,
+                           waiting_reason=None,
+                           waiting_message=None):
+    """Build a V1ContainerStatus with the given current/last/waiting state."""
+    state = kubernetes.client.V1ContainerState()
+    if terminated_reason is not None or terminated_exit_code is not None:
+        state.terminated = kubernetes.client.V1ContainerStateTerminated(
+            exit_code=terminated_exit_code or 0, reason=terminated_reason)
+    if waiting_reason is not None:
+        state.waiting = kubernetes.client.V1ContainerStateWaiting(
+            reason=waiting_reason, message=waiting_message)
+    last_state = kubernetes.client.V1ContainerState()
+    if last_terminated_reason is not None or last_terminated_exit_code is not None:
+        last_state.terminated = kubernetes.client.V1ContainerStateTerminated(
+            exit_code=last_terminated_exit_code or 0,
+            reason=last_terminated_reason)
+    return kubernetes.client.V1ContainerStatus(name='c',
+                                               image='img',
+                                               image_id='',
+                                               ready=False,
+                                               restart_count=0,
+                                               state=state,
+                                               last_state=last_state)
+
+
+def _make_pod(*, phase=None, conditions=None, container_statuses=None):
+    return kubernetes.client.V1Pod(status=kubernetes.client.V1PodStatus(
+        phase=phase,
+        conditions=conditions,
+        container_statuses=container_statuses))
+
+
+def test_get_condensed_pod_reason_oomkilled():
+    pod = _make_pod(phase='Failed',
+                    container_statuses=[
+                        _make_container_status(terminated_reason='OOMKilled',
+                                               terminated_exit_code=137)
+                    ])
+    assert utils.get_condensed_pod_reason(pod) == 'OOMKilled (exit code 137)'
+
+
+def test_get_condensed_pod_reason_uses_last_state():
+    # OOMKilled recorded only in last_state (e.g. mid-restart).
+    pod = _make_pod(phase='Running',
+                    container_statuses=[
+                        _make_container_status(
+                            last_terminated_reason='OOMKilled',
+                            last_terminated_exit_code=137)
+                    ])
+    assert utils.get_condensed_pod_reason(pod) == 'OOMKilled (exit code 137)'
+
+
+def test_get_condensed_pod_reason_no_reason_has_exit_code():
+    pod = _make_pod(
+        phase='Failed',
+        container_statuses=[_make_container_status(terminated_exit_code=1)])
+    assert utils.get_condensed_pod_reason(pod) == 'Terminated with exit code 1'
+
+
+def test_get_condensed_pod_reason_kueue_preemption_wins():
+    cond = kubernetes.client.V1PodCondition(type='TerminationTarget',
+                                            status='True',
+                                            reason='Preempted',
+                                            message='by higher priority')
+    pod = _make_pod(phase='Failed',
+                    conditions=[cond],
+                    container_statuses=[
+                        _make_container_status(terminated_reason='OOMKilled',
+                                               terminated_exit_code=137)
+                    ])
+    assert utils.get_condensed_pod_reason(pod) == (
+        'Preempted by Kueue: Preempted (by higher priority)')
+
+
+def test_get_condensed_pod_reason_fallback():
+    pod = _make_pod(phase='Failed', container_statuses=[])
+    assert utils.get_condensed_pod_reason(pod) == 'Terminated unexpectedly'
+
+
+def test_pod_terminated_abnormally_failed_phase():
+    assert utils._pod_terminated_abnormally(_make_pod(phase='Failed')) is True
+
+
+def test_pod_terminated_abnormally_nonzero_container_exit():
+    pod = _make_pod(phase='Running',
+                    container_statuses=[
+                        _make_container_status(terminated_reason='OOMKilled',
+                                               terminated_exit_code=137)
+                    ])
+    assert utils._pod_terminated_abnormally(pod) is True
+
+
+def test_pod_terminated_abnormally_crashloopbackoff():
+    pod = _make_pod(
+        phase='Running',
+        container_statuses=[
+            _make_container_status(waiting_reason='CrashLoopBackOff')
+        ])
+    assert utils._pod_terminated_abnormally(pod) is True
+
+
+def test_pod_terminated_abnormally_clean_success():
+    pod = _make_pod(phase='Succeeded',
+                    container_statuses=[
+                        _make_container_status(terminated_reason='Completed',
+                                               terminated_exit_code=0)
+                    ])
+    assert utils._pod_terminated_abnormally(pod) is False
+
+
+def _patch_read_pod(monkeypatch, pod=None, side_effect=None):
+    core_api = mock.MagicMock()
+    if side_effect is not None:
+        core_api.read_namespaced_pod.side_effect = side_effect
+    else:
+        core_api.read_namespaced_pod.return_value = pod
+    monkeypatch.setattr(utils.kubernetes, 'core_api', lambda context: core_api)
+    return core_api
+
+
+def test_diagnose_terminated_pod_oom_includes_reason_and_hint(monkeypatch):
+    pod = _make_pod(phase='Failed',
+                    container_statuses=[
+                        _make_container_status(terminated_reason='OOMKilled',
+                                               terminated_exit_code=137)
+                    ])
+    _patch_read_pod(monkeypatch, pod=pod)
+    msg = utils.diagnose_terminated_pod('ctx', 'ns', 'mypod')
+    assert msg is not None
+    assert 'OOMKilled (exit code 137)' in msg
+    assert 'mypod' in msg
+    assert 'Hint:' in msg
+    assert 'ran out of memory' in msg
+
+
+def test_diagnose_terminated_pod_healthy_returns_none(monkeypatch):
+    pod = _make_pod(phase='Running',
+                    container_statuses=[_make_container_status()])
+    _patch_read_pod(monkeypatch, pod=pod)
+    assert utils.diagnose_terminated_pod('ctx', 'ns', 'mypod') is None
+
+
+def test_diagnose_terminated_pod_read_error_returns_none(monkeypatch):
+    _patch_read_pod(monkeypatch, side_effect=RuntimeError('api down'))
+    assert utils.diagnose_terminated_pod('ctx', 'ns', 'mypod') is None
+
+
+def test_diagnose_terminated_pod_non_oom_has_no_hint(monkeypatch):
+    pod = _make_pod(phase='Failed',
+                    container_statuses=[
+                        _make_container_status(terminated_reason='Error',
+                                               terminated_exit_code=1)
+                    ])
+    _patch_read_pod(monkeypatch, pod=pod)
+    msg = utils.diagnose_terminated_pod('ctx', 'ns', 'mypod')
+    assert msg is not None
+    assert 'Error (exit code 1)' in msg
+    assert 'Hint:' not in msg
+
+
+def test_match_kubernetes_failure_hint_oom():
+    assert 'ran out of memory' in utils.match_kubernetes_failure_hint(
+        'OOMKilled (exit code 137)')
+
+
+def test_match_kubernetes_failure_hint_multi_substring():
+    # ErrImagePull is one of two substrings mapped to the image hint.
+    assert 'image tag' in utils.match_kubernetes_failure_hint('ErrImagePull')
+
+
+def test_match_kubernetes_failure_hint_no_match_returns_none():
+    assert utils.match_kubernetes_failure_hint('SomeUnknownReason') is None
+
+
+def test_diagnose_terminated_pod_substitutes_dashboard_url_token(monkeypatch):
+    # A matched hint containing {dashboard_url} is rendered with a generic
+    # phrase, since this module can't resolve the real URL.
+    pod = _make_pod(phase='Failed',
+                    container_statuses=[
+                        _make_container_status(
+                            terminated_reason='Insufficient memory',
+                            terminated_exit_code=1)
+                    ])
+    _patch_read_pod(monkeypatch, pod=pod)
+    msg = utils.diagnose_terminated_pod('ctx', 'ns', 'mypod')
+    assert msg is not None
+    assert '{dashboard_url}' not in msg
+    assert 'the SkyPilot dashboard infra page' in msg

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -4983,6 +4983,8 @@ def test_v1node_get_taints_mixed_tolerated_and_untolerated():
     out = node.get_taints(tolerations=tols)
     by_key = {t['key']: t['tolerated'] for t in out}
     assert by_key == {'workload_pool': True, 'dangerous': False}
+
+
 # ---------------------------------------------------------------------------
 # Pod termination reason / OOM diagnosis helpers
 # (get_condensed_pod_reason, _pod_terminated_abnormally,
@@ -5104,6 +5106,12 @@ def test_get_condensed_pod_reason_oomkilled_not_masked_by_pod_reason():
     assert utils.get_condensed_pod_reason(pod) == 'OOMKilled (exit code 137)'
 
 
+def test_get_condensed_pod_reason_status_none():
+    # A pod with no status (e.g. not yet scheduled) must not crash.
+    pod = kubernetes.client.V1Pod(status=None)
+    assert utils.get_condensed_pod_reason(pod) == 'Terminated unexpectedly'
+
+
 def test_pod_terminated_abnormally_failed_phase():
     assert utils._pod_terminated_abnormally(_make_pod(phase='Failed')) is True
 
@@ -5132,6 +5140,12 @@ def test_pod_terminated_abnormally_clean_success():
                         _make_container_status(terminated_reason='Completed',
                                                terminated_exit_code=0)
                     ])
+    assert utils._pod_terminated_abnormally(pod) is False
+
+
+def test_pod_terminated_abnormally_status_none():
+    # A pod with no status must not crash and is not considered abnormal.
+    pod = kubernetes.client.V1Pod(status=None)
     assert utils._pod_terminated_abnormally(pod) is False
 
 

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -5019,11 +5019,18 @@ def _make_container_status(*,
                                                last_state=last_state)
 
 
-def _make_pod(*, phase=None, conditions=None, container_statuses=None):
+def _make_pod(*,
+              phase=None,
+              conditions=None,
+              container_statuses=None,
+              reason=None,
+              message=None):
     return kubernetes.client.V1Pod(status=kubernetes.client.V1PodStatus(
         phase=phase,
         conditions=conditions,
-        container_statuses=container_statuses))
+        container_statuses=container_statuses,
+        reason=reason,
+        message=message))
 
 
 def test_get_condensed_pod_reason_oomkilled():
@@ -5071,6 +5078,30 @@ def test_get_condensed_pod_reason_kueue_preemption_wins():
 def test_get_condensed_pod_reason_fallback():
     pod = _make_pod(phase='Failed', container_statuses=[])
     assert utils.get_condensed_pod_reason(pod) == 'Terminated unexpectedly'
+
+
+def test_get_condensed_pod_reason_evicted_ephemeral():
+    # Ephemeral-storage eviction is recorded at the pod level, not in
+    # container statuses.
+    pod = _make_pod(
+        phase='Failed',
+        reason='Evicted',
+        message='Pod ephemeral local storage usage exceeds the total limit '
+        'of containers 1Gi.',
+        container_statuses=[])
+    reason = utils.get_condensed_pod_reason(pod)
+    assert reason.startswith('Evicted: ')
+    assert 'ephemeral' in reason
+
+
+def test_get_condensed_pod_reason_oomkilled_not_masked_by_pod_reason():
+    # Container OOMKilled (no pod-level reason set) still wins.
+    pod = _make_pod(phase='Failed',
+                    container_statuses=[
+                        _make_container_status(terminated_reason='OOMKilled',
+                                               terminated_exit_code=137)
+                    ])
+    assert utils.get_condensed_pod_reason(pod) == 'OOMKilled (exit code 137)'
 
 
 def test_pod_terminated_abnormally_failed_phase():
@@ -5154,6 +5185,21 @@ def test_diagnose_terminated_pod_non_oom_has_no_hint(monkeypatch):
     assert 'Hint:' not in msg
 
 
+def test_diagnose_terminated_pod_evicted_ephemeral(monkeypatch):
+    pod = _make_pod(
+        phase='Failed',
+        reason='Evicted',
+        message='Pod ephemeral local storage usage exceeds the total limit '
+        'of containers 1Gi.',
+        container_statuses=[])
+    _patch_read_pod(monkeypatch, pod=pod)
+    msg = utils.diagnose_terminated_pod('ctx', 'ns', 'mypod')
+    assert msg is not None
+    assert 'Evicted' in msg
+    assert 'ephemeral' in msg
+    assert 'Hint:' in msg
+
+
 def test_match_kubernetes_failure_hint_oom():
     assert 'ran out of memory' in utils.match_kubernetes_failure_hint(
         'OOMKilled (exit code 137)')
@@ -5166,6 +5212,22 @@ def test_match_kubernetes_failure_hint_multi_substring():
 
 def test_match_kubernetes_failure_hint_no_match_returns_none():
     assert utils.match_kubernetes_failure_hint('SomeUnknownReason') is None
+
+
+def test_match_kubernetes_failure_hint_ephemeral_precedes_evicted():
+    # An ephemeral-storage eviction reason contains both substrings; the more
+    # specific 'ephemeral' hint must win.
+    hint = utils.match_kubernetes_failure_hint(
+        'Evicted: Pod ephemeral local storage usage exceeds the total limit')
+    assert hint is not None
+    assert 'ephemeral' in hint
+
+
+def test_match_kubernetes_failure_hint_generic_eviction():
+    # A non-ephemeral eviction falls to the general eviction hint.
+    hint = utils.match_kubernetes_failure_hint(
+        'Evicted: The node was low on resource: memory')
+    assert hint == 'The pod was evicted by the node under resource pressure.'
 
 
 def test_diagnose_terminated_pod_substitutes_dashboard_url_token(monkeypatch):

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -5241,7 +5241,9 @@ def test_match_kubernetes_failure_hint_generic_eviction():
     # A non-ephemeral eviction falls to the general eviction hint.
     hint = utils.match_kubernetes_failure_hint(
         'Evicted: The node was low on resource: memory')
-    assert hint == 'The pod was evicted by the node under resource pressure.'
+    assert hint is not None
+    assert hint.startswith(
+        'The pod was evicted by the node under resource pressure.')
 
 
 def test_get_failure_hint_reasons_flattens_table():

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -416,6 +416,8 @@ def test_pod_termination_reason_start_error(monkeypatch):
     pod = mock.MagicMock()
     pod.metadata.name = 'test-pod'
     pod.status.start_time = now
+    pod.status.reason = None
+    pod.status.message = None
 
     # Ready condition showing PodFailed
     ready_condition = mock.MagicMock()
@@ -511,6 +513,8 @@ def test_pod_termination_reason_null_finished_at(monkeypatch):
     pod = mock.MagicMock()
     pod.metadata.name = 'test-pod'
     pod.status.start_time = now
+    pod.status.reason = None
+    pod.status.message = None
 
     # Ready condition
     ready_condition = mock.MagicMock()
@@ -1615,6 +1619,10 @@ def _make_mock_pod(phase='Failed',
     pod.status.conditions = conditions or []
     pod.status.container_statuses = container_statuses or []
     pod.status.init_container_statuses = init_container_statuses or []
+    # A real pod has no pod-level kubelet reason unless evicted/preempted;
+    # leave it unset so condition/container-derived reasons are exercised.
+    pod.status.reason = None
+    pod.status.message = None
     return pod
 
 

--- a/tests/unit_tests/test_backend_utils_init_reason.py
+++ b/tests/unit_tests/test_backend_utils_init_reason.py
@@ -133,6 +133,31 @@ class TestUpdateClusterStatusInitReason:
         assert 'Evicted' in msg, msg
         assert 'ephemeral' in msg, msg
 
+    def test_oom_recovered_from_pod_last_state(self):
+        # A container that OOMKilled and restarted reports Ready again, so the
+        # live per-pod status names no cause and the events lookup finds
+        # nothing (OOM is not a pod event). The durable last_state reason is
+        # recovered from the pods fallback.
+        oom = 'OOMKilled (exit code 137)'
+        with mock.patch.object(
+                backend_utils.global_user_state,
+                'get_cluster_yaml_dict',
+                return_value={'provider': {
+                    'namespace': 'default',
+                    'context': 'ctx'
+                }}), \
+             mock.patch.object(
+                 backend_utils.k8s_instance,
+                 'get_cluster_failure_reason_from_events',
+                 return_value=None), \
+             mock.patch.object(
+                 backend_utils.k8s_instance,
+                 'get_cluster_failure_reason_from_pods',
+                 return_value=oom):
+            msg = _capture_init_log_message(
+                {'pod-0': (status_lib.ClusterStatus.UP, None)})
+        assert 'OOMKilled' in msg, msg
+
     def test_some_nodes_terminated(self):
         # 1 of 2 launched nodes is missing from node_statuses.
         msg = _capture_init_log_message(

--- a/tests/unit_tests/test_backend_utils_init_reason.py
+++ b/tests/unit_tests/test_backend_utils_init_reason.py
@@ -111,6 +111,28 @@ class TestUpdateClusterStatusInitReason:
             launched_nodes=2)
         assert 'some but not all nodes are stopped' in msg, msg
 
+    def test_eviction_recovered_from_pod_events(self):
+        # When pod.status names no cause (reason=None) but an eviction is in
+        # the pod's events, the abnormal reason should surface it instead of
+        # the generic message.
+        evict = ('Evicted: Pod ephemeral local storage usage exceeds the '
+                 'total limit of containers 2Gi.')
+        with mock.patch.object(
+                backend_utils.global_user_state,
+                'get_cluster_yaml_dict',
+                return_value={'provider': {
+                    'namespace': 'default',
+                    'context': 'ctx'
+                }}), \
+             mock.patch.object(
+                 backend_utils.k8s_instance,
+                 'get_cluster_failure_reason_from_events',
+                 return_value=evict):
+            msg = _capture_init_log_message(
+                {'pod-0': (status_lib.ClusterStatus.UP, None)})
+        assert 'Evicted' in msg, msg
+        assert 'ephemeral' in msg, msg
+
     def test_some_nodes_terminated(self):
         # 1 of 2 launched nodes is missing from node_statuses.
         msg = _capture_init_log_message(

--- a/tests/unit_tests/test_sky/jobs/test_jobs_state.py
+++ b/tests/unit_tests/test_sky/jobs/test_jobs_state.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import contextlib
+import datetime
 import time
 from unittest import mock
 
@@ -713,3 +714,69 @@ class TestGetManagedJobsWithFilters:
         # All jobs have workspaces starting with 'ws'
         assert len(jobs) == 5
         assert total == 5
+
+
+class TestGetLatestRecoveryReasons:
+    """Tests for get_latest_recovery_reasons."""
+
+    def test_empty_job_ids(self, _mock_managed_jobs_db_conn):
+        assert state.get_latest_recovery_reasons([]) == {}
+
+    def test_latest_reason_wins_and_filters(self, _mock_managed_jobs_db_conn):
+        early = datetime.datetime(2026, 1, 1, 0, 0, 0)
+        late = datetime.datetime(2026, 1, 1, 0, 5, 0)
+        # Job 1: two RECOVERING events -> the latest reason wins.
+        state.add_job_event(1,
+                            0,
+                            state.ManagedJobStatus.RECOVERING,
+                            'older reason',
+                            timestamp=early)
+        state.add_job_event(1,
+                            0,
+                            state.ManagedJobStatus.RECOVERING,
+                            'OOMKilled (exit code 137)',
+                            timestamp=late)
+        # Job 2: a RUNNING event is ignored; only the RECOVERING reason returns.
+        state.add_job_event(2,
+                            0,
+                            state.ManagedJobStatus.RUNNING,
+                            'Job has recovered',
+                            timestamp=late)
+        state.add_job_event(2,
+                            0,
+                            state.ManagedJobStatus.RECOVERING,
+                            'preempted',
+                            timestamp=early)
+        # Job 3 has a RECOVERING event but is not requested.
+        state.add_job_event(3,
+                            0,
+                            state.ManagedJobStatus.RECOVERING,
+                            'unrelated',
+                            timestamp=late)
+        result = state.get_latest_recovery_reasons([1, 2])
+        assert result == {
+            1: 'OOMKilled (exit code 137)',
+            2: 'preempted',
+        }
+
+    def test_empty_reason_skipped(self, _mock_managed_jobs_db_conn):
+        early = datetime.datetime(2026, 1, 1, 0, 0, 0)
+        late = datetime.datetime(2026, 1, 1, 0, 5, 0)
+        # The most recent RECOVERING event has an empty reason -> fall back to
+        # the most recent non-empty one.
+        state.add_job_event(1,
+                            0,
+                            state.ManagedJobStatus.RECOVERING,
+                            'real reason',
+                            timestamp=early)
+        state.add_job_event(1,
+                            0,
+                            state.ManagedJobStatus.RECOVERING,
+                            '',
+                            timestamp=late)
+        assert state.get_latest_recovery_reasons([1]) == {1: 'real reason'}
+
+    def test_no_recovering_events_returns_empty(self,
+                                                _mock_managed_jobs_db_conn):
+        state.add_job_event(1, 0, state.ManagedJobStatus.RUNNING, 'running')
+        assert state.get_latest_recovery_reasons([1]) == {}

--- a/tests/unit_tests/test_sky/jobs/test_recovery_strategy.py
+++ b/tests/unit_tests/test_sky/jobs/test_recovery_strategy.py
@@ -1,0 +1,25 @@
+"""Unit tests for sky.jobs.recovery_strategy helpers."""
+
+from sky.jobs import recovery_strategy
+
+
+def test_is_oom_failure_detects_oomkilled():
+    exc = RuntimeError(
+        'Failed to run setup commands on an instance. (exit code 1). '
+        'Pod p terminated: OOMKilled (exit code 137).')
+    assert recovery_strategy._is_oom_failure(exc) is True
+
+
+def test_is_oom_failure_detects_out_of_memory_phrase():
+    assert recovery_strategy._is_oom_failure(
+        RuntimeError('The container ran out of memory.')) is True
+
+
+def test_is_oom_failure_is_case_insensitive():
+    assert recovery_strategy._is_oom_failure(
+        RuntimeError('reason: oomkilled')) is True
+
+
+def test_is_oom_failure_false_for_unrelated():
+    assert recovery_strategy._is_oom_failure(
+        RuntimeError('/bin/bash: line 1: conda: command not found')) is False

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -990,11 +990,13 @@ class TestFormatJobDetails:
                  schedule_state='ALIVE',
                  failure_reason=None,
                  status='RECOVERING',
-                 recovery_reason=None):
+                 recovery_reason=None,
+                 cloud=None):
         job = {
             'schedule_state': schedule_state,
             'failure_reason': failure_reason,
             'status': status,
+            'cloud': cloud,
         }
         jobs_utils._format_job_details(job=job,
                                        highest_blocking_priority=0,
@@ -1030,3 +1032,28 @@ class TestFormatJobDetails:
         assert self._details(
             schedule_state='ALIVE_BACKOFF',
             recovery_reason='ignored') == 'In backoff, waiting for resources'
+
+    def test_recovery_reason_oom_appends_hint_on_kubernetes(self):
+        result = self._details(cloud='Kubernetes',
+                               recovery_reason='podX OOMKilled (exit code 137)')
+        assert result.startswith('Recovering: podX OOMKilled (exit code 137)')
+        assert 'resources.memory' in result
+
+    def test_recovery_reason_ephemeral_appends_hint_on_kubernetes(self):
+        result = self._details(
+            cloud='Kubernetes',
+            recovery_reason='Evicted: Pod ephemeral local storage usage '
+            'exceeds the total limit of containers 2Gi.')
+        assert 'resources.ephemeral_storage' in result
+
+    def test_recovery_reason_no_hint_on_non_kubernetes(self):
+        # A non-k8s reason containing a matched word ('Insufficient') must not
+        # be decorated with a Kubernetes hint.
+        result = self._details(cloud='AWS',
+                               recovery_reason='Insufficient capacity')
+        assert result == 'Recovering: Insufficient capacity'
+
+    def test_recovery_reason_no_hint_when_cloud_unknown(self):
+        # No cloud info -> surface the reason without a (possibly wrong) hint.
+        result = self._details(recovery_reason='podX OOMKilled (exit code 137)')
+        assert result == 'Recovering: podX OOMKilled (exit code 137)'

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -980,3 +980,53 @@ class TestStreamLogsByIdTaskFiltering:
         assert exit_code == exceptions.JobExitCode.NOT_FOUND
         # Single task should show '0' not '0-0'
         assert 'Valid task IDs are 0.' in msg or 'Valid task IDs are 0,' in msg
+
+
+class TestFormatJobDetails:
+    """Tests for _format_job_details (the 'details' column)."""
+
+    def _details(self,
+                 *,
+                 schedule_state='ALIVE',
+                 failure_reason=None,
+                 status='RECOVERING',
+                 recovery_reason=None):
+        job = {
+            'schedule_state': schedule_state,
+            'failure_reason': failure_reason,
+            'status': status,
+        }
+        jobs_utils._format_job_details(job=job,
+                                       highest_blocking_priority=0,
+                                       recovery_reason=recovery_reason)
+        return job['details']
+
+    def test_recovery_reason_surfaced(self):
+        assert self._details(
+            recovery_reason='podX is not ready (OOMKilled (exit code 137))'
+        ) == 'Recovering: podX is not ready (OOMKilled (exit code 137))'
+
+    def test_recovery_reason_multiline_collapsed(self):
+        # Multi-line pod-termination reasons must render as a single line.
+        multiline = ('Cluster is abnormal because head is not ready '
+                     '(Terminated unexpectedly.\nLast known state: PodFailed.\n'
+                     'Container errors: OOMKilled). Transitioned to INIT.')
+        result = self._details(recovery_reason=multiline)
+        assert '\n' not in result
+        assert result == (
+            'Recovering: Cluster is abnormal because head is not ready '
+            '(Terminated unexpectedly. Last known state: PodFailed. '
+            'Container errors: OOMKilled). Transitioned to INIT.')
+
+    def test_no_recovery_reason_is_none(self):
+        assert self._details(recovery_reason=None) is None
+
+    def test_failure_reason_takes_precedence_over_recovery(self):
+        # A terminal failure_reason should win over a (stale) recovery reason.
+        assert self._details(failure_reason='boom',
+                             recovery_reason='ignored') == 'Failure: boom'
+
+    def test_backoff_state_takes_precedence_over_recovery(self):
+        assert self._details(
+            schedule_state='ALIVE_BACKOFF',
+            recovery_reason='ignored') == 'In backoff, waiting for resources'

--- a/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
+++ b/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
@@ -539,3 +539,51 @@ class TestGetClusterFailureReasonFromEvents:
         mock_events.return_value = [_make_event('Scheduled', 'assigned')]
         assert k8s_instance.get_cluster_failure_reason_from_events(
             {}, ['pod-0', 'pod-1']) is None
+
+
+class TestGetClusterFailureReasonFromPods:
+    """Tests for get_cluster_failure_reason_from_pods (durable last_state).
+
+    The condensed-reason derivation itself (incl. OOMKilled recovered from a
+    container's last_state) is covered in test_kubernetes_utils.py; here we
+    cover this helper's control flow: read each pod, return the first that
+    terminated abnormally, never raise on a per-pod read error.
+    """
+
+    @mock.patch('sky.adaptors.kubernetes.core_api')
+    @mock.patch('sky.provision.kubernetes.instance.kubernetes_utils')
+    def test_returns_condensed_reason_for_abnormal_pod(self, mock_kutils,
+                                                       mock_core_api):
+        mock_kutils.get_namespace_from_config.return_value = 'ns'
+        mock_kutils.get_context_from_config.return_value = 'ctx'
+        mock_kutils.pod_terminated_abnormally.return_value = True
+        mock_kutils.get_condensed_pod_reason.return_value = (
+            'OOMKilled (exit code 137)')
+        result = k8s_instance.get_cluster_failure_reason_from_pods({},
+                                                                   ['pod-0'])
+        assert result == 'OOMKilled (exit code 137)'
+
+    @mock.patch('sky.adaptors.kubernetes.core_api')
+    @mock.patch('sky.provision.kubernetes.instance.kubernetes_utils')
+    def test_none_when_no_pod_abnormal(self, mock_kutils, mock_core_api):
+        mock_kutils.get_namespace_from_config.return_value = 'ns'
+        mock_kutils.get_context_from_config.return_value = 'ctx'
+        mock_kutils.pod_terminated_abnormally.return_value = False
+        assert k8s_instance.get_cluster_failure_reason_from_pods(
+            {}, ['pod-0', 'pod-1']) is None
+
+    @mock.patch('sky.adaptors.kubernetes.core_api')
+    @mock.patch('sky.provision.kubernetes.instance.kubernetes_utils')
+    def test_skips_pod_read_errors(self, mock_kutils, mock_core_api):
+        mock_kutils.get_namespace_from_config.return_value = 'ns'
+        mock_kutils.get_context_from_config.return_value = 'ctx'
+        # First pod read raises; the second pod is abnormal.
+        mock_core_api.return_value.read_namespaced_pod.side_effect = [
+            Exception('boom'),
+            mock.MagicMock(),
+        ]
+        mock_kutils.pod_terminated_abnormally.return_value = True
+        mock_kutils.get_condensed_pod_reason.return_value = 'OOMKilled'
+        result = k8s_instance.get_cluster_failure_reason_from_pods(
+            {}, ['pod-0', 'pod-1'])
+        assert result == 'OOMKilled'

--- a/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
+++ b/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
@@ -435,8 +435,9 @@ class TestGetPodFailureReasonFromEvents:
     @mock.patch('sky.provision.kubernetes.instance._get_pod_events')
     def test_evicted_event_surfaced(self, mock_events):
         mock_events.return_value = [
-            _make_event('Evicted', 'Pod ephemeral local storage usage exceeds '
-                        'the total limit of containers 1Gi.'),
+            _make_event(
+                'Evicted', 'Pod ephemeral local storage usage exceeds '
+                'the total limit of containers 1Gi.'),
             _make_event('Scheduled', 'Successfully assigned default/p to n'),
         ]
         result = k8s_instance._get_pod_failure_reason_from_events(
@@ -474,8 +475,9 @@ class TestQueryInstancesEventEnrichment:
             _make_full_pod('worker-0', 'Running', 'node-1', ready=False),
         ]
         mock_events.return_value = [
-            _make_event('Evicted', 'Pod ephemeral local storage usage exceeds '
-                        'the total limit of containers 1Gi.'),
+            _make_event(
+                'Evicted', 'Pod ephemeral local storage usage exceeds '
+                'the total limit of containers 1Gi.'),
         ]
         result = k8s_instance.query_instances(
             cluster_name='c',
@@ -508,3 +510,32 @@ class TestQueryInstancesEventEnrichment:
         assert result['worker-0'][1] is None
         # Healthy pods must not incur an extra events API call.
         mock_events.assert_not_called()
+
+
+class TestGetClusterFailureReasonFromEvents:
+    """Tests for get_cluster_failure_reason_from_events."""
+
+    @mock.patch('sky.provision.kubernetes.instance.kubernetes_utils')
+    @mock.patch('sky.provision.kubernetes.instance._get_pod_events')
+    def test_returns_first_evicted(self, mock_events, mock_kutils):
+        mock_kutils.get_namespace_from_config.return_value = 'ns'
+        mock_kutils.get_context_from_config.return_value = 'ctx'
+        mock_events.return_value = [
+            _make_event(
+                'Evicted', 'Pod ephemeral local storage usage '
+                'exceeds the total limit of containers 2Gi.'),
+        ]
+        result = k8s_instance.get_cluster_failure_reason_from_events({},
+                                                                     ['pod-0'])
+        assert result is not None
+        assert 'Evicted' in result
+        assert 'ephemeral' in result
+
+    @mock.patch('sky.provision.kubernetes.instance.kubernetes_utils')
+    @mock.patch('sky.provision.kubernetes.instance._get_pod_events')
+    def test_none_when_no_failure_event(self, mock_events, mock_kutils):
+        mock_kutils.get_namespace_from_config.return_value = 'ns'
+        mock_kutils.get_context_from_config.return_value = 'ctx'
+        mock_events.return_value = [_make_event('Scheduled', 'assigned')]
+        assert k8s_instance.get_cluster_failure_reason_from_events(
+            {}, ['pod-0', 'pod-1']) is None

--- a/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
+++ b/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
@@ -23,6 +23,8 @@ def _make_condition(type_: str,
 def _make_container_status(ready: bool,
                            waiting_reason: Optional[str] = None,
                            terminated_exit_code: Optional[int] = None,
+                           last_terminated_exit_code: Optional[int] = None,
+                           last_terminated_reason: Optional[str] = None,
                            name: str = 'ray-node'):
     """Create a mock container status."""
     cs = mock.MagicMock()
@@ -39,6 +41,14 @@ def _make_container_status(ready: bool,
     else:
         cs.state.waiting = None
         cs.state.terminated = None
+
+    # Default: no previous termination. MagicMock would otherwise auto-create
+    # a truthy last_state.terminated and confuse the prior-termination check.
+    if last_terminated_exit_code is not None:
+        cs.last_state.terminated.exit_code = last_terminated_exit_code
+        cs.last_state.terminated.reason = last_terminated_reason
+    else:
+        cs.last_state.terminated = None
     return cs
 
 
@@ -122,6 +132,56 @@ class TestGetPodHealthIssues:
             container_statuses=[
                 _make_container_status(ready=False,
                                        waiting_reason='ContainerCreating'),
+            ],
+        )
+        assert _get_pod_health_issues(pod) is None
+
+    def test_restarting_after_oom_surfaces_last_state(self):
+        # Container OOMKilled, now restarting (waiting) -> surface the prior
+        # OOM that the current waiting state alone does not explain.
+        pod = _make_pod(
+            conditions=[
+                _make_condition('Ready', 'False', reason='ContainersNotReady')
+            ],
+            container_statuses=[
+                _make_container_status(ready=False,
+                                       waiting_reason='CrashLoopBackOff',
+                                       last_terminated_exit_code=137,
+                                       last_terminated_reason='OOMKilled'),
+            ],
+        )
+        result = _get_pod_health_issues(pod)
+        assert result is not None
+        assert 'CrashLoopBackOff' in result
+        assert 'OOMKilled' in result
+        assert '137' in result
+
+    def test_running_again_after_oom_surfaces_last_state(self):
+        # Container restarted after OOM and is running but not yet ready, with
+        # no current waiting/terminated reason -- the OOM lives only in
+        # last_state and must still be surfaced.
+        pod = _make_pod(
+            conditions=[
+                _make_condition('Ready', 'False', reason='ContainersNotReady')
+            ],
+            container_statuses=[
+                _make_container_status(ready=False,
+                                       last_terminated_exit_code=137,
+                                       last_terminated_reason='OOMKilled'),
+            ],
+        )
+        result = _get_pod_health_issues(pod)
+        assert result is not None
+        assert 'OOMKilled (exit code 137)' in result
+
+    def test_ready_pod_with_prior_oom_returns_none(self):
+        # A fully-recovered (Ready=True) pod must not surface a stale prior OOM.
+        pod = _make_pod(
+            conditions=[_make_condition('Ready', 'True')],
+            container_statuses=[
+                _make_container_status(ready=True,
+                                       last_terminated_exit_code=137,
+                                       last_terminated_reason='OOMKilled'),
             ],
         )
         assert _get_pod_health_issues(pod) is None

--- a/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
+++ b/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
@@ -419,3 +419,92 @@ class TestGetPodTerminationReason:
         pod = self._make_terminated_pod(reason=None, message=None)
         result = k8s_instance._get_pod_termination_reason(pod, 'cluster')
         assert 'Terminated unexpectedly' in result
+
+
+def _make_event(reason, message):
+    """Create a mock kubelet pod event."""
+    e = mock.MagicMock()
+    e.reason = reason
+    e.message = message
+    return e
+
+
+class TestGetPodFailureReasonFromEvents:
+    """Tests for _get_pod_failure_reason_from_events."""
+
+    @mock.patch('sky.provision.kubernetes.instance._get_pod_events')
+    def test_evicted_event_surfaced(self, mock_events):
+        mock_events.return_value = [
+            _make_event('Evicted', 'Pod ephemeral local storage usage exceeds '
+                        'the total limit of containers 1Gi.'),
+            _make_event('Scheduled', 'Successfully assigned default/p to n'),
+        ]
+        result = k8s_instance._get_pod_failure_reason_from_events(
+            'ctx', 'ns', 'p')
+        assert result is not None
+        assert result.startswith('Evicted: ')
+        assert 'ephemeral' in result
+
+    @mock.patch('sky.provision.kubernetes.instance._get_pod_events')
+    def test_no_failure_event_returns_none(self, mock_events):
+        mock_events.return_value = [
+            _make_event('Scheduled', 'Successfully assigned default/p to n'),
+            _make_event('Pulled', 'Container image already present'),
+        ]
+        assert k8s_instance._get_pod_failure_reason_from_events(
+            'ctx', 'ns', 'p') is None
+
+    @mock.patch('sky.provision.kubernetes.instance._get_pod_events',
+                side_effect=Exception('api down'))
+    def test_event_lookup_error_returns_none(self, mock_events):
+        assert k8s_instance._get_pod_failure_reason_from_events(
+            'ctx', 'ns', 'p') is None
+
+
+class TestQueryInstancesEventEnrichment:
+    """query_instances recovers an eviction reason from events."""
+
+    @mock.patch('sky.provision.kubernetes.instance._get_pod_events')
+    @mock.patch('sky.provision.kubernetes.instance.list_namespaced_pod')
+    def test_running_not_ready_pod_recovers_eviction(self, mock_list,
+                                                     mock_events):
+        # Pod still reports Running + not-ready; the eviction lives only in the
+        # event.
+        mock_list.return_value = [
+            _make_full_pod('worker-0', 'Running', 'node-1', ready=False),
+        ]
+        mock_events.return_value = [
+            _make_event('Evicted', 'Pod ephemeral local storage usage exceeds '
+                        'the total limit of containers 1Gi.'),
+        ]
+        result = k8s_instance.query_instances(
+            cluster_name='c',
+            cluster_name_on_cloud='c',
+            provider_config={
+                'namespace': 'default',
+                'context': 'ctx',
+                'services': [],
+            },
+        )
+        reason = result['worker-0'][1]
+        assert 'Evicted' in reason
+        assert 'ephemeral' in reason
+
+    @mock.patch('sky.provision.kubernetes.instance._get_pod_events')
+    @mock.patch('sky.provision.kubernetes.instance.list_namespaced_pod')
+    def test_healthy_pod_skips_event_lookup(self, mock_list, mock_events):
+        mock_list.return_value = [
+            _make_full_pod('worker-0', 'Running', 'node-1', ready=True),
+        ]
+        result = k8s_instance.query_instances(
+            cluster_name='c',
+            cluster_name_on_cloud='c',
+            provider_config={
+                'namespace': 'default',
+                'context': 'ctx',
+                'services': [],
+            },
+        )
+        assert result['worker-0'][1] is None
+        # Healthy pods must not incur an extra events API call.
+        mock_events.assert_not_called()

--- a/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
+++ b/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
@@ -1,4 +1,5 @@
 """Tests for Kubernetes pod health issue detection."""
+import datetime
 from typing import Optional
 from unittest import mock
 
@@ -382,3 +383,57 @@ class TestQueryInstancesHealthIntegration:
         )
         assert result['head'][1] is None
         assert result['worker-0'][1] is None
+
+
+class TestGetPodTerminationReason:
+    """Tests for _get_pod_termination_reason (Failed-phase path)."""
+
+    def _make_terminated_pod(self, *, reason=None, message=None):
+        pod = mock.MagicMock()
+        pod.metadata.name = 'p'
+        pod.status.start_time = datetime.datetime(
+            2026, 1, 1, tzinfo=datetime.timezone.utc)
+        pod.status.conditions = []
+        pod.status.container_statuses = []
+        pod.status.reason = reason
+        pod.status.message = message
+        return pod
+
+    def _patch(self, monkeypatch, *, events=None):
+        monkeypatch.setattr(k8s_instance.global_user_state, 'add_cluster_event',
+                            lambda *a, **k: None)
+        monkeypatch.setattr(k8s_instance, '_get_pod_events',
+                            lambda *a, **k: events or [])
+
+    def test_evicted_via_pod_event(self, monkeypatch):
+        # The authoritative ephemeral-storage eviction signal is a kubelet
+        # 'Evicted' Event, not pod.status (which stays empty here).
+        evicted = mock.MagicMock()
+        evicted.reason = 'Evicted'
+        evicted.message = ('Pod ephemeral local storage usage exceeds the '
+                           'total limit of containers 2Gi.')
+        self._patch(monkeypatch, events=[evicted])
+        pod = self._make_terminated_pod(reason=None, message=None)
+        result = k8s_instance._get_pod_termination_reason(pod, 'cluster', 'ctx',
+                                                          'ns')
+        assert 'Evicted' in result
+        assert 'ephemeral' in result
+
+    def test_evicted_via_pod_status_reason(self, monkeypatch):
+        # Some kubelets do populate pod.status.reason; that path still works.
+        self._patch(monkeypatch)
+        pod = self._make_terminated_pod(
+            reason='Evicted',
+            message='Pod ephemeral local storage usage exceeds the total '
+            'limit of containers 1Gi.')
+        result = k8s_instance._get_pod_termination_reason(pod, 'cluster', 'ctx',
+                                                          'ns')
+        assert 'Evicted' in result
+        assert 'ephemeral' in result
+
+    def test_no_reason_no_event_keeps_default(self, monkeypatch):
+        self._patch(monkeypatch)  # no events
+        pod = self._make_terminated_pod(reason=None, message=None)
+        result = k8s_instance._get_pod_termination_reason(pod, 'cluster', 'ctx',
+                                                          'ns')
+        assert 'Terminated unexpectedly' in result

--- a/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
+++ b/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
@@ -561,7 +561,7 @@ class TestGetClusterFailureReasonFromPods:
             'OOMKilled (exit code 137)')
         result = k8s_instance.get_cluster_failure_reason_from_pods({},
                                                                    ['pod-0'])
-        assert result == 'OOMKilled (exit code 137)'
+        assert result == 'pod-0 is not ready (OOMKilled (exit code 137))'
 
     @mock.patch('sky.adaptors.kubernetes.core_api')
     @mock.patch('sky.provision.kubernetes.instance.kubernetes_utils')
@@ -586,4 +586,4 @@ class TestGetClusterFailureReasonFromPods:
         mock_kutils.get_condensed_pod_reason.return_value = 'OOMKilled'
         result = k8s_instance.get_cluster_failure_reason_from_pods(
             {}, ['pod-0', 'pod-1'])
-        assert result == 'OOMKilled'
+        assert result == 'pod-1 is not ready (OOMKilled)'

--- a/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
+++ b/tests/unit_tests/test_sky/provision/test_k8s_pod_health.py
@@ -391,49 +391,31 @@ class TestGetPodTerminationReason:
     def _make_terminated_pod(self, *, reason=None, message=None):
         pod = mock.MagicMock()
         pod.metadata.name = 'p'
-        pod.status.start_time = datetime.datetime(
-            2026, 1, 1, tzinfo=datetime.timezone.utc)
+        pod.status.start_time = datetime.datetime(2026,
+                                                  1,
+                                                  1,
+                                                  tzinfo=datetime.timezone.utc)
         pod.status.conditions = []
         pod.status.container_statuses = []
         pod.status.reason = reason
         pod.status.message = message
         return pod
 
-    def _patch(self, monkeypatch, *, events=None):
+    def test_evicted_ephemeral_storage_surfaced(self, monkeypatch):
+        # Ephemeral-storage eviction is recorded only at the pod level.
         monkeypatch.setattr(k8s_instance.global_user_state, 'add_cluster_event',
                             lambda *a, **k: None)
-        monkeypatch.setattr(k8s_instance, '_get_pod_events',
-                            lambda *a, **k: events or [])
-
-    def test_evicted_via_pod_event(self, monkeypatch):
-        # The authoritative ephemeral-storage eviction signal is a kubelet
-        # 'Evicted' Event, not pod.status (which stays empty here).
-        evicted = mock.MagicMock()
-        evicted.reason = 'Evicted'
-        evicted.message = ('Pod ephemeral local storage usage exceeds the '
-                           'total limit of containers 2Gi.')
-        self._patch(monkeypatch, events=[evicted])
-        pod = self._make_terminated_pod(reason=None, message=None)
-        result = k8s_instance._get_pod_termination_reason(pod, 'cluster', 'ctx',
-                                                          'ns')
-        assert 'Evicted' in result
-        assert 'ephemeral' in result
-
-    def test_evicted_via_pod_status_reason(self, monkeypatch):
-        # Some kubelets do populate pod.status.reason; that path still works.
-        self._patch(monkeypatch)
         pod = self._make_terminated_pod(
             reason='Evicted',
             message='Pod ephemeral local storage usage exceeds the total '
             'limit of containers 1Gi.')
-        result = k8s_instance._get_pod_termination_reason(pod, 'cluster', 'ctx',
-                                                          'ns')
+        result = k8s_instance._get_pod_termination_reason(pod, 'cluster')
         assert 'Evicted' in result
         assert 'ephemeral' in result
 
-    def test_no_reason_no_event_keeps_default(self, monkeypatch):
-        self._patch(monkeypatch)  # no events
+    def test_no_pod_reason_keeps_default(self, monkeypatch):
+        monkeypatch.setattr(k8s_instance.global_user_state, 'add_cluster_event',
+                            lambda *a, **k: None)
         pod = self._make_terminated_pod(reason=None, message=None)
-        result = k8s_instance._get_pod_termination_reason(pod, 'cluster', 'ctx',
-                                                          'ns')
+        result = k8s_instance._get_pod_termination_reason(pod, 'cluster')
         assert 'Terminated unexpectedly' in result

--- a/tests/unit_tests/test_sky/utils/test_command_runner.py
+++ b/tests/unit_tests/test_sky/utils/test_command_runner.py
@@ -723,3 +723,83 @@ class TestProxyJumpToProxyCommand:
                 port_forward=None,
                 connect_timeout=None,
             )
+
+
+def test_kubernetes_runner_diagnose_dead_pod_surfaces_oom() -> None:
+    """A 'pod gone' exec error triggers a pod-termination diagnosis."""
+    oom_msg = 'Pod pod terminated: OOMKilled (exit code 137).\nHint: ...'
+    with mock.patch('sky.provision.kubernetes.utils.diagnose_terminated_pod',
+                    return_value=oom_msg) as mock_diagnose:
+        runner = command_runner.KubernetesCommandRunner((('ns', 'ctx'), 'pod'))
+        result = runner._diagnose_dead_pod(
+            'error: cannot exec into a container in a completed pod; '
+            'current phase is Failed')
+    assert result == oom_msg
+    mock_diagnose.assert_called_once_with('ctx', 'ns', 'pod')
+
+
+def test_kubernetes_runner_diagnose_dead_pod_ignores_unrelated_stderr() -> None:
+    """Ordinary command failures (e.g. exit 127) don't query the pod."""
+    with mock.patch('sky.provision.kubernetes.utils.diagnose_terminated_pod'
+                   ) as mock_diagnose:
+        runner = command_runner.KubernetesCommandRunner((('ns', 'ctx'), 'pod'))
+        result = runner._diagnose_dead_pod(
+            '/bin/bash: line 1: conda: command not found')
+    assert result is None
+    mock_diagnose.assert_not_called()
+
+
+def test_kubernetes_runner_diagnose_dead_pod_skips_deployment() -> None:
+    """Deployment targets have no single pod_name to diagnose."""
+    with mock.patch('sky.provision.kubernetes.utils.diagnose_terminated_pod'
+                   ) as mock_diagnose:
+        runner = command_runner.KubernetesCommandRunner((('ns', 'ctx'), 'pod'),
+                                                        deployment='dep')
+        result = runner._diagnose_dead_pod(
+            'cannot exec into a container in a completed pod')
+    assert result is None
+    mock_diagnose.assert_not_called()
+
+
+def test_kubernetes_runner_run_enriches_stderr_on_oom() -> None:
+    """run() appends the OOM diagnosis to stderr on a failed exec."""
+    pod_gone_stderr = ('error: cannot exec into a container in a completed '
+                       'pod; current phase is Failed')
+    oom_msg = 'Pod pod terminated: OOMKilled (exit code 137).'
+
+    def fake_run_with_log(*args, **kwargs):
+        return 1, '', pod_gone_stderr
+
+    with mock.patch.object(command_runner.log_lib,
+                           'run_with_log',
+                           side_effect=fake_run_with_log), \
+         mock.patch('sky.provision.kubernetes.utils.diagnose_terminated_pod',
+                    return_value=oom_msg):
+        runner = command_runner.KubernetesCommandRunner((('ns', 'ctx'), 'pod'))
+        returncode, _, stderr = runner.run('echo hi',
+                                           require_outputs=True,
+                                           stream_logs=False)
+
+    assert returncode == 1
+    assert pod_gone_stderr in stderr
+    assert oom_msg in stderr
+
+
+def test_kubernetes_runner_run_does_not_enrich_on_success() -> None:
+    """A successful exec is returned unchanged, with no pod query."""
+
+    def fake_run_with_log(*args, **kwargs):
+        return 0, 'ok', ''
+
+    with mock.patch.object(command_runner.log_lib,
+                           'run_with_log',
+                           side_effect=fake_run_with_log), \
+         mock.patch('sky.provision.kubernetes.utils.diagnose_terminated_pod'
+                   ) as mock_diagnose:
+        runner = command_runner.KubernetesCommandRunner((('ns', 'ctx'), 'pod'))
+        returncode, stdout, stderr = runner.run('echo hi',
+                                                require_outputs=True,
+                                                stream_logs=False)
+
+    assert (returncode, stdout, stderr) == (0, 'ok', '')
+    mock_diagnose.assert_not_called()


### PR DESCRIPTION
## Summary
<img width="1362" height="260" alt="Screenshot 2026-05-29 at 2 54 42 PM" src="https://github.com/user-attachments/assets/6c14ca6f-22c6-4268-ab40-6e765ac302ff" />
<img width="1341" height="253" alt="Screenshot 2026-05-29 at 12 36 11 PM" src="https://github.com/user-attachments/assets/2deca39d-5fb5-46e5-8da0-0e4e3b5058c0" />
<img width="1324" height="203" alt="Screenshot 2026-05-29 at 12 35 59 PM" src="https://github.com/user-attachments/assets/2587d425-ee6d-4e36-97f1-133b444b5578" />
<img width="1345" height="350" alt="Screenshot 2026-05-29 at 12 35 38 PM" src="https://github.com/user-attachments/assets/324f3286-c1e9-4129-862c-96b6b57d77ca" />
<img width="1355" height="328" alt="Screenshot 2026-05-29 at 12 35 28 PM" src="https://github.com/user-attachments/assets/919b1337-3dcc-4729-8e99-299dc9fc2429" />


When a Kubernetes pod backing a managed job (or cluster) fails — OOM-killed, or evicted for ephemeral-storage / disk / memory pressure — SkyPilot previously surfaced only a generic error (`cannot exec into a container in a completed pod`, or `ray cluster is unhealthy (0/1 ready)`) and, for managed jobs, retried the launch forever with no failure reason on the dashboard/CLI. This PR threads the real Kubernetes failure cause through to the user.

The reason-extraction lives in **shared** provisioning/backend/command-runner code, so regular `sky launch` clusters benefit too — only the terminal job-status transition and the managed-job *details* display are jobs-specific.

**Launch-phase OOM (managed jobs):**
- `KubernetesCommandRunner` enriches a failed `kubectl exec`'s stderr with the pod's termination reason (e.g. `OOMKilled (exit code 137)`) plus a remediation hint, gated on "pod gone" signatures so ordinary command failures don't trigger an extra API read.
- `recovery_strategy` detects an OOM launch failure and raises `ClusterSetUpError` instead of retrying; `controller` maps it to `FAILED_SETUP` with the reason written to `failure_reason`.

**Run-phase OOM (managed jobs):** `_get_pod_health_issues` surfaces a non-zero `last_state.terminated` (the OOM survives a container restart), so the reason flows through `query_instances → _summarize_pod_reasons →` the cluster `STATUS_CHANGE` event `→` the `RECOVERING` job event. Visibility only — recovery behavior is unchanged.

**Eviction / ephemeral-storage (jobs and clusters):** an eviction is recorded in the pod's kubelet events while `pod.status` still reports `Running`/`Ready` (status lags). Three timing windows are covered, following Kubernetes' own information hierarchy:
1. `pod.status.reason`/`message` once the kubelet populates it (`get_condensed_pod_reason`, `_get_pod_termination_reason`).
2. Pod events when a flagged pod's status-derived reason is generic (`query_instances`), scoped to already-flagged pods so healthy pods incur no extra API call.
3. Pod events at cluster-abnormal detection when all pods still report UP with no status reason (`backend_utils._update_cluster_status` → `get_cluster_failure_reason_from_events`), bounded to abnormal k8s clusters.

**Display (managed jobs):** the managed-job listing batch-fetches the latest `RECOVERING` event reason (one query, scoped to the recovering subset) and renders it as `Recovering: <reason>` in the details column, collapsed to a single line.

**Refactors:** `get_condensed_pod_reason` is lifted from `instance.py` into `kubernetes/utils.py` and shared; the duplicate K8s failure-hint tables are unified into a canonical `KUBERNETES_FAILURE_HINTS` consumed by both the provision-failure formatter and the pod-diagnosis path. No DB schema change — the recovery reason is read from the existing `job_events` table.

## Test plan

Unit tests added/updated (all passing, `format.sh` clean — mypy ok, pylint 10.00/10):
- `tests/unit_tests/kubernetes/test_kubernetes_utils.py` — `get_condensed_pod_reason`, `_pod_terminated_abnormally`, `diagnose_terminated_pod`, `match_kubernetes_failure_hint` (ephemeral hint beats generic eviction).
- `tests/unit_tests/test_sky/provision/test_k8s_pod_health.py` — eviction via `pod.status.reason`; run-phase OOM via `last_state`; `Ready=True` no-stale-OOM guard; events recovery for a not-ready pod; healthy pod skips the events lookup.
- `tests/unit_tests/test_sky/utils/test_command_runner.py` — `_diagnose_dead_pod` + `run()` stderr enrichment.
- `tests/unit_tests/test_sky/jobs/test_recovery_strategy.py` — `_is_oom_failure`.
- `tests/unit_tests/test_sky/jobs/test_jobs_state.py` — `get_latest_recovery_reasons` (latest-per-job, RUNNING ignored, empty skipped, scoping).
- `tests/unit_tests/test_sky/jobs/test_utils.py` — `_format_job_details` recovery reason, single-line collapse, precedence.
- `tests/unit_tests/test_backend_utils_init_reason.py` — a Running/UP pod with `reason=None` plus an `Evicted` event surfaces the eviction as the abnormal reason.

Manual e2e on a Kubernetes cluster:
- Launch-phase OOM: job whose pod OOMs during setup reaches `FAILED_SETUP` in ~45s with `failure_reason` containing `OOMKilled (exit code 137)` + the memory hint, vs. hanging in `STARTING`.
- Run-phase OOM: OOM mid-run shows in the cluster-abnormal / recovery reason on the dashboard.
- Ephemeral-storage eviction: the eviction message (`Pod ephemeral local storage usage exceeds the total limit of containers 2Gi.`) surfaces in the dashboard Events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->