### PR TITLE
[Core] Support specifying both cloud VM image and Docker image

### DIFF
--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -821,7 +821,7 @@ class AWS(clouds.Cloud):
 
         docker_run_options = []
         if resources.extract_docker_image() is not None:
-            image_id_to_use = None
+            image_id_to_use = resources.get_cloud_image_id()
             if enable_efa:
                 docker_run_options = _EFA_DOCKER_RUN_OPTIONS
         else:

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -365,8 +365,8 @@ class Azure(clouds.Cloud):
         custom_resources = resources_utils.make_ray_custom_resources_str(
             acc_dict)
 
-        if (resources.image_id is None or
-                resources.extract_docker_image() is not None):
+        cloud_image_id = resources.get_cloud_image_id()
+        if cloud_image_id is None:
             # pylint: disable=import-outside-toplevel
             from sky.catalog import azure_catalog
             gen_version = azure_catalog.get_gen_version_from_instance_type(
@@ -374,11 +374,11 @@ class Azure(clouds.Cloud):
             image_id = self._get_default_image_tag(gen_version,
                                                    resources.instance_type)
         else:
-            if None in resources.image_id:
-                image_id = resources.image_id[None]
+            if None in cloud_image_id:
+                image_id = cloud_image_id[None]
             else:
-                assert region_name in resources.image_id, resources.image_id
-                image_id = resources.image_id[region_name]
+                assert region_name in cloud_image_id, cloud_image_id
+                image_id = cloud_image_id[region_name]
 
         # Checked basic image syntax in resources.py
         if image_id.startswith('skypilot:'):

--- a/sky/clouds/do.py
+++ b/sky/clouds/do.py
@@ -214,13 +214,13 @@ class DO(clouds.Cloud):
         else:
             custom_resources = None
         image_id = None
-        if (resources.image_id is not None and
-                resources.extract_docker_image() is None):
-            if None in resources.image_id:
-                image_id = resources.image_id[None]
+        cloud_image_id = resources.get_cloud_image_id()
+        if cloud_image_id is not None:
+            if None in cloud_image_id:
+                image_id = cloud_image_id[None]
             else:
-                assert region.name in resources.image_id
-                image_id = resources.image_id[region.name]
+                assert region.name in cloud_image_id
+                image_id = cloud_image_id[region.name]
         return {
             'instance_type': resources.instance_type,
             'custom_resources': custom_resources,

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -608,13 +608,13 @@ class GCP(clouds.Cloud):
                         # CUDA driver version 535.86.10, CUDA Library 12.2
                         image_id = _DEFAULT_GPU_IMAGE_ID
 
-        if (resources.image_id is not None and
-                resources.extract_docker_image() is None):
-            if None in resources.image_id:
-                image_id = resources.image_id[None]
+        cloud_image_id = resources.get_cloud_image_id()
+        if cloud_image_id is not None:
+            if None in cloud_image_id:
+                image_id = cloud_image_id[None]
             else:
-                assert region_name in resources.image_id, resources.image_id
-                image_id = resources.image_id[region_name]
+                assert region_name in cloud_image_id, cloud_image_id
+                image_id = cloud_image_id[region_name]
         if image_id.startswith('skypilot:'):
             image_id = catalog.get_image_id_from_tag(image_id, clouds='gcp')
 

--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -313,14 +313,14 @@ class Nebius(clouds.Cloud):
             raise RuntimeError('Unsupported instance type for Nebius cloud:'
                                f' {resources.instance_type}')
 
-        if (resources.image_id is None or
-                resources.extract_docker_image() is not None):
+        cloud_image_id = resources.get_cloud_image_id()
+        if cloud_image_id is None:
             image_id = default_image_family
         else:
-            if None in resources.image_id:
-                image_id = resources.image_id[None]
+            if None in cloud_image_id:
+                image_id = cloud_image_id[None]
             else:
-                image_id = resources.image_id[region.name]
+                image_id = cloud_image_id[region.name]
 
         config_fs = skypilot_config.get_effective_region_config(
             cloud='nebius',

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -156,7 +156,7 @@ class Resources:
     """
     # If any fields changed, increment the version. For backward compatibility,
     # modify the __setstate__ method to handle the old version.
-    _VERSION = 33  # add _hooks list + scrub AutostopConfig.hook/hook_timeout.
+    _VERSION = 34  # add _docker_image from image_id dict 'docker' key.
 
     def __init__(
         self,
@@ -374,16 +374,43 @@ class Resources:
             self._ephemeral_storage = None
 
         self._image_id: Optional[Dict[Optional[str], str]] = None
+        self._docker_image: Optional[str] = None
         if isinstance(image_id, str):
             self._image_id = {self._region: image_id.strip()}
         elif isinstance(image_id, dict):
-            if None in image_id:
+            image_id = dict(image_id)
+            # 'docker' is a reserved key for specifying a Docker image
+            # alongside a cloud VM image.
+            if 'docker' in image_id:
+                docker_val = image_id.pop('docker').strip()
+                if docker_val.startswith('docker:'):
+                    docker_val = docker_val[len('docker:'):]
+                self._docker_image = docker_val
+            if not image_id:
+                self._image_id = None
+            elif None in image_id:
                 self._image_id = {self._region: image_id[None].strip()}
             else:
                 self._image_id = {
                     typing.cast(str, k).strip(): v.strip()
                     for k, v in image_id.items()
                 }
+            # Reject ambiguous specs: docker key + docker:-prefixed region
+            # values (e.g. {us-east-1: 'docker:img1', docker: 'img2'}).
+            if self._docker_image is not None and self._image_id is not None:
+                docker_prefixed = [
+                    f'{v} (region: {k})'
+                    for k, v in self._image_id.items()
+                    if v.startswith('docker:')
+                ]
+                if docker_prefixed:
+                    with ux_utils.print_exception_no_traceback():
+                        raise ValueError(
+                            'image_id has both a \'docker\' key and '
+                            'docker:-prefixed region values: '
+                            f'{", ".join(docker_prefixed)}. '
+                            'Please use only one mechanism to specify '
+                            'the Docker image.')
         else:
             self._image_id = image_id
         if isinstance(self._cloud, clouds.Kubernetes):
@@ -534,11 +561,16 @@ class Resources:
             use_spot = '[Spot]'
 
         image_id = ''
+        image_parts = []
         if self.image_id is not None:
             if None in self.image_id:
-                image_id = f', image_id={self.image_id[None]}'
+                image_parts.append(f'{self.image_id[None]}')
             else:
-                image_id = f', image_id={self.image_id}'
+                image_parts.append(f'{self.image_id}')
+        if self._docker_image is not None:
+            image_parts.append(f'docker:{self._docker_image}')
+        if image_parts:
+            image_id = f', image_id={" | ".join(image_parts)}'
 
         disk_tier = ''
         if self.disk_tier is not None:
@@ -1476,6 +1508,8 @@ class Resources:
                 raise
 
     def extract_docker_image(self) -> Optional[str]:
+        if self._docker_image is not None:
+            return self._docker_image
         if self.image_id is None:
             return None
         # Handle dict image_id
@@ -1487,6 +1521,24 @@ class Resources:
                 if image_id.startswith('docker:'):
                     return image_id[len('docker:'):]
         return None
+
+    def get_cloud_image_id(self) -> Optional[Dict[Optional[str], str]]:
+        """Returns the cloud VM image_id, or None if only a docker image.
+
+        When both a cloud image and a docker image are specified (via the
+        'docker' key), returns just the cloud image portion. For the legacy
+        'image_id: docker:xxx' format, returns None since there is no
+        separate cloud image.
+        """
+        if self._image_id is None:
+            return None
+        # Filter out any docker:-prefixed entries (legacy format).
+        cloud_only = {
+            k: v
+            for k, v in self._image_id.items()
+            if not v.startswith('docker:')
+        }
+        return cloud_only if cloud_only else None
 
     def _try_validate_image_id(self) -> None:
         """Try to validate the image_id attribute.
@@ -1526,14 +1578,25 @@ class Resources:
                             f'(prefix with "docker:"), or '
                             f'(2) leave image_id empty to use the default')
 
-        if self._image_id is None:
+        if self._image_id is None and self._docker_image is None:
             return
 
-        if self.extract_docker_image() is not None:
-            # TODO(tian): validate the docker image exists / of reasonable size
+        if self._docker_image is not None:
             if self.cloud is not None:
                 self.cloud.check_features_are_supported(
                     self, {clouds.CloudImplementationFeatures.DOCKER_IMAGE})
+            if self._image_id is None:
+                return
+
+        if self._image_id is not None and self.extract_docker_image() is not None:
+            # Legacy docker: prefix in image_id (no separate _docker_image)
+            if self._docker_image is None:
+                if self.cloud is not None:
+                    self.cloud.check_features_are_supported(
+                        self, {clouds.CloudImplementationFeatures.DOCKER_IMAGE})
+                return
+
+        if self._image_id is None:
             return
 
         if self.cloud is None:
@@ -2081,6 +2144,7 @@ class Resources:
             self._disk_tier is None,
             self._network_tier is None,
             self._image_id is None,
+            self._docker_image is None,
             self._ports is None,
             self._docker_login_config is None,
         ])
@@ -2208,6 +2272,13 @@ class Resources:
             hooks_override)
 
         override_configs = dict(override_configs) if override_configs else None
+        # Reconstruct the 'docker' key in image_id so _docker_image is preserved
+        # across the copy, since self.image_id excludes the popped 'docker' key.
+        default_image_id = self.image_id
+        if self._docker_image is not None:
+            image_id_dict = dict(default_image_id) if default_image_id else {}
+            image_id_dict['docker'] = self._docker_image
+            default_image_id = image_id_dict
         resources = Resources(
             cloud=override.pop('cloud', self.cloud),
             instance_type=override.pop('instance_type', self.instance_type),
@@ -2226,7 +2297,7 @@ class Resources:
                                            self._ephemeral_storage),
             region=override.pop('region', self.region),
             zone=override.pop('zone', self.zone),
-            image_id=override.pop('image_id', self.image_id),
+            image_id=override.pop('image_id', default_image_id),
             disk_tier=override.pop('disk_tier', self.disk_tier),
             network_tier=override.pop('network_tier', self.network_tier),
             local_disk=override.pop('local_disk', self._local_disk),
@@ -2280,7 +2351,7 @@ class Resources:
             features.add(clouds.CloudImplementationFeatures.CUSTOM_NETWORK_TIER)
         if self.extract_docker_image() is not None:
             features.add(clouds.CloudImplementationFeatures.DOCKER_IMAGE)
-        elif self.image_id is not None:
+        if self.get_cloud_image_id() is not None:
             features.add(clouds.CloudImplementationFeatures.IMAGE_ID)
         if self.ports is not None:
             features.add(clouds.CloudImplementationFeatures.OPEN_PORTS)
@@ -2638,7 +2709,12 @@ class Resources:
         add_if_not_none('job_recovery', self.job_recovery)
         add_if_not_none('disk_size', self.disk_size)
         add_if_not_none('ephemeral_storage', self._ephemeral_storage)
-        add_if_not_none('image_id', self.image_id)
+        image_id_config = self.image_id
+        if self._docker_image is not None:
+            image_id_dict = dict(image_id_config) if image_id_config else {}
+            image_id_dict['docker'] = self._docker_image
+            image_id_config = image_id_dict
+        add_if_not_none('image_id', image_id_config)
         if self.disk_tier is not None:
             config['disk_tier'] = self.disk_tier.value
         if self.network_tier is not None:
@@ -2863,6 +2939,9 @@ class Resources:
 
         if version < 32:
             self._ephemeral_storage = None
+
+        if version < 34:
+            self._docker_image = None
 
         if version < 33:
             # Route legacy AutostopConfig.hook / hook_timeout attrs into the

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -399,8 +399,7 @@ class Resources:
             # values (e.g. {us-east-1: 'docker:img1', docker: 'img2'}).
             if self._docker_image is not None and self._image_id is not None:
                 docker_prefixed = [
-                    f'{v} (region: {k})'
-                    for k, v in self._image_id.items()
+                    f'{v} (region: {k})' for k, v in self._image_id.items()
                     if v.startswith('docker:')
                 ]
                 if docker_prefixed:
@@ -1588,7 +1587,8 @@ class Resources:
             if self._image_id is None:
                 return
 
-        if self._image_id is not None and self.extract_docker_image() is not None:
+        if (self._image_id is not None and
+                self.extract_docker_image() is not None):
             # Legacy docker: prefix in image_id (no separate _docker_image)
             if self._docker_image is None:
                 if self.cloud is not None:

--- a/sky/task.py
+++ b/sky/task.py
@@ -206,7 +206,12 @@ def _with_docker_login_config(
                            'in `image_id`. The login configs will be '
                            f'ignored.{colorama.Style.RESET_ALL}')
             return resources
-        # Already checked in extract_docker_image
+        # If docker image comes from the 'docker' key in image_id dict,
+        # don't overwrite image_id — just attach login config.
+        if resources._docker_image is not None:  # pylint: disable=protected-access
+            return resources.copy(
+                _docker_login_config=docker_login_config)
+        # Legacy path: image_id contains docker: prefix
         assert resources.image_id is not None and len(
             resources.image_id) == 1, resources.image_id
         region = list(resources.image_id.keys())[0]

--- a/sky/task.py
+++ b/sky/task.py
@@ -207,10 +207,9 @@ def _with_docker_login_config(
                            f'ignored.{colorama.Style.RESET_ALL}')
             return resources
         # If docker image comes from the 'docker' key in image_id dict,
-        # don't overwrite image_id — just attach login config.
+        # don't overwrite image_id, just attach login config.
         if resources._docker_image is not None:  # pylint: disable=protected-access
-            return resources.copy(
-                _docker_login_config=docker_login_config)
+            return resources.copy(_docker_login_config=docker_login_config)
         # Legacy path: image_id contains docker: prefix
         assert resources.image_id is not None and len(
             resources.image_id) == 1, resources.image_id

--- a/tests/smoke_tests/test_images.py
+++ b/tests/smoke_tests/test_images.py
@@ -30,6 +30,7 @@ import pytest
 from smoke_tests import smoke_tests_utils
 
 import sky
+from sky import catalog
 from sky import skypilot_config
 from sky.skylet import constants
 
@@ -110,6 +111,43 @@ def test_aws_image_id_dict():
             f'sky logs {name} 3 --status',
         ],
         f'sky down -y {name}',
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
+@pytest.mark.aws
+def test_aws_image_id_dict_with_docker():
+    """Specify both a cloud VM image (AMI) and a Docker image (PR #9759).
+
+    Regression test for the old behavior where specifying a Docker image
+    caused a custom cloud VM image to be ignored. The motivating case is a
+    too-old default AMI driver for new GPUs: users want to boot a custom AMI
+    (correct NVIDIA driver) and still run their own container on top.
+
+    Asserts both halves are honored: the job runs inside the container, and
+    the VM booted from the requested AMI (read from instance metadata, which
+    is reachable because the container runs with --net=host).
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    region = 'us-east-1'
+    # Resolve the AMI that the SkyPilot CPU image tag maps to in this region,
+    # so we can assert the VM actually booted from the requested cloud image.
+    expected_ami = catalog.get_image_id_from_tag('skypilot:cpu-ubuntu-2004',
+                                                 region,
+                                                 clouds='aws')
+    test = smoke_tests_utils.Test(
+        'aws_image_id_dict_with_docker',
+        [
+            f'sky launch -y -c {name} {smoke_tests_utils.LOW_RESOURCE_ARG} '
+            f'tests/test_yamls/test_aws_ami_and_docker.yaml',
+            f'sky logs {name} 1 --status',
+            # The job ran inside the Docker container.
+            f'sky logs {name} 1 --no-follow | grep "SKY_IN_CONTAINER=yes"',
+            # The VM booted from the requested AMI, not the default image.
+            f'sky logs {name} 1 --no-follow | grep "SKY_BOOTED_AMI={expected_ami}"',
+        ],
+        f'sky down -y {name}',
+        timeout=20 * 60,
     )
     smoke_tests_utils.run_one_test(test)
 

--- a/tests/smoke_tests/test_images.py
+++ b/tests/smoke_tests/test_images.py
@@ -129,10 +129,11 @@ def test_aws_image_id_dict_with_docker():
     is reachable because the container runs with --net=host).
     """
     name = smoke_tests_utils.get_cluster_name()
-    region = 'us-east-1'
-    # Resolve the AMI that the SkyPilot CPU image tag maps to in this region,
-    # so we can assert the VM actually booted from the requested cloud image.
-    expected_ami = catalog.get_image_id_from_tag('skypilot:cpu-ubuntu-2004',
+    region = 'us-west-2'
+    # Resolve the AMI that the SkyPilot image tag maps to in this region, so
+    # we can assert the VM actually booted from the requested cloud image.
+    # Must match tests/test_yamls/test_aws_ami_and_docker.yaml.
+    expected_ami = catalog.get_image_id_from_tag('skypilot:gpu-ubuntu-2004',
                                                  region,
                                                  clouds='aws')
     test = smoke_tests_utils.Test(

--- a/tests/test_yamls/test_aws_ami_and_docker.yaml
+++ b/tests/test_yamls/test_aws_ami_and_docker.yaml
@@ -1,11 +1,15 @@
 # Specifies both a cloud VM image (a SkyPilot-published AMI) and a Docker
 # image in the same image_id field (PR #9759). The VM should boot from the
 # given AMI and the job should run inside the Docker container.
+#
+# skypilot:gpu-ubuntu-2004 in us-west-2 is a known-valid AWS image tag (also
+# used by test_aws_image_id_dict_region); it is docker-ready. We run it on a
+# cheap CPU instance, the point is the AMI, not the GPU.
 resources:
-  infra: aws/us-east-1
+  infra: aws/us-west-2
   cpus: 2+
   image_id:
-    us-east-1: skypilot:cpu-ubuntu-2004
+    us-west-2: skypilot:gpu-ubuntu-2004
     docker: ubuntu:22.04
 
 run: |

--- a/tests/test_yamls/test_aws_ami_and_docker.yaml
+++ b/tests/test_yamls/test_aws_ami_and_docker.yaml
@@ -1,0 +1,22 @@
+# Specifies both a cloud VM image (a SkyPilot-published AMI) and a Docker
+# image in the same image_id field (PR #9759). The VM should boot from the
+# given AMI and the job should run inside the Docker container.
+resources:
+  infra: aws/us-east-1
+  cpus: 2+
+  image_id:
+    us-east-1: skypilot:cpu-ubuntu-2004
+    docker: ubuntu:22.04
+
+run: |
+  # 1) Prove we are running inside the Docker container.
+  if [ -f /.dockerenv ]; then
+    echo "SKY_IN_CONTAINER=yes"
+  else
+    echo "SKY_IN_CONTAINER=no"
+  fi
+  # 2) Prove the VM booted from the requested AMI. The container runs with
+  #    --net=host, so the EC2 instance metadata service is reachable.
+  TOKEN=$(python3 -c "import urllib.request as u; print(u.urlopen(u.Request('http://169.254.169.254/latest/api/token', method='PUT', headers={'X-aws-ec2-metadata-token-ttl-seconds': '60'})).read().decode())")
+  AMI=$(python3 -c "import sys, urllib.request as u; t=sys.argv[1]; print(u.urlopen(u.Request('http://169.254.169.254/latest/meta-data/ami-id', headers={'X-aws-ec2-metadata-token': t})).read().decode())" "$TOKEN")
+  echo "SKY_BOOTED_AMI=$AMI"

--- a/tests/unit_tests/test_resources.py
+++ b/tests/unit_tests/test_resources.py
@@ -1,5 +1,6 @@
 import importlib
 import os
+import pickle
 from typing import Dict
 from unittest import mock
 
@@ -654,6 +655,134 @@ def test_kubernetes_image_id_formats_in_resources(enable_all_clouds):
         assert isinstance(
             loaded_res.cloud,
             clouds.Kubernetes), (f'Loaded cloud type mismatch for {input_id}')
+
+
+def test_image_id_dual_cloud_and_docker():
+    """image_id can carry both a cloud VM image and a docker image.
+
+    Uses the reserved 'docker' key alongside a region-keyed AMI. See the
+    AMI-missing-driver-for-B300 motivation (PR #9759): users want to boot a
+    custom AMI (correct NVIDIA driver) and still run their own container.
+    """
+    r = Resources(cloud='aws',
+                  image_id={
+                      'us-east-1': 'ami-0abcdef',
+                      'docker': 'myimage:latest',
+                  })
+    # The docker image is split out and stored separately.
+    assert r.extract_docker_image() == 'myimage:latest'
+    # The public image_id / get_cloud_image_id only expose the cloud image.
+    assert r.get_cloud_image_id() == {'us-east-1': 'ami-0abcdef'}
+    assert r.image_id == {'us-east-1': 'ami-0abcdef'}
+    # Both features are required (regression: was an elif, dropping IMAGE_ID).
+    features = {f.value for f in r.get_required_cloud_features()}
+    assert 'docker_image' in features
+    assert 'image_id' in features
+
+
+def test_image_id_docker_key_strips_prefix():
+    """A 'docker:' prefix on the reserved docker key is stripped."""
+    r = Resources(cloud='aws',
+                  image_id={
+                      'us-east-1': 'ami-0abcdef',
+                      'docker': 'docker:myimage:latest',
+                  })
+    assert r.extract_docker_image() == 'myimage:latest'
+    assert r.get_cloud_image_id() == {'us-east-1': 'ami-0abcdef'}
+
+
+def test_image_id_docker_key_only():
+    """A dict with only the 'docker' key behaves like docker:-only."""
+    r = Resources(cloud='aws', image_id={'docker': 'myimage:latest'})
+    assert r.extract_docker_image() == 'myimage:latest'
+    assert r.get_cloud_image_id() is None
+    assert r.image_id is None
+
+
+def test_image_id_ambiguous_docker_spec_rejected():
+    """docker key + a docker:-prefixed region value is ambiguous -> error."""
+    with pytest.raises(ValueError, match='only one mechanism'):
+        Resources(cloud='aws',
+                  image_id={
+                      'us-east-1': 'docker:img1',
+                      'docker': 'img2',
+                  })
+
+
+@pytest.mark.parametrize(
+    'image_id, expected_docker, expected_cloud',
+    [
+        # Legacy docker:-prefixed string: no separate cloud image.
+        ('docker:myimage:latest', 'myimage:latest', None),
+        # Legacy region-agnostic docker dict.
+        ({
+            None: 'docker:myimage:latest'
+        }, 'myimage:latest', None),
+    ])
+def test_image_id_legacy_docker_formats_unchanged(image_id, expected_docker,
+                                                  expected_cloud):
+    """Existing docker: image_id formats keep their old semantics."""
+    r = Resources(cloud='aws', image_id=image_id)
+    assert r.extract_docker_image() == expected_docker
+    assert r.get_cloud_image_id() == expected_cloud
+
+
+def test_image_id_legacy_ami_unchanged():
+    """A plain AMI image_id is unaffected by the docker-key support."""
+    r = Resources(cloud='aws', region='us-east-1', image_id='ami-12345')
+    assert r.extract_docker_image() is None
+    assert r.get_cloud_image_id() == {'us-east-1': 'ami-12345'}
+    assert r._docker_image is None
+
+
+def test_image_id_dual_yaml_round_trip():
+    """to_yaml_config / from_yaml_config preserves both images."""
+    r = Resources(cloud='aws',
+                  image_id={
+                      'us-east-1': 'ami-0abcdef',
+                      'docker': 'myimage:latest',
+                  })
+    config = r.to_yaml_config()
+    assert config['image_id'] == {
+        'us-east-1': 'ami-0abcdef',
+        'docker': 'myimage:latest',
+    }
+    loaded = list(Resources.from_yaml_config(config))[0]
+    assert loaded.extract_docker_image() == 'myimage:latest'
+    assert loaded.get_cloud_image_id() == {'us-east-1': 'ami-0abcdef'}
+
+
+def test_image_id_dual_copy_preserves_both():
+    """Resources.copy() keeps both the cloud image and the docker image."""
+    r = Resources(cloud='aws',
+                  image_id={
+                      'us-east-1': 'ami-0abcdef',
+                      'docker': 'myimage:latest',
+                  })
+    copied = r.copy()
+    assert copied.extract_docker_image() == 'myimage:latest'
+    assert copied.get_cloud_image_id() == {'us-east-1': 'ami-0abcdef'}
+
+
+def test_image_id_dual_pickle_round_trip():
+    """Pickling preserves both images, and old pickles migrate cleanly."""
+    r = Resources(cloud='aws',
+                  image_id={
+                      'us-east-1': 'ami-0abcdef',
+                      'docker': 'myimage:latest',
+                  })
+    unpickled = pickle.loads(pickle.dumps(r))
+    assert unpickled.extract_docker_image() == 'myimage:latest'
+    assert unpickled.get_cloud_image_id() == {'us-east-1': 'ami-0abcdef'}
+
+    # Simulate an object pickled before _VERSION 34 (no _docker_image attr).
+    legacy = Resources(cloud='aws', region='us-east-1', image_id='ami-12345')
+    state = dict(legacy.__dict__)
+    state.pop('_docker_image', None)
+    state['_version'] = 33
+    migrated = Resources.__new__(Resources)
+    migrated.__setstate__(state)
+    assert migrated._docker_image is None
 
 
 def test_network_tier_basic():


### PR DESCRIPTION
## Summary

- Allow users to specify both a cloud VM image (e.g., AMI) and a Docker image in the same `image_id` field by using `docker` as a reserved key in the `image_id` dict
- Cloud backends now use `get_cloud_image_id()` to retrieve the VM image, correctly preserving custom images when a Docker image is also specified
- All existing `image_id` formats remain fully backward compatible

### Motivation

Previously, `image_id` was overloaded — it could be either a cloud image string (`ami-xxx`) or a `docker:`-prefixed string (`docker:myimage:latest`), but not both. This made it impossible to boot a custom AMI and run a Docker container on top of it without resorting to manual `docker pull`/`docker run` in setup/run commands.

### Usage

```yaml
resources:
  cloud: aws
  image_id:
    us-east-1: ami-0abcdef1234
    docker: myimage:latest
```

## Test plan

- Verified backward compatibility: `image_id: docker:xxx`, `image_id: ami-xxx`, and region-keyed dicts all work as before
- Verified new dual-image format: `extract_docker_image()` returns the docker image, `get_cloud_image_id()` returns the cloud image
- Verified YAML serialization round-trip preserves both images
- Verified pickle round-trip and backward compat with old pickled Resources (version < 34)
- Existing unit tests pass (`test_resources.py` image tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->