### PR TITLE
[Slurm] Add slurm.srun_options and preserve SLURM_JOB_ID for SPANK plugins

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -55,6 +55,7 @@ from sky.provision import metadata_utils
 from sky.provision import provisioner
 from sky.provision.kubernetes import config as config_lib
 from sky.provision.kubernetes import utils as kubernetes_utils
+from sky.provision.slurm import instance as slurm_instance
 from sky.provision.slurm import utils as slurm_utils
 from sky.serve import constants as serve_constants
 from sky.server import common as server_common
@@ -6574,9 +6575,24 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 container_name = slurm_utils.pyxis_container_name(
                     handle.cluster_name_on_cloud)
 
+            # Resolve srun_options at exec time so changes in the user's
+            # config.yaml take effect without re-launching the cluster.
+            # Task-YAML overrides flow through the launched resources, same
+            # as sbatch_options. The merge uses the launch-time cluster /
+            # partition (region/zone on the resources object).
+            srun_options = clouds.slurm._merge_slurm_options(  # pylint: disable=protected-access
+                'srun_options',
+                handle.launched_resources.region,
+                handle.launched_resources.zone,
+                handle.launched_resources.cluster_config_overrides,
+            )
+            srun_extra_args = slurm_instance._build_custom_srun_args(  # pylint: disable=protected-access
+                srun_options)
+
             return task_codegen.SlurmCodeGen(
                 slurm_job_id,
                 container_name,
+                srun_extra_args=srun_extra_args,
             )
         else:
             return task_codegen.RayCodeGen()

--- a/sky/backends/task_codegen.py
+++ b/sky/backends/task_codegen.py
@@ -691,16 +691,22 @@ class SlurmCodeGen(TaskCodeGen):
         self,
         slurm_job_id: str,
         container_name: Optional[str],
+        srun_extra_args: str = '',
     ):
         """Initialize SlurmCodeGen.
 
         Args:
             slurm_job_id: The Slurm job ID, i.e. SLURM_JOB_ID
             container_name: pyxis container name, or None
+            srun_extra_args: Pre-built CLI-arg string from
+                ``slurm.srun_options`` (e.g. ``"--auto-resume=1"``),
+                appended to the run-section srun. Empty when no user
+                options are set.
         """
         super().__init__()
         self._slurm_job_id = slurm_job_id
         self._container_name = container_name
+        self._srun_extra_args = srun_extra_args
 
     def add_prologue(self, job_id: int) -> None:
         assert not self._has_prologue, 'add_prologue() called twice?'
@@ -930,6 +936,13 @@ class SlurmCodeGen(TaskCodeGen):
                     #   resolve_ctls_from_dns_srv: res_nsearch error: Unknown host
                     #   fetch_config: DNS SRV lookup failed
                     #   fatal: Could not establish a configuration source
+                    #
+                    # Also re-export SLURM_JOB_ID after the strip: SPANK plugins
+                    # such as AWS HyperPod's spank_auto_resume.so call
+                    # getenv("SLURM_JOB_ID") in slurm_spank_local_user_init to
+                    # detect "am I inside an existing allocation?". Without it,
+                    # they reject srun with "Auto Resume can only run within an
+                    # exiting allocation" even when --jobid is passed.
                     cmd_parts = []
                     # Only unset SKY_RUNTIME_DIR for container runs. For non-container
                     # runs, we want to inherit the node-local SKY_RUNTIME_DIR set by
@@ -944,6 +957,7 @@ class SlurmCodeGen(TaskCodeGen):
                     bash_cmd = shlex.quote(' '.join(cmd_parts))
                     srun_cmd = (
                         "unset $(env | awk -F= '/^SLURM_/ && $1 !~ /^SLURM_CONF/ {{print $1}}') && "
+                        f'export SLURM_JOB_ID={self._slurm_job_id} && '
                         f'srun --export=ALL --quiet --unbuffered --kill-on-bad-exit --jobid={self._slurm_job_id} '
                         f'--job-name=sky-{self.job_id}{{job_suffix}} --ntasks-per-node=1{container_flags} {{extra_flags}} '
                         f'/bin/bash -c {{bash_cmd}}'
@@ -958,7 +972,12 @@ class SlurmCodeGen(TaskCodeGen):
                 def run_thread_func():
                     # This blocks until Slurm allocates resources (--exclusive)
                     # --mem=0 to match RayCodeGen's behavior where we don't explicitly request memory.
-                    run_flags = f'--nodes={num_nodes} --cpus-per-task={task_cpu_demand} --mem=0 {{gpu_arg}} --exclusive'
+                    # User-supplied slurm.srun_options are appended here so
+                    # resilience flags like AWS HyperPod's --auto-resume=1 take
+                    # effect on the task's primary srun step. Not propagated to
+                    # the setup srun (see setup_flags below) since auto-resume
+                    # semantics during --overlap setup are unclear.
+                    run_flags = f'--nodes={num_nodes} --cpus-per-task={task_cpu_demand} --mem=0 {{gpu_arg}} --exclusive {self._srun_extra_args}'
                     srun_cmd, cleanup = build_task_runner_cmd(
                         script, run_flags, {log_dir!r}, sky_env_vars_dict,
                         task_name={task_name!r},

--- a/sky/clouds/slurm.py
+++ b/sky/clouds/slurm.py
@@ -28,6 +28,42 @@ logger = sky_logging.init_logger(__name__)
 CREDENTIAL_PATH = slurm_utils.DEFAULT_SLURM_PATH
 
 
+def _merge_slurm_options(
+    option_key: str,
+    cluster: Optional[str],
+    partition: Optional[str],
+    cluster_config_overrides: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Merge a slurm.* options dict across four precedence levels.
+
+    Lowest to highest: global < cluster < partition < task-YAML
+    cluster_config_overrides. Later levels overwrite earlier ones.
+
+    ``cluster`` and ``partition`` may be ``None``; the corresponding levels
+    are simply skipped.
+    """
+    merged: Dict[str, Any] = {}
+    keys_to_try: List[Tuple[str, ...]] = [('slurm', option_key)]
+    if cluster is not None:
+        keys_to_try.append(('slurm', 'cluster_configs', cluster, option_key))
+        if partition is not None:
+            keys_to_try.append(('slurm', 'cluster_configs', cluster,
+                                'partition_configs', partition, option_key))
+    for keys in keys_to_try:
+        level_config = skypilot_config.get_nested(keys, default_value=None)
+        if level_config is not None:
+            merged.update(level_config)
+    if cluster_config_overrides and cluster is not None:
+        task_level = config_utils.get_cloud_config_value_from_dict(
+            dict_config=cluster_config_overrides,
+            cloud='slurm',
+            region=cluster,
+            keys=(option_key,))
+        if task_level is not None:
+            merged.update(task_level)
+    return merged
+
+
 @registry.CLOUD_REGISTRY.register
 class Slurm(clouds.Cloud):
     """Slurm."""
@@ -560,27 +596,13 @@ class Slurm(clouds.Cloud):
                 # are a lot of pending jobs to be processed.
                 provision_timeout = 2 * 60  # 2 minutes
 
-        # Read sbatch_options with three-level merge:
-        # global < cluster < partition.
-        sbatch_options: Dict[str, Any] = {}
-        for config_keys in [
-            ('slurm', 'sbatch_options'),
-            ('slurm', 'cluster_configs', cluster, 'sbatch_options'),
-            ('slurm', 'cluster_configs', cluster, 'partition_configs',
-             partition, 'sbatch_options'),
-        ]:
-            level_config = skypilot_config.get_nested(config_keys,
-                                                      default_value=None)
-            if level_config is not None:
-                sbatch_options.update(level_config)
-        # Merge task-level config overrides (from `config:` in task YAML).
-        task_sbatch = config_utils.get_cloud_config_value_from_dict(
-            dict_config=resources.cluster_config_overrides,
-            cloud='slurm',
-            region=cluster,
-            keys=('sbatch_options',))
-        if task_sbatch is not None:
-            sbatch_options.update(task_sbatch)
+        # Read sbatch_options / srun_options with the same four-level merge:
+        # global < cluster < partition < task-YAML cluster_config_overrides.
+        sbatch_options = _merge_slurm_options(
+            'sbatch_options', cluster, partition,
+            resources.cluster_config_overrides)
+        srun_options = _merge_slurm_options('srun_options', cluster, partition,
+                                            resources.cluster_config_overrides)
 
         deploy_vars = {
             'instance_type': resources.instance_type,
@@ -609,6 +631,7 @@ class Slurm(clouds.Cloud):
                 (constants.SKY_CLUSTER_NAME_ENV_VAR_KEY),
             'image_id': image_id,
             'sbatch_options': sbatch_options,
+            'srun_options': srun_options,
         }
 
         return deploy_vars

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -55,6 +55,76 @@ _SBATCH_PROTECTED_OPTIONS = frozenset({
     'partition',
 })
 
+# srun options that SkyPilot controls and must not be overridden by users.
+# Union across all SkyPilot-owned srun invocations in task_codegen.py
+# (run-section srun + the shared template). Filtering is done up front
+# rather than per-call-site for simplicity; if a user actually has a
+# legitimate need to override one of these, we can revisit.
+_SRUN_PROTECTED_OPTIONS = frozenset({
+    'export',
+    'quiet',
+    'unbuffered',
+    'kill-on-bad-exit',
+    'jobid',
+    'job-name',
+    'ntasks-per-node',
+    'nodes',
+    'cpus-per-task',
+    'mem',
+    'gpus-per-node',
+    'exclusive',
+    'overlap',
+    'container-name',
+    'container-image',
+    'container-mounts',
+    'container-remap-root',
+    'container-writable',
+    'no-container-mount-home',
+    'label',
+})
+
+
+def _build_custom_srun_args(srun_options: Dict[str, Any]) -> str:
+    """Build srun CLI args from user-supplied ``srun_options``.
+
+    Returns a space-separated string of ``--key=value`` / ``--key`` args
+    suitable for appending to an srun command. Protected options managed
+    by SkyPilot are dropped with a warning. Returns the empty string when
+    nothing would be emitted.
+    """
+    if not srun_options:
+        return ''
+
+    # Normalize: srun accepts both underscores and hyphens for some options,
+    # but we standardize on hyphens to match _build_custom_sbatch_directives.
+    normalized = {k.replace('_', '-'): v for k, v in srun_options.items()}
+
+    conflicting = set(normalized.keys()) & _SRUN_PROTECTED_OPTIONS
+    if conflicting:
+        logger.warning(
+            f'{colorama.Fore.YELLOW}Ignoring protected srun options '
+            f'managed by SkyPilot: {sorted(conflicting)}. Remove them '
+            f'from slurm.srun_options in ~/.sky/config.yaml.'
+            f'{colorama.Style.RESET_ALL}')
+        for key in conflicting:
+            del normalized[key]
+
+    parts: List[str] = []
+    for key in sorted(normalized):
+        value = normalized[key]
+        if value is None or value is False:
+            continue
+        str_value = str(value)
+        if '\n' in key or '\n' in str_value:
+            raise ValueError(
+                f'Newline characters are not allowed in srun options: '
+                f'{key!r}={str_value!r}')
+        if value is True:
+            parts.append(f'--{key}')
+        else:
+            parts.append(f'--{key}={shlex.quote(str_value)}')
+    return ' '.join(parts)
+
 
 def _build_custom_sbatch_directives(sbatch_options: Dict[str, Any]) -> str:
     """Build #SBATCH directive lines from user-supplied sbatch_options.

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -562,6 +562,7 @@ OVERRIDEABLE_CONFIG_KEYS_IN_TASK: List[Tuple[str, ...]] = [
     ('vast', 'datacenter_only'),
     ('vast', 'create_instance_kwargs'),
     ('slurm', 'sbatch_options'),
+    ('slurm', 'srun_options'),
     ('slurm', 'cpu_partition'),
     ('active_workspace',),
 ]

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1465,6 +1465,30 @@ _SBATCH_OPTIONS_SCHEMA = {
     },
 }
 
+_SRUN_OPTIONS_SCHEMA = {
+    'type': 'object',
+    'required': [],
+    'additionalProperties': {
+        'oneOf': [
+            {
+                'type': 'string',
+                # Disallow newlines to prevent shell-quoting issues when
+                # the option is appended to the srun command line.
+                'pattern': r'^[^\n]*$'
+            },
+            {
+                'type': 'number'
+            },
+            {
+                'type': 'boolean'
+            },
+            {
+                'type': 'null'
+            },
+        ]
+    },
+}
+
 _GPU_PARTITION_MAP_SCHEMA = {
     'type': 'object',
     'required': [],
@@ -2048,6 +2072,7 @@ def get_config_schema():
                 },
                 'pricing': _PRICING_SCHEMA,
                 'sbatch_options': _SBATCH_OPTIONS_SCHEMA,
+                'srun_options': _SRUN_OPTIONS_SCHEMA,
                 'gpu_partition_map': _GPU_PARTITION_MAP_SCHEMA,
                 'cpu_partition': {
                     'type': 'string',
@@ -2069,6 +2094,7 @@ def get_config_schema():
                             },
                             'pricing': _PRICING_SCHEMA,
                             'sbatch_options': _SBATCH_OPTIONS_SCHEMA,
+                            'srun_options': _SRUN_OPTIONS_SCHEMA,
                             'gpu_partition_map': _GPU_PARTITION_MAP_SCHEMA,
                             'cpu_partition': {
                                 'type': 'string',
@@ -2084,6 +2110,7 @@ def get_config_schema():
                                     'properties': {
                                         'pricing': _PRICING_SCHEMA,
                                         'sbatch_options': _SBATCH_OPTIONS_SCHEMA,  # pylint: disable=line-too-long
+                                        'srun_options': _SRUN_OPTIONS_SCHEMA,
                                     },
                                 },
                             },

--- a/tests/unit_tests/test_sky/backends/test_task_codegen.py
+++ b/tests/unit_tests/test_sky/backends/test_task_codegen.py
@@ -229,6 +229,72 @@ def test_slurm_codegen_with_container():
                                     testdata_dir=SLURM_TESTDATA_DIR)
 
 
+def _build_slurm_task_code(srun_extra_args: str = '') -> str:
+    """Drive SlurmCodeGen through a minimal task to inspect the generated code."""
+    codegen = task_codegen.SlurmCodeGen(
+        slurm_job_id='12345',
+        container_name=None,
+        srun_extra_args=srun_extra_args,
+    )
+    codegen.add_prologue(job_id=2)
+    codegen.add_setup(
+        1,
+        resources_dict={'CPU': 1.0},
+        stable_cluster_internal_ips=['10.0.0.1'],
+        env_vars={},
+        log_dir='/sky/logs',
+        setup_cmd=None,
+    )
+    codegen.add_task(
+        1,
+        bash_script='echo hello',
+        task_name='hello',
+        resources_dict={'CPU': 1.0},
+        log_dir='/sky/logs/tasks',
+        env_vars={},
+    )
+    codegen.add_epilogue()
+    return codegen.build()
+
+
+def test_slurm_codegen_preserves_slurm_job_id():
+    """SLURM_JOB_ID must be re-exported after the env strip.
+
+    Several SPANK plugins (notably AWS HyperPod's spank_auto_resume.so) call
+    getenv("SLURM_JOB_ID") in slurm_spank_local_user_init to detect "am I
+    inside an existing allocation?". Without re-exporting it after stripping
+    SLURM_*, those plugins reject the srun even though --jobid is passed.
+    """
+    code = _build_slurm_task_code()
+    # The strip still runs.
+    assert "unset $(env | awk -F= '/^SLURM_/ && $1 !~ /^SLURM_CONF/" in code
+    # And SLURM_JOB_ID is re-exported with the configured job id.
+    assert 'export SLURM_JOB_ID=12345' in code
+    # Sanity: the previously problematic vars are NOT re-exported.
+    assert 'export SLURM_CPU_BIND' not in code
+    assert 'export SLURM_NNODES' not in code
+    assert 'export SLURM_NODELIST' not in code
+
+
+def test_slurm_codegen_threads_srun_extra_args():
+    """srun_extra_args from slurm.srun_options must be appended to run_flags."""
+    code = _build_slurm_task_code(srun_extra_args='--auto-resume=1')
+    # The run-section srun has --exclusive followed by the extra args.
+    assert '--exclusive --auto-resume=1' in code
+
+
+def test_slurm_codegen_empty_srun_extra_args_is_default():
+    """Default empty srun_extra_args must not break the run_flags string."""
+    code = _build_slurm_task_code(srun_extra_args='')
+    # The flag-concatenation pattern --exclusive --<something>= must not
+    # appear when no options are configured. (Bare "--auto-resume" appears
+    # in the explanatory comment in task_codegen.py, so we look for the
+    # composed form instead.)
+    assert '--exclusive --auto-resume' not in code
+    # And the run srun still has --exclusive.
+    assert '--exclusive' in code
+
+
 class TestRcloneFlushScript:
     """Unit tests for the rclone flush script output format."""
 

--- a/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_codegen_with_container.py
+++ b/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_codegen_with_container.py
@@ -541,6 +541,13 @@ if script or False:
         #   resolve_ctls_from_dns_srv: res_nsearch error: Unknown host
         #   fetch_config: DNS SRV lookup failed
         #   fatal: Could not establish a configuration source
+        #
+        # Also re-export SLURM_JOB_ID after the strip: SPANK plugins
+        # such as AWS HyperPod's spank_auto_resume.so call
+        # getenv("SLURM_JOB_ID") in slurm_spank_local_user_init to
+        # detect "am I inside an existing allocation?". Without it,
+        # they reject srun with "Auto Resume can only run within an
+        # exiting allocation" even when --jobid is passed.
         cmd_parts = []
         # Only unset SKY_RUNTIME_DIR for container runs. For non-container
         # runs, we want to inherit the node-local SKY_RUNTIME_DIR set by
@@ -555,6 +562,7 @@ if script or False:
         bash_cmd = shlex.quote(' '.join(cmd_parts))
         srun_cmd = (
             "unset $(env | awk -F= '/^SLURM_/ && $1 !~ /^SLURM_CONF/ {print $1}') && "
+            f'export SLURM_JOB_ID=12345 && '
             f'srun --export=ALL --quiet --unbuffered --kill-on-bad-exit --jobid=12345 '
             f'--job-name=sky-2{job_suffix} --ntasks-per-node=1 --container-remap-root --container-name=test-cluster:exec {extra_flags} '
             f'/bin/bash -c {bash_cmd}'
@@ -569,7 +577,12 @@ if script or False:
     def run_thread_func():
         # This blocks until Slurm allocates resources (--exclusive)
         # --mem=0 to match RayCodeGen's behavior where we don't explicitly request memory.
-        run_flags = f'--nodes=1 --cpus-per-task=1 --mem=0 {gpu_arg} --exclusive'
+        # User-supplied slurm.srun_options are appended here so
+        # resilience flags like AWS HyperPod's --auto-resume=1 take
+        # effect on the task's primary srun step. Not propagated to
+        # the setup srun (see setup_flags below) since auto-resume
+        # semantics during --overlap setup are unclear.
+        run_flags = f'--nodes=1 --cpus-per-task=1 --mem=0 {gpu_arg} --exclusive '
         srun_cmd, cleanup = build_task_runner_cmd(
             script, run_flags, '/sky/logs/tasks', sky_env_vars_dict,
             task_name='hello',

--- a/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_single_node_with_gpu.py
+++ b/tests/unit_tests/test_sky/backends/testdata/slurm_codegen/slurm_single_node_with_gpu.py
@@ -543,6 +543,13 @@ if script or True:
         #   resolve_ctls_from_dns_srv: res_nsearch error: Unknown host
         #   fetch_config: DNS SRV lookup failed
         #   fatal: Could not establish a configuration source
+        #
+        # Also re-export SLURM_JOB_ID after the strip: SPANK plugins
+        # such as AWS HyperPod's spank_auto_resume.so call
+        # getenv("SLURM_JOB_ID") in slurm_spank_local_user_init to
+        # detect "am I inside an existing allocation?". Without it,
+        # they reject srun with "Auto Resume can only run within an
+        # exiting allocation" even when --jobid is passed.
         cmd_parts = []
         # Only unset SKY_RUNTIME_DIR for container runs. For non-container
         # runs, we want to inherit the node-local SKY_RUNTIME_DIR set by
@@ -557,6 +564,7 @@ if script or True:
         bash_cmd = shlex.quote(' '.join(cmd_parts))
         srun_cmd = (
             "unset $(env | awk -F= '/^SLURM_/ && $1 !~ /^SLURM_CONF/ {print $1}') && "
+            f'export SLURM_JOB_ID=12345 && '
             f'srun --export=ALL --quiet --unbuffered --kill-on-bad-exit --jobid=12345 '
             f'--job-name=sky-2{job_suffix} --ntasks-per-node=1 {extra_flags} '
             f'/bin/bash -c {bash_cmd}'
@@ -571,7 +579,12 @@ if script or True:
     def run_thread_func():
         # This blocks until Slurm allocates resources (--exclusive)
         # --mem=0 to match RayCodeGen's behavior where we don't explicitly request memory.
-        run_flags = f'--nodes=1 --cpus-per-task=4 --mem=0 {gpu_arg} --exclusive'
+        # User-supplied slurm.srun_options are appended here so
+        # resilience flags like AWS HyperPod's --auto-resume=1 take
+        # effect on the task's primary srun step. Not propagated to
+        # the setup srun (see setup_flags below) since auto-resume
+        # semantics during --overlap setup are unclear.
+        run_flags = f'--nodes=1 --cpus-per-task=4 --mem=0 {gpu_arg} --exclusive '
         srun_cmd, cleanup = build_task_runner_cmd(
             script, run_flags, '/sky/logs/tasks', sky_env_vars_dict,
             task_name='train_task',

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -805,6 +805,162 @@ class TestSbatchOptionsPrecedence:
         assert result == {'account': 'task-cluster-account'}
 
 
+class TestSrunOptionsPrecedence:
+    """Test 4-level srun_options merge in make_deploy_resources_variables.
+
+    Mirrors TestSbatchOptionsPrecedence — same precedence, same merge
+    semantics, just a different deploy_vars key.
+    """
+
+    FAKE_SSH_CONFIG = {
+        'hostname': '10.0.0.1',
+        'port': '22',
+        'user': 'slurm',
+        'identityfile': ['/home/user/.ssh/id_rsa'],
+    }
+
+    def _load_config_and_get_srun_options(self,
+                                          tmp_path,
+                                          skypilot_config_dict,
+                                          cluster_config_overrides=None):
+        from sky import skypilot_config
+        from sky.utils import yaml_utils
+
+        config_path = tmp_path / 'config.yaml'
+        config_path.write_text(yaml_utils.dump_yaml_str(skypilot_config_dict))
+
+        saved_global = skypilot_config._GLOBAL_CONFIG_PATH
+        saved_project = skypilot_config._PROJECT_CONFIG_PATH
+        saved_ctx = skypilot_config._global_config_context
+        try:
+            skypilot_config._GLOBAL_CONFIG_PATH = str(config_path)
+            skypilot_config._PROJECT_CONFIG_PATH = str(tmp_path /
+                                                       'nonexistent.yaml')
+            skypilot_config._global_config_context = (
+                skypilot_config.ConfigContext())
+            skypilot_config.reload_config()
+
+            cloud = slurm_cloud.Slurm()
+
+            mock_resources = mock.MagicMock(unsafe=True)
+            mock_resources.zone = 'gpu'
+            mock_resources.instance_type = '4CPU--16GB'
+            mock_resources.assert_launchable.return_value = mock_resources
+            mock_resources.extract_docker_image.return_value = None
+            mock_resources.cluster_config_overrides = (cluster_config_overrides
+                                                       or {})
+
+            region = mock.MagicMock()
+            region.name = 'mycluster'
+            zone_mock = mock.MagicMock()
+            zone_mock.name = 'gpu'
+
+            mock_ssh_config = mock.MagicMock()
+            mock_ssh_config.lookup.return_value = self.FAKE_SSH_CONFIG
+
+            with patch(
+                    'sky.clouds.slurm.slurm_utils.get_slurm_ssh_config',
+                    return_value=mock_ssh_config), \
+                 patch(
+                    'sky.clouds.slurm.slurm_utils.get_partitions',
+                    return_value=['gpu', 'cpu']), \
+                 patch(
+                    'sky.clouds.slurm.slurm_utils.resolve_gres_gpu_type',
+                    side_effect=lambda cluster, t, count=1, partition=None: t):
+                deploy_vars = cloud.make_deploy_resources_variables(
+                    resources=mock_resources,
+                    cluster_name=mock.MagicMock(),
+                    region=region,
+                    zones=[zone_mock],
+                    num_nodes=1,
+                )
+            return deploy_vars['srun_options']
+        finally:
+            skypilot_config._GLOBAL_CONFIG_PATH = saved_global
+            skypilot_config._PROJECT_CONFIG_PATH = saved_project
+            skypilot_config._global_config_context = saved_ctx
+
+    def test_global_only(self, tmp_path):
+        result = self._load_config_and_get_srun_options(tmp_path, {
+            'slurm': {
+                'srun_options': {
+                    'auto-resume': 1,
+                },
+            },
+        })
+        assert result == {'auto-resume': 1}
+
+    def test_cluster_overrides_global(self, tmp_path):
+        result = self._load_config_and_get_srun_options(
+            tmp_path, {
+                'slurm': {
+                    'srun_options': {
+                        'auto-resume': 1,
+                        'cpu-bind': 'cores',
+                    },
+                    'cluster_configs': {
+                        'mycluster': {
+                            'srun_options': {
+                                'auto-resume': 3,
+                            },
+                        },
+                    },
+                },
+            })
+        assert result == {'auto-resume': 3, 'cpu-bind': 'cores'}
+
+    def test_partition_overrides_cluster_and_global(self, tmp_path):
+        result = self._load_config_and_get_srun_options(
+            tmp_path, {
+                'slurm': {
+                    'srun_options': {
+                        'auto-resume': 1,
+                    },
+                    'cluster_configs': {
+                        'mycluster': {
+                            'srun_options': {
+                                'auto-resume': 2,
+                            },
+                            'partition_configs': {
+                                'gpu': {
+                                    'srun_options': {
+                                        'auto-resume': 5,
+                                        'cpu-bind': 'cores',
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            })
+        assert result == {'auto-resume': 5, 'cpu-bind': 'cores'}
+
+    def test_task_overrides_all(self, tmp_path):
+        result = self._load_config_and_get_srun_options(
+            tmp_path,
+            skypilot_config_dict={
+                'slurm': {
+                    'srun_options': {
+                        'auto-resume': 1,
+                    },
+                },
+            },
+            cluster_config_overrides={
+                'slurm': {
+                    'srun_options': {
+                        'auto-resume': 10,
+                    },
+                },
+            },
+        )
+        assert result == {'auto-resume': 10}
+
+    def test_no_srun_options(self, tmp_path):
+        result = self._load_config_and_get_srun_options(tmp_path,
+                                                        skypilot_config_dict={})
+        assert result == {}
+
+
 class TestSlurmProvisionTimeout:
     """Test conditional provision timeout logic in make_deploy_resources_variables.
 

--- a/tests/unit_tests/test_sky/provision/slurm/test_srun_config.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_srun_config.py
@@ -1,0 +1,194 @@
+"""Unit tests for srun_options support in Slurm provisioner."""
+
+import jsonschema
+import pytest
+
+from sky.provision.slurm.instance import _build_custom_srun_args
+from sky.provision.slurm.instance import _SRUN_PROTECTED_OPTIONS
+from sky.utils.schemas import get_config_schema
+
+
+class TestBuildCustomSrunArgs:
+    """Test _build_custom_srun_args()."""
+
+    def test_empty_config(self):
+        assert _build_custom_srun_args({}) == ''
+
+    def test_none_config(self):
+        # The caller may pass None when no options are configured.
+        assert _build_custom_srun_args({}) == ''
+
+    def test_string_value(self):
+        assert _build_custom_srun_args({'cpu-bind': 'cores'}) == (
+            "--cpu-bind=cores")
+
+    def test_numeric_value(self):
+        assert _build_custom_srun_args({'auto-resume': 1}) == '--auto-resume=1'
+
+    def test_boolean_true_flag(self):
+        assert _build_custom_srun_args({'pty': True}) == '--pty'
+
+    def test_boolean_false_omitted(self):
+        assert _build_custom_srun_args({'pty': False}) == ''
+
+    def test_null_omitted(self):
+        assert _build_custom_srun_args({'cpu-bind': None}) == ''
+
+    def test_multiple_options_sorted(self):
+        result = _build_custom_srun_args({
+            'cpu-bind': 'cores',
+            'auto-resume': 1,
+            'comment': 'hi',
+        })
+        assert result == '--auto-resume=1 --comment=hi --cpu-bind=cores'
+
+    def test_underscore_normalized_to_hyphen(self):
+        assert _build_custom_srun_args({'auto_resume': 1}) == '--auto-resume=1'
+
+    @pytest.mark.parametrize('option', sorted(_SRUN_PROTECTED_OPTIONS))
+    def test_all_protected_options_skipped(self, option):
+        assert _build_custom_srun_args({option: 'value'}) == ''
+
+    def test_protected_skipped_non_protected_kept(self):
+        result = _build_custom_srun_args({
+            'jobid': 'override-attempt',
+            'auto-resume': 2,
+        })
+        assert result == '--auto-resume=2'
+
+    def test_newline_in_value_raises(self):
+        with pytest.raises(ValueError, match='Newline'):
+            _build_custom_srun_args({'comment': 'foo\nbar'})
+
+    def test_newline_in_key_raises(self):
+        with pytest.raises(ValueError, match='Newline'):
+            _build_custom_srun_args({'foo\nbar': 'value'})
+
+    @pytest.mark.parametrize('value', [
+        'foo; rm -rf /',
+        'foo && echo pwned',
+        '$(whoami)',
+        '`whoami`',
+        "foo' || echo pwned #",
+    ])
+    def test_shell_metacharacters_are_quoted(self, value):
+        """Shell metacharacters in values must be shell-quoted, because srun
+        args are appended directly to a shell command (unlike sbatch which
+        injects into a script as comment-prefixed directives)."""
+        import shlex
+        result = _build_custom_srun_args({'comment': value})
+        # Round-trip through shlex.split: the shell would parse the same args.
+        parsed = shlex.split(result)
+        assert parsed == [f'--comment={value}']
+
+
+class TestSrunConfigSchema:
+    """Test srun_options schema validation in config YAML."""
+
+    def _validate(self, config):
+        schema = get_config_schema()
+        jsonschema.validate(instance=config, schema=schema)
+
+    def test_valid_cloud_level(self):
+        self._validate(
+            {'slurm': {
+                'srun_options': {
+                    'auto-resume': 1,
+                }
+            }})
+
+    def test_valid_cluster_level(self):
+        self._validate({
+            'slurm': {
+                'cluster_configs': {
+                    'mycluster': {
+                        'srun_options': {
+                            'auto-resume': 3,
+                        }
+                    }
+                }
+            }
+        })
+
+    def test_valid_partition_level(self):
+        self._validate({
+            'slurm': {
+                'cluster_configs': {
+                    'mycluster': {
+                        'partition_configs': {
+                            'gpu': {
+                                'srun_options': {
+                                    'auto-resume': 5,
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+
+    def test_valid_all_three_levels(self):
+        self._validate({
+            'slurm': {
+                'srun_options': {
+                    'cpu-bind': 'cores',
+                },
+                'cluster_configs': {
+                    'mycluster': {
+                        'srun_options': {
+                            'auto-resume': 1,
+                        },
+                        'partition_configs': {
+                            'gpu': {
+                                'srun_options': {
+                                    'auto-resume': 5,
+                                }
+                            }
+                        },
+                    }
+                }
+            }
+        })
+
+    def test_valid_value_types(self):
+        self._validate({
+            'slurm': {
+                'srun_options': {
+                    'cpu-bind': 'cores',
+                    'auto-resume': 1,
+                    'pty': True,
+                    'overcommit': False,
+                    'comment': None,
+                }
+            }
+        })
+
+    def test_invalid_nested_object_value(self):
+        with pytest.raises(jsonschema.ValidationError):
+            self._validate(
+                {'slurm': {
+                    'srun_options': {
+                        'cpu-bind': {
+                            'nested': 'no'
+                        }
+                    }
+                }})
+
+    def test_invalid_list_value(self):
+        with pytest.raises(jsonschema.ValidationError):
+            self._validate(
+                {'slurm': {
+                    'srun_options': {
+                        'cpu-bind': ['a', 'b'],
+                    }
+                }})
+
+    def test_invalid_newline_in_value(self):
+        with pytest.raises(jsonschema.ValidationError):
+            self._validate({
+                'slurm': {
+                    'srun_options': {
+                        'comment': 'innocent\ntouch /tmp/pwned',
+                    }
+                }
+            })


### PR DESCRIPTION
## Summary

- New `slurm.srun_options` config (global / cluster / partition / task-YAML) mirroring `slurm.sbatch_options`. Values are appended as CLI args to the run-section `srun`, with a protected-options filter shielding flags SkyPilot manages.
- Preserve `SLURM_JOB_ID` across the existing `SLURM_*` env-strip in `task_codegen.py`. This is the actual unblock for AWS HyperPod's `--auto-resume`: HyperPod's `spank_auto_resume.so` calls `getenv(\"SLURM_JOB_ID\")` in `slurm_spank_local_user_init` to detect \"am I inside an existing allocation?\". Without it, `srun --jobid=...` is rejected even though the `--jobid` flag is set.

## Why both changes ship together

Adding `srun_options` alone is necessary but not sufficient. A user who writes `srun_options: {auto-resume: 1}` would still get \"Auto Resume can only run within an exiting allocation\" because of the env-strip. Re-exporting `SLURM_JOB_ID` is the missing piece. Verified by probing the SPANK plugin (.so) and behavior on a live HyperPod Slurm cluster.

The previously problematic vars (`SLURM_CPU_BIND`, `SLURM_NNODES`, `SLURM_NODELIST`) — see comment block above the srun template — stay stripped.

## Example usage

\`\`\`yaml
# ~/.sky/config.yaml
slurm:
  cluster_configs:
    my-hyperpod-cluster:
      srun_options:
        auto-resume: 1
\`\`\`

Equivalent dict keys with hyphens or underscores are accepted (`auto-resume` and `auto_resume`).

## Scope decisions

- `srun_options` applies to the **run-section** srun only (the `--exclusive` allocator). Not threaded into the setup-section srun (which uses `--overlap` inside the run-srun's allocation) because resilience-flag semantics during overlapped steps are unclear. Easy to revisit.
- Protected options (filter list in `_SRUN_PROTECTED_OPTIONS`): the union of flags SkyPilot already passes — `jobid`, `job-name`, `export`, `quiet`, `unbuffered`, `kill-on-bad-exit`, `ntasks-per-node`, `nodes`, `cpus-per-task`, `mem`, `gpus-per-node`, `exclusive`, `overlap`, `container-*`, `label`. Conflicts are logged and dropped.
- `SLURM_JOB_ID` is preserved unconditionally (not gated on `srun_options` being non-empty), so any future SPANK plugin gating on allocation context works.

## Test plan

Unit tests added/updated (274 pass locally):

- `tests/unit_tests/test_sky/clouds/test_slurm.py::TestSrunOptionsPrecedence` — 4-level merge: global → cluster → partition → task-YAML.
- `tests/unit_tests/test_sky/provision/slurm/test_srun_config.py` — arg-string builder, protected-options filter, schema validation at all three config levels, newline-injection rejection, shell-quoting safety.
- `tests/unit_tests/test_sky/backends/test_task_codegen.py` — asserts `SLURM_JOB_ID` re-export, that `SLURM_CPU_BIND` / `SLURM_NNODES` / `SLURM_NODELIST` are *not* re-exported, and that `srun_extra_args` reach the run-section srun.
- Updated codegen snapshots: `tests/unit_tests/test_sky/backends/testdata/slurm_codegen/*.py`.

Manual:

- Verified against a live AWS HyperPod cluster that preserving `SLURM_JOB_ID` after the env-strip clears the SPANK plugin's \"must be within an existing allocation\" error. Probe: `srun --jobid=$JID --auto-resume=1` after `unset SLURM_*` succeeds plugin init when `SLURM_JOB_ID` is re-exported; fails without.
- End-to-end auto-resume step replay (plugin-driven node replacement + step resume on the new node) is the outstanding validation — needs coordination with the AWS team. Note: HyperPod`s default lifecycle config sets `TaskPlugin=task/cgroup,task/affinity` deliberately (for process isolation). The plugin`s `local_user_init` passes under this setting once `SLURM_JOB_ID` is preserved (this PR), but the plugin`s *resume* action is documented by AWS as requiring `task/none` and gating on non-GRES jobs. So even with this PR, full auto-resume step replay still depends on AWS-side conditions outside SkyPilot`s control — this PR makes the integration possible, it does not by itself guarantee replay.

Recommend `/smoke-test` to exercise Slurm-relevant paths before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


