### PR TITLE
[Jobs] Show provisioning spinner during sky jobs launch

### DIFF
--- a/agent/skills/skypilot/references/python-sdk.md
+++ b/agent/skills/skypilot/references/python-sdk.md
@@ -1168,7 +1168,7 @@ may cause GET /api/get being sent to a restarted API server.
 ### `sky.stream_and_get`
 
 ```python
-sky.stream_and_get(request_id: Optional[server_common.RequestId[T]] = None, log_path: Optional[str] = None, tail: Optional[int] = None, follow: bool = True, output_stream: Optional['io.TextIOBase'] = None) -> Optional[T]
+sky.stream_and_get(request_id: Optional[server_common.RequestId[T]] = None, log_path: Optional[str] = None, tail: Optional[int] = None, follow: bool = True, output_stream: Optional['io.TextIOBase'] = None, relay_rich_status: bool = False) -> Optional[T]
 ```
 
 Streams the logs of a request or a log file and gets the final result.
@@ -1187,6 +1187,11 @@ prefix of the full request id.
     follow: Whether to follow the logs.
     output_stream: The output stream to write to. If None, print to the
         console.
+    relay_rich_status: If True, forward encoded rich-status control payloads
+        verbatim to the output instead of rendering a local spinner. Used by
+        the managed jobs controller to preserve provisioning spinner codes
+        in its per-job log. See
+        :func:`sky.utils.rich_utils.decode_rich_status`.
 
 **Returns:**
     The ``Request Returns`` of the specified request. See the documentation
@@ -1406,7 +1411,7 @@ as managed jobs or services.
 ### `sky.stream_response`
 
 ```python
-sky.stream_response(request_id: Optional[server_common.RequestId[T]], response: 'requests.Response', output_stream: Optional['io.TextIOBase'] = None, resumable: bool = False, get_result: bool = True) -> Optional[T]
+sky.stream_response(request_id: Optional[server_common.RequestId[T]], response: 'requests.Response', output_stream: Optional['io.TextIOBase'] = None, resumable: bool = False, get_result: bool = True, relay_rich_status: bool = False) -> Optional[T]
 ```
 
 Streams the response to the console.
@@ -1424,6 +1429,9 @@ Streams the response to the console.
     get_result: Whether to get the result of the request. This will
         typically be set to False for `--no-follow` flags as requests may
         continue to run for long periods of time without further streaming.
+    relay_rich_status: If True, forward encoded rich-status control payloads
+        verbatim to the output instead of rendering a local spinner. See
+        :func:`sky.utils.rich_utils.decode_rich_status`.
 
 ### `sky.tail_autostop_logs`
 

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -114,7 +114,8 @@ def stream_response(request_id: None,
                     response: 'requests.Response',
                     output_stream: Optional['io.TextIOBase'] = None,
                     resumable: bool = False,
-                    get_result: bool = True) -> None:
+                    get_result: bool = True,
+                    relay_rich_status: bool = False) -> None:
     ...
 
 
@@ -123,7 +124,8 @@ def stream_response(request_id: server_common.RequestId[T],
                     response: 'requests.Response',
                     output_stream: Optional['io.TextIOBase'] = None,
                     resumable: bool = False,
-                    get_result: Literal[True] = True) -> T:
+                    get_result: Literal[True] = True,
+                    relay_rich_status: bool = False) -> T:
     ...
 
 
@@ -132,7 +134,8 @@ def stream_response(request_id: server_common.RequestId[T],
                     response: 'requests.Response',
                     output_stream: Optional['io.TextIOBase'] = None,
                     resumable: bool = False,
-                    get_result: bool = True) -> Optional[T]:
+                    get_result: bool = True,
+                    relay_rich_status: bool = False) -> Optional[T]:
     ...
 
 
@@ -140,7 +143,8 @@ def stream_response(request_id: Optional[server_common.RequestId[T]],
                     response: 'requests.Response',
                     output_stream: Optional['io.TextIOBase'] = None,
                     resumable: bool = False,
-                    get_result: bool = True) -> Optional[T]:
+                    get_result: bool = True,
+                    relay_rich_status: bool = False) -> Optional[T]:
     """Streams the response to the console.
 
     Args:
@@ -156,6 +160,9 @@ def stream_response(request_id: Optional[server_common.RequestId[T]],
         get_result: Whether to get the result of the request. This will
             typically be set to False for `--no-follow` flags as requests may
             continue to run for long periods of time without further streaming.
+        relay_rich_status: If True, forward encoded rich-status control payloads
+            verbatim to the output instead of rendering a local spinner. See
+            :func:`sky.utils.rich_utils.decode_rich_status`.
     """
 
     # Always fetch the retry context (if any) so we can report progress to
@@ -165,7 +172,8 @@ def stream_response(request_id: Optional[server_common.RequestId[T]],
     try:
         line_count = 0
 
-        for line in rich_utils.decode_rich_status(response):
+        for line in rich_utils.decode_rich_status(
+                response, relay_rich_status=relay_rich_status):
             # Report forward progress to the retry decorator for every
             # message received from the wire, including None control
             # messages (e.g. heartbeats). Receiving any message
@@ -2271,7 +2279,8 @@ def stream_and_get(request_id: server_common.RequestId[T],
                    log_path: Optional[str] = None,
                    tail: Optional[int] = None,
                    follow: bool = True,
-                   output_stream: Optional['io.TextIOBase'] = None) -> T:
+                   output_stream: Optional['io.TextIOBase'] = None,
+                   relay_rich_status: bool = False) -> T:
     ...
 
 
@@ -2280,7 +2289,8 @@ def stream_and_get(request_id: None = None,
                    log_path: Optional[str] = None,
                    tail: Optional[int] = None,
                    follow: bool = True,
-                   output_stream: Optional['io.TextIOBase'] = None) -> None:
+                   output_stream: Optional['io.TextIOBase'] = None,
+                   relay_rich_status: bool = False) -> None:
     ...
 
 
@@ -2294,6 +2304,7 @@ def stream_and_get(
     tail: Optional[int] = None,
     follow: bool = True,
     output_stream: Optional['io.TextIOBase'] = None,
+    relay_rich_status: bool = False,
 ) -> Optional[T]:
     """Streams the logs of a request or a log file and gets the final result.
 
@@ -2311,6 +2322,11 @@ def stream_and_get(
         follow: Whether to follow the logs.
         output_stream: The output stream to write to. If None, print to the
             console.
+        relay_rich_status: If True, forward encoded rich-status control payloads
+            verbatim to the output instead of rendering a local spinner. Used by
+            the managed jobs controller to preserve provisioning spinner codes
+            in its per-job log. See
+            :func:`sky.utils.rich_utils.decode_rich_status`.
 
     Returns:
         The ``Request Returns`` of the specified request. See the documentation
@@ -2358,7 +2374,8 @@ def stream_and_get(
                            response,
                            output_stream,
                            resumable=True,
-                           get_result=follow)
+                           get_result=follow,
+                           relay_rich_status=relay_rich_status)
 
 
 @usage_lib.entrypoint

--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -569,9 +569,17 @@ class StrategyExecutor:
                                 )
                                 logger.debug('sdk.launch request ID: '
                                              f'{request_id}')
+                                # Relay the encoded rich-status payloads from
+                                # the inner cluster launch into this per-job
+                                # controller log (instead of rendering/dropping
+                                # them here). `stream_logs_by_id` decodes them
+                                # to drive the provisioning spinner shown by
+                                # `sky jobs launch` / `sky jobs logs`, matching
+                                # the `sky launch` experience.
                                 await asyncio.to_thread(
                                     sdk.stream_and_get,
                                     request_id,
+                                    relay_rich_status=True,
                                 )
                             except asyncio.CancelledError:
                                 if request_id:

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1385,6 +1385,20 @@ def read_provision_status_from_log(
     return pos, msg
 
 
+def _provision_status_headline(provision_msg: str) -> Optional[str]:
+    """Returns the blue headline of a provisioning spinner message.
+
+    Provisioning messages from the cluster launch look like
+    ``[bold cyan]Preparing SkyPilot runtime (1/3)[/]  [dim]<log hint>[/]``. We
+    keep only the colored (blue) headline and drop the trailing log-path hint,
+    so the caller can show it as a secondary detail under the "Waiting for task
+    to start" line. Returns ``None`` when the message has no blue headline, so
+    the caller can show nothing rather than a raw/unstyled message.
+    """
+    match = re.search(r'\[bold cyan\](.*?)\[/\]', provision_msg)
+    return match.group(1) if match else None
+
+
 def stream_logs_by_id(
         job_id: int,
         follow: bool = True,
@@ -1720,9 +1734,13 @@ def stream_logs_by_id(
                     # the live cluster-launch status, so it's clear the job is
                     # waiting on its cluster to be provisioned.
                     provision_msg = _latest_provision_status_msg()
-                    provision_str = (
-                        '' if provision_msg is None else
-                        f'\n  [dim]Launching cluster:[/] {provision_msg}')
+                    # Show only the blue headline of the cluster-launch status
+                    # as a secondary detail under the waiting line; show nothing
+                    # when there is no headline to display.
+                    headline = (None if provision_msg is None else
+                                _provision_status_headline(provision_msg))
+                    provision_str = (''
+                                     if headline is None else f'\n  {headline}')
                     msg = _JOB_WAITING_STATUS_MESSAGE.format(
                         status_str=status_str,
                         provision_str=provision_str,

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1349,10 +1349,16 @@ def read_provision_status_from_log(
     Returns:
         A tuple ``(new_pos, latest_msg)``. ``latest_msg`` is ``None`` if
         provisioning has not emitted a spinner yet, or if it has finished
-        (a STOP/EXIT control clears the message).
+        (an EXIT control clears the message).
     """
     msg = current_msg
     try:
+        # If the log was truncated or recreated (e.g. controller recovery or a
+        # job retry), the saved offset can be past the new EOF; restart from the
+        # beginning so following doesn't get stuck reading nothing.
+        if os.path.exists(log_path) and pos > os.path.getsize(log_path):
+            pos = 0
+            msg = None
         with open(log_path, 'r', encoding='utf-8') as f:
             f.seek(pos)
             while True:
@@ -1372,17 +1378,35 @@ def read_provision_status_from_log(
                     continue
                 control, encoded_status = rich_utils.Control.decode(decoded)
                 if control in (rich_utils.Control.INIT,
-                               rich_utils.Control.UPDATE,
-                               rich_utils.Control.START):
+                               rich_utils.Control.UPDATE):
+                    # INIT/UPDATE carry the live spinner text.
                     msg = encoded_status
-                elif control in (rich_utils.Control.STOP,
-                                 rich_utils.Control.EXIT):
+                elif control == rich_utils.Control.EXIT:
+                    # The spinner is done.
                     msg = None
+                # START/STOP only toggle the spinner's visibility and carry the
+                # original (possibly stale) init message rather than the live
+                # one: entering a nested status emits UPDATE(nested) then
+                # START(original), so updating `msg` on START would revert the
+                # headline to the stale text. Leave `msg` unchanged for both.
     except (OSError, ValueError):
         # Best-effort: the log may not exist yet (FileNotFoundError) or be
         # mid-write; never let log following break job-log streaming.
         pass
     return pos, msg
+
+
+def _is_relayed_status_payload_line(line: str) -> bool:
+    """Whether a controller-log line is a relayed rich-status payload.
+
+    With ``relay_rich_status=True``, the jobs controller writes the inner
+    cluster launch's encoded rich-status payloads into its per-job log to drive
+    the provisioning spinner (see ``read_provision_status_from_log``). These
+    encoded ``<sky-payload>`` lines are control-plane only and must be hidden
+    from the human-readable ``sky jobs logs --controller`` output.
+    """
+    is_payload, _ = message_utils.decode_payload(line, raise_for_mismatch=False)
+    return is_payload
 
 
 def _provision_status_headline(provision_msg: str) -> Optional[str]:
@@ -1395,7 +1419,12 @@ def _provision_status_headline(provision_msg: str) -> Optional[str]:
     to start" line. Returns ``None`` when the message has no blue headline, so
     the caller can show nothing rather than a raw/unstyled message.
     """
-    match = re.search(r'\[bold cyan\](.*?)\[/\]', provision_msg)
+    # Drop the trailing dim log-path hint (``  [dim]...[/]``), if any, then peel
+    # off the outer ``[bold cyan]...[/]`` wrapper. The inner capture is greedy
+    # so nested markup (e.g. ``[bold cyan]Doing [bold]X[/] now[/]``) is kept
+    # intact instead of being truncated at the first ``[/]``.
+    headline = re.sub(r'\s*\[dim\].*\[/\]\s*$', '', provision_msg)
+    match = re.match(r'\s*\[bold cyan\](.*)\[/\]\s*$', headline)
     return match.group(1) if match else None
 
 
@@ -2037,12 +2066,16 @@ def stream_logs(job_id: Optional[int],
             tail_lines, end_pos = log_lib.tail_lines_from_end(
                 controller_log_path, tail, offset_arg)
             for line in tail_lines:
+                if _is_relayed_status_payload_line(line):
+                    continue
                 print(line, end='')
             print(end='', flush=True)
         else:
             with open(controller_log_path, 'r', newline='',
                       encoding='utf-8') as f:
                 for line in f:
+                    if _is_relayed_status_payload_line(line):
+                        continue
                     print(line, end='')
                 end_pos = f.tell()
                 print(end='', flush=True)
@@ -2058,7 +2091,8 @@ def stream_logs(job_id: Optional[int],
                     # Print all new lines, if there are any.
                     line = f.readline()
                     while line is not None and line != '':
-                        print(line, end='')
+                        if not _is_relayed_status_payload_line(line):
+                            print(line, end='')
                         line = f.readline()
 
                     # Flush.
@@ -2080,7 +2114,13 @@ def stream_logs(job_id: Optional[int],
                 time.sleep(1 + log_lib.SKY_LOG_TAILING_GAP_SECONDS)
 
                 # Print any remaining logs including incomplete line.
-                print(f.read(), end='', flush=True)
+                remaining = f.read()
+                if remaining:
+                    print(''.join(
+                        line for line in remaining.splitlines(keepends=True)
+                        if not _is_relayed_status_payload_line(line)),
+                          end='',
+                          flush=True)
 
         if follow:
             return ux_utils.finishing_message(

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -92,6 +92,12 @@ JOB_STARTED_STATUS_CHECK_GAP_SECONDS = 5
 
 _LOG_STREAM_CHECK_CONTROLLER_GAP_SECONDS = 5
 
+# While a managed job is provisioning, we poll the jobs controller log this
+# often to relay the cluster-launch spinner messages (e.g. "Preparing SkyPilot
+# runtime (1/3)") to the user. This is faster than JOB_STATUS_CHECK_GAP_SECONDS
+# so the spinner feels responsive without polling the job-status DB as often.
+_PROVISION_LOG_POLL_GAP_SECONDS = 1
+
 _JOB_STATUS_FETCH_TIMEOUT_SECONDS = 30
 JOB_STATUS_FETCH_TOTAL_TIMEOUT_SECONDS = 60
 
@@ -110,7 +116,7 @@ _CONTROLLER_UUID_LOG_RE = re.compile(
 
 _JOB_WAITING_STATUS_MESSAGE = ux_utils.spinner_message(
     'Waiting for task to start[/]'
-    '{status_str}. It may take a few minutes.\n'
+    '{status_str}. It may take a few minutes.{provision_str}\n'
     '  [dim]View controller logs: sky jobs logs --controller {job_id}')
 _JOB_CANCELLED_MESSAGE = (
     ux_utils.spinner_message('Waiting for task status to be updated.') +
@@ -1322,6 +1328,63 @@ def controller_log_file_for_job(job_id: int,
     return os.path.join(log_dir, f'{job_id}.log')
 
 
+def read_provision_status_from_log(
+        log_path: str, pos: int,
+        current_msg: Optional[str]) -> Tuple[int, Optional[str]]:
+    """Reads rich-status spinner messages relayed into a controller log.
+
+    The jobs controller relays the inner cluster-launch rich-status payloads
+    into its per-job log (see ``recovery_strategy._launch``'s
+    ``relay_rich_status=True``). This decodes any payloads appended since
+    ``pos`` and returns the new read position together with the latest
+    provisioning spinner message, so ``sky jobs launch`` / ``sky jobs logs``
+    can show the same provisioning progress (e.g. "Preparing SkyPilot runtime
+    (1/3)") that ``sky launch`` displays.
+
+    Args:
+        log_path: Path to the jobs controller log for the job.
+        pos: Byte/character offset to resume reading from (0 on first call).
+        current_msg: The previously returned spinner message.
+
+    Returns:
+        A tuple ``(new_pos, latest_msg)``. ``latest_msg`` is ``None`` if
+        provisioning has not emitted a spinner yet, or if it has finished
+        (a STOP/EXIT control clears the message).
+    """
+    msg = current_msg
+    try:
+        with open(log_path, 'r', encoding='utf-8') as f:
+            f.seek(pos)
+            while True:
+                line_start = f.tell()
+                line = f.readline()
+                if line == '':
+                    # EOF.
+                    break
+                if not line.endswith('\n'):
+                    # Partial line still being written; re-read it next time.
+                    f.seek(line_start)
+                    break
+                pos = f.tell()
+                is_payload, decoded = message_utils.decode_payload(
+                    line, raise_for_mismatch=False)
+                if not is_payload:
+                    continue
+                control, encoded_status = rich_utils.Control.decode(decoded)
+                if control in (rich_utils.Control.INIT,
+                               rich_utils.Control.UPDATE,
+                               rich_utils.Control.START):
+                    msg = encoded_status
+                elif control in (rich_utils.Control.STOP,
+                                 rich_utils.Control.EXIT):
+                    msg = None
+    except (OSError, ValueError):
+        # Best-effort: the log may not exist yet (FileNotFoundError) or be
+        # mid-write; never let log following break job-log streaming.
+        pass
+    return pos, msg
+
+
 def stream_logs_by_id(
         job_id: int,
         follow: bool = True,
@@ -1439,7 +1502,9 @@ def stream_logs_by_id(
         # task_filter is a str, match by task name
         return task_name == task_filter
 
-    msg = _JOB_WAITING_STATUS_MESSAGE.format(status_str='', job_id=job_id)
+    msg = _JOB_WAITING_STATUS_MESSAGE.format(status_str='',
+                                             provision_str='',
+                                             job_id=job_id)
     status_display = rich_utils.safe_status(msg)
     num_tasks = managed_job_state.get_num_tasks(job_id)
 
@@ -1462,6 +1527,21 @@ def stream_logs_by_id(
             return (f'No task found matching {task!r} in job {job_id}. '
                     f'Valid task IDs are {valid_range}.',
                     exceptions.JobExitCode.NOT_FOUND)
+
+    # Follow the jobs controller log during provisioning so the user sees the
+    # same spinner messages that `sky launch` shows. The controller relays the
+    # inner cluster-launch rich-status payloads into its per-job log (see
+    # recovery_strategy._launch's relay_rich_status=True); here we decode them
+    # to drive the single status spinner.
+    controller_log_path = controller_log_file_for_job(job_id)
+    provision_pos = 0
+    provision_msg: Optional[str] = None
+
+    def _latest_provision_status_msg() -> Optional[str]:
+        nonlocal provision_pos, provision_msg
+        provision_pos, provision_msg = read_provision_status_from_log(
+            controller_log_path, provision_pos, provision_msg)
+        return provision_msg
 
     with status_display:
         prev_msg = msg
@@ -1631,12 +1711,29 @@ def stream_logs_by_id(
                 logger.debug(
                     f'INFO: The log is not ready yet{status_str}. '
                     f'Waiting for {JOB_STATUS_CHECK_GAP_SECONDS} seconds.')
-                msg = _JOB_WAITING_STATUS_MESSAGE.format(status_str=status_str,
-                                                         job_id=job_id)
-                if msg != prev_msg:
-                    status_display.update(msg)
-                    prev_msg = msg
-                time.sleep(JOB_STATUS_CHECK_GAP_SECONDS)
+                # Poll the controller log frequently for provisioning spinner
+                # updates, but only re-check the (more expensive) managed job
+                # status every JOB_STATUS_CHECK_GAP_SECONDS.
+                waited = 0.0
+                while True:
+                    # Keep the "Waiting for task to start" context and append
+                    # the live cluster-launch status, so it's clear the job is
+                    # waiting on its cluster to be provisioned.
+                    provision_msg = _latest_provision_status_msg()
+                    provision_str = (
+                        '' if provision_msg is None else
+                        f'\n  [dim]Launching cluster:[/] {provision_msg}')
+                    msg = _JOB_WAITING_STATUS_MESSAGE.format(
+                        status_str=status_str,
+                        provision_str=provision_str,
+                        job_id=job_id)
+                    if msg != prev_msg:
+                        status_display.update(msg)
+                        prev_msg = msg
+                    if waited >= JOB_STATUS_CHECK_GAP_SECONDS:
+                        break
+                    time.sleep(_PROVISION_LOG_POLL_GAP_SECONDS)
+                    waited += _PROVISION_LOG_POLL_GAP_SECONDS
                 latest_task_id, managed_job_status = (
                     managed_job_state.get_latest_task_id_status(job_id))
                 # Preserve filtered task_id if specified

--- a/sky/utils/rich_utils.py
+++ b/sky/utils/rich_utils.py
@@ -299,8 +299,20 @@ def client_status(msg: str) -> Union['rich_console.Status', _NoOpConsoleStatus]:
 
 
 def decode_rich_status(
-        response: 'requests.Response') -> Iterator[Optional[str]]:
-    """Decode the rich status message from the response."""
+        response: 'requests.Response',
+        relay_rich_status: bool = False) -> Iterator[Optional[str]]:
+    """Decode the rich status message from the response.
+
+    Args:
+        response: The HTTP response to decode.
+        relay_rich_status: If True, encoded rich-status control payloads are
+            forwarded verbatim (yielded as raw lines) instead of being rendered
+            into a local spinner. This lets a process that is not itself the
+            final consumer (e.g. the managed jobs controller streaming an inner
+            cluster launch into its per-job log) preserve the spinner control
+            codes so that a downstream reader can re-render the spinner. See
+            ``sky/jobs/recovery_strategy.py``.
+    """
     decoding_status = None
     try:
         last_line = ''
@@ -381,6 +393,13 @@ def decode_rich_status(
                 if control == Control.RETRY:
                     raise exceptions.RequestInterruptedError(
                         'Streaming interrupted. Please retry.')
+                if relay_rich_status:
+                    # Forward the encoded payload verbatim instead of rendering
+                    # it locally. Heartbeats are control-plane only and are
+                    # dropped to avoid bloating the relayed log.
+                    if control != Control.HEARTBEAT:
+                        yield line
+                    continue
                 # control is not None, i.e. it is a rich status control message.
                 if threading.current_thread() is not threading.main_thread():
                     yield None

--- a/sky/utils/rich_utils.py
+++ b/sky/utils/rich_utils.py
@@ -395,10 +395,15 @@ def decode_rich_status(
                         'Streaming interrupted. Please retry.')
                 if relay_rich_status:
                     # Forward the encoded payload verbatim instead of rendering
-                    # it locally. Heartbeats are control-plane only and are
-                    # dropped to avoid bloating the relayed log.
+                    # it locally. Heartbeats are control-plane only and are not
+                    # relayed (they would bloat the log), but we still yield
+                    # None for them so `stream_response` advances its progress
+                    # counter and the `retry_transient_errors` decorator sees
+                    # forward progress during quiet provisioning phases.
                     if control != Control.HEARTBEAT:
                         yield line
+                    else:
+                        yield None
                     continue
                 # control is not None, i.e. it is a rich status control message.
                 if threading.current_thread() is not threading.main_thread():

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -1118,3 +1118,21 @@ class TestReadProvisionStatusFromLog:
             f.write('\n')
         _, msg2 = jobs_utils.read_provision_status_from_log(str(path), pos, msg)
         assert msg2 == 'half'
+
+
+class TestProvisionStatusHeadline:
+    """Tests for extracting the blue headline from a provisioning message."""
+
+    def test_extracts_blue_headline_and_drops_hint(self):
+        msg = ('[bold cyan]Preparing SkyPilot runtime (1/3)[/]  '
+               '[dim]View logs at: ~/sky_logs/x/provision.log[/]')
+        assert (jobs_utils._provision_status_headline(msg) ==
+                'Preparing SkyPilot runtime (1/3)')
+
+    def test_headline_without_hint(self):
+        msg = '[bold cyan]Launching[/]'
+        assert jobs_utils._provision_status_headline(msg) == 'Launching'
+
+    def test_returns_none_when_not_blue(self):
+        # No [bold cyan] wrapper: nothing should be displayed.
+        assert jobs_utils._provision_status_headline('Launching') is None

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -1057,3 +1057,64 @@ class TestFormatJobDetails:
         # No cloud info -> surface the reason without a (possibly wrong) hint.
         result = self._details(recovery_reason='podX OOMKilled (exit code 137)')
         assert result == 'Recovering: podX OOMKilled (exit code 137)'
+
+
+class TestReadProvisionStatusFromLog:
+    """Tests for relaying the provisioning spinner from the controller log."""
+
+    @staticmethod
+    def _status_line(control, msg=''):
+        from sky.utils import message_utils
+        return message_utils.encode_payload(control.encode(msg))
+
+    def test_missing_file_returns_inputs(self, tmp_path):
+        path = str(tmp_path / 'missing.log')
+        pos, msg = jobs_utils.read_provision_status_from_log(path, 0, 'prev')
+        assert pos == 0
+        assert msg == 'prev'
+
+    def test_reads_latest_spinner_message_incrementally(self, tmp_path):
+        from sky.utils import rich_utils
+        path = tmp_path / 'controller.log'
+        path.write_text('a plain provisioning log line\n' +
+                        self._status_line(rich_utils.Control.INIT, 'Launching'))
+
+        pos, msg = jobs_utils.read_provision_status_from_log(str(path), 0, None)
+        assert msg == 'Launching'
+        assert pos > 0
+
+        # Append an UPDATE; only the newly appended bytes should be read.
+        with open(path, 'a', encoding='utf-8') as f:
+            f.write(
+                self._status_line(rich_utils.Control.UPDATE,
+                                  'Preparing SkyPilot runtime (1/3)'))
+        pos2, msg2 = jobs_utils.read_provision_status_from_log(
+            str(path), pos, msg)
+        assert msg2 == 'Preparing SkyPilot runtime (1/3)'
+        assert pos2 > pos
+
+    def test_stop_control_clears_message(self, tmp_path):
+        from sky.utils import rich_utils
+        path = tmp_path / 'controller.log'
+        path.write_text(
+            self._status_line(rich_utils.Control.INIT, 'Launching') +
+            self._status_line(rich_utils.Control.EXIT))
+        _, msg = jobs_utils.read_provision_status_from_log(str(path), 0, None)
+        assert msg is None
+
+    def test_partial_trailing_line_is_not_consumed(self, tmp_path):
+        from sky.utils import rich_utils
+        path = tmp_path / 'controller.log'
+        full = self._status_line(rich_utils.Control.INIT, 'Launching')
+        # Write a complete payload plus a partial (no trailing newline) one.
+        partial = self._status_line(rich_utils.Control.UPDATE,
+                                    'half').rstrip('\n')
+        path.write_text(full + partial)
+
+        pos, msg = jobs_utils.read_provision_status_from_log(str(path), 0, None)
+        assert msg == 'Launching'
+        # Complete the partial line; the next read should pick it up.
+        with open(path, 'a', encoding='utf-8') as f:
+            f.write('\n')
+        _, msg2 = jobs_utils.read_provision_status_from_log(str(path), pos, msg)
+        assert msg2 == 'half'

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -1119,6 +1119,45 @@ class TestReadProvisionStatusFromLog:
         _, msg2 = jobs_utils.read_provision_status_from_log(str(path), pos, msg)
         assert msg2 == 'half'
 
+    def test_start_does_not_revert_to_stale_message(self, tmp_path):
+        from sky.utils import rich_utils
+        path = tmp_path / 'controller.log'
+        # A nested status enter emits UPDATE(nested) then START(original); the
+        # START carries the stale init message, so it must not overwrite the
+        # live UPDATE text.
+        path.write_text(
+            self._status_line(rich_utils.Control.INIT, 'Launching') +
+            self._status_line(rich_utils.Control.UPDATE,
+                              'Preparing SkyPilot runtime (1/3)') +
+            self._status_line(rich_utils.Control.START, 'Launching'))
+        _, msg = jobs_utils.read_provision_status_from_log(str(path), 0, None)
+        assert msg == 'Preparing SkyPilot runtime (1/3)'
+
+    def test_stop_keeps_message(self, tmp_path):
+        from sky.utils import rich_utils
+        path = tmp_path / 'controller.log'
+        # STOP only pauses the spinner; it must not clear the message.
+        path.write_text(
+            self._status_line(rich_utils.Control.INIT, 'Launching') +
+            self._status_line(rich_utils.Control.STOP))
+        _, msg = jobs_utils.read_provision_status_from_log(str(path), 0, None)
+        assert msg == 'Launching'
+
+    def test_truncated_log_resets_offset(self, tmp_path):
+        from sky.utils import rich_utils
+        path = tmp_path / 'controller.log'
+        path.write_text(
+            self._status_line(rich_utils.Control.INIT, 'Launching') +
+            self._status_line(rich_utils.Control.UPDATE, 'Preparing'))
+        pos, msg = jobs_utils.read_provision_status_from_log(str(path), 0, None)
+        assert msg == 'Preparing'
+        assert pos > 0
+
+        # Recreate (truncate) the log; the saved offset now points past EOF.
+        path.write_text(self._status_line(rich_utils.Control.INIT, 'Relaunch'))
+        _, msg2 = jobs_utils.read_provision_status_from_log(str(path), pos, msg)
+        assert msg2 == 'Relaunch'
+
 
 class TestProvisionStatusHeadline:
     """Tests for extracting the blue headline from a provisioning message."""
@@ -1136,3 +1175,25 @@ class TestProvisionStatusHeadline:
     def test_returns_none_when_not_blue(self):
         # No [bold cyan] wrapper: nothing should be displayed.
         assert jobs_utils._provision_status_headline('Launching') is None
+
+    def test_nested_markup_is_preserved(self):
+        # Nested markup inside the headline must not be truncated at the first
+        # closing tag, and the trailing dim hint is still dropped.
+        msg = '[bold cyan]Doing [bold]X[/] now[/]  [dim]hint[/]'
+        assert (jobs_utils._provision_status_headline(msg) ==
+                'Doing [bold]X[/] now')
+
+
+class TestIsRelayedStatusPayloadLine:
+    """Tests for hiding relayed rich-status payloads from --controller logs."""
+
+    def test_payload_line_detected(self):
+        from sky.utils import message_utils
+        from sky.utils import rich_utils
+        line = message_utils.encode_payload(
+            rich_utils.Control.UPDATE.encode('Preparing'))
+        assert jobs_utils._is_relayed_status_payload_line(line) is True
+
+    def test_plain_log_line_not_detected(self):
+        assert jobs_utils._is_relayed_status_payload_line(
+            'Preparing SkyPilot runtime (1/3)\n') is False

--- a/tests/unit_tests/test_sky/server/test_sdk.py
+++ b/tests/unit_tests/test_sky/server/test_sdk.py
@@ -845,7 +845,7 @@ def test_stream_response_resumable_retry_skips_replayed_lines():
     output_stream = io.StringIO()
     decode_call_count = 0
 
-    def decode_side_effect(_response):
+    def decode_side_effect(_response, relay_rich_status=False):
         nonlocal decode_call_count
         decode_call_count += 1
         if decode_call_count == 1:

--- a/tests/unit_tests/test_sky/utils/test_rich_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_rich_utils.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import requests
 
+from sky.utils import message_utils
 from sky.utils import rich_utils
 
 
@@ -81,3 +82,44 @@ class RichUtilsTest(unittest.TestCase):
         # Verify the output
         joined_result = ''.join(r for r in result if r is not None)
         self.assertEqual(joined_result, progress_bar)
+
+    def test_decode_rich_status_relay_forwards_payloads_verbatim(self):
+        """relay_rich_status should forward encoded payloads as raw lines."""
+        status = rich_utils.EncodedStatusMessage('Launching')
+        init_line = status.init()
+        update_line = status.update('Preparing SkyPilot runtime (1/3)')
+        exit_line = status.exit()
+        chunks = [
+            b'Some provisioning log line\n',
+            init_line.encode('utf-8'),
+            update_line.encode('utf-8'),
+            exit_line.encode('utf-8'),
+        ]
+        mock_response = mock.MagicMock(spec=requests.Response)
+        mock_response.iter_content.return_value = chunks
+
+        result = list(
+            rich_utils.decode_rich_status(mock_response,
+                                          relay_rich_status=True))
+        # The plain log line plus every (non-heartbeat) control payload should
+        # be forwarded verbatim so a downstream reader can re-render the
+        # spinner.
+        self.assertIn('Some provisioning log line\n', result)
+        self.assertIn(init_line, result)
+        self.assertIn(update_line, result)
+        self.assertIn(exit_line, result)
+        # No control payload should have been swallowed (the default
+        # non-relay path would consume them and yield None instead).
+        self.assertNotIn(None, result)
+
+    def test_decode_rich_status_relay_drops_heartbeat(self):
+        """Heartbeats must not be relayed (they would bloat the log)."""
+        heartbeat = message_utils.encode_payload(
+            rich_utils.Control.HEARTBEAT.encode(''))
+        mock_response = mock.MagicMock(spec=requests.Response)
+        mock_response.iter_content.return_value = [heartbeat.encode('utf-8')]
+
+        result = list(
+            rich_utils.decode_rich_status(mock_response,
+                                          relay_rich_status=True))
+        self.assertEqual([r for r in result if r is not None], [])

--- a/tests/unit_tests/test_sky/utils/test_rich_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_rich_utils.py
@@ -113,7 +113,12 @@ class RichUtilsTest(unittest.TestCase):
         self.assertNotIn(None, result)
 
     def test_decode_rich_status_relay_drops_heartbeat(self):
-        """Heartbeats must not be relayed (they would bloat the log)."""
+        """Heartbeats are not relayed, but still yield None for retry progress.
+
+        The encoded payload must not reach the log (it would bloat it), yet we
+        still yield None so `stream_response` advances its progress counter and
+        the retry decorator sees forward progress during quiet phases.
+        """
         heartbeat = message_utils.encode_payload(
             rich_utils.Control.HEARTBEAT.encode(''))
         mock_response = mock.MagicMock(spec=requests.Response)
@@ -122,4 +127,8 @@ class RichUtilsTest(unittest.TestCase):
         result = list(
             rich_utils.decode_rich_status(mock_response,
                                           relay_rich_status=True))
+        # The encoded heartbeat line is not relayed...
+        self.assertNotIn(heartbeat, result)
         self.assertEqual([r for r in result if r is not None], [])
+        # ...but a None is yielded so progress_count still advances.
+        self.assertEqual(result, [None])


### PR DESCRIPTION
## Summary

`sky jobs launch` previously showed no provisioning progress: the cluster launch runs asynchronously inside the jobs controller, whose rich-status spinner codes were consumed (and dropped on a worker thread) there and never reached the client. Until the job started running, users only saw a generic `Waiting for task to start` message — unlike `sky launch`, which shows a live spinner with `Pulling images`, `Preparing SkyPilot runtime (1/3)`, etc.

This bridges the provisioning spinner from the controller to the client:

- **Relay mode** (`relay_rich_status`, default off) added to `decode_rich_status` / `stream_response` / `stream_and_get`: forwards encoded rich-status payloads verbatim instead of rendering or dropping them. Heartbeats are skipped; `RETRY` still propagates.
- **Controller** (`recovery_strategy._launch`) streams the inner cluster launch with relay enabled, so the provisioning spinner codes are preserved in the per-job controller log — the durable buffer that bridges the async gap between provisioning starting and the user attaching.
- **Client** (`stream_logs_by_id`) follows that controller log during the pre-`RUNNING` phase (`read_provision_status_from_log`) and drives the single existing status spinner with the live provisioning status, then switches to job logs once running.

The provisioning status is appended **under** the `Waiting for task to start` line (preserving the job-launch context), and only the colored headline is shown, restyled dim:

```
⠴ Waiting for task to start (status: STARTING). It may take a few minutes.
  Preparing SkyPilot runtime (1/3 - initializing)
  View controller logs: sky jobs logs --controller 5
```

Falls back to the original generic waiting message when no spinner is available (job still queued, pool jobs, old controllers), so behavior is backward compatible. Old client + new controller still works (the spinner is driven server-side via standard rich payloads the old client already decodes).

## Test plan

Unit tests:
- `tests/unit_tests/test_sky/utils/test_rich_utils.py`: relay forwards payloads verbatim; relay drops heartbeats.
- `tests/unit_tests/test_sky/jobs/test_utils.py`: `read_provision_status_from_log` incremental reads, STOP/EXIT clearing, partial-line safety; `_provision_status_headline` blue-headline extraction and fallback.
- Updated an existing `test_sdk.py` mock to accept the new kwarg.
- `bash format.sh` clean (mypy, pylint 10/10); affected unit suites pass.

Manual:
1. `sky api stop && sky api start`.
2. `sky jobs launch task.yaml` on a task that provisions a fresh cluster (ideally with an image pull).
3. Observe the live provisioning status appended under `Waiting for task to start` (e.g. `Launching` → `Preparing SkyPilot runtime (1/3 …)`) before it switches to streaming job logs — matching `sky launch`.
4. Cross-check the same progress in `sky jobs logs --controller <job-id>`.
5. Backward-compat: with an old controller (no relay), the command falls back to the previous generic waiting spinner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->