### PR TITLE
[Core] Inline encode_payload in ray-status command to skip remote `import sky`

### DIFF
--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -4,9 +4,11 @@ from concurrent import futures
 import functools
 import gzip
 import hashlib
+import inspect
 import json
 import os
 import shlex
+import textwrap
 import time
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -26,6 +28,7 @@ from sky.utils import accelerator_registry
 from sky.utils import command_runner
 from sky.utils import common_utils
 from sky.utils import env_options
+from sky.utils import message_utils
 from sky.utils import resources_utils
 from sky.utils import source_utils
 from sky.utils import subprocess_utils
@@ -130,11 +133,34 @@ _READ_RAY_PORT_PY = (
     f'\'{constants.SKY_RUNTIME_DIR_ENV_VAR_KEY}\', \'~\')); '
     'print(json.load(open(os.path.join(d, '
     f'\'{constants.SKY_REMOTE_RAY_PORT_FILE}\')))[\'ray_port\'])')
+
+
+def _build_inlined_encode_payload_script() -> str:
+    """Build a stdlib-only python script that encodes ``{'ray_port': $RAY_PORT}``
+    using the same payload format as ``message_utils.encode_payload``.
+
+    Importing ``sky.utils.message_utils`` on the remote head pulls in the full
+    ``sky`` package (~2s cold start). The function itself is stdlib-only (json
+    + a string format), so we copy its source via ``inspect`` and inline it,
+    keeping the wire format coupled to the real implementation. A drift-guard
+    test (``tests/unit_tests/test_ray_port_inline_encode.py``) executes this
+    script in a fresh interpreter and compares against ``encode_payload``.
+    """
+    encode_src = textwrap.dedent(inspect.getsource(message_utils.encode_payload))
+    return (f'_PAYLOAD_STR = {message_utils._PAYLOAD_STR!r}\n'  # pylint: disable=protected-access
+            f'from typing import Any, Optional\n'
+            f'import json\n'
+            f'import os\n'
+            f'{encode_src}\n'
+            f'print(encode_payload({{"ray_port": int(os.environ["RAY_PORT"])}}))')
+
+
+_RAY_PORT_ENCODE_SCRIPT = _build_inlined_encode_payload_script()
 _RAY_PORT_COMMAND = (
     f'RAY_PORT=$({constants.SKY_PYTHON_CMD} -c "{_READ_RAY_PORT_PY}" '
-    f'2> /dev/null || echo {constants.SKY_REMOTE_RAY_PORT});'
-    f'{constants.SKY_PYTHON_CMD} -c "from sky.utils import message_utils; '
-    'print(message_utils.encode_payload({\'ray_port\': $RAY_PORT}))"')
+    f'2> /dev/null || echo {constants.SKY_REMOTE_RAY_PORT}); '
+    f'RAY_PORT=$RAY_PORT {constants.SKY_PYTHON_CMD} -c '
+    f'{shlex.quote(_RAY_PORT_ENCODE_SCRIPT)}')
 
 # Command that calls `ray status` with SkyPilot's Ray port set.
 RAY_STATUS_WITH_SKY_RAY_PORT_COMMAND = (

--- a/tests/unit_tests/test_ray_port_inline_encode.py
+++ b/tests/unit_tests/test_ray_port_inline_encode.py
@@ -1,0 +1,55 @@
+"""Drift guard for the inlined ray_port encode script in instance_setup.
+
+The remote ray-status command embeds a stdlib-only copy of
+``message_utils.encode_payload`` (built via ``inspect.getsource``) so the head
+pod doesn't pay the ~2s ``import sky`` tax to encode a single integer. This
+test executes that inlined script in a fresh interpreter and asserts the wire
+format matches what ``encode_payload`` produces — so the next time anyone
+changes ``encode_payload`` in a way the inlining can't handle (new module-level
+state, an annotation that references ``sky.*``, etc.), CI fails here.
+"""
+import os
+import subprocess
+import sys
+
+from sky.provision import instance_setup
+from sky.utils import message_utils
+
+
+def _run_inlined_script(ray_port: int) -> str:
+    env = {**os.environ, 'RAY_PORT': str(ray_port)}
+    return subprocess.check_output(
+        [sys.executable, '-c', instance_setup._RAY_PORT_ENCODE_SCRIPT],
+        env=env,
+        text=True,
+    )
+
+
+def test_inlined_encode_matches_real_encode_payload():
+    """The inlined script must produce the same bytes as
+    ``print(encode_payload(...))``."""
+    for port in (6380, 6379, 12345):
+        out = _run_inlined_script(port)
+        # The remote runs ``print(encode_payload(...))``, so the captured
+        # stdout has encode_payload's trailing newline plus print's newline.
+        expected = message_utils.encode_payload({'ray_port': port}) + '\n'
+        assert out == expected, (
+            f'inlined script drift for port={port}:\n'
+            f'  got      : {out!r}\n  expected : {expected!r}')
+
+
+def test_inlined_encode_decodes_with_decode_payload():
+    """``decode_payload`` (consumer in provisioner.py) must accept the
+    inlined script's output and recover the original port."""
+    for port in (6380, 6379, 12345):
+        out = _run_inlined_script(port)
+        decoded = message_utils.decode_payload(out)
+        assert decoded == {'ray_port': port}, decoded
+
+
+def test_inlined_script_does_not_import_sky():
+    """The inlined script must not contain ``import sky`` or
+    ``from sky``: that's the entire point of inlining."""
+    script = instance_setup._RAY_PORT_ENCODE_SCRIPT
+    assert 'import sky' not in script, script
+    assert 'from sky' not in script, script


### PR DESCRIPTION
## Summary

The remote `RAY_STATUS_WITH_SKY_RAY_PORT_COMMAND` paid a ~2s `import sky` cost just to base64-encode a single integer (the ray port) via `from sky.utils import message_utils`. Importing any `sky.*` module pulls in the full top-level `sky` package (25+ clouds, the SDK, jobs, storage, optimizer, …), which is the actual cost — `encode_payload` itself is stdlib-only (`json` + a string format).

This PR replaces the second `python -c` invocation inside `_RAY_PORT_COMMAND` with an `inspect.getsource`-built stdlib-only copy of `encode_payload`, keeping the wire format byte-identical (still consumed by `provisioner.py:634` via `decode_payload`). Using `inspect` means the inlined script is always coupled to the real implementation — if `encode_payload` changes, the next run picks it up automatically.

A drift-guard unit test executes the inlined script in a fresh interpreter and asserts the output matches `encode_payload` byte-for-byte and decodes cleanly via `decode_payload`, so any future change the inlining can't handle (new module-level state, a `sky.*` annotation, etc.) trips CI here.

## Measurement

Full `RAY_STATUS_WITH_SKY_RAY_PORT_COMMAND` (the actual hot-path command in status refresh):

| | run 1 | run 2 | run 3 | mean |
|---|---|---|---|---|
| OLD | 2.535s | 2.200s | 2.169s | **2.30s** |
| NEW | 1.048s | 1.070s | 1.037s | **1.05s** |
| **Δ** | -1.49s | -1.13s | -1.13s | **-1.25s / call** |

Just the encode step (5 runs each):

| | range |
|---|---|
| OLD (`from sky.utils import message_utils`) | 1.17–1.24s |
| NEW (inlined, stdlib only) | 0.025–0.027s |

Per-cluster status refresh saves ~1.25s on the wallclock of the ray-status step.

## Test plan

- [x] `pytest tests/unit_tests/test_ray_port_inline_encode.py` — 3 tests:
    - inlined output is byte-identical to `print(encode_payload(...))`
    - `decode_payload` (consumer in `provisioner.py:634`) recovers the original port
    - the inlined script contains no `import sky` / `from sky`
- [x] Verified on a live k8s pod that `RAY_STATUS_WITH_SKY_RAY_PORT_COMMAND` produces byte-identical output (same `<sky-payload>{"ray_port": 6380}</sky-payload>` and same `Autoscaler status` block).
- [ ] Smoke test: `sky launch` a small cluster on k8s, then `sky status -r` to exercise refresh through `_update_cluster_status` → `RAY_STATUS_WITH_SKY_RAY_PORT_COMMAND`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->