### PR TITLE
[Kubernetes] Treat pods as scheduled on binding, not on container status

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -91,6 +91,37 @@ def _get_head_pod_name(pods: Dict[str, Any]) -> Optional[str]:
                 None)
 
 
+def _pod_is_scheduled(pod) -> bool:
+    """Whether the kube-scheduler has bound this pod to a node.
+
+    The scheduler sets ``spec.nodeName`` (and the ``PodScheduled`` status
+    condition to ``True``) the moment it places a pod -- i.e. capacity has
+    been found. The kubelet on the target node only later populates
+    ``status.container_statuses`` / ``host_ip`` once it picks the pod up and
+    starts the sandbox. That kubelet pickup can occasionally lag past
+    ``provision_timeout`` when the control plane is slow to propagate the
+    binding to the kubelet, even though the pod is already bound to a node.
+
+    We treat a bound pod as scheduled so that provisioning hands off to
+    ``_wait_for_pods_to_run`` (which waits for containers without the short
+    ``provision_timeout``) instead of failing over as if the cluster were out
+    of resources. A genuinely unschedulable pod keeps ``PodScheduled`` False
+    and no ``nodeName``, so it stays in the scheduling wait loop.
+    """
+    # Running/Succeeded/Failed pods are clearly past scheduling; Failed pods
+    # are surfaced as errors later in _wait_for_pods_to_run.
+    if pod.status.phase != 'Pending':
+        return True
+    # spec.nodeName is set atomically when the scheduler binds the pod.
+    if pod.spec.node_name:
+        return True
+    # Fall back to the PodScheduled status condition.
+    for condition in (pod.status.conditions or []):
+        if condition.type == 'PodScheduled' and condition.status == 'True':
+            return True
+    return False
+
+
 def _get_pvc_name(cluster_name: str, volume_name: str) -> str:
     return f'{cluster_name}-{volume_name}'
 
@@ -615,16 +646,14 @@ def _wait_for_pods_to_schedule(namespace, context, new_nodes, timeout: int,
             time.sleep(0.5)
             continue
 
-        # Check if all pods are scheduled
-        all_scheduled = True
-        for pod in pods:
-            if (pod.metadata.name in expected_pod_names and
-                    pod.status.phase == 'Pending'):
-                # If container_statuses is None, then the pod hasn't
-                # been scheduled yet.
-                if pod.status.container_statuses is None:
-                    all_scheduled = False
-                    break
+        # A pod is considered scheduled once the kube-scheduler has bound it
+        # to a node (capacity found). We deliberately do not wait for the
+        # kubelet to populate container_statuses here -- that can lag and is
+        # handled by _wait_for_pods_to_run, which has no provision_timeout.
+        all_scheduled = all(
+            _pod_is_scheduled(pod)
+            for pod in pods
+            if pod.metadata.name in expected_pod_names)
 
         if all_scheduled:
             return

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -831,11 +831,18 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
                     context, namespace, pod.metadata.name)
                 if pending_reason is not None:
                     reason, event_message = pending_reason
-            if reason is not None:
-                log_msg = f'Pod {pod.metadata.name} is pending: {reason}'
-                if event_message:
-                    log_msg += f': {event_message}'
-                logger.debug(log_msg)
+            if reason is None:
+                # A freshly-bound pod that the kubelet has not picked up yet
+                # (and the uninformative 'ContainerCreating' state) has no
+                # container-status reason and no event yet. Default to
+                # 'container creation' so the launch spinner shows useful
+                # detail (e.g. 'Launching (1 pod(s) pending due to container
+                # creation)') instead of a bare 'Launching'.
+                reason = 'container creation'
+            log_msg = f'Pod {pod.metadata.name} is pending: {reason}'
+            if event_message:
+                log_msg += f': {event_message}'
+            logger.debug(log_msg)
             return False, reason
 
         # phase == 'Running' but not all containers running (e.g. one is in

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -831,18 +831,21 @@ def _wait_for_pods_to_run(namespace, context, cluster_name, new_pods):
                     context, namespace, pod.metadata.name)
                 if pending_reason is not None:
                     reason, event_message = pending_reason
-            if reason is None:
+            if reason is None and _pod_is_scheduled(pod):
                 # A freshly-bound pod that the kubelet has not picked up yet
                 # (and the uninformative 'ContainerCreating' state) has no
                 # container-status reason and no event yet. Default to
                 # 'container creation' so the launch spinner shows useful
                 # detail (e.g. 'Launching (1 pod(s) pending due to container
-                # creation)') instead of a bare 'Launching'.
+                # creation)') instead of a bare 'Launching'. Gate on
+                # _pod_is_scheduled so an unbound pod still waiting for
+                # capacity is not mislabeled as creating a container.
                 reason = 'container creation'
-            log_msg = f'Pod {pod.metadata.name} is pending: {reason}'
-            if event_message:
-                log_msg += f': {event_message}'
-            logger.debug(log_msg)
+            if reason is not None:
+                log_msg = f'Pod {pod.metadata.name} is pending: {reason}'
+                if event_message:
+                    log_msg += f': {event_message}'
+                logger.debug(log_msg)
             return False, reason
 
         # phase == 'Running' but not all containers running (e.g. one is in

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -1320,10 +1320,11 @@ class TestWaitForPodsToScheduleAutoscaleTimeout:
 
     @staticmethod
     def _make_pending_pod(name: str, cluster_name_on_cloud: str):
-        """Build a pod that is Pending with no container_statuses.
+        """Build a pod that is Pending and not yet bound by the scheduler.
 
-        This represents a pod that has not yet been scheduled — the loop
-        should keep waiting for it.
+        This represents a pod that has not yet been scheduled — no
+        spec.node_name and no PodScheduled=True condition — so the loop
+        should keep waiting for it (and eventually time out).
         """
         from sky.provision import constants as prov_constants
         pod = mock.MagicMock()
@@ -1333,6 +1334,12 @@ class TestWaitForPodsToScheduleAutoscaleTimeout:
         }
         pod.status.phase = 'Pending'
         pod.status.container_statuses = None
+        # The scheduler has not bound this pod: no node assignment and no
+        # PodScheduled=True condition. Set explicitly so the MagicMock does
+        # not auto-create truthy attributes that _pod_is_scheduled would
+        # misread as "bound".
+        pod.spec.node_name = None
+        pod.status.conditions = []
         return pod
 
     def _setup(self, monkeypatch, autoscaler_type, autoscale_detected):
@@ -1598,6 +1605,183 @@ class TestWaitForPodsToScheduleAutoscaleTimeout:
         kwargs = launch_progress_calls[0].kwargs
         assert kwargs['reason'].startswith('Launching (')
         assert kwargs['nop_if_duplicate'] is True
+
+
+class TestWaitForPodsToScheduleBoundPod:
+    """Tests that _wait_for_pods_to_schedule treats a pod as scheduled once
+    the kube-scheduler has bound it to a node, even before the kubelet has
+    populated status.container_statuses.
+
+    Regression: the previous implementation decided a pod was scheduled by
+    checking ``container_statuses is not None``. container_statuses is
+    populated by the kubelet only after it picks the pod up and starts the
+    sandbox, which can lag the scheduler binding when the control plane is
+    slow to propagate the binding to the kubelet. At the provision_timeout
+    deadline a fully bound pod (PodScheduled True / spec.node_name set) could
+    still have container_statuses == None and be wrongly reported as out of
+    resources. The function must instead hand off to _wait_for_pods_to_run.
+    """
+
+    @staticmethod
+    def _make_node(name: str, cluster_name_on_cloud: str):
+        from sky.provision import constants as prov_constants
+        node = mock.MagicMock()
+        node.metadata.name = name
+        node.metadata.labels = {
+            prov_constants.TAG_SKYPILOT_CLUSTER_NAME: cluster_name_on_cloud
+        }
+        return node
+
+    @staticmethod
+    def _make_bound_pending_pod(name: str,
+                                cluster_name_on_cloud: str,
+                                node_name=None,
+                                pod_scheduled_condition: bool = False):
+        """A Pending pod that the scheduler has bound but the kubelet has not
+        yet picked up: container_statuses / host_ip / start_time are still
+        None. Binding is expressed via spec.node_name and/or a PodScheduled
+        condition.
+        """
+        from sky.provision import constants as prov_constants
+        pod = mock.MagicMock()
+        pod.metadata.name = name
+        pod.metadata.labels = {
+            prov_constants.TAG_SKYPILOT_CLUSTER_NAME: cluster_name_on_cloud
+        }
+        pod.status.phase = 'Pending'
+        # The kubelet has not populated any of these yet.
+        pod.status.container_statuses = None
+        pod.status.host_ip = None
+        pod.status.start_time = None
+        # The scheduler has bound the pod.
+        pod.spec.node_name = node_name
+        if pod_scheduled_condition:
+            cond = mock.MagicMock()
+            cond.type = 'PodScheduled'
+            cond.status = 'True'
+            pod.status.conditions = [cond]
+        else:
+            pod.status.conditions = []
+        return pod
+
+    @staticmethod
+    def _make_unbound_pending_pod(name: str, cluster_name_on_cloud: str):
+        """A Pending pod the scheduler has NOT bound: no node_name and no
+        PodScheduled=True condition. This pod is genuinely unschedulable and
+        must keep the loop waiting until the timeout.
+        """
+        from sky.provision import constants as prov_constants
+        pod = mock.MagicMock()
+        pod.metadata.name = name
+        pod.metadata.labels = {
+            prov_constants.TAG_SKYPILOT_CLUSTER_NAME: cluster_name_on_cloud
+        }
+        pod.status.phase = 'Pending'
+        pod.status.container_statuses = None
+        pod.status.host_ip = None
+        pod.status.start_time = None
+        pod.spec.node_name = None
+        pod.status.conditions = []
+        return pod
+
+    @staticmethod
+    def _wire_common_mocks(monkeypatch, pod, autoscaler_type=None):
+        """Mock config lookup, core_api, autoscale detection and the
+        error-surfacing path. Returns the raise_errors marker mock."""
+
+        def mock_config(cloud, region, keys, default_value=None, **kwargs):
+            if keys == ('autoscaler',):
+                return autoscaler_type
+            return default_value
+
+        monkeypatch.setattr('sky.skypilot_config.get_effective_region_config',
+                            mock_config)
+
+        pods_list = mock.MagicMock()
+        pods_list.items = [pod]
+        core_api = mock.MagicMock()
+        core_api.list_namespaced_pod.return_value = pods_list
+        monkeypatch.setattr('sky.adaptors.kubernetes.core_api',
+                            lambda *a, **kw: core_api)
+
+        monkeypatch.setattr(instance, '_cluster_had_autoscale_event',
+                            lambda *a, **kw: False)
+        monkeypatch.setattr(instance, '_cluster_maybe_autoscaling',
+                            lambda *a, **kw: False)
+
+        raise_errors = mock.MagicMock(
+            side_effect=config_lib.KubernetesError('simulated-timeout'))
+        monkeypatch.setattr(instance, '_raise_pod_scheduling_errors',
+                            raise_errors)
+        monkeypatch.setattr('sky.utils.rich_utils.force_update_status',
+                            lambda *a, **kw: None)
+        return raise_errors
+
+    @pytest.mark.parametrize('node_name, pod_scheduled_condition', [
+        ('node-1', False),
+        (None, True),
+        ('node-1', True),
+    ])
+    def test_bound_pending_pod_without_container_statuses_returns(
+            self, monkeypatch, node_name, pod_scheduled_condition):
+        """The regression case: a bound but not-yet-picked-up pod (no
+        container_statuses / host_ip) must be treated as scheduled, so the
+        function returns promptly without raising — handing off to
+        _wait_for_pods_to_run."""
+        cluster_name_on_cloud = 'my-cluster'
+        pod = self._make_bound_pending_pod(
+            'pod-0',
+            cluster_name_on_cloud,
+            node_name=node_name,
+            pod_scheduled_condition=pod_scheduled_condition)
+        raise_errors = self._wire_common_mocks(monkeypatch, pod)
+
+        node = self._make_node('pod-0', cluster_name_on_cloud)
+        import datetime  # pylint: disable=import-outside-toplevel
+
+        # A positive timeout; the function must return well before it without
+        # raising because the pod is bound.
+        instance._wait_for_pods_to_schedule(
+            namespace='ns',
+            context='test-context',
+            new_nodes=[node],
+            timeout=30,
+            cluster_name='cn',
+            create_pods_start=datetime.datetime.now(datetime.timezone.utc))
+
+        assert not raise_errors.called, (
+            'A bound pod (scheduler placed it) must not trigger the '
+            'out-of-resources error path even though the kubelet has not '
+            'populated container_statuses yet.')
+
+    def test_unbound_pending_pod_times_out_and_raises(self, monkeypatch):
+        """A genuinely unschedulable pod (no node_name, no PodScheduled=True)
+        must keep the loop waiting and eventually raise once the timeout
+        elapses."""
+        cluster_name_on_cloud = 'my-cluster'
+        pod = self._make_unbound_pending_pod('pod-0', cluster_name_on_cloud)
+        # No autoscaler configured, so the timeout is not bumped to the
+        # autoscaler minimum and stays at the tiny value below.
+        raise_errors = self._wire_common_mocks(monkeypatch,
+                                               pod,
+                                               autoscaler_type=None)
+
+        node = self._make_node('pod-0', cluster_name_on_cloud)
+        import datetime  # pylint: disable=import-outside-toplevel
+
+        with pytest.raises(config_lib.KubernetesError,
+                           match='simulated-timeout'):
+            instance._wait_for_pods_to_schedule(
+                namespace='ns',
+                context='test-context',
+                new_nodes=[node],
+                timeout=1,
+                cluster_name='cn',
+                create_pods_start=datetime.datetime.now(datetime.timezone.utc))
+
+        assert raise_errors.called, (
+            'An unbound (unschedulable) pod must drive the timeout/error '
+            'path.')
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -2752,6 +2752,31 @@ class TestInspectPodStatusTierIntegration:
         assert ('Launching (1 pod(s) pending due to container creation)'
                 in lp_calls[0].kwargs['reason'])
 
+    def test_pending_pod_not_scheduled_does_not_default_reason(
+            self, monkeypatch):
+        """A Pending pod the scheduler has NOT bound yet (no spec.node_name,
+        no PodScheduled=True) with no determinable reason must NOT be labeled
+        'container creation' -- it is still waiting for capacity, not creating
+        a container. _inspect_pod_status returns (False, None), so no
+        LAUNCH_PROGRESS row is emitted and the spinner stays a bare
+        'Launching'."""
+        pod = self._make_pod(
+            phase='Pending',
+            container_statuses=None,
+        )
+        pod.status.host_ip = None
+        # Not bound: no node assignment and no PodScheduled=True condition.
+        pod.spec.node_name = None
+        pod.status.conditions = []
+        # No events → tier-2 and tier-3 return None.
+        monkeypatch.setattr(instance, '_get_pod_events', lambda *a, **kw: [])
+        add_event = self._drive_one_iteration(monkeypatch, pod)
+        lp_calls = [
+            c for c in add_event.call_args_list if c.kwargs.get('event_type') is
+            instance.global_user_state.ClusterEventType.LAUNCH_PROGRESS
+        ]
+        assert not lp_calls
+
 
 class TestCheckInitContainersEnrichedRaise:
     """Tests the enriched raise message in _check_init_containers when an

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -2706,7 +2706,8 @@ class TestInspectPodStatusTierIntegration:
     def test_pending_pod_container_creating_does_not_raise(self, monkeypatch):
         """phase=Pending, ContainerCreating: tier-1 returns None, tier-2/3
         consulted, no raise. Smoke check that the happy in-flight case still
-        loops."""
+        loops. With no container-status reason and no event, the pending reason
+        defaults to 'container creation' so the spinner shows useful detail."""
         pod = self._make_pod(
             phase='Pending',
             container_statuses=[
@@ -2721,9 +2722,35 @@ class TestInspectPodStatusTierIntegration:
             c for c in add_event.call_args_list if c.kwargs.get('event_type') is
             instance.global_user_state.ClusterEventType.LAUNCH_PROGRESS
         ]
-        # Bare 'Launching' status text is skipped per the existing guard at
-        # instance.py:845. So no LAUNCH_PROGRESS row.
-        assert lp_calls == []
+        # The reason defaults to 'container creation', so a LAUNCH_PROGRESS row
+        # is emitted with the enriched 'Launching (...)' status text.
+        assert len(lp_calls) == 1
+        assert ('Launching (1 pod(s) pending due to container creation)'
+                in lp_calls[0].kwargs['reason'])
+
+    def test_pending_pod_bound_no_container_statuses_defaults_reason(
+            self, monkeypatch):
+        """A freshly-bound pod the kubelet has not picked up yet sits Pending
+        with container_statuses == None, host_ip == None, and no events. The
+        pending reason must default to 'container creation' so the spinner shows
+        'Launching (1 pod(s) pending due to container creation)' instead of a
+        bare 'Launching' during the kubelet-pickup window. We assert on the
+        LAUNCH_PROGRESS reason, whose value is the spinner status text."""
+        pod = self._make_pod(
+            phase='Pending',
+            container_statuses=None,
+        )
+        pod.status.host_ip = None
+        # No events → tier-2 and tier-3 return None, so the default kicks in.
+        monkeypatch.setattr(instance, '_get_pod_events', lambda *a, **kw: [])
+        add_event = self._drive_one_iteration(monkeypatch, pod)
+        lp_calls = [
+            c for c in add_event.call_args_list if c.kwargs.get('event_type') is
+            instance.global_user_state.ClusterEventType.LAUNCH_PROGRESS
+        ]
+        assert len(lp_calls) == 1
+        assert ('Launching (1 pod(s) pending due to container creation)'
+                in lp_calls[0].kwargs['reason'])
 
 
 class TestCheckInitContainersEnrichedRaise:


### PR DESCRIPTION
## Summary

`_wait_for_pods_to_schedule` (bounded by `provision_timeout`, which defaults to ~10s) decides whether a pod has been scheduled by checking `pod.status.container_statuses is not None`. But `container_statuses` is populated by the **kubelet** only after it picks the pod up and starts the sandbox — *after* the **kube-scheduler** has already bound the pod (`spec.nodeName` set / `PodScheduled` condition `True`).

When the control plane is slow to propagate the binding to the kubelet, a pod can be fully bound to a node at the `provision_timeout` deadline yet still have `container_statuses == None`. `_wait_for_pods_to_schedule` then raises:

```
KubernetesError: Timed out while waiting for nodes to start. Cluster may be out of resources or may be too slow to autoscale. Pod status: Pending
```

SkyPilot tears the cluster down, and failover surfaces a misleading `ResourcesUnavailableError` — even though capacity *was* found and the pods were placed on free nodes. This is most visible on clusters where the kubelet's own pod-start overhead (excluding image pull, i.e. `kubelet_pod_start_sli_duration_seconds`) routinely approaches the 10s window: the scheduler binds instantly, but a freshly-bound pod can still read `start_time` / `host_ip` / `container_statuses` all `None` when the deadline fires.

## Fix

Treat a pod as scheduled once the scheduler has **bound** it — `phase != Pending`, `spec.nodeName` set, or the `PodScheduled` condition is `True` — rather than waiting for the kubelet to populate `container_statuses`. A bound pod hands off to `_wait_for_pods_to_run`, which waits for containers to come up *without* the short `provision_timeout`.

Genuinely unschedulable pods keep `PodScheduled` False and no `nodeName`, so they remain in the scheduling wait loop. Out-of-resources detection and autoscaler handling are unchanged.

## Tested

- `pytest tests/unit_tests/kubernetes/test_provision.py` — **107 passed**.
- New `TestWaitForPodsToScheduleBoundPod`:
  - a bound Pending pod with `container_statuses == None` (binding expressed via `spec.nodeName` and/or `PodScheduled=True`) returns promptly without raising — handing off to `_wait_for_pods_to_run`;
  - an unbound Pending pod (no `nodeName`, no `PodScheduled=True`) still times out and raises `KubernetesError`.
- `format.sh` clean (yapf / isort / mypy / pylint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->