### PR TITLE
fix(data_utils): require container segment in is_az_container_endpoint

### DIFF
--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -425,7 +425,7 @@ def is_az_container_endpoint(endpoint_url: str) -> bool:
     # Storage account must be length of 3-24
     # Reference: https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftstorage # pylint: disable=line-too-long
     pattern = re.compile(
-        r'^https://([a-z0-9]{3,24})\.blob\.core\.windows\.net(/[^/]+)*$')
+        r'^https://([a-z0-9]{3,24})\.blob\.core\.windows\.net(/[^/]+)+$')
     match = pattern.match(endpoint_url)
     if match is None:
         return False

--- a/tests/unit_tests/test_sky/storage/test_data_utils.py
+++ b/tests/unit_tests/test_sky/storage/test_data_utils.py
@@ -7,6 +7,20 @@ from sky.adaptors import coreweave
 from sky.data import data_utils
 
 
+class TestIsAzContainerEndpoint:
+    """Tests for is_az_container_endpoint function."""
+
+    def test_bare_storage_account_url_returns_false(self):
+        """Bare storage-account URL (no container) must return False."""
+        assert not data_utils.is_az_container_endpoint(
+            'https://myaccount.blob.core.windows.net')
+
+    def test_valid_container_url_returns_true(self):
+        """URL with a container name must return True."""
+        assert data_utils.is_az_container_endpoint(
+            'https://myaccount.blob.core.windows.net/mycontainer')
+
+
 class TestSplitCoreweavePath:
     """Tests for split_coreweave_path function."""
 


### PR DESCRIPTION
## What's broken

`is_az_container_endpoint()` in `sky/data/data_utils.py` accepts bare storage-account URLs such as `https://myaccount.blob.core.windows.net` (no container name) because the path-component group uses `*` (zero-or-more). Callers in `storage.py` (lines 1326, 2022, etc.) then pass the URL to `split_az_path()`, which does `path_parts.pop(0)` on an empty list and raises `IndexError: pop from empty list`.

## Why it happens

The regex `(/[^/]+)*` allows zero path segments, so a URL with no container passes validation and reaches `split_az_path()` which unconditionally pops the container name from the path list.

## Fix

Changed `*` to `+` in the path-component group (`(/[^/]+)+`) so at least one `/container-name` segment is required for the URL to be considered a valid container endpoint.

## Test

Added `TestIsAzContainerEndpoint` in `tests/unit_tests/test_sky/storage/test_data_utils.py` with two cases: a bare storage-account URL asserts `False`, and a URL with a container name asserts `True`.

Fixes #9767
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->