### PR TITLE
[Jobs] Fix provisioning headline extraction regression in sky jobs launch

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1412,20 +1412,35 @@ def _is_relayed_status_payload_line(line: str) -> bool:
 def _provision_status_headline(provision_msg: str) -> Optional[str]:
     """Returns the blue headline of a provisioning spinner message.
 
-    Provisioning messages from the cluster launch look like
-    ``[bold cyan]Preparing SkyPilot runtime (1/3)[/]  [dim]<log hint>[/]``. We
-    keep only the colored (blue) headline and drop the trailing log-path hint,
-    so the caller can show it as a secondary detail under the "Waiting for task
-    to start" line. Returns ``None`` when the message has no blue headline, so
-    the caller can show nothing rather than a raw/unstyled message.
+    Provisioning messages from the cluster launch are built by
+    ``ux_utils.spinner_message`` and look like
+    ``[bold cyan]Preparing SkyPilot runtime (1/3)[/]  <dim log hint>``, where
+    the trailing hint is colored with raw ANSI (colorama) codes rather than
+    rich markup -- so the message does *not* end at the headline's ``[/]``. We
+    keep only the ``[bold cyan]...[/]`` headline and drop the trailing hint, so
+    the caller can show it as a secondary detail under the "Waiting for task to
+    start" line. Returns ``None`` when the message has no ``[bold cyan]``
+    headline, so the caller can show nothing rather than a raw/unstyled message.
     """
-    # Drop the trailing dim log-path hint (``  [dim]...[/]``), if any, then peel
-    # off the outer ``[bold cyan]...[/]`` wrapper. The inner capture is greedy
-    # so nested markup (e.g. ``[bold cyan]Doing [bold]X[/] now[/]``) is kept
-    # intact instead of being truncated at the first ``[/]``.
-    headline = re.sub(r'\s*\[dim\].*\[/\]\s*$', '', provision_msg)
-    match = re.match(r'\s*\[bold cyan\](.*)\[/\]\s*$', headline)
-    return match.group(1) if match else None
+    open_tag = '[bold cyan]'
+    start = provision_msg.find(open_tag)
+    if start == -1:
+        return None
+    start += len(open_tag)
+    # Walk the rich-markup tags after the opening tag, tracking nesting depth,
+    # and stop at the ``[/]`` that closes this ``[bold cyan]``. This keeps any
+    # nested markup (e.g. ``[bold]X[/]``) inside the headline intact -- instead
+    # of truncating at the first ``[/]`` -- and ignores the trailing log hint
+    # (which is ANSI-colored and contains no rich tags).
+    depth = 1
+    for match in re.finditer(r'\[[^\]]*\]', provision_msg[start:]):
+        if match.group(0).startswith('[/'):
+            depth -= 1
+            if depth == 0:
+                return provision_msg[start:start + match.start()]
+        else:
+            depth += 1
+    return None
 
 
 def stream_logs_by_id(

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -1183,6 +1183,25 @@ class TestProvisionStatusHeadline:
         assert (jobs_utils._provision_status_headline(msg) ==
                 'Doing [bold]X[/] now')
 
+    def test_extracts_headline_from_real_spinner_message(self):
+        # Regression: real spinner messages append the log hint with raw ANSI
+        # (colorama) codes, not rich `[dim]...[/]` markup, so the headline does
+        # not end the string. The headline must still be extracted (otherwise
+        # the provisioning detail under "Waiting for task to start" vanishes).
+        from sky.utils import ux_utils
+        msg = ux_utils.spinner_message('Preparing SkyPilot runtime (1/3)',
+                                       log_path='~/sky_logs/x/provision.log')
+        assert msg != '[bold cyan]Preparing SkyPilot runtime (1/3)[/]'
+        assert (jobs_utils._provision_status_headline(msg) ==
+                'Preparing SkyPilot runtime (1/3)')
+
+    def test_extracts_headline_with_provision_hint(self):
+        # The provision-log hint variant (sky logs --provision <cluster>) also
+        # appends an ANSI-colored, bold-wrapped hint after the headline.
+        from sky.utils import ux_utils
+        msg = ux_utils.spinner_message('Launching', cluster_name='my-cluster')
+        assert jobs_utils._provision_status_headline(msg) == 'Launching'
+
 
 class TestIsRelayedStatusPayloadLine:
     """Tests for hiding relayed rich-status payloads from --controller logs."""


### PR DESCRIPTION
## Summary

Follow-up fix to #9761. A review-feedback change in that PR rewrote `_provision_status_headline` (the helper that drives the provisioning detail line shown under `Waiting for task to start` during `sky jobs launch`) with a regex that broke the common case, so the provisioning status text no longer shows up.

- The rewritten regex anchored the headline close with `\[/\]\s*$` and stripped a `[dim]...[/]` hint. But real spinner messages from `ux_utils.spinner_message` append the log hint with **raw ANSI (colorama) codes**, not rich `[dim]...[/]` markup:

  ```
  [bold cyan]Preparing SkyPilot runtime (1/3)[/]  \x1b[2mView logs: ...\x1b[0m
  ```

  So the message does *not* end at the headline's `[/]`, and there is no literal `[dim]`. The anchored `re.match` matched nothing → `_provision_status_headline` returned `None` → the provisioning detail line disappeared.

- Replace it with a depth-aware scan from the `[bold cyan]` open tag to its matching `[/]`. This keeps nested markup intact (the original review nit that motivated the rewrite) **and** ignores the trailing ANSI hint (the common real case).

## Test plan

Unit tests (`tests/unit_tests/test_sky/jobs/test_utils.py::TestProvisionStatusHeadline`):
- Added `test_extracts_headline_from_real_spinner_message` and `test_extracts_headline_with_provision_hint`, which feed **real** `ux_utils.spinner_message` output (log-path and `--provision` hint variants) — the exact case the merged regex broke.
- Existing nested-markup / no-hint / non-blue cases still pass. 6/6 pass.

Manual:
1. `sky api stop && sky api start`.
2. `sky jobs launch task.yaml` on a task that provisions a fresh cluster.
3. Confirm the live provisioning detail (e.g. `Preparing SkyPilot runtime (1/3 …)`) again appears under `Waiting for task to start`, then switches to streaming job logs once running.

Direct before/after check:
```
OLD (merged) result: None        # text vanished
NEW result: Preparing SkyPilot runtime (1/3)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->