### PR TITLE
[Dashboard] Add plugin slot for top-bar icons

### DIFF
--- a/sky/dashboard/src/components/elements/sidebar.jsx
+++ b/sky/dashboard/src/components/elements/sidebar.jsx
@@ -646,6 +646,13 @@ export function TopBar() {
                   </a>
                 </CustomTooltip>
 
+                {/* Slot for plugin-provided top-bar icons (e.g. an icon with
+                    a dropdown panel). */}
+                <PluginSlot
+                  name="topbar.icons"
+                  wrapperClassName="flex items-center space-x-1"
+                />
+
                 <div className="border-l border-gray-200 h-6"></div>
 
                 {/* Version Display */}


### PR DESCRIPTION
## Summary

Adds a `topbar.icons` `PluginSlot` to the dashboard's top navigation bar so plugins can render icon-style controls (for example, an icon button that opens a dropdown panel) next to the existing Docs / GitHub / Slack / Feedback actions.

The dashboard already exposes `PluginSlot`s for page content (e.g. `clusters.detail.*`) and the user menu (`user-menu`), but the top bar's action area had no extension point for plugin-provided components — `registerTopNavLink` only renders a label/href link, not an interactive component. This change adds a single slot, rendered on desktop alongside the other top-bar icons.

```jsx
<PluginSlot
  name="topbar.icons"
  wrapperClassName="flex items-center space-x-1"
/>
```

`PluginSlot` is already imported in this file; no other changes are required. When no plugin registers into the slot, it renders nothing.

## Test plan

- Built the dashboard (`npm --prefix sky/dashboard run build`) — compiles cleanly.
- With no plugin registered, the top bar is unchanged (the slot renders `null`).
- Registering a component via `registerComponent({ slot: 'topbar.icons', component })` mounts it in the top bar action area, between the Feedback icon and the version display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/9773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->