### PR TITLE
[Azure] Cap azure-cli<2.87.0 (azure-mgmt-storage 25.0.0 breaks Azure storage)

### DIFF
--- a/.github/actions/run-python-tests/action.yaml
+++ b/.github/actions/run-python-tests/action.yaml
@@ -28,7 +28,7 @@ runs:
       run: |
         uv venv --seed ~/test-env
         source ~/test-env/bin/activate
-        uv pip install --prerelease=allow "azure-cli>=2.65.0"
+        uv pip install --prerelease=allow "azure-cli>=2.65.0,<2.87.0"
         # Use -e to include examples and tests folder in the path for unit
         # tests to access them.
         uv pip install -e ".[all]"

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         uv venv --seed ~/test-env
         source ~/test-env/bin/activate
-        uv pip install --prerelease=allow "azure-cli>=2.65.0"
+        uv pip install --prerelease=allow "azure-cli>=2.65.0,<2.87.0"
         uv pip install ".[all]"
         uv pip install pylint==2.14.5
         uv pip install pylint-quotes==0.2.3

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           uv venv --seed ~/test-env
           source ~/test-env/bin/activate
-          uv pip install --prerelease=allow "azure-cli>=2.65.0"
+          uv pip install --prerelease=allow "azure-cli>=2.65.0,<2.87.0"
           # Install limited dependencies only
           uv pip install -e ".[kubernetes,aws,gcp,azure]"
           uv pip install pytest pytest-xdist pytest-env>=0.6 pytest-asyncio memory-profiler==0.61.0 buildkite-test-collector
@@ -149,7 +149,7 @@ jobs:
         run: |
           uv venv --seed ~/test-env
           source ~/test-env/bin/activate
-          uv pip install --prerelease=allow "azure-cli>=2.65.0"
+          uv pip install --prerelease=allow "azure-cli>=2.65.0,<2.87.0"
           # Use -e to include examples and tests folder in the path for unit
           # tests to access them.
           uv pip install -e ".[all]"

--- a/Dockerfile
+++ b/Dockerfile
@@ -124,7 +124,9 @@ RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
 RUN curl -sSL https://storage.eu-north1.nebius.cloud/cli/install.sh | NEBIUS_INSTALL_FOLDER=/usr/local/bin bash
 # Install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ~/.local/bin/uv pip install --prerelease allow azure-cli --system && \
+    # Cap azure-cli<2.87.0: 2.87.0 pulls the broken azure-mgmt-storage 25.0.0
+    # (see sky/setup_files/dependencies.py).
+    ~/.local/bin/uv pip install --prerelease allow "azure-cli<2.87.0" --system && \
     # Upgrade setuptools in base image to mitigate CVE-2024-6345
     ~/.local/bin/uv pip install --system --upgrade setuptools==78.1.1 && \
     ~/.local/bin/uv cache clean && \

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ Sphinx docs based on ReadTheDocs.
 ### Install dependencies
 ```bash
 # full setup matching CI in .github/workflows/test-doc-build.yml
-uv pip install --prerelease=allow "azure-cli>=2.65.0"
+uv pip install --prerelease=allow "azure-cli>=2.65.0,<2.87.0"
 uv pip install ".[all]"
 cd docs
 uv pip install -r requirements-docs.txt

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -566,11 +566,11 @@ Install the necessary dependencies for Azure.
       # SkyPilot requires 3.7 <= python <= 3.13.
       # From stable release
       # Azure CLI has an issue with uv, and requires '--prerelease allow'.
-      uv pip install --prerelease allow azure-cli
+      uv pip install --prerelease allow "azure-cli<2.87.0"
       uv pip install "skypilot[azure]"
       # From nightly build
       # Azure CLI has an issue with uv, and requires '--prerelease allow'.
-      uv pip install --prerelease allow azure-cli
+      uv pip install --prerelease allow "azure-cli<2.87.0"
       uv pip install "skypilot-nightly[azure]"
 
   .. tab-item:: uv tool

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -177,7 +177,9 @@ kubernetes_dependencies = [
 
 # azure-cli cannot be installed normally by uv, so we need to work around it in
 # a few places.
-AZURE_CLI = 'azure-cli>=2.65.0'
+# Cap <2.87.0: 2.87.0 pulls azure-mgmt-storage 25.0.0, whose TypeSpec models
+# break our Azure storage code (storage-account create and key listing).
+AZURE_CLI = 'azure-cli>=2.65.0,<2.87.0'
 
 cloud_dependencies: Dict[str, List[str]] = {
     'aws': aws_dependencies,

--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -152,7 +152,13 @@ class TestBackwardCompatibility:
         self._run_cmd(
             f'{self.ACTIVATE_BASE} && '
             'uv pip uninstall skypilot && '
-            'uv pip install --prerelease=allow "azure-cli>=2.65.0" && '
+            # Cap azure-cli<2.87.0 in the base (old, published) env, which
+            # can't be fixed retroactively: 2.87.0 pulls the broken
+            # azure-mgmt-storage 25.0.0 (see dependencies.py). Mirrors the
+            # kubernetes<36.0.0 base-env pin below.
+            # TODO: Remove once the base version tested against caps
+            # azure-cli<2.87.0.
+            'uv pip install --prerelease=allow "azure-cli>=2.65.0,<2.87.0" && '
             # Fix https://github.com/skypilot-org/skypilot/issues/7287
             # for legacy skypilot versions.
             'uv pip install uvicorn==0.35.0 && '
@@ -194,7 +200,9 @@ class TestBackwardCompatibility:
         self._run_cmd(
             f'{self.ACTIVATE_CURRENT} && '
             'uv pip uninstall skypilot && '
-            'uv pip install --prerelease=allow "azure-cli>=2.65.0" && '
+            # Cap azure-cli<2.87.0 to match dependencies.py; see the base-env
+            # note above.
+            'uv pip install --prerelease=allow "azure-cli>=2.65.0,<2.87.0" && '
             'uv pip install -e .[all]',)
 
         base_sky_api_version = subprocess.run(

--- a/tests/smoke_tests/docker/Dockerfile_test
+++ b/tests/smoke_tests/docker/Dockerfile_test
@@ -150,7 +150,7 @@ RUN source ~/miniconda3/etc/profile.d/conda.sh && \
     conda activate base && \
     export PATH="$PATH:$HOME/.local/bin" && \
     uv pip uninstall skypilot --system && \
-    uv pip install --prerelease=allow "azure-cli>=2.65.0" --system && \
+    uv pip install --prerelease=allow "azure-cli>=2.65.0,<2.87.0" --system && \
     uv pip install -r requirements-dev.txt --system && \
     uv pip install -e ".[all]" --system && \
     # Install httpx with SOCKS support for proxy environments - necessary when system has proxy enabled

--- a/tests/smoke_tests/docker/entrypoint.sh
+++ b/tests/smoke_tests/docker/entrypoint.sh
@@ -103,7 +103,7 @@ fi
 
 cd /skypilot
 uv pip uninstall --system skypilot
-uv pip install --system --prerelease=allow "azure-cli>=2.65.0"
+uv pip install --system --prerelease=allow "azure-cli>=2.65.0,<2.87.0"
 uv pip install --system -r requirements-dev.txt
 uv pip install --system -e ".[all]"
 sky api start

--- a/tests/test_yamls/apiserver-start-stop.yaml
+++ b/tests/test_yamls/apiserver-start-stop.yaml
@@ -7,7 +7,7 @@ workdir: .
 setup: |
   set -e
   sudo apt update
-  uv pip install --system --prerelease allow azure-cli
+  uv pip install --system --prerelease allow "azure-cli<2.87.0"
   uv pip install --system -e '.[all]'
 
 run: |

--- a/tests/unit_tests/test_controller_utils.py
+++ b/tests/unit_tests/test_controller_utils.py
@@ -352,9 +352,10 @@ def test_get_cloud_dependencies_installation_commands_azure_only(
         'sky.utils.controller_utils.storage_lib.get_cached_enabled_storage_cloud_names_or_refresh',
         mock_get_cached_enabled_storage_cloud_names_or_refresh)
 
-    # Mock dependencies
+    # Mock dependencies. Must match the AZURE_CLI value in
+    # extras_require['azure'], since the code removes it from that list.
     monkeypatch.setattr('sky.utils.controller_utils.dependencies.AZURE_CLI',
-                        'azure-cli>=2.65.0')
+                        'azure-cli>=2.65.0,<2.87.0')
 
     controller = controller_utils.Controllers.from_type(controller_type)
     commands = controller_utils._get_cloud_dependencies_installation_commands(


### PR DESCRIPTION
## Failure / root cause

As of **2026-06-02 00:04 UTC**, Microsoft published `azure-cli 2.87.0`, which hard-pins `azure-mgmt-storage==25.0.0` (2026-05-20). SkyPilot's `azure` extra installs `azure-cli>=2.65.0` (unbounded), so every fresh install now resolves to it. Yesterday's nightly used `azure-cli 2.86.0` → `azure-mgmt-storage 24.0.0` and passed; today's failed — nothing in SkyPilot changed, only the upstream publish.

`azure-mgmt-storage 25.0.0` migrated to TypeSpec-generated models, which breaks our Azure storage code in **multiple** places:

1. **storage-account create** (`_create_storage_account`): the encoder serializes a raw-dict body verbatim, so the top-level `encryption` key is no longer mapped to `properties.encryption` and ARM rejects it (`Could not find member 'encryption' on object of type 'ResourceDefinition'`).
2. **`get_az_storage_account_key`** (`data_utils.py`): TypeSpec models are dict-like (`MutableMapping`), so `StorageAccountListKeysResult.keys` is shadowed by the mapping's `keys()` method — `[k.value for k in keys.keys]` raises `TypeError` on **every** Azure container mount/access.

## Fix: cap `azure-cli<2.87.0`

A typed-model fix handles (1), but (2) and the systemic dict-like-model change make code shims whack-a-mole (cf. the `kubernetes>=36` shims reverted for a pin in #9685). So we avoid `azure-mgmt-storage 25.0.0` by capping the package that pulls it, `azure-cli<2.87.0`.

**Why cap at the install sites, not only pin `azure-mgmt-storage<25`:** SkyPilot installs azure-cli in two steps everywhere — `uv pip install --prerelease=allow azure-cli` then `uv pip install .[all]` (the second *without* `--prerelease=allow`, by design). Any constraint that merely *excludes* 2.87.0 forces that second step to **downgrade** the pre-installed azure-cli, but every azure-cli depends on pre-release packages, so the non-prerelease resolve fails. Capping `azure-cli<2.87.0` at the `--prerelease=allow` step installs 2.86.0 up front, so no downgrade is ever needed.

Capped at: `sky/setup_files/dependencies.py` (the `AZURE_CLI` constant, used by `pip install skypilot[azure]` and the controller install), `Dockerfile`, the CI workflows/actions, the smoke-test docker images, `test_yamls/apiserver-start-stop.yaml`, the docs, and both back-compat test envs.

## Validation

The breakage and fix are reproduced **deterministically offline** by pinning the SDK version (no Azure account needed), using SkyPilot's exact code paths:

| azure-mgmt-storage | `_create_storage_account` body | `get_az_storage_account_key` (`keys.keys`) |
|---|---|---|
| **25.0.0** (azure-cli 2.87.0) | top-level `encryption` → ARM `ResourceDefinition` error | `TypeError: 'method' object is not iterable` |
| **24.0.0** (azure-cli 2.86.0, what the cap installs) | nested under `properties.encryption` ✓ | returns the keys ✓ |

Real-world: the bug first surfaced in nightly back-compat [quicktest-core #3316](https://buildkite.com/skypilot-1/quicktest-core/builds/3316), whose base venv is a **fresh** install that resolves azure-cli 2.87.0 → mgmt-storage 25.0.0.

Note: the standing buildkite **smoke** agents run an image that baked azure-cli **2.86.0** (built before 2.87.0's 2026-06-02 release), and `azure-cli>=2.65.0` does not upgrade an already-satisfying install — so a plain smoke run does not exercise the 2.87.0 bug (a "before" smoke run still passes). The cap is what guarantees 2.86.0 on fresh installs / new image builds (`pip install skypilot[azure]`, Dockerfile, CI, controller). The buildkite agent image is capped in assemble-org/prototype#1136.

Fix CI: [quicktest-core #3324](https://buildkite.com/skypilot-1/quicktest-core/builds/3324) (k8s back-compat) and [smoke #11067](https://buildkite.com/skypilot-1/smoke-tests/builds/11067) on `035afc344`; GitHub Actions green.
