### PR TITLE
fix(azure): use typed model for storage account creation to fix azure-mgmt-storage >= 25.0.0

### DIFF
--- a/sky/adaptors/azure.py
+++ b/sky/adaptors/azure.py
@@ -78,6 +78,9 @@ def azure_mgmt_models(name: str):
     elif name == 'network':
         from azure.mgmt.network import models
         return models
+    elif name == 'storage':
+        from azure.mgmt.storage import models
+        return models
 
 
 # We should keep the order of the decorators having 'lru_cache' followed

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -3504,24 +3504,21 @@ class AzureBlobStore(AbstractStore):
                 storage account.
         """
         try:
+            storage_models = azure.azure_mgmt_models('storage')
             creation_response = (
                 self.storage_client.storage_accounts.begin_create(
-                    resource_group_name, storage_account_name, {
-                        'sku': {
-                            'name': 'Standard_GRS'
-                        },
-                        'kind': 'StorageV2',
-                        'location': self.region,
-                        'encryption': {
-                            'services': {
-                                'blob': {
-                                    'key_type': 'Account',
-                                    'enabled': True
-                                }
-                            },
-                            'key_source': 'Microsoft.Storage'
-                        },
-                    }).result())
+                    resource_group_name, storage_account_name,
+                    storage_models.StorageAccountCreateParameters(
+                        sku=storage_models.Sku(name='Standard_GRS'),
+                        kind='StorageV2',
+                        location=self.region,
+                        encryption=storage_models.Encryption(
+                            services=storage_models.EncryptionServices(
+                                blob=storage_models.EncryptionService(
+                                    key_type='Account',
+                                    enabled=True)),
+                            key_source='Microsoft.Storage'),
+                    )).result())
         except azure.exceptions().ResourceExistsError as error:
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.StorageBucketCreateError(


### PR DESCRIPTION
## Problem

Fixes #9775

`_create_storage_account` passes a raw dict to `storage_accounts.begin_create`. On **azure-mgmt-storage >= 25.0.0** (TypeSpec-based serializer), dicts are serialized verbatim — the `_attribute_map` remapping that msrest (<= 24.x) applied no longer happens. This causes `encryption` to appear at the top level of the request body instead of under `properties.encryption`, and ARM rejects it:

```
(InvalidRequestContent) The request content was invalid and could not be deserialized:
'Could not find member 'encryption' on object of type 'ResourceDefinition'.
Path 'encryption', line 1, position 84.'
```

## Fix

Replace the raw dict with typed model objects:
- `StorageAccountCreateParameters` (top-level)
- `Sku`, `Encryption`, `EncryptionServices`, `EncryptionService`

These models correctly serialize `encryption` under `properties` in their `as_dict()` output, making the body shape portable across SDK versions (both msrest and TypeSpec).

Also adds `'storage'` to the `azure_mgmt_models` adaptor helper so the models are imported through the existing lazy-loading pattern.

## Verification

```python
from azure.mgmt.storage import models
params = models.StorageAccountCreateParameters(
    sku=models.Sku(name='Standard_GRS'),
    kind='StorageV2',
    location='eastus',
    encryption=models.Encryption(
        services=models.EncryptionServices(
            blob=models.EncryptionService(key_type='Account', enabled=True)),
        key_source='Microsoft.Storage'),
)
d = params.as_dict()
assert 'encryption' not in d  # not at top level
assert 'encryption' in d['properties']  # correctly under properties
```

This also allows removing the `azure-mgmt-storage<25.0.0` pin from #9774 once merged.