### PR TITLE
[Azure] Pass typed StorageAccountCreateParameters to begin_create

### DIFF
--- a/sky/adaptors/azure.py
+++ b/sky/adaptors/azure.py
@@ -78,6 +78,9 @@ def azure_mgmt_models(name: str):
     elif name == 'network':
         from azure.mgmt.network import models
         return models
+    elif name == 'storage':
+        from azure.mgmt.storage import models
+        return models
 
 
 # We should keep the order of the decorators having 'lru_cache' followed

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -3503,25 +3503,30 @@ class AzureBlobStore(AbstractStore):
                 created already exists or fails to assign role to the create
                 storage account.
         """
+        # Build a typed StorageAccountCreateParameters model rather than a
+        # hand-built dict. azure-mgmt-storage 25.0.0 switched to a TypeSpec
+        # serializer that serializes a dict verbatim and no longer remaps the
+        # top-level `encryption` key to `properties.encryption`, so a raw dict
+        # is rejected by ARM (InvalidRequestContent). The typed model serializes
+        # to the correct `properties.encryption` body under both msrest (<=24.x)
+        # and the TypeSpec encoder (25.x).
+        # See https://github.com/skypilot-org/skypilot/issues/9775.
+        storage_models = azure.azure_mgmt_models('storage')
+        create_parameters = storage_models.StorageAccountCreateParameters(
+            sku=storage_models.Sku(name='Standard_GRS'),
+            kind='StorageV2',
+            location=self.region,
+            encryption=storage_models.Encryption(
+                services=storage_models.EncryptionServices(
+                    blob=storage_models.EncryptionService(key_type='Account',
+                                                          enabled=True)),
+                key_source='Microsoft.Storage'),
+        )
         try:
             creation_response = (
                 self.storage_client.storage_accounts.begin_create(
-                    resource_group_name, storage_account_name, {
-                        'sku': {
-                            'name': 'Standard_GRS'
-                        },
-                        'kind': 'StorageV2',
-                        'location': self.region,
-                        'encryption': {
-                            'services': {
-                                'blob': {
-                                    'key_type': 'Account',
-                                    'enabled': True
-                                }
-                            },
-                            'key_source': 'Microsoft.Storage'
-                        },
-                    }).result())
+                    resource_group_name, storage_account_name,
+                    create_parameters).result())
         except azure.exceptions().ResourceExistsError as error:
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.StorageBucketCreateError(

--- a/tests/unit_tests/test_azure_storage.py
+++ b/tests/unit_tests/test_azure_storage.py
@@ -35,7 +35,7 @@ def test_create_storage_account_passes_typed_model(monkeypatch):
 
     # Short-circuit the post-create role-assignment retry loop.
     monkeypatch.setattr(storage_lib.azure, 'assign_storage_account_iam_role',
-                        lambda **kwargs: None)
+                        lambda *args, **kwargs: None)
 
     store._create_storage_account('my-rg', 'myaccount')
 

--- a/tests/unit_tests/test_azure_storage.py
+++ b/tests/unit_tests/test_azure_storage.py
@@ -1,0 +1,54 @@
+"""Unit tests for Azure blob storage account creation.
+
+Regression test for https://github.com/skypilot-org/skypilot/issues/9775:
+`_create_storage_account` must pass a typed ``StorageAccountCreateParameters``
+model rather than a hand-built dict. azure-mgmt-storage 25.0.0 switched to a
+TypeSpec serializer that serializes a dict verbatim and no longer remaps the
+top-level ``encryption`` key to ``properties.encryption``, so a raw dict is
+rejected by ARM. A typed model serializes to the correct body under both
+msrest (<=24.x) and the TypeSpec encoder (25.x).
+"""
+import unittest.mock as mock
+
+import pytest
+
+
+def test_create_storage_account_passes_typed_model(monkeypatch):
+    storage_models = pytest.importorskip('azure.mgmt.storage.models')
+    from sky.data import storage as storage_lib
+
+    # Build an AzureBlobStore without running its heavy __init__; we only
+    # exercise _create_storage_account.
+    store = storage_lib.AzureBlobStore.__new__(storage_lib.AzureBlobStore)
+    store.region = 'eastus'
+    store.storage_client = mock.MagicMock()
+
+    captured = {}
+
+    def fake_begin_create(resource_group_name, storage_account_name,
+                          parameters):
+        captured['parameters'] = parameters
+        return mock.MagicMock()
+
+    store.storage_client.storage_accounts.begin_create.side_effect = (
+        fake_begin_create)
+
+    # Short-circuit the post-create role-assignment retry loop.
+    monkeypatch.setattr(storage_lib.azure, 'assign_storage_account_iam_role',
+                        lambda **kwargs: None)
+
+    store._create_storage_account('my-rg', 'myaccount')
+
+    params = captured['parameters']
+    # Must be a typed model, not a raw dict.
+    assert isinstance(params, storage_models.StorageAccountCreateParameters), (
+        f'expected a typed model, got {type(params)}')
+
+    # The model must serialize with `encryption` nested under `properties`,
+    # never at the top level. msrest (<=24.x) exposes .serialize(); the
+    # TypeSpec model (25.x) exposes .as_dict() -- both yield the wire body.
+    body = params.serialize() if hasattr(params,
+                                         'serialize') else params.as_dict()
+    assert isinstance(body.get('properties'), dict), body
+    assert 'encryption' in body['properties'], body
+    assert 'encryption' not in body, body


### PR DESCRIPTION
## Summary

`sky/data/storage.py:_create_storage_account` passed a hand-built **dict** with a top-level `encryption` key to `storage_accounts.begin_create`. On the wire, `encryption` belongs under `properties`.

- **azure-mgmt-storage <= 24.x** (msrest): the serializer remapped the dict (`encryption` -> `properties.encryption`) via `_attribute_map`, so the body was correct and the call succeeded.
- **azure-mgmt-storage 25.0.0** (TypeSpec / `_model_base`): `_create_initial` does `json.dumps(parameters, cls=SdkJSONEncoder)`, serializing the dict **verbatim** with no key remapping. `encryption` stays at the top level and ARM rejects the request:
  > `(InvalidRequestContent) The request content was invalid and could not be deserialized: 'Could not find member 'encryption' on object of type 'ResourceDefinition'. Path 'encryption', line 1, position 84.'`

Relying on the SDK to silently fix a malformed dict is fragile and not portable across serializers. This PR passes a typed `StorageAccountCreateParameters` model (`Sku`, `Encryption`, `EncryptionServices`, `EncryptionService`), obtained via a new `'storage'` case in the existing `azure_mgmt_models()` adaptor helper. The model serializes to the correct `properties.encryption` body under **both** serializers, which also lets the `azure-mgmt-storage<25.0.0` pin (#9774) be dropped afterwards.

Fixes #9775

## Changes

- `sky/adaptors/azure.py` — add a `'storage'` case to `azure_mgmt_models()`.
- `sky/data/storage.py` — build a typed `StorageAccountCreateParameters` instead of a raw dict.
- `tests/unit_tests/test_azure_storage.py` — regression test: asserts a typed model (not a dict) is passed to `begin_create`, and that it serializes `encryption` under `properties`.

## Test plan

**Offline repro (no Azure account).** Captured the exact wire body `begin_create` would send — for both the current dict and the typed model — under each SDK version:

| azure-mgmt-storage | current raw dict | typed model (this PR) |
| --- | --- | --- |
| 24.0.0 (msrest) | `properties.encryption` ✅ | `properties.encryption` ✅ |
| 25.0.0 (TypeSpec) | top-level `encryption` ❌ (ARM rejects) | `properties.encryption` ✅ |

- `pytest tests/unit_tests/test_azure_storage.py` → **passes** (uses `importorskip`, so it skips cleanly when azure-mgmt-storage isn't installed).
- `bash format.sh --files <changed>` → yapf / isort clean, **pylint 10.00/10** on changed files.
