### PR TITLE
[GCP] Set provisioningModel=RESERVATION_BOUND for DENSE reservations

### DIFF
--- a/sky/provision/gcp/instance_utils.py
+++ b/sky/provision/gcp/instance_utils.py
@@ -39,6 +39,47 @@ _FIREWALL_RESOURCE_NOT_FOUND_PATTERN = re.compile(
     r'The resource \'projects/.*/global/firewalls/.*\' was not found')
 
 
+def _is_reservation_bound(project_id: str, zone: str,
+                          reservation_name: str) -> bool:
+    """Check if a reservation requires the RESERVATION_BOUND provisioning model.
+
+    GCP DENSE reservations (used for large GPU blocks like A100/H100) require
+    instances to set provisioningModel=RESERVATION_BOUND. This function queries
+    the reservation metadata to determine if RESERVATION_BOUND is needed.
+
+    Uses reservations().list() with a name filter, which requires
+    compute.reservations.list (already in SkyPilot's required permissions).
+
+    Returns True if the reservation has deploymentType=DENSE, False otherwise
+    (including on API errors, to avoid blocking standard reservations).
+    """
+    # Parse reservation name — may be a full URI or just a name
+    parts = reservation_name.split('/')
+    short_name = parts[-1] if '/' in reservation_name else reservation_name
+    try:
+        compute = GCPComputeInstance.load_resource()
+        result = compute.reservations().list(
+            project=project_id,
+            zone=zone,
+            filter=f'name={short_name}',
+        ).execute(num_retries=GCP_MAX_RETRIES)
+        items = result.get('items', [])
+        if not items:
+            return False
+        deployment_type = items[0].get('deploymentType', '')
+        if deployment_type == 'DENSE':
+            logger.debug(f'Reservation {reservation_name} has '
+                         f'deploymentType={deployment_type!r}, '
+                         f'will set provisioningModel=RESERVATION_BOUND')
+            return True
+        return False
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning(
+            f'Failed to query reservation {reservation_name} metadata: {e}. '
+            'Assuming standard reservation (no provisioningModel override).')
+        return False
+
+
 def _retry_on_gcp_http_exception(
     regex: Optional[str] = None,
     max_retries: int = GCP_MAX_RETRIES,
@@ -714,10 +755,19 @@ class GCPComputeInstance(GCPInstance):
                 reservation_count = min(reservation_count, count)
                 logger.debug(f'Creating {reservation_count} instances '
                              f'with reservation {reservation}')
-                config['reservationAffinity']['values'] = [reservation]
+                reservation_config = copy.deepcopy(config)
+                reservation_config['reservationAffinity']['values'] = [
+                    reservation
+                ]
+                if _is_reservation_bound(project_id, zone, reservation):
+                    reservation_config.setdefault('scheduling', {})
+                    reservation_config['scheduling'][
+                        'provisioningModel'] = 'RESERVATION_BOUND'
+                    reservation_config['scheduling'][
+                        'onHostMaintenance'] = 'TERMINATE'
                 created_names = names[:reservation_count]
                 errors = cls._create_instances(
-                    created_names, project_id, zone, config,
+                    created_names, project_id, zone, reservation_config,
                     head_tag_needed[:reservation_count])
                 all_names.extend(created_names)
                 if errors:

--- a/tests/unit_tests/test_gcp.py
+++ b/tests/unit_tests/test_gcp.py
@@ -433,3 +433,128 @@ def test_gcp_network_config_override_in_cluster_config(monkeypatch):
             wheel_hash='fake-wheel-hash',
             region=Region(name='us-central1'),
             zones=[Zone(name='us-central1-a')])
+
+
+# --- Tests for _is_reservation_bound ---
+
+
+class TestIsReservationBound:
+    """Tests for DENSE/CALENDAR reservation detection."""
+
+    @patch('sky.provision.gcp.instance_utils'
+           '.GCPComputeInstance.load_resource')
+    def test_dense_reservation_returns_true(self, mock_load):
+        """DENSE reservation should trigger RESERVATION_BOUND."""
+        from sky.provision.gcp.instance_utils import _is_reservation_bound
+        mock_compute = MagicMock()
+        mock_load.return_value = mock_compute
+        mock_compute.reservations.return_value.list.return_value \
+            .execute.return_value = {
+                'items': [{
+                    'name': 'my-dense-reservation',
+                    'deploymentType': 'DENSE',
+                }]
+            }
+
+        result = _is_reservation_bound('my-project', 'us-central1-a',
+                                       'my-dense-reservation')
+        assert result is True
+
+        mock_compute.reservations.return_value.list.assert_called_once_with(
+            project='my-project',
+            zone='us-central1-a',
+            filter='name=my-dense-reservation',
+        )
+
+    @patch('sky.provision.gcp.instance_utils'
+           '.GCPComputeInstance.load_resource')
+    def test_standard_reservation_returns_false(self, mock_load):
+        """Standard (SPECIFIC) reservation should not trigger override."""
+        from sky.provision.gcp.instance_utils import _is_reservation_bound
+        mock_compute = MagicMock()
+        mock_load.return_value = mock_compute
+        mock_compute.reservations.return_value.list.return_value \
+            .execute.return_value = {
+                'items': [{
+                    'name': 'my-standard-reservation',
+                    'deploymentType': 'DEPLOYMENT_TYPE_UNSPECIFIED',
+                }]
+            }
+
+        result = _is_reservation_bound('my-project', 'us-central1-a',
+                                       'my-standard-reservation')
+        assert result is False
+
+    @patch('sky.provision.gcp.instance_utils'
+           '.GCPComputeInstance.load_resource')
+    def test_no_deployment_type_returns_false(self, mock_load):
+        """Reservation without deploymentType field should not override."""
+        from sky.provision.gcp.instance_utils import _is_reservation_bound
+        mock_compute = MagicMock()
+        mock_load.return_value = mock_compute
+        mock_compute.reservations.return_value.list.return_value \
+            .execute.return_value = {
+                'items': [{
+                    'name': 'my-reservation',
+                }]
+            }
+
+        result = _is_reservation_bound('my-project', 'us-central1-a',
+                                       'my-reservation')
+        assert result is False
+
+    @patch('sky.provision.gcp.instance_utils'
+           '.GCPComputeInstance.load_resource')
+    def test_reservation_not_found_returns_false(self, mock_load):
+        """Empty list result should return False."""
+        from sky.provision.gcp.instance_utils import _is_reservation_bound
+        mock_compute = MagicMock()
+        mock_load.return_value = mock_compute
+        mock_compute.reservations.return_value.list.return_value \
+            .execute.return_value = {
+                'items': []
+            }
+
+        result = _is_reservation_bound('my-project', 'us-central1-a',
+                                       'nonexistent-reservation')
+        assert result is False
+
+    @patch('sky.provision.gcp.instance_utils'
+           '.GCPComputeInstance.load_resource')
+    def test_api_failure_returns_false(self, mock_load):
+        """API errors should gracefully fall back to False."""
+        from sky.provision.gcp.instance_utils import _is_reservation_bound
+        mock_compute = MagicMock()
+        mock_load.return_value = mock_compute
+        mock_compute.reservations.return_value.list.return_value \
+            .execute.side_effect = Exception('Permission denied')
+
+        result = _is_reservation_bound('my-project', 'us-central1-a',
+                                       'my-reservation')
+        assert result is False
+
+    @patch('sky.provision.gcp.instance_utils'
+           '.GCPComputeInstance.load_resource')
+    def test_full_uri_parses_short_name(self, mock_load):
+        """Full reservation URI should be parsed to short name for API call."""
+        from sky.provision.gcp.instance_utils import _is_reservation_bound
+        mock_compute = MagicMock()
+        mock_load.return_value = mock_compute
+        mock_compute.reservations.return_value.list.return_value \
+            .execute.return_value = {
+                'items': [{
+                    'name': 'my-dense-res',
+                    'deploymentType': 'DENSE',
+                }]
+            }
+
+        full_uri = ('projects/my-project/zones/us-central1-a'
+                    '/reservations/my-dense-res')
+        result = _is_reservation_bound('my-project', 'us-central1-a', full_uri)
+        assert result is True
+
+        mock_compute.reservations.return_value.list.assert_called_once_with(
+            project='my-project',
+            zone='us-central1-a',
+            filter='name=my-dense-res',
+        )


### PR DESCRIPTION
GCP DENSE reservations (used for large GPU blocks like A100/H100) require instances to set provisioningModel=RESERVATION_BOUND. Without this, the GCE API rejects the insert call with a 400 error.

This change:
- Adds _is_reservation_bound() which queries the reservation metadata via compute.reservations().get() to check deploymentType
- Sets RESERVATION_BOUND + onHostMaintenance=TERMINATE when the reservation is DENSE
- Falls back gracefully on API errors (assumes standard reservation)
- Adds 5 unit tests covering DENSE, standard, missing field, API failure, and full URI parsing

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
