### PR TITLE
do not try to decode empty stdout

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4609,6 +4609,16 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                                                       separate_stderr=True)
         subprocess_utils.handle_returncode(returncode, code,
                                            'Failed to get job status.', stderr)
+        if not stdout:
+            # We see some cases in the wild where a misbehaving cluster/k8s
+            # apiserver (not sure which) can have a returncode of 0 but
+            # incorrectly empty stdout. Treat this as a failure.
+            raise exceptions.CommandFailureException(
+                command=code,
+                failure='produced no output',
+                error_msg='Failed to get job status.',
+                detailed_reason=f'stderr="{stderr}"',
+            )
         statuses = job_lib.load_statuses_payload(stdout)
         return statuses
 
@@ -5792,7 +5802,10 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             code = autostop_lib.AutostopCodeGen.is_autostopping()
             returncode, stdout, stderr = self.run_on_head(
                 handle, code, require_outputs=True, stream_logs=stream_logs)
-            if returncode == 0:
+            # We see some cases in the wild where a misbehaving cluster/k8s
+            # apiserver (not sure which) can have a returncode of 0 but
+            # incorrectly empty stdout. Don't try to decode this.
+            if returncode == 0 and stdout:
                 is_autostopping = message_utils.decode_payload(stdout)
             else:
                 logger.debug('Failed to check if cluster is autostopping with '

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -313,12 +313,18 @@ class CommandError(CommandFailureException):
         command: The command that was run.
         error_msg: The error message to print.
         detailed_reason: The stderr of the command.
+        failure: Normally constructed from returncode, but included for serde.
     """
 
-    def __init__(self, returncode: int, command: str, error_msg: str,
-                 detailed_reason: Optional[str]) -> None:
+    def __init__(self,
+                 returncode: int,
+                 command: str,
+                 error_msg: str,
+                 detailed_reason: Optional[str],
+                 failure: Optional[str] = None) -> None:
         self.returncode = returncode
-        failure = f'failed with return code {returncode}'
+        if failure is None:
+            failure = f'failed with return code {returncode}'
         super().__init__(command, failure, error_msg, detailed_reason)
 
 

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -276,20 +276,20 @@ class SkyPilotExcludeArgsBaseException(Exception):
     pass
 
 
-class CommandError(SkyPilotExcludeArgsBaseException):
-    """Raised when a command fails.
+class CommandFailureException(SkyPilotExcludeArgsBaseException):
+    """Raised if a command fails for some reason.
 
     Args:
-        returncode: The returncode of the command.
         command: The command that was run.
-        error_message: The error message to print.
-        detailed_reason: The stderr of the command.
+        failure: The mode of failure.
+        error_msg: The error message to print.
+        detailed_reason: Detailed output from the failure, if possible.
     """
 
-    def __init__(self, returncode: int, command: str, error_msg: str,
+    def __init__(self, command: str, failure: str, error_msg: str,
                  detailed_reason: Optional[str]) -> None:
-        self.returncode = returncode
         self.command = command
+        self.failure = failure
         self.error_msg = error_msg
         self.detailed_reason = detailed_reason
 
@@ -300,9 +300,26 @@ class CommandError(SkyPilotExcludeArgsBaseException):
                     not env_options.Options.SHOW_DEBUG_INFO.get()):
                 # Chunk the command to avoid overflow.
                 command = command[:100] + '...'
-            message = (f'Command {command} failed with return code '
-                       f'{returncode}.\n{error_msg}\n{detailed_reason}')
+            message = (f'Command {command} {failure}.\n'
+                       f'{error_msg}\n{detailed_reason}')
         super().__init__(message)
+
+
+class CommandError(CommandFailureException):
+    """Raised when a command returns a non-zero exit code.
+
+    Args:
+        returncode: The returncode of the command.
+        command: The command that was run.
+        error_msg: The error message to print.
+        detailed_reason: The stderr of the command.
+    """
+
+    def __init__(self, returncode: int, command: str, error_msg: str,
+                 detailed_reason: Optional[str]) -> None:
+        self.returncode = returncode
+        failure = f'failed with return code {returncode}'
+        super().__init__(command, failure, error_msg, detailed_reason)
 
 
 class ClusterNotUpError(Exception):

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -461,14 +461,20 @@ async def get_job_status(
         status = list(statuses.values())[0]
         _log_job_status(status)
         return status, None
-    except (exceptions.CommandError, grpc.RpcError, grpc.FutureTimeoutError,
-            ValueError, TypeError, asyncio.TimeoutError) as e:
+    except (exceptions.CommandError, exceptions.CommandFailureException,
+            grpc.RpcError, grpc.FutureTimeoutError, ValueError, TypeError,
+            asyncio.TimeoutError) as e:
         # Note: Each of these exceptions has some additional conditions to
         # limit how we handle it and whether or not we catch it.
         potential_transient_error_reason = None
         if isinstance(e, exceptions.CommandError):
             returncode = e.returncode
             potential_transient_error_reason = (f'Returncode: {returncode}. '
+                                                f'{e.detailed_reason}')
+        elif isinstance(e, exceptions.CommandFailureException):
+            # Note: this should come after the CommandError handler, as this is
+            # the supertype of CommandError
+            potential_transient_error_reason = (f'Command {e.failure}. '
                                                 f'{e.detailed_reason}')
         elif isinstance(e, grpc.RpcError):
             potential_transient_error_reason = e.details()

--- a/tests/unit_tests/test_exceptions.py
+++ b/tests/unit_tests/test_exceptions.py
@@ -59,6 +59,22 @@ def test_provision_prechecks_error():
     assert deserialized.stacktrace == 'test_stacktrace'
 
 
+def test_command_failure_exception():
+    """Test that exceptions can be serialized and deserialized."""
+    e = exceptions.CommandFailureException('test_command', 'test_failure',
+                                           'test_error_msg',
+                                           'test_detailed_reason')
+    setattr(e, 'stacktrace', 'test_stacktrace')
+    deserialized = _serialize_deserialize(e)
+    assert isinstance(deserialized, exceptions.CommandFailureException)
+    assert str(deserialized).startswith('Command test_command test_failure.')
+    assert deserialized.command == 'test_command'
+    assert deserialized.failure == 'test_failure'
+    assert deserialized.error_msg == 'test_error_msg'
+    assert deserialized.detailed_reason == 'test_detailed_reason'
+    assert deserialized.stacktrace == 'test_stacktrace'
+
+
 def test_command_error():
     """Test that exceptions can be serialized and deserialized."""
     e = exceptions.CommandError(1, 'test_command', 'test_error_msg',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
We saw some cases in the wild, especially in managed jobs (that do a lot of cluster/status checks) where the job status check or the cluster check can fail because `kubectl exec` returns with an empty stdout but still returncode 0. This seems correlated with k8s apiserver instability but the exact mechanism remains unknown.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
