### PR TITLE
[Core] Let packages expose client SDKs under the sky namespace

### DIFF
--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -1,11 +1,12 @@
 """The SkyPilot package."""
+import functools
 import importlib
 import importlib.abc
 import importlib.util
 import os
 import subprocess
 import sys
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, Dict, Optional, TYPE_CHECKING
 import urllib.request
 
 from sky.utils import directory_utils
@@ -264,9 +265,9 @@ __all__ = [
 ]
 
 # --------------------- Client SDK namespace --------------------- #
-# Installed packages can surface a client SDK under the ``sky`` namespace by
-# registering an entry point in the ``sky.client_sdks`` group whose value is
-# the dotted path of the module to expose:
+# Installed packages can surface a client SDK *module* under the ``sky``
+# namespace by registering an entry point in the ``sky.client_sdks`` group
+# whose value is the dotted path of the module to expose:
 #
 #     # in the providing package's setup.py / pyproject.toml
 #     entry_points={'sky.client_sdks': ['foo = some_package.foo.sdk']}
@@ -274,12 +275,20 @@ __all__ = [
 # ``sky.foo``, ``from sky import foo`` and ``import sky.foo`` then all resolve
 # (lazily) to ``some_package.foo.sdk``, letting add-on packages extend the
 # ``sky`` namespace without SkyPilot having to know about them at build time.
-# This mirrors the other entry-point hooks SkyPilot already exposes.
+# This mirrors the other entry-point hooks SkyPilot already exposes. The entry
+# point exposes a single module, not a sub-namespace: ``sky.foo.bar`` is not
+# aliased (it raises the usual "not a package" error for a module target).
 _CLIENT_SDK_ENTRY_POINT_GROUP = 'sky.client_sdks'
 
 
-def _find_client_sdk_entry_point(name: str) -> Optional['EntryPoint']:
-    """Return the ``sky.client_sdks`` entry point named ``name``, if any."""
+@functools.lru_cache(maxsize=1)
+def _client_sdk_entry_points() -> Dict[str, 'EntryPoint']:
+    """Map of name -> entry point in the ``sky.client_sdks`` group.
+
+    Cached for the process lifetime: ``importlib.metadata.entry_points()``
+    scans every installed distribution, which is far too expensive to repeat
+    on each attribute miss or unresolved ``sky.*`` import.
+    """
     # Imported lazily: importlib.metadata adds measurable time to ``import
     # sky`` and is only needed the first time a contributed SDK is resolved.
     # pylint: disable-next=import-outside-toplevel
@@ -294,10 +303,12 @@ def _find_client_sdk_entry_point(name: str) -> Optional['EntryPoint']:
     else:
         group_entry_points = all_entry_points.get(_CLIENT_SDK_ENTRY_POINT_GROUP,
                                                   [])
-    for entry_point in group_entry_points:
-        if entry_point.name == name:
-            return entry_point
-    return None
+    return {ep.name: ep for ep in group_entry_points}
+
+
+def _find_client_sdk_entry_point(name: str) -> Optional['EntryPoint']:
+    """Return the ``sky.client_sdks`` entry point named ``name``, if any."""
+    return _client_sdk_entry_points().get(name)
 
 
 class _ClientSdkLoader(importlib.abc.Loader):
@@ -333,6 +344,9 @@ class _ClientSdkFinder(importlib.abc.MetaPathFinder):
         if not fullname.startswith(prefix):
             return None
         name = fullname[len(prefix):]
+        # Only top-level ``sky.<name>`` is aliased: the entry point exposes a
+        # single module, not a sub-namespace. Submodule imports
+        # (``sky.<name>.<sub>``) fall through to the default finders.
         if '.' in name:
             return None
         entry_point = _find_client_sdk_entry_point(name)

--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -1,10 +1,17 @@
 """The SkyPilot package."""
+import importlib
+import importlib.abc
+import importlib.util
 import os
 import subprocess
-from typing import Optional
+import sys
+from typing import Any, Optional, TYPE_CHECKING
 import urllib.request
 
 from sky.utils import directory_utils
+
+if TYPE_CHECKING:
+    from importlib.metadata import EntryPoint
 
 # Replaced with the current commit when building the wheels.
 _SKYPILOT_COMMIT_SHA = '{{SKYPILOT_COMMIT_SHA}}'
@@ -255,3 +262,102 @@ __all__ = [
     # Batch processing
     'batch',
 ]
+
+# --------------------- Client SDK namespace --------------------- #
+# Installed packages can surface a client SDK under the ``sky`` namespace by
+# registering an entry point in the ``sky.client_sdks`` group whose value is
+# the dotted path of the module to expose:
+#
+#     # in the providing package's setup.py / pyproject.toml
+#     entry_points={'sky.client_sdks': ['foo = some_package.foo.sdk']}
+#
+# ``sky.foo``, ``from sky import foo`` and ``import sky.foo`` then all resolve
+# (lazily) to ``some_package.foo.sdk``, letting add-on packages extend the
+# ``sky`` namespace without SkyPilot having to know about them at build time.
+# This mirrors the other entry-point hooks SkyPilot already exposes.
+_CLIENT_SDK_ENTRY_POINT_GROUP = 'sky.client_sdks'
+
+
+def _find_client_sdk_entry_point(name: str) -> Optional['EntryPoint']:
+    """Return the ``sky.client_sdks`` entry point named ``name``, if any."""
+    # Imported lazily: importlib.metadata adds measurable time to ``import
+    # sky`` and is only needed the first time a contributed SDK is resolved.
+    # pylint: disable-next=import-outside-toplevel
+    import importlib.metadata as importlib_metadata
+    all_entry_points = importlib_metadata.entry_points()
+    # ``entry_points().select(group=...)`` is the API on Python 3.10+ (and the
+    # only one on 3.12+). On 3.8/3.9 ``entry_points()`` returns a plain mapping
+    # of group name to entry points, so fall back to ``.get()`` there.
+    select = getattr(all_entry_points, 'select', None)
+    if select is not None:
+        group_entry_points = select(group=_CLIENT_SDK_ENTRY_POINT_GROUP)
+    else:
+        group_entry_points = all_entry_points.get(_CLIENT_SDK_ENTRY_POINT_GROUP,
+                                                  [])
+    for entry_point in group_entry_points:
+        if entry_point.name == name:
+            return entry_point
+    return None
+
+
+class _ClientSdkLoader(importlib.abc.Loader):
+    """importlib loader that aliases ``sky.<name>`` to an existing module."""
+
+    def __init__(self, target_module: str) -> None:
+        self._target_module = target_module
+
+    def create_module(self, spec: Any) -> Any:
+        del spec  # Unused; the module name comes from the registered target.
+        # Return the target module itself so that, e.g.,
+        # ``sky.foo is some_package.foo.sdk`` and it is not executed again
+        # under a second name.
+        return importlib.import_module(self._target_module)
+
+    def exec_module(self, module: Any) -> None:
+        del module  # Already initialized by import_module in create_module.
+
+
+class _ClientSdkFinder(importlib.abc.MetaPathFinder):
+    """importlib meta-path finder for entry-point-registered client SDKs.
+
+    Appended to ``sys.meta_path`` so it only runs after the default finders;
+    real ``sky`` submodules always take precedence.
+    """
+
+    def find_spec(self,
+                  fullname: str,
+                  path: Any = None,
+                  target: Any = None) -> Any:
+        del path, target  # Unused; resolution is keyed only on ``fullname``.
+        prefix = f'{__name__}.'
+        if not fullname.startswith(prefix):
+            return None
+        name = fullname[len(prefix):]
+        if '.' in name:
+            return None
+        entry_point = _find_client_sdk_entry_point(name)
+        if entry_point is None:
+            return None
+        return importlib.util.spec_from_loader(
+            fullname, _ClientSdkLoader(entry_point.value))
+
+
+def __getattr__(name: str) -> Any:  # pylint: disable=invalid-name
+    """Lazily resolve client SDKs registered under ``sky.client_sdks``.
+
+    PEP 562 module hook, consulted only for attributes not already defined on
+    ``sky``, so it never shadows real submodules or symbols. This handles bare
+    attribute access (``import sky; sky.foo``), which does not go through the
+    meta-path finder above.
+    """
+    if name.startswith('_'):
+        raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
+    if _find_client_sdk_entry_point(name) is None:
+        raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
+    # Routes through _ClientSdkFinder, which binds ``sky.<name>`` and registers
+    # it in sys.modules; any error importing the SDK propagates unchanged.
+    return importlib.import_module(f'{__name__}.{name}')
+
+
+if not any(isinstance(finder, _ClientSdkFinder) for finder in sys.meta_path):
+    sys.meta_path.append(_ClientSdkFinder())

--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -316,16 +316,28 @@ class _ClientSdkLoader(importlib.abc.Loader):
 
     def __init__(self, target_module: str) -> None:
         self._target_module = target_module
+        self._original_spec: Any = None
 
     def create_module(self, spec: Any) -> Any:
         del spec  # Unused; the module name comes from the registered target.
         # Return the target module itself so that, e.g.,
         # ``sky.foo is some_package.foo.sdk`` and it is not executed again
         # under a second name.
-        return importlib.import_module(self._target_module)
+        target = importlib.import_module(self._target_module)
+        # Capture the target's real spec now: module_from_spec() will shortly
+        # overwrite ``target.__spec__`` with this alias's spec (whose name is
+        # ``sky.<name>`` and whose loader is this object). exec_module restores
+        # it.
+        self._original_spec = getattr(target, '__spec__', None)
+        return target
 
     def exec_module(self, module: Any) -> None:
-        del module  # Already initialized by import_module in create_module.
+        # Restore the target's real spec that module_from_spec() just
+        # overwrote, so the aliased module keeps a consistent ``__name__`` /
+        # ``__spec__.name`` and stays reloadable (importlib.reload keys off
+        # ``__spec__``, not ``__name__``).
+        if self._original_spec is not None:
+            module.__spec__ = self._original_spec
 
 
 class _ClientSdkFinder(importlib.abc.MetaPathFinder):

--- a/tests/unit_tests/test_client_sdks.py
+++ b/tests/unit_tests/test_client_sdks.py
@@ -1,0 +1,109 @@
+"""Unit tests for the ``sky.client_sdks`` namespace entry-point loader.
+
+These exercise the lazy resolution of client SDKs that installed packages can
+register under the ``sky`` namespace (e.g. ``sky.foo``) via the
+``sky.client_sdks`` entry-point group, without SkyPilot knowing about them at
+build time.
+"""
+# fake_sdk is a pytest fixture; receiving it as an argument is intentional.
+# pylint: disable=redefined-outer-name
+import importlib
+import importlib.metadata
+import sys
+import types
+
+import pytest
+
+import sky
+
+_SDK_NAME = 'fakesdk'
+_TARGET_MODULE = 'sky_fake_sdk_target'
+
+
+def _make_entry_point():
+    return importlib.metadata.EntryPoint(_SDK_NAME, _TARGET_MODULE,
+                                         'sky.client_sdks')
+
+
+class _SelectableEntryPoints(list):
+    """Minimal stand-in for the ``entry_points()`` result on Python 3.10+."""
+
+    def select(self, *, group):
+        return [ep for ep in self if ep.group == group]
+
+
+@pytest.fixture
+def fake_sdk(monkeypatch):
+    """Register a fake client SDK and the target module it aliases to."""
+    target = types.ModuleType(_TARGET_MODULE)
+    target.create = lambda: 'created'  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, _TARGET_MODULE, target)
+
+    def _entry_points():
+        return _SelectableEntryPoints([_make_entry_point()])
+
+    monkeypatch.setattr(importlib.metadata, 'entry_points', _entry_points)
+    yield target
+    # The loader caches resolution in sys.modules and as an attribute on the
+    # ``sky`` module; undo both so each test starts from a cold state.
+    sys.modules.pop(f'sky.{_SDK_NAME}', None)
+    if hasattr(sky, _SDK_NAME):
+        delattr(sky, _SDK_NAME)
+
+
+def test_attribute_access_resolves_sdk(fake_sdk):
+    # ``import sky; sky.fakesdk`` (bare attribute access via __getattr__).
+    resolved = getattr(sky, _SDK_NAME)
+    assert resolved is fake_sdk
+    assert resolved.create() == 'created'
+
+
+def test_dotted_import_resolves_sdk(fake_sdk):
+    # Cold ``import sky.fakesdk`` (dotted submodule form via the meta-path
+    # finder); the alias must be the same module object, not a re-execution.
+    module = importlib.import_module(f'sky.{_SDK_NAME}')
+    assert module is fake_sdk
+    assert sys.modules[f'sky.{_SDK_NAME}'] is fake_sdk
+
+
+def test_from_import_resolves_sdk(fake_sdk):
+    # ``from sky import fakesdk`` (exercises the from-list import machinery).
+    module = __import__('sky', fromlist=[_SDK_NAME])
+    assert getattr(module, _SDK_NAME) is fake_sdk
+
+
+@pytest.mark.usefixtures('fake_sdk')
+def test_unknown_name_raises():
+    with pytest.raises(AttributeError):
+        getattr(sky, 'not_a_registered_sdk')
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module('sky.not_a_registered_sdk')
+
+
+def test_underscore_names_are_not_resolved():
+    # Dunder / private probes must short-circuit before any entry-point scan.
+    with pytest.raises(AttributeError):
+        getattr(sky, '_definitely_private')
+
+
+@pytest.mark.usefixtures('fake_sdk')
+def test_find_entry_point_select_api():
+    # pylint: disable=protected-access
+    entry_point = sky._find_client_sdk_entry_point(_SDK_NAME)
+    assert entry_point is not None
+    assert entry_point.value == _TARGET_MODULE
+    assert sky._find_client_sdk_entry_point('missing') is None
+
+
+def test_find_entry_point_legacy_mapping(monkeypatch):
+    # On Python < 3.10 ``entry_points()`` returns a plain mapping with no
+    # ``.select`` method, so the loader falls back to ``.get(group)``.
+    def _legacy_entry_points():
+        return {'sky.client_sdks': [_make_entry_point()]}
+
+    monkeypatch.setattr(importlib.metadata, 'entry_points',
+                        _legacy_entry_points)
+    # pylint: disable=protected-access
+    entry_point = sky._find_client_sdk_entry_point(_SDK_NAME)
+    assert entry_point is not None
+    assert entry_point.value == _TARGET_MODULE

--- a/tests/unit_tests/test_client_sdks.py
+++ b/tests/unit_tests/test_client_sdks.py
@@ -8,6 +8,7 @@ build time.
 # fake_sdk is a pytest fixture; receiving it as an argument is intentional.
 # pylint: disable=redefined-outer-name
 import importlib
+import importlib.machinery
 import importlib.metadata
 import sys
 import types
@@ -21,8 +22,9 @@ _TARGET_MODULE = 'sky_fake_sdk_target'
 
 
 def _make_entry_point():
-    return importlib.metadata.EntryPoint(_SDK_NAME, _TARGET_MODULE,
-                                         'sky.client_sdks')
+    return importlib.metadata.EntryPoint(name=_SDK_NAME,
+                                         value=_TARGET_MODULE,
+                                         group='sky.client_sdks')
 
 
 class _SelectableEntryPoints(list):
@@ -49,6 +51,10 @@ def _reset_client_sdk_cache():
 def fake_sdk(monkeypatch):
     """Register a fake client SDK and the target module it aliases to."""
     target = types.ModuleType(_TARGET_MODULE)
+    # A real imported module has a populated __spec__; give the fake target one
+    # so the alias loader can preserve it (see test_resolved_sdk_keeps_spec).
+    target.__spec__ = importlib.machinery.ModuleSpec(_TARGET_MODULE,
+                                                     loader=None)
     target.create = lambda: 'created'  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, _TARGET_MODULE, target)
 
@@ -83,6 +89,34 @@ def test_from_import_resolves_sdk(fake_sdk):
     # ``from sky import fakesdk`` (exercises the from-list import machinery).
     module = __import__('sky', fromlist=[_SDK_NAME])
     assert getattr(module, _SDK_NAME) is fake_sdk
+
+
+def test_resolved_sdk_keeps_spec(fake_sdk):
+    # Aliasing must not corrupt the target module's spec: ``__name__`` and
+    # ``__spec__.name`` stay consistent (so e.g. importlib.reload still works),
+    # rather than being mutated to the ``sky.<name>`` alias name.
+    module = importlib.import_module(f'sky.{_SDK_NAME}')
+    assert module is fake_sdk
+    assert module.__spec__ is not None
+    assert module.__spec__.name == module.__name__ == _TARGET_MODULE
+
+
+def test_target_import_error_propagates(monkeypatch):
+    # A registered SDK whose target module is missing must surface the real
+    # ModuleNotFoundError, not be masked as AttributeError.
+    bad = importlib.metadata.EntryPoint(name='brokensdk',
+                                        value='sky_no_such_target_xyz',
+                                        group='sky.client_sdks')
+    monkeypatch.setattr(importlib.metadata, 'entry_points',
+                        lambda: _SelectableEntryPoints([bad]))
+    try:
+        with pytest.raises(ModuleNotFoundError):
+            getattr(sky, 'brokensdk')
+    finally:
+        # Clean up via __dict__: hasattr()/getattr() would re-trigger
+        # __getattr__ and re-raise the same ModuleNotFoundError.
+        sys.modules.pop('sky.brokensdk', None)
+        vars(sky).pop('brokensdk', None)
 
 
 @pytest.mark.usefixtures('fake_sdk')

--- a/tests/unit_tests/test_client_sdks.py
+++ b/tests/unit_tests/test_client_sdks.py
@@ -32,6 +32,19 @@ class _SelectableEntryPoints(list):
         return [ep for ep in self if ep.group == group]
 
 
+@pytest.fixture(autouse=True)
+def _reset_client_sdk_cache():
+    """Clear the loader's process-lifetime entry-point cache around each test.
+
+    The loader memoizes ``importlib.metadata.entry_points()``; clearing it
+    before and after every test ensures monkeypatched entry points take effect
+    and never leak between tests.
+    """
+    sky._client_sdk_entry_points.cache_clear()  # pylint: disable=protected-access
+    yield
+    sky._client_sdk_entry_points.cache_clear()  # pylint: disable=protected-access
+
+
 @pytest.fixture
 def fake_sdk(monkeypatch):
     """Register a fake client SDK and the target module it aliases to."""
@@ -70,6 +83,15 @@ def test_from_import_resolves_sdk(fake_sdk):
     # ``from sky import fakesdk`` (exercises the from-list import machinery).
     module = __import__('sky', fromlist=[_SDK_NAME])
     assert getattr(module, _SDK_NAME) is fake_sdk
+
+
+@pytest.mark.usefixtures('fake_sdk')
+def test_submodule_import_raises_for_module_target():
+    # The entry point exposes a single *module*, so a submodule import under it
+    # (``sky.fakesdk.sub``) is intentionally not aliased; it fails like any
+    # attempt to import a submodule of a non-package module.
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module(f'sky.{_SDK_NAME}.sub')
 
 
 @pytest.mark.usefixtures('fake_sdk')


### PR DESCRIPTION
## Summary

Adds a lazy loader so an installed package can surface a client SDK under the `sky` namespace by registering an entry point in a new `sky.client_sdks` group whose value is the dotted path of the module to expose:

```python
# in the providing package's setup.py / pyproject.toml
entry_points={'sky.client_sdks': ['foo = some_package.foo.sdk']}
```

With that, `sky.foo`, `from sky import foo`, and `import sky.foo` all resolve (lazily) to `some_package.foo.sdk`, letting add-on packages extend the `sky` namespace without SkyPilot having to know about them at build time. This is analogous to the other Python entry-point extension hooks SkyPilot already
exposes.

Resolution is fully lazy:
- a PEP 562 module-level `__getattr__` handles bare attribute access
  (`import sky; sky.foo`), and
- a `sys.meta_path` finder handles the dotted-import form (`import sky.foo`).

It adds no import-time cost when no such SDK is installed, and the finder is appended to `sys.meta_path` so real `sky` submodules always take precedence. Cross-version safe: uses `entry_points().select(group=...)` on Python 3.10+ and falls back to the legacy mapping form on 3.8/3.9.

## Test plan

- `tests/unit_tests/test_client_sdks.py`: attribute / dotted / from-import resolution and module identity, unknown-name errors (`AttributeError` and `ModuleNotFoundError`), the underscore short-circuit, and the Python <3.10 `entry_points()` mapping fallback.
- `format.sh` clean (pylint 10.00/10, mypy clean, yapf/isort).
- Manually verified all three import forms resolve to a registered module with correct identity (`sky.foo is some_package.foo.sdk`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
