### PR TITLE
[Core] Fix set_pod_resource_limits silently ignored in task-level config

### DIFF
--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -510,10 +510,6 @@ OVERRIDEABLE_CONFIG_KEYS_IN_TASK: List[Tuple[str, ...]] = [
     ('kubernetes', 'kueue'),
     ('kubernetes', 'remote_identity'),
     ('kubernetes', 'enable_docker'),
-    # SSH Node Pools reuse the Kubernetes backend and read
-    # set_pod_resource_limits under the 'kubernetes' config key (see
-    # Kubernetes.make_deploy_resources_variables), so only the kubernetes
-    # entry is needed to cover both Kubernetes and SSH.
     ('kubernetes', 'set_pod_resource_limits'),
     ('azure', 'remote_identity'),
     ('azure', 'vpc_name'),

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -510,6 +510,11 @@ OVERRIDEABLE_CONFIG_KEYS_IN_TASK: List[Tuple[str, ...]] = [
     ('kubernetes', 'kueue'),
     ('kubernetes', 'remote_identity'),
     ('kubernetes', 'enable_docker'),
+    # SSH Node Pools reuse the Kubernetes backend and read
+    # set_pod_resource_limits under the 'kubernetes' config key (see
+    # Kubernetes.make_deploy_resources_variables), so only the kubernetes
+    # entry is needed to cover both Kubernetes and SSH.
+    ('kubernetes', 'set_pod_resource_limits'),
     ('azure', 'remote_identity'),
     ('azure', 'vpc_name'),
     ('gcp', 'vpc_name'),

--- a/tests/unit_tests/test_resources.py
+++ b/tests/unit_tests/test_resources.py
@@ -773,6 +773,37 @@ def test_network_tier_copy():
     assert r_override.cpus == '4'  # Other properties preserved
 
 
+@pytest.mark.parametrize('value', [True, 2.0])
+def test_set_pod_resource_limits_task_config_override(value):
+    """set_pod_resource_limits in a task-level config block must survive.
+
+    Regression test for https://github.com/skypilot-org/skypilot/issues/9785:
+    the field was silently dropped by Resources.copy() (invoked during the
+    launch/optimize flow) because it was missing from
+    OVERRIDEABLE_CONFIG_KEYS_IN_TASK.
+    """
+    overrides = {'kubernetes': {'set_pod_resource_limits': value}}
+    r = Resources(infra='kubernetes',
+                  cpus=2,
+                  memory=8,
+                  _cluster_config_overrides=overrides)
+    assert r.cluster_config_overrides == overrides
+
+    # copy() is called during the launch/optimize flow; the override must be
+    # preserved rather than silently stripped.
+    r_copy = r.copy()
+    assert r_copy.cluster_config_overrides == overrides
+
+    # The read path used by make_deploy_resources_variables must see it.
+    read = skypilot_config.get_effective_workspace_region_config(
+        cloud='kubernetes',
+        region=None,
+        keys=('set_pod_resource_limits',),
+        default_value=False,
+        override_configs=r_copy.cluster_config_overrides)
+    assert read == value
+
+
 def test_network_tier_repr():
     """Test that network tier appears in the string representation."""
     r = Resources(network_tier='best')


### PR DESCRIPTION
## Summary

- Fixes #9785: `set_pod_resource_limits` set in a task-level `config:` block was silently ignored — the resulting Kubernetes pod had no CPU/memory limits and QoS class `Burstable` instead of `Guaranteed`.
- Root cause: `Task.from_yaml` parses the field correctly into `Resources._cluster_config_overrides`, but `Resources.copy()` (invoked during the launch/optimize flow) rebuilds the overrides using the allow-list `OVERRIDEABLE_CONFIG_KEYS_IN_TASK`, which was missing `('kubernetes', 'set_pod_resource_limits')`, so the field was dropped. `pod_config` worked because it *is* in the allow-list (which is what made this so confusing). Note the `kubernetes` config schema uses `additionalProperties: True`, so the field passes schema validation without error — hence the silent failure.
- Fix: add `('kubernetes', 'set_pod_resource_limits')` to the allow-list. SSH Node Pools reuse the Kubernetes backend and read this value under the `kubernetes` config key (the read in `Kubernetes.make_deploy_resources_variables` hardcodes `cloud='kubernetes'`), so the single entry covers both Kubernetes and SSH.

## Test plan

- **Unit test**: added a parametrized regression test in `tests/unit_tests/test_resources.py` (over `True` and a numeric multiplier) that verifies the override survives `Resources.copy()` and is visible via the read path used by `make_deploy_resources_variables`. It fails before the fix and passes after.
- **End-to-end on a real Kubernetes cluster**, controlled before/after with `sky launch` of a task containing `config.kubernetes.set_pod_resource_limits: true`:

  | | container resources | QoS class |
  |---|---|---|
  | Without fix | `{"requests": {"cpu": "2", "memory": "8G"}}` | `Burstable` ❌ |
  | With fix | `{"limits": {"cpu": "2", "memory": "8G"}, "requests": {"cpu": "2", "memory": "8G"}}` | `Guaranteed` ✅ |

  This matches the expected vs. actual behavior described in #9785.
- `format.sh` passes (mypy clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)