### PR TITLE
[Image] Use legacy CUDA 12 image for pre-Turing GPUs; fix arm64 build

### DIFF
--- a/sky/catalog/images/provisioners/cuda.sh
+++ b/sky/catalog/images/provisioners/cuda.sh
@@ -27,7 +27,10 @@ ARCH=$(uname -m)
 
 if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
     echo "Detected ARM architecture: $ARCH"
-    ARCH_PATH="arm64"
+    # Use the SBSA (Server Base System Architecture) repo for ARM server GPUs
+    # (AWS Graviton + GPU, GH200, GB200). The `arm64` repo is the Jetson/Tegra
+    # (L4T) repo and does not carry CUDA 13.0.
+    ARCH_PATH="sbsa"
 else
     echo "Detected x86_64 architecture"
     ARCH_PATH="x86_64"

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -25,6 +25,7 @@ from sky.adaptors import aws
 from sky.adaptors import common
 from sky.catalog import common as catalog_common
 from sky.clouds.utils import aws_utils
+from sky.clouds.utils import gpu_utils
 from sky.skylet import constants
 from sky.utils import annotations
 from sky.utils import common_utils
@@ -51,8 +52,14 @@ _DEFAULT_CPU_IMAGE_ID = 'skypilot:custom-cpu-ubuntu'
 _DEFAULT_CPU_ARM64_IMAGE_ID = 'skypilot:custom-cpu-ubuntu-arm64'
 # For GPU-related package version,
 # see sky/catalog/images/provisioners/cuda.sh
-_DEFAULT_GPU_IMAGE_ID = 'skypilot:custom-gpu-ubuntu'
-_DEFAULT_GPU_ARM64_IMAGE_ID = 'skypilot:custom-gpu-ubuntu-arm64'
+# Default GPU image: NVIDIA 580 open kernel module + CUDA 13. Supports Turing
+# and later only.
+_DEFAULT_GPU_IMAGE_ID = 'skypilot:custom-gpu-ubuntu-cuda13'
+_DEFAULT_GPU_ARM64_IMAGE_ID = 'skypilot:custom-gpu-ubuntu-arm64-cuda13'
+# Legacy GPU image: NVIDIA 535 proprietary driver + CUDA 12. Used for pre-Turing
+# GPUs (V100, M60) that the open kernel module does not support.
+_DEFAULT_GPU_CUDA12_IMAGE_ID = 'skypilot:custom-gpu-ubuntu'
+_DEFAULT_GPU_CUDA12_ARM64_IMAGE_ID = 'skypilot:custom-gpu-ubuntu-arm64'
 _DEFAULT_GPU_K80_IMAGE_ID = 'skypilot:k80-ubuntu-2004'
 _DEFAULT_NEURON_IMAGE_ID = 'skypilot:neuron-ubuntu-2204'
 
@@ -443,6 +450,16 @@ class AWS(clouds.Cloud):
             if acc_name == 'K80':
                 image_id = catalog.get_image_id_from_tag(
                     _DEFAULT_GPU_K80_IMAGE_ID, region_name, clouds='aws')
+            elif gpu_utils.is_legacy_driver_gpu(acc_name):
+                # Pre-Turing GPUs (V100, M60) are not supported by the open
+                # kernel module in the default image, so fall back to the
+                # legacy proprietary-driver (CUDA 12) image.
+                legacy_tag = (_DEFAULT_GPU_CUDA12_ARM64_IMAGE_ID
+                              if arch == constants.ARM64_ARCH else
+                              _DEFAULT_GPU_CUDA12_IMAGE_ID)
+                image_id = catalog.get_image_id_from_tag(legacy_tag,
+                                                         region_name,
+                                                         clouds='aws')
             if acc_name.startswith('Trainium') or acc_name.startswith(
                     'Inferentia'):
                 image_id = catalog.get_image_id_from_tag(

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -18,6 +18,7 @@ from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import gcp
 from sky.clouds.utils import gcp_utils
+from sky.clouds.utils import gpu_utils
 from sky.provision.gcp import constants
 from sky.provision.gcp import volume_utils
 from sky.utils import annotations
@@ -117,8 +118,13 @@ _IMAGE_NOT_FOUND_UX_MESSAGE = (
 
 # Image ID tags
 _DEFAULT_CPU_IMAGE_ID = 'skypilot:custom-cpu-ubuntu-2204'
-# For GPU-related package version, see sky/clouds/catalog/images/provisioners/cuda.sh
-_DEFAULT_GPU_IMAGE_ID = 'skypilot:custom-gpu-ubuntu-2204'
+# For GPU-related package version, see sky/catalog/images/provisioners/cuda.sh
+# Default GPU image: NVIDIA 580 open kernel module + CUDA 13. Supports Turing
+# and later only.
+_DEFAULT_GPU_IMAGE_ID = 'skypilot:custom-gpu-ubuntu-2204-cuda13'
+# Legacy GPU image: NVIDIA 535 proprietary driver + CUDA 12. Used for pre-Turing
+# GPUs (V100, P100, P4, M60) that the open kernel module does not support.
+_DEFAULT_GPU_CUDA12_IMAGE_ID = 'skypilot:custom-gpu-ubuntu-2204'
 _DEFAULT_GPU_K80_IMAGE_ID = 'skypilot:k80-debian-10'
 # Use COS image with GPU Direct support.
 # Need to contact GCP support to build our own image for GPUDirect-TCPX support.
@@ -509,6 +515,22 @@ class GCP(clouds.Cloud):
             start_index += 1
         assert False, 'Low disk tier should always be supported on GCP.'
 
+    @staticmethod
+    def _get_gpu_image_id(acc: str) -> str:
+        """Returns the default image tag for a (non-GPU-direct) GPU."""
+        if acc == 'K80':
+            # Though the image is called cu113, it actually has later
+            # versions of CUDA as noted below.
+            # CUDA driver version 470.57.02, CUDA Library 11.4
+            return _DEFAULT_GPU_K80_IMAGE_ID
+        if gpu_utils.is_legacy_driver_gpu(acc):
+            # Pre-Turing GPUs (V100, P100, P4, M60) are not supported by the
+            # open kernel module in the default image.
+            # CUDA driver version 535, CUDA Library 12.
+            return _DEFAULT_GPU_CUDA12_IMAGE_ID
+        # CUDA driver version 580 (open), CUDA Library 13.
+        return _DEFAULT_GPU_IMAGE_ID
+
     def make_deploy_resources_variables(
         self,
         resources: 'resources.Resources',
@@ -599,14 +621,7 @@ class GCP(clouds.Cloud):
                     # and reference GCP_GPU_DIRECT_IMAGE_ID
                     image_id = _DEFAULT_GPU_DIRECT_IMAGE_ID
                 else:
-                    if acc == 'K80':
-                        # Though the image is called cu113, it actually has later
-                        # versions of CUDA as noted below.
-                        # CUDA driver version 470.57.02, CUDA Library 11.4
-                        image_id = _DEFAULT_GPU_K80_IMAGE_ID
-                    else:
-                        # CUDA driver version 535.86.10, CUDA Library 12.2
-                        image_id = _DEFAULT_GPU_IMAGE_ID
+                    image_id = GCP._get_gpu_image_id(acc)
 
         cloud_image_id = resources.get_cloud_image_id()
         if cloud_image_id is not None:

--- a/sky/clouds/utils/gpu_utils.py
+++ b/sky/clouds/utils/gpu_utils.py
@@ -1,0 +1,25 @@
+"""Shared GPU helpers for cloud image selection.
+
+The default SkyPilot GPU image installs the NVIDIA open kernel module (see
+sky/catalog/images/provisioners/cuda.sh). The open module depends on the GSP
+firmware first introduced in Turing, so it only supports Turing and later
+(T4, A100, L4, H100, B200, RTX PRO 6000, ...). Maxwell, Pascal (P100, P4) and
+Volta (V100) are not supported and must keep using the older proprietary-driver
+image. K80 is even older and uses its own dedicated image, so it is handled
+separately by each cloud and is not listed here.
+"""
+
+# Pre-Turing GPUs that the open kernel module does not support. These must be
+# launched with the legacy (proprietary driver / CUDA 12) image instead of the
+# default image.
+LEGACY_DRIVER_GPUS = frozenset({
+    'M60',
+    'P100',
+    'P4',
+    'V100',
+})
+
+
+def is_legacy_driver_gpu(accelerator_name: str) -> bool:
+    """Returns True if the GPU needs the legacy proprietary-driver image."""
+    return accelerator_name in LEGACY_DRIVER_GPUS

--- a/tests/unit_tests/test_sky/clouds/test_aws_cloud.py
+++ b/tests/unit_tests/test_sky/clouds/test_aws_cloud.py
@@ -802,3 +802,39 @@ class TestAwsConfigFileEnvVar:
         assert mounts == {
             aws_mod._DEFAULT_AWS_CONFIG_PATH: str(credential_file)
         }
+
+
+class TestGetDefaultAmi:
+    """Tests for AWS._get_default_ami GPU image selection."""
+
+    def _patch(self, monkeypatch, acc, arch):
+        # Echo the requested tag back so we can assert which image was chosen.
+        monkeypatch.setattr(aws_mod.catalog, 'get_image_id_from_tag',
+                            lambda tag, region, clouds: tag)
+        monkeypatch.setattr(aws_mod.AWS, 'get_accelerators_from_instance_type',
+                            classmethod(lambda cls, instance_type: acc))
+        monkeypatch.setattr(aws_mod.AWS, 'get_arch_from_instance_type',
+                            classmethod(lambda cls, instance_type: arch))
+
+    def test_turing_gpu_uses_cuda13_default(self, monkeypatch):
+        self._patch(monkeypatch, {'T4': 1}, 'x86_64')
+        result = aws_mod.AWS._get_default_ami('us-east-1', 'g4dn.xlarge')
+        assert result == aws_mod._DEFAULT_GPU_IMAGE_ID
+
+    @pytest.mark.parametrize('acc_name', ['V100', 'M60'])
+    def test_pre_turing_gpu_uses_legacy_cuda12(self, monkeypatch, acc_name):
+        self._patch(monkeypatch, {acc_name: 1}, 'x86_64')
+        result = aws_mod.AWS._get_default_ami('us-east-1', 'p3.2xlarge')
+        assert result == aws_mod._DEFAULT_GPU_CUDA12_IMAGE_ID
+
+    def test_k80_uses_k80_image(self, monkeypatch):
+        self._patch(monkeypatch, {'K80': 1}, 'x86_64')
+        result = aws_mod.AWS._get_default_ami('us-east-1', 'p2.xlarge')
+        assert result == aws_mod._DEFAULT_GPU_K80_IMAGE_ID
+
+    def test_arm64_gpu_uses_cuda13_arm64(self, monkeypatch):
+        # All arm64 GPUs (e.g. GH200) are Turing+, so they use the default
+        # cuda13 arm64 image.
+        self._patch(monkeypatch, {'GH200': 1}, 'arm64')
+        result = aws_mod.AWS._get_default_ami('us-east-1', 'g5g.xlarge')
+        assert result == aws_mod._DEFAULT_GPU_ARM64_IMAGE_ID

--- a/tests/unit_tests/test_sky/clouds/test_gcp_cloud.py
+++ b/tests/unit_tests/test_sky/clouds/test_gcp_cloud.py
@@ -1,0 +1,24 @@
+"""Test the GCP class."""
+
+import pytest
+
+from sky.clouds import gcp as gcp_mod
+
+
+class TestGetGpuImageId:
+    """Tests for GCP._get_gpu_image_id GPU image selection."""
+
+    @pytest.mark.parametrize('acc_name',
+                             ['T4', 'A100', 'A100-80GB', 'L4', 'H100', 'B200'])
+    def test_turing_and_later_uses_cuda13_default(self, acc_name):
+        assert gcp_mod.GCP._get_gpu_image_id(
+            acc_name) == gcp_mod._DEFAULT_GPU_IMAGE_ID
+
+    @pytest.mark.parametrize('acc_name', ['V100', 'P100', 'P4', 'M60'])
+    def test_pre_turing_uses_legacy_cuda12(self, acc_name):
+        assert gcp_mod.GCP._get_gpu_image_id(
+            acc_name) == gcp_mod._DEFAULT_GPU_CUDA12_IMAGE_ID
+
+    def test_k80_uses_k80_image(self):
+        assert gcp_mod.GCP._get_gpu_image_id(
+            'K80') == gcp_mod._DEFAULT_GPU_K80_IMAGE_ID

--- a/tests/unit_tests/test_sky/clouds/test_gpu_utils.py
+++ b/tests/unit_tests/test_sky/clouds/test_gpu_utils.py
@@ -1,0 +1,28 @@
+"""Tests for the shared GPU image-selection helpers."""
+
+import pytest
+
+from sky.clouds.utils import gpu_utils
+
+
+@pytest.mark.parametrize('acc_name', ['V100', 'P100', 'P4', 'M60'])
+def test_pre_turing_gpus_are_legacy(acc_name):
+    assert gpu_utils.is_legacy_driver_gpu(acc_name)
+    assert acc_name in gpu_utils.LEGACY_DRIVER_GPUS
+
+
+@pytest.mark.parametrize('acc_name',
+                         ['T4', 'A100', 'A100-80GB', 'L4', 'H100', 'B200'])
+def test_turing_and_later_gpus_are_not_legacy(acc_name):
+    assert not gpu_utils.is_legacy_driver_gpu(acc_name)
+
+
+def test_k80_is_not_in_legacy_set():
+    # K80 has its own dedicated image and is handled separately by each cloud,
+    # so it must not be routed through the legacy proprietary-driver image.
+    assert not gpu_utils.is_legacy_driver_gpu('K80')
+    assert 'K80' not in gpu_utils.LEGACY_DRIVER_GPUS
+
+
+def test_unknown_gpu_is_not_legacy():
+    assert not gpu_utils.is_legacy_driver_gpu('NotAGPU')


### PR DESCRIPTION
## Summary

Follow-up to #9639, which bumped the default GPU image provisioner to the **NVIDIA 580 open kernel module + CUDA 13**. The open kernel module depends on GSP firmware first introduced in Turing, so it only supports **Turing and later** — it drops support for the pre-Turing GPUs (V100, P100, P4, M60) that the previous 535 proprietary driver covered. This PR makes the launch path route those GPUs to the older image so they keep working.

- Add `sky/clouds/utils/gpu_utils.py` as the single source of truth for which GPUs need the legacy proprietary-driver image (`LEGACY_DRIVER_GPUS = {M60, P100, P4, V100}`). K80 is intentionally excluded — it has its own dedicated image and is handled separately by each cloud.
- **AWS / GCP**: point the default GPU image variable at a new `*-cuda13` image tag, and add a new `*-cuda12` variable pointing at the **existing 535 image tag** (reused unchanged). Pre-Turing GPUs route to the cuda12 tag; everything else uses the cuda13 default; K80 keeps its own image. The GCP selection is extracted into `GCP._get_gpu_image_id` for testability.
- **Backward compatibility**: the existing `custom-gpu-ubuntu(-2204)` tags are not modified, so older clients continue resolving them to the 535 image for all GPUs — zero regression. New clients use cuda13 by default and fall back to the existing tag for pre-Turing GPUs.
- **`cuda.sh` arm64 fix**: use the **SBSA** CUDA repo for ARM server GPUs (Graviton+GPU, GH200, GB200) instead of the `arm64` (Jetson/Tegra L4T) repo. The `arm64` repo does not carry `cuda-toolkit-13-0`, so the arm64 image build introduced in #9639 fails with `Unable to locate package cuda-toolkit-13-0`.

### Catalog

The new `skypilot:custom-gpu-ubuntu[-arm64]-cuda13` (AWS) and `skypilot:custom-gpu-ubuntu-2204-cuda13` (GCP) image tags haven been built and shipped to [`skypilot-catalog`](https://github.com/skypilot-org/skypilot-catalog). The existing 535 rows stay as-is to back the cuda12 tags.

## Test plan

- `pytest tests/unit_tests/test_sky/clouds/test_gpu_utils.py tests/unit_tests/test_sky/clouds/test_gcp_cloud.py tests/unit_tests/test_sky/clouds/test_aws_cloud.py::TestGetDefaultAmi` — 28 new cases, all pass. Covers: pre-Turing → cuda12, Turing+ → cuda13, K80 → k80 image, AWS arm64 → cuda13-arm64.
- Verified against the NVIDIA repos that `cuda-toolkit-13-0` / `nvidia-driver-580-open` / `libcudnn9-cuda-13` exist under `ubuntu2204/sbsa` and that `cuda-toolkit-13-0` is **absent** from `ubuntu2204/arm64` (only 12.4 present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)