### PR TITLE
Example cosmos3 nano

### DIFF
--- a/docs/source/examples/training/cosmos3-finetuning.md
+++ b/docs/source/examples/training/cosmos3-finetuning.md
@@ -1,0 +1,1 @@
+../../generated-examples/cosmos3-finetuning.md

--- a/docs/source/examples/training/index.rst
+++ b/docs/source/examples/training/index.rst
@@ -9,6 +9,7 @@ Training
    Distributed PyTorch <distributed-pytorch.md>
    Distributed TensorFlow <distributed-tensorflow.md>
    Fairseq2 <fairseq2.md>
+   Finetuning Cosmos 3 <cosmos3-finetuning.md>
    Finetuning GPT-OSS <gpt-oss-finetuning.md>
    Finetuning Llama 4 <llama-4-finetuning.md>
    Finetuning Llama 3 <llama-3_1-finetuning.md>

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,7 +14,7 @@ Machine learning examples:
 
 - [**`huggingface_glue_imdb_app.yaml`**](./huggingface_glue_imdb_app.yaml): Use [Huggingface Transformers](https://github.com/huggingface/transformers/) to finetune a pretrained BERT model.
 
-- [**`cosmos3-finetuning/`**](./cosmos3-finetuning/README.md): Fine-tune [NVIDIA Cosmos 3](https://github.com/NVIDIA/cosmos-framework) (`Cosmos3-Nano`, a 16B omnimodal world foundation model for Physical AI) on a robot-manipulation video dataset, using NVIDIA's official `vision_sft_nano` SFT recipe with FSDP across 8 GPUs.
+- [**`cosmos3-finetuning/`**](./cosmos3-finetuning/README.md): Fine-tune [NVIDIA Cosmos 3](https://github.com/NVIDIA/cosmos-framework) (`Cosmos3-Nano`, a 16B world foundation model for Physical AI) on robot-manipulation video as a managed job, using NVIDIA's `vision_sft_nano` SFT recipe with checkpoint-to-bucket auto-recovery.
 
 - [**`resnet_distributed_torch.yaml`**](./resnet_distributed_torch.yaml): Run Distributed PyTorch (DDP) training of ResNet50 on 2 nodes.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,8 @@ Machine learning examples:
 
 - [**`huggingface_glue_imdb_app.yaml`**](./huggingface_glue_imdb_app.yaml): Use [Huggingface Transformers](https://github.com/huggingface/transformers/) to finetune a pretrained BERT model.
 
+- [**`cosmos3-finetuning/`**](./cosmos3-finetuning/README.md): Fine-tune [NVIDIA Cosmos 3](https://github.com/NVIDIA/cosmos-framework) (`Cosmos3-Nano`, a 16B omnimodal world foundation model for Physical AI) on a robot-manipulation video dataset, using NVIDIA's official `vision_sft_nano` SFT recipe with FSDP across 8 GPUs.
+
 - [**`resnet_distributed_torch.yaml`**](./resnet_distributed_torch.yaml): Run Distributed PyTorch (DDP) training of ResNet50 on 2 nodes.
 
 - [**`detectron2_app.yaml`**](./detectron2_app.yaml): Run Detectron2 on a V100 GPU.

--- a/examples/cosmos3-finetuning/README.md
+++ b/examples/cosmos3-finetuning/README.md
@@ -22,9 +22,11 @@ post-trains the Cosmos3-Nano generation pathway (text/image/video → video) wit
 FSDP across 8 GPUs in bfloat16. It trains on
 [`nvidia/bridge-v2-subset-synthetic-captions`](https://huggingface.co/datasets/nvidia/bridge-v2-subset-synthetic-captions),
 a ~650 MB subset of [BridgeData V2](https://rail-berkeley.github.io/bridgedata/)
-robot-manipulation videos. To fine-tune on your own data, make it available on the
-instance (e.g. via another `file_mounts` bucket) laid out like
-`train/video_dataset_file.jsonl` and pass `--env DATASET_PATH=/path/to/it` (see
+robot-manipulation videos. To fine-tune on your own data, mount it on the instance with a
+`file_mounts` bucket (e.g. `source: s3://your-bucket/`, see
+[Cloud Buckets](https://docs.skypilot.co/en/latest/reference/storage.html)) or a
+[volume](https://docs.skypilot.co/en/stable/reference/volumes.html), laid out like
+`train/video_dataset_file.jsonl`, and pass `--env DATASET_PATH=/path/to/it` (see
 [`docs/dataset_jsonl.md`](https://github.com/NVIDIA/cosmos-framework/blob/main/docs/dataset_jsonl.md)).
 
 ## Run it

--- a/examples/cosmos3-finetuning/README.md
+++ b/examples/cosmos3-finetuning/README.md
@@ -1,84 +1,91 @@
 # Fine-tuning NVIDIA Cosmos 3 with SkyPilot
 
 [NVIDIA Cosmos 3](https://developer.nvidia.com/blog/develop-physical-ai-reasoning-world-and-action-models-with-nvidia-cosmos-3/)
-is a family of open **omnimodal world foundation models** for Physical AI —
+is a family of open **omnimodal world foundation models** for Physical AI:
 robotics, autonomous vehicles, and smart spaces. Built on a Mixture-of-Transformers
 architecture, a Cosmos 3 model pairs a **reasoner** tower (a vision-language model
 over text/image/video/audio/action) with a **generator** tower (a diffusion model
 that synthesizes future video/image/action). This example fine-tunes the smallest
-member, `Cosmos3-Nano` (16B), on a single SkyPilot cluster.
+member, `Cosmos3-Nano` (16B), as a SkyPilot managed job with checkpoint-to-bucket
+auto-recovery.
 
 | Model | Params | Notes |
 | ----- | ------ | ----- |
-| [`nvidia/Cosmos3-Nano`](https://huggingface.co/nvidia/Cosmos3-Nano)   | 16B | Workstation/efficient tier — used in this example |
+| [`nvidia/Cosmos3-Nano`](https://huggingface.co/nvidia/Cosmos3-Nano)   | 16B | Workstation/efficient tier, used in this example |
 | [`nvidia/Cosmos3-Super`](https://huggingface.co/nvidia/Cosmos3-Super) | 64B | Datacenter / frontier tier |
 | [`nvidia/Cosmos3-Super-Image2Video`](https://huggingface.co/nvidia/Cosmos3-Super-Image2Video) | 64B | Image-to-video specialization |
 
 It runs NVIDIA's official supervised fine-tuning recipe
 [`vision_sft_nano`](https://github.com/NVIDIA/cosmos-framework/blob/main/examples/launch_sft_vision_nano.sh)
-from [cosmos-framework](https://github.com/NVIDIA/cosmos-framework) — which
+from [cosmos-framework](https://github.com/NVIDIA/cosmos-framework): it
 post-trains the Cosmos3-Nano generation pathway (text/image/video → video) with
-FSDP across 8 GPUs in bfloat16 — on
+FSDP across 8 GPUs in bfloat16. It trains on
 [`nvidia/bridge-v2-subset-synthetic-captions`](https://huggingface.co/datasets/nvidia/bridge-v2-subset-synthetic-captions),
 a ~650 MB subset of [BridgeData V2](https://rail-berkeley.github.io/bridgedata/)
-robot-manipulation videos with synthetic captions. This is the dataset NVIDIA
-ships with the recipe, so it cleanly exercises the full pipeline: download →
-checkpoint conversion → training → checkpoint → safetensors export.
-
-To fine-tune on your own data, point the launcher at a dataset laid out like
-`train/video_dataset_file.jsonl` by setting its `DATASET_PATH` in the `run` block
-(see [`docs/dataset_jsonl.md`](https://github.com/NVIDIA/cosmos-framework/blob/main/docs/dataset_jsonl.md)).
+robot-manipulation videos. To fine-tune on your own data, make it available on the
+instance (e.g. via another `file_mounts` bucket) laid out like
+`train/video_dataset_file.jsonl` and pass `--env DATASET_PATH=/path/to/it` (see
+[`docs/dataset_jsonl.md`](https://github.com/NVIDIA/cosmos-framework/blob/main/docs/dataset_jsonl.md)).
 
 ## Run it
 
 ```bash
-# Full reference recipe (max_iter=500). The model + dataset are public, so no token is needed.
-sky launch -c cosmos3 examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml
+pip install "skypilot-nightly[aws,gcp,kubernetes]"  # pick your clouds
+sky check
 ```
 
-SkyPilot picks the cheapest cloud/region with 8× H100/H200; add `--infra nebius`
-(or `aws`, `gcp`, …) to pin one. To authenticate to Hugging Face (e.g. to avoid
-download rate limits), `export HF_TOKEN=...` and add `--secret HF_TOKEN`.
-
-The first launch provisions the cluster and runs `setup` (install env, download
-the dataset + Wan2.2 VAE, download Cosmos3-Nano and convert it to DCP format),
-then `run` (train + export). Setup downloads ~35 GB (NGC image, CUDA-13 deps, the
-16B model, VAE, dataset), so it can take 30+ minutes and looks idle while the
-quiet downloads run. Subsequent runs reuse the cached setup.
-
-**Quick smoke test** — run a handful of steps to verify the whole pipeline
-cheaply; it still produces a real checkpoint and safetensors export:
+Pick a globally-unique `CHECKPOINT_BUCKET_NAME`. SkyPilot creates the bucket and
+mounts it at `/checkpoints` (the recipe's `OUTPUT_ROOT`), so the job auto-resumes
+from the latest checkpoint after a recovery and the outputs outlive its cluster.
 
 ```bash
-sky launch -c cosmos3 examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml \
-    --env MAX_ITER=10 --env SAVE_ITER=5
+sky jobs launch -n cosmos3 examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml \
+    --env CHECKPOINT_BUCKET_NAME=my-cosmos3-checkpoints
 ```
 
-`setup` is cached, so you can iterate on training alone with
-`sky exec cosmos3 examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml --env MAX_ITER=200`.
+SkyPilot picks the cheapest cloud/region with 8× H100/H200; add `--infra <cloud>`
+(e.g. `aws`, `gcp`, `k8s`) to pin one, or `--use-spot` for cheaper preemptible GPUs
+(the job auto-resumes after a preemption). The model and dataset are public, so no token is needed; for HF auth,
+`export HF_TOKEN=...` and add `--secret HF_TOKEN`. The first run downloads ~35 GB in
+`setup` (base model + VAE + dataset; 30+ min, and looks idle during the quiet
+downloads), then trains + exports.
+
+**Smoke test** (a few steps to exercise the whole pipeline, still checkpoints + exports):
+
+```bash
+sky jobs launch -n cosmos3 examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml \
+    --env CHECKPOINT_BUCKET_NAME=my-cosmos3-checkpoints --env MAX_ITER=10 --env SAVE_ITER=5
+```
+
+Monitor and manage it:
+
+```bash
+sky jobs queue            # status of all managed jobs
+sky jobs logs -n cosmos3  # stream logs
+sky jobs cancel -n cosmos3
+```
 
 ### Tunable knobs (`--env`)
 
 | Env var | Default | Meaning |
 | ------- | ------- | ------- |
+| `CHECKPOINT_BUCKET_NAME` | `my-cosmos3-checkpoints` | Globally-unique cloud bucket for checkpoints + auto-resume (change to your own). |
+| `DATASET_PATH` | bridge subset | Dataset dir the launcher trains on (override for your own data). |
 | `MAX_ITER` | `500` | Number of optimizer steps (set small for a smoke test). |
 | `SAVE_ITER` | `100` | Save a DCP checkpoint every N steps. |
-| `BASE_CHECKPOINT_NAME` | `Cosmos3-Nano` | Base checkpoint to fine-tune (catalog name). |
 | `EXPORT_SAFETENSORS` | `1` | Export the trained checkpoint to HF safetensors. |
 | `COSMOS_FRAMEWORK_REF` | pinned commit | cosmos-framework git ref to install. |
 
 ## Outputs
 
-Training writes to `~/cosmos-framework/outputs/train/cosmos3/sft/vision_sft_nano/`:
-
-- `checkpoints/iter_<N>/` — sharded DCP checkpoints.
-- `model/` — the exported Hugging Face safetensors (when `EXPORT_SAFETENSORS=1`).
-
-Fetch them with `ssh cosmos3` or `rsync`. Tear down with `sky down cosmos3`.
+Checkpoints (`checkpoints/iter_<N>/`), the resolved `config.yaml`, and the exported
+safetensors (`model/`) land in your bucket under `cosmos3/sft/vision_sft_nano/`. Run
+`sky storage ls` to find the bucket, then download with that cloud's CLI, e.g.
+`aws s3 sync s3://my-cosmos3-checkpoints/ .`.
 
 ## References
 
 - Cosmos 3 blog: https://developer.nvidia.com/blog/develop-physical-ai-reasoning-world-and-action-models-with-nvidia-cosmos-3/
 - Technical report: https://research.nvidia.com/labs/cosmos-lab/cosmos3/technical-report.pdf
-- cosmos-framework (training/serving): https://github.com/NVIDIA/cosmos-framework
-- NVIDIA Cosmos (models, inference): https://github.com/NVIDIA/Cosmos
+- cosmos-framework: https://github.com/NVIDIA/cosmos-framework
+- NVIDIA Cosmos: https://github.com/NVIDIA/Cosmos

--- a/examples/cosmos3-finetuning/README.md
+++ b/examples/cosmos3-finetuning/README.md
@@ -1,0 +1,84 @@
+# Fine-tuning NVIDIA Cosmos 3 with SkyPilot
+
+[NVIDIA Cosmos 3](https://developer.nvidia.com/blog/develop-physical-ai-reasoning-world-and-action-models-with-nvidia-cosmos-3/)
+is a family of open **omnimodal world foundation models** for Physical AI —
+robotics, autonomous vehicles, and smart spaces. Built on a Mixture-of-Transformers
+architecture, a Cosmos 3 model pairs a **reasoner** tower (a vision-language model
+over text/image/video/audio/action) with a **generator** tower (a diffusion model
+that synthesizes future video/image/action). This example fine-tunes the smallest
+member, `Cosmos3-Nano` (16B), on a single SkyPilot cluster.
+
+| Model | Params | Notes |
+| ----- | ------ | ----- |
+| [`nvidia/Cosmos3-Nano`](https://huggingface.co/nvidia/Cosmos3-Nano)   | 16B | Workstation/efficient tier — used in this example |
+| [`nvidia/Cosmos3-Super`](https://huggingface.co/nvidia/Cosmos3-Super) | 64B | Datacenter / frontier tier |
+| [`nvidia/Cosmos3-Super-Image2Video`](https://huggingface.co/nvidia/Cosmos3-Super-Image2Video) | 64B | Image-to-video specialization |
+
+It runs NVIDIA's official supervised fine-tuning recipe
+[`vision_sft_nano`](https://github.com/NVIDIA/cosmos-framework/blob/main/examples/launch_sft_vision_nano.sh)
+from [cosmos-framework](https://github.com/NVIDIA/cosmos-framework) — which
+post-trains the Cosmos3-Nano generation pathway (text/image/video → video) with
+FSDP across 8 GPUs in bfloat16 — on
+[`nvidia/bridge-v2-subset-synthetic-captions`](https://huggingface.co/datasets/nvidia/bridge-v2-subset-synthetic-captions),
+a ~650 MB subset of [BridgeData V2](https://rail-berkeley.github.io/bridgedata/)
+robot-manipulation videos with synthetic captions. This is the dataset NVIDIA
+ships with the recipe, so it cleanly exercises the full pipeline: download →
+checkpoint conversion → training → checkpoint → safetensors export.
+
+To fine-tune on your own data, point the launcher at a dataset laid out like
+`train/video_dataset_file.jsonl` by setting its `DATASET_PATH` in the `run` block
+(see [`docs/dataset_jsonl.md`](https://github.com/NVIDIA/cosmos-framework/blob/main/docs/dataset_jsonl.md)).
+
+## Run it
+
+```bash
+# Full reference recipe (max_iter=500). The model + dataset are public, so no token is needed.
+sky launch -c cosmos3 examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml
+```
+
+SkyPilot picks the cheapest cloud/region with 8× H100/H200; add `--infra nebius`
+(or `aws`, `gcp`, …) to pin one. To authenticate to Hugging Face (e.g. to avoid
+download rate limits), `export HF_TOKEN=...` and add `--secret HF_TOKEN`.
+
+The first launch provisions the cluster and runs `setup` (install env, download
+the dataset + Wan2.2 VAE, download Cosmos3-Nano and convert it to DCP format),
+then `run` (train + export). Setup downloads ~35 GB (NGC image, CUDA-13 deps, the
+16B model, VAE, dataset), so it can take 30+ minutes and looks idle while the
+quiet downloads run. Subsequent runs reuse the cached setup.
+
+**Quick smoke test** — run a handful of steps to verify the whole pipeline
+cheaply; it still produces a real checkpoint and safetensors export:
+
+```bash
+sky launch -c cosmos3 examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml \
+    --env MAX_ITER=10 --env SAVE_ITER=5
+```
+
+`setup` is cached, so you can iterate on training alone with
+`sky exec cosmos3 examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml --env MAX_ITER=200`.
+
+### Tunable knobs (`--env`)
+
+| Env var | Default | Meaning |
+| ------- | ------- | ------- |
+| `MAX_ITER` | `500` | Number of optimizer steps (set small for a smoke test). |
+| `SAVE_ITER` | `100` | Save a DCP checkpoint every N steps. |
+| `BASE_CHECKPOINT_NAME` | `Cosmos3-Nano` | Base checkpoint to fine-tune (catalog name). |
+| `EXPORT_SAFETENSORS` | `1` | Export the trained checkpoint to HF safetensors. |
+| `COSMOS_FRAMEWORK_REF` | pinned commit | cosmos-framework git ref to install. |
+
+## Outputs
+
+Training writes to `~/cosmos-framework/outputs/train/cosmos3/sft/vision_sft_nano/`:
+
+- `checkpoints/iter_<N>/` — sharded DCP checkpoints.
+- `model/` — the exported Hugging Face safetensors (when `EXPORT_SAFETENSORS=1`).
+
+Fetch them with `ssh cosmos3` or `rsync`. Tear down with `sky down cosmos3`.
+
+## References
+
+- Cosmos 3 blog: https://developer.nvidia.com/blog/develop-physical-ai-reasoning-world-and-action-models-with-nvidia-cosmos-3/
+- Technical report: https://research.nvidia.com/labs/cosmos-lab/cosmos3/technical-report.pdf
+- cosmos-framework (training/serving): https://github.com/NVIDIA/cosmos-framework
+- NVIDIA Cosmos (models, inference): https://github.com/NVIDIA/Cosmos

--- a/examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml
+++ b/examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml
@@ -1,13 +1,19 @@
-# Fine-tune NVIDIA Cosmos3-Nano (16B omnimodal world model) with SkyPilot.
+# Fine-tune NVIDIA Cosmos3-Nano (16B omnimodal world model) as a SkyPilot managed job.
 #
 # Runs NVIDIA's official `vision_sft_nano` SFT recipe from
 # github.com/NVIDIA/cosmos-framework: an 8-GPU FSDP fine-tune of the Cosmos3-Nano
 # generation pathway on the public nvidia/bridge-v2-subset-synthetic-captions
 # robot-video dataset, then exports to Hugging Face safetensors. See README.md.
 #
-#   sky launch -c cosmos3 examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml
+# Checkpoints are written to a mounted cloud bucket, so the managed job auto-resumes
+# from the latest checkpoint after a recovery, and the outputs survive job teardown.
+#
+# Usage (CHECKPOINT_BUCKET_NAME must be a globally-unique bucket name):
+#   sky jobs launch -n cosmos3 examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml \
+#       --env CHECKPOINT_BUCKET_NAME=my-cosmos3-checkpoints
 #   # Quick smoke test (a few steps, still checkpoints + exports):
-#   sky launch -c cosmos3 examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml --env MAX_ITER=10 --env SAVE_ITER=5
+#   sky jobs launch -n cosmos3 examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml \
+#       --env CHECKPOINT_BUCKET_NAME=my-cosmos3-checkpoints --env MAX_ITER=10 --env SAVE_ITER=5
 
 name: cosmos3-nano-finetune
 
@@ -23,14 +29,30 @@ num_nodes: 1
 envs:
   COSMOS_FRAMEWORK_REF: 411d25b2e35bc441126f48c44a4b93e1c0564274  # pinned for reproducibility
   BASE_CHECKPOINT_NAME: Cosmos3-Nano  # cosmos-framework catalog name -> nvidia/Cosmos3-Nano on HF
+  # Dataset dir the launcher trains on. Defaults to the bridge subset downloaded in
+  # `setup`; override to fine-tune on your own data (see README).
+  DATASET_PATH: examples/data/bridge-v2-subset-synthetic-captions/sft_dataset_bridge
   MAX_ITER: "500"          # optimizer steps (recipe default 500; set small for a smoke test)
   SAVE_ITER: "100"         # save a DCP checkpoint every N steps
   EXPORT_SAFETENSORS: "1"  # export the trained checkpoint to HF safetensors (1=yes, 0=no)
+  # Globally-unique cloud bucket for durable checkpoints + exports. SkyPilot creates it
+  # and mounts it at /checkpoints, which `run` sets as the recipe's OUTPUT_ROOT, so the
+  # job auto-resumes from the latest checkpoint after a recovery. Change to your own name.
+  CHECKPOINT_BUCKET_NAME: my-cosmos3-checkpoints
 
 secrets:
   # Base model + dataset are public, so this defaults to empty (no token needed).
   # To authenticate, `export HF_TOKEN=...` and pass `--secret HF_TOKEN`.
   HF_TOKEN: ""
+
+file_mounts:
+  # Durable checkpoint store. `run` points the recipe's OUTPUT_ROOT here, so DCP
+  # checkpoints, the resolved config, and the exported safetensors all land in the
+  # bucket, surviving managed-job recovery (auto-resume) and post-job teardown.
+  # mode: MOUNT is write-through, so each checkpoint is flushed straight to the bucket.
+  /checkpoints:
+    name: ${CHECKPOINT_BUCKET_NAME}
+    mode: MOUNT
 
 setup: |
   set -e
@@ -40,7 +62,7 @@ setup: |
   export DEBIAN_FRONTEND=noninteractive
   SUDO=""; [ "$(id -u)" -ne 0 ] && SUDO="sudo"
   $SUDO apt-get update -y
-  $SUDO apt-get install -y --no-install-recommends curl ffmpeg git git-lfs libx11-dev tree wget
+  $SUDO apt-get install -y --no-install-recommends curl ffmpeg git git-lfs libx11-dev wget
 
   if ! command -v uv >/dev/null 2>&1; then
     curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -86,6 +108,11 @@ run: |
   [ -n "${HF_TOKEN:-}" ] && export HF_TOKEN
   export NPROC_PER_NODE="${SKYPILOT_NUM_GPUS_PER_NODE}"  # FSDP shards across every GPU
 
+  # Write all training outputs to the mounted checkpoint bucket so the recipe
+  # auto-resumes from the latest checkpoint after a managed-job recovery.
+  export OUTPUT_ROOT=/checkpoints
+  RUN_DIR="$OUTPUT_ROOT/cosmos3/sft/vision_sft_nano"
+
   # Set step count + checkpoint frequency in the recipe TOML.
   TOML=examples/toml/sft_config/vision_sft_nano.toml
   sed -i "s/^max_iter[[:space:]]*=.*/max_iter = ${MAX_ITER}/" "$TOML"
@@ -95,12 +122,11 @@ run: |
   bash examples/launch_sft_vision_nano.sh
 
   # Export the fine-tuned DCP checkpoint to Hugging Face safetensors.
-  RUN_DIR=outputs/train/cosmos3/sft/vision_sft_nano
   if [ "${EXPORT_SAFETENSORS}" = "1" ] && [ -f "$RUN_DIR/checkpoints/latest_checkpoint.txt" ]; then
     CKPT_ITER="$(cat "$RUN_DIR/checkpoints/latest_checkpoint.txt")"
     python -m cosmos_framework.scripts.export_model \
       --checkpoint-path "$RUN_DIR/checkpoints/$CKPT_ITER" \
       --config-file "$RUN_DIR/config.yaml" \
       -o "$RUN_DIR/model"
-    echo ">>> Fine-tuned safetensors written to $HOME/cosmos-framework/$RUN_DIR/model"
+    echo ">>> Fine-tuned safetensors written to the $CHECKPOINT_BUCKET_NAME bucket: $RUN_DIR/model"
   fi

--- a/examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml
+++ b/examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml
@@ -71,7 +71,8 @@ setup: |
 
   # Clone cosmos-framework at the pinned commit (skip large LFS assets).
   cd "$HOME"
-  if [ ! -d cosmos-framework ]; then
+  if [ ! -d cosmos-framework/.git ]; then
+    rm -rf cosmos-framework
     GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/NVIDIA/cosmos-framework.git
   fi
   cd cosmos-framework
@@ -115,8 +116,8 @@ run: |
 
   # Set step count + checkpoint frequency in the recipe TOML.
   TOML=examples/toml/sft_config/vision_sft_nano.toml
-  sed -i "s/^max_iter[[:space:]]*=.*/max_iter = ${MAX_ITER}/" "$TOML"
-  sed -i "s/^save_iter[[:space:]]*=.*/save_iter = ${SAVE_ITER}/" "$TOML"
+  sed -i "s/^[[:space:]]*max_iter[[:space:]]*=.*/max_iter = ${MAX_ITER}/" "$TOML"
+  sed -i "s/^[[:space:]]*save_iter[[:space:]]*=.*/save_iter = ${SAVE_ITER}/" "$TOML"
 
   # Launch multi-GPU FSDP supervised fine-tuning.
   bash examples/launch_sft_vision_nano.sh

--- a/examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml
+++ b/examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml
@@ -30,7 +30,8 @@ envs:
   COSMOS_FRAMEWORK_REF: 411d25b2e35bc441126f48c44a4b93e1c0564274  # pinned for reproducibility
   BASE_CHECKPOINT_NAME: Cosmos3-Nano  # cosmos-framework catalog name -> nvidia/Cosmos3-Nano on HF
   # Dataset dir the launcher trains on. Defaults to the bridge subset downloaded in
-  # `setup`; override to fine-tune on your own data (see README).
+  # `setup`; override to fine-tune on your own data (see the bring-your-own-dataset
+  # note under file_mounts below).
   DATASET_PATH: examples/data/bridge-v2-subset-synthetic-captions/sft_dataset_bridge
   MAX_ITER: "500"          # optimizer steps (recipe default 500; set small for a smoke test)
   SAVE_ITER: "100"         # save a DCP checkpoint every N steps
@@ -53,6 +54,17 @@ file_mounts:
   /checkpoints:
     name: ${CHECKPOINT_BUCKET_NAME}
     mode: MOUNT
+
+  # Bring your own dataset: mount an existing cloud bucket, then point the recipe at it
+  # with `--env DATASET_PATH=/my-dataset` (that dir must contain
+  # `train/video_dataset_file.jsonl`; see README), so it trains on your data instead of
+  # the bridge subset `setup` downloads by default. Uncomment and set your bucket:
+  # /my-dataset:
+  #   source: s3://my-dataset-bucket/  # or gs://..., r2://..., etc.; read-only is fine
+  #   mode: MOUNT
+  # To use a SkyPilot volume instead, attach one with a top-level `volumes:` field
+  # (`volumes: {/my-dataset: my-vol}`); see
+  # https://docs.skypilot.co/en/stable/reference/volumes.html
 
 setup: |
   set -e

--- a/examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml
+++ b/examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml
@@ -1,0 +1,106 @@
+# Fine-tune NVIDIA Cosmos3-Nano (16B omnimodal world model) with SkyPilot.
+#
+# Runs NVIDIA's official `vision_sft_nano` SFT recipe from
+# github.com/NVIDIA/cosmos-framework: an 8-GPU FSDP fine-tune of the Cosmos3-Nano
+# generation pathway on the public nvidia/bridge-v2-subset-synthetic-captions
+# robot-video dataset, then exports to Hugging Face safetensors. See README.md.
+#
+#   sky launch -c cosmos3 examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml
+#   # Quick smoke test (a few steps, still checkpoints + exports):
+#   sky launch -c cosmos3 examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml --env MAX_ITER=10 --env SAVE_ITER=5
+
+name: cosmos3-nano-finetune
+
+resources:
+  # Cosmos3 needs Ampere or newer; NVIDIA's recipe is tested on 8x H100 80GB.
+  accelerators: {H100:8, H200:8}
+  # NVIDIA's recommended CUDA 13 base image; the training env layers on with `uv sync`.
+  image_id: docker:nvcr.io/nvidia/pytorch:25.09-py3
+  disk_size: 1000
+
+num_nodes: 1
+
+envs:
+  COSMOS_FRAMEWORK_REF: 411d25b2e35bc441126f48c44a4b93e1c0564274  # pinned for reproducibility
+  BASE_CHECKPOINT_NAME: Cosmos3-Nano  # cosmos-framework catalog name -> nvidia/Cosmos3-Nano on HF
+  MAX_ITER: "500"          # optimizer steps (recipe default 500; set small for a smoke test)
+  SAVE_ITER: "100"         # save a DCP checkpoint every N steps
+  EXPORT_SAFETENSORS: "1"  # export the trained checkpoint to HF safetensors (1=yes, 0=no)
+
+secrets:
+  # Base model + dataset are public, so this defaults to empty (no token needed).
+  # To authenticate, `export HF_TOKEN=...` and pass `--secret HF_TOKEN`.
+  HF_TOKEN: ""
+
+setup: |
+  set -e
+  # The NGC image auto-activates a conda base env; drop it so uv's venv is the only one.
+  conda deactivate 2>/dev/null || true
+
+  export DEBIAN_FRONTEND=noninteractive
+  SUDO=""; [ "$(id -u)" -ne 0 ] && SUDO="sudo"
+  $SUDO apt-get update -y
+  $SUDO apt-get install -y --no-install-recommends curl ffmpeg git git-lfs libx11-dev tree wget
+
+  if ! command -v uv >/dev/null 2>&1; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+  fi
+  source "$HOME/.local/bin/env" 2>/dev/null || export PATH="$HOME/.local/bin:$PATH"
+
+  # Clone cosmos-framework at the pinned commit (skip large LFS assets).
+  cd "$HOME"
+  if [ ! -d cosmos-framework ]; then
+    GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/NVIDIA/cosmos-framework.git
+  fi
+  cd cosmos-framework
+  git fetch origin "$COSMOS_FRAMEWORK_REF" 2>/dev/null || git fetch origin
+  git checkout "$COSMOS_FRAMEWORK_REF"
+
+  # Install the CUDA 13 training environment.
+  uv python install
+  uv sync --all-extras --group=cu130-train
+  source .venv/bin/activate
+  export LD_LIBRARY_PATH=  # keep host CUDA libs out of the venv's torch
+  [ -n "${HF_TOKEN:-}" ] && export HF_TOKEN
+
+  # Download the dataset + Wan2.2 VAE into the launcher's default locations.
+  uvx hf@latest download --repo-type dataset nvidia/bridge-v2-subset-synthetic-captions \
+      --revision 46468e12ac0dd36901e9e3240d4fc7620942b5d7 \
+      --local-dir examples/data/bridge-v2-subset-synthetic-captions --quiet
+  uvx hf@latest download Wan-AI/Wan2.2-TI2V-5B Wan2.2_VAE.pth \
+      --local-dir examples/checkpoints/wan22_vae --quiet
+
+  # Download Cosmos3-Nano and convert it to PyTorch Distributed Checkpoint (DCP) format.
+  if [ ! -d "examples/checkpoints/${BASE_CHECKPOINT_NAME}" ]; then
+    python -m cosmos_framework.scripts.convert_model_to_dcp \
+      -o "examples/checkpoints/${BASE_CHECKPOINT_NAME}" \
+      --checkpoint-path "${BASE_CHECKPOINT_NAME}"
+  fi
+
+run: |
+  set -e
+  conda deactivate 2>/dev/null || true
+  cd "$HOME/cosmos-framework"
+  source .venv/bin/activate
+  export LD_LIBRARY_PATH=
+  [ -n "${HF_TOKEN:-}" ] && export HF_TOKEN
+  export NPROC_PER_NODE="${SKYPILOT_NUM_GPUS_PER_NODE}"  # FSDP shards across every GPU
+
+  # Set step count + checkpoint frequency in the recipe TOML.
+  TOML=examples/toml/sft_config/vision_sft_nano.toml
+  sed -i "s/^max_iter[[:space:]]*=.*/max_iter = ${MAX_ITER}/" "$TOML"
+  sed -i "s/^save_iter[[:space:]]*=.*/save_iter = ${SAVE_ITER}/" "$TOML"
+
+  # Launch multi-GPU FSDP supervised fine-tuning.
+  bash examples/launch_sft_vision_nano.sh
+
+  # Export the fine-tuned DCP checkpoint to Hugging Face safetensors.
+  RUN_DIR=outputs/train/cosmos3/sft/vision_sft_nano
+  if [ "${EXPORT_SAFETENSORS}" = "1" ] && [ -f "$RUN_DIR/checkpoints/latest_checkpoint.txt" ]; then
+    CKPT_ITER="$(cat "$RUN_DIR/checkpoints/latest_checkpoint.txt")"
+    python -m cosmos_framework.scripts.export_model \
+      --checkpoint-path "$RUN_DIR/checkpoints/$CKPT_ITER" \
+      --config-file "$RUN_DIR/config.yaml" \
+      -o "$RUN_DIR/model"
+    echo ">>> Fine-tuned safetensors written to $HOME/cosmos-framework/$RUN_DIR/model"
+  fi


### PR DESCRIPTION
Adds `examples/cosmos3-finetuning/`: fine-tunes NVIDIA Cosmos3-Nano (16B world model) via NVIDIA's `vision_sft_nano` recipe as a managed job (8-GPU FSDP), writing checkpoints + the HF safetensors export to a cloud bucket for auto-resume on recovery. Cloud-agnostic, on-demand by default, runs token-free. Wired into docs under Examples -> Training.