### PR TITLE
[Dashboard] Default users sort: add Clusters, Jobs tiers

### DIFF
--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -2012,7 +2012,8 @@ function UsersTable({
     }
 
     if (sortConfig.key === 'default') {
-      // Default sort: GPUs desc, then Joined (most recent first), then Name asc.
+      // Default sort: GPUs desc, then Clusters desc, then Jobs desc, then
+      // Joined (most recent first), then Name asc.
       const cmpStr = (a, b) => {
         const sa = (a ?? '').toString().toLowerCase();
         const sb = (b ?? '').toString().toLowerCase();
@@ -2024,6 +2025,10 @@ function UsersTable({
       return [...filtered].sort((a, b) => {
         const byGpu = cmpNum(b.gpuCount, a.gpuCount);
         if (byGpu !== 0) return byGpu;
+        const byClusters = cmpNum(b.clusterCount, a.clusterCount);
+        if (byClusters !== 0) return byClusters;
+        const byJobs = cmpNum(b.jobCount, a.jobCount);
+        if (byJobs !== 0) return byJobs;
         const byJoined = cmpNum(b.created_at, a.created_at);
         if (byJoined !== 0) return byJoined;
         return cmpStr(a.usernameDisplay, b.usernameDisplay);


### PR DESCRIPTION
## Summary
- Extends the default sort on the `/users` page from **GPUs → Joined → Name** to **GPUs → Clusters → Jobs → Joined → Name**.
- Count tiers (GPUs, Clusters, Jobs) sort descending (more first); Joined is most-recent-first; Name is ascending.
- Clicking any column header still switches to single-column sort, unchanged.

This is a small follow-up to the existing default-sort behavior, adding the Clusters and Jobs tiers as additional tiebreakers.

## Test plan
- Open the dashboard `/users` page with users that have varying GPU/cluster/job counts.
- Verify the initial ordering is GPUs desc, then Clusters desc, then Jobs desc, then most-recently-joined, then name A→Z.
- Click each column header and confirm single-column sort still toggles asc/desc as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)