### PR TITLE
[Kubernetes] Route CPU-only launches to a separate Kueue queue

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -873,7 +873,11 @@ class Kubernetes(clouds.Cloud):
                 # TODO(kyuds): Support SSH node pools as well.
                 cloud='kubernetes',
                 region=context,
-                override_configs=resources.cluster_config_overrides))
+                override_configs=resources.cluster_config_overrides,
+                # `resources` is the finalized resource for this launch
+                # attempt, so route CPU-only launches to `quota.cpu_queue`
+                # when configured.
+                has_accelerators=bool(resources.accelerators)))
 
         # Check DWS configuration for GKE.
         (enable_flex_start, enable_flex_start_queued_provisioning,

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -904,6 +904,15 @@ _QUEUE_NAME_KEYS: List[Tuple[str, ...]] = [
     ('kueue', 'local_queue_name'),
 ]
 
+# Queue used for launches that request no accelerators. When set, it takes
+# precedence over `_QUEUE_NAME_KEYS` at the same scope for CPU-only launches;
+# accelerator launches ignore it. The accelerator determination is made by the
+# caller from the finalized resource of the launch attempt (a single task may
+# define multiple resources that resolve to different queues).
+_CPU_QUEUE_NAME_KEYS: List[Tuple[str, ...]] = [
+    ('quota', 'cpu_queue'),
+]
+
 _NAMESPACE_KEYS: List[Tuple[str, ...]] = [('namespace',)]
 
 # Hooks invoked at the end of `update_api_server_config_no_lock`, after the
@@ -989,16 +998,33 @@ def get_effective_queue_name(
         cloud: str,
         region: Optional[str] = None,
         workspace: Optional[str] = None,
-        override_configs: Optional[Dict[str, Any]] = None) -> Optional[str]:
+        override_configs: Optional[Dict[str, Any]] = None,
+        has_accelerators: Optional[bool] = None) -> Optional[str]:
     """Returns the effective Kueue local queue name from config.
 
     Supports two equivalent spellings, ``kueue.local_queue_name`` and
     ``quota.queue``. Scope precedence (workspace > global; context > cloud)
     takes priority over spelling; within the same scope, ``quota.queue``
     wins over ``kueue.local_queue_name`` when both are set.
+
+    ``has_accelerators`` lets a launch attempt route CPU-only workloads to a
+    separate ``quota.cpu_queue``:
+
+    - ``None`` (default) / ``True``: only the regular queue spellings are
+      considered; ``quota.cpu_queue`` is ignored.
+    - ``False``: the launch requests no accelerators, so ``quota.cpu_queue``
+      takes precedence over the regular spellings at the same scope, falling
+      back to them when it is unset.
+
+    The caller must derive ``has_accelerators`` from the *finalized* resource
+    of the launch attempt, since a single task may define multiple resources
+    that resolve to different queues.
     """
+    property_keys = _QUEUE_NAME_KEYS
+    if has_accelerators is False:
+        property_keys = _CPU_QUEUE_NAME_KEYS + _QUEUE_NAME_KEYS
     return _get_effective_k8s_config_value(cloud=cloud,
-                                           property_keys=_QUEUE_NAME_KEYS,
+                                           property_keys=property_keys,
                                            region=region,
                                            workspace=workspace,
                                            override_configs=override_configs)
@@ -1042,7 +1068,7 @@ def remove_queue_name_from_config() -> Iterator[None]:
     config = to_dict()
 
     def update_to_none_if_set(keys: Tuple[str, ...]) -> None:
-        for queue_key in _QUEUE_NAME_KEYS:
+        for queue_key in _QUEUE_NAME_KEYS + _CPU_QUEUE_NAME_KEYS:
             if config.get_nested(keys + queue_key, None) is not None:
                 logger.debug(f'removing local queue name: setting '
                              f'{keys + queue_key} to None')

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1615,6 +1615,11 @@ _CONTEXT_CONFIG_SCHEMA_KUBERNETES = {
             'queue': {
                 'type': 'string',
             },
+            # Queue used for launches that request no accelerators; when set,
+            # CPU-only launches route here instead of `queue`.
+            'cpu_queue': {
+                'type': 'string',
+            },
         },
     },
     'dws': {
@@ -2478,6 +2483,9 @@ def get_config_schema():
                                 'queue': {
                                     'type': 'string',
                                 },
+                                'cpu_queue': {
+                                    'type': 'string',
+                                },
                             },
                         },
                         'context_configs': {
@@ -2519,6 +2527,9 @@ def get_config_schema():
                                         'additionalProperties': True,
                                         'properties': {
                                             'queue': {
+                                                'type': 'string',
+                                            },
+                                            'cpu_queue': {
                                                 'type': 'string',
                                             },
                                         },

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1332,6 +1332,49 @@ def test_get_effective_queue_name(monkeypatch, tmp_path) -> None:
         workspace='workspaceA') == 'workspaceA-queue-via-quota'
 
 
+def test_get_effective_queue_name_cpu_queue(monkeypatch, tmp_path) -> None:
+    """`quota.cpu_queue` routes CPU-only launches to a separate queue."""
+    with open(tmp_path / 'cpu_queue.yaml', 'w', encoding='utf-8') as f:
+        f.write("""\
+        kubernetes:
+            quota:
+                queue: gpu-queue
+                cpu_queue: cpu-queue
+            context_configs:
+                # Only a regular queue here; CPU launches fall back to it.
+                contextA:
+                    quota:
+                        queue: contextA-gpu-queue
+        """)
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH',
+                        tmp_path / 'cpu_queue.yaml')
+    skypilot_config.reload_config()
+
+    # Default (`has_accelerators=None`) ignores `cpu_queue`.
+    assert skypilot_config.get_effective_queue_name(
+        cloud='kubernetes', workspace='default') == 'gpu-queue'
+    # Accelerator launch uses the regular queue.
+    assert skypilot_config.get_effective_queue_name(
+        cloud='kubernetes', workspace='default',
+        has_accelerators=True) == 'gpu-queue'
+    # CPU-only launch uses `cpu_queue` when set at the same scope.
+    assert skypilot_config.get_effective_queue_name(
+        cloud='kubernetes', workspace='default',
+        has_accelerators=False) == 'cpu-queue'
+    # CPU-only launch falls back to the regular queue when `cpu_queue` is
+    # unset at the resolved scope.
+    assert skypilot_config.get_effective_queue_name(
+        cloud='kubernetes',
+        region='contextA',
+        workspace='default',
+        has_accelerators=False) == 'contextA-gpu-queue'
+    assert skypilot_config.get_effective_queue_name(
+        cloud='kubernetes',
+        region='contextA',
+        workspace='default',
+        has_accelerators=True) == 'contextA-gpu-queue'
+
+
 def test_get_effective_queue_name_workspace_override(monkeypatch,
                                                      tmp_path) -> None:
     """Cloud-level `override_configs` must apply inside workspace scope.
@@ -1735,7 +1778,8 @@ class TestRemoveQueueNameFromConfig:
                     'local_queue_name': 'root-q'
                 },
                 'quota': {
-                    'queue': 'root-quota-q'
+                    'queue': 'root-quota-q',
+                    'cpu_queue': 'root-cpu-q'
                 },
                 'context_configs': {
                     'ctx1': {
@@ -1743,7 +1787,8 @@ class TestRemoveQueueNameFromConfig:
                             'local_queue_name': 'ctx1-q'
                         },
                         'quota': {
-                            'queue': 'ctx1-quota-q'
+                            'queue': 'ctx1-quota-q',
+                            'cpu_queue': 'ctx1-cpu-q'
                         }
                     }
                 }
@@ -1777,9 +1822,12 @@ class TestRemoveQueueNameFromConfig:
                 for keys in [
                     ('kubernetes', 'kueue', 'local_queue_name'),
                     ('kubernetes', 'quota', 'queue'),
+                    ('kubernetes', 'quota', 'cpu_queue'),
                     ('kubernetes', 'context_configs', 'ctx1', 'kueue',
                      'local_queue_name'),
                     ('kubernetes', 'context_configs', 'ctx1', 'quota', 'queue'),
+                    ('kubernetes', 'context_configs', 'ctx1', 'quota',
+                     'cpu_queue'),
                     ('workspaces', 'ws1', 'kubernetes', 'kueue',
                      'local_queue_name'),
                     ('workspaces', 'ws1', 'kubernetes', 'quota', 'queue'),


### PR DESCRIPTION
## Summary

Adds a `kubernetes.quota.cpu_queue` config field. When set, launch attempts that request **no accelerators** are routed to this queue instead of `quota.queue` / `kueue.local_queue_name`. Accelerator launches are unaffected.

A single task may define multiple resources that resolve to different queues (e.g. one GPU resource and one CPU fallback), so the queue must be chosen once the actual resource for a launch attempt is finalized:

- `get_effective_queue_name` takes a new `has_accelerators` hint.
  - `None` (default) / `True`: only the regular queue spellings are considered; `cpu_queue` is ignored (unchanged behavior).
  - `False`: `quota.cpu_queue` takes precedence over the regular spellings at the same config scope, falling back to them when unset.
- `Kubernetes.make_deploy_resources_variables` derives the hint from the finalized `resources` (`bool(resources.accelerators)`).
- `remove_queue_name_from_config` now strips `cpu_queue` alongside the existing queue keys.
- Schema documents `cpu_queue` at cloud, context, and workspace scope.

Example config:

```yaml
kubernetes:
  quota:
    queue: gpu-queue       # accelerator launches
    cpu_queue: cpu-queue   # CPU-only launches
```

## Tested

- [x] Code formatting: `bash format.sh` on changed files
- [x] New unit test `test_get_effective_queue_name_cpu_queue` (accelerator vs CPU-only resolution, scope fallback, default `None` behavior); extended `TestRemoveQueueNameFromConfig`.
- [x] `pytest tests/test_config.py -k "queue_name or RemoveQueueName"` — 6 passed