### PR TITLE
[Test] Tag Buildkite Test Engine executions with test configuration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -583,11 +583,22 @@ def _common_execution_tags(config) -> Dict[str, str]:
 def _item_cloud(config, item, cloud_to_run: List[str],
                 generic_cloud: str) -> str:
     """Resolve which cloud a collected test item runs on."""
-    for cloud in all_clouds_in_smoke_tests:
-        if cloud_to_pytest_keyword[cloud] in item.keywords and (
-                cloud in cloud_to_run or config.getoption(f'--{cloud}')):
+    marked_clouds = [
+        cloud for cloud in all_clouds_in_smoke_tests
+        if cloud_to_pytest_keyword[cloud] in item.keywords
+    ]
+    if not marked_clouds:
+        # Generic test: runs on the generic cloud.
+        return generic_cloud
+    # A test may be marked for multiple clouds; prefer the one that is
+    # active in this run.
+    for cloud in marked_clouds:
+        if cloud in cloud_to_run or config.getoption(f'--{cloud}'):
             return cloud
-    return generic_cloud
+    # None of the marked clouds is active in this run, so the item is
+    # collected but skipped. Tag it with its first marked cloud rather
+    # than the generic cloud of the run.
+    return marked_clouds[0]
 
 
 @annotations.lru_cache(scope='session')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import filelock
 import pytest
@@ -495,6 +495,20 @@ def pytest_collection_modifyitems(config, items):
                 item.add_marker(serial_mark)
                 item._nodeid = f'{item.nodeid}@serial_{generic_cloud_keyword}'  # See comment on item.nodeid above
 
+    # Tag test executions reported to Buildkite Test Engine with the test
+    # configuration, so that test history can be filtered/grouped by
+    # configuration (cloud, server mode, consolidation, etc.). The
+    # ``execution_tag`` marker is provided by buildkite-test-collector.
+    if smoke_tests_utils.is_in_buildkite_env():
+        common_tags = _common_execution_tags(config)
+        for item in items:
+            if 'smoke_tests' not in item.location[0]:
+                continue
+            cloud = _item_cloud(config, item, cloud_to_run, generic_cloud)
+            item.add_marker(pytest.mark.execution_tag('cloud', cloud))
+            for key, value in common_tags.items():
+                item.add_marker(pytest.mark.execution_tag(key, value))
+
     if config.option.collectonly:
         for item in items:
             full_name = item.nodeid
@@ -514,6 +528,66 @@ def _generic_cloud(config) -> str:
     if generic_cloud_option is not None:
         return generic_cloud_option
     return _get_cloud_to_run(config)[0]
+
+
+def _common_execution_tags(config) -> Dict[str, str]:
+    """Session-level execution tags for Buildkite Test Engine.
+
+    These tags describe the test configuration of the current run and are
+    attached to every reported test execution (via the ``execution_tag``
+    marker of buildkite-test-collector), so that test history can be
+    filtered and grouped by configuration in Test Engine.
+
+    Note: Test Engine allows at most 10 custom tags per execution; keep
+    this set (plus the per-item ``cloud`` tag) under that limit.
+    """
+    server = 'local'
+    env_file = config.getoption('--env-file')
+    if env_file and _get_and_check_env_file(env_file)[0]:
+        # The env file points the tests at an existing API server endpoint.
+        server = 'shared'
+    elif config.getoption('--remote-server'):
+        server = 'remote'
+
+    consolidation_modes = [
+        mode for mode, option in (('jobs', '--jobs-consolidation'),
+                                  ('serve', '--serve-consolidation'))
+        if config.getoption(option)
+    ]
+
+    tags = {
+        'server': server,
+        'consolidation': '-'.join(consolidation_modes) or 'none',
+        'db': 'postgres' if config.getoption('--postgres') else 'sqlite',
+    }
+
+    # Agent queue distinguishes the backing infra (e.g. which Kubernetes
+    # backend a test ran on).
+    queue = os.environ.get('BUILDKITE_AGENT_META_DATA_QUEUE')
+    if queue:
+        tags['queue'] = queue
+    if config.getoption('--grpc'):
+        tags['grpc'] = 'true'
+    base_branch = config.getoption('--base-branch')
+    if base_branch:
+        tags['base_branch'] = base_branch
+    controller_cloud = config.getoption('--controller-cloud')
+    if controller_cloud:
+        tags['controller_cloud'] = controller_cloud
+    dependency = config.getoption('--dependency')
+    if dependency != 'all':
+        tags['dependency'] = dependency if dependency else 'base'
+    return tags
+
+
+def _item_cloud(config, item, cloud_to_run: List[str],
+                generic_cloud: str) -> str:
+    """Resolve which cloud a collected test item runs on."""
+    for cloud in all_clouds_in_smoke_tests:
+        if cloud_to_pytest_keyword[cloud] in item.keywords and (
+                cloud in cloud_to_run or config.getoption(f'--{cloud}')):
+            return cloud
+    return generic_cloud
 
 
 @annotations.lru_cache(scope='session')


### PR DESCRIPTION
## Motivation

Smoke tests run under many configurations — cloud (`--aws`, `--gcp`, `--kubernetes`, ...), local vs remote vs shared API server, jobs/serve consolidation, postgres vs sqlite, grpc, backward-compat base branch, client dependency set — but the executions reported to Buildkite Test Engine carry no configuration metadata. Test history for a given test therefore mixes all configurations together and cannot be filtered or compared (e.g. "is this test only flaky in consolidation mode?", "did the remote-server variant regress?").

## What this PR does

Attach [execution tags](https://buildkite.com/docs/test-engine/test-suites/tags) to every smoke-test execution at collection time in `tests/conftest.py`, derived from the pytest options that already encode the run configuration:

| Tag | Values | Source |
|---|---|---|
| `cloud` | `aws`, `gcp`, `kubernetes`, ... | per-item cloud marker, falling back to the generic cloud |
| `server` | `local` / `remote` / `shared` | `--remote-server`, `--env-file` (with api_server config) |
| `consolidation` | `none` / `jobs` / `serve` / `jobs-serve` | `--jobs-consolidation`, `--serve-consolidation` |
| `db` | `sqlite` / `postgres` | `--postgres` |
| `queue` | agent queue name | `BUILDKITE_AGENT_META_DATA_QUEUE` (distinguishes the backing infra, e.g. k8s backend) |
| `grpc` | `true` (only when set) | `--grpc` |
| `base_branch` | branch (only when set) | `--base-branch` (backward-compat runs) |
| `controller_cloud` | cloud (only when set) | `--controller-cloud` |
| `dependency` | extras or `base` (only when non-default) | `--dependency` |

Tags are emitted via the `execution_tag` marker supported by `buildkite-test-collector` (>= 1.4, already a `required_plugins` entry), and only when running in Buildkite CI — local runs and GitHub Actions are unaffected. Worst case is 9 custom tags, within Test Engine's limit of 10 per execution.

With these tags, the Test Engine test page supports filtering/grouping history by tag (duration p50/p95, reliability), and the test index supports tag conditions.

## Notes

- Tags only apply to newly uploaded executions; existing history is not backfilled.
- Smoke tests in Buildkite run with xdist disabled (`numprocesses=0`, see `pytest_configure`), which `buildkite-test-collector` >= 1.4.1 handles correctly for tag submission.

## Tested

- Dry-run with a collection-time plugin printing resolved tags per item:
  - `BUILDKITE=true ... pytest tests/smoke_tests/test_basic.py::test_minimal --kubernetes --jobs-consolidation --postgres --collect-only` → `{'cloud': 'kubernetes', 'server': 'local', 'consolidation': 'jobs', 'db': 'postgres', 'queue': 'kind'}`
  - `--aws --remote-server --grpc --dependency aws` → `{'cloud': 'aws', 'server': 'remote', 'consolidation': 'none', 'db': 'sqlite', 'queue': 'generic_cloud_remote_server', 'grpc': 'true', 'dependency': 'aws'}`
  - `tests/smoke_tests/backward_compat/ --aws --base-branch releases/0.10.0` → includes `'base_branch': 'releases/0.10.0'`
  - Without `BUILDKITE` env: no tags added.
- Will verify end-to-end on this PR via `/smoke-test -k test_minimal --aws` and checking the execution drawer in Test Engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)