### PR TITLE
[Workspaces] Polish per-user resolver UX: scoped error, surfaced log, shared constants

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -102,6 +102,7 @@ from sky.utils import volume as volume_utils
 from sky.utils import yaml_utils
 from sky.utils.cli_utils import status_utils
 from sky.volumes.client import sdk as volumes_sdk
+from sky.workspaces import constants as workspace_constants
 
 if typing.TYPE_CHECKING:
 
@@ -8135,8 +8136,6 @@ def workspace_info(output_format: str):
     # alignment, so render it as a separate paragraph below. The text
     # comes from `WorkspaceAmbiguousError.recovery_hint()` so the CLI
     # and launch-path error message share a single source.
-    # pylint: disable=import-outside-toplevel
-    from sky.workspaces import constants as workspace_constants
     if info.get('source') == workspace_constants.WORKSPACE_SOURCE_AMBIGUOUS:
         click.echo()
         click.echo(exceptions.WorkspaceAmbiguousError.recovery_hint())

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -8130,6 +8130,17 @@ def workspace_info(output_format: str):
     ])
     click.echo('\n'.join(lines))
 
+    # AMBIGUOUS is the only state whose recovery message is multi-line
+    # (5+ lines) — inlining it into `Note:` would break the tree
+    # alignment, so render it as a separate paragraph below. The text
+    # comes from `WorkspaceAmbiguousError.recovery_hint()` so the CLI
+    # and launch-path error message share a single source.
+    # pylint: disable=import-outside-toplevel
+    from sky.workspaces import constants as workspace_constants
+    if info.get('source') == workspace_constants.WORKSPACE_SOURCE_AMBIGUOUS:
+        click.echo()
+        click.echo(exceptions.WorkspaceAmbiguousError.recovery_hint())
+
 
 @cli.group(cls=_NaturalOrderGroup)
 def ssh():

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -476,24 +476,38 @@ class WorkspaceAmbiguousError(SkyPilotExcludeArgsBaseException):
 
     Carries the list of accessible workspace names so callers (CLI / API
     handlers) can format consistent guidance pointing the user at
-    `sky workspace use <name>`, `--workspace`, or `~/.sky/config.yaml`.
+    `sky workspace use <name>` or `~/.sky/config.yaml`. The `--workspace`
+    flag is listed as a footnote because it only exists on the launch
+    commands (`sky launch` / `sky jobs launch`); listing it as a main
+    fix would mislead users running `sky status` / `sky queue` / etc.
 
     `note` is an optional drift explanation populated when the user has a
     saved preference that is no longer accessible — so the user understands
     why their previous default stopped working.
     """
 
+    # Recovery guidance shared between the exception message and the
+    # `sky workspace info` hint paragraph. Kept as a classmethod so the
+    # two surfaces don't drift; not parameterized on `accessible` because
+    # both call sites already show the list separately (the exception
+    # message via the preamble, the CLI via the `Accessible:` tree row).
+    @classmethod
+    def recovery_hint(cls) -> str:
+        return ('SkyPilot can\'t pick one automatically for this command. '
+                'To proceed:\n'
+                '  - run `sky workspace use <name>` to set your default, or\n'
+                '  - set `active_workspace: <name>` in `~/.sky/config.yaml`.\n'
+                '\n'
+                'Or, for a one-shot override on `sky launch` / '
+                '`sky jobs launch`, pass `--workspace <name>`.')
+
     def __init__(self, accessible: List[str], note: Optional[str] = None):
         self.accessible = sorted(accessible)
         self.note = note
         names = ', '.join(self.accessible)
         note_line = f'\nNote: {note}.' if note else ''
-        super().__init__(
-            f'You belong to multiple workspaces: {names}.{note_line}\n'
-            f'To proceed:\n'
-            f'  - run `sky workspace use <name>` to set your default, or\n'
-            f'  - pass `--workspace <name>` on this command, or\n'
-            f'  - set `active_workspace:` in `~/.sky/config.yaml`.')
+        super().__init__(f'You belong to multiple workspaces: {names}.'
+                         f'{note_line}\n{self.recovery_hint()}')
 
     def __reduce__(self):
         # SkyPilot's request executor pickles exceptions raised by a

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -64,6 +64,7 @@ from sky.utils import tempstore
 from sky.utils import timeline
 from sky.utils import yaml_utils
 from sky.utils.db import db_utils
+from sky.workspaces import constants as workspace_constants
 from sky.workspaces import core as workspaces_core
 
 if typing.TYPE_CHECKING:
@@ -355,6 +356,37 @@ def _get_queue(schedule_type: api_requests.ScheduleType) -> RequestQueue:
     return RequestQueue(factory.create_queue(schedule_type.value))
 
 
+# Request names where a non-explicit workspace pick is worth surfacing
+# at INFO level (i.e. visible in the streamed CLI output, not just debug
+# logs). Resource-creating commands record the resolved workspace into
+# durable state (cluster.workspace / job_info.workspace) — users care
+# which workspace that ended up being. Read-only commands resolve the
+# same way under the hood but the log line would just be noise.
+#
+# To extend coverage to other resource-creating verbs (e.g. SERVE_UP),
+# add the request_name here.
+_RESOURCE_CREATING_REQUEST_NAMES_FOR_RESOLUTION_LOG = {
+    server_constants.REQUEST_NAME_PREFIX +
+    request_names.RequestName.CLUSTER_LAUNCH.value,
+    server_constants.REQUEST_NAME_PREFIX +
+    request_names.RequestName.JOBS_LAUNCH.value,
+}
+
+# Sources we DON'T announce, even on a resource-creating request:
+#   EXPLICIT          — the user already named the workspace; repeating
+#                       it in the log is noise.
+#   DEFAULT_FALLBACK  — landing on 'default' is the pre-existing implicit
+#                       behavior; surfacing it on every launch for every
+#                       single-default user would clutter output for the
+#                       common case while telling them nothing new.
+# PREFERRED / SINGLE_MEMBERSHIP are the cases worth surfacing — the user
+# may not realize where the resource landed.
+_SILENT_WORKSPACE_RESOLUTION_SOURCES = {
+    workspace_constants.WORKSPACE_SOURCE_EXPLICIT,
+    workspace_constants.WORKSPACE_SOURCE_DEFAULT_FALLBACK,
+}
+
+
 def _should_apply_workspace_resolver(is_daemon: bool,
                                      client_api_version: Optional[int]) -> bool:
     """Returns True iff the per-user workspace resolver should run for
@@ -488,6 +520,22 @@ def override_request_env_and_config(
                     logger.debug(f'{request_id} resolved workspace '
                                  f'{resolution.workspace!r} from '
                                  f'{resolution.source} for user {user.name}')
+                    # For resource-creating commands, surface the
+                    # resolver's pick at INFO level so the user sees
+                    # which workspace their cluster / job actually
+                    # landed in. Two filters compose:
+                    #   - request_name whitelist (resource-creating verbs)
+                    #   - source NOT in the silent set (EXPLICIT /
+                    #     DEFAULT_FALLBACK) — EXPLICIT repeats what the
+                    #     user just said; DEFAULT_FALLBACK is the silent
+                    #     pre-existing behavior. Only PREFERRED /
+                    #     SINGLE_MEMBERSHIP are worth surfacing.
+                    if (request_name in
+                            _RESOURCE_CREATING_REQUEST_NAMES_FOR_RESOLUTION_LOG
+                            and resolution.source
+                            not in _SILENT_WORKSPACE_RESOLUTION_SOURCES):
+                        logger.info(f'Using workspace {resolution.workspace!r} '
+                                    f'(source: {resolution.source}).')
                 with workspace_ctx:
                     try:
                         # Reject requests that the user does not have

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -26,6 +26,7 @@ from sky.users import token_service
 from sky.utils import common
 from sky.utils import common_utils
 from sky.utils import resource_checker
+from sky.workspaces import constants as workspace_constants
 from sky.workspaces import core as workspaces_core
 
 logger = sky_logging.init_logger(__name__)
@@ -229,13 +230,35 @@ def get_user_workspace(
     try:
         resolution = workspaces_core.resolve_workspace_for_user(
             user_for_resolve, requested=requested)
-    except (exceptions.WorkspaceAmbiguousError,
-            exceptions.NoWorkspaceAccessError,
-            exceptions.PermissionDeniedError) as e:
-        # All three are "tell me my state" answers from the user's
-        # perspective, not server faults. Surface the message in
-        # `note` and return 200 so callers can render guidance
-        # uniformly without parsing 4xx bodies.
+    except exceptions.WorkspaceAmbiguousError as e:
+        # Per-user state, not a server fault — return 200 with a state-
+        # coded `source` and a SHORT `note`. The CLI / dashboard show
+        # the long recovery guidance separately (see
+        # `WorkspaceAmbiguousError.recovery_hint`) so the structured
+        # payload (`workspace` / `source` / `note` / `preferred` /
+        # `accessible`) stays clean and grep-able.
+        response['source'] = workspace_constants.WORKSPACE_SOURCE_AMBIGUOUS
+        # `e.note` only carries drift context ("preferred 'X' not
+        # accessible"); fall back to a generic one-liner otherwise.
+        response['note'] = (e.note
+                            if e.note else 'multiple workspaces accessible; '
+                            'no preferred or active workspace set')
+        return response
+    except exceptions.NoWorkspaceAccessError as e:
+        # One-line message from the raise site ("User <name> (<id>) has
+        # no accessible workspaces.") — short enough to fit in the tree
+        # row and more informative than a generic stand-in.
+        response['source'] = workspace_constants.WORKSPACE_SOURCE_NO_ACCESS
+        response['note'] = str(e)
+        return response
+    except exceptions.PermissionDeniedError as e:
+        # Per-workspace deny — raised when an explicit `requested`
+        # workspace exists but the user can't access it. We keep the
+        # exception message here because it names the specific
+        # workspace and the reason (RBAC / not-in-allowed-users),
+        # which the payload alone wouldn't convey.
+        response['source'] = (
+            workspace_constants.WORKSPACE_SOURCE_PERMISSION_DENIED)
         response['note'] = str(e)
         return response
     response['workspace'] = resolution.workspace

--- a/sky/workspaces/constants.py
+++ b/sky/workspaces/constants.py
@@ -1,0 +1,29 @@
+"""Workspace protocol constants.
+
+Source codes returned alongside a resolved workspace (and surfaced by
+``GET /users/me/workspace``). Kept in their own leaf module — separate
+from :mod:`sky.workspaces.core` — so client-side callers (CLI, SDK
+docs, dashboard helpers) can compare against them without dragging in
+the heavy server-side resolver dependencies (DB, RBAC, backend_utils).
+"""
+
+# Sources reported by `resolve_workspace_for_user()` on the success
+# path. Used by the launch flow and logged so users / operators can
+# trace why a particular workspace was picked.
+WORKSPACE_SOURCE_EXPLICIT = 'explicit'
+WORKSPACE_SOURCE_PREFERRED = 'preferred'
+# Preserves today's behavior for users (and admins) who can access the
+# 'default' workspace and have not set a preference — they continue
+# landing on 'default' instead of being surprised by an AMBIGUOUS error
+# after upgrade.
+WORKSPACE_SOURCE_DEFAULT_FALLBACK = 'default-fallback'
+WORKSPACE_SOURCE_SINGLE_MEMBERSHIP = 'single-membership'
+
+# Resolver-error states surfaced through `GET /users/me/workspace`. Not
+# returned by `resolve_workspace_for_user()` itself (that path raises) —
+# the handler writes one of these into the payload so callers (CLI /
+# dashboard) can render a state code instead of parsing a multi-line
+# English `note`.
+WORKSPACE_SOURCE_AMBIGUOUS = 'ambiguous'
+WORKSPACE_SOURCE_NO_ACCESS = 'no-access'
+WORKSPACE_SOURCE_PERMISSION_DENIED = 'permission-denied'

--- a/sky/workspaces/core.py
+++ b/sky/workspaces/core.py
@@ -22,17 +22,8 @@ from sky.utils import config_utils
 from sky.utils import locks
 from sky.utils import resource_checker
 from sky.utils import schemas
+from sky.workspaces import constants as workspace_constants
 from sky.workspaces import utils as workspaces_utils
-
-# Sources reported by resolve_workspace_for_user() so callers (launch path,
-# logs) can format consistent provenance strings.
-WORKSPACE_SOURCE_EXPLICIT = 'explicit'
-WORKSPACE_SOURCE_PREFERRED = 'preferred'
-# Preserves today's behavior for users (and admins) who can access the
-# 'default' workspace and have not set a preference — they continue landing
-# on 'default' instead of being surprised by an AMBIGUOUS error after upgrade.
-WORKSPACE_SOURCE_DEFAULT_FALLBACK = 'default-fallback'
-WORKSPACE_SOURCE_SINGLE_MEMBERSHIP = 'single-membership'
 
 logger = sky_logging.init_logger(__name__)
 
@@ -1109,8 +1100,9 @@ def resolve_workspace_for_user(
     """
     if requested is not None:
         check_workspace_permission(user, requested)
-        return WorkspaceResolution(workspace=requested,
-                                   source=WORKSPACE_SOURCE_EXPLICIT)
+        return WorkspaceResolution(
+            workspace=requested,
+            source=workspace_constants.WORKSPACE_SOURCE_EXPLICIT)
 
     accessible = sorted(
         _accessible_workspace_names_for_user(user.id,
@@ -1122,8 +1114,9 @@ def resolve_workspace_for_user(
     # users table per request would be redundant on the hot path.
     preferred = user.preferred_workspace
     if preferred is not None and preferred in accessible:
-        return WorkspaceResolution(workspace=preferred,
-                                   source=WORKSPACE_SOURCE_PREFERRED)
+        return WorkspaceResolution(
+            workspace=preferred,
+            source=workspace_constants.WORKSPACE_SOURCE_PREFERRED)
 
     drift_note: Optional[str] = None
     if preferred is not None and preferred not in accessible:
@@ -1137,13 +1130,14 @@ def resolve_workspace_for_user(
         # admins who used to land on 'default' implicitly.
         return WorkspaceResolution(
             workspace=constants.SKYPILOT_DEFAULT_WORKSPACE,
-            source=WORKSPACE_SOURCE_DEFAULT_FALLBACK,
+            source=workspace_constants.WORKSPACE_SOURCE_DEFAULT_FALLBACK,
             note=drift_note)
 
     if len(accessible) == 1:
-        return WorkspaceResolution(workspace=accessible[0],
-                                   source=WORKSPACE_SOURCE_SINGLE_MEMBERSHIP,
-                                   note=drift_note)
+        return WorkspaceResolution(
+            workspace=accessible[0],
+            source=workspace_constants.WORKSPACE_SOURCE_SINGLE_MEMBERSHIP,
+            note=drift_note)
 
     if not accessible:
         raise exceptions.NoWorkspaceAccessError(

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -801,3 +801,167 @@ def test_resolve_blob_missing_file(tmp_path, monkeypatch):
     from sky.server import common as server_common
     with pytest.raises(FileNotFoundError, match='Blob not found'):
         server_common.resolve_blob_dir(blob_id, 'testuser')
+
+
+# ---- Workspace resolution info log -------------------------------------
+#
+# `override_request_env_and_config` writes an INFO-level log when the
+# resolver picks a workspace implicitly (preferred / default-fallback /
+# single-membership) for a resource-creating request. The launch flow
+# streams that log back to the CLI, so the user sees which workspace
+# their cluster / job ended up in.
+#
+# The tests below are unit-level: they stub the resolver + permission
+# check and verify the log gating logic, not the resolver itself
+# (covered in test_resolve_workspace_for_user.py).
+
+
+def _resolution(workspace, source):
+    """Build a fake WorkspaceResolution for tests below."""
+    from sky.workspaces import core as workspaces_core
+    return workspaces_core.WorkspaceResolution(workspace=workspace,
+                                               source=source)
+
+
+@pytest.fixture()
+def resolver_log_deps(monkeypatch, stub_override_request_env_deps):
+    """Pin the resolver gate to ON and stub the resolver itself."""
+    monkeypatch.setattr(
+        'sky.server.requests.executor._should_apply_workspace_resolver',
+        lambda is_daemon, client_api_version: True)
+    return monkeypatch
+
+
+def _run_override(request_name: str, resolution):
+    """Drive override_request_env_and_config with a mocked resolution.
+
+    Returns the list of `logger.info` calls (so tests can assert on the
+    "Using workspace ..." line without depending on log capture).
+    """
+    from sky.workspaces import core as workspaces_core
+    body = payloads.RequestBody(
+        env_vars={
+            constants.USER_ID_ENV_VAR: 'client-user-id',
+            constants.USER_ENV_VAR: 'client-user',
+        })
+    info_calls: List[str] = []
+    with mock.patch.object(workspaces_core,
+                           'resolve_workspace_for_user',
+                           return_value=resolution), \
+         mock.patch.object(executor.logger, 'info',
+                           side_effect=lambda msg, *a, **k: info_calls.append(
+                               msg)):
+        with executor.override_request_env_and_config(
+                body, request_id='not-a-daemon-uuid',
+                request_name=request_name):
+            pass
+    return info_calls
+
+
+def test_resolution_log_fires_for_launch_with_implicit_source(
+        resolver_log_deps):
+    """`sky launch` with no explicit workspace → resolver picks via
+    preferred / default-fallback / single-membership. The user sees
+    "Using workspace 'X' (source: …)" so they know which workspace
+    SkyPilot stamped onto the cluster row.
+
+    The request_name passed to override_request_env_and_config is the
+    name as stored on the task row — `REQUEST_NAME_PREFIX + <enum>`.
+    `prepare_request_async` does the prefixing once at enqueue time."""
+    from sky.workspaces import constants as workspace_constants
+    info_calls = _run_override(
+        request_name=(server_constants.REQUEST_NAME_PREFIX + 'launch'),
+        resolution=_resolution(
+            'team-a', workspace_constants.WORKSPACE_SOURCE_SINGLE_MEMBERSHIP))
+    matching = [m for m in info_calls if 'Using workspace' in m]
+    assert len(matching) == 1, (
+        f'Expected one resolution-log line, got: {info_calls}')
+    msg = matching[0]
+    assert "'team-a'" in msg
+    assert workspace_constants.WORKSPACE_SOURCE_SINGLE_MEMBERSHIP in msg
+
+
+def test_resolution_log_fires_for_jobs_launch_with_preferred(resolver_log_deps):
+    """Same log path for managed jobs — `sky jobs launch` is also a
+    resource-creating verb (writes job_info.workspace), users need to
+    see which workspace it landed in."""
+    from sky.workspaces import constants as workspace_constants
+    info_calls = _run_override(
+        request_name=(server_constants.REQUEST_NAME_PREFIX + 'jobs.launch'),
+        resolution=_resolution('team-b',
+                               workspace_constants.WORKSPACE_SOURCE_PREFERRED))
+    matching = [m for m in info_calls if 'Using workspace' in m]
+    assert len(matching) == 1
+    assert "'team-b'" in matching[0]
+
+
+def test_resolution_log_silent_when_source_default_fallback(resolver_log_deps):
+    """Landing on 'default' via default-fallback is the pre-existing
+    silent behavior — every user without a preferred who has access to
+    'default' lands there. Surfacing that in the log on every launch
+    would clutter the common case while telling the user nothing new
+    (they're already used to landing on 'default').
+
+    Revert check: drop DEFAULT_FALLBACK from
+    `_SILENT_WORKSPACE_RESOLUTION_SOURCES` and this test flips to a
+    log-firing assertion failure."""
+    from sky.workspaces import constants as workspace_constants
+    info_calls = _run_override(
+        request_name=(server_constants.REQUEST_NAME_PREFIX + 'launch'),
+        resolution=_resolution(
+            'default', workspace_constants.WORKSPACE_SOURCE_DEFAULT_FALLBACK))
+    assert not [m for m in info_calls if 'Using workspace' in m
+               ], (f'DEFAULT_FALLBACK must not log; got: {info_calls}')
+
+
+def test_resolution_log_silent_when_source_explicit(resolver_log_deps):
+    """When `active_workspace` was explicitly set (--workspace flag or
+    a config file), the user already named the workspace — repeating
+    it in the log is noise. EXPLICIT must not trigger the line."""
+    from sky.workspaces import constants as workspace_constants
+    info_calls = _run_override(
+        request_name=(server_constants.REQUEST_NAME_PREFIX + 'launch'),
+        resolution=_resolution('team-c',
+                               workspace_constants.WORKSPACE_SOURCE_EXPLICIT))
+    assert not [m for m in info_calls if 'Using workspace' in m
+               ], (f'EXPLICIT source must not log; got: {info_calls}')
+
+
+def test_resolution_log_silent_for_non_resource_creating_request(
+        resolver_log_deps):
+    """`sky status` / `sky queue` etc. resolve the same way but don't
+    persist the workspace onto durable state. Logging there would be
+    noise on commands the user runs frequently. The whitelist
+    (_RESOURCE_CREATING_REQUEST_NAMES_FOR_RESOLUTION_LOG) is what
+    keeps this scoped — extend it when adding a new resource-creating
+    verb (SERVE_UP, etc.)."""
+    from sky.workspaces import constants as workspace_constants
+    info_calls = _run_override(
+        request_name=(server_constants.REQUEST_NAME_PREFIX + 'status'),
+        resolution=_resolution(
+            'team-a', workspace_constants.WORKSPACE_SOURCE_SINGLE_MEMBERSHIP))
+    assert not [m for m in info_calls if 'Using workspace' in m], (
+        f'`status` must not surface the resolution log; got: {info_calls}')
+
+
+def test_resolution_log_silent_for_bare_launch_without_prefix(
+        resolver_log_deps):
+    """Protocol lock: the runtime `request_name` (read off
+    `request_task.name`) is always the prefixed form
+    (`'sky.launch'`); the raw enum value `'launch'` never reaches
+    `override_request_env_and_config`. If a future refactor drops the
+    prefix in the whitelist, this test would START passing the log
+    line and then break BOTH this case AND production — keep this case
+    locking the prefix in.
+
+    Revert check: drop `REQUEST_NAME_PREFIX +` from the whitelist and
+    this test still passes (no log) but the prefixed tests above flip
+    to failing — the two sides together pin the contract."""
+    from sky.workspaces import constants as workspace_constants
+    info_calls = _run_override(
+        request_name='launch',
+        resolution=_resolution(
+            'team-a', workspace_constants.WORKSPACE_SOURCE_SINGLE_MEMBERSHIP))
+    assert not [m for m in info_calls if 'Using workspace' in m], (
+        f'bare `launch` (without prefix) must not match the whitelist; '
+        f'got: {info_calls}')

--- a/tests/unit_tests/test_sky/server/test_sdk.py
+++ b/tests/unit_tests/test_sky/server/test_sdk.py
@@ -498,7 +498,7 @@ def test_api_login_clears_residual_sa_token(monkeypatch: pytest.MonkeyPatch,
 
     # Step 1: Login with service account token. This writes the sa token
     # into config and sets local user hash to the sa user.
-    sa_user = {'id': sa_user_hash, 'name': 'hailong'}
+    sa_user = {'id': sa_user_hash, 'name': 'alice'}
     with mock.patch('sky.server.common.check_server_healthy') as mock_check:
         mock_check.return_value = (
             server_common.ApiServerStatus.HEALTHY,

--- a/tests/unit_tests/test_sky/test_cli_workspace.py
+++ b/tests/unit_tests/test_sky/test_cli_workspace.py
@@ -120,6 +120,32 @@ class TestLaunchAmbiguousSurfaced(unittest.TestCase):
             self.assertIn(needle, msg,
                           f'AMBIGUOUS message missing {needle!r}: {msg}')
 
+    def test_ambiguous_message_scopes_workspace_flag_to_launch(self):
+        """`--workspace <name>` only exists on `sky launch` / `sky jobs
+        launch`. The message must NOT advertise it as a universal fix —
+        users running `sky status` / `sky queue` / etc. would try a flag
+        that doesn't exist on their command. The wording was changed
+        deliberately to push `--workspace` into a footnote that names
+        the two commands where it applies."""
+        e = exceptions.WorkspaceAmbiguousError(['team-a', 'team-b'])
+        msg = str(e)
+        # The launch-specific footnote must mention BOTH launch commands.
+        self.assertIn('sky launch', msg)
+        self.assertIn('sky jobs launch', msg)
+        # The universal fix list (`sky workspace use` + `~/.sky/config.yaml`)
+        # must not include `--workspace` — that would be misleading.
+        # Grab the substring before the launch-specific footnote and
+        # assert `--workspace` isn't in it.
+        footnote_marker = 'for a one-shot override'
+        self.assertIn(
+            footnote_marker, msg,
+            f'Expected launch footnote marker {footnote_marker!r}: {msg}')
+        universal_section = msg.split(footnote_marker)[0]
+        self.assertNotIn(
+            '--workspace', universal_section,
+            f'`--workspace` leaked into the universal fix list: '
+            f'{universal_section!r}')
+
     def test_ambiguous_message_with_drift_note(self):
         """When the user had a preferred that lost access, the drift note
         explains why they're now in AMBIGUOUS — keeps the user oriented."""
@@ -245,6 +271,89 @@ class TestSkyWorkspaceInfoCommand(unittest.TestCase):
             result = self.runner.invoke(command.cli, ['workspace', 'info'])
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn('Preferred: (not set)', result.output)
+
+    def test_ambiguous_source_appends_recovery_hint_below_tree(self):
+        """When the resolver couldn't pick a workspace, the handler
+        returns `source='ambiguous'` with a SHORT `note`. The CLI must
+        render the tree uniformly (so `Preferred` / `Accessible` aren't
+        pushed sideways by a multi-line `Note:`), then append the long
+        recovery guidance as a separate block below. The hint text
+        comes from `WorkspaceAmbiguousError.recovery_hint()` so the
+        CLI and the launch-path exception message stay in sync.
+
+        Revert check: drop the appended `recovery_hint()` echo in
+        `workspace_info` and the `sky workspace use` substring assertion
+        below fails (the hint lives only in the appended paragraph,
+        never in `note`)."""
+        payload = {
+            'workspace': None,
+            'source': 'ambiguous',
+            'note': 'multiple workspaces accessible; '
+                    'no preferred or active workspace set',
+            'preferred': None,
+            'accessible': ['team-a', 'team-b'],
+        }
+        with mock.patch.object(sdk, 'get_user_workspace', return_value=payload):
+            result = self.runner.invoke(command.cli, ['workspace', 'info'])
+        self.assertEqual(result.exit_code, 0, result.output)
+        # Tree row carries only the SHORT note — no multi-line spill.
+        self.assertIn('Source: ambiguous', result.output)
+        self.assertIn('Note: multiple workspaces accessible', result.output)
+        # The recovery hint appears as a separate paragraph below.
+        self.assertIn(exceptions.WorkspaceAmbiguousError.recovery_hint(),
+                      result.output)
+        # The hint must follow the tree, not be embedded in it.
+        accessible_idx = result.output.index('Accessible:')
+        hint_idx = result.output.index('sky workspace use')
+        self.assertLess(
+            accessible_idx, hint_idx,
+            'Recovery hint must come AFTER the tree (`Accessible:` row),'
+            ' otherwise the tree alignment breaks visually.')
+
+    def test_no_access_source_renders_note_without_extra_hint(self):
+        """User has no accessible workspaces. The raise-site note
+        ("User <name> (<id>) has no accessible workspaces.") fits in
+        the tree row — no separate recovery paragraph is appended.
+        The AMBIGUOUS state is special because its hint is multi-line;
+        NO_ACCESS doesn't share that problem."""
+        payload = {
+            'workspace': None,
+            'source': 'no-access',
+            'note': 'User alice (alice) has no accessible workspaces.',
+            'preferred': None,
+            'accessible': [],
+        }
+        with mock.patch.object(sdk, 'get_user_workspace', return_value=payload):
+            result = self.runner.invoke(command.cli, ['workspace', 'info'])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn('Source: no-access', result.output)
+        self.assertIn('Accessible: (none)', result.output)
+        self.assertIn('User alice (alice) has no accessible workspaces.',
+                      result.output)
+        # No appended recovery paragraph — the note already says it all.
+        self.assertNotIn('sky workspace use', result.output)
+
+    def test_permission_denied_source_does_not_append_generic_hint(self):
+        """For permission-denied the `note` already names the specific
+        workspace + reason. A generic recovery paragraph here would be
+        noise on top of the specific message — verify the CLI suppresses
+        the append for this state."""
+        payload = {
+            'workspace': None,
+            'source': 'permission-denied',
+            'note': "User does not have permission to access workspace "
+                    "'team-locked'",
+            'preferred': None,
+            'accessible': ['team-a'],
+        }
+        with mock.patch.object(sdk, 'get_user_workspace', return_value=payload):
+            result = self.runner.invoke(command.cli, ['workspace', 'info'])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn('Source: permission-denied', result.output)
+        self.assertIn('team-locked', result.output)
+        # No generic recovery paragraph for this state.
+        self.assertNotIn('sky workspace use', result.output)
+        self.assertNotIn('Ask an admin', result.output)
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests/test_sky/users/test_preferred_workspace_endpoints.py
+++ b/tests/unit_tests/test_sky/users/test_preferred_workspace_endpoints.py
@@ -16,6 +16,7 @@ from sky import models
 from sky.server import constants as server_constants
 from sky.server.requests import payloads
 from sky.users import server as users_server
+from sky.workspaces import constants as workspace_constants
 from sky.workspaces import core as workspaces_core
 
 
@@ -31,7 +32,7 @@ def _fake_request(auth_user):
 class TestSetUsersMeWorkspace(unittest.TestCase):
 
     def setUp(self):
-        self.user = models.User(id='hailong', name='hailong')
+        self.user = models.User(id='alice', name='alice')
 
     def _body(self, preferred):
         b = mock.MagicMock(spec=payloads.UserPreferredWorkspaceBody)
@@ -108,7 +109,7 @@ class TestGetUsersMeWorkspace(unittest.TestCase):
         # Matches how AuthProxyMiddleware constructs `auth_user` from a
         # header — which the handler must NOT blindly trust for fields
         # that live in the DB.
-        self.auth_user = models.User(id='hailong', name='hailong')
+        self.auth_user = models.User(id='alice', name='alice')
 
     def _patch(self, fresh_user, resolution, accessible):
         return [
@@ -134,12 +135,12 @@ class TestGetUsersMeWorkspace(unittest.TestCase):
     def test_happy_path_preferred(self):
         """Preferred set + accessible -> resolver returns preferred, the
         handler echoes both alongside the accessible set."""
-        fresh = models.User(id='hailong',
-                            name='hailong',
+        fresh = models.User(id='alice',
+                            name='alice',
                             preferred_workspace='team-a')
         resolution = workspaces_core.WorkspaceResolution(
             workspace='team-a',
-            source=workspaces_core.WORKSPACE_SOURCE_PREFERRED)
+            source=workspace_constants.WORKSPACE_SOURCE_PREFERRED)
         patches = self._patch(fresh, resolution, {'team-a', 'team-b'})
         for p in patches:
             p.start()
@@ -151,7 +152,7 @@ class TestGetUsersMeWorkspace(unittest.TestCase):
                 p.stop()
         self.assertEqual(resp['workspace'], 'team-a')
         self.assertEqual(resp['source'],
-                         workspaces_core.WORKSPACE_SOURCE_PREFERRED)
+                         workspace_constants.WORKSPACE_SOURCE_PREFERRED)
         self.assertIsNone(resp['note'])
         self.assertEqual(resp['preferred'], 'team-a')
         # `accessible` is sorted to make the wire format deterministic
@@ -162,12 +163,12 @@ class TestGetUsersMeWorkspace(unittest.TestCase):
         """Preferred='team-x' but the user lost access (RBAC drift).
         Resolver falls back to default; handler exposes the drift note
         AND echoes the stale preferred so the UI can surface it."""
-        fresh = models.User(id='hailong',
-                            name='hailong',
+        fresh = models.User(id='alice',
+                            name='alice',
                             preferred_workspace='team-x')
         resolution = workspaces_core.WorkspaceResolution(
             workspace='default',
-            source=workspaces_core.WORKSPACE_SOURCE_DEFAULT_FALLBACK,
+            source=workspace_constants.WORKSPACE_SOURCE_DEFAULT_FALLBACK,
             note="preferred 'team-x' not accessible")
         patches = self._patch(fresh, resolution, {'default', 'team-a'})
         for p in patches:
@@ -180,7 +181,7 @@ class TestGetUsersMeWorkspace(unittest.TestCase):
                 p.stop()
         self.assertEqual(resp['workspace'], 'default')
         self.assertEqual(resp['source'],
-                         workspaces_core.WORKSPACE_SOURCE_DEFAULT_FALLBACK)
+                         workspace_constants.WORKSPACE_SOURCE_DEFAULT_FALLBACK)
         self.assertEqual(resp['note'], "preferred 'team-x' not accessible")
         # The persisted preferred is reported even though it's not
         # accessible — the dashboard surfaces this to explain the drift.
@@ -190,10 +191,10 @@ class TestGetUsersMeWorkspace(unittest.TestCase):
         """User has not set preferred but has access to default.
         Returned `preferred` is None (not the resolved fallback), so a
         client can tell "I haven't set anything" from "I set default"."""
-        fresh = models.User(id='hailong', name='hailong')
+        fresh = models.User(id='alice', name='alice')
         resolution = workspaces_core.WorkspaceResolution(
             workspace='default',
-            source=workspaces_core.WORKSPACE_SOURCE_DEFAULT_FALLBACK)
+            source=workspace_constants.WORKSPACE_SOURCE_DEFAULT_FALLBACK)
         patches = self._patch(fresh, resolution, {'default', 'team-a'})
         for p in patches:
             p.start()
@@ -219,12 +220,12 @@ class TestGetUsersMeWorkspace(unittest.TestCase):
         precedence branch. Without this, `sky workspace info` would
         contradict `sky launch` for users with an active workspace set
         locally — same machinery, different answer."""
-        fresh = models.User(id='hailong',
-                            name='hailong',
+        fresh = models.User(id='alice',
+                            name='alice',
                             preferred_workspace='team-a')
         resolution = workspaces_core.WorkspaceResolution(
             workspace='team-b',
-            source=workspaces_core.WORKSPACE_SOURCE_EXPLICIT)
+            source=workspace_constants.WORKSPACE_SOURCE_EXPLICIT)
         with mock.patch.object(users_server.global_user_state,
                                'get_user',
                                return_value=fresh), \
@@ -244,7 +245,7 @@ class TestGetUsersMeWorkspace(unittest.TestCase):
         resolve_mock.assert_called_once_with(fresh, requested='team-b')
         self.assertEqual(resp['workspace'], 'team-b')
         self.assertEqual(resp['source'],
-                         workspaces_core.WORKSPACE_SOURCE_EXPLICIT)
+                         workspace_constants.WORKSPACE_SOURCE_EXPLICIT)
         # Preferred is reported alongside even though the explicit
         # override won — the caller may want to surface "you're
         # overriding your saved preference for this one launch".
@@ -256,10 +257,10 @@ class TestGetUsersMeWorkspace(unittest.TestCase):
         usually unset, but admins may pin it). Matches launch-path
         precedence: the server's loaded config flows into the
         resolver's `requested` slot."""
-        fresh = models.User(id='hailong', name='hailong')
+        fresh = models.User(id='alice', name='alice')
         resolution = workspaces_core.WorkspaceResolution(
             workspace='server-pinned',
-            source=workspaces_core.WORKSPACE_SOURCE_EXPLICIT)
+            source=workspace_constants.WORKSPACE_SOURCE_EXPLICIT)
         with mock.patch.object(users_server.global_user_state,
                                'get_user',
                                return_value=fresh), \
@@ -280,14 +281,19 @@ class TestGetUsersMeWorkspace(unittest.TestCase):
         resolve_mock.assert_called_once_with(fresh, requested='server-pinned')
         self.assertEqual(resp['workspace'], 'server-pinned')
 
-    def test_ambiguous_resolver_surfaces_as_note_with_null_workspace(self):
-        """When the resolver raises WorkspaceAmbiguousError (multi-ws
-        user, no preferred, no 'default' access), the GET handler
-        returns 200 with `workspace=None` + the guidance message in
-        `note`. The CLI uses `note` to print "run `sky workspace use
-        <name>`" — a 4xx body would force every caller to parse error
-        envelopes."""
-        fresh = models.User(id='hailong', name='hailong')
+    def test_ambiguous_resolver_surfaces_as_state_coded_source(self):
+        """Resolver raises WorkspaceAmbiguousError (multi-ws user, no
+        preferred, no 'default' access). The GET handler must NOT dump
+        the exception's multi-line recovery text into `note` — that
+        breaks the CLI tree renderer and clutters the wire shape.
+        Instead, `source` is the state code `ambiguous` and `note` is
+        a short one-liner; the CLI / dashboard look up the recovery
+        hint separately via `WorkspaceAmbiguousError.recovery_hint()`.
+
+        If you revert the handler change, `source` would be `None` and
+        `note` would be the 5-line English block — this test would fail
+        on both assertions."""
+        fresh = models.User(id='alice', name='alice')
         with mock.patch.object(users_server.global_user_state,
                                'get_user',
                                return_value=fresh), \
@@ -305,15 +311,102 @@ class TestGetUsersMeWorkspace(unittest.TestCase):
             resp = users_server.get_user_workspace(_fake_request(
                 self.auth_user))
         self.assertIsNone(resp['workspace'])
-        self.assertIsNone(resp['source'])
-        # The exception's formatted message lists candidates + guidance —
-        # we surface it verbatim in `note` so the CLI doesn't need to
-        # re-format.
-        self.assertIn('multiple workspaces', resp['note'])
-        self.assertIn('team-a', resp['note'])
-        self.assertIn('sky workspace use', resp['note'])
+        self.assertEqual(resp['source'],
+                         workspace_constants.WORKSPACE_SOURCE_AMBIGUOUS)
+        # Short, single-line note — no embedded recovery paragraph.
+        self.assertNotIn('\n', resp['note'])
+        self.assertNotIn('sky workspace use', resp['note'])
         # Accessible is still populated so the CLI can list candidates.
         self.assertEqual(resp['accessible'], ['team-a', 'team-b'])
+
+    def test_ambiguous_with_drift_note_surfaces_drift_in_note(self):
+        """Drift case: user had a preferred that lost access AND ended
+        up ambiguous. The exception carries a short `note` (the drift
+        explanation); the handler must prefer that over the generic
+        one-liner so the CLI surfaces the actual cause."""
+        fresh = models.User(id='alice',
+                            name='alice',
+                            preferred_workspace='team-x')
+        with mock.patch.object(users_server.global_user_state,
+                               'get_user',
+                               return_value=fresh), \
+             mock.patch.object(
+                 users_server.workspaces_core,
+                 'resolve_workspace_for_user',
+                 side_effect=exceptions.WorkspaceAmbiguousError(
+                     accessible=['team-a', 'team-b'],
+                     note="preferred 'team-x' not accessible")), \
+             mock.patch.object(users_server.workspaces_core,
+                               'get_accessible_workspace_names',
+                               return_value={'team-a', 'team-b'}), \
+             mock.patch.object(users_server.skypilot_config,
+                               'is_active_workspace_set',
+                               return_value=False):
+            resp = users_server.get_user_workspace(_fake_request(
+                self.auth_user))
+        self.assertEqual(resp['source'],
+                         workspace_constants.WORKSPACE_SOURCE_AMBIGUOUS)
+        self.assertEqual(resp['note'], "preferred 'team-x' not accessible")
+
+    def test_no_workspace_access_surfaces_message_verbatim(self):
+        """User has zero accessible workspaces. The raise-site message
+        already names the user ("User <name> (<id>) has no accessible
+        workspaces.") — short enough to fit in the tree row AND more
+        informative than a generic stand-in, so the handler surfaces it
+        verbatim (same pattern as PERMISSION_DENIED)."""
+        fresh = models.User(id='alice', name='alice')
+        raise_msg = 'User alice (alice) has no accessible workspaces.'
+        with mock.patch.object(users_server.global_user_state,
+                               'get_user',
+                               return_value=fresh), \
+             mock.patch.object(
+                 users_server.workspaces_core,
+                 'resolve_workspace_for_user',
+                 side_effect=exceptions.NoWorkspaceAccessError(raise_msg)), \
+             mock.patch.object(users_server.workspaces_core,
+                               'get_accessible_workspace_names',
+                               return_value=set()), \
+             mock.patch.object(users_server.skypilot_config,
+                               'is_active_workspace_set',
+                               return_value=False):
+            resp = users_server.get_user_workspace(_fake_request(
+                self.auth_user))
+        self.assertIsNone(resp['workspace'])
+        self.assertEqual(resp['source'],
+                         workspace_constants.WORKSPACE_SOURCE_NO_ACCESS)
+        self.assertEqual(resp['note'], raise_msg)
+        self.assertEqual(resp['accessible'], [])
+
+    def test_permission_denied_surfaces_permission_denied_source(self):
+        """Explicit `requested` workspace the user can't access. The
+        handler keeps `str(e)` here (unlike the ambiguous path) because
+        the exception names the specific workspace + RBAC reason —
+        information the structured payload alone does not carry."""
+        fresh = models.User(id='alice', name='alice')
+        denied_msg = ("User 'alice' does not have permission to "
+                      "access workspace 'team-locked'")
+        with mock.patch.object(users_server.global_user_state,
+                               'get_user',
+                               return_value=fresh), \
+             mock.patch.object(
+                 users_server.workspaces_core,
+                 'resolve_workspace_for_user',
+                 side_effect=exceptions.PermissionDeniedError(denied_msg)), \
+             mock.patch.object(users_server.workspaces_core,
+                               'get_accessible_workspace_names',
+                               return_value={'team-a', 'team-b'}), \
+             mock.patch.object(users_server.skypilot_config,
+                               'is_active_workspace_set',
+                               return_value=False):
+            resp = users_server.get_user_workspace(_fake_request(
+                self.auth_user),
+                                                   requested='team-locked')
+        self.assertIsNone(resp['workspace'])
+        self.assertEqual(resp['source'],
+                         workspace_constants.WORKSPACE_SOURCE_PERMISSION_DENIED)
+        # The note retains the exception message — it names the
+        # specific workspace, which the payload doesn't.
+        self.assertEqual(resp['note'], denied_msg)
 
 
 # Version gate constant -----------------------------------------------

--- a/tests/unit_tests/test_sky/workspaces/test_resolve_workspace_for_user.py
+++ b/tests/unit_tests/test_sky/workspaces/test_resolve_workspace_for_user.py
@@ -17,6 +17,7 @@ from sky import exceptions
 from sky import models
 from sky import skypilot_config
 from sky.skylet import constants
+from sky.workspaces import constants as workspace_constants
 from sky.workspaces import core as workspaces_core
 
 # Helper -----------------------------------------------------------------
@@ -49,9 +50,7 @@ def _patch_resolver(accessible, workspaces=None):
 
 def _user_with_preferred(preferred):
     """Build the standard test User with `preferred_workspace` set."""
-    return models.User(id='hailong',
-                       name='hailong',
-                       preferred_workspace=preferred)
+    return models.User(id='alice', name='alice', preferred_workspace=preferred)
 
 
 class _Patcher:
@@ -77,7 +76,7 @@ class TestResolverPrecedence(unittest.TestCase):
     """Exercises every branch of resolve_workspace_for_user."""
 
     def setUp(self):
-        self.user = models.User(id='hailong', name='hailong')
+        self.user = models.User(id='alice', name='alice')
 
     def test_explicit_requested_wins(self):
         """`requested` is honored over preferred and accessibility heuristics."""
@@ -87,7 +86,8 @@ class TestResolverPrecedence(unittest.TestCase):
             r = workspaces_core.resolve_workspace_for_user(user,
                                                            requested='team-a')
         self.assertEqual(r.workspace, 'team-a')
-        self.assertEqual(r.source, workspaces_core.WORKSPACE_SOURCE_EXPLICIT)
+        self.assertEqual(r.source,
+                         workspace_constants.WORKSPACE_SOURCE_EXPLICIT)
 
     def test_explicit_requested_validates_access(self):
         """A requested workspace the user can't access raises."""
@@ -108,7 +108,8 @@ class TestResolverPrecedence(unittest.TestCase):
                     [constants.SKYPILOT_DEFAULT_WORKSPACE, 'team-a'])):
             r = workspaces_core.resolve_workspace_for_user(user)
         self.assertEqual(r.workspace, 'team-a')
-        self.assertEqual(r.source, workspaces_core.WORKSPACE_SOURCE_PREFERRED)
+        self.assertEqual(r.source,
+                         workspace_constants.WORKSPACE_SOURCE_PREFERRED)
         self.assertIsNone(r.note)
 
     def test_preferred_revoked_falls_through_with_note(self):
@@ -121,7 +122,7 @@ class TestResolverPrecedence(unittest.TestCase):
             r = workspaces_core.resolve_workspace_for_user(user)
         self.assertEqual(r.workspace, constants.SKYPILOT_DEFAULT_WORKSPACE)
         self.assertEqual(r.source,
-                         workspaces_core.WORKSPACE_SOURCE_DEFAULT_FALLBACK)
+                         workspace_constants.WORKSPACE_SOURCE_DEFAULT_FALLBACK)
         self.assertIsNotNone(r.note)
         self.assertIn('team-a', r.note)
 
@@ -135,7 +136,7 @@ class TestResolverPrecedence(unittest.TestCase):
             r = workspaces_core.resolve_workspace_for_user(self.user)
         self.assertEqual(r.workspace, 'team-only')
         self.assertEqual(r.source,
-                         workspaces_core.WORKSPACE_SOURCE_SINGLE_MEMBERSHIP)
+                         workspace_constants.WORKSPACE_SOURCE_SINGLE_MEMBERSHIP)
 
     def test_zero_accessible_raises_no_workspace_access(self):
         with _Patcher(_patch_resolver([])):
@@ -176,7 +177,7 @@ class TestResolverPrecedence(unittest.TestCase):
             r = workspaces_core.resolve_workspace_for_user(self.user)
         self.assertEqual(r.workspace, constants.SKYPILOT_DEFAULT_WORKSPACE)
         self.assertEqual(r.source,
-                         workspaces_core.WORKSPACE_SOURCE_DEFAULT_FALLBACK)
+                         workspace_constants.WORKSPACE_SOURCE_DEFAULT_FALLBACK)
         self.assertIsNone(r.note)
 
     def test_admin_lands_on_default_no_ambiguous(self):
@@ -192,7 +193,7 @@ class TestResolverPrecedence(unittest.TestCase):
             r = workspaces_core.resolve_workspace_for_user(self.user)
         self.assertEqual(r.workspace, constants.SKYPILOT_DEFAULT_WORKSPACE)
         self.assertEqual(r.source,
-                         workspaces_core.WORKSPACE_SOURCE_DEFAULT_FALLBACK)
+                         workspace_constants.WORKSPACE_SOURCE_DEFAULT_FALLBACK)
 
     # ---- Gap-fill cases from the function-test matrix --------
 
@@ -205,7 +206,7 @@ class TestResolverPrecedence(unittest.TestCase):
             r = workspaces_core.resolve_workspace_for_user(self.user)
         self.assertEqual(r.workspace, constants.SKYPILOT_DEFAULT_WORKSPACE)
         self.assertEqual(r.source,
-                         workspaces_core.WORKSPACE_SOURCE_DEFAULT_FALLBACK)
+                         workspace_constants.WORKSPACE_SOURCE_DEFAULT_FALLBACK)
 
     def test_preferred_default_single_accessible_default(self):
         """preferred='default' explicit overrides the default-fallback
@@ -217,7 +218,8 @@ class TestResolverPrecedence(unittest.TestCase):
         with _Patcher(_patch_resolver([constants.SKYPILOT_DEFAULT_WORKSPACE])):
             r = workspaces_core.resolve_workspace_for_user(user)
         self.assertEqual(r.workspace, constants.SKYPILOT_DEFAULT_WORKSPACE)
-        self.assertEqual(r.source, workspaces_core.WORKSPACE_SOURCE_PREFERRED)
+        self.assertEqual(r.source,
+                         workspace_constants.WORKSPACE_SOURCE_PREFERRED)
 
     def test_preferred_inaccessible_single_accessible_default(self):
         """Preferred revoked, only 'default' left → default-fallback with a
@@ -228,7 +230,7 @@ class TestResolverPrecedence(unittest.TestCase):
             r = workspaces_core.resolve_workspace_for_user(user)
         self.assertEqual(r.workspace, constants.SKYPILOT_DEFAULT_WORKSPACE)
         self.assertEqual(r.source,
-                         workspaces_core.WORKSPACE_SOURCE_DEFAULT_FALLBACK)
+                         workspace_constants.WORKSPACE_SOURCE_DEFAULT_FALLBACK)
         self.assertIsNotNone(r.note)
         self.assertIn('team-revoked', r.note)
 
@@ -240,7 +242,8 @@ class TestResolverPrecedence(unittest.TestCase):
         with _Patcher(_patch_resolver(['team-only'])):
             r = workspaces_core.resolve_workspace_for_user(user)
         self.assertEqual(r.workspace, 'team-only')
-        self.assertEqual(r.source, workspaces_core.WORKSPACE_SOURCE_PREFERRED)
+        self.assertEqual(r.source,
+                         workspace_constants.WORKSPACE_SOURCE_PREFERRED)
 
     def test_preferred_mismatch_single_non_default_with_drift(self):
         """Preferred set but inaccessible, the only accessible is a
@@ -252,7 +255,7 @@ class TestResolverPrecedence(unittest.TestCase):
             r = workspaces_core.resolve_workspace_for_user(user)
         self.assertEqual(r.workspace, 'team-only')
         self.assertEqual(r.source,
-                         workspaces_core.WORKSPACE_SOURCE_SINGLE_MEMBERSHIP)
+                         workspace_constants.WORKSPACE_SOURCE_SINGLE_MEMBERSHIP)
         self.assertIsNotNone(r.note)
         self.assertIn('team-revoked', r.note)
 
@@ -266,7 +269,8 @@ class TestResolverPrecedence(unittest.TestCase):
         with _Patcher(_patch_resolver(['team-a', 'team-b', 'team-c'])):
             r = workspaces_core.resolve_workspace_for_user(user)
         self.assertEqual(r.workspace, 'team-b')
-        self.assertEqual(r.source, workspaces_core.WORKSPACE_SOURCE_PREFERRED)
+        self.assertEqual(r.source,
+                         workspace_constants.WORKSPACE_SOURCE_PREFERRED)
 
     def test_preferred_set_zero_accessible(self):
         """Edge: preferred set but the user has zero accessible workspaces
@@ -291,7 +295,8 @@ class TestResolverPrecedence(unittest.TestCase):
             r = workspaces_core.resolve_workspace_for_user(user,
                                                            requested='team-a')
         self.assertEqual(r.workspace, 'team-a')
-        self.assertEqual(r.source, workspaces_core.WORKSPACE_SOURCE_EXPLICIT)
+        self.assertEqual(r.source,
+                         workspace_constants.WORKSPACE_SOURCE_EXPLICIT)
         # No drift note when explicit — drift only arises from the
         # automatic resolution path.
         self.assertIsNone(r.note)
@@ -307,13 +312,13 @@ class TestResolverPrecedence(unittest.TestCase):
             r = workspaces_core.resolve_workspace_for_user(self.user)
         self.assertEqual(r.workspace, constants.SKYPILOT_DEFAULT_WORKSPACE)
         self.assertEqual(r.source,
-                         workspaces_core.WORKSPACE_SOURCE_DEFAULT_FALLBACK)
+                         workspace_constants.WORKSPACE_SOURCE_DEFAULT_FALLBACK)
         # Sub-case 2: single ws non-default (admin happens to see only one)
         with _Patcher(_patch_resolver(['team-only-admin'])):
             r = workspaces_core.resolve_workspace_for_user(self.user)
         self.assertEqual(r.workspace, 'team-only-admin')
         self.assertEqual(r.source,
-                         workspaces_core.WORKSPACE_SOURCE_SINGLE_MEMBERSHIP)
+                         workspace_constants.WORKSPACE_SOURCE_SINGLE_MEMBERSHIP)
 
     def test_admin_with_preferred_uses_preferred(self):
         """Admin who has set a preferred → preferred wins over
@@ -327,7 +332,8 @@ class TestResolverPrecedence(unittest.TestCase):
         with _Patcher(_patch_resolver(all_workspaces)):
             r = workspaces_core.resolve_workspace_for_user(user)
         self.assertEqual(r.workspace, 'team-b')
-        self.assertEqual(r.source, workspaces_core.WORKSPACE_SOURCE_PREFERRED)
+        self.assertEqual(r.source,
+                         workspace_constants.WORKSPACE_SOURCE_PREFERRED)
 
 
 # Preferred-workspace setter RBAC ----------------------------------------
@@ -336,7 +342,7 @@ class TestResolverPrecedence(unittest.TestCase):
 class TestPreferredSetterRBAC(unittest.TestCase):
 
     def setUp(self):
-        self.user = models.User(id='hailong', name='hailong')
+        self.user = models.User(id='alice', name='alice')
 
     def test_setter_rejects_inaccessible_ws(self):
         with mock.patch.object(workspaces_core, '_load_workspaces',


### PR DESCRIPTION
## Summary

Follow-ups after the per-user workspace resolver merge (#9755):

- **AMBIGUOUS recovery message** no longer advertises `--workspace` as a universal fix — it only exists on `sky launch` / `sky jobs launch`, so callers running `sky status` / `sky queue` etc. were being pointed at a flag that doesn't apply on their command. Reworded so the three recovery options read as parallel choices (not replacements): "Or, for a one-shot override on `sky launch` / `sky jobs launch`, pass `--workspace <name>`."
- **Resolver INFO log on resource-creating commands.** When `sky launch` / `sky jobs launch` lands on `PREFERRED` or `SINGLE_MEMBERSHIP`, log `Using workspace 'X' (source: …)` at INFO so the user sees where their cluster / job actually landed. `EXPLICIT` (user-named) and `DEFAULT_FALLBACK` (pre-existing implicit behavior) stay silent to avoid noise on the common cases. The whitelist now correctly uses the prefixed task name (`sky.launch`) — the previous draft compared against the bare enum value and never matched at runtime.
- **`sky workspace info` payload contract.** When the resolver raises `WorkspaceAmbiguousError` / `NoWorkspaceAccessError` / `PermissionDeniedError`, the handler now returns a state-coded `source` (`ambiguous` / `no-access` / `permission-denied`) plus a short single-line `note`, instead of dumping the multi-line exception text into `note` (which broke the CLI tree renderer). The CLI appends the AMBIGUOUS recovery hint as a separate paragraph below the tree, via a `WorkspaceAmbiguousError.recovery_hint()` classmethod shared between the exception and the CLI.
- **Move `WORKSPACE_SOURCE_*` constants to a new leaf module** `sky/workspaces/constants.py` so client-side callers (CLI) no longer drag the resolver's server-only deps (`check`, `global_user_state`, `backend_utils`, `permission`, `resource_checker`) into a read path.

## Tested

```
pytest \
  tests/unit_tests/test_sky/test_cli_workspace.py \
  tests/unit_tests/test_sky/users/test_preferred_workspace_endpoints.py \
  tests/unit_tests/test_sky/workspaces/test_resolve_workspace_for_user.py \
  tests/unit_tests/test_sky/server/requests/test_executor.py \
  tests/unit_tests/test_sky/workspaces/test_resolver_compat_matrix.py
```

103 passed. New regressions added:

- `test_resolution_log_silent_for_bare_launch_without_prefix` — bare `'launch'` (no `sky.` prefix) must NOT match the whitelist. Pins the prefix protocol from both sides (positive tests use prefixed names, this one fails the moment the prefix is dropped).
- `test_resolution_log_silent_when_source_default_fallback` — DEFAULT_FALLBACK must stay silent.
- `test_ambiguous_message_scopes_workspace_flag_to_launch` — `--workspace` must live in the launch footnote, not the universal section.
- `test_ambiguous_resolver_surfaces_as_state_coded_source` + `test_no_workspace_access_surfaces_message_verbatim` + `test_permission_denied_surfaces_permission_denied_source` — error payloads carry their state code + short note, never the multi-line exception text.
- `test_ambiguous_source_appends_recovery_hint_below_tree` — CLI appends `recovery_hint()` as a separate paragraph below the tree (asserts ordering vs. the `Accessible:` row).

Manual verification:

1. Multi-workspace user with no preferred and no `default` access → `sky launch` errors with the new message structure (universal `sky workspace use` / `~/.sky/config.yaml` options + parallel "Or, for a one-shot override..." footnote).
2. Same user runs `sky workspace info` → tree stays aligned (`Source: ambiguous`, short `Note:`), recovery hint renders as a separate paragraph below.
3. User with `preferred_workspace='team-a'` runs `sky launch` → streamed output includes `Using workspace 'team-a' (source: preferred).` from `executor.py`. Repeat with no preferred but access to `default` → no extra log line.