### PR TITLE
[Test] Pin transformers<5.10 in batch diffusion example

### DIFF
--- a/examples/batch/diffusion/pool.yaml
+++ b/examples/batch/diffusion/pool.yaml
@@ -11,4 +11,8 @@ setup: |
   uv venv .venv
   source .venv/bin/activate
   uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cu124
-  uv pip install diffusers transformers accelerate safetensors huggingface_hub
+  # transformers must stay <5.10: the cu124 index tops out at torch 2.6.0,
+  # while transformers 5.10.x references torch.float8_e8m0fnu (torch >= 2.7)
+  # at import time, crashing `from diffusers import StableDiffusionPipeline`.
+  # See https://github.com/huggingface/transformers/issues/46389.
+  uv pip install diffusers 'transformers<5.10' accelerate safetensors huggingface_hub


### PR DESCRIPTION
## Summary

- Pins `transformers<5.10` in `examples/batch/diffusion/pool.yaml` to fix `test_batch_diffusion` timing out in nightly CI ([build 11109](https://buildkite.com/skypilot-1/smoke-tests/builds/11109), failed 4/4 attempts).

## Root cause

- transformers 5.10.0/5.10.1 (released 2026-06-03 ~15:30 UTC, between the passing June 3 nightly and the failing June 4 nightly) evaluates `torch.float8_e8m0fnu` at **module import time** (`integrations/finegrained_fp8.py`), which only exists in torch >= 2.7.
- The diffusion pool installs torch from the `cu124` index, which tops out at **torch 2.6.0**, so the worker's `from diffusers import StableDiffusionPipeline` crashes with `AttributeError: module 'torch' has no attribute 'float8_e8m0fnu'`.
- Upstream issue: huggingface/transformers#46389; fix (huggingface/transformers#46393) not yet released, so unpinned installs remain broken.
- Reproduced locally in a fresh venv: `torch==2.6.0` + `transformers==5.10.1` → exact AttributeError on `from diffusers import StableDiffusionPipeline`.

The mapper crashing before the first batch also exposes a sky.batch robustness bug — the managed job stays `RUNNING 0%` instead of failing (error swallowed in `sky/batch/worker.py::start_worker`; `signal_batch_done` is a no-op when `_current_batch is None`). That will be filed as a separate issue; this PR just unblocks nightly CI.

Other suspects ruled out: the CUDA 13 AMI catalog update landed under a new `skypilot:custom-gpu-ubuntu-cuda13` tag (default tag rows untouched); CPU-pool batch tests passed in the same build.

## Test plan

- `/smoke-test -k test_batch_diffusion` on this PR (will monitor the Buildkite run and worker logs).
- Verified the import crash and the `<5.10` resolution locally in a scratch venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)