### PR TITLE
[Serve] Add ServiceStatusRunner extension point

### DIFF
--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -471,6 +471,12 @@ export async function getPoolStatus() {
     const data = await fetchedData.json();
     const poolData = data.return_value ? JSON.parse(data.return_value) : [];
 
+    // Skip the active-jobs fetch entirely when there are no pools — the
+    // job counts it computes have nothing to attach to.
+    if (poolData.length === 0) {
+      return { pools: [], controllerStopped: false };
+    }
+
     // Also fetch managed jobs to get job counts by pool
     let jobsData = { jobs: [] };
     try {

--- a/sky/serve/runner.py
+++ b/sky/serve/runner.py
@@ -1,0 +1,87 @@
+"""Service / pool status runner: abstraction + registry.
+
+A ``ServiceStatusRunner`` is the strategy object that the server's
+service/pool status entry points delegate to. The registered runner
+decides *how* the operation executes — the default runner talks to the
+controller via gRPC or codegen+subprocess, while a plugin-provided
+runner might call the serve DB directly when the controller is
+in-process (consolidation mode).
+
+At most one runner is registered at a time. If nothing has registered,
+``current()`` lazily constructs ``_DefaultServiceStatusRunner`` from
+``sky.serve.server.impl`` so there's always a usable runner regardless
+of import ordering. Plugins override the default by calling
+``register(MyRunner())`` in their ``install()`` phase.
+
+Thread-safety: ``register()`` is only expected to be called during
+server/plugin startup, before request handling begins. The module-level
+reference is written and read atomically under the GIL, and only the
+default + plugin-provided runner are registered (sequentially), so no
+lock is needed.
+"""
+import typing
+from typing import Any, Dict, List, Optional, Protocol
+
+from sky import sky_logging
+
+if typing.TYPE_CHECKING:
+    from sky import backends
+
+logger = sky_logging.init_logger(__name__)
+
+
+class ServiceStatusRunner(Protocol):
+    """Strategy interface for service/pool status fetching.
+
+    Note: only ``handle`` is passed in. The default runner's RPC path
+    does not need a ``CloudVmRayBackend``, so we don't compute one
+    eagerly. Implementations that need a backend (e.g. the legacy
+    codegen + ``run_on_head`` fallback) should derive it lazily from
+    ``handle`` via ``backend_utils.get_backend_from_handle``.
+    """
+
+    def get_service_status(
+        self,
+        *,
+        handle: 'backends.CloudVmRayResourceHandle',
+        service_names: Optional[List[str]],
+        pool: bool,
+    ) -> List[Dict[str, Any]]:
+        ...
+
+
+_current: Optional[ServiceStatusRunner] = None
+
+
+def register(runner: ServiceStatusRunner) -> None:
+    """Install ``runner`` as the currently-active service status runner.
+
+    Last registration wins. Plugins override the default in ``install()``.
+    """
+    # pylint: disable=global-statement
+    global _current
+    _current = runner
+    logger.debug('Registered ServiceStatusRunner: %s', type(runner).__name__)
+
+
+def current() -> ServiceStatusRunner:
+    """Return the registered runner, falling back to the default.
+
+    If nothing has been registered, constructs and installs
+    ``_DefaultServiceStatusRunner`` so there's always a usable runner
+    regardless of import ordering.
+    """
+    # pylint: disable=global-statement
+    global _current
+    if _current is None:
+        # pylint: disable=import-outside-toplevel
+        from sky.serve.server.impl import _DefaultServiceStatusRunner
+        _current = _DefaultServiceStatusRunner()
+    return _current
+
+
+def reset_for_testing() -> None:
+    """Reset the registered runner. Tests only."""
+    # pylint: disable=global-statement
+    global _current
+    _current = None

--- a/sky/serve/runner.py
+++ b/sky/serve/runner.py
@@ -14,11 +14,14 @@ of import ordering. Plugins override the default by calling
 ``register(MyRunner())`` in their ``install()`` phase.
 
 Thread-safety: ``register()`` is only expected to be called during
-server/plugin startup, before request handling begins. The module-level
-reference is written and read atomically under the GIL, and only the
-default + plugin-provided runner are registered (sequentially), so no
-lock is needed.
+server/plugin startup, before request handling begins. ``current()``'s
+default-runner lazy init is double-checked-locked because uvicorn runs
+sync request handlers in a thread pool — concurrent first calls would
+otherwise construct ``_DefaultServiceStatusRunner`` twice. The lock is
+not held on the hot path (post-init reads short-circuit before the
+``with`` block).
 """
+import threading
 import typing
 from typing import Any, Dict, List, Optional, Protocol
 
@@ -51,6 +54,7 @@ class ServiceStatusRunner(Protocol):
 
 
 _current: Optional[ServiceStatusRunner] = None
+_lock = threading.Lock()
 
 
 def register(runner: ServiceStatusRunner) -> None:
@@ -70,13 +74,22 @@ def current() -> ServiceStatusRunner:
     If nothing has been registered, constructs and installs
     ``_DefaultServiceStatusRunner`` so there's always a usable runner
     regardless of import ordering.
+
+    Uvicorn dispatches sync handlers to a thread pool, so concurrent
+    first calls can race here. Double-checked locking avoids
+    constructing the default runner twice — benign today (the class
+    has no ``__init__`` side effects) but cheap insurance against
+    future side effects.
     """
     # pylint: disable=global-statement
     global _current
     if _current is None:
-        # pylint: disable=import-outside-toplevel
-        from sky.serve.server.impl import _DefaultServiceStatusRunner
-        _current = _DefaultServiceStatusRunner()
+        with _lock:
+            if _current is None:
+                # In-function import: a top-level import would deadlock
+                # pylint: disable=import-outside-toplevel
+                from sky.serve.server.impl import _DefaultServiceStatusRunner
+                _current = _DefaultServiceStatusRunner()
     return _current
 
 

--- a/sky/serve/server/impl.py
+++ b/sky/serve/server/impl.py
@@ -24,6 +24,7 @@ from sky.backends import backend_utils
 from sky.catalog import common as service_catalog_common
 from sky.data import storage as storage_lib
 from sky.serve import constants as serve_constants
+from sky.serve import runner as serve_runner
 from sky.serve import serve_rpc_utils
 from sky.serve import serve_state
 from sky.serve import serve_utils
@@ -810,6 +811,60 @@ def down(
     logger.info(stdout)
 
 
+class _DefaultServiceStatusRunner:
+    """Default implementation — gRPC with codegen + run_on_head fallback.
+
+    Registered lazily by ``sky.serve.runner.current()``. Plugins override
+    by calling ``sky.serve.runner.register()`` with their own
+    implementation (e.g. an in-process runner for consolidation mode).
+    """
+
+    def get_service_status(
+        self,
+        *,
+        handle: 'backends.CloudVmRayResourceHandle',
+        service_names: Optional[List[str]],
+        pool: bool,
+    ) -> List[Dict[str, Any]]:
+        noun = 'pool' if pool else 'service'
+        use_legacy = not handle.is_grpc_enabled_with_flag
+
+        service_records: List[Dict[str, Any]] = []
+        if not use_legacy:
+            try:
+                service_records = serve_rpc_utils.RpcRunner.get_service_status(
+                    handle, service_names, pool)
+            except exceptions.SkyletMethodNotImplementedError:
+                use_legacy = True
+
+        if use_legacy:
+            backend = backend_utils.get_backend_from_handle(handle)
+            assert isinstance(backend, backends.CloudVmRayBackend)
+
+            code = serve_utils.ServeCodeGen.get_service_status(service_names,
+                                                               pool=pool)
+            returncode, serve_status_payload, stderr = backend.run_on_head(
+                handle,
+                code,
+                require_outputs=True,
+                stream_logs=False,
+                separate_stderr=True)
+
+            try:
+                subprocess_utils.handle_returncode(returncode,
+                                                   code,
+                                                   f'Failed to fetch {noun}s',
+                                                   stderr,
+                                                   stream_logs=True)
+            except exceptions.CommandError as e:
+                raise RuntimeError(e.error_msg) from e
+
+            service_records = serve_utils.load_service_status(
+                serve_status_payload)
+
+        return service_records
+
+
 def status(
     service_names: Optional[Union[str, List[str]]] = None,
     pool: bool = False,
@@ -834,38 +889,9 @@ def status(
         replace('service', noun))
 
     assert isinstance(handle, backends.CloudVmRayResourceHandle)
-    use_legacy = not handle.is_grpc_enabled_with_flag
 
-    if not use_legacy:
-        try:
-            service_records = serve_rpc_utils.RpcRunner.get_service_status(
-                handle, service_names, pool)
-        except exceptions.SkyletMethodNotImplementedError:
-            use_legacy = True
-
-    if use_legacy:
-        backend = backend_utils.get_backend_from_handle(handle)
-        assert isinstance(backend, backends.CloudVmRayBackend)
-
-        code = serve_utils.ServeCodeGen.get_service_status(service_names,
-                                                           pool=pool)
-        returncode, serve_status_payload, stderr = backend.run_on_head(
-            handle,
-            code,
-            require_outputs=True,
-            stream_logs=False,
-            separate_stderr=True)
-
-        try:
-            subprocess_utils.handle_returncode(returncode,
-                                               code,
-                                               f'Failed to fetch {noun}s',
-                                               stderr,
-                                               stream_logs=True)
-        except exceptions.CommandError as e:
-            raise RuntimeError(e.error_msg) from e
-
-        service_records = serve_utils.load_service_status(serve_status_payload)
+    service_records = serve_runner.current().get_service_status(
+        handle=handle, service_names=service_names, pool=pool)
 
     # Get the endpoint for each service
     for service_record in service_records:

--- a/tests/unit_tests/test_serve_runner.py
+++ b/tests/unit_tests/test_serve_runner.py
@@ -5,6 +5,7 @@ default codegen+subprocess status fetcher for an in-process one when
 the controller is consolidated into the API server.
 """
 # pylint: disable=invalid-name,protected-access
+import contextlib
 from unittest import mock
 
 import pytest
@@ -200,14 +201,10 @@ class TestStatusDelegatesToRunner:
 
         serve_runner.register(mock.Mock(get_service_status=fake_get))
 
-        patches = self._common_patches()
-        try:
-            for p in patches:
-                p.start()
+        with contextlib.ExitStack() as stack:
+            for p in self._common_patches():
+                stack.enter_context(p)
             impl.status(service_names='single', pool=True)
-        finally:
-            for p in patches:
-                p.stop()
 
         # service_names should be normalized from str -> [str].
         assert captured['service_names'] == ['single']
@@ -228,27 +225,26 @@ class TestStatusDelegatesToRunner:
             'load_balancer_port': None,
             'tls_encrypted': False,
         }]
-        patches = self._common_patches(handle=handle,
-                                       get_backend_return=backend)
-        with mock.patch(
-                'sky.serve.server.impl.serve_rpc_utils.RpcRunner.'
-                'get_service_status',
-                side_effect=exceptions.SkyletMethodNotImplementedError(
-                    'old skylet')) as rpc, \
-             mock.patch(
-                'sky.serve.server.impl.serve_utils.ServeCodeGen.'
-                'get_service_status',
-                return_value='CODE') as codegen, \
-             mock.patch(
-                'sky.serve.server.impl.serve_utils.load_service_status',
-                return_value=legacy_records):
-            try:
-                for p in patches:
-                    p.start()
-                result = impl.status(pool=False)
-            finally:
-                for p in patches:
-                    p.stop()
+        with contextlib.ExitStack() as stack:
+            for p in self._common_patches(handle=handle,
+                                          get_backend_return=backend):
+                stack.enter_context(p)
+            rpc = stack.enter_context(
+                mock.patch(
+                    'sky.serve.server.impl.serve_rpc_utils.RpcRunner.'
+                    'get_service_status',
+                    side_effect=exceptions.SkyletMethodNotImplementedError(
+                        'old skylet')))
+            codegen = stack.enter_context(
+                mock.patch(
+                    'sky.serve.server.impl.serve_utils.ServeCodeGen.'
+                    'get_service_status',
+                    return_value='CODE'))
+            stack.enter_context(
+                mock.patch(
+                    'sky.serve.server.impl.serve_utils.load_service_status',
+                    return_value=legacy_records))
+            result = impl.status(pool=False)
 
         rpc.assert_called_once()
         codegen.assert_called_once()
@@ -271,14 +267,10 @@ class TestStatusDelegatesToRunner:
         runner.get_service_status.return_value = records
         serve_runner.register(runner)
 
-        patches = self._common_patches()
-        try:
-            for p in patches:
-                p.start()
+        with contextlib.ExitStack() as stack:
+            for p in self._common_patches():
+                stack.enter_context(p)
             result = impl.status(pool=False)
-        finally:
-            for p in patches:
-                p.stop()
 
         # serve path with no load_balancer_port → endpoint stays None
         assert result == [{

--- a/tests/unit_tests/test_serve_runner.py
+++ b/tests/unit_tests/test_serve_runner.py
@@ -1,0 +1,289 @@
+"""Tests for sky.serve.runner registry and _DefaultServiceStatusRunner.
+
+Covers the strategy/registry pattern that lets plugins swap out the
+default codegen+subprocess status fetcher for an in-process one when
+the controller is consolidated into the API server.
+"""
+# pylint: disable=invalid-name,protected-access
+from unittest import mock
+
+import pytest
+
+from sky import backends
+from sky import exceptions
+from sky.serve import runner as serve_runner
+from sky.serve.server import impl
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    """Ensure each test starts with no plugin runner registered."""
+    serve_runner.reset_for_testing()
+    yield
+    serve_runner.reset_for_testing()
+
+
+def _handle_mock(grpc_enabled: bool = True):
+    h = mock.MagicMock(spec=backends.CloudVmRayResourceHandle)
+    h.is_grpc_enabled_with_flag = grpc_enabled
+    return h
+
+
+def _backend_mock():
+    return mock.MagicMock(spec=backends.CloudVmRayBackend)
+
+
+class TestRegistry:
+
+    def test_current_returns_default_when_unregistered(self):
+        runner = serve_runner.current()
+        assert isinstance(runner, impl._DefaultServiceStatusRunner)
+
+    def test_current_caches_default(self):
+        a = serve_runner.current()
+        b = serve_runner.current()
+        assert a is b
+
+    def test_register_replaces_default(self):
+        custom = mock.Mock()
+        serve_runner.register(custom)
+        assert serve_runner.current() is custom
+
+    def test_register_last_wins(self):
+        first = mock.Mock()
+        second = mock.Mock()
+        serve_runner.register(first)
+        serve_runner.register(second)
+        assert serve_runner.current() is second
+
+
+class TestDefaultRunnerRpcPath:
+    """gRPC path: ``is_grpc_enabled_with_flag`` true and RpcRunner returns."""
+
+    def test_rpc_success_no_legacy_fallback(self):
+        runner = impl._DefaultServiceStatusRunner()
+        handle = _handle_mock(grpc_enabled=True)
+        expected = [{'name': 'p1', 'status': 'READY'}]
+        with mock.patch(
+                'sky.serve.server.impl.serve_rpc_utils.RpcRunner.'
+                'get_service_status',
+                return_value=expected) as rpc, \
+             mock.patch(
+                'sky.serve.server.impl.serve_utils.ServeCodeGen.'
+                'get_service_status') as codegen, \
+             mock.patch(
+                'sky.serve.server.impl.backend_utils.'
+                'get_backend_from_handle') as get_backend:
+            result = runner.get_service_status(handle=handle,
+                                               service_names=['p1'],
+                                               pool=True)
+        assert result == expected
+        rpc.assert_called_once_with(handle, ['p1'], True)
+        codegen.assert_not_called()
+        # RPC path must not even materialize a backend.
+        get_backend.assert_not_called()
+
+    def test_rpc_not_implemented_falls_back_to_legacy(self):
+        runner = impl._DefaultServiceStatusRunner()
+        handle = _handle_mock(grpc_enabled=True)
+        backend = _backend_mock()
+        backend.run_on_head.return_value = (0, b'PAYLOAD', '')
+        legacy_records = [{'name': 'p2'}]
+        with mock.patch(
+                'sky.serve.server.impl.serve_rpc_utils.RpcRunner.'
+                'get_service_status',
+                side_effect=exceptions.SkyletMethodNotImplementedError(
+                    'old skylet')), \
+             mock.patch(
+                'sky.serve.server.impl.serve_utils.ServeCodeGen.'
+                'get_service_status',
+                return_value='CODE') as codegen, \
+             mock.patch(
+                'sky.serve.server.impl.serve_utils.load_service_status',
+                return_value=legacy_records) as load, \
+             mock.patch(
+                'sky.serve.server.impl.backend_utils.'
+                'get_backend_from_handle',
+                return_value=backend):
+            result = runner.get_service_status(handle=handle,
+                                               service_names=None,
+                                               pool=False)
+        assert result == legacy_records
+        codegen.assert_called_once_with(None, pool=False)
+        backend.run_on_head.assert_called_once()
+        load.assert_called_once_with(b'PAYLOAD')
+
+
+class TestDefaultRunnerLegacyPath:
+    """Direct legacy path: ``is_grpc_enabled_with_flag`` false."""
+
+    def test_legacy_when_grpc_disabled(self):
+        runner = impl._DefaultServiceStatusRunner()
+        handle = _handle_mock(grpc_enabled=False)
+        backend = _backend_mock()
+        backend.run_on_head.return_value = (0, b'PAYLOAD', '')
+        with mock.patch(
+                'sky.serve.server.impl.serve_rpc_utils.RpcRunner.'
+                'get_service_status') as rpc, \
+             mock.patch(
+                'sky.serve.server.impl.serve_utils.ServeCodeGen.'
+                'get_service_status',
+                return_value='CODE'), \
+             mock.patch(
+                'sky.serve.server.impl.serve_utils.load_service_status',
+                return_value=[{'name': 'p3'}]), \
+             mock.patch(
+                'sky.serve.server.impl.backend_utils.'
+                'get_backend_from_handle',
+                return_value=backend):
+            result = runner.get_service_status(handle=handle,
+                                               service_names=['p3'],
+                                               pool=True)
+        rpc.assert_not_called()
+        backend.run_on_head.assert_called_once()
+        assert result == [{'name': 'p3'}]
+
+    def test_legacy_command_error_surfaces_as_runtimeerror(self):
+        runner = impl._DefaultServiceStatusRunner()
+        handle = _handle_mock(grpc_enabled=False)
+        backend = _backend_mock()
+        backend.run_on_head.return_value = (1, b'', 'boom')
+        with mock.patch(
+                'sky.serve.server.impl.serve_utils.ServeCodeGen.'
+                'get_service_status',
+                return_value='CODE'), \
+             mock.patch(
+                'sky.serve.server.impl.subprocess_utils.handle_returncode',
+                side_effect=exceptions.CommandError(returncode=1,
+                                                    command='CODE',
+                                                    error_msg='boom failed',
+                                                    detailed_reason=None)), \
+             mock.patch(
+                'sky.serve.server.impl.backend_utils.'
+                'get_backend_from_handle',
+                return_value=backend):
+            with pytest.raises(RuntimeError, match='boom failed'):
+                runner.get_service_status(handle=handle,
+                                          service_names=None,
+                                          pool=True)
+
+
+class TestStatusDelegatesToRunner:
+    """`status()` entry point passes the right args to the registered runner."""
+
+    def _common_patches(self, handle=None, get_backend_return=None):
+        if handle is None:
+            handle = _handle_mock(grpc_enabled=True)
+        return [
+            mock.patch('sky.serve.server.impl.backend_utils.'
+                       'check_network_connection'),
+            mock.patch(
+                'sky.serve.server.impl.controller_utils.get_controller_for_pool'
+            ),
+            mock.patch(
+                'sky.serve.server.impl.backend_utils.is_controller_accessible',
+                return_value=handle),
+            mock.patch(
+                'sky.serve.server.impl.backend_utils.get_backend_from_handle',
+                return_value=get_backend_return or _backend_mock()),
+        ]
+
+    def test_calls_registered_runner_with_normalized_args(self):
+        captured = {}
+
+        def fake_get(*, handle, service_names, pool):
+            captured['handle'] = handle
+            captured['service_names'] = service_names
+            captured['pool'] = pool
+            # Pool path: skip the endpoint-augmentation loop.
+            return []
+
+        serve_runner.register(mock.Mock(get_service_status=fake_get))
+
+        patches = self._common_patches()
+        try:
+            for p in patches:
+                p.start()
+            impl.status(service_names='single', pool=True)
+        finally:
+            for p in patches:
+                p.stop()
+
+        # service_names should be normalized from str -> [str].
+        assert captured['service_names'] == ['single']
+        assert captured['pool'] is True
+
+    def test_rpc_then_legacy_fallback_end_to_end_via_status(self):
+        """status() -> default runner -> RPC raises NotImplemented -> legacy.
+
+        This is the operationally important path (old skylets) and the
+        only one that exercises the full status() + default-runner chain
+        without registering a mock runner.
+        """
+        handle = _handle_mock(grpc_enabled=True)
+        backend = _backend_mock()
+        backend.run_on_head.return_value = (0, b'PAYLOAD', '')
+        legacy_records = [{
+            'name': 'svc',
+            'load_balancer_port': None,
+            'tls_encrypted': False,
+        }]
+        patches = self._common_patches(handle=handle,
+                                       get_backend_return=backend)
+        with mock.patch(
+                'sky.serve.server.impl.serve_rpc_utils.RpcRunner.'
+                'get_service_status',
+                side_effect=exceptions.SkyletMethodNotImplementedError(
+                    'old skylet')) as rpc, \
+             mock.patch(
+                'sky.serve.server.impl.serve_utils.ServeCodeGen.'
+                'get_service_status',
+                return_value='CODE') as codegen, \
+             mock.patch(
+                'sky.serve.server.impl.serve_utils.load_service_status',
+                return_value=legacy_records):
+            try:
+                for p in patches:
+                    p.start()
+                result = impl.status(pool=False)
+            finally:
+                for p in patches:
+                    p.stop()
+
+        rpc.assert_called_once()
+        codegen.assert_called_once()
+        backend.run_on_head.assert_called_once()
+        # Endpoint augmentation runs (serve path, load_balancer_port=None).
+        assert result == [{
+            'name': 'svc',
+            'load_balancer_port': None,
+            'tls_encrypted': False,
+            'endpoint': None,
+        }]
+
+    def test_returns_runner_output(self):
+        records = [{
+            'name': 'svc',
+            'load_balancer_port': None,
+            'tls_encrypted': False,
+        }]
+        runner = mock.Mock()
+        runner.get_service_status.return_value = records
+        serve_runner.register(runner)
+
+        patches = self._common_patches()
+        try:
+            for p in patches:
+                p.start()
+            result = impl.status(pool=False)
+        finally:
+            for p in patches:
+                p.stop()
+
+        # serve path with no load_balancer_port → endpoint stays None
+        assert result == [{
+            'name': 'svc',
+            'load_balancer_port': None,
+            'tls_encrypted': False,
+            'endpoint': None,
+        }]


### PR DESCRIPTION
## Summary

- Add ``ServiceStatusRunner`` Protocol + registry in ``sky/serve/runner.py``, mirroring ``sky/jobs/runner.py`` from #9420. Extracts the RPC-with-codegen-fallback dispatch in ``sky.serve.server.impl.status()`` into a new ``_DefaultServiceStatusRunner`` and routes ``status()`` through ``serve_runner.current()``.

  Plugins can call ``sky.serve.runner.register()`` to provide an in-process runner that bypasses codegen + ``run_on_head`` — the same speedup #9420 enabled for managed jobs queue / cancel / logs is now available for pool / serve status. Pure refactor on its own; default runner preserves the existing control flow exactly.

  One small behavioral correction along the way: the backend is now computed lazily inside the legacy branch instead of unconditionally in ``status()``. The gRPC path doesn't need a ``CloudVmRayBackend`` and shouldn't pay for ``get_backend_from_handle``.

- Skip the per-pool job-counts fetch in the dashboard pool connector when ``poolData`` is empty. The active-jobs round-trip has nothing to attach to when there are no pools, and that's the common case for users who never created one. Saves one round-trip on every dashboard load for them.

## Test plan

- [x] ``tests/unit_tests/test_serve_runner.py`` (new) — 11 tests:
  - registry: ``current()`` falls back to default; ``register()`` replaces; last registration wins
  - default runner: RPC happy path (no codegen call, no backend fetch); RPC raises ``SkyletMethodNotImplementedError`` → legacy fallback; legacy path on ``grpc_disabled``; legacy ``CommandError`` → ``RuntimeError``
  - ``status()``: arg normalization (str → ``[str]``), runner delegation, end-to-end RPC → legacy fallback through ``status()`` (covers the operationally important old-skylet path)
- [x] ``tests/unit_tests/test_serve_impl.py`` — 7 existing tests still pass.
- Total: 18 passed.