### PR TITLE
[Test] Only pin storage stores enabled on the API server in managed-jobs storage test

### DIFF
--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -1236,21 +1236,40 @@ def test_managed_jobs_storage(generic_cloud: str):
             'azure': storage_lib.StoreType.AZURE,
             'nebius': storage_lib.StoreType.NEBIUS,
         }
+        # A remote API server may have only a subset of storage clouds
+        # enabled (e.g. the shared GKE API server only enables AWS), and
+        # specifying a store whose cloud is disabled on the server fails the
+        # job at FAILED_PRECHECKS. Only pin stores whose cloud is enabled on
+        # the server.
+        if smoke_tests_utils.is_remote_server_test():
+            enabled_storage_cloud_names = {
+                str(cloud).lower()
+                for cloud in smoke_tests_utils.get_enabled_cloud_storages()
+            }
+            pinned_stores = {
+                store_str: store_type
+                for store_str, store_type in pinned_stores.items()
+                if store_type.to_cloud().lower() in enabled_storage_cloud_names
+            }
+            assert pinned_stores, ('No object store enabled on the API server: '
+                                   f'{enabled_storage_cloud_names}')
         # For Azure, the bucket lands in the configured storage account when
         # the API server shares the client config, or in the default per-user
         # account (AzureBlobStore's default region) when a remote API server
         # does not receive the client config. Check both.
-        az_account_names = [
-            test_mount_and_storage.TestStorageWithCredentials.
-            get_az_storage_account_name()
-        ]
-        try:
-            default_az_account = (storage_lib.AzureBlobStore.
-                                  get_default_storage_account_name('eastus'))
-            if default_az_account not in az_account_names:
-                az_account_names.append(default_az_account)
-        except Exception:  # pylint: disable=broad-except
-            pass
+        az_account_names = []
+        if storage_lib.StoreType.AZURE in pinned_stores.values():
+            az_account_names.append(
+                test_mount_and_storage.TestStorageWithCredentials.
+                get_az_storage_account_name())
+            try:
+                default_az_account = (
+                    storage_lib.AzureBlobStore.get_default_storage_account_name(
+                        'eastus'))
+                if default_az_account not in az_account_names:
+                    az_account_names.append(default_az_account)
+            except Exception:  # pylint: disable=broad-except
+                pass
         output_check_cmds = []
         for store_str, store_type in pinned_stores.items():
             bucket_name = f'{output_storage_name}-{store_str}'


### PR DESCRIPTION
Follow-up to #9798, fixing `test_managed_jobs_storage` on the shared GKE API server nightly: [nightly-build-shared-gke-api-server build 395](https://buildkite.com/skypilot-1/nightly-build-shared-gke-api-server/builds/395).

## Root cause

#9798 pins one output bucket to each object store (`s3`/`gcs`/`azure`/`nebius`) in the kubernetes/slurm branch, assuming every storage cloud is enabled on the API server. That holds for the local-server and docker `--remote-server` CI environments (full credential set), but the shared GKE API server only has **kubernetes + aws** enabled. Since the jobs controller validates stores server-side, the job fails prechecks in ~2s, on all 3 attempts:

```
sky.exceptions.ResourcesUnavailableError: Storage 'store: gcs' specified,
but GCP access is disabled. To fix, enable GCP by running `sky check`.
```

(`sky/data/storage.py` `GcsStore._validate`, raised on the server → `FAILED_PRECHECKS` → `FAILED_CONTROLLER`.)

Build 394 (last nightly before #9798) passed; build 395 is the first nightly containing it. The PR-time `/smoke-test --kubernetes --remote-server` runs (builds 11116/11120) passed because the docker remote server has all four storage clouds enabled — no pre-merge environment exercises a restricted-cloud server.

## Fix

- For remote-server tests (`is_remote_server_test()`, set both for `--remote-server` and for `--env-file` with an `api_server.endpoint`), filter the pinned stores by the server's storage-enabled clouds using the existing `smoke_tests_utils.get_enabled_cloud_storages()` helper (same pattern as `test_mount_and_storage.py`), matching via `StoreType.to_cloud()`.
- Only look up Azure storage accounts when the `azure` store is actually pinned.
- Local-server runs keep pinning all four stores, preserving the deterministic coverage introduced by #9798.

On the shared GKE nightly this pins only `s3`; on the docker remote server it still pins all four.

## Tested

- Verified the filtering logic against the real `StoreType.to_cloud()` mapping: server with only AWS enabled → pins `['s3']`; server with all four enabled → pins `['s3', 'gcs', 'azure', 'nebius']`.
- `bash format.sh --files tests/smoke_tests/test_managed_job.py` passes.
- `/smoke-test --kubernetes --remote-server -k test_managed_jobs_storage` (all-stores path, no regression) — triggered below.
- **Cross-verified on the shared GKE pipeline itself** (`/shared-gke-postgres -k test_managed_jobs_storage`):
  - Without fix (master, [nightly build 395](https://buildkite.com/skypilot-1/nightly-build-shared-gke-api-server/builds/395)): FAILED — `FAILED_CONTROLLER` in 2s on all attempts with the GCS precheck error.
  - With fix ([build 396](https://buildkite.com/skypilot-1/nightly-build-shared-gke-api-server/builds/396)): **PASSED** — only the `s3` store pinned, managed job `SUCCEEDED`, `1 passed in 337.18s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
