### PR TITLE
[Jobs] Pin active_workspace to cluster row in terminate_cluster

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -190,17 +190,12 @@ def terminate_cluster(
     # workspace and the owner-identity check at
     # `backend_utils._check_owner_identity_with_record` fails for any
     # cluster whose recorded workspace is not 'default'.
+    # DB lookup once outside the loop — cluster workspace is immutable.
+    # `None` when the cluster row is already gone: `core.down` will then
+    # raise `ClusterDoesNotExist` immediately and we return — no
+    # workspace to pin in that case.
     record = global_user_state.get_cluster_from_name(cluster_name)
     cluster_workspace = record.get('workspace') if record else None
-    workspace_ctx: contextlib.AbstractContextManager
-    if cluster_workspace:
-        workspace_ctx = skypilot_config.local_active_workspace_ctx(
-            cluster_workspace)
-    else:
-        # Cluster row already gone: `core.down` will raise
-        # `ClusterDoesNotExist` immediately and we return — no
-        # workspace to pin.
-        workspace_ctx = contextlib.nullcontext()
 
     retry_cnt = 0
     # In some cases, e.g. botocore.exceptions.NoCredentialsError due to AWS
@@ -218,6 +213,14 @@ def terminate_cluster(
     while True:
         try:
             usage_lib.messages.usage.set_internal()
+            # Construct the ctx inside the loop: `local_active_workspace_ctx`
+            # is a `@contextlib.contextmanager` generator and cannot be
+            # re-entered — reusing one instance across retries raises
+            # `RuntimeError` from the spent generator and masks the real
+            # failure.
+            workspace_ctx: contextlib.AbstractContextManager = (
+                skypilot_config.local_active_workspace_ctx(cluster_workspace)
+                if cluster_workspace else contextlib.nullcontext())
             with workspace_ctx:
                 core.down(cluster_name,
                           graceful=graceful,

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -182,6 +182,26 @@ def terminate_cluster(
 ) -> None:
     """Terminate the cluster."""
     from sky import core  # pylint: disable=import-outside-toplevel
+
+    # Pin the active workspace to the cluster's recorded workspace before
+    # calling `core.down`. Controller-side callers (cancel and recovery
+    # teardown paths) run in the system/daemon process, without this pin
+    # `skypilot_config.get_active_workspace()` falls back to the default
+    # workspace and the owner-identity check at
+    # `backend_utils._check_owner_identity_with_record` fails for any
+    # cluster whose recorded workspace is not 'default'.
+    record = global_user_state.get_cluster_from_name(cluster_name)
+    cluster_workspace = record.get('workspace') if record else None
+    workspace_ctx: contextlib.AbstractContextManager
+    if cluster_workspace:
+        workspace_ctx = skypilot_config.local_active_workspace_ctx(
+            cluster_workspace)
+    else:
+        # Cluster row already gone: `core.down` will raise
+        # `ClusterDoesNotExist` immediately and we return — no
+        # workspace to pin.
+        workspace_ctx = contextlib.nullcontext()
+
     retry_cnt = 0
     # In some cases, e.g. botocore.exceptions.NoCredentialsError due to AWS
     # metadata service throttling, the failed sky.down attempt can take 10-11
@@ -198,9 +218,10 @@ def terminate_cluster(
     while True:
         try:
             usage_lib.messages.usage.set_internal()
-            core.down(cluster_name,
-                      graceful=graceful,
-                      graceful_timeout=graceful_timeout)
+            with workspace_ctx:
+                core.down(cluster_name,
+                          graceful=graceful,
+                          graceful_timeout=graceful_timeout)
             return
         except exceptions.ClusterDoesNotExist:
             # The cluster is already down.

--- a/tests/unit_tests/test_jobs_utils.py
+++ b/tests/unit_tests/test_jobs_utils.py
@@ -281,6 +281,60 @@ def test_terminate_cluster_no_record_skips_workspace_pin(
     mock_sky_down.assert_called_once()
 
 
+@mock.patch('sky.jobs.utils.global_user_state.get_cluster_from_name')
+@mock.patch('sky.jobs.utils.time.sleep'
+           )  # Don't actually sleep between retries.
+@mock.patch('sky.core.down')
+@mock.patch('sky.usage.usage_lib.messages.usage.set_internal')
+def test_terminate_cluster_retry_reenters_workspace_ctx(
+        mock_set_internal, mock_sky_down, mock_sleep, mock_get_cluster) -> None:
+    """`skypilot_config.local_active_workspace_ctx` is implemented with
+    `@contextlib.contextmanager` (a generator), which can only be
+    entered ONCE per instance. If the retry loop reuses a single
+    `workspace_ctx` instance across attempts, the second `with` raises
+    `RuntimeError` ("generator didn't yield" / "already executed") and
+    masks the real underlying failure.
+
+    The fix is to construct a fresh ctx per retry attempt inside the
+    loop. This test exercises that: cluster row carries a non-default
+    workspace (so the live ctx path, not `nullcontext()`, is taken),
+    and `core.down` is set to fail twice then succeed. Without the
+    fix, the second iteration raises `RuntimeError` from the spent
+    generator and the function crashes. With the fix, all three
+    iterations construct a fresh ctx and the function completes.
+
+    Revert check: lift `workspace_ctx = ...` back outside the
+    `while True:` loop → the second retry raises `RuntimeError` →
+    test fails."""
+    from sky import skypilot_config
+    mock_get_cluster.return_value = {
+        'name': 'test-cluster',
+        'workspace': 'team-a',
+    }
+
+    observed = []
+
+    def _fail_twice_then_succeed(*args, **kwargs):
+        observed.append(skypilot_config.get_active_workspace())
+        if len(observed) < 3:
+            raise ValueError(f'transient error {len(observed)}')
+
+    mock_sky_down.side_effect = _fail_twice_then_succeed
+
+    # Must complete without RuntimeError (which would arise from
+    # re-entering a spent @contextlib.contextmanager generator).
+    utils.terminate_cluster('test-cluster')
+
+    assert mock_sky_down.call_count == 3
+    # Every attempt must see the pinned workspace, not just the first.
+    # If the ctx were a no-op on retries (e.g. wrong restore order),
+    # this would record 'default' on attempts 2 and 3.
+    assert observed == ['team-a', 'team-a', 'team-a'], observed
+    # Single DB lookup outside the loop is sufficient — cluster
+    # workspace is immutable.
+    mock_get_cluster.assert_called_once_with('test-cluster')
+
+
 def test_cancel_signal_file_no_graceful():
     """Test that cancel_jobs_by_id writes an empty signal file (touch)
     for non-graceful cancels on the new controller."""

--- a/tests/unit_tests/test_jobs_utils.py
+++ b/tests/unit_tests/test_jobs_utils.py
@@ -225,6 +225,62 @@ def test_terminate_cluster_graceful_no_timeout(mock_set_internal,
                                           graceful_timeout=None)
 
 
+@mock.patch('sky.jobs.utils.global_user_state.get_cluster_from_name')
+@mock.patch('sky.core.down')
+@mock.patch('sky.usage.usage_lib.messages.usage.set_internal')
+def test_terminate_cluster_pins_active_workspace_from_cluster_record(
+        mock_set_internal, mock_sky_down, mock_get_cluster) -> None:
+    """Controller-side callers (cancel/recovery teardown) run with the
+    daemon-process workspace context, which falls back to 'default'.
+    Without pinning, `_check_owner_identity_with_record` raises
+    `ClusterOwnerIdentityMismatchError` for any cluster whose recorded
+    workspace is not 'default'.
+
+    This test pins the cluster row to workspace 'team-a' and asserts the
+    active workspace during the `core.down` call is 'team-a'.
+    """
+    from sky import skypilot_config
+    mock_get_cluster.return_value = {
+        'name': 'test-cluster',
+        'workspace': 'team-a',
+    }
+
+    observed_workspace = []
+
+    def _record_workspace(*args, **kwargs):
+        observed_workspace.append(skypilot_config.get_active_workspace())
+
+    mock_sky_down.side_effect = _record_workspace
+
+    utils.terminate_cluster('test-cluster')
+
+    mock_get_cluster.assert_called_once_with('test-cluster')
+    assert observed_workspace == [
+        'team-a'
+    ], (f'Expected active workspace to be pinned to the cluster row '
+        f"workspace 'team-a' during core.down, got: {observed_workspace}")
+
+
+@mock.patch('sky.jobs.utils.global_user_state.get_cluster_from_name')
+@mock.patch('sky.core.down')
+@mock.patch('sky.usage.usage_lib.messages.usage.set_internal')
+def test_terminate_cluster_no_record_skips_workspace_pin(
+        mock_set_internal, mock_sky_down, mock_get_cluster) -> None:
+    """If the cluster row is already gone, there is no workspace to pin
+    — `core.down` will raise `ClusterDoesNotExist` and we return. The
+    function must NOT crash trying to enter
+    `local_active_workspace_ctx(None)`.
+    """
+    mock_get_cluster.return_value = None
+    mock_sky_down.side_effect = ClusterDoesNotExist('test-cluster')
+
+    # Must not raise.
+    utils.terminate_cluster('test-cluster')
+
+    mock_get_cluster.assert_called_once_with('test-cluster')
+    mock_sky_down.assert_called_once()
+
+
 def test_cancel_signal_file_no_graceful():
     """Test that cancel_jobs_by_id writes an empty signal file (touch)
     for non-graceful cancels on the new controller."""


### PR DESCRIPTION
## Summary

Fixes `ClusterOwnerIdentityMismatchError` raised by managed-job **cancel** and **recovery** when the underlying cluster lives in a non-default workspace:

```
Failed to terminate the cluster e82-X. Retrying.
Details: ClusterOwnerIdentityMismatchError: The cluster 'e82-X' is in
workspace 'pub', but the active workspace is 'default'.
```

**Root cause.** The jobs controller's [`terminate_cluster`](sky/jobs/utils.py#L177) calls `core.down` directly. `core.down` → `backend.teardown` → `_teardown` does a **RAW** [`backend_utils.check_owner_identity`](sky/backends/cloud_vm_ray_backend.py#L4519) (not auto-wrapped). The controller runs in the system/daemon process — the executor's per-request resolver doesn't fire here (skipped by the daemon gate), so `skypilot_config.get_active_workspace()` falls back to `'default'` and the check raises for any cluster recorded in another workspace.

Pre-existing latent bug, surfaced more often after #9755 (per-user preferred workspace) because users no longer need an explicit `active_workspace:` in `~/.sky/config.yaml` to land on a non-default workspace.

**Fix.** In `terminate_cluster`, look up the cluster row once before the retry loop and wrap `core.down` in `local_active_workspace_ctx(cluster.workspace)` — same pattern [`_update_cluster_status_no_lock`](sky/backends/backend_utils.py#L3210-L3216) already uses for its own owner check. `nullcontext()` when the cluster row is gone (`core.down` will raise `ClusterDoesNotExist` immediately and we return).

## Why other controller-side call sites don't need a fix

- [`controller.py:1935 core.status`](sky/jobs/controller.py#L1935) and [`:1947 core.cancel`](sky/jobs/controller.py#L1947) route their owner check through `_update_cluster_status_no_lock`, which already auto-wraps in `local_active_workspace_ctx(record['workspace'])`.
- [`recovery_strategy.py`](sky/jobs/recovery_strategy.py)'s `sdk.launch` / `sdk.exec` / `sdk.cancel` go HTTP → executor → resolver. The controller's process env carries the original submitter's `SKYPILOT_USER_ID` / `SKYPILOT_USER` (injected by [`controller_utils.controller_only_vars_to_fill`](sky/utils/controller_utils.py#L619-L622)), so the executor builds the original `User` row including its `preferred_workspace` and the resolver picks the right workspace.
- SkyServe replicas + jobs pool reuse the same controller-env injection and use `sdk.down` (HTTP) for teardown, so no equivalent bug.

## Test plan

- [x] `pytest tests/unit_tests/test_jobs_utils.py -k terminate_cluster` — **6 passed (4 existing + 2 new)**:
  - `test_terminate_cluster_pins_active_workspace_from_cluster_record` mocks `get_cluster_from_name` to return `workspace='team-a'`, captures `get_active_workspace()` at the `core.down` call time and asserts `'team-a'`. **Revert-check**: drop the `with workspace_ctx:` wrap → assertion flips.
  - `test_terminate_cluster_no_record_skips_workspace_pin` confirms the function doesn't crash when the cluster row is already gone.
- [x] Manual: launched a managed job in workspace `pub` with `preferred_workspace='pub'`. Both `sky jobs cancel` and triggered recovery (force-deleted underlying VM from cloud console) now tear down + re-provision cleanly. Without the fix both surfaced `ClusterOwnerIdentityMismatchError`.