### PR TITLE
Refactor Cosmos3 fine-tuning to use Kubernetes volumes instead of cloud buckets

### DIFF
--- a/examples/cosmos3-finetuning/README.md
+++ b/examples/cosmos3-finetuning/README.md
@@ -6,8 +6,9 @@ robotics, autonomous vehicles, and smart spaces. Built on a Mixture-of-Transform
 architecture, a Cosmos 3 model pairs a **reasoner** tower (a vision-language model
 over text/image/video/audio/action) with a **generator** tower (a diffusion model
 that synthesizes future video/image/action). This example fine-tunes the smallest
-member, `Cosmos3-Nano` (16B), as a SkyPilot managed job with checkpoint-to-bucket
-auto-recovery.
+member, `Cosmos3-Nano` (16B), as a SkyPilot managed job on **Kubernetes**, with
+checkpoints on a SkyPilot [volume](https://docs.skypilot.co/en/stable/reference/volumes.html)
+for auto-recovery.
 
 | Model | Params | Notes |
 | ----- | ------ | ----- |
@@ -22,41 +23,57 @@ post-trains the Cosmos3-Nano generation pathway (text/image/video → video) wit
 FSDP across 8 GPUs in bfloat16. It trains on
 [`nvidia/bridge-v2-subset-synthetic-captions`](https://huggingface.co/datasets/nvidia/bridge-v2-subset-synthetic-captions),
 a ~650 MB subset of [BridgeData V2](https://rail-berkeley.github.io/bridgedata/)
-robot-manipulation videos. To fine-tune on your own data, mount it on the instance with a
-`file_mounts` bucket (e.g. `source: s3://your-bucket/`, see
-[Cloud Buckets](https://docs.skypilot.co/en/latest/reference/storage.html)) or a
-[volume](https://docs.skypilot.co/en/stable/reference/volumes.html), laid out like
+robot-manipulation videos. To fine-tune on your own data, mount it as a second
+[volume](https://docs.skypilot.co/en/stable/reference/volumes.html) (or a
+[cloud bucket](https://docs.skypilot.co/en/latest/reference/storage.html)), laid out like
 `train/video_dataset_file.jsonl`, and pass `--env DATASET_PATH=/path/to/it` (see
 [`docs/dataset_jsonl.md`](https://github.com/NVIDIA/cosmos-framework/blob/main/docs/dataset_jsonl.md)).
 
 ## Run it
 
-```bash
-pip install "skypilot-nightly[aws,gcp,kubernetes]"  # pick your clouds
-sky check
-```
-
-Pick a globally-unique `CHECKPOINT_BUCKET_NAME`. SkyPilot creates the bucket and
-mounts it at `/checkpoints` (the recipe's `OUTPUT_ROOT`), so the job auto-resumes
-from the latest checkpoint after a recovery and the outputs outlive its cluster.
+You'll need a Kubernetes cluster with 8× H100/H200 GPUs. Point SkyPilot at it and verify:
 
 ```bash
-sky jobs launch -n cosmos3 examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml \
-    --env CHECKPOINT_BUCKET_NAME=my-cosmos3-checkpoints
+pip install "skypilot-nightly[kubernetes]"
+sky check k8s
 ```
 
-SkyPilot picks the cheapest cloud/region with 8× H100/H200; add `--infra <cloud>`
-(e.g. `aws`, `gcp`, `k8s`) to pin one, or `--use-spot` for cheaper preemptible GPUs
-(the job auto-resumes after a preemption). The model and dataset are public, so no token is needed; for HF auth,
-`export HF_TOKEN=...` and add `--secret HF_TOKEN`. The first run downloads ~35 GB in
-`setup` (base model + VAE + dataset; 30+ min, and looks idle during the quiet
-downloads), then trains + exports.
+### 1. Create the checkpoint volume
+
+SkyPilot [volumes](https://docs.skypilot.co/en/stable/reference/volumes.html) are
+Kubernetes PVCs with a lifecycle independent of any cluster — perfect for durable
+checkpoints. Create one (mounted at `/checkpoints`, the recipe's `OUTPUT_ROOT`) so
+the managed job auto-resumes from the latest checkpoint after a recovery and the
+outputs outlive the job's cluster:
+
+```bash
+sky volumes apply examples/cosmos3-finetuning/cosmos3_checkpoints_volume.yaml
+```
+
+This creates a 1 Ti `cosmos3-checkpoints` PVC. See
+[`cosmos3_checkpoints_volume.yaml`](cosmos3_checkpoints_volume.yaml) to set the size,
+storage class, or access mode for your cluster.
+
+### 2. Launch the fine-tuning job
+
+```bash
+sky jobs launch -n cosmos3 examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml
+```
+
+SkyPilot schedules the job on a Kubernetes node with 8× H100/H200 and mounts the
+`cosmos3-checkpoints` volume at `/checkpoints`. The model and dataset are public, so
+no token is needed; for HF auth, `export HF_TOKEN=...` and add `--secret HF_TOKEN`.
+The first run downloads ~35 GB in `setup` (base model + VAE + dataset; 30+ min, and
+looks idle during the quiet downloads), then trains + exports.
+
+> **Multiple Kubernetes clusters?** Pin one with `--infra k8s/<context>`. To run on a
+> cloud instead, see *Using a cloud bucket* below.
 
 **Smoke test** (a few steps to exercise the whole pipeline, still checkpoints + exports):
 
 ```bash
 sky jobs launch -n cosmos3 examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml \
-    --env CHECKPOINT_BUCKET_NAME=my-cosmos3-checkpoints --env MAX_ITER=10 --env SAVE_ITER=5
+    --env MAX_ITER=10 --env SAVE_ITER=5
 ```
 
 Monitor and manage it:
@@ -71,7 +88,6 @@ sky jobs cancel -n cosmos3
 
 | Env var | Default | Meaning |
 | ------- | ------- | ------- |
-| `CHECKPOINT_BUCKET_NAME` | `my-cosmos3-checkpoints` | Globally-unique cloud bucket for checkpoints + auto-resume (change to your own). |
 | `DATASET_PATH` | bridge subset | Dataset dir the launcher trains on (override for your own data). |
 | `MAX_ITER` | `500` | Number of optimizer steps (set small for a smoke test). |
 | `SAVE_ITER` | `100` | Save a DCP checkpoint every N steps. |
@@ -81,9 +97,44 @@ sky jobs cancel -n cosmos3
 ## Outputs
 
 Checkpoints (`checkpoints/iter_<N>/`), the resolved `config.yaml`, and the exported
-safetensors (`model/`) land in your bucket under `cosmos3/sft/vision_sft_nano/`. Run
-`sky storage ls` to find the bucket, then download with that cloud's CLI, e.g.
-`aws s3 sync s3://my-cosmos3-checkpoints/ .`.
+safetensors (`model/`) land on the `cosmos3-checkpoints` volume under
+`cosmos3/sft/vision_sft_nano/`. The volume persists after the job finishes — inspect
+it with `sky volumes ls`, or mount it from another SkyPilot task (e.g. a serving job)
+with a `volumes:` block to read the exported model.
+
+## Bring your own dataset
+
+Put your data on a second volume and point the recipe at it. Create the volume (laid
+out with `train/video_dataset_file.jsonl`; see the
+[dataset docs](https://github.com/NVIDIA/cosmos-framework/blob/main/docs/dataset_jsonl.md)),
+then in `cosmos3_nano_finetune.yaml` uncomment the dataset mount under `volumes:`:
+
+```yaml
+volumes:
+  /checkpoints: cosmos3-checkpoints
+  /my-dataset: my-dataset-volume
+```
+
+and launch with `--env DATASET_PATH=/my-dataset`.
+
+## Using a cloud bucket instead of a volume
+
+Most of this example is Kubernetes + volume centric, but nothing requires it. To run
+on a cloud (or to keep checkpoints in object storage for cross-region access), drop
+the `volumes:` block in `cosmos3_nano_finetune.yaml` and mount a bucket at
+`/checkpoints` instead:
+
+```yaml
+file_mounts:
+  /checkpoints:
+    name: my-cosmos3-checkpoints  # globally-unique bucket name; SkyPilot creates it
+    mode: MOUNT
+```
+
+Then remove `infra: kubernetes` (or set `--infra <cloud>`) and SkyPilot picks the
+cheapest cloud/region with 8× H100/H200. Add `--use-spot` for cheaper preemptible
+GPUs — the job auto-resumes from the bucket after a preemption. See
+[Cloud Buckets](https://docs.skypilot.co/en/latest/reference/storage.html).
 
 ## References
 
@@ -91,3 +142,4 @@ safetensors (`model/`) land in your bucket under `cosmos3/sft/vision_sft_nano/`.
 - Technical report: https://research.nvidia.com/labs/cosmos-lab/cosmos3/technical-report.pdf
 - cosmos-framework: https://github.com/NVIDIA/cosmos-framework
 - NVIDIA Cosmos: https://github.com/NVIDIA/Cosmos
+- SkyPilot Volumes: https://docs.skypilot.co/en/stable/reference/volumes.html

--- a/examples/cosmos3-finetuning/README.md
+++ b/examples/cosmos3-finetuning/README.md
@@ -50,9 +50,8 @@ outputs outlive the job's cluster:
 sky volumes apply examples/cosmos3-finetuning/cosmos3_checkpoints_volume.yaml
 ```
 
-This creates a 1 Ti `cosmos3-checkpoints` PVC. See
-[`cosmos3_checkpoints_volume.yaml`](cosmos3_checkpoints_volume.yaml) to set the size,
-storage class, or access mode for your cluster.
+This creates a 1 Ti `cosmos3-checkpoints` PVC. See `cosmos3_checkpoints_volume.yaml`
+to set the size, storage class, or access mode for your cluster.
 
 ### 2. Launch the fine-tuning job
 
@@ -67,7 +66,7 @@ The first run downloads ~35 GB in `setup` (base model + VAE + dataset; 30+ min, 
 looks idle during the quiet downloads), then trains + exports.
 
 > **Multiple Kubernetes clusters?** Pin one with `--infra k8s/<context>`. To run on a
-> cloud instead, see *Using a cloud bucket* below.
+> cloud instead, see [Using a cloud bucket instead of a volume](#using-a-cloud-bucket-instead-of-a-volume) below.
 
 **Smoke test** (a few steps to exercise the whole pipeline, still checkpoints + exports):
 

--- a/examples/cosmos3-finetuning/cosmos3_checkpoints_volume.yaml
+++ b/examples/cosmos3-finetuning/cosmos3_checkpoints_volume.yaml
@@ -1,0 +1,23 @@
+# A persistent SkyPilot volume (Kubernetes PVC) for Cosmos3 checkpoints + exports.
+#
+# Create it once, then the fine-tuning job mounts it at /checkpoints so the
+# managed job auto-resumes from the latest checkpoint after a recovery and the
+# outputs outlive the job's cluster:
+#
+#   sky volumes apply examples/cosmos3-finetuning/cosmos3_checkpoints_volume.yaml
+#
+# See https://docs.skypilot.co/en/stable/reference/volumes.html
+
+name: cosmos3-checkpoints
+type: k8s-pvc
+infra: k8s  # or k8s/<context>
+size: 1000Gi
+
+config:
+  # ReadWriteMany lets the volume be reattached across managed-job recoveries
+  # (and shared by all nodes if you scale to multi-node). Point storage_class_name
+  # at a class in your cluster that supports RWX (e.g. a shared filesystem such as
+  # JuiceFS, Nebius shared FS, AWS EFS, or GCP Filestore). Drop both lines to fall
+  # back to your cluster's default StorageClass (typically ReadWriteOnce).
+  access_mode: ReadWriteMany
+  # storage_class_name: csi-mounted-fs-path-sc

--- a/examples/cosmos3-finetuning/cosmos3_checkpoints_volume.yaml
+++ b/examples/cosmos3-finetuning/cosmos3_checkpoints_volume.yaml
@@ -15,9 +15,10 @@ size: 1000Gi
 
 config:
   # ReadWriteMany lets the volume be reattached across managed-job recoveries
-  # (and shared by all nodes if you scale to multi-node). Point storage_class_name
-  # at a class in your cluster that supports RWX (e.g. a shared filesystem such as
-  # JuiceFS, Nebius shared FS, AWS EFS, or GCP Filestore). Drop both lines to fall
-  # back to your cluster's default StorageClass (typically ReadWriteOnce).
+  # (and shared by all nodes if you scale to multi-node). It needs a storage class
+  # that supports RWX (e.g. a shared filesystem such as JuiceFS, Nebius shared FS,
+  # AWS EFS, or GCP Filestore) -- set storage_class_name to one below. If your
+  # cluster only has ReadWriteOnce block storage, change access_mode to
+  # ReadWriteOnce (this single-node job works fine with it).
   access_mode: ReadWriteMany
-  # storage_class_name: csi-mounted-fs-path-sc
+  # storage_class_name: csi-mounted-fs-path-sc  # omit to use the default StorageClass

--- a/examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml
+++ b/examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml
@@ -143,5 +143,5 @@ run: |
       --checkpoint-path "$RUN_DIR/checkpoints/$CKPT_ITER" \
       --config-file "$RUN_DIR/config.yaml" \
       -o "$RUN_DIR/model"
-    echo ">>> Fine-tuned safetensors written to the cosmos3-checkpoints volume: $RUN_DIR/model"
+    echo ">>> Fine-tuned safetensors written to: $RUN_DIR/model"
   fi

--- a/examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml
+++ b/examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml
@@ -5,19 +5,23 @@
 # generation pathway on the public nvidia/bridge-v2-subset-synthetic-captions
 # robot-video dataset, then exports to Hugging Face safetensors. See README.md.
 #
-# Checkpoints are written to a mounted cloud bucket, so the managed job auto-resumes
-# from the latest checkpoint after a recovery, and the outputs survive job teardown.
+# Checkpoints are written to a mounted SkyPilot volume (a Kubernetes PVC), so the
+# managed job auto-resumes from the latest checkpoint after a recovery, and the
+# outputs survive job teardown.
 #
-# Usage (CHECKPOINT_BUCKET_NAME must be a globally-unique bucket name):
-#   sky jobs launch -n cosmos3 examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml \
-#       --env CHECKPOINT_BUCKET_NAME=my-cosmos3-checkpoints
+# Usage (create the checkpoint volume once, then launch):
+#   sky volumes apply examples/cosmos3-finetuning/cosmos3_checkpoints_volume.yaml
+#   sky jobs launch -n cosmos3 examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml
 #   # Quick smoke test (a few steps, still checkpoints + exports):
 #   sky jobs launch -n cosmos3 examples/cosmos3-finetuning/cosmos3_nano_finetune.yaml \
-#       --env CHECKPOINT_BUCKET_NAME=my-cosmos3-checkpoints --env MAX_ITER=10 --env SAVE_ITER=5
+#       --env MAX_ITER=10 --env SAVE_ITER=5
 
 name: cosmos3-nano-finetune
 
 resources:
+  # Run on Kubernetes. Drop this line to let SkyPilot pick any infra (e.g. a cloud),
+  # or set `infra: k8s/<context>` to pin a specific cluster.
+  infra: kubernetes
   # Cosmos3 needs Ampere or newer; NVIDIA's recipe is tested on 8x H100 80GB.
   accelerators: {H100:8, H200:8}
   # NVIDIA's recommended CUDA 13 base image; the training env layers on with `uv sync`.
@@ -26,45 +30,43 @@ resources:
 
 num_nodes: 1
 
+volumes:
+  # Durable checkpoint store, mounted at /checkpoints (the recipe's OUTPUT_ROOT).
+  # DCP checkpoints, the resolved config, and the exported safetensors all land on
+  # this volume, so they survive managed-job recovery (auto-resume) and post-job
+  # teardown. Create it first with:
+  #   sky volumes apply examples/cosmos3-finetuning/cosmos3_checkpoints_volume.yaml
+  /checkpoints: cosmos3-checkpoints
+
+  # Bring your own dataset: mount a second volume holding your data, then point the
+  # recipe at it with `--env DATASET_PATH=/my-dataset` (that dir must contain
+  # `train/video_dataset_file.jsonl`; see README), so it trains on your data instead
+  # of the bridge subset `setup` downloads by default. Uncomment and set your volume:
+  # /my-dataset: my-dataset-volume
+
 envs:
   COSMOS_FRAMEWORK_REF: 411d25b2e35bc441126f48c44a4b93e1c0564274  # pinned for reproducibility
   BASE_CHECKPOINT_NAME: Cosmos3-Nano  # cosmos-framework catalog name -> nvidia/Cosmos3-Nano on HF
   # Dataset dir the launcher trains on. Defaults to the bridge subset downloaded in
   # `setup`; override to fine-tune on your own data (see the bring-your-own-dataset
-  # note under file_mounts below).
+  # note under volumes above).
   DATASET_PATH: examples/data/bridge-v2-subset-synthetic-captions/sft_dataset_bridge
   MAX_ITER: "500"          # optimizer steps (recipe default 500; set small for a smoke test)
   SAVE_ITER: "100"         # save a DCP checkpoint every N steps
   EXPORT_SAFETENSORS: "1"  # export the trained checkpoint to HF safetensors (1=yes, 0=no)
-  # Globally-unique cloud bucket for durable checkpoints + exports. SkyPilot creates it
-  # and mounts it at /checkpoints, which `run` sets as the recipe's OUTPUT_ROOT, so the
-  # job auto-resumes from the latest checkpoint after a recovery. Change to your own name.
-  CHECKPOINT_BUCKET_NAME: my-cosmos3-checkpoints
 
 secrets:
   # Base model + dataset are public, so this defaults to empty (no token needed).
   # To authenticate, `export HF_TOKEN=...` and pass `--secret HF_TOKEN`.
   HF_TOKEN: ""
 
-file_mounts:
-  # Durable checkpoint store. `run` points the recipe's OUTPUT_ROOT here, so DCP
-  # checkpoints, the resolved config, and the exported safetensors all land in the
-  # bucket, surviving managed-job recovery (auto-resume) and post-job teardown.
-  # mode: MOUNT is write-through, so each checkpoint is flushed straight to the bucket.
-  /checkpoints:
-    name: ${CHECKPOINT_BUCKET_NAME}
-    mode: MOUNT
-
-  # Bring your own dataset: mount an existing cloud bucket, then point the recipe at it
-  # with `--env DATASET_PATH=/my-dataset` (that dir must contain
-  # `train/video_dataset_file.jsonl`; see README), so it trains on your data instead of
-  # the bridge subset `setup` downloads by default. Uncomment and set your bucket:
-  # /my-dataset:
-  #   source: s3://my-dataset-bucket/  # or gs://..., r2://..., etc.; read-only is fine
-  #   mode: MOUNT
-  # To use a SkyPilot volume instead, attach one with a top-level `volumes:` field
-  # (`volumes: {/my-dataset: my-vol}`); see
-  # https://docs.skypilot.co/en/stable/reference/volumes.html
+# Prefer a cloud bucket over a volume (e.g. for cross-region access)? Drop the
+# `volumes:` block above and mount a bucket at /checkpoints instead:
+#   file_mounts:
+#     /checkpoints:
+#       name: my-cosmos3-checkpoints  # globally-unique bucket name; SkyPilot creates it
+#       mode: MOUNT
+# See https://docs.skypilot.co/en/latest/reference/storage.html
 
 setup: |
   set -e
@@ -121,7 +123,7 @@ run: |
   [ -n "${HF_TOKEN:-}" ] && export HF_TOKEN
   export NPROC_PER_NODE="${SKYPILOT_NUM_GPUS_PER_NODE}"  # FSDP shards across every GPU
 
-  # Write all training outputs to the mounted checkpoint bucket so the recipe
+  # Write all training outputs to the mounted checkpoint volume so the recipe
   # auto-resumes from the latest checkpoint after a managed-job recovery.
   export OUTPUT_ROOT=/checkpoints
   RUN_DIR="$OUTPUT_ROOT/cosmos3/sft/vision_sft_nano"
@@ -141,5 +143,5 @@ run: |
       --checkpoint-path "$RUN_DIR/checkpoints/$CKPT_ITER" \
       --config-file "$RUN_DIR/config.yaml" \
       -o "$RUN_DIR/model"
-    echo ">>> Fine-tuned safetensors written to the $CHECKPOINT_BUCKET_NAME bucket: $RUN_DIR/model"
+    echo ">>> Fine-tuned safetensors written to the cosmos3-checkpoints volume: $RUN_DIR/model"
   fi


### PR DESCRIPTION
## Description

This PR refactors the Cosmos3 fine-tuning example to use SkyPilot volumes (Kubernetes PVCs) as the primary checkpoint storage mechanism, replacing the cloud bucket approach. This makes the example more Kubernetes-native while maintaining backward compatibility with cloud-based deployments.

### Key Changes

**README.md:**
- Updated introduction to clarify the example runs on Kubernetes with volumes for checkpoint storage
- Restructured setup instructions into numbered steps: (1) create checkpoint volume, (2) launch job
- Added new section "Bring your own dataset" with volume-based approach
- Added new section "Using a cloud bucket instead of a volume" documenting the legacy cloud bucket approach
- Removed `CHECKPOINT_BUCKET_NAME` environment variable from documentation
- Updated output section to reference the persistent volume instead of cloud buckets
- Added SkyPilot Volumes reference link

**cosmos3_nano_finetune.yaml:**
- Added `infra: kubernetes` to resources to pin execution to Kubernetes
- Replaced `file_mounts` (cloud bucket) with `volumes` block for checkpoint storage
- Removed `CHECKPOINT_BUCKET_NAME` environment variable
- Updated comments to reference volumes instead of buckets
- Added commented examples for bringing custom datasets via volumes
- Added commented section showing how to use cloud buckets as an alternative
- Updated output message to reference the volume instead of bucket

**cosmos3_checkpoints_volume.yaml (new file):**
- New manifest for creating a persistent Kubernetes PVC for checkpoints
- Configurable size (default 1 Ti), storage class, and access mode
- Includes documentation on ReadWriteMany for multi-node scenarios
- References SkyPilot volumes documentation

### Design Rationale

- **Kubernetes-first approach**: The example now explicitly targets Kubernetes with persistent volumes, which is more natural for K8s deployments
- **Durable outputs**: Volumes persist independently of job lifecycle, enabling auto-resume and post-job artifact access
- **Backward compatible**: Cloud bucket approach is documented as an alternative for users preferring cloud storage
- **Clearer workflow**: Separates volume creation (one-time setup) from job launching, making the process more explicit

### Testing

No testing needed — this is a documentation and configuration example update. The changes are:
- Documentation clarifications and restructuring
- YAML configuration updates (no code logic changes)
- New volume manifest (declarative configuration)

Users can validate by following the updated README instructions to create the volume and launch the job.

https://claude.ai/code/session_01U7JALBgkBRYpTfKWBRe8DN