### PR TITLE
[Jobs] Re-read managed job priority on recovery

### DIFF
--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -20,6 +20,7 @@ from sky import sky_logging
 from sky import skypilot_config
 from sky.backends import backend_utils
 from sky.client import sdk
+from sky.jobs import file_content_utils
 from sky.jobs import runtime as managed_job_runtime
 from sky.jobs import scheduler
 from sky.jobs import state
@@ -29,6 +30,7 @@ from sky.skylet import constants
 from sky.skylet import job_lib
 from sky.usage import usage_lib
 from sky.utils import common_utils
+from sky.utils import dag_utils
 from sky.utils import env_options
 from sky.utils import instance_links as instance_links_utils
 from sky.utils import registry
@@ -453,6 +455,50 @@ class StrategyExecutor:
         if self.pool is None:
             managed_job_utils.terminate_cluster(self.cluster_name)
 
+    def _refresh_priority_from_persisted_dag(self) -> None:
+        """Re-read the persisted job DAG and apply any updated priority.
+
+        A managed job's priority can be changed out of band after submission
+        by rewriting the persisted DAG. The controller otherwise caches the
+        DAG in memory for its lifetime, so without this refresh a recovery
+        would relaunch at the original priority. Only the priority (and its
+        optional priority class) is re-read here; the rest of the in-memory
+        task — envs, file mounts, name — is preserved.
+        """
+        try:
+            content = file_content_utils.get_job_dag_content(self.job_id)
+            if content is None:
+                return
+            fresh_dag = dag_utils.load_dag_from_yaml_str(content)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(
+                f'Failed to re-read persisted DAG for job {self.job_id}; '
+                f'keeping current priority: {e}')
+            return
+        if self.task_id >= len(fresh_dag.tasks) or not self.dag.tasks:
+            return
+        fresh_resources = list(fresh_dag.tasks[self.task_id].resources)
+        if not fresh_resources:
+            return
+        # Priority is uniform across a task's resources; take the first.
+        new_priority = fresh_resources[0].priority
+        new_priority_class = fresh_resources[0].priority_class
+        task = self.dag.tasks[0]
+        changed = False
+        new_list = []
+        for r in task.resources:
+            if (r.priority != new_priority or
+                    r.priority_class != new_priority_class):
+                r = r.copy(priority=new_priority,
+                           priority_class=new_priority_class)
+                changed = True
+            new_list.append(r)
+        if changed:
+            task.set_resources(type(task.resources)(new_list))
+            logger.info(
+                f'Refreshed priority for job {self.job_id} to {new_priority} '
+                f'(priority_class={new_priority_class}) from persisted DAG.')
+
     async def _launch(self,
                       max_retry: Optional[int] = 3,
                       raise_on_failure: bool = True,
@@ -491,6 +537,11 @@ class StrategyExecutor:
                 3. Any unexpected error happens during the `sky.launch`.
         Other exceptions may be raised depending on the backend.
         """
+        # On recovery, re-read the persisted DAG so an out-of-band priority
+        # change takes effect on this relaunch (the controller caches the DAG
+        # in memory for its lifetime).
+        if recovery:
+            self._refresh_priority_from_persisted_dag()
         # TODO(zhwu): handle the failure during `preparing sky runtime`.
         retry_cnt = 0
         backoff = common_utils.Backoff(self.RETRY_INIT_GAP_SECONDS)

--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -485,16 +485,19 @@ class StrategyExecutor:
         new_priority_class = fresh_resources[0].priority_class
         task = self.dag.tasks[0]
         changed = False
-        new_list = []
+        new_resources = []
         for r in task.resources:
             if (r.priority != new_priority or
                     r.priority_class != new_priority_class):
                 r = r.copy(priority=new_priority,
                            priority_class=new_priority_class)
                 changed = True
-            new_list.append(r)
+            new_resources.append(r)
         if changed:
-            task.set_resources(type(task.resources)(new_list))
+            # task.resources may be a list or a set; rebuild with the original
+            # container type so the semantics are preserved (mirrors
+            # Task.set_resources_override).
+            task.set_resources(type(task.resources)(new_resources))
             logger.info(
                 f'Refreshed priority for job {self.job_id} to {new_priority} '
                 f'(priority_class={new_priority_class}) from persisted DAG.')

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -1951,6 +1951,32 @@ def scheduler_set_waiting(job_ids: List[int],
         assert updated_count == len(job_ids), (job_ids, updated_count)
 
 
+@db_retries.retry
+def set_job_dag_yaml_content(job_id: int,
+                             dag_yaml_content: str,
+                             priority: Optional[int] = None,
+                             priority_class: Optional[str] = None) -> None:
+    """Overwrite a managed job's persisted DAG YAML (and optional priority).
+
+    Lets the persisted job spec be updated out of band after submission. A
+    running controller picks the new spec up on its next recovery (it
+    re-reads the DAG before each recovery attempt); a brand-new controller or
+    a fresh launch reads it directly.
+    """
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        updates: Dict[Any, Any] = {
+            job_info_table.c.dag_yaml_content: dag_yaml_content,
+        }
+        if priority is not None:
+            updates[job_info_table.c.priority] = priority
+        if priority_class is not None:
+            updates[job_info_table.c.priority_class] = priority_class
+        session.query(job_info_table).filter(
+            job_info_table.c.spot_job_id == job_id).update(updates)
+        session.commit()
+
+
 def get_job_file_contents(job_id: int) -> Dict[str, Optional[str]]:
     """Return file information and stored contents for a managed job."""
     engine = _db_manager.get_engine()


### PR DESCRIPTION
## Summary

A managed job's priority can be updated out of band after submission by rewriting its persisted DAG. However, the controller loads the job DAG once (`_get_dag` is an lru-cache held for the controller's lifetime) and never re-reads it, so a recovery would relaunch the job at its original priority.

This PR makes an updated priority take effect on the next recovery:

- Add `jobs.state.set_job_dag_yaml_content()` to overwrite a job's persisted DAG YAML (and optionally its `priority` / `priority_class`).
- In `StrategyExecutor`, re-read the persisted DAG before each recovery and apply any updated priority to the in-memory task's resources. Only the priority (and its optional priority class) is refreshed; the rest of the in-memory task — envs, file mounts, name — is preserved. The first launch is unaffected.

## Test plan

- Unit: load a job DAG, rewrite its priority via the new setter, and confirm a recovery picks up the new value while leaving other resource fields intact.
- Manual: submitted a quota-blocked managed job, updated its priority, and verified the next recovery relaunched at the new priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)