### PR TITLE
[Dashboard] Show batch select checkboxes on hover instead of by default

### DIFF
--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -2354,6 +2354,9 @@ function UsersTable({
               <TableRow>
                 {showBulkColumn && (
                   <TableHead className="w-8 whitespace-nowrap">
+                    {/* Header "select all" stays visible as a discoverable
+                        cue that the table supports selection; row checkboxes
+                        remain hover-only to reduce clutter. */}
                     <input
                       type="checkbox"
                       aria-label="Select all users on this page"
@@ -2439,16 +2442,24 @@ function UsersTable({
                   (currentUserRole === 'admin' ||
                     user.userId === currentUserId);
                 return (
-                  <TableRow key={user.userId}>
+                  <TableRow key={user.userId} className="group">
                     {showBulkColumn && (
                       <TableCell className="w-8 whitespace-nowrap">
                         {!isSystemUser && (
-                          <input
-                            type="checkbox"
-                            aria-label={`Select user ${user.usernameDisplay || user.userId}`}
-                            checked={selectedUserIds.has(user.userId)}
-                            onChange={() => toggleSelectOne(user.userId)}
-                          />
+                          <div
+                            className={`transition-opacity duration-150 ${
+                              selectedUserIds.size > 0
+                                ? 'opacity-100'
+                                : 'opacity-0 group-hover:opacity-100 focus-within:opacity-100'
+                            }`}
+                          >
+                            <input
+                              type="checkbox"
+                              aria-label={`Select user ${user.usernameDisplay || user.userId}`}
+                              checked={selectedUserIds.has(user.userId)}
+                              onChange={() => toggleSelectOne(user.userId)}
+                            />
+                          </div>
                         )}
                       </TableCell>
                     )}


### PR DESCRIPTION
## Summary

The `/users` page showed batch-select checkboxes in a dedicated column by default (for admins), which is non-standard UI and adds visual clutter. This PR applies front-end best practices for batch selection in data tables:

- **Per-row checkboxes are hidden by default** and fade in on row hover (`group-hover`) or keyboard focus (`focus-within`, so the focus outline stays usable for keyboard navigation).
- **Once any checkbox is checked, all row checkboxes stay visible** so the admin can continue selecting; clearing the selection returns them to hover-only mode.
- The **header "select all" checkbox stays visible** as a discoverable cue that the table supports selection.
- Smooth `transition-opacity` for a polished feel.

This mirrors the hover-to-reveal pattern used by Gmail and other modern interfaces. No change to the underlying batch-action logic (Role / Add to workspaces / Remove from workspaces) or to who can see the column (admins only).

## Test plan

Manual verification on the dashboard (`/users` as an admin user):

1. Build & run the dashboard:
   ```bash
   npm --prefix sky/dashboard install
   npm --prefix sky/dashboard run build
   sky api stop && sky api start
   ```
2. Navigate to `/users` as an admin (the view where the bulk column is enabled).
3. Confirm the checkbox column is clean by default — no visible row checkboxes; the header "select all" checkbox remains visible.
4. Hover over a row → its checkbox fades in. Tab to a checkbox with the keyboard → it becomes visible (focus-within).
5. Click a checkbox → all rows' checkboxes become visible; the floating batch-action bar appears.
6. Clear the selection → row checkboxes fade back to hover-only mode.
7. Verify system users still have no checkbox, and the batch dialogs (Role / Add / Remove workspaces) still work.

`npm run lint` passes with no warnings or errors.