### PR TITLE
[Core] FileMountHelper: configurable sudo prefix in make_safe_symlink_command

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -497,7 +497,7 @@ class FileMountHelper(object):
                                   *,
                                   source: str,
                                   target: str,
-                                  sudo: str = 'sudo') -> str:
+                                  sudo_cmd: str = 'sudo') -> str:
         """Returns a command that safely symlinks 'source' to 'target'.
 
         All intermediate directories of 'source' will be owned by $(whoami),
@@ -510,11 +510,11 @@ class FileMountHelper(object):
         fail: 'source' can have multiple levels (/a/b/c), its parent dirs may
         or may not exist, can end with a slash, or may need sudo access, etc.
 
-        'sudo' is the command prefix prepended to the privileged steps (mkdir,
-        chown, rm, ln); it defaults to 'sudo'. Pass an empty string when the
-        caller already has enough privilege and a sudo binary may be absent --
-        e.g. a container running as root, or a minimal image without sudo
-        installed -- so the command does not depend on sudo being on PATH.
+        'sudo_cmd' is the command prepended to privileged steps (mkdir, chown,
+        rm, ln); it defaults to 'sudo'. Pass an empty string when the caller
+        already has enough privilege and a sudo binary may be absent -- e.g. a
+        container running as root, or a minimal image without sudo installed --
+        so the command does not depend on sudo being on PATH.
 
         Cases of <target: local> file mounts and their behaviors:
 
@@ -531,6 +531,7 @@ class FileMountHelper(object):
         assert os.path.isabs(source), source
         assert not source.endswith('/') and not target.endswith('/'), (source,
                                                                        target)
+        sudo = f'{sudo_cmd} ' if sudo_cmd else ''
         # Prepare to create the symlink:
         #  1. make sure its dir(s) exist & are owned by $(whoami).
         dir_of_symlink = os.path.dirname(source)
@@ -538,27 +539,27 @@ class FileMountHelper(object):
             # mkdir, then loop over '/a/b/c' as /a, /a/b, /a/b/c.  For each,
             # chown $(whoami) on it so user can use these intermediate dirs
             # (excluding /).
-            f'{sudo} mkdir -p {dir_of_symlink}',
+            f'{sudo}mkdir -p {dir_of_symlink}',
             # p: path so far
             ('(p=""; '
              f'for w in $(echo {dir_of_symlink} | tr "/" " "); do '
-             f'p=${{p}}/${{w}}; {sudo} chown $(whoami) $p; done)')
+             f'p=${{p}}/${{w}}; {sudo}chown $(whoami) $p; done)')
         ]
         #  2. remove any existing symlink (ln -f may throw 'cannot
         #     overwrite directory', if the link exists and points to a
         #     directory).
         commands += [
             # Error out if source is an existing, non-symlink directory/file.
-            f'((test -L {source} && {sudo} rm {source} >/dev/null 2>&1) || '
+            f'((test -L {source} && {sudo}rm {source} >/dev/null 2>&1) || '
             f'(test ! -e {source} || '
             f'(echo "!!! Failed mounting because path exists ({source})"; '
             'exit 1)))',
         ]
         commands += [
             # Link.
-            f'{sudo} ln -s {target} {source}',
+            f'{sudo}ln -s {target} {source}',
             # chown.  -h to affect symlinks only.
-            f'{sudo} chown -h $(whoami) {source}',
+            f'{sudo}chown -h $(whoami) {source}',
         ]
         return ' && '.join(commands)
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -493,7 +493,11 @@ class FileMountHelper(object):
         return os.path.join(_SKY_REMOTE_FILE_MOUNTS_DIR, path.lstrip('/'))
 
     @classmethod
-    def make_safe_symlink_command(cls, *, source: str, target: str) -> str:
+    def make_safe_symlink_command(cls,
+                                  *,
+                                  source: str,
+                                  target: str,
+                                  sudo: str = 'sudo') -> str:
         """Returns a command that safely symlinks 'source' to 'target'.
 
         All intermediate directories of 'source' will be owned by $(whoami),
@@ -505,6 +509,12 @@ class FileMountHelper(object):
         This function is needed because a simple 'ln -s target source' may
         fail: 'source' can have multiple levels (/a/b/c), its parent dirs may
         or may not exist, can end with a slash, or may need sudo access, etc.
+
+        'sudo' is the command prefix prepended to the privileged steps (mkdir,
+        chown, rm, ln); it defaults to 'sudo'. Pass an empty string when the
+        caller already has enough privilege and a sudo binary may be absent --
+        e.g. a container running as root, or a minimal image without sudo
+        installed -- so the command does not depend on sudo being on PATH.
 
         Cases of <target: local> file mounts and their behaviors:
 
@@ -521,7 +531,6 @@ class FileMountHelper(object):
         assert os.path.isabs(source), source
         assert not source.endswith('/') and not target.endswith('/'), (source,
                                                                        target)
-        # Below, use sudo in case the symlink needs sudo access to create.
         # Prepare to create the symlink:
         #  1. make sure its dir(s) exist & are owned by $(whoami).
         dir_of_symlink = os.path.dirname(source)
@@ -529,27 +538,27 @@ class FileMountHelper(object):
             # mkdir, then loop over '/a/b/c' as /a, /a/b, /a/b/c.  For each,
             # chown $(whoami) on it so user can use these intermediate dirs
             # (excluding /).
-            f'sudo mkdir -p {dir_of_symlink}',
+            f'{sudo} mkdir -p {dir_of_symlink}',
             # p: path so far
             ('(p=""; '
              f'for w in $(echo {dir_of_symlink} | tr "/" " "); do '
-             'p=${p}/${w}; sudo chown $(whoami) $p; done)')
+             f'p=${{p}}/${{w}}; {sudo} chown $(whoami) $p; done)')
         ]
         #  2. remove any existing symlink (ln -f may throw 'cannot
         #     overwrite directory', if the link exists and points to a
         #     directory).
         commands += [
             # Error out if source is an existing, non-symlink directory/file.
-            f'((test -L {source} && sudo rm {source} &>/dev/null) || '
+            f'((test -L {source} && {sudo} rm {source} >/dev/null 2>&1) || '
             f'(test ! -e {source} || '
             f'(echo "!!! Failed mounting because path exists ({source})"; '
             'exit 1)))',
         ]
         commands += [
             # Link.
-            f'sudo ln -s {target} {source}',
+            f'{sudo} ln -s {target} {source}',
             # chown.  -h to affect symlinks only.
-            f'sudo chown -h $(whoami) {source}',
+            f'{sudo} chown -h $(whoami) {source}',
         ]
         return ' && '.join(commands)
 

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -630,13 +630,13 @@ def test_make_safe_symlink_command_default_uses_sudo():
     assert 'sudo ln -s /home/user/.sky/etc/config /etc/config' in cmd
 
 
-def test_make_safe_symlink_command_empty_sudo_omits_sudo():
-    """Passing sudo='' drops the prefix so the command does not depend on a
-    sudo binary (e.g. a container already running as root)."""
+def test_make_safe_symlink_command_empty_sudo_cmd_omits_sudo():
+    """Passing sudo_cmd='' drops the prefix so the command does not depend on
+    a sudo binary (e.g. a container already running as root)."""
     cmd = backend_utils.FileMountHelper.make_safe_symlink_command(
-        source='/etc/config', target='/home/user/.sky/etc/config', sudo='')
+        source='/etc/config', target='/home/user/.sky/etc/config', sudo_cmd='')
     assert 'sudo' not in cmd
-    assert cmd.lstrip().startswith('mkdir -p /etc')
+    assert cmd.startswith('mkdir -p /etc')
     assert 'ln -s /home/user/.sky/etc/config /etc/config' in cmd
 
 

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -620,3 +620,30 @@ def test_replace_yaml_dicts_restores_new_nested_field_when_old_is_null():
         backend_utils._RAY_YAML_KEYS_TO_RESTORE_EXCEPTIONS)
     result = yaml_utils.read_yaml_str(out)
     assert result['provider']['security_group']['GroupName'] == 'new-name'
+
+
+def test_make_safe_symlink_command_default_uses_sudo():
+    """By default the privileged steps are prefixed with sudo."""
+    cmd = backend_utils.FileMountHelper.make_safe_symlink_command(
+        source='/etc/config', target='/home/user/.sky/etc/config')
+    assert 'sudo mkdir -p /etc' in cmd
+    assert 'sudo ln -s /home/user/.sky/etc/config /etc/config' in cmd
+
+
+def test_make_safe_symlink_command_empty_sudo_omits_sudo():
+    """Passing sudo='' drops the prefix so the command does not depend on a
+    sudo binary (e.g. a container already running as root)."""
+    cmd = backend_utils.FileMountHelper.make_safe_symlink_command(
+        source='/etc/config', target='/home/user/.sky/etc/config', sudo='')
+    assert 'sudo' not in cmd
+    assert cmd.lstrip().startswith('mkdir -p /etc')
+    assert 'ln -s /home/user/.sky/etc/config /etc/config' in cmd
+
+
+def test_make_safe_symlink_command_leaves_target_unquoted():
+    """The target is interpolated unquoted so a leading ~ still expands to
+    $HOME at runtime -- the wrapped file-mount dir starts with ~/."""
+    cmd = backend_utils.FileMountHelper.make_safe_symlink_command(
+        source='/etc/config', target='~/.sky/file_mounts/etc/config')
+    assert 'ln -s ~/.sky/file_mounts/etc/config /etc/config' in cmd
+    assert "'~/.sky/file_mounts/etc/config'" not in cmd


### PR DESCRIPTION
- Add an optional `sudo` parameter (default `'sudo'`, existing callers
  unchanged); pass `''` to drop the dependency on a sudo binary.
- Switch the bash-only `&>/dev/null` to POSIX `>/dev/null 2>&1` so the
  emitted command also runs under `sh`/`dash`.
- Add unit tests for the helper (there were none).
