### PR TITLE
[Jobs] Plugin-overridable exception handling in the managed-jobs controller

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -1821,30 +1821,51 @@ class JobController:
             cancelled = True
             raise
         except (Exception, SystemExit) as e:  # pylint: disable=broad-except
-            logger.error(
-                f'Unexpected error in JobsController run for task {task_id}')
-            with ux_utils.enable_traceback():
-                logger.error(traceback.format_exc())
-            msg = ('Unexpected error occurred: ' +
-                   common_utils.format_exception(e, use_bracket=True))
-            logger.error(msg)
-            await self._update_failed_task_state(
-                task_id, managed_job_state.ManagedJobStatus.FAILED_CONTROLLER,
-                msg)
+            await self._handle_run_exception(task_id, e)
         finally:
-            callback_func = managed_job_utils.event_callback_func(
-                job_id=self._job_id,
-                task_id=task_id,
-                task=self._dag.tasks[task_id])
-            await managed_job_state.set_cancelling_async(
+            await self._after_run_cleanup(task_id, cancelled)
+
+    async def _handle_run_exception(self, task_id: int,
+                                    exc: BaseException) -> None:
+        """Handle an unknown exception escaping the main ``run`` loop.
+
+        Default behavior: log and mark the task FAILED_CONTROLLER. Plugins
+        may monkey-patch this method to install a typed exception
+        taxonomy (e.g. routing transient DB errors away from terminal
+        writes) without changing the OSS catch-all wrapping in ``run``.
+        """
+        logger.error(
+            f'Unexpected error in JobsController run for task {task_id}')
+        with ux_utils.enable_traceback():
+            logger.error(traceback.format_exc())
+        msg = ('Unexpected error occurred: ' +
+               common_utils.format_exception(exc, use_bracket=True))
+        logger.error(msg)
+        await self._update_failed_task_state(
+            task_id, managed_job_state.ManagedJobStatus.FAILED_CONTROLLER, msg)
+
+    async def _after_run_cleanup(self, task_id: int, cancelled: bool) -> None:
+        """Post-``run`` cleanup writes for the per-task coroutine.
+
+        Default behavior: write CANCELLING (and, if the task was not
+        externally cancelled, CANCELLED) on the way out. Plugins may
+        monkey-patch this to skip these writes when an earlier handler
+        already marked the task terminal, or to wrap the writes with
+        retry/swallow semantics for the DB-down case.
+        """
+        callback_func = managed_job_utils.event_callback_func(
+            job_id=self._job_id,
+            task_id=task_id,
+            task=self._dag.tasks[task_id])
+        await managed_job_state.set_cancelling_async(
+            job_id=self._job_id, callback_func=callback_func)
+        if not cancelled:
+            # the others haven't been run yet so we can set them to
+            # cancelled immediately (no resources to clean up).
+            # if we are running and get cancelled, we need to clean up the
+            # resources first so this will be done later.
+            await managed_job_state.set_cancelled_async(
                 job_id=self._job_id, callback_func=callback_func)
-            if not cancelled:
-                # the others haven't been run yet so we can set them to
-                # cancelled immediately (no resources to clean up).
-                # if we are running and get cancelled, we need to clean up the
-                # resources first so this will be done later.
-                await managed_job_state.set_cancelled_async(
-                    job_id=self._job_id, callback_func=callback_func)
 
     async def _update_failed_task_state(
             self, task_id: int,
@@ -2191,6 +2212,11 @@ class ControllerManager:
 
         cancelling = False
         graceful, graceful_timeout = False, None
+        # Pre-declare so the post-run cleanup helper can accept these as
+        # arguments uniformly. They are only used when ``cancelling`` is True,
+        # which only happens after the CancelledError branch populates both.
+        task_id: Optional[int] = None
+        dag: Any = None
         try:
             controller = JobController(job_id, self.starting,
                                        self._job_tasks_lock,
@@ -2270,68 +2296,99 @@ class ControllerManager:
                          f'{common_utils.format_exception(e)}')
             raise
         finally:
+            await self._after_run_job_loop_cleanup(
+                job_id=job_id,
+                task_id=task_id,
+                dag=dag,
+                pool=pool,
+                graceful=graceful,
+                graceful_timeout=graceful_timeout,
+                cancelling=cancelling)
+
+    async def _after_run_job_loop_cleanup(self,
+                                          job_id: int,
+                                          task_id: Optional[int],
+                                          dag: Any,
+                                          pool: Optional[str],
+                                          graceful: bool,
+                                          graceful_timeout: Optional[float],
+                                          cancelling: bool) -> None:
+        """Post-``run_job_loop`` cleanup: cluster teardown + terminal writes.
+
+        Default behavior preserves the existing OSS sequence: run
+        ``_cleanup``; on cleanup failure stamp ``FAILED_CONTROLLER``;
+        flush a ``set_cancelled_async`` if cancelling; stamp
+        ``FAILED_CONTROLLER`` if the job is still non-terminal; then
+        bookkeeping (``job_done_async``, ``starting`` set, ``job_tasks``
+        dict).
+
+        Plugins may monkey-patch this method to layer retry/swallow on
+        the two ``set_failed_async`` writes (so a DB blip during teardown
+        does not leave a zombie row) or to short-circuit them entirely
+        when an earlier handler already wrote a terminal state.
+        """
+        try:
+            await self._cleanup(job_id,
+                                pool=pool,
+                                graceful=graceful,
+                                graceful_timeout=graceful_timeout)
+            logger.info(
+                f'Cluster of managed job {job_id} has been cleaned up.')
+        except Exception as e:  # pylint: disable=broad-except
+            failure_reason = ('Failed to clean up: '
+                              f'{common_utils.format_exception(e)}')
+            await managed_job_state.set_failed_async(
+                job_id,
+                task_id=None,
+                failure_type=managed_job_state.ManagedJobStatus.
+                FAILED_CONTROLLER,
+                failure_reason=failure_reason,
+                override_terminal=True)
+
+        if cancelling:
+            # Since it's set with cancelling
+            assert task_id is not None, job_id
+            await managed_job_state.set_cancelled_async(
+                job_id=job_id,
+                callback_func=managed_job_utils.event_callback_func(
+                    job_id=job_id, task_id=task_id,
+                    task=dag.tasks[task_id]))
+
+        # We should check job status after 'set_cancelled', otherwise
+        # the job status is not terminal.
+        job_status = await managed_job_state.get_status_async(job_id)
+        assert job_status is not None
+        # The job can be non-terminal if the controller exited abnormally,
+        # e.g. failed to launch cluster after reaching the MAX_RETRY.
+        if not job_status.is_terminal():
+            logger.info(f'Previous job status: {job_status.value}')
+            await managed_job_state.set_failed_async(
+                job_id,
+                task_id=None,
+                failure_type=managed_job_state.ManagedJobStatus.
+                FAILED_CONTROLLER,
+                failure_reason=(
+                    'Unexpected error occurred. For details, '
+                    f'run: sky jobs logs --controller {job_id}'))
+
+        await scheduler.job_done_async(job_id)
+
+        async with self._job_tasks_lock:
             try:
-                await self._cleanup(job_id,
-                                    pool=pool,
-                                    graceful=graceful,
-                                    graceful_timeout=graceful_timeout)
-                logger.info(
-                    f'Cluster of managed job {job_id} has been cleaned up.')
-            except Exception as e:  # pylint: disable=broad-except
-                failure_reason = ('Failed to clean up: '
-                                  f'{common_utils.format_exception(e)}')
-                await managed_job_state.set_failed_async(
-                    job_id,
-                    task_id=None,
-                    failure_type=managed_job_state.ManagedJobStatus.
-                    FAILED_CONTROLLER,
-                    failure_reason=failure_reason,
-                    override_terminal=True)
+                # just in case we were cancelled or some other error
+                # occurred during launch
+                self.starting.remove(job_id)
+                # its fine if we notify again, better to wake someone up
+                # and have them go to sleep again, then have some stuck
+                # sleeping.
+                self._starting_signal.notify()
+            except KeyError:
+                pass
 
-            if cancelling:
-                # Since it's set with cancelling
-                assert task_id is not None, job_id
-                await managed_job_state.set_cancelled_async(
-                    job_id=job_id,
-                    callback_func=managed_job_utils.event_callback_func(
-                        job_id=job_id, task_id=task_id,
-                        task=dag.tasks[task_id]))
-
-            # We should check job status after 'set_cancelled', otherwise
-            # the job status is not terminal.
-            job_status = await managed_job_state.get_status_async(job_id)
-            assert job_status is not None
-            # The job can be non-terminal if the controller exited abnormally,
-            # e.g. failed to launch cluster after reaching the MAX_RETRY.
-            if not job_status.is_terminal():
-                logger.info(f'Previous job status: {job_status.value}')
-                await managed_job_state.set_failed_async(
-                    job_id,
-                    task_id=None,
-                    failure_type=managed_job_state.ManagedJobStatus.
-                    FAILED_CONTROLLER,
-                    failure_reason=(
-                        'Unexpected error occurred. For details, '
-                        f'run: sky jobs logs --controller {job_id}'))
-
-            await scheduler.job_done_async(job_id)
-
-            async with self._job_tasks_lock:
-                try:
-                    # just in case we were cancelled or some other error
-                    # occurred during launch
-                    self.starting.remove(job_id)
-                    # its fine if we notify again, better to wake someone up
-                    # and have them go to sleep again, then have some stuck
-                    # sleeping.
-                    self._starting_signal.notify()
-                except KeyError:
-                    pass
-
-            # Remove the job from the job_tasks dictionary.
-            async with self._job_tasks_lock:
-                if job_id in self.job_tasks:
-                    del self.job_tasks[job_id]
+        # Remove the job from the job_tasks dictionary.
+        async with self._job_tasks_lock:
+            if job_id in self.job_tasks:
+                del self.job_tasks[job_id]
 
     async def start_job(
         self,

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -2943,7 +2943,47 @@ async def set_failed_async(
     end_time: Optional[float] = None,
     override_terminal: bool = False,
 ):
-    """Set an entire job or task to failed."""
+    """Set an entire job or task to failed.
+
+    Routes through the optional plugin-registered managed-jobs db-write
+    wrapper (see ``sky.server.plugins.register_managed_jobs_db_write_wrapper``)
+    so an out-of-tree plugin can layer idempotency + retry semantics around
+    the write without forking this module. With no wrapper registered, this
+    is equivalent to a direct call to ``_set_failed_async_impl`` — the
+    default behavior is unchanged.
+    """
+    # Lazy import avoids a sky.jobs.state ↔ sky.server.plugins import cycle
+    # during module load (state.py is imported very early in the controller).
+    from sky.server import plugins as _plugins  # pylint: disable=import-outside-toplevel
+    wrapper = _plugins.get_managed_jobs_db_write_wrapper()
+    if wrapper is not None:
+        return await wrapper(_set_failed_async_impl,
+                             job_id,
+                             task_id=task_id,
+                             failure_type=failure_type,
+                             failure_reason=failure_reason,
+                             callback_func=callback_func,
+                             end_time=end_time,
+                             override_terminal=override_terminal)
+    return await _set_failed_async_impl(job_id,
+                                        task_id=task_id,
+                                        failure_type=failure_type,
+                                        failure_reason=failure_reason,
+                                        callback_func=callback_func,
+                                        end_time=end_time,
+                                        override_terminal=override_terminal)
+
+
+async def _set_failed_async_impl(
+    job_id: int,
+    task_id: Optional[int],
+    failure_type: ManagedJobStatus,
+    failure_reason: str,
+    callback_func: Optional[AsyncCallbackType] = None,
+    end_time: Optional[float] = None,
+    override_terminal: bool = False,
+):
+    """Implementation of ``set_failed_async``. See that function for docs."""
     await add_job_event_async(job_id, task_id, failure_type,
                               f'Job failed: {failure_reason}')
     assert failure_type.is_failed(), failure_type
@@ -3044,7 +3084,22 @@ async def update_links_async(job_id: int, task_id: int,
 
 async def set_cancelling_async(job_id: int, callback_func: AsyncCallbackType):
     """Set tasks in the job as cancelling, if they are in non-terminal
-    states."""
+    states.
+
+    Routes through the optional plugin-registered managed-jobs db-write
+    wrapper. See ``set_failed_async`` for the rationale.
+    """
+    # Lazy import to avoid sky.jobs.state ↔ sky.server.plugins cycle.
+    from sky.server import plugins as _plugins  # pylint: disable=import-outside-toplevel
+    wrapper = _plugins.get_managed_jobs_db_write_wrapper()
+    if wrapper is not None:
+        return await wrapper(_set_cancelling_async_impl, job_id, callback_func)
+    return await _set_cancelling_async_impl(job_id, callback_func)
+
+
+async def _set_cancelling_async_impl(job_id: int,
+                                     callback_func: AsyncCallbackType):
+    """Implementation of ``set_cancelling_async``."""
     await add_job_event_async(job_id, None, ManagedJobStatus.CANCELLING,
                               'Job is cancelling')
 
@@ -3069,7 +3124,22 @@ async def set_cancelling_async(job_id: int, callback_func: AsyncCallbackType):
 
 
 async def set_cancelled_async(job_id: int, callback_func: AsyncCallbackType):
-    """Set tasks in the job as cancelled, if they are in CANCELLING state."""
+    """Set tasks in the job as cancelled, if they are in CANCELLING state.
+
+    Routes through the optional plugin-registered managed-jobs db-write
+    wrapper. See ``set_failed_async`` for the rationale.
+    """
+    # Lazy import to avoid sky.jobs.state ↔ sky.server.plugins cycle.
+    from sky.server import plugins as _plugins  # pylint: disable=import-outside-toplevel
+    wrapper = _plugins.get_managed_jobs_db_write_wrapper()
+    if wrapper is not None:
+        return await wrapper(_set_cancelled_async_impl, job_id, callback_func)
+    return await _set_cancelled_async_impl(job_id, callback_func)
+
+
+async def _set_cancelled_async_impl(job_id: int,
+                                    callback_func: AsyncCallbackType):
+    """Implementation of ``set_cancelled_async``."""
     await add_job_event_async(job_id, None, ManagedJobStatus.CANCELLED,
                               'Job has been cancelled')
 

--- a/sky/server/plugins.py
+++ b/sky/server/plugins.py
@@ -682,3 +682,46 @@ def get_plugin_viewer_allowlist() -> List[Dict[str, str]]:
 def get_extension_context() -> Optional[ExtensionContext]:
     """Return the extension context created during plugin loading."""
     return _EXTENSION_CONTEXT
+
+
+# ---------------------------------------------------------------------------
+# Managed-jobs controller robustness hooks
+# ---------------------------------------------------------------------------
+#
+# These module-level registries let an out-of-tree plugin install custom
+# behavior for the managed-jobs controller's outer DB-write boundary
+# without forking ``sky.jobs.state``. They are intentionally side-effect-free
+# until a plugin calls ``register_managed_jobs_db_write_wrapper``; when no
+# wrapper is registered, ``sky.jobs.state.set_failed_async`` and friends
+# behave exactly as before.
+#
+# The wrapper is invoked as ``await wrapper(impl, *args, **kwargs)`` and is
+# expected to ultimately return ``await impl(*args, **kwargs)`` (with any
+# retry, idempotency, or swallow-on-exhaustion logic the plugin wants to
+# layer on top). It must not raise on its own — letting an exception escape
+# the wrapper for a terminal write defeats the point. See
+# ``sky/jobs/state.py`` for the call sites.
+
+_managed_jobs_db_write_wrapper: Optional[Any] = None
+
+
+def register_managed_jobs_db_write_wrapper(wrapper: Any) -> None:
+    """Register a plugin-supplied wrapper for managed-jobs terminal writes.
+
+    ``wrapper`` is an async callable with signature
+    ``async def wrapper(impl, *args, **kwargs)``. It will be invoked instead
+    of the underlying ``set_failed_async`` / ``set_cancelling_async`` /
+    ``set_cancelled_async`` implementation. The wrapper is responsible for
+    delegating to ``impl`` (typically with retry/swallow semantics).
+
+    Only one wrapper may be registered at a time; calling this again
+    replaces the previous one. With no wrapper registered, the writers run
+    unwrapped (current OSS behavior).
+    """
+    global _managed_jobs_db_write_wrapper
+    _managed_jobs_db_write_wrapper = wrapper
+
+
+def get_managed_jobs_db_write_wrapper() -> Optional[Any]:
+    """Return the registered managed-jobs db-write wrapper, or ``None``."""
+    return _managed_jobs_db_write_wrapper

--- a/tests/unit_tests/test_managed_jobs_db_write_wrapper.py
+++ b/tests/unit_tests/test_managed_jobs_db_write_wrapper.py
@@ -1,0 +1,206 @@
+"""Tests for the plugin-registerable managed-jobs db-write wrapper.
+
+The hook in ``sky.server.plugins`` lets out-of-tree plugins layer
+idempotency / retry / swallow semantics around ``set_failed_async`` /
+``set_cancelling_async`` / ``set_cancelled_async`` without forking
+``sky.jobs.state``.
+
+These tests pin two contracts:
+
+1. With no wrapper registered, the writers call the underlying impl
+   exactly once with the original arguments (i.e. the OSS default
+   behavior is preserved bit-for-bit).
+2. With a wrapper registered, the writers route through the wrapper,
+   and the wrapper receives the impl + the original args so it can
+   delegate (or short-circuit).
+"""
+import asyncio
+from unittest import mock
+
+import pytest
+
+from sky.jobs import state as managed_job_state
+from sky.server import plugins as server_plugins
+
+
+@pytest.fixture(autouse=True)
+def _reset_wrapper():
+    """Ensure each test starts with no wrapper registered."""
+    server_plugins.register_managed_jobs_db_write_wrapper(None)
+    yield
+    server_plugins.register_managed_jobs_db_write_wrapper(None)
+
+
+def test_get_wrapper_returns_none_by_default():
+    assert server_plugins.get_managed_jobs_db_write_wrapper() is None
+
+
+def test_register_and_get_round_trip():
+    sentinel = object()
+    server_plugins.register_managed_jobs_db_write_wrapper(sentinel)
+    assert server_plugins.get_managed_jobs_db_write_wrapper() is sentinel
+
+
+@pytest.mark.asyncio
+async def test_set_failed_async_no_wrapper_calls_impl_directly():
+    """With no wrapper, set_failed_async hits the impl with original args."""
+    with mock.patch.object(managed_job_state,
+                           '_set_failed_async_impl',
+                           new=mock.AsyncMock(
+                               return_value=None)) as mock_impl:
+        await managed_job_state.set_failed_async(
+            job_id=42,
+            task_id=0,
+            failure_type=managed_job_state.ManagedJobStatus.FAILED,
+            failure_reason='unit test')
+    mock_impl.assert_called_once()
+    # The wrapper-less path should pass args+kwargs through unchanged.
+    args, kwargs = mock_impl.call_args
+    assert args == (42,)
+    assert kwargs['task_id'] == 0
+    assert kwargs['failure_type'] == managed_job_state.ManagedJobStatus.FAILED
+    assert kwargs['failure_reason'] == 'unit test'
+
+
+@pytest.mark.asyncio
+async def test_set_cancelling_async_no_wrapper_calls_impl_directly():
+    async def _cb(_status):  # pragma: no cover - never called
+        return None
+
+    with mock.patch.object(managed_job_state,
+                           '_set_cancelling_async_impl',
+                           new=mock.AsyncMock(
+                               return_value=None)) as mock_impl:
+        await managed_job_state.set_cancelling_async(7, _cb)
+    mock_impl.assert_called_once_with(7, _cb)
+
+
+@pytest.mark.asyncio
+async def test_set_cancelled_async_no_wrapper_calls_impl_directly():
+    async def _cb(_status):  # pragma: no cover - never called
+        return None
+
+    with mock.patch.object(managed_job_state,
+                           '_set_cancelled_async_impl',
+                           new=mock.AsyncMock(
+                               return_value=None)) as mock_impl:
+        await managed_job_state.set_cancelled_async(7, _cb)
+    mock_impl.assert_called_once_with(7, _cb)
+
+
+@pytest.mark.asyncio
+async def test_set_failed_async_routes_through_wrapper_when_registered():
+    """When a wrapper is registered, set_failed_async delegates to it."""
+    calls = []
+
+    async def wrapper(impl, *args, **kwargs):
+        calls.append((impl, args, kwargs))
+        # Sentinel: don't actually call the impl in the test. A real
+        # wrapper would (and should) call ``await impl(*args, **kwargs)``.
+        return 'wrapped-sentinel'
+
+    server_plugins.register_managed_jobs_db_write_wrapper(wrapper)
+
+    with mock.patch.object(managed_job_state,
+                           '_set_failed_async_impl',
+                           new=mock.AsyncMock(
+                               return_value=None)) as mock_impl:
+        result = await managed_job_state.set_failed_async(
+            job_id=99,
+            task_id=None,
+            failure_type=managed_job_state.ManagedJobStatus.FAILED_CONTROLLER,
+            failure_reason='wrapper test')
+
+    assert result == 'wrapped-sentinel'
+    # Wrapper called; impl NOT directly called by set_failed_async (the
+    # wrapper itself is responsible for calling it — and in this test it
+    # deliberately doesn't, to confirm the routing).
+    assert len(calls) == 1
+    delegated_impl, args, kwargs = calls[0]
+    # The public ``set_failed_async`` passes the module-level
+    # ``_set_failed_async_impl`` attribute to the wrapper; we don't pin the
+    # identity here (mock.patch.object replaces the attribute), only that
+    # the args were forwarded correctly.
+    assert delegated_impl is mock_impl
+    # ``job_id`` is passed positionally to the wrapper; the rest are kwargs.
+    assert args == (99,)
+    assert kwargs['task_id'] is None
+    assert (kwargs['failure_type']
+            == managed_job_state.ManagedJobStatus.FAILED_CONTROLLER)
+    assert kwargs['failure_reason'] == 'wrapper test'
+    mock_impl.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_cancelling_async_routes_through_wrapper_when_registered():
+    calls = []
+
+    async def wrapper(impl, *args, **kwargs):
+        calls.append((impl, args, kwargs))
+        return None
+
+    server_plugins.register_managed_jobs_db_write_wrapper(wrapper)
+
+    async def _cb(_status):  # pragma: no cover - never called
+        return None
+
+    with mock.patch.object(managed_job_state,
+                           '_set_cancelling_async_impl',
+                           new=mock.AsyncMock(
+                               return_value=None)) as mock_impl:
+        await managed_job_state.set_cancelling_async(11, _cb)
+
+    assert len(calls) == 1
+    delegated_impl, args, _kwargs = calls[0]
+    assert delegated_impl is mock_impl
+    assert args == (11, _cb)
+    mock_impl.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_cancelled_async_routes_through_wrapper_when_registered():
+    calls = []
+
+    async def wrapper(impl, *args, **kwargs):
+        calls.append((impl, args, kwargs))
+        return None
+
+    server_plugins.register_managed_jobs_db_write_wrapper(wrapper)
+
+    async def _cb(_status):  # pragma: no cover - never called
+        return None
+
+    with mock.patch.object(managed_job_state,
+                           '_set_cancelled_async_impl',
+                           new=mock.AsyncMock(
+                               return_value=None)) as mock_impl:
+        await managed_job_state.set_cancelled_async(11, _cb)
+
+    assert len(calls) == 1
+    delegated_impl, args, _kwargs = calls[0]
+    assert delegated_impl is mock_impl
+    assert args == (11, _cb)
+    mock_impl.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_wrapper_can_delegate_to_impl():
+    """Smoke-test that a wrapper which calls impl(*args, **kwargs) works."""
+
+    async def wrapper(impl, *args, **kwargs):
+        return await impl(*args, **kwargs)
+
+    server_plugins.register_managed_jobs_db_write_wrapper(wrapper)
+
+    with mock.patch.object(managed_job_state,
+                           '_set_failed_async_impl',
+                           new=mock.AsyncMock(
+                               return_value='delegated')) as mock_impl:
+        result = await managed_job_state.set_failed_async(
+            job_id=1,
+            task_id=None,
+            failure_type=managed_job_state.ManagedJobStatus.FAILED,
+            failure_reason='delegate')
+
+    assert result == 'delegated'
+    mock_impl.assert_called_once()


### PR DESCRIPTION
## Summary

Refactor the managed-jobs controller's outer exception/cleanup boundaries into named protected methods, and add a plugin hook so out-of-tree plugins can layer custom semantics on top of the three terminal-state DB writers (`set_failed_async` / `set_cancelling_async` / `set_cancelled_async`) without forking `sky.jobs.state`.

**Behavior change with no plugin loaded: zero.** All defaults preserve the current OSS behavior.

- `sky/jobs/controller.py`: extract the catch-all in `JobController.run()` into `_handle_run_exception()`, the post-run finally into `_after_run_cleanup()`, and the outer finally in `ControllerManager.run_job_loop()` into `_after_run_job_loop_cleanup()`. These become natural override points for plugins that want to install a typed exception taxonomy (routing transient DB errors away from terminal writes) or wrap the cleanup writers with retry/swallow semantics.
- `sky/server/plugins.py`: add `register_managed_jobs_db_write_wrapper` / `get_managed_jobs_db_write_wrapper`. With no wrapper registered, the writers run unwrapped — the current OSS behavior.
- `sky/jobs/state.py`: extract `set_failed_async` / `set_cancelling_async` / `set_cancelled_async` bodies into `_impl` helpers; the public functions route through the registered wrapper if any.

## Test plan

- [x] `pytest tests/unit_tests/test_managed_jobs_db_write_wrapper.py` — 9 tests, all green.
  - Pins that with no wrapper registered, public writers call the impl once with the original args (default OSS behavior preserved).
  - Pins that with a wrapper registered, public writers route through it, and the wrapper can delegate by `await impl(*args, **kwargs)`.
- [x] Tested in dev: the refactored cleanup paths execute the same sequence of writes as before (no plugin loaded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)