### PR TITLE
[API] Run user-management sync handlers in their own request context

### DIFF
--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -25,6 +25,7 @@ from sky.users import resolver as user_resolver
 from sky.users import token_service
 from sky.utils import common
 from sky.utils import common_utils
+from sky.utils import context
 from sky.utils import resource_checker
 from sky.workspaces import constants as workspace_constants
 from sky.workspaces import core as workspaces_core
@@ -142,6 +143,7 @@ def set_user_preferred_workspace(
 
 
 @router.get('/me/workspace')
+@context.contextual
 def get_user_workspace(
     request: fastapi.Request,
     requested: Optional[str] = None,
@@ -301,6 +303,7 @@ def user_create(user_create_body: payloads.UserCreateBody) -> None:
 
 
 @router.post('/update')
+@context.contextual
 def user_update(request: fastapi.Request,
                 user_update_body: payloads.UserUpdateBody) -> None:
     """Updates the user role."""
@@ -375,6 +378,7 @@ def user_update(request: fastapi.Request,
 
 
 @router.post('/batch_update')
+@context.contextual
 def user_batch_update(request: fastapi.Request,
                       body: payloads.UserBatchUpdateBody) -> Dict[str, Any]:
     """Updates the role for a batch of users.
@@ -519,6 +523,7 @@ def _delete_user(user_id: str) -> None:
 
 
 @router.post('/delete')
+@context.contextual
 def user_delete(request: fastapi.Request,
                 user_delete_body: payloads.UserDeleteBody) -> None:
     current_user = request.state.auth_user

--- a/tests/unit_tests/test_sky/users/test_server.py
+++ b/tests/unit_tests/test_sky/users/test_server.py
@@ -13,6 +13,7 @@ from sky.skylet import constants
 from sky.users import rbac
 from sky.users import server
 from sky.utils import common
+from sky.utils import common_utils
 
 
 class TestGetUserType:
@@ -1142,3 +1143,35 @@ charlie,pw789,user
         assert result['total_processed'] == 2
         assert len(result['parse_errors']) == 1
         assert 'Line 3: Invalid number of columns' in result['parse_errors'][0]
+
+
+class TestUserContextIsolation:
+    """The sync user handlers run under @context.contextual.
+
+    They must set the request user in their own per-request context (so
+    workspace/RBAC resolution sees the caller) without leaking it into the
+    process-global context after the handler returns. user_delete is the
+    simplest of the four (get_user_workspace/user_update/user_batch_update
+    share the same @context.contextual + set_current_user pattern).
+    """
+
+    def test_user_delete_user_context_is_isolated_and_not_leaked(self):
+        user = models.User(id='u-alice', name='alice')
+        request = mock.MagicMock()
+        request.state.auth_user = user
+
+        captured = {}
+
+        def _capture(user_id):
+            # Runs inside the handler's context; current user must be ours.
+            captured['inside'] = common_utils.get_current_user().id
+
+        before = common_utils.get_current_user().id
+        with mock.patch.object(server, '_delete_user', side_effect=_capture):
+            server.user_delete(
+                request=request,
+                user_delete_body=payloads.UserDeleteBody(user_id='u-bob'))
+        after = common_utils.get_current_user().id
+
+        assert captured['inside'] == 'u-alice'  # set inside the context
+        assert after == before  # no leak after the handler returns


### PR DESCRIPTION
## Summary

The synchronous handlers in `sky/users/server.py` — `get_user_workspace`, `user_update`, `user_batch_update`, `user_delete` — bypass the executor framework, which would normally establish a per-request context. They call `common_utils.set_current_user()` directly, but with no active `SkyPilotContext` that write lands in a **process-global fallback** (`_PROCESS_GLOBAL_VARS` in `sky/utils/context.py`) shared across all worker threads.

Consequences:
- **Leak:** a request's identity stays in the process-global store after the handler returns, so a later request on the same worker that reads `get_current_user()` without setting it sees the wrong user.
- **Race:** two concurrent sync-handler requests can clobber each other's current user between set and read.

Either way, `get_accessible_workspace_names()` / `get_workspaces()` (which call `get_current_user()`) can resolve the wrong user's accessible workspaces.

Fix: wrap these handlers in `@context.contextual` so `set_current_user()` writes to a **per-request `SkyPilotContext`** that is torn down when the handler returns — no leak, no cross-request race. This mirrors how the executor establishes a per-request context for the normal (non-sync) path.

## Test plan

- Added `TestUserContextIsolation` in `tests/unit_tests/test_sky/users/test_server.py` (covers `user_delete`, representative of the shared pattern):
  - the request user is visible to `get_current_user()` **inside** the handler;
  - `get_current_user()` **after** the handler is unchanged (no leak).
- Revert check: removing `@context.contextual` from the handler makes the test fail (the user leaks to the process-global context).
- `pytest tests/unit_tests/test_sky/users/test_server.py` passes; pre-commit (isort/mypy/yapf/pylint) clean.
- Manual test - run `sky workspace info` concurrently for different users and the results are correct for all the users

🤖 Generated with [Claude Code](https://claude.com/claude-code)