### PR TITLE
[Kubernetes] Don't match distinct canonical GPU names (e.g. A100 vs A100-80GB)

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -795,14 +795,21 @@ def _accelerator_name_matches(requested_acc: str,
                               viable_names: List[str]) -> bool:
     """Check if requested accelerator matches any viable name.
 
-    For backward compatibility with GPU name changes (e.g., when canonical names
-    like 'H200' are added to replace fallback names like 'H200-SXM-80GB'), this
-    function also matches if one name is a prefix of the other separated by '-'.
+    A request matches a node's GPU name when they denote compatible hardware:
+    - An exact (case-insensitive) match.
+    - A canonical name against a non-canonical legacy/descriptive label for the
+      same GPU, matched via a '-'-separated prefix. This keeps clusters working
+      across GPU name canonicalization changes, e.g. a node label that maps to
+      the canonical 'H200' also matching the older fallback 'H200-SXM-80GB'
+      (and vice versa), or 'GH200' matching 'GH200-480GB'.
+    - Two canonical names that are explicit aliases of the same hardware (see
+      gpu_names.are_canonical_aliases), e.g. 'H100' <-> 'H100-80GB'.
 
-    This handles cases where:
-    - Clusters were launched with fallback names (e.g., 'H200-SXM-80GB') but
-      after upgrading, the same label now maps to canonical name (e.g., 'H200').
-    - Users specify canonical names but the cluster uses fallback names.
+    Crucially, two *distinct* canonical names are different hardware and do NOT
+    match: 'A100' (40GB) must never satisfy an 'A100-80GB' request (and vice
+    versa), nor 'V100' (16GB) a 'V100-32GB' request, nor 'H100' an 'H100-MEGA'
+    request. The prefix rule is therefore only applied when at least one side is
+    a non-canonical name.
 
     Args:
         requested_acc: The accelerator type requested (e.g., from launched_resources).
@@ -811,13 +818,22 @@ def _accelerator_name_matches(requested_acc: str,
     Returns:
         True if the requested accelerator matches any viable name.
     """
+    canonical_lower = {name.lower() for name in gpu_names.CANONICAL_GPU_NAMES}
     requested_lower = requested_acc.lower()
+    requested_is_canonical = requested_lower in canonical_lower
     for viable in viable_names:
         viable_lower = viable.lower()
         if requested_lower == viable_lower:
             return True
-        # Check prefix match with '-' separator for backward compatibility.
-        # E.g., 'H200' matches 'H200-SXM-80GB' and vice versa.
+        if requested_is_canonical and viable_lower in canonical_lower:
+            # Both are canonical names: they are distinct hardware unless
+            # explicitly aliased (a canonicalization rename of the same GPU).
+            if gpu_names.are_canonical_aliases(requested_lower, viable_lower):
+                return True
+            continue
+        # Exactly one side is a non-canonical (legacy/descriptive) label, e.g.
+        # 'H200-SXM-80GB' for 'H200'. Treat it as a match for its canonical
+        # form via a '-'-separated prefix match in either direction.
         shorter, longer = ((requested_lower, viable_lower)
                            if len(requested_lower) <= len(viable_lower) else
                            (viable_lower, requested_lower))

--- a/sky/utils/gpu_names.py
+++ b/sky/utils/gpu_names.py
@@ -47,3 +47,32 @@ CANONICAL_GPU_NAMES = [
     'K80',
     'M60',
 ]
+
+# Canonical GPU names that refer to the *same hardware* under different
+# canonical names, i.e. a node label that used to canonicalize to one name now
+# canonicalizes to the other (a historical rename). These are distinct entries
+# in CANONICAL_GPU_NAMES but must be treated as equivalent when matching a
+# requested accelerator against a node's GPU label.
+#
+# This is intentionally an explicit allow-list, NOT a structural/lexical rule.
+# 'H100' and 'H100-80GB' are the same hardware (a bare 'H100' is already 80GB),
+# but 'A100' (40GB) and 'A100-80GB' (80GB) -- which are structurally identical
+# pairs -- are *different* hardware and must never match. A purely lexical rule
+# (e.g. '-'-prefix matching) cannot tell these apart, so the equivalence is
+# enumerated here.
+_CANONICAL_GPU_NAME_ALIASES = {
+    'h100': {'h100-80gb'},
+    'h100-80gb': {'h100'},
+}
+
+
+def are_canonical_aliases(name_a: str, name_b: str) -> bool:
+    """Returns whether two canonical GPU names refer to the same hardware.
+
+    Used to keep clusters working across GPU label canonicalization renames
+    (e.g. a label that used to map to 'H100' now maps to 'H100-80GB') while
+    still treating genuinely different hardware (e.g. 'A100' (40GB) vs
+    'A100-80GB' (80GB)) as distinct. Matching is case-insensitive.
+    """
+    return name_b.lower() in _CANONICAL_GPU_NAME_ALIASES.get(
+        name_a.lower(), frozenset())

--- a/tests/unit_tests/kubernetes/test_gpu_label_formatters.py
+++ b/tests/unit_tests/kubernetes/test_gpu_label_formatters.py
@@ -367,25 +367,46 @@ class TestAcceleratorNameMatches:
         assert _accelerator_name_matches('H100-80GB',
                                          ['h100', 'nvidia-h100-sxm-80gb'])
 
-        # Same for A100-80GB (already existed but worth testing)
-        assert _accelerator_name_matches('A100', ['a100-80gb'])
-        assert _accelerator_name_matches('A100-80GB', ['a100'])
+        # Unlike H100, 'A100' (40GB) and 'A100-80GB' (80GB) are *different*
+        # hardware, not a rename of the same GPU, so they must NOT match. See
+        # test_distinct_canonical_variants_do_not_match.
+        assert not _accelerator_name_matches('A100', ['a100-80gb'])
+        assert not _accelerator_name_matches('A100-80GB', ['a100'])
 
-        # GH200 variants (GH200-480GB is a possible variant)
+        # GH200-480GB is a non-canonical legacy/descriptive label for the
+        # canonical 'GH200', so it still matches via the prefix rule.
         assert _accelerator_name_matches('GH200', ['gh200-480gb'])
         assert _accelerator_name_matches('GH200-480GB', ['gh200'])
 
     def test_no_cross_variant_matching(self):
         """Test that different GPU variants don't incorrectly match.
 
-        H100 and H100-MEGA are different GPUs and should not match each
-        other. However, due to prefix matching, H100 will match H100-MEGA.
-        This is a known limitation that's acceptable because:
-        1. It's unlikely a user launches with H100-MEGA and expects H100
-        2. Not matching would break backward compat for valid cases
+        'H100' and 'H100-MEGA' are distinct canonical names (different GPUs),
+        so they must not match each other. Only explicit canonicalization
+        aliases (e.g. 'H100' <-> 'H100-80GB') match between two canonical names.
         """
-        # These will match due to prefix logic - this is expected behavior
-        assert _accelerator_name_matches('H100', ['h100-mega'])
-        # But ensure unrelated GPUs don't match
+        assert not _accelerator_name_matches('H100', ['h100-mega'])
+        assert not _accelerator_name_matches('H100-MEGA', ['h100'])
+        # Unrelated GPUs don't match either.
         assert not _accelerator_name_matches('H200', ['h100-mega'])
         assert not _accelerator_name_matches('A100', ['h100-mega'])
+
+    def test_distinct_canonical_variants_do_not_match(self):
+        """Distinct canonical memory variants must never match.
+
+        A request for a larger-memory variant must not be satisfied by the
+        smaller one (or vice versa), regardless of what other nodes exist:
+        scheduling an 'A100-80GB' job onto a 40GB A100 node would OOM. Only
+        explicitly aliased canonicalization renames (e.g. 'H100' <->
+        'H100-80GB', same hardware) may match between two canonical names.
+        """
+        assert not _accelerator_name_matches('A100-80GB', ['a100'])
+        assert not _accelerator_name_matches('A100', ['a100-80gb'])
+        assert not _accelerator_name_matches('V100-32GB', ['v100'])
+        assert not _accelerator_name_matches('V100', ['v100-32gb'])
+        # Even when the raw 40GB GFD label is also in the viable list.
+        assert not _accelerator_name_matches('A100-80GB',
+                                             ['nvidia-a100-sxm4-40gb', 'a100'])
+        # The genuine same-hardware rename still matches.
+        assert _accelerator_name_matches('H100', ['h100-80gb'])
+        assert _accelerator_name_matches('H100-80GB', ['h100'])

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -746,6 +746,79 @@ def test_heterogenous_gpu_detection():
         assert available == {'H100': 1}
 
 
+def test_get_accelerator_label_selects_correct_memory_variant():
+    """An A100-80GB request must resolve to an 80GB node, not a 40GB one.
+
+    On a cluster with both A100 (40GB) and A100-80GB nodes, the GFD label
+    'NVIDIA-A100-SXM4-40GB' (canonical 'A100') is a *different* GPU from
+    'A100-80GB' and must not satisfy the request -- even though it is listed
+    first. The request must be pinned to the 80GB node's label.
+    """
+    key_name = 'nvidia.com/gpu.product'
+    # 40GB node intentionally first to show selection is order-independent.
+    node_labels = {
+        'node-40gb': [(key_name, 'NVIDIA-A100-SXM4-40GB')],
+        'node-80gb': [(key_name, 'NVIDIA-A100-SXM4-80GB')],
+    }
+    with mock.patch(
+            'sky.provision.kubernetes.utils.detect_accelerator_resource',
+            return_value=(True, {'nvidia.com/gpu'})), \
+         mock.patch(
+             'sky.provision.kubernetes.utils.detect_gpu_label_formatter',
+             return_value=(utils.GFDLabelFormatter(), node_labels)):
+        key, values, _, _ = utils.get_accelerator_label_key_values(
+            'ctx', 'A100-80GB', 1)
+        assert key == key_name
+        assert values == ['NVIDIA-A100-SXM4-80GB']
+
+        key, values, _, _ = utils.get_accelerator_label_key_values(
+            'ctx', 'A100', 1)
+        assert key == key_name
+        assert values == ['NVIDIA-A100-SXM4-40GB']
+
+
+def test_get_accelerator_label_no_match_for_missing_memory_variant():
+    """An A100-80GB request must fail loudly when only 40GB A100 nodes exist.
+
+    Previously the request would silently fall back to the 40GB label (and OOM
+    at runtime). The 40GB node is a different GPU, so it must not match at all.
+    """
+    key_name = 'nvidia.com/gpu.product'
+    node_labels = {
+        'n1': [(key_name, 'NVIDIA-A100-SXM4-40GB')],
+        'n2': [(key_name, 'NVIDIA-A100-SXM4-40GB')],
+    }
+    with mock.patch(
+            'sky.provision.kubernetes.utils.detect_accelerator_resource',
+            return_value=(True, {'nvidia.com/gpu'})), \
+         mock.patch(
+             'sky.provision.kubernetes.utils.detect_gpu_label_formatter',
+             return_value=(utils.GFDLabelFormatter(), node_labels)):
+        with pytest.raises(exceptions.ResourcesUnavailableError):
+            utils.get_accelerator_label_key_values('ctx', 'A100-80GB', 1)
+
+
+def test_get_accelerator_label_matches_canonicalization_alias():
+    """A request must still match a renamed canonical label (same hardware).
+
+    A cluster launched before a GPU name canonicalization change may request
+    'H100' while nodes are now labeled 'H100-80GB' (e.g. NVIDIA-H100-80GB-HBM3,
+    the same hardware). The explicit alias keeps this working.
+    """
+    key_name = 'nvidia.com/gpu.product'
+    node_labels = {'node-h100': [(key_name, 'NVIDIA-H100-80GB-HBM3')]}
+    with mock.patch(
+            'sky.provision.kubernetes.utils.detect_accelerator_resource',
+            return_value=(True, {'nvidia.com/gpu'})), \
+         mock.patch(
+             'sky.provision.kubernetes.utils.detect_gpu_label_formatter',
+             return_value=(utils.GFDLabelFormatter(), node_labels)):
+        key, values, _, _ = utils.get_accelerator_label_key_values(
+            'ctx', 'H100', 1)
+        assert key == key_name
+        assert values == ['NVIDIA-H100-80GB-HBM3']
+
+
 def test_low_priority_pod_filtering():
     """Tests that low priority pods (e.g., CoreWeave HPC verification) are excluded from GPU allocation calculations."""
     # Mock node with 8 GPUs


### PR DESCRIPTION
## Problem

When SkyPilot picks the node-label selector for a requested accelerator on Kubernetes, a request for a specific memory variant could be satisfied by a **different** variant of the same GPU family.

`_accelerator_name_matches` matched any two GPU names where one was a `-`-separated prefix of the other. That rule exists so a canonical name like `H200` keeps matching the older fallback label `H200-SXM-80GB` across a canonicalization change. But it also made a bare `A100` (40GB) label a valid match for an `A100-80GB` request:

- On a cluster with **both** 40GB and 80GB A100 nodes, an `A100-80GB` request could be pinned to a `nvidia.com/gpu.product=NVIDIA-A100-SXM4-40GB` selector (whichever node was iterated first) → the job runs on a 40GB card and OOMs.
- The same lexical collision applies to `V100` vs `V100-32GB`, and `H100` vs `H100-MEGA`.

## Fix

Two **distinct canonical** GPU names are different hardware and must not match. The prefix fallback is now only applied when **at least one side is a non-canonical** legacy/descriptive label (e.g. `H200-SXM-80GB`, `GH200-480GB`, `H100-PCIE-80GB`) — the only case it was ever meant for.

Genuine same-hardware **canonicalization renames** between two canonical names — currently only `H100` ↔ `H100-80GB` (a bare `H100` is already 80GB) — are kept via an **explicit alias table** in `sky/utils/gpu_names.py`, rather than inferred lexically. `A100`/`A100-80GB` and `V100`/`V100-32GB` are deliberately **not** aliases.

This makes selection correct **independent of cluster composition**:
- `A100-80GB` request → resolves to an 80GB node when present;
- `A100-80GB` request on a cluster with only 40GB A100 nodes → now fails with `ResourcesUnavailableError` instead of **silently downgrading to 40GB**;
- `A100` → still resolves to a 40GB node;
- `H100` request on nodes labeled `H100-80GB` (e.g. `NVIDIA-H100-80GB-HBM3`, same hardware) → still resolves, via the alias.

`get_accelerator_label_key_values` itself is unchanged — the fix is in the matching predicate, so all callers (provisioning selection and launched-cluster reconciliation) get consistent, correct behavior.

## Test plan

- `tests/unit_tests/kubernetes/test_gpu_label_formatters.py`
  - New `test_distinct_canonical_variants_do_not_match`: `A100-80GB`↛`A100`, `V100-32GB`↛`V100` (both directions), incl. raw GFD labels.
  - Updated `test_no_cross_variant_matching`: `H100`↛`H100-MEGA` (distinct GPUs).
  - Updated `test_h100_80gb_backward_compat`: `H100`↔`H100-80GB` and `GH200`↔`GH200-480GB` still match; the previous `A100`↔`A100-80GB` assertions are corrected to non-matches.
- `tests/unit_tests/kubernetes/test_kubernetes_utils.py` (end-to-end `get_accelerator_label_key_values`)
  - selects the 80GB node on a mixed cluster (40GB node listed first);
  - raises `ResourcesUnavailableError` when only 40GB nodes exist;
  - still resolves the `H100`↔`H100-80GB` canonicalization alias.
- Existing GPU label formatter / detection tests pass unchanged.
- `bash format.sh --files ...` clean (yapf/isort).