### PR TITLE
[Kubernetes] Don't schedule a -80GB GPU request onto a smaller-memory node

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -826,15 +826,15 @@ def _accelerator_name_matches(requested_acc: str,
             if len(longer) == len(shorter) or longer[len(shorter)] == '-':
                 # Guard against the OOM direction: a request must not be
                 # satisfied by a node with strictly LESS device memory (e.g.
-                # an 'A100-80GB' request on a 40GB 'A100' node). Only applies
-                # when both names have known memory; same-or-larger node
-                # memory still matches, which preserves backward compatibility
-                # (an 'A100' request may still land on an 'A100-80GB' node) and
-                # same-hardware renames (e.g. 'H100' == 'H100-80GB', both 80GB).
-                requested_mem = gpu_names.get_canonical_gpu_memory_gib(
+                # an 'A100-80GB' (or typo'd 'A100-80G') request on a 40GB
+                # 'A100' node). Only applies when both names imply a known
+                # memory size; same-or-larger node memory still matches, which
+                # preserves backward compatibility (an 'A100' request may still
+                # land on an 'A100-80GB' node) and same-hardware renames (e.g.
+                # 'H100' == 'H100-80GB', both 80GB).
+                requested_mem = gpu_names.get_gpu_device_memory_gib(
                     requested_lower)
-                viable_mem = gpu_names.get_canonical_gpu_memory_gib(
-                    viable_lower)
+                viable_mem = gpu_names.get_gpu_device_memory_gib(viable_lower)
                 if (requested_mem is not None and viable_mem is not None and
                         requested_mem > viable_mem):
                     continue

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -824,6 +824,20 @@ def _accelerator_name_matches(requested_acc: str,
         if longer.startswith(shorter):
             # Ensure it's a proper prefix (followed by '-' or end of string)
             if len(longer) == len(shorter) or longer[len(shorter)] == '-':
+                # Guard against the OOM direction: a request must not be
+                # satisfied by a node with strictly LESS device memory (e.g.
+                # an 'A100-80GB' request on a 40GB 'A100' node). Only applies
+                # when both names have known memory; same-or-larger node
+                # memory still matches, which preserves backward compatibility
+                # (an 'A100' request may still land on an 'A100-80GB' node) and
+                # same-hardware renames (e.g. 'H100' == 'H100-80GB', both 80GB).
+                requested_mem = gpu_names.get_canonical_gpu_memory_gib(
+                    requested_lower)
+                viable_mem = gpu_names.get_canonical_gpu_memory_gib(
+                    viable_lower)
+                if (requested_mem is not None and viable_mem is not None and
+                        requested_mem > viable_mem):
+                    continue
                 return True
     return False
 

--- a/sky/utils/gpu_names.py
+++ b/sky/utils/gpu_names.py
@@ -1,5 +1,6 @@
 """Canonical GPU names shared across backends (Kubernetes, Slurm, etc.)."""
 
+import re
 from typing import Optional
 
 # Canonical GPU names for GPU detection and labeling.
@@ -50,32 +51,53 @@ CANONICAL_GPU_NAMES = [
     'M60',
 ]
 
-# Single-device memory (GiB) for canonical GPU names that participate in
-# memory-variant prefix relationships (e.g. 'A100' 40GB vs 'A100-80GB' 80GB).
-# Used to distinguish a real memory variant (different hardware) from a
-# same-hardware rename (e.g. 'H100' == 'H100-80GB', equal memory) during
-# prefix-based name matching, so that an 'A100-80GB' request is not silently
-# scheduled onto a 40GB A100 node.
+# Single-device memory (GiB) for bare GPU names that have a memory-variant
+# sibling (e.g. 'A100' 40GB vs 'A100-80GB' 80GB). These bare names carry no
+# memory suffix to parse, so their memory must be stated explicitly. Used to
+# distinguish a real memory variant (different hardware) from a same-hardware
+# rename (e.g. 'H100' == 'H100-80GB', equal memory) during prefix-based name
+# matching, so that an 'A100-80GB' request is not silently scheduled onto a
+# 40GB A100 node.
 #
-# This is a conservative allowlist: only names listed here are disambiguated.
-# Any other pair keeps the legacy prefix-match behavior. Add an entry only
-# when a canonical name has a sibling that differs solely by a memory suffix.
+# Conservative allowlist: only bare names whose memory differs from a suffixed
+# sibling need an entry. Names with an explicit memory suffix (e.g. 'A100-80GB',
+# 'A100-80G', 'V100-32GB') are handled by parsing the suffix, so they need no
+# entry here.
 CANONICAL_GPU_MEMORY_GIB = {
     'A100': 40,
-    'A100-80GB': 80,
     'V100': 16,
-    'V100-32GB': 32,
 }
 _CANONICAL_GPU_MEMORY_GIB_LOWER = {
     k.lower(): v for k, v in CANONICAL_GPU_MEMORY_GIB.items()
 }
 
+# Matches a trailing memory suffix like '-80GB', '-80G', or '-32gb' and
+# captures the size in GiB. Tolerates the common typo of dropping the 'B'
+# (e.g. 'A100-80G') since user-typed names are not always canonicalized.
+_MEMORY_SUFFIX_RE = re.compile(r'-(\d+)\s*gb?(?:-|$)', re.IGNORECASE)
 
-def get_canonical_gpu_memory_gib(name: str) -> Optional[int]:
-    """Returns the single-device memory (GiB) for a canonical GPU name.
 
-    Lookup is case-insensitive. Returns None if the name is not a known
-    memory-variant canonical name (in which case callers should fall back to
-    their default matching behavior).
+def get_gpu_device_memory_gib(name: str) -> Optional[int]:
+    """Returns the single-device memory (GiB) implied by a GPU name.
+
+    Resolution is intentionally scoped to the GPU families listed in
+    CANONICAL_GPU_MEMORY_GIB, so this never changes matching for GPUs we don't
+    explicitly track:
+    1. An exact bare-name match (e.g. 'A100' -> 40) returns the mapped value.
+    2. A memory suffix (e.g. 'A100-80GB', or the typo 'A100-80G') is parsed
+       only when the part before the suffix is itself a tracked bare name
+       (e.g. 'a100'). This handles names that were not canonicalized on
+       Kubernetes-only clusters without widening the blast radius.
+
+    Returns None otherwise, in which case callers should fall back to their
+    default matching behavior. Lookup is case-insensitive.
     """
-    return _CANONICAL_GPU_MEMORY_GIB_LOWER.get(name.lower())
+    lower = name.lower()
+    if lower in _CANONICAL_GPU_MEMORY_GIB_LOWER:
+        return _CANONICAL_GPU_MEMORY_GIB_LOWER[lower]
+    match = _MEMORY_SUFFIX_RE.search(lower)
+    if match is not None:
+        base = lower[:match.start()]
+        if base in _CANONICAL_GPU_MEMORY_GIB_LOWER:
+            return int(match.group(1))
+    return None

--- a/sky/utils/gpu_names.py
+++ b/sky/utils/gpu_names.py
@@ -1,5 +1,7 @@
 """Canonical GPU names shared across backends (Kubernetes, Slurm, etc.)."""
 
+from typing import Optional
+
 # Canonical GPU names for GPU detection and labeling.
 #
 # IMPORTANT: Order matters — more-specific names must come before
@@ -47,3 +49,33 @@ CANONICAL_GPU_NAMES = [
     'K80',
     'M60',
 ]
+
+# Single-device memory (GiB) for canonical GPU names that participate in
+# memory-variant prefix relationships (e.g. 'A100' 40GB vs 'A100-80GB' 80GB).
+# Used to distinguish a real memory variant (different hardware) from a
+# same-hardware rename (e.g. 'H100' == 'H100-80GB', equal memory) during
+# prefix-based name matching, so that an 'A100-80GB' request is not silently
+# scheduled onto a 40GB A100 node.
+#
+# This is a conservative allowlist: only names listed here are disambiguated.
+# Any other pair keeps the legacy prefix-match behavior. Add an entry only
+# when a canonical name has a sibling that differs solely by a memory suffix.
+CANONICAL_GPU_MEMORY_GIB = {
+    'A100': 40,
+    'A100-80GB': 80,
+    'V100': 16,
+    'V100-32GB': 32,
+}
+_CANONICAL_GPU_MEMORY_GIB_LOWER = {
+    k.lower(): v for k, v in CANONICAL_GPU_MEMORY_GIB.items()
+}
+
+
+def get_canonical_gpu_memory_gib(name: str) -> Optional[int]:
+    """Returns the single-device memory (GiB) for a canonical GPU name.
+
+    Lookup is case-insensitive. Returns None if the name is not a known
+    memory-variant canonical name (in which case callers should fall back to
+    their default matching behavior).
+    """
+    return _CANONICAL_GPU_MEMORY_GIB_LOWER.get(name.lower())

--- a/tests/unit_tests/kubernetes/test_gpu_label_formatters.py
+++ b/tests/unit_tests/kubernetes/test_gpu_label_formatters.py
@@ -367,13 +367,36 @@ class TestAcceleratorNameMatches:
         assert _accelerator_name_matches('H100-80GB',
                                          ['h100', 'nvidia-h100-sxm-80gb'])
 
-        # Same for A100-80GB (already existed but worth testing)
-        assert _accelerator_name_matches('A100', ['a100-80gb'])
-        assert _accelerator_name_matches('A100-80GB', ['a100'])
-
         # GH200 variants (GH200-480GB is a possible variant)
         assert _accelerator_name_matches('GH200', ['gh200-480gb'])
         assert _accelerator_name_matches('GH200-480GB', ['gh200'])
+
+    def test_memory_variant_no_oom_match(self):
+        """A request must not match a node with less device memory.
+
+        A request for the 80GB variant must not be silently scheduled onto a
+        40GB node (which would OOM at runtime), while the harmless reverse
+        direction and same-hardware renames keep matching.
+        """
+        # OOM direction: 80GB request must not match a 40GB node.
+        assert not _accelerator_name_matches('A100-80GB', ['a100'])
+        assert not _accelerator_name_matches('A100-80GB',
+                                             ['nvidia-a100-sxm4-40gb', 'a100'])
+        assert not _accelerator_name_matches('V100-32GB', ['v100'])
+
+        # Backward-compat direction: a smaller-memory request may still land
+        # on a larger-memory node (pre-existing benign behavior).
+        assert _accelerator_name_matches('A100', ['a100-80gb'])
+        assert _accelerator_name_matches('V100', ['v100-32gb'])
+
+        # Same-hardware renames (equal memory) must still match.
+        assert _accelerator_name_matches('H100', ['h100-80gb'])
+        assert _accelerator_name_matches('H100-80GB', ['h100'])
+
+        # H100-MEGA is the same H100 80GB silicon (A3 Mega instance), so
+        # cross-matching with H100 is harmless and preserved.
+        assert _accelerator_name_matches('H100', ['h100-mega'])
+        assert _accelerator_name_matches('H100-MEGA', ['h100'])
 
     def test_no_cross_variant_matching(self):
         """Test that different GPU variants don't incorrectly match.

--- a/tests/unit_tests/kubernetes/test_gpu_label_formatters.py
+++ b/tests/unit_tests/kubernetes/test_gpu_label_formatters.py
@@ -35,6 +35,25 @@ class TestCanonicalGPUNames:
         # T4g must come before T4
         assert names.index('T4g') < names.index('T4')
 
+    def test_gpu_device_memory_parsing(self):
+        """Memory resolution is scoped to tracked families (A100/V100)."""
+        # Bare names with an explicit memory entry.
+        assert gpu_names.get_gpu_device_memory_gib('A100') == 40
+        assert gpu_names.get_gpu_device_memory_gib('v100') == 16
+        # Memory suffix parsed for tracked families (incl. the 'A100-80G' typo).
+        assert gpu_names.get_gpu_device_memory_gib('A100-80GB') == 80
+        assert gpu_names.get_gpu_device_memory_gib('A100-80G') == 80
+        assert gpu_names.get_gpu_device_memory_gib('V100-32GB') == 32
+        # Untracked families are NOT parsed -> None, keeping the blast radius
+        # limited. Raw labels and renames fall back to default matching.
+        assert gpu_names.get_gpu_device_memory_gib('GH200-480GB') is None
+        assert gpu_names.get_gpu_device_memory_gib(
+            'nvidia-a100-sxm4-40gb') is None
+        assert gpu_names.get_gpu_device_memory_gib('H100') is None
+        assert gpu_names.get_gpu_device_memory_gib('H100-80GB') is None
+        assert gpu_names.get_gpu_device_memory_gib('H100-MEGA') is None
+        assert gpu_names.get_gpu_device_memory_gib('A10G') is None
+
     def test_canonical_gpu_names_contains_latest_gpus(self):
         """Test that all latest generation GPUs are included."""
         names = gpu_names.CANONICAL_GPU_NAMES
@@ -383,6 +402,15 @@ class TestAcceleratorNameMatches:
         assert not _accelerator_name_matches('A100-80GB',
                                              ['nvidia-a100-sxm4-40gb', 'a100'])
         assert not _accelerator_name_matches('V100-32GB', ['v100'])
+
+        # Same, but with names that are NOT canonicalized. On a Kubernetes-only
+        # cluster a user-typed 'A100-80G' (missing the 'B') is not normalized to
+        # 'A100-80GB', so the guard must parse the memory suffix to still reject
+        # the 40GB node. This is the exact shape that reached production.
+        assert not _accelerator_name_matches('A100-80G', ['a100'])
+        assert not _accelerator_name_matches('A100-80G',
+                                             ['nvidia-a100-sxm4-40gb', 'a100'])
+        assert not _accelerator_name_matches('V100-32G', ['v100'])
 
         # Backward-compat direction: a smaller-memory request may still land
         # on a larger-memory node (pre-existing benign behavior).


### PR DESCRIPTION
## Summary

On Kubernetes, a request for a high-memory GPU variant (e.g. `accelerators: A100-80GB`) could be scheduled onto a node with a smaller-memory sibling (e.g. a 40GB `A100`), causing the workload to OOM at runtime. The same class affects `V100-32GB` vs `V100`.

Root cause: `_accelerator_name_matches` in `sky/provision/kubernetes/utils.py` treats any `-`-separated prefix as a match (for GPU-name backward compatibility, e.g. canonical `H200` ↔ fallback `H200-SXM-80GB`). The lexical rule has a false positive: a bare `A100` (a 40GB card) satisfies an `A100-80GB` request because `"a100-80gb".startswith("a100")`. `get_accelerator_label_key_values` returns the first matching node label, so a 40GB node iterated first wins.

String matching alone can't tell a same-hardware rename (`H100` == `H100-80GB`, both 80GB — must keep matching) from a real memory variant (`A100` 40GB vs `A100-80GB` 80GB — must not match). The discriminator is the bare name's actual device memory.

## Changes

- `sky/utils/gpu_names.py`: add `CANONICAL_GPU_MEMORY_GIB` (per-device memory for canonical names with memory-variant siblings) and `get_canonical_gpu_memory_gib()`.
- `sky/provision/kubernetes/utils.py`: guard the prefix match — reject only when the **requested** GPU needs strictly **more** memory than the candidate node provides (the OOM direction). The benign reverse direction (a smaller request landing on a larger node) and same-hardware renames keep matching, so this is backward compatible. Unknown names fall through to the legacy behavior.

After the fix, an `A100-80GB:1` request skips 40GB nodes; if only 40GB nodes exist it raises `ResourcesUnavailableError` instead of silently OOMing.

## Test plan

- Added `TestAcceleratorNameMatches::test_memory_variant_no_oom_match` covering the OOM direction, the backward-compat direction, and same-hardware renames (`H100`/`H100-80GB`/`H100-MEGA`).
- Updated an existing assertion that codified the buggy behavior (`A100-80GB` matching a bare `A100`).
- `pytest tests/unit_tests/kubernetes/test_gpu_label_formatters.py` → 26 passed.
- Reverting the guard makes the new `assert not ...` cases fail, confirming they catch the regression.
- Manual test with A100 and A100-80GB and confirm that A100-80GB cannot land on node with A100