### PR TITLE
[Kubernetes] Refactor FUSE setup command

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -966,8 +966,7 @@ class Kubernetes(clouds.Cloud):
             'k8s_kueue_local_queue_name': k8s_kueue_local_queue_name,
             # Namespace to run the fusermount-server daemonset in
             'k8s_skypilot_system_namespace': _SKYPILOT_SYSTEM_NAMESPACE,
-            'k8s_fusermount_shared_dir':
-                kubernetes_fuse.FUSERMOUNT_SHARED_DIR,
+            'k8s_fusermount_shared_dir': kubernetes_fuse.FUSERMOUNT_SHARED_DIR,
             'k8s_fusermount_setup_command':
                 kubernetes_fuse.get_fusermount_shim_setup_command(
                     sudo_cmd='$(prefix_cmd)',

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -20,6 +20,7 @@ from sky.adaptors import kubernetes
 from sky.clouds.utils import gcp_utils
 from sky.provision import instance_setup
 from sky.provision.gcp import constants as gcp_constants
+from sky.provision.kubernetes import fuse as kubernetes_fuse
 from sky.provision.kubernetes import host_network_probe
 from sky.provision.kubernetes import network_utils
 from sky.provision.kubernetes import utils as kubernetes_utils
@@ -43,10 +44,6 @@ logger = sky_logging.init_logger(__name__)
 # same cluster (even if they might be running in different namespaces).
 # E.g., FUSE device manager daemonset is run in this namespace.
 _SKYPILOT_SYSTEM_NAMESPACE = 'skypilot-system'
-
-# Shared directory to communicate with fusermount-server, refer to
-# addons/fuse-proxy/README.md for more details.
-_FUSERMOUNT_SHARED_DIR = '/var/run/fusermount'
 
 AWS_EFA_RESOURCE_KEY = 'vpc.amazonaws.com/efa'
 
@@ -969,7 +966,12 @@ class Kubernetes(clouds.Cloud):
             'k8s_kueue_local_queue_name': k8s_kueue_local_queue_name,
             # Namespace to run the fusermount-server daemonset in
             'k8s_skypilot_system_namespace': _SKYPILOT_SYSTEM_NAMESPACE,
-            'k8s_fusermount_shared_dir': _FUSERMOUNT_SHARED_DIR,
+            'k8s_fusermount_shared_dir':
+                kubernetes_fuse.FUSERMOUNT_SHARED_DIR,
+            'k8s_fusermount_setup_command':
+                kubernetes_fuse.get_fusermount_shim_setup_command(
+                    sudo_cmd='$(prefix_cmd)',
+                    shared_dir=kubernetes_fuse.FUSERMOUNT_SHARED_DIR),
             'k8s_spot_label_key': spot_label_key,
             'k8s_spot_label_value': spot_label_value,
             'tpu_requested': tpu_requested,

--- a/sky/provision/kubernetes/fuse.py
+++ b/sky/provision/kubernetes/fuse.py
@@ -1,0 +1,63 @@
+"""Kubernetes FUSE mounting helpers."""
+
+import textwrap
+
+# Shared directory to communicate with fusermount-server, refer to
+# addons/fuse-proxy/README.md for more details.
+FUSERMOUNT_SHARED_DIR = '/var/run/fusermount'
+
+
+def get_fusermount_shim_setup_command(
+        sudo_cmd: str = 'sudo',
+        shared_dir: str = '$FUSERMOUNT_SHARED_DIR') -> str:
+    """Return the pod-side setup command for the fusermount shim."""
+    sudo = f'{sudo_cmd} ' if sudo_cmd else ''
+    command = textwrap.dedent("""
+        set -e
+        # Mask fusermount binary before enabling SSH access
+        FUSERMOUNT_PATH=$(which fusermount)
+        if [ -z "$FUSERMOUNT_PATH" ]; then
+            echo "Error: fusermount binary not found"
+            exit 1
+        fi
+        __SUDO__cp -p "$FUSERMOUNT_PATH" "${FUSERMOUNT_PATH}-original"
+        __SUDO__ln -sf "__SHARED_DIR__/fusermount-shim" "$FUSERMOUNT_PATH"
+        # "|| true" because fusermount3 is not always available
+        FUSERMOUNT3_PATH=$(which fusermount3) || true
+        if [ -z "$FUSERMOUNT3_PATH" ]; then
+            FUSERMOUNT3_PATH="${FUSERMOUNT_PATH}3"
+        fi
+        # Also mask fusermount3 for rclone and blobfuse2 (for unmount operation)
+        __SUDO__ln -sf "$FUSERMOUNT_PATH" "$FUSERMOUNT3_PATH"
+        # Add fusermount-wrapper to handle adapters that use libfuse directly,
+        # e.g. blobfuse2.
+        __SUDO__ln -sf "__SHARED_DIR__/fusermount-wrapper" /bin/fusermount-wrapper
+        # Wait for the server to setup the fusermount shim binary in case:
+        # 1. The server daemonset was just deployed and is still starting up.
+        # 2. The node was just started and the server Pod is still starting up.
+        wait_for_fusermount() {
+            local timeout=60
+            local start_time=$(date +%s)
+            while ! command -v fusermount >/dev/null 2>&1; do
+                current_time=$(date +%s)
+                elapsed=$((current_time - start_time))
+                if [ $elapsed -ge $timeout ]; then
+                    echo "Error: fusermount not ready after $timeout seconds"
+                    exit 1
+                fi
+                sleep 1
+            done
+        }
+        wait_for_fusermount
+        # Some distributions may mount hostPath with noexec, copy the binary
+        # in this case.
+        if ! fusermount -V; then
+            echo "fusermount -V failed, copying fusermount-shim directly"
+            __SUDO__rm -f "$FUSERMOUNT_PATH"
+            __SUDO__cp -p "__SHARED_DIR__/fusermount-shim" "$FUSERMOUNT_PATH"
+            __SUDO__rm -f /bin/fusermount-wrapper
+            __SUDO__cp -p "__SHARED_DIR__/fusermount-wrapper" /bin/fusermount-wrapper
+        fi
+    """).strip()
+    return command.replace('__SUDO__', sudo).replace('__SHARED_DIR__',
+                                                     shared_dir)

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -1096,49 +1096,7 @@ available_node_types:
                 {% endif %}
 
                 {% if k8s_fuse_device_required %}
-                set -e
-                # Mask fusermount binary before enabling SSH access
-                FUSERMOUNT_PATH=$(which fusermount)
-                if [ -z "$FUSERMOUNT_PATH" ]; then
-                    echo "Error: fusermount binary not found"
-                    exit 1
-                fi
-                $(prefix_cmd) cp -p "$FUSERMOUNT_PATH" "${FUSERMOUNT_PATH}-original"
-                $(prefix_cmd) ln -sf {{k8s_fusermount_shared_dir}}/fusermount-shim "$FUSERMOUNT_PATH"
-                # "|| true" because fusermount3 is not always available
-                FUSERMOUNT3_PATH=$(which fusermount3) || true
-                if [ -z "$FUSERMOUNT3_PATH" ]; then
-                    FUSERMOUNT3_PATH="${FUSERMOUNT_PATH}3"
-                fi
-                # Also mask fusermount3 for rclone and blobfuse2 (for unmount operation)
-                $(prefix_cmd) ln -sf "$FUSERMOUNT_PATH" "$FUSERMOUNT3_PATH"
-                # Add fusermount-wrapper to handle adapters that use libfuse directly, e.g. blobfuse2
-                $(prefix_cmd) ln -sf {{k8s_fusermount_shared_dir}}/fusermount-wrapper /bin/fusermount-wrapper
-                # Wait for the server to setup the fusermount shim binary in case:
-                # 1. The server daemonset was just deployed and is still starting up.
-                # 2. The node was just started and the server Pod is still starting up.
-                wait_for_fusermount() {
-                    local timeout=60
-                    local start_time=$(date +%s)
-                    while ! command -v fusermount >/dev/null 2>&1; do
-                        current_time=$(date +%s)
-                        elapsed=$((current_time - start_time))
-                        if [ $elapsed -ge $timeout ]; then
-                            echo "Error: fusermount not ready after $timeout seconds"
-                            exit 1
-                        fi
-                        sleep 1
-                    done
-                }
-                wait_for_fusermount
-                # Some distributions may mount hostPath with noexec, copy the binary in this case.
-                if ! fusermount -V; then
-                    echo "fusermount -V failed, copying fusermount-shim directly"
-                    $(prefix_cmd) rm -f "$FUSERMOUNT_PATH"
-                    $(prefix_cmd) cp -p {{k8s_fusermount_shared_dir}}/fusermount-shim "$FUSERMOUNT_PATH"
-                    $(prefix_cmd) rm -f /bin/fusermount-wrapper
-                    $(prefix_cmd) cp -p {{k8s_fusermount_shared_dir}}/fusermount-wrapper /bin/fusermount-wrapper
-                fi
+                {{ k8s_fusermount_setup_command | indent(16) }}
                 {% endif %}
 
                 $(prefix_cmd) mkdir -p /var/run/sshd;

--- a/tests/unit_tests/kubernetes/test_fuse.py
+++ b/tests/unit_tests/kubernetes/test_fuse.py
@@ -1,0 +1,23 @@
+"""Tests for Kubernetes FUSE helpers."""
+
+from sky.provision.kubernetes import fuse
+
+
+def test_fusermount_shim_setup_command_uses_supplied_sudo_and_shared_dir():
+    command = fuse.get_fusermount_shim_setup_command(
+        sudo_cmd='$(prefix_cmd)',
+        shared_dir='/var/run/fusermount')
+
+    assert '$(prefix_cmd) cp -p "$FUSERMOUNT_PATH"' in command
+    assert ('$(prefix_cmd) ln -sf "/var/run/fusermount/fusermount-shim" '
+            '"$FUSERMOUNT_PATH"') in command
+    assert ('$(prefix_cmd) cp -p "/var/run/fusermount/fusermount-wrapper" '
+            '/bin/fusermount-wrapper') in command
+    assert 'wait_for_fusermount()' in command
+
+
+def test_fusermount_shim_setup_command_allows_empty_sudo():
+    command = fuse.get_fusermount_shim_setup_command(sudo_cmd='')
+
+    assert 'sudo cp -p' not in command
+    assert 'cp -p "$FUSERMOUNT_PATH"' in command

--- a/tests/unit_tests/kubernetes/test_fuse.py
+++ b/tests/unit_tests/kubernetes/test_fuse.py
@@ -5,8 +5,7 @@ from sky.provision.kubernetes import fuse
 
 def test_fusermount_shim_setup_command_uses_supplied_sudo_and_shared_dir():
     command = fuse.get_fusermount_shim_setup_command(
-        sudo_cmd='$(prefix_cmd)',
-        shared_dir='/var/run/fusermount')
+        sudo_cmd='$(prefix_cmd)', shared_dir='/var/run/fusermount')
 
     assert '$(prefix_cmd) cp -p "$FUSERMOUNT_PATH"' in command
     assert ('$(prefix_cmd) ln -sf "/var/run/fusermount/fusermount-shim" '


### PR DESCRIPTION
## Summary
- Move Kubernetes fusermount setup script generation into a helper
- Reuse the helper when rendering the Kubernetes template
- Add a narrow unit test for the generated command

## Tests
- python -m py_compile sky/clouds/kubernetes.py sky/provision/kubernetes/fuse.py tests/unit_tests/kubernetes/test_fuse.py
- pytest tests/unit_tests/kubernetes/test_fuse.py -q