### PR TITLE
[CI] Tune nightly Buildkite wait timeouts to measured p95

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -140,7 +140,7 @@ jobs:
       message: "nightly-build-pypi --aws"
       pipeline: "smoke-tests"
       build_env_vars: '{"ARGS": "--aws"}'
-      timeout_minutes: 90  # Increased from 60 (actual: ~70min)
+      timeout_minutes: 180  # p50 69m / p95 128m over 28 nights
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
@@ -154,7 +154,7 @@ jobs:
       message: "nightly-build-pypi backward compatibility test --base-branch pypi/skypilot-nightly"
       pipeline: "quicktest-core"
       build_env_vars: '{"ARGS": "--kubernetes --base-branch pypi/skypilot-nightly"}'
-      timeout_minutes: 60
+      timeout_minutes: 240  # p50 104m / p95 ~227m; old 60m timed out 18/28 nights
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
@@ -168,7 +168,7 @@ jobs:
       message: "nightly-build-pypi backward compatibility test --base-branch pypi/skypilot"
       pipeline: "quicktest-core"
       build_env_vars: '{"ARGS": "--base-branch pypi/skypilot"}'
-      timeout_minutes: 60
+      timeout_minutes: 90  # p50 48m / p95 67m over 28 nights
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
@@ -182,7 +182,7 @@ jobs:
       message: "nightly-build-pypi --kubernetes --resource-heavy"
       pipeline: "smoke-tests"
       build_env_vars: '{"ARGS": "--kubernetes --resource-heavy"}'
-      timeout_minutes: 100
+      timeout_minutes: 150  # p50 70m / p95 115m over 28 nights
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
@@ -196,7 +196,7 @@ jobs:
       message: "nightly-build-pypi --kubernetes --no-resource-heavy"
       pipeline: "smoke-tests"
       build_env_vars: '{"ARGS": "--kubernetes --no-resource-heavy"}'
-      timeout_minutes: 180  # Increased from 80 (actual: ~163min with queue delays)
+      timeout_minutes: 270  # p50 107m / p95 222m over 28 nights
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
@@ -210,7 +210,7 @@ jobs:
       message: "nightly-build-pypi --kubernetes --no-resource-heavy --dependency"
       pipeline: "smoke-tests"
       build_env_vars: '{"ARGS": "--kubernetes --no-resource-heavy --dependency"}'
-      timeout_minutes: 120  # Increased from 80 (actual: ~99min)
+      timeout_minutes: 270  # p50 97m / p95 185m over 28 nights
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
@@ -224,8 +224,7 @@ jobs:
       message: "nightly-build-pypi --remote-server --kubernetes"
       pipeline: "smoke-tests"
       build_env_vars: '{"ARGS": "--remote-server --kubernetes"}'
-      timeout_minutes: 120  # Increased from 80 (actual: ~97min)
-      sleep_seconds: 600  # 10 minute delay to reduce buildkite resource usage
+      timeout_minutes: 300  # p50 134m / p95 264m; old 120m timed out 23/28 nights
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
@@ -239,7 +238,7 @@ jobs:
       message: "nightly-build-pypi --kubernetes --jobs-consolidation --no-resource-heavy"
       pipeline: "smoke-tests"
       build_env_vars: '{"ARGS": "--kubernetes --jobs-consolidation --no-resource-heavy"}'
-      timeout_minutes: 90  # Increased from 60 (actual: ~79min)
+      timeout_minutes: 210  # p50 94m / p95 168m; old 90m timed out 17/28 nights
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
@@ -252,7 +251,7 @@ jobs:
       branch: ${{ github.ref_name }}
       message: "nightly-build-pypi shared-gke-api-server with postgres tests"
       pipeline: "nightly-build-shared-gke-api-server"
-      timeout_minutes: 180  # Increased from 120 to account for queue delays
+      timeout_minutes: 300  # p50 144m / p95 ~250m (excludes rare multi-hour hangs)
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
@@ -266,7 +265,7 @@ jobs:
       message: "nightly-build-pypi test_minimal --slurm"
       pipeline: "smoke-tests"
       build_env_vars: '{"ARGS": "-k test_minimal --slurm", "FILE_PATTERN": "test_basic.py"}'
-      timeout_minutes: 60
+      timeout_minutes: 90  # p50 10m / p95 53m over 28 nights
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 


### PR DESCRIPTION
## Summary

- The nightly fans out ~10 Buildkite builds; the GitHub `wait-for-buildkite` jobs were timing out **below the builds' actual run time**, so the nightly went red even though Buildkite passed. The workaround was a manual *"re-run failed jobs"* once Buildkite finished. This PR raises the timeouts to measured p95 so the nightly passes one-shot.
- Removed the lone `sleep_seconds: 600` on `--remote-server` — it doesn't help a throughput-bound queue (details below).

## Data (28 scheduled nights, May–Jun 2026, Buildkite API)

On a quiet 01:00 UTC night, per-job queue wait is small (~7–18 min). The long builds are long because the **`kind` queue is a hard cap of ~50 agents**, saturated ~2h with a ~900-job backlog (throughput-bound). Several timeouts sat **below the median runtime**:

| variant | p50 | p90 | old t/o | nights over t/o |
|---|--:|--:|--:|--:|
| `--remote-server --kubernetes` | 134 | 225 | 120 | **23/28** |
| `backward-compat nightly` | 104 | 130 | 60 | **18/28** |
| `--kubernetes --jobs-consolidation` | 94 | 146 | 90 | **17/28** |

## Timeout changes (clean-p95 + margin; hang outliers >400m excluded)

| GH job | old → new |
|---|---|
| smoke-tests-aws | 90 → 180 |
| backward-compat-test-nightly | 60 → 240 |
| backward-compat-test-stable | 60 → 90 |
| resource-heavy | 100 → 150 |
| no-resource-heavy | 180 → 270 |
| no-resource-heavy-limit-deps | 120 → 270 |
| remote-server-kubernetes | 120 → 300 |
| jobs-consolidation | 90 → 210 |
| shared-gke-api-server | 180 → 300 |
| slurm-minimal | 60 → 90 |

All stay <340 min, under the GitHub 6h job cap (the `wait` job has no `timeout-minutes`).

## Why remove the stagger

`sleep_seconds: 600` on remote-server was meant to "reduce buildkite resource usage", but `kind` is a hard-capped, throughput-bound queue — the delay only pushed those jobs to the back of an already-full queue, making remote-server finish *last*. Staggering can't help a saturated fixed-size queue; capacity can (cf. #7486, which scaled `kind` and dropped the original 20–30 min staggers).

## Test plan

- YAML validated: `python -c "import yaml; yaml.safe_load(open('.github/workflows/nightly-build.yml'))"`.
- New timeout ≥ clean p95 for every variant, derived from `finished_at - created_at` across 28 scheduled nightly builds.
- Expected: next scheduled nightly completes one-shot without a manual re-run. The rare multi-hour **starvation** incidents (8/28 nights, builds held 6–23h with no agents) are an autoscaler/capacity issue, tracked separately — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)