### PR TITLE
[Test] Fix flaky test_backoff_progression from cross-thread sleep mock

### DIFF
--- a/tests/unit_tests/test_sky/server/test_rest.py
+++ b/tests/unit_tests/test_sky/server/test_rest.py
@@ -447,14 +447,18 @@ class TestRetryOnServerUnavailableDecorator:
                     "Server error")
             return "success"
 
-        # Only record sleeps from this thread: mock.patch('time.sleep') is
-        # process-wide, so a background thread's sleep loop would otherwise
-        # flood sleep_times and make the count assertion flaky.
+        # mock.patch('time.sleep') is process-wide. Only record (and fake)
+        # sleeps from this thread, otherwise a background thread's sleep loop
+        # would flood sleep_times and make the count assertion flaky. Other
+        # threads keep the real sleep so they don't busy-loop during the patch.
+        original_sleep = time.sleep
         test_thread_id = threading.get_ident()
 
         def mock_sleep(seconds):
             if threading.get_ident() == test_thread_id:
                 sleep_times.append(seconds)
+            else:
+                original_sleep(seconds)
 
         with mock.patch('time.sleep', side_effect=mock_sleep):
             result = failing_function()

--- a/tests/unit_tests/test_sky/server/test_rest.py
+++ b/tests/unit_tests/test_sky/server/test_rest.py
@@ -1,4 +1,5 @@
 """Unit tests for the SkyPilot REST API client module."""
+import threading
 import time
 from unittest import mock
 
@@ -446,8 +447,14 @@ class TestRetryOnServerUnavailableDecorator:
                     "Server error")
             return "success"
 
+        # Only record sleeps from this thread: mock.patch('time.sleep') is
+        # process-wide, so a background thread's sleep loop would otherwise
+        # flood sleep_times and make the count assertion flaky.
+        test_thread_id = threading.get_ident()
+
         def mock_sleep(seconds):
-            sleep_times.append(seconds)
+            if threading.get_ident() == test_thread_id:
+                sleep_times.append(seconds)
 
         with mock.patch('time.sleep', side_effect=mock_sleep):
             result = failing_function()


### PR DESCRIPTION
## Summary

- `TestRetryOnServerUnavailableDecorator::test_backoff_progression` is flaky on CI (seen on `master` and on unrelated PRs, e.g. #9821). It patches `time.sleep` process-wide and asserts `len(sleep_times) == 3`.
- `mock.patch('time.sleep')` replaces `sleep` for **every thread**, so any background daemon thread that calls `time.sleep` during the patched window turns into a busy loop and floods the shared `sleep_times` list.
- Tell-tale sign: the decorator sleeps a *jittered float* (e.g. `4.7`), but failing runs recorded thousands of identical integer `5`s — clearly from another thread, not the decorator:
  - `assert 6061 == 3` (PR #9821 unit-test run)
  - `assert 19999 == 3` (master run `27135679564`)

## Fix

Record only sleeps issued from the test's own thread. The decorator runs synchronously on the calling thread, so filtering by `threading.get_ident()` keeps the intended 3 backoff sleeps and ignores unrelated concurrent threads.

## Test plan

- Reproduced the mechanism in isolation: a background thread looping `time.sleep(5)` under a process-wide mock floods the list (10141 entries); the thread-id filter records exactly the 3 main-thread sleeps.
- `pytest tests/unit_tests/test_sky/server/test_rest.py::TestRetryOnServerUnavailableDecorator::test_backoff_progression` passes.
- Other tests in the class assert on the function's own `call_count` (main-thread only), so they were never affected and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)