### PR TITLE
[Kubernetes] Honor in-cluster exclusion env var on all context-derivation paths

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -338,6 +338,14 @@ class Kubernetes(clouds.Cloud):
                 keys=('allowed_contexts',),
                 default_value=None)
 
+        # Whether the user explicitly pinned the contexts to a list, as
+        # opposed to leaving them to be derived (`'all'`, the allow-all env
+        # var, or the in-cluster fallback below). The in-cluster exclusion at
+        # the end of this method only applies to the derived case; an explicit
+        # list is a deliberate choice and is honored as-is.
+        contexts_explicitly_set = (allowed_contexts is not None and
+                                   allowed_contexts != 'all')
+
         # Exclude contexts starting with `ssh-`
         # TODO(romilb): Remove when SSH Node Pools use a separate kubeconfig.
         all_contexts = [
@@ -348,19 +356,7 @@ class Kubernetes(clouds.Cloud):
             allowed_contexts is None and
             env_options.Options.ALLOW_ALL_KUBERNETES_CONTEXTS.get())
         if allow_all_contexts:
-            # `SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER=false`
-            # excludes the API server's own in-cluster context from the
-            # `'all'` expansion, so the cluster running the API server is
-            # not surfaced as a user-facing compute target. Default is to
-            # include in-cluster (backward compatible).
-            if (env_options.Options.ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER.
-                    get()):
-                allowed_contexts = all_contexts
-            else:
-                in_cluster_name = kubernetes.in_cluster_context_name()
-                allowed_contexts = [
-                    c for c in all_contexts if c != in_cluster_name
-                ]
+            allowed_contexts = all_contexts
 
         if allowed_contexts is None:
             # Try kubeconfig if present
@@ -384,6 +380,21 @@ class Kubernetes(clouds.Cloud):
                 if context.startswith('ssh-'):
                     continue
                 skipped_contexts.append(context)
+
+        # `SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER=false` keeps the
+        # API server's own in-cluster context from being surfaced as a
+        # user-facing compute target. Applied to the final result so it holds
+        # regardless of how the contexts were derived -- the `allowed_contexts:
+        # all` expansion, the allow-all env var, or the in-cluster fallback
+        # above. An explicitly configured list is honored as-is. Default is to
+        # include in-cluster (backward compatible).
+        if (not contexts_explicitly_set and not env_options.Options.
+                ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER.get()):
+            in_cluster_name = kubernetes.in_cluster_context_name()
+            existing_contexts = [
+                c for c in existing_contexts if c != in_cluster_name
+            ]
+
         if not silent:
             cls._log_skipped_contexts_once(tuple(skipped_contexts))
         return existing_contexts

--- a/tests/unit_tests/test_sky/clouds/test_kubernetes.py
+++ b/tests/unit_tests/test_sky/clouds/test_kubernetes.py
@@ -488,11 +488,16 @@ class TestKubernetesAllIncludesInCluster(unittest.TestCase):
            'get_current_kube_config_context_name')
     @patch('sky.provision.kubernetes.utils.is_incluster_config_available')
     @patch('sky.adaptors.kubernetes.in_cluster_context_name')
-    def test_no_kubeconfig_fallback_unaffected_by_env(
-            self, mock_in_cluster_name, mock_is_incluster, mock_current,
-            mock_get_nested, mock_get_workspace, mock_get_all_contexts):
-        """The "no kubeconfig -> in-cluster" fallback is independent of
-        the filter env var: the filter only applies to the `'all'` path.
+    def test_no_kubeconfig_fallback_respects_env(self, mock_in_cluster_name,
+                                                 mock_is_incluster,
+                                                 mock_current, mock_get_nested,
+                                                 mock_get_workspace,
+                                                 mock_get_all_contexts):
+        """The "no kubeconfig -> in-cluster" fallback also honors the filter
+        env var: with it false the in-cluster context is not surfaced, even
+        when it is the only derived context. Without an explicit
+        `allowed_contexts` list the contexts are derived, so the same
+        exclusion that applies to the `'all'` path applies here.
         """
         mock_get_all_contexts.return_value = ['in-cluster']
         mock_get_workspace.return_value.get.return_value = None
@@ -503,6 +508,29 @@ class TestKubernetesAllIncludesInCluster(unittest.TestCase):
 
         with patch.dict(os.environ, {self.ENV_VAR: 'false'}, clear=False):
             result = kubernetes.Kubernetes.existing_allowed_contexts()
+
+        self.assertEqual(result, [])
+
+    @patch('sky.provision.kubernetes.utils.get_all_kube_context_names')
+    @patch('sky.skypilot_config.get_workspace_cloud')
+    @patch('sky.skypilot_config.get_nested')
+    @patch('sky.provision.kubernetes.utils.'
+           'get_current_kube_config_context_name')
+    @patch('sky.provision.kubernetes.utils.is_incluster_config_available')
+    @patch('sky.adaptors.kubernetes.in_cluster_context_name')
+    def test_no_kubeconfig_fallback_default_keeps_in_cluster(
+            self, mock_in_cluster_name, mock_is_incluster, mock_current,
+            mock_get_nested, mock_get_workspace, mock_get_all_contexts):
+        """The fallback keeps in-cluster by default (env unset) so existing
+        single-cluster deployments are unaffected."""
+        mock_get_all_contexts.return_value = ['in-cluster']
+        mock_get_workspace.return_value.get.return_value = None
+        mock_get_nested.return_value = None
+        mock_current.return_value = None
+        mock_is_incluster.return_value = True
+        mock_in_cluster_name.return_value = 'in-cluster'
+
+        result = kubernetes.Kubernetes.existing_allowed_contexts()
 
         self.assertEqual(result, ['in-cluster'])
 


### PR DESCRIPTION
## Summary

`SKYPILOT_ALL_KUBERNETES_CONTEXTS_INCLUDES_IN_CLUSTER=false` is meant to keep the API server's own in-cluster context from being surfaced as a user-facing compute target. However, `Kubernetes.existing_allowed_contexts()` only applied the exclusion inside the `allowed_contexts: all` expansion.

When `allowed_contexts` is **unset**, context selection falls through to the "no kubeconfig → in-cluster" fallback, which appended the in-cluster context **unconditionally** — the env var was never consulted there. As a result, `sky.all_contexts` (e.g. the dashboard's context picker) still listed the in-cluster context even with the env var set to `false`.

## Changes

- Record up front whether the user **explicitly pinned** an `allowed_contexts` list, versus leaving it to be derived (`all`, the legacy allow-all env var, or the in-cluster fallback).
- Apply the in-cluster exclusion **once on the final result**, so it covers every derived path uniformly.
- An explicitly configured `allowed_contexts` list is still honored as-is; the default (env unset) still includes in-cluster, so existing single-cluster deployments are unaffected.

## Test plan

- `pytest tests/unit_tests/test_sky/clouds/test_kubernetes.py` — 134 passed.
- Updated `test_no_kubeconfig_fallback_unaffected_by_env` → `test_no_kubeconfig_fallback_respects_env` (the old test encoded the pre-fix behavior).
- Added `test_no_kubeconfig_fallback_default_keeps_in_cluster` to lock in the backward-compatible default.