### PR TITLE
[Kubernetes] Add TerminationCleanup extension point for cluster termination

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1858,6 +1858,14 @@ def terminate_instances(
         # terminating workers only (head services should remain).
         _delete_cluster_services(cluster_name_on_cloud, namespace, context)
 
+    # Let plugins clean up external resources they associate with the
+    # cluster (e.g. objects created by an external scheduler or admission
+    # system for the cluster's pod group). Runs after the pods are deleted
+    # so cleanup cannot race controllers that derive state from live pods.
+    plugin_extensions.TerminationCleanup.run(cluster_name_on_cloud,
+                                             provider_config,
+                                             worker_only=worker_only)
+
 
 def cleanup_cluster_resources(
     cluster_name_on_cloud: str,

--- a/sky/utils/plugin_extensions/__init__.py
+++ b/sky/utils/plugin_extensions/__init__.py
@@ -10,6 +10,7 @@ from sky.utils.plugin_extensions.external_failure_source import (
 from sky.utils.plugin_extensions.node_info_source import NodeInfoSource
 from sky.utils.plugin_extensions.pod_info_source import PodInfoSource
 from sky.utils.plugin_extensions.recipe_validator import RecipeValidator
+from sky.utils.plugin_extensions.termination_cleanup import TerminationCleanup
 
 __all__ = [
     'ExternalClusterFailure',
@@ -17,4 +18,5 @@ __all__ = [
     'NodeInfoSource',
     'PodInfoSource',
     'RecipeValidator',
+    'TerminationCleanup',
 ]

--- a/sky/utils/plugin_extensions/termination_cleanup.py
+++ b/sky/utils/plugin_extensions/termination_cleanup.py
@@ -1,0 +1,76 @@
+"""Extension point for cleanup callbacks on cluster termination.
+
+This module provides an extension point that allows plugins to clean up
+external resources they associate with a cluster (e.g. objects created
+by an external scheduler or admission system for the cluster's pod
+group) when the cluster is terminated. By default, no callbacks are
+registered and termination behaves as before.
+
+Example usage in a plugin:
+    from sky.utils.plugin_extensions import TerminationCleanup
+
+    def my_cleanup(cluster_name_on_cloud: str,
+                   provider_config: Dict[str, Any],
+                   worker_only: bool) -> None:
+        ...
+
+    TerminationCleanup.register(my_cleanup)
+
+Example usage in core SkyPilot:
+    from sky.utils import plugin_extensions
+
+    # After the cluster's instances have been terminated:
+    plugin_extensions.TerminationCleanup.run(cluster_name_on_cloud,
+                                             provider_config,
+                                             worker_only=worker_only)
+"""
+from typing import Any, Callable, Dict, List
+
+from sky import sky_logging
+
+logger = sky_logging.init_logger(__name__)
+
+# Type alias for termination cleanup callbacks.
+# Signature: (cluster_name_on_cloud, provider_config, worker_only) -> None
+# worker_only is True when only the worker nodes were terminated (the
+# head node stays up); callbacks decide for themselves whether a partial
+# termination warrants any cleanup.
+TerminationCleanupFunc = Callable[[str, Dict[str, Any], bool], None]
+
+
+class TerminationCleanup:
+    """Singleton registry of post-termination cleanup callbacks.
+
+    Plugins can register callbacks during their install() phase. Core
+    SkyPilot invokes run() after a cluster's instances have been
+    terminated. Callbacks are best-effort: an exception from a callback
+    is logged and never fails the termination, and remaining callbacks
+    still run.
+    """
+
+    _callbacks: List[TerminationCleanupFunc] = []
+
+    @classmethod
+    def register(cls, callback: TerminationCleanupFunc) -> None:
+        """Register a cleanup callback to run on cluster termination."""
+        cls._callbacks.append(callback)
+        logger.debug('Registered termination cleanup callback '
+                     f'{getattr(callback, "__name__", callback)!r}')
+
+    @classmethod
+    def is_registered(cls) -> bool:
+        """Check if any cleanup callback is registered."""
+        return bool(cls._callbacks)
+
+    @classmethod
+    def run(cls, cluster_name_on_cloud: str, provider_config: Dict[str, Any],
+            worker_only: bool) -> None:
+        """Run all registered cleanup callbacks, best-effort."""
+        for callback in cls._callbacks:
+            try:
+                callback(cluster_name_on_cloud, provider_config, worker_only)
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning(
+                    'Termination cleanup callback '
+                    f'{getattr(callback, "__name__", callback)!r} failed for '
+                    f'cluster {cluster_name_on_cloud!r}: {e}')

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -12,6 +12,7 @@ from sky.backends import cloud_vm_ray_backend
 from sky.provision.kubernetes import config as config_lib
 from sky.provision.kubernetes import instance
 from sky.provision.kubernetes.instance import logger
+from sky.utils import plugin_extensions
 
 
 def _remove_colorama_escape_codes(error_output):
@@ -3196,3 +3197,78 @@ class TestInspectPodStatusInitContainerReason:
         assert len(pending_logs) == 1
         assert 'init container' in pending_logs[0]
         assert 'Pulling image' not in pending_logs[0]
+
+
+class TestTerminationCleanup:
+    """Tests for the TerminationCleanup extension point on termination.
+
+    Plugins can register cleanup callbacks for external per-cluster
+    resources; terminate_instances must invoke them after the pods are
+    deleted, pass through worker_only, and never let a callback failure
+    fail the termination.
+    """
+
+    _PROVIDER_CONFIG = {'namespace': 'default', 'context': 'test-context'}
+
+    @pytest.fixture(autouse=True)
+    def _isolate_callbacks(self):
+        saved = plugin_extensions.TerminationCleanup._callbacks
+        plugin_extensions.TerminationCleanup._callbacks = []
+        yield
+        plugin_extensions.TerminationCleanup._callbacks = saved
+
+    def _make_pod(self, name: str):
+        pod = mock.MagicMock()
+        pod.metadata.name = name
+        pod.metadata.labels = {}
+        return pod
+
+    def _run_terminate(self, monkeypatch, worker_only=False):
+        pods = {'head': self._make_pod('test-cluster-abcd1234-head')}
+        monkeypatch.setattr(
+            'sky.provision.kubernetes.utils.get_namespace_from_config',
+            lambda _: 'default')
+        monkeypatch.setattr(
+            'sky.provision.kubernetes.utils.get_context_from_config',
+            lambda _: 'test-context')
+        monkeypatch.setattr('sky.provision.kubernetes.utils.filter_pods',
+                            lambda *args, **kwargs: pods)
+        monkeypatch.setattr(instance, 'is_high_availability_cluster_by_kubectl',
+                            lambda *args, **kwargs: False)
+        monkeypatch.setattr(instance, '_terminate_node', mock.MagicMock())
+        monkeypatch.setattr(instance, '_is_head', lambda pod: False)
+        monkeypatch.setattr(instance, '_delete_cluster_services',
+                            mock.MagicMock())
+        instance.terminate_instances('test-cluster-abcd1234',
+                                     self._PROVIDER_CONFIG,
+                                     worker_only=worker_only)
+
+    def test_callback_invoked_on_full_termination(self, monkeypatch):
+        callback = mock.MagicMock(__name__='callback')
+        plugin_extensions.TerminationCleanup.register(callback)
+        self._run_terminate(monkeypatch)
+        callback.assert_called_once_with('test-cluster-abcd1234',
+                                         self._PROVIDER_CONFIG, False)
+
+    def test_callback_invoked_with_worker_only(self, monkeypatch):
+        """worker_only is passed through; the callback decides what to do."""
+        callback = mock.MagicMock(__name__='callback')
+        plugin_extensions.TerminationCleanup.register(callback)
+        self._run_terminate(monkeypatch, worker_only=True)
+        callback.assert_called_once_with('test-cluster-abcd1234',
+                                         self._PROVIDER_CONFIG, True)
+
+    def test_no_callbacks_registered(self, monkeypatch):
+        assert not plugin_extensions.TerminationCleanup.is_registered()
+        self._run_terminate(monkeypatch)
+
+    def test_callback_failure_does_not_fail_termination(self, monkeypatch):
+        failing = mock.MagicMock(__name__='failing',
+                                 side_effect=RuntimeError('boom'))
+        succeeding = mock.MagicMock(__name__='succeeding')
+        plugin_extensions.TerminationCleanup.register(failing)
+        plugin_extensions.TerminationCleanup.register(succeeding)
+        self._run_terminate(monkeypatch)
+        failing.assert_called_once()
+        # A failing callback must not prevent later callbacks from running.
+        succeeding.assert_called_once()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

**Problem:**

Plugins may create external per-cluster resources alongside a SkyPilot cluster's pods — e.g. objects that an external scheduler or admission system keeps for the cluster's pod group. There is currently no supported way for a plugin to clean those up when the cluster is terminated, short of monkey-patching `terminate_instances`.

**Change:**

Add a `TerminationCleanup` extension point, following the existing `sky/utils/plugin_extensions` pattern (e.g. `PodInfoSource` from #9082):

- Plugins register cleanup callbacks at install time via `TerminationCleanup.register(...)`.
- The Kubernetes provisioner's `terminate_instances` invokes the callbacks after the pods and services have been deleted, passing through `worker_only` so callbacks can decide how to treat partial termination.
- Callbacks are best-effort: a failure is logged and never fails the termination, and remaining callbacks still run.

Tested (run the relevant ones):

- [x] Unit tests: `pytest tests/unit_tests/kubernetes/test_provision.py` (113 passed, incl. 4 new in `TestTerminationCleanup`)
- [ ] Any manual tests for this PR (please specify below)
- [ ] Relevant individual tests
- [ ] Backward compatibility tests
