### PR TITLE
[Jobs][Dashboard] Fix managed-job log download and refresh on the detail page

### DIFF
--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -1246,6 +1246,11 @@ function JobDetailsContent({
           selectedNode,
           isController: false,
           onNodesExtracted,
+          // Forward the refresh-button signal so a plugin owning this slot
+          // can re-fetch on refresh (the OSS streamer it replaces consumes
+          // the same flag). Without this the refresh button is a no-op for
+          // plugin-owned log panels.
+          refreshTrigger: refreshFlag,
         }}
         fallback={defaultLogsContent}
       />
@@ -1285,6 +1290,8 @@ function JobDetailsContent({
           status: jobData.status,
           isPreStart,
           isController: true,
+          // Forward the refresh-button signal (see jobs.detail.logs slot).
+          refreshTrigger: refreshFlag,
         }}
         fallback={defaultControllerLogsContent}
       />

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -1575,6 +1575,15 @@ def tail_logs(name: Optional[str],
         ValueError: invalid arguments.
         sky.exceptions.ClusterNotUpError: the jobs controller is not up.
     """
+    # A non-positive tail (0 or -1) is the established "all lines" sentinel
+    # (e.g. `sky jobs logs --tail 0`, and the dashboard log-download button
+    # which posts tail=0). Normalize it to None at this single server-side
+    # entry point so downstream tailing -- the OSS backward-seek reader, which
+    # asserts tail > 0, and any log-runtime plugin -- does not have to
+    # special-case it. Without this, tail=0 reaches the backward-seek read and
+    # raises AssertionError, producing an empty log download.
+    if tail is not None and tail <= 0:
+        tail = None
     # TODO(zhwu): Automatically restart the jobs controller
     if name is not None and job_id is not None:
         with ux_utils.print_exception_no_traceback():

--- a/tests/unit_tests/test_sky/jobs/test_server_core.py
+++ b/tests/unit_tests/test_sky/jobs/test_server_core.py
@@ -1,0 +1,49 @@
+"""Tests for sky.jobs.server.core."""
+from unittest import mock
+
+import pytest
+
+from sky import backends
+from sky.jobs.server import core as jobs_core
+
+
+def _forwarded_tail(tail):
+    """Call ``jobs_core.tail_logs`` with ``tail`` (mocking out the controller
+    restart / backend / runner) and return the ``tail`` value forwarded to
+    ``tail_managed_job_logs``."""
+    fake_backend = mock.MagicMock(spec=backends.CloudVmRayBackend)
+    fake_runner = mock.MagicMock()
+    fake_runner.tail_managed_job_logs.return_value = 0
+    with mock.patch.object(jobs_core, '_maybe_restart_controller',
+                           return_value=mock.MagicMock()), \
+         mock.patch.object(jobs_core.backend_utils,
+                           'get_backend_from_handle',
+                           return_value=fake_backend), \
+         mock.patch.object(jobs_core.managed_job_runner,
+                           'current',
+                           return_value=fake_runner):
+        jobs_core.tail_logs(name=None,
+                            job_id=1,
+                            follow=False,
+                            controller=False,
+                            refresh=False,
+                            tail=tail)
+    fake_runner.tail_managed_job_logs.assert_called_once()
+    return fake_runner.tail_managed_job_logs.call_args.kwargs['tail']
+
+
+@pytest.mark.parametrize(
+    ('given', 'expected'),
+    [
+        (0, None),  # dashboard download button's "all lines" sentinel
+        (-1, None),  # `sky jobs logs --tail -1`
+        (None, None),  # no tail -> all
+        (200, 200),  # positive tail forwarded unchanged
+        (5000, 5000),
+    ])
+def test_tail_logs_normalizes_non_positive_tail(given, expected):
+    """A non-positive tail (0 / -1) means "all lines" and must be normalized
+    to None before reaching the backward-seek tail reader (which asserts
+    tail > 0). Otherwise the dashboard download (tail=0) raises
+    AssertionError and produces an empty log."""
+    assert _forwarded_tail(given) == expected


### PR DESCRIPTION
## Summary

Two managed-job log bugs on the dashboard job detail page:

1. **Log download produces an empty (0-byte) file.** The download button dispatches `POST /jobs/logs` with `tail=0` ("all lines"). For a terminal job this reaches the backward-seek tail reader, which `assert tail > 0` — raising `AssertionError`, so the dispatched request produces no log and the streamed `.log.gz` is empty. The CLI avoids this only because its SDK sends `None`. Fix: normalize `tail <= 0` to `None` at the single server-side entry (`core.tail_logs`), so every downstream path — the OSS reader and any log-runtime plugin — treats it as "all", matching the documented `--tail 0/-1` semantics.

2. **The Logs-section refresh button is a no-op when a plugin owns the log panel.** The refresh flag was only wired to the OSS `useLogStreamer` (which is disabled when a plugin overrides the `jobs.detail.logs` / `jobs.detail.controllerlogs` slot) and was never included in the slot context. Fix: forward it as `refreshTrigger` so a plugin-owned panel can re-fetch on refresh.

## Test plan

- `pytest tests/unit_tests/test_sky/jobs/test_server_core.py` — new test asserts `tail_logs` forwards `None` for `tail` of `0` / `-1` / `None` and forwards positive values unchanged. Revert-checked: the `0` / `-1` cases fail without the normalization.
- Manual: on a SUCCEEDED managed job with a large log, the download button now yields the full `.log.gz` (was 0 bytes); with a plugin owning the log slot, the refresh button now re-fetches.

Dashboard change is a plain prop addition to the existing plugin-slot context; no behavior change for the OSS fallback rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
