### PR TITLE
[Kubernetes] Strip falsy runtimeClassName override from all pods

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -1255,6 +1255,27 @@ def _wait_for_deployment_pod(context,
         'ready.')
 
 
+def _configure_runtime_class(pod_spec: Dict[str,
+                                            Any], nvidia_runtime_exists: bool,
+                             needs_gpus_nvidia: bool) -> None:
+    """Sets or strips runtimeClassName on the pod spec in-place.
+
+    A falsy runtimeClassName (e.g. '' or None from a
+    kubernetes.pod_config override) means the user explicitly disabled
+    the runtime class. It is stripped from all pods regardless of GPU
+    requests: the Kubernetes API rejects pods with an empty-string
+    runtimeClassName ('resource name may not be empty'), and it must
+    also suppress the automatic 'nvidia' assignment below.
+    """
+    spec = pod_spec['spec']
+    if 'runtimeClassName' in spec and not spec['runtimeClassName']:
+        del spec['runtimeClassName']
+        return
+    if (nvidia_runtime_exists and needs_gpus_nvidia and
+            'runtimeClassName' not in spec):
+        spec['runtimeClassName'] = 'nvidia'
+
+
 @timeline.event
 def _create_pods(region: str, cluster_name: str, cluster_name_on_cloud: str,
                  config: common.ProvisionConfig) -> common.ProvisionRecord:
@@ -1417,12 +1438,7 @@ def _create_pods(region: str, cluster_name: str, cluster_name_on_cloud: str,
 
     # TPU pods provisioned on GKE use the default containerd runtime.
     # Reference: https://cloud.google.com/kubernetes-engine/docs/how-to/migrate-containerd#overview  # pylint: disable=line-too-long
-    if nvidia_runtime_exists and needs_gpus_nvidia:
-        spec = pod_spec['spec']
-        if 'runtimeClassName' not in spec:
-            spec['runtimeClassName'] = 'nvidia'
-        elif not spec['runtimeClassName']:
-            del spec['runtimeClassName']
+    _configure_runtime_class(pod_spec, nvidia_runtime_exists, needs_gpus_nvidia)
 
     logger.debug(f'run_instances: calling create_namespaced_pod '
                  f'(count={to_start_count}).')

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -3196,3 +3196,69 @@ class TestInspectPodStatusInitContainerReason:
         assert len(pending_logs) == 1
         assert 'init container' in pending_logs[0]
         assert 'Pulling image' not in pending_logs[0]
+
+
+class TestConfigureRuntimeClass:
+    """Tests for _configure_runtime_class.
+
+    A falsy runtimeClassName (e.g. '' or None from a
+    kubernetes.pod_config override) means the user explicitly disabled
+    the runtime class. It must be stripped from ALL pods: the
+    Kubernetes API rejects an empty string with 'resource name may not
+    be empty', so leaving it on CPU-only pods breaks their creation.
+    """
+
+    def _pod_spec(self, runtime_class_name=...):
+        spec = {'containers': [{'name': 'c'}]}
+        if runtime_class_name is not ...:
+            spec['runtimeClassName'] = runtime_class_name
+        return {'spec': spec}
+
+    def test_cpu_pod_empty_string_override_is_stripped(self):
+        pod_spec = self._pod_spec(runtime_class_name='')
+        instance._configure_runtime_class(pod_spec,
+                                          nvidia_runtime_exists=True,
+                                          needs_gpus_nvidia=False)
+        assert 'runtimeClassName' not in pod_spec['spec']
+
+    def test_cpu_pod_none_override_is_stripped(self):
+        pod_spec = self._pod_spec(runtime_class_name=None)
+        instance._configure_runtime_class(pod_spec,
+                                          nvidia_runtime_exists=False,
+                                          needs_gpus_nvidia=False)
+        assert 'runtimeClassName' not in pod_spec['spec']
+
+    def test_gpu_pod_falsy_override_not_replaced_with_nvidia(self):
+        pod_spec = self._pod_spec(runtime_class_name='')
+        instance._configure_runtime_class(pod_spec,
+                                          nvidia_runtime_exists=True,
+                                          needs_gpus_nvidia=True)
+        assert 'runtimeClassName' not in pod_spec['spec']
+
+    def test_gpu_pod_gets_nvidia_when_runtime_exists(self):
+        pod_spec = self._pod_spec()
+        instance._configure_runtime_class(pod_spec,
+                                          nvidia_runtime_exists=True,
+                                          needs_gpus_nvidia=True)
+        assert pod_spec['spec']['runtimeClassName'] == 'nvidia'
+
+    def test_gpu_pod_unchanged_when_runtime_missing(self):
+        pod_spec = self._pod_spec()
+        instance._configure_runtime_class(pod_spec,
+                                          nvidia_runtime_exists=False,
+                                          needs_gpus_nvidia=True)
+        assert 'runtimeClassName' not in pod_spec['spec']
+
+    def test_user_custom_runtime_class_is_preserved(self):
+        pod_spec = self._pod_spec(runtime_class_name='sysbox-runc')
+        instance._configure_runtime_class(pod_spec,
+                                          nvidia_runtime_exists=True,
+                                          needs_gpus_nvidia=True)
+        assert pod_spec['spec']['runtimeClassName'] == 'sysbox-runc'
+
+    def test_cpu_pod_custom_runtime_class_is_preserved(self):
+        pod_spec = self._pod_spec(runtime_class_name='sysbox-runc')
+        instance._configure_runtime_class(pod_spec,
+                                          nvidia_runtime_exists=True,
+                                          needs_gpus_nvidia=False)
+        assert pod_spec['spec']['runtimeClassName'] == 'sysbox-runc'


### PR DESCRIPTION
## Summary

- A `kubernetes.pod_config` override of `runtimeClassName: ''` (or `null`) is the escape hatch for clusters where the `nvidia` RuntimeClass exists in the API but the runtime handler is not actually configured on nodes (e.g. CRI-O clusters where the GPU operator installs the container toolkit in hook mode, such as Oracle OKE — GPU injection works via the OCI prestart hook, and pods requesting the `nvidia` handler fail sandbox creation with `failed to find runtime handler nvidia from runtime list map[runc:...]`).
- The strip logic for falsy `runtimeClassName` previously ran only for pods requesting `nvidia.com/gpu`, so CPU-only pods were submitted with `runtimeClassName: ""` and rejected by the API server: `spec.runtimeClassName: Invalid value: "": resource name may not be empty`.
- This PR extracts the logic into `_configure_runtime_class()` and strips a falsy `runtimeClassName` from **all** pods, treating an explicit falsy override as user intent to disable the runtime class (also suppressing the automatic `nvidia` assignment). Non-empty values and default behavior are unchanged.

## Tested

- New unit tests covering the full behavior matrix: `pytest tests/unit_tests/kubernetes/test_provision.py -k TestConfigureRuntimeClass` (the two CPU-pod strip cases verified to fail before the fix).
- Full `tests/unit_tests/kubernetes/` suite: 354 passed.
- Exhaustive old-vs-new comparison across override value × RuntimeClass-exists × GPU-request: only falsy-override cases change, and those previously produced pods the API rejects (`""`) or treats as unset anyway (`null`).
- Verified on a live CRI-O 1.35 cluster: pod creation with the field absent or JSON `null` is accepted; `""` is rejected.
- `bash format.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)