### PR TITLE
[Storage] Support OCI Object Storage via the S3-compatible API

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -973,6 +973,37 @@ By default, the provisioned nodes will be in the root `compartment <https://docs
       default:
         compartment_ocid: ocid1.compartment.oc1..aaaaaaaa......
 
+OCI also offers `Object Storage <https://www.oracle.com/cloud/storage/object-storage/>`_, which supports both a native API and an `S3-compatible API <https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi.htm>`_.
+SkyPilot can download/upload data to OCI buckets and mount them as local filesystem on clusters launched by SkyPilot. To set up OCI Object Storage, first create a `Customer Secret Key <https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingcredentials.htm#create-secret-key>`_ from the OCI console.
+
+SkyPilot uses separate configuration files for OCI Object Storage to avoid conflicts with your AWS credentials. Run the following command to configure your OCI Object Storage credentials:
+
+.. code-block:: shell
+
+  AWS_SHARED_CREDENTIALS_FILE=~/.oci/s3.credentials aws configure --profile oci
+
+When prompted, enter your OCI Object Storage credentials:
+
+.. code-block:: text
+
+  AWS Access Key ID [None]: <your_access_key_id>
+  AWS Secret Access Key [None]: <your_secret_access_key>
+  Default region name [None]:
+  Default output format [None]: json
+
+Next, configure the endpoint URL for OCI Object Storage. Replace ``<namespace>`` and ``<region>`` with your tenancy's object storage namespace and region:
+
+.. code-block:: shell
+
+  AWS_CONFIG_FILE=~/.oci/s3.config aws configure set endpoint_url \
+    https://<namespace>.compat.objectstorage.<region>.oci.customer-oci.com --profile oci
+  AWS_CONFIG_FILE=~/.oci/s3.config aws configure set region <region> --profile oci
+  AWS_CONFIG_FILE=~/.oci/s3.config aws configure set s3.addressing_style path --profile oci
+
+.. note::
+
+  When the S3-compatible credential files (``~/.oci/s3.credentials`` and ``~/.oci/s3.config``) are present, SkyPilot will use the S3-compatible API for ``oci://`` storage, and the native OCI API key (``~/.oci/config``) is **not** required for storage operations. Without the S3-compatible credential files, SkyPilot falls back to the native OCI SDK path.
+
 Lambda Cloud |community-badge|
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -973,7 +973,7 @@ By default, the provisioned nodes will be in the root `compartment <https://docs
       default:
         compartment_ocid: ocid1.compartment.oc1..aaaaaaaa......
 
-OCI also offers `Object Storage <https://www.oracle.com/cloud/storage/object-storage/>`_, which supports both a native API and an `S3-compatible API <https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi.htm>`_.
+OCI also offers `Object Storage <https://www.oracle.com/cloud/storage/object-storage/>`__, which supports both a native API and an `S3-compatible API <https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi.htm>`__.
 SkyPilot can download/upload data to OCI buckets and mount them as local filesystem on clusters launched by SkyPilot. To set up OCI Object Storage, first create a `Customer Secret Key <https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingcredentials.htm#create-secret-key>`_ from the OCI console.
 
 SkyPilot uses separate configuration files for OCI Object Storage to avoid conflicts with your AWS credentials. Run the following command to configure your OCI Object Storage credentials:

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -998,7 +998,6 @@ Next, configure the endpoint URL for OCI Object Storage. Replace ``<namespace>``
   AWS_CONFIG_FILE=~/.oci/s3.config aws configure set endpoint_url \
     https://<namespace>.compat.objectstorage.<region>.oci.customer-oci.com --profile oci
   AWS_CONFIG_FILE=~/.oci/s3.config aws configure set region <region> --profile oci
-  AWS_CONFIG_FILE=~/.oci/s3.config aws configure set s3.addressing_style path --profile oci
 
 .. note::
 

--- a/sky/adaptors/oci_s3.py
+++ b/sky/adaptors/oci_s3.py
@@ -123,6 +123,22 @@ def session():
         return session_
 
 
+def _botocore_config():
+    """Return a botocore Config suitable for OCI's S3-compatible API.
+
+    OCI's S3-compatible API returns 501 for uploads that use aws-chunked
+    content encoding, which newer AWS SDKs enable by default to carry a
+    trailing integrity checksum. Restrict checksum calculation to
+    when_required so PutObject is sent as a plain (non-chunked) request.
+    Response validation is relaxed to match, so downloads of checksummed
+    objects aren't rejected.
+    https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi_topic-Amazon_S3_Compatibility_API_Support.htm
+    """
+    return botocore.config.Config(s3={'addressing_style': 'path'},
+                                  request_checksum_calculation='when_required',
+                                  response_checksum_validation='when_required')
+
+
 @annotations.lru_cache(scope='global')
 def resource(resource_name: str, **kwargs):
     """Create an OCI S3-compatible resource.
@@ -146,17 +162,7 @@ def resource(resource_name: str, **kwargs):
         aws_access_key_id=oci_s3_credentials.access_key,
         aws_secret_access_key=oci_s3_credentials.secret_key,
         region_name=get_region(),
-        config=botocore.config.Config(
-            s3={'addressing_style': 'path'},
-            # OCI's S3-compatible API returns 501 for uploads that use
-            # aws-chunked content encoding, which newer AWS SDKs enable by
-            # default to carry a trailing integrity checksum. Restrict
-            # checksum calculation to when_required so PutObject is sent as
-            # a plain (non-chunked) request. Response validation is relaxed
-            # to match, so downloads of checksummed objects aren't rejected.
-            # https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi_topic-Amazon_S3_Compatibility_API_Support.htm
-            request_checksum_calculation='when_required',
-            response_checksum_validation='when_required'),
+        config=_botocore_config(),
         **kwargs)
 
 
@@ -182,17 +188,7 @@ def client(service_name: str):
         aws_access_key_id=oci_s3_credentials.access_key,
         aws_secret_access_key=oci_s3_credentials.secret_key,
         region_name=get_region(),
-        config=botocore.config.Config(
-            s3={'addressing_style': 'path'},
-            # OCI's S3-compatible API returns 501 for uploads that use
-            # aws-chunked content encoding, which newer AWS SDKs enable by
-            # default to carry a trailing integrity checksum. Restrict
-            # checksum calculation to when_required so PutObject is sent as
-            # a plain (non-chunked) request. Response validation is relaxed
-            # to match, so downloads of checksummed objects aren't rejected.
-            # https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi_topic-Amazon_S3_Compatibility_API_Support.htm
-            request_checksum_calculation='when_required',
-            response_checksum_validation='when_required'),
+        config=_botocore_config(),
     )
 
 

--- a/sky/adaptors/oci_s3.py
+++ b/sky/adaptors/oci_s3.py
@@ -16,8 +16,11 @@ using AWS-style credential/config files:
         endpoint_url = https://<namespace>.compat.objectstorage.\
             <region>.oci.customer-oci.com
         region = <region>
-        s3 =
-            addressing_style = path
+
+Requests use path-style addressing (the bucket in the URL path, not the
+hostname): it is what the namespaced compat endpoint expects, and it works
+for every legal OCI bucket name — names with uppercase or underscores are
+not valid DNS labels, so virtual-hosted addressing cannot reach them.
 
 The presence of both files opts the deployment into the S3-compatible API
 for `oci://` storage (see use_s3_api()); without them, SkyPilot uses the
@@ -279,10 +282,6 @@ def check_storage_credentials() -> Tuple[bool, Optional[str]]:
             hints += (f'\n{_INDENT_PREFIX}  $ AWS_CONFIG_FILE='
                       f'{OCI_S3_CONFIG_PATH} aws configure set region '
                       f'<region> --profile {OCI_S3_PROFILE_NAME}')
-            hints += (f'\n{_INDENT_PREFIX}  $ AWS_CONFIG_FILE='
-                      f'{OCI_S3_CONFIG_PATH} aws configure set '
-                      f's3.addressing_style path --profile '
-                      f'{OCI_S3_PROFILE_NAME}')
         hints += f'\n{_INDENT_PREFIX}For more info: '
         hints += 'https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi.htm'  # pylint: disable=line-too-long
 

--- a/sky/adaptors/oci_s3.py
+++ b/sky/adaptors/oci_s3.py
@@ -146,7 +146,17 @@ def resource(resource_name: str, **kwargs):
         aws_access_key_id=oci_s3_credentials.access_key,
         aws_secret_access_key=oci_s3_credentials.secret_key,
         region_name=get_region(),
-        config=botocore.config.Config(s3={'addressing_style': 'path'}),
+        config=botocore.config.Config(
+            s3={'addressing_style': 'path'},
+            # OCI's S3-compatible API returns 501 for uploads that use
+            # aws-chunked content encoding, which newer AWS SDKs enable by
+            # default to carry a trailing integrity checksum. Restrict
+            # checksum calculation to when_required so PutObject is sent as
+            # a plain (non-chunked) request. Response validation is relaxed
+            # to match, so downloads of checksummed objects aren't rejected.
+            # https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi_topic-Amazon_S3_Compatibility_API_Support.htm
+            request_checksum_calculation='when_required',
+            response_checksum_validation='when_required'),
         **kwargs)
 
 
@@ -172,7 +182,17 @@ def client(service_name: str):
         aws_access_key_id=oci_s3_credentials.access_key,
         aws_secret_access_key=oci_s3_credentials.secret_key,
         region_name=get_region(),
-        config=botocore.config.Config(s3={'addressing_style': 'path'}),
+        config=botocore.config.Config(
+            s3={'addressing_style': 'path'},
+            # OCI's S3-compatible API returns 501 for uploads that use
+            # aws-chunked content encoding, which newer AWS SDKs enable by
+            # default to carry a trailing integrity checksum. Restrict
+            # checksum calculation to when_required so PutObject is sent as
+            # a plain (non-chunked) request. Response validation is relaxed
+            # to match, so downloads of checksummed objects aren't rejected.
+            # https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi_topic-Amazon_S3_Compatibility_API_Support.htm
+            request_checksum_calculation='when_required',
+            response_checksum_validation='when_required'),
     )
 
 

--- a/sky/adaptors/oci_s3.py
+++ b/sky/adaptors/oci_s3.py
@@ -1,0 +1,328 @@
+"""OCI Object Storage S3-compatible API adaptor.
+
+OCI Object Storage exposes an Amazon S3 Compatibility API, authenticated
+with a Customer Secret Key (an access key / secret key pair) instead of
+the native OCI API key:
+https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi.htm
+
+This adaptor accesses OCI Object Storage through that API with boto3,
+using AWS-style credential/config files:
+    ~/.oci/s3.credentials
+        [oci]
+        aws_access_key_id = ...
+        aws_secret_access_key = ...
+    ~/.oci/s3.config
+        [profile oci]
+        endpoint_url = https://<namespace>.compat.objectstorage.\
+            <region>.oci.customer-oci.com
+        region = <region>
+        s3 =
+            addressing_style = path
+
+The presence of both files opts the deployment into the S3-compatible API
+for `oci://` storage (see use_s3_api()); without them, SkyPilot uses the
+native OCI SDK/CLI.
+"""
+
+import configparser
+import contextlib
+import os
+import threading
+from typing import Dict, Optional, Tuple
+
+from sky import exceptions
+from sky import sky_logging
+from sky.adaptors import common
+from sky.clouds import cloud
+from sky.utils import annotations
+from sky.utils import ux_utils
+
+logger = sky_logging.init_logger(__name__)
+
+OCI_S3_PROFILE_NAME = 'oci'
+OCI_S3_CREDENTIALS_PATH = '~/.oci/s3.credentials'
+OCI_S3_CONFIG_PATH = '~/.oci/s3.config'
+NAME = 'OCI'
+_INDENT_PREFIX = '    '
+
+_IMPORT_ERROR_MESSAGE = ('Failed to import dependencies for OCI S3 '
+                         'compatibility API. Try pip install "skypilot[aws]"')
+
+boto3 = common.LazyImport('boto3', import_error_message=_IMPORT_ERROR_MESSAGE)
+botocore = common.LazyImport('botocore',
+                             import_error_message=_IMPORT_ERROR_MESSAGE)
+
+_LAZY_MODULES = (boto3, botocore)
+_session_creation_lock = threading.RLock()
+
+
+@contextlib.contextmanager
+def _load_oci_s3_credentials_env():
+    """Context manager to temporarily change the AWS credentials file path."""
+    prev_credentials_path = os.environ.get('AWS_SHARED_CREDENTIALS_FILE')
+    prev_config_path = os.environ.get('AWS_CONFIG_FILE')
+    os.environ['AWS_SHARED_CREDENTIALS_FILE'] = OCI_S3_CREDENTIALS_PATH
+    os.environ['AWS_CONFIG_FILE'] = OCI_S3_CONFIG_PATH
+    try:
+        yield
+    finally:
+        if prev_credentials_path is None:
+            del os.environ['AWS_SHARED_CREDENTIALS_FILE']
+        else:
+            os.environ['AWS_SHARED_CREDENTIALS_FILE'] = prev_credentials_path
+        if prev_config_path is None:
+            del os.environ['AWS_CONFIG_FILE']
+        else:
+            os.environ['AWS_CONFIG_FILE'] = prev_config_path
+
+
+def use_s3_api() -> bool:
+    """Whether to access OCI Object Storage via the S3-compatible API.
+
+    True iff the S3-compatible credential and config files both exist with
+    the expected profile. Their presence opts the deployment into the
+    S3-compatible API for `oci://` storage; otherwise SkyPilot uses the
+    native OCI SDK/CLI.
+    """
+    return oci_s3_profile_in_cred() and oci_s3_profile_in_config()
+
+
+def get_oci_s3_credentials(boto3_session):
+    """Gets the OCI S3 credentials from the boto3 session object.
+
+    Args:
+        boto3_session: The boto3 session object.
+    Returns:
+        botocore.credentials.ReadOnlyCredentials object with the OCI
+        Customer Secret Key credentials.
+    """
+    with _load_oci_s3_credentials_env():
+        oci_s3_credentials = boto3_session.get_credentials()
+        if oci_s3_credentials is None:
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError('OCI S3-compatible credentials not found. '
+                                 'Run `sky check` to verify credentials are '
+                                 'correctly set up.')
+        return oci_s3_credentials.get_frozen_credentials()
+
+
+@annotations.lru_cache(scope='global')
+def session():
+    """Create an AWS session for OCI Object Storage."""
+    # Creating the session object is not thread-safe for boto3,
+    # so we add a reentrant lock to synchronize the session creation.
+    # Reference: https://github.com/boto/boto3/issues/1592
+    # However, the session object itself is thread-safe, so we are
+    # able to use lru_cache() to cache the session object.
+    with _session_creation_lock:
+        with _load_oci_s3_credentials_env():
+            session_ = boto3.session.Session(profile_name=OCI_S3_PROFILE_NAME)
+        return session_
+
+
+@annotations.lru_cache(scope='global')
+def resource(resource_name: str, **kwargs):
+    """Create an OCI S3-compatible resource.
+
+    Args:
+        resource_name: resource name (e.g., 's3').
+        kwargs: Other options.
+    """
+    # Need to use the resource retrieved from the per-thread session
+    # to avoid thread-safety issues (Directly creating the client
+    # with boto3.resource() is not thread-safe).
+    # Reference: https://stackoverflow.com/a/59635814
+
+    session_ = session()
+    oci_s3_credentials = get_oci_s3_credentials(session_)
+    endpoint = get_endpoint()
+
+    return session_.resource(
+        resource_name,
+        endpoint_url=endpoint,
+        aws_access_key_id=oci_s3_credentials.access_key,
+        aws_secret_access_key=oci_s3_credentials.secret_key,
+        region_name=get_region(),
+        config=botocore.config.Config(s3={'addressing_style': 'path'}),
+        **kwargs)
+
+
+@annotations.lru_cache(scope='global')
+def client(service_name: str):
+    """Create an OCI S3-compatible client of a certain service.
+
+    Args:
+        service_name: service name (e.g., 's3').
+    """
+    # Need to use the client retrieved from the per-thread session
+    # to avoid thread-safety issues (Directly creating the client
+    # with boto3.client() is not thread-safe).
+    # Reference: https://stackoverflow.com/a/59635814
+
+    session_ = session()
+    oci_s3_credentials = get_oci_s3_credentials(session_)
+    endpoint = get_endpoint()
+
+    return session_.client(
+        service_name,
+        endpoint_url=endpoint,
+        aws_access_key_id=oci_s3_credentials.access_key,
+        aws_secret_access_key=oci_s3_credentials.secret_key,
+        region_name=get_region(),
+        config=botocore.config.Config(s3={'addressing_style': 'path'}),
+    )
+
+
+@common.load_lazy_modules(_LAZY_MODULES)
+def botocore_exceptions():
+    """AWS botocore exception."""
+    # pylint: disable=import-outside-toplevel
+    from botocore import exceptions as boto_exceptions
+    return boto_exceptions
+
+
+def _read_config_option(option: str) -> Optional[str]:
+    """Reads an option from the [profile oci] section of OCI_S3_CONFIG_PATH."""
+    config_path = os.path.expanduser(OCI_S3_CONFIG_PATH)
+    if not os.path.isfile(config_path):
+        return None
+    try:
+        config = configparser.ConfigParser()
+        config.read(config_path)
+        profile_section = f'profile {OCI_S3_PROFILE_NAME}'
+        if config.has_section(profile_section):
+            if config.has_option(profile_section, option):
+                return config.get(profile_section, option).strip()
+    except (configparser.Error, OSError) as e:
+        logger.warning(f'Failed to parse OCI S3-compatible config file: {e}.')
+    return None
+
+
+def get_endpoint() -> str:
+    """Parse the OCI_S3_CONFIG_PATH to get the endpoint_url.
+
+    Unlike providers with a global endpoint, the OCI S3-compatible endpoint
+    embeds the tenancy's Object Storage namespace and region, e.g.
+    https://<namespace>.compat.objectstorage.<region>.oci.customer-oci.com,
+    so there is no default to fall back to.
+
+    Raises:
+        ValueError: If the endpoint_url is not found in the config file.
+    """
+    endpoint = _read_config_option('endpoint_url')
+    if endpoint is None:
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError(
+                'OCI S3-compatible endpoint not found. Set endpoint_url '
+                f'under [profile {OCI_S3_PROFILE_NAME}] in '
+                f'{OCI_S3_CONFIG_PATH}, e.g. https://<namespace>.compat.'
+                'objectstorage.<region>.oci.customer-oci.com')
+    return endpoint
+
+
+def get_region() -> Optional[str]:
+    """Parse the OCI_S3_CONFIG_PATH to get the region, if set.
+
+    The region is used for SigV4 signing and must be the OCI region
+    identifier embedded in the endpoint (e.g. us-sanjose-1).
+    """
+    return _read_config_option('region')
+
+
+def check_credentials(
+        cloud_capability: cloud.CloudCapability) -> Tuple[bool, Optional[str]]:
+    if cloud_capability == cloud.CloudCapability.STORAGE:
+        return check_storage_credentials()
+    else:
+        raise exceptions.NotSupportedError(
+            f'{NAME} S3-compatible API does not support {cloud_capability}.')
+
+
+def check_storage_credentials() -> Tuple[bool, Optional[str]]:
+    """Checks credentials for OCI Object Storage via the S3-compatible API.
+
+    Returns:
+        A tuple of a boolean value and a hint message where the bool
+        is True when both credentials needed for OCI S3-compatible storage
+        are set. It is False when either of those are not set, which would
+        hint with a string on the unset credential.
+    """
+    hints = None
+    profile_in_cred = oci_s3_profile_in_cred()
+    profile_in_config = oci_s3_profile_in_config()
+
+    if not profile_in_cred:
+        hints = (f'[{OCI_S3_PROFILE_NAME}] profile is not set in '
+                 f'{OCI_S3_CREDENTIALS_PATH}.')
+    if not profile_in_config:
+        if hints:
+            hints += ' Additionally, '
+        else:
+            hints = ''
+        hints += (f'[profile {OCI_S3_PROFILE_NAME}] is not set in '
+                  f'{OCI_S3_CONFIG_PATH}.')
+
+    if hints:
+        hints += (' Generate a Customer Secret Key in the OCI console, then'
+                  ' run the following commands:')
+        if not profile_in_cred:
+            hints += f'\n{_INDENT_PREFIX}  $ pip install boto3'
+            hints += (f'\n{_INDENT_PREFIX}  $ AWS_SHARED_CREDENTIALS_FILE='
+                      f'{OCI_S3_CREDENTIALS_PATH} aws configure --profile '
+                      f'{OCI_S3_PROFILE_NAME}')
+        if not profile_in_config:
+            hints += (f'\n{_INDENT_PREFIX}  $ AWS_CONFIG_FILE='
+                      f'{OCI_S3_CONFIG_PATH} aws configure set endpoint_url'
+                      ' https://<namespace>.compat.objectstorage.<region>'
+                      '.oci.customer-oci.com --profile '
+                      f'{OCI_S3_PROFILE_NAME}')
+            hints += (f'\n{_INDENT_PREFIX}  $ AWS_CONFIG_FILE='
+                      f'{OCI_S3_CONFIG_PATH} aws configure set region '
+                      f'<region> --profile {OCI_S3_PROFILE_NAME}')
+            hints += (f'\n{_INDENT_PREFIX}  $ AWS_CONFIG_FILE='
+                      f'{OCI_S3_CONFIG_PATH} aws configure set '
+                      f's3.addressing_style path --profile '
+                      f'{OCI_S3_PROFILE_NAME}')
+        hints += f'\n{_INDENT_PREFIX}For more info: '
+        hints += 'https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi.htm'  # pylint: disable=line-too-long
+
+    return (False, hints) if hints else (True, hints)
+
+
+def oci_s3_profile_in_config() -> bool:
+    """Checks if the OCI S3 profile is set in the config file."""
+    conf_path = os.path.expanduser(OCI_S3_CONFIG_PATH)
+    profile_exists = False
+    if os.path.isfile(conf_path):
+        with open(conf_path, 'r', encoding='utf-8') as file:
+            for line in file:
+                if f'[profile {OCI_S3_PROFILE_NAME}]' in line:
+                    profile_exists = True
+                    break
+    return profile_exists
+
+
+def oci_s3_profile_in_cred() -> bool:
+    """Checks if the OCI S3 profile is set in the credentials file."""
+    cred_path = os.path.expanduser(OCI_S3_CREDENTIALS_PATH)
+    profile_exists = False
+    if os.path.isfile(cred_path):
+        with open(cred_path, 'r', encoding='utf-8') as file:
+            for line in file:
+                if f'[{OCI_S3_PROFILE_NAME}]' in line:
+                    profile_exists = True
+                    break
+    return profile_exists
+
+
+def get_credential_file_mounts() -> Dict[str, str]:
+    """Returns credential file mounts for OCI S3-compatible storage.
+
+    Returns:
+        Dict[str, str]: A dictionary mapping source paths to destination paths
+        for credential files.
+    """
+    return {
+        OCI_S3_CREDENTIALS_PATH: OCI_S3_CREDENTIALS_PATH,
+        OCI_S3_CONFIG_PATH: OCI_S3_CONFIG_PATH,
+    }

--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -23,6 +23,7 @@ from sky.adaptors import huggingface
 from sky.adaptors import ibm
 from sky.adaptors import nebius
 from sky.adaptors import oci
+from sky.adaptors import oci_s3
 from sky.adaptors import vastdata
 from sky.clouds import gcp
 from sky.data import data_utils
@@ -551,6 +552,78 @@ class OciCloudStorage(CloudStorage):
         return download_via_ocicli
 
 
+class OciS3CloudStorage(CloudStorage):
+    """OCI Cloud Storage accessed via the S3-compatible API.
+
+    Used in place of OciCloudStorage when the S3-compatible credential
+    files are present (see sky.adaptors.oci_s3), so remote nodes only need
+    the AWS CLI and the mounted credential files, not the OCI CLI or the
+    native OCI credentials.
+    """
+
+    # List of commands to install AWS CLI
+    _GET_AWSCLI = [
+        'aws --version >/dev/null 2>&1 || '
+        f'{constants.SKY_UV_PIP_CMD} install awscli',
+    ]
+
+    def is_directory(self, url: str) -> bool:
+        """Returns whether OCI 'url' is a directory.
+
+        In cloud object stores, a "directory" refers to a regular object
+        whose name is a prefix of other objects.
+        """
+        oci_s3_resource = oci_s3.resource('s3')
+        bucket_name, path = data_utils.split_oci_path(url)
+        bucket = oci_s3_resource.Bucket(bucket_name)
+
+        num_objects = 0
+        for obj in bucket.objects.filter(Prefix=path):
+            num_objects += 1
+            if obj.key == path:
+                return False
+            # If there are more than 1 object in filter, then it is a directory
+            if num_objects == 3:
+                return True
+
+        # A directory with few or no items
+        return True
+
+    def make_sync_dir_command(self, source: str, destination: str) -> str:
+        """Downloads using AWS CLI."""
+        # AWS Sync by default uses 10 threads to upload files to the bucket.
+        # To increase parallelism, modify max_concurrent_requests in your
+        # aws config file (Default path: ~/.oci/s3.config).
+        assert 'oci://' in source, 'oci:// is not in source'
+        source = source.replace('oci://', 's3://')
+        download_via_awscli = ('AWS_SHARED_CREDENTIALS_FILE='
+                               f'{oci_s3.OCI_S3_CREDENTIALS_PATH} '
+                               f'AWS_CONFIG_FILE={oci_s3.OCI_S3_CONFIG_PATH} '
+                               f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+                               'sync --no-follow-symlinks '
+                               f'{source} {destination} '
+                               f'--profile={oci_s3.OCI_S3_PROFILE_NAME}')
+
+        all_commands = list(self._GET_AWSCLI)
+        all_commands.append(download_via_awscli)
+        return ' && '.join(all_commands)
+
+    def make_sync_file_command(self, source: str, destination: str) -> str:
+        """Downloads a file using AWS CLI."""
+        assert 'oci://' in source, 'oci:// is not in source'
+        source = source.replace('oci://', 's3://')
+        download_via_awscli = ('AWS_SHARED_CREDENTIALS_FILE='
+                               f'{oci_s3.OCI_S3_CREDENTIALS_PATH} '
+                               f'AWS_CONFIG_FILE={oci_s3.OCI_S3_CONFIG_PATH} '
+                               f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+                               f'cp {source} {destination} '
+                               f'--profile={oci_s3.OCI_S3_PROFILE_NAME}')
+
+        all_commands = list(self._GET_AWSCLI)
+        all_commands.append(download_via_awscli)
+        return ' && '.join(all_commands)
+
+
 class NebiusCloudStorage(CloudStorage):
     """Nebius Cloud Storage."""
 
@@ -945,8 +1018,14 @@ def get_storage_from_path(url: str) -> CloudStorage:
     if result.scheme not in _REGISTRY:
         assert False, (f'Scheme {result.scheme} not found in'
                        f' supported storage ({_REGISTRY.keys()}); path {url}')
+    if result.scheme == 'oci' and oci_s3.use_s3_api():
+        return _OCI_S3_CLOUD_STORAGE
     return _REGISTRY[result.scheme]
 
+
+# Serves oci:// instead of _REGISTRY['oci'] when the S3-compatible
+# credential files are present (see get_storage_from_path).
+_OCI_S3_CLOUD_STORAGE = OciS3CloudStorage()
 
 # Maps bucket's URIs prefix(scheme) to its corresponding storage class
 _REGISTRY = {

--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -596,13 +596,19 @@ class OciS3CloudStorage(CloudStorage):
         # aws config file (Default path: ~/.oci/s3.config).
         assert 'oci://' in source, 'oci:// is not in source'
         source = source.replace('oci://', 's3://')
-        download_via_awscli = ('AWS_SHARED_CREDENTIALS_FILE='
-                               f'{oci_s3.OCI_S3_CREDENTIALS_PATH} '
-                               f'AWS_CONFIG_FILE={oci_s3.OCI_S3_CONFIG_PATH} '
-                               f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
-                               'sync --no-follow-symlinks '
-                               f'{source} {destination} '
-                               f'--profile={oci_s3.OCI_S3_PROFILE_NAME}')
+        download_via_awscli = (
+            'AWS_SHARED_CREDENTIALS_FILE='
+            f'{oci_s3.OCI_S3_CREDENTIALS_PATH} '
+            f'AWS_CONFIG_FILE={oci_s3.OCI_S3_CONFIG_PATH} '
+            # OCI rejects aws-chunked transfers; keep the
+            # AWS CLI's checksum behavior off to match the
+            # upload path and OCI's S3 SDK guidance.
+            'AWS_REQUEST_CHECKSUM_CALCULATION=when_required '
+            'AWS_RESPONSE_CHECKSUM_VALIDATION=when_required '
+            f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+            'sync --no-follow-symlinks '
+            f'{source} {destination} '
+            f'--profile={oci_s3.OCI_S3_PROFILE_NAME}')
 
         all_commands = list(self._GET_AWSCLI)
         all_commands.append(download_via_awscli)
@@ -612,12 +618,18 @@ class OciS3CloudStorage(CloudStorage):
         """Downloads a file using AWS CLI."""
         assert 'oci://' in source, 'oci:// is not in source'
         source = source.replace('oci://', 's3://')
-        download_via_awscli = ('AWS_SHARED_CREDENTIALS_FILE='
-                               f'{oci_s3.OCI_S3_CREDENTIALS_PATH} '
-                               f'AWS_CONFIG_FILE={oci_s3.OCI_S3_CONFIG_PATH} '
-                               f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
-                               f'cp {source} {destination} '
-                               f'--profile={oci_s3.OCI_S3_PROFILE_NAME}')
+        download_via_awscli = (
+            'AWS_SHARED_CREDENTIALS_FILE='
+            f'{oci_s3.OCI_S3_CREDENTIALS_PATH} '
+            f'AWS_CONFIG_FILE={oci_s3.OCI_S3_CONFIG_PATH} '
+            # OCI rejects aws-chunked transfers; keep the
+            # AWS CLI's checksum behavior off to match the
+            # upload path and OCI's S3 SDK guidance.
+            'AWS_REQUEST_CHECKSUM_CALCULATION=when_required '
+            'AWS_RESPONSE_CHECKSUM_VALIDATION=when_required '
+            f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
+            f'cp {source} {destination} '
+            f'--profile={oci_s3.OCI_S3_PROFILE_NAME}')
 
         all_commands = list(self._GET_AWSCLI)
         all_commands.append(download_via_awscli)

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -30,6 +30,7 @@ from sky import clouds
 from sky import exceptions
 from sky.adaptors import common
 from sky.adaptors import oci as oci_adaptor
+from sky.adaptors import oci_s3
 from sky.clouds.utils import oci_utils
 from sky.provision.oci.query_utils import query_helper
 from sky.utils import common_utils
@@ -446,6 +447,11 @@ class OCI(clouds.Cloud):
             cls) -> Tuple[bool, Optional[Union[str, Dict[str, str]]]]:
         """Checks if the user has access credentials to
         OCI's storage service."""
+        if oci_s3.use_s3_api():
+            # OCI Object Storage is accessed via the S3-compatible API,
+            # authenticated with a Customer Secret Key; the native OCI
+            # credentials are not required for storage.
+            return oci_s3.check_storage_credentials()
         # TODO(seungjin): Implement separate check for
         # if the user has access to OCI Object Storage.
         return cls._check_credentials()
@@ -525,6 +531,13 @@ class OCI(clouds.Cloud):
 
     def get_credential_file_mounts(self) -> Dict[str, str]:
         """Returns a dict of credential file paths to mount paths."""
+        file_mounts: Dict[str, str] = {}
+        if oci_s3.use_s3_api():
+            # Object Storage is accessed via the S3-compatible API; the
+            # native credentials below are still mounted if configured
+            # (compute provisioning needs them), but are not required.
+            file_mounts.update(oci_s3.get_credential_file_mounts())
+
         try:
             oci_cfg_file = oci_adaptor.get_config_file()
             # Pass-in a profile parameter so that multiple profile in oci
@@ -537,9 +550,9 @@ class OCI(clouds.Cloud):
         # Must catch ImportError before any oci_adaptor.oci.exceptions
         # because oci_adaptor.oci.exceptions can throw ImportError.
         except ImportError:
-            return {}
+            return file_mounts
         except oci_adaptor.oci.exceptions.ConfigFileNotFound:
-            return {}
+            return file_mounts
 
         # OCI config and API key file are mandatory
         credential_files = [oci_cfg_file, api_key_file]
@@ -548,9 +561,8 @@ class OCI(clouds.Cloud):
         if os.path.exists(os.path.expanduser(sky_cfg_file)):
             credential_files.append(sky_cfg_file)
 
-        file_mounts = {
-            f'{filename}': f'{filename}' for filename in credential_files
-        }
+        file_mounts.update(
+            {f'{filename}': f'{filename}' for filename in credential_files})
 
         logger.debug(f'OCI credential file mounts: {file_mounts}')
         return file_mounts

--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -25,6 +25,7 @@ from sky.adaptors import huggingface
 from sky.adaptors import ibm
 from sky.adaptors import nebius
 from sky.adaptors import oci
+from sky.adaptors import oci_s3
 from sky.adaptors import vastdata
 from sky.skylet import constants
 from sky.skylet import log_lib
@@ -745,6 +746,7 @@ class Rclone:
         NEBIUS = 'NEBIUS'
         COREWEAVE = 'COREWEAVE'
         VASTDATA = 'VASTDATA'
+        OCI = 'OCI'
 
         def get_profile_name(self, bucket_name: str) -> str:
             """Gets the Rclone profile name for a given bucket.
@@ -765,6 +767,7 @@ class Rclone:
                 Rclone.RcloneStores.NEBIUS: 'sky-nebius',
                 Rclone.RcloneStores.COREWEAVE: 'sky-coreweave',
                 Rclone.RcloneStores.VASTDATA: 'sky-vastdata',
+                Rclone.RcloneStores.OCI: 'sky-oci',
             }
             return f'{profile_prefix[self]}-{bucket_name}'
 
@@ -903,6 +906,26 @@ class Rclone:
                     acl = private
                     force_path_style = false
                     """)
+            elif self is Rclone.RcloneStores.OCI:
+                oci_s3_session = oci_s3.session()
+                oci_s3_credentials = oci_s3.get_oci_s3_credentials(
+                    oci_s3_session)
+                endpoint_url = oci_s3.get_endpoint()
+                access_key_id = oci_s3_credentials.access_key
+                secret_access_key = oci_s3_credentials.secret_key
+                config = textwrap.dedent(f"""\
+                    [{rclone_profile_name}]
+                    type = s3
+                    provider = Other
+                    access_key_id = {access_key_id}
+                    secret_access_key = {secret_access_key}
+                    endpoint = {endpoint_url}
+                    acl = private
+                    force_path_style = true
+                    """)
+                oci_region = oci_s3.get_region()
+                if oci_region:
+                    config += f'region = {oci_region}\n'
             elif self is Rclone.RcloneStores.VASTDATA:
                 vastdata_session = vastdata.session()
                 vastdata_credentials = vastdata.get_vastdata_credentials(
@@ -1080,6 +1103,28 @@ def split_oci_path(oci_path: str) -> Tuple[str, str]:
     bucket = path_parts.pop(0)
     key = '/'.join(path_parts)
     return bucket, key
+
+
+def create_oci_s3_client() -> Client:
+    """Create a client for OCI Object Storage's S3-compatible API."""
+    return oci_s3.client('s3')
+
+
+def verify_oci_s3_bucket(name: str) -> bool:
+    """Verify an OCI bucket exists via the S3-compatible API."""
+    client = create_oci_s3_client()
+    try:
+        client.head_bucket(Bucket=name)
+        return True
+    except oci_s3.botocore.exceptions.ClientError as e:  # type: ignore[union-attr] # pylint: disable=line-too-long
+        error_code = e.response['Error']['Code']
+        if error_code == '403':
+            logger.error(f'Access denied to OCI bucket {name}')
+        elif error_code == '404':
+            logger.debug(f'OCI bucket {name} does not exist')
+        else:
+            logger.debug(f'Unexpected error checking OCI bucket {name}: {e}')
+        return False
 
 
 def create_coreweave_client() -> Client:

--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -1116,7 +1116,7 @@ def verify_oci_s3_bucket(name: str) -> bool:
     try:
         client.head_bucket(Bucket=name)
         return True
-    except oci_s3.botocore.exceptions.ClientError as e:  # type: ignore[union-attr] # pylint: disable=line-too-long
+    except oci_s3.botocore_exceptions().ClientError as e:
         error_code = e.response['Error']['Code']
         if error_code == '403':
             logger.error(f'Access denied to OCI bucket {name}')

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -115,6 +115,7 @@ def _get_s3_compatible_mount_cmd(bucket_name: str,
                                  mount_path: str,
                                  _bucket_sub_path: Optional[str] = None,
                                  endpoint_url: Optional[str] = None,
+                                 region: Optional[str] = None,
                                  cred_env: str = '',
                                  rclone_extra_flags: str = '',
                                  goofys_extra_flags: str = '',
@@ -131,6 +132,9 @@ def _get_s3_compatible_mount_cmd(bucket_name: str,
         _bucket_sub_path: Optional sub-path within the bucket.
         endpoint_url: S3-compatible endpoint URL. If None, uses the
             default AWS S3 endpoint.
+        region: SigV4 signing region. If None, goofys defaults to
+            'us-east-1'. Required for providers that validate the signing
+            region against a region-specific endpoint (e.g. OCI).
         cred_env: Credential environment variable prefix string
             (e.g., 'AWS_SHARED_CREDENTIALS_FILE=... AWS_PROFILE=... ').
         rclone_extra_flags: Extra flags for rclone mount command
@@ -156,6 +160,10 @@ def _get_s3_compatible_mount_cmd(bucket_name: str,
     if endpoint_url:
         rclone_extra_flags += f'--s3-endpoint {endpoint_url} '
         goofys_extra_flags += f'--endpoint {endpoint_url} '
+
+    if region:
+        rclone_extra_flags += f'--s3-region {region} '
+        goofys_extra_flags += f'--region {region} '
 
     if read_only:
         rclone_extra_flags += '--read-only '
@@ -241,16 +249,28 @@ def get_oci_s3_mount_cmd(oci_s3_credentials_path: str,
                          bucket_name: str,
                          endpoint_url: str,
                          mount_path: str,
+                         region: Optional[str] = None,
                          _bucket_sub_path: Optional[str] = None,
                          read_only: bool = False) -> str:
-    """Returns a command to mount an OCI bucket via the S3-compatible API."""
+    """Returns a command to mount an OCI bucket via the S3-compatible API.
+
+    OCI validates the SigV4 signing region against the region-specific
+    endpoint, so the region must be passed explicitly; goofys would
+    otherwise default to 'us-east-1' and be rejected. OCI also returns 501
+    for uploads using aws-chunked content encoding, which goofys's AWS SDK
+    enables by default to carry a trailing checksum; AWS_REQUEST_CHECKSUM_
+    CALCULATION=when_required disables it so writes are sent as plain PUTs.
+    """
     cred_env = (f'AWS_SHARED_CREDENTIALS_FILE={oci_s3_credentials_path} '
-                f'AWS_PROFILE={oci_s3_profile_name}')
+                f'AWS_PROFILE={oci_s3_profile_name} '
+                'AWS_REQUEST_CHECKSUM_CALCULATION=when_required '
+                'AWS_RESPONSE_CHECKSUM_VALIDATION=when_required')
     return _get_s3_compatible_mount_cmd(
         bucket_name=bucket_name,
         mount_path=mount_path,
         _bucket_sub_path=_bucket_sub_path,
         endpoint_url=endpoint_url,
+        region=region,
         cred_env=cred_env,
         rclone_extra_flags='--s3-force-path-style=true',
         read_only=read_only)

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -236,6 +236,26 @@ def get_coreweave_mount_cmd(cw_credentials_path: str,
         read_only=read_only)
 
 
+def get_oci_s3_mount_cmd(oci_s3_credentials_path: str,
+                         oci_s3_profile_name: str,
+                         bucket_name: str,
+                         endpoint_url: str,
+                         mount_path: str,
+                         _bucket_sub_path: Optional[str] = None,
+                         read_only: bool = False) -> str:
+    """Returns a command to mount an OCI bucket via the S3-compatible API."""
+    cred_env = (f'AWS_SHARED_CREDENTIALS_FILE={oci_s3_credentials_path} '
+                f'AWS_PROFILE={oci_s3_profile_name}')
+    return _get_s3_compatible_mount_cmd(
+        bucket_name=bucket_name,
+        mount_path=mount_path,
+        _bucket_sub_path=_bucket_sub_path,
+        endpoint_url=endpoint_url,
+        cred_env=cred_env,
+        rclone_extra_flags='--s3-force-path-style=true',
+        read_only=read_only)
+
+
 def get_vastdata_mount_cmd(vastdata_credentials_path: str,
                            vastdata_profile_name: str,
                            bucket_name: str,

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -5287,12 +5287,15 @@ class OciS3CompatibleStore(S3CompatibleStore):
                  _bucket_sub_path: Optional[str] = None):
         # The native OciStore supports a <bucket>@<region> suffix. The
         # S3-compatible endpoint is pinned to a single region, so a region
-        # suffix cannot be honored here.
+        # suffix cannot be honored here. Only reject @ in source when it is
+        # an oci:// URI; a local path containing @ is valid.
         for bucket_expr in (name, source):
-            if isinstance(bucket_expr,
-                          str) and bucket_expr.startswith('oci://'):
+            if not isinstance(bucket_expr, str):
+                continue
+            is_oci_uri = bucket_expr.startswith('oci://')
+            if is_oci_uri:
                 bucket_expr = data_utils.split_oci_path(bucket_expr)[0]
-            if isinstance(bucket_expr, str) and '@' in bucket_expr:
+            if (bucket_expr == name or is_oci_uri) and '@' in bucket_expr:
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.StorageNameError(
                         f'<bucket>@<region> ({bucket_expr!r}) is not '

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -32,6 +32,7 @@ from sky.adaptors import huggingface
 from sky.adaptors import ibm
 from sky.adaptors import nebius
 from sky.adaptors import oci
+from sky.adaptors import oci_s3
 from sky.adaptors import vastdata
 from sky.clouds import cloud as sky_cloud
 from sky.data import data_transfer
@@ -1399,7 +1400,10 @@ class Storage(object):
                         sync_on_reconstruction=self.sync_on_reconstruction,
                         _bucket_sub_path=self._bucket_sub_path)
                 elif s_type == StoreType.OCI:
-                    store = OciStore.from_metadata(
+                    oci_store_cls: Type[AbstractStore] = (
+                        OciS3CompatibleStore
+                        if oci_s3.use_s3_api() else OciStore)
+                    store = oci_store_cls.from_metadata(
                         s_metadata,
                         source=self.source,
                         sync_on_reconstruction=self.sync_on_reconstruction,
@@ -1521,7 +1525,8 @@ class Storage(object):
         elif store_type == StoreType.IBM:
             store_cls = IBMCosStore
         elif store_type == StoreType.OCI:
-            store_cls = OciStore
+            store_cls = (OciS3CompatibleStore
+                         if oci_s3.use_s3_api() else OciStore)
         elif store_type == StoreType.HF:
             store_cls = HuggingFaceStore
         else:
@@ -5242,6 +5247,106 @@ class VastDataStore(S3CompatibleStore):
         rclone_profile_name = (
             data_utils.Rclone.RcloneStores.VASTDATA.get_profile_name(self.name))
         rclone_config = data_utils.Rclone.RcloneStores.VASTDATA.get_config(
+            rclone_profile_name=rclone_profile_name)
+        mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
+            rclone_config, rclone_profile_name, self.bucket.name, mount_path,
+            config)
+        return mounting_utils.get_mounting_command(mount_path, install_cmd,
+                                                   mount_cached_cmd)
+
+
+class OciS3CompatibleStore(S3CompatibleStore):
+    """OciS3CompatibleStore represents the backend for OCI buckets accessed
+    via OCI Object Storage's Amazon S3 Compatibility API.
+
+    https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi.htm
+
+    It shares StoreType.OCI and the oci:// prefix with the native OciStore;
+    which class serves a request is decided at the StoreType.OCI dispatch
+    sites based on oci_s3.use_s3_api(). It must therefore not be decorated
+    with @register_s3_compatible_store: the registry is consulted before
+    the StoreType.OCI dispatch branches, and registering under 'OCI' would
+    take over all OCI dispatch unconditionally.
+    """
+
+    def __init__(self,
+                 name: str,
+                 source: str,
+                 region: Optional[str] = None,
+                 is_sky_managed: Optional[bool] = None,
+                 sync_on_reconstruction: bool = True,
+                 _bucket_sub_path: Optional[str] = None):
+        # The native OciStore supports a <bucket>@<region> suffix. The
+        # S3-compatible endpoint is pinned to a single region, so a region
+        # suffix cannot be honored here.
+        for bucket_expr in (name, source):
+            if isinstance(bucket_expr,
+                          str) and bucket_expr.startswith('oci://'):
+                bucket_expr = data_utils.split_oci_path(bucket_expr)[0]
+            if isinstance(bucket_expr, str) and '@' in bucket_expr:
+                with ux_utils.print_exception_no_traceback():
+                    raise exceptions.StorageNameError(
+                        f'<bucket>@<region> ({bucket_expr!r}) is not '
+                        'supported when accessing OCI via the S3-compatible '
+                        'API; the region is determined by the endpoint in '
+                        f'{oci_s3.OCI_S3_CONFIG_PATH}.')
+        super().__init__(name, source, region, is_sky_managed,
+                         sync_on_reconstruction, _bucket_sub_path)
+
+    @classmethod
+    def get_config(cls) -> S3CompatibleConfig:
+        """Return the configuration for the OCI S3-compatible API."""
+        return S3CompatibleConfig(
+            store_type='OCI',
+            url_prefix='oci://',
+            client_factory=lambda region: data_utils.create_oci_s3_client(),
+            resource_factory=lambda name: oci_s3.resource('s3').Bucket(name),
+            split_path=data_utils.split_oci_path,
+            verify_bucket=data_utils.verify_oci_s3_bucket,
+            aws_profile=oci_s3.OCI_S3_PROFILE_NAME,
+            get_endpoint_url=oci_s3.get_endpoint,
+            credentials_file=oci_s3.OCI_S3_CREDENTIALS_PATH,
+            config_file=oci_s3.OCI_S3_CONFIG_PATH,
+            cloud_name=str(clouds.OCI()),
+            default_region=oci_s3.get_region(),
+            mount_cmd_factory=cls._get_oci_s3_mount_cmd,
+        )
+
+    @classmethod
+    def validate_name(cls, name: str) -> str:
+        """Validates the store name using OCI bucket naming rules.
+
+        OCI bucket names allow uppercase letters and underscores, which the
+        generic S3 rules would reject; buckets created via the native API
+        must remain accessible via the S3-compatible API.
+        """
+        return OciStore.validate_name(name)
+
+    @classmethod
+    def _get_oci_s3_mount_cmd(cls,
+                              bucket_name: str,
+                              mount_path: str,
+                              bucket_sub_path: Optional[str],
+                              read_only: bool = False) -> str:
+        """Factory method for the OCI S3-compatible mount command."""
+        endpoint_url = oci_s3.get_endpoint()
+        return mounting_utils.get_oci_s3_mount_cmd(
+            oci_s3.OCI_S3_CREDENTIALS_PATH,
+            oci_s3.OCI_S3_PROFILE_NAME,
+            bucket_name,
+            endpoint_url,
+            mount_path,
+            bucket_sub_path,
+            read_only=read_only)
+
+    def mount_cached_command(self,
+                             mount_path: str,
+                             config: Optional[MountCachedConfig] = None) -> str:
+        """OCI S3-compatible cached mount implementation using rclone."""
+        install_cmd = mounting_utils.get_rclone_install_cmd()
+        rclone_profile_name = (
+            data_utils.Rclone.RcloneStores.OCI.get_profile_name(self.name))
+        rclone_config = data_utils.Rclone.RcloneStores.OCI.get_config(
             rclone_profile_name=rclone_profile_name)
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.bucket.name, mount_path,

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1832,6 +1832,9 @@ class S3CompatibleConfig:
     credentials_file: Optional[str] = None
     config_file: Optional[str] = None
     extra_cli_args: Optional[List[str]] = None
+    # Extra environment variables to prefix onto the AWS CLI upload commands.
+    # Used by OCI to disable aws-chunked uploads (see OciS3CompatibleStore).
+    extra_cli_env: Optional[Dict[str, str]] = None
 
     # Provider-specific settings
     cloud_name: str = ''
@@ -1845,6 +1848,8 @@ class S3CompatibleConfig:
     def __post_init__(self):
         if self.extra_cli_args is None:
             self.extra_cli_args = []
+        if self.extra_cli_env is None:
+            self.extra_cli_env = {}
 
 
 class S3CompatibleStore(AbstractStore):
@@ -2285,6 +2290,8 @@ class S3CompatibleStore(AbstractStore):
             if self.config.config_file:
                 cmd = 'AWS_CONFIG_FILE=' + \
                 f'{self.config.config_file} {cmd}'
+            for env_key, env_val in (self.config.extra_cli_env or {}).items():
+                cmd = f'{env_key}={env_val} {cmd}'
 
             return cmd
 
@@ -2333,6 +2340,8 @@ class S3CompatibleStore(AbstractStore):
             if self.config.config_file:
                 cmd = 'AWS_CONFIG_FILE=' + \
                 f'{self.config.config_file} {cmd}'
+            for env_key, env_val in (self.config.extra_cli_env or {}).items():
+                cmd = f'{env_key}={env_val} {cmd}'
 
             return cmd
 
@@ -5307,6 +5316,14 @@ class OciS3CompatibleStore(S3CompatibleStore):
             get_endpoint_url=oci_s3.get_endpoint,
             credentials_file=oci_s3.OCI_S3_CREDENTIALS_PATH,
             config_file=oci_s3.OCI_S3_CONFIG_PATH,
+            # OCI returns 501 for aws-chunked uploads, which the AWS CLI
+            # enables by default to carry a trailing checksum. Disable it so
+            # `aws s3 sync` uploads are sent as plain (non-chunked) requests.
+            # Response validation is relaxed to match.
+            extra_cli_env={
+                'AWS_REQUEST_CHECKSUM_CALCULATION': 'when_required',
+                'AWS_RESPONSE_CHECKSUM_VALIDATION': 'when_required',
+            },
             cloud_name=str(clouds.OCI()),
             default_region=oci_s3.get_region(),
             mount_cmd_factory=cls._get_oci_s3_mount_cmd,
@@ -5336,7 +5353,8 @@ class OciS3CompatibleStore(S3CompatibleStore):
             bucket_name,
             endpoint_url,
             mount_path,
-            bucket_sub_path,
+            region=oci_s3.get_region(),
+            _bucket_sub_path=bucket_sub_path,
             read_only=read_only)
 
     def mount_cached_command(self,

--- a/tests/unit_tests/test_sky/adaptors/test_oci_s3.py
+++ b/tests/unit_tests/test_sky/adaptors/test_oci_s3.py
@@ -1,0 +1,221 @@
+"""Unit tests for the OCI S3-compatible API adaptor."""
+
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from sky import exceptions
+from sky.adaptors import oci_s3
+from sky.clouds import cloud
+
+
+class TestOciS3Adaptor(unittest.TestCase):
+    """Test cases for OCI S3 adaptor functions."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Clear any cached values
+        if hasattr(oci_s3.session, 'cache_clear'):
+            oci_s3.session.cache_clear()
+        if hasattr(oci_s3.resource, 'cache_clear'):
+            oci_s3.resource.cache_clear()
+        if hasattr(oci_s3.client, 'cache_clear'):
+            oci_s3.client.cache_clear()
+
+    def _write_temp_file(self, content: str) -> str:
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+            f.write(content)
+            return f.name
+
+    def test_load_oci_s3_credentials_env_sets_and_restores_env_vars(self):
+        original_cred = os.environ.get('AWS_SHARED_CREDENTIALS_FILE')
+        original_config = os.environ.get('AWS_CONFIG_FILE')
+
+        with oci_s3._load_oci_s3_credentials_env():
+            self.assertEqual(os.environ.get('AWS_SHARED_CREDENTIALS_FILE'),
+                             oci_s3.OCI_S3_CREDENTIALS_PATH)
+            self.assertEqual(os.environ.get('AWS_CONFIG_FILE'),
+                             oci_s3.OCI_S3_CONFIG_PATH)
+
+        if original_cred is None:
+            self.assertNotIn('AWS_SHARED_CREDENTIALS_FILE', os.environ)
+        else:
+            self.assertEqual(os.environ.get('AWS_SHARED_CREDENTIALS_FILE'),
+                             original_cred)
+        if original_config is None:
+            self.assertNotIn('AWS_CONFIG_FILE', os.environ)
+        else:
+            self.assertEqual(os.environ.get('AWS_CONFIG_FILE'), original_config)
+
+    def test_use_s3_api_false_when_files_missing(self):
+        with mock.patch('os.path.isfile', return_value=False):
+            self.assertFalse(oci_s3.use_s3_api())
+
+    def test_use_s3_api_true_when_both_profiles_exist(self):
+        cred_path = self._write_temp_file(
+            '[oci]\n'
+            'aws_access_key_id = test_key\n'
+            'aws_secret_access_key = test_secret\n')
+        config_path = self._write_temp_file(
+            '[profile oci]\n'
+            'endpoint_url = https://ns.compat.objectstorage.us-sanjose-1'
+            '.oci.customer-oci.com\n'
+            'region = us-sanjose-1\n')
+        try:
+            with mock.patch('sky.adaptors.oci_s3.OCI_S3_CREDENTIALS_PATH',
+                            cred_path), \
+                 mock.patch('sky.adaptors.oci_s3.OCI_S3_CONFIG_PATH',
+                            config_path):
+                self.assertTrue(oci_s3.use_s3_api())
+        finally:
+            os.unlink(cred_path)
+            os.unlink(config_path)
+
+    def test_use_s3_api_false_when_only_credentials_exist(self):
+        cred_path = self._write_temp_file(
+            '[oci]\n'
+            'aws_access_key_id = test_key\n'
+            'aws_secret_access_key = test_secret\n')
+        try:
+            with mock.patch('sky.adaptors.oci_s3.OCI_S3_CREDENTIALS_PATH',
+                            cred_path), \
+                 mock.patch('sky.adaptors.oci_s3.OCI_S3_CONFIG_PATH',
+                            '/nonexistent/oci/s3.config'):
+                self.assertFalse(oci_s3.use_s3_api())
+        finally:
+            os.unlink(cred_path)
+
+    def test_get_endpoint_raises_when_config_missing(self):
+        with mock.patch('os.path.isfile', return_value=False):
+            with self.assertRaises(ValueError) as context:
+                oci_s3.get_endpoint()
+            self.assertIn('endpoint not found', str(context.exception))
+
+    def test_get_endpoint_raises_when_endpoint_url_missing(self):
+        config_path = self._write_temp_file('[profile oci]\n'
+                                            'region = us-sanjose-1\n')
+        try:
+            with mock.patch('sky.adaptors.oci_s3.OCI_S3_CONFIG_PATH',
+                            config_path):
+                with self.assertRaises(ValueError):
+                    oci_s3.get_endpoint()
+        finally:
+            os.unlink(config_path)
+
+    def test_get_endpoint_from_config_file(self):
+        endpoint = ('https://ns.compat.objectstorage.us-sanjose-1'
+                    '.oci.customer-oci.com')
+        config_path = self._write_temp_file('[profile oci]\n'
+                                            f'endpoint_url = {endpoint}\n')
+        try:
+            with mock.patch('sky.adaptors.oci_s3.OCI_S3_CONFIG_PATH',
+                            config_path):
+                self.assertEqual(oci_s3.get_endpoint(), endpoint)
+        finally:
+            os.unlink(config_path)
+
+    def test_get_region_from_config_file(self):
+        config_path = self._write_temp_file('[profile oci]\n'
+                                            'endpoint_url = https://e\n'
+                                            'region = us-sanjose-1\n')
+        try:
+            with mock.patch('sky.adaptors.oci_s3.OCI_S3_CONFIG_PATH',
+                            config_path):
+                self.assertEqual(oci_s3.get_region(), 'us-sanjose-1')
+        finally:
+            os.unlink(config_path)
+
+    def test_get_region_none_when_unset(self):
+        config_path = self._write_temp_file('[profile oci]\n'
+                                            'endpoint_url = https://e\n')
+        try:
+            with mock.patch('sky.adaptors.oci_s3.OCI_S3_CONFIG_PATH',
+                            config_path):
+                self.assertIsNone(oci_s3.get_region())
+        finally:
+            os.unlink(config_path)
+
+    @mock.patch('sky.adaptors.oci_s3.oci_s3_profile_in_config')
+    @mock.patch('sky.adaptors.oci_s3.oci_s3_profile_in_cred')
+    def test_check_storage_credentials_success(self, mock_cred, mock_config):
+        mock_cred.return_value = True
+        mock_config.return_value = True
+
+        result, hints = oci_s3.check_storage_credentials()
+
+        self.assertTrue(result)
+        self.assertIsNone(hints)
+
+    @mock.patch('sky.adaptors.oci_s3.oci_s3_profile_in_config')
+    @mock.patch('sky.adaptors.oci_s3.oci_s3_profile_in_cred')
+    def test_check_storage_credentials_missing_cred(self, mock_cred,
+                                                    mock_config):
+        mock_cred.return_value = False
+        mock_config.return_value = True
+
+        result, hints = oci_s3.check_storage_credentials()
+
+        self.assertFalse(result)
+        self.assertIsNotNone(hints)
+        self.assertIn(oci_s3.OCI_S3_CREDENTIALS_PATH, hints)
+
+    @mock.patch('sky.adaptors.oci_s3.oci_s3_profile_in_config')
+    @mock.patch('sky.adaptors.oci_s3.oci_s3_profile_in_cred')
+    def test_check_storage_credentials_missing_both(self, mock_cred,
+                                                    mock_config):
+        mock_cred.return_value = False
+        mock_config.return_value = False
+
+        result, hints = oci_s3.check_storage_credentials()
+
+        self.assertFalse(result)
+        self.assertIsNotNone(hints)
+        self.assertIn(oci_s3.OCI_S3_CREDENTIALS_PATH, hints)
+        self.assertIn(oci_s3.OCI_S3_CONFIG_PATH, hints)
+
+    def test_check_credentials_unsupported_capability(self):
+        with self.assertRaises(exceptions.NotSupportedError):
+            oci_s3.check_credentials(cloud.CloudCapability.COMPUTE)
+
+    def test_get_credential_file_mounts(self):
+        mounts = oci_s3.get_credential_file_mounts()
+
+        self.assertEqual(
+            mounts, {
+                oci_s3.OCI_S3_CREDENTIALS_PATH: oci_s3.OCI_S3_CREDENTIALS_PATH,
+                oci_s3.OCI_S3_CONFIG_PATH: oci_s3.OCI_S3_CONFIG_PATH,
+            })
+
+    @mock.patch('sky.adaptors.oci_s3.session')
+    @mock.patch('sky.adaptors.oci_s3.get_oci_s3_credentials')
+    @mock.patch('sky.adaptors.oci_s3.get_endpoint')
+    @mock.patch('sky.adaptors.oci_s3.get_region')
+    def test_client_creation(self, mock_get_region, mock_get_endpoint,
+                             mock_get_creds, mock_session):
+        mock_session_obj = mock.Mock()
+        mock_session.return_value = mock_session_obj
+
+        mock_creds = mock.Mock()
+        mock_creds.access_key = 'test_access_key'
+        mock_creds.secret_key = 'test_secret_key'
+        mock_get_creds.return_value = mock_creds
+
+        mock_get_endpoint.return_value = 'https://test-endpoint.com'
+        mock_get_region.return_value = 'us-sanjose-1'
+
+        oci_s3.client('s3')
+
+        mock_session_obj.client.assert_called_once()
+        call_args = mock_session_obj.client.call_args
+        self.assertEqual(call_args[0][0], 's3')
+        self.assertEqual(call_args[1]['endpoint_url'],
+                         'https://test-endpoint.com')
+        self.assertEqual(call_args[1]['aws_access_key_id'], 'test_access_key')
+        self.assertEqual(call_args[1]['aws_secret_access_key'],
+                         'test_secret_key')
+        self.assertEqual(call_args[1]['region_name'], 'us-sanjose-1')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit_tests/test_sky/storage/test_oci_s3_store.py
+++ b/tests/unit_tests/test_sky/storage/test_oci_s3_store.py
@@ -1,0 +1,155 @@
+"""Unit tests for OCI S3-compatible storage dispatch and store behavior."""
+
+import unittest
+from unittest import mock
+
+from sky import cloud_stores
+from sky import exceptions
+from sky.data import storage as storage_lib
+
+
+def _make_storage(**attrs):
+    """Creates a bare Storage object without running __init__."""
+    obj = object.__new__(storage_lib.Storage)
+    obj.name = attrs.get('name', 'test-bucket')
+    obj.source = attrs.get('source', None)
+    obj.sync_on_reconstruction = attrs.get('sync_on_reconstruction', False)
+    obj._bucket_sub_path = attrs.get('_bucket_sub_path', None)
+    obj.stores = attrs.get('stores', {})
+    obj._constructed = True
+    obj._is_sky_managed = attrs.get('_is_sky_managed', None)
+    return obj
+
+
+class TestOciStoreDispatch(unittest.TestCase):
+    """StoreType.OCI must dispatch on oci_s3.use_s3_api()."""
+
+    def test_oci_s3_store_not_in_s3_compatible_registry(self):
+        # Registering under 'OCI' would take over all StoreType.OCI dispatch
+        # unconditionally (the registry is consulted before the StoreType.OCI
+        # branches), bypassing the use_s3_api() gate.
+        self.assertNotIn('OCI', storage_lib._S3_COMPATIBLE_STORES)
+
+    def _run_from_metadata(self, use_s3_api: bool):
+        metadata = storage_lib.AbstractStore.StoreMetadata(name='test-bucket',
+                                                           source=None,
+                                                           region=None,
+                                                           is_sky_managed=True)
+        sky_stores = {storage_lib.StoreType.OCI: metadata}
+        storage_obj = _make_storage()
+
+        native_sentinel = mock.Mock(name='native_store')
+        s3_sentinel = mock.Mock(name='s3_store')
+        with mock.patch.object(storage_lib.OciStore, 'from_metadata',
+                               return_value=native_sentinel), \
+             mock.patch.object(storage_lib.OciS3CompatibleStore,
+                               'from_metadata', return_value=s3_sentinel), \
+             mock.patch('sky.data.storage.oci_s3.use_s3_api',
+                        return_value=use_s3_api), \
+             mock.patch.object(storage_obj, '_add_store') as mock_add:
+            storage_obj._add_store_from_metadata(sky_stores)
+
+        mock_add.assert_called_once()
+        return mock_add.call_args[0][0], native_sentinel, s3_sentinel
+
+    def test_from_metadata_native_mode(self):
+        store, native_sentinel, _ = self._run_from_metadata(use_s3_api=False)
+        self.assertIs(store, native_sentinel)
+
+    def test_from_metadata_s3_mode(self):
+        store, _, s3_sentinel = self._run_from_metadata(use_s3_api=True)
+        self.assertIs(store, s3_sentinel)
+
+    def _run_add_store(self, use_s3_api: bool):
+        storage_obj = _make_storage()
+        native_cls = mock.Mock(name='OciStore')
+        s3_cls = mock.Mock(name='OciS3CompatibleStore')
+        with mock.patch('sky.data.storage.OciStore', native_cls), \
+             mock.patch('sky.data.storage.OciS3CompatibleStore', s3_cls), \
+             mock.patch('sky.data.storage.oci_s3.use_s3_api',
+                        return_value=use_s3_api), \
+             mock.patch.object(storage_obj, '_add_store'), \
+             mock.patch.object(storage_obj, '_sync_store'):
+            storage_obj.add_store(storage_lib.StoreType.OCI)
+        return native_cls, s3_cls
+
+    def test_add_store_native_mode(self):
+        native_cls, s3_cls = self._run_add_store(use_s3_api=False)
+        native_cls.assert_called_once()
+        s3_cls.assert_not_called()
+
+    def test_add_store_s3_mode(self):
+        native_cls, s3_cls = self._run_add_store(use_s3_api=True)
+        s3_cls.assert_called_once()
+        native_cls.assert_not_called()
+
+
+class TestOciS3CompatibleStore(unittest.TestCase):
+    """OciS3CompatibleStore behavior that needs no cloud access."""
+
+    def test_get_config(self):
+        config = storage_lib.OciS3CompatibleStore.get_config()
+        self.assertEqual(config.store_type, 'OCI')
+        self.assertEqual(config.url_prefix, 'oci://')
+        self.assertEqual(config.cloud_name, 'OCI')
+
+    def test_region_suffix_in_name_rejected(self):
+        with self.assertRaises(exceptions.StorageNameError) as context:
+            storage_lib.OciS3CompatibleStore(name='bucket@us-sanjose-1',
+                                             source=None)
+        self.assertIn('S3-compatible', str(context.exception))
+
+    def test_region_suffix_in_source_rejected(self):
+        with self.assertRaises(exceptions.StorageNameError):
+            storage_lib.OciS3CompatibleStore(name='bucket',
+                                             source='oci://bucket@us-sanjose-1')
+
+    def test_validate_name_follows_oci_rules(self):
+        # OCI bucket names allow uppercase letters and underscores, which
+        # the generic S3 naming rules would reject.
+        name = 'My_Bucket.2024'
+        self.assertEqual(storage_lib.OciS3CompatibleStore.validate_name(name),
+                         name)
+
+
+class TestOciCloudStorageDispatch(unittest.TestCase):
+    """cloud_stores.get_storage_from_path must dispatch on use_s3_api()."""
+
+    def test_native_mode(self):
+        with mock.patch('sky.cloud_stores.oci_s3.use_s3_api',
+                        return_value=False):
+            store = cloud_stores.get_storage_from_path('oci://bucket/path')
+        self.assertIsInstance(store, cloud_stores.OciCloudStorage)
+
+    def test_s3_mode(self):
+        with mock.patch('sky.cloud_stores.oci_s3.use_s3_api',
+                        return_value=True):
+            store = cloud_stores.get_storage_from_path('oci://bucket/path')
+        self.assertIsInstance(store, cloud_stores.OciS3CloudStorage)
+
+
+class TestOciS3CloudStorageCommands(unittest.TestCase):
+    """Generated sync commands must use the AWS CLI with the OCI S3 files."""
+
+    def test_make_sync_dir_command(self):
+        cmd = cloud_stores.OciS3CloudStorage().make_sync_dir_command(
+            'oci://bucket/path', '/dest')
+        self.assertIn('s3://bucket/path', cmd)
+        self.assertNotIn('oci://', cmd)
+        self.assertIn('aws s3 sync', cmd)
+        self.assertIn('AWS_SHARED_CREDENTIALS_FILE=~/.oci/s3.credentials', cmd)
+        self.assertIn('AWS_CONFIG_FILE=~/.oci/s3.config', cmd)
+        self.assertIn('--profile=oci', cmd)
+
+    def test_make_sync_file_command(self):
+        cmd = cloud_stores.OciS3CloudStorage().make_sync_file_command(
+            'oci://bucket/path/file', '/dest')
+        self.assertIn('s3://bucket/path/file', cmd)
+        self.assertNotIn('oci://', cmd)
+        self.assertIn('aws s3 cp', cmd)
+        self.assertIn('AWS_SHARED_CREDENTIALS_FILE=~/.oci/s3.credentials', cmd)
+        self.assertIn('--profile=oci', cmd)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit_tests/test_sky/storage/test_oci_s3_store.py
+++ b/tests/unit_tests/test_sky/storage/test_oci_s3_store.py
@@ -104,6 +104,19 @@ class TestOciS3CompatibleStore(unittest.TestCase):
             storage_lib.OciS3CompatibleStore(name='bucket',
                                              source='oci://bucket@us-sanjose-1')
 
+    def test_local_source_with_at_sign_accepted(self):
+        # A local path containing '@' (e.g. run@v2) must not be rejected.
+        # Only oci:// source URIs are inspected for the <bucket>@<region> form.
+        # The region-suffix check runs before super().__init__; mock the
+        # parent constructor so the test never validates credentials or
+        # touches the cloud (the real initialize() creates missing buckets).
+        with mock.patch.object(storage_lib.S3CompatibleStore,
+                               '__init__',
+                               return_value=None) as mock_parent_init:
+            storage_lib.OciS3CompatibleStore(name='bucket',
+                                             source='~/ckpts/run@v2')
+        mock_parent_init.assert_called_once()
+
     def test_validate_name_follows_oci_rules(self):
         # OCI bucket names allow uppercase letters and underscores, which
         # the generic S3 naming rules would reject.


### PR DESCRIPTION
## Summary

OCI Object Storage exposes an [Amazon S3 Compatibility API](https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi.htm) authenticated with a Customer Secret Key (an access/secret key pair, distinct from the native OCI API key). This PR adds support for accessing `oci://` storage through that API, following the same `S3CompatibleStore` pattern as CoreWeave/Nebius/VastData:

- **`OciS3CompatibleStore(S3CompatibleStore)`**: serves `StoreType.OCI` instead of the native `OciStore` when the S3-compatible credential files are present (`~/.oci/s3.credentials` + `~/.oci/s3.config`, the latter carrying the tenancy-specific `endpoint_url`). The class is intentionally **not** registered via `@register_s3_compatible_store`: the registry is consulted before the `StoreType.OCI` dispatch branches, so registering under `'OCI'` would take over all OCI dispatch unconditionally instead of respecting the runtime gate.
- **`sky/adaptors/oci_s3.py`**: boto3 session/client/resource against the tenancy endpoint with path-style addressing, credential checks with setup hints, and credential file mounts.
- **`OciS3CloudStorage`** in `cloud_stores.py`: `oci://` file_mounts are fetched with the AWS CLI in S3-compatible mode — remote nodes need neither the OCI CLI nor the native API key.
- **`sky/clouds/oci.py`**: the storage credential check passes on the S3 credential files alone in S3-compatible mode (the compute check is unchanged); credential file mounts include the S3 files so they propagate to clusters and the jobs controller.
- Mount (goofys/rclone) and cached-mount (rclone) support.
- **Signing region & upload encoding**: the SigV4 signing region is passed to the goofys (`--region`) and rclone (`--s3-region`) mount commands — OCI validates it against the region-specific endpoint, and goofys would otherwise default to `us-east-1` and be rejected outside the home region. Checksum calculation is set to `when_required` for the boto3 client, the AWS CLI sync/cp paths, and the goofys mount, because OCI returns **HTTP 501** for uploads using `aws-chunked` content encoding (the trailing-checksum transfer newer AWS SDKs enable by default). See OCI's [S3 SDK support notes](https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi_topic-Amazon_S3_Compatibility_API_Support.htm).

**`sky/setup_files/dependencies.py` is unchanged**: `boto3`/`botocore` are loaded via `LazyImport` in `oci_s3.py`, so they are not hard dependencies. Unlike CoreWeave/Nebius/VastData where S3-compatible is the only storage path, OCI has both native and S3-compatible paths — adding `aws_dependencies` to `'oci'` would force `boto3`/`awscli` on all `pip install "skypilot[oci]"` users regardless. Users who opt into S3-compatible mode without `boto3` installed get a clear runtime error with a `pip install boto3` hint.

**Backward compatibility:** without the new credential files, behavior is unchanged — the native OCI SDK/CLI path is used, and the files live at newly introduced paths so no existing deployment can switch unintentionally. Data written via either API is readable via the other (the datasets are congruent per Oracle docs), so enabling S3-compatible mode on an existing deployment keeps existing buckets accessible. The `<bucket>@<region>` suffix is not supported in S3-compatible mode (the endpoint pins a single region) and raises a clear error.

## Test plan

Unit tests (included):

```
pytest tests/unit_tests/test_sky/storage/ tests/unit_tests/test_sky/adaptors/
# 229 passed — includes new tests for adaptor INI parsing/detection,
# StoreType.OCI dispatch gating (add_store + metadata reconstruction),
# cloud_stores dispatch and generated sync commands, @<region> rejection,
# and OCI bucket naming rules.
```

Verified end-to-end against a real OCI tenancy (`us-sanjose-1` home region, path-style namespaced endpoint).

Setup:

```
AWS_SHARED_CREDENTIALS_FILE=~/.oci/s3.credentials aws configure --profile oci
AWS_CONFIG_FILE=~/.oci/s3.config aws configure set endpoint_url \
  https://<namespace>.compat.objectstorage.<region>.oci.customer-oci.com --profile oci
AWS_CONFIG_FILE=~/.oci/s3.config aws configure set region <region> --profile oci
```

- **`sky check oci`** → storage enabled from the S3 credential files alone (no `~/.oci/config`); compute check unchanged.
- **MOUNT** (goofys): wrote a file into the bucket and read it back; content persisted (confirmed server-side).
- **MOUNT_CACHED** (rclone): wrote a file into the bucket; persisted.
- **COPY**: downloaded an existing bucket to the VM and read its objects.
- **Upload** a local directory via `store: oci` (`aws s3 sync`, multipart for large files), then read it back.
- **boto3** `put_object`/`get_object` directly against the endpoint.
- **Bucket auto-creation**: a non-existent bucket given via `store:`+`name:` is created (`CreateBucket`); a bare `source: oci://<nonexistent>` correctly errors with "non-existent bucket as a source".
- **Large-object integrity**: uploaded a 3.25 GB model out-of-band via the AWS CLI (multipart), then read it back through MOUNT and COPY — `sha256` matched byte-for-byte.
- **Region**: confirmed signing must use the endpoint's region; the default `us-east-1` is rejected outside the home region.
- **aws-chunked**: confirmed default trailing-checksum uploads return HTTP 501, and `request_checksum_calculation=when_required` resolves it across boto3, the AWS CLI, and goofys.
- **Backward compatibility**: removed the credential files and confirmed the native OCI path is used unchanged.

- [x] Verified against a real OCI tenancy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
