### PR TITLE
[Test] Mark test_workspace_k8s_remote_identity as no_dependency

### DIFF
--- a/tests/smoke_tests/test_workspaces.py
+++ b/tests/smoke_tests/test_workspaces.py
@@ -335,6 +335,8 @@ def test_workspace_multiple_aws_profiles():
 # ---------- Test per-workspace Kubernetes remote_identity ----------
 @pytest.mark.kubernetes
 @pytest.mark.no_remote_server
+# We can't restart the api server in the dependency test.
+@pytest.mark.no_dependency
 def test_workspace_k8s_remote_identity():
     """Does each team's cluster run under its own Kubernetes ServiceAccount?
 


### PR DESCRIPTION
## Summary

- `test_workspace_k8s_remote_identity` (added in #9787) restarts the API server via `SKY_API_RESTART`, which breaks `--dependency` smoke-test builds: the client env there only has the base `skypilot` package (no extras), so the restarted server fails to import the Kubernetes dependencies, `sky check` disables kubernetes, and the next `sky launch --infra kubernetes` fails with `Task 'sky-cmd' requires kubernetes which is not enabled`.
- Mark it `@pytest.mark.no_dependency`, same as the sibling `test_workspace_switching` and other API-server-restarting tests ("We can't restart the api server in the dependency test").

Failed nightly: https://buildkite.com/skypilot-1/smoke-tests/builds/11215 (`nightly-build-pypi --kubernetes --no-resource-heavy --dependency`) — the only failed job, with `Reason [compute]: Failed to get SSH contexts: Failed to import dependencies for Kubernetes. Try running: pip install "skypilot[kubernetes]"` in the post-failure `sky check` output. The test passes on plain `--kubernetes` builds where the env has full deps.

Note: `test_workspace_multiple_aws_profiles` also restarts the API server without `no_dependency`; it hasn't failed only because it's `aws`-marked and doesn't run in kubernetes dependency builds. Left out per scope, can follow up.

## Test plan

- The change is a pytest marker only; `tests/conftest.py` skips `no_dependency`-marked tests when `--dependency` is set, so the next `--dependency` nightly will skip this test while plain `--kubernetes` runs keep it.
- Verified collection locally:
  `pytest tests/smoke_tests/test_workspaces.py::test_workspace_k8s_remote_identity --collect-only -q --kubernetes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)