### PR TITLE
[Test] Fix false failure in storage mount checks with a local API server

### DIFF
--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -997,7 +997,9 @@ def run_cloud_cmd_on_cluster(test_cluster_name: str,
         if setup_cmd is not None:
             # Group `cmd` so that a setup failure fails the whole command
             # instead of falling through to any `||` branches in `cmd`.
-            cmd = f'{setup_cmd} && {{ {cmd}; }}'
+            # Strip trailing semicolons from `cmd` first: `;;` inside the
+            # group is a bash syntax error.
+            cmd = f'{setup_cmd} && {{ {cmd.rstrip().rstrip(";")}; }}'
         cmd = f'{constants.ACTIVATE_SKY_REMOTE_PYTHON_ENV} && {cmd}'
         wait_for_cluster_up = get_cmd_wait_until_cluster_status_contains(
             cluster_name=cluster_name,

--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -977,13 +977,27 @@ def run_cloud_cmd_on_cluster(test_cluster_name: str,
                              cmd: str,
                              envs: Set[str] = None,
                              timeout: int = 180,
-                             skip_remote_server_check: bool = False) -> str:
-    """Run the cloud command on the remote cluster for cloud commands."""
+                             skip_remote_server_check: bool = False,
+                             setup_cmd: Optional[str] = None) -> str:
+    """Run the cloud command on the remote cluster for cloud commands.
+
+    Args:
+        setup_cmd: Optional command to prepare the remote cloud-cmd cluster
+            (e.g. installing cloud CLIs into the SkyPilot runtime venv). Only
+            run when `cmd` targets the remote cluster: when the API server is
+            local, `cmd` runs verbatim on the local machine, where the
+            runtime venv does not exist and the local environment is assumed
+            to already have the cloud dependencies.
+    """
     cluster_name = test_cluster_name + _CLOUD_CMD_CLUSTER_NAME_SUFFIX
     if not skip_remote_server_check and sky.server.common.is_api_server_local(
     ) and not is_remote_server_test():
         return cmd
     else:
+        if setup_cmd is not None:
+            # Group `cmd` so that a setup failure fails the whole command
+            # instead of falling through to any `||` branches in `cmd`.
+            cmd = f'{setup_cmd} && {{ {cmd}; }}'
         cmd = f'{constants.ACTIVATE_SKY_REMOTE_PYTHON_ENV} && {cmd}'
         wait_for_cluster_up = get_cmd_wait_until_cluster_status_contains(
             cluster_name=cluster_name,

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -1302,9 +1302,9 @@ def test_managed_jobs_storage(generic_cloud: str):
             '2> /dev/null || true')
         all_output_checks = ' && '.join(output_check_cmds)
         output_check_cmd = smoke_tests_utils.run_cloud_cmd_on_cluster(
-            name, f'{cloud_dependencies_setup_cmd}; '
-            f'{try_activating_gcp_service_account}; '
-            f'{all_output_checks}')
+            name, f'{try_activating_gcp_service_account}; '
+            f'{all_output_checks}',
+            setup_cmd=cloud_dependencies_setup_cmd)
         # Replace the single output bucket in the YAML with one per store, and
         # write output.txt to each. 'sky-output-bucket' is replaced with the
         # unique output_storage_name below, same as for other clouds.

--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -257,12 +257,16 @@ def test_concurrent_file_mounts_jobs_launch(generic_cloud: str):
 
 
 # ---------- storage ----------
-def _storage_mounts_commands_generator(f: TextIO, cluster_name: str,
-                                       storage_name: str,
-                                       empty_storage_name: str,
-                                       ls_hello_command: str, cloud: str,
-                                       only_mount: bool,
-                                       include_mount_cached: bool):
+def _storage_mounts_commands_generator(
+        f: TextIO,
+        cluster_name: str,
+        storage_name: str,
+        empty_storage_name: str,
+        ls_hello_command: str,
+        cloud: str,
+        only_mount: bool,
+        include_mount_cached: bool,
+        cloud_cmd_setup_cmd: Optional[str] = None):
     assert cloud in ['aws', 'gcp', 'azure', 'kubernetes']
     template_str = pathlib.Path(
         'tests/test_yamls/test_storage_mounting.yaml.j2').read_text()
@@ -304,8 +308,8 @@ def _storage_mounts_commands_generator(f: TextIO, cluster_name: str,
         *smoke_tests_utils.STORAGE_SETUP_COMMANDS,
         f'sky launch -y -c {cluster_name} --infra {cloud} {smoke_tests_utils.LOW_RESOURCE_ARG} {file_path}',
         f'sky logs {cluster_name} 1 --status',  # Ensure job succeeded.
-        smoke_tests_utils.run_cloud_cmd_on_cluster(cluster_name,
-                                                   cmd=ls_hello_command),
+        smoke_tests_utils.run_cloud_cmd_on_cluster(
+            cluster_name, cmd=ls_hello_command, setup_cmd=cloud_cmd_setup_cmd),
         stop_command,
         f'sky start -y {cluster_name}',
         # Check if hello.txt from mounting bucket exists after restart in
@@ -610,14 +614,26 @@ def test_kubernetes_storage_mounts(storage_name_prefix: str):
                         f'{gcs_ls_cmd}; }} || {{ '
                         f'{azure_check_cmd}; }} || {{ '
                         f'{nebius_ls_cmd}; }}')
+    # The cloud-cmd cluster needs the cloud CLIs installed into the SkyPilot
+    # runtime venv to run the check. This must NOT be prepended to
+    # ls_hello_command directly: with a local API server the command runs
+    # verbatim on the local machine, where the venv does not exist, and the
+    # failed install would silently skip the `aws s3 ls` branch above and
+    # fall through to the wrong-cloud fallbacks.
     cloud_cmd_cluster_setup_cmd_list = controller_utils._get_cloud_dependencies_installation_commands(
         controller_utils.Controllers.JOBS_CONTROLLER)
     cloud_cmd_cluster_setup_cmd = ' && '.join(cloud_cmd_cluster_setup_cmd_list)
-    ls_hello_command = f'{cloud_cmd_cluster_setup_cmd} && {ls_hello_command}'
     with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
         test_commands, clean_command = _storage_mounts_commands_generator(
-            f, name, storage_name, empty_storage_name, ls_hello_command,
-            'kubernetes', False, False)
+            f,
+            name,
+            storage_name,
+            empty_storage_name,
+            ls_hello_command,
+            'kubernetes',
+            False,
+            False,
+            cloud_cmd_setup_cmd=cloud_cmd_cluster_setup_cmd)
         test = smoke_tests_utils.Test(
             'kubernetes_storage_mounts',
             test_commands,


### PR DESCRIPTION
## Why the test fails

`test_kubernetes_storage_mounts` verifies the mounted bucket with a single shell chain that **prepends the jobs-controller cloud-deps install** (`uv pip install awscli boto3 ...` into the `$HOME/skypilot-runtime` venv) in front of a 4-leg fallback check:

```
<deps install> && aws s3 ls s3://<bucket>/hello.txt \
  || { gsutil ls ...; } || { az storage blob list ...; } || { aws s3 ls --profile=nebius ...; }
```

`run_cloud_cmd_on_cluster()` has two execution paths:

- **Remote API server**: the command runs via `sky exec` on the `-cloud-cmd` helper cluster, where the runtime venv exists → install works as intended.
- **Local API server**: the command is returned **verbatim and runs on the local machine**, where `$HOME/skypilot-runtime` does not exist → the install always fails:

  ```
  error: Failed to inspect Python interpreter from active virtual environment
  Caused by: Python interpreter not found at ~/skypilot-runtime/bin/python3
  ```

Because the install is `&&`-bound only to the first (`aws s3 ls`) leg, shell `||` fallthrough silently skips the S3 check and tries the gsutil/az/nebius legs instead.

## In what case it bites

The bucket's store is `Task._get_preferred_store()` = the **first storage cloud `sky check` enables**, which varies per environment. So with a local API server:

- Bucket lands in **GCS/Azure** → a fallback leg happens to pass → test green, install failure invisible (this is why it has gone unnoticed — the install has been silently failing in green runs all along).
- Bucket lands in **S3** → no fallback can find it → exit 255 → test **fails deterministically, even though `hello.txt` is verifiably in the S3 bucket the whole time** (confirmed with a 3s-interval watcher on the bucket during a failing CI run; a forced-`store: s3` mount probe also landed the file in S3 within ~1s, exonerating the product mount/write path).

So the test is a per-environment coin flip between "always green" and "always red". This hit our CI where the environment enabled S3 first, failing all 3 parametrized variants.

## Why this is bad test design

1. **Environment-dependent commands baked into the check**: the deps install only makes sense on the remote helper cluster, but it was glued into a command that may also run locally.
2. **Failure masking via `||` fallthrough**: a setup failure doesn't fail the test — it silently changes *which* check runs, converting an infra error into either a false pass or a false failure depending on unrelated state (store selection order).

## Fix

- `run_cloud_cmd_on_cluster()` gains an optional `setup_cmd` that is **only prepended on the remote `-cloud-cmd` cluster path** (after `ACTIVATE_SKY_REMOTE_PYTHON_ENV`, where the venv exists). The local path returns the check command untouched — the local environment already has the cloud CLIs.
- On the remote path the main command is grouped as `setup && { cmd; }`, so a setup failure now fails the whole command loudly instead of falling through to wrong-cloud legs.
- `test_kubernetes_storage_mounts` and the same pattern in `test_managed_jobs_storage` pass the deps install via `setup_cmd` instead of baking it into the command.

## Tested

- Unit-style verification of command construction with `is_api_server_local` mocked both ways:
  - local path: check command returned verbatim, no install present;
  - remote path: `... skypilot-runtime/bin/activate && <install> && { s3 || gcs || az || nebius; }` wrapped in `sky exec`;
  - no `setup_cmd`: output identical to before this change.
- Shell semantics check: `install-that-fails && { false || echo FALLBACK; }` exits 1 without running the fallback leg.
- `pytest --collect-only` on `test_kubernetes_storage_mounts` (3 variants) and `test_managed_jobs_storage` collects cleanly.
- Reproduced the original failure standalone on a CI agent (`VIRTUAL_ENV=$HOME/skypilot-runtime uv pip install awscli boto3` → interpreter-not-found) and confirmed the object was present in S3 during a failing run.
- `bash format.sh --files` on the three touched files passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)