### PR TITLE
[Dashboard] Show "—" for clusters/jobs on storage-only infra rows

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -2733,6 +2733,10 @@ export function GPUs() {
         name: r.name || r.id,
         clusters: 0,
         jobs: 0,
+        // Storage-only infrastructure (object storage that cannot host
+        // clusters or managed jobs). Such rows render a "—" in the Clusters
+        // and Jobs columns instead of a misleading 0.
+        storageOnly: r.storageOnly === true,
       }));
     return [...base, ...extras];
   }, [cloudInfraData, workspaceEnabledClouds, extraInfraRows]);
@@ -3060,7 +3064,14 @@ export function GPUs() {
                           </div>
                         </td>
                         <td className="p-3">
-                          {clusterDataLoading ? (
+                          {cloud.storageOnly ? (
+                            <span
+                              className="text-gray-400"
+                              title="Storage-only infrastructure does not run clusters"
+                            >
+                              —
+                            </span>
+                          ) : clusterDataLoading ? (
                             <SkeletonBadge />
                           ) : (
                             <span className="px-2 py-0.5 bg-gray-100 text-gray-500 rounded text-xs font-medium">
@@ -3069,7 +3080,14 @@ export function GPUs() {
                           )}
                         </td>
                         <td className="p-3">
-                          {sshAndKubeJobsDataLoading ? (
+                          {cloud.storageOnly ? (
+                            <span
+                              className="text-gray-400"
+                              title="Storage-only infrastructure does not run managed jobs"
+                            >
+                              —
+                            </span>
+                          ) : sshAndKubeJobsDataLoading ? (
                             <SkeletonBadge />
                           ) : (
                             <span className="px-2 py-0.5 bg-gray-100 text-gray-500 rounded text-xs font-medium">

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -3066,7 +3066,7 @@ export function GPUs() {
                         <td className="p-3">
                           {cloud.storageOnly ? (
                             <span
-                              className="px-2 py-0.5 text-gray-400 text-xs font-medium"
+                              className="py-0.5 text-gray-400 text-xs font-medium"
                               title="Storage-only infrastructure does not run clusters"
                             >
                               —
@@ -3082,7 +3082,7 @@ export function GPUs() {
                         <td className="p-3">
                           {cloud.storageOnly ? (
                             <span
-                              className="px-2 py-0.5 text-gray-400 text-xs font-medium"
+                              className="py-0.5 text-gray-400 text-xs font-medium"
                               title="Storage-only infrastructure does not run managed jobs"
                             >
                               —

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -3066,7 +3066,7 @@ export function GPUs() {
                         <td className="p-3">
                           {cloud.storageOnly ? (
                             <span
-                              className="text-gray-400"
+                              className="px-2 py-0.5 text-gray-400 text-xs font-medium"
                               title="Storage-only infrastructure does not run clusters"
                             >
                               —
@@ -3082,7 +3082,7 @@ export function GPUs() {
                         <td className="p-3">
                           {cloud.storageOnly ? (
                             <span
-                              className="text-gray-400"
+                              className="px-2 py-0.5 text-gray-400 text-xs font-medium"
                               title="Storage-only infrastructure does not run managed jobs"
                             >
                               —

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -3065,12 +3065,11 @@ export function GPUs() {
                         </td>
                         <td className="p-3">
                           {cloud.storageOnly ? (
-                            <span
-                              className="px-1.5 py-0.5 text-gray-400 text-xs font-medium"
-                              title="Storage-only infrastructure does not run clusters"
-                            >
-                              —
-                            </span>
+                            <NonCapitalizedTooltip content="Storage-only infrastructure does not run clusters">
+                              <span className="px-1.5 py-0.5 text-gray-400 text-xs font-medium cursor-help">
+                                —
+                              </span>
+                            </NonCapitalizedTooltip>
                           ) : clusterDataLoading ? (
                             <SkeletonBadge />
                           ) : (
@@ -3081,12 +3080,11 @@ export function GPUs() {
                         </td>
                         <td className="p-3">
                           {cloud.storageOnly ? (
-                            <span
-                              className="px-1.5 py-0.5 text-gray-400 text-xs font-medium"
-                              title="Storage-only infrastructure does not run managed jobs"
-                            >
-                              —
-                            </span>
+                            <NonCapitalizedTooltip content="Storage-only infrastructure does not run managed jobs">
+                              <span className="px-1.5 py-0.5 text-gray-400 text-xs font-medium cursor-help">
+                                —
+                              </span>
+                            </NonCapitalizedTooltip>
                           ) : sshAndKubeJobsDataLoading ? (
                             <SkeletonBadge />
                           ) : (

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -3066,7 +3066,7 @@ export function GPUs() {
                         <td className="p-3">
                           {cloud.storageOnly ? (
                             <span
-                              className="py-0.5 text-gray-400 text-xs font-medium"
+                              className="px-1.5 py-0.5 text-gray-400 text-xs font-medium"
                               title="Storage-only infrastructure does not run clusters"
                             >
                               —
@@ -3082,7 +3082,7 @@ export function GPUs() {
                         <td className="p-3">
                           {cloud.storageOnly ? (
                             <span
-                              className="py-0.5 text-gray-400 text-xs font-medium"
+                              className="px-1.5 py-0.5 text-gray-400 text-xs font-medium"
                               title="Storage-only infrastructure does not run managed jobs"
                             >
                               —


### PR DESCRIPTION
## Summary

Infra-row data providers can contribute cloud rows for storage-only infrastructure (object storage that can't host clusters or managed jobs). Those rows previously rendered a misleading `0` under Clusters/Jobs.

- Let a contributed row declare `storageOnly: true` on the extra-infra-row object
- Render `—` (em-dash, gray, with an explanatory tooltip) in the Clusters and Jobs columns for such rows
- Ordinary cloud rows are unaffected

## Test plan

- With a data provider contributing a `storageOnly: true` cloud row via `useExtraInfraRows`, the Infra page shows `—` (not `0`) for that row's Clusters and Jobs columns
- Hovering the `—` shows the tooltip ("Storage-only infrastructure does not run clusters / managed jobs")
- Ordinary cloud rows continue to show their live cluster/job counts (or skeleton badges while loading) unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_019zYTYwizZZajG3XRis4zTe)_