### PR TITLE
[Jobs] Show last-cached infra/resources for finished jobs

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -2272,6 +2272,17 @@ def _update_fields(fields: List[str],) -> Tuple[List[str], bool]:
     for field in _NON_DB_FIELDS:
         if field in new_fields:
             new_fields.remove(field)
+    if cluster_handle_required:
+        # When a job has reached a terminal state, its cluster handle is gone,
+        # so infra/resources can no longer be read from the handle. Make sure
+        # the last-cached infra ('cloud'/'region'/'zone') and the requested
+        # 'resources' string are still selected from the DB so they can be used
+        # as a fallback in get_managed_job_queue. These are real DB columns
+        # ('cloud'/'region'/'zone' are also in _NON_DB_FIELDS and were removed
+        # above, so re-add them here).
+        for field in ('cloud', 'region', 'zone', 'resources'):
+            if field not in new_fields:
+                new_fields.append(field)
     return new_fields, cluster_handle_required
 
 
@@ -2504,13 +2515,31 @@ def get_managed_job_queue(
                     'cluster_name': cluster_name,
                 })
             else:
-                # FIXME(zongheng): display the last cached values for these.
-                job['cluster_resources'] = '-'
-                job['cluster_resources_full'] = '-'
-                job['cloud'] = '-'
-                job['region'] = '-'
-                job['zone'] = '-'
-                job['infra'] = '-'
+                # The cluster handle is no longer available (e.g. the job has
+                # reached a terminal state and its cluster has been torn down),
+                # so infra/resources can no longer be read from the live
+                # handle. Fall back to the last-cached infra
+                # ('cloud'/'region'/'zone', persisted on each successful
+                # launch/recovery via set_job_infra) and the requested
+                # resources string from the jobs DB, so the dashboard/CLI can
+                # still show where the job last ran instead of a bare '-'.
+                cloud = job.get('cloud')
+                region = job.get('region')
+                zone = job.get('zone')
+                # formatted_str() returns '-' when cloud is None/empty (e.g.
+                # legacy jobs without persisted infra).
+                job['infra'] = infra_utils.InfraInfo(cloud, region,
+                                                     zone).formatted_str()
+                job['cloud'] = cloud if cloud else '-'
+                job['region'] = region if region else '-'
+                job['zone'] = zone if zone else '-'
+                # The launched cluster resources string is not persisted, so
+                # fall back to the requested resources string from the DB.
+                cached_resources = job.get('resources')
+                job['cluster_resources'] = (cached_resources
+                                            if cached_resources else '-')
+                job['cluster_resources_full'] = (cached_resources
+                                                 if cached_resources else '-')
                 job['labels'] = None
                 job['cluster_name_on_cloud'] = None
                 job['internal_services'] = None

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -2535,7 +2535,12 @@ def get_managed_job_queue(
                 job['zone'] = zone if zone else '-'
                 # The launched cluster resources string is not persisted, so
                 # fall back to the requested resources string from the DB.
-                cached_resources = job.get('resources')
+                # Only do so if the job was actually launched at least once
+                # (i.e. the infra was persisted); otherwise (e.g. PENDING
+                # jobs, or jobs that failed before launching) showing the
+                # requested resources as the launched resources is
+                # misleading.
+                cached_resources = job.get('resources') if cloud else None
                 job['cluster_resources'] = (cached_resources
                                             if cached_resources else '-')
                 job['cluster_resources_full'] = (cached_resources

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -105,11 +105,14 @@ class TestUpdateFields:
         updated_fields, _ = jobs_utils._update_fields(fields)
         # These are _NON_DB_FIELDS and should be removed
         assert 'cluster_resources' not in updated_fields
-        assert 'cloud' not in updated_fields
         assert 'user_name' not in updated_fields
         assert 'details' not in updated_fields
         # But job_id should remain
         assert 'job_id' in updated_fields
+        # 'cloud' is a non-DB handle field, but because a cluster handle is
+        # required here it is re-added as a DB column for the cached infra
+        # fallback (see _update_fields).
+        assert 'cloud' in updated_fields
 
     def test_cluster_handle_required_false_when_no_handle_fields(self):
         """Test that cluster_handle_required is False when no cluster handle fields."""
@@ -161,10 +164,38 @@ class TestUpdateFields:
         # Always added
         assert 'status' in updated_fields
         assert 'job_id' in updated_fields
-        # Cloud should be removed (non-DB field)
-        assert 'cloud' not in updated_fields
+        # 'cloud' is re-added as a DB column for the cached infra fallback
+        # since a cluster handle is required.
+        assert 'cloud' in updated_fields
         # Should be true due to cloud
         assert cluster_handle_required is True
+
+    def test_adds_cached_infra_fields_when_handle_required(self):
+        """Cached infra/resources fields are re-added for the fallback.
+
+        When a cluster handle is required, the last-cached infra columns
+        ('cloud'/'region'/'zone') and the requested 'resources' string must be
+        selected from the DB so get_managed_job_queue can fall back to them for
+        finished jobs whose cluster handle is gone.
+        """
+        fields = ['job_id', 'cluster_resources']
+        updated_fields, cluster_handle_required = jobs_utils._update_fields(
+            fields)
+        assert cluster_handle_required is True
+        # cluster_resources itself is a non-DB field and is removed.
+        assert 'cluster_resources' not in updated_fields
+        # The DB-backed fallback fields are present.
+        for field in ('cloud', 'region', 'zone', 'resources'):
+            assert field in updated_fields
+
+    def test_does_not_add_cached_infra_fields_when_handle_not_required(self):
+        """Fallback fields are not force-added when no handle is required."""
+        fields = ['job_id', 'status']
+        updated_fields, cluster_handle_required = jobs_utils._update_fields(
+            fields)
+        assert cluster_handle_required is False
+        for field in ('cloud', 'region', 'zone', 'resources'):
+            assert field not in updated_fields
 
 
 class TestGetManagedJobQueue:
@@ -312,6 +343,55 @@ class TestGetManagedJobQueue:
         # For finished job: duration = end_at - (last_recovered_at - job_duration)
         expected_duration = (current_time - 50) - (current_time - 200 - 50)
         assert job['job_duration'] == expected_duration
+
+    def test_finished_job_falls_back_to_cached_infra(self, monkeypatch):
+        """A finished job with no live handle shows last-cached infra/resources.
+
+        When the cluster handle is gone (e.g. the job finished and the cluster
+        was torn down), infra/resources should fall back to the values
+        persisted in the jobs DB instead of a bare '-'.
+        """
+        jobs = [
+            self._make_test_job(
+                1,
+                status=managed_job_state.ManagedJobStatus.SUCCEEDED,
+                cloud='AWS',
+                region='us-east-1',
+                zone='us-east-1a',
+                resources='1x[Spot]A100:8',
+            )
+        ]
+        self._patch_managed_job_state(monkeypatch, jobs)
+        self._patch_global_user_state(monkeypatch)  # empty handle map
+
+        result = jobs_utils.get_managed_job_queue()
+
+        job = result['jobs'][0]
+        assert job['cloud'] == 'AWS'
+        assert job['region'] == 'us-east-1'
+        assert job['zone'] == 'us-east-1a'
+        assert job['infra'] == 'AWS (us-east-1a)'
+        assert job['cluster_resources'] == '1x[Spot]A100:8'
+        assert job['cluster_resources_full'] == '1x[Spot]A100:8'
+
+    def test_finished_job_without_cached_infra_shows_dash(self, monkeypatch):
+        """Legacy finished jobs without persisted infra still show '-'."""
+        jobs = [
+            self._make_test_job(
+                1, status=managed_job_state.ManagedJobStatus.SUCCEEDED)
+        ]
+        self._patch_managed_job_state(monkeypatch, jobs)
+        self._patch_global_user_state(monkeypatch)  # empty handle map
+
+        result = jobs_utils.get_managed_job_queue()
+
+        job = result['jobs'][0]
+        assert job['cloud'] == '-'
+        assert job['region'] == '-'
+        assert job['zone'] == '-'
+        assert job['infra'] == '-'
+        assert job['cluster_resources'] == '-'
+        assert job['cluster_resources_full'] == '-'
 
     def test_status_converted_to_string(self, monkeypatch):
         """Test that status is converted from enum to string."""

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -393,6 +393,31 @@ class TestGetManagedJobQueue:
         assert job['cluster_resources'] == '-'
         assert job['cluster_resources_full'] == '-'
 
+    def test_unlaunched_job_does_not_show_requested_resources(
+            self, monkeypatch):
+        """A job that never launched does not show requested resources.
+
+        The cached resources fallback only applies when the job was actually
+        launched (infra persisted); a PENDING job with a requested resources
+        string should still show '-' for cluster resources.
+        """
+        jobs = [
+            self._make_test_job(
+                1,
+                status=managed_job_state.ManagedJobStatus.PENDING,
+                resources='1x[CPU:1+]',
+            )
+        ]
+        self._patch_managed_job_state(monkeypatch, jobs)
+        self._patch_global_user_state(monkeypatch)  # empty handle map
+
+        result = jobs_utils.get_managed_job_queue()
+
+        job = result['jobs'][0]
+        assert job['cluster_resources'] == '-'
+        assert job['cluster_resources_full'] == '-'
+        assert job['infra'] == '-'
+
     def test_status_converted_to_string(self, monkeypatch):
         """Test that status is converted from enum to string."""
         jobs = [self._make_test_job(1)]

--- a/tests/unit_tests/test_sky/skylet/test_managed_jobs_service.py
+++ b/tests/unit_tests/test_sky/skylet/test_managed_jobs_service.py
@@ -329,10 +329,10 @@ class TestGetJobTable:
         assert target_job.schedule_state == state.ManagedJobScheduleState.INACTIVE.to_protobuf(
         )
         assert target_job.resources == '{}'
-        # No live cluster handle (job not launched), so cluster_resources falls
-        # back to the requested resources string cached in the DB.
-        assert target_job.cluster_resources == '{}'
-        assert target_job.cluster_resources_full == '{}'
+        # The job was never launched (no persisted infra), so the cached
+        # resources fallback does not apply and '-' is shown.
+        assert target_job.cluster_resources == '-'
+        assert target_job.cluster_resources_full == '-'
         assert target_job.cloud == '-'
         assert target_job.region == '-'
         assert target_job.infra == '-'
@@ -393,10 +393,10 @@ class TestGetJobTable:
         assert target_job.schedule_state == state.ManagedJobScheduleState.INACTIVE.to_protobuf(
         )
         assert target_job.resources == '{}'
-        # No live cluster handle (job not launched), so cluster_resources falls
-        # back to the requested resources string cached in the DB.
-        assert target_job.cluster_resources == '{}'
-        assert target_job.cluster_resources_full == '{}'
+        # The job was never launched (no persisted infra), so the cached
+        # resources fallback does not apply and '-' is shown.
+        assert target_job.cluster_resources == '-'
+        assert target_job.cluster_resources_full == '-'
         assert target_job.cloud == '-'
         assert target_job.region == '-'
         assert target_job.infra == '-'

--- a/tests/unit_tests/test_sky/skylet/test_managed_jobs_service.py
+++ b/tests/unit_tests/test_sky/skylet/test_managed_jobs_service.py
@@ -329,8 +329,10 @@ class TestGetJobTable:
         assert target_job.schedule_state == state.ManagedJobScheduleState.INACTIVE.to_protobuf(
         )
         assert target_job.resources == '{}'
-        assert target_job.cluster_resources == '-'
-        assert target_job.cluster_resources_full == '-'
+        # No live cluster handle (job not launched), so cluster_resources falls
+        # back to the requested resources string cached in the DB.
+        assert target_job.cluster_resources == '{}'
+        assert target_job.cluster_resources_full == '{}'
         assert target_job.cloud == '-'
         assert target_job.region == '-'
         assert target_job.infra == '-'
@@ -391,8 +393,10 @@ class TestGetJobTable:
         assert target_job.schedule_state == state.ManagedJobScheduleState.INACTIVE.to_protobuf(
         )
         assert target_job.resources == '{}'
-        assert target_job.cluster_resources == '-'
-        assert target_job.cluster_resources_full == '-'
+        # No live cluster handle (job not launched), so cluster_resources falls
+        # back to the requested resources string cached in the DB.
+        assert target_job.cluster_resources == '{}'
+        assert target_job.cluster_resources_full == '{}'
         assert target_job.cloud == '-'
         assert target_job.region == '-'
         assert target_job.infra == '-'


### PR DESCRIPTION
## Summary

- For a finished managed job (SUCCEEDED/FAILED/CANCELLED/etc.) whose cluster has been torn down, the jobs queue could not read infra/resources from the live cluster handle and returned a bare `-` for **Infra** & **Resources** — e.g. on the dashboard job detail page `/dashboard/jobs/[id]`. This resolves the `FIXME(zongheng)` in `get_managed_job_queue`.
- The infra (`cloud`/`region`/`zone`) is already persisted in the `job_info` DB table on each successful launch/recovery (via `set_job_infra`), and the requested resources string is persisted in the `spot` table. `get_managed_job_queue` now falls back to these last-cached values when the cluster handle is gone, instead of hard-coding `-`.
- `_update_fields` now re-adds `cloud`/`region`/`zone`/`resources` to the DB-selected columns when a cluster handle is required, so the fallback has the data available.

Note: the *launched* cluster resources string is not persisted in the DB, so terminal jobs show the *requested* resources string as the Resources fallback. Since `set_job_infra` is written on every successful launch/recovery, a job that failed over from infra1 to infra2 shows infra2 (the last infra it actually ran on) after reaching a terminal state.

Tested:
<img width="653" height="345" alt="Screenshot 2026-06-11 at 14 33 38" src="https://github.com/user-attachments/assets/65c83026-6f72-4dfd-b73b-eb02c2bfefa0" />


## Test plan

- Unit tests added:
  - `TestGetManagedJobQueue::test_finished_job_falls_back_to_cached_infra` — finished job with persisted infra shows cached cloud/region/zone/infra/resources.
  - `TestGetManagedJobQueue::test_finished_job_without_cached_infra_shows_dash` — legacy jobs without persisted infra still show `-`.
  - `TestUpdateFields::test_adds_cached_infra_fields_when_handle_required` / `test_does_not_add_cached_infra_fields_when_handle_not_required`.
  - Updated existing expectations in `test_managed_jobs_service.py` that encoded the old `-` behavior.
- `pytest tests/unit_tests/test_sky/jobs/test_utils.py tests/unit_tests/test_sky/jobs/test_server_queue.py tests/unit_tests/test_sky/skylet/test_managed_jobs_service.py` — 133 passed.
- Manual verification (in progress, results to be posted): `sky local up`, launch managed jobs reaching various terminal states (SUCCEEDED / FAILED / FAILED_SETUP / CANCELLED), confirm `sky jobs queue -v` and the dashboard job detail page show the last infra/resources instead of `-`; also verify an infra1 → infra2 failover shows infra2 after the job terminates.

https://claude.ai/code/session_01TezxKgun5E3FfsPK4PjDQT

---
_Generated by [Claude Code](https://claude.ai/code/session_01TezxKgun5E3FfsPK4PjDQT)_