### PR TITLE
[Dashboard] Feed External Links extraction from plugin-owned log panels

### DIFF
--- a/sky/dashboard/src/pages/clusters/[cluster]/[job].js
+++ b/sky/dashboard/src/pages/clusters/[cluster]/[job].js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { Card } from '@/components/ui/card';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -22,11 +22,7 @@ import { CheckIcon, CopyIcon } from 'lucide-react';
 import PropTypes from 'prop-types';
 import { useLogStreamer } from '@/hooks/useLogStreamer';
 import { useCallback } from 'react';
-import {
-  extractLinksFromLogs,
-  normalizeUrl,
-  useCustomUrlPatterns,
-} from '@/utils/externalLinks';
+import { normalizeUrl, useLogLinkExtractor } from '@/utils/externalLinks';
 
 // Custom header component with buttons inline
 function JobHeader({
@@ -136,31 +132,10 @@ export function JobDetailPage() {
 
   // Scan streamed logs against built-in plus admin-configured URL patterns
   // and surface matches in the Details card as an External Links row.
-  const urlPatterns = useCustomUrlPatterns();
-  const extractedLinksRef = useRef({});
-  const [extractedLinks, setExtractedLinks] = useState({});
+  const { extractedLinks, scanLines } = useLogLinkExtractor();
   useEffect(() => {
-    if (!displayLines || displayLines.length === 0) return;
-    const next = extractLinksFromLogs(
-      displayLines,
-      urlPatterns,
-      extractedLinksRef.current
-    );
-    extractedLinksRef.current = next;
-    if (Object.keys(next).length > 0) {
-      setExtractedLinks((prev) => {
-        const merged = { ...prev };
-        let changed = false;
-        for (const [label, url] of Object.entries(next)) {
-          if (merged[label] !== url) {
-            merged[label] = url;
-            changed = true;
-          }
-        }
-        return changed ? merged : prev;
-      });
-    }
-  }, [displayLines, urlPatterns]);
+    scanLines(displayLines);
+  }, [displayLines, scanLines]);
 
   const handleRefreshLogs = () => {
     setLogsRefreshToken((token) => token + 1);

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -62,11 +62,7 @@ import dashboardCache from '@/lib/cache';
 import { PluginSlot } from '@/plugins/PluginSlot';
 import { usePluginComponents } from '@/plugins/PluginProvider';
 import { checkGrafanaAvailability } from '@/utils/grafana';
-import {
-  extractLinksFromLogs,
-  normalizeUrl,
-  useCustomUrlPatterns,
-} from '@/utils/externalLinks';
+import { normalizeUrl, useLogLinkExtractor } from '@/utils/externalLinks';
 import { TelemetrySection } from '@/components/TelemetrySection';
 import { hasAccelerator } from '@/utils/gpuUtils';
 import { useLogStreamer } from '@/hooks/useLogStreamer';
@@ -1147,24 +1143,17 @@ function JobDetailsContent({
     }
   }, [logs, onNodesExtracted]);
 
-  // Persist extracted links across tab changes using a ref
-  const extractedLinksRef = useRef({});
+  // External-link extraction from log lines. Matches accumulate inside
+  // the hook so they survive tab switches and re-renders. `scanLines` is
+  // a stable callback: besides feeding it from the OSS streamer below,
+  // it is handed to a plugin that owns the logs slot — the OSS streamer
+  // does not run in that case, so the plugin forwards its own lines.
+  const { extractedLinks: logExtractedLinks, scanLines } =
+    useLogLinkExtractor();
 
-  // Merge built-in (W&B) and admin-configured patterns. The hook fetches the
-  // admin list on mount; until it returns, only built-ins are active.
-  const urlPatterns = useCustomUrlPatterns();
-
-  // Extract URLs from logs using the merged pattern map. Matches accumulate
-  // in a ref so they survive tab switches and re-renders.
-  const logExtractedLinks = useMemo(() => {
-    const extractedLinks = extractLinksFromLogs(
-      logs,
-      urlPatterns,
-      extractedLinksRef.current
-    );
-    extractedLinksRef.current = extractedLinks;
-    return extractedLinks;
-  }, [logs, urlPatterns]);
+  useEffect(() => {
+    scanLines(logs);
+  }, [logs, scanLines]);
 
   // Notify parent when links are extracted (for cross-component sharing)
   useEffect(() => {
@@ -1246,6 +1235,11 @@ function JobDetailsContent({
           selectedNode,
           isController: false,
           onNodesExtracted,
+          // The OSS streamer that feeds External Links extraction does
+          // not run when a plugin owns this slot. The plugin should
+          // forward its visible log lines (raw buffer string or array of
+          // lines) through this callback so extraction keeps working.
+          onLogLines: scanLines,
           // Forward the refresh-button signal so a plugin owning this slot
           // can re-fetch on refresh (the OSS streamer it replaces consumes
           // the same flag). Without this the refresh button is a no-op for

--- a/sky/dashboard/src/utils/externalLinks.js
+++ b/sky/dashboard/src/utils/externalLinks.js
@@ -69,6 +69,13 @@ export const extractLinksFromLogs = (logLines, patterns, existingMatches) => {
       break;
     }
 
+    // Plugins can feed arbitrary arrays through `onLogLines`; skip
+    // non-string entries instead of letting one bad element throw and
+    // take down the page.
+    if (typeof line !== 'string') {
+      continue;
+    }
+
     // Strip ANSI escape codes so color/reset sequences adjacent to a URL
     // do not leak into the matched token. Lines from the OSS streamer are
     // already stripped (this is a no-op); raw buffers forwarded by log

--- a/sky/dashboard/src/utils/externalLinks.js
+++ b/sky/dashboard/src/utils/externalLinks.js
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { stripAnsiCodes } from '@/components/utils';
 import { getDashboardConfig } from '@/data/connectors/dashboard_config';
 
 // Built-in URL patterns that ship with SkyPilot. Admin-configured patterns
@@ -68,7 +69,11 @@ export const extractLinksFromLogs = (logLines, patterns, existingMatches) => {
       break;
     }
 
-    const tokens = line.split(/[\s"'<>()[\]{},;]+/);
+    // Strip ANSI escape codes so color/reset sequences adjacent to a URL
+    // do not leak into the matched token. Lines from the OSS streamer are
+    // already stripped (this is a no-op); raw buffers forwarded by log
+    // plugins are not.
+    const tokens = stripAnsiCodes(line).split(/[\s"'<>()[\]{},;]+/);
     for (const token of tokens) {
       const cleanToken = token.replace(/[.,:;!?]+$/, '');
       if (!cleanToken) continue;
@@ -117,6 +122,59 @@ export const useCustomUrlPatterns = () => {
   }, []);
 
   return patterns;
+};
+
+/**
+ * React hook that owns external-link extraction from log lines.
+ *
+ * Returns `extractedLinks` (an accumulated label -> url map) and
+ * `scanLines`, a stable callback that accepts either an array of log
+ * lines or a raw newline-separated buffer and scans it against the
+ * merged built-in + admin-configured URL patterns. Matches accumulate
+ * across calls so they survive tab switches, re-renders, and streaming
+ * buffer resets; the most recent lines are re-scanned when the
+ * admin-configured patterns finish loading.
+ *
+ * `scanLines` being a stable callback makes it usable both by the OSS
+ * log streamer effects and as a slot-context callback for dashboard
+ * plugins that own a logs panel and forward their own lines.
+ *
+ * @returns {{extractedLinks: Object<string, string>,
+ *            scanLines: (lines: string[]|string) => void}}
+ */
+export const useLogLinkExtractor = () => {
+  const urlPatterns = useCustomUrlPatterns();
+  const [extractedLinks, setExtractedLinks] = useState({});
+  const extractedLinksRef = useRef({});
+  const urlPatternsRef = useRef(urlPatterns);
+  const lastLinesRef = useRef(null);
+
+  const scanLines = useCallback((lines) => {
+    const lineArray = typeof lines === 'string' ? lines.split('\n') : lines;
+    if (!Array.isArray(lineArray) || lineArray.length === 0) {
+      return;
+    }
+    lastLinesRef.current = lineArray;
+    const prev = extractedLinksRef.current;
+    const next = extractLinksFromLogs(lineArray, urlPatternsRef.current, prev);
+    // Matches only ever accumulate, so a size change means new links.
+    if (Object.keys(next).length !== Object.keys(prev).length) {
+      extractedLinksRef.current = next;
+      setExtractedLinks(next);
+    }
+  }, []);
+
+  useEffect(() => {
+    urlPatternsRef.current = urlPatterns;
+    // Admin patterns load asynchronously; re-scan the most recent lines
+    // so links matching late-arriving patterns are not missed when the
+    // stream has already gone quiet (e.g. a finished job).
+    if (lastLinesRef.current) {
+      scanLines(lastLinesRef.current);
+    }
+  }, [urlPatterns, scanLines]);
+
+  return { extractedLinks, scanLines };
 };
 
 /**

--- a/sky/dashboard/src/utils/externalLinks.test.js
+++ b/sky/dashboard/src/utils/externalLinks.test.js
@@ -40,6 +40,15 @@ describe('extractLinksFromLogs', () => {
     expect(links).toEqual({ 'W&B Run': WANDB_URL });
   });
 
+  it('skips non-string entries without throwing', () => {
+    const links = extractLinksFromLogs(
+      [null, undefined, 42, { msg: 'metadata' }, WANDB_LINE],
+      BUILTIN_URL_PATTERNS,
+      {}
+    );
+    expect(links).toEqual({ 'W&B Run': WANDB_URL });
+  });
+
   it('preserves existing matches', () => {
     const existing = { 'W&B Run': 'https://wandb.ai/a/b/runs/first' };
     const links = extractLinksFromLogs(

--- a/sky/dashboard/src/utils/externalLinks.test.js
+++ b/sky/dashboard/src/utils/externalLinks.test.js
@@ -1,0 +1,99 @@
+import { act, renderHook } from '@testing-library/react';
+
+import {
+  BUILTIN_URL_PATTERNS,
+  extractLinksFromLogs,
+  useLogLinkExtractor,
+} from '@/utils/externalLinks';
+
+jest.mock('@/data/connectors/dashboard_config', () => ({
+  getDashboardConfig: jest.fn().mockResolvedValue({ externalLinks: [] }),
+}));
+
+const WANDB_URL = 'https://wandb.ai/test-entity/test-project/runs/abc12345';
+const WANDB_LINE =
+  '(wandb-link-test, pid=886) wandb: 🚀 View run b300-smoke-test at: ' +
+  WANDB_URL;
+
+describe('extractLinksFromLogs', () => {
+  it('extracts a W&B run URL from a prefixed log line', () => {
+    const links = extractLinksFromLogs(
+      ['Starting fake training run...', WANDB_LINE],
+      BUILTIN_URL_PATTERNS,
+      {}
+    );
+    expect(links).toEqual({ 'W&B Run': WANDB_URL });
+  });
+
+  it('ignores non-run W&B URLs (project page)', () => {
+    const links = extractLinksFromLogs(
+      ['wandb: ⭐️ View project at: https://wandb.ai/test-entity/test-project'],
+      BUILTIN_URL_PATTERNS,
+      {}
+    );
+    expect(links).toEqual({});
+  });
+
+  it('strips ANSI escape codes around the URL', () => {
+    const ansiLine = `\x1b[36mwandb:\x1b[0m View run at: ${WANDB_URL}\x1b[0m`;
+    const links = extractLinksFromLogs([ansiLine], BUILTIN_URL_PATTERNS, {});
+    expect(links).toEqual({ 'W&B Run': WANDB_URL });
+  });
+
+  it('preserves existing matches', () => {
+    const existing = { 'W&B Run': 'https://wandb.ai/a/b/runs/first' };
+    const links = extractLinksFromLogs(
+      [WANDB_LINE],
+      BUILTIN_URL_PATTERNS,
+      existing
+    );
+    expect(links).toEqual(existing);
+  });
+});
+
+describe('useLogLinkExtractor', () => {
+  // Flush the async admin-config fetch inside useCustomUrlPatterns so
+  // its setState lands inside act().
+  const flushConfigFetch = () => act(async () => {});
+
+  it('accumulates links from line arrays (OSS streamer path)', async () => {
+    const { result } = renderHook(() => useLogLinkExtractor());
+    await flushConfigFetch();
+    expect(result.current.extractedLinks).toEqual({});
+
+    act(() => {
+      result.current.scanLines(['no links here']);
+    });
+    expect(result.current.extractedLinks).toEqual({});
+
+    act(() => {
+      result.current.scanLines([WANDB_LINE]);
+    });
+    expect(result.current.extractedLinks).toEqual({ 'W&B Run': WANDB_URL });
+
+    // A later scan without the link (e.g. a streaming buffer reset)
+    // must not lose the accumulated match.
+    act(() => {
+      result.current.scanLines(['later lines without links']);
+    });
+    expect(result.current.extractedLinks).toEqual({ 'W&B Run': WANDB_URL });
+  });
+
+  it('accepts a raw newline-separated buffer (plugin slot path)', async () => {
+    const { result } = renderHook(() => useLogLinkExtractor());
+    await flushConfigFetch();
+
+    act(() => {
+      result.current.scanLines(`step 1: loss 0.5\n${WANDB_LINE}\nstep 2\n`);
+    });
+    expect(result.current.extractedLinks).toEqual({ 'W&B Run': WANDB_URL });
+  });
+
+  it('keeps scanLines referentially stable across renders', async () => {
+    const { result, rerender } = renderHook(() => useLogLinkExtractor());
+    await flushConfigFetch();
+    const first = result.current.scanLines;
+    rerender();
+    expect(result.current.scanLines).toBe(first);
+  });
+});


### PR DESCRIPTION
The External Links row on the managed job page extracts URLs (e.g. W&B run links) by scanning lines from the built-in log streamer. When a dashboard plugin registers a component into the `jobs.detail.logs` slot, the built-in streamer is intentionally disabled so the plugin can own the log panel, but that also silently disabled link extraction: the External Links row always showed `-` even when a matching URL was clearly visible in the rendered logs.

This mirrors the existing `onNodesExtracted` plumbing, which was added for the same reason (the node-filter dropdown also depended on the built-in streamer).

**Changes**

- Extract the scan-and-accumulate logic into a shared `useLogLinkExtractor` hook in `externalLinks.js`, and reuse it on both the managed job page and the cluster job page (net removal of the duplicated inline implementations). The hook accepts either an array of lines or a raw newline-separated buffer, accumulates matches across streaming buffer resets, and re-scans when admin-configured patterns finish loading.
- Pass the hook's stable `scanLines` callback into the `jobs.detail.logs` slot context as `onLogLines`, so a plugin that owns the log panel can forward its visible lines and keep the External Links row working. With no plugin registered, behavior is unchanged.
- Strip ANSI escape codes per line in `extractLinksFromLogs` so raw buffers forwarded through `onLogLines` cannot leak escape sequences into matched tokens (lines from the built-in streamer are already stripped, so this is a no-op for them).

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

**Tests**

- New `sky/dashboard/src/utils/externalLinks.test.js` (7 tests): extraction from a real prefixed W&B log line, non-run URLs ignored, ANSI stripping, existing-match preservation, hook accumulation across buffer resets, raw-buffer input, and `scanLines` referential stability. `npx jest src/utils/externalLinks.test.js` passes; `npx next lint` clean on all touched files.
- Manual: launched a managed job that prints `wandb: 🚀 View run ... at: https://wandb.ai/<entity>/<project>/runs/<id>`, opened the job detail page, and verified the External Links row shows a working "W&B Run" link both with the default log panel and with a plugin component registered into `jobs.detail.logs` that forwards its lines via `onLogLines`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)