### PR TITLE
[Core] Allow additive kubernetes.allowed_contexts workspace changes

### DIFF
--- a/sky/workspaces/core.py
+++ b/sky/workspaces/core.py
@@ -174,8 +174,11 @@ def _extract_k8s_allowed_contexts(
     Returns a tuple of (config_without_that_field, allowed_contexts_value). The
     value is None when the field is absent. The input config is not mutated.
     """
-    kubernetes_config = config.get('kubernetes', {})
-    if 'allowed_contexts' not in kubernetes_config:
+    # The kubernetes block may be missing or explicitly null (e.g. a bare
+    # `kubernetes:` in YAML), so guard against non-dict values.
+    kubernetes_config = config.get('kubernetes')
+    if (not isinstance(kubernetes_config, dict) or
+            'allowed_contexts' not in kubernetes_config):
         return config, None
     remaining = dict(config)
     remaining['kubernetes'] = {

--- a/sky/workspaces/core.py
+++ b/sky/workspaces/core.py
@@ -49,6 +49,9 @@ class WorkspaceConfigComparison:
         allowed_users_new: New allowed users list
         removed_users: Users removed from allowed_users
         added_users: Users added to allowed_users
+        additive_allowed_contexts: True if the only non-user-access change is an
+            additive kubernetes.allowed_contexts change (old contexts remain a
+            subset of the new contexts)
     """
     only_user_access_changes: bool
     private_changed: bool
@@ -59,6 +62,7 @@ class WorkspaceConfigComparison:
     allowed_users_new: List[str]
     removed_users: List[str]
     added_users: List[str]
+    additive_allowed_contexts: bool = False
 
 
 # =========================
@@ -163,6 +167,46 @@ def _validate_workspace_config(workspace_name: str,
         raise ValueError(str(e)) from e
 
 
+def _extract_k8s_allowed_contexts(
+        config: Dict[str, Any]) -> Tuple[Dict[str, Any], Any]:
+    """Split out kubernetes.allowed_contexts from a workspace config.
+
+    Returns a tuple of (config_without_that_field, allowed_contexts_value). The
+    value is None when the field is absent. The input config is not mutated.
+    """
+    kubernetes_config = config.get('kubernetes', {})
+    if 'allowed_contexts' not in kubernetes_config:
+        return config, None
+    remaining = dict(config)
+    remaining['kubernetes'] = {
+        k: v for k, v in kubernetes_config.items() if k != 'allowed_contexts'
+    }
+    return remaining, kubernetes_config['allowed_contexts']
+
+
+def _is_additive_contexts(current_allowed_contexts: Any,
+                          new_allowed_contexts: Any) -> bool:
+    """Return True if allowed_contexts only grew (no existing context dropped).
+
+    Additive cases:
+    - list -> list where the old contexts are a subset of the new contexts.
+    - list -> 'all' (broadening to every kubeconfig context).
+
+    Everything else (no change, 'all' -> list, absent/None on either side,
+    removals, or reorders that drop a context) is not additive.
+    """
+    if current_allowed_contexts == new_allowed_contexts:
+        return False
+    # list -> 'all' is broadening.
+    if new_allowed_contexts == 'all':
+        return isinstance(current_allowed_contexts, list)
+    # list -> list must keep old as a subset of new.
+    if (isinstance(current_allowed_contexts, list) and
+            isinstance(new_allowed_contexts, list)):
+        return set(current_allowed_contexts).issubset(set(new_allowed_contexts))
+    return False
+
+
 def _compare_workspace_configs(
     current_config: Dict[str, Any],
     new_config: Dict[str, Any],
@@ -222,6 +266,18 @@ def _compare_workspace_configs(
 
     only_user_access_changes = current_without_access == new_without_access
 
+    # Extract kubernetes.allowed_contexts once, getting back both the remaining
+    # config and the value. Same pattern as above: if the remaining configs are
+    # equal, then allowed_contexts is the ONLY non-user-access change (fails
+    # fast on namespace, context_configs, other clouds, etc.).
+    current_without_contexts, current_allowed_contexts = (
+        _extract_k8s_allowed_contexts(current_without_access))
+    new_without_contexts, new_allowed_contexts = (
+        _extract_k8s_allowed_contexts(new_without_access))
+    additive_allowed_contexts = (
+        current_without_contexts == new_without_contexts and
+        _is_additive_contexts(current_allowed_contexts, new_allowed_contexts))
+
     return WorkspaceConfigComparison(
         only_user_access_changes=only_user_access_changes,
         private_changed=private_changed,
@@ -231,7 +287,8 @@ def _compare_workspace_configs(
         allowed_users_old=allowed_users_old,
         allowed_users_new=allowed_users_new,
         removed_users=removed_users,
-        added_users=added_users)
+        added_users=added_users,
+        additive_allowed_contexts=additive_allowed_contexts)
 
 
 def _validate_workspace_config_changes_with_lock(
@@ -269,13 +326,18 @@ def _validate_workspace_config_changes(
     """Validate workspace configuration changes based on active resources.
 
     This function implements the logic:
-    - If only allowed_users or private changed:
+    - If only allowed_users or private changed, or the only non-user-access
+      change is an additive kubernetes.allowed_contexts change:
       - If private changed from true to false: allow it
       - If private changed from false to true: check that all active resources
         belong to allowed_users
       - If private didn't change: check that removed users don't have active
         resources
     - Otherwise: check that workspace has no active resources
+
+    Additive kubernetes.allowed_contexts changes (old contexts remain a subset
+    of the new contexts) are safe because every existing context stays allowed,
+    so running clusters and jobs keep resolving to a still-allowed context.
 
     Args:
         workspace_name: The name of the workspace.
@@ -297,8 +359,16 @@ def _validate_workspace_config_changes(
                                                    new_config,
                                                    resolver=resolver)
 
-    if config_comparison.only_user_access_changes:
-        # Only user access settings changed
+    if (config_comparison.only_user_access_changes or
+            config_comparison.additive_allowed_contexts):
+        # Only user access settings changed, and/or allowed_contexts grew
+        # additively. Both are safe for active resources; still run the
+        # user-access validation below (a no-op when only contexts changed).
+        if config_comparison.additive_allowed_contexts:
+            logger.info(
+                f'Workspace {workspace_name!r} only adds Kubernetes '
+                'allowed_contexts; existing contexts remain allowed. Skipping '
+                'the active-resource check for this change.')
         if config_comparison.private_changed:
             if (config_comparison.private_old and
                     not config_comparison.private_new):

--- a/tests/unit_tests/test_sky/workspaces/test_workspace_management.py
+++ b/tests/unit_tests/test_sky/workspaces/test_workspace_management.py
@@ -649,6 +649,193 @@ class TestWorkspaceManagement(unittest.TestCase):
         # Should not call resource checker since no users were removed
         mock_check_resources.assert_not_called()
 
+    @mock.patch('sky.workspaces.utils.get_workspace_users')
+    @mock.patch('sky.users.permission.permission_service.get_users_for_role')
+    def test_compare_workspace_configs_additive_allowed_contexts(
+            self, mock_get_users_for_role, mock_get_users):
+        """allowed_contexts-only changes are flagged additive or not."""
+        mock_get_users.return_value = []
+        mock_get_users_for_role.return_value = []
+
+        # Sentinel for "allowed_contexts is absent from the kubernetes block".
+        absent = object()
+
+        def k8s_config(allowed_contexts):
+            kubernetes = {}
+            if allowed_contexts is not absent:
+                kubernetes['allowed_contexts'] = allowed_contexts
+            return {'kubernetes': kubernetes}
+
+        # (current_contexts, new_contexts, expected_additive)
+        cases = [
+            (['ctx-a'], ['ctx-a', 'ctx-b'], True),  # append
+            (['ctx-a', 'ctx-b'], ['ctx-a'], False),  # removal
+            # Reorder keeps the same set, so nothing is stranded -> additive.
+            (['ctx-a', 'ctx-b'], ['ctx-b', 'ctx-a'], True),
+            (['ctx-a'], 'all', True),  # broaden to all
+            ('all', ['ctx-a'], False),  # narrow from all
+            (absent, ['ctx-a'], False),  # absent -> list
+            (['ctx-a'], absent, False),  # list -> absent
+        ]
+        for current_contexts, new_contexts, expected in cases:
+            with self.subTest(current=current_contexts, new=new_contexts):
+                result = core._compare_workspace_configs(
+                    k8s_config(current_contexts), k8s_config(new_contexts))
+                self.assertEqual(result.additive_allowed_contexts, expected)
+                # allowed_contexts changed, so this is never user-access-only.
+                self.assertFalse(result.only_user_access_changes)
+
+    @mock.patch('sky.workspaces.utils.get_workspace_users')
+    @mock.patch('sky.users.permission.permission_service.get_users_for_role')
+    def test_compare_workspace_configs_additive_contexts_with_other_changes(
+            self, mock_get_users_for_role, mock_get_users):
+        """Additive contexts alongside any other change is not additive."""
+        mock_get_users.return_value = []
+        mock_get_users_for_role.return_value = []
+
+        # Additive contexts but a sibling kubernetes field also changed.
+        result = core._compare_workspace_configs(
+            {'kubernetes': {
+                'allowed_contexts': ['ctx-a'],
+                'namespace': 'n1'
+            }}, {
+                'kubernetes': {
+                    'allowed_contexts': ['ctx-a', 'ctx-b'],
+                    'namespace': 'n2'
+                }
+            })
+        self.assertFalse(result.additive_allowed_contexts)
+
+        # Additive contexts but a non-kubernetes field also changed.
+        result = core._compare_workspace_configs(
+            {
+                'kubernetes': {
+                    'allowed_contexts': ['ctx-a']
+                },
+                'gcp': {
+                    'project_id': 'p1'
+                }
+            }, {
+                'kubernetes': {
+                    'allowed_contexts': ['ctx-a', 'ctx-b']
+                },
+                'gcp': {
+                    'project_id': 'p2'
+                }
+            })
+        self.assertFalse(result.additive_allowed_contexts)
+
+    @mock.patch('sky.workspaces.utils.get_workspace_users')
+    @mock.patch('sky.users.permission.permission_service.get_users_for_role')
+    def test_compare_workspace_configs_added_user_and_additive_contexts(
+            self, mock_get_users_for_role, mock_get_users):
+        """Adding a user and a context together is still flagged additive."""
+        mock_get_users.side_effect = lambda config, **_kw: config.get(
+            'allowed_users', [])
+        mock_get_users_for_role.return_value = []
+
+        current_config = {
+            'private': True,
+            'allowed_users': ['user1'],
+            'kubernetes': {
+                'allowed_contexts': ['ctx-a']
+            }
+        }
+        new_config = {
+            'private': True,
+            'allowed_users': ['user1', 'user2'],
+            'kubernetes': {
+                'allowed_contexts': ['ctx-a', 'ctx-b']
+            }
+        }
+
+        result = core._compare_workspace_configs(current_config, new_config)
+
+        # User-access was stripped before the context comparison, so the added
+        # user does not block additive detection.
+        self.assertTrue(result.additive_allowed_contexts)
+        self.assertFalse(result.only_user_access_changes)
+        self.assertEqual(set(result.added_users), {'user2'})
+        self.assertEqual(result.removed_users, [])
+
+    @mock.patch(
+        'sky.utils.resource_checker.check_no_active_resources_for_workspaces')
+    @mock.patch('sky.workspaces.core._compare_workspace_configs')
+    def test_validate_workspace_config_changes_additive_contexts(
+            self, mock_compare_configs, mock_check_resources):
+        """Additive allowed_contexts changes skip the teardown check."""
+        mock_compare_configs.return_value = core.WorkspaceConfigComparison(
+            only_user_access_changes=False,
+            private_changed=False,
+            private_old=False,
+            private_new=False,
+            allowed_users_changed=False,
+            allowed_users_old=[],
+            allowed_users_new=[],
+            removed_users=[],
+            added_users=[],
+            additive_allowed_contexts=True)
+
+        # Should not raise any exception.
+        core._validate_workspace_config_changes('test-workspace', {}, {})
+
+        # Additive context changes do not require an empty workspace.
+        mock_check_resources.assert_not_called()
+
+    @mock.patch(
+        'sky.utils.resource_checker.check_users_workspaces_active_resources')
+    @mock.patch(
+        'sky.utils.resource_checker.check_no_active_resources_for_workspaces')
+    @mock.patch('sky.workspaces.core._compare_workspace_configs')
+    def test_validate_workspace_config_changes_added_user_and_additive_contexts(
+            self, mock_compare_configs, mock_check_resources, mock_check_users):
+        """Adding a user and a context together skips all teardown checks."""
+        mock_compare_configs.return_value = core.WorkspaceConfigComparison(
+            only_user_access_changes=False,
+            private_changed=False,
+            private_old=True,
+            private_new=True,
+            allowed_users_changed=True,
+            allowed_users_old=['user1'],
+            allowed_users_new=['user1', 'user2'],
+            removed_users=[],
+            added_users=['user2'],
+            additive_allowed_contexts=True)
+
+        # Should not raise any exception.
+        core._validate_workspace_config_changes('test-workspace', {}, {})
+
+        # No removed users -> no user resource check; additive contexts -> no
+        # workspace teardown check.
+        mock_check_resources.assert_not_called()
+        mock_check_users.assert_not_called()
+
+    @mock.patch(
+        'sky.utils.resource_checker.check_no_active_resources_for_workspaces')
+    @mock.patch('sky.workspaces.core._compare_workspace_configs')
+    def test_validate_workspace_config_changes_added_user_non_additive_contexts(
+            self, mock_compare_configs, mock_check_resources):
+        """Adding a user with a non-additive context change keeps the guard."""
+        mock_compare_configs.return_value = core.WorkspaceConfigComparison(
+            only_user_access_changes=False,
+            private_changed=False,
+            private_old=True,
+            private_new=True,
+            allowed_users_changed=True,
+            allowed_users_old=['user1'],
+            allowed_users_new=['user1', 'user2'],
+            removed_users=[],
+            added_users=['user2'],
+            additive_allowed_contexts=False)
+        mock_check_resources.return_value = None
+
+        # Should not raise any exception.
+        core._validate_workspace_config_changes('test-workspace', {}, {})
+
+        # Non-additive change -> teardown guard still enforced.
+        mock_check_resources.assert_called_once_with([('test-workspace',
+                                                       'update')])
+
 
 class TestWorkspaceNameBackwardCompatibility(unittest.TestCase):
     """Tests that existing workspaces with non-conforming names still work."""

--- a/tests/unit_tests/test_sky/workspaces/test_workspace_management.py
+++ b/tests/unit_tests/test_sky/workspaces/test_workspace_management.py
@@ -735,7 +735,8 @@ class TestWorkspaceManagement(unittest.TestCase):
 
         # `kubernetes: null` in YAML parses to None; must not raise TypeError.
         result = core._compare_workspace_configs(
-            {'kubernetes': None}, {'kubernetes': {
+            {'kubernetes': None},
+            {'kubernetes': {
                 'allowed_contexts': ['ctx-a']
             }})
         self.assertFalse(result.additive_allowed_contexts)

--- a/tests/unit_tests/test_sky/workspaces/test_workspace_management.py
+++ b/tests/unit_tests/test_sky/workspaces/test_workspace_management.py
@@ -727,6 +727,27 @@ class TestWorkspaceManagement(unittest.TestCase):
 
     @mock.patch('sky.workspaces.utils.get_workspace_users')
     @mock.patch('sky.users.permission.permission_service.get_users_for_role')
+    def test_compare_workspace_configs_kubernetes_block_is_none(
+            self, mock_get_users_for_role, mock_get_users):
+        """A null kubernetes block must not crash and is not additive."""
+        mock_get_users.return_value = []
+        mock_get_users_for_role.return_value = []
+
+        # `kubernetes: null` in YAML parses to None; must not raise TypeError.
+        result = core._compare_workspace_configs(
+            {'kubernetes': None}, {'kubernetes': {
+                'allowed_contexts': ['ctx-a']
+            }})
+        self.assertFalse(result.additive_allowed_contexts)
+
+        result = core._compare_workspace_configs(
+            {'kubernetes': {
+                'allowed_contexts': ['ctx-a']
+            }}, {'kubernetes': None})
+        self.assertFalse(result.additive_allowed_contexts)
+
+    @mock.patch('sky.workspaces.utils.get_workspace_users')
+    @mock.patch('sky.users.permission.permission_service.get_users_for_role')
     def test_compare_workspace_configs_added_user_and_additive_contexts(
             self, mock_get_users_for_role, mock_get_users):
         """Adding a user and a context together is still flagged additive."""


### PR DESCRIPTION
## Summary

Adding a context to a workspace's `kubernetes.allowed_contexts` is currently rejected if the workspace has any active clusters or managed jobs, forcing a full teardown first. In `sky/workspaces/core.py`, `_validate_workspace_config_changes` only special-cases `private`/`allowed_users`; every other change falls into the `else` branch and calls `check_no_active_resources_for_workspaces(...)`.

A pure addition strands nothing: every existing context stays in the list, so running clusters/jobs keep resolving to a still-allowed context. This is the exact primitive a multi-cluster rollout needs — grow the allowed contexts incrementally without disrupting active workloads.

- Add `additive_allowed_contexts` to `WorkspaceConfigComparison`, computed in `_compare_workspace_configs`.
- `_validate_workspace_config_changes` now skips the teardown guard for additive-only context changes while still running the user-access validation body.
- Covers both `update_workspace` and `update_config`, since both share `_validate_workspace_config_changes`.

### Semantics

- Additive (allowed without teardown): `list -> list` where old is a subset of new, and `list -> 'all'` (broadening). Same-set reorders are also additive since no context is dropped.
- Not additive (teardown still required): `'all' -> list`, absent/`None` on either side, removals, or any change to other kubernetes fields (`namespace`, `context_configs`, etc.) or any other cloud.

## Test plan

- `pytest tests/unit_tests/test_sky/workspaces/test_workspace_management.py` (32 passed).
- New unit tests cover:
  - The additive truth table on `_compare_workspace_configs` (append, removal, reorder, `list -> 'all'`, `'all' -> list`, absent on either side).
  - Additive contexts combined with a sibling kubernetes field or a non-k8s field -> not additive.
  - `_validate_workspace_config_changes`: additive change skips `check_no_active_resources_for_workspaces`; non-additive change still calls it.
  - Combined added-user + additive-context (no teardown, no user check); combined added-user + non-additive-context (teardown guard enforced).
- Manual verification: with a cluster running on `ctx-a` in a workspace configured `allowed_contexts: [ctx-a]`, updating to `[ctx-a, ctx-b]` now succeeds; changing to `[ctx-b]` (removal) is still rejected until resources are torn down.

Made with [Cursor](https://cursor.com)