### PR TITLE
[Dashboard] Fix Users page per-user GPU count exceeding cluster capacity

### DIFF
--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -178,7 +178,7 @@ const extractNumNodes = (clusterResourcesFull) => {
 // GPU_CONSUMING_JOB_STATUSES) so per-user GPU totals never exceed the physical
 // cluster capacity.
 export const getJobGpuCount = (job) => {
-  if (!GPU_CONSUMING_JOB_STATUSES.has(job.status)) {
+  if (!job || !GPU_CONSUMING_JOB_STATUSES.has(job.status)) {
     return 0;
   }
   const gpuCountPerNode = getGPUCount(

--- a/sky/dashboard/src/components/users.jsx
+++ b/sky/dashboard/src/components/users.jsx
@@ -85,6 +85,21 @@ import { trackUserAction, trackFilterUsed } from '@/lib/analytics';
 
 const ACTIVE_JOB_STATUSES = new Set(statusGroups.active);
 
+// Statuses for which a managed job actually occupies GPUs and should be
+// counted toward a user's GPU usage. A job's accelerators are derived from its
+// live cluster handle, so a STARTING job (cluster still provisioning, e.g. a
+// k8s pod sitting Pending) can report accelerators it has not yet been
+// allocated, inflating per-user GPU totals above physical cluster capacity.
+// Only count jobs that have actually acquired GPUs: RUNNING, RECOVERING (a
+// previously-running job re-acquiring the same resources), and CANCELLING (the
+// cluster still holds GPUs until teardown completes). PENDING/SUBMITTED jobs
+// have no cluster handle and already report no accelerators.
+const GPU_CONSUMING_JOB_STATUSES = new Set([
+  'RUNNING',
+  'RECOVERING',
+  'CANCELLING',
+]);
+
 // Define filter options for the filter dropdown
 const PROPERTY_OPTIONS = [
   {
@@ -146,6 +161,32 @@ const getGPUCount = (accelerators, source) => {
   }
 
   return 0;
+};
+
+// Extract num_nodes from a cluster_resources_full string (e.g. "3x(...)").
+// Defaults to 1 when the count cannot be determined.
+const extractNumNodes = (clusterResourcesFull) => {
+  if (!clusterResourcesFull || typeof clusterResourcesFull !== 'string') {
+    return 1;
+  }
+  const match = clusterResourcesFull.match(/^(\d+)x/);
+  return match ? parseInt(match[1], 10) : 1;
+};
+
+// Total GPUs a managed job currently occupies, across all of its nodes.
+// Returns 0 for jobs that have not actually been allocated GPUs yet (see
+// GPU_CONSUMING_JOB_STATUSES) so per-user GPU totals never exceed the physical
+// cluster capacity.
+export const getJobGpuCount = (job) => {
+  if (!GPU_CONSUMING_JOB_STATUSES.has(job.status)) {
+    return 0;
+  }
+  const gpuCountPerNode = getGPUCount(
+    job.accelerators,
+    `Job ${job.job_name || job.job_id}`
+  );
+  const numNodes = extractNumNodes(job.resources_str_full);
+  return gpuCountPerNode * numNodes;
 };
 
 // Helper function to fetch clusters and managed jobs data with independent error handling
@@ -1585,18 +1626,6 @@ function UsersTable({
           updateCombinedLookup(userId, infra, gpuType, 1, 0, gpuCount);
         }
 
-        // Helper to extract num_nodes from cluster_resources_full (e.g., "3x(...)")
-        const extractNumNodes = (clusterResourcesFull) => {
-          if (
-            !clusterResourcesFull ||
-            typeof clusterResourcesFull !== 'string'
-          ) {
-            return 1;
-          }
-          const match = clusterResourcesFull.match(/^(\d+)x/);
-          return match ? parseInt(match[1], 10) : 1;
-        };
-
         // Process jobs to build lookup
         for (const job of jobsData || []) {
           if (!ACTIVE_JOB_STATUSES.has(job.status)) continue;
@@ -1606,14 +1635,9 @@ function UsersTable({
 
           const gpuType = extractGPUType(job.accelerators);
           const infra = job.infra;
-          const gpuCountPerNode = getGPUCount(
-            job.accelerators,
-            `Job ${job.job_id}`
-          );
-
-          // Multiply by number of nodes to get total GPU count
-          const numNodes = extractNumNodes(job.resources_str_full);
-          const gpuCount = gpuCountPerNode * numNodes;
+          // The job is always counted toward the (active) job count, but only
+          // contributes GPUs if it has actually been allocated them.
+          const gpuCount = getJobGpuCount(job);
 
           updateCombinedLookup(userId, infra, gpuType, 0, 1, gpuCount);
         }
@@ -1656,13 +1680,7 @@ function UsersTable({
               ACTIVE_JOB_STATUSES.has(job.status)
             ) {
               jobCount++;
-              const gpuCountPerNode = getGPUCount(
-                job.accelerators,
-                `Job ${job.job_id}`
-              );
-              // Multiply by number of nodes to get total GPU count
-              const numNodes = extractNumNodes(job.resources_str_full);
-              jobGPUCount += gpuCountPerNode * numNodes;
+              jobGPUCount += getJobGpuCount(job);
             }
           }
 
@@ -2883,10 +2901,7 @@ function ServiceAccountTokensView({
               ACTIVE_JOB_STATUSES.has(job.status)
             ) {
               jobCount++;
-              jobGPUCount += getGPUCount(
-                job.accelerators,
-                `Job ${job.job_name || job.job_id}`
-              );
+              jobGPUCount += getJobGpuCount(job);
             }
           }
 

--- a/sky/dashboard/src/components/users.test.jsx
+++ b/sky/dashboard/src/components/users.test.jsx
@@ -1,0 +1,77 @@
+import { getJobGpuCount } from '@/components/users';
+
+// getJobGpuCount decides how many GPUs a managed job contributes to a user's
+// GPU total on the Users page. The critical regression it guards against:
+// jobs that are STARTING/PENDING (cluster still provisioning, e.g. a k8s pod
+// sitting Pending) must NOT be counted, otherwise per-user GPU totals can
+// exceed the physical cluster capacity (SKY-5730).
+describe('getJobGpuCount', () => {
+  const makeJob = (overrides) => ({
+    status: 'RUNNING',
+    accelerators: { H100: 8 },
+    resources_str_full: '1x(H100:8)',
+    job_id: 1,
+    ...overrides,
+  });
+
+  it('counts GPUs for a single-node RUNNING job', () => {
+    expect(getJobGpuCount(makeJob({ status: 'RUNNING' }))).toBe(8);
+  });
+
+  it('multiplies per-node GPUs by the number of nodes', () => {
+    expect(
+      getJobGpuCount(
+        makeJob({ status: 'RUNNING', resources_str_full: '4x(H100:8)' })
+      )
+    ).toBe(32);
+  });
+
+  // Regression: these transient states reported their requested accelerators
+  // before the GPUs were actually allocated, inflating the total above
+  // cluster capacity.
+  it.each(['STARTING', 'PENDING', 'SUBMITTED'])(
+    'does not count GPUs for a %s job',
+    (status) => {
+      expect(getJobGpuCount(makeJob({ status }))).toBe(0);
+    }
+  );
+
+  // A RECOVERING job is re-acquiring the same resources, and a CANCELLING job
+  // still holds GPUs until its cluster is torn down, so both are counted.
+  it.each(['RECOVERING', 'CANCELLING'])(
+    'counts GPUs for a %s job',
+    (status) => {
+      expect(
+        getJobGpuCount(makeJob({ status, accelerators: { A100: 4 } }))
+      ).toBe(4);
+    }
+  );
+
+  it('returns 0 for a RUNNING job with no accelerators (CPU-only)', () => {
+    expect(
+      getJobGpuCount(
+        makeJob({
+          status: 'RUNNING',
+          accelerators: null,
+          resources_str_full: '1x(vcpu=4)',
+        })
+      )
+    ).toBe(0);
+  });
+
+  it('parses accelerators provided as a string', () => {
+    expect(
+      getJobGpuCount(
+        makeJob({ status: 'RUNNING', accelerators: "{'V100': 4}" })
+      )
+    ).toBe(4);
+  });
+
+  it('defaults to a single node when resources_str_full is missing', () => {
+    expect(
+      getJobGpuCount(
+        makeJob({ status: 'RUNNING', resources_str_full: undefined })
+      )
+    ).toBe(8);
+  });
+});

--- a/sky/dashboard/src/components/users.test.jsx
+++ b/sky/dashboard/src/components/users.test.jsx
@@ -74,4 +74,9 @@ describe('getJobGpuCount', () => {
       )
     ).toBe(8);
   });
+
+  it('returns 0 for a null or undefined job', () => {
+    expect(getJobGpuCount(null)).toBe(0);
+    expect(getJobGpuCount(undefined)).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

- On the Users page, a single user's GPU count could exceed the physical cluster capacity (e.g. 280 GPUs reported on a 256-GPU cluster) and fluctuate when the user had many jobs starting.
- Root cause: the per-user GPU total summed accelerators over **all** active managed-job statuses. A managed job's `accelerators` is derived from its live cluster handle, so a `STARTING` job (cluster still provisioning — e.g. a Kubernetes pod sitting `Pending`) reports requested GPUs it has not actually been allocated yet. As jobs bounce between `PENDING` and `STARTING`, the count both overshoots capacity and flickers.
- Fix: only count GPUs for jobs that actually occupy them — `RUNNING`, `RECOVERING` (a previously-running job re-acquiring the same resources), and `CANCELLING` (the cluster still holds GPUs until teardown completes). `PENDING`/`SUBMITTED` jobs have no cluster handle and already report no accelerators. **Job counts are unchanged** (still all active statuses).
- Refactor: extracted the GPU-summing logic into a pure `getJobGpuCount()` helper used at all three aggregation sites (filter lookup, Users table, Service Accounts table). The Service Accounts site now also multiplies by `num_nodes`, matching the other two.

## Test plan

- Added `sky/dashboard/src/components/users.test.jsx` with unit tests for `getJobGpuCount`:
  - `STARTING` / `PENDING` / `SUBMITTED` → contributes 0 GPUs (the regression guard).
  - `RUNNING` / `RECOVERING` / `CANCELLING` → counted.
  - Multi-node multiplication (`4x(...)` → ×4), string-form accelerators (`"{'V100': 4}"`), and CPU-only jobs → 0.
  - `npx jest src/components/users.test.jsx` → 10/10 passing.
- Pre-commit dashboard lint + format pass.
- Manual: on a cluster near capacity, submit several GPU jobs so some sit in `STARTING`/`PENDING`; confirm the Users-page GPU number for that user no longer exceeds cluster capacity, stops fluctuating, and equals (active-cluster GPUs + RUNNING/RECOVERING/CANCELLING job GPUs). Job counts in the Jobs column are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)