### PR TITLE
[Backend] Default a new cluster handle to no runtime set up

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2007,8 +2007,18 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
         self.launched_resources = launched_resources
         self.docker_user: Optional[str] = None
         self.is_grpc_enabled = True
+        # A handle is created before provisioning runs, so nothing is set up
+        # on the cluster yet; bulk_provision() fills in the real record on
+        # completion. Defaulting to no-Ray keeps teardown of a cluster that
+        # crashed or recovered mid-provisioning from attempting `ray stop` on
+        # a cluster where Ray never started.
         self.provision_runtime_metadata = (
-            provision_common.ProvisionRuntimeMetadata())
+            provision_common.ProvisionRuntimeMetadata(
+                has_ray=False,
+                has_skylet=False,
+                has_job_queue=False,
+                ssh_available=False,
+            ))
 
     def __repr__(self):
         return (f'ResourceHandle('

--- a/tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend.py
+++ b/tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend.py
@@ -611,3 +611,25 @@ class TestCloudVmRayBackendTeardownNoLock:
 
         mock_run_on_head.assert_not_called()
         mock_get_yaml.assert_called_once_with(refreshed_handle.cluster_yaml)
+
+
+class TestNewHandleRuntimeMetadata:
+    """Runtime metadata a freshly constructed handle starts with."""
+
+    def test_new_handle_has_no_runtime_established(self):
+        """A new handle is created before provisioning, so it claims no Ray.
+
+        Otherwise teardown of a cluster that crashed or recovered during
+        provisioning attempts ``ray stop`` on a runtime that was never set
+        up.
+        """
+        handle = CloudVmRayResourceHandle(
+            cluster_name='test-cluster',
+            cluster_name_on_cloud='test-cluster-abc',
+            cluster_yaml=None,
+            launched_nodes=1,
+            launched_resources=MagicMock(),
+        )
+        metadata = handle.provision_runtime_metadata
+        assert (metadata.has_ray, metadata.has_skylet, metadata.has_job_queue,
+                metadata.ssh_available) == (False, False, False, False)


### PR DESCRIPTION
## Summary

`CloudVmRayResourceHandle` is constructed before provisioning runs — the backend records it while the cluster is still in the `INIT` status, so that a crash or recovery in the middle of provisioning still leaves a row that `sky status` and teardown can see. Its `__init__` defaulted `provision_runtime_metadata` to `ProvisionRuntimeMetadata()`, which claims `has_ray=True` — but the SkyPilot runtime (Ray, skylet, job queue, SSH) isn't established until provisioning completes (the metadata is overwritten with the real record at the end of `bulk_provision()`).

So teardown of a cluster that crashed or recovered mid-provisioning read that optimistic default and attempted `ray stop` on a runtime that never came up.

## Fix

Default the constructed handle to **nothing established** (`has_ray=False, has_skylet=False, has_job_queue=False, ssh_available=False`) instead. A handle is born before provisioning, so this is the truthful initial state.

`bulk_provision()` overwrites it with the real record on completion, so a fully-provisioned cluster is unchanged:

https://github.com/skypilot-org/skypilot/blob/ab26dc27c621e0a3fe86cf1cf7b165e1f6a16763/sky/backends/cloud_vm_ray_backend.py#L3481-L3486

Handles reconstructed from the DB via `from_dict()` / `__setstate__` skip `__init__` (they use `cls.__new__`) and keep their persisted metadata → existing clusters are unaffected; pre-field rows still default to the Ray-based metadata in those paths.

### Behavior change

A cluster interrupted *during* `bulk_provision()` no longer attempts `ray stop` on teardown. This is correct: Ray isn't started until after `bulk_provision()` returns, and teardown terminates the instances regardless.

## Test

`tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend.py::TestNewHandleRuntimeMetadata` constructs a handle and asserts it starts with no runtime established. The existing `TestCloudVmRayBackendTeardownNoLock` already covers that a `has_ray=False` handle skips `run_on_head`/`ray stop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
