### PR TITLE
[Examples] Add vime RL post-training example with SkyPilot Job Groups

### DIFF
--- a/docs/source/examples/training/index.rst
+++ b/docs/source/examples/training/index.rst
@@ -25,4 +25,5 @@ Training
    Unsloth <unsloth.md>
    Verl (RLHF) <verl.md>
    SkyRL <skyrl.md>
+   vime (RL Post-Training) <vime-jobgroup.md>
    Vertex AI <https://medium.com/google-cloud/streamline-ai-ml-model-development-on-gke-with-skypilot-and-vertex-ai-workbench-453729a8897c>

--- a/docs/source/examples/training/vime-jobgroup.md
+++ b/docs/source/examples/training/vime-jobgroup.md
@@ -1,0 +1,1 @@
+../../generated-examples/vime-jobgroup.md

--- a/llm/vime-jobgroup/README.md
+++ b/llm/vime-jobgroup/README.md
@@ -1,0 +1,169 @@
+# RL Post-Training with vime + SkyPilot Job Groups
+
+This example runs [**vime**](https://github.com/vllm-project/vime) (an LLM RL
+post-training framework from the vLLM project that pairs **vLLM** rollout with a
+**Megatron** training backend) on top of **SkyPilot Job Groups**.
+
+vime is built on [Ray](https://www.ray.io/) and runs in two placement modes:
+
+- **Colocated**: training and rollout share the same GPUs.
+- **Disaggregated**: training (Megatron) and rollout (vLLM) run on *separate*
+  GPUs, in parallel.
+
+Disaggregated mode is where Job Groups shine: each RL component becomes its own
+task with its own resources, and SkyPilot wires them together automatically.
+
+```
+                 SkyPilot Job Group: "vime-grpo"
+   ┌─────────────────────────────┐     ┌─────────────────────────────┐
+   │  vime-trainer  (primary)    │     │  vime-rollout  (auxiliary)  │
+   │  8 × H100                   │     │  8 × H100                   │
+   │                             │     │                             │
+   │  Ray head + GRPO driver     │◄───►│  Ray worker                 │
+   │  Megatron actors (learner)  │     │  vLLM engines + router      │
+   └─────────────┬───────────────┘     └──────────────┬──────────────┘
+                 │   policy weights (NCCL) ──────────► │
+                 │ ◄──────────── rollouts / log-probs  │
+                 └──────── one Ray cluster over ───────┘
+                          Job Group DNS
+```
+
+## Architecture
+
+Two tasks run in parallel as a single managed Job Group:
+
+1. **vime-rollout** (auxiliary, 8×H100): joins the trainer's Ray cluster and
+   contributes its GPUs to host the **vLLM rollout engines**. vime's driver
+   places the engines here; the task itself prepares the model (see below),
+   joins Ray, and stays alive until training finishes.
+
+2. **vime-trainer** (primary, 8×H100): starts the Ray head, waits for the
+   rollout worker to join, and submits the vime GRPO job. vime runs the
+   **Megatron actors** (learner) on one task's GPUs and the **vLLM engines** on
+   the other's.
+
+Both GPU tasks download the model and convert it to Megatron `torch_dist` format
+in `setup`. vime places the Megatron actor group on one of the two tasks (the
+choice is symmetric), so both need the converted checkpoint available locally.
+This is what lets the example run without a shared filesystem.
+
+### How the components are distributed
+
+vime launches a single Ray cluster (`ray start --head` + `ray job submit
+train.py`) and decides GPU placement from its arguments. Two things make the
+disaggregation map cleanly onto Job Group tasks:
+
+- The **vime-trainer** task starts the Ray head; the **vime-rollout** task joins
+  it as a Ray worker over the Job Group network
+  (`vime-trainer-0.${SKYPILOT_JOBGROUP_NAME}:6379`).
+- Training is launched with `--actor-num-gpus-per-node 8 --rollout-num-gpus 8`
+  and **without** `--colocate`, so vime keeps the 8 training GPUs and the 8
+  rollout GPUs separate, i.e. on the two separate tasks/pods.
+
+Each task downloads its own copy of the model, so **no shared filesystem is
+required**: the trainer reads it for Megatron, the rollout reads it to start
+vLLM, and the two sync policy weights over Ray/NCCL rather than over disk.
+
+> **Ray co-existence note.** SkyPilot manages its own Ray instance on port
+> `6380`; vime's Ray runs on `6379` with its own `--temp-dir`, so the two do not
+> collide. (This is why the example does **not** run vime's usual
+> `ray stop --force` / `pkill ray` lines, which would kill SkyPilot's Ray.)
+
+### Primary / auxiliary lifecycle
+
+`vime-trainer` is the **primary** task. When training completes, the
+`vime-rollout` auxiliary task is terminated automatically after a 30s grace
+period (`termination_delay: 30s`), releasing its GPUs promptly.
+
+## Usage
+
+```bash
+sky jobs launch llm/vime-jobgroup/vime-grpo-jobgroup.yaml
+```
+
+The default model and datasets are public, so no token is needed. To use a
+Hugging Face token (recommended for the large 4B download, required for gated
+models), set it locally and forward it:
+
+```bash
+export HF_TOKEN=...
+sky jobs launch llm/vime-jobgroup/vime-grpo-jobgroup.yaml --env HF_TOKEN
+```
+
+This trains **Qwen3-4B** with GRPO on the
+[dapo-math-17k](https://huggingface.co/datasets/zhuzilin/dapo-math-17k) dataset
+(verifiable math rewards), evaluating on
+[aime-2024](https://huggingface.co/datasets/zhuzilin/aime-2024).
+
+### Monitor
+
+```bash
+# Status of all tasks in the group
+sky jobs queue
+
+# Logs for a specific task
+sky jobs logs <job-id> vime-trainer
+sky jobs logs <job-id> vime-rollout
+```
+
+## Configuration
+
+Override any of the task environment variables at launch with `--env`:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `HF_MODEL_REPO` | `Qwen/Qwen3-4B` | HF model repo to download |
+| `MODEL_DIR` | `Qwen3-4B` | Local dir under `/models` |
+| `VIME_MODEL_SCRIPT` | `qwen3-4B` | vime model config in `scripts/models/` |
+| `NUM_ROLLOUT` | `30` | Number of rollout→train iterations |
+
+For example, a quick smoke test with a smaller model:
+
+```bash
+sky jobs launch llm/vime-jobgroup/vime-grpo-jobgroup.yaml \
+  --env HF_MODEL_REPO=Qwen/Qwen3-0.6B \
+  --env MODEL_DIR=Qwen3-0.6B \
+  --env VIME_MODEL_SCRIPT=qwen3-0.6B \
+  --env NUM_ROLLOUT=2
+```
+
+> **Checkpoints.** vime writes checkpoints (`--save`) to
+> `/models/<MODEL_DIR>_vime` on the pod hosting the Megatron actors, which is
+> ephemeral. Two ways to persist them:
+>
+> - **SkyPilot volume:** mount a
+>   [volume](https://docs.skypilot.co/en/latest/reference/volumes.html) (or any
+>   `ReadWriteOnce` PVC) and point `--save` at it.
+> - **Hugging Face Storage bucket:** mount an `hf://` Bucket and save there. It
+>   persists to the Hub with no egress, and (unlike a `ReadWriteOnce` volume) the
+>   same bucket mounts on both GPU tasks at once, so the checkpoint survives
+>   wherever vime places the actor group:
+>
+>   ```yaml
+>   file_mounts:
+>     /checkpoints:
+>       source: hf://buckets/<namespace>/vime-grpo
+>       store: hf
+>       mode: MOUNT
+>   ```
+>
+>   Then point `--save` (and `--load`, to resume across runs) at
+>   `/checkpoints/...`, add the extra (`pip install "skypilot[huggingface]"`), and
+>   pass your token with `--secret HF_TOKEN`. See the [storage
+>   docs](https://docs.skypilot.co/en/latest/reference/storage.html).
+
+### Scaling
+
+- **More rollout throughput**: increase the `vime-rollout` GPU count and
+  `--rollout-num-gpus`; vime's vLLM router load-balances across the extra
+  engines (`dp_size = rollout-num-gpus / rollout-num-gpus-per-engine`).
+- **Larger models / longer training**: bump the trainer GPU count and the
+  Megatron parallelism (`--tensor-model-parallel-size`,
+  `--pipeline-model-parallel-size`, `--context-parallel-size`).
+
+## References
+
+- [vime](https://github.com/vllm-project/vime): vLLM RL post-training framework
+- [vime quick start](https://github.com/vllm-project/vime/blob/main/docs/en/get_started/quick_start.md)
+- [SkyPilot Job Groups](https://docs.skypilot.co/en/latest/examples/job-groups.html)
+- [GRPO paper](https://arxiv.org/abs/2402.03300)

--- a/llm/vime-jobgroup/vime-grpo-jobgroup.yaml
+++ b/llm/vime-jobgroup/vime-grpo-jobgroup.yaml
@@ -1,0 +1,348 @@
+# vime GRPO post-training with SkyPilot Job Groups
+#
+# This example runs vime (https://github.com/vllm-project/vime) — an LLM RL
+# post-training framework that pairs vLLM rollout with a Megatron training
+# backend — in *disaggregated* mode, where the training GPUs and rollout GPUs
+# are separate. SkyPilot Job Groups are a natural fit: each RL component becomes
+# its own task with its own resources, wired together automatically.
+#
+# Architecture (two tasks running in parallel):
+#
+#   vime-rollout  (auxiliary, 8xGPU): joins the trainer's Ray cluster and hosts
+#                                     the vLLM rollout engines.
+#   vime-trainer  (primary, 8xGPU):   starts the Ray head and drives the GRPO
+#                                     loop. vime places Megatron actors on these
+#                                     GPUs and vLLM engines on the rollout GPUs.
+#
+# vime is built on Ray: the trainer runs `ray start --head` + `ray job submit`,
+# and the rollout task joins as a Ray worker over the Job Group network. Because
+# we launch with `--rollout-num-gpus 8` and *without* `--colocate`, vime keeps
+# training and rollout on separate GPUs — i.e. on separate tasks/pods here.
+#
+# Each task downloads its own copy of the model (no shared filesystem required):
+# the trainer reads it for Megatron, the rollout reads it to start vLLM. Trainer
+# and rollout sync policy weights over Ray/NCCL, not over disk.
+#
+# When the trainer (primary) finishes, the rollout auxiliary task is terminated
+# automatically after a short grace period.
+#
+# Usage:
+#   sky jobs launch llm/vime-jobgroup/vime-grpo-jobgroup.yaml
+#   # The default model + datasets are public. To avoid HF rate-limits (or to use
+#   # a gated model), set HF_TOKEN locally and add: --env HF_TOKEN
+#
+# Service discovery uses Job Group DNS: the trainer's Ray head is reachable at
+#   vime-trainer-0.${SKYPILOT_JOBGROUP_NAME}:6379
+
+---
+name: vime-grpo
+execution: parallel
+primary_tasks: [vime-trainer]
+termination_delay: 30s
+
+---
+# Rollout (auxiliary): contributes its GPUs to vime's Ray cluster to host the
+# vLLM rollout engines. vime's trainer driver places the engines here; this task
+# downloads the model (for vLLM to load), joins the Ray cluster, and stays alive
+# until the trainer finishes.
+name: vime-rollout
+
+envs:
+  VIME_MODEL_SCRIPT: qwen3-4B
+  HF_MODEL_REPO: Qwen/Qwen3-4B
+  MODEL_DIR: Qwen3-4B
+  HF_TOKEN: ""
+
+resources:
+  accelerators: H100:8
+  memory: 200+
+  infra: kubernetes
+  image_id: docker:inferactinc/public:vime-latest
+
+config:
+  kubernetes:
+    pod_config:
+      spec:
+        containers:
+          - volumeMounts:
+              - mountPath: /dev/shm
+                name: dshm
+              - mountPath: /models
+                name: models
+        volumes:
+          - name: dshm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 64Gi
+          - name: models
+            emptyDir: {}
+
+setup: |
+  set -e
+  pip install -q -U huggingface_hub
+  export HF_TOKEN=${HF_TOKEN}
+  echo "Downloading model ${HF_MODEL_REPO} -> /models/${MODEL_DIR}"
+  hf download "${HF_MODEL_REPO}" --local-dir "/models/${MODEL_DIR}"
+
+  # Convert to Megatron torch_dist format. vime places the Megatron actor group
+  # on one of the two GPU tasks (the choice is symmetric), so BOTH tasks must
+  # have the converted checkpoint available locally.
+  cd /root/vime
+  source scripts/models/${VIME_MODEL_SCRIPT}.sh
+  echo "Converting ${MODEL_DIR} to Megatron torch_dist format ..."
+  PYTHONPATH=/root/Megatron-LM python tools/convert_hf_to_torch_dist.py \
+    "${MODEL_ARGS[@]}" \
+    --hf-checkpoint /models/${MODEL_DIR} \
+    --save /models/${MODEL_DIR}_torch_dist
+
+run: |
+  set -e
+  export PYTHONUNBUFFERED=1
+  # SkyPilot's own Ray (port 6380) is exposed via RAY_ADDRESS; unset it so vime's
+  # Ray CLI/ray.init() only talk to vime's Ray cluster (port 6379).
+  unset RAY_ADDRESS
+  NUM_GPUS=${SKYPILOT_NUM_GPUS_PER_NODE}
+  HEAD_HOST="vime-trainer-0.${SKYPILOT_JOBGROUP_NAME}"
+
+  # Wait for the trainer's Ray head (port 6379) to come up, then join it.
+  echo "Waiting for Ray head at ${HEAD_HOST}:6379 ..."
+  while true; do
+    HEAD_IP=$(getent hosts "${HEAD_HOST}" | awk '{print $1}')
+    if [ -n "${HEAD_IP}" ] && (exec 3<>/dev/tcp/${HEAD_IP}/6379) 2>/dev/null; then
+      break
+    fi
+    echo "  ...waiting for Ray head"; sleep 10
+  done
+  echo "Ray head reachable at ${HEAD_IP}:6379"
+
+  MY_IP=$(hostname -i | awk '{print $1}')
+  # Join vime's Ray cluster (kept on its own temp-dir + non-default agent/metrics
+  # ports so it does not clash with the SkyPilot-managed Ray instance that runs
+  # the task — they share the node, and Ray's default agent port 52365 would
+  # otherwise collide and break job submission).
+  ray start --address "${HEAD_IP}:6379" --node-ip-address "${MY_IP}" \
+    --num-gpus ${NUM_GPUS} --temp-dir /tmp/vime-ray --disable-usage-stats \
+    --dashboard-agent-listen-port 52366 \
+    --dashboard-agent-grpc-port 52367 \
+    --runtime-env-agent-port 52368 \
+    --metrics-export-port 52369
+
+  echo "Joined Ray cluster as the rollout worker (${NUM_GPUS} GPUs)."
+  echo "Idling — the trainer (primary) drives vLLM engine placement on these GPUs."
+  sleep infinity
+
+---
+# Trainer (primary): Ray head + GRPO driver. Converts the model to Megatron
+# format, waits for the rollout worker to join, then submits the vime training
+# job in disaggregated mode (Megatron actors here, vLLM engines on vime-rollout).
+name: vime-trainer
+
+envs:
+  VIME_MODEL_SCRIPT: qwen3-4B
+  HF_MODEL_REPO: Qwen/Qwen3-4B
+  MODEL_DIR: Qwen3-4B
+  TRAIN_DATASET_REPO: zhuzilin/dapo-math-17k
+  TRAIN_DATASET_DIR: dapo-math-17k
+  EVAL_DATASET_REPO: zhuzilin/aime-2024
+  EVAL_DATASET_DIR: aime-2024
+  NUM_ROLLOUT: "30"
+  HF_TOKEN: ""
+
+resources:
+  accelerators: H100:8
+  memory: 200+
+  infra: kubernetes
+  image_id: docker:inferactinc/public:vime-latest
+
+config:
+  kubernetes:
+    pod_config:
+      spec:
+        containers:
+          - volumeMounts:
+              - mountPath: /dev/shm
+                name: dshm
+              - mountPath: /models
+                name: models
+        volumes:
+          - name: dshm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 64Gi
+          - name: models
+            emptyDir: {}
+
+setup: |
+  set -e
+  pip install -q -U huggingface_hub
+  export HF_TOKEN=${HF_TOKEN}
+
+  echo "Downloading model ${HF_MODEL_REPO} -> /models/${MODEL_DIR}"
+  hf download "${HF_MODEL_REPO}" --local-dir "/models/${MODEL_DIR}"
+
+  echo "Downloading train dataset ${TRAIN_DATASET_REPO} -> /models/${TRAIN_DATASET_DIR}"
+  hf download --repo-type dataset "${TRAIN_DATASET_REPO}" --local-dir "/models/${TRAIN_DATASET_DIR}"
+
+  echo "Downloading eval dataset ${EVAL_DATASET_REPO} -> /models/${EVAL_DATASET_DIR}"
+  hf download --repo-type dataset "${EVAL_DATASET_REPO}" --local-dir "/models/${EVAL_DATASET_DIR}"
+
+  # Convert to Megatron torch_dist format. vime places the Megatron actor group
+  # on one of the two GPU tasks (the choice is symmetric), so BOTH tasks must
+  # have the converted checkpoint available locally.
+  cd /root/vime
+  source scripts/models/${VIME_MODEL_SCRIPT}.sh
+  echo "Converting ${MODEL_DIR} to Megatron torch_dist format ..."
+  PYTHONPATH=/root/Megatron-LM python tools/convert_hf_to_torch_dist.py \
+    "${MODEL_ARGS[@]}" \
+    --hf-checkpoint /models/${MODEL_DIR} \
+    --save /models/${MODEL_DIR}_torch_dist
+
+run: |
+  set -e
+  export PYTHONUNBUFFERED=1
+  # SkyPilot's own Ray (port 6380) is exposed via RAY_ADDRESS; unset it so vime's
+  # Ray CLI/ray.init() only talk to vime's Ray cluster (port 6379).
+  unset RAY_ADDRESS
+  cd /root/vime
+
+  NUM_GPUS=${SKYPILOT_NUM_GPUS_PER_NODE}
+  TOTAL_GPUS=$((NUM_GPUS * 2))
+  MY_IP=$(hostname -i | awk '{print $1}')
+  echo "Trainer head IP: ${MY_IP}, GPUs per node: ${NUM_GPUS}, total expected: ${TOTAL_GPUS}"
+
+  # NVLink detection for intra-node NCCL (NVLS); cross-node weight sync uses TCP.
+  NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+  [ "${NVLINK_COUNT}" -gt 0 ] && HAS_NVLINK=1 || HAS_NVLINK=0
+  echo "HAS_NVLINK: ${HAS_NVLINK}"
+
+  # Start vime's Ray head on port 6379 (SkyPilot's own Ray uses 6380, so the GCS
+  # ports do not collide). Use a separate temp-dir and non-default agent/metrics
+  # ports too: vime's Ray shares the node with the SkyPilot-managed Ray, and
+  # Ray's default dashboard-agent port (52365) would otherwise collide and break
+  # job submission ("No available agent to submit job").
+  ray start --head --node-ip-address "${MY_IP}" --port 6379 \
+    --num-gpus ${NUM_GPUS} --temp-dir /tmp/vime-ray \
+    --dashboard-host 0.0.0.0 --dashboard-port 8265 --disable-usage-stats \
+    --dashboard-agent-listen-port 52366 \
+    --dashboard-agent-grpc-port 52367 \
+    --runtime-env-agent-port 52368 \
+    --metrics-export-port 52369
+
+  # MODEL_ARGS (Megatron hyperparameters) for the training job below. The model
+  # was already downloaded and converted to torch_dist in setup (on both tasks).
+  source scripts/models/${VIME_MODEL_SCRIPT}.sh
+
+  # Wait for the rollout task to join the Ray cluster (2x GPUs total).
+  echo "Waiting for the Ray cluster to reach ${TOTAL_GPUS} GPUs ..."
+  until ray status --address 127.0.0.1:6379 2>/dev/null | grep -qE "/${TOTAL_GPUS}\.0 GPU"; do
+    echo "  ...waiting for the rollout worker to join"; sleep 10
+  done
+  echo "Ray cluster is ready with ${TOTAL_GPUS} GPUs."
+
+  # vime training argument groups (adapted from vime's scripts/run-qwen3-4B.sh).
+  # --load and --save point at the same dir: vime resumes from it if a prior
+  # checkpoint exists, else starts fresh from --ref-load (the first-run case).
+  CKPT_ARGS=(
+    --hf-checkpoint /models/${MODEL_DIR}
+    --ref-load /models/${MODEL_DIR}_torch_dist
+    --load /models/${MODEL_DIR}_vime
+    --save /models/${MODEL_DIR}_vime
+    --save-interval 20
+  )
+  ROLLOUT_ARGS=(
+    --prompt-data /models/${TRAIN_DATASET_DIR}/${TRAIN_DATASET_DIR}.jsonl
+    --input-key prompt
+    --label-key label
+    --apply-chat-template
+    --rollout-shuffle
+    --rm-type deepscaler
+    --num-rollout ${NUM_ROLLOUT}
+    --rollout-batch-size 32
+    --n-samples-per-prompt 8
+    --rollout-max-response-len 8192
+    --rollout-temperature 1
+    --global-batch-size 256
+    --balance-data
+  )
+  EVAL_ARGS=(
+    --eval-interval 20
+    --eval-prompt-data aime /models/${EVAL_DATASET_DIR}/${EVAL_DATASET_DIR}.jsonl
+    --n-samples-per-eval-prompt 16
+    --eval-max-response-len 16384
+    --eval-top-p 1
+  )
+  PERF_ARGS=(
+    --tensor-model-parallel-size 2
+    --sequence-parallel
+    --pipeline-model-parallel-size 1
+    --context-parallel-size 1
+    --recompute-granularity full
+    --recompute-method uniform
+    --recompute-num-layers 1
+    --use-dynamic-batch-size
+    --max-tokens-per-gpu 9216
+  )
+  GRPO_ARGS=(
+    --advantage-estimator grpo
+    --use-kl-loss
+    --kl-loss-coef 0.00
+    --kl-loss-type low_var_kl
+    --entropy-coef 0.00
+    --eps-clip 0.2
+    --eps-clip-high 0.28
+  )
+  OPTIMIZER_ARGS=(
+    --optimizer adam
+    --lr 1e-6
+    --lr-decay-style constant
+    --weight-decay 0.1
+    --adam-beta1 0.9
+    --adam-beta2 0.98
+  )
+  VLLM_ARGS=(
+    --rollout-num-gpus-per-engine 2
+    --vllm-gpu-memory-utilization 0.7
+  )
+  MISC_ARGS=(
+    --attention-dropout 0.0
+    --hidden-dropout 0.0
+    --accumulate-allreduce-grads-in-fp32
+    --attention-softmax-in-fp32
+    --attention-backend flash
+  )
+
+  RUNTIME_ENV_JSON="{
+    \"env_vars\": {
+      \"PYTHONPATH\": \"/root/vime:/root/Megatron-LM/\",
+      \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+      \"NCCL_NVLS_ENABLE\": \"${HAS_NVLINK}\",
+      \"NCCL_SOCKET_IFNAME\": \"eth0\",
+      \"GLOO_SOCKET_IFNAME\": \"eth0\",
+      \"NCCL_IB_DISABLE\": \"1\",
+      \"HF_TOKEN\": \"${HF_TOKEN}\"
+    }
+  }"
+
+  # Wait for the Ray job agent to be ready before submitting.
+  echo "Waiting for the Ray job agent ..."
+  until ray job list --address http://127.0.0.1:8265 >/dev/null 2>&1; do sleep 5; done
+
+  echo "Submitting vime GRPO job (disaggregated: ${NUM_GPUS} actor GPUs + ${NUM_GPUS} rollout GPUs) ..."
+  ray job submit --address="http://127.0.0.1:8265" \
+    --runtime-env-json="${RUNTIME_ENV_JSON}" \
+    -- python3 train.py \
+    --train-backend megatron \
+    --actor-num-nodes 1 \
+    --actor-num-gpus-per-node ${NUM_GPUS} \
+    --rollout-num-gpus ${NUM_GPUS} \
+    "${MODEL_ARGS[@]}" \
+    "${CKPT_ARGS[@]}" \
+    "${ROLLOUT_ARGS[@]}" \
+    "${OPTIMIZER_ARGS[@]}" \
+    "${GRPO_ARGS[@]}" \
+    "${PERF_ARGS[@]}" \
+    "${EVAL_ARGS[@]}" \
+    "${VLLM_ARGS[@]}" \
+    "${MISC_ARGS[@]}"
+
+  echo "vime GRPO training complete. Checkpoints (saved every --save-interval steps) are under /models/${MODEL_DIR}_vime."


### PR DESCRIPTION
Adds `llm/vime-jobgroup/`: a 2-task SkyPilot Job Group running https://github.com/vllm-project/vime
(GRPO) in disaggregated mode: Megatron trainer + vLLM rollout on separate
8×H100 pods, wired over Job Group DNS. Registered in the docs Training gallery.

Tested: verified end-to-end on Kubernetes (16×H100):

 full Qwen3-4B / 30-iter run
completed, checkpoints saved, eval AIME 0.573; primary->auxiliary teardown works.
