### PR TITLE
[Jobs] Add --status filter to sky jobs queue

### DIFF
--- a/agent/skills/skypilot/references/cli-reference.md
+++ b/agent/skills/skypilot/references/cli-reference.md
@@ -462,7 +462,7 @@ Show statuses of managed jobs.
 - `--limit`, `-l` (default: `50`) — Number of jobs to show, default is 50, use "-a/--all" to show all jobs.
 - `--refresh`, `-r` — Query the latest statuses, restarting the jobs controller if stopped.
 - `--skip-finished` — Show only pending/running jobs' information.
-- `-s`, `--status` — Filter by status, comma-separated or repeated (e.g. -s FAILED,FAILED_SETUP). A bare -s (no value) is a deprecated alias for --skip-finished.
+- `-s`, `--status` — Filter by status, comma-separated (e.g. -s FAILED,FAILED_SETUP). A bare -s (no value) is a deprecated alias for --skip-finished.
 - `--all-users`, `-u` — Show jobs from all users.
 - `--all`, `-a` — Show all jobs.
 - `--output`, `-o` (default: `table`) — Output format. Choices: table, json. Default: table.

--- a/agent/skills/skypilot/references/cli-reference.md
+++ b/agent/skills/skypilot/references/cli-reference.md
@@ -462,6 +462,7 @@ Show statuses of managed jobs.
 - `--limit`, `-l` (default: `50`) — Number of jobs to show, default is 50, use "-a/--all" to show all jobs.
 - `--refresh`, `-r` — Query the latest statuses, restarting the jobs controller if stopped.
 - `--skip-finished`, `-s` — Show only pending/running jobs' information.
+- `--status` — Filter by status, comma-separated or repeated (e.g. --status FAILED,FAILED_SETUP).
 - `--all-users`, `-u` — Show jobs from all users.
 - `--all`, `-a` — Show all jobs.
 - `--output`, `-o` (default: `table`) — Output format. Choices: table, json. Default: table.

--- a/agent/skills/skypilot/references/cli-reference.md
+++ b/agent/skills/skypilot/references/cli-reference.md
@@ -461,8 +461,8 @@ Show statuses of managed jobs.
 - `--verbose`, `-v` — Show all information in full.
 - `--limit`, `-l` (default: `50`) — Number of jobs to show, default is 50, use "-a/--all" to show all jobs.
 - `--refresh`, `-r` — Query the latest statuses, restarting the jobs controller if stopped.
-- `--skip-finished`, `-s` — Show only pending/running jobs' information.
-- `--status` — Filter by status, comma-separated or repeated (e.g. --status FAILED,FAILED_SETUP).
+- `--skip-finished` — Show only pending/running jobs' information.
+- `-s`, `--status` — Filter by status, comma-separated or repeated (e.g. -s FAILED,FAILED_SETUP). A bare -s (no value) is a deprecated alias for --skip-finished.
 - `--all-users`, `-u` — Show jobs from all users.
 - `--all`, `-a` — Show all jobs.
 - `--output`, `-o` (default: `table`) — Output format. Choices: table, json. Default: table.

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -5962,6 +5962,13 @@ def jobs_launch(
                     f'{ux_utils.RESET_BOLD}')
 
 
+# Value the ``-s``/``--status`` option takes when given with no argument. It is
+# a deprecated alias for ``--skip-finished`` (see jobs_queue).
+# TODO(kevin): remove in 0.15.0, after which a bare ``-s`` is invalid and ``-s``
+# is solely the short flag for ``--status``.
+_SKIP_FINISHED_SENTINEL = '__skip_finished__'
+
+
 class StatusList(click.Choice):
     """Comma-separated, case-insensitive choices.
 
@@ -5971,6 +5978,10 @@ class StatusList(click.Choice):
     """
 
     def convert(self, value, param, ctx):
+        # A bare ``-s`` yields the sentinel; pass it through unvalidated so the
+        # handler can treat it as --skip-finished.
+        if value == _SKIP_FINISHED_SENTINEL:
+            return [value]
         return [
             super(StatusList, self).convert(v.strip(), param, ctx)
             for v in value.split(',')
@@ -5998,19 +6009,22 @@ class StatusList(click.Choice):
     help='Query the latest statuses, restarting the jobs controller if stopped.'
 )
 @click.option('--skip-finished',
-              '-s',
               default=False,
               is_flag=True,
               required=False,
               help='Show only pending/running jobs\' information.')
-@click.option('--status',
+@click.option('-s',
+              '--status',
               'statuses',
+              is_flag=False,
+              flag_value=_SKIP_FINISHED_SENTINEL,
               multiple=True,
               type=StatusList([s.value for s in ManagedJobStatus],
                               case_sensitive=False),
               required=False,
               help='Filter by status, comma-separated or repeated '
-              '(e.g. --status FAILED,FAILED_SETUP).')
+              '(e.g. -s FAILED,FAILED_SETUP). A bare -s (no value) is a '
+              'deprecated alias for --skip-finished.')
 @flags.all_users_option('Show jobs from all users.')
 @flags.all_option('Show all jobs.')
 @flags.output_format_option()
@@ -6080,11 +6094,12 @@ def jobs_queue(verbose: bool,
 
       sky jobs queue -l 10
 
-    (Tip) To filter by status, use ``--status`` (comma-separated or repeated):
+    (Tip) To filter by status, use ``-s``/``--status`` (comma-separated or
+    repeated):
 
     .. code-block:: bash
 
-      sky jobs queue --status FAILED,FAILED_SETUP
+      sky jobs queue -s FAILED,FAILED_SETUP
 
     (Tip) To show only active (pending/running) jobs, use ``--skip-finished``:
 
@@ -6093,9 +6108,23 @@ def jobs_queue(verbose: bool,
       sky jobs queue --skip-finished
 
     """
+    status_filter = [status for group in statuses for status in group]
+    # TODO(kevin): remove in 0.15.0, along with _SKIP_FINISHED_SENTINEL and the
+    # flag_value on -s/--status.
+    if _SKIP_FINISHED_SENTINEL in status_filter:
+        click.secho(
+            'Warning: `-s` without a value is a deprecated alias for '
+            '`--skip-finished` and will be removed in 0.15.0. Use '
+            '`--skip-finished`, or pass a status (e.g. `-s RUNNING`).',
+            fg='yellow',
+            err=True)
+        skip_finished = True
+        status_filter = [
+            s for s in status_filter if s != _SKIP_FINISHED_SENTINEL
+        ]
+    status_filter = status_filter or None
     if output_format != flags.OUTPUT_FORMAT_JSON:
         click.secho('Fetching managed job statuses...', fg='cyan')
-    status_filter = [status for group in statuses for status in group] or None
     with rich_utils.client_status('[cyan]Checking managed jobs[/]'):
         max_num_jobs_to_show = (limit if not all else None)
         fields = _DEFAULT_MANAGED_JOB_FIELDS_TO_GET

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -6086,11 +6086,11 @@ def jobs_queue(verbose: bool,
 
       sky jobs queue --status FAILED,FAILED_SETUP
 
-    (Tip) To show only active (pending/running) jobs, use ``-s``:
+    (Tip) To show only active (pending/running) jobs, use ``--skip-finished``:
 
     .. code-block:: bash
 
-      sky jobs queue -s
+      sky jobs queue --skip-finished
 
     """
     if output_format != flags.OUTPUT_FORMAT_JSON:

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -6022,7 +6022,7 @@ class StatusList(click.Choice):
               type=StatusList([s.value for s in ManagedJobStatus],
                               case_sensitive=False),
               required=False,
-              help='Filter by status, comma-separated or repeated '
+              help='Filter by status, comma-separated '
               '(e.g. -s FAILED,FAILED_SETUP). A bare -s (no value) is a '
               'deprecated alias for --skip-finished.')
 @flags.all_users_option('Show jobs from all users.')
@@ -6094,8 +6094,7 @@ def jobs_queue(verbose: bool,
 
       sky jobs queue -l 10
 
-    (Tip) To filter by status, use ``-s``/``--status`` (comma-separated or
-    repeated):
+    (Tip) To filter by status, use ``-s``/``--status`` (comma-separated):
 
     .. code-block:: bash
 

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -5962,6 +5962,22 @@ def jobs_launch(
                     f'{ux_utils.RESET_BOLD}')
 
 
+class StatusList(click.Choice):
+    """Comma-separated, case-insensitive choices.
+
+    Returns a list so a single ``--status FAILED,FAILED_SETUP`` and a repeated
+    ``--status FAILED --status FAILED_SETUP`` are both accepted; with
+    ``multiple=True`` the option then yields a tuple of lists to flatten.
+    """
+
+    def convert(self, value, param, ctx):
+        return [
+            super(StatusList, self).convert(v.strip(), param, ctx)
+            for v in value.split(',')
+            if v.strip()
+        ]
+
+
 @jobs.command('queue', cls=_DocumentedCodeCommand)
 @flags.config_option(expose_value=False)
 @flags.verbose_option()
@@ -5990,11 +6006,11 @@ def jobs_launch(
 @click.option('--status',
               'statuses',
               multiple=True,
-              type=click.Choice([s.value for s in ManagedJobStatus],
-                                case_sensitive=False),
+              type=StatusList([s.value for s in ManagedJobStatus],
+                              case_sensitive=False),
               required=False,
-              help='Filter by status; repeat for multiple '
-              '(e.g. --status FAILED --status FAILED_SETUP).')
+              help='Filter by status, comma-separated or repeated '
+              '(e.g. --status FAILED,FAILED_SETUP).')
 @flags.all_users_option('Show jobs from all users.')
 @flags.all_option('Show all jobs.')
 @flags.output_format_option()
@@ -6003,7 +6019,7 @@ def jobs_launch(
 def jobs_queue(verbose: bool,
                refresh: bool,
                skip_finished: bool,
-               statuses: Tuple[str, ...],
+               statuses: Tuple[List[str], ...],
                all_users: bool,
                all: bool,
                limit: int,
@@ -6064,11 +6080,11 @@ def jobs_queue(verbose: bool,
 
       sky jobs queue -l 10
 
-    (Tip) To filter by status, use ``--status`` (repeat for multiple):
+    (Tip) To filter by status, use ``--status`` (comma-separated or repeated):
 
     .. code-block:: bash
 
-      sky jobs queue --status FAILED --status FAILED_SETUP
+      sky jobs queue --status FAILED,FAILED_SETUP
 
     (Tip) To show only active (pending/running) jobs, use ``-s``:
 
@@ -6079,6 +6095,7 @@ def jobs_queue(verbose: bool,
     """
     if output_format != flags.OUTPUT_FORMAT_JSON:
         click.secho('Fetching managed job statuses...', fg='cyan')
+    status_filter = [status for group in statuses for status in group] or None
     with rich_utils.client_status('[cyan]Checking managed jobs[/]'):
         max_num_jobs_to_show = (limit if not all else None)
         fields = _DEFAULT_MANAGED_JOB_FIELDS_TO_GET
@@ -6096,8 +6113,7 @@ def jobs_queue(verbose: bool,
                                                    all_users=all_users,
                                                    limit=max_num_jobs_to_show,
                                                    fields=fields,
-                                                   statuses=list(statuses) or
-                                                   None)
+                                                   statuses=status_filter)
 
         def get_pool_status():
             try:

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -5987,6 +5987,14 @@ def jobs_launch(
               is_flag=True,
               required=False,
               help='Show only pending/running jobs\' information.')
+@click.option('--status',
+              'statuses',
+              multiple=True,
+              type=click.Choice([s.value for s in ManagedJobStatus],
+                                case_sensitive=False),
+              required=False,
+              help='Filter by status; repeat for multiple '
+              '(e.g. --status FAILED --status FAILED_SETUP).')
 @flags.all_users_option('Show jobs from all users.')
 @flags.all_option('Show all jobs.')
 @flags.output_format_option()
@@ -5995,6 +6003,7 @@ def jobs_launch(
 def jobs_queue(verbose: bool,
                refresh: bool,
                skip_finished: bool,
+               statuses: Tuple[str, ...],
                all_users: bool,
                all: bool,
                limit: int,
@@ -6055,6 +6064,18 @@ def jobs_queue(verbose: bool,
 
       sky jobs queue -l 10
 
+    (Tip) To filter by status, use ``--status`` (repeat for multiple):
+
+    .. code-block:: bash
+
+      sky jobs queue --status FAILED --status FAILED_SETUP
+
+    (Tip) To show only active (pending/running) jobs, use ``-s``:
+
+    .. code-block:: bash
+
+      sky jobs queue -s
+
     """
     if output_format != flags.OUTPUT_FORMAT_JSON:
         click.secho('Fetching managed job statuses...', fg='cyan')
@@ -6074,7 +6095,9 @@ def jobs_queue(verbose: bool,
                                                    skip_finished=skip_finished,
                                                    all_users=all_users,
                                                    limit=max_num_jobs_to_show,
-                                                   fields=fields)
+                                                   fields=fields,
+                                                   statuses=list(statuses) or
+                                                   None)
 
         def get_pool_status():
             try:

--- a/sky/client/cli/utils.py
+++ b/sky/client/cli/utils.py
@@ -36,6 +36,7 @@ def get_managed_job_queue(
     job_ids: Optional[List[int]] = None,
     limit: Optional[int] = None,
     fields: Optional[List[str]] = None,
+    statuses: Optional[List[str]] = None,
 ) -> Tuple[server_common.RequestId[Union[List[responses.ManagedJobRecord],
                                          Tuple[List[responses.ManagedJobRecord],
                                                int, Dict[str, int], int]]],
@@ -51,6 +52,7 @@ def get_managed_job_queue(
         job_ids: IDs of the managed jobs to show.
         limit: Number of jobs to show.
         fields: Fields to get for the managed jobs.
+        statuses: Only return jobs whose status is in this list.
 
     Returns:
         - the request ID of the queue request
@@ -67,8 +69,13 @@ def get_managed_job_queue(
                 Union[List[responses.ManagedJobRecord],
                       Tuple[List[responses.ManagedJobRecord], int,
                             Dict[str, int], int]]],
-            managed_jobs.queue_v2(refresh, skip_finished, all_users, job_ids,
-                                  limit, fields)), QueueResultVersion.V2
+            managed_jobs.queue_v2(refresh,
+                                  skip_finished,
+                                  all_users,
+                                  job_ids,
+                                  limit,
+                                  fields,
+                                  statuses=statuses)), QueueResultVersion.V2
     except exceptions.APINotSupportedError:
         return typing.cast(
             server_common.RequestId[

--- a/sky/client/cli/utils.py
+++ b/sky/client/cli/utils.py
@@ -5,8 +5,11 @@ from typing import Dict, List, Optional, Tuple, Union
 
 from sky import exceptions
 from sky import jobs as managed_jobs
+from sky import sky_logging
 from sky.schemas.api import responses
 from sky.server import common as server_common
+
+logger = sky_logging.init_logger(__name__)
 
 
 class QueueResultVersion(enum.Enum):
@@ -77,6 +80,11 @@ def get_managed_job_queue(
                                   fields,
                                   statuses=statuses)), QueueResultVersion.V2
     except exceptions.APINotSupportedError:
+        if statuses is not None:
+            logger.warning(
+                'Filtering by status is not supported in your API server. '
+                'Please upgrade to a newer API server to use --status. '
+                'Showing all jobs.')
         return typing.cast(
             server_common.RequestId[
                 Union[List[responses.ManagedJobRecord],

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -178,6 +178,7 @@ def queue_v2(
     fields: Optional[List[str]] = None,
     sort_by: Optional[str] = None,
     sort_order: Optional[str] = None,
+    statuses: Optional[List[str]] = None,
 ) -> server_common.RequestId[Tuple[List[responses.ManagedJobRecord], int, Dict[
         str, int], int]]:
     """Gets statuses of managed jobs.
@@ -193,6 +194,7 @@ def queue_v2(
         fields: Fields to get for the managed jobs.
         sort_by: Field to sort by (e.g., 'job_id', 'name', 'submitted_at').
         sort_order: Sort direction ('asc' or 'desc').
+        statuses: Only return jobs whose status is in this list.
 
     Returns:
         The request ID of the queue request.
@@ -251,6 +253,7 @@ def queue_v2(
         fields=fields,
         sort_by=sort_by,
         sort_order=sort_order,
+        statuses=statuses,
     )
     path = '/jobs/queue/v2'
     response = server_common.make_authenticated_request(

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -89,11 +89,12 @@ def test_managed_jobs_basic(generic_cloud: str):
             f's=$(sky jobs logs --controller -n {name}-2 --no-follow); echo "$s"; echo "$s" | grep "Cluster launched:"',
             rf'{smoke_tests_utils.GET_JOB_QUEUE} | grep {name}-2 | head -n1 | grep "RUNNING\|SUCCEEDED"',
             # Filtering by --status keeps matching jobs and drops the rest:
-            # {name}-1 is CANCELLED, {name}-2 is RUNNING/SUCCEEDED.
-            f's=$(sky jobs queue --status CANCELLED); echo "$s"; '
+            # {name}-1 is CANCELLED, {name}-2 is RUNNING/SUCCEEDED. Use
+            # lowercase to exercise case-insensitive matching.
+            f's=$(sky jobs queue --status cancelled); echo "$s"; '
             f'echo "$s" | grep {name}-1 && ! echo "$s" | grep {name}-2',
             # Comma-separated values are also accepted.
-            f's=$(sky jobs queue --status RUNNING,SUCCEEDED); echo "$s"; '
+            f's=$(sky jobs queue --status running,succeeded); echo "$s"; '
             f'echo "$s" | grep {name}-2 && ! echo "$s" | grep {name}-1',
         ],
         # TODO(zhwu): Change to f'sky jobs cancel -y -n {name}-1 -n {name}-2' when

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -88,6 +88,13 @@ def test_managed_jobs_basic(generic_cloud: str):
             f's=$(sky jobs logs -n {name}-2 --no-follow); echo "$s"; echo "$s" | grep "start counting"',
             f's=$(sky jobs logs --controller -n {name}-2 --no-follow); echo "$s"; echo "$s" | grep "Cluster launched:"',
             rf'{smoke_tests_utils.GET_JOB_QUEUE} | grep {name}-2 | head -n1 | grep "RUNNING\|SUCCEEDED"',
+            # Filtering by --status keeps matching jobs and drops the rest:
+            # {name}-1 is CANCELLED, {name}-2 is RUNNING/SUCCEEDED.
+            f's=$(sky jobs queue --status CANCELLED); echo "$s"; '
+            f'echo "$s" | grep {name}-1 && ! echo "$s" | grep {name}-2',
+            # Comma-separated values are also accepted.
+            f's=$(sky jobs queue --status RUNNING,SUCCEEDED); echo "$s"; '
+            f'echo "$s" | grep {name}-2 && ! echo "$s" | grep {name}-1',
         ],
         # TODO(zhwu): Change to f'sky jobs cancel -y -n {name}-1 -n {name}-2' when
         # canceling multiple job names is supported.

--- a/tests/unit_tests/test_sky/jobs/test_jobs_state.py
+++ b/tests/unit_tests/test_sky/jobs/test_jobs_state.py
@@ -161,6 +161,92 @@ def _seed_test_jobs(_mock_managed_jobs_db_conn):
         loop.close()
 
 
+@pytest.fixture
+def _seed_multi_task_job(_mock_managed_jobs_db_conn):
+    """Seed a multi-task (pipeline) job plus an unrelated terminal job.
+
+    The pipeline job has task 0 SUCCEEDED and task 1 RUNNING, so the job
+    overall is still running. A second single-task FAILED job exists so that
+    filter assertions prove row selection among other jobs, not just against
+    a one-job database. Used to characterize how the row/task-level
+    `statuses` filter behaves on pipelines.
+
+    Returns a dict with 'pipeline_job_id' and 'failed_job_id'.
+    """
+
+    async def mock_callback(status: str):
+        pass
+
+    async def create_jobs():
+        pipeline_job_id = state.set_job_info_without_job_id(
+            name='pipe-status-test',
+            workspace='ws1',
+            entrypoint='ep',
+            pool=None,
+            pool_hash=None,
+            user_hash='user1')
+        # Two tasks under one job.
+        state.set_pending(pipeline_job_id,
+                          task_id=0,
+                          task_name='extract',
+                          resources_str='{}',
+                          metadata='{}')
+        state.set_pending(pipeline_job_id,
+                          task_id=1,
+                          task_name='transform',
+                          resources_str='{}',
+                          metadata='{}')
+        state.scheduler_set_waiting([pipeline_job_id], '/tmp/dag.yaml',
+                                    '/tmp/user.yaml', '/tmp/env', None, 100)
+        # Task 0 -> SUCCEEDED.
+        await state.set_starting_async(pipeline_job_id, 0, 'run_0', time.time(),
+                                       '{}', {}, mock_callback)
+        await state.set_started_async(pipeline_job_id, 0, time.time(),
+                                      mock_callback)
+        await state.set_succeeded_async(pipeline_job_id, 0, time.time(),
+                                        mock_callback)
+        # Task 1 -> RUNNING (job not done: no scheduler_set_done).
+        await state.set_starting_async(pipeline_job_id, 1, 'run_1', time.time(),
+                                       '{}', {}, mock_callback)
+        await state.set_started_async(pipeline_job_id, 1, time.time(),
+                                      mock_callback)
+
+        # An unrelated single-task job that already FAILED.
+        failed_job_id = state.set_job_info_without_job_id(
+            name='other-failed-job',
+            workspace='ws1',
+            entrypoint='ep',
+            pool=None,
+            pool_hash=None,
+            user_hash='user1')
+        state.set_pending(failed_job_id,
+                          task_id=0,
+                          task_name='task0',
+                          resources_str='{}',
+                          metadata='{}')
+        state.scheduler_set_waiting([failed_job_id], '/tmp/dag-failed.yaml',
+                                    '/tmp/user-failed.yaml', '/tmp/env-failed',
+                                    None, 100)
+        await state.set_starting_async(failed_job_id, 0, 'run_failed',
+                                       time.time(), '{}', {}, mock_callback)
+        await state.set_started_async(failed_job_id, 0, time.time(),
+                                      mock_callback)
+        await state.set_failed_async(failed_job_id, 0,
+                                     state.ManagedJobStatus.FAILED,
+                                     'Test failure', mock_callback)
+        state.scheduler_set_done(failed_job_id)
+        return {
+            'pipeline_job_id': pipeline_job_id,
+            'failed_job_id': failed_job_id,
+        }
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(create_jobs())
+    finally:
+        loop.close()
+
+
 class TestMapResponseFieldToDbColumn:
     """Test class for _map_response_field_to_db_column function."""
 
@@ -780,3 +866,74 @@ class TestGetLatestRecoveryReasons:
                                                 _mock_managed_jobs_db_conn):
         state.add_job_event(1, 0, state.ManagedJobStatus.RUNNING, 'running')
         assert state.get_latest_recovery_reasons([1]) == {}
+
+
+class TestMultiTaskStatusFilterCharacterization:
+    """Pin the CURRENT (row/task-level) behavior of the `statuses` filter on a
+    multi-task (pipeline) job.
+
+    The `statuses` filter matches individual task rows, unlike `skip_finished`,
+    which is job-level. So filtering a pipeline by a terminal status returns a
+    partial view of a job that is still running. These assertions characterize
+    today's behavior; if `statuses` is ever made job-aware, they are expected
+    to change.
+    """
+
+    def test_terminal_status_returns_only_the_finished_task(
+            self, _seed_multi_task_job):
+        pipeline_id = _seed_multi_task_job['pipeline_job_id']
+        # --status SUCCEEDED returns only the pipeline's finished task, even
+        # though the job is still running (task 1 is RUNNING). The FAILED job
+        # does not match.
+        jobs, total = state.get_managed_jobs_with_filters(
+            statuses=[state.ManagedJobStatus.SUCCEEDED.value])
+        assert [(j['job_id'], j['task_id']) for j in jobs] == [(pipeline_id, 0)]
+        assert jobs[0]['status'] == state.ManagedJobStatus.SUCCEEDED
+        assert total == 1
+
+    def test_running_status_returns_only_the_running_task(
+            self, _seed_multi_task_job):
+        pipeline_id = _seed_multi_task_job['pipeline_job_id']
+        jobs, total = state.get_managed_jobs_with_filters(
+            statuses=[state.ManagedJobStatus.RUNNING.value])
+        assert [(j['job_id'], j['task_id']) for j in jobs] == [(pipeline_id, 1)]
+        assert jobs[0]['status'] == state.ManagedJobStatus.RUNNING
+        assert total == 1
+
+    def test_failed_status_returns_only_the_other_job(self,
+                                                      _seed_multi_task_job):
+        failed_id = _seed_multi_task_job['failed_job_id']
+        jobs, total = state.get_managed_jobs_with_filters(
+            statuses=[state.ManagedJobStatus.FAILED.value])
+        assert [(j['job_id'], j['task_id']) for j in jobs] == [(failed_id, 0)]
+        assert jobs[0]['status'] == state.ManagedJobStatus.FAILED
+        assert total == 1
+
+    def test_both_statuses_return_both_tasks(self, _seed_multi_task_job):
+        pipeline_id = _seed_multi_task_job['pipeline_job_id']
+        jobs, total = state.get_managed_jobs_with_filters(statuses=[
+            state.ManagedJobStatus.SUCCEEDED.value,
+            state.ManagedJobStatus.RUNNING.value,
+        ])
+        assert sorted((j['job_id'], j['task_id']) for j in jobs) == [
+            (pipeline_id, 0),
+            (pipeline_id, 1),
+        ]
+        # total counts unique jobs that have a matching task: two matching
+        # task rows, one job.
+        assert total == 1
+
+    def test_skip_finished_is_job_level(self, _seed_multi_task_job):
+        pipeline_id = _seed_multi_task_job['pipeline_job_id']
+        # Contrast: skip_finished is job-level. The still-active pipeline
+        # keeps ALL its tasks, including the finished one, while the FAILED
+        # job is dropped entirely.
+        jobs, total = state.get_managed_jobs_with_filters(skip_finished=True)
+        assert sorted((j['job_id'], j['task_id']) for j in jobs) == [
+            (pipeline_id, 0),
+            (pipeline_id, 1),
+        ]
+        assert {j['status'] for j in jobs} == {
+            state.ManagedJobStatus.SUCCEEDED, state.ManagedJobStatus.RUNNING
+        }
+        assert total == 1

--- a/tests/unit_tests/test_sky/test_cli_json_output.py
+++ b/tests/unit_tests/test_sky/test_cli_json_output.py
@@ -188,6 +188,30 @@ class TestJobsQueueJsonOutput:
         assert len(parsed) == 2
         assert parsed[1]['status'] == 'SUCCEEDED'
 
+    def test_status_filter_forwarded(self, monkeypatch):
+        """--status flags are forwarded to the queue call as a list."""
+        records = [self._make_job_record()]
+        mock_result = (records, 1, {'RUNNING': 1}, 0)
+        captured = {}
+
+        def fake_get_managed_job_queue(**kw):
+            captured.update(kw)
+            return ('req-1', mock.MagicMock(v2=lambda: True))
+
+        monkeypatch.setattr('sky.client.cli.utils.get_managed_job_queue',
+                            fake_get_managed_job_queue)
+        monkeypatch.setattr('sky.jobs.pool_status', lambda **kw: None)
+        monkeypatch.setattr('sky.client.sdk.stream_and_get',
+                            lambda *a, **kw: mock_result)
+
+        runner = cli_testing.CliRunner()
+        result = runner.invoke(
+            command.jobs_queue,
+            ['-o', 'json', '--status', 'FAILED', '--status', 'FAILED_SETUP'])
+
+        assert result.exit_code == 0, result.output
+        assert captured['statuses'] == ['FAILED', 'FAILED_SETUP']
+
 
 class TestGpusListJsonOutput:
     """Tests for `sky gpus list -o json` output format."""

--- a/tests/unit_tests/test_sky/test_cli_json_output.py
+++ b/tests/unit_tests/test_sky/test_cli_json_output.py
@@ -7,6 +7,7 @@ import json
 from unittest import mock
 
 from click import testing as cli_testing
+import pytest
 
 from sky.catalog import common as catalog_common
 from sky.client import sdk
@@ -188,8 +189,23 @@ class TestJobsQueueJsonOutput:
         assert len(parsed) == 2
         assert parsed[1]['status'] == 'SUCCEEDED'
 
-    def test_status_filter_forwarded(self, monkeypatch):
-        """--status flags are forwarded to the queue call as a list."""
+    @pytest.mark.parametrize(
+        'args,expected',
+        [
+            # Repeated flag.
+            (['--status', 'FAILED', '--status', 'FAILED_SETUP'
+             ], ['FAILED', 'FAILED_SETUP']),
+            # Comma-separated single flag.
+            (['--status', 'FAILED,FAILED_SETUP'], ['FAILED', 'FAILED_SETUP']),
+            # Mixed repeated + comma-separated, order preserved.
+            (['--status', 'RUNNING,FAILED', '--status', 'FAILED_SETUP'
+             ], ['RUNNING', 'FAILED', 'FAILED_SETUP']),
+            # Case-insensitive, with surrounding whitespace.
+            (['--status', 'failed, failed_setup'], ['FAILED', 'FAILED_SETUP']),
+        ])
+    def test_status_filter_forwarded(self, monkeypatch, args, expected):
+        """--status accepts repeated and comma-separated values as a flat list.
+        """
         records = [self._make_job_record()]
         mock_result = (records, 1, {'RUNNING': 1}, 0)
         captured = {}
@@ -205,12 +221,18 @@ class TestJobsQueueJsonOutput:
                             lambda *a, **kw: mock_result)
 
         runner = cli_testing.CliRunner()
-        result = runner.invoke(
-            command.jobs_queue,
-            ['-o', 'json', '--status', 'FAILED', '--status', 'FAILED_SETUP'])
+        result = runner.invoke(command.jobs_queue, ['-o', 'json'] + args)
 
         assert result.exit_code == 0, result.output
-        assert captured['statuses'] == ['FAILED', 'FAILED_SETUP']
+        assert captured['statuses'] == expected
+
+    def test_status_filter_rejects_invalid(self):
+        """An unknown status value is rejected with a non-zero exit code."""
+        runner = cli_testing.CliRunner()
+        result = runner.invoke(command.jobs_queue,
+                               ['-o', 'json', '--status', 'FAILED,BOGUS'])
+        assert result.exit_code != 0
+        assert 'BOGUS' in result.output
 
 
 class TestGpusListJsonOutput:

--- a/tests/unit_tests/test_sky/test_cli_json_output.py
+++ b/tests/unit_tests/test_sky/test_cli_json_output.py
@@ -202,10 +202,13 @@ class TestJobsQueueJsonOutput:
              ], ['RUNNING', 'FAILED', 'FAILED_SETUP']),
             # Case-insensitive, with surrounding whitespace.
             (['--status', 'failed, failed_setup'], ['FAILED', 'FAILED_SETUP']),
+            # The -s short flag works the same as --status.
+            (['-s', 'FAILED', '-s', 'FAILED_SETUP'], ['FAILED', 'FAILED_SETUP']
+            ),
+            (['-s', 'FAILED,FAILED_SETUP'], ['FAILED', 'FAILED_SETUP']),
         ])
     def test_status_filter_forwarded(self, monkeypatch, args, expected):
-        """--status accepts repeated and comma-separated values as a flat list.
-        """
+        """-s/--status accepts repeated and comma-separated values as a list."""
         records = [self._make_job_record()]
         mock_result = (records, 1, {'RUNNING': 1}, 0)
         captured = {}
@@ -233,6 +236,44 @@ class TestJobsQueueJsonOutput:
                                ['-o', 'json', '--status', 'FAILED,BOGUS'])
         assert result.exit_code != 0
         assert 'BOGUS' in result.output
+
+    def _run_capturing(self, monkeypatch, args):
+        """Invoke jobs_queue with args, returning (result, captured kwargs)."""
+        records = [self._make_job_record()]
+        mock_result = (records, 1, {'RUNNING': 1}, 0)
+        captured = {}
+
+        def fake_get_managed_job_queue(**kw):
+            captured.update(kw)
+            return ('req-1', mock.MagicMock(v2=lambda: True))
+
+        monkeypatch.setattr('sky.client.cli.utils.get_managed_job_queue',
+                            fake_get_managed_job_queue)
+        monkeypatch.setattr('sky.jobs.pool_status', lambda **kw: None)
+        monkeypatch.setattr('sky.client.sdk.stream_and_get',
+                            lambda *a, **kw: mock_result)
+        runner = cli_testing.CliRunner()
+        result = runner.invoke(command.jobs_queue, ['-o', 'json'] + args)
+        return result, captured
+
+    def test_bare_s_is_deprecated_skip_finished_alias(self, monkeypatch):
+        """A bare -s (no value) maps to skip_finished and warns (TODO: 0.15.0).
+
+        statuses is not forwarded (the sentinel is stripped).
+        """
+        result, captured = self._run_capturing(monkeypatch, ['-s'])
+        assert result.exit_code == 0, result.output
+        assert captured['skip_finished'] is True
+        assert captured['statuses'] is None
+        assert 'deprecated' in result.output.lower()
+
+    def test_skip_finished_long_flag_does_not_warn(self, monkeypatch):
+        """--skip-finished keeps working and is not deprecated."""
+        result, captured = self._run_capturing(monkeypatch, ['--skip-finished'])
+        assert result.exit_code == 0, result.output
+        assert captured['skip_finished'] is True
+        assert captured['statuses'] is None
+        assert 'deprecated' not in result.output.lower()
 
 
 class TestGpusListJsonOutput:


### PR DESCRIPTION
## Summary

`sky jobs queue` had no way to filter by job status from the CLI or Python
SDK — you could show only in-progress jobs (`--skip-finished`) or everything
(`--all`), with nothing in between. The server-side jobs-queue path already
supports filtering by a list of statuses (`JobsQueueV2Body.statuses` →
`core.queue_v2` → SQL `status IN (...)`), but it was never exposed on the
CLI/SDK. This PR surfaces it and tidies up the related flags.

### What's added

- **`-s` / `--status` filter** on `sky jobs queue`, accepting **comma-separated
  and/or repeated** values (case-insensitive), validated against
  `ManagedJobStatus`:

  ```bash
  sky jobs queue -s FAILED,FAILED_SETUP          # comma-separated
  sky jobs queue --status FAILED --status RUNNING # repeated
  ```

  A small `StatusList(click.Choice)` type splits each occurrence on commas and
  validates each piece; the handler flattens the resulting tuple-of-lists.

- **`-s` is the short flag for `--status`** (s = status, a common CLI
  convention). To avoid breaking existing
  `sky jobs queue -s` (skip-finished) usage, `-s` is an *optional-value*
  option: a **bare `-s` (no value)** still means `--skip-finished` but now
  prints a deprecation warning. `--skip-finished` remains as the long flag.
  `TODO(kevin)`: in **0.15.0**, drop the bare-`-s` alias so `-s` is solely
  `--status` (2-minor-version deprecation window, per CONTRIBUTING.md cadence).

- **`statuses` parameter on the `queue_v2` SDK**, so API-first users can filter
  too.

- **Old-server safety:** if the server is too old to support `queue_v2` and we
  fall back to V1 `queue` (which has no `statuses`), we now emit a
  `logger.warning` that the filter is unsupported and all jobs are shown,
  instead of silently dropping it (matches the existing `wait_for`
  not-supported pattern).

- Docstring tips surface `-s`/`--status` and `--skip-finished`.

No DB or proto changes — this surfaces an existing capability.

### Known behavior on multi-task (pipeline) jobs

`statuses` filters at the **task-row** level (unlike `--skip-finished`, which is
**job-level**). So `--status SUCCEEDED` on a pipeline whose tasks span statuses
returns only the matching task row, which renders as a single-task job in that
status. This matches the existing dashboard behavior (same `queue_v2` path) and
is left as-is here; a characterization test pins it.

## Test plan

### Unit tests
- `test_cli_json_output.py::TestJobsQueueJsonOutput` — parametrized over
  `--status`/`-s` repeated, comma-separated, mixed, and case-insensitive forms
  (asserts the flattened list forwarded to the queue call); invalid-value
  rejection; **bare `-s` → `skip_finished=True` + deprecation warning + no
  status filter**; `--skip-finished` → no warning.
- `test_jobs_state.py::TestMultiTaskStatusFilterCharacterization` — seeds a real
  2-task job (task 0 SUCCEEDED, task 1 RUNNING) + an unrelated FAILED job, and
  pins current row/task-level `statuses` behavior vs job-level `skip_finished`.

All pass; `bash format.sh` clean (yapf / isort / mypy / pylint); CLI reference
docs regenerated.

### Manual CLI smoke (live API server)
Verified `-o json` (asserting the returned status set) **and** the human table,
across: comma / repeated / mixed / lowercase / single-distinct / trailing-comma
/ invalid-value(exit 2) / empty, plus `-s FAILED`, bare `-s` (deprecation
warning), and `--skip-finished`.

### Managed-jobs smoke test
Extended `test_managed_jobs_basic` to assert `--status` filters the queue
(`{name}-1` CANCELLED kept by `--status CANCELLED` and dropped by
`--status RUNNING,SUCCEEDED`, and vice-versa). Ran locally against a Kubernetes
controller — passes.
