### PR TITLE
[Helm] History dashboard: exclude unscheduled pods from GPU allocation

### DIFF
--- a/charts/skypilot/manifests/compute-overview-dashboard.json
+++ b/charts/skypilot/manifests/compute-overview-dashboard.json
@@ -159,7 +159,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(max by (cluster, namespace, pod, container) (kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\", namespace!=\"cw-hpc-verification\"})) / sum(max by (cluster, node) (kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) * 100",
+          "expr": "sum(max by (cluster, namespace, pod, container) (kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\", namespace!=\"cw-hpc-verification\", node!=\"\"})) / sum(max by (cluster, node) (kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) * 100",
           "instant": false,
           "legendFormat": "",
           "range": true,
@@ -289,7 +289,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(max by (cluster, namespace, pod, container) (kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\", namespace!=\"cw-hpc-verification\"})) / sum(max by (cluster, node) (kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) * 100",
+          "expr": "sum(max by (cluster, namespace, pod, container) (kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\", namespace!=\"cw-hpc-verification\", node!=\"\"})) / sum(max by (cluster, node) (kube_node_status_allocatable{resource=\"nvidia_com_gpu\", cluster=~\"$cluster\"})) * 100",
           "instant": false,
           "legendFormat": "GPU Allocation",
           "range": true,


### PR DESCRIPTION
## Summary

- The "GPU Allocation" series in the SkyPilot History Grafana dashboard could report values far above 100% (e.g. ~1000% sustained for days). `kube_pod_container_resource_requests` is emitted by kube-state-metrics for every pod object regardless of scheduling state, so Pending pods that were never scheduled — e.g. a pod requesting more GPUs than any node has, or a rolling-update surge replica waiting for capacity — are counted against fixed node capacity. The chart's y-axis is capped at 100, so the line looks plausible while the legend mean (computed from raw data) shows impossible values.
- Fix: add `node!=""` to the numerator selector in both the GPU Allocation gauge and the Allocation & Utilization Over Time panel, so only pods actually scheduled to a node count. This matches the semantics of the instantaneous allocation computed from the Kubernetes API (which skips pods with no `node_name`).

## Test plan

Verified against a live deployment's Prometheus over a 30-day window:
- Original query: peaked at 1083.3% (four unschedulable pods each requesting 64 GPUs vs 24 allocatable), with a smaller 108–120% excursion from a rolling-update surge replica; 1-month legend mean showed 197.7%.
- Fixed query over the same window: max 87.5%, mean 34.0%, zero samples above 100%.
- `python3 -m json.tool` validates the edited dashboard JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)