### PR TITLE
[Core] Fix ray job submit failure in Ray cluster template by deconflicting dashboard agent port

### DIFF
--- a/examples/distributed_ray_train/README.md
+++ b/examples/distributed_ray_train/README.md
@@ -28,7 +28,7 @@ Customize the Ray cluster by setting environment variables before calling `start
 | `RAY_HEAD_PORT` | `6379` | Ray head node port (must differ from SkyPilot's 6380) |
 | `RAY_DASHBOARD_PORT` | `8265` | Ray dashboard port (must differ from SkyPilot's 8266) |
 | `RAY_DASHBOARD_HOST` | `127.0.0.1` | Dashboard host (set to `0.0.0.0` to expose externally) |
-| `RAY_DASHBOARD_AGENT_LISTEN_PORT` | `null` | Optional dashboard agent listen port |
+| `RAY_DASHBOARD_AGENT_LISTEN_PORT` | `52366` | Dashboard agent listen port (must differ from SkyPilot's 52365) |
 | `RAY_HEAD_IP_ADDRESS` | `null` | Optional head node IP address override |
 | `RAY_CMD` | `ray` | Ray command (e.g., `uv run ray`) |
 

--- a/sky_templates/ray/start_cluster
+++ b/sky_templates/ray/start_cluster
@@ -6,11 +6,17 @@
 # This allows users to run their own Ray applications independently of
 # SkyPilot's internal Ray cluster.
 #
+# The dashboard agent listen port defaults to 52366 instead of Ray's
+# default (52365), since SkyPilot's system Ray cluster already occupies
+# 52365 on every node. Without this, the user Ray cluster's dashboard
+# agents fail to start their HTTP server and `ray job submit` fails with
+# "No available agent to submit job".
+#
 # Environment Variables:
 #   RAY_HEAD_PORT=6379                     - Ray head node port
 #   RAY_DASHBOARD_PORT=8265                - Ray dashboard port
 #   RAY_DASHBOARD_HOST=127.0.0.1           - Dashboard host (set to 0.0.0.0 to expose externally)
-#   RAY_DASHBOARD_AGENT_LISTEN_PORT=       - (Optional) Dashboard agent listen port
+#   RAY_DASHBOARD_AGENT_LISTEN_PORT=52366  - Dashboard agent listen port
 #   RAY_HEAD_IP_ADDRESS=                   - (Optional) Node IP address
 #   RAY_CMD=ray                            - (Optional) Command to invoke Ray (e.g., "uv run ray")
 #
@@ -37,7 +43,9 @@ NC='\033[0m' # No Color
 RAY_HEAD_PORT=${RAY_HEAD_PORT:-6379}
 RAY_DASHBOARD_PORT=${RAY_DASHBOARD_PORT:-8265}
 RAY_DASHBOARD_HOST=${RAY_DASHBOARD_HOST:-127.0.0.1}
-RAY_DASHBOARD_AGENT_LISTEN_PORT=${RAY_DASHBOARD_AGENT_LISTEN_PORT:-}
+# Default to 52366 to avoid colliding with the dashboard agent of
+# SkyPilot's system Ray cluster, which listens on Ray's default 52365.
+RAY_DASHBOARD_AGENT_LISTEN_PORT=${RAY_DASHBOARD_AGENT_LISTEN_PORT:-52366}
 RAY_HEAD_IP_ADDRESS=${RAY_HEAD_IP_ADDRESS:-}
 
 RAY_CMD=${RAY_CMD:-ray}
@@ -103,17 +111,13 @@ if [ "${SKYPILOT_NODE_RANK}" -eq 0 ]; then
         --port=${RAY_HEAD_PORT} \
         --dashboard-port=${RAY_DASHBOARD_PORT} \
         --dashboard-host=${RAY_DASHBOARD_HOST} \
+        --dashboard-agent-listen-port=${RAY_DASHBOARD_AGENT_LISTEN_PORT} \
         --disable-usage-stats \
         --include-dashboard=True"
 
     # Add --num-gpus only if > 0
     if [ "${SKYPILOT_NUM_GPUS_PER_NODE}" -gt 0 ]; then
         RAY_START_CMD="${RAY_START_CMD} --num-gpus=${SKYPILOT_NUM_GPUS_PER_NODE}"
-    fi
-
-    # Add optional dashboard agent listen port if specified
-    if [ -n "${RAY_DASHBOARD_AGENT_LISTEN_PORT}" ]; then
-        RAY_START_CMD="${RAY_START_CMD} --dashboard-agent-listen-port=${RAY_DASHBOARD_AGENT_LISTEN_PORT}"
     fi
 
     # Add optional node IP address if specified
@@ -171,7 +175,12 @@ else
     done
 
     echo -e "${GREEN}Head node is healthy. Starting worker node...${NC}"
-    WORKER_CMD="start --address=${RAY_ADDRESS} --disable-usage-stats"
+    # The dashboard agent listen port must also be set on workers: the
+    # head's job submission server proxies through per-node agents, and
+    # workers otherwise collide with SkyPilot's system Ray agent on 52365.
+    WORKER_CMD="start --address=${RAY_ADDRESS} \
+        --dashboard-agent-listen-port=${RAY_DASHBOARD_AGENT_LISTEN_PORT} \
+        --disable-usage-stats"
 
     # Add --num-gpus only if > 0
     if [ "${SKYPILOT_NUM_GPUS_PER_NODE}" -gt 0 ]; then


### PR DESCRIPTION
## Summary

- The `sky_templates/ray/start_cluster` template deconflicts the Ray head port (6379 vs SkyPilot's 6380) and dashboard port (8265 vs 8266) from SkyPilot's system Ray cluster, but left the dashboard agent listen port at Ray's default (**52365**), which SkyPilot's system Ray already occupies on every node. The user Ray cluster's dashboard agents then fail to bind their HTTP server, and `ray job submit` fails with `RuntimeError: Request failed with status code 500: No available agent to submit job, please try again later.` (See also https://discuss.ray.io/t/error-in-ray-job-submit-on-local-machine-if-multiple-clusters-are-running-at-the-same-time/14723 for the same failure mode with co-located Ray clusters.)
- Default `RAY_DASHBOARD_AGENT_LISTEN_PORT` to **52366** (still overridable via the env var), following the template's existing port-deconfliction pattern.
- Pass `--dashboard-agent-listen-port` on **worker nodes** too. Previously the flag was only applied on the head node, so worker agents collided on 52365 even when the env var was set explicitly, and job submissions routed through a worker agent would still fail.
- Update the template header docs and the `examples/distributed_ray_train/README.md` env-var table.

## Test plan

- `bash -n sky_templates/ray/start_cluster` passes.
- Verified on a 2-node Kubernetes cluster launched with this branch (`sky launch --num-nodes 2` with `infra: k8s`), running `~/sky_templates/ray/start_cluster` on all nodes with no env vars set:
  - Both nodes' user-Ray dashboard agents bind 52366 (checked via socket connect on each rank).
  - Agent logs confirm the deconfliction: SkyPilot's system Ray agent (`/tmp/ray_skypilot/session_latest/logs/dashboard_agent.log`) holds `0.0.0.0:52365`, while the user Ray agent (`/tmp/ray/session_latest/logs/dashboard_agent.log`) binds `<node-ip>:52366`.
  - `ray job submit --address=http://127.0.0.1:8265 -- python3 -c "import ray; ray.init(); print('nodes:', len(ray.nodes()))"` succeeds (`Job 'raysubmit_...' succeeded`, prints `nodes: 2`) — previously this failed with the 500 "No available agent to submit job" error.
- Override path: `RAY_DASHBOARD_AGENT_LISTEN_PORT` env var still takes precedence over the new default on both head and worker branches (same `${VAR:-52366}` expansion feeds both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
