### PR TITLE
fix: .skyignore negation patterns (!) not re-including files

### DIFF
--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -22,9 +22,24 @@ _USE_SKYIGNORE_HINT = (
     'To avoid using .gitignore, you can create a .skyignore file instead.')
 
 
+def _resolve_skyignore_pattern(pattern: str,
+                               src_dir: str) -> Set[str]:
+    """Resolve a .skyignore pattern to a set of relative file paths."""
+    if pattern.startswith('/'):
+        pattern = '.' + pattern
+    else:
+        pattern = '**/' + pattern
+    matching_files = glob.glob(os.path.join(src_dir, pattern),
+                               recursive=True)
+    return {os.path.relpath(f, src_dir) for f in matching_files}
+
+
 def get_excluded_files_from_skyignore(src_dir_path: str) -> List[str]:
     """List files and patterns ignored by the .skyignore file
     in the given source directory.
+
+    Supports negation patterns (lines starting with '!') that
+    re-include files previously excluded, same as .gitignore.
     """
     excluded_list: Set[str] = set()
     expand_src_dir_path = os.path.expanduser(src_dir_path)
@@ -35,22 +50,21 @@ def get_excluded_files_from_skyignore(src_dir_path: str) -> List[str]:
         with open(skyignore_path, 'r', encoding='utf-8') as f:
             for line in f:
                 line = line.strip()
-                if line and not line.startswith('#'):
-                    # Make parsing consistent with rsync.
-                    # Rsync uses '/' as current directory.
-                    if line.startswith('/'):
-                        line = '.' + line
-                    else:
-                        line = '**/' + line
-                    # Find all files matching the pattern.
-                    matching_files = glob.glob(os.path.join(
-                        expand_src_dir_path, line),
-                                               recursive=True)
-                    # Process filenames to comply with cloud rsync format.
-                    for i in range(len(matching_files)):
-                        matching_files[i] = os.path.relpath(
-                            matching_files[i], expand_src_dir_path)
-                    excluded_list.update(matching_files)
+                if not line or line.startswith('#'):
+                    continue
+                if line.startswith('!'):
+                    # Negation: re-include files matching the pattern
+                    # after stripping the '!' prefix.
+                    pattern = line[1:]
+                    if not pattern:
+                        continue
+                    matching = _resolve_skyignore_pattern(
+                        pattern, expand_src_dir_path)
+                    excluded_list.difference_update(matching)
+                else:
+                    matching = _resolve_skyignore_pattern(
+                        line, expand_src_dir_path)
+                    excluded_list.update(matching)
     except IOError as e:
         logger.warning(f'Error reading {skyignore_path}: '
                        f'{common_utils.format_exception(e, use_bracket=True)}')

--- a/tests/unit_tests/test_sky/storage/test_storage_utils.py
+++ b/tests/unit_tests/test_sky/storage/test_storage_utils.py
@@ -139,6 +139,62 @@ def test_get_excluded_files_from_skyignore(skyignore_dir):
     assert len(excluded_files) == len(expected_excluded_files)
 
 
+def test_get_excluded_files_from_skyignore_negation():
+    """Test that ! negation patterns in .skyignore re-include files."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create test files
+        files = ['a.json', 'b.json', 'config.json', 'keep.txt']
+        for fname in files:
+            with open(os.path.join(tmpdir, fname), 'w') as f:
+                f.write('test')
+
+        skyignore_path = os.path.join(tmpdir, constants.SKY_IGNORE_FILE)
+        with open(skyignore_path, 'w') as f:
+            f.write('# ignore all json\n*.json\n# but keep config\n!config.json\n')
+
+        excluded = storage_utils.get_excluded_files_from_skyignore(tmpdir)
+        assert 'a.json' in excluded
+        assert 'b.json' in excluded
+        assert 'config.json' not in excluded, \
+            'config.json should be re-included by negation'
+        assert 'keep.txt' not in excluded
+
+
+def test_get_excluded_files_from_skyignore_negation_order():
+    """Test that later exclusion patterns can re-exclude after negation."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        files = ['a.json', 'config.json']
+        for fname in files:
+            with open(os.path.join(tmpdir, fname), 'w') as f:
+                f.write('test')
+
+        skyignore_path = os.path.join(tmpdir, constants.SKY_IGNORE_FILE)
+        with open(skyignore_path, 'w') as f:
+            f.write('*.json\n!config.json\nconfig.*\n')
+
+        excluded = storage_utils.get_excluded_files_from_skyignore(tmpdir)
+        # config.json matched by *.json, re-included by !config.json,
+        # but then re-excluded by config.*
+        assert 'config.json' in excluded
+
+
+def test_get_excluded_files_from_skyignore_negation_empty():
+    """Test that empty negation pattern (!) is safely ignored."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        files = ['a.json', 'b.json']
+        for fname in files:
+            with open(os.path.join(tmpdir, fname), 'w') as f:
+                f.write('test')
+
+        skyignore_path = os.path.join(tmpdir, constants.SKY_IGNORE_FILE)
+        with open(skyignore_path, 'w') as f:
+            f.write('*.json\n!\n')
+
+        excluded = storage_utils.get_excluded_files_from_skyignore(tmpdir)
+        assert 'a.json' in excluded
+        assert 'b.json' in excluded
+
+
 def test_get_excluded_files_from_gitignore(gitignore_dir):
     # Test function
     excluded_files = storage_utils.get_excluded_files_from_gitignore(


### PR DESCRIPTION
## Summary
- `.skyignore` documents "same syntax as .gitignore" but `!` negation patterns were silently ignored
- Files excluded by a prior pattern (e.g. `*.json`) could not be re-included via `!` (e.g. `!config.json`)
- Now `!` prefixed lines remove matching paths from the excluded set, processed sequentially so later exclusion rules can still re-exclude

## Changes
- Extract `_resolve_skyignore_pattern()` helper to avoid duplication
- Add `!` negation handling in `get_excluded_files_from_skyignore()`
- Guard against empty `!` pattern (single `!` on a line)
- Add 3 unit tests: basic negation, sequential re-exclusion, empty negation guard

## Test plan
- [x] All existing `skyignore` tests pass (no regression)
- [x] New negation tests pass
- [x] Issue #8812 reproduction scenario verified

Fixes #8812