### PR TITLE
[Storage] Set bucket region in rclone profile for MOUNT_CACHED S3 mounts

### DIFF
--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -824,6 +824,13 @@ class Rclone:
                         secret_access_key = {secret_access_key}
                         acl = private
                         """)
+                if region is not None:
+                    # Pin the profile to the bucket's region so rclone uses
+                    # the region-specific endpoint. Without this, rclone
+                    # defaults to us-east-1 and requests to buckets in opt-in
+                    # regions (e.g., eu-south-2) fail with
+                    # IllegalLocationConstraintException. See #9540.
+                    config += f'region = {region}\n'
             elif self is Rclone.RcloneStores.GCS:
                 config = textwrap.dedent(f"""\
                     [{rclone_profile_name}]

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -4954,14 +4954,43 @@ class S3Store(S3CompatibleStore):
             mount_cmd_factory=mounting_utils.get_s3_mount_cmd,
         )
 
+    def _get_bucket_region(self) -> Optional[str]:
+        """Returns the region the bucket actually resides in.
+
+        self.region cannot be used here: for existing buckets it defaults to
+        us-east-1 (see __init__), which may differ from the bucket's actual
+        region. We query S3 instead, which reports the bucket's region in the
+        x-amz-bucket-region header of HeadBucket responses.
+
+        Returns:
+            The bucket's region, or None if it could not be determined.
+        """
+        try:
+            response = self.client.head_bucket(Bucket=self.name)
+        except aws.botocore_exceptions().ClientError as e:
+            # The region header is present even on error responses
+            # (e.g., 301/403 for cross-region or restricted access).
+            response = e.response
+        region = response.get('ResponseMetadata',
+                              {}).get('HTTPHeaders',
+                                      {}).get('x-amz-bucket-region')
+        if region is None:
+            logger.debug('Failed to detect the region of S3 bucket '
+                         f'{self.name!r}.')
+        return region
+
     def mount_cached_command(self,
                              mount_path: str,
                              config: Optional[MountCachedConfig] = None) -> str:
         install_cmd = mounting_utils.get_rclone_install_cmd()
         rclone_profile_name = (
             data_utils.Rclone.RcloneStores.S3.get_profile_name(self.name))
+        # Pass the bucket's actual region so rclone hits the correct
+        # region-specific endpoint, which is required for buckets in opt-in
+        # regions (e.g., eu-south-2). See #9540.
         rclone_config = data_utils.Rclone.RcloneStores.S3.get_config(
-            rclone_profile_name=rclone_profile_name)
+            rclone_profile_name=rclone_profile_name,
+            region=self._get_bucket_region())
         mount_cached_cmd = mounting_utils.get_mount_cached_cmd(
             rclone_config, rclone_profile_name, self.bucket.name, mount_path,
             config)

--- a/tests/unit_tests/test_sky/storage/test_data_utils.py
+++ b/tests/unit_tests/test_sky/storage/test_data_utils.py
@@ -228,3 +228,37 @@ class TestVerifyCoreweaveBucket:
 
         assert result is True
         mock_client.head_bucket.assert_called_once_with(Bucket='test-bucket')
+
+
+class TestRcloneS3GetConfig:
+    """Tests for region handling in Rclone.RcloneStores.S3.get_config."""
+
+    @mock.patch('sky.clouds.AWS.should_use_env_auth_for_s3', return_value=True)
+    def test_env_auth_config_includes_region(self, mock_env_auth):
+        """Region must be written to the env_auth rclone profile."""
+        config = data_utils.Rclone.RcloneStores.S3.get_config(
+            bucket_name='test-bucket', region='eu-south-2')
+        assert 'env_auth = true' in config
+        assert 'region = eu-south-2' in config
+
+    @mock.patch('sky.clouds.AWS.should_use_env_auth_for_s3', return_value=False)
+    @mock.patch('sky.data.data_utils.aws.session')
+    def test_static_credentials_config_includes_region(self, mock_session,
+                                                       mock_env_auth):
+        """Region must be written to the static-credentials rclone profile."""
+        mock_credentials = mock.MagicMock(access_key='test-access-key',
+                                          secret_key='test-secret-key')
+        mock_session.return_value.get_credentials.return_value.\
+            get_frozen_credentials.return_value = mock_credentials
+        config = data_utils.Rclone.RcloneStores.S3.get_config(
+            bucket_name='test-bucket', region='eu-south-2')
+        assert 'access_key_id = test-access-key' in config
+        assert 'secret_access_key = test-secret-key' in config
+        assert 'region = eu-south-2' in config
+
+    @mock.patch('sky.clouds.AWS.should_use_env_auth_for_s3', return_value=True)
+    def test_no_region_omits_region_line(self, mock_env_auth):
+        """Without a region, the profile must stay unchanged."""
+        config = data_utils.Rclone.RcloneStores.S3.get_config(
+            bucket_name='test-bucket')
+        assert 'region =' not in config

--- a/tests/unit_tests/test_sky/storage/test_s3_store.py
+++ b/tests/unit_tests/test_sky/storage/test_s3_store.py
@@ -1,0 +1,81 @@
+"""Unit tests for S3Store region handling in MOUNT_CACHED commands."""
+
+from unittest import mock
+
+from sky.adaptors import aws
+from sky.data import storage as storage_lib
+
+
+def _make_s3_store(client=None, **attrs):
+    """Creates a bare S3Store object without running __init__."""
+    store = object.__new__(storage_lib.S3Store)
+    store.name = attrs.get('name', 'test-bucket')
+    store.source = attrs.get('source', 's3://test-bucket')
+    store.region = attrs.get('region', 'us-east-1')
+    store._bucket_sub_path = attrs.get('_bucket_sub_path', None)
+    store.client = client if client is not None else mock.MagicMock()
+    store.bucket = mock.MagicMock()
+    store.bucket.name = store.name
+    return store
+
+
+def _head_bucket_response(region):
+    headers = {} if region is None else {'x-amz-bucket-region': region}
+    return {'ResponseMetadata': {'HTTPHeaders': headers}}
+
+
+class TestS3StoreGetBucketRegion:
+    """Tests for S3Store._get_bucket_region."""
+
+    def test_returns_region_from_head_bucket(self):
+        client = mock.MagicMock()
+        client.head_bucket.return_value = _head_bucket_response('eu-south-2')
+        store = _make_s3_store(client=client)
+        assert store._get_bucket_region() == 'eu-south-2'
+        client.head_bucket.assert_called_once_with(Bucket='test-bucket')
+
+    def test_returns_region_from_error_response(self):
+        """The region header is present even on error responses."""
+        error_response = _head_bucket_response('eu-south-2')
+        error_response['Error'] = {
+            'Code': '301',
+            'Message': 'Moved Permanently'
+        }
+        client = mock.MagicMock()
+        client.head_bucket.side_effect = aws.botocore_exceptions().ClientError(
+            error_response, 'HeadBucket')
+        store = _make_s3_store(client=client)
+        assert store._get_bucket_region() == 'eu-south-2'
+
+    def test_returns_none_when_header_missing(self):
+        client = mock.MagicMock()
+        client.head_bucket.return_value = _head_bucket_response(None)
+        store = _make_s3_store(client=client)
+        assert store._get_bucket_region() is None
+
+
+class TestS3StoreMountCachedCommand:
+    """Tests for S3Store.mount_cached_command region handling."""
+
+    @mock.patch('sky.clouds.AWS.should_use_env_auth_for_s3', return_value=True)
+    def test_rclone_profile_sets_bucket_region(self, mock_env_auth):
+        """The bucket's actual region must end up in the rclone profile.
+
+        Regression test for #9540: rclone defaulted to the us-east-1
+        endpoint, breaking MOUNT_CACHED for buckets in opt-in regions
+        such as eu-south-2.
+        """
+        client = mock.MagicMock()
+        client.head_bucket.return_value = _head_bucket_response('eu-south-2')
+        store = _make_s3_store(client=client)
+        cmd = store.mount_cached_command('/mnt/data')
+        assert 'region = eu-south-2' in cmd
+
+    @mock.patch('sky.clouds.AWS.should_use_env_auth_for_s3', return_value=True)
+    def test_rclone_profile_without_detected_region(self, mock_env_auth):
+        """If the region cannot be detected, the profile stays unchanged."""
+        client = mock.MagicMock()
+        client.head_bucket.return_value = _head_bucket_response(None)
+        store = _make_s3_store(client=client)
+        cmd = store.mount_cached_command('/mnt/data')
+        assert 'region =' not in cmd


### PR DESCRIPTION
Fixes #9540.

The rclone profile SkyPilot generates for `MOUNT_CACHED` S3 mounts never sets a `region`, so rclone defaults to the us-east-1 endpoint and buckets in opt-in regions like `eu-south-2` fail with `IllegalLocationConstraintException`.

Two gaps had to close: `Rclone.RcloneStores.get_config`'s S3 branch accepts a `region` parameter but never writes it into the profile (unlike the IBM/OCI branches), and `S3Store.mount_cached_command` doesn't pass one. The store's `self.region` can't be used for this — it defaults to `us-east-1` for existing buckets, and `S3Store.__init__` coerces opt-in regions to `us-east-1` as the #3405 stopgap — so `S3Store` now reads the bucket's actual region from the `x-amz-bucket-region` header of a `HeadBucket` response (present even on 301/403 responses, and requiring no permission beyond what mounting already needs, unlike `GetBucketLocation`) and threads it into the generated profile.

`region` alone is sufficient: rclone derives the regional endpoint from it for `provider = AWS`, matching what the reporter verified manually. When the region can't be determined, the profile is byte-identical to before, so existing mounts are unaffected. The stale-static-credentials half of the issue was already fixed by #8358 (`env_auth`).

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh` — yapf/isort/mypy clean, pylint 10.00/10 on the changed files.
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

New unit tests:
- `tests/unit_tests/test_sky/storage/test_data_utils.py::TestRcloneS3GetConfig` — `region` emitted in both env_auth and static-credential profiles, omitted when unknown.
- `tests/unit_tests/test_sky/storage/test_s3_store.py` — region detection from `HeadBucket` success/error responses; `mount_cached_command` embeds `region = eu-south-2`. All fail before this change.
- `pytest tests/unit_tests/test_sky/storage/` — 137 passed (2 pre-existing `test_huggingface.py` failures from a missing optional dep, identical on master).

This PR was prepared with the help of Claude Code.
