### PR TITLE
[Storage] Use `gcloud storage` for GCS downloads (#8457)

### DIFF
--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -109,11 +109,11 @@ class S3CloudStorage(CloudStorage):
 class GcsCloudStorage(CloudStorage):
     """Google Cloud Storage."""
 
-    # We use gsutil as a basic implementation.  One pro is that its -m
-    # multi-threaded download is nice, which frees us from implementing
-    # parellel workers on our end.
-    # The gsutil command is part of the Google Cloud SDK, and we reuse
-    # the installation logic here.
+    # Download paths use `gcloud storage`, which saturates the available
+    # network throughput and parallelizes transfers automatically (so we no
+    # longer need gsutil's `-m` flag or our own parallel workers). `gcloud
+    # storage` ships with the Google Cloud SDK, so we reuse the same
+    # installation logic. gsutil is still used by `is_directory` below.
     _INSTALL_GSUTIL = gcp.GOOGLE_SDK_INSTALLATION_COMMAND
 
     @property
@@ -129,6 +129,20 @@ class GcsCloudStorage(CloudStorage):
             '--key-file=$GOOGLE_APPLICATION_CREDENTIALS '
             '2> /dev/null || true; '
             f'{gsutil_alias}')
+
+    @property
+    def _gcloud_command(self):
+        return (
+            f'GOOGLE_APPLICATION_CREDENTIALS='
+            f'{gcp.DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH}; '
+            # Explicitly activate the service account so that `gcloud storage`
+            # authenticates with it. Setting GOOGLE_APPLICATION_CREDENTIALS
+            # alone is not sufficient: the gcloud CLI reads credentials from
+            # its own credential store rather than that environment variable.
+            'gcloud auth activate-service-account '
+            '--key-file=$GOOGLE_APPLICATION_CREDENTIALS '
+            '2> /dev/null || true; '
+            'gcloud storage')
 
     def is_directory(self, url: str) -> bool:
         """Returns whether 'url' is a directory.
@@ -162,19 +176,21 @@ class GcsCloudStorage(CloudStorage):
         return True
 
     def make_sync_dir_command(self, source: str, destination: str) -> str:
-        """Downloads a directory using gsutil."""
-        download_via_gsutil = (f'{self._gsutil_command} '
-                               f'rsync -e -r {source} {destination}')
+        """Downloads a directory using gcloud storage."""
+        # `gcloud storage rsync` ignores symlinks by default, which matches
+        # the previous `gsutil rsync -e` behavior.
+        download_via_gcloud = (f'{self._gcloud_command} '
+                               f'rsync -r {source} {destination}')
         all_commands = [self._INSTALL_GSUTIL]
-        all_commands.append(download_via_gsutil)
+        all_commands.append(download_via_gcloud)
         return ' && '.join(all_commands)
 
     def make_sync_file_command(self, source: str, destination: str) -> str:
-        """Downloads a file using gsutil."""
-        download_via_gsutil = f'{self._gsutil_command} ' \
-                              f'cp {source} {destination}'
+        """Downloads a file using gcloud storage."""
+        download_via_gcloud = (f'{self._gcloud_command} '
+                               f'cp {source} {destination}')
         all_commands = [self._INSTALL_GSUTIL]
-        all_commands.append(download_via_gsutil)
+        all_commands.append(download_via_gcloud)
         return ' && '.join(all_commands)
 
 

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -2939,7 +2939,7 @@ class GcsStore(AbstractStore):
                 next(bucket.list_blobs())
                 return bucket, False
             except (gcp.not_found_exception(), ValueError) as e:
-                command = f'gsutil ls gs://{self.name}'
+                command = f'gcloud storage ls gs://{self.name}'
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.StorageBucketGetError(
                         _BUCKET_FAIL_TO_CONNECT_MESSAGE.format(name=self.name) +

--- a/tests/unit_tests/test_sky/storage/test_gcs_cloud_storage.py
+++ b/tests/unit_tests/test_sky/storage/test_gcs_cloud_storage.py
@@ -1,0 +1,38 @@
+"""Unit tests for GcsCloudStorage download command construction.
+
+Regression tests for the gsutil -> ``gcloud storage`` migration (issue #8457):
+the GCS download path must invoke ``gcloud storage cp``/``gcloud storage
+rsync`` rather than the slower ``gsutil`` alias, while still explicitly
+activating the service account.
+"""
+
+import unittest
+
+from sky import cloud_stores
+
+
+class TestGcsCloudStorageCommands(unittest.TestCase):
+    """GCS download commands must use ``gcloud storage`` (issue #8457)."""
+
+    def test_make_sync_file_command_uses_gcloud_storage(self):
+        cmd = cloud_stores.GcsCloudStorage().make_sync_file_command(
+            'gs://bucket/path/file', '/dest')
+        self.assertIn('gcloud storage cp gs://bucket/path/file /dest', cmd)
+        # The legacy gsutil alias must no longer be used on the download path.
+        self.assertNotIn('skypilot_gsutil', cmd)
+        # The service account must still be activated explicitly, otherwise
+        # the gcloud CLI would not authenticate with the key file.
+        self.assertIn('gcloud auth activate-service-account', cmd)
+
+    def test_make_sync_dir_command_uses_gcloud_storage(self):
+        cmd = cloud_stores.GcsCloudStorage().make_sync_dir_command(
+            'gs://bucket/path', '/dest')
+        # ``gcloud storage rsync`` ignores symlinks by default, matching the
+        # previous ``gsutil rsync -e``; recursion is requested with ``-r``.
+        self.assertIn('gcloud storage rsync -r gs://bucket/path /dest', cmd)
+        self.assertNotIn('skypilot_gsutil', cmd)
+        self.assertIn('gcloud auth activate-service-account', cmd)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Migrate the GCS **download** path from `gsutil` to `gcloud storage`. `gsutil -m`
does not parallelize a single-file download, so `gsutil cp` is throughput-limited;
`gcloud storage cp`/`rsync` parallelize automatically and saturate the link.

Closes #8457 (download path; see "Deferred" below).

## Changes

- `sky/cloud_stores.py` (`GcsCloudStorage`):
  - new `_gcloud_command` property (SA activation + `gcloud storage`)
  - `make_sync_file_command`: `gsutil cp` → `gcloud storage cp`
  - `make_sync_dir_command`: `gsutil rsync -e -r` → `gcloud storage rsync -r`
  - updated class docstring/comment
- `sky/data/storage.py`: `gsutil ls` debug hint → `gcloud storage ls`
- `tests/unit_tests/test_sky/storage/test_gcs_cloud_storage.py`: new unit tests

### Notes on equivalence
- **Symlinks:** `gcloud storage rsync` ignores symlinks by default, which is
  exactly what `gsutil rsync -e` did — so `-e` is dropped, not lost.
- **Service account:** still activated explicitly
  (`gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS`),
  because the gcloud CLI reads credentials from its own store rather than from
  the `GOOGLE_APPLICATION_CREDENTIALS` env var.
- **`-m`:** dropped — `gcloud storage` parallelizes by default.

## Benchmark

e2-standard-4, us-central1, 2 GB file, in-region GCS → tmpfs (`/dev/shm`), 3 runs each:

| command | throughput | wall time |
|---|---|---|
| `gsutil -m cp` | 80–84 MB/s | ~24–26 s |
| `gcloud storage cp` | 552–584 MB/s | ~3.5 s |

~7× faster on a single large object.

## Tests

`python -m unittest tests.unit_tests.test_sky.storage.test_gcs_cloud_storage` → 2 passing.
OCI storage-command baseline unchanged. yapf/isort/mypy clean; pylint 10.00/10.

## Deferred (follow-ups, differing semantics)

- `is_directory` `gsutil ls -d` output parsing (gcloud output format differs)
- upload `batch_gsutil_rsync` `-x` regex exclude (gcloud `--exclude` relative-path semantics)
- bucket `rm -r`
