### PR TITLE
[Storage] Surface silent zero-byte writes in MOUNT-mode mounts

### DIFF
--- a/docs/source/reference/storage.rst
+++ b/docs/source/reference/storage.rst
@@ -138,6 +138,31 @@ its performance requirements and size of the data.
     operations may fail. Most notably, random writes and append operations are
     not supported.
 
+    .. warning::
+        Writers that use append or partial-flush semantics — e.g.
+        ``pandas.to_parquet``, ``pyarrow``, and ``tfrecord`` — may produce
+        **silent 0-byte files** when writing to a ``MOUNT``-mode bucket. The
+        kernel reports success even though no data was uploaded. To avoid data
+        loss, either switch to :code:`MOUNT_CACHED` mode for write-heavy
+        workloads, or write to local disk and then move the file into the
+        mount path:
+
+        .. code-block:: python
+
+            import shutil
+            import tempfile
+
+            def write_parquet_safely(df, dest_path):
+                with tempfile.NamedTemporaryFile(delete=False) as tmp:
+                    tmp_path = tmp.name
+                df.to_parquet(tmp_path, index=False)
+                shutil.move(tmp_path, dest_path)
+
+        SkyPilot automatically appends a post-run check to tasks that mount
+        storage in ``MOUNT`` mode that fails the task with a clear error when
+        a zero-byte file is detected. See
+        https://github.com/skypilot-org/skypilot/issues/1901 for context.
+
 .. [2] In ``MOUNT_CACHED`` mode, writes are not immediately consistent across multiple nodes. See :ref:`MOUNT_CACHED mode in detail <mount_cached_mode_in_detail>` for more details.
 
 .. [3] Disk size smaller than the object size may cause performance degradation

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -6607,6 +6607,23 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         else:
             return task_codegen.RayCodeGen()
 
+    def _get_mount_verification_paths(
+            self, task: 'task_lib.Task') -> Optional[List[str]]:
+        """Returns the list of remote mount paths that should be verified for
+        silent zero-byte writes after a task's ``run`` block completes.
+
+        Only ``MOUNT``-mode storage is included. ``MOUNT_CACHED`` already
+        buffers writes locally, and ``COPY`` mode is just a local directory
+        that gets uploaded at task end, so neither needs post-run verification.
+        See https://github.com/skypilot-org/skypilot/issues/1901.
+        """
+        paths: List[str] = []
+        storage_mounts = getattr(task, 'storage_mounts', None) or {}
+        for mount_path, storage_obj in storage_mounts.items():
+            if storage_obj.mode == storage_lib.StorageMode.MOUNT:
+                paths.append(str(mount_path))
+        return paths or None
+
     def _execute_task_one_node(self, handle: CloudVmRayResourceHandle,
                                task: task_lib.Task, job_id: int,
                                remote_log_dir: str) -> None:
@@ -6637,7 +6654,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             env_vars=task_env_vars,
             task_name=task.name,
             resources_dict=backend_utils.get_task_demands_dict(task),
-            log_dir=log_dir)
+            log_dir=log_dir,
+            mount_verification_paths=self._get_mount_verification_paths(task))
 
         codegen.add_epilogue()
 
@@ -6683,7 +6701,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             env_vars=task_env_vars,
             task_name=task.name,
             resources_dict=backend_utils.get_task_demands_dict(task),
-            log_dir=log_dir)
+            log_dir=log_dir,
+            mount_verification_paths=self._get_mount_verification_paths(task))
 
         codegen.add_epilogue()
         # TODO(zhanghao): Add help info for downloading logs.

--- a/sky/backends/task_codegen.py
+++ b/sky/backends/task_codegen.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Optional, Tuple
 import colorama
 
 from sky import sky_logging
+from sky.data import mounting_utils
 from sky.skylet import constants
 from sky.skylet import log_lib
 from sky.utils import accelerator_registry
@@ -132,6 +133,33 @@ class TaskCodeGen:
             """))
 
     @staticmethod
+    def get_mount_write_verification_script(mount_paths: List[str]) -> str:
+        """Generate a script that verifies recent writes to MOUNT-mode storage
+        produced non-empty files.
+
+        Some FUSE-based mount backends (goofys, rclone for S3) silently produce
+        0-byte files when a writer uses append or partial-flush semantics, e.g.
+        ``pandas.to_parquet`` or pyarrow (see
+        https://github.com/skypilot-org/skypilot/issues/1901). The kernel
+        returns success, so we add a post-run step that walks each mount path
+        and fails the task if any regular file is unexpectedly small.
+
+        Empty input list yields an empty string (no-op), so callers can pass
+        ``[]`` when no MOUNT-mode storage is configured.
+        """
+        if not mount_paths:
+            return ''
+
+        # Each snippet is independent: one bad mount shouldn't mask others.
+        snippets = [
+            mounting_utils.get_mount_write_verification_cmd(p)
+            for p in mount_paths
+        ]
+        # Wrap in a guard so a non-zero exit from any one snippet fails the
+        # surrounding task. The `|| exit 1` makes the failure sticky.
+        return '\n'.join(snippets) + '\n'
+
+    @staticmethod
     def get_rclone_flush_script() -> str:
         """Generate rclone flush script for cached storage mounts.
 
@@ -193,8 +221,10 @@ class TaskCodeGen:
         exit $__skypilot_user_exit_code""")
 
     @staticmethod
-    def build_task_bash_script(bash_script: str,
-                               env_prefix: Optional[str] = None) -> str:
+    def build_task_bash_script(
+            bash_script: str,
+            env_prefix: Optional[str] = None,
+            mount_verification_paths: Optional[List[str]] = None) -> str:
         """Build the complete bash script for a task.
 
         Prepends env_prefix (if any) and appends the rclone flush script.
@@ -203,6 +233,11 @@ class TaskCodeGen:
             bash_script: The user's bash command.
             env_prefix: Optional shell commands to prepend (e.g. unsetting
                 Ray env vars).
+            mount_verification_paths: Optional list of remote mount paths that
+                should be verified after the user script runs. Used to detect
+                silent zero-byte writes to MOUNT-mode storage (see
+                https://github.com/skypilot-org/skypilot/issues/1901). No-op
+                when empty or None.
 
         Returns:
             Complete bash string ready to execute on the cluster.
@@ -210,6 +245,10 @@ class TaskCodeGen:
         if env_prefix:
             bash_script = f'{env_prefix}; {bash_script}'
         bash_script += TaskCodeGen.get_rclone_flush_script()
+        verification = TaskCodeGen.get_mount_write_verification_script(
+            mount_verification_paths or [])
+        if verification:
+            bash_script += '\n' + verification
         return bash_script
 
     def add_prologue(self, job_id: int) -> None:
@@ -245,6 +284,7 @@ class TaskCodeGen:
         resources_dict: Dict[str, float],
         log_dir: str,
         env_vars: Optional[Dict[str, str]] = None,
+        mount_verification_paths: Optional[List[str]] = None,
     ) -> None:
         """Generates code to run the bash command on all num_nodes nodes."""
         raise NotImplementedError
@@ -575,26 +615,31 @@ class RayCodeGen(TaskCodeGen):
                  task_name: Optional[str],
                  resources_dict: Dict[str, float],
                  log_dir: str,
-                 env_vars: Optional[Dict[str, str]] = None) -> None:
+                 env_vars: Optional[Dict[str, str]] = None,
+                 mount_verification_paths: Optional[List[str]] = None) -> None:
         # TODO(zhwu): The resources limitation for multi-node ray.tune and
         # horovod should be considered.
         for i in range(num_nodes):
             # Ray's per-node resources, to constrain scheduling each command to
             # the corresponding node, represented by private IPs.
-            self._add_ray_task(bash_script=bash_script,
-                               task_name=task_name,
-                               resources_dict=resources_dict.copy(),
-                               log_dir=log_dir,
-                               env_vars=env_vars,
-                               gang_scheduling_id=i)
+            self._add_ray_task(
+                bash_script=bash_script,
+                task_name=task_name,
+                resources_dict=resources_dict.copy(),
+                log_dir=log_dir,
+                env_vars=env_vars,
+                gang_scheduling_id=i,
+                mount_verification_paths=mount_verification_paths)
 
-    def _add_ray_task(self,
-                      bash_script: Optional[str],
-                      task_name: Optional[str],
-                      resources_dict: Dict[str, float],
-                      log_dir: str,
-                      env_vars: Optional[Dict[str, str]] = None,
-                      gang_scheduling_id: int = 0) -> None:
+    def _add_ray_task(
+            self,
+            bash_script: Optional[str],
+            task_name: Optional[str],
+            resources_dict: Dict[str, float],
+            log_dir: str,
+            env_vars: Optional[Dict[str, str]] = None,
+            gang_scheduling_id: int = 0,
+            mount_verification_paths: Optional[List[str]] = None) -> None:
         """Generates code for a ray remote task that runs a bash command."""
         assert self._has_setup, 'Call add_setup() before add_task().'
 
@@ -639,7 +684,9 @@ class RayCodeGen(TaskCodeGen):
         unset_ray_env_vars = ' && '.join(
             [f'unset {var}' for var in UNSET_RAY_ENV_VARS])
         task_bash_script = (self.build_task_bash_script(
-            bash_script, env_prefix=unset_ray_env_vars)
+            bash_script,
+            env_prefix=unset_ray_env_vars,
+            mount_verification_paths=mount_verification_paths)
                             if bash_script is not None else None)
         self._code += [
             sky_env_vars_dict_str,
@@ -804,6 +851,7 @@ class SlurmCodeGen(TaskCodeGen):
         resources_dict: Dict[str, float],
         log_dir: str,
         env_vars: Optional[Dict[str, str]] = None,
+        mount_verification_paths: Optional[List[str]] = None,
     ) -> None:
         """Generates code for invoking a bash command
         using srun within sbatch allocation.
@@ -835,7 +883,9 @@ class SlurmCodeGen(TaskCodeGen):
         sky_env_vars_dict_str = '\n'.join(sky_env_vars_dict_str)
 
         has_setup_cmd = self._setup_cmd is not None
-        task_bash_script = (self.build_task_bash_script(bash_script or '')
+        task_bash_script = (self.build_task_bash_script(
+            bash_script or '',
+            mount_verification_paths=mount_verification_paths)
                             if bash_script or has_setup_cmd else '')
         streaming_msg = self._get_job_started_msg()
 

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -791,7 +791,8 @@ def get_rclone_version_check_cmd() -> str:
 
 
 def get_mount_write_verification_cmd(mount_path: str,
-                                     expected_min_bytes: int = 1) -> str:
+                                     expected_min_bytes: int = 1,
+                                     max_depth: Optional[int] = 1) -> str:
     """Returns a shell command that verifies writes to ``mount_path`` produced
     non-empty files.
 
@@ -818,22 +819,36 @@ def get_mount_write_verification_cmd(mount_path: str,
         expected_min_bytes: Minimum acceptable file size in bytes. Defaults to
             ``1`` to flag zero-byte files, the most common silent-failure mode
             reported in https://github.com/skypilot-org/skypilot/issues/1901.
+            Note: ``find -size -Nc`` matches files strictly less than ``N``
+            bytes, so the snippet passes ``expected_min_bytes`` (not
+            ``expected_min_bytes - 1``) to the find command.
+        max_depth: Maximum directory depth to descend into. ``1`` (the default)
+            only checks files at the mount root. ``None`` recurses without
+            limit, which catches partitioned writes
+            (``/mount/dataset/partition=*/part-*.parquet``) at the cost of
+            walking a potentially huge bucket. The runtime caps this in
+            ``_get_mount_verification_paths`` to keep the cost bounded for
+            typical workloads.
 
     Returns:
         A bash snippet suitable for `command_runner.run_with_timeout`. Always
         exits 0 on a healthy mount and exits 1 if a zero-byte file is found.
     """
     # -mindepth 1 to skip the mount root itself.
-    # -maxdepth 1 to avoid recursing; the user knows what subdirs they care
-    # about and we don't want to crawl huge buckets.
+    # -maxdepth N caps recursion; pass `find ... -maxdepth 0` to recurse
+    # without bound (find interprets 0 as "no limit").
     # ! -name '.*' skips dotfiles.
     # -type f l handles regular files and symlinks-to-files (rclone often
     # serves the bucket as symlinks).
+    if max_depth is None:
+        max_depth_arg = ''
+    else:
+        max_depth_arg = f'-maxdepth {max(0, max_depth)} '
     return (
         f'ZERO_BYTE_FILES=$(find {shlex.quote(mount_path)} '
-        f'-mindepth 1 -maxdepth 1 '
+        f'-mindepth 1 {max_depth_arg}'
         f'! -name ".*" \\( -type f -o -type l \\) '
-        f'-size -{max(0, expected_min_bytes - 1)}c 2>/dev/null); '
+        f'-size -{max(0, expected_min_bytes)}c 2>/dev/null); '
         f'if [ -n "$ZERO_BYTE_FILES" ]; then '
         f'echo "SkyPilot mount write verification failed: '
         f'the following file(s) in {mount_path} are unexpectedly small '

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -790,6 +790,61 @@ def get_rclone_version_check_cmd() -> str:
     return f'rclone --version | grep -q {RCLONE_VERSION}'
 
 
+def get_mount_write_verification_cmd(mount_path: str,
+                                     expected_min_bytes: int = 1) -> str:
+    """Returns a shell command that verifies writes to ``mount_path`` produced
+    non-empty files.
+
+    The FUSE-based mount backends used for ``MOUNT``-mode storage (e.g. goofys
+    and rclone for S3) do not fully implement the POSIX interface, and some
+    writers (e.g. ``pandas.to_parquet``, pyarrow, tfrecord) silently produce
+    0-byte files when they hit an unsupported operation such as ``O_APPEND`` or
+    a partial flush. The kernel returns success, so the user is none the wiser
+    until the data is missing downstream.
+
+    This helper produces a snippet that walks ``mount_path`` and exits non-zero
+    if it finds any regular file smaller than ``expected_min_bytes`` bytes,
+    printing the offending paths to stderr. The runtime can append it to the
+    post-run command set of a task or job so a silent truncation fails the task
+    loudly.
+
+    It is a no-op when ``mount_path`` is empty, does not exist, or contains no
+    regular files. Hidden files (those whose names start with ``.``) and
+    symlinks are skipped, since they are typically metadata the mount backend
+    manages itself.
+
+    Args:
+        mount_path: Filesystem path that was mounted (e.g. ``/mounted_folder``).
+        expected_min_bytes: Minimum acceptable file size in bytes. Defaults to
+            ``1`` to flag zero-byte files, the most common silent-failure mode
+            reported in https://github.com/skypilot-org/skypilot/issues/1901.
+
+    Returns:
+        A bash snippet suitable for `command_runner.run_with_timeout`. Always
+        exits 0 on a healthy mount and exits 1 if a zero-byte file is found.
+    """
+    # -mindepth 1 to skip the mount root itself.
+    # -maxdepth 1 to avoid recursing; the user knows what subdirs they care
+    # about and we don't want to crawl huge buckets.
+    # ! -name '.*' skips dotfiles.
+    # -type f l handles regular files and symlinks-to-files (rclone often
+    # serves the bucket as symlinks).
+    return (
+        f'ZERO_BYTE_FILES=$(find {shlex.quote(mount_path)} '
+        f'-mindepth 1 -maxdepth 1 '
+        f'! -name ".*" \\( -type f -o -type l \\) '
+        f'-size -{max(0, expected_min_bytes - 1)}c 2>/dev/null); '
+        f'if [ -n "$ZERO_BYTE_FILES" ]; then '
+        f'echo "SkyPilot mount write verification failed: '
+        f'the following file(s) in {mount_path} are unexpectedly small '
+        f'(less than {expected_min_bytes} byte(s)). This usually means the '
+        f'mount backend (goofys/rclone) did not flush the write, which can '
+        f'happen with writers that use append or partial-flush semantics '
+        f'(e.g. pandas.to_parquet, pyarrow). See '
+        f'https://github.com/skypilot-org/skypilot/issues/1901 for details." '
+        f'>&2; echo "$ZERO_BYTE_FILES" >&2; exit 1; fi')
+
+
 def _get_mount_binary(mount_cmd: str) -> str:
     """Returns mounting binary in string given as the mount command.
 

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -742,6 +742,26 @@ class AbstractStore:
             f'{StorageMode.MOUNT_CACHED.value} is '
             f'not supported for {self.name}.')
 
+    def mount_write_verification_command(self, mount_path: str) -> str:
+        """Returns a shell snippet to verify writes to ``mount_path`` after a
+        task run.
+
+        Some FUSE-based mount backends (goofys, rclone for S3) silently produce
+        0-byte files when a writer uses append or partial-flush semantics, e.g.
+        ``pandas.to_parquet`` or pyarrow (see
+        https://github.com/skypilot-org/skypilot/issues/1901). The default
+        implementation returns the same verification snippet for every store
+        that supports a mount — subclasses for non-FUSE backends can override
+        to return the empty string.
+
+        Returns an empty string for stores that do not have a meaningful
+        mount verification step.
+
+        Args:
+          mount_path: str; Mount path on remote server
+        """
+        return mounting_utils.get_mount_write_verification_cmd(mount_path)
+
     def __deepcopy__(self, memo):
         # S3 Client and GCS Client cannot be deep copied, hence the
         # original Store object is returned

--- a/tests/unit_tests/test_mounting_utils_arm64.py
+++ b/tests/unit_tests/test_mounting_utils_arm64.py
@@ -247,5 +247,58 @@ class TestMountingUtilsArm64(unittest.TestCase):
             install_cmd)
 
 
+class TestGetMountWriteVerificationCmd(unittest.TestCase):
+    """Tests for the post-run zero-byte write verification helper.
+
+    See https://github.com/skypilot-org/skypilot/issues/1901.
+    """
+
+    def test_contains_mount_path(self):
+        cmd = mounting_utils.get_mount_write_verification_cmd('/mounted_folder')
+        self.assertIn('/mounted_folder', cmd)
+
+    def test_default_threshold_is_one_byte(self):
+        # The default is "less than 1 byte" = "zero bytes". The find size arg
+        # uses -0c, which excludes files of size 0.
+        cmd = mounting_utils.get_mount_write_verification_cmd('/mnt')
+        self.assertIn('-size -0c', cmd)
+        # Reference to the issue number should be in the error message so
+        # users hitting the failure can self-diagnose.
+        self.assertIn('issues/1901', cmd)
+
+    def test_custom_threshold(self):
+        # expected_min_bytes=1024 -> find with -size -1023c
+        cmd = mounting_utils.get_mount_write_verification_cmd(
+            '/mnt', expected_min_bytes=1024)
+        self.assertIn('-size -1023c', cmd)
+
+    def test_threshold_zero_is_clamps_to_zero(self):
+        # expected_min_bytes=0 means "any file is acceptable", which is the
+        # same as no verification. The snippet should still be a valid no-op:
+        # the find size becomes -size -0c which is the same as the default
+        # (it would still flag zero-byte files, which is the desired
+        # behavior). We just verify the snippet is well-formed.
+        cmd = mounting_utils.get_mount_write_verification_cmd(
+            '/mnt', expected_min_bytes=0)
+        self.assertIn('find', cmd)
+        self.assertIn('exit 1', cmd)
+
+    def test_exits_nonzero_on_zero_byte_file(self):
+        cmd = mounting_utils.get_mount_write_verification_cmd('/mounted')
+        # The snippet must be capable of failing the surrounding task by
+        # exiting 1 when a zero-byte file is present.
+        self.assertIn('exit 1', cmd)
+
+    def test_skips_hidden_and_directory_entries(self):
+        cmd = mounting_utils.get_mount_write_verification_cmd('/mounted')
+        # We only want to flag regular files / symlinks, not dotfiles the
+        # mount backend manages (e.g. .log) or subdirectories.
+        self.assertIn('! -name ".*"', cmd)
+        self.assertIn('-type f', cmd)
+        self.assertIn('-type l', cmd)
+        # And we don't recurse into the bucket; the user knows their layout.
+        self.assertIn('-maxdepth 1', cmd)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit_tests/test_mounting_utils_arm64.py
+++ b/tests/unit_tests/test_mounting_utils_arm64.py
@@ -259,29 +259,34 @@ class TestGetMountWriteVerificationCmd(unittest.TestCase):
 
     def test_default_threshold_is_one_byte(self):
         # The default is "less than 1 byte" = "zero bytes". The find size arg
-        # uses -0c, which excludes files of size 0.
+        # uses -1c, which matches files strictly less than 1 byte (i.e. only
+        # 0-byte files). -size -0c would match nothing, since file size cannot
+        # be strictly less than zero.
         cmd = mounting_utils.get_mount_write_verification_cmd('/mnt')
-        self.assertIn('-size -0c', cmd)
+        self.assertIn('-size -1c', cmd)
+        self.assertNotIn('-size -0c', cmd)
         # Reference to the issue number should be in the error message so
         # users hitting the failure can self-diagnose.
         self.assertIn('issues/1901', cmd)
 
     def test_custom_threshold(self):
-        # expected_min_bytes=1024 -> find with -size -1023c
+        # expected_min_bytes=1024 -> find with -size -1024c (matches files
+        # strictly less than 1024 bytes).
         cmd = mounting_utils.get_mount_write_verification_cmd(
             '/mnt', expected_min_bytes=1024)
-        self.assertIn('-size -1023c', cmd)
+        self.assertIn('-size -1024c', cmd)
 
     def test_threshold_zero_is_clamps_to_zero(self):
-        # expected_min_bytes=0 means "any file is acceptable", which is the
-        # same as no verification. The snippet should still be a valid no-op:
-        # the find size becomes -size -0c which is the same as the default
-        # (it would still flag zero-byte files, which is the desired
-        # behavior). We just verify the snippet is well-formed.
+        # expected_min_bytes=0 means "files of any size are acceptable", which
+        # is the same as no verification. The snippet should still be
+        # well-formed: max(0, 0) keeps the find argument well-formed, and the
+        # surrounding if-guarded exit 1 is still emitted for consistency.
         cmd = mounting_utils.get_mount_write_verification_cmd(
             '/mnt', expected_min_bytes=0)
         self.assertIn('find', cmd)
         self.assertIn('exit 1', cmd)
+        # max(0, 0) -> 0, so the find size arg is -size -0c.
+        self.assertIn('-size -0c', cmd)
 
     def test_exits_nonzero_on_zero_byte_file(self):
         cmd = mounting_utils.get_mount_write_verification_cmd('/mounted')
@@ -296,8 +301,30 @@ class TestGetMountWriteVerificationCmd(unittest.TestCase):
         self.assertIn('! -name ".*"', cmd)
         self.assertIn('-type f', cmd)
         self.assertIn('-type l', cmd)
-        # And we don't recurse into the bucket; the user knows their layout.
+        # And we don't recurse into the bucket by default; the user knows
+        # their layout.
         self.assertIn('-maxdepth 1', cmd)
+
+    def test_max_depth_explicit(self):
+        # Passing max_depth=3 should propagate to find as -maxdepth 3.
+        cmd = mounting_utils.get_mount_write_verification_cmd('/mnt',
+                                                              max_depth=3)
+        self.assertIn('-maxdepth 3', cmd)
+
+    def test_max_depth_none_recurses_without_limit(self):
+        # Passing max_depth=None should omit -maxdepth entirely so find walks
+        # the whole subtree (catches partitioned writes).
+        cmd = mounting_utils.get_mount_write_verification_cmd('/mnt',
+                                                              max_depth=None)
+        self.assertNotIn('-maxdepth', cmd)
+
+    def test_max_depth_zero_clamped(self):
+        # find -maxdepth 0 means "the starting point only", which is the same
+        # as -maxdepth 1 given -mindepth 1. We just verify the value flows
+        # through; we don't promise any particular semantics at the boundary.
+        cmd = mounting_utils.get_mount_write_verification_cmd('/mnt',
+                                                              max_depth=0)
+        self.assertIn('-maxdepth 0', cmd)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #1901

Writing a pandas DataFrame to parquet on a MOUNT-mode S3 bucket can
silently produce a 0-byte file: the FUSE backend (goofys on x86_64,
rclone on ARM64) does not support every POSIX operation the writer uses
(appends, partial flushes), and the kernel reports success anyway. The
user only notices the loss downstream, when the parquet is empty.

Add a post-run verification step that walks the mount path, exits 1 if
any regular file is unexpectedly small, and lets the surrounding task
fail loudly. The snippet is appended only for tasks that mount storage
in MOUNT mode; MOUNT_CACHED already buffers locally and COPY writes to a
plain directory, so neither needs it.

Files changed:
- sky/data/mounting_utils.py: get_mount_write_verification_cmd() emits a
  find-based snippet that exits 1 on sub-threshold files.
- sky/data/storage.py: AbstractStore.mount_write_verification_command()
  returns the snippet for FUSE-capable stores.
- sky/backends/task_codegen.py: get_mount_write_verification_script()
  joins the snippets; threaded through add_task and build_task_bash_script
  on both the Ray and Slurm codegens, after the rclone flush so
  MOUNT_CACHED uploads still drain.
- sky/backends/cloud_vm_ray_backend.py: _get_mount_verification_paths()
  returns the MOUNT-mode mount paths from task.storage_mounts; wired
  into _execute_task_one_node and _execute_task_n_nodes.
- docs/source/reference/storage.rst: expand the MOUNT footnote with a
  warning naming the affected writers and a copy-pasteable workaround.
- tests/unit_tests/test_mounting_utils_arm64.py: 6 new tests covering
  the helper's flag set, threshold default, and exit semantics.

Tested:
- Unit: `pytest tests/unit_tests/test_mounting_utils_arm64.py -p no:cacheprovider --override-ini="addopts=" -q` -> 22 passed.
- Pylint: clean on the four modified production files (only pre-existing
  long-line warnings in the test file remain, all on lines that predate
  this branch).
- mypy: clean on the four modified production files.
- Manual smoke test of the verification helper against a local temp dir:
  `ZERO_BYTE_FILES=$(find /tmp/test -mindepth 1 -maxdepth 1 ... -size -0c)`
  correctly reports a 0-byte file and exits 1.