### PR TITLE
[Dashboard] Add jobs.header.badge plugin slot to Managed Jobs page

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -397,6 +397,12 @@ export function ManagedJobs() {
             Managed Jobs
           </Link>
         </div>
+        {/* Extension point for a small summary badge next to the page
+            title. Renders nothing when no plugin fills it. */}
+        <PluginSlot
+          name="jobs.header.badge"
+          wrapperClassName="flex items-center"
+        />
         <div className="w-full sm:w-auto max-w-xl">
           <FilterDropdown
             propertyList={PROPERTY_OPTIONS}


### PR DESCRIPTION
## Summary

Adds a `PluginSlot` next to the **Managed Jobs** page title so dashboard
plugins can render a small summary badge there (e.g. a status or utilization
pill), mirroring the existing per-row `jobs.table.status.badge` slot. The
Managed Jobs page previously exposed no header/summary-level extension point.

The slot renders nothing when no plugin fills it (`PluginSlot` returns its
`fallback`, which is `null` here), so the default UI is unchanged.

## Changes

- `sky/dashboard/src/components/jobs.jsx`: add `<PluginSlot name="jobs.header.badge" />`
  in the Managed Jobs page header, right after the page title.

## Test plan

- Without any plugin registered for the slot, the Managed Jobs page renders
  identically to before (slot emits nothing).
- A plugin registering a component for `jobs.header.badge` via
  `api.registerComponent({ slot: 'jobs.header.badge', component })` renders it
  inline next to the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)