### PR TITLE
[Test] Pin fastapi<0.137 in test_skyserve_llm to fix nightly regression

### DIFF
--- a/tests/skyserve/llm/service.yaml
+++ b/tests/skyserve/llm/service.yaml
@@ -28,7 +28,16 @@ resources:
 setup: |
   uv venv --python 3.10 --seed
   source .venv/bin/activate
-  uv pip install vllm==0.10.0
+  # fastapi 0.137.0 made app.routes a nested tree (it stops cloning included
+  # routers, leaving intermediate `_IncludedRouter` nodes in app.routes instead
+  # of a flat list of APIRoute). vLLM bundles prometheus-fastapi-instrumentator,
+  # whose middleware iterates app.routes and does `route.path`, which raises
+  # `AttributeError: '_IncludedRouter' object has no attribute 'path'` and 500s
+  # on every request -- including the /v1/models readiness probe, so the replica
+  # never becomes ready and hits FAILED_INITIAL_DELAY. vLLM 0.10.0 leaves fastapi
+  # unpinned, so the nightly picked up 0.137.0. Pin below it until the bundled
+  # instrumentator handles the new routing tree.
+  uv pip install vllm==0.10.0 'fastapi<0.137'
   # Have to use triton==3.2.0 to avoid https://github.com/triton-lang/triton/issues/6698
   uv pip install triton==3.2.0
   # Pin transformers to avoid https://github.com/verl-project/verl/issues/4337


### PR DESCRIPTION
## Summary

Fixes the nightly `test_skyserve_llm[accelerator0]` failure on the `--aws` smoke-test pipeline (e.g. [build 11262](https://buildkite.com/skypilot-1/smoke-tests/builds/11262)). Root cause is an **upstream FastAPI release**, not SkyPilot code.

- Pin `fastapi<0.137` in `tests/skyserve/llm/service.yaml`'s vLLM install.

## What caused the regression

The test's replica runs `uv pip install vllm==0.10.0`, and **vLLM 0.10.0 leaves `fastapi` unpinned**, so the nightly always installs whatever is latest on PyPI.

**`fastapi==0.137.0` was published 2026-06-14 12:51 UTC** — ~12h before the failing 06-15 nightly — and ships an intentional breaking change: `app.routes` is no longer a flat list of `APIRoute`. Included routers are now kept as a nested tree with intermediate `_IncludedRouter` nodes (FastAPI stopped cloning included routers).

vLLM bundles `prometheus-fastapi-instrumentator`, whose metrics middleware iterates `app.routes` and calls `route.path` on every entry. On the new tree it hits an `_IncludedRouter` node and raises:

```
AttributeError: '_IncludedRouter' object has no attribute 'path'
INFO:  ... "GET /v1/models HTTP/1.1" 500 Internal Server Error
```

So **every** request 500s — including the service's `/v1/models` readiness probe. The replica (Qwen/Qwen3-0.6B on a T4, which itself loaded fine in ~5s) never passes readiness, so after the 1800s initial delay it is marked `FAILED_INITIAL_DELAY`, and the test's `sky serve status` wait-loop exits 1.

This is **deterministic, not a flake** (probe 500s 100% of the time), and reproduces on every run until pinned.

### Pass → fail timeline (reconstructed with `uv pip compile --exclude-newer`)

| nightly | fastapi | starlette | prometheus-fastapi-instrumentator | result |
|---|---|---|---|---|
| 06-11 (build 11214, last green `--aws`) | **0.136.3** | 1.3.0 | 8.0.0 | ✅ passed |
| 06-15 (build 11262) | **0.137.0** | 1.3.1 | 8.0.0 | ❌ failed |

The only material change is `fastapi 0.136.3 → 0.137.0`.

## The fix

`fastapi<0.137` resolves to **fastapi 0.136.3 / starlette 1.3.1 / prometheus-fastapi-instrumentator 8.0.0 / vllm 0.10.0** — i.e. the exact stack the last green AWS nightly (06-11) ran with. It excludes only the broken release (and future 0.138+, since the routing-tree change is permanent) until the bundled instrumentator learns to walk the tree.

## Test plan

- Verified the pin resolves cleanly against current PyPI with `uv pip compile` (vllm 0.10.0 requires `fastapi[standard]>=0.115.0`, so the pin is well within range).
- `/smoke-test -k test_skyserve_llm --aws` on this PR (below).
